### PR TITLE
Fix relative framework paths

### DIFF
--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -43,12 +43,12 @@
     <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' == 'true'">
-    <ProjectReference Include="../../../Ivy/Ivy.csproj" />
-    <ProjectReference Include="../../../Ivy.Hooks.Pty/Ivy.Hooks.Pty.csproj" />
-    <ProjectReference Include="../../../widgets/Ivy.Widgets.Xterm/Ivy.Widgets.Xterm.csproj" />
-    <ProjectReference Include="../../../widgets/Ivy.Widgets.DiffView/Ivy.Widgets.DiffView.csproj" />
-    <ProjectReference Include="../../../widgets/Ivy.Widgets.ClaudeJsonRenderer/Ivy.Widgets.ClaudeJsonRenderer.csproj" />
-    <ProjectReference Include="../../../Ivy.Desktop/Ivy.Desktop.csproj" />
+    <ProjectReference Include="../../../Ivy-Framework/src/Ivy/Ivy.csproj" />
+    <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Hooks.Pty/Ivy.Hooks.Pty.csproj" />
+    <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.Xterm/Ivy.Widgets.Xterm.csproj" />
+    <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.DiffView/Ivy.Widgets.DiffView.csproj" />
+    <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.ClaudeJsonRenderer/Ivy.Widgets.ClaudeJsonRenderer.csproj" />
+    <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Desktop/Ivy.Desktop.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
     <PackageReference Include="Ivy" Version="1.2.42" />
@@ -59,7 +59,7 @@
     <PackageReference Include="Ivy.Desktop" Version="1.2.42" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' == 'true'">
-    <ProjectReference Include="../../../Ivy.Analyser/Ivy.Analyser.csproj">
+    <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Analyser/Ivy.Analyser.csproj">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/Ivy.Tendril/Ivy.Tendril.slnx
+++ b/src/Ivy.Tendril/Ivy.Tendril.slnx
@@ -6,6 +6,6 @@
   </Configurations>
   <Project Path="Ivy.Tendril.csproj" />
   <Project Path="../Ivy.Tendril.Test/Ivy.Tendril.Test.csproj" />
-  <Project Path="../../../Ivy/Ivy.csproj" />
+  <Project Path="../../../Ivy-Framework/src/Ivy/Ivy.csproj" />
   <Project Path="../Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj" />
 </Solution>


### PR DESCRIPTION
Without this fix:
```
% dotnet run --project Ivy.Tendril/Ivy.Tendril.csproj
/usr/local/share/dotnet/sdk/10.0.201/Microsoft.Common.CurrentVersion.targets(2203,5): warning MSB9008: The referenced project ../../../Ivy/Ivy.csproj does not exist.
/Users/zachwolfe/Code/ivy-root/Ivy-Tendril/src/Ivy.Tendril/Apps/ClaudeApp.cs(1,11): error CS0234: The type or namespace name 'Hooks' does not exist in the namespace 'Ivy' (are you missing an assembly reference?)
/Users/zachwolfe/Code/ivy-root/Ivy-Tendril/src/Ivy.Tendril/Apps/Icebox/ContentView.cs(1,11): error CS0234: The type or namespace name 'Core' does not exist in the namespace 'Ivy' (are you missing an assembly reference?)
/Users/zachwolfe/Code/ivy-root/Ivy-Tendril/src/Ivy.Tendril/Apps/IceboxApp.cs(1,14): error CS0234: The type or namespace name 'Reactive' does not exist in the namespace 'System' (are you missing an assembly reference?)
/Users/zachwolfe/Code/ivy-root/Ivy-Tendril/src/Ivy.Tendril/Apps/JobsApp.cs(1,14): error CS0234: The type or namespace name 'Reactive' does not exist in the namespace 'System' (are you missing an assembly reference?)
/Users/zachwolfe/Code/ivy-root/Ivy-Tendril/src/Ivy.Tendril/Apps/JobsApp.cs(2,14): error CS0234: The type or namespace name 'Reactive' does not exist in the namespace 'System' (are you missing an assembly reference?)
/Users/zachwolfe/Code/ivy-root/Ivy-Tendril/src/Ivy.Tendril/Apps/JobsApp.cs(8,11): error CS0234: The type or namespace name 'Widgets' does not exist in the namespace 'Ivy' (are you missing an assembly reference?)
/Users/zachwolfe/Code/ivy-root/Ivy-Tendril/src/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs(2,11): error CS0234: The type or namespace name 'Helpers' does not exist in the namespace 'Ivy' (are you missing an assembly reference?)
/Users/zachwolfe/Code/ivy-root/Ivy-Tendril/src/Ivy.Tendril/Apps/Plans/ContentView.cs(2,11): error CS0234: The type or namespace name 'Core' does not exist in the namespace 'Ivy' (are you missing an assembly reference?)
/Users/zachwolfe/Code/ivy-root/Ivy-Tendril/src/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs(1,11): error CS0234: The type or namespace name 'Core' does not exist in the namespace 'Ivy' (are you missing an assembly reference?)
/Users/zachwolfe/Code/ivy-root/Ivy-Tendril/src/Ivy.Tendril/Apps/PlansApp.cs(1,14): error CS0234: The type or namespace name 'Reactive' does not exist in the namespace 'System' (are you missing an assembly reference?)
/Users/zachwolfe/Code/ivy-root/Ivy-Tendril/src/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs(1,11): error CS0234: The type or namespace name 'Core' does not exist in the namespace 'Ivy' (are you missing an assembly reference?)
...
```