### PR TITLE
Update repo links from Ivy-Framework to Ivy-Tendril, add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Ivy Tendril — Repository Instructions
+
+## Branching
+
+All development work must target the `development` branch. PRs should use `development` as their base branch. The `main` branch is updated by merging `development` into it for releases.

--- a/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/01_Introduction.md
+++ b/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/01_Introduction.md
@@ -18,7 +18,7 @@ Tendril is an AI orchestration app on the Ivy stack: a cross-platform UI plus au
 <Embed Url="https://youtu.be/Gkj5aj5nEKA"/>
 
 <Callout type="tip">
-You can always report issues and suggestions on the [GitHub repository](https://github.com/Ivy-Interactive/Ivy-Framework/issues).
+You can always report issues and suggestions on the [GitHub repository](https://github.com/Ivy-Interactive/Ivy-Tendril/issues).
 If you need direct help, please join our [Discord](https://discord.gg/FHgxkDga3y).
 </Callout>
 

--- a/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
+++ b/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
@@ -22,13 +22,13 @@ One-liner: installs Tendril and required backend tools.
 ### macOS / Linux
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/Ivy-Interactive/Ivy-Framework/main/src/tendril/install.sh | sh
+curl -sSf https://raw.githubusercontent.com/Ivy-Interactive/Ivy-Tendril/main/src/install.sh | sh
 ```
 
 ### Windows
 
 ```powershell
-Invoke-RestMethod -Uri https://raw.githubusercontent.com/Ivy-Interactive/Ivy-Framework/main/src/tendril/install.ps1 | Invoke-Expression
+Invoke-RestMethod -Uri https://raw.githubusercontent.com/Ivy-Interactive/Ivy-Tendril/main/src/install.ps1 | Invoke-Expression
 ```
 
 ## .NET Tool

--- a/src/Ivy.Tendril.Docs/TendrilDocsServer.cs
+++ b/src/Ivy.Tendril.Docs/TendrilDocsServer.cs
@@ -48,7 +48,7 @@ public static class TendrilDocsServer
                 var githubItem = MenuItem.Default("View on Github")
                     .Tag("$github")
                     .Icon(Icons.Github)
-                    .OnSelect(() => navigator.Navigate("https://github.com/Ivy-Interactive/Ivy-Framework/tree/development/src/tendril"));
+                    .OnSelect(() => navigator.Navigate("https://github.com/Ivy-Interactive/Ivy-Tendril"));
                 return new[] { githubItem }.Concat(items);
             });
         server.UseAppShell(() => new DefaultSidebarAppShell(appShellSettings));

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/MakePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/MakePlan/Program.md
@@ -177,7 +177,7 @@ If the plan references other plans (from `[number]` syntax in args), add them to
 **Validate repo paths**: After determining the project and repos from config.yaml, verify each repo path exists locally:
 - For each repo in the plan's repos list, check `Test-Path <repo-path>`
 - If any repo path doesn't exist, fail with error: "Repository path does not exist: `<path>`. Check config.yaml project configuration."
-- This prevents creating plans targeting non-existent repo paths (e.g. a deprecated `Ivy-Tendril` repo when the code actually lives in `Ivy-Framework/src/tendril/`)
+- This prevents creating plans targeting non-existent repo paths
 
 **Rename/refactor plans (caller enumeration)**: When creating plans that rename functions, change method signatures, extract interfaces, or otherwise require updating callers:
 1. Use `Grep` to search the **entire repo root** (not just the expected directory) for all usage patterns of the symbol being changed

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/MakePr/Tools/Utils.ps1
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/MakePr/Tools/Utils.ps1
@@ -1,7 +1,7 @@
 # Utils.ps1 - Shared utility functions for MakePr promptware
 
 $script:configCache = $null
-$script:configPath = "D:\Repos\_Ivy\Ivy-Framework\src\tendril\Ivy.Tendril.TeamIvyConfig\config.yaml"
+$script:configPath = $env:TENDRIL_CONFIG
 
 function Get-ConfigYaml {
     <#

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/UpdatePlan/Tools/Utils.ps1
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/UpdatePlan/Tools/Utils.ps1
@@ -14,7 +14,7 @@ function Get-ConfigYaml {
     }
 
     # Try to find config.yaml in the repository
-    $configPath = "D:\Repos\_Ivy\Ivy-Framework\src\tendril\Ivy.Tendril.TeamIvyConfig\config.yaml"
+    $configPath = $env:TENDRIL_CONFIG
 
     if (Test-Path $configPath) {
         $config = Get-Content $configPath -Raw | ConvertFrom-Yaml

--- a/src/Ivy.Tendril.TeamIvyConfig/README.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/README.md
@@ -9,22 +9,22 @@ This folder contains the Team Ivy configuration for Tendril, a self-contained co
 **Windows (PowerShell):**
 ```powershell
 # Set permanently
-[System.Environment]::SetEnvironmentVariable('TENDRIL_HOME', 'D:\Repos\_Ivy\Ivy-Framework\src\tendril\Ivy.Tendril.TeamIvyConfig', 'User')
+[System.Environment]::SetEnvironmentVariable('TENDRIL_HOME', 'D:\Repos\_Ivy\Ivy-Tendril\src\Ivy.Tendril.TeamIvyConfig', 'User')
 [System.Environment]::SetEnvironmentVariable('REPOS_HOME', 'D:\Repos\_Ivy', 'User')
 
 # Or set for current session only
-$env:TENDRIL_HOME = "D:\Repos\_Ivy\Ivy-Framework\src\tendril\Ivy.Tendril.TeamIvyConfig"
+$env:TENDRIL_HOME = "D:\Repos\_Ivy\Ivy-Tendril\src\Ivy.Tendril.TeamIvyConfig"
 $env:REPOS_HOME = "D:\Repos\_Ivy"
 ```
 
 **macOS/Linux (Bash/Zsh):**
 ```bash
 # Add to ~/.bashrc or ~/.zshrc for persistence
-export TENDRIL_HOME=~/repos/Ivy-Framework/src/tendril/Ivy.Tendril.TeamIvyConfig
+export TENDRIL_HOME=~/repos/Ivy-Tendril/src/Ivy.Tendril.TeamIvyConfig
 export REPOS_HOME=~/repos
 
 # Or set for current session only
-export TENDRIL_HOME=~/repos/Ivy-Framework/src/tendril/Ivy.Tendril.TeamIvyConfig
+export TENDRIL_HOME=~/repos/Ivy-Tendril/src/Ivy.Tendril.TeamIvyConfig
 export REPOS_HOME=~/repos
 ```
 
@@ -34,7 +34,7 @@ If you want to use the LLM features, configure your API credentials using .NET u
 
 ```bash
 # Navigate to this directory
-cd D:\Repos\_Ivy\Ivy-Framework\src\tendril\Ivy.Tendril.TeamIvyConfig
+cd D:\Repos\_Ivy\Ivy-Tendril\src\Ivy.Tendril.TeamIvyConfig
 
 # Set your OpenAI credentials
 dotnet user-secrets set "OpenAi:Endpoint" "https://api.openai.com/v1"
@@ -105,7 +105,7 @@ It reads `plan.yaml` to extract the plan title, project name, and PR URLs, then 
 
 ```bash
 # From the Ivy.Tendril application directory
-cd D:\Repos\_Ivy\Ivy-Framework\src\tendril\Ivy.Tendril
+cd D:\Repos\_Ivy\Ivy-Tendril\src\Ivy.Tendril
 dotnet run
 ```
 

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -148,21 +148,23 @@ projects:
   meta:
     slackEmoji: ':seedling:'
   repos:
-  - *o5
+  - path: '%REPOS_HOME%\Ivy-Tendril'
+    prRule: yolo
+    baseBranch: development
   verifications:
   - *o0
   - *o1
   - name: DotnetTest
   - *o3
   context: >
-    Plan management TUI. Key folders: - Services\ — ConfigService, PlanReaderService, JobService - Apps\ — PlansApp, JobsApp UI - Promptwares\ — MakePlan, UpdatePlan, SplitPlan, ExpandPlan This project uses the Ivy Framework - there's CLI helper methods you can use:  ivy docs AGENTS.md  ivy question "How do I make a button in Ivy?"
+    Plan management TUI. Key folders: - src\Ivy.Tendril\Services\ — ConfigService, PlanReaderService, JobService - src\Ivy.Tendril\Apps\ — PlansApp, JobsApp UI - src\Ivy.Tendril\Promptwares\ — MakePlan, UpdatePlan, SplitPlan, ExpandPlan This project uses the Ivy Framework - there's CLI helper methods you can use:  ivy docs AGENTS.md  ivy question "How do I make a button in Ivy?"
   reviewActions:
   - name: Tendril
-    condition: Test-Path "worktrees\Ivy-Framework\src\tendril\Ivy.Tendril"
-    action: dotnet run --project worktrees\Ivy-Framework\src\tendril\Ivy.Tendril
+    condition: Test-Path "worktrees\Ivy-Tendril\src\Ivy.Tendril"
+    action: dotnet run --project worktrees\Ivy-Tendril\src\Ivy.Tendril
   - name: Docs
-    condition: Test-Path "worktrees\Ivy-Framework\src\tendril\Ivy.Tendril.Docs"
-    action: dotnet run --project worktrees\Ivy-Framework\src\tendril\Ivy.Tendril.Docs --browse --find-available-port
+    condition: Test-Path "worktrees\Ivy-Tendril\src\Ivy.Tendril.Docs"
+    action: dotnet run --project worktrees\Ivy-Tendril\src\Ivy.Tendril.Docs --browse --find-available-port
   hooks:
   - name: SlackNotify
     when: after
@@ -171,7 +173,7 @@ projects:
     condition: ''
     action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
   repoPaths:
-  - D:\Repos\_Ivy\Ivy-Framework
+  - '%REPOS_HOME%\Ivy-Tendril'
 - name: Mcp
   color: Sky
   meta:

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml.backup
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml.backup
@@ -158,11 +158,11 @@ projects:
     Plan management TUI. Key folders: - Services\ — ConfigService, PlanReaderService, JobService - Apps\ — PlansApp, JobsApp UI - Promptwares\ — MakePlan, UpdatePlan, SplitPlan, ExpandPlan This project uses the Ivy Framework - there's CLI helper methods you can use:  ivy docs AGENTS.md  ivy question "How do I make a button in Ivy?"
   reviewActions:
   - name: Tendril
-    condition: Test-Path "worktrees\Ivy-Framework\src\tendril\Ivy.Tendril"
-    action: dotnet run --project worktrees\Ivy-Framework\src\tendril\Ivy.Tendril
+    condition: Test-Path "worktrees\Ivy-Tendril\src\Ivy.Tendril"
+    action: dotnet run --project worktrees\Ivy-Tendril\src\Ivy.Tendril
   - name: Docs
-    condition: Test-Path "worktrees\Ivy-Framework\src\tendril\Ivy.Tendril.Docs"
-    action: dotnet run --project worktrees\Ivy-Framework\src\tendril\Ivy.Tendril.Docs --browse --find-available-port
+    condition: Test-Path "worktrees\Ivy-Tendril\src\Ivy.Tendril.Docs"
+    action: dotnet run --project worktrees\Ivy-Tendril\src\Ivy.Tendril.Docs --browse --find-available-port
   hooks:
   - name: SlackNotify
     when: after

--- a/src/Ivy.Tendril/Apps/HelpApp.cs
+++ b/src/Ivy.Tendril/Apps/HelpApp.cs
@@ -30,7 +30,7 @@ public class HelpApp : ViewBase
                       .Icon(Icons.Bug, Align.Right)
                       .OnClick(() =>
                           client.OpenUrl(
-                              "https://github.com/Ivy-Interactive/Ivy-Framework/issues/new?title=%28tendril%29%20"))
+                              "https://github.com/Ivy-Interactive/Ivy-Tendril/issues/new"))
                );
     }
 }

--- a/src/Ivy.Tendril/Promptwares/MakePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/MakePlan/Program.md
@@ -170,7 +170,7 @@ If the plan references other plans (from `[number]` syntax in args), add them to
 **Validate repo paths**: After determining the project and repos from config.yaml, verify each repo path exists locally:
 - For each repo in the plan's repos list, check `Test-Path <repo-path>`
 - If any repo path doesn't exist, fail with error: "Repository path does not exist: `<path>`. Check config.yaml project configuration."
-- This prevents creating plans targeting non-existent repo paths (e.g. a deprecated `Ivy-Tendril` repo when the code actually lives in `Ivy-Framework/src/tendril/`)
+- This prevents creating plans targeting non-existent repo paths
 
 **Rename/refactor plans (caller enumeration)**: When creating plans that rename functions, change method signatures, extract interfaces, or otherwise require updating callers:
 1. Use `Grep` to search the **entire repo root** (not just the expected directory) for all usage patterns of the symbol being changed

--- a/src/Ivy.Tendril/Promptwares/MakePlan/Tools/Utils.ps1
+++ b/src/Ivy.Tendril/Promptwares/MakePlan/Tools/Utils.ps1
@@ -1,7 +1,7 @@
 # Utils.ps1 - Shared utility functions for MakePr promptware
 
 $script:configCache = $null
-$script:configPath = "D:\Repos\_Ivy\Ivy-Framework\src\tendril\Ivy.Tendril.TeamIvyConfig\config.yaml"
+$script:configPath = $env:TENDRIL_CONFIG
 
 function Get-ConfigYaml {
     <#

--- a/src/Ivy.Tendril/Promptwares/MakePr/Tools/Utils.ps1
+++ b/src/Ivy.Tendril/Promptwares/MakePr/Tools/Utils.ps1
@@ -1,7 +1,7 @@
 # Utils.ps1 - Shared utility functions for MakePr promptware
 
 $script:configCache = $null
-$script:configPath = "D:\Repos\_Ivy\Ivy-Framework\src\tendril\Ivy.Tendril.TeamIvyConfig\config.yaml"
+$script:configPath = $env:TENDRIL_CONFIG
 
 function Get-ConfigYaml {
     <#

--- a/src/Ivy.Tendril/Promptwares/UpdatePlan/Tools/Utils.ps1
+++ b/src/Ivy.Tendril/Promptwares/UpdatePlan/Tools/Utils.ps1
@@ -14,7 +14,7 @@ function Get-ConfigYaml {
     }
 
     # Try to find config.yaml in the repository
-    $configPath = "D:\Repos\_Ivy\Ivy-Framework\src\tendril\Ivy.Tendril.TeamIvyConfig\config.yaml"
+    $configPath = $env:TENDRIL_CONFIG
 
     if (Test-Path $configPath) {
         $config = Get-Content $configPath -Raw | ConvertFrom-Yaml


### PR DESCRIPTION
## Summary
- Updated all GitHub URLs and hardcoded paths that still referenced the old `Ivy-Framework/src/tendril` location to point to the standalone `Ivy-Tendril` repo
- Replaced hardcoded config paths in promptware `Utils.ps1` files with `$env:TENDRIL_CONFIG`
- Updated Tendril project in `config.yaml` to use `%REPOS_HOME%\Ivy-Tendril` instead of the `*o5` YAML anchor pointing to Ivy-Framework
- Added root `AGENTS.md` with development branch policy

## Files changed
- **Docs**: `TendrilDocsServer.cs`, `01_Introduction.md`, `02_Installation.md` — GitHub links
- **App code**: `HelpApp.cs` — issue submission URL
- **Promptwares**: `Utils.ps1` (MakePlan, MakePr, UpdatePlan) — config path to `$env:TENDRIL_CONFIG`
- **Promptwares**: `Program.md` (MakePlan) — removed stale repo structure comment
- **Config**: `config.yaml`, `config.yaml.backup`, `README.md` — Tendril project paths
- **Root**: `AGENTS.md` — new file with branching policy

## Test plan
- [ ] Verify `tendril` starts and loads config correctly
- [ ] Verify docs site "View on Github" link points to Ivy-Tendril
- [ ] Verify HelpApp "Submit Issue" opens Ivy-Tendril issues