### PR TITLE
Fix docs Dockerfile: add Node.js and vite-plus

### DIFF
--- a/.github/docker/Dockerfile.tendril-docs
+++ b/.github/docker/Dockerfile.tendril-docs
@@ -14,7 +14,12 @@ ARG TARGETARCH
 ARG IVY_FRAMEWORK_REF=main
 WORKDIR /src
 
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js + pnpm + vite-plus (Ivy.csproj MSBuild targets run "vp install/build")
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g pnpm@10.33.0 vite-plus@0.1.13
 
 RUN git clone --depth 1 --branch $IVY_FRAMEWORK_REF \
     https://github.com/Ivy-Interactive/Ivy-Framework.git /src/Ivy-Framework


### PR DESCRIPTION
## Summary
- The Ivy-Framework `Ivy.csproj` has MSBuild targets that run `vp install` and `vp run build` to compile the frontend
- The Docker build stage was missing Node.js, pnpm, and vite-plus, causing `vp: not found` error
- Adds NodeSource 20.x, pnpm 10.33.0, and vite-plus 0.1.13 to the build stage

Fixes deploy-docs failure in v1.0.18 release.