### PR TITLE
Fix build: add dotnet-tools manifest and fix test project references

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "ivy.docs.compiler": {
+      "version": "0.1.0",
+      "commands": ["ivy-docs-cli"]
+    }
+  }
+}

--- a/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
+++ b/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
@@ -33,7 +33,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Ivy.Tendril\Ivy.Tendril.csproj" />
-    <ProjectReference Include="..\..\..\Ivy\Ivy.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IvySource)' == 'true'">
+    <ProjectReference Include="..\..\..\Ivy-Framework\src\Ivy\Ivy.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IvySource)' != 'true'">
+    <PackageReference Include="Ivy" Version="1.2.43" />
   </ItemGroup>
 
 </Project>

--- a/src/Ivy.Tendril/Apps/Jobs/Models.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Models.cs
@@ -17,6 +17,12 @@ public enum JobStatus
 
 public record JobItem
 {
+    /// <summary>
+    /// Maximum number of output lines retained per job during execution.
+    /// Lines beyond this limit are discarded (not just hidden from display).
+    /// Memory is freed when EvictStaleJobs() removes completed jobs after 1 hour.
+    /// Output is not persisted to SQLite—this in-memory queue is the only retention.
+    /// </summary>
     private const int MaxOutputLines = 10_000;
     private int _completionGuard;
 


### PR DESCRIPTION
## Summary
- Add `.config/dotnet-tools.json` with `ivy-docs-cli` tool so the Docs project build can restore and run the markdown converter
- Fix `Ivy.Tendril.Test.csproj`: replace broken unconditional reference to `../../../Ivy/Ivy.csproj` with conditional `IvySource` pattern matching the other projects

## Test plan
- [x] `dotnet build Ivy.Tendril.slnx` succeeds with 0 errors