### PR TITLE
[03375] Add comment explaining MaxOutputLines retention policy

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/Models.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Models.cs
@@ -17,6 +17,12 @@ public enum JobStatus
 
 public record JobItem
 {
+    /// <summary>
+    /// Maximum number of output lines retained per job during execution.
+    /// Lines beyond this limit are discarded (not just hidden from display).
+    /// Memory is freed when EvictStaleJobs() removes completed jobs after 1 hour.
+    /// Output is not persisted to SQLite—this in-memory queue is the only retention.
+    /// </summary>
     private const int MaxOutputLines = 10_000;
     private int _completionGuard;
 


### PR DESCRIPTION
# Summary

## Changes

Added a comprehensive XML documentation comment to the `MaxOutputLines` constant in `Ivy.Tendril\Apps\Jobs\Models.cs` explaining its purpose, retention behavior, memory lifecycle, and the fact that output is in-memory only and not persisted to SQLite.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Jobs/Models.cs` — Added XML doc comment to `MaxOutputLines` constant (lines 20-25)

## Commits

- e62ca20 [03375] Add comment explaining MaxOutputLines retention policy