### PR TITLE
[03392] Set Tendril Desktop icon to ivy green quarter circle

### DIFF
--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -132,7 +132,8 @@ public class Program
         {
             var window = new DesktopWindow(server)
                 .Title("Ivy Tendril")
-                .Size(1400, 900);
+                .Size(1400, 900)
+                .Icon(typeof(Program), "Ivy.Tendril.Assets.Tendril.ico");
 
             return window.Run();
         }


### PR DESCRIPTION
# Summary

## Changes

Added the icon configuration call to the DesktopWindow builder chain in Program.cs to explicitly set the Tendril-specific ivy green quarter circle icon. The change adds a single line using the existing `.Icon()` method with the embedded resource name `Ivy.Tendril.Assets.Tendril.ico`.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Program.cs` (lines 136) — Added `.Icon()` method call to DesktopWindow builder

---

**Commits:**
- 8f542e0