### PR TITLE
[03395] Add Name column to Promptwares table

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
@@ -14,25 +14,26 @@ public class PromptwaresSetupView : ViewBase
 
         var promptwares = config.Settings.Promptwares;
 
-        var rows = promptwares.Select(kvp => new PromptwareRow(
+        var rows = promptwares.Select((kvp, i) => new PromptwareRow(
             kvp.Key,
             kvp.Value.Profile,
-            string.Join(", ", kvp.Value.AllowedTools)
+            string.Join(", ", kvp.Value.AllowedTools),
+            i
         )).ToList();
 
         var table = new TableBuilder<PromptwareRow>(rows)
-            .Header(t => t.Name, "")
-            .Builder(t => t.Name, f => f.Func<PromptwareRow, string>(name =>
+            .Header(t => t.Index, "")
+            .Builder(t => t.Index, f => f.Func<PromptwareRow, PromptwareRow>(row =>
                 Layout.Horizontal().Gap(1)
                 | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit this promptware").OnClick(() =>
                 {
-                    editKey.Set(name);
+                    editKey.Set(row.Name);
                 })
                 | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete this promptware").OnClick(() =>
                 {
-                    promptwares.Remove(name);
+                    promptwares.Remove(row.Name);
                     config.SaveSettings();
-                    client.Toast($"Promptware '{name}' deleted", "Deleted");
+                    client.Toast($"Promptware '{row.Name}' deleted", "Deleted");
                     refreshToken.Refresh();
                 })
             ));
@@ -49,5 +50,5 @@ public class PromptwaresSetupView : ViewBase
                | new EditPromptwareDialog(editKey, promptwares, config, client, refreshToken);
     }
 
-    private record PromptwareRow(string Name, string Profile, string AllowedTools);
+    private record PromptwareRow(string Name, string Profile, string AllowedTools, int Index);
 }


### PR DESCRIPTION
# Summary

## Changes

Fixed the Promptwares configuration table by adding an Index field to the PromptwareRow record and refactoring the table builder to use Index for the action buttons column. This allows the Name, Profile, and AllowedTools columns to be automatically displayed by the TableBuilder, making promptware names visible in the table alongside their configuration details.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs` — Updated PromptwareRow record, rows creation with index enumeration, and table builder configuration

## Commits

- 00894cd
