### PR TITLE
[00249] Add VitePlusCheck verification to Framework and Console projects

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -28,6 +28,8 @@ projects:
   - name: IvyFrameworkVerification
     required: true
   - name: NewWidgetChecklist
+  - name: VitePlusCheck
+    required: true
   - &o3
     name: CheckResult
     required: true
@@ -127,6 +129,8 @@ projects:
   - *o0
   - *o1
   - *o2
+  - name: VitePlusCheck
+    required: true
   - *o3
   context: >
     - Ivy.Console\ — desktop CLI and TUI client - Ivy.Internals\ — shared internals - Ivy.Studio\ — vibe-coding agent
@@ -301,6 +305,14 @@ verifications:
     Run `go vet ./...` in the Go source directory of the project repo.
     For Services: `cd ivy-proxy && go vet ./...`
     Verify no issues are reported.
+- name: VitePlusCheck
+  prompt: >
+    Run `vp check` in the VitePlus frontend directory of the project repo.
+    For PrCostCalculator: run in repo root.
+    For Framework: `cd src\frontend && vp check`
+    For Console: `cd Ivy.Studio\Widgets\frontend && vp check`
+    If `vp check` reports fixable issues, run `vp check --fix`, then stage and commit the changes.
+    Also run `vp build` to verify the production build succeeds.
 planTemplate: >
   # {title}
 


### PR DESCRIPTION
# Summary

## Changes

Added `VitePlusCheck` verification to the **Framework** and **Console** projects in `config.yaml`, and updated the `VitePlusCheck` verification prompt to include per-project directory instructions for running `vp check` in the correct frontend subdirectory.

## API Changes

None. This is a configuration-only change.

## Files Modified

- **config.yaml** — Added `VitePlusCheck` (required: true) to Framework project verifications
- **config.yaml** — Added `VitePlusCheck` (required: true) to Console project verifications
- **config.yaml** — Added `VitePlusCheck` verification prompt with per-project directory instructions for Framework (`src\frontend`), Console (`Ivy.Studio\Widgets\frontend`), and PrCostCalculator (repo root)

## Commits

- `d183920` [00249] Add VitePlusCheck verification to Framework and Console projects