### PR TITLE
ci: fallback to Directory.Build.props version for manual workflows

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -15,15 +15,21 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - name: Determine version from tag
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine version
         id: version
         run: |
           if [[ "${{ github.event_name }}" == "release" ]]; then
             TAG="${{ github.event.release.tag_name }}"
-          else
+            VERSION="${TAG#v}"
+          elif [[ "${{ github.ref_type }}" == "tag" ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
+            VERSION="${TAG#v}"
+          else
+            VERSION=$(grep -oP '(?<=<Version>)[^<]+' src/Directory.Build.props | head -n 1)
           fi
-          VERSION="${TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved version: $VERSION"
 


### PR DESCRIPTION
Fixes the issue where manual workflow dispatches on the main branch fail because the branch name `refs/heads/main` is incorrectly passed as the version to MSBuild. With this change, the workflow parses the `<Version>` from `src/Directory.Build.props` as a reliable fallback.