### PR TITLE
chore: ensure deploy-docs job waits for ivy tendril release

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -270,6 +270,7 @@ jobs:
             --clobber
 
   deploy-docs:
+    needs: [publish-nuget, publish-desktop]
     runs-on: ubuntu-latest
     environment: production
     env:


### PR DESCRIPTION
Added needs: [publish-nuget, publish-desktop] to deploy-docs to ensure documentation is only published upon a successful release.