### PR TITLE
fix: wrap Card in Box to enable Margin

### DIFF
--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -51,7 +51,7 @@ public class WallpaperApp : ViewBase
                         | Text.Block($"Tendril v{versionInfo.Value.LatestVersion} is available!")
                         | Text.Muted($"You're running v{versionInfo.Value.CurrentVersion}")
                         | Text.Muted("Run: tendril --version && dotnet tool update -g Ivy.Tendril"))
-            ).Margin(2));
+            ).WithBox().Margin(2));
 
         return new Fragment(elements.ToArray());
     }


### PR DESCRIPTION
Fixes build error CS1929 by wrapping the Card widget with .WithBox() to enable the .Margin(2) extension method.