### PR TITLE
chore: remove ivy framework from tendril repository

### DIFF
--- a/src/Ivy.Tendril/Ivy.Tendril.slnx
+++ b/src/Ivy.Tendril/Ivy.Tendril.slnx
@@ -6,6 +6,5 @@
   </Configurations>
   <Project Path="Ivy.Tendril.csproj" />
   <Project Path="../Ivy.Tendril.Test/Ivy.Tendril.Test.csproj" />
-  <Project Path="../../../Ivy-Framework/src/Ivy/Ivy.csproj" />
   <Project Path="../Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj" />
 </Solution>


### PR DESCRIPTION
## Description
Moving the .slnx file to the repository root standardizes project references and resolves a discrepancy in how Sliplane computes paths for Dockerfiles relative to the  file context, which was causing the 'open src/Ivy.Tendril.Docs/Dockerfile: no such file or directory' deployment failure.