### PR TITLE
[03406] Fix NullReferenceException in Review ContentView when selectedPlan is null

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -251,6 +251,12 @@ public class ContentView(
 
         var planData = planContentQuery.Value;
 
+        // Early null guard: _selectedPlan may become null due to state updates
+        if (_selectedPlan is null)
+        {
+            return Text.Muted("No plan selected");
+        }
+
         // Plan tab content (not dependent on query — uses in-memory data)
         var reviewAnnotated = MarkdownHelper.AnnotateAllBrokenLinks(_selectedPlan.LatestRevisionContent, _planService.PlansDirectory);
         var planTabContent = new Markdown(reviewAnnotated)


### PR DESCRIPTION
# Summary

## Changes

Fixed a `NullReferenceException` in `ContentView.Build()` by adding an early null guard when `_selectedPlan` is null. The issue occurred when `_selectedPlan` became null during state updates or navigation, causing a crash when accessing `_selectedPlan.LatestRevisionContent` on line 255.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — Added null check at line 254 before accessing `_selectedPlan` properties


## Commits

- e496a32

---

Closes Ivy-Interactive/Ivy-Tendril#59