### PR TITLE
[03415] Improve version update notification design

### DIFF
--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -44,14 +44,14 @@ public class WallpaperApp : ViewBase
         };
 
         if (versionInfo.Value?.HasUpdate == true)
-            elements.Insert(0, new Box(new Card(
-                Layout.Horizontal().Gap(2).AlignContent(Align.Center)
-                    | Icons.Info
-                    | (Layout.Vertical().Gap(1)
-                        | Text.Block($"Tendril v{versionInfo.Value.LatestVersion} is available!")
-                        | Text.Muted($"You're running v{versionInfo.Value.CurrentVersion}")
-                        | Text.Muted("Run: tendril --version && dotnet tool update -g Ivy.Tendril"))
-            )).Margin(2));
+            elements.Insert(0, new Box(
+                Callout.Info(
+                    $"**Tendril v{versionInfo.Value.LatestVersion} is available!**\n\n" +
+                    $"You're currently running v{versionInfo.Value.CurrentVersion}.\n\n" +
+                    $"Update with: `tendril --version && dotnet tool update -g Ivy.Tendril`",
+                    "Update Available"
+                )
+            ).Margin(2));
 
         return new Fragment(elements.ToArray());
     }


### PR DESCRIPTION
# Summary

## Changes

Successfully replaced the Card-based version update notification in WallpaperApp with the Ivy Framework's `Callout.Info` widget. The change improves semantic clarity by using a purpose-built notification component, leverages the framework's design system conventions for consistent styling, and enables markdown support for better text formatting (bold titles, inline code).

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/WallpaperApp.cs` — Replaced manual Card layout composition (lines 46-54) with `Callout.Info()` for version notifications, improving visual hierarchy and maintainability

## Commits

- 0370b30