### PR TITLE
[03408] Include Completed plans in Review app filter

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/SidebarView.cs
@@ -9,6 +9,7 @@ public class SidebarView(
     IState<string?> projectFilter,
     IState<string?> levelFilter,
     IState<string?> textFilter,
+    IState<bool> showCompleted,
     IConfigService config) : ViewBase
 {
     private readonly IConfigService _config = config;
@@ -17,6 +18,7 @@ public class SidebarView(
     private readonly IState<string?> _projectFilter = projectFilter;
     private readonly IState<string?> _levelFilter = levelFilter;
     private readonly IState<string?> _textFilter = textFilter;
+    private readonly IState<bool> _showCompleted = showCompleted;
 
     public override object Build()
     {
@@ -54,7 +56,8 @@ public class SidebarView(
                       | _projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
                           .WithField().Label("Project")
                       | _levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
-                          .WithField().Label("Level");
+                          .WithField().Label("Level")
+                      | _showCompleted.ToBoolInput("Show Completed");
         }
 
         var content = new List(filteredPlans.Select(plan =>

--- a/src/Ivy.Tendril/Apps/ReviewApp.cs
+++ b/src/Ivy.Tendril/Apps/ReviewApp.cs
@@ -21,6 +21,7 @@ public class ReviewApp : ViewBase
         var projectFilter = UseState<string?>(null);
         var levelFilter = UseState<string?>(null);
         var textFilter = UseState<string?>("");
+        var showCompleted = UseState(false);
         var refreshToken = UseRefreshToken();
 
         UseEffect(() =>
@@ -37,7 +38,9 @@ public class ReviewApp : ViewBase
         var previousPlans = UseRef(new List<PlanFile>());
 
         var plans = planService.GetPlans()
-            .Where(p => p.Status is PlanStatus.ReadyForReview or PlanStatus.Failed)
+            .Where(p => showCompleted.Value
+                ? p.Status is PlanStatus.ReadyForReview or PlanStatus.Failed or PlanStatus.Completed
+                : p.Status is PlanStatus.ReadyForReview or PlanStatus.Failed)
             .ToList();
         var filteredPlans = PlanFilters.ApplyFilters(plans, projectFilter.Value, levelFilter.Value, textFilter.Value).ToList();
 
@@ -59,7 +62,7 @@ public class ReviewApp : ViewBase
 
         previousPlans.Value = filteredPlans;
 
-        var sidebar = new SidebarView(plans, selectedPlanState, projectFilter, levelFilter, textFilter, configService);
+        var sidebar = new SidebarView(plans, selectedPlanState, projectFilter, levelFilter, textFilter, showCompleted, configService);
 
         return new SidebarLayout(
             new ContentView(selectedPlanState.Value, filteredPlans, selectedPlanState, planService, jobService,


### PR DESCRIPTION
# Summary

## Changes

Added a "Show Completed" toggle filter to the Review app sidebar that allows users to optionally include completed plans in the view. When enabled, the filter includes plans with status `Completed` in addition to the default `ReadyForReview` and `Failed` statuses. This enables users to re-run completed tasks for testing or regression checks.

## API Changes

- `SidebarView` constructor now accepts an additional `IState<bool> showCompleted` parameter
- ReviewApp filter logic now conditionally includes `PlanStatus.Completed` based on the toggle state

## Files Modified

- `src/Ivy.Tendril/Apps/ReviewApp.cs` — Added `showCompleted` state and updated filter logic
- `src/Ivy.Tendril/Apps/Review/SidebarView.cs` — Added `showCompleted` parameter to constructor, added field, and added toggle UI in Build() method

## Commits

- c671d2f [03408] Add Show Completed filter toggle to Review app