### PR TITLE
[03421] "Create your first Plan" message appears despite existing plans

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -210,7 +210,7 @@ public class JobServiceCompletionGuardTests
         public List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7, string? projectFilter = null) => [];
         public List<Recommendation> GetRecommendations() => [];
         public int GetPendingRecommendationsCount() => 0;
-        public PlanReaderService.PlanCountSnapshot ComputePlanCounts() => new(0, 0, 0, 0, 0);
+        public PlanReaderService.PlanCountSnapshot ComputePlanCounts() => new(0, 0, 0, 0, 0, 0);
         public void UpdateRecommendationState(string planFolderName, string recommendationTitle, string newState, string? declineReason = null) { }
         public void InvalidateCaches() { }
         public Task FlushPendingWritesAsync() => Task.CompletedTask;

--- a/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
@@ -114,7 +114,7 @@ public class JobServiceDeletionTests
         public List<PlanFile> GetPlans(PlanStatus? statusFilter = null) => new();
         public PlanFile? GetPlanByFolder(string folderPath) => null;
         public PlanFile? GetPlanById(int planId) => null;
-        public PlanReaderService.PlanCountSnapshot ComputePlanCounts() => new(0, 0, 0, 0, 0);
+        public PlanReaderService.PlanCountSnapshot ComputePlanCounts() => new(0, 0, 0, 0, 0, 0);
         public DashboardStats GetDashboardData(string? projectFilter) => new(0, 0, 0, 0, 0, 0, 0, new(), new());
         public decimal GetPlanTotalCost(int planId) => 0;
         public int GetPlanTotalTokens(int planId) => 0;

--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -23,7 +23,7 @@ public class WallpaperApp : ViewBase
 
         var counts = countsService.Current;
 
-        var hasActivity = counts.Drafts > 0 || counts.ActiveJobs > 0 || counts.Reviews > 0;
+        var hasActivity = counts.TotalPlans > 0;
 
         var heading = hasActivity ? "What are we making next?" : "Welcome to Ivy Tendril";
         var subtitle = hasActivity ? BuildSummary(counts) : "Manage your plans, track jobs, and review pull requests.";

--- a/src/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/Ivy.Tendril/Services/PlanCountsService.cs
@@ -2,7 +2,7 @@ using Ivy.Tendril.Apps.Jobs;
 
 namespace Ivy.Tendril.Services;
 
-public record PlanCounts(int Drafts, int ActiveJobs, int Reviews, int Icebox, int Recommendations);
+public record PlanCounts(int Drafts, int ActiveJobs, int Reviews, int Icebox, int Recommendations, int TotalPlans);
 
 public class PlanCountsService : IPlanCountsService
 {
@@ -70,7 +70,8 @@ public class PlanCountsService : IPlanCountsService
             jobs.Count(j => j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Blocked),
             snapshot.ReadyForReview + snapshot.Failed,
             snapshot.Icebox,
-            snapshot.PendingRecommendations
+            snapshot.PendingRecommendations,
+            snapshot.TotalPlans
         );
     }
 }

--- a/src/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/PlanReaderService.cs
@@ -1348,11 +1348,12 @@ public class PlanReaderService(
 
     private PlanCountSnapshot ComputePlanCountsInternal()
     {
-        int drafts = 0, reviews = 0, failed = 0, icebox = 0, pendingRecs = 0;
+        int drafts = 0, reviews = 0, failed = 0, icebox = 0, pendingRecs = 0, total = 0;
 
         foreach (var (folderPath, _, planYamlPath) in EnumerateValidPlanFolders())
             try
             {
+                total++;
                 var yaml = FileHelper.ReadAllText(planYamlPath);
                 var stateMatch = Regex.Match(yaml, @"(?m)^state:\s*(.+)$");
                 if (stateMatch.Success)
@@ -1387,7 +1388,7 @@ public class PlanReaderService(
                 // Skip malformed plans
             }
 
-        return new PlanCountSnapshot(drafts, reviews, failed, icebox, pendingRecs);
+        return new PlanCountSnapshot(drafts, reviews, failed, icebox, pendingRecs, total);
     }
 
     /// <summary>
@@ -1457,7 +1458,8 @@ public class PlanReaderService(
         int ReadyForReview,
         int Failed,
         int Icebox,
-        int PendingRecommendations
+        int PendingRecommendations,
+        int TotalPlans
     );
 }
 


### PR DESCRIPTION
# Summary

## Changes

Added a `TotalPlans` field to track all plans regardless of state (Completed, Building, Executing, Skipped, etc.). Updated the wallpaper app's welcome message logic to show only when no plans exist at all, instead of checking only for Drafts, ActiveJobs, or Reviews. This fixes the issue where users see "Create your first Plan" despite having completed or executed plans.

## API Changes

- `PlanCountSnapshot`: Added `int TotalPlans` field
- `PlanCounts`: Added `int TotalPlans` field
- `WallpaperApp.hasActivity`: Changed from checking specific plan states to checking `counts.TotalPlans > 0`

## Files Modified

- `src/Ivy.Tendril/Services/PlanReaderService.cs` — Added total plan count tracking in `ComputePlanCountsInternal()` and updated `PlanCountSnapshot` record
- `src/Ivy.Tendril/Services/PlanCountsService.cs` — Updated `PlanCounts` record and `ComputeCounts()` method to include TotalPlans
- `src/Ivy.Tendril/Apps/WallpaperApp.cs` — Fixed `hasActivity` logic to use TotalPlans
- `src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs` — Updated test mock
- `src/Ivy.Tendril.Test/JobServiceDeletionTests.cs` — Updated test mock

## Commits

- ad26677

---

Closes Ivy-Interactive/Ivy-Tendril#62
