### PR TITLE
[03440] Fix installation command in docs

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
+++ b/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
@@ -38,7 +38,7 @@ Invoke-RestMethod -Uri https://raw.githubusercontent.com/Ivy-Interactive/Ivy-Ten
 Global install from NuGet:
 
 ```bash
-dotnet tool install --g Ivy.Tendril
+dotnet tool install -g Ivy.Tendril
 ```
 
 <Callout type="Tip">
@@ -57,5 +57,5 @@ tendril
 You can update Ivy Tendril at anytime after the initial install using the dotnet tool update command:
 
 ```bash
-dotnet tool update --g Ivy.Tendril
+dotnet tool update -g Ivy.Tendril
 ```


### PR DESCRIPTION
# Summary

## Changes

Fixed incorrect dotnet CLI flag usage in Installation.md documentation. Changed the global tool installation flag from `--g` to the correct `-g` on both the install and update command examples.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md` — Fixed dotnet CLI flags on lines 41 and 60

## Commits

- 54ed7b6 [03440] Fix installation command flags in docs from --g to -g