### PR TITLE
[03444] Filter empty PR entries in Slack notifications

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1
+++ b/src/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1
@@ -60,6 +60,11 @@ if (Test-Path $configPath) {
 # Build PR links for Slack
 $prLinks = @()
 foreach ($pr in $prs) {
+    # Skip empty or whitespace-only entries
+    if ([string]::IsNullOrWhiteSpace($pr)) {
+        continue
+    }
+
     # Extract owner/repo#number from URL like https://github.com/owner/repo/pull/123
     if ($pr -match "github\.com/([^/]+/[^/]+)/pull/(\d+)") {
         $repoSlug = $Matches[1]


### PR DESCRIPTION
# Summary

## Changes

Added filtering logic to NotifySlack.ps1 to skip empty or whitespace-only PR entries before building Slack notification links. This prevents unnecessary commas from appearing in Slack messages when the `prs` array contains empty strings.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.TeamIvyConfig/Hooks/NotifySlack.ps1` — Added empty entry filter in PR link building logic

## Commits

- a9e264a [03444] Filter empty PR entries in Slack notifications