### PR TITLE
Fix test plan pollution and read-only file write errors

### DIFF
--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -156,6 +156,7 @@ public record ConfigParseError(string Message, string FilePath, Exception? Inner
 
 public class ConfigService : IConfigService
 {
+    private readonly bool _explicitHome;
     private string[]? _levelNamesCache;
     private string? _pendingCodingAgent;
     private ProjectConfig? _pendingProject;
@@ -166,6 +167,7 @@ public class ConfigService : IConfigService
     {
         Settings = settings;
         TendrilHome = tendrilHome ?? Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        _explicitHome = tendrilHome != null;
         ConfigPath = !string.IsNullOrEmpty(TendrilHome)
             ? Path.Combine(TendrilHome, "config.yaml")
             : Path.Combine(System.AppContext.BaseDirectory, "config.yaml");
@@ -251,7 +253,7 @@ public class ConfigService : IConfigService
     public string ConfigPath { get; private set; }
 
     public string PlanFolder =>
-        Environment.GetEnvironmentVariable("TENDRIL_PLANS")?.Trim() is { Length: > 0 } plans
+        !_explicitHome && Environment.GetEnvironmentVariable("TENDRIL_PLANS")?.Trim() is { Length: > 0 } plans
             ? plans
             : string.IsNullOrEmpty(TendrilHome) ? "" : Path.Combine(TendrilHome, "Plans");
 

--- a/src/Ivy.Tendril/Services/FileHelper.cs
+++ b/src/Ivy.Tendril/Services/FileHelper.cs
@@ -83,6 +83,7 @@ internal static class FileHelper
 
     public static void WriteAllText(string path, string contents)
     {
+        ClearReadOnly(path);
         for (var attempt = 0; ; attempt++)
             try
             {
@@ -118,6 +119,7 @@ internal static class FileHelper
 
     public static async Task WriteAllTextAsync(string path, string contents)
     {
+        ClearReadOnly(path);
         for (var attempt = 0; ; attempt++)
             try
             {
@@ -163,6 +165,7 @@ internal static class FileHelper
 
     public static void AppendAllText(string path, string contents)
     {
+        ClearReadOnly(path);
         for (var attempt = 0; ; attempt++)
             try
             {
@@ -175,5 +178,13 @@ internal static class FileHelper
             {
                 Thread.Sleep(RetryDelaysMs[attempt]);
             }
+    }
+
+    private static void ClearReadOnly(string path)
+    {
+        if (!File.Exists(path)) return;
+        var attrs = File.GetAttributes(path);
+        if ((attrs & FileAttributes.ReadOnly) != 0)
+            File.SetAttributes(path, attrs & ~FileAttributes.ReadOnly);
     }
 }


### PR DESCRIPTION
## Summary
- **Test isolation**: `ConfigService.PlanFolder` now ignores the `TENDRIL_PLANS` env var when an explicit `tendrilHome` is passed (internal test constructor), preventing tests from writing plan folders into the real `D:\Plans` directory.
- **Read-only fix**: `FileHelper.WriteAllText`, `WriteAllTextAsync`, and `AppendAllText` now clear the read-only file attribute before writing, fixing `UnauthorizedAccessException` in `PlanReaderService.RepairPlans`.
- **Cleanup**: Removed 18 leaked test plan folders from `D:\Plans`.

## Test plan
- [x] All 38 plan-related tests pass
- [x] Build succeeds with no warnings