### PR TITLE
Add REST API and MCP parity with CLI for plan management

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/03_Configuration/01_Setup.md
+++ b/src/Ivy.Tendril.Docs/Docs/03_Configuration/01_Setup.md
@@ -62,6 +62,7 @@ coworkers:
 | `maxConcurrentJobs` | Cap on parallel agent runs (worktrees). |
 | `projects` | Registered repositories and their settings. |
 | `coworkers` | GitHub users for PR assignment / team features. |
+| `api.apiKey` | Protect the REST API with a shared secret (see [REST API](../08_API/01_REST.md)). |
 
 ## Verifications
 

--- a/src/Ivy.Tendril.Docs/Docs/07_CLI/05_Other.md
+++ b/src/Ivy.Tendril.Docs/Docs/07_CLI/05_Other.md
@@ -44,7 +44,7 @@ Prints the installed Tendril version (e.g. `1.0.18`).
 tendril mcp [args...]
 ```
 
-Launches the Tendril MCP (Model Context Protocol) server for integration with AI coding agents like Claude Code. Additional arguments are forwarded to the MCP runtime.
+Launches the Tendril MCP (Model Context Protocol) server for integration with AI coding agents like Claude Code. Additional arguments are forwarded to the MCP runtime. See [MCP Server](../08_API/02_MCP.md) for available tools and configuration.
 
 ## hash-password
 

--- a/src/Ivy.Tendril.Docs/Docs/08_API/01_REST.md
+++ b/src/Ivy.Tendril.Docs/Docs/08_API/01_REST.md
@@ -1,0 +1,196 @@
+---
+icon: Globe
+searchHints:
+  - api
+  - rest
+  - http
+  - endpoint
+  - plans
+  - inbox
+  - authentication
+  - X-Api-Key
+---
+
+<Text Color="Green" Small Bold>API</Text>
+
+# REST API
+
+<Ingress>
+Tendril exposes a REST API for programmatic plan management. All endpoints are available at your Tendril server URL (default `https://localhost:5010`).
+</Ingress>
+
+## Authentication
+
+When `api.apiKey` is set in `config.yaml`, all API requests (except `/api/jobs/*`) require the `X-Api-Key` header:
+
+```yaml
+# config.yaml
+api:
+  apiKey: "your-secret-key"
+```
+
+```bash
+curl -H "X-Api-Key: your-secret-key" https://localhost:5010/api/plans
+```
+
+If no `apiKey` is configured, all routes are open.
+
+The `/api/jobs/*` endpoints are intentionally unprotected so agent processes can post status updates without credentials.
+
+## Plans
+
+### Get Plan
+
+```
+GET /api/plans/{planId}
+GET /api/plans/{planId}?field=state
+```
+
+Returns the full plan object, or a single field value when `?field=` is specified.
+
+### List Plans
+
+```
+GET /api/plans?state=Draft&project=MyProject&limit=50
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `state` | string | Filter by plan state |
+| `project` | string | Filter by project name |
+| `limit` | int | Maximum results (default 50) |
+
+### Update Field
+
+```
+PUT /api/plans/{planId}
+Content-Type: application/json
+
+{ "field": "state", "value": "Executing" }
+```
+
+Supported fields: `state`, `project`, `level`, `title`, `executionProfile`, `initialPrompt`, `sourceUrl`, `priority`.
+
+### Add Repository
+
+```
+POST /api/plans/{planId}/repos
+Content-Type: application/json
+
+{ "repoPath": "D:\\Repos\\MyRepo" }
+```
+
+### Remove Repository
+
+```
+DELETE /api/plans/{planId}/repos
+Content-Type: application/json
+
+{ "repoPath": "D:\\Repos\\MyRepo" }
+```
+
+### Add PR
+
+```
+POST /api/plans/{planId}/prs
+Content-Type: application/json
+
+{ "prUrl": "https://github.com/org/repo/pull/42" }
+```
+
+### Add Commit
+
+```
+POST /api/plans/{planId}/commits
+Content-Type: application/json
+
+{ "sha": "abc1234def5678" }
+```
+
+### Set Verification
+
+```
+PUT /api/plans/{planId}/verifications
+Content-Type: application/json
+
+{ "name": "DotnetBuild", "status": "Pass" }
+```
+
+Valid statuses: `Pending`, `Pass`, `Fail`, `Skipped`.
+
+### Add Log
+
+```
+POST /api/plans/{planId}/logs
+Content-Type: application/json
+
+{ "action": "ExecutePlan", "summary": "Completed successfully" }
+```
+
+## Recommendations
+
+### List Recommendations
+
+```
+GET /api/plans/{planId}/recommendations
+GET /api/plans/{planId}/recommendations?state=Pending
+```
+
+### Add Recommendation
+
+```
+POST /api/plans/{planId}/recommendations
+Content-Type: application/json
+
+{ "title": "Add tests", "description": "Coverage is low", "impact": "Medium", "risk": "Small" }
+```
+
+### Accept Recommendation
+
+```
+PUT /api/plans/{planId}/recommendations/{title}/accept
+Content-Type: application/json
+
+{ "notes": "Only integration tests" }
+```
+
+### Decline Recommendation
+
+```
+PUT /api/plans/{planId}/recommendations/{title}/decline
+Content-Type: application/json
+
+{ "reason": "Not needed for this scope" }
+```
+
+### Remove Recommendation
+
+```
+DELETE /api/plans/{planId}/recommendations/{title}
+```
+
+## Inbox
+
+### Submit Plan
+
+```
+POST /api/inbox
+Content-Type: application/json
+
+{ "description": "Fix the login bug", "project": "MyProject", "sourcePath": "D:\\Sessions\\Session1" }
+```
+
+Starts a `CreatePlan` job and returns the job ID.
+
+## Jobs
+
+### Post Status
+
+```
+POST /api/jobs/{jobId}/status
+Content-Type: application/json
+
+{ "message": "Running verifications..." }
+```
+
+Updates the status message for a running job. This endpoint does **not** require authentication.

--- a/src/Ivy.Tendril.Docs/Docs/08_API/02_MCP.md
+++ b/src/Ivy.Tendril.Docs/Docs/08_API/02_MCP.md
@@ -1,0 +1,105 @@
+---
+icon: Bot
+searchHints:
+  - mcp
+  - model context protocol
+  - claude
+  - tools
+  - tendril_get_plan
+  - tendril_list_plans
+  - tendril_plan_set
+---
+
+<Text Color="Green" Small Bold>API</Text>
+
+# MCP Server
+
+<Ingress>
+Tendril includes a Model Context Protocol (MCP) server that exposes plan management tools to AI coding agents like Claude Code.
+</Ingress>
+
+## Starting the MCP Server
+
+```bash
+tendril mcp
+```
+
+This launches the MCP server via stdio transport, suitable for use in Claude Code's MCP configuration.
+
+## Authentication
+
+Set the `TENDRIL_MCP_TOKEN` environment variable to require a token for all MCP tool calls. When set, the agent must provide the matching token. When unset, all calls are allowed.
+
+## Available Tools
+
+All tools are prefixed with `tendril_` and provide the same capabilities as the CLI and REST API.
+
+### Plan CRUD
+
+| Tool | Description |
+|------|-------------|
+| `tendril_get_plan` | Get plan details (full or single field) |
+| `tendril_list_plans` | List plans with optional state/project filters |
+| `tendril_inbox` | Submit a new plan to the inbox |
+| `tendril_plan_set` | Update a plan field (state, title, project, level, priority, etc.) |
+
+### Repositories & Artifacts
+
+| Tool | Description |
+|------|-------------|
+| `tendril_plan_add_repo` | Add a repository path to a plan |
+| `tendril_plan_remove_repo` | Remove a repository from a plan |
+| `tendril_plan_add_pr` | Add a PR URL to a plan |
+| `tendril_plan_add_commit` | Add a commit SHA to a plan |
+
+### Verifications & Logs
+
+| Tool | Description |
+|------|-------------|
+| `tendril_plan_set_verification` | Set verification status (Pending/Pass/Fail/Skipped) |
+| `tendril_plan_add_log` | Write an execution log entry |
+
+### Recommendations
+
+| Tool | Description |
+|------|-------------|
+| `tendril_plan_rec_list` | List recommendations (optionally filtered by state) |
+| `tendril_plan_rec_add` | Add a recommendation with impact/risk assessment |
+| `tendril_plan_rec_accept` | Accept a recommendation (with optional notes) |
+| `tendril_plan_rec_decline` | Decline a recommendation (with optional reason) |
+| `tendril_plan_rec_remove` | Remove a recommendation |
+
+## Claude Code Configuration
+
+Add Tendril's MCP server to your Claude Code settings (`.claude/settings.json` or project-level):
+
+```json
+{
+  "mcpServers": {
+    "tendril": {
+      "command": "tendril",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+With authentication:
+
+```json
+{
+  "mcpServers": {
+    "tendril": {
+      "command": "tendril",
+      "args": ["mcp"],
+      "env": {
+        "TENDRIL_MCP_TOKEN": "your-secret-token"
+      }
+    }
+  }
+}
+```
+
+## Parity
+
+The MCP tools, REST API, and CLI all operate on the same plan data and share the same validation logic. Changes made through any interface are immediately visible to the others.

--- a/src/Ivy.Tendril.Docs/Docs/08_API/_Index.md
+++ b/src/Ivy.Tendril.Docs/Docs/08_API/_Index.md
@@ -1,0 +1,4 @@
+---
+groupExpanded: false
+icon: Globe
+---

--- a/src/Ivy.Tendril.Test/ApiKeyAuthMiddlewareTests.cs
+++ b/src/Ivy.Tendril.Test/ApiKeyAuthMiddlewareTests.cs
@@ -1,0 +1,177 @@
+using Ivy.Tendril.Controllers;
+using Ivy.Tendril.Services;
+using Microsoft.AspNetCore.Http;
+
+namespace Ivy.Tendril.Test;
+
+public class ApiKeyAuthMiddlewareTests
+{
+    [Fact]
+    public async Task ApiRoute_WithValidKey_CallsNext()
+    {
+        var settings = new TendrilSettings { Api = new ApiSettings { ApiKey = "secret-123" } };
+        var configService = new ConfigService(settings, "/tmp");
+        var nextCalled = false;
+        var middleware = new ApiKeyAuthMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, configService);
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/plans/00001";
+        context.Request.Headers["X-Api-Key"] = "secret-123";
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextCalled);
+        Assert.NotEqual(401, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ApiRoute_WithInvalidKey_Returns401()
+    {
+        var settings = new TendrilSettings { Api = new ApiSettings { ApiKey = "secret-123" } };
+        var configService = new ConfigService(settings, "/tmp");
+        var nextCalled = false;
+        var middleware = new ApiKeyAuthMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, configService);
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/plans/00001";
+        context.Request.Headers["X-Api-Key"] = "wrong-key";
+        context.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(context);
+
+        Assert.False(nextCalled);
+        Assert.Equal(401, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ApiRoute_WithMissingKey_Returns401()
+    {
+        var settings = new TendrilSettings { Api = new ApiSettings { ApiKey = "secret-123" } };
+        var configService = new ConfigService(settings, "/tmp");
+        var nextCalled = false;
+        var middleware = new ApiKeyAuthMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, configService);
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/plans/00001";
+        context.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(context);
+
+        Assert.False(nextCalled);
+        Assert.Equal(401, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ApiRoute_NoAuthConfigured_CallsNext()
+    {
+        var settings = new TendrilSettings();
+        var configService = new ConfigService(settings, "/tmp");
+        var nextCalled = false;
+        var middleware = new ApiKeyAuthMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, configService);
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/plans/00001";
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextCalled);
+    }
+
+    [Fact]
+    public async Task ApiRoute_EmptyApiKey_AllowsAccess()
+    {
+        var settings = new TendrilSettings { Api = new ApiSettings { ApiKey = "" } };
+        var configService = new ConfigService(settings, "/tmp");
+        var nextCalled = false;
+        var middleware = new ApiKeyAuthMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, configService);
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/inbox";
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextCalled);
+    }
+
+    [Fact]
+    public async Task NonApiRoute_WithAuthConfigured_SkipsAuth()
+    {
+        var settings = new TendrilSettings { Api = new ApiSettings { ApiKey = "secret-123" } };
+        var configService = new ConfigService(settings, "/tmp");
+        var nextCalled = false;
+        var middleware = new ApiKeyAuthMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, configService);
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/ivy/health";
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextCalled);
+    }
+
+    [Fact]
+    public async Task ApiRoute_JobsEndpoint_SkipsAuth()
+    {
+        var settings = new TendrilSettings { Api = new ApiSettings { ApiKey = "secret-123" } };
+        var configService = new ConfigService(settings, "/tmp");
+        var nextCalled = false;
+        var middleware = new ApiKeyAuthMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, configService);
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/jobs/job-1/status";
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextCalled);
+    }
+
+    [Fact]
+    public async Task ApiRoute_ProtectsInboxEndpoint()
+    {
+        var settings = new TendrilSettings { Api = new ApiSettings { ApiKey = "secret-123" } };
+        var configService = new ConfigService(settings, "/tmp");
+        var nextCalled = false;
+        var middleware = new ApiKeyAuthMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, configService);
+
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/inbox";
+        context.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(context);
+
+        Assert.False(nextCalled);
+        Assert.Equal(401, context.Response.StatusCode);
+    }
+}

--- a/src/Ivy.Tendril.Test/InboxControllerTests.cs
+++ b/src/Ivy.Tendril.Test/InboxControllerTests.cs
@@ -13,8 +13,7 @@ public class InboxControllerTests
     public void PostPlan_ValidRequest_ReturnsOkWithJobId()
     {
         var jobService = new StubJobService();
-        var configService = new ConfigService(new TendrilSettings(), "/tmp");
-        var controller = CreateController(jobService, configService);
+        var controller = CreateController(jobService);
 
         var result = controller.PostPlan(new CreatePlanRequest("Fix a bug", "Tendril"));
 
@@ -28,8 +27,7 @@ public class InboxControllerTests
     public void PostPlan_EmptyDescription_ReturnsBadRequest()
     {
         var jobService = new StubJobService();
-        var configService = new ConfigService(new TendrilSettings(), "/tmp");
-        var controller = CreateController(jobService, configService);
+        var controller = CreateController(jobService);
 
         var result = controller.PostPlan(new CreatePlanRequest(""));
 
@@ -38,66 +36,10 @@ public class InboxControllerTests
     }
 
     [Fact]
-    public void PostPlan_WithAuthentication_ValidKey_ReturnsOk()
-    {
-        var jobService = new StubJobService();
-        var settings = new TendrilSettings { Api = new ApiSettings { ApiKey = "secret-123" } };
-        var configService = new ConfigService(settings, "/tmp");
-        var controller = CreateController(jobService, configService, apiKey: "secret-123");
-
-        var result = controller.PostPlan(new CreatePlanRequest("Add feature"));
-
-        Assert.IsType<OkObjectResult>(result);
-        Assert.Single(jobService.StartedJobs);
-    }
-
-    [Fact]
-    public void PostPlan_WithAuthentication_InvalidKey_ReturnsUnauthorized()
-    {
-        var jobService = new StubJobService();
-        var settings = new TendrilSettings { Api = new ApiSettings { ApiKey = "secret-123" } };
-        var configService = new ConfigService(settings, "/tmp");
-        var controller = CreateController(jobService, configService, apiKey: "wrong-key");
-
-        var result = controller.PostPlan(new CreatePlanRequest("Add feature"));
-
-        Assert.IsType<UnauthorizedObjectResult>(result);
-        Assert.Empty(jobService.StartedJobs);
-    }
-
-    [Fact]
-    public void PostPlan_WithAuthentication_MissingKey_ReturnsUnauthorized()
-    {
-        var jobService = new StubJobService();
-        var settings = new TendrilSettings { Api = new ApiSettings { ApiKey = "secret-123" } };
-        var configService = new ConfigService(settings, "/tmp");
-        var controller = CreateController(jobService, configService);
-
-        var result = controller.PostPlan(new CreatePlanRequest("Add feature"));
-
-        Assert.IsType<UnauthorizedObjectResult>(result);
-        Assert.Empty(jobService.StartedJobs);
-    }
-
-    [Fact]
-    public void PostPlan_NoAuthConfigured_AllowsAccess()
-    {
-        var jobService = new StubJobService();
-        var configService = new ConfigService(new TendrilSettings(), "/tmp");
-        var controller = CreateController(jobService, configService);
-
-        var result = controller.PostPlan(new CreatePlanRequest("Do something"));
-
-        Assert.IsType<OkObjectResult>(result);
-        Assert.Single(jobService.StartedJobs);
-    }
-
-    [Fact]
     public void PostPlan_WithSourcePath_PassesItToJobService()
     {
         var jobService = new StubJobService();
-        var configService = new ConfigService(new TendrilSettings(), "/tmp");
-        var controller = CreateController(jobService, configService);
+        var controller = CreateController(jobService);
 
         var result = controller.PostPlan(new CreatePlanRequest("Fix bug", "Tendril", @"D:\Tests\Session1"));
 
@@ -111,8 +53,7 @@ public class InboxControllerTests
     public void PostPlan_NullProject_DefaultsToAuto()
     {
         var jobService = new StubJobService();
-        var configService = new ConfigService(new TendrilSettings(), "/tmp");
-        var controller = CreateController(jobService, configService);
+        var controller = CreateController(jobService);
 
         var result = controller.PostPlan(new CreatePlanRequest("Some task"));
 
@@ -121,16 +62,13 @@ public class InboxControllerTests
         Assert.Contains("Auto", job.Args);
     }
 
-    private static InboxController CreateController(
-        IJobService jobService,
-        IConfigService configService,
-        string? apiKey = null)
+    private static InboxController CreateController(IJobService jobService)
     {
-        var controller = new InboxController(jobService, configService);
-        var httpContext = new DefaultHttpContext();
-        if (apiKey != null)
-            httpContext.Request.Headers["X-Api-Key"] = apiKey;
-        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        var controller = new InboxController(jobService);
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
         return controller;
     }
 

--- a/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
@@ -8,6 +8,7 @@ namespace Ivy.Tendril.Test.Mcp;
 public class PlanToolsTests : IDisposable
 {
     private readonly string _tempDir;
+    private readonly string _repoDir;
     private readonly string _originalTendrilHome;
     private readonly string? _originalTendrilPlans;
     private readonly string? _originalToken;
@@ -17,12 +18,14 @@ public class PlanToolsTests : IDisposable
     {
         _tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid()}");
         Directory.CreateDirectory(_tempDir);
+        _repoDir = Path.Combine(_tempDir, "repos", "TestRepo");
+        Directory.CreateDirectory(_repoDir);
         _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
         _originalTendrilPlans = Environment.GetEnvironmentVariable("TENDRIL_PLANS");
         _originalToken = Environment.GetEnvironmentVariable("TENDRIL_MCP_TOKEN");
         Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir);
         Environment.SetEnvironmentVariable("TENDRIL_PLANS", null);
-        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", null); // No auth for tests
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", null);
         _planTools = new PlanTools(new McpAuthenticationService());
     }
 
@@ -35,223 +38,423 @@ public class PlanToolsTests : IDisposable
             Directory.Delete(_tempDir, true);
     }
 
-    [Fact]
-    public void TestTransitionPlanSuccess()
+    private string CreateTestPlan(string id = "00001", string title = "Test Plan", string state = "Draft")
     {
-        // Arrange
         var plansDir = Path.Combine(_tempDir, "Plans");
-        var planFolder = Path.Combine(plansDir, "00001-TestPlan");
+        var planFolder = Path.Combine(plansDir, $"{id}-{title.Replace(" ", "")}");
         Directory.CreateDirectory(planFolder);
 
-        var planYaml = """
-            state: Draft
-            project: TestProject
-            level: NiceToHave
-            title: Test Plan
-            repos: []
-            commits: []
-            prs: []
-            created: 2026-04-01T10:00:00.0000000Z
-            updated: 2026-04-01T10:00:00.0000000Z
-            verifications: []
-            relatedPlans: []
-            dependsOn: []
-            executionProfile: balanced
-            initialPrompt: Test prompt
-            sourceUrl:
-            priority: 0
-            """;
-
-        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
-
-        // Act
-        var result = _planTools.TransitionPlan("00001", "Icebox");
-
-        // Assert
-        Assert.Contains("Successfully transitioned", result);
-        Assert.Contains("Draft to Icebox", result);
-
-        var updatedYaml = File.ReadAllText(Path.Combine(planFolder, "plan.yaml"));
-        Assert.Contains("state: Icebox", updatedYaml);
-    }
-
-    [Fact]
-    public void TestTransitionPlanInvalidState()
-    {
-        // Arrange
-        var plansDir = Path.Combine(_tempDir, "Plans");
-        var planFolder = Path.Combine(plansDir, "00001-TestPlan");
-        Directory.CreateDirectory(planFolder);
-
-        var planYaml = """
-            state: Draft
-            project: TestProject
-            level: NiceToHave
-            title: Test Plan
-            repos: []
-            commits: []
-            prs: []
-            created: 2026-04-01T10:00:00.0000000Z
-            updated: 2026-04-01T10:00:00.0000000Z
-            verifications: []
-            relatedPlans: []
-            dependsOn: []
-            executionProfile: balanced
-            initialPrompt: Test prompt
-            sourceUrl:
-            priority: 0
-            """;
-
-        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
-
-        // Act
-        var result = _planTools.TransitionPlan("00001", "InvalidState");
-
-        // Assert
-        Assert.Contains("Error: Invalid state", result);
-        Assert.Contains("InvalidState", result);
-    }
-
-    [Fact]
-    public void TestTransitionPlanNonexistentPlan()
-    {
-        // Arrange
-        var plansDir = Path.Combine(_tempDir, "Plans");
-        Directory.CreateDirectory(plansDir);
-
-        // Act
-        var result = _planTools.TransitionPlan("99999", "Draft");
-
-        // Assert
-        Assert.Contains("Error: Plan '99999' not found", result);
-    }
-
-    [Fact]
-    public void TestTransitionPlanPreservesFields()
-    {
-        // Arrange
-        var plansDir = Path.Combine(_tempDir, "Plans");
-        var planFolder = Path.Combine(plansDir, "00001-TestPlan");
-        Directory.CreateDirectory(planFolder);
-
-        var planYaml = """
-            state: Draft
-            project: TestProject
-            level: Critical
-            title: Test Plan With Many Fields
-            repos:
-            - D:\Repos\TestRepo
-            commits:
-            - abc123
-            prs:
-            - https://github.com/test/repo/pull/1
-            created: 2026-04-01T10:00:00.0000000Z
-            updated: 2026-04-01T10:00:00.0000000Z
-            verifications:
-            - name: DotnetBuild
-              status: Pending
-            - name: DotnetTest
-              status: Skipped
-            relatedPlans:
-            - D:\Plans\00002-RelatedPlan
-            dependsOn:
-            - D:\Plans\00003-Dependency
-            executionProfile: performance
-            initialPrompt: Test prompt with details
-            sourceUrl: https://example.com
-            priority: 10
-            sessionId: session-123
-            """;
-
-        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
-
-        // Act
-        var result = _planTools.TransitionPlan("00001", "Executing");
-
-        // Assert
-        Assert.Contains("Successfully transitioned", result);
-
-        var updatedYaml = File.ReadAllText(Path.Combine(planFolder, "plan.yaml"));
-        Assert.Contains("state: Executing", updatedYaml);
-        Assert.Contains("project: TestProject", updatedYaml);
-        Assert.Contains("level: Critical", updatedYaml);
-        Assert.Contains("title: Test Plan With Many Fields", updatedYaml);
-        Assert.Contains("- D:\\Repos\\TestRepo", updatedYaml);
-        Assert.Contains("- abc123", updatedYaml);
-        Assert.Contains("https://github.com/test/repo/pull/1", updatedYaml);
-        Assert.Contains("name: DotnetBuild", updatedYaml);
-        Assert.Contains("status: Pending", updatedYaml);
-        Assert.Contains("- D:\\Plans\\00002-RelatedPlan", updatedYaml);
-        Assert.Contains("- D:\\Plans\\00003-Dependency", updatedYaml);
-        Assert.Contains("executionProfile: performance", updatedYaml);
-        Assert.Contains("initialPrompt: Test prompt with details", updatedYaml);
-        Assert.Contains("sourceUrl: https://example.com", updatedYaml);
-        Assert.Contains("priority: 10", updatedYaml);
-        Assert.Contains("sessionId: session-123", updatedYaml);
-    }
-
-    [Fact]
-    public void TestTransitionPlanUpdatesTimestamp()
-    {
-        // Arrange
-        var plansDir = Path.Combine(_tempDir, "Plans");
-        var planFolder = Path.Combine(plansDir, "00001-TestPlan");
-        Directory.CreateDirectory(planFolder);
-
-        var oldTimestamp = DateTime.UtcNow.AddHours(-1);
         var planYaml = $"""
-            state: Draft
+            state: {state}
             project: TestProject
             level: NiceToHave
-            title: Test Plan
-            repos: []
+            title: {title}
+            repos:
+            - {_repoDir}
             commits: []
             prs: []
-            created: {oldTimestamp:O}
-            updated: {oldTimestamp:O}
+            created: 2026-04-01T10:00:00.0000000Z
+            updated: 2026-04-01T10:00:00.0000000Z
             verifications: []
             relatedPlans: []
             dependsOn: []
-            executionProfile: balanced
-            initialPrompt: Test prompt
-            sourceUrl:
             priority: 0
             """;
 
         File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
+        return planFolder;
+    }
 
-        // Act
-        var beforeTransition = DateTime.UtcNow;
-        var result = _planTools.TransitionPlan("00001", "Icebox");
-        var afterTransition = DateTime.UtcNow;
+    // --- GetPlan ---
 
-        // Assert
-        Assert.Contains("Successfully transitioned", result);
-
-        var updatedYaml = File.ReadAllText(Path.Combine(planFolder, "plan.yaml"));
-
-        // Extract the updated timestamp
-        var updatedMatch = System.Text.RegularExpressions.Regex.Match(updatedYaml, @"updated: (.+)");
-        Assert.True(updatedMatch.Success, "Updated timestamp not found in YAML");
-
-        var updatedTimestamp = DateTime.Parse(updatedMatch.Groups[1].Value).ToUniversalTime();
-
-        // Verify the timestamp was updated to a recent time
-        Assert.True(updatedTimestamp >= beforeTransition, "Updated timestamp should be after transition started");
-        Assert.True(updatedTimestamp <= afterTransition.AddSeconds(1), "Updated timestamp should be before transition completed");
-        Assert.True(updatedTimestamp > oldTimestamp, "Updated timestamp should be newer than original");
+    [Fact]
+    public void GetPlan_ReturnsSummary()
+    {
+        CreateTestPlan();
+        var result = _planTools.GetPlan("00001");
+        Assert.Contains("Plan 00001", result);
+        Assert.Contains("Test Plan", result);
+        Assert.Contains("Draft", result);
     }
 
     [Fact]
-    public void TestTransitionPlanTendrilHomeNotSet()
+    public void GetPlan_WithField_ReturnsValue()
     {
-        // Arrange
+        CreateTestPlan();
+        Assert.Equal("Draft", _planTools.GetPlan("00001", "state"));
+        Assert.Equal("TestProject", _planTools.GetPlan("00001", "project"));
+        Assert.Equal("NiceToHave", _planTools.GetPlan("00001", "level"));
+        Assert.Equal("Test Plan", _planTools.GetPlan("00001", "title"));
+    }
+
+    [Fact]
+    public void GetPlan_NotFound_ReturnsError()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempDir, "Plans"));
+        var result = _planTools.GetPlan("99999");
+        Assert.Contains("Error:", result);
+    }
+
+    // --- ListPlans ---
+
+    [Fact]
+    public void ListPlans_ReturnsMatchingPlans()
+    {
+        CreateTestPlan("00001", "First Plan", "Draft");
+        CreateTestPlan("00002", "Second Plan", "Executing");
+
+        var result = _planTools.ListPlans();
+        Assert.Contains("First Plan", result);
+        Assert.Contains("Second Plan", result);
+        Assert.Contains("Found 2 plan(s)", result);
+    }
+
+    [Fact]
+    public void ListPlans_FilterByState()
+    {
+        CreateTestPlan("00001", "Draft Plan", "Draft");
+        CreateTestPlan("00002", "Executing Plan", "Executing");
+
+        var result = _planTools.ListPlans(state: "Draft");
+        Assert.Contains("Draft Plan", result);
+        Assert.DoesNotContain("Executing Plan", result);
+    }
+
+    [Fact]
+    public void ListPlans_FilterByProject()
+    {
+        CreateTestPlan("00001", "MyPlan");
+
+        var result = _planTools.ListPlans(project: "TestProject");
+        Assert.Contains("MyPlan", result);
+
+        var result2 = _planTools.ListPlans(project: "OtherProject");
+        Assert.Contains("No plans found", result2);
+    }
+
+    // --- SetField ---
+
+    [Fact]
+    public void SetField_UpdatesState()
+    {
+        CreateTestPlan();
+        var result = _planTools.SetField("00001", "state", "Icebox");
+        Assert.Contains("Updated state", result);
+        Assert.Equal("Icebox", _planTools.GetPlan("00001", "state"));
+    }
+
+    [Fact]
+    public void SetField_UpdatesTitle()
+    {
+        CreateTestPlan();
+        var result = _planTools.SetField("00001", "title", "New Title");
+        Assert.Contains("Updated title", result);
+        Assert.Equal("New Title", _planTools.GetPlan("00001", "title"));
+    }
+
+    [Fact]
+    public void SetField_UpdatesPriority()
+    {
+        CreateTestPlan();
+        var result = _planTools.SetField("00001", "priority", "5");
+        Assert.Contains("Updated priority", result);
+        Assert.Equal("5", _planTools.GetPlan("00001", "priority"));
+    }
+
+    [Fact]
+    public void SetField_InvalidPriority_ReturnsError()
+    {
+        CreateTestPlan();
+        var result = _planTools.SetField("00001", "priority", "abc");
+        Assert.Contains("Error:", result);
+    }
+
+    [Fact]
+    public void SetField_UnknownField_ReturnsError()
+    {
+        CreateTestPlan();
+        var result = _planTools.SetField("00001", "nosuchfield", "value");
+        Assert.Contains("Error: Unknown field", result);
+    }
+
+    [Fact]
+    public void SetField_NonexistentPlan_ReturnsError()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempDir, "Plans"));
+        var result = _planTools.SetField("99999", "state", "Draft");
+        Assert.Contains("Error:", result);
+    }
+
+    // --- AddRepo / RemoveRepo ---
+
+    [Fact]
+    public void AddRepo_AddsRepository()
+    {
+        CreateTestPlan();
+        var newRepo = Path.Combine(_tempDir, "repos", "AnotherRepo");
+        Directory.CreateDirectory(newRepo);
+
+        var result = _planTools.AddRepo("00001", newRepo);
+        Assert.Contains("Added repository", result);
+
+        var repos = _planTools.GetPlan("00001", "repos");
+        Assert.Contains("AnotherRepo", repos);
+    }
+
+    [Fact]
+    public void AddRepo_Duplicate_ReturnsMessage()
+    {
+        CreateTestPlan();
+        var result = _planTools.AddRepo("00001", _repoDir);
+        Assert.Contains("already in plan", result);
+    }
+
+    [Fact]
+    public void RemoveRepo_RemovesRepository()
+    {
+        CreateTestPlan();
+        var extraRepo = Path.Combine(_tempDir, "repos", "ExtraRepo");
+        Directory.CreateDirectory(extraRepo);
+        _planTools.AddRepo("00001", extraRepo);
+
+        var result = _planTools.RemoveRepo("00001", extraRepo);
+        Assert.Contains("Removed repository", result);
+
+        var repos = _planTools.GetPlan("00001", "repos");
+        Assert.DoesNotContain("ExtraRepo", repos);
+    }
+
+    [Fact]
+    public void RemoveRepo_NotFound_ReturnsError()
+    {
+        CreateTestPlan();
+        var result = _planTools.RemoveRepo("00001", @"D:\Repos\NonExistent");
+        Assert.Contains("Error:", result);
+    }
+
+    // --- AddPr ---
+
+    [Fact]
+    public void AddPr_AddsPrUrl()
+    {
+        CreateTestPlan();
+        var result = _planTools.AddPr("00001", "https://github.com/owner/repo/pull/1");
+        Assert.Contains("Added PR", result);
+
+        var prs = _planTools.GetPlan("00001", "prs");
+        Assert.Contains("https://github.com/owner/repo/pull/1", prs);
+    }
+
+    [Fact]
+    public void AddPr_Duplicate_ReturnsMessage()
+    {
+        CreateTestPlan();
+        _planTools.AddPr("00001", "https://github.com/owner/repo/pull/1");
+        var result = _planTools.AddPr("00001", "https://github.com/owner/repo/pull/1");
+        Assert.Contains("already in plan", result);
+    }
+
+    // --- AddCommit ---
+
+    [Fact]
+    public void AddCommit_AddsCommitSha()
+    {
+        CreateTestPlan();
+        var result = _planTools.AddCommit("00001", "abc123def456");
+        Assert.Contains("Added commit", result);
+
+        var commits = _planTools.GetPlan("00001", "commits");
+        Assert.Contains("abc123def456", commits);
+    }
+
+    [Fact]
+    public void AddCommit_Duplicate_ReturnsMessage()
+    {
+        CreateTestPlan();
+        _planTools.AddCommit("00001", "abc123def456");
+        var result = _planTools.AddCommit("00001", "abc123def456");
+        Assert.Contains("already in plan", result);
+    }
+
+    // --- SetVerification ---
+
+    [Fact]
+    public void SetVerification_AddsNew()
+    {
+        CreateTestPlan();
+        var result = _planTools.SetVerification("00001", "DotnetBuild", "Pass");
+        Assert.Contains("Set verification", result);
+
+        var verifications = _planTools.GetPlan("00001", "verifications");
+        Assert.Contains("DotnetBuild=Pass", verifications);
+    }
+
+    [Fact]
+    public void SetVerification_UpdatesExisting()
+    {
+        CreateTestPlan();
+        _planTools.SetVerification("00001", "DotnetBuild", "Pending");
+        _planTools.SetVerification("00001", "DotnetBuild", "Pass");
+
+        var verifications = _planTools.GetPlan("00001", "verifications");
+        Assert.Contains("DotnetBuild=Pass", verifications);
+    }
+
+    // --- AddLog ---
+
+    [Fact]
+    public void AddLog_WritesLogFile()
+    {
+        var planFolder = CreateTestPlan();
+        var result = _planTools.AddLog("00001", "ExecutePlan", "Test summary");
+        Assert.Contains("Log written", result);
+
+        var logsDir = Path.Combine(planFolder, "logs");
+        Assert.True(Directory.Exists(logsDir));
+        var logFiles = Directory.GetFiles(logsDir, "*.md");
+        Assert.Single(logFiles);
+        Assert.Contains("001-ExecutePlan.md", Path.GetFileName(logFiles[0]));
+
+        var content = File.ReadAllText(logFiles[0]);
+        Assert.Contains("Test summary", content);
+    }
+
+    // --- Recommendations ---
+
+    [Fact]
+    public void RecAdd_AddsRecommendation()
+    {
+        CreateTestPlan();
+        var result = _planTools.RecAdd("00001", "Add tests", "Need unit tests", "Medium", "Small");
+        Assert.Contains("Added recommendation", result);
+
+        var recs = _planTools.RecList("00001");
+        Assert.Contains("Add tests", recs);
+        Assert.Contains("Medium", recs);
+    }
+
+    [Fact]
+    public void RecAdd_Duplicate_ReturnsError()
+    {
+        CreateTestPlan();
+        _planTools.RecAdd("00001", "Add tests", "Need unit tests");
+        var result = _planTools.RecAdd("00001", "Add tests", "Duplicate");
+        Assert.Contains("Error:", result);
+        Assert.Contains("already exists", result);
+    }
+
+    [Fact]
+    public void RecAccept_AcceptsRecommendation()
+    {
+        CreateTestPlan();
+        _planTools.RecAdd("00001", "Add tests", "Need unit tests");
+        var result = _planTools.RecAccept("00001", "Add tests");
+        Assert.Contains("Accepted", result);
+
+        var recs = _planTools.RecList("00001");
+        Assert.Contains("Accepted", recs);
+    }
+
+    [Fact]
+    public void RecAccept_WithNotes_SetsAcceptedWithNotes()
+    {
+        CreateTestPlan();
+        _planTools.RecAdd("00001", "Add tests", "Need unit tests");
+        _planTools.RecAccept("00001", "Add tests", "Only integration tests");
+
+        var recs = _planTools.RecList("00001");
+        Assert.Contains("AcceptedWithNotes", recs);
+    }
+
+    [Fact]
+    public void RecDecline_DeclinesRecommendation()
+    {
+        CreateTestPlan();
+        _planTools.RecAdd("00001", "Add tests", "Need unit tests");
+        var result = _planTools.RecDecline("00001", "Add tests", "Not needed");
+        Assert.Contains("Declined", result);
+
+        var recs = _planTools.RecList("00001");
+        Assert.Contains("Declined", recs);
+    }
+
+    [Fact]
+    public void RecRemove_RemovesRecommendation()
+    {
+        CreateTestPlan();
+        _planTools.RecAdd("00001", "Add tests", "Need unit tests");
+        var result = _planTools.RecRemove("00001", "Add tests");
+        Assert.Contains("Removed", result);
+
+        var recs = _planTools.RecList("00001");
+        Assert.Contains("No recommendations found", recs);
+    }
+
+    [Fact]
+    public void RecList_FiltersByState()
+    {
+        CreateTestPlan();
+        _planTools.RecAdd("00001", "Rec1", "Desc1");
+        _planTools.RecAdd("00001", "Rec2", "Desc2");
+        _planTools.RecAccept("00001", "Rec1");
+
+        var pending = _planTools.RecList("00001", "Pending");
+        Assert.Contains("Rec2", pending);
+        Assert.DoesNotContain("Rec1", pending);
+
+        var accepted = _planTools.RecList("00001", "Accepted");
+        Assert.Contains("Rec1", accepted);
+        Assert.DoesNotContain("Rec2", accepted);
+    }
+
+    [Fact]
+    public void RecAccept_NotFound_ReturnsError()
+    {
+        CreateTestPlan();
+        var result = _planTools.RecAccept("00001", "NonExistent");
+        Assert.Contains("Error:", result);
+        Assert.Contains("not found", result);
+    }
+
+    // --- Authentication ---
+
+    [Fact]
+    public void AuthEnabled_WithoutToken_ReturnsError()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", "secret-token");
+        var authedService = new McpAuthenticationService();
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", null);
+
+        var authedTools = new PlanTools(authedService);
+        var result = authedTools.GetPlan("00001");
+        Assert.Contains("Error: Authentication failed", result);
+    }
+
+    // --- TENDRIL_HOME not set ---
+
+    [Fact]
+    public void GetPlan_NoTendrilHome_ReturnsError()
+    {
         Environment.SetEnvironmentVariable("TENDRIL_HOME", null);
+        var result = _planTools.GetPlan("00001");
+        Assert.Contains("Error:", result);
+    }
 
-        // Act
-        var result = _planTools.TransitionPlan("00001", "Draft");
+    // --- CreatePlan (inbox) ---
 
-        // Assert
-        Assert.Contains("Error: TENDRIL_HOME is not set", result);
+    [Fact]
+    public void CreatePlan_WritesInboxFile()
+    {
+        var result = _planTools.CreatePlan("Build a widget", "TestProject");
+        Assert.Contains("Plan submitted to inbox", result);
+
+        var inboxDir = Path.Combine(_tempDir, "Inbox");
+        Assert.True(Directory.Exists(inboxDir));
+        var files = Directory.GetFiles(inboxDir, "*.md");
+        Assert.Single(files);
+
+        var content = File.ReadAllText(files[0]);
+        Assert.Contains("Build a widget", content);
+        Assert.Contains("project: TestProject", content);
     }
 }

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -10,6 +10,7 @@ public class PlanCliCommandTests : IDisposable
     private readonly string _tempDir;
     private readonly string _plansDir;
     private readonly string _originalTendrilHome;
+    private readonly string? _originalTendrilPlans;
 
     public PlanCliCommandTests()
     {
@@ -18,12 +19,15 @@ public class PlanCliCommandTests : IDisposable
         Directory.CreateDirectory(_plansDir);
 
         _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        _originalTendrilPlans = Environment.GetEnvironmentVariable("TENDRIL_PLANS");
         Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", null);
     }
 
     public void Dispose()
     {
         Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", _originalTendrilPlans);
         if (Directory.Exists(_tempDir))
             try { Directory.Delete(_tempDir, true); }
             catch { }

--- a/src/Ivy.Tendril.Test/PlanControllerTests.cs
+++ b/src/Ivy.Tendril.Test/PlanControllerTests.cs
@@ -1,0 +1,584 @@
+using Ivy.Tendril.Controllers;
+using Ivy.Tendril.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ivy.Tendril.Test;
+
+[Collection("TendrilHome")]
+public class PlanControllerTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _repoDir;
+    private readonly string _originalTendrilHome;
+    private readonly string? _originalTendrilPlans;
+
+    public PlanControllerTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"tendril-api-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+        _repoDir = Path.Combine(_tempDir, "repos", "TestRepo");
+        Directory.CreateDirectory(_repoDir);
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        _originalTendrilPlans = Environment.GetEnvironmentVariable("TENDRIL_PLANS");
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", null);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", _originalTendrilPlans);
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    private string CreateTestPlan(string id = "00001", string title = "Test Plan", string state = "Draft")
+    {
+        var plansDir = Path.Combine(_tempDir, "Plans");
+        var planFolder = Path.Combine(plansDir, $"{id}-{title.Replace(" ", "")}");
+        Directory.CreateDirectory(planFolder);
+
+        var planYaml = $"""
+            state: {state}
+            project: TestProject
+            level: NiceToHave
+            title: {title}
+            repos:
+            - {_repoDir}
+            commits: []
+            prs: []
+            created: 2026-04-01T10:00:00.0000000Z
+            updated: 2026-04-01T10:00:00.0000000Z
+            verifications: []
+            relatedPlans: []
+            dependsOn: []
+            priority: 0
+            """;
+
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
+        return planFolder;
+    }
+
+    private static PlanController CreateController()
+    {
+        var controller = new PlanController();
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+        return controller;
+    }
+
+    // --- GetPlan ---
+
+    [Fact]
+    public void GetPlan_ReturnsFullPlan()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.GetPlan("00001");
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(ok.Value);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("\"title\":\"Test Plan\"", json);
+        Assert.Contains("\"state\":\"Draft\"", json);
+        Assert.Contains("\"project\":\"TestProject\"", json);
+    }
+
+    [Fact]
+    public void GetPlan_WithField_ReturnsFieldValue()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.GetPlan("00001", "state");
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("\"value\":\"Draft\"", json);
+    }
+
+    [Fact]
+    public void GetPlan_NotFound_Returns404()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempDir, "Plans"));
+        var controller = CreateController();
+
+        var result = controller.GetPlan("99999");
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    // --- ListPlans ---
+
+    [Fact]
+    public void ListPlans_ReturnsAllPlans()
+    {
+        CreateTestPlan("00001", "First Plan", "Draft");
+        CreateTestPlan("00002", "Second Plan", "Executing");
+        var controller = CreateController();
+
+        var result = controller.ListPlans();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("First Plan", json);
+        Assert.Contains("Second Plan", json);
+    }
+
+    [Fact]
+    public void ListPlans_FilterByState()
+    {
+        CreateTestPlan("00001", "DraftPlan", "Draft");
+        CreateTestPlan("00002", "ExecPlan", "Executing");
+        var controller = CreateController();
+
+        var result = controller.ListPlans(state: "Draft");
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("DraftPlan", json);
+        Assert.DoesNotContain("ExecPlan", json);
+    }
+
+    [Fact]
+    public void ListPlans_FilterByProject()
+    {
+        CreateTestPlan("00001", "MyPlan");
+        var controller = CreateController();
+
+        var result = controller.ListPlans(project: "TestProject");
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("MyPlan", json);
+    }
+
+    [Fact]
+    public void ListPlans_FilterByProject_NoMatch()
+    {
+        CreateTestPlan("00001", "MyPlan");
+        var controller = CreateController();
+
+        var result = controller.ListPlans(project: "OtherProject");
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Equal("[]", json);
+    }
+
+    [Fact]
+    public void ListPlans_RespectsLimit()
+    {
+        CreateTestPlan("00001", "Plan1");
+        CreateTestPlan("00002", "Plan2");
+        CreateTestPlan("00003", "Plan3");
+        var controller = CreateController();
+
+        var result = controller.ListPlans(limit: 2);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var list = ok.Value as System.Collections.IList
+            ?? (ok.Value as System.Collections.IEnumerable)?.Cast<object>().ToList();
+        Assert.NotNull(list);
+        Assert.Equal(2, list.Count);
+    }
+
+    // --- SetField ---
+
+    [Fact]
+    public void SetField_UpdatesState()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.SetField("00001", new SetFieldRequest("state", "Icebox"));
+
+        Assert.IsType<OkObjectResult>(result);
+
+        var getResult = controller.GetPlan("00001", "state");
+        var ok = Assert.IsType<OkObjectResult>(getResult);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("Icebox", json);
+    }
+
+    [Fact]
+    public void SetField_UpdatesTitle()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.SetField("00001", new SetFieldRequest("title", "New Title"));
+
+        Assert.IsType<OkObjectResult>(result);
+
+        var getResult = controller.GetPlan("00001", "title");
+        var ok = Assert.IsType<OkObjectResult>(getResult);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("New Title", json);
+    }
+
+    [Fact]
+    public void SetField_UpdatesPriority()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.SetField("00001", new SetFieldRequest("priority", "5"));
+
+        Assert.IsType<OkObjectResult>(result);
+
+        var getResult = controller.GetPlan("00001", "priority");
+        var ok = Assert.IsType<OkObjectResult>(getResult);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("5", json);
+    }
+
+    [Fact]
+    public void SetField_InvalidPriority_ReturnsBadRequest()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.SetField("00001", new SetFieldRequest("priority", "abc"));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public void SetField_UnknownField_ReturnsBadRequest()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.SetField("00001", new SetFieldRequest("nosuchfield", "value"));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public void SetField_NotFound_Returns404()
+    {
+        Directory.CreateDirectory(Path.Combine(_tempDir, "Plans"));
+        var controller = CreateController();
+
+        var result = controller.SetField("99999", new SetFieldRequest("state", "Draft"));
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    // --- AddRepo / RemoveRepo ---
+
+    [Fact]
+    public void AddRepo_AddsRepository()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        var newRepo = Path.Combine(_tempDir, "repos", "AnotherRepo");
+        Directory.CreateDirectory(newRepo);
+
+        var result = controller.AddRepo("00001", new AddRepoRequest(newRepo));
+
+        Assert.IsType<OkObjectResult>(result);
+
+        var getResult = controller.GetPlan("00001");
+        var ok = Assert.IsType<OkObjectResult>(getResult);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("AnotherRepo", json);
+    }
+
+    [Fact]
+    public void AddRepo_Duplicate_ReturnsOkMessage()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.AddRepo("00001", new AddRepoRequest(_repoDir));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("already in plan", json);
+    }
+
+    [Fact]
+    public void RemoveRepo_RemovesRepository()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        var extraRepo = Path.Combine(_tempDir, "repos", "ExtraRepo");
+        Directory.CreateDirectory(extraRepo);
+        controller.AddRepo("00001", new AddRepoRequest(extraRepo));
+
+        var result = controller.RemoveRepo("00001", new RemoveRepoRequest(extraRepo));
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public void RemoveRepo_NotFound_Returns404()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.RemoveRepo("00001", new RemoveRepoRequest(@"D:\Repos\NonExistent"));
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    // --- AddPr ---
+
+    [Fact]
+    public void AddPr_AddsPrUrl()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.AddPr("00001", new AddPrRequest("https://github.com/owner/repo/pull/1"));
+
+        Assert.IsType<OkObjectResult>(result);
+
+        var getResult = controller.GetPlan("00001");
+        var ok = Assert.IsType<OkObjectResult>(getResult);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("https://github.com/owner/repo/pull/1", json);
+    }
+
+    [Fact]
+    public void AddPr_Duplicate_ReturnsOkMessage()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddPr("00001", new AddPrRequest("https://github.com/owner/repo/pull/1"));
+
+        var result = controller.AddPr("00001", new AddPrRequest("https://github.com/owner/repo/pull/1"));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("already in plan", json);
+    }
+
+    // --- AddCommit ---
+
+    [Fact]
+    public void AddCommit_AddsCommitSha()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.AddCommit("00001", new AddCommitRequest("abc123def456"));
+
+        Assert.IsType<OkObjectResult>(result);
+
+        var getResult = controller.GetPlan("00001");
+        var ok = Assert.IsType<OkObjectResult>(getResult);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("abc123def456", json);
+    }
+
+    [Fact]
+    public void AddCommit_Duplicate_ReturnsOkMessage()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddCommit("00001", new AddCommitRequest("abc123def456"));
+
+        var result = controller.AddCommit("00001", new AddCommitRequest("abc123def456"));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("already in plan", json);
+    }
+
+    // --- SetVerification ---
+
+    [Fact]
+    public void SetVerification_AddsNew()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.SetVerification("00001", new SetVerificationRequest("DotnetBuild", "Pass"));
+
+        Assert.IsType<OkObjectResult>(result);
+
+        var getResult = controller.GetPlan("00001");
+        var ok = Assert.IsType<OkObjectResult>(getResult);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("DotnetBuild", json);
+        Assert.Contains("Pass", json);
+    }
+
+    [Fact]
+    public void SetVerification_UpdatesExisting()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.SetVerification("00001", new SetVerificationRequest("DotnetBuild", "Pending"));
+
+        var result = controller.SetVerification("00001", new SetVerificationRequest("DotnetBuild", "Pass"));
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    // --- AddLog ---
+
+    [Fact]
+    public void AddLog_WritesLogFile()
+    {
+        var planFolder = CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.AddLog("00001", new AddLogRequest("ExecutePlan", "Test summary"));
+
+        Assert.IsType<OkObjectResult>(result);
+        var logsDir = Path.Combine(planFolder, "logs");
+        Assert.True(Directory.Exists(logsDir));
+        var logFiles = Directory.GetFiles(logsDir, "*.md");
+        Assert.Single(logFiles);
+    }
+
+    // --- Recommendations ---
+
+    [Fact]
+    public void AddRecommendation_AddsRec()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.AddRecommendation("00001", new AddRecRequest("Add tests", "Need unit tests", "Medium", "Small"));
+
+        Assert.IsType<OkObjectResult>(result);
+
+        var listResult = controller.ListRecommendations("00001");
+        var ok = Assert.IsType<OkObjectResult>(listResult);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("Add tests", json);
+    }
+
+    [Fact]
+    public void AddRecommendation_Duplicate_ReturnsConflict()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddRecommendation("00001", new AddRecRequest("Add tests"));
+
+        var result = controller.AddRecommendation("00001", new AddRecRequest("Add tests"));
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+
+    [Fact]
+    public void AcceptRecommendation_AcceptsRec()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddRecommendation("00001", new AddRecRequest("Add tests"));
+
+        var result = controller.AcceptRecommendation("00001", "Add tests");
+
+        Assert.IsType<OkObjectResult>(result);
+
+        var listResult = controller.ListRecommendations("00001");
+        var ok = Assert.IsType<OkObjectResult>(listResult);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("Accepted", json);
+    }
+
+    [Fact]
+    public void AcceptRecommendation_WithNotes_SetsAcceptedWithNotes()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddRecommendation("00001", new AddRecRequest("Add tests"));
+
+        var result = controller.AcceptRecommendation("00001", "Add tests", new AcceptRecRequest("Only integration"));
+
+        Assert.IsType<OkObjectResult>(result);
+
+        var listResult = controller.ListRecommendations("00001");
+        var ok = Assert.IsType<OkObjectResult>(listResult);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("AcceptedWithNotes", json);
+    }
+
+    [Fact]
+    public void AcceptRecommendation_NotFound_Returns404()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.AcceptRecommendation("00001", "NonExistent");
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public void DeclineRecommendation_DeclinesRec()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddRecommendation("00001", new AddRecRequest("Add tests"));
+
+        var result = controller.DeclineRecommendation("00001", "Add tests", new DeclineRecRequest("Not needed"));
+
+        Assert.IsType<OkObjectResult>(result);
+
+        var listResult = controller.ListRecommendations("00001");
+        var ok = Assert.IsType<OkObjectResult>(listResult);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("Declined", json);
+    }
+
+    [Fact]
+    public void RemoveRecommendation_RemovesRec()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddRecommendation("00001", new AddRecRequest("Add tests"));
+
+        var result = controller.RemoveRecommendation("00001", "Add tests");
+
+        Assert.IsType<OkObjectResult>(result);
+
+        var listResult = controller.ListRecommendations("00001");
+        var ok = Assert.IsType<OkObjectResult>(listResult);
+        var json = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+        Assert.DoesNotContain("Add tests", json);
+    }
+
+    [Fact]
+    public void RemoveRecommendation_NotFound_Returns404()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.RemoveRecommendation("00001", "NonExistent");
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public void ListRecommendations_FilterByState()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddRecommendation("00001", new AddRecRequest("Rec1"));
+        controller.AddRecommendation("00001", new AddRecRequest("Rec2"));
+        controller.AcceptRecommendation("00001", "Rec1");
+
+        var pendingResult = controller.ListRecommendations("00001", "Pending");
+        var ok1 = Assert.IsType<OkObjectResult>(pendingResult);
+        var json1 = System.Text.Json.JsonSerializer.Serialize(ok1.Value);
+        Assert.Contains("Rec2", json1);
+        Assert.DoesNotContain("Rec1", json1);
+
+        var acceptedResult = controller.ListRecommendations("00001", "Accepted");
+        var ok2 = Assert.IsType<OkObjectResult>(acceptedResult);
+        var json2 = System.Text.Json.JsonSerializer.Serialize(ok2.Value);
+        Assert.Contains("Rec1", json2);
+        Assert.DoesNotContain("Rec2", json2);
+    }
+}

--- a/src/Ivy.Tendril.Test/PlanRecCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanRecCommandTests.cs
@@ -9,6 +9,7 @@ public class PlanRecCommandTests : IDisposable
     private readonly string _tempDir;
     private readonly string _plansDir;
     private readonly string _originalTendrilHome;
+    private readonly string? _originalTendrilPlans;
 
     public PlanRecCommandTests()
     {
@@ -17,12 +18,15 @@ public class PlanRecCommandTests : IDisposable
         Directory.CreateDirectory(_plansDir);
 
         _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        _originalTendrilPlans = Environment.GetEnvironmentVariable("TENDRIL_PLANS");
         Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", null);
     }
 
     public void Dispose()
     {
         Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", _originalTendrilPlans);
         if (Directory.Exists(_tempDir))
             try { Directory.Delete(_tempDir, true); }
             catch { }

--- a/src/Ivy.Tendril/Controllers/ApiKeyAuthMiddleware.cs
+++ b/src/Ivy.Tendril/Controllers/ApiKeyAuthMiddleware.cs
@@ -1,0 +1,28 @@
+using Ivy.Tendril.Services;
+using Microsoft.AspNetCore.Http;
+
+namespace Ivy.Tendril.Controllers;
+
+public class ApiKeyAuthMiddleware(RequestDelegate next, IConfigService configService)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context.Request.Path.StartsWithSegments("/api")
+            && !context.Request.Path.StartsWithSegments("/api/jobs"))
+        {
+            var apiKey = configService.Settings.Api?.ApiKey;
+            if (!string.IsNullOrEmpty(apiKey))
+            {
+                var providedKey = context.Request.Headers["X-Api-Key"].FirstOrDefault();
+                if (string.IsNullOrEmpty(providedKey) || providedKey != apiKey)
+                {
+                    context.Response.StatusCode = 401;
+                    await context.Response.WriteAsJsonAsync(new { error = "Invalid or missing API key" });
+                    return;
+                }
+            }
+        }
+
+        await next(context);
+    }
+}

--- a/src/Ivy.Tendril/Controllers/InboxController.cs
+++ b/src/Ivy.Tendril/Controllers/InboxController.cs
@@ -5,19 +5,11 @@ namespace Ivy.Tendril.Controllers;
 
 [ApiController]
 [Route("api/inbox")]
-public class InboxController(IJobService jobService, IConfigService configService) : ControllerBase
+public class InboxController(IJobService jobService) : ControllerBase
 {
     [HttpPost]
     public IActionResult PostPlan([FromBody] CreatePlanRequest request)
     {
-        var apiKey = configService.Settings.Api?.ApiKey;
-        if (!string.IsNullOrEmpty(apiKey))
-        {
-            var providedKey = Request.Headers["X-Api-Key"].FirstOrDefault();
-            if (string.IsNullOrEmpty(providedKey) || providedKey != apiKey)
-                return Unauthorized(new { error = "Invalid or missing API key" });
-        }
-
         if (string.IsNullOrWhiteSpace(request.Description))
             return BadRequest(new { error = "Description is required" });
 

--- a/src/Ivy.Tendril/Controllers/PlanController.cs
+++ b/src/Ivy.Tendril/Controllers/PlanController.cs
@@ -1,0 +1,495 @@
+using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ivy.Tendril.Controllers;
+
+[ApiController]
+[Route("api/plans")]
+public class PlanController : ControllerBase
+{
+    [HttpGet("{planId}")]
+    public IActionResult GetPlan(string planId, [FromQuery] string? field = null)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            if (!string.IsNullOrEmpty(field))
+                return Ok(new { value = GetField(plan, planFolder, field) });
+
+            return Ok(PlanToDto(plan, planFolder));
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpGet]
+    public IActionResult ListPlans(
+        [FromQuery] string? state = null,
+        [FromQuery] string? project = null,
+        [FromQuery] int limit = 50)
+    {
+        try
+        {
+            var plansDir = PlanCommandHelpers.GetPlansDirectory();
+            var results = new List<object>();
+
+            foreach (var dir in Directory.GetDirectories(plansDir).OrderByDescending(d => Path.GetFileName(d)))
+            {
+                var folderName = Path.GetFileName(dir);
+                if (!ExtractPlanId(folderName, out var id)) continue;
+
+                PlanYaml yaml;
+                try { yaml = PlanCommandHelpers.ReadPlan(dir); }
+                catch { continue; }
+
+                if (!string.IsNullOrEmpty(state) &&
+                    !string.Equals(yaml.State, state, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (!string.IsNullOrEmpty(project) &&
+                    !string.Equals(yaml.Project, project, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                results.Add(new { id, title = yaml.Title, state = yaml.State, project = yaml.Project, level = yaml.Level });
+
+                if (results.Count >= limit) break;
+            }
+
+            return Ok(results);
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPut("{planId}")]
+    public IActionResult SetField(string planId, [FromBody] SetFieldRequest request)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            switch (request.Field.ToLower())
+            {
+                case "state": plan.State = request.Value; break;
+                case "project": plan.Project = request.Value; break;
+                case "level": plan.Level = request.Value; break;
+                case "title": plan.Title = request.Value; break;
+                case "executionprofile": plan.ExecutionProfile = request.Value; break;
+                case "initialprompt": plan.InitialPrompt = request.Value; break;
+                case "sourceurl": plan.SourceUrl = request.Value; break;
+                case "priority":
+                    if (!int.TryParse(request.Value, out var priority))
+                        return BadRequest(new { error = $"Invalid priority: {request.Value}" });
+                    plan.Priority = priority;
+                    break;
+                default:
+                    return BadRequest(new { error = $"Unknown field: {request.Field}" });
+            }
+
+            if (request.Field.ToLower() != "updated")
+                plan.Updated = DateTime.UtcNow;
+
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return Ok(new { message = $"Updated {request.Field} to '{request.Value}'" });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPost("{planId}/repos")]
+    public IActionResult AddRepo(string planId, [FromBody] AddRepoRequest request)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            if (plan.Repos.Contains(request.RepoPath, StringComparer.OrdinalIgnoreCase))
+                return Ok(new { message = $"Repository already in plan: {request.RepoPath}" });
+
+            plan.Repos.Add(request.RepoPath);
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return Ok(new { message = $"Added repository: {request.RepoPath}" });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpDelete("{planId}/repos")]
+    public IActionResult RemoveRepo(string planId, [FromBody] RemoveRepoRequest request)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            var removed = plan.Repos.RemoveAll(r => r.Equals(request.RepoPath, StringComparison.OrdinalIgnoreCase));
+            if (removed == 0)
+                return NotFound(new { error = $"Repository not found in plan: {request.RepoPath}" });
+
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return Ok(new { message = $"Removed repository: {request.RepoPath}" });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPost("{planId}/prs")]
+    public IActionResult AddPr(string planId, [FromBody] AddPrRequest request)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            if (plan.Prs.Contains(request.PrUrl))
+                return Ok(new { message = $"PR already in plan: {request.PrUrl}" });
+
+            plan.Prs.Add(request.PrUrl);
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return Ok(new { message = $"Added PR: {request.PrUrl}" });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPost("{planId}/commits")]
+    public IActionResult AddCommit(string planId, [FromBody] AddCommitRequest request)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            if (plan.Commits.Contains(request.Sha))
+                return Ok(new { message = $"Commit already in plan: {request.Sha}" });
+
+            plan.Commits.Add(request.Sha);
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return Ok(new { message = $"Added commit: {request.Sha}" });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPut("{planId}/verifications")]
+    public IActionResult SetVerification(string planId, [FromBody] SetVerificationRequest request)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            var verification = plan.Verifications.FirstOrDefault(v =>
+                v.Name.Equals(request.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (verification != null)
+                verification.Status = request.Status;
+            else
+                plan.Verifications.Add(new PlanVerificationEntry { Name = request.Name, Status = request.Status });
+
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return Ok(new { message = $"Set verification '{request.Name}' to '{request.Status}'" });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPost("{planId}/logs")]
+    public IActionResult AddLog(string planId, [FromBody] AddLogRequest request)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var logPath = PlanAddLogCommand.WriteLog(planFolder, request.Action, request.Summary);
+            return Ok(new { message = $"Log written: {Path.GetFileName(logPath)}" });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpGet("{planId}/recommendations")]
+    public IActionResult ListRecommendations(string planId, [FromQuery] string? state = null)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var recs = plan.Recommendations ?? [];
+
+            if (!string.IsNullOrEmpty(state))
+                recs = recs.Where(r => r.State.Equals(state, StringComparison.OrdinalIgnoreCase)).ToList();
+
+            return Ok(recs.Select(r => new
+            {
+                title = r.Title, description = r.Description, state = r.State,
+                impact = r.Impact, risk = r.Risk, declineReason = r.DeclineReason
+            }));
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPost("{planId}/recommendations")]
+    public IActionResult AddRecommendation(string planId, [FromBody] AddRecRequest request)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            plan.Recommendations ??= [];
+            if (plan.Recommendations.Any(r => r.Title.Equals(request.Title, StringComparison.OrdinalIgnoreCase)))
+                return Conflict(new { error = $"Recommendation '{request.Title}' already exists" });
+
+            plan.Recommendations.Add(new RecommendationYaml
+            {
+                Title = request.Title,
+                Description = request.Description ?? "",
+                State = "Pending",
+                Impact = request.Impact,
+                Risk = request.Risk
+            });
+
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return Ok(new { message = $"Added recommendation '{request.Title}'" });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPut("{planId}/recommendations/{title}/accept")]
+    public IActionResult AcceptRecommendation(string planId, string title, [FromBody] AcceptRecRequest? request = null)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            var rec = (plan.Recommendations ?? [])
+                .FirstOrDefault(r => r.Title.Equals(title, StringComparison.OrdinalIgnoreCase));
+            if (rec == null)
+                return NotFound(new { error = $"Recommendation '{title}' not found" });
+
+            rec.State = string.IsNullOrEmpty(request?.Notes) ? "Accepted" : "AcceptedWithNotes";
+            rec.DeclineReason = null;
+
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return Ok(new { message = $"Accepted recommendation '{title}'" });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPut("{planId}/recommendations/{title}/decline")]
+    public IActionResult DeclineRecommendation(string planId, string title, [FromBody] DeclineRecRequest? request = null)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            var rec = (plan.Recommendations ?? [])
+                .FirstOrDefault(r => r.Title.Equals(title, StringComparison.OrdinalIgnoreCase));
+            if (rec == null)
+                return NotFound(new { error = $"Recommendation '{title}' not found" });
+
+            rec.State = "Declined";
+            rec.DeclineReason = request?.Reason;
+
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return Ok(new { message = $"Declined recommendation '{title}'" });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpDelete("{planId}/recommendations/{title}")]
+    public IActionResult RemoveRecommendation(string planId, string title)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            var recs = plan.Recommendations ?? [];
+            var match = recs.FirstOrDefault(r => r.Title.Equals(title, StringComparison.OrdinalIgnoreCase));
+            if (match == null)
+                return NotFound(new { error = $"Recommendation '{title}' not found" });
+
+            recs.Remove(match);
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return Ok(new { message = $"Removed recommendation '{title}'" });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    private static bool ExtractPlanId(string folderName, out string id)
+    {
+        id = "";
+        var dash = folderName.IndexOf('-');
+        if (dash <= 0) return false;
+        var prefix = folderName[..dash];
+        if (!int.TryParse(prefix, out _)) return false;
+        id = prefix;
+        return true;
+    }
+
+    private static string? GetField(PlanYaml plan, string planFolder, string field)
+    {
+        return field.ToLower() switch
+        {
+            "state" => plan.State,
+            "project" => plan.Project,
+            "level" => plan.Level,
+            "title" => plan.Title,
+            "created" => plan.Created.ToString("O"),
+            "updated" => plan.Updated.ToString("O"),
+            "executionprofile" => plan.ExecutionProfile,
+            "initialprompt" => plan.InitialPrompt,
+            "sourceurl" => plan.SourceUrl,
+            "priority" => plan.Priority.ToString(),
+            _ => null
+        };
+    }
+
+    private static object PlanToDto(PlanYaml plan, string planFolder)
+    {
+        var folderName = Path.GetFileName(planFolder);
+        var dash = folderName.IndexOf('-');
+        var id = dash > 0 ? folderName[..dash] : folderName;
+
+        return new
+        {
+            id,
+            title = plan.Title,
+            state = plan.State,
+            project = plan.Project,
+            level = plan.Level,
+            created = plan.Created,
+            updated = plan.Updated,
+            repos = plan.Repos,
+            prs = plan.Prs,
+            commits = plan.Commits,
+            verifications = plan.Verifications.Select(v => new { name = v.Name, status = v.Status }),
+            relatedPlans = plan.RelatedPlans,
+            dependsOn = plan.DependsOn,
+            priority = plan.Priority,
+            executionProfile = plan.ExecutionProfile,
+            initialPrompt = plan.InitialPrompt,
+            sourceUrl = plan.SourceUrl,
+            recommendations = (plan.Recommendations ?? []).Select(r => new
+            {
+                title = r.Title, description = r.Description, state = r.State,
+                impact = r.Impact, risk = r.Risk
+            })
+        };
+    }
+}
+
+// Request DTOs
+public record SetFieldRequest(string Field, string Value);
+public record AddRepoRequest(string RepoPath);
+public record RemoveRepoRequest(string RepoPath);
+public record AddPrRequest(string PrUrl);
+public record AddCommitRequest(string Sha);
+public record SetVerificationRequest(string Name, string Status);
+public record AddLogRequest(string Action, string? Summary = null);
+public record AddRecRequest(string Title, string? Description = null, string? Impact = null, string? Risk = null);
+public record AcceptRecRequest(string? Notes = null);
+public record DeclineRecRequest(string? Reason = null);

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -1,42 +1,40 @@
 using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
+using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Services;
 using ModelContextProtocol.Server;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Ivy.Tendril.Mcp.Tools;
 
 [McpServerToolType]
 public sealed class PlanTools(McpAuthenticationService authService)
 {
-    private static readonly IDeserializer YamlDeserializer = new DeserializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .IgnoreUnmatchedProperties()
-        .Build();
-
-    private static readonly ISerializer YamlSerializer = new SerializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .Build();
-
     private static readonly Regex FolderNameRegex = new(@"^(\d{5})-(.+)$", RegexOptions.Compiled);
 
     [McpServerTool(Name = "tendril_get_plan"), Description("Fetch plan metadata by ID or folder path")]
     public string GetPlan(
-        [Description("Plan ID (e.g., '03228') or full folder path")] string planId)
+        [Description("Plan ID (e.g., '03228') or full folder path")] string planId,
+        [Description("Optional field name to return a single value (state, project, level, title, repos, prs, commits, verifications, recommendations, etc.)")] string? field = null)
     {
         if (!authService.ValidateEnvironmentToken())
             return "Error: Authentication failed. Access denied.";
 
-        var plansDir = GetPlansDirectory();
-        if (plansDir == null)
-            return "Error: TENDRIL_HOME is not set.";
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-        var planFolder = ResolvePlanFolder(plansDir, planId);
-        if (planFolder == null)
-            return $"Error: Plan '{planId}' not found.";
+            if (!string.IsNullOrEmpty(field))
+                return GetPlanField(plan, planFolder, field);
 
-        return ReadPlanSummary(planFolder);
+            return ReadPlanSummary(plan, planFolder);
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
     }
 
     [McpServerTool(Name = "tendril_list_plans"), Description("Query plans by state, project, or date range")]
@@ -48,56 +46,59 @@ public sealed class PlanTools(McpAuthenticationService authService)
         if (!authService.ValidateEnvironmentToken())
             return "Error: Authentication failed. Access denied.";
 
-        var plansDir = GetPlansDirectory();
-        if (plansDir == null)
-            return "Error: TENDRIL_HOME is not set.";
-
-        if (!Directory.Exists(plansDir))
-            return "Error: Plans directory does not exist.";
-
-        DateTime? sinceDate = null;
-        if (!string.IsNullOrEmpty(since) && DateTime.TryParse(since, out var parsed))
-            sinceDate = parsed;
-
-        var sb = new StringBuilder();
-        var count = 0;
-
-        foreach (var dir in Directory.GetDirectories(plansDir).OrderByDescending(d => Path.GetFileName(d)))
+        try
         {
-            var folderName = Path.GetFileName(dir);
-            var match = FolderNameRegex.Match(folderName);
-            if (!match.Success) continue;
+            var plansDir = PlanCommandHelpers.GetPlansDirectory();
 
-            var yaml = ReadPlanYaml(dir);
-            if (yaml == null) continue;
+            DateTime? sinceDate = null;
+            if (!string.IsNullOrEmpty(since) && DateTime.TryParse(since, out var parsed))
+                sinceDate = parsed;
 
-            if (!string.IsNullOrEmpty(state) &&
-                !string.Equals(yaml.State, state, StringComparison.OrdinalIgnoreCase))
-                continue;
+            var sb = new StringBuilder();
+            var count = 0;
 
-            if (!string.IsNullOrEmpty(project) &&
-                !string.Equals(yaml.Project, project, StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            if (sinceDate.HasValue && yaml.Created < sinceDate.Value)
-                continue;
-
-            var id = match.Groups[1].Value;
-            sb.AppendLine($"- [{id}] {yaml.Title} | State: {yaml.State} | Project: {yaml.Project} | Level: {yaml.Level}");
-            count++;
-
-            if (count >= 50)
+            foreach (var dir in Directory.GetDirectories(plansDir).OrderByDescending(d => Path.GetFileName(d)))
             {
-                sb.AppendLine($"... (showing first 50 of potentially more results)");
-                break;
+                var folderName = Path.GetFileName(dir);
+                var match = FolderNameRegex.Match(folderName);
+                if (!match.Success) continue;
+
+                PlanYaml yaml;
+                try { yaml = PlanCommandHelpers.ReadPlan(dir); }
+                catch { continue; }
+
+                if (!string.IsNullOrEmpty(state) &&
+                    !string.Equals(yaml.State, state, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (!string.IsNullOrEmpty(project) &&
+                    !string.Equals(yaml.Project, project, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (sinceDate.HasValue && yaml.Created < sinceDate.Value)
+                    continue;
+
+                var id = match.Groups[1].Value;
+                sb.AppendLine($"- [{id}] {yaml.Title} | State: {yaml.State} | Project: {yaml.Project} | Level: {yaml.Level}");
+                count++;
+
+                if (count >= 50)
+                {
+                    sb.AppendLine("... (showing first 50 of potentially more results)");
+                    break;
+                }
             }
+
+            if (count == 0)
+                return "No plans found matching the specified criteria.";
+
+            sb.Insert(0, $"Found {count} plan(s):\n");
+            return sb.ToString();
         }
-
-        if (count == 0)
-            return "No plans found matching the specified criteria.";
-
-        sb.Insert(0, $"Found {count} plan(s):\n");
-        return sb.ToString();
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
     }
 
     [McpServerTool(Name = "tendril_inbox"), Description("Create a new plan by writing to the Tendril inbox")]
@@ -110,8 +111,8 @@ public sealed class PlanTools(McpAuthenticationService authService)
         if (!authService.ValidateEnvironmentToken())
             return "Error: Authentication failed. Access denied.";
 
-        var tendrilHome = GetTendrilHome();
-        if (tendrilHome == null)
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
+        if (string.IsNullOrEmpty(tendrilHome))
             return "Error: TENDRIL_HOME is not set.";
 
         var inboxDir = Path.Combine(tendrilHome, "Inbox");
@@ -147,135 +148,430 @@ public sealed class PlanTools(McpAuthenticationService authService)
         return $"Plan submitted to inbox: {fileName}\nThe InboxWatcher will pick it up and create a plan automatically.";
     }
 
-    [McpServerTool(Name = "tendril_transition_plan"), Description("Transition a plan to a different state")]
-    public string TransitionPlan(
+    [McpServerTool(Name = "tendril_plan_set"), Description("Set a scalar field on a plan")]
+    public string SetField(
         [Description("Plan ID (e.g., '03228') or full folder path")] string planId,
-        [Description("Target state: Draft, Building, Updating, Executing, Completed, Failed, ReadyForReview, Skipped, Icebox, Blocked")] string targetState)
+        [Description("Field name (state, project, level, title, executionProfile, initialPrompt, sourceUrl, priority)")] string field,
+        [Description("New value")] string value)
     {
         if (!authService.ValidateEnvironmentToken())
             return "Error: Authentication failed. Access denied.";
 
-        var plansDir = GetPlansDirectory();
-        if (plansDir == null)
-            return "Error: TENDRIL_HOME is not set.";
-
-        var planFolder = ResolvePlanFolder(plansDir, planId);
-        if (planFolder == null)
-            return $"Error: Plan '{planId}' not found.";
-
-        // Validate target state
-        var validStates = new[] { "Draft", "Building", "Updating", "Executing", "Completed",
-                                  "Failed", "ReadyForReview", "Skipped", "Icebox", "Blocked" };
-        if (!validStates.Contains(targetState, StringComparer.OrdinalIgnoreCase))
-            return $"Error: Invalid state '{targetState}'. Valid states: {string.Join(", ", validStates)}";
-
-        // Read current plan.yaml
-        var planYamlPath = Path.Combine(planFolder, "plan.yaml");
-        if (!File.Exists(planYamlPath))
-            return $"Error: plan.yaml not found in {planFolder}";
-
         try
         {
-            var yaml = File.ReadAllText(planYamlPath);
-            var planYaml = YamlDeserializer.Deserialize<PlanYamlDto>(yaml);
-            if (planYaml == null)
-                return "Error: Failed to parse plan.yaml";
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-            var oldState = planYaml.State;
+            switch (field.ToLower())
+            {
+                case "state": plan.State = value; break;
+                case "project": plan.Project = value; break;
+                case "level": plan.Level = value; break;
+                case "title": plan.Title = value; break;
+                case "executionprofile": plan.ExecutionProfile = value; break;
+                case "initialprompt": plan.InitialPrompt = value; break;
+                case "sourceurl": plan.SourceUrl = value; break;
+                case "priority":
+                    if (!int.TryParse(value, out var priority))
+                        return $"Error: Invalid priority value: {value}. Must be an integer.";
+                    plan.Priority = priority;
+                    break;
+                default:
+                    return $"Error: Unknown field '{field}'. Valid: state, project, level, title, executionProfile, initialPrompt, sourceUrl, priority";
+            }
 
-            // Update state and timestamp
-            planYaml.State = validStates.First(s => s.Equals(targetState, StringComparison.OrdinalIgnoreCase));
-            planYaml.Updated = DateTime.UtcNow;
+            if (field.ToLower() != "updated")
+                plan.Updated = DateTime.UtcNow;
 
-            // Serialize and write back
-            var updatedYaml = YamlSerializer.Serialize(planYaml);
-            File.WriteAllText(planYamlPath, updatedYaml);
-
-            var folderName = Path.GetFileName(planFolder);
-            return $"Successfully transitioned plan {folderName} from {oldState} to {planYaml.State}";
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return $"Updated {field} to '{value}'";
         }
         catch (Exception ex)
         {
-            return $"Error: Failed to update plan state: {ex.Message}";
+            return $"Error: {ex.Message}";
         }
     }
 
-    private static string? GetTendrilHome()
+    [McpServerTool(Name = "tendril_plan_add_repo"), Description("Add a repository path to a plan")]
+    public string AddRepo(
+        [Description("Plan ID")] string planId,
+        [Description("Repository path")] string repoPath)
     {
-        var home = Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
-        if (!string.IsNullOrEmpty(home) && home.StartsWith('"') && home.EndsWith('"'))
-            home = home[1..^1];
-        return string.IsNullOrEmpty(home) ? null : home;
-    }
-
-    private static string? GetPlansDirectory()
-    {
-        var plans = Environment.GetEnvironmentVariable("TENDRIL_PLANS")?.Trim();
-        if (!string.IsNullOrEmpty(plans))
-            return plans;
-        var home = GetTendrilHome();
-        return home == null ? null : Path.Combine(home, "Plans");
-    }
-
-    private static string? ResolvePlanFolder(string plansDir, string planId)
-    {
-        if (Directory.Exists(planId))
-            return planId;
-
-        var paddedId = planId.PadLeft(5, '0');
-        var matching = Directory.GetDirectories(plansDir, $"{paddedId}-*");
-        return matching.Length > 0 ? matching[0] : null;
-    }
-
-    private static PlanYamlDto? ReadPlanYaml(string planFolder)
-    {
-        var planYamlPath = Path.Combine(planFolder, "plan.yaml");
-        if (!File.Exists(planYamlPath)) return null;
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
 
         try
         {
-            var content = File.ReadAllText(planYamlPath);
-            return YamlDeserializer.Deserialize<PlanYamlDto>(content);
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            if (plan.Repos.Contains(repoPath, StringComparer.OrdinalIgnoreCase))
+                return $"Repository already in plan: {repoPath}";
+
+            plan.Repos.Add(repoPath);
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return $"Added repository: {repoPath}";
         }
-        catch
+        catch (Exception ex)
         {
-            return null;
+            return $"Error: {ex.Message}";
         }
     }
 
-    private static string ReadPlanSummary(string planFolder)
+    [McpServerTool(Name = "tendril_plan_remove_repo"), Description("Remove a repository path from a plan")]
+    public string RemoveRepo(
+        [Description("Plan ID")] string planId,
+        [Description("Repository path")] string repoPath)
     {
-        var yaml = ReadPlanYaml(planFolder);
-        if (yaml == null)
-            return $"Error: Could not parse plan.yaml in {planFolder}";
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
 
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            var removed = plan.Repos.RemoveAll(r => r.Equals(repoPath, StringComparison.OrdinalIgnoreCase));
+            if (removed == 0)
+                return $"Error: Repository not found in plan: {repoPath}";
+
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return $"Removed repository: {repoPath}";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_add_pr"), Description("Add a PR URL to a plan")]
+    public string AddPr(
+        [Description("Plan ID")] string planId,
+        [Description("PR URL")] string prUrl)
+    {
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            if (plan.Prs.Contains(prUrl))
+                return $"PR already in plan: {prUrl}";
+
+            plan.Prs.Add(prUrl);
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return $"Added PR: {prUrl}";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_add_commit"), Description("Add a commit SHA to a plan")]
+    public string AddCommit(
+        [Description("Plan ID")] string planId,
+        [Description("Commit SHA")] string sha)
+    {
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            if (plan.Commits.Contains(sha))
+                return $"Commit already in plan: {sha}";
+
+            plan.Commits.Add(sha);
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return $"Added commit: {sha}";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_set_verification"), Description("Set a verification status on a plan")]
+    public string SetVerification(
+        [Description("Plan ID")] string planId,
+        [Description("Verification name (e.g., DotnetBuild, DotnetTest)")] string name,
+        [Description("Status: Pending, Pass, Fail, Skipped")] string status)
+    {
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            var verification = plan.Verifications.FirstOrDefault(v =>
+                v.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+            if (verification != null)
+                verification.Status = status;
+            else
+                plan.Verifications.Add(new PlanVerificationEntry { Name = name, Status = status });
+
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return $"Set verification '{name}' to '{status}'";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_add_log"), Description("Write an execution log entry to a plan")]
+    public string AddLog(
+        [Description("Plan ID")] string planId,
+        [Description("Action name (e.g., CreatePlan, ExecutePlan)")] string action,
+        [Description("Optional summary text")] string? summary = null)
+    {
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var logPath = PlanAddLogCommand.WriteLog(planFolder, action, summary);
+            return $"Log written: {Path.GetFileName(logPath)}";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_rec_add"), Description("Add a recommendation to a plan")]
+    public string RecAdd(
+        [Description("Plan ID")] string planId,
+        [Description("Recommendation title")] string title,
+        [Description("Recommendation description")] string description,
+        [Description("Impact level: Small, Medium, High (optional)")] string? impact = null,
+        [Description("Risk level: Small, Medium, High (optional)")] string? risk = null)
+    {
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            plan.Recommendations ??= [];
+            if (plan.Recommendations.Any(r => r.Title.Equals(title, StringComparison.OrdinalIgnoreCase)))
+                return $"Error: Recommendation '{title}' already exists";
+
+            plan.Recommendations.Add(new RecommendationYaml
+            {
+                Title = title,
+                Description = description,
+                State = "Pending",
+                Impact = impact,
+                Risk = risk
+            });
+
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return $"Added recommendation '{title}'";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_rec_accept"), Description("Accept a recommendation")]
+    public string RecAccept(
+        [Description("Plan ID")] string planId,
+        [Description("Recommendation title")] string title,
+        [Description("Optional notes")] string? notes = null)
+    {
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            var rec = (plan.Recommendations ?? [])
+                .FirstOrDefault(r => r.Title.Equals(title, StringComparison.OrdinalIgnoreCase));
+            if (rec == null)
+                return $"Error: Recommendation '{title}' not found";
+
+            rec.State = string.IsNullOrEmpty(notes) ? "Accepted" : "AcceptedWithNotes";
+            rec.DeclineReason = null;
+
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return $"Accepted recommendation '{title}'";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_rec_decline"), Description("Decline a recommendation")]
+    public string RecDecline(
+        [Description("Plan ID")] string planId,
+        [Description("Recommendation title")] string title,
+        [Description("Decline reason (optional)")] string? reason = null)
+    {
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            var rec = (plan.Recommendations ?? [])
+                .FirstOrDefault(r => r.Title.Equals(title, StringComparison.OrdinalIgnoreCase));
+            if (rec == null)
+                return $"Error: Recommendation '{title}' not found";
+
+            rec.State = "Declined";
+            rec.DeclineReason = reason;
+
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return $"Declined recommendation '{title}'";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_rec_remove"), Description("Remove a recommendation from a plan")]
+    public string RecRemove(
+        [Description("Plan ID")] string planId,
+        [Description("Recommendation title")] string title)
+    {
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            var recs = plan.Recommendations ?? [];
+            var match = recs.FirstOrDefault(r => r.Title.Equals(title, StringComparison.OrdinalIgnoreCase));
+            if (match == null)
+                return $"Error: Recommendation '{title}' not found";
+
+            recs.Remove(match);
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return $"Removed recommendation '{title}'";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_rec_list"), Description("List recommendations on a plan")]
+    public string RecList(
+        [Description("Plan ID")] string planId,
+        [Description("Filter by state: Pending, Accepted, Declined (optional)")] string? state = null)
+    {
+        if (!authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var recs = plan.Recommendations ?? [];
+
+            if (!string.IsNullOrEmpty(state))
+                recs = recs.Where(r => r.State.Equals(state, StringComparison.OrdinalIgnoreCase)).ToList();
+
+            if (recs.Count == 0)
+                return "No recommendations found.";
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Found {recs.Count} recommendation(s):");
+            foreach (var rec in recs)
+                sb.AppendLine($"- {rec.Title} | State: {rec.State} | Impact: {rec.Impact ?? "-"} | Risk: {rec.Risk ?? "-"}");
+
+            return sb.ToString();
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    private static string GetPlanField(PlanYaml plan, string planFolder, string field)
+    {
+        return field.ToLower() switch
+        {
+            "state" => plan.State,
+            "project" => plan.Project,
+            "level" => plan.Level,
+            "title" => plan.Title,
+            "created" => plan.Created.ToString("O"),
+            "updated" => plan.Updated.ToString("O"),
+            "executionprofile" => plan.ExecutionProfile ?? "",
+            "initialprompt" => plan.InitialPrompt ?? "",
+            "sourceurl" => plan.SourceUrl ?? "",
+            "priority" => plan.Priority.ToString(),
+            "repos" => string.Join("\n", plan.Repos),
+            "prs" => string.Join("\n", plan.Prs),
+            "commits" => string.Join("\n", plan.Commits),
+            "verifications" => string.Join("\n", plan.Verifications.Select(v => $"{v.Name}={v.Status}")),
+            "dependson" => string.Join("\n", plan.DependsOn),
+            "relatedplans" => string.Join("\n", plan.RelatedPlans),
+            "recommendations" => string.Join("\n", (plan.Recommendations ?? []).Select(r => $"{r.Title}={r.State}")),
+            _ => $"Error: Unknown field '{field}'"
+        };
+    }
+
+    private static string ReadPlanSummary(PlanYaml plan, string planFolder)
+    {
         var folderName = Path.GetFileName(planFolder);
         var match = FolderNameRegex.Match(folderName);
         var id = match.Success ? match.Groups[1].Value : folderName;
 
         var sb = new StringBuilder();
-        sb.AppendLine($"# Plan {id}: {yaml.Title}");
+        sb.AppendLine($"# Plan {id}: {plan.Title}");
         sb.AppendLine();
-        sb.AppendLine($"- **State:** {yaml.State}");
-        sb.AppendLine($"- **Project:** {yaml.Project}");
-        sb.AppendLine($"- **Level:** {yaml.Level}");
-        sb.AppendLine($"- **Created:** {yaml.Created:O}");
-        sb.AppendLine($"- **Updated:** {yaml.Updated:O}");
+        sb.AppendLine($"- **State:** {plan.State}");
+        sb.AppendLine($"- **Project:** {plan.Project}");
+        sb.AppendLine($"- **Level:** {plan.Level}");
+        sb.AppendLine($"- **Created:** {plan.Created:O}");
+        sb.AppendLine($"- **Updated:** {plan.Updated:O}");
 
-        if (yaml.Repos is { Count: > 0 })
-            sb.AppendLine($"- **Repos:** {string.Join(", ", yaml.Repos)}");
+        if (plan.Repos.Count > 0)
+            sb.AppendLine($"- **Repos:** {string.Join(", ", plan.Repos)}");
 
-        if (yaml.Commits is { Count: > 0 })
-            sb.AppendLine($"- **Commits:** {string.Join(", ", yaml.Commits)}");
+        if (plan.Commits.Count > 0)
+            sb.AppendLine($"- **Commits:** {string.Join(", ", plan.Commits)}");
 
-        if (yaml.Prs is { Count: > 0 })
-            sb.AppendLine($"- **PRs:** {string.Join(", ", yaml.Prs)}");
+        if (plan.Prs.Count > 0)
+            sb.AppendLine($"- **PRs:** {string.Join(", ", plan.Prs)}");
 
-        if (!string.IsNullOrEmpty(yaml.InitialPrompt))
+        if (!string.IsNullOrEmpty(plan.InitialPrompt))
         {
             sb.AppendLine();
-            sb.AppendLine($"## Initial Prompt");
-            sb.AppendLine(yaml.InitialPrompt);
+            sb.AppendLine("## Initial Prompt");
+            sb.AppendLine(plan.InitialPrompt);
         }
 
         var revisionsDir = Path.Combine(planFolder, "revisions");
@@ -301,32 +597,5 @@ public sealed class PlanTools(McpAuthenticationService authService)
         }
 
         return sb.ToString();
-    }
-
-    internal class PlanYamlDto
-    {
-        public string State { get; set; } = "";
-        public string Project { get; set; } = "";
-        public string Level { get; set; } = "";
-        public string Title { get; set; } = "";
-        public List<string>? Repos { get; set; }
-        public List<string>? Commits { get; set; }
-        public List<string>? Prs { get; set; }
-        public DateTime Created { get; set; }
-        public DateTime Updated { get; set; }
-        public string? InitialPrompt { get; set; }
-        public string? SourceUrl { get; set; }
-        public string? SessionId { get; set; }
-        public List<string>? DependsOn { get; set; }
-        public List<string>? RelatedPlans { get; set; }
-        public List<VerificationEntry>? Verifications { get; set; }
-        public int Priority { get; set; }
-        public string? ExecutionProfile { get; set; }
-    }
-
-    internal class VerificationEntry
-    {
-        public string Name { get; set; } = "";
-        public string Status { get; set; } = "Pending";
     }
 }

--- a/src/Ivy.Tendril/Services/PlanCommandHelpers.cs
+++ b/src/Ivy.Tendril/Services/PlanCommandHelpers.cs
@@ -13,13 +13,7 @@ public static class PlanCommandHelpers
     /// </summary>
     public static string ResolvePlanFolder(string planId)
     {
-        var plansDirectory = Environment.GetEnvironmentVariable("TENDRIL_HOME");
-        if (string.IsNullOrWhiteSpace(plansDirectory))
-            throw new InvalidOperationException("TENDRIL_HOME environment variable is not set");
-
-        plansDirectory = Path.Combine(plansDirectory, "Plans");
-        if (!Directory.Exists(plansDirectory))
-            throw new DirectoryNotFoundException($"Plans directory not found: {plansDirectory}");
+        var plansDirectory = GetPlansDirectory();
 
         var normalized = NormalizePlanId(planId, plansDirectory);
 
@@ -51,6 +45,30 @@ public static class PlanCommandHelpers
             return num.ToString("D5");
 
         return input;
+    }
+
+    /// <summary>
+    ///     Resolves the plans directory from TENDRIL_PLANS or TENDRIL_HOME/Plans.
+    /// </summary>
+    public static string GetPlansDirectory()
+    {
+        var plans = Environment.GetEnvironmentVariable("TENDRIL_PLANS")?.Trim();
+        if (!string.IsNullOrEmpty(plans))
+        {
+            if (!Directory.Exists(plans))
+                throw new DirectoryNotFoundException($"Plans directory not found: {plans}");
+            return plans;
+        }
+
+        var home = Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
+        if (string.IsNullOrWhiteSpace(home))
+            throw new InvalidOperationException("TENDRIL_HOME environment variable is not set");
+
+        var plansDirectory = Path.Combine(home, "Plans");
+        if (!Directory.Exists(plansDirectory))
+            throw new DirectoryNotFoundException($"Plans directory not found: {plansDirectory}");
+
+        return plansDirectory;
     }
 
     /// <summary>

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -1,7 +1,9 @@
 using System.ClientModel;
 using Ivy.Helpers;
 using Ivy.Tendril.AppShell;
+using Ivy.Tendril.Controllers;
 using Ivy.Tendril.Services;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -163,6 +165,8 @@ public static class TendrilServer
 
         server.UseWebApplication(app =>
         {
+            app.UseMiddleware<ApiKeyAuthMiddleware>();
+
             // Publish the actual bound URL so child processes can reach this server
             var serverUrl = app.Urls.FirstOrDefault();
             if (serverUrl != null)


### PR DESCRIPTION
## Summary
- New PlanController with 15 REST endpoints matching CLI plan management capabilities
- ApiKeyAuthMiddleware for centralized API auth (`X-Api-Key` header, excludes `/api/jobs/*` for agent access)
- Rewrote MCP PlanTools to use shared PlanCommandHelpers (same validation and atomic writes as CLI)
- Added `GetPlansDirectory()` supporting `TENDRIL_PLANS` env var override
- 76 new tests (34 PlanController + 8 middleware + 34 MCP)
- Fixed `TENDRIL_PLANS` env var leak in existing PlanCliCommand/PlanRecCommand tests
- New docs section `08_API` with REST and MCP reference documentation

## Test plan
- [x] 42 new API tests pass (PlanController + ApiKeyAuthMiddleware)
- [x] 34 MCP tests pass
- [x] Full suite: 923/924 pass (1 pre-existing SQLite concurrency flake)
- [x] Docs build clean