### PR TITLE
Retry on UnauthorizedAccessException in FileHelper

### DIFF
--- a/src/Ivy.Tendril/Services/FileHelper.cs
+++ b/src/Ivy.Tendril/Services/FileHelper.cs
@@ -57,7 +57,7 @@ internal static class FileHelper
                 using var reader = new StreamReader(stream);
                 return reader.ReadToEnd();
             }
-            catch (IOException) when (attempt < MaxRetries)
+            catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < MaxRetries)
             {
                 Thread.Sleep(RetryDelaysMs[attempt]);
             }
@@ -75,7 +75,7 @@ internal static class FileHelper
                     lines.Add(line);
                 return lines.ToArray();
             }
-            catch (IOException) when (attempt < MaxRetries)
+            catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < MaxRetries)
             {
                 Thread.Sleep(RetryDelaysMs[attempt]);
             }
@@ -92,7 +92,7 @@ internal static class FileHelper
                 writer.Write(contents);
                 return;
             }
-            catch (IOException) when (attempt < MaxRetries)
+            catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < MaxRetries)
             {
                 Thread.Sleep(RetryDelaysMs[attempt]);
             }
@@ -111,7 +111,7 @@ internal static class FileHelper
                     return await reader.ReadToEndAsync().ConfigureAwait(false);
                 }
             }
-            catch (IOException) when (attempt < MaxRetries)
+            catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < MaxRetries)
             {
                 await Task.Delay(RetryDelaysMs[attempt]).ConfigureAwait(false);
             }
@@ -131,7 +131,7 @@ internal static class FileHelper
                     return;
                 }
             }
-            catch (IOException) when (attempt < MaxRetries)
+            catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < MaxRetries)
             {
                 await Task.Delay(RetryDelaysMs[attempt]).ConfigureAwait(false);
             }
@@ -150,7 +150,7 @@ internal static class FileHelper
                 stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 break;
             }
-            catch (IOException) when (attempt < MaxRetries)
+            catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < MaxRetries)
             {
                 Thread.Sleep(RetryDelaysMs[attempt]);
             }
@@ -174,7 +174,7 @@ internal static class FileHelper
                 writer.Write(contents);
                 return;
             }
-            catch (IOException) when (attempt < MaxRetries)
+            catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < MaxRetries)
             {
                 Thread.Sleep(RetryDelaysMs[attempt]);
             }


### PR DESCRIPTION
Windows antivirus/indexer can surface transient file locks as
UnauthorizedAccessException instead of IOException. Include it
in all retry catch filters so operations self-heal.
