### PR TITLE
[03437] Add loading message for job output initial 300ms window

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -25,6 +25,7 @@ public class JobsApp : ViewBase
         var outputStream = UseStream<string>();
         var lastProcessedIndex = UseState(0);
         var streamingJobId = UseState<string?>(null);
+        var hasStreamContent = UseState(false);
 
         UseInterval(() =>
         {
@@ -39,6 +40,7 @@ public class JobsApp : ViewBase
             {
                 streamingJobId.Set(activeJobId);
                 startIdx = 0;
+                hasStreamContent.Set(false);
 
                 // Immediately seed the stream with existing lines
                 var existingLines = activeJob.OutputLines.ToArray();
@@ -46,6 +48,12 @@ public class JobsApp : ViewBase
                 {
                     outputStream.Write(line);
                 }
+
+                if (existingLines.Length > 0 && !hasStreamContent.Value)
+                {
+                    hasStreamContent.Set(true);
+                }
+
                 lastProcessedIndex.Set(existingLines.Length);
             }
             else
@@ -56,6 +64,12 @@ public class JobsApp : ViewBase
                 {
                     outputStream.Write(currentLines[i]);
                 }
+
+                if (currentLines.Length > 0 && !hasStreamContent.Value)
+                {
+                    hasStreamContent.Set(true);
+                }
+
                 lastProcessedIndex.Set(currentLines.Length);
             }
         }, TimeSpan.FromMilliseconds(300));
@@ -403,12 +417,19 @@ public class JobsApp : ViewBase
 
             if (job is { Status: JobStatus.Running })
             {
-                outputContent = new ClaudeJsonRenderer()
-                    .Stream(outputStream)
-                    .ShowThinking(true)
-                    .ShowSystemEvents(true)
-                    .AutoScroll(true)
-                    .Height(Size.Full());
+                if (!hasStreamContent.Value)
+                {
+                    outputContent = Text.P("Loading Output...");
+                }
+                else
+                {
+                    outputContent = new ClaudeJsonRenderer()
+                        .Stream(outputStream)
+                        .ShowThinking(true)
+                        .ShowSystemEvents(true)
+                        .AutoScroll(true)
+                        .Height(Size.Full());
+                }
             }
             else if (job is not null && job.OutputLines.Count > 0)
             {


### PR DESCRIPTION
# Summary

## Changes

Implemented a loading state for the job output viewer to improve UX during the initial 300ms delay before the first `UseInterval` tick populates the stream. The implementation adds a state flag that tracks whether the output stream has received content, conditionally showing "Loading Output..." text instead of a blank renderer during the loading window.

## API Changes

None. This is a UX enhancement to existing UI with no public API modifications.

## Files Modified

- `src/Ivy.Tendril/Apps/JobsApp.cs` — Added loading state management and conditional rendering for job output viewer
  - New state variable: `hasStreamContent` (UseState<bool>)
  - Updated: UseInterval callback to set flag when stream receives content
  - Updated: Job-switching logic to reset flag
  - Updated: Running job output rendering to show loading message vs renderer based on flag

## Commits

- 89f76d5 [03437] Add loading message for job output initial 300ms window