### PR TITLE
Add Ivy-Framework to Tendril project repoPaths so worktrees resolve sibling dependency

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -84,6 +84,7 @@ projects:
     action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
   repoPaths:
   - '%REPOS_HOME%\Ivy-Tendril'
+  - '%REPOS_HOME%\Ivy-Framework'
 - name: Rustino
   color: Orange
   meta:


### PR DESCRIPTION
## Summary
- Adds `Ivy-Framework` to the Tendril project's `repoPaths` in TeamIvyConfig
- Fixes worktree builds failing because the `../../../Ivy-Framework/` project references couldn't resolve
- The "Tendril" and "Docs" ReviewAction buttons now work for Tendril project plans

## Context
The Ivy.Tendril.csproj references Ivy-Framework via relative paths (`../../../Ivy-Framework/`). In plan worktrees, only `Ivy-Tendril` was cloned, so the sibling `Ivy-Framework` directory was missing, causing all builds to fail with CS0234 errors.