### PR TITLE
Fix CreatePlan verification false failures by adding filesystem fallback

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(grep -E \"\\\\.\\(cs|xaml\\)$\")",
+      "Bash(xargs grep *)"
+    ]
+  }
+}

--- a/src/Ivy.Tendril/Apps/Jobs/Models.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Models.cs
@@ -63,6 +63,9 @@ public record JobItem
     // Path to the .processing inbox file for CreatePlan job recovery
     public string? InboxFile { get; set; }
 
+    // Pre-allocated plan ID for CreatePlan jobs (used for filesystem verification)
+    public string? AllocatedPlanId { get; set; }
+
     public void EnqueueOutput(string line)
     {
         OutputLines.Enqueue(line);

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -855,6 +855,10 @@ public class JobService : IJobService
             var description = GetNamedArg(job.Args, "-Description") ?? string.Join(" ", job.Args);
             values["Args"] = description;
             values["PlansDirectory"] = _configService.PlanFolder;
+
+            var planId = AllocatePlanId(_configService.PlanFolder);
+            values["PlanId"] = planId;
+            job.AllocatedPlanId = planId;
         }
         else
         {
@@ -1499,19 +1503,114 @@ public class JobService : IJobService
             }
             else if (!duplicate)
             {
-                // Agent exited 0 but didn't create a plan or detect a duplicate — flag it
-                job.EnqueueOutput(
-                    "[Tendril] WARNING: CreatePlan completed but no plan folder or trash entry was found.");
-                job.Status = JobStatus.Failed;
+                // Fallback: check filesystem for plan folder matching the allocated PlanId
+                var planFolder = FindPlanFolderById(plansDir, job.AllocatedPlanId);
+                if (planFolder != null)
+                {
+                    job.PlanFile = planFolder;
+                }
+                else
+                {
+                    // Check Trash directory for duplicate entries
+                    var trashDir = _configService != null
+                        ? Path.Combine(_configService.TendrilHome, "Trash")
+                        : null;
+                    var trashEntry = trashDir != null && !string.IsNullOrEmpty(job.AllocatedPlanId)
+                        ? FindTrashEntryById(trashDir, job.AllocatedPlanId)
+                        : null;
 
-                // Check for failure artifact to provide better diagnostics
-                var failureMessage = TryReadFailureArtifact(job.OutputLines.ToList());
-                job.StatusMessage = failureMessage ?? "No plan created";
+                    if (trashEntry != null)
+                    {
+                        // Agent trashed as duplicate but didn't output the marker text
+                    }
+                    else
+                    {
+                        job.EnqueueOutput(
+                            "[Tendril] WARNING: CreatePlan completed but no plan folder or trash entry was found.");
+                        job.Status = JobStatus.Failed;
+
+                        var failureMessage = TryReadFailureArtifact(job.OutputLines.ToList());
+                        job.StatusMessage = failureMessage ?? "No plan created";
+                    }
+                }
             }
         }
         catch
         {
             /* Don't let verification failures crash job completion */
+        }
+    }
+
+    private static string? FindPlanFolderById(string plansDir, string? planId)
+    {
+        if (string.IsNullOrEmpty(planId)) return null;
+
+        try
+        {
+            var matches = Directory.GetDirectories(plansDir, $"{planId}-*");
+            return matches.Length > 0 ? Path.GetFileName(matches[0]) : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? FindTrashEntryById(string trashDir, string planId)
+    {
+        if (!Directory.Exists(trashDir)) return null;
+
+        try
+        {
+            var matches = Directory.GetFiles(trashDir, $"{planId}-*.md");
+            return matches.Length > 0 ? matches[0] : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string AllocatePlanId(string plansDir)
+    {
+        Directory.CreateDirectory(plansDir);
+        var counterFile = Path.Combine(plansDir, ".counter");
+        var lockFile = Path.Combine(plansDir, ".counter.lock");
+
+        FileStream? lockStream = null;
+        try
+        {
+            for (var i = 0; i < 20; i++)
+            {
+                try
+                {
+                    lockStream = new FileStream(lockFile, FileMode.OpenOrCreate, FileAccess.ReadWrite,
+                        FileShare.None);
+                    break;
+                }
+                catch (IOException)
+                {
+                    Thread.Sleep(500);
+                }
+            }
+
+            if (lockStream == null)
+                throw new InvalidOperationException("Could not acquire plan counter lock");
+
+            var counter = 1;
+            if (File.Exists(counterFile))
+            {
+                var text = File.ReadAllText(counterFile).Trim();
+                if (int.TryParse(text, out var parsed)) counter = parsed;
+            }
+
+            var id = counter.ToString("D5");
+            File.WriteAllText(counterFile, (counter + 1).ToString());
+            return id;
+        }
+        finally
+        {
+            lockStream?.Dispose();
         }
     }
 


### PR DESCRIPTION
## Summary
- The migration from .ps1 scripts to agent-direct C# (`be740d0`) removed the `MakePlan.ps1` wrapper that wrote `Plan created: <folder>` to stdout
- `VerifyCreatePlanResult` still depended on that stdout marker, causing every successful plan creation to be marked Failed/"No plan created"
- Adds `AllocatePlanId()` to C# path and passes PlanId in firmware header
- Adds filesystem fallback: scans PlansDirectory for `{PlanId}-*` folders and Trash/ for duplicate entries

## Test plan
- [x] All 135 JobService tests pass
- [x] Build succeeds with 0 warnings