### PR TITLE
Fix CLI commands silently falling through to server startup (#128)

### DIFF
--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -113,20 +113,13 @@ public class Program
                 });
             });
 
-            try
+            // Check if this is a recognized CLI command
+            var firstArg = filteredArgs[0];
+            if (firstArg == "doctor" || firstArg == "db-version" || firstArg == "db-migrate" ||
+                firstArg == "db-reset" || firstArg == "update-promptwares" || firstArg == "plan" ||
+                firstArg == "promptware")
             {
-                // Check if this is a recognized CLI command
-                var firstArg = filteredArgs[0];
-                if (firstArg == "doctor" || firstArg == "db-version" || firstArg == "db-migrate" ||
-                    firstArg == "db-reset" || firstArg == "update-promptwares" || firstArg == "plan" ||
-                    firstArg == "promptware")
-                {
-                    return app.Run(filteredArgs);
-                }
-            }
-            catch (Exception)
-            {
-                // If command parsing fails, fall through to legacy handlers
+                return app.Run(filteredArgs);
             }
         }
 


### PR DESCRIPTION
## Summary

- Remove try/catch around CLI command dispatch in `Program.cs` that swallowed Spectre.Console parse errors
- Previously, unrecognized flags (e.g. `--find-available-port` on `plan create`) silently fell through to starting the full web server
- Now recognized CLI commands properly propagate errors, giving users a clear error message for invalid flags

Closes #128