### PR TITLE
Use sidebarHeader slot for sticky search/filter headers

### DIFF
--- a/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
@@ -20,45 +20,10 @@ public class SidebarView(
 
     public override object Build()
     {
-        var filtersOpen = UseState(false);
-
         var filteredPlans =
             PlanFilters.ApplyFilters(_plans, _projectFilter.Value, _levelFilter.Value, _textFilter.Value);
 
-        var levelOptions = _config.LevelNames;
-
-        var levelFilteredPlans = _plans.AsEnumerable();
-        if (_levelFilter.Value is { } level)
-            levelFilteredPlans = levelFilteredPlans.Where(p => p.Level == level);
-
-        var projectCounts = levelFilteredPlans
-            .GroupBy(p => p.Project)
-            .OrderByDescending(g => g.Count())
-            .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
-            .ToArray<IAnyOption>();
-
-        var searchInput = _textFilter.ToSearchInput()
-            .Placeholder("Search...")
-            .Suffix(
-                new Button()
-                    .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
-                    .Ghost()
-                    .Small()
-                    .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
-            );
-
-        var header = Layout.Vertical() | searchInput;
-
-        if (filtersOpen.Value)
-        {
-            header |= Layout.Vertical()
-                      | _projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
-                          .WithField().Label("Project")
-                      | _levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
-                          .WithField().Label("Level");
-        }
-
-        var content = new List(filteredPlans.Select(plan =>
+        return new List(filteredPlans.Select(plan =>
         {
             var clickablePlan = plan;
             return new ListItem($"#{plan.Id} {plan.Title}")
@@ -68,7 +33,5 @@ public class SidebarView(
                          | new Badge(plan.Level).Variant(_config.GetBadgeVariant(plan.Level)).Small())
                 .OnClick(() => _selectedPlanState.Set(clickablePlan));
         }));
-
-        return new HeaderLayout(header, content);
     }
 }

--- a/src/Ivy.Tendril/Apps/IceboxApp.cs
+++ b/src/Ivy.Tendril/Apps/IceboxApp.cs
@@ -53,12 +53,44 @@ public class IceboxApp : ViewBase
 
         previousPlans.Value = filteredPlans;
 
+        var filtersOpen = UseState(false);
+
+        var levelFilteredPlans = plans.AsEnumerable();
+        if (levelFilter.Value is { } level)
+            levelFilteredPlans = levelFilteredPlans.Where(p => p.Level == level);
+        var projectCounts = levelFilteredPlans
+            .GroupBy(p => p.Project)
+            .OrderByDescending(g => g.Count())
+            .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
+            .ToArray<IAnyOption>();
+        var levelOptions = configService.LevelNames;
+
+        var searchInput = textFilter.ToSearchInput()
+            .Placeholder("Search...")
+            .Suffix(
+                new Button()
+                    .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
+                    .Ghost()
+                    .Small()
+                    .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
+            );
+        var sidebarHeader = Layout.Vertical() | searchInput;
+        if (filtersOpen.Value)
+        {
+            sidebarHeader |= Layout.Vertical()
+                | projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
+                    .WithField().Label("Project")
+                | levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
+                    .WithField().Label("Level");
+        }
+
         var sidebar = new SidebarView(plans, selectedPlanState, projectFilter, levelFilter, textFilter, configService);
 
         return new SidebarLayout(
             new ContentView(selectedPlanState.Value, filteredPlans, selectedPlanState, planService, jobService,
                 RefreshPlans, configService),
-            sidebar
+            sidebar,
+            sidebarHeader: sidebarHeader
         );
 
         void RefreshPlans()

--- a/src/Ivy.Tendril/Apps/Plans/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/SidebarView.cs
@@ -13,45 +13,10 @@ public class SidebarView(
 {
     public override object Build()
     {
-        var filtersOpen = UseState(false);
-
         var filteredPlans =
             PlanFilters.ApplyFilters(plans, projectFilter.Value, levelFilter.Value, textFilter.Value);
 
-        var levelOptions = config.LevelNames;
-
-        var levelFilteredPlans = plans.AsEnumerable();
-        if (levelFilter.Value is { } level)
-            levelFilteredPlans = levelFilteredPlans.Where(p => p.Level == level);
-
-        var projectCounts = levelFilteredPlans
-            .GroupBy(p => p.Project)
-            .OrderByDescending(g => g.Count())
-            .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
-            .ToArray<IAnyOption>();
-
-        var searchInput = textFilter.ToSearchInput()
-            .Placeholder("Search...")
-            .Suffix(
-                new Button()
-                    .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
-                    .Ghost()
-                    .Small()
-                    .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
-            );
-
-        var header = Layout.Vertical() | searchInput;
-
-        if (filtersOpen.Value)
-        {
-            header |= Layout.Vertical()
-                      | projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
-                          .WithField().Label("Project")
-                      | levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
-                          .WithField().Label("Level");
-        }
-
-        var content = new List(filteredPlans.Select(plan =>
+        return new List(filteredPlans.Select(plan =>
         {
             var clickablePlan = plan;
             var stateBadgeVariant = StatusMappings.PlanStatusBadgeVariants.TryGetValue(plan.Status, out var variant)
@@ -73,7 +38,5 @@ public class SidebarView(
                 .Content(badges)
                 .OnClick(() => selectedPlanState.Set(clickablePlan));
         }));
-
-        return new HeaderLayout(header, content);
     }
 }

--- a/src/Ivy.Tendril/Apps/PlansApp.cs
+++ b/src/Ivy.Tendril/Apps/PlansApp.cs
@@ -58,12 +58,45 @@ public class PlansApp : ViewBase
 
         previousPlans.Value = filteredPlans;
 
+        var filtersOpen = UseState(false);
+
+        // Compute project counts for filter dropdown
+        var levelFilteredPlans = plans.AsEnumerable();
+        if (levelFilter.Value is { } level)
+            levelFilteredPlans = levelFilteredPlans.Where(p => p.Level == level);
+        var projectCounts = levelFilteredPlans
+            .GroupBy(p => p.Project)
+            .OrderByDescending(g => g.Count())
+            .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
+            .ToArray<IAnyOption>();
+        var levelOptions = configService.LevelNames;
+
+        var searchInput = textFilter.ToSearchInput()
+            .Placeholder("Search...")
+            .Suffix(
+                new Button()
+                    .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
+                    .Ghost()
+                    .Small()
+                    .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
+            );
+        var sidebarHeader = Layout.Vertical() | searchInput;
+        if (filtersOpen.Value)
+        {
+            sidebarHeader |= Layout.Vertical()
+                | projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
+                    .WithField().Label("Project")
+                | levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
+                    .WithField().Label("Level");
+        }
+
         var sidebar = new SidebarView(plans, selectedPlanState, projectFilter, levelFilter, textFilter, configService);
 
         return new SidebarLayout(
             new ContentView(selectedPlanState.Value, filteredPlans, selectedPlanState, planService, jobService,
                 RefreshPlans, configService, gitService),
-            sidebar
+            sidebar,
+            sidebarHeader: sidebarHeader
         );
 
         void RefreshPlans()

--- a/src/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -21,49 +21,7 @@ public class SidebarView(
     private readonly IState<string?> _textFilter = textFilter;
     private readonly int _totalCount = totalCount;
 
-    private object BuildHeader(IState<bool> filtersOpen)
-    {
-        var projectOptions = _recommendations
-            .GroupBy(r => r.Project)
-            .OrderByDescending(g => g.Count())
-            .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
-            .ToArray<IAnyOption>();
-
-        var searchInput = _textFilter.ToSearchInput()
-            .Placeholder("Search...")
-            .Suffix(
-                new Button()
-                    .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
-                    .Ghost()
-                    .Small()
-                    .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
-            );
-
-        var header = Layout.Vertical() | searchInput;
-
-        if (filtersOpen.Value)
-        {
-            var impactLevelOptions = new[] { "Small", "Medium", "High" }
-                .Select(l => new Option<string>(l, l))
-                .ToArray<IAnyOption>();
-
-            var riskLevelOptions = new[] { "Small", "Medium", "High" }
-                .Select(l => new Option<string>(l, l))
-                .ToArray<IAnyOption>();
-
-            header |= Layout.Vertical()
-                      | _projectFilter.ToSelectInput(projectOptions).Placeholder("All Projects").Nullable()
-                          .WithField().Label("Project")
-                      | _impactFilter.ToSelectInput(impactLevelOptions).Placeholder("All Impacts").Nullable()
-                          .WithField().Label("Impact")
-                      | _riskFilter.ToSelectInput(riskLevelOptions).Placeholder("All Risk Levels").Nullable()
-                          .WithField().Label("Risk");
-        }
-
-        return header;
-    }
-
-    private object BuildContent()
+    public override object Build()
     {
         var filtered = _recommendations
             .Where(r => _projectFilter.Value == null || r.Project == _projectFilter.Value)
@@ -91,18 +49,11 @@ public class SidebarView(
             var clickableRec = rec;
 
             var preview = rec.Description.Length > 120
-                ? rec.Description[..120] + "…"
+                ? rec.Description[..120] + "..."
                 : rec.Description;
 
             return new ListItem($"#{rec.PlanId} {rec.Title}", preview)
                 .OnClick(() => _selectedState.Set(clickableRec));
         }));
-    }
-
-    public override object Build()
-    {
-        var filtersOpen = UseState(false);
-
-        return new HeaderLayout(BuildHeader(filtersOpen), BuildContent());
     }
 }

--- a/src/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -55,6 +55,42 @@ public class RecommendationsApp : ViewBase
                                impactFilter.Value != null || riskFilter.Value != null ||
                                !string.IsNullOrWhiteSpace(textFilter.Value);
 
+        var filtersOpen = UseState(false);
+
+        var projectOptions = allPending
+            .GroupBy(r => r.Project)
+            .OrderByDescending(g => g.Count())
+            .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
+            .ToArray<IAnyOption>();
+
+        var searchInput = textFilter.ToSearchInput()
+            .Placeholder("Search...")
+            .Suffix(
+                new Button()
+                    .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
+                    .Ghost()
+                    .Small()
+                    .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
+            );
+        var sidebarHeader = Layout.Vertical() | searchInput;
+        if (filtersOpen.Value)
+        {
+            var impactLevelOptions = new[] { "Small", "Medium", "High" }
+                .Select(l => new Option<string>(l, l))
+                .ToArray<IAnyOption>();
+            var riskLevelOptions = new[] { "Small", "Medium", "High" }
+                .Select(l => new Option<string>(l, l))
+                .ToArray<IAnyOption>();
+
+            sidebarHeader |= Layout.Vertical()
+                | projectFilter.ToSelectInput(projectOptions).Placeholder("All Projects").Nullable()
+                    .WithField().Label("Project")
+                | impactFilter.ToSelectInput(impactLevelOptions).Placeholder("All Impacts").Nullable()
+                    .WithField().Label("Impact")
+                | riskFilter.ToSelectInput(riskLevelOptions).Placeholder("All Risk Levels").Nullable()
+                    .WithField().Label("Risk");
+        }
+
         var sidebar = new SidebarView(
             allPending,
             selectedState,
@@ -68,7 +104,8 @@ public class RecommendationsApp : ViewBase
 
         return new SidebarLayout(
             new ContentView(selectedState.Value, filtered, selectedState, planService, jobService, Refresh),
-            sidebar
+            sidebar,
+            sidebarHeader: sidebarHeader
         );
     }
 }

--- a/src/Ivy.Tendril/Apps/Review/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/SidebarView.cs
@@ -9,7 +9,6 @@ public class SidebarView(
     IState<string?> projectFilter,
     IState<string?> levelFilter,
     IState<string?> textFilter,
-    IState<bool> showCompleted,
     IConfigService config) : ViewBase
 {
     private readonly IConfigService _config = config;
@@ -18,49 +17,12 @@ public class SidebarView(
     private readonly IState<string?> _projectFilter = projectFilter;
     private readonly IState<string?> _levelFilter = levelFilter;
     private readonly IState<string?> _textFilter = textFilter;
-    private readonly IState<bool> _showCompleted = showCompleted;
 
     public override object Build()
     {
-        var filtersOpen = UseState(false);
-
         var filteredPlans = PlanFilters.ApplyFilters(_plans, _projectFilter.Value, _levelFilter.Value, _textFilter.Value);
 
-        var levelOptions = _config.LevelNames;
-
-        var levelFilteredPlans = _plans.AsEnumerable();
-        if (_levelFilter.Value is { } level)
-            levelFilteredPlans = levelFilteredPlans.Where(p => p.Level == level);
-
-        var projectCounts = levelFilteredPlans
-            .GroupBy(p => p.Project)
-            .OrderByDescending(g => g.Count())
-            .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
-            .ToArray<IAnyOption>();
-
-        var searchInput = _textFilter.ToSearchInput()
-            .Placeholder("Search...")
-            .Suffix(
-                new Button()
-                    .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
-                    .Ghost()
-                    .Small()
-                    .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
-            );
-
-        var header = Layout.Vertical() | searchInput;
-
-        if (filtersOpen.Value)
-        {
-            header |= Layout.Vertical()
-                      | _projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
-                          .WithField().Label("Project")
-                      | _levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
-                          .WithField().Label("Level")
-                      | _showCompleted.ToBoolInput("Show Completed");
-        }
-
-        var content = new List(filteredPlans.Select(plan =>
+        return new List(filteredPlans.Select(plan =>
         {
             var clickablePlan = plan;
             var verificationsPassed = plan.Verifications.Count > 0
@@ -76,7 +38,5 @@ public class SidebarView(
                 )
                 .OnClick(() => _selectedPlanState.Set(clickablePlan));
         }));
-
-        return new HeaderLayout(header, content);
     }
 }

--- a/src/Ivy.Tendril/Apps/ReviewApp.cs
+++ b/src/Ivy.Tendril/Apps/ReviewApp.cs
@@ -62,12 +62,45 @@ public class ReviewApp : ViewBase
 
         previousPlans.Value = filteredPlans;
 
-        var sidebar = new SidebarView(plans, selectedPlanState, projectFilter, levelFilter, textFilter, showCompleted, configService);
+        var filtersOpen = UseState(false);
+
+        var levelFilteredPlans = plans.AsEnumerable();
+        if (levelFilter.Value is { } level)
+            levelFilteredPlans = levelFilteredPlans.Where(p => p.Level == level);
+        var projectCounts = levelFilteredPlans
+            .GroupBy(p => p.Project)
+            .OrderByDescending(g => g.Count())
+            .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
+            .ToArray<IAnyOption>();
+        var levelOptions = configService.LevelNames;
+
+        var searchInput = textFilter.ToSearchInput()
+            .Placeholder("Search...")
+            .Suffix(
+                new Button()
+                    .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
+                    .Ghost()
+                    .Small()
+                    .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
+            );
+        var sidebarHeader = Layout.Vertical() | searchInput;
+        if (filtersOpen.Value)
+        {
+            sidebarHeader |= Layout.Vertical()
+                | projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
+                    .WithField().Label("Project")
+                | levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
+                    .WithField().Label("Level")
+                | showCompleted.ToBoolInput("Show Completed");
+        }
+
+        var sidebar = new SidebarView(plans, selectedPlanState, projectFilter, levelFilter, textFilter, configService);
 
         return new SidebarLayout(
             new ContentView(selectedPlanState.Value, filteredPlans, selectedPlanState, planService, jobService,
                 RefreshPlans, configService, gitService),
-            sidebar
+            sidebar,
+            sidebarHeader: sidebarHeader
         );
 
         void RefreshPlans()

--- a/src/Ivy.Tendril/Apps/Trash/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Trash/SidebarView.cs
@@ -25,25 +25,20 @@ public class SidebarView(
 
         var filteredList = filteredFiles.ToList();
 
-        var header = _searchFilter.ToSearchInput().Placeholder("Search trash...");
-
-        object content;
         if (filteredList.Count == 0)
-            content = Layout.Vertical().AlignContent(Align.Center).Gap(2).Padding(4)
-                      | new Icon(Icons.Trash2).Size(Size.Units(6)).Color(Colors.Gray)
-                      | Text.Muted("No trash items")
-                      | Text.Muted("Duplicate plans will appear here").Small();
-        else
-            content = new List(filteredList.Select(f =>
-            {
-                var item = f;
-                return new ListItem(item.FileName.Replace(".md", ""))
-                    .Content(Layout.Horizontal().Gap(1)
-                             | new Badge(item.Project).Variant(BadgeVariant.Outline).Small()
-                             | Text.Muted(item.Date.ToString("yyyy-MM-dd")).Small())
-                    .OnClick(() => _selectedFile.Set(item.FilePath));
-            }));
+            return Layout.Vertical().AlignContent(Align.Center).Gap(2).Padding(4)
+                   | new Icon(Icons.Trash2).Size(Size.Units(6)).Color(Colors.Gray)
+                   | Text.Muted("No trash items")
+                   | Text.Muted("Duplicate plans will appear here").Small();
 
-        return new HeaderLayout(header, content);
+        return new List(filteredList.Select(f =>
+        {
+            var item = f;
+            return new ListItem(item.FileName.Replace(".md", ""))
+                .Content(Layout.Horizontal().Gap(1)
+                         | new Badge(item.Project).Variant(BadgeVariant.Outline).Small()
+                         | Text.Muted(item.Date.ToString("yyyy-MM-dd")).Small())
+                .OnClick(() => _selectedFile.Set(item.FilePath));
+        }));
     }
 }

--- a/src/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/Ivy.Tendril/Apps/TrashApp.cs
@@ -54,6 +54,8 @@ public class TrashApp : ViewBase
 
         var selected = filteredList.FirstOrDefault(f => f.FilePath == selectedFile.Value);
 
+        var sidebarHeader = searchFilter.ToSearchInput().Placeholder("Search trash...");
+
         var sidebar = new SidebarView(files, selectedFile, searchFilter);
 
         // Main content
@@ -111,7 +113,8 @@ public class TrashApp : ViewBase
         {
             new SidebarLayout(
                 mainContent,
-                sidebar
+                sidebar,
+                sidebarHeader: sidebarHeader
             )
         };
 


### PR DESCRIPTION
## Summary
- Move search/filter header UI from SidebarView into App files
- Pass headers via `sidebarHeader` slot of SidebarLayout (renders as shrink-0, non-scrolling)
- SidebarView now returns just the list content
- Applies to: Drafts, Review, Icebox, Recommendations, and Trash

## Test plan
- [ ] Verify sidebar search/filter header stays fixed when scrolling in all apps
- [ ] Verify sidebar list content still scrolls properly
- [ ] Verify filter toggle (expand/collapse) still works
- [ ] Verify search filtering still works
- [ ] Verify plan selection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)