### PR TITLE
[03452] Fix missing tooltips in Dashboard bar chart

### DIFF
--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -166,7 +166,7 @@ public class DashboardApp : ViewBase
                 style: BarChartStyles.Default,
                 polish: chart => chart with
                 {
-                    Tooltip = new ChartTooltip(),
+                    Tooltip = new ChartTooltip().Animated(true),
                     Bars =
                     [
                         new Bar(costMeasureName).Radius(0).YAxisIndex(0),


### PR DESCRIPTION
# Summary

## Changes

Fixed missing tooltips in the Dashboard hourly cost/tokens bar chart by adding animation to the `ChartTooltip` configuration. The tooltip now displays when hovering over bars, providing visual feedback with smooth animation.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/DashboardApp.cs:169` — Added `.Animated(true)` to `ChartTooltip` configuration in the chart polish callback.


## Commits

- 49777c5fb9d3e7ca66f28c4958d6c8d20750e104