### PR TITLE
Add buildDependencies config for read-only worktree repos

### DIFF
--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -216,7 +216,7 @@ fi
 
 ### 2. Create Worktrees
 
-For each repo listed in `plan.yaml` `repos` (or the project's repos from `config.yaml` if empty):
+For each repo in `RepoConfigs` (this includes both the plan's repos AND any read-only build dependencies from the project config):
 
 1. Fetch latest from remote: `git fetch origin`
 2. Determine the base branch:
@@ -260,14 +260,22 @@ git worktree add "<PlanFolder>/worktrees/<RepoName>" -b "tendril/<PlanId>-<SafeT
 
 **Important:** Always branch from `origin/<resolved-base-branch>`, not local HEAD. This ensures the PR only contains the plan's commits, not any unpushed local work. The `<resolved-base-branch>` comes from either the `RepoConfigs` firmware header (if `baseBranch` is configured) or auto-detection.
 
-**Note on `RepoConfigs`:** The firmware header may include a `RepoConfigs` value injected by ExecutePlan.ps1. It contains per-repo configuration from `config.yaml`:
+**Note on `RepoConfigs`:** The firmware header may include a `RepoConfigs` value injected by Tendril. It contains per-repo configuration from `config.yaml`:
 ```yaml
 RepoConfigs: |
-  Ivy-Framework:
-    baseBranch: develop
-    syncStrategy: rebase
+  - path: D:\Repos\Ivy-Tendril
+    baseBranch: development
+    syncStrategy: fetch
+    prRule: yolo
+  - path: D:\Repos\Ivy-Framework
+    baseBranch: development
+    syncStrategy: fetch
+    prRule: default
+    readOnly: true
 ```
 If `baseBranch` is present for a repo, use it instead of auto-detecting. If absent, fall back to `git symbolic-ref refs/remotes/origin/HEAD`.
+
+**Read-only repos** (`readOnly: true`) are build dependencies — they need worktrees so that cross-repo project references resolve, but you must NOT make changes, commits, or PRs in them. Create their worktrees the same way (branching from `origin/<baseBranch>`), but skip them during implementation steps 3-5.
 
 4. After creating the worktree, **verify the `.git` file exists** and fail fast if it's missing:
 

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -31,6 +31,7 @@ public record ProjectConfig
     public string Context { get; set; } = "";
     public List<ReviewActionConfig> ReviewActions { get; set; } = new();
     public List<PromptwareHookConfig> Hooks { get; set; } = new();
+    public List<string> BuildDependencies { get; set; } = new();
     public List<string> RepoPaths => Repos.Select(r => r.Path).ToList();
 
     public string? GetMeta(string key)
@@ -594,9 +595,14 @@ public class ConfigService : IConfigService
     {
         if (Settings.Projects != null)
             foreach (var proj in Settings.Projects)
+            {
                 if (proj.Repos != null)
                     foreach (var repo in proj.Repos)
                         repo.Path = VariableExpansion.ExpandVariables(repo.Path, TendrilHome);
+
+                for (var i = 0; i < proj.BuildDependencies.Count; i++)
+                    proj.BuildDependencies[i] = VariableExpansion.ExpandVariables(proj.BuildDependencies[i], TendrilHome);
+            }
     }
 
     internal static string? MigrateProjectColor(string? colorValue)

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -952,38 +952,51 @@ public class JobService : IJobService
     {
         if (plan.Repos.Count == 0) return null;
 
+        var projectConfig = _configService?.GetProject(project);
+        var planRepoNames = new HashSet<string>(
+            plan.Repos.Select(r => Path.GetFileName(Environment.ExpandEnvironmentVariables(r))),
+            StringComparer.OrdinalIgnoreCase);
+
         var lines = new List<string>();
-        foreach (var repoPath in plan.Repos)
+
+        void AddRepo(string expanded, string baseBranch, string syncStrategy, string prRule, bool readOnly)
         {
-            var expanded = Environment.ExpandEnvironmentVariables(repoPath);
-            var repoName = Path.GetFileName(expanded);
-
-            // Get repo-specific config from project settings
-            string baseBranch = "main";
-            string syncStrategy = "fetch";
-            string prRule = "default";
-
-            if (_configService != null)
-            {
-                var projectConfig = _configService.GetProject(project);
-                if (projectConfig != null)
-                {
-                    var repoRef = projectConfig.Repos.FirstOrDefault(r =>
-                        Path.GetFileName(Environment.ExpandEnvironmentVariables(r.Path))
-                            .Equals(repoName, StringComparison.OrdinalIgnoreCase));
-                    if (repoRef != null)
-                    {
-                        baseBranch = repoRef.BaseBranch ?? "main";
-                        syncStrategy = repoRef.SyncStrategy;
-                        prRule = repoRef.PrRule;
-                    }
-                }
-            }
-
             lines.Add($"- path: {expanded}");
             lines.Add($"  baseBranch: {baseBranch}");
             lines.Add($"  syncStrategy: {syncStrategy}");
             lines.Add($"  prRule: {prRule}");
+            if (readOnly)
+                lines.Add("  readOnly: true");
+        }
+
+        RepoRef? FindRepoRef(string repoName)
+        {
+            return projectConfig?.Repos.FirstOrDefault(r =>
+                Path.GetFileName(Environment.ExpandEnvironmentVariables(r.Path))
+                    .Equals(repoName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        foreach (var repoPath in plan.Repos)
+        {
+            var expanded = Environment.ExpandEnvironmentVariables(repoPath);
+            var repoRef = FindRepoRef(Path.GetFileName(expanded));
+            AddRepo(expanded,
+                repoRef?.BaseBranch ?? "main",
+                repoRef?.SyncStrategy ?? "fetch",
+                repoRef?.PrRule ?? "default",
+                false);
+        }
+
+        // Include build dependencies as read-only worktrees
+        if (projectConfig != null)
+        {
+            foreach (var depPath in projectConfig.BuildDependencies)
+            {
+                var expanded = Environment.ExpandEnvironmentVariables(depPath);
+                var repoName = Path.GetFileName(expanded);
+                if (!planRepoNames.Contains(repoName))
+                    AddRepo(expanded, "main", "fetch", "default", true);
+            }
         }
 
         return string.Join("\n", lines);

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -118,6 +118,11 @@ promptwares:
 #         promptwares: [CreatePr]
 #         condition: ''
 #         action: pwsh -NoProfile -File %TENDRIL_HOME%/Hooks/NotifySlack.ps1
+#     # buildDependencies — repos needed for building but not modified by plans.
+#     # Worktrees are created for these repos (read-only) so cross-repo project
+#     # references resolve during build. No commits or PRs are created for them.
+#     buildDependencies:
+#       - "%REPOS_HOME%/shared-framework"
 projects: []
 
 # Standard verification definitions — these prompts are used when verifications are referenced by projects.


### PR DESCRIPTION
## Summary
- New `buildDependencies` field on `ProjectConfig` — lists repos needed for building but not modified by plans
- `BuildRepoConfigsYaml` appends these as `readOnly: true` entries in the RepoConfigs firmware
- ExecutePlan instructions updated to create worktrees for read-only repos and skip them during implementation
- Fixes Tendril worktree builds failing because Ivy-Framework wasn't present as a sibling worktree

## Test plan
- [ ] Verify Tendril config loads with `buildDependencies` field
- [ ] Run ExecutePlan on a Tendril plan — confirm Ivy-Framework worktree is created
- [ ] Verify `dotnet build` succeeds in the worktree with IvySource=true