### PR TITLE
[03454] Add Worktrees Section To Git Tab In Plans App

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -290,74 +290,21 @@ public class ContentView(
                 );
             }
 
-            // Git tab content (combines commits and PRs)
-            var gitLayout = Layout.Vertical().Gap(2);
-
-            var problematicCommits = planData.CommitRows
-                .Where(r => string.IsNullOrEmpty(r.Title) || r.FileCount == 0)
-                .ToList();
-
-            if (problematicCommits.Count > 0)
-            {
-                var warnings = problematicCommits.Select(r =>
+            // Git tab content (uses shared helper)
+            var gitData = GitTabHelper.BuildGitTabData(_selectedPlan!, _config, _gitService);
+            var gitLayout = GitTabHelper.RenderGitTab(
+                gitData,
+                _selectedPlan!,
+                client,
+                _config,
+                hash => openCommit.Set(hash),
+                path =>
                 {
-                    if (string.IsNullOrEmpty(r.Title))
-                        return $"`{r.ShortHash}` — commit not found or has no message";
-                    return $"`{r.ShortHash}` — commit has no file changes";
-                });
-                gitLayout |= Callout.Warning(
-                    string.Join("\n", warnings),
-                    "Potentially corrupted commits");
-            }
-
-            if (_selectedPlan.Commits.Count > 0)
-            {
-                gitLayout |= Text.Block("Commits").Bold();
-                var commitsTable = new Table(
-                    new TableRow(
-                            new TableCell("Commit").IsHeader(),
-                            new TableCell("Message").IsHeader(),
-                            new TableCell("Files").IsHeader()
-                        )
-                    { IsHeader = true }
-                );
-                foreach (var row in planData.CommitRows)
-                    commitsTable |= new TableRow(
-                        new TableCell(new Button(row.ShortHash).Inline().OnClick(() => openCommit.Set(row.Hash))),
-                        new TableCell(row.Title),
-                        new TableCell(row.FileCount?.ToString() ?? "–")
-                    );
-                gitLayout |= commitsTable;
-            }
-
-            if (_selectedPlan.Prs.Count > 0)
-            {
-                if (_selectedPlan.Commits.Count > 0)
-                    gitLayout |= new Separator();
-
-                gitLayout |= Text.Block("Pull Requests").Bold();
-                var prsTable = new Table(
-                    new TableRow(
-                            new TableCell("Repository").IsHeader(),
-                            new TableCell("PR").IsHeader()
-                        )
-                    { IsHeader = true }
-                );
-                foreach (var pr in _selectedPlan.Prs.Where(PullRequestApp.IsValidUrl))
-                {
-                    var prCapture = pr;
-                    prsTable |= new TableRow(
-                        new TableCell(PullRequestApp.ExtractRepo(pr)),
-                        new TableCell(new Button(pr).Link().OnClick(() => client.OpenUrl(prCapture)))
-                    );
+                    copyToClipboard(path);
+                    client.Toast("Copied path to clipboard", "Path Copied");
+                    return null!; // Return type doesn't matter, just need to satisfy Func
                 }
-                gitLayout |= prsTable;
-            }
-
-            if (_selectedPlan.Commits.Count == 0 && _selectedPlan.Prs.Count == 0)
-            {
-                gitLayout |= Text.Muted("No commits or pull requests yet.");
-            }
+            );
 
             // Changes tab content
             object changesTabContent;

--- a/src/Ivy.Tendril/Apps/Plans/GitTabHelper.cs
+++ b/src/Ivy.Tendril/Apps/Plans/GitTabHelper.cs
@@ -1,0 +1,195 @@
+using Ivy.Core;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Plans;
+
+public static class GitTabHelper
+{
+    public record GitTabData(
+        List<PlanContentHelpers.CommitRow> CommitRows,
+        List<WorktreeRow> WorktreeRows
+    );
+
+    public record WorktreeRow(
+        string Name,
+        string Path,
+        string Branch,
+        string ShortHash
+    );
+
+    public static GitTabData BuildGitTabData(
+        PlanFile plan,
+        IConfigService config,
+        IGitService gitService)
+    {
+        var commitRows = PlanContentHelpers.BuildCommitRows(plan, config, gitService);
+        var worktreeRows = BuildWorktreeRows(plan, config, gitService);
+
+        return new GitTabData(commitRows, worktreeRows);
+    }
+
+    private static List<WorktreeRow> BuildWorktreeRows(
+        PlanFile plan,
+        IConfigService config,
+        IGitService gitService)
+    {
+        var rows = new List<WorktreeRow>();
+        var worktreesDir = Path.Combine(plan.FolderPath, "worktrees");
+
+        if (!Directory.Exists(worktreesDir)) return rows;
+
+        var repoDirs = Directory.GetDirectories(worktreesDir);
+        foreach (var repoDir in repoDirs)
+        {
+            var worktrees = gitService.GetWorktrees(repoDir);
+            if (worktrees == null) continue;
+
+            // Find the worktree that matches this directory (not the main repo)
+            var worktree = worktrees.FirstOrDefault(w =>
+                Path.GetFullPath(w.Path).Equals(Path.GetFullPath(repoDir), StringComparison.OrdinalIgnoreCase));
+
+            if (worktree == null) continue;
+
+            var shortHash = worktree.CommitHash.Length > 7
+                ? worktree.CommitHash.Substring(0, 7)
+                : worktree.CommitHash;
+
+            rows.Add(new WorktreeRow(
+                Path.GetFileName(repoDir),
+                repoDir,
+                worktree.Branch,
+                shortHash
+            ));
+        }
+
+        return rows;
+    }
+
+    public static object RenderGitTab(
+        GitTabData gitData,
+        PlanFile plan,
+        IClientProvider client,
+        IConfigService config,
+        Action<string?> setOpenCommit,
+        Func<string, object> copyToClipboard)
+    {
+        var gitLayout = Layout.Vertical().Gap(2);
+
+        // Worktrees section (new)
+        if (gitData.WorktreeRows.Count > 0)
+        {
+            gitLayout |= Text.Block("Worktrees").Bold();
+            var worktreesTable = new Table(
+                new TableRow(
+                    new TableCell("Name").IsHeader(),
+                    new TableCell("Branch").IsHeader(),
+                    new TableCell("Commit").IsHeader(),
+                    new TableCell("Actions").IsHeader()
+                )
+                { IsHeader = true }
+            );
+
+            foreach (var row in gitData.WorktreeRows)
+            {
+                var pathCapture = row.Path;
+                var actionsMenu = new Button().Icon(Icons.EllipsisVertical).Ghost().Small()
+                    .WithDropDown(
+                        new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
+                            .OnSelect(() => PlatformHelper.OpenInFileManager(pathCapture)),
+                        new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal")
+                            .OnSelect(() => PlatformHelper.OpenInTerminal(pathCapture)),
+                        new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
+                            .OnSelect(() => config.OpenInEditor(pathCapture)),
+                        new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
+                            .OnSelect(() => copyToClipboard(pathCapture))
+                    );
+
+                worktreesTable |= new TableRow(
+                    new TableCell(row.Name),
+                    new TableCell(row.Branch),
+                    new TableCell(row.ShortHash),
+                    new TableCell(actionsMenu)
+                );
+            }
+
+            gitLayout |= worktreesTable;
+            gitLayout |= new Separator();
+        }
+
+        // Problematic commits warning
+        var problematicCommits = gitData.CommitRows
+            .Where(r => string.IsNullOrEmpty(r.Title) || r.FileCount == 0)
+            .ToList();
+
+        if (problematicCommits.Count > 0)
+        {
+            var warnings = problematicCommits.Select(r =>
+            {
+                if (string.IsNullOrEmpty(r.Title))
+                    return $"`{r.ShortHash}` — commit not found or has no message";
+                return $"`{r.ShortHash}` — commit has no file changes";
+            });
+            gitLayout |= Callout.Warning(
+                string.Join("\n", warnings),
+                "Potentially corrupted commits");
+        }
+
+        // Commits section
+        if (plan.Commits.Count > 0)
+        {
+            gitLayout |= Text.Block("Commits").Bold();
+            var commitsTable = new Table(
+                new TableRow(
+                    new TableCell("Commit").IsHeader(),
+                    new TableCell("Message").IsHeader(),
+                    new TableCell("Files").IsHeader()
+                )
+                { IsHeader = true }
+            );
+
+            foreach (var row in gitData.CommitRows)
+                commitsTable |= new TableRow(
+                    new TableCell(new Button(row.ShortHash).Inline().OnClick(() => setOpenCommit(row.Hash))),
+                    new TableCell(row.Title),
+                    new TableCell(row.FileCount?.ToString() ?? "–")
+                );
+
+            gitLayout |= commitsTable;
+        }
+
+        // Pull requests section
+        if (plan.Prs.Count > 0)
+        {
+            if (plan.Commits.Count > 0)
+                gitLayout |= new Separator();
+
+            gitLayout |= Text.Block("Pull Requests").Bold();
+            var prsTable = new Table(
+                new TableRow(
+                    new TableCell("Repository").IsHeader(),
+                    new TableCell("PR").IsHeader()
+                )
+                { IsHeader = true }
+            );
+
+            foreach (var pr in plan.Prs.Where(PullRequestApp.IsValidUrl))
+            {
+                var prCapture = pr;
+                prsTable |= new TableRow(
+                    new TableCell(PullRequestApp.ExtractRepo(pr)),
+                    new TableCell(new Button(pr).Link().OnClick(() => client.OpenUrl(prCapture)))
+                );
+            }
+
+            gitLayout |= prsTable;
+        }
+
+        // Empty state
+        if (plan.Commits.Count == 0 && plan.Prs.Count == 0 && gitData.WorktreeRows.Count == 0)
+        {
+            gitLayout |= Text.Muted("No worktrees, commits, or pull requests yet.");
+        }
+
+        return gitLayout;
+    }
+}

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -339,73 +339,21 @@ public class ContentView(
                 );
             }
 
-            // Git tab content (combines commits and PRs)
-            var gitLayout = Layout.Vertical().Gap(2);
-
-            var problematicCommits = planData.CommitRows
-                .Where(r => string.IsNullOrEmpty(r.Title) || r.FileCount == 0)
-                .ToList();
-
-            if (problematicCommits.Count > 0)
-            {
-                var warnings = problematicCommits.Select(r =>
+            // Git tab content (uses shared helper)
+            var gitData = GitTabHelper.BuildGitTabData(_selectedPlan!, _config, _gitService);
+            var gitLayout = GitTabHelper.RenderGitTab(
+                gitData,
+                _selectedPlan!,
+                client,
+                _config,
+                hash => openCommit.Set(hash),
+                path =>
                 {
-                    if (string.IsNullOrEmpty(r.Title))
-                        return $"`{r.ShortHash}` — commit not found or has no message";
-                    return $"`{r.ShortHash}` — commit has no file changes";
-                });
-                gitLayout |= Callout.Warning(
-                    string.Join("\n", warnings),
-                    "Potentially corrupted commits");
-            }
-
-            if (_selectedPlan.Commits.Count > 0)
-            {
-                gitLayout |= Text.Block("Commits").Bold();
-                var commitsTable = new Table(
-                    new TableRow(
-                            new TableCell("Commit").IsHeader(),
-                            new TableCell("Message").IsHeader(),
-                            new TableCell("Files").IsHeader()
-                        )
-                    { IsHeader = true }
-                );
-                foreach (var row in planData.CommitRows)
-                    commitsTable |= new TableRow(
-                        new TableCell(new Button(row.ShortHash).Inline().OnClick(() => openCommit.Set(row.Hash))),
-                        new TableCell(row.Title),
-                        new TableCell(row.FileCount?.ToString() ?? "–")
-                    );
-                gitLayout |= commitsTable;
-            }
-            if (_selectedPlan.Prs.Count > 0)
-            {
-                if (_selectedPlan.Commits.Count > 0)
-                    gitLayout |= new Separator();
-
-                gitLayout |= Text.Block("Pull Requests").Bold();
-                var prsTable = new Table(
-                    new TableRow(
-                            new TableCell("Repository").IsHeader(),
-                            new TableCell("PR").IsHeader()
-                        )
-                    { IsHeader = true }
-                );
-                foreach (var pr in _selectedPlan.Prs.Where(PullRequestApp.IsValidUrl))
-                {
-                    var prCapture = pr;
-                    prsTable |= new TableRow(
-                        new TableCell(PullRequestApp.ExtractRepo(pr)),
-                        new TableCell(new Button(pr).Link().OnClick(() => client.OpenUrl(prCapture)))
-                    );
+                    copyToClipboard(path);
+                    client.Toast("Copied path to clipboard", "Path Copied");
+                    return null!; // Return type doesn't matter, just need to satisfy Func
                 }
-                gitLayout |= prsTable;
-            }
-
-            if (_selectedPlan.Commits.Count == 0 && _selectedPlan.Prs.Count == 0)
-            {
-                gitLayout |= Text.Muted("No commits or pull requests yet.");
-            }
+            );
 
             // Artifacts tab content
             var artifactsLayout = Layout.Vertical().Gap(2);

--- a/src/Ivy.Tendril/Services/GitService.cs
+++ b/src/Ivy.Tendril/Services/GitService.cs
@@ -172,4 +172,67 @@ public class GitService : IGitService
             return null;
         }
     }
+
+    public List<WorktreeInfo>? GetWorktrees(string repoPath)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("git", "worktree list --porcelain")
+            {
+                WorkingDirectory = repoPath,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8
+            };
+            using var process = Process.Start(psi);
+            var output = process?.StandardOutput.ReadToEnd();
+            process.WaitForExitOrKill(_timeoutMs);
+            if (process?.ExitCode != 0 || output == null) return null;
+
+            var worktrees = new List<WorktreeInfo>();
+            var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+            string? currentPath = null;
+            string? currentBranch = null;
+            string? currentHash = null;
+
+            foreach (var line in lines)
+            {
+                if (line.StartsWith("worktree "))
+                {
+                    // Save previous worktree if complete
+                    if (currentPath != null && currentBranch != null && currentHash != null)
+                    {
+                        worktrees.Add(new WorktreeInfo(currentPath, currentBranch, currentHash));
+                    }
+
+                    currentPath = line.Substring(9).Trim();
+                    currentBranch = null;
+                    currentHash = null;
+                }
+                else if (line.StartsWith("HEAD "))
+                {
+                    currentHash = line.Substring(5).Trim();
+                }
+                else if (line.StartsWith("branch "))
+                {
+                    var branchRef = line.Substring(7).Trim();
+                    currentBranch = branchRef.Replace("refs/heads/", "");
+                }
+            }
+
+            // Save last worktree
+            if (currentPath != null && currentBranch != null && currentHash != null)
+            {
+                worktrees.Add(new WorktreeInfo(currentPath, currentBranch, currentHash));
+            }
+
+            return worktrees;
+        }
+        catch
+        {
+            return null; /* git may not be installed, or repo path invalid */
+        }
+    }
 }

--- a/src/Ivy.Tendril/Services/IGitService.cs
+++ b/src/Ivy.Tendril/Services/IGitService.cs
@@ -8,4 +8,7 @@ public interface IGitService
     int? GetCommitFileCount(string repoPath, string commitHash);
     string? GetCombinedDiff(string repoPath, string firstCommit, string lastCommit);
     List<(string Status, string FilePath)>? GetCombinedChangedFiles(string repoPath, string firstCommit, string lastCommit);
+    List<WorktreeInfo>? GetWorktrees(string repoPath);
 }
+
+public record WorktreeInfo(string Path, string Branch, string CommitHash);


### PR DESCRIPTION
# Summary

## Changes

Added a "Worktrees" section to the Git tab in both the Plans and Review apps. The section displays all worktrees in the plan's `worktrees/` directory with their branch name, commit hash, and context menu actions. Extracted duplicate Git tab rendering logic into a shared helper class to avoid code duplication between the two apps.

## API Changes

**IGitService** (new):
- `List<WorktreeInfo>? GetWorktrees(string repoPath)` — retrieves all worktrees for a repository
- `WorktreeInfo` record — contains `Path`, `Branch`, `CommitHash`

**GitTabHelper** (new static class):
- `GitTabData BuildGitTabData(PlanFile, IConfigService, IGitService)` — builds data for Git tab
- `object RenderGitTab(GitTabData, PlanFile, IClientProvider, IConfigService, Action<string?>, Func<string, object>)` — renders Git tab UI

## Files Modified

**Services:**
- `Services/IGitService.cs` — added GetWorktrees method and WorktreeInfo record
- `Services/GitService.cs` — implemented worktree listing using `git worktree list --porcelain`

**Apps:**
- `Apps/Plans/GitTabHelper.cs` (new) — shared Git tab rendering logic
- `Apps/Plans/ContentView.cs` — replaced inline Git tab code with GitTabHelper
- `Apps/Review/ContentView.cs` — replaced inline Git tab code with GitTabHelper


## Commits

- 54c5757