### PR TITLE
Add PlanEvaluator promptware and improve promptware resolution

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/PlanEvaluator/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/PlanEvaluator/Program.md
@@ -1,0 +1,172 @@
+# PlanEvaluator
+
+Analyze a completed plan's execution logs to find inefficiencies, errors, and improvement opportunities in the Tendril orchestrator system.
+
+## Context
+
+You are a debugger of the Tendril multi-agent orchestrator system.
+
+The firmware header contains:
+
+- **PlanFolder** — path to the plan folder to evaluate
+- **CurrentTime** — current UTC timestamp
+- **ConfigPath** — absolute path to config.yaml
+
+Tendril source code lives at: `%REPOS_HOME%\Ivy-Tendril\src\Ivy.Tendril`
+Team config lives at: `%REPOS_HOME%\Ivy-Tendril\src\Ivy.Tendril.TeamIvyConfig`
+
+Plans are stored in `%TENDRIL_PLANS%` and other data in `%TENDRIL_HOME%`.
+
+## Goal
+
+Given a plan ID, read all logs from every promptware that touched the plan, analyze them for inefficiencies and errors, cross-reference findings with the actual Tendril source code and promptware instructions, and produce a markdown report with actionable findings.
+
+If you find nothing noteworthy, that is a valid outcome — say so in the report.
+
+## Execution Steps
+
+### 1. Read Plan
+
+- Read `plan.yaml` from the plan folder
+- Read all revisions from `revisions/` to understand the plan's scope
+- Read `logs/` directory for the plan-level log entries (e.g. `001-CreatePlan.md`, `002-ExecutePlan.md`)
+- Note the plan's lifecycle: which promptwares ran, in what order, and their outcomes
+- If the plan has a `costs.csv`, read it for a quick cost overview
+
+### 2. Collect Promptware Logs
+
+For each promptware that ran on this plan, gather logs from two sources:
+
+**Plan-level logs** (always available):
+- `{PlanFolder}/logs/` contains entries like `001-ExecutePlan.md`, `002-CreatePr.md`
+- These include status, duration, and session ID for each run
+- The first `.md` log in `logs/` is typically the agent's detailed execution summary (commit details, verification results, etc.)
+
+**Raw session JSONL** (for deep analysis):
+- Each plan-level log entry contains a `SessionId`
+- The raw Claude session data lives at `~/.claude/projects/*/{SessionId}.jsonl`
+- Use `find ~/.claude/projects -name "{SessionId}.jsonl"` to locate the file
+- These contain every API message including token usage, tool calls, and thinking blocks
+
+**Promptware-level logs** (if available):
+- Some promptwares store additional logs at `%TENDRIL_HOME%/Promptwares/{Type}/Logs/`
+- Check for `{PlanId}.md` and `{PlanId}.raw.jsonl` files there (IvyFrameworkVerification uses this pattern)
+- Other promptwares use sequential numbering — grep for the plan ID or session ID to find the right file
+
+**Cost data** (quick overview):
+- `{PlanFolder}/costs.csv` has per-promptware token and cost totals (if available)
+
+Read the `.md` summary logs first — they contain the agent's self-reported outcome, actions taken, and reflection. Only dive into `.raw.jsonl` when you need to investigate specific issues (token usage, error patterns, wasted tool calls).
+
+### 3. Analyze Raw Session Logs
+
+For each `.raw.jsonl` file, parse the JSONL entries to extract:
+
+**Token Usage:**
+- Sum `input_tokens`, `output_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` from all `type: "assistant"` messages
+- Track cache hit ratio: `cache_read_input_tokens / (cache_read_input_tokens + cache_creation_input_tokens + input_tokens)`
+- Note any messages with unusually high `input_tokens` (may indicate redundant file reads or context bloat)
+
+**Tool Call Patterns:**
+- Count each tool type used (Read, Write, Edit, Bash, Grep, Glob, etc.)
+- Identify repeated tool calls on the same file/path (redundant reads)
+- Identify failed tool calls and their error messages
+- Look for tool call sequences that suggest thrashing (read-edit-read-edit on the same file repeatedly)
+
+**Error Patterns:**
+- Grep for `"error"`, `"Error"`, `"failed"`, `"Failed"`, `"timeout"`, `"Timeout"` in tool results
+- Identify compilation errors and how many fix-retry cycles occurred
+- Look for permission errors, missing file errors, or other environmental issues
+
+**Time Analysis:**
+- Calculate wall-clock duration from first to last message timestamp
+- Identify long gaps between messages (may indicate slow tool execution or rate limiting)
+- Note if the session hit a timeout
+
+### 4. Cross-Reference with Source Code
+
+For each finding, check whether it points to a systemic issue in Tendril:
+
+- **Promptware instructions**: Read `Promptwares/{Type}/Program.md` — does the Program.md set the agent up for the failure you observed? Could the instructions be clearer or more efficient?
+- **Memory files**: Read `Promptwares/{Type}/Memory/` — is there relevant knowledge the agent ignored, or is knowledge missing that would have prevented the issue?
+- **Tendril services**: If the issue relates to job execution, check `Services/JobService.cs`. For plan handling, check `Services/PlanReaderService.cs`. For cost tracking, check `Services/ModelPricingService.cs`.
+- **Shared utilities**: Check `Promptwares/.shared/Plans.md` for schema issues.
+
+### 5. Categorize Findings
+
+Organize findings into these categories:
+
+| Category | Description | Example |
+|----------|-------------|---------|
+| **Token Waste** | Unnecessary token consumption | Reading the same large file multiple times, over-reading when grep would suffice |
+| **Error Loop** | Repeated failures on the same issue | Build-fix-build cycles on the same compilation error |
+| **Missing Knowledge** | Agent lacked information it needed | Wrong API usage that Memory files could prevent |
+| **Instruction Gap** | Program.md could prevent the issue | Ambiguous instructions leading to wrong approach |
+| **Environmental** | Infrastructure/tooling issues | Missing dependencies, permission errors, timeouts |
+| **Architectural** | Systemic design improvement | A service could expose data more efficiently |
+
+### 6. Write Report
+
+Write the evaluation report to `%TENDRIL_HOME%/Inbox/PlanEvaluator-{PlanId}.md` where `{PlanId}` is the 5-digit plan ID.
+
+Use this format:
+
+```markdown
+# Plan Evaluation: {PlanId} — {Title}
+
+- **Evaluated:** {CurrentTime}
+- **Plan State:** {state from plan.yaml}
+- **Promptwares Run:** {list of promptware types that executed}
+- **Total Tokens:** {sum across all sessions}
+- **Cache Hit Ratio:** {percentage}
+
+## Executive Summary
+
+{2-3 sentences: was this plan executed efficiently? What is the single biggest improvement opportunity?}
+
+## Token Breakdown
+
+| Promptware | Input | Output | Cache Read | Cache Write | Total |
+|------------|-------|--------|------------|-------------|-------|
+| CreatePlan | ... | ... | ... | ... | ... |
+| ExecutePlan | ... | ... | ... | ... | ... |
+| ... | ... | ... | ... | ... | ... |
+
+## Findings
+
+### {Finding Title}
+
+- **Category:** {Token Waste | Error Loop | Missing Knowledge | Instruction Gap | Environmental | Architectural}
+- **Severity:** {Low | Medium | High}
+- **Promptware:** {which promptware}
+- **Impact:** {estimated token waste or time lost}
+
+{Description of the finding with specific evidence from the logs.}
+
+**Recommendation:** {What should change — in Program.md, Memory files, or Tendril source code.}
+
+---
+
+{Repeat for each finding}
+
+## No Issues Found
+
+{If no significant findings, state: "This plan executed cleanly with no notable inefficiencies or errors."}
+
+## Raw Statistics
+
+- Wall-clock time per promptware: {list}
+- Tool call counts: {summary}
+- Compilation fix cycles: {count, if applicable}
+- Files read more than once: {list, if any}
+```
+
+### Rules
+
+- Do NOT modify any source code, promptware instructions, or memory files — this is an evaluation step only
+- Always produce a report, even if there are no findings
+- Be specific: cite line numbers, tool call IDs, or message timestamps when reporting issues
+- Focus on actionable improvements, not theoretical concerns
+- A plan that ran smoothly and completed quickly is a success — say so
+- The raw JSONL files can be very large — use targeted reads (offset/limit) rather than reading entire files
+- When calculating token totals, deduplicate: multiple content blocks in the same assistant message share one usage object

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/PlanEvaluator/Tools/Analyze-SessionJsonl.ps1
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/PlanEvaluator/Tools/Analyze-SessionJsonl.ps1
@@ -1,0 +1,128 @@
+<#
+.SYNOPSIS
+    Analyzes a Claude session JSONL file for token usage, tool calls, and error patterns.
+.PARAMETER Path
+    Path to the .jsonl file
+.OUTPUTS
+    PSCustomObject with TokenUsage, ToolCalls, Errors, Timestamps
+#>
+param(
+    [Parameter(Mandatory)]
+    [string]$Path
+)
+
+$lines = Get-Content $Path -Encoding UTF8
+$totalInput = 0
+$totalOutput = 0
+$totalCacheRead = 0
+$totalCacheWrite = 0
+$toolCalls = @{}
+$toolErrors = @()
+$failedToolCalls = @()
+$fileReads = @{}
+$timestamps = @()
+$messageCount = 0
+$assistantMessages = 0
+
+foreach ($line in $lines) {
+    if ([string]::IsNullOrWhiteSpace($line)) { continue }
+    try {
+        $obj = $line | ConvertFrom-Json -ErrorAction Stop
+    } catch { continue }
+
+    # Extract timestamps
+    if ($obj.timestamp) {
+        $timestamps += $obj.timestamp
+    }
+
+    # Count messages
+    $messageCount++
+
+    # Token usage from assistant messages
+    if ($obj.type -eq "assistant" -and $obj.message -and $obj.message.usage) {
+        $assistantMessages++
+        $u = $obj.message.usage
+        if ($u.input_tokens) { $totalInput += [long]$u.input_tokens }
+        if ($u.output_tokens) { $totalOutput += [long]$u.output_tokens }
+        if ($u.cache_read_input_tokens) { $totalCacheRead += [long]$u.cache_read_input_tokens }
+        if ($u.cache_creation_input_tokens) { $totalCacheWrite += [long]$u.cache_creation_input_tokens }
+    }
+
+    # Tool use from assistant messages
+    if ($obj.type -eq "assistant" -and $obj.message -and $obj.message.content) {
+        foreach ($block in $obj.message.content) {
+            if ($block.type -eq "tool_use") {
+                $toolName = $block.name
+                if (-not $toolCalls.ContainsKey($toolName)) {
+                    $toolCalls[$toolName] = 0
+                }
+                $toolCalls[$toolName]++
+
+                # Track file reads
+                if ($toolName -eq "Read" -and $block.input -and $block.input.file_path) {
+                    $fp = $block.input.file_path
+                    if (-not $fileReads.ContainsKey($fp)) {
+                        $fileReads[$fp] = 0
+                    }
+                    $fileReads[$fp]++
+                }
+            }
+        }
+    }
+
+    # Tool results - check for errors
+    if ($obj.type -eq "tool_result" -or ($obj.message -and $obj.message.content)) {
+        $content = if ($obj.type -eq "tool_result") { $obj.content }
+                   elseif ($obj.message) { $obj.message.content }
+                   else { $null }
+        if ($content) {
+            $contentStr = if ($content -is [string]) { $content }
+                         elseif ($content -is [array]) { ($content | ForEach-Object { $_.text }) -join " " }
+                         else { $content | ConvertTo-Json -Compress }
+            if ($contentStr -match '(?i)(error|failed|exception|could not|cannot|timeout)') {
+                if ($obj.type -eq "tool_result") {
+                    $snippet = if ($contentStr.Length -gt 200) { $contentStr.Substring(0, 200) + "..." } else { $contentStr }
+                    $toolErrors += $snippet
+                }
+            }
+        }
+    }
+}
+
+# Calculate cache hit ratio
+$totalCacheTokens = $totalCacheRead + $totalCacheWrite + $totalInput
+$cacheHitRatio = if ($totalCacheTokens -gt 0) { [math]::Round(($totalCacheRead / $totalCacheTokens) * 100, 1) } else { 0 }
+
+# Files read more than once
+$duplicateReads = $fileReads.GetEnumerator() | Where-Object { $_.Value -gt 1 } | Sort-Object Value -Descending
+
+# Time analysis
+$firstTime = $null
+$lastTime = $null
+if ($timestamps.Count -gt 0) {
+    try {
+        $firstTime = [DateTimeOffset]::Parse($timestamps[0]).UtcDateTime
+        $lastTime = [DateTimeOffset]::Parse($timestamps[-1]).UtcDateTime
+    } catch {}
+}
+
+$result = [PSCustomObject]@{
+    InputTokens = $totalInput
+    OutputTokens = $totalOutput
+    CacheReadTokens = $totalCacheRead
+    CacheWriteTokens = $totalCacheWrite
+    TotalTokens = $totalInput + $totalOutput + $totalCacheRead + $totalCacheWrite
+    CacheHitRatio = $cacheHitRatio
+    AssistantMessages = $assistantMessages
+    TotalMessages = $messageCount
+    ToolCalls = ($toolCalls.GetEnumerator() | Sort-Object Value -Descending | ForEach-Object { "$($_.Key): $($_.Value)" }) -join ", "
+    ToolCallsTotal = ($toolCalls.Values | Measure-Object -Sum).Sum
+    DuplicateReads = ($duplicateReads | ForEach-Object { "$($_.Key) (x$($_.Value))" }) -join "; "
+    ErrorCount = $toolErrors.Count
+    Errors = $toolErrors
+    FirstTimestamp = $firstTime
+    LastTimestamp = $lastTime
+    WallClockSeconds = if ($firstTime -and $lastTime) { [math]::Round(($lastTime - $firstTime).TotalSeconds) } else { $null }
+}
+
+$result | Format-List

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -13,8 +13,7 @@ projects:
     prRule: yolo
     baseBranch: development
   verifications:
-  - &o0
-    name: DotnetBuild
+  - name: FrameworkDotnetBuild
     required: true
   - &o1
     name: DotnetFormat
@@ -51,6 +50,12 @@ projects:
     - CreatePr
     condition: ''
     action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
+  - name: PlanEvaluator
+    when: after
+    promptwares:
+    - CreatePr
+    condition: ''
+    action: Start-Process -FilePath 'tendril' -ArgumentList 'promptware','PlanEvaluator',$PWD -WindowStyle Hidden
 - name: Tendril
   color: Emerald
   meta:
@@ -60,7 +65,8 @@ projects:
     prRule: yolo
     baseBranch: development
   verifications:
-  - *o0
+  - name: DotnetBuild
+    required: true
   - *o1
   - name: DotnetTest
   - *o3
@@ -80,6 +86,12 @@ projects:
     - CreatePr
     condition: ''
     action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
+  - name: PlanEvaluator
+    when: after
+    promptwares:
+    - CreatePr
+    condition: ''
+    action: Start-Process -FilePath 'tendril' -ArgumentList 'promptware','PlanEvaluator',$PWD -WindowStyle Hidden
   buildDependencies:
   - '%REPOS_HOME%\Ivy-Framework'
 - name: Rustino
@@ -91,7 +103,8 @@ projects:
     prRule: yolo
     baseBranch: development
   verifications:
-  - *o0
+  - name: DotnetBuild
+    required: true
   - *o1
   - *o2
   - name: RustBuild
@@ -120,7 +133,20 @@ projects:
     - CreatePr
     condition: ''
     action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
+  - name: PlanEvaluator
+    when: after
+    promptwares:
+    - CreatePr
+    condition: ''
+    action: Start-Process -FilePath 'tendril' -ArgumentList 'promptware','PlanEvaluator',$PWD -WindowStyle Hidden
 verifications:
+- name: FrameworkDotnetBuild
+  prompt: >
+    Run `dotnet build --warnaserror` in the plan's worktree directory (not the original repo) and verify it succeeds with zero errors and zero warnings.
+    Then also build the sample and documentation projects to catch breaking changes:
+    1. `dotnet build --warnaserror` in `src/Ivy.Samples`
+    2. `dotnet build --warnaserror` in `src/Ivy.Docs`
+    All three builds must pass.
 - name: DotnetBuild
   prompt: Run `dotnet build --warnaserror` in the plan's worktree directory (not the original repo) and verify it succeeds with zero errors and zero warnings.
 - name: DotnetTest
@@ -139,7 +165,14 @@ verifications:
 - name: FrameworkFrontendLint
   prompt: Run `cd src\frontend && npm run lint && npm run format:check` and verify no errors.
 - name: IvyFrameworkVerification
-  prompt: 'Run the IvyFrameworkVerification promptware to visually verify UI changes. Execute: `pwsh -NoProfile -File "$TENDRIL_HOME\Promptwares\IvyFrameworkVerification\IvyFrameworkVerification.ps1" -PlanPath "<PlanFolder>"`. Creates a temp project with demo apps, runs Playwright tests, and copies artifacts to <PlanFolder>\artifacts\. Write the verification report to <PlanFolder>\verification\IvyFrameworkVerification.md.'
+  prompt: >
+    Visually verify UI changes by delegating to the IvyFrameworkVerification promptware.
+    You MUST run this as an external process — do NOT attempt to do the verification yourself or write the report directly.
+    Execute: `tendril promptware IvyFrameworkVerification "<PlanFolder>" --value VerificationDir="<PlanFolder>\verification" --value ArtifactsDir="<PlanFolder>\artifacts" --value IvyFrameworkPath="<worktree path to Ivy-Framework>"`
+    Wait for the process to complete (it may take several minutes).
+    If exit code is 0, read `<PlanFolder>\verification\IvyFrameworkVerification.md` and set status based on the Result field.
+    If exit code is non-zero or the report file was not created, set status to Fail.
+    Do NOT write the verification report yourself — the promptware creates it.
 - name: CheckResult
   prompt: >
     Verify the implementation matches what was requested in the plan. 1. Read the plan revision from `<PlanFolder>\revisions\` (latest numbered .md file) 2. Read all commits made by this execution from `plan.yaml` `commits` list 3. For each commit, review the diff (`git show <hash>`) in the worktree 4. Compare the plan's **Problem** and **Solution** sections against the actual changes:
@@ -275,6 +308,14 @@ promptwares:
     - Read
     - Write
     - Bash
+  PlanEvaluator:
+    profile: balanced
+    allowedTools:
+    - Read
+    - Glob
+    - Grep
+    - Bash
+    - Write
 codingAgents:
 - name: claude
   arguments: ''

--- a/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
@@ -9,26 +9,21 @@ public class OutputSheet(
     IWriteStream<string> outputStream,
     IState<bool> hasStreamContent) : ViewBase
 {
-    private readonly string _jobId = jobId;
-    private readonly IJobService _jobService = jobService;
-    private readonly IWriteStream<string> _outputStream = outputStream;
-    private readonly IState<bool> _hasStreamContent = hasStreamContent;
-
     public override object Build()
     {
-        var job = _jobService.GetJob(_jobId);
+        var job = jobService.GetJob(jobId);
         object outputContent;
 
         if (job is { Status: JobStatus.Running })
         {
-            if (!_hasStreamContent.Value)
+            if (!hasStreamContent.Value)
             {
                 outputContent = Text.P("Loading Output...");
             }
             else
             {
                 outputContent = new ClaudeJsonRenderer()
-                    .Stream(_outputStream)
+                    .Stream(outputStream)
                     .ShowThinking(true)
                     .ShowSystemEvents(false)
                     .AutoScroll(true)
@@ -41,7 +36,7 @@ public class OutputSheet(
             outputContent = new ClaudeJsonRenderer()
                 .JsonStream(jsonStream)
                 .ShowThinking(true)
-                .ShowSystemEvents(true)
+                .ShowSystemEvents(false)
                 .AutoScroll(false)
                 .Height(Size.Full());
         }
@@ -55,7 +50,7 @@ public class OutputSheet(
 
     public string GetSheetTitle()
     {
-        var job = _jobService.GetJob(_jobId);
+        var job = jobService.GetJob(jobId);
         return job is not null ? $"{job.Type} — {ExtractPlanId(job.PlanFile)}" : "Job Output";
     }
 

--- a/src/Ivy.Tendril/Apps/Jobs/PlanSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/PlanSheet.cs
@@ -10,38 +10,33 @@ public class PlanSheet(
     IConfigService config,
     IState<string?> openFile) : ViewBase
 {
-    private readonly string _planPath = planPath;
-    private readonly IPlanReaderService _planService = planService;
-    private readonly IConfigService _config = config;
-    private readonly IState<string?> _openFile = openFile;
-
     public override object Build()
     {
-        var folderName = Path.GetFileName(_planPath);
-        var content = _planService.ReadLatestRevision(folderName);
-        var plan = _planService.GetPlanByFolder(_planPath);
+        var folderName = Path.GetFileName(planPath);
+        var content = planService.ReadLatestRevision(folderName);
+        var plan = planService.GetPlanByFolder(planPath);
 
         object sheetContent = string.IsNullOrEmpty(content)
             ? Text.P("Plan not found or empty.")
-            : new Markdown(MarkdownHelper.AnnotateAllBrokenLinks(content, _planService.PlansDirectory))
+            : new Markdown(MarkdownHelper.AnnotateAllBrokenLinks(content, planService.PlansDirectory))
                 .DangerouslyAllowLocalFiles()
-                .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(_openFile));
+                .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile));
 
         return sheetContent;
     }
 
     public object? BuildFileLinkSheet()
     {
-        var plan = _planService.GetPlanByFolder(_planPath);
-        var repoPaths = plan?.GetEffectiveRepoPaths(_config) ?? [];
+        var plan = planService.GetPlanByFolder(planPath);
+        var repoPaths = plan?.GetEffectiveRepoPaths(config) ?? [];
         return FileLinkHelper.BuildFileLinkSheet(
-            _openFile.Value, () => _openFile.Set(null), repoPaths, _config);
+            openFile.Value, () => openFile.Set(null), repoPaths, config);
     }
 
     public string GetSheetTitle()
     {
-        var folderName = Path.GetFileName(_planPath);
-        var plan = _planService.GetPlanByFolder(_planPath);
+        var folderName = Path.GetFileName(planPath);
+        var plan = planService.GetPlanByFolder(planPath);
         return plan?.Title ?? folderName;
     }
 }

--- a/src/Ivy.Tendril/Apps/Jobs/PromptSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/PromptSheet.cs
@@ -2,10 +2,8 @@ namespace Ivy.Tendril.Apps.Jobs;
 
 public class PromptSheet(string promptText) : ViewBase
 {
-    private readonly string _promptText = promptText;
-
     public override object Build()
     {
-        return new Markdown($"```\n{_promptText}\n```");
+        return new Markdown($"```\n{promptText}\n```");
     }
 }

--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -5,7 +5,6 @@ using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
-using Ivy.Widgets.ClaudeJsonRenderer;
 
 namespace Ivy.Tendril.Apps;
 
@@ -339,7 +338,7 @@ public class JobsApp : ViewBase
                                 var folderName = Path.GetFileName(job.Args[0]);
                                 planService.TransitionState(folderName, PlanStatus.Building);
                             }
-                            else if (job.Type == "UpdatePlan" && job.Args.Length > 0)
+                            else if (job is { Type: "UpdatePlan", Args.Length: > 0 })
                             {
                                 var folderName = Path.GetFileName(job.Args[0]);
                                 planService.TransitionState(folderName, PlanStatus.Updating);

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -45,13 +45,42 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
         }
     }
 
+    /// <summary>
+    ///     Resolves the promptware folder by checking the source root first,
+    ///     then falling back to TENDRIL_HOME/Promptwares/ for promptwares that
+    ///     only exist in the deployed location (e.g. team config promptwares).
+    /// </summary>
+    private static (string ProgramFolder, string SharedRoot) ResolvePromptwareFolder(string promptwareName)
+    {
+        var sourceRoot = JobService.ResolvePromptsRoot();
+        var sourceFolder = Path.Combine(sourceRoot, promptwareName);
+        var sourceShared = Path.Combine(sourceRoot, ".shared");
+
+        if (File.Exists(Path.Combine(sourceFolder, "Program.md")))
+            return (sourceFolder, sourceShared);
+
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        if (!string.IsNullOrEmpty(tendrilHome))
+        {
+            var deployedRoot = Path.Combine(tendrilHome, "Promptwares");
+            var deployedFolder = Path.Combine(deployedRoot, promptwareName);
+            var deployedShared = Path.Combine(deployedRoot, ".shared");
+            if (File.Exists(Path.Combine(deployedFolder, "Program.md")))
+            {
+                var shared = Directory.Exists(deployedShared) ? deployedShared : sourceShared;
+                return (deployedFolder, shared);
+            }
+        }
+
+        return (sourceFolder, sourceShared);
+    }
+
     internal static int Run(PromptwareRunSettings settings, CancellationToken cancellationToken = default)
     {
         var configService = new ConfigService();
         var tendrilSettings = configService.Settings;
 
-        var promptsRoot = JobService.ResolvePromptsRoot();
-        var programFolder = Path.Combine(promptsRoot, settings.Promptware);
+        var (programFolder, sharedRoot) = ResolvePromptwareFolder(settings.Promptware);
         var programMd = Path.Combine(programFolder, "Program.md");
 
         if (!File.Exists(programMd))
@@ -98,7 +127,7 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
         // Compile firmware
         var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
         var sharedDocs = new List<(string Name, string Content)>();
-        var plansMdPath = Path.Combine(JobService.SharedRoot, "Plans.md");
+        var plansMdPath = Path.Combine(sharedRoot, "Plans.md");
         if (File.Exists(plansMdPath))
             sharedDocs.Add(("Plans", File.ReadAllText(plansMdPath)));
 

--- a/src/Ivy.Tendril/Promptwares/UpdatePlan/Tools/Find-ListPatterns.ps1
+++ b/src/Ivy.Tendril/Promptwares/UpdatePlan/Tools/Find-ListPatterns.ps1
@@ -1,0 +1,55 @@
+# Find-ListPatterns.ps1
+# Searches for list-like patterns in Claude raw.jsonl output
+
+param(
+    [string]$Path
+)
+
+$patterns = @()
+
+Get-Content $Path | ForEach-Object {
+    if (-not $_.StartsWith('{')) { return }
+
+    try {
+        $obj = $_ | ConvertFrom-Json
+
+        # Extract text from various message structures
+        $text = $null
+
+        if ($obj.type -eq 'assistant' -and $obj.message.content) {
+            foreach ($block in $obj.message.content) {
+                if ($block.type -eq 'text' -and $block.text) {
+                    $text = $block.text
+                }
+            }
+        }
+
+        if ($text) {
+            # Look for patterns: "text:\nItem\nItem" (colon followed by newlines and lines without bullets)
+            if ($text -match ':\s*\n([A-Z][^\n]+\n)+') {
+                $match = $text -match '(.{0,50}:\s*\n(?:[A-Z][^\n]+\n){2,})'
+                if ($match) {
+                    $patterns += [PSCustomObject]@{
+                        Pattern = $Matches[0]
+                        HasBullets = ($text -match ':\s*\n\s*[-*+]\s')
+                    }
+                }
+            }
+        }
+    }
+    catch {
+        # Skip malformed JSON
+    }
+}
+
+if ($patterns.Count -gt 0) {
+    Write-Output "Found $($patterns.Count) list-like patterns:"
+    $patterns | ForEach-Object {
+        Write-Output "---"
+        Write-Output "Has bullets: $($_.HasBullets)"
+        Write-Output $_.Pattern
+        Write-Output ""
+    }
+} else {
+    Write-Output "No list-like patterns found"
+}

--- a/src/Ivy.Tendril/Promptwares/UpdatePlan/Tools/Parse-RawJsonl.ps1
+++ b/src/Ivy.Tendril/Promptwares/UpdatePlan/Tools/Parse-RawJsonl.ps1
@@ -1,0 +1,46 @@
+# Parse-RawJsonl.ps1
+# Extracts Claude text content from raw.jsonl log files
+
+param(
+    [string]$Path,
+    [int]$MaxBlocks = 50
+)
+
+$blockCount = 0
+$inTextBlock = $false
+$currentText = ""
+
+Get-Content $Path | ForEach-Object {
+    if ($blockCount -ge $MaxBlocks) { return }
+
+    # Skip non-JSON lines
+    if (-not $_.StartsWith('{')) { return }
+
+    try {
+        $obj = $_ | ConvertFrom-Json
+
+        # Look for content blocks with text
+        if ($obj.type -eq 'content_block_start' -and $obj.content_block.type -eq 'text') {
+            $inTextBlock = $true
+            $currentText = ""
+        }
+        elseif ($obj.type -eq 'content_block_delta' -and $obj.delta.type -eq 'text_delta') {
+            if ($inTextBlock) {
+                $currentText += $obj.delta.text
+            }
+        }
+        elseif ($obj.type -eq 'content_block_stop') {
+            if ($inTextBlock -and $currentText) {
+                Write-Output "=== Text Block $($blockCount + 1) ==="
+                Write-Output $currentText
+                Write-Output ""
+                $blockCount++
+            }
+            $inTextBlock = $false
+            $currentText = ""
+        }
+    }
+    catch {
+        # Skip malformed JSON
+    }
+}


### PR DESCRIPTION
## Summary
- Add PlanEvaluator promptware with config hooks for Framework, Tendril, and Rustino projects
- Add FrameworkDotnetBuild verification that also builds samples and docs projects
- Resolve promptwares from both source root and TENDRIL_HOME/Promptwares fallback
- Improve IvyFrameworkVerification to delegate to external promptware process
- Add Find-ListPatterns and Parse-RawJsonl tools for UpdatePlan promptware
- Refactor job sheets (OutputSheet, PlanSheet, PromptSheet) cleanup