### PR TITLE
Fix UpdatePlan state transition, job table updates, and concurrent plan modification guard

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceConcurrentPlanModificationTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceConcurrentPlanModificationTests.cs
@@ -1,0 +1,270 @@
+using Ivy.Helpers;
+using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+/// <summary>
+/// Tests for preventing concurrent plan-modifying jobs (UpdatePlan, ExpandPlan, SplitPlan)
+/// that would cause race conditions and state corruption.
+/// </summary>
+public class JobServiceConcurrentPlanModificationTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly string _planFolder;
+
+    public JobServiceConcurrentPlanModificationTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), "tendril-test-" + Guid.NewGuid().ToString("N")[..8]);
+        _planFolder = Path.Combine(_testDir, "Plans", "00001-TestPlan");
+        Directory.CreateDirectory(_planFolder);
+
+        // Create a minimal plan.yaml
+        var planYaml = """
+            state: Draft
+            project: Test
+            level: Bug
+            title: Test Plan
+            repos: []
+            created: 2026-04-21T00:00:00Z
+            updated: 2026-04-21T00:00:00Z
+            verifications: []
+            """;
+        FileHelper.WriteAllText(Path.Combine(_planFolder, "plan.yaml"), planYaml);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_testDir))
+                Directory.Delete(_testDir, true);
+        }
+        catch
+        {
+            // Best-effort cleanup
+        }
+    }
+
+    [Fact]
+    public void StartJob_UpdatePlan_WhenAnotherUpdatePlanRunning_FailsWithConflictMessage()
+    {
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 10);
+
+        // Start first UpdatePlan job (will be in Running state after CreateTestJob)
+        var firstJobId = service.CreateTestJob("UpdatePlan", _planFolder);
+        var firstJob = service.GetJob(firstJobId);
+        Assert.NotNull(firstJob);
+        Assert.Equal(JobStatus.Running, firstJob.Status);
+
+        // Try to start second UpdatePlan job for the same plan
+        var secondJobId = service.StartJob("UpdatePlan", _planFolder);
+        var secondJob = service.GetJob(secondJobId);
+
+        // Second job should fail immediately with conflict message
+        Assert.NotNull(secondJob);
+        Assert.Equal(JobStatus.Failed, secondJob.Status);
+        Assert.Contains("already in progress", secondJob.StatusMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(firstJobId, secondJob.StatusMessage);
+    }
+
+    [Fact]
+    public void StartJob_ExpandPlan_WhenAnotherExpandPlanRunning_FailsWithConflictMessage()
+    {
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 10);
+
+        var firstJobId = service.CreateTestJob("ExpandPlan", _planFolder);
+        var secondJobId = service.StartJob("ExpandPlan", _planFolder);
+        var secondJob = service.GetJob(secondJobId);
+
+        Assert.NotNull(secondJob);
+        Assert.Equal(JobStatus.Failed, secondJob.Status);
+        Assert.Contains("already in progress", secondJob.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void StartJob_SplitPlan_WhenAnotherSplitPlanRunning_FailsWithConflictMessage()
+    {
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 10);
+
+        var firstJobId = service.CreateTestJob("SplitPlan", _planFolder);
+        var secondJobId = service.StartJob("SplitPlan", _planFolder);
+        var secondJob = service.GetJob(secondJobId);
+
+        Assert.NotNull(secondJob);
+        Assert.Equal(JobStatus.Failed, secondJob.Status);
+        Assert.Contains("already in progress", secondJob.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void StartJob_UpdatePlan_WhenFirstJobCompleted_AllowsSecondJob()
+    {
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 10);
+
+        // Start and complete first job
+        var firstJobId = service.CreateTestJob("UpdatePlan", _planFolder);
+        service.CompleteJob(firstJobId, 0);
+        var firstJob = service.GetJob(firstJobId);
+        Assert.NotNull(firstJob);
+        Assert.Equal(JobStatus.Completed, firstJob.Status);
+
+        // Second job should be allowed (will fail to launch process, but should attempt)
+        try
+        {
+            var secondJobId = service.StartJob("UpdatePlan", _planFolder);
+            var secondJob = service.GetJob(secondJobId);
+            Assert.NotNull(secondJob);
+            // Should not be Failed due to conflict (might be Failed due to process launch, but that's OK)
+            if (secondJob.Status == JobStatus.Failed)
+                Assert.DoesNotContain("already in progress", secondJob.StatusMessage ?? "", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            // Process launch failures are acceptable in this test
+        }
+    }
+
+    [Fact]
+    public void StartJob_UpdatePlan_WhenFirstJobQueued_FailsWithConflictMessage()
+    {
+        // Use maxConcurrentJobs=0 to force queueing
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 0);
+
+        var firstJobId = service.StartJob("UpdatePlan", _planFolder);
+        var firstJob = service.GetJob(firstJobId);
+        Assert.NotNull(firstJob);
+        Assert.Equal(JobStatus.Queued, firstJob.Status);
+
+        // Second job should fail even though first is only queued
+        var secondJobId = service.StartJob("UpdatePlan", _planFolder);
+        var secondJob = service.GetJob(secondJobId);
+
+        Assert.NotNull(secondJob);
+        Assert.Equal(JobStatus.Failed, secondJob.Status);
+        Assert.Contains("already in progress", secondJob.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void StartJob_UpdatePlan_WhenFirstJobPending_FailsWithConflictMessage()
+    {
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 10);
+
+        // Create a job manually in Pending state
+        var firstJobId = service.CreateTestJob("UpdatePlan", _planFolder);
+        var firstJob = service.GetJob(firstJobId);
+        Assert.NotNull(firstJob);
+        firstJob.Status = JobStatus.Pending;
+
+        // Second job should fail
+        var secondJobId = service.StartJob("UpdatePlan", _planFolder);
+        var secondJob = service.GetJob(secondJobId);
+
+        Assert.NotNull(secondJob);
+        Assert.Equal(JobStatus.Failed, secondJob.Status);
+        Assert.Contains("already in progress", secondJob.StatusMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void StartJob_UpdatePlan_ForDifferentPlan_AllowsBothJobs()
+    {
+        var otherPlanFolder = Path.Combine(_testDir, "Plans", "00002-OtherPlan");
+        Directory.CreateDirectory(otherPlanFolder);
+        var planYaml = """
+            state: Draft
+            project: Test
+            level: Bug
+            title: Other Plan
+            repos: []
+            created: 2026-04-21T00:00:00Z
+            updated: 2026-04-21T00:00:00Z
+            verifications: []
+            """;
+        FileHelper.WriteAllText(Path.Combine(otherPlanFolder, "plan.yaml"), planYaml);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 10);
+
+        // Start UpdatePlan for first plan
+        var firstJobId = service.CreateTestJob("UpdatePlan", _planFolder);
+        var firstJob = service.GetJob(firstJobId);
+        Assert.NotNull(firstJob);
+        Assert.Equal(JobStatus.Running, firstJob.Status);
+
+        // Start UpdatePlan for different plan — should be allowed
+        try
+        {
+            var secondJobId = service.StartJob("UpdatePlan", otherPlanFolder);
+            var secondJob = service.GetJob(secondJobId);
+            Assert.NotNull(secondJob);
+            // Should not fail due to conflict
+            if (secondJob.Status == JobStatus.Failed)
+                Assert.DoesNotContain("already in progress", secondJob.StatusMessage ?? "", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            // Process launch failures are acceptable
+        }
+    }
+
+    [Fact]
+    public void StartJob_ExecutePlan_NotAffectedByConcurrentPlanModificationCheck()
+    {
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 10);
+
+        // Start UpdatePlan
+        var updateJobId = service.CreateTestJob("UpdatePlan", _planFolder);
+
+        // ExecutePlan should not be blocked by UpdatePlan (they're different job types)
+        try
+        {
+            var executeJobId = service.StartJob("ExecutePlan", _planFolder);
+            var executeJob = service.GetJob(executeJobId);
+            Assert.NotNull(executeJob);
+            // Should not fail due to plan modification conflict
+            if (executeJob.Status == JobStatus.Failed)
+                Assert.DoesNotContain("already in progress", executeJob.StatusMessage ?? "", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            // Process launch or dependency check failures are acceptable
+        }
+    }
+
+    [Fact]
+    public void StartJob_RaisesNotificationWhenConcurrentJobBlocked()
+    {
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 10);
+
+        JobNotification? receivedNotification = null;
+        service.NotificationReady += n => receivedNotification = n;
+
+        // Start first job
+        var firstJobId = service.CreateTestJob("UpdatePlan", _planFolder);
+
+        // Try to start conflicting second job
+        var secondJobId = service.StartJob("UpdatePlan", _planFolder);
+
+        // Should have received a notification
+        Assert.NotNull(receivedNotification);
+        Assert.Contains("Already Running", receivedNotification.Title);
+        Assert.False(receivedNotification.IsSuccess);
+        Assert.Contains("Cannot start", receivedNotification.Message);
+    }
+}

--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -89,13 +89,18 @@ public class JobsApp : ViewBase
 
         UseEffect(() =>
         {
-            void OnJobsStructureChanged()
+            void OnJobsChanged()
             {
                 refreshToken.Refresh();
             }
 
-            jobService.JobsStructureChanged += OnJobsStructureChanged;
-            return Disposable.Create(() => jobService.JobsStructureChanged -= OnJobsStructureChanged);
+            jobService.JobsStructureChanged += OnJobsChanged;
+            jobService.JobPropertyChanged += OnJobsChanged;
+            return Disposable.Create(() =>
+            {
+                jobService.JobsStructureChanged -= OnJobsChanged;
+                jobService.JobPropertyChanged -= OnJobsChanged;
+            });
         });
 
         UseInterval(() =>
@@ -119,7 +124,7 @@ public class JobsApp : ViewBase
                         .Where(j => j.Status == JobStatus.Running ||
                                     ((j.Status is JobStatus.Stopped or JobStatus.Failed or JobStatus.Timeout or JobStatus.Completed)
                                      && j.CompletedAt.HasValue
-                                     && DateTime.UtcNow - j.CompletedAt.Value < TimeSpan.FromSeconds(5)))
+                                     && DateTime.UtcNow - j.CompletedAt.Value < TimeSpan.FromMinutes(1)))
                         .SelectMany(j => new[]
                         {
                             new DataTableCellUpdate(j.Id, "Timer", FormatTimer(j)),

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps.Plans.Dialogs;
@@ -24,6 +25,13 @@ public class UpdatePlanDialog(
         var isCreating = UseState(false);
         if (!_dialogOpen.Value) return null;
 
+        // Check if there's already an UpdatePlan job running for this plan
+        var hasActiveJob = _jobService.GetJobs().Any(j =>
+            j.Type == "UpdatePlan" &&
+            j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
+            j.Args.Length > 0 &&
+            j.Args[0].Equals(_selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
+
         return new Dialog(
             _ =>
             {
@@ -34,6 +42,7 @@ public class UpdatePlanDialog(
             new DialogBody(
                 Layout.Vertical()
                 | Text.P("Provide instructions for revising this draft plan.")
+                | (hasActiveJob ? Text.P("⚠️ UpdatePlan is already running for this plan. Please wait...").Color(Colors.Warning) : null)
                 | _updateText.ToTextareaInput("Enter update instructions...").Rows(6).AutoFocus()
             ),
             new DialogFooter(
@@ -42,7 +51,7 @@ public class UpdatePlanDialog(
                     _updateText.Set("");
                     _dialogOpen.Set(false);
                 }),
-                new Button("Submit Update").Primary().Disabled(isCreating.Value || string.IsNullOrWhiteSpace(_updateText.Value)).ShortcutKey("Ctrl+Enter").OnClick(() =>
+                new Button("Submit Update").Primary().Disabled(hasActiveJob || isCreating.Value || string.IsNullOrWhiteSpace(_updateText.Value)).ShortcutKey("Ctrl+Enter").OnClick(() =>
                 {
                     if (!string.IsNullOrWhiteSpace(_updateText.Value) && !isCreating.Value)
                     {

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -201,6 +201,10 @@ public class JobService : IJobService
             SetPlanState(job, "Completed");
             RetryBlockedDependents(job.Args.Length > 0 ? job.Args[0] : "");
         }
+        else if (isSuccess && job.Type is "UpdatePlan" or "ExpandPlan" or "SplitPlan")
+        {
+            SetPlanState(job, "Draft");
+        }
         else if (isSuccess && job.Type == "CreatePlan")
         {
             VerifyCreatePlanResult(job);
@@ -580,6 +584,34 @@ public class JobService : IJobService
                 {
                     /* Best-effort — don't fail the job if we can't write the recovery file */
                 }
+        }
+
+        // Check for concurrent plan-modifying jobs (UpdatePlan, ExpandPlan, SplitPlan)
+        // to prevent race conditions and state corruption
+        if (type is "UpdatePlan" or "ExpandPlan" or "SplitPlan")
+        {
+            var planFolder = args.Length > 0 ? args[0] : "";
+            var conflictingJob = _jobs.Values.FirstOrDefault(j =>
+                j.Type == type &&
+                j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
+                j.Args.Length > 0 &&
+                j.Args[0].Equals(planFolder, StringComparison.OrdinalIgnoreCase));
+
+            if (conflictingJob != null)
+            {
+                job.Status = JobStatus.Failed;
+                job.StatusMessage = $"{type} already in progress for this plan (job {conflictingJob.Id})";
+                job.CompletedAt = DateTime.UtcNow;
+                _jobs[id] = job;
+
+                var notification = new JobNotification(
+                    $"{type} Already Running",
+                    $"{planFile}: Cannot start {type} while another is in progress",
+                    false);
+                RaiseNotification(notification);
+                RaiseJobsStructureChanged();
+                return id;
+            }
         }
 
         _jobs[id] = job;


### PR DESCRIPTION
- Transition plan state back to Draft on successful UpdatePlan/ExpandPlan/SplitPlan completion
- Subscribe JobsApp to JobPropertyChanged so Cost/Tokens/Status refresh after delayed calculation
- Extend updateStream window from 5s to 1m so cell updates arrive during cost calculation delay
- Persist conflict-failed jobs to _jobs dict so GetJob() returns them
- Add concurrent plan modification guard preventing duplicate UpdatePlan/ExpandPlan/SplitPlan jobs
- Add UI warning in UpdatePlanDialog when an UpdatePlan job is already running
