### PR TITLE
Extract shared tab/sheet views and reorganize models and helpers into dedicated folders

### DIFF
--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.AppShell.Dialogs;
 

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -5,6 +5,7 @@ using Ivy.Core.Apps;
 using Ivy.Tendril.AppShell.Dialogs;
 using Ivy.Tendril.Apps;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Views;
 using Ivy.Widgets.Internal;
 

--- a/src/Ivy.Tendril/Apps/ConfigErrorApp.cs
+++ b/src/Ivy.Tendril/Apps/ConfigErrorApp.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps;
 

--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps;
 

--- a/src/Ivy.Tendril/Apps/FileApp.cs
+++ b/src/Ivy.Tendril/Apps/FileApp.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps;
 

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -1,7 +1,9 @@
 using Ivy.Core;
 using Ivy.Tendril.Apps.Icebox.Dialogs;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Icebox;
 

--- a/src/Ivy.Tendril/Apps/Icebox/Dialogs/DeletePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/Dialogs/DeletePlanDialog.cs
@@ -1,5 +1,7 @@
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Icebox.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
@@ -1,5 +1,7 @@
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Icebox;
 

--- a/src/Ivy.Tendril/Apps/IceboxApp.cs
+++ b/src/Ivy.Tendril/Apps/IceboxApp.cs
@@ -1,6 +1,8 @@
 using System.Reactive.Disposables;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using ContentView = Ivy.Tendril.Apps.Icebox.ContentView;
 using SidebarView = Ivy.Tendril.Apps.Icebox.SidebarView;
 

--- a/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
@@ -1,4 +1,6 @@
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Ivy.Widgets.ClaudeJsonRenderer;
 
 namespace Ivy.Tendril.Apps.Jobs;

--- a/src/Ivy.Tendril/Apps/Jobs/PlanSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/PlanSheet.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 

--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -3,6 +3,7 @@ using System.Reactive.Linq;
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -1,4 +1,6 @@
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Onboarding;
 

--- a/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Onboarding;
 

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Onboarding.Dialogs;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Onboarding;
 

--- a/src/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Models;
 using System.Diagnostics;
 using Ivy.Helpers;
 

--- a/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Onboarding;
 

--- a/src/Ivy.Tendril/Apps/OnboardingApp.cs
+++ b/src/Ivy.Tendril/Apps/OnboardingApp.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Apps.Onboarding;
+using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Apps;
 

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -1,9 +1,12 @@
+using Ivy.Tendril.Models;
 using System.Text.RegularExpressions;
 using Ivy.Core;
 using Ivy.Tendril.Apps.Plans.Dialogs;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Views;
-using Ivy.Widgets.DiffView;
+using Ivy.Tendril.Views.Sheets;
+using Ivy.Tendril.Views.Tabs;
 
 namespace Ivy.Tendril.Apps.Plans;
 
@@ -52,45 +55,6 @@ public class ContentView(
         var openCommit = UseState<string?>(null);
 
         var selectedPlanRef = UseRef(_selectedPlan);
-
-        var verificationReportQuery = UseQuery<string, string>(
-            openVerification.Value ?? "",
-            async (name, ct) =>
-            {
-                if (string.IsNullOrEmpty(name) || _selectedPlan is null) return "";
-                var verificationDir = Path.GetFullPath(Path.Combine(_selectedPlan.FolderPath, "verification"));
-                var resolvedPath = Path.GetFullPath(Path.Combine(verificationDir, $"{name}.md"));
-                if (!resolvedPath.StartsWith(verificationDir, StringComparison.OrdinalIgnoreCase))
-                    return "Access denied: file is outside the verification folder.";
-                return await Task.Run(() =>
-                    File.Exists(resolvedPath) ? FileHelper.ReadAllText(resolvedPath) : $"No report found for {name}.", ct);
-            },
-            initialValue: ""
-        );
-
-        var commitQuery = UseQuery<PlanContentHelpers.CommitDetailData?, string>(
-            openCommit.Value ?? "",
-            async (hash, ct) =>
-            {
-                if (string.IsNullOrEmpty(hash)) return null;
-                var repoPaths2 = _selectedPlan!.GetEffectiveRepoPaths(_config);
-                return await Task.Run(() =>
-                {
-                    foreach (var repo in repoPaths2)
-                    {
-                        var title = _gitService.GetCommitTitle(repo, hash);
-                        if (title != null)
-                        {
-                            var diff = _gitService.GetCommitDiff(repo, hash);
-                            var files = _gitService.GetCommitFiles(repo, hash);
-                            return new PlanContentHelpers.CommitDetailData(title, diff, files);
-                        }
-                    }
-                    return null;
-                }, ct);
-            },
-            initialValue: null
-        );
 
         var planContentQuery = UseQuery<PlanContentData, string>(
             _selectedPlan?.FolderPath ?? "",
@@ -258,38 +222,6 @@ public class ContentView(
         }
         else
         {
-            // Summary tab content
-            object summaryTabContent;
-            if (planData.SummaryMarkdown is { } summaryMd)
-                summaryTabContent = new Markdown(summaryMd).DangerouslyAllowLocalFiles();
-            else
-                summaryTabContent = Text.Muted("No summary available.");
-
-            // Verifications tab content
-            var verificationsTable = new Table(
-                new TableRow(
-                        new TableCell("Status").IsHeader(),
-                        new TableCell("Name").IsHeader()
-                    )
-                { IsHeader = true }
-            );
-            foreach (var v in _selectedPlan.Verifications)
-            {
-                var hasReport = planData.VerificationReports.TryGetValue(v.Name, out var exists) && exists;
-                var nameCapture = v.Name;
-                var nameCell = hasReport
-                    ? new Button(v.Name).Inline().OnClick(() => openVerification.Set(nameCapture))
-                    : (object)Text.Block(v.Name);
-
-                verificationsTable |= new TableRow(
-                    new TableCell(new Badge(v.Status).Variant(
-                        StatusMappings.VerificationStatusBadgeVariants.TryGetValue(v.Status, out var variant)
-                            ? variant
-                            : BadgeVariant.Outline)),
-                    new TableCell(nameCell)
-                );
-            }
-
             // Git tab content (uses shared helper)
             var gitData = GitTabHelper.BuildGitTabData(_selectedPlan!, _config, _gitService);
             var gitLayout = GitTabHelper.RenderGitTab(
@@ -306,96 +238,31 @@ public class ContentView(
                 }
             );
 
-            // Changes tab content
-            object changesTabContent;
-            var changesData = planContentQuery.Value.AllChanges;
-            var changesFileCount = 0;
-
-            if (planContentQuery.Loading)
-            {
-                changesTabContent = Text.Muted("Loading...");
-            }
-            else if (changesData is null)
-            {
-                var errorMsg = planContentQuery.Error is { } err
-                    ? $"Failed to load changes: {err.Message}"
-                    : "No commits yet.";
-                changesTabContent = Text.Muted(errorMsg);
-            }
-            else
-            {
-                changesFileCount = changesData.Files.Count;
-                var changesLayout = Layout.Vertical().Gap(4).Padding(2);
-
-                var statsText =
-                    $"{changesData.Files.Count} files changed ({changesData.AddedCount} added, {changesData.ModifiedCount} modified, {changesData.DeletedCount} deleted)";
-                changesLayout |= Text.Block(statsText).Bold();
-
-                if (changesData.Files.Count > 0)
-                {
-                    var filesLayout = Layout.Vertical().Gap(1);
-                    foreach (var (status, filePath) in changesData.Files)
-                    {
-                        var (label, variant) = status switch
-                        {
-                            "A" => ("Added", BadgeVariant.Success),
-                            "D" => ("Deleted", BadgeVariant.Destructive),
-                            _ => ("Modified", BadgeVariant.Outline)
-                        };
-                        filesLayout |= Layout.Horizontal().Gap(2)
-                            | new Badge(label).Variant(variant).Small()
-                            | Text.Block(filePath);
-                    }
-
-                    changesLayout |= filesLayout;
-                }
-
-                if (!string.IsNullOrWhiteSpace(changesData.Diff))
-                {
-                    changesLayout |= new DiffView().Diff(changesData.Diff).Split();
-                }
-
-                changesTabContent = changesLayout;
-            }
+            // Changes tab
+            var changesTabView = new ChangesTabView(planData.AllChanges, planContentQuery.Loading, planContentQuery.Error);
 
             // Artifacts tab content
-            var artifactsLayout = Layout.Vertical().Gap(2);
-            artifactsLayout |= PlanContentHelpers.RenderArtifactScreenshots(planData.Artifacts);
-
             var totalArtifacts = (planData.Artifacts.GetValueOrDefault("screenshots")?.Count ?? 0)
                                  + (planData.Artifacts.ContainsKey("sample") ? 1 : 0);
 
             // Build tabs
             var tabs = Layout.Tabs(
                 new Tab("Plan", Cap(planTabContent)),
-                new Tab("Summary", Cap(summaryTabContent)),
-                new Tab("Verifications", Cap(verificationsTable)).Badge(_selectedPlan.Verifications.Count.ToString()),
+                new Tab("Summary", Cap(new SummaryTabView(planData.SummaryMarkdown))),
+                new Tab("Verifications", Cap(new VerificationsTabView(
+                    _selectedPlan.Verifications, planData.VerificationReports,
+                    v => openVerification.Set(v)))).Badge(_selectedPlan.Verifications.Count.ToString()),
                 new Tab("Git", Cap(gitLayout)).Badge((_selectedPlan.Commits.Count + _selectedPlan.Prs.Count).ToString()),
-                new Tab("Changes", Cap(changesTabContent)).Badge(changesFileCount > 0 ? changesFileCount.ToString() : ""),
-                new Tab("Artifacts", Cap(artifactsLayout)).Badge(totalArtifacts.ToString())
+                new Tab("Changes", Cap(changesTabView)).Badge(changesTabView.FileCount > 0 ? changesTabView.FileCount.ToString() : ""),
+                new Tab("Artifacts", Cap(new ArtifactsTabView(planData.Artifacts))).Badge(totalArtifacts.ToString())
             ).OnSelect(v => selectedTab.Set(v)).SelectedIndex(selectedTab.Value).Variant(TabsVariant.Content);
 
             content |= tabs;
         }
 
         // Sheet modals
-        if (openVerification.Value is { } verName)
-            content |= new Sheet(
-                () => openVerification.Set(null),
-                verificationReportQuery.Loading
-                    ? Text.Muted("Loading...")
-                    : new Markdown(verificationReportQuery.Value).DangerouslyAllowLocalFiles(),
-                verName
-            ).Width(Size.Half()).Resizable();
-
-        if (openCommit.Value is { } commitHash && _selectedPlan is not null)
-        {
-            content |= PlanContentHelpers.RenderCommitDetailSheet(
-                commitQuery.Value,
-                commitQuery.Loading || commitQuery.Value is null && !string.IsNullOrEmpty(openCommit.Value),
-                commitHash,
-                () => openCommit.Set(null));
-        }
+        content |= new VerificationReportSheet(openVerification, _selectedPlan);
+        content |= new CommitDetailSheet(openCommit, _selectedPlan, _config, _gitService);
 
         var actionBar = Layout.Horizontal().AlignContent(Align.Center).Gap(2).Padding(1)
                         | new Button("Update").Icon(Icons.Pencil).Outline().ShortcutKey("u")

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
@@ -1,4 +1,6 @@
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Plans.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs
@@ -1,4 +1,6 @@
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Plans.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
@@ -1,5 +1,7 @@
 using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Plans.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/Plans/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/SidebarView.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 

--- a/src/Ivy.Tendril/Apps/PlansApp.cs
+++ b/src/Ivy.Tendril/Apps/PlansApp.cs
@@ -1,6 +1,8 @@
 using System.Reactive.Disposables;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps;
 

--- a/src/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -1,9 +1,11 @@
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Apps.Plans.Dialogs;
 using Ivy.Tendril.Apps.PullRequest;
 using Ivy.Tendril.Apps.PullRequest.Dialogs;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps;
 

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -1,6 +1,8 @@
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Apps.Recommendations.Dialogs;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Recommendations;
 

--- a/src/Ivy.Tendril/Apps/Recommendations/Dialogs/AcceptWithNotesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/Dialogs/AcceptWithNotesDialog.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Recommendations.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/Recommendations/Dialogs/DeclineRecommendationDialog.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/Dialogs/DeclineRecommendationDialog.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Recommendations.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Recommendations;
 

--- a/src/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Recommendations;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps;
 

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -1,8 +1,11 @@
 using Ivy.Core;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Apps.Review.Dialogs;
 using Ivy.Tendril.Services;
-using Ivy.Widgets.DiffView;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Views.Sheets;
+using Ivy.Tendril.Views.Tabs;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Apps.Review;
@@ -73,21 +76,6 @@ public class ContentView(
         );
         var selectedTab = UseState(0);
 
-        var verificationReportQuery = UseQuery<string, string>(
-            openVerification.Value ?? "",
-            async (name, ct) =>
-            {
-                if (string.IsNullOrEmpty(name) || _selectedPlan is null) return "";
-                var verificationDir = Path.GetFullPath(Path.Combine(_selectedPlan.FolderPath, "verification"));
-                var resolvedPath = Path.GetFullPath(Path.Combine(verificationDir, $"{name}.md"));
-                if (!resolvedPath.StartsWith(verificationDir, StringComparison.OrdinalIgnoreCase))
-                    return "Access denied: file is outside the verification folder.";
-                return await Task.Run(() =>
-                    File.Exists(resolvedPath) ? FileHelper.ReadAllText(resolvedPath) : $"No report found for {name}.", ct);
-            },
-            initialValue: ""
-        );
-
         var artifactContentQuery = UseQuery<string, string>(
             openArtifact.Value ?? "",
             async (filePath, ct) =>
@@ -102,31 +90,6 @@ public class ContentView(
                     File.Exists(resolvedPath) ? FileHelper.ReadAllText(resolvedPath) : "File not found.", ct);
             },
             initialValue: ""
-        );
-
-        var commitQuery = UseQuery<PlanContentHelpers.CommitDetailData?, string>(
-            openCommit.Value ?? "",
-            async (hash, ct) =>
-            {
-                if (string.IsNullOrEmpty(hash)) return null;
-                if (_selectedPlan is null) return null;
-                var repoPaths2 = _selectedPlan.GetEffectiveRepoPaths(_config);
-                return await Task.Run(() =>
-                {
-                    foreach (var repo in repoPaths2)
-                    {
-                        var title = _gitService.GetCommitTitle(repo, hash);
-                        if (title != null)
-                        {
-                            var diff = _gitService.GetCommitDiff(repo, hash);
-                            var files = _gitService.GetCommitFiles(repo, hash);
-                            return new PlanContentHelpers.CommitDetailData(title, diff, files);
-                        }
-                    }
-                    return null;
-                }, ct);
-            },
-            initialValue: null
         );
 
         var planContentQuery = UseQuery<PlanContentData, string>(
@@ -301,44 +264,6 @@ public class ContentView(
         }
         else
         {
-            // Summary tab content
-            object summaryTabContent;
-            if (planData.SummaryMarkdown is { } summaryMd)
-            {
-                var summaryLayout = Layout.Vertical().Gap(2);
-                summaryLayout |= new Markdown(summaryMd).DangerouslyAllowLocalFiles();
-                summaryTabContent = summaryLayout;
-            }
-            else
-            {
-                summaryTabContent = Text.Muted("No summary available.");
-            }
-
-            // Verifications tab content
-            var verificationsTable = new Table(
-                new TableRow(
-                        new TableCell("Status").IsHeader(),
-                        new TableCell("Name").IsHeader()
-                    )
-                { IsHeader = true }
-            );
-            foreach (var v in _selectedPlan.Verifications)
-            {
-                var hasReport = planData.VerificationReports.TryGetValue(v.Name, out var exists) && exists;
-                var nameCapture = v.Name;
-                var nameCell = hasReport
-                    ? new Button(v.Name).Inline().OnClick(() => openVerification.Set(nameCapture))
-                    : (object)Text.Block(v.Name);
-
-                verificationsTable |= new TableRow(
-                    new TableCell(new Badge(v.Status).Variant(
-                        StatusMappings.VerificationStatusBadgeVariants.TryGetValue(v.Status, out var variant)
-                            ? variant
-                            : BadgeVariant.Outline)),
-                    new TableCell(nameCell)
-                );
-            }
-
             // Git tab content (uses shared helper)
             var gitData = GitTabHelper.BuildGitTabData(_selectedPlan!, _config, _gitService);
             var gitLayout = GitTabHelper.RenderGitTab(
@@ -356,9 +281,6 @@ public class ContentView(
             );
 
             // Artifacts tab content
-            var artifactsLayout = Layout.Vertical().Gap(2);
-            artifactsLayout |= PlanContentHelpers.RenderArtifactScreenshots(planData.Artifacts);
-
             var totalArtifacts = (planData.Artifacts.GetValueOrDefault("screenshots")?.Count ?? 0)
                                  + (planData.Artifacts.ContainsKey("sample") ? 1 : 0);
 
@@ -430,64 +352,18 @@ public class ContentView(
                     recommendationsLayout |= new Separator();
                 }
 
-            // Changes tab content
-            object changesTabContent;
-            var changesData = planContentQuery.Value.AllChanges;
-            var changesFileCount = 0;
-            if (planContentQuery.Loading)
-            {
-                changesTabContent = Text.Muted("Loading...");
-            }
-            else if (changesData is null)
-            {
-                var errorMsg = planContentQuery.Error is { } err
-                    ? $"Failed to load changes: {err.Message}"
-                    : "No commits yet.";
-                changesTabContent = Text.Muted(errorMsg);
-            }
-            else
-            {
-                changesFileCount = changesData.Files.Count;
-                var changesLayout = Layout.Vertical().Gap(4).Padding(2);
-
-                var statsText =
-                    $"{changesData.Files.Count} files changed ({changesData.AddedCount} added, {changesData.ModifiedCount} modified, {changesData.DeletedCount} deleted)";
-                changesLayout |= Text.Block(statsText).Bold();
-
-                if (changesData.Files.Count > 0)
-                {
-                    var filesLayout = Layout.Vertical().Gap(1);
-                    foreach (var (status, filePath) in changesData.Files)
-                    {
-                        var (label, variant) = status switch
-                        {
-                            "A" => ("Added", BadgeVariant.Success),
-                            "D" => ("Deleted", BadgeVariant.Destructive),
-                            _ => ("Modified", BadgeVariant.Outline)
-                        };
-                        filesLayout |= Layout.Horizontal().Gap(2)
-                            | new Badge(label).Variant(variant).Small()
-                            | Text.Block(filePath);
-                    }
-
-                    changesLayout |= filesLayout;
-                }
-
-                if (!string.IsNullOrWhiteSpace(changesData.Diff))
-                {
-                    changesLayout |= new DiffView().Diff(changesData.Diff).Split();
-                }
-
-                changesTabContent = changesLayout;
-            }
+            // Changes tab
+            var changesTabView = new ChangesTabView(planData.AllChanges, planContentQuery.Loading, planContentQuery.Error);
 
             // Build tabs
             var tabs = Layout.Tabs(
-                new Tab("Summary", Cap(summaryTabContent)),
-                new Tab("Verifications", Cap(verificationsTable)).Badge(_selectedPlan.Verifications.Count.ToString()),
+                new Tab("Summary", Cap(new SummaryTabView(planData.SummaryMarkdown))),
+                new Tab("Verifications", Cap(new VerificationsTabView(
+                    _selectedPlan.Verifications, planData.VerificationReports,
+                    v => openVerification.Set(v)))).Badge(_selectedPlan.Verifications.Count.ToString()),
                 new Tab("Git", Cap(gitLayout)).Badge((_selectedPlan.Commits.Count + _selectedPlan.Prs.Count).ToString()),
-                new Tab("Changes", Cap(changesTabContent)).Badge(changesFileCount > 0 ? changesFileCount.ToString() : ""),
-                new Tab("Artifacts", Cap(artifactsLayout)).Badge(totalArtifacts.ToString()),
+                new Tab("Changes", Cap(changesTabView)).Badge(changesTabView.FileCount > 0 ? changesTabView.FileCount.ToString() : ""),
+                new Tab("Artifacts", Cap(new ArtifactsTabView(planData.Artifacts))).Badge(totalArtifacts.ToString()),
                 new Tab("Recommendations", Cap(recommendationsLayout)).Badge(planData.Recommendations.Count.ToString()),
                 new Tab("Plan", Cap(planTabContent))
             ).OnSelect(v => selectedTab.Set(v)).SelectedIndex(selectedTab.Value).Variant(TabsVariant.Content);
@@ -496,26 +372,8 @@ public class ContentView(
         }
 
         // Sheet modals (outside TabsLayout so they render as overlays)
-        if (openVerification.Value is { } verName)
-            content |= new Sheet(
-                () => openVerification.Set(null),
-                verificationReportQuery.Loading
-                    ? Text.Muted("Loading...")
-                    : verificationReportQuery.Error is { } err
-                        ? Text.Muted($"Failed to load verification report: {err.Message}")
-                        : new Markdown(verificationReportQuery.Value).DangerouslyAllowLocalFiles(),
-                verName
-            ).Width(Size.Half()).Resizable();
-
-        if (openCommit.Value is { } commitHash && _selectedPlan is not null)
-        {
-            content |= PlanContentHelpers.RenderCommitDetailSheet(
-                commitQuery.Value,
-                commitQuery.Loading || commitQuery.Value is null && !string.IsNullOrEmpty(openCommit.Value),
-                commitHash,
-                () => openCommit.Set(null),
-                commitQuery.Error);
-        }
+        content |= new VerificationReportSheet(openVerification, _selectedPlan);
+        content |= new CommitDetailSheet(openCommit, _selectedPlan, _config, _gitService);
 
         if (openArtifact.Value is { } artifactPath)
         {

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -1,5 +1,7 @@
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
@@ -1,5 +1,7 @@
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Review.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
@@ -1,5 +1,7 @@
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Apps.Review.Dialogs;

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
@@ -1,5 +1,7 @@
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Review.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/Review/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/SidebarView.cs
@@ -1,5 +1,7 @@
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Review;
 

--- a/src/Ivy.Tendril/Apps/ReviewApp.cs
+++ b/src/Ivy.Tendril/Apps/ReviewApp.cs
@@ -1,6 +1,8 @@
 using System.Reactive.Disposables;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using ContentView = Ivy.Tendril.Apps.Review.ContentView;
 using SidebarView = Ivy.Tendril.Apps.Review.SidebarView;
 

--- a/src/Ivy.Tendril/Apps/Setup/AdvancedSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/AdvancedSetupView.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Setup;
 

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/DeleteProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/DeleteProjectDialog.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Setup.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditLevelDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditLevelDialog.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Setup.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Setup.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditPromptwareDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditPromptwareDialog.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Setup.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditVerificationDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditVerificationDialog.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Setup.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/Setup/GeneralSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/GeneralSetupView.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Setup;
 

--- a/src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Setup.Dialogs;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Setup;
 

--- a/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Setup.Dialogs;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Setup;
 

--- a/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Setup.Dialogs;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Setup;
 

--- a/src/Ivy.Tendril/Apps/Setup/SecuritySetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/SecuritySetupView.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Isopoh.Cryptography.Argon2;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Setup;
 

--- a/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Setup.Dialogs;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Setup;
 

--- a/src/Ivy.Tendril/Apps/StatusMappings.cs
+++ b/src/Ivy.Tendril/Apps/StatusMappings.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Apps;
 

--- a/src/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/Ivy.Tendril/Apps/TrashApp.cs
@@ -1,6 +1,7 @@
 using Ivy.Tendril.Apps.Trash;
 using Ivy.Tendril.Apps.Trash.Dialogs;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps;
 

--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Views;
 
 namespace Ivy.Tendril.Apps;

--- a/src/Ivy.Tendril/Auth/TendrilAuthProvider.cs
+++ b/src/Ivy.Tendril/Auth/TendrilAuthProvider.cs
@@ -2,6 +2,7 @@ using System.Text;
 using Isopoh.Cryptography.Argon2;
 using Ivy.Core;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -1,6 +1,8 @@
+using Ivy.Tendril.Models;
 using System.Diagnostics;
 using Ivy.Helpers;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Microsoft.Data.Sqlite;
 using Spectre.Console;
 
@@ -642,7 +644,7 @@ public static class DoctorCommand
             // Try strict deserialization first
             try
             {
-                var plan = Services.YamlHelper.Deserializer.Deserialize<Apps.Plans.PlanYaml>(content);
+                var plan = Helpers.YamlHelper.Deserializer.Deserialize<Models.PlanYaml>(content);
                 if (plan == null)
                     return (false, "Null after parse", "Unknown");
 
@@ -756,7 +758,7 @@ public static class DoctorCommand
         try
         {
             var content = File.ReadAllText(planYamlPath);
-            var plan = Services.YamlHelper.Deserializer.Deserialize<Apps.Plans.PlanYaml>(content);
+            var plan = Helpers.YamlHelper.Deserializer.Deserialize<Models.PlanYaml>(content);
             // Recommendations are optional — only validate if present
             if (plan?.Recommendations != null && plan.Recommendations.Count > 0)
                 return null;

--- a/src/Ivy.Tendril/Commands/PlanAddCommitCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddCommitCommand.cs
@@ -1,5 +1,7 @@
+using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;

--- a/src/Ivy.Tendril/Commands/PlanAddLogCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddLogCommand.cs
@@ -1,5 +1,7 @@
+using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;

--- a/src/Ivy.Tendril/Commands/PlanAddPrCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddPrCommand.cs
@@ -1,5 +1,7 @@
+using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;

--- a/src/Ivy.Tendril/Commands/PlanAddRepoCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddRepoCommand.cs
@@ -1,5 +1,7 @@
+using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;

--- a/src/Ivy.Tendril/Commands/PlanCleanupCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCleanupCommand.cs
@@ -1,5 +1,7 @@
+using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console;
 using Spectre.Console.Cli;
 

--- a/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;

--- a/src/Ivy.Tendril/Commands/PlanGetCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanGetCommand.cs
@@ -1,5 +1,7 @@
+using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;

--- a/src/Ivy.Tendril/Commands/PlanListCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanListCommand.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console;
 using Spectre.Console.Cli;
 

--- a/src/Ivy.Tendril/Commands/PlanRecCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRecCommand.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console;
 using Spectre.Console.Cli;
 

--- a/src/Ivy.Tendril/Commands/PlanRemoveRepoCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveRepoCommand.cs
@@ -1,5 +1,7 @@
+using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;

--- a/src/Ivy.Tendril/Commands/PlanSetCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetCommand.cs
@@ -1,5 +1,7 @@
+using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;

--- a/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;

--- a/src/Ivy.Tendril/Commands/PlanUpdateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanUpdateCommand.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;

--- a/src/Ivy.Tendril/Commands/PlanValidateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanValidateCommand.cs
@@ -1,5 +1,7 @@
+using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services.Agents;
 using Spectre.Console.Cli;
 

--- a/src/Ivy.Tendril/Commands/RunCommand.cs
+++ b/src/Ivy.Tendril/Commands/RunCommand.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Database;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;

--- a/src/Ivy.Tendril/Commands/UpdatePromptwaresCliCommand.cs
+++ b/src/Ivy.Tendril/Commands/UpdatePromptwaresCliCommand.cs
@@ -1,5 +1,6 @@
 using Spectre.Console.Cli;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Commands;
 

--- a/src/Ivy.Tendril/Controllers/ApiKeyAuthMiddleware.cs
+++ b/src/Ivy.Tendril/Controllers/ApiKeyAuthMiddleware.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Microsoft.AspNetCore.Http;
 
 namespace Ivy.Tendril.Controllers;

--- a/src/Ivy.Tendril/Controllers/InboxController.cs
+++ b/src/Ivy.Tendril/Controllers/InboxController.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Ivy.Tendril.Controllers;

--- a/src/Ivy.Tendril/Controllers/PlanController.cs
+++ b/src/Ivy.Tendril/Controllers/PlanController.cs
@@ -1,6 +1,8 @@
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Commands;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Ivy.Tendril.Controllers;

--- a/src/Ivy.Tendril/Controllers/StatusController.cs
+++ b/src/Ivy.Tendril/Controllers/StatusController.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Ivy.Tendril.Controllers;

--- a/src/Ivy.Tendril/Helpers/FileHelper.cs
+++ b/src/Ivy.Tendril/Helpers/FileHelper.cs
@@ -3,7 +3,7 @@ using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Text.RegularExpressions;
 
-namespace Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 /// <summary>
 ///     File I/O helpers that use FileShare.ReadWrite and retry on transient lock errors.

--- a/src/Ivy.Tendril/Helpers/FileLinkHelper.cs
+++ b/src/Ivy.Tendril/Helpers/FileLinkHelper.cs
@@ -1,7 +1,8 @@
 using System.Diagnostics;
 using Ivy.Tendril.Apps;
 
-namespace Ivy.Tendril.Services;
+using Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 public static class FileLinkHelper
 {

--- a/src/Ivy.Tendril/Helpers/FormatHelper.cs
+++ b/src/Ivy.Tendril/Helpers/FormatHelper.cs
@@ -1,4 +1,4 @@
-namespace Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 /// <summary>
 ///     Shared formatting utilities for human-readable display values.

--- a/src/Ivy.Tendril/Helpers/MarkdownHelper.cs
+++ b/src/Ivy.Tendril/Helpers/MarkdownHelper.cs
@@ -1,6 +1,6 @@
 using System.Text.RegularExpressions;
 
-namespace Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 public static class MarkdownHelper
 {

--- a/src/Ivy.Tendril/Helpers/MarkdownLinkPolisher.cs
+++ b/src/Ivy.Tendril/Helpers/MarkdownLinkPolisher.cs
@@ -1,6 +1,6 @@
 using System.Text.RegularExpressions;
 
-namespace Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 public class MarkdownLinkPolisher
 {

--- a/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
@@ -1,6 +1,7 @@
-using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 /// <summary>
 ///     Shared utilities for plan CLI commands.

--- a/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
@@ -1,7 +1,8 @@
-using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Widgets.DiffView;
 
-namespace Ivy.Tendril.Services;
+using Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 public static class PlanContentHelpers
 {

--- a/src/Ivy.Tendril/Helpers/PlanDownloadHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanDownloadHelper.cs
@@ -1,6 +1,7 @@
-using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 
-namespace Ivy.Tendril.Services;
+using Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 public static class PlanDownloadHelper
 {

--- a/src/Ivy.Tendril/Helpers/PlanExportHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanExportHelper.cs
@@ -1,6 +1,6 @@
-using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 
-namespace Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 public static class PlanExportHelper
 {

--- a/src/Ivy.Tendril/Helpers/PlanFileExtensions.cs
+++ b/src/Ivy.Tendril/Helpers/PlanFileExtensions.cs
@@ -1,6 +1,8 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
-namespace Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
+namespace Ivy.Tendril.Helpers;
 
 public static class PlanFileExtensions
 {

--- a/src/Ivy.Tendril/Helpers/PlatformHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlatformHelper.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Ivy.Helpers;
 
-namespace Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 public static class PlatformHelper
 {

--- a/src/Ivy.Tendril/Helpers/TimeCache.cs
+++ b/src/Ivy.Tendril/Helpers/TimeCache.cs
@@ -1,4 +1,4 @@
-namespace Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 /// <summary>
 ///     Generic time-based cache that stores a value with an expiration time.

--- a/src/Ivy.Tendril/Helpers/VariableExpansion.cs
+++ b/src/Ivy.Tendril/Helpers/VariableExpansion.cs
@@ -1,7 +1,7 @@
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Configuration;
 
-namespace Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 /// <summary>
 ///     Handles variable expansion in configuration values.

--- a/src/Ivy.Tendril/Helpers/WorktreeValidationHelper.cs
+++ b/src/Ivy.Tendril/Helpers/WorktreeValidationHelper.cs
@@ -1,4 +1,4 @@
-namespace Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 public static class WorktreeValidationHelper
 {

--- a/src/Ivy.Tendril/Helpers/YamlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/YamlHelper.cs
@@ -1,7 +1,7 @@
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
-namespace Ivy.Tendril.Services;
+namespace Ivy.Tendril.Helpers;
 
 /// <summary>
 ///     Shared YAML serialization helpers for consistent configuration handling.

--- a/src/Ivy.Tendril/Hooks/UseStartJob.cs
+++ b/src/Ivy.Tendril/Hooks/UseStartJob.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Hooks;
 

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -2,8 +2,10 @@ using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Commands;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using ModelContextProtocol.Server;
 
 namespace Ivy.Tendril.Mcp.Tools;

--- a/src/Ivy.Tendril/Models/DashboardStats.cs
+++ b/src/Ivy.Tendril/Models/DashboardStats.cs
@@ -1,4 +1,4 @@
-namespace Ivy.Tendril.Services;
+namespace Ivy.Tendril.Models;
 
 public record DashboardStats(
     int TotalCount,

--- a/src/Ivy.Tendril/Models/HealthCheckStatus.cs
+++ b/src/Ivy.Tendril/Models/HealthCheckStatus.cs
@@ -1,3 +1,3 @@
-namespace Ivy.Tendril.Apps.Onboarding;
+namespace Ivy.Tendril.Models;
 
 public enum HealthCheckStatus { Authenticated, NotAuthenticated, CheckFailed }

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -1,7 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 
-namespace Ivy.Tendril.Apps.Jobs;
+namespace Ivy.Tendril.Models;
 
 public enum JobStatus
 {

--- a/src/Ivy.Tendril/Models/PlanModels.cs
+++ b/src/Ivy.Tendril/Models/PlanModels.cs
@@ -1,6 +1,6 @@
 using Ivy.Tendril.Helpers;
 
-namespace Ivy.Tendril.Apps.Plans;
+namespace Ivy.Tendril.Models;
 
 public enum PlanStatus
 {

--- a/src/Ivy.Tendril/Models/PlanYaml.cs
+++ b/src/Ivy.Tendril/Models/PlanYaml.cs
@@ -1,6 +1,6 @@
 using YamlDotNet.Serialization;
 
-namespace Ivy.Tendril.Apps.Plans;
+namespace Ivy.Tendril.Models;
 
 public class PlanVerificationEntry
 {

--- a/src/Ivy.Tendril/Models/PullRequestModels.cs
+++ b/src/Ivy.Tendril/Models/PullRequestModels.cs
@@ -1,4 +1,4 @@
-namespace Ivy.Tendril.Apps.PullRequest;
+namespace Ivy.Tendril.Models;
 
 public record PrRow
 {

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -5,6 +5,7 @@ using Ivy.Helpers;
 using Ivy.Tendril.Commands;
 using Ivy.Tendril.Database;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 using Velopack;
 

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Helpers;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;

--- a/src/Ivy.Tendril/Services/IJobService.cs
+++ b/src/Ivy.Tendril/Services/IJobService.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Services;
 

--- a/src/Ivy.Tendril/Services/IPlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/IPlanDatabaseService.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Services;
 

--- a/src/Ivy.Tendril/Services/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/IPlanReaderService.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Services;
 

--- a/src/Ivy.Tendril/Services/ITelemetryService.cs
+++ b/src/Ivy.Tendril/Services/ITelemetryService.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Services;
 

--- a/src/Ivy.Tendril/Services/InboxWatcherService.cs
+++ b/src/Ivy.Tendril/Services/InboxWatcherService.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Helpers;
 using System.Collections.Concurrent;
 using Ivy.Helpers;
 

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Helpers;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
@@ -6,6 +7,7 @@ using Ivy.Helpers;
 using Ivy.Tendril.Apps;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services.Agents;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/Ivy.Tendril/Services/ModelPricingService.cs
+++ b/src/Ivy.Tendril/Services/ModelPricingService.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Helpers;
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;

--- a/src/Ivy.Tendril/Services/OnboardingSetupService.cs
+++ b/src/Ivy.Tendril/Services/OnboardingSetupService.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Helpers;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Services;

--- a/src/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/Ivy.Tendril/Services/PlanCountsService.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Services;
 

--- a/src/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Database;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;

--- a/src/Ivy.Tendril/Services/PlanDatabaseSyncService.cs
+++ b/src/Ivy.Tendril/Services/PlanDatabaseSyncService.cs
@@ -1,6 +1,8 @@
+using Ivy.Tendril.Helpers;
 using System.Diagnostics;
 using System.Globalization;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Services;

--- a/src/Ivy.Tendril/Services/PlanPdfService.cs
+++ b/src/Ivy.Tendril/Services/PlanPdfService.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Helpers;
 using System.Diagnostics;
 using System.Text;
 using Ivy.Helpers;

--- a/src/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/PlanReaderService.cs
@@ -2,7 +2,9 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Ivy.Helpers;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Services;

--- a/src/Ivy.Tendril/Services/PlanValidationService.cs
+++ b/src/Ivy.Tendril/Services/PlanValidationService.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Services;
 

--- a/src/Ivy.Tendril/Services/TelemetryService.cs
+++ b/src/Ivy.Tendril/Services/TelemetryService.cs
@@ -1,4 +1,6 @@
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Models;
 using Microsoft.Extensions.Logging;
 using PostHog;
 

--- a/src/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -1,6 +1,8 @@
+using Ivy.Tendril.Helpers;
 using System.Diagnostics;
 using System.Globalization;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Models;
 using Microsoft.Extensions.Logging;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -3,6 +3,7 @@ using Ivy.Helpers;
 using Ivy.Tendril.AppShell;
 using Ivy.Tendril.Controllers;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs
+++ b/src/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Plans.Dialogs;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Views;
 

--- a/src/Ivy.Tendril/Views/Sheets/CommitDetailSheet.cs
+++ b/src/Ivy.Tendril/Views/Sheets/CommitDetailSheet.cs
@@ -1,0 +1,50 @@
+using Ivy.Core;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Helpers;
+
+using Ivy.Tendril.Services;
+namespace Ivy.Tendril.Views.Sheets;
+
+public class CommitDetailSheet(
+    IState<string?> openCommit,
+    PlanFile? selectedPlan,
+    IConfigService config,
+    IGitService gitService) : ViewBase
+{
+    public override object Build()
+    {
+        var commitQuery = UseQuery<PlanContentHelpers.CommitDetailData?, string>(
+            openCommit.Value ?? "",
+            async (hash, ct) =>
+            {
+                if (string.IsNullOrEmpty(hash) || selectedPlan is null) return null;
+                var repoPaths = selectedPlan.GetEffectiveRepoPaths(config);
+                return await Task.Run(() =>
+                {
+                    foreach (var repo in repoPaths)
+                    {
+                        var title = gitService.GetCommitTitle(repo, hash);
+                        if (title != null)
+                        {
+                            var diff = gitService.GetCommitDiff(repo, hash);
+                            var files = gitService.GetCommitFiles(repo, hash);
+                            return new PlanContentHelpers.CommitDetailData(title, diff, files);
+                        }
+                    }
+                    return null;
+                }, ct);
+            },
+            initialValue: null
+        );
+
+        if (openCommit.Value is not { } commitHash || selectedPlan is null)
+            return new Empty();
+
+        return PlanContentHelpers.RenderCommitDetailSheet(
+            commitQuery.Value,
+            commitQuery.Loading || commitQuery.Value is null && !string.IsNullOrEmpty(openCommit.Value),
+            commitHash,
+            () => openCommit.Set(null),
+            commitQuery.Error);
+    }
+}

--- a/src/Ivy.Tendril/Views/Sheets/VerificationReportSheet.cs
+++ b/src/Ivy.Tendril/Views/Sheets/VerificationReportSheet.cs
@@ -1,0 +1,41 @@
+using Ivy.Core;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Views.Sheets;
+
+public class VerificationReportSheet(
+    IState<string?> openVerification,
+    PlanFile? selectedPlan) : ViewBase
+{
+    public override object Build()
+    {
+        var verificationReportQuery = UseQuery<string, string>(
+            openVerification.Value ?? "",
+            async (name, ct) =>
+            {
+                if (string.IsNullOrEmpty(name) || selectedPlan is null) return "";
+                var verificationDir = Path.GetFullPath(Path.Combine(selectedPlan.FolderPath, "verification"));
+                var resolvedPath = Path.GetFullPath(Path.Combine(verificationDir, $"{name}.md"));
+                if (!resolvedPath.StartsWith(verificationDir, StringComparison.OrdinalIgnoreCase))
+                    return "Access denied: file is outside the verification folder.";
+                return await Task.Run(() =>
+                    File.Exists(resolvedPath) ? FileHelper.ReadAllText(resolvedPath) : $"No report found for {name}.", ct);
+            },
+            initialValue: ""
+        );
+
+        if (openVerification.Value is not { } verName)
+            return new Empty();
+
+        return new Sheet(
+            () => openVerification.Set(null),
+            verificationReportQuery.Loading
+                ? Text.Muted("Loading...")
+                : verificationReportQuery.Error is { } err
+                    ? Text.Muted($"Failed to load verification report: {err.Message}")
+                    : new Markdown(verificationReportQuery.Value).DangerouslyAllowLocalFiles(),
+            verName
+        ).Width(Size.Half()).Resizable();
+    }
+}

--- a/src/Ivy.Tendril/Views/Tabs/ArtifactsTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ArtifactsTabView.cs
@@ -1,0 +1,13 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Views.Tabs;
+
+public class ArtifactsTabView(Dictionary<string, List<string>> artifacts) : ViewBase
+{
+    public override object Build()
+    {
+        var layout = Layout.Vertical().Gap(2);
+        layout |= PlanContentHelpers.RenderArtifactScreenshots(artifacts);
+        return layout;
+    }
+}

--- a/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
@@ -1,0 +1,58 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Widgets.DiffView;
+
+namespace Ivy.Tendril.Views.Tabs;
+
+public class ChangesTabView(
+    PlanContentHelpers.AllChangesData? changesData,
+    bool loading,
+    Exception? error) : ViewBase
+{
+    public int FileCount => changesData?.Files.Count ?? 0;
+
+    public override object Build()
+    {
+        if (loading)
+            return Text.Muted("Loading...");
+
+        if (changesData is null)
+        {
+            var errorMsg = error is { } err
+                ? $"Failed to load changes: {err.Message}"
+                : "No commits yet.";
+            return Text.Muted(errorMsg);
+        }
+
+        var layout = Layout.Vertical().Gap(4).Padding(2);
+
+        var statsText =
+            $"{changesData.Files.Count} files changed ({changesData.AddedCount} added, {changesData.ModifiedCount} modified, {changesData.DeletedCount} deleted)";
+        layout |= Text.Block(statsText).Bold();
+
+        if (changesData.Files.Count > 0)
+        {
+            var filesLayout = Layout.Vertical().Gap(1);
+            foreach (var (status, filePath) in changesData.Files)
+            {
+                var (label, variant) = status switch
+                {
+                    "A" => ("Added", BadgeVariant.Success),
+                    "D" => ("Deleted", BadgeVariant.Destructive),
+                    _ => ("Modified", BadgeVariant.Outline)
+                };
+                filesLayout |= Layout.Horizontal().Gap(2)
+                    | new Badge(label).Variant(variant).Small()
+                    | Text.Block(filePath);
+            }
+
+            layout |= filesLayout;
+        }
+
+        if (!string.IsNullOrWhiteSpace(changesData.Diff))
+        {
+            layout |= new DiffView().Diff(changesData.Diff).Split();
+        }
+
+        return layout;
+    }
+}

--- a/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
+++ b/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
@@ -1,7 +1,10 @@
 using Ivy.Core;
+using Ivy.Tendril.Apps;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Helpers;
 
-namespace Ivy.Tendril.Apps.Plans;
+namespace Ivy.Tendril.Views.Tabs;
 
 public static class GitTabHelper
 {

--- a/src/Ivy.Tendril/Views/Tabs/SummaryTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/SummaryTabView.cs
@@ -1,0 +1,16 @@
+namespace Ivy.Tendril.Views.Tabs;
+
+public class SummaryTabView(string? summaryMarkdown) : ViewBase
+{
+    public override object Build()
+    {
+        if (summaryMarkdown is { } md)
+        {
+            var layout = Layout.Vertical().Gap(2);
+            layout |= new Markdown(md).DangerouslyAllowLocalFiles();
+            return layout;
+        }
+
+        return Text.Muted("No summary available.");
+    }
+}

--- a/src/Ivy.Tendril/Views/Tabs/VerificationsTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/VerificationsTabView.cs
@@ -1,0 +1,40 @@
+using Ivy.Tendril.Apps;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Views.Tabs;
+
+public class VerificationsTabView(
+    List<PlanVerificationEntry> verifications,
+    Dictionary<string, bool> verificationReports,
+    Action<string> openVerification) : ViewBase
+{
+    public override object Build()
+    {
+        var table = new Table(
+            new TableRow(
+                    new TableCell("Status").IsHeader(),
+                    new TableCell("Name").IsHeader()
+                )
+            { IsHeader = true }
+        );
+
+        foreach (var v in verifications)
+        {
+            var hasReport = verificationReports.TryGetValue(v.Name, out var exists) && exists;
+            var nameCapture = v.Name;
+            var nameCell = hasReport
+                ? new Button(v.Name).Inline().OnClick(() => openVerification(nameCapture))
+                : (object)Text.Block(v.Name);
+
+            table |= new TableRow(
+                new TableCell(new Badge(v.Status).Variant(
+                    StatusMappings.VerificationStatusBadgeVariants.TryGetValue(v.Status, out var variant)
+                        ? variant
+                        : BadgeVariant.Outline)),
+                new TableCell(nameCell)
+            );
+        }
+
+        return table;
+    }
+}


### PR DESCRIPTION
## Summary
- Extract shared tab views (Summary, Verifications, Changes, Artifacts) into `Views/Tabs/`
- Extract shared sheet views (VerificationReport, CommitDetail) into `Views/Sheets/`
- Move GitTabHelper from `Apps/Plans/` to `Views/Tabs/`
- Move all model classes to `Models/` (PlanModels, PlanYaml, JobModels, PullRequestModels, HealthCheckStatus, DashboardStats)
- Move all non-UI helpers to `Helpers/` (FileHelper, FormatHelper, MarkdownHelper, PlanContentHelpers, PlanCommandHelpers, etc.)
- Update 125 files with new using statements
- Reduces Review/ContentView.cs from 663 to ~519 lines and Plans/ContentView.cs from 602 to ~468 lines