### PR TITLE
Remove non-existent SidebarContentScroll calls that broke the build

### DIFF
--- a/src/Ivy.Tendril/Apps/IceboxApp.cs
+++ b/src/Ivy.Tendril/Apps/IceboxApp.cs
@@ -62,7 +62,7 @@ public class IceboxApp : ViewBase
             new ContentView(selectedPlanState.Value, filteredPlans, selectedPlanState, planService, jobService,
                 RefreshPlans, configService),
             sidebar
-        ).SidebarContentScroll(Scroll.None);
+        );
 
         void RefreshPlans()
         {

--- a/src/Ivy.Tendril/Apps/PlansApp.cs
+++ b/src/Ivy.Tendril/Apps/PlansApp.cs
@@ -67,7 +67,7 @@ public class PlansApp : ViewBase
             new ContentView(selectedPlanState.Value, filteredPlans, selectedPlanState, planService, jobService,
                 RefreshPlans, configService, gitService),
             sidebar
-        ).SidebarContentScroll(Scroll.None);
+        );
 
         void RefreshPlans()
         {

--- a/src/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -72,6 +72,6 @@ public class RecommendationsApp : ViewBase
         return new SidebarLayout(
             new ContentView(selectedState.Value, filtered, selectedState, planService, jobService, Refresh),
             sidebar
-        ).SidebarContentScroll(Scroll.None);
+        );
     }
 }

--- a/src/Ivy.Tendril/Apps/ReviewApp.cs
+++ b/src/Ivy.Tendril/Apps/ReviewApp.cs
@@ -71,7 +71,7 @@ public class ReviewApp : ViewBase
             new ContentView(selectedPlanState.Value, filteredPlans, selectedPlanState, planService, jobService,
                 RefreshPlans, configService, gitService),
             sidebar
-        ).SidebarContentScroll(Scroll.None);
+        );
 
         void RefreshPlans()
         {

--- a/src/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/Ivy.Tendril/Apps/TrashApp.cs
@@ -113,7 +113,7 @@ public class TrashApp : ViewBase
             new SidebarLayout(
                 mainContent,
                 sidebar
-            ).SidebarContentScroll(Scroll.None)
+            )
         };
 
         if (openFile.Value is { } filePath)


### PR DESCRIPTION
## Summary
- Remove `.SidebarContentScroll(Scroll.None)` calls from 5 App files — this method doesn't exist on `SidebarLayout`
- Introduced by commit 8aadf1c which assumed a framework API that doesn't exist yet
- Build: 0 errors, Tests: 950 passed