### PR TITLE
[03467] Update Plan dialog not reset after first use

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
@@ -38,6 +38,7 @@ public class UpdatePlanDialog(
             _ =>
             {
                 _updateText.Set("");
+                isCreating.Set(false);
                 _dialogOpen.Set(false);
             },
             new DialogHeader($"Update Plan #{_selectedPlan.Id}"),
@@ -51,6 +52,7 @@ public class UpdatePlanDialog(
                 new Button("Cancel").Outline().OnClick(() =>
                 {
                     _updateText.Set("");
+                    isCreating.Set(false);
                     _dialogOpen.Set(false);
                 }),
                 new Button("Submit Update").Primary().Disabled(hasActiveJob || isCreating.Value || string.IsNullOrWhiteSpace(_updateText.Value)).ShortcutKey("Ctrl+Enter").OnClick(() =>
@@ -77,6 +79,7 @@ public class UpdatePlanDialog(
                         _jobService.StartJob("UpdatePlan", _selectedPlan.FolderPath);
                         _refreshPlans();
                         _updateText.Set("");
+                        isCreating.Set(false);
                         _dialogOpen.Set(false);
                     }
                 })


### PR DESCRIPTION
# Summary

## Changes

Fixed UpdatePlanDialog's "Submit Update" button becoming permanently disabled after first use by resetting the `isCreating` state to `false` when the dialog closes, matching the existing pattern for `_updateText`.

## API Changes

None.

## Files Modified

- **Apps/Plans/Dialogs/UpdatePlanDialog.cs** — Added `isCreating.Set(false)` in three dialog close handlers (OnClose callback, Cancel button, and Submit button)


## Commits

- b8cae72a430d7c7d5f009636186df1e7eb4d4a56