### PR TITLE
[03469] Tendril corrupts plan.yaml with garbage characters when updating plans

### DIFF
--- a/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
@@ -105,7 +105,7 @@ public static class PlanCommandHelpers
         {
             // Serialize to temp file
             var yaml = YamlHelper.Serializer.Serialize(plan);
-            File.WriteAllText(tempPath, yaml);
+            FileHelper.WriteAllText(tempPath, yaml);
 
             // Read back and validate
             var content = File.ReadAllText(tempPath);


### PR DESCRIPTION
# Summary

## Changes

Fixed a race condition in plan.yaml writing that caused garbage characters to be appended to the file. Replaced `File.WriteAllText()` with `FileHelper.WriteAllText()` in `PlanCommandHelpers.WritePlan()` to ensure proper stream flushing before the atomic file move.

## API Changes

None. This is an internal implementation fix in `PlanCommandHelpers.WritePlan()` that doesn't change any public APIs.

## Files Modified

- `src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs` — Line 108: Replaced `File.WriteAllText()` with `FileHelper.WriteAllText()`


## Commits

- 90607a4, 37056bc

---

Closes Ivy-Interactive/Ivy-Tendril#150