### PR TITLE
[03472] tendril --version opens tendril desktop instead of printing version

### DIFF
--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -132,6 +132,13 @@ public class Program
 
             // Check if this is a recognized CLI command
             var firstArg = filteredArgs[0];
+
+            // Handle --version flag by converting it to "version" command
+            if (firstArg == "--version")
+            {
+                filteredArgs = new[] { "version" };
+            }
+
             if (firstArg == "doctor" || firstArg == "db-version" || firstArg == "db-migrate" ||
                 firstArg == "db-reset" || firstArg == "update-promptwares" || firstArg == "plan" ||
                 firstArg == "promptware" || firstArg == "version" || firstArg == "--version")

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -77,6 +77,8 @@ public class Program
                     .WithDescription("Update embedded promptwares");
                 config.AddCommand<PromptwareRunCommand>("promptware")
                     .WithDescription("Run a promptware directly");
+                config.AddCommand<VersionCommand>("version")
+                    .WithDescription("Show version information");
 
                 // Plan management commands
                 config.AddBranch("plan", plan =>
@@ -132,7 +134,7 @@ public class Program
             var firstArg = filteredArgs[0];
             if (firstArg == "doctor" || firstArg == "db-version" || firstArg == "db-migrate" ||
                 firstArg == "db-reset" || firstArg == "update-promptwares" || firstArg == "plan" ||
-                firstArg == "promptware")
+                firstArg == "promptware" || firstArg == "version" || firstArg == "--version")
             {
                 return app.Run(filteredArgs);
             }


### PR DESCRIPTION
# Summary

## Changes

Registered the existing `VersionCommand` in the Spectre.Console CLI configuration and added logic to handle both `version` command and `--version` flag. The `--version` flag is converted to the `version` command before being passed to Spectre.Console.Cli to avoid option parsing errors. This fixes the bug where running `tendril --version` would launch the desktop application instead of printing the version number.

## API Changes

- CLI command added: `tendril version` - prints version information and exits
- CLI flag added: `tendril --version` - prints version information and exits (internally converted to `version` command)

## Files Modified

- [Program.cs:80-81](file:///D:/Plans/03472-TendrilVersionOpensTendrilDesktopInsteadOfPrintingVersion/worktrees/Ivy-Tendril/src/Ivy.Tendril/Program.cs) - Added VersionCommand registration
- [Program.cs:134-145](file:///D:/Plans/03472-TendrilVersionOpensTendrilDesktopInsteadOfPrintingVersion/worktrees/Ivy-Tendril/src/Ivy.Tendril/Program.cs) - Added --version to version command conversion and updated recognized commands check


## Commits

- c0630c3467fb6f2663665528cbef3da93c03b523, c911ebcba8ade9927f885beafcef8dc435afcb17

---

Closes Ivy-Interactive/Ivy-Tendril#107