### PR TITLE
Fix inspectcode issues: redundant verbatim strings, unused variables, redundant assignments

### DIFF
--- a/src/Ivy.Tendril.Test/DatabaseCommandsTests.cs
+++ b/src/Ivy.Tendril.Test/DatabaseCommandsTests.cs
@@ -48,7 +48,7 @@ public class DatabaseCommandsTests : IDisposable
     [Fact]
     public void DbMigrate_AppliesPendingMigrations()
     {
-        var output = CaptureConsoleOutput(() =>
+        CaptureConsoleOutput(() =>
         {
             var result = DatabaseCommands.DbMigrateInternal(_dbPath);
             Assert.Equal(0, result);

--- a/src/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -259,8 +259,8 @@ public class GithubServiceTests
         var githubService = new GithubService(configService);
         var testRepo = "nonexistent-xyz-999";
 
-        var (assignees1, error1) = await githubService.GetAssigneesAsync(testRepo, testRepo);
-        var (assignees2, error2) = await githubService.GetAssigneesAsync(testRepo, testRepo);
+        var (_, error1) = await githubService.GetAssigneesAsync(testRepo, testRepo);
+        var (_, error2) = await githubService.GetAssigneesAsync(testRepo, testRepo);
 
         Assert.Equal(error1, error2);
     }

--- a/src/Ivy.Tendril.Test/InboxRecoveryTests.cs
+++ b/src/Ivy.Tendril.Test/InboxRecoveryTests.cs
@@ -79,9 +79,6 @@ public class InboxRecoveryTests
             File.WriteAllText(processingFile, "---\nproject: Tendril\n---\nRunning task");
 
             // Also no .md files
-            var config = new ConfigService(new TendrilSettings(), tempDir);
-            var jobService = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), inboxDir);
-
             // Don't use InboxWatcherService constructor (it calls RecoverProcessingFiles).
             // Instead, directly test ProcessExistingFiles won't pick up .processing files.
             // The watcher glob is *.md, so .processing files are inherently excluded.
@@ -280,7 +277,6 @@ public class InboxRecoveryTests
             // then picked up by ProcessExistingFiles, renamed back to .processing, and a job started.
             // After the job launches, the .md file should be gone (renamed to .processing by the watcher).
             var mdFiles = Directory.GetFiles(inboxDir, "*.md");
-            var processingFiles = Directory.GetFiles(inboxDir, "*.processing");
 
             // The file should either be .processing (job running) or gone (job completed/processed)
             Assert.Empty(mdFiles);

--- a/src/Ivy.Tendril.Test/JobServiceConcurrentPlanModificationTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceConcurrentPlanModificationTests.cs
@@ -77,7 +77,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 10);
 
-        var firstJobId = service.CreateTestJob("ExpandPlan", _planFolder);
+        _ = service.CreateTestJob("ExpandPlan", _planFolder);
         var secondJobId = service.StartJob("ExpandPlan", _planFolder);
         var secondJob = service.GetJob(secondJobId);
 
@@ -93,7 +93,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 10);
 
-        var firstJobId = service.CreateTestJob("SplitPlan", _planFolder);
+        _ = service.CreateTestJob("SplitPlan", _planFolder);
         var secondJobId = service.StartJob("SplitPlan", _planFolder);
         var secondJob = service.GetJob(secondJobId);
 
@@ -229,7 +229,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         // Start UpdatePlan
-        var updateJobId = service.CreateTestJob("UpdatePlan", _planFolder);
+        _ = service.CreateTestJob("UpdatePlan", _planFolder);
 
         // ExecutePlan should not be blocked by UpdatePlan (they're different job types)
         try
@@ -259,10 +259,10 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
         service.NotificationReady += n => receivedNotification = n;
 
         // Start first job
-        var firstJobId = service.CreateTestJob("UpdatePlan", _planFolder);
+        _ = service.CreateTestJob("UpdatePlan", _planFolder);
 
         // Try to start conflicting second job
-        var secondJobId = service.StartJob("UpdatePlan", _planFolder);
+        _ = service.StartJob("UpdatePlan", _planFolder);
 
         // Should have received a notification
         Assert.NotNull(receivedNotification);

--- a/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
@@ -33,7 +33,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         var folder = Path.Combine(_plansDir, name);
         Directory.CreateDirectory(folder);
 
-        var depsYaml = "";
+        string depsYaml;
         if (dependsOn is { Count: > 0 })
             depsYaml = "dependsOn:\n" + string.Join("\n", dependsOn.Select(d => $"- '{d}'"));
         else
@@ -82,7 +82,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
     public void RetryBlockedDependents_WhenNotAllDependenciesMet_DoesNotRequeue()
     {
         var planB = CreatePlanFolder("02200-PlanB", "Completed");
-        var planC = CreatePlanFolder("02201-PlanC", "Executing"); // Not completed
+        _ = CreatePlanFolder("02201-PlanC", "Executing"); // Not completed
         var planA = CreatePlanFolder("02202-PlanA", "Blocked", ["02200-PlanB", "02201-PlanC"]);
 
         var service = CreateService();
@@ -130,7 +130,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
     public void ResetPlanStateToBlocked_WritesBlockedState()
     {
         // Create a plan with an unmet dependency
-        var depPlan = CreatePlanFolder("02700-DepPlan", "Executing"); // Not completed
+        _ = CreatePlanFolder("02700-DepPlan", "Executing"); // Not completed
         var planA = CreatePlanFolder("02701-PlanA", "Draft", ["02700-DepPlan"]);
 
         var service = CreateService();
@@ -192,7 +192,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
     public void RetryBlockedDependents_SkipsDuplicateBlockedJobs()
     {
         // Create planC with an unmet dependency to generate a blocked job
-        var depPlan = CreatePlanFolder("02802-DepPlan", "Executing");
+        _ = CreatePlanFolder("02802-DepPlan", "Executing");
         var planB = CreatePlanFolder("02800-PlanB", "Completed");
         var planC = CreatePlanFolder("02803-PlanC", "Blocked", ["02802-DepPlan", "02800-PlanB"]);
 
@@ -227,7 +227,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
     public void RetryBlockedJobs_SuccessfulRetryDoesNotReBlock()
     {
         // Create a plan with a dependency that is completed (no PRs to check)
-        var depPlan = CreatePlanFolder("02900-DepPlan", "Completed");
+        _ = CreatePlanFolder("02900-DepPlan", "Completed");
         var planA = CreatePlanFolder("02901-PlanA", "Draft", ["02900-DepPlan"]);
 
         var service = CreateService();

--- a/src/Ivy.Tendril.Test/JobServicePromptsRootTests.cs
+++ b/src/Ivy.Tendril.Test/JobServicePromptsRootTests.cs
@@ -9,9 +9,6 @@ public class JobServicePromptsRootTests
     {
         // In test/debug mode, AppContext.BaseDirectory is in bin/Debug/net10.0
         // Going ../../.. should land in the project dir where Promptwares/ exists
-        var sourceRoot = Path.GetFullPath(
-            Path.Combine(System.AppContext.BaseDirectory, "..", "..", "..", "..", "Ivy.Tendril", "Promptwares"));
-
         var result = JobService.ResolvePromptsRoot();
 
         // The resolved path should exist (either source or TENDRIL_HOME)

--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -10,13 +10,13 @@ public class JobServiceRetryBlockedTests
         var tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid():N}");
         Directory.CreateDirectory(tempDir);
 
-        var depsYaml = "";
+        string depsYaml;
         if (dependsOn is { Count: > 0 })
             depsYaml = "dependsOn:\n" + string.Join("\n", dependsOn.Select(d => $"- {d}"));
         else
             depsYaml = "dependsOn: []";
 
-        var prsYaml = "";
+        string prsYaml;
         if (prs is { Count: > 0 })
             prsYaml = "prs:\n" + string.Join("\n", prs.Select(p => $"- {p}"));
         else

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -1016,7 +1016,7 @@ public class PlanCliCommandTests : IDisposable
         CreatePlanFolder("30001", "TestLog");
         var planDir = Path.Combine(_plansDir, "30001-TestLog");
 
-        var logPath = PlanAddLogCommand.WriteLog(planDir, "CreatePlan");
+        _ = PlanAddLogCommand.WriteLog(planDir, "CreatePlan");
 
         var logsDir = Path.Combine(planDir, "logs");
         Assert.True(Directory.Exists(logsDir));

--- a/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -356,7 +356,7 @@ public class WorktreeCleanupServiceTests : IDisposable
         var logger = new CapturingLogger(logEntries);
 
         // Open the file with exclusive access to force Directory.Delete to fail.
-        using (var stream = new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
+        using (new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
         {
             // Expect IOException: Directory.Delete fails because of the lock, and
             // rmdir /s /q also can't delete the file while it's held open.
@@ -388,7 +388,7 @@ public class WorktreeCleanupServiceTests : IDisposable
         var logEntries = new List<string>();
         var logger = new CapturingLogger(logEntries);
 
-        using (var stream = new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
+        using (new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
         {
             var ex = Assert.Throws<IOException>(() =>
                 WorktreeCleanupService.ForceDeleteDirectory(testDir, logger));
@@ -537,7 +537,7 @@ public class WorktreeCleanupServiceTests : IDisposable
         var lockedFile = Path.Combine(nestedPlans, "locked.txt");
         File.WriteAllText(lockedFile, "content");
 
-        using (var stream = new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
+        using (new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
         {
             service.RunCleanup();
         }
@@ -564,10 +564,9 @@ public class WorktreeCleanupServiceTests : IDisposable
         File.WriteAllText(lockedFile, "content");
 
         var logEntries = new List<string>();
-        var logger = new CapturingLogger(logEntries);
         var service = new WorktreeCleanupService(_plansDir, new CapturingLogger<WorktreeCleanupService>(logEntries));
 
-        using (var stream = new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
+        using (new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
         {
             service.CleanupLegacyPromptwaresDirs();
         }
@@ -591,7 +590,7 @@ public class WorktreeCleanupServiceTests : IDisposable
             ("99999-Name_With_Underscores", "Name_With_Underscores")
         };
 
-        foreach (var (folderName, expectedSafeTitle) in testCases)
+        foreach (var (folderName, _) in testCases)
         {
             var dir = CreatePlan(folderName, "Failed", DateTime.UtcNow.AddHours(-2));
             var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");

--- a/src/Ivy.Tendril/Apps/Jobs/PlanSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/PlanSheet.cs
@@ -15,7 +15,6 @@ public class PlanSheet(
     {
         var folderName = Path.GetFileName(planPath);
         var content = planService.ReadLatestRevision(folderName);
-        var plan = planService.GetPlanByFolder(planPath);
 
         object sheetContent = string.IsNullOrEmpty(content)
             ? Text.P("Plan not found or empty.")

--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -39,7 +39,6 @@ public class JobsApp : ViewBase
             if (streamingJobId.Value != activeJobId)
             {
                 streamingJobId.Set(activeJobId);
-                startIdx = 0;
                 hasStreamContent.Set(false);
 
                 // Immediately seed the stream with existing lines

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -531,7 +531,7 @@ public static class DoctorCommand
                 AnsiConsole.MarkupLine($"[yellow]Found {pruneCandidates.Count} plan(s) that appear to be test/junk data:[/]");
                 AnsiConsole.WriteLine();
 
-                foreach (var (dir, result, reason) in pruneCandidates)
+                foreach (var (_, result, reason) in pruneCandidates)
                 {
                     AnsiConsole.MarkupLine($"[grey]  {result.Id}-{result.Title}  ({reason})[/]");
                 }
@@ -828,12 +828,11 @@ public static class DoctorCommand
                 {
                     var content = File.ReadAllText(yamlPath);
                     var repaired = PlanReaderService.RepairPlanYaml(content);
-                    var changed = repaired != content;
 
                     var folderTitle = TitleFromFolderName(Path.GetFileName(planPath));
 
                     repaired = RepairYamlFields(repaired, folderTitle);
-                    changed = repaired != content;
+                    var changed = repaired != content;
 
                     if (changed)
                     {
@@ -888,7 +887,7 @@ public static class DoctorCommand
         var match = System.Text.RegularExpressions.Regex.Match(folderName, @"^\d{5}-(.+)$");
         if (!match.Success) return folderName;
         var raw = match.Groups[1].Value;
-        var spaced = System.Text.RegularExpressions.Regex.Replace(raw, @"(?<=[a-z])(?=[A-Z])", " ");
+        var spaced = System.Text.RegularExpressions.Regex.Replace(raw, "(?<=[a-z])(?=[A-Z])", " ");
         return spaced.Replace('-', ' ');
     }
 

--- a/src/Ivy.Tendril/Helpers/MarkdownLinkPolisher.cs
+++ b/src/Ivy.Tendril/Helpers/MarkdownLinkPolisher.cs
@@ -150,7 +150,7 @@ public class MarkdownLinkPolisher
     internal static string NormalizePath(string path)
     {
         path = path.Replace('\\', '/');
-        path = Regex.Replace(path, @"/{2,}", "/");
+        path = Regex.Replace(path, "/{2,}", "/");
 
         if (path.Length >= 2 && path[1] == ':')
             path = path[0] + ":" + path.Substring(2);

--- a/src/Ivy.Tendril/Helpers/VariableExpansion.cs
+++ b/src/Ivy.Tendril/Helpers/VariableExpansion.cs
@@ -29,7 +29,7 @@ public static class VariableExpansion
             var csprojContent = FileHelper.ReadAllText(csprojPath);
 
             // Extract UserSecretsId from .csproj
-            var match = Regex.Match(csprojContent, @"<UserSecretsId>([^<]+)</UserSecretsId>");
+            var match = Regex.Match(csprojContent, "<UserSecretsId>([^<]+)</UserSecretsId>");
             if (!match.Success) return;
 
             var userSecretsId = match.Groups[1].Value;
@@ -94,7 +94,7 @@ public static class VariableExpansion
         var sep = Path.DirectorySeparatorChar.ToString();
         var doubleSep = sep + sep;
         if (value.Contains(doubleSep))
-            value = Regex.Replace(value, @"(?<!:)(" + Regex.Escape(doubleSep) + @")", sep);
+            value = Regex.Replace(value, "(?<!:)(" + Regex.Escape(doubleSep) + ")", sep);
 
         return value;
     }

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -1245,7 +1245,7 @@ public class JobService : IJobService
             @"At line:\d+",
             @"CategoryInfo\s+:",
             @"TerminatingError\(",
-            @"ScriptHalted",
+            "ScriptHalted",
             @"^\s*\+\s+CategoryInfo",  // PowerShell error location marker
         });
         if (psError != null) return psError;
@@ -1254,9 +1254,9 @@ public class JobService : IJobService
         var apiError = FindPattern(outputLines, new[] {
             @"""type"":\s*""error""",
             @"""error"":\s*\{",
-            @"rate_limit_error",
-            @"overloaded_error",
-            @"authentication_error",
+            "rate_limit_error",
+            "overloaded_error",
+            "authentication_error",
         });
         if (apiError != null) return ParseClaudeApiError(apiError);
 
@@ -1264,10 +1264,10 @@ public class JobService : IJobService
         if (jobType == "CreatePlan")
         {
             var makePlanError = FindPattern(outputLines, new[] {
-                @"ERROR: Plan",
-                @"WARNING: TENDRIL_HOME",
-                @"Failed to parse",
-                @"Repository path does not exist",
+                "ERROR: Plan",
+                "WARNING: TENDRIL_HOME",
+                "Failed to parse",
+                "Repository path does not exist",
             });
             if (makePlanError != null) return makePlanError;
 
@@ -1280,7 +1280,7 @@ public class JobService : IJobService
         var validationError = FindPattern(outputLines, new[] {
             @"validation\s+failed",
             @"assertion\s+failed",
-            @"Repository path does not exist",
+            "Repository path does not exist",
             @"\[stderr\].*(?-i)ERROR:",
         });
         if (validationError != null) return validationError;
@@ -1416,7 +1416,7 @@ public class JobService : IJobService
         text = Regex.Replace(text, @"[\x00-\x1F]", " ");
 
         // Collapse multiple consecutive spaces into one
-        text = Regex.Replace(text, @" {2,}", " ");
+        text = Regex.Replace(text, " {2,}", " ");
 
         text = text.Trim();
 
@@ -1542,7 +1542,7 @@ public class JobService : IJobService
 
             var outputText = string.Join("\n", job.OutputLines);
             var createdMatch = Regex.Match(outputText, @"Plan created:\s*(\S+)");
-            var duplicate = Regex.IsMatch(outputText, @"identified as duplicate:");
+            var duplicate = Regex.IsMatch(outputText, "identified as duplicate:");
 
             if (createdMatch.Success)
             {

--- a/src/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -299,7 +299,6 @@ public class PlanDatabaseService : IPlanDatabaseService
                 var days = new List<string>();
                 for (var i = 0; i < 7; i++)
                     days.Add(DateTime.UtcNow.Date.AddDays(-i).ToString("yyyy-MM-dd"));
-                var dayParams = string.Join(",", days.Select((_, idx) => $"@day{idx}"));
 
                 cmd.CommandText = $"""
                     WITH cte_created AS (

--- a/src/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/PlanReaderService.cs
@@ -768,8 +768,8 @@ public class PlanReaderService(
         var seenKeys = new HashSet<string>();
         var structuredListKeys = new Dictionary<string, (string itemStartPattern, string subKeyPattern)>
         {
-            ["verifications"] = (@"^-\s+name:", @"^(name|status):"),
-            ["recommendations"] = (@"^-\s+title:", @"^(title|description|state|impact|risk|declineReason):")
+            ["verifications"] = (@"^-\s+name:", "^(name|status):"),
+            ["recommendations"] = (@"^-\s+title:", "^(title|description|state|impact|risk|declineReason):")
         };
 
         static bool IsBlockScalarValue(string value)
@@ -781,7 +781,7 @@ public class PlanReaderService(
         {
             normalizedLine = trimmedLine;
 
-            var keyMatch = Regex.Match(trimmedLine, @"^([A-Za-z][A-Za-z0-9]*):");
+            var keyMatch = Regex.Match(trimmedLine, "^([A-Za-z][A-Za-z0-9]*):");
             if (keyMatch.Success && topLevelKeys.Contains(keyMatch.Groups[1].Value))
                 return keyMatch.Groups[1].Value;
 
@@ -892,7 +892,7 @@ public class PlanReaderService(
                 }
                 else
                 {
-                    var strayKeyMatch = Regex.Match(trimmed, @"^([A-Za-z][A-Za-z0-9]+):");
+                    var strayKeyMatch = Regex.Match(trimmed, "^([A-Za-z][A-Za-z0-9]+):");
                     if (strayKeyMatch.Success && topLevelKeys.Contains(strayKeyMatch.Groups[1].Value))
                     {
                         var key = strayKeyMatch.Groups[1].Value;
@@ -916,7 +916,7 @@ public class PlanReaderService(
                 continue;
             }
 
-            var unknownKeyMatch = Regex.Match(trimmed, @"^([A-Za-z][A-Za-z0-9]+):");
+            var unknownKeyMatch = Regex.Match(trimmed, "^([A-Za-z][A-Za-z0-9]+):");
             if (unknownKeyMatch.Success)
             {
                 inUnknownKey = true;
@@ -1362,7 +1362,7 @@ public class PlanReaderService(
     {
         var recommendations = new List<Recommendation>();
 
-        foreach (var (folderPath, folderName, planYamlPath) in EnumerateValidPlanFolders())
+        foreach (var (_, folderName, planYamlPath) in EnumerateValidPlanFolders())
         {
             try
             {
@@ -1413,7 +1413,7 @@ public class PlanReaderService(
     {
         int drafts = 0, reviews = 0, failed = 0, icebox = 0, pendingRecs = 0, total = 0;
 
-        foreach (var (folderPath, _, planYamlPath) in EnumerateValidPlanFolders())
+        foreach (var (_, _, planYamlPath) in EnumerateValidPlanFolders())
             try
             {
                 total++;


### PR DESCRIPTION
## Summary
- Removed 21 redundant `@` verbatim string prefixes across 5 files (strings contain no backslashes or special chars)
- Fixed 28 unused variable warnings across 14 files (discards, removals, underscore prefixes)
- Removed 3 redundant assignments in DoctorCommand and JobsApp

## Test plan
- [x] `dotnet build` passes (0 errors)
- [x] `dotnet test` passes (949/950, 1 pre-existing flaky test)