### PR TITLE
Extract hardcoded URLs from HelpApp to Constants

### DIFF
--- a/src/Ivy.Tendril/Apps/HelpApp.cs
+++ b/src/Ivy.Tendril/Apps/HelpApp.cs
@@ -10,27 +10,25 @@ public class HelpApp : ViewBase
         return Layout.TopCenter()
                | (Layout.Vertical().Margin(0, 20).Width(150).Gap(3)
                   | Text.H1("Help")
-                  | Text.Muted("View documentation at https://tendril.ivy.app or join us on Discord for help.")
+                  | Text.Muted($"View documentation at {Constants.DocsUrl} or join us on Discord for help.")
                   | (Layout.Horizontal()
                      | new Button("Open Documentation")
                          .Primary()
                          .Large()
                          .Icon(Icons.ExternalLink, Align.Right)
-                         .OnClick(() => client.OpenUrl("https://tendril.ivy.app"))
+                         .OnClick(() => client.OpenUrl(Constants.DocsUrl))
                      | new Button("Join Discord")
                          .Primary()
                          .Large()
                          .Icon(Icons.Discord, Align.Right)
-                         .OnClick(() => client.OpenUrl("https://discord.gg/FHgxkDga3y")))
+                         .OnClick(() => client.OpenUrl(Constants.DiscordUrl)))
                   | new Separator()
                   | Text.Muted("Found a bug? Submit an issue on GitHub.")
                   | new Button("Submit Issue")
                       .Secondary()
                       .Large()
                       .Icon(Icons.Bug, Align.Right)
-                      .OnClick(() =>
-                          client.OpenUrl(
-                              "https://github.com/Ivy-Interactive/Ivy-Tendril/issues/new"))
+                      .OnClick(() => client.OpenUrl(Constants.IssuesUrl))
                );
     }
 }

--- a/src/Ivy.Tendril/Constants.cs
+++ b/src/Ivy.Tendril/Constants.cs
@@ -17,4 +17,8 @@ public static class Constants
     public const int Trash = 90;
     public const int Help = 100;
     public const int Onboarding = 110;
+
+    public const string DocsUrl = "https://tendril.ivy.app";
+    public const string DiscordUrl = "https://discord.gg/FHgxkDga3y";
+    public const string IssuesUrl = "https://github.com/Ivy-Interactive/Ivy-Tendril/issues/new";
 }


### PR DESCRIPTION
## Summary
- Added `DocsUrl`, `DiscordUrl`, and `IssuesUrl` constants to `Constants.cs`
- Updated `HelpApp.cs` to reference constants instead of hardcoded URL strings

## Test plan
- [x] Build passes (0 errors, 0 warnings)