### PR TITLE
Refactor JobService: extract helpers to improve Code Health from 3.08 to 9.09

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(grep -E \"\\\\.\\(cs|xaml\\)$\")",
-      "Bash(xargs grep *)"
-    ]
-  }
-}

--- a/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
@@ -1,0 +1,122 @@
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Helpers;
+
+internal static class PlanYamlHelper
+{
+    internal static PlanYaml? ReadPlanYaml(string planFolder)
+    {
+        var yaml = ReadPlanYamlRaw(planFolder);
+        if (yaml == null) return null;
+
+        try
+        {
+            return YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    internal static string? ReadPlanYamlRaw(string planFolder)
+    {
+        var planYamlPath = Path.Combine(planFolder, "plan.yaml");
+        return File.Exists(planYamlPath) ? FileHelper.ReadAllText(planYamlPath) : null;
+    }
+
+    internal static void UpdatePlanYamlFields(string planFolder, params (string field, string value)[] updates)
+    {
+        var content = ReadPlanYamlRaw(planFolder);
+        if (content == null) return;
+
+        foreach (var (field, value) in updates)
+        {
+            var pattern = $@"(?m)^{Regex.Escape(field)}:\s*.*$";
+            var replacement = $"{field}: {value}";
+            content = Regex.Replace(content, pattern, replacement);
+        }
+
+        var planYamlPath = Path.Combine(planFolder, "plan.yaml");
+        FileHelper.WriteAllText(planYamlPath, content);
+    }
+
+    internal static void SetPlanStateByFolder(string planFolder, string state)
+    {
+        UpdatePlanYamlFields(planFolder,
+            ("state", state),
+            ("updated", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")));
+    }
+
+    internal static string? GetNamedArg(string[] args, string name)
+    {
+        for (var i = 0; i < args.Length - 1; i++)
+            if (args[i].Equals(name, StringComparison.OrdinalIgnoreCase))
+                return args[i + 1];
+        return null;
+    }
+
+    private static readonly object PlanIdLock = new();
+
+    internal static string AllocatePlanId(string plansDir)
+    {
+        Directory.CreateDirectory(plansDir);
+        var counterFile = Path.Combine(plansDir, ".counter");
+
+        lock (PlanIdLock)
+        {
+            var counter = 1;
+            if (File.Exists(counterFile))
+            {
+                var text = File.ReadAllText(counterFile).Trim();
+                if (int.TryParse(text, out var parsed)) counter = parsed;
+            }
+
+            var id = counter.ToString("D5");
+            File.WriteAllText(counterFile, (counter + 1).ToString());
+            return id;
+        }
+    }
+
+    internal static string? FindPlanFolderById(string plansDir, string? planId)
+    {
+        if (string.IsNullOrEmpty(planId)) return null;
+
+        try
+        {
+            var matches = Directory.GetDirectories(plansDir, $"{planId}-*");
+            return matches.Length > 0 ? Path.GetFileName(matches[0]) : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    internal static string? FindTrashEntryById(string trashDir, string planId)
+    {
+        if (!Directory.Exists(trashDir)) return null;
+
+        try
+        {
+            var matches = Directory.GetFiles(trashDir, $"{planId}-*.md");
+            return matches.Length > 0 ? matches[0] : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    internal static void LogCostToCsv(string planFolder, string jobType, int tokens, double cost)
+    {
+        if (!Directory.Exists(planFolder)) return;
+
+        var csvPath = Path.Combine(planFolder, "costs.csv");
+        if (!File.Exists(csvPath)) FileHelper.WriteAllText(csvPath, "Promptware,Tokens,Cost\n");
+
+        var line = $"{jobType},{tokens},{cost:F4}\n";
+        FileHelper.AppendAllText(csvPath, line);
+    }
+}

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -1,0 +1,641 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Ivy.Helpers;
+using Ivy.Tendril.Apps;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services;
+
+internal class JobCompletionHandler
+{
+    private readonly IConfigService? _configService;
+    private readonly ILogger _logger;
+    private readonly ModelPricingService? _modelPricingService;
+    private readonly IPlanReaderService? _planReaderService;
+    private readonly IPlanWatcherService? _planWatcherService;
+    private readonly ITelemetryService? _telemetryService;
+    private readonly IWorktreeLifecycleLogger? _worktreeLifecycleLogger;
+    private readonly string _promptsRoot;
+
+    internal JobCompletionHandler(
+        IConfigService? configService,
+        ILogger logger,
+        ModelPricingService? modelPricingService,
+        IPlanReaderService? planReaderService,
+        ITelemetryService? telemetryService,
+        IPlanWatcherService? planWatcherService,
+        IWorktreeLifecycleLogger? worktreeLifecycleLogger,
+        string promptsRoot)
+    {
+        _configService = configService;
+        _logger = logger;
+        _modelPricingService = modelPricingService;
+        _planReaderService = planReaderService;
+        _telemetryService = telemetryService;
+        _planWatcherService = planWatcherService;
+        _worktreeLifecycleLogger = worktreeLifecycleLogger;
+        _promptsRoot = promptsRoot;
+    }
+
+    internal void HandleCompletion(
+        JobItem job,
+        ConcurrentDictionary<string, JobItem> jobs,
+        Action<JobItem> persistJob,
+        Action<JobNotification> raiseNotification,
+        Action raisePropertyChanged,
+        Func<string, string[], string> startJobSkipDepCheck)
+    {
+        var isSuccess = job.Status == JobStatus.Completed;
+
+        RunAfterHooks(job);
+        SendCompletionNotification(job, isSuccess, raiseNotification);
+        HandlePlanStateTransition(job, isSuccess);
+        TrackTelemetry(job, isSuccess);
+        CleanupInboxFile(job);
+        WriteJobLog(job);
+        NotifyPlanWatcher(job);
+        ScheduleCostCalculation(job, jobs, persistJob, raisePropertyChanged);
+
+        if (job.Status is JobStatus.Failed or JobStatus.Timeout)
+            ScheduleWorktreeCleanup(job);
+
+        if (isSuccess && job.Type is "ExecutePlan" or "CreatePr")
+            RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
+
+        if (isSuccess && job.Type is "ExecutePlan" or "CreatePr" or "CreateIssue")
+        {
+            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            RetryBlockedDependents(planFolder, jobs, startJobSkipDepCheck);
+        }
+    }
+
+    private void RunAfterHooks(JobItem job)
+    {
+        var planFolderForHooks = job.Args.Length > 0 ? job.Args[0] : "";
+        RunHooks("after", job.Type, planFolderForHooks, job.Project, job);
+    }
+
+    private static void SendCompletionNotification(JobItem job, bool isSuccess, Action<JobNotification> raiseNotification)
+    {
+        var title = job.Status == JobStatus.Timeout ? $"{job.Type} Timed Out" :
+            isSuccess ? $"{job.Type} Completed" : $"{job.Type} Failed";
+        var message = job.PlanFile ?? job.Type;
+        if (!isSuccess && job.StatusMessage != null)
+            message += $": {job.StatusMessage}";
+        raiseNotification(new JobNotification(title, message, isSuccess));
+    }
+
+    private void HandlePlanStateTransition(JobItem job, bool isSuccess)
+    {
+        if (job.Status is JobStatus.Failed or JobStatus.Timeout)
+        {
+            ResetPlanState(job);
+        }
+        else if (isSuccess && job.Type == "ExecutePlan")
+        {
+            EnsurePlanStateTransitioned(job);
+        }
+        else if (isSuccess && job.Type == "CreateIssue")
+        {
+            SetPlanState(job, "Completed");
+        }
+        else if (isSuccess && job.Type is "UpdatePlan" or "ExpandPlan" or "SplitPlan")
+        {
+            SetPlanState(job, "Draft");
+        }
+        else if (isSuccess && job.Type == "CreatePlan")
+        {
+            VerifyCreatePlanResult(job);
+        }
+    }
+
+    private void TrackTelemetry(JobItem job, bool isSuccess)
+    {
+        if (isSuccess && job.Type == "CreatePlan" && job.Status == JobStatus.Completed)
+        {
+            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            var level = "NiceToHave";
+            if (Directory.Exists(planFolder))
+            {
+                var plan = PlanYamlHelper.ReadPlanYaml(planFolder);
+                if (plan != null) level = plan.Level;
+            }
+
+            _telemetryService?.TrackPlanCreated(new PlanCreatedContext(level, job.DurationSeconds));
+        }
+
+        if (isSuccess && job.Type == "CreatePr")
+        {
+            _telemetryService?.TrackPrCreated(new PrCreatedContext(job.DurationSeconds));
+        }
+
+        _telemetryService?.TrackJobCompleted(job.Type, job.Status, job.DurationSeconds);
+
+        if (_telemetryService != null)
+            _ = Task.Run(async () => { try { await _telemetryService.FlushAsync(); } catch { /* best-effort */ } });
+    }
+
+    private void NotifyPlanWatcher(JobItem job)
+    {
+        var notifyFolder = job.Args.Length > 0 ? job.Args[0] : null;
+        _planWatcherService?.NotifyChanged(Directory.Exists(notifyFolder) ? notifyFolder : null);
+    }
+
+    private void ScheduleCostCalculation(
+        JobItem job,
+        ConcurrentDictionary<string, JobItem> jobs,
+        Action<JobItem> persistJob,
+        Action raisePropertyChanged)
+    {
+        var isSuccess = job.Status == JobStatus.Completed;
+        if (!isSuccess || _modelPricingService == null || string.IsNullOrEmpty(job.SessionId))
+            return;
+
+        var sessionId = job.SessionId;
+        var jobArgs = job.Args;
+        var jobType = job.Type;
+        var jobId = job.Id;
+        var provider = job.Provider;
+
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30));
+
+            try
+            {
+                var costCalc = _modelPricingService.CalculateSessionCost(sessionId, provider);
+                if (costCalc.TotalCost > 0)
+                {
+                    if (jobs.TryGetValue(jobId, out var j))
+                    {
+                        j.Cost = (decimal)costCalc.TotalCost;
+                        j.Tokens = costCalc.TotalTokens;
+                        persistJob(j);
+                        raisePropertyChanged();
+                    }
+
+                    if (jobArgs.Length > 0)
+                        PlanYamlHelper.LogCostToCsv(jobArgs[0], jobType, costCalc.TotalTokens, costCalc.TotalCost);
+                }
+            }
+            catch
+            {
+                /* Best-effort cost tracking */
+            }
+        });
+    }
+
+    internal void RunHooks(string when, string jobType, string planFolder, string project, JobItem job)
+    {
+        if (_configService == null) return;
+
+        var projectConfig = _configService.GetProject(project);
+        if (projectConfig == null) return;
+
+        var hooks = projectConfig.Hooks
+            .Where(h => h.When.Equals(when, StringComparison.OrdinalIgnoreCase))
+            .Where(h => h.Promptwares.Count == 0 || h.Promptwares.Contains(jobType, StringComparer.OrdinalIgnoreCase))
+            .ToList();
+
+        foreach (var hook in hooks)
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(hook.Condition))
+                {
+                    var condPsi = new ProcessStartInfo
+                    {
+                        FileName = "pwsh",
+                        Arguments = $"-NoProfile -NonInteractive -EncodedCommand {EncodeForPowerShell(hook.Condition)}",
+                        WorkingDirectory = string.IsNullOrEmpty(planFolder) ? "." : planFolder,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        RedirectStandardInput = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    };
+                    using var condProc = Process.Start(condPsi);
+                    var condOutput = condProc?.StandardOutput.ReadToEnd().Trim() ?? "";
+                    condProc.WaitForExitOrKill(10000);
+
+                    if (condProc?.ExitCode != 0 ||
+                        condOutput.Equals("False", StringComparison.OrdinalIgnoreCase))
+                    {
+                        job.EnqueueOutput($"[hook:{hook.Name}] Condition not met, skipping");
+                        continue;
+                    }
+                }
+
+                var actionPsi = new ProcessStartInfo
+                {
+                    FileName = "pwsh",
+                    Arguments = $"-NoProfile -NonInteractive -EncodedCommand {EncodeForPowerShell(hook.Action)}",
+                    WorkingDirectory = string.IsNullOrEmpty(planFolder) ? "." : planFolder,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    RedirectStandardInput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                actionPsi.Environment["TENDRIL_JOB_ID"] = job.Id;
+                actionPsi.Environment["TENDRIL_JOB_TYPE"] = jobType;
+                actionPsi.Environment["TENDRIL_JOB_STATUS"] = job.Status.ToString();
+                actionPsi.Environment["TENDRIL_PLAN_FOLDER"] = planFolder;
+                actionPsi.Environment["TENDRIL_CONFIG"] = _configService.ConfigPath;
+
+                using var actionProc = Process.Start(actionPsi);
+                var output = actionProc?.StandardOutput.ReadToEnd().Trim() ?? "";
+                var stderr = actionProc?.StandardError.ReadToEnd().Trim() ?? "";
+                actionProc.WaitForExitOrKill(30000);
+
+                if (!string.IsNullOrEmpty(output))
+                    job.EnqueueOutput($"[hook:{hook.Name}] {output}");
+                if (!string.IsNullOrEmpty(stderr))
+                    job.EnqueueOutput($"[hook:{hook.Name}] [stderr] {stderr}");
+
+                if (actionProc?.ExitCode != 0)
+                    job.EnqueueOutput($"[hook:{hook.Name}] Hook failed with exit code {actionProc?.ExitCode}");
+            }
+            catch (Exception ex)
+            {
+                job.EnqueueOutput($"[hook:{hook.Name}] Error: {ex.Message}");
+            }
+    }
+
+    private static string EncodeForPowerShell(string command)
+    {
+        var bytes = Encoding.Unicode.GetBytes(command);
+        return Convert.ToBase64String(bytes);
+    }
+
+    private void EnsurePlanStateTransitioned(JobItem job)
+    {
+        try
+        {
+            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            var planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
+            if (planYaml == null) return;
+
+            if (planYaml.State is "Executing" or "Building")
+            {
+                var hasIncomplete = planYaml.Verifications?
+                    .Any(v => v.Status is "Pending" or "Fail") ?? false;
+                var targetState = hasIncomplete ? PlanStatus.Failed : PlanStatus.ReadyForReview;
+
+                var folderName = Path.GetFileName(planFolder);
+                if (_planReaderService != null)
+                    _planReaderService.TransitionState(folderName, targetState);
+                else
+                    PlanYamlHelper.SetPlanStateByFolder(planFolder, targetState.ToString());
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private void SetPlanState(JobItem job, string state)
+    {
+        try
+        {
+            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            if (_planReaderService != null && Enum.TryParse<PlanStatus>(state, true, out var status))
+                _planReaderService.TransitionState(Path.GetFileName(planFolder), status);
+            else
+                PlanYamlHelper.SetPlanStateByFolder(planFolder, state);
+        }
+        catch
+        {
+        }
+    }
+
+    private void VerifyCreatePlanResult(JobItem job)
+    {
+        try
+        {
+            if (_planReaderService == null) return;
+            var plansDir = _planReaderService.PlansDirectory;
+            if (!Directory.Exists(plansDir)) return;
+
+            var outputText = string.Join("\n", job.OutputLines);
+            var createdMatch = Regex.Match(outputText, @"Plan created:\s*(\S+)");
+            var duplicate = Regex.IsMatch(outputText, "identified as duplicate:");
+
+            if (createdMatch.Success)
+            {
+                job.PlanFile = createdMatch.Groups[1].Value;
+            }
+            else if (!duplicate)
+            {
+                var planFolder = PlanYamlHelper.FindPlanFolderById(plansDir, job.AllocatedPlanId);
+                if (planFolder != null)
+                {
+                    job.PlanFile = planFolder;
+                }
+                else
+                {
+                    var trashDir = _configService != null
+                        ? Path.Combine(_configService.TendrilHome, "Trash")
+                        : null;
+                    var trashEntry = trashDir != null && !string.IsNullOrEmpty(job.AllocatedPlanId)
+                        ? PlanYamlHelper.FindTrashEntryById(trashDir, job.AllocatedPlanId)
+                        : null;
+
+                    if (trashEntry == null)
+                    {
+                        job.EnqueueOutput(
+                            "[Tendril] WARNING: CreatePlan completed but no plan folder or trash entry was found.");
+                        job.Status = JobStatus.Failed;
+
+                        var failureMessage = JobFailureAnalyzer.TryReadFailureArtifact(job.OutputLines.ToList());
+                        job.StatusMessage = failureMessage ?? "No plan created";
+                    }
+                }
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    internal void ResetPlanState(JobItem job)
+    {
+        try
+        {
+            if (job.Type is "CreatePlan" or "CreatePr" or "CreateIssue") return;
+
+            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            var newState = job.Type == "ExecutePlan" ? "Failed" : "Draft";
+            PlanYamlHelper.SetPlanStateByFolder(planFolder, newState);
+        }
+        catch
+        {
+        }
+    }
+
+    internal void ResetPlanStateToBlocked(JobItem job)
+    {
+        try
+        {
+            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            PlanYamlHelper.SetPlanStateByFolder(planFolder, "Blocked");
+        }
+        catch
+        {
+        }
+    }
+
+    internal static void CleanupInboxFile(JobItem job)
+    {
+        if (string.IsNullOrEmpty(job.InboxFile)) return;
+        try
+        {
+            if (File.Exists(job.InboxFile))
+                File.Delete(job.InboxFile);
+        }
+        catch
+        {
+        }
+    }
+
+    private void ScheduleWorktreeCleanup(JobItem job)
+    {
+        if (job.Type != "ExecutePlan") return;
+
+        var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+        if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder)) return;
+
+        var worktreesDir = Path.Combine(planFolder, "worktrees");
+        if (!Directory.Exists(worktreesDir)) return;
+
+        var lifecycleLogger = _worktreeLifecycleLogger;
+
+        Task.Run(async () =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30));
+            try
+            {
+                PlanReaderService.RemoveWorktrees(planFolder, lifecycleLogger: lifecycleLogger);
+
+                if (Directory.Exists(worktreesDir) && Directory.GetDirectories(worktreesDir).Length == 0)
+                    Directory.Delete(worktreesDir, false);
+            }
+            catch
+            {
+            }
+        });
+    }
+
+    internal (bool Ok, string? BlockReason) CheckDependencies(string planFolder)
+    {
+        try
+        {
+            var planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
+            if (planYaml?.DependsOn == null || planYaml.DependsOn.Count == 0)
+                return (true, null);
+
+            var plansDir = _planReaderService?.PlansDirectory;
+            if (plansDir == null) return (true, null);
+
+            foreach (var dep in planYaml.DependsOn)
+            {
+                var depFolder = Path.Combine(plansDir, dep);
+                var depPlan = PlanYamlHelper.ReadPlanYaml(depFolder);
+
+                if (depPlan == null)
+                    return (false, $"Dependency '{dep}' not found");
+
+                if (!depPlan.State.Equals("Completed", StringComparison.OrdinalIgnoreCase))
+                    return (false, $"Dependency '{dep}' is '{depPlan.State}', not Completed");
+
+                if (depPlan.Prs.Count == 0)
+                    continue;
+
+                foreach (var prUrl in depPlan.Prs.Where(PullRequestApp.IsValidUrl))
+                    try
+                    {
+                        var psi = new ProcessStartInfo
+                        {
+                            FileName = "gh",
+                            Arguments = $"pr view \"{prUrl}\" --json state -q .state",
+                            RedirectStandardOutput = true,
+                            RedirectStandardError = true,
+                            UseShellExecute = false,
+                            CreateNoWindow = true
+                        };
+                        using var proc = Process.Start(psi);
+                        var output = proc?.StandardOutput.ReadToEnd().Trim() ?? "";
+                        proc.WaitForExitOrKill(10000);
+
+                        if (!output.Equals("MERGED", StringComparison.OrdinalIgnoreCase))
+                            return (false, $"Dependency '{dep}' PR {prUrl} is '{output}', not MERGED");
+                    }
+                    catch (Exception ex)
+                    {
+                        return (false, $"Failed to check PR status for '{dep}': {ex.Message}");
+                    }
+            }
+
+            return (true, null);
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Dependency check failed: {ex.Message}");
+        }
+    }
+
+    private void RetryBlockedJobs(
+        ConcurrentDictionary<string, JobItem> jobs,
+        Action<JobNotification> raiseNotification,
+        Func<string, string[], string> startJobSkipDepCheck)
+    {
+        var blockedJobs = jobs.Values
+            .Where(j => j.Status == JobStatus.Blocked && j.Type == "ExecutePlan")
+            .ToList();
+
+        foreach (var blockedJob in blockedJobs)
+        {
+            var planFolder = blockedJob.Args.Length > 0 ? blockedJob.Args[0] : "";
+            if (string.IsNullOrEmpty(planFolder)) continue;
+
+            var (ok, _) = CheckDependencies(planFolder);
+            if (!ok) continue;
+
+            if (!jobs.TryRemove(blockedJob.Id, out _)) continue;
+
+            if (HasActiveJobForPlan(planFolder, jobs)) continue;
+
+            PlanYamlHelper.SetPlanStateByFolder(planFolder, "Building");
+            startJobSkipDepCheck(blockedJob.Type, blockedJob.Args);
+
+            raiseNotification(new JobNotification(
+                "Job Unblocked",
+                $"{blockedJob.PlanFile}: dependencies now satisfied, auto-restarting",
+                true));
+        }
+    }
+
+    private void RetryBlockedDependents(
+        string completedPlanFolder,
+        ConcurrentDictionary<string, JobItem> jobs,
+        Func<string, string[], string> startJobSkipDepCheck)
+    {
+        try
+        {
+            var completedFolderName = Path.GetFileName(completedPlanFolder);
+            var plansDir = _planReaderService?.PlansDirectory;
+            if (string.IsNullOrEmpty(plansDir) || !Directory.Exists(plansDir)) return;
+
+            foreach (var dir in Directory.GetDirectories(plansDir))
+            {
+                var planYaml = PlanYamlHelper.ReadPlanYaml(dir);
+                if (planYaml == null) continue;
+                if (!planYaml.State.Equals("Blocked", StringComparison.OrdinalIgnoreCase)) continue;
+                if (!planYaml.DependsOn.Contains(completedFolderName, StringComparer.OrdinalIgnoreCase)) continue;
+
+                var hasExistingJob = jobs.Values.Any(j =>
+                    j.Type == "ExecutePlan" &&
+                    j.Status is JobStatus.Blocked or JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
+                    j.Args.Length > 0 &&
+                    j.Args[0].Equals(dir, StringComparison.OrdinalIgnoreCase));
+                if (hasExistingJob) continue;
+
+                var (allMet, _) = CheckDependencies(dir);
+                if (allMet)
+                {
+                    PlanYamlHelper.SetPlanStateByFolder(dir, "Building");
+                    startJobSkipDepCheck("ExecutePlan", new[] { dir });
+                }
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private static bool HasActiveJobForPlan(string planFolder, ConcurrentDictionary<string, JobItem> jobs)
+    {
+        return jobs.Values.Any(j =>
+            j.Type == "ExecutePlan" &&
+            j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
+            j.Args.Length > 0 &&
+            j.Args[0].Equals(planFolder, StringComparison.OrdinalIgnoreCase));
+    }
+
+    internal void WriteJobLog(JobItem job)
+    {
+        try
+        {
+            WriteRawOutputLog(job);
+        }
+        catch
+        {
+        }
+
+        if (_planReaderService == null || string.IsNullOrEmpty(job.PlanFile))
+            return;
+
+        if (job.Type == "CreatePlan")
+            return;
+
+        try
+        {
+            var duration = job.DurationSeconds.HasValue ? $"{job.DurationSeconds}s" : "unknown";
+            var logContent = $"# {job.Type}\n\n" +
+                             $"- **Status:** {job.Status}\n" +
+                             $"- **Started:** {job.StartedAt:u}\n" +
+                             $"- **Completed:** {job.CompletedAt:u}\n" +
+                             $"- **Duration:** {duration}\n";
+
+            if (!string.IsNullOrEmpty(job.SessionId))
+                logContent += $"- **SessionId:** {job.SessionId}\n";
+
+            if (job.Status == JobStatus.Timeout && job.StatusMessage != null)
+                logContent += $"- **Timeout Reason:** {job.StatusMessage}\n";
+
+            _planReaderService.AddLog(job.PlanFile, job.Type, logContent);
+
+            if (job.Status is JobStatus.Failed or JobStatus.Timeout && job.OutputLines.Count > 0)
+            {
+                var planFolder = job.Args.Length > 0 ? job.Args[0] : null;
+
+                if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder))
+                {
+                    var logRoot = Path.Combine(
+                        Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? ".",
+                        "Logs", "Jobs");
+                    FileHelper.EnsureDirectory(logRoot);
+                    planFolder = logRoot;
+                }
+
+                var logsDir = Path.Combine(planFolder, "logs");
+                FileHelper.EnsureDirectory(logsDir);
+                var outputFile = Path.Combine(logsDir, $"{job.Type}-{job.Id}.output.log");
+                File.WriteAllLines(outputFile, job.OutputLines);
+
+                job.EnqueueOutput($"[Tendril] Full output saved to: {outputFile}");
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private void WriteRawOutputLog(JobItem job)
+    {
+        if (job.OutputLines.Count == 0) return;
+
+        var logsDir = Path.Combine(_promptsRoot, job.Type, "Logs");
+        if (!Directory.Exists(logsDir)) return;
+
+        var logName = !string.IsNullOrEmpty(job.AllocatedPlanId)
+            ? job.AllocatedPlanId
+            : job.Id;
+
+        var rawFile = Path.Combine(logsDir, $"{logName}.raw.jsonl");
+        File.WriteAllLines(rawFile, job.OutputLines);
+    }
+}

--- a/src/Ivy.Tendril/Services/JobFailureAnalyzer.cs
+++ b/src/Ivy.Tendril/Services/JobFailureAnalyzer.cs
@@ -1,0 +1,185 @@
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Services;
+
+internal static class JobFailureAnalyzer
+{
+    internal static string ExtractFailureReason(List<string> outputLines, string jobType)
+    {
+        if (outputLines.Count == 0)
+            return "Unknown error (exit code non-zero)";
+
+        // 1. Check for PowerShell terminating errors
+        var psError = FindPattern(outputLines, new[] {
+            @"At line:\d+",
+            @"CategoryInfo\s+:",
+            @"TerminatingError\(",
+            "ScriptHalted",
+            @"^\s*\+\s+CategoryInfo",
+        });
+        if (psError != null) return psError;
+
+        // 2. Check for Claude API errors (from JSON stream)
+        var apiError = FindPattern(outputLines, new[] {
+            @"""type"":\s*""error""",
+            @"""error"":\s*\{",
+            "rate_limit_error",
+            "overloaded_error",
+            "authentication_error",
+        });
+        if (apiError != null) return ParseClaudeApiError(apiError);
+
+        // 3. Check for CreatePlan-specific failures and failure artifacts
+        if (jobType == "CreatePlan")
+        {
+            var makePlanError = FindPattern(outputLines, new[] {
+                "ERROR: Plan",
+                "WARNING: TENDRIL_HOME",
+                "Failed to parse",
+                "Repository path does not exist",
+            });
+            if (makePlanError != null) return makePlanError;
+
+            var failureArtifactMessage = TryReadFailureArtifact(outputLines);
+            if (failureArtifactMessage != null) return failureArtifactMessage;
+        }
+
+        // 4. Check for validation/assertion failures
+        var validationError = FindPattern(outputLines, new[] {
+            @"validation\s+failed",
+            @"assertion\s+failed",
+            "Repository path does not exist",
+            @"\[stderr\].*(?-i)ERROR:",
+        });
+        if (validationError != null) return validationError;
+
+        // 5. Search from end for stderr lines
+        var stderrLines = new List<string>();
+        for (var i = outputLines.Count - 1; i >= 0 && stderrLines.Count < 3; i--)
+        {
+            var line = outputLines[i];
+            if (line.StartsWith("[stderr] "))
+            {
+                var content = line["[stderr] ".Length..].Trim();
+                if (content.Length > 0 && !IsProgressMessage(content))
+                    stderrLines.Insert(0, content);
+            }
+        }
+
+        if (stderrLines.Count > 0)
+            return SanitizeForDisplay(string.Join(" | ", stderrLines));
+
+        // 6. Fall back to last non-progress line
+        for (var i = outputLines.Count - 1; i >= 0; i--)
+        {
+            var trimmed = outputLines[i].Trim();
+            if (trimmed.Length > 0 && !IsProgressMessage(trimmed))
+                return SanitizeForDisplay(trimmed);
+        }
+
+        return "Unknown error (exit code non-zero)";
+    }
+
+    internal static string SanitizeForDisplay(string text)
+    {
+        text = Regex.Replace(text, @"\x1B\[[0-9;]*[A-Za-z]", "");
+        text = Regex.Replace(text, @"[\x00-\x1F]", " ");
+        text = Regex.Replace(text, " {2,}", " ");
+        text = text.Trim();
+
+        if (text.Length > 200)
+            text = text[..200] + "...";
+
+        return text;
+    }
+
+    private static bool IsProgressMessage(string line)
+    {
+        var progressPatterns = new[] {
+            "Creating Plan", "Executing Plan", "Building", "Researching",
+            "Reading", "Analyzing", "Writing", "Searching",
+            @"^\d+%", @"^\[.*\]\s+(Starting|Running|Completed)",
+        };
+
+        return progressPatterns.Any(p => Regex.IsMatch(line, p, RegexOptions.IgnoreCase));
+    }
+
+    private static string? FindPattern(List<string> lines, string[] patterns)
+    {
+        for (var i = lines.Count - 1; i >= Math.Max(0, lines.Count - 50); i--)
+        {
+            foreach (var pattern in patterns)
+            {
+                if (Regex.IsMatch(lines[i], pattern, RegexOptions.IgnoreCase))
+                {
+                    var start = Math.Max(0, i - 2);
+                    var end = Math.Min(lines.Count - 1, i + 1);
+                    var context = string.Join(" | ", lines.Skip(start).Take(end - start + 1));
+                    return SanitizeForDisplay(context);
+                }
+            }
+        }
+        return null;
+    }
+
+    private static string ParseClaudeApiError(string jsonErrorLine)
+    {
+        try
+        {
+            var match = Regex.Match(jsonErrorLine, @"""message"":\s*""([^""]+)""");
+            if (match.Success)
+                return $"Claude API: {match.Groups[1].Value}";
+        }
+        catch { }
+
+        return "Claude API error (see output for details)";
+    }
+
+    internal static string? TryReadFailureArtifact(List<string> outputLines)
+    {
+        try
+        {
+            var artifactLine = outputLines.FirstOrDefault(line =>
+                line.Contains("Failure artifact written:") && line.Contains("Failed"));
+
+            if (artifactLine == null) return null;
+
+            var pathMatch = Regex.Match(artifactLine, @"Failure artifact written:\s*(.+)");
+            if (!pathMatch.Success) return null;
+
+            var artifactPath = pathMatch.Groups[1].Value.Trim();
+            if (!File.Exists(artifactPath)) return null;
+
+            var lines = File.ReadAllLines(artifactPath);
+            var errorOutputSection = false;
+            var errorLines = new List<string>();
+
+            foreach (var line in lines)
+            {
+                if (line.StartsWith("## Error Output"))
+                {
+                    errorOutputSection = true;
+                    continue;
+                }
+                if (line.StartsWith("## Investigation Steps"))
+                {
+                    break;
+                }
+                if (errorOutputSection && !line.StartsWith("```"))
+                {
+                    errorLines.Add(line.Trim());
+                }
+            }
+
+            if (errorLines.Count > 0)
+            {
+                var summary = string.Join(" | ", errorLines.Take(3).Where(l => l.Length > 0));
+                return string.IsNullOrWhiteSpace(summary) ? null : SanitizeForDisplay(summary);
+            }
+        }
+        catch { }
+
+        return null;
+    }
+}

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -1,0 +1,429 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text;
+using Ivy.Helpers;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Agents;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services;
+
+internal class JobLauncher
+{
+    private readonly IConfigService? _configService;
+    private readonly ILogger _logger;
+    private readonly string _promptsRoot;
+    private readonly string _sharedRoot;
+
+    internal JobLauncher(IConfigService? configService, ILogger logger, string promptsRoot, string sharedRoot)
+    {
+        _configService = configService;
+        _logger = logger;
+        _promptsRoot = promptsRoot;
+        _sharedRoot = sharedRoot;
+    }
+
+    internal void LaunchJob(
+        JobItem job,
+        ConcurrentDictionary<string, JobItem> jobs,
+        SemaphoreSlim jobSlotSemaphore,
+        TimeSpan jobTimeout,
+        TimeSpan staleOutputTimeout,
+        Action<string, string, string, string, JobItem> runHooks,
+        Action<string, int?, bool, bool> completeJob,
+        Action raiseStructureChanged)
+    {
+        var id = job.Id;
+        var type = job.Type;
+        var args = job.Args;
+        var scriptPath = job.ScriptPath;
+
+        job.Status = JobStatus.Running;
+        job.StartedAt = DateTime.UtcNow;
+        job.StatusMessage = null;
+
+        var planFolderForHooks = type != "CreatePlan" && args.Length > 0 ? args[0] : "";
+        runHooks("before", type, planFolderForHooks, job.Project, job);
+
+        job.SessionId = Guid.NewGuid().ToString();
+
+        var psi = TryBuildAgentProcessStart(job);
+
+        if (psi == null)
+        {
+            psi = BuildLegacyProcessStart(job, scriptPath);
+        }
+
+        var process = new Process { StartInfo = psi };
+        AttachOutputHandlers(process, job, id);
+
+        try
+        {
+            process.Start();
+        }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            _logger.LogError(ex, "Job {JobId}: Failed to start process '{FileName}'", id, psi.FileName);
+            job.Status = JobStatus.Failed;
+            job.StatusMessage = $"Agent binary not found: {psi.FileName}";
+            job.CompletedAt = DateTime.UtcNow;
+            jobSlotSemaphore.Release();
+            raiseStructureChanged();
+            return;
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        job.Process = process;
+        job.ProcessId = process.Id;
+
+        var cts = new CancellationTokenSource(jobTimeout);
+        job.TimeoutCts = cts;
+
+        Task.Run(async () =>
+        {
+            _logger.LogDebug("Job {JobId}: Monitor task started", id);
+
+            try
+            {
+                if (await process.WaitForExitOrKillAsync(cts.Token))
+                {
+                    if (jobs.TryGetValue(id, out var j) && j.StaleOutputDetected)
+                    {
+                        _logger.LogInformation("Job {JobId}: Process exited, stale output detected", id);
+                        completeJob(id, null, true, true);
+                    }
+                    else
+                    {
+                        _logger.LogInformation("Job {JobId}: Process exited with code {ExitCode}", id, process.ExitCode);
+                        completeJob(id, process.ExitCode, false, false);
+                    }
+                }
+                else
+                {
+                    _logger.LogWarning("Job {JobId}: Process killed after timeout", id);
+                    completeJob(id, null, true, false);
+                }
+
+                _logger.LogDebug("Job {JobId}: Monitor task completed normally", id);
+            }
+            catch (ObjectDisposedException)
+            {
+                _logger.LogDebug("Job {JobId}: Monitor task exiting (CTS disposed, job completed elsewhere)", id);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Job {JobId}: Monitor task exception", id);
+                CrashLog.Write($"[{DateTime.UtcNow:O}] JobService process monitor exception for job {id}: {ex}");
+                completeJob(id, null, false, false);
+            }
+        });
+
+        if (staleOutputTimeout > TimeSpan.Zero)
+            _ = RunStaleOutputWatchdog(id, cts, jobs, staleOutputTimeout);
+
+        raiseStructureChanged();
+    }
+
+    internal async Task RunStaleOutputWatchdog(
+        string id,
+        CancellationTokenSource timeoutCts,
+        ConcurrentDictionary<string, JobItem> jobs,
+        TimeSpan staleOutputTimeout)
+    {
+        const int checkIntervalSeconds = 60;
+
+        try
+        {
+            while (!timeoutCts.Token.IsCancellationRequested)
+            {
+                for (var i = 0; i < checkIntervalSeconds; i++)
+                {
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(1), timeoutCts.Token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return;
+                    }
+
+                    if (timeoutCts.Token.IsCancellationRequested) return;
+                }
+
+                if (!jobs.TryGetValue(id, out var job) || job.Status != JobStatus.Running)
+                    break;
+
+                if (job.LastOutputAt.HasValue)
+                {
+                    var sinceLastOutput = DateTime.UtcNow - job.LastOutputAt.Value;
+                    if (sinceLastOutput >= staleOutputTimeout)
+                    {
+                        job.StaleOutputDetected = true;
+                        try { timeoutCts.Cancel(); } catch (ObjectDisposedException) { }
+                        break;
+                    }
+                }
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    private ProcessStartInfo BuildLegacyProcessStart(JobItem job, string scriptPath)
+    {
+        var processArgs = new List<string> { "-NoProfile", "-NonInteractive", "-File", scriptPath };
+        processArgs.AddRange(job.Args);
+
+        var workingDirectory = Path.GetFullPath(
+            Path.Combine(System.AppContext.BaseDirectory, "..", "..", ".."));
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8
+        };
+
+        psi.Environment["TENDRIL_JOB_ID"] = job.Id;
+        psi.Environment["TENDRIL_URL"] = Environment.GetEnvironmentVariable("TENDRIL_URL") ?? "https://localhost:5010";
+        psi.Environment["TENDRIL_SHARED"] = _sharedRoot;
+        psi.Environment["TENDRIL_SESSION_ID"] = job.SessionId;
+        if (_configService != null)
+            psi.Environment["TENDRIL_CONFIG"] = _configService.ConfigPath;
+
+        psi.Environment["CI"] = "true";
+        psi.Environment["TERM"] = "dumb";
+
+        foreach (var arg in processArgs)
+            psi.ArgumentList.Add(arg);
+
+        return psi;
+    }
+
+    private static void AttachOutputHandlers(Process process, JobItem job, string id)
+    {
+        process.OutputDataReceived += (_, e) =>
+        {
+            try
+            {
+                if (e.Data != null)
+                {
+                    job.LastOutputAt = DateTime.UtcNow;
+                    if (!e.Data.Contains("\"type\":\"heartbeat\"")) job.EnqueueOutput(e.Data);
+                }
+            }
+            catch (Exception ex)
+            {
+                CrashLog.Write($"[{DateTime.UtcNow:O}] OutputDataReceived exception for job {id}: {ex}");
+            }
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            try
+            {
+                if (e.Data != null)
+                {
+                    job.EnqueueOutput($"[stderr] {e.Data}");
+                    job.LastOutputAt = DateTime.UtcNow;
+                }
+            }
+            catch (Exception ex)
+            {
+                CrashLog.Write($"[{DateTime.UtcNow:O}] ErrorDataReceived exception for job {id}: {ex}");
+            }
+        };
+    }
+
+    private ProcessStartInfo? TryBuildAgentProcessStart(JobItem job)
+    {
+        if (_configService == null) return null;
+
+        var programFolder = Path.Combine(_promptsRoot, job.Type);
+        if (!HasAgentDirectProgram(programFolder, job.Type)) return null;
+
+        var settings = _configService.Settings;
+        var (values, planYaml, profileOverride) = BuildFirmwareValues(job, programFolder);
+
+        values["Project"] = job.Project;
+
+        var resolution = AgentProviderFactory.Resolve(settings, job.Type, profileOverride);
+        var workDir = ResolveWorkingDirectory(job, programFolder);
+
+        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
+        var sharedDocs = new List<(string Name, string Content)>();
+        var plansMdPath = Path.Combine(_sharedRoot, "Plans.md");
+        if (File.Exists(plansMdPath))
+            sharedDocs.Add(("Plans", File.ReadAllText(plansMdPath)));
+
+        var context = new FirmwareContext(programFolder, logFile, values, sharedDocs);
+        var prompt = FirmwareCompiler.Compile(context);
+
+        var invocation = new AgentInvocation(
+            PromptContent: prompt,
+            WorkingDirectory: workDir,
+            Model: resolution.Model,
+            Effort: resolution.Effort,
+            SessionId: job.SessionId ?? "",
+            AllowedTools: resolution.AllowedTools,
+            ExtraArgs: resolution.ExtraArgs);
+
+        var psi = resolution.Provider.BuildProcessStart(invocation);
+        SetTendrilEnvironment(psi, job);
+
+        _logger.LogInformation(
+            "Job {JobId}: Agent-direct launch ({Provider}, model={Model}, effort={Effort})",
+            job.Id, resolution.Provider.Name, resolution.Model, resolution.Effort);
+
+        return psi;
+    }
+
+    private static bool HasAgentDirectProgram(string programFolder, string jobType)
+    {
+        var programMd = Path.Combine(programFolder, "Program.md");
+        if (!File.Exists(programMd)) return false;
+        var scriptFile = Path.Combine(programFolder, $"{jobType}.ps1");
+        return !File.Exists(scriptFile);
+    }
+
+    private (Dictionary<string, string> Values, PlanYaml? PlanYaml, string? ProfileOverride)
+        BuildFirmwareValues(JobItem job, string programFolder)
+    {
+        var values = new Dictionary<string, string>
+        {
+            ["ClaudeSessionId"] = job.SessionId ?? ""
+        };
+
+        string? profileOverride = null;
+        PlanYaml? planYaml = null;
+
+        if (job.Type == "CreatePlan")
+        {
+            var description = PlanYamlHelper.GetNamedArg(job.Args, "-Description") ?? string.Join(" ", job.Args);
+            values["Args"] = description;
+            values["PlansDirectory"] = _configService!.PlanFolder;
+
+            var planId = PlanYamlHelper.AllocatePlanId(_configService.PlanFolder);
+            values["PlanId"] = planId;
+            job.AllocatedPlanId = planId;
+        }
+        else
+        {
+            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            values["Args"] = planFolder;
+
+            if (!string.IsNullOrEmpty(planFolder) && Directory.Exists(planFolder))
+            {
+                var folderName = Path.GetFileName(planFolder);
+                var dashIdx = folderName.IndexOf('-');
+                if (dashIdx > 0) values["PlanId"] = folderName[..dashIdx];
+                values["PlanFolder"] = planFolder;
+                values["PlansDirectory"] = Path.GetDirectoryName(planFolder) ?? "";
+
+                planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
+
+                if (job.Type == "ExecutePlan" && planYaml != null &&
+                    !string.IsNullOrEmpty(planYaml.ExecutionProfile))
+                {
+                    profileOverride = planYaml.ExecutionProfile;
+                }
+
+                if (job.Type is "ExecutePlan" or "CreatePr" && planYaml != null)
+                {
+                    var repoConfigs = BuildRepoConfigsYaml(planYaml, job.Project);
+                    if (!string.IsNullOrEmpty(repoConfigs))
+                        values["RepoConfigs"] = repoConfigs;
+                }
+            }
+        }
+
+        return (values, planYaml, profileOverride);
+    }
+
+    private string ResolveWorkingDirectory(JobItem job, string programFolder)
+    {
+        var workDir = programFolder;
+        if (!string.IsNullOrEmpty(job.Project) && job.Project != "Auto")
+        {
+            var projectConfig = _configService?.GetProject(job.Project);
+            if (projectConfig?.Repos.Count > 0)
+            {
+                var repoPath = Environment.ExpandEnvironmentVariables(projectConfig.Repos[0].Path);
+                if (Directory.Exists(repoPath)) workDir = repoPath;
+            }
+        }
+        return workDir;
+    }
+
+    private void SetTendrilEnvironment(ProcessStartInfo psi, JobItem job)
+    {
+        psi.Environment["TENDRIL_JOB_ID"] = job.Id;
+        psi.Environment["TENDRIL_URL"] = Environment.GetEnvironmentVariable("TENDRIL_URL") ?? "https://localhost:5010";
+        psi.Environment["TENDRIL_SESSION_ID"] = job.SessionId;
+        var tendrilHome = _configService!.TendrilHome;
+        if (!string.IsNullOrEmpty(tendrilHome))
+            psi.Environment["TENDRIL_HOME"] = tendrilHome;
+        psi.Environment["TENDRIL_CONFIG"] = _configService.ConfigPath;
+    }
+
+    private string? BuildRepoConfigsYaml(PlanYaml plan, string project)
+    {
+        if (plan.Repos.Count == 0) return null;
+
+        var projectConfig = _configService?.GetProject(project);
+        var planRepoNames = new HashSet<string>(
+            plan.Repos.Select(r => Path.GetFileName(Environment.ExpandEnvironmentVariables(r))),
+            StringComparer.OrdinalIgnoreCase);
+
+        var lines = new List<string>();
+
+        void AddRepo(string expanded, string baseBranch, string syncStrategy, string prRule, bool readOnly)
+        {
+            lines.Add($"- path: {expanded}");
+            lines.Add($"  baseBranch: {baseBranch}");
+            lines.Add($"  syncStrategy: {syncStrategy}");
+            lines.Add($"  prRule: {prRule}");
+            if (readOnly)
+                lines.Add("  readOnly: true");
+        }
+
+        RepoRef? FindRepoRef(string repoName)
+        {
+            return projectConfig?.Repos.FirstOrDefault(r =>
+                Path.GetFileName(Environment.ExpandEnvironmentVariables(r.Path))
+                    .Equals(repoName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        foreach (var repoPath in plan.Repos)
+        {
+            var expanded = Environment.ExpandEnvironmentVariables(repoPath);
+            var repoRef = FindRepoRef(Path.GetFileName(expanded));
+            AddRepo(expanded,
+                repoRef?.BaseBranch ?? "main",
+                repoRef?.SyncStrategy ?? "fetch",
+                repoRef?.PrRule ?? "default",
+                false);
+        }
+
+        if (projectConfig != null)
+        {
+            foreach (var depPath in projectConfig.BuildDependencies)
+            {
+                var expanded = Environment.ExpandEnvironmentVariables(depPath);
+                var repoName = Path.GetFileName(expanded);
+                if (!planRepoNames.Contains(repoName))
+                    AddRepo(expanded, "main", "fetch", "default", true);
+            }
+        }
+
+        return string.Join("\n", lines);
+    }
+}

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -1,18 +1,10 @@
-using Ivy.Tendril.Helpers;
 using System.Collections.Concurrent;
-using System.Diagnostics;
-using System.Text;
-using System.Text.RegularExpressions;
-using Ivy.Helpers;
-using Ivy.Tendril.Apps;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
-using Ivy.Tendril.Services.Agents;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Ivy.Tendril.Services;
 
@@ -75,6 +67,8 @@ public class JobService : IJobService
     private readonly ITelemetryService? _telemetryService;
     private readonly IWorktreeLifecycleLogger? _worktreeLifecycleLogger;
     private readonly ILogger<JobService> _logger;
+    private readonly JobLauncher _jobLauncher;
+    private readonly JobCompletionHandler _completionHandler;
     private int _counter;
 
     public JobService(
@@ -103,6 +97,10 @@ public class JobService : IJobService
             ? new SemaphoreSlim(_maxConcurrentJobs, _maxConcurrentJobs)
             : new SemaphoreSlim(0, 1);
         _inboxPath = Path.Combine(configService.TendrilHome, "Inbox");
+        _jobLauncher = new JobLauncher(configService, _logger, PromptsRoot, SharedRoot);
+        _completionHandler = new JobCompletionHandler(
+            configService, _logger, modelPricingService, planReaderService,
+            telemetryService, planWatcherService, worktreeLifecycleLogger, PromptsRoot);
         configService.SettingsReloaded += OnSettingsReloaded;
         LoadHistoricalJobs();
     }
@@ -129,6 +127,10 @@ public class JobService : IJobService
         _planReaderService = planReaderService;
         _telemetryService = telemetryService;
         _database = database;
+        _jobLauncher = new JobLauncher(null, _logger, PromptsRoot, SharedRoot);
+        _completionHandler = new JobCompletionHandler(
+            null, _logger, null, planReaderService, telemetryService,
+            null, null, PromptsRoot);
     }
 
     public event Action? JobsChanged;
@@ -151,13 +153,27 @@ public class JobService : IJobService
         if (!_jobs.TryGetValue(id, out var job)) return;
         if (!job.TryClaimCompletion()) return;
 
+        SetCompletionStatus(job, exitCode, timedOut, staleOutput);
+        _jobSlotSemaphore.Release();
+
+        _completionHandler.HandleCompletion(
+            job, _jobs, PersistJob, RaiseNotification, RaiseJobsPropertyChanged, StartJobSkipDepCheck);
+
+        job.DisposeResources();
+        PersistJob(job);
+        EvictStaleJobs();
+        RaiseJobsStructureChanged();
+        ProcessJobQueue();
+    }
+
+    private void SetCompletionStatus(JobItem job, int? exitCode, bool timedOut, bool staleOutput)
+    {
         if (timedOut)
         {
             job.Status = JobStatus.Timeout;
-            var reason = (staleOutput || job.StaleOutputDetected)
+            job.StatusMessage = (staleOutput || job.StaleOutputDetected)
                 ? $"No output for {(int)_staleOutputTimeout.TotalMinutes} minutes"
                 : $"Exceeded {(int)_jobTimeout.TotalMinutes} minute timeout";
-            job.StatusMessage = reason;
         }
         else
         {
@@ -172,137 +188,6 @@ public class JobService : IJobService
         job.CompletedAt = DateTime.UtcNow;
         if (job.StartedAt.HasValue)
             job.DurationSeconds = (int)(job.CompletedAt.Value - job.StartedAt.Value).TotalSeconds;
-
-        // Release job slot for next queued job
-        _jobSlotSemaphore.Release();
-
-        // Run after-hooks
-        var planFolderForHooks = job.Args.Length > 0 ? job.Args[0] : "";
-        RunHooks("after", job.Type, planFolderForHooks, job.Project, job);
-
-        var isSuccess = job.Status == JobStatus.Completed;
-        var title = job.Status == JobStatus.Timeout ? $"{job.Type} Timed Out" :
-            isSuccess ? $"{job.Type} Completed" : $"{job.Type} Failed";
-        var message = job.PlanFile ?? job.Type;
-        if (!isSuccess && job.StatusMessage != null)
-            message += $": {job.StatusMessage}";
-        var completionNotification = new JobNotification(title, message, isSuccess);
-        RaiseNotification(completionNotification);
-
-        if (job.Status is JobStatus.Failed or JobStatus.Timeout)
-        {
-            ResetPlanState(job);
-            ScheduleWorktreeCleanup(job);
-        }
-        else if (isSuccess && job.Type == "ExecutePlan")
-        {
-            EnsurePlanStateTransitioned(job);
-        }
-        else if (isSuccess && job.Type == "CreateIssue")
-        {
-            SetPlanState(job, "Completed");
-            RetryBlockedDependents(job.Args.Length > 0 ? job.Args[0] : "");
-        }
-        else if (isSuccess && job.Type is "UpdatePlan" or "ExpandPlan" or "SplitPlan")
-        {
-            SetPlanState(job, "Draft");
-        }
-        else if (isSuccess && job.Type == "CreatePlan")
-        {
-            VerifyCreatePlanResult(job);
-            if (job.Status == JobStatus.Completed)
-            {
-                var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
-                var level = "NiceToHave";
-                if (Directory.Exists(planFolder))
-                {
-                    var plan = ReadPlanYaml(planFolder);
-                    if (plan != null) level = plan.Level;
-                }
-
-                _telemetryService?.TrackPlanCreated(new PlanCreatedContext(
-                    level,
-                    job.DurationSeconds));
-            }
-        }
-
-        if (isSuccess && job.Type == "CreatePr")
-        {
-            _telemetryService?.TrackPrCreated(new PrCreatedContext(
-                job.DurationSeconds));
-            RetryBlockedDependents(job.Args.Length > 0 ? job.Args[0] : "");
-        }
-
-        _telemetryService?.TrackJobCompleted(job.Type, job.Status, job.DurationSeconds);
-
-        // Flush telemetry events to ensure they reach PostHog
-        if (_telemetryService != null)
-            _ = Task.Run(async () => { try { await _telemetryService.FlushAsync(); } catch { /* best-effort */ } });
-
-        CleanupInboxFile(job);
-        WriteJobLog(job);
-
-        // Notify plan watcher so the database sync picks up any new/changed plans
-        var notifyFolder = job.Args.Length > 0 ? job.Args[0] : null;
-        _planWatcherService?.NotifyChanged(Directory.Exists(notifyFolder) ? notifyFolder : null);
-
-        // Calculate and log costs automatically (delayed to allow session to complete)
-        if (isSuccess && _modelPricingService != null && !string.IsNullOrEmpty(job.SessionId))
-        {
-            var sessionId = job.SessionId;
-            var jobArgs = job.Args;
-            var jobType = job.Type;
-            var jobId = job.Id;
-            var provider = job.Provider;
-
-            _ = Task.Run(async () =>
-            {
-                // Wait for Claude session to write final usage data
-                await Task.Delay(TimeSpan.FromSeconds(30));
-
-                try
-                {
-                    var costCalc = _modelPricingService.CalculateSessionCost(sessionId, provider);
-                    if (costCalc.TotalCost > 0)
-                    {
-                        if (_jobs.TryGetValue(jobId, out var j))
-                        {
-                            j.Cost = (decimal)costCalc.TotalCost;
-                            j.Tokens = costCalc.TotalTokens;
-                            PersistJob(j);
-                            RaiseJobsPropertyChanged();
-                        }
-
-                        if (jobArgs.Length > 0)
-                            LogCostToCsv(jobArgs[0], jobType, costCalc.TotalTokens, costCalc.TotalCost);
-                    }
-                }
-                catch
-                {
-                    /* Best-effort cost tracking */
-                }
-            });
-        }
-
-        // Release process and timeout resources
-        job.DisposeResources();
-
-        // Persist completed job to SQLite
-        PersistJob(job);
-
-        // Evict stale finished jobs from memory to prevent unbounded dictionary growth.
-        // Job metadata is already persisted to SQLite; the in-memory copy is only needed
-        // for active display and is reloaded from DB on next startup.
-        EvictStaleJobs();
-
-        RaiseJobsStructureChanged();
-
-        // After successful completion of jobs that may unblock dependencies
-        if (isSuccess && job.Type is "ExecutePlan" or "CreatePr") RetryBlockedJobs();
-
-        // Try to start queued jobs now that a slot is free
-        ProcessJobQueue();
-
     }
 
     public void StopJob(string id)
@@ -341,8 +226,8 @@ public class JobService : IJobService
         if (wasRunning)
             _jobSlotSemaphore.Release();
 
-        CleanupInboxFile(job);
-        ResetPlanState(job);
+        JobCompletionHandler.CleanupInboxFile(job);
+        _completionHandler.ResetPlanState(job);
         RaiseJobsStructureChanged();
 
         // Try to start queued jobs now that a slot is free
@@ -384,34 +269,21 @@ public class JobService : IJobService
     }
 
     public void ClearCompletedJobs()
-    {
-        var completedIds = _jobs.Values
-            .Where(j => j.Status == JobStatus.Completed)
-            .Select(j => j.Id)
-            .ToList();
-        foreach (var id in completedIds)
-        {
-            if (_jobs.TryRemove(id, out var removed))
-                removed.DisposeResources();
-            try { _database?.DeleteJob(id); } catch { /* Best-effort */ }
-        }
-        if (completedIds.Count > 0)
-            RaiseJobsStructureChanged();
-    }
+        => ClearJobsByStatus(j => j.Status == JobStatus.Completed);
 
     public void ClearFailedJobs()
+        => ClearJobsByStatus(j => j.Status is JobStatus.Failed or JobStatus.Timeout or JobStatus.Blocked);
+
+    private void ClearJobsByStatus(Func<JobItem, bool> predicate)
     {
-        var failedIds = _jobs.Values
-            .Where(j => j.Status is JobStatus.Failed or JobStatus.Timeout or JobStatus.Blocked)
-            .Select(j => j.Id)
-            .ToList();
-        foreach (var id in failedIds)
+        var ids = _jobs.Values.Where(predicate).Select(j => j.Id).ToList();
+        foreach (var id in ids)
         {
             if (_jobs.TryRemove(id, out var removed))
                 removed.DisposeResources();
             try { _database?.DeleteJob(id); } catch { /* Best-effort */ }
         }
-        if (failedIds.Count > 0)
+        if (ids.Count > 0)
             RaiseJobsStructureChanged();
     }
 
@@ -518,38 +390,36 @@ public class JobService : IJobService
     private string StartJobInternal(string type, string[] args, string? inboxFilePath, bool skipDependencyCheck = false)
     {
         var id = $"job-{Interlocked.Increment(ref _counter):D3}";
+        var job = BuildJobItem(id, type, args, inboxFilePath);
+
+        if (TryRejectConflictingJob(job))
+            return id;
+
+        _jobs[id] = job;
+
+        if (TryBlockForDependencies(job, skipDependencyCheck))
+            return id;
+
+        if (type is "ExecutePlan" or "ExpandPlan" or "UpdatePlan" or "SplitPlan")
+            _planReaderService?.FlushPendingWritesAsync().GetAwaiter().GetResult();
+
+        if (!_jobSlotSemaphore.Wait(0))
+        {
+            job.Status = JobStatus.Queued;
+            job.StatusMessage = $"Waiting (max {_maxConcurrentJobs} concurrent jobs)";
+            lock (_queueLock) { _jobQueue.Enqueue(id, -job.Priority); }
+            RaiseJobsStructureChanged();
+            return id;
+        }
+
+        LaunchJob(job);
+        return id;
+    }
+
+    private JobItem BuildJobItem(string id, string type, string[] args, string? inboxFilePath)
+    {
         var scriptPath = ScriptPaths.GetValueOrDefault(type, "");
-
-        // Extract plan folder and project from args
-        var planFile = "";
-        var project = "Auto";
-
-        // For CreatePlan: args are named params like -Description "..." -Project "..."
-        // For others: args[0] is the plan folder path
-        var priority = 0;
-        if (type == "CreatePlan")
-        {
-            planFile = GetNamedArg(args, "-Description") is { Length: > 0 } desc
-                ? desc.Length > 50 ? desc[..50] + "..." : desc
-                : "New Plan";
-            project = GetNamedArg(args, "-Project") ?? "Auto";
-            if (int.TryParse(GetNamedArg(args, "-Priority"), out var parsedPriority))
-                priority = parsedPriority;
-        }
-        else
-        {
-            var planFolder = args.Length > 0 ? args[0] : "";
-            planFile = Path.GetFileName(planFolder);
-            if (Directory.Exists(planFolder))
-            {
-                var plan = ReadPlanYaml(planFolder);
-                if (plan != null)
-                {
-                    project = plan.Project;
-                    priority = plan.Priority;
-                }
-            }
-        }
+        var (planFile, project, priority) = ExtractJobMetadata(type, args);
 
         var job = new JobItem
         {
@@ -564,98 +434,103 @@ public class JobService : IJobService
             Priority = priority
         };
 
-        // For CreatePlan jobs: track the inbox file for crash recovery
+        if (type == "CreatePlan")
+            SetupInboxTracking(job, id, args, inboxFilePath);
+
+        return job;
+    }
+
+    private static (string PlanFile, string Project, int Priority) ExtractJobMetadata(string type, string[] args)
+    {
         if (type == "CreatePlan")
         {
-            if (inboxFilePath != null)
-                // Inbox-originated job — file already renamed to .processing by InboxWatcherService
-                job.InboxFile = inboxFilePath;
-            else if (_inboxPath != null)
-                // Manual CreatePlan — write a .processing inbox file as a write-ahead log
-                try
-                {
-                    FileHelper.EnsureDirectory(_inboxPath);
-                    var description = GetNamedArg(args, "-Description") ?? "New Plan";
-                    var inboxProject = GetNamedArg(args, "-Project") ?? "Auto";
-                    var pendingFile = Path.Combine(_inboxPath, $"pending-{id}.md.processing");
-                    var content = $"---\nproject: {inboxProject}\n---\n{description}";
-                    FileHelper.WriteAllText(pendingFile, content);
-                    job.InboxFile = pendingFile;
-                }
-                catch
-                {
-                    /* Best-effort — don't fail the job if we can't write the recovery file */
-                }
+            var planFile = GetNamedArg(args, "-Description") is { Length: > 0 } desc
+                ? desc.Length > 50 ? desc[..50] + "..." : desc
+                : "New Plan";
+            var project = GetNamedArg(args, "-Project") ?? "Auto";
+            int.TryParse(GetNamedArg(args, "-Priority"), out var priority);
+            return (planFile, project, priority);
         }
 
-        // Check for concurrent plan-modifying jobs (UpdatePlan, ExpandPlan, SplitPlan)
-        // to prevent race conditions and state corruption
-        if (type is "UpdatePlan" or "ExpandPlan" or "SplitPlan")
-        {
-            var planFolder = args.Length > 0 ? args[0] : "";
-            var conflictingJob = _jobs.Values.FirstOrDefault(j =>
-                j.Type == type &&
-                j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
-                j.Args.Length > 0 &&
-                j.Args[0].Equals(planFolder, StringComparison.OrdinalIgnoreCase));
+        var folder = args.Length > 0 ? args[0] : "";
+        var file = Path.GetFileName(folder);
+        if (!Directory.Exists(folder))
+            return (file, "Auto", 0);
 
-            if (conflictingJob != null)
+        var plan = ReadPlanYaml(folder);
+        return plan != null
+            ? (file, plan.Project, plan.Priority)
+            : (file, "Auto", 0);
+    }
+
+    private void SetupInboxTracking(JobItem job, string id, string[] args, string? inboxFilePath)
+    {
+        if (inboxFilePath != null)
+        {
+            job.InboxFile = inboxFilePath;
+        }
+        else if (_inboxPath != null)
+        {
+            try
             {
-                job.Status = JobStatus.Failed;
-                job.StatusMessage = $"{type} already in progress for this plan (job {conflictingJob.Id})";
-                job.CompletedAt = DateTime.UtcNow;
-                _jobs[id] = job;
-
-                var notification = new JobNotification(
-                    $"{type} Already Running",
-                    $"{planFile}: Cannot start {type} while another is in progress",
-                    false);
-                RaiseNotification(notification);
-                RaiseJobsStructureChanged();
-                return id;
+                FileHelper.EnsureDirectory(_inboxPath);
+                var description = GetNamedArg(args, "-Description") ?? "New Plan";
+                var inboxProject = GetNamedArg(args, "-Project") ?? "Auto";
+                var pendingFile = Path.Combine(_inboxPath, $"pending-{id}.md.processing");
+                var content = $"---\nproject: {inboxProject}\n---\n{description}";
+                FileHelper.WriteAllText(pendingFile, content);
+                job.InboxFile = pendingFile;
             }
+            catch { /* Best-effort */ }
         }
+    }
 
-        _jobs[id] = job;
+    private bool TryRejectConflictingJob(JobItem job)
+    {
+        if (job.Type is not ("UpdatePlan" or "ExpandPlan" or "SplitPlan"))
+            return false;
 
-        // Check dependencies for ExecutePlan jobs
-        if (type == "ExecutePlan" && !skipDependencyCheck)
-        {
-            var planFolder = args.Length > 0 ? args[0] : "";
-            var (ok, blockReason) = CheckDependencies(planFolder);
-            if (!ok)
-            {
-                job.Status = JobStatus.Blocked;
-                job.StatusMessage = blockReason;
-                job.CompletedAt = DateTime.UtcNow;
+        var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+        var conflictingJob = _jobs.Values.FirstOrDefault(j =>
+            j.Type == job.Type &&
+            j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
+            j.Args.Length > 0 &&
+            j.Args[0].Equals(planFolder, StringComparison.OrdinalIgnoreCase));
 
-                // Reset plan state back to Draft since we can't execute
-                ResetPlanStateToBlocked(job);
+        if (conflictingJob == null)
+            return false;
 
-                var blockedNotification = new JobNotification("Job Blocked", $"{planFile}: {blockReason}", false);
-                RaiseNotification(blockedNotification);
-                RaiseJobsStructureChanged();
-                return id;
-            }
+        job.Status = JobStatus.Failed;
+        job.StatusMessage = $"{job.Type} already in progress for this plan (job {conflictingJob.Id})";
+        job.CompletedAt = DateTime.UtcNow;
+        _jobs[job.Id] = job;
 
-        }
+        RaiseNotification(new JobNotification(
+            $"{job.Type} Already Running",
+            $"{job.PlanFile}: Cannot start {job.Type} while another is in progress",
+            false));
+        RaiseJobsStructureChanged();
+        return true;
+    }
 
-        // Ensure any pending plan state writes are flushed to disk before scripts read plan.yaml
-        if (type is "ExecutePlan" or "ExpandPlan" or "UpdatePlan" or "SplitPlan")
-            _planReaderService?.FlushPendingWritesAsync().GetAwaiter().GetResult();
+    private bool TryBlockForDependencies(JobItem job, bool skipDependencyCheck)
+    {
+        if (job.Type != "ExecutePlan" || skipDependencyCheck)
+            return false;
 
-        // Try to acquire a job slot
-        if (!_jobSlotSemaphore.Wait(0))
-        {
-            job.Status = JobStatus.Queued;
-            job.StatusMessage = $"Waiting (max {_maxConcurrentJobs} concurrent jobs)";
-            lock (_queueLock) { _jobQueue.Enqueue(id, -job.Priority); }
-            RaiseJobsStructureChanged();
-            return id;
-        }
+        var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+        var (ok, blockReason) = CheckDependencies(planFolder);
+        if (ok)
+            return false;
 
-        LaunchJob(job);
-        return id;
+        job.Status = JobStatus.Blocked;
+        job.StatusMessage = blockReason;
+        job.CompletedAt = DateTime.UtcNow;
+        ResetPlanStateToBlocked(job);
+
+        RaiseNotification(new JobNotification("Job Blocked", $"{job.PlanFile}: {blockReason}", false));
+        RaiseJobsStructureChanged();
+        return true;
     }
 
     /// <summary>
@@ -703,504 +578,19 @@ public class JobService : IJobService
 
     private void LaunchJob(JobItem job)
     {
-        var id = job.Id;
-        var type = job.Type;
-        var args = job.Args;
-        var scriptPath = job.ScriptPath;
-
-        job.Status = JobStatus.Running;
-        job.StartedAt = DateTime.UtcNow;
-        job.StatusMessage = null;
-
-        // Run before-hooks
-        var planFolderForHooks = type != "CreatePlan" && args.Length > 0 ? args[0] : "";
-        RunHooks("before", type, planFolderForHooks, job.Project, job);
-
-        // Generate session ID for cost tracking — passed to child process so both sides share the same ID
-        job.SessionId = Guid.NewGuid().ToString();
-
-        // Try agent-direct launch (new path: Program.md exists, no .ps1 needed)
-        var psi = TryBuildAgentProcessStart(job);
-
-        if (psi == null)
-        {
-            // Legacy path: launch via pwsh script
-            var processArgs = new List<string> { "-NoProfile", "-NonInteractive", "-File", scriptPath };
-            processArgs.AddRange(args);
-
-            var workingDirectory = Path.GetFullPath(
-                Path.Combine(System.AppContext.BaseDirectory, "..", "..", ".."));
-
-            psi = new ProcessStartInfo
-            {
-                FileName = "pwsh",
-                WorkingDirectory = workingDirectory,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                RedirectStandardInput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                StandardOutputEncoding = Encoding.UTF8,
-                StandardErrorEncoding = Encoding.UTF8
-            };
-
-            psi.Environment["TENDRIL_JOB_ID"] = id;
-            psi.Environment["TENDRIL_URL"] = Environment.GetEnvironmentVariable("TENDRIL_URL") ?? "https://localhost:5010";
-            psi.Environment["TENDRIL_SHARED"] = SharedRoot;
-            psi.Environment["TENDRIL_SESSION_ID"] = job.SessionId;
-            if (_configService != null)
-                psi.Environment["TENDRIL_CONFIG"] = _configService.ConfigPath;
-
-            psi.Environment["CI"] = "true";
-            psi.Environment["TERM"] = "dumb";
-
-            foreach (var arg in processArgs)
-                psi.ArgumentList.Add(arg);
-        }
-
-        var process = new Process { StartInfo = psi };
-        process.OutputDataReceived += (_, e) =>
-        {
-            try
-            {
-                if (e.Data != null)
-                {
-                    job.LastOutputAt = DateTime.UtcNow;
-                    if (!e.Data.Contains("\"type\":\"heartbeat\"")) job.EnqueueOutput(e.Data);
-                }
-            }
-            catch (Exception ex)
-            {
-                CrashLog.Write($"[{DateTime.UtcNow:O}] OutputDataReceived exception for job {id}: {ex}");
-            }
-        };
-        process.ErrorDataReceived += (_, e) =>
-        {
-            try
-            {
-                if (e.Data != null)
-                {
-                    job.EnqueueOutput($"[stderr] {e.Data}");
-                    job.LastOutputAt = DateTime.UtcNow;
-                }
-            }
-            catch (Exception ex)
-            {
-                CrashLog.Write($"[{DateTime.UtcNow:O}] ErrorDataReceived exception for job {id}: {ex}");
-            }
-        };
-
-        try
-        {
-            process.Start();
-        }
-        catch (System.ComponentModel.Win32Exception ex)
-        {
-            _logger.LogError(ex, "Job {JobId}: Failed to start process '{FileName}'", id, psi.FileName);
-            job.Status = JobStatus.Failed;
-            job.StatusMessage = $"Agent binary not found: {psi.FileName}";
-            job.CompletedAt = DateTime.UtcNow;
-            _jobSlotSemaphore.Release();
-            RaiseJobsStructureChanged();
-            return;
-        }
-
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-        job.Process = process;
-        job.ProcessId = process.Id;
-
-        // Monitor for completion in background with timeout and stale output detection
-        var cts = new CancellationTokenSource(_jobTimeout);
-        job.TimeoutCts = cts;
-
-        Task.Run(async () =>
-        {
-            _logger.LogDebug("Job {JobId}: Monitor task started", id);
-
-            try
-            {
-                if (await process.WaitForExitOrKillAsync(cts.Token))
-                {
-                    if (_jobs.TryGetValue(id, out var j) && j.StaleOutputDetected)
-                    {
-                        _logger.LogInformation("Job {JobId}: Process exited, stale output detected", id);
-                        CompleteJob(id, null, timedOut: true, staleOutput: true);
-                    }
-                    else
-                    {
-                        _logger.LogInformation("Job {JobId}: Process exited with code {ExitCode}", id, process.ExitCode);
-                        CompleteJob(id, process.ExitCode);
-                    }
-                }
-                else
-                {
-                    _logger.LogWarning("Job {JobId}: Process killed after timeout", id);
-                    CompleteJob(id, null, timedOut: true);
-                }
-
-                _logger.LogDebug("Job {JobId}: Monitor task completed normally", id);
-            }
-            catch (ObjectDisposedException)
-            {
-                _logger.LogDebug("Job {JobId}: Monitor task exiting (CTS disposed, job completed elsewhere)", id);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Job {JobId}: Monitor task exception", id);
-                CrashLog.Write($"[{DateTime.UtcNow:O}] JobService process monitor exception for job {id}: {ex}");
-                CompleteJob(id, null, timedOut: false);
-            }
-        });
-
-        // Start stale output watchdog
-        if (_staleOutputTimeout > TimeSpan.Zero) _ = RunStaleOutputWatchdog(id, cts);
-
-        RaiseJobsStructureChanged();
-    }
-
-    private ProcessStartInfo? TryBuildAgentProcessStart(JobItem job)
-    {
-        if (_configService == null) return null;
-
-        var programFolder = Path.Combine(PromptsRoot, job.Type);
-        var programMd = Path.Combine(programFolder, "Program.md");
-
-        // Only use agent-direct if Program.md exists AND no .ps1 script is present
-        if (!File.Exists(programMd)) return null;
-        var scriptFile = Path.Combine(programFolder, $"{job.Type}.ps1");
-        if (File.Exists(scriptFile)) return null;
-
-        var settings = _configService.Settings;
-        string? profileOverride = null;
-
-        // Build firmware values
-        var values = new Dictionary<string, string>
-        {
-            ["ClaudeSessionId"] = job.SessionId ?? ""
-        };
-
-        var planFolder = "";
-        PlanYaml? planYaml = null;
-
-        if (job.Type == "CreatePlan")
-        {
-            // CreatePlan: Args is the description text, not raw parameters
-            var description = GetNamedArg(job.Args, "-Description") ?? string.Join(" ", job.Args);
-            values["Args"] = description;
-            values["PlansDirectory"] = _configService.PlanFolder;
-
-            var planId = AllocatePlanId(_configService.PlanFolder);
-            values["PlanId"] = planId;
-            job.AllocatedPlanId = planId;
-        }
-        else
-        {
-            // Plan-based jobs: first arg is the plan folder path
-            planFolder = job.Args.Length > 0 ? job.Args[0] : "";
-            values["Args"] = planFolder;
-
-            if (!string.IsNullOrEmpty(planFolder) && Directory.Exists(planFolder))
-            {
-                var folderName = Path.GetFileName(planFolder);
-                var dashIdx = folderName.IndexOf('-');
-                if (dashIdx > 0) values["PlanId"] = folderName[..dashIdx];
-                values["PlanFolder"] = planFolder;
-                values["PlansDirectory"] = Path.GetDirectoryName(planFolder) ?? "";
-
-                planYaml = ReadPlanYaml(planFolder);
-
-                // ExecutePlan: use plan's executionProfile as profile override
-                if (job.Type == "ExecutePlan" && planYaml != null &&
-                    !string.IsNullOrEmpty(planYaml.ExecutionProfile))
-                {
-                    profileOverride = planYaml.ExecutionProfile;
-                }
-
-                // ExecutePlan/CreatePr: build RepoConfigs YAML for firmware
-                if ((job.Type == "ExecutePlan" || job.Type == "CreatePr") && planYaml != null)
-                {
-                    var repoConfigs = BuildRepoConfigsYaml(planYaml, job.Project);
-                    if (!string.IsNullOrEmpty(repoConfigs))
-                        values["RepoConfigs"] = repoConfigs;
-                }
-            }
-        }
-
-        values["Project"] = job.Project;
-
-        var resolution = AgentProviderFactory.Resolve(settings, job.Type, profileOverride);
-
-        // Resolve working directory
-        var workDir = programFolder;
-        if (!string.IsNullOrEmpty(job.Project) && job.Project != "Auto")
-        {
-            var projectConfig = _configService.GetProject(job.Project);
-            if (projectConfig?.Repos.Count > 0)
-            {
-                var repoPath = Environment.ExpandEnvironmentVariables(projectConfig.Repos[0].Path);
-                if (Directory.Exists(repoPath)) workDir = repoPath;
-            }
-        }
-
-        // Prepare firmware + Program.md
-        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
-        var sharedDocs = new List<(string Name, string Content)>();
-
-        var plansMdPath = Path.Combine(SharedRoot, "Plans.md");
-        if (File.Exists(plansMdPath))
-            sharedDocs.Add(("Plans", File.ReadAllText(plansMdPath)));
-
-        var context = new FirmwareContext(programFolder, logFile, values, sharedDocs);
-        var prompt = FirmwareCompiler.Compile(context);
-
-        // Build agent invocation
-        var invocation = new AgentInvocation(
-            PromptContent: prompt,
-            WorkingDirectory: workDir,
-            Model: resolution.Model,
-            Effort: resolution.Effort,
-            SessionId: job.SessionId ?? "",
-            AllowedTools: resolution.AllowedTools,
-            ExtraArgs: resolution.ExtraArgs);
-
-        var psi = resolution.Provider.BuildProcessStart(invocation);
-
-        // Set environment for Tendril CLI access from within the agent
-        psi.Environment["TENDRIL_JOB_ID"] = job.Id;
-        psi.Environment["TENDRIL_URL"] = Environment.GetEnvironmentVariable("TENDRIL_URL") ?? "https://localhost:5010";
-        psi.Environment["TENDRIL_SESSION_ID"] = job.SessionId;
-        var tendrilHome = _configService.TendrilHome;
-        if (!string.IsNullOrEmpty(tendrilHome))
-            psi.Environment["TENDRIL_HOME"] = tendrilHome;
-        psi.Environment["TENDRIL_CONFIG"] = _configService.ConfigPath;
-
-        _logger.LogInformation(
-            "Job {JobId}: Agent-direct launch ({Provider}, model={Model}, effort={Effort})",
-            job.Id, resolution.Provider.Name, resolution.Model, resolution.Effort);
-
-        return psi;
-    }
-
-    private string? BuildRepoConfigsYaml(PlanYaml plan, string project)
-    {
-        if (plan.Repos.Count == 0) return null;
-
-        var projectConfig = _configService?.GetProject(project);
-        var planRepoNames = new HashSet<string>(
-            plan.Repos.Select(r => Path.GetFileName(Environment.ExpandEnvironmentVariables(r))),
-            StringComparer.OrdinalIgnoreCase);
-
-        var lines = new List<string>();
-
-        void AddRepo(string expanded, string baseBranch, string syncStrategy, string prRule, bool readOnly)
-        {
-            lines.Add($"- path: {expanded}");
-            lines.Add($"  baseBranch: {baseBranch}");
-            lines.Add($"  syncStrategy: {syncStrategy}");
-            lines.Add($"  prRule: {prRule}");
-            if (readOnly)
-                lines.Add("  readOnly: true");
-        }
-
-        RepoRef? FindRepoRef(string repoName)
-        {
-            return projectConfig?.Repos.FirstOrDefault(r =>
-                Path.GetFileName(Environment.ExpandEnvironmentVariables(r.Path))
-                    .Equals(repoName, StringComparison.OrdinalIgnoreCase));
-        }
-
-        foreach (var repoPath in plan.Repos)
-        {
-            var expanded = Environment.ExpandEnvironmentVariables(repoPath);
-            var repoRef = FindRepoRef(Path.GetFileName(expanded));
-            AddRepo(expanded,
-                repoRef?.BaseBranch ?? "main",
-                repoRef?.SyncStrategy ?? "fetch",
-                repoRef?.PrRule ?? "default",
-                false);
-        }
-
-        // Include build dependencies as read-only worktrees
-        if (projectConfig != null)
-        {
-            foreach (var depPath in projectConfig.BuildDependencies)
-            {
-                var expanded = Environment.ExpandEnvironmentVariables(depPath);
-                var repoName = Path.GetFileName(expanded);
-                if (!planRepoNames.Contains(repoName))
-                    AddRepo(expanded, "main", "fetch", "default", true);
-            }
-        }
-
-        return string.Join("\n", lines);
+        _jobLauncher.LaunchJob(
+            job, _jobs, _jobSlotSemaphore, _jobTimeout, _staleOutputTimeout,
+            (when, type, folder, project, j) => RunHooks(when, type, folder, project, j),
+            (id, exitCode, timedOut, staleOutput) => CompleteJob(id, exitCode, timedOut, staleOutput),
+            RaiseJobsStructureChanged);
     }
 
     internal void RunHooks(string when, string jobType, string planFolder, string project, JobItem job)
-    {
-        if (_configService == null) return;
+        => _completionHandler.RunHooks(when, jobType, planFolder, project, job);
 
-        var projectConfig = _configService.GetProject(project);
-        if (projectConfig == null) return;
+    internal Task RunStaleOutputWatchdog(string id, CancellationTokenSource timeoutCts)
+        => _jobLauncher.RunStaleOutputWatchdog(id, timeoutCts, _jobs, _staleOutputTimeout);
 
-        var hooks = projectConfig.Hooks
-            .Where(h => h.When.Equals(when, StringComparison.OrdinalIgnoreCase))
-            .Where(h => h.Promptwares.Count == 0 || h.Promptwares.Contains(jobType, StringComparer.OrdinalIgnoreCase))
-            .ToList();
-
-        foreach (var hook in hooks)
-            try
-            {
-                // Evaluate condition if set
-                if (!string.IsNullOrWhiteSpace(hook.Condition))
-                {
-                    var condPsi = new ProcessStartInfo
-                    {
-                        FileName = "pwsh",
-                        Arguments = $"-NoProfile -NonInteractive -EncodedCommand {EncodeForPowerShell(hook.Condition)}",
-                        WorkingDirectory = string.IsNullOrEmpty(planFolder) ? "." : planFolder,
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true,
-                        RedirectStandardInput = true,
-                        UseShellExecute = false,
-                        CreateNoWindow = true
-                    };
-                    using var condProc = Process.Start(condPsi);
-                    var condOutput = condProc?.StandardOutput.ReadToEnd().Trim() ?? "";
-                    condProc.WaitForExitOrKill(10000);
-
-                    if (condProc?.ExitCode != 0 ||
-                        condOutput.Equals("False", StringComparison.OrdinalIgnoreCase))
-                    {
-                        job.EnqueueOutput($"[hook:{hook.Name}] Condition not met, skipping");
-                        continue;
-                    }
-                }
-
-                // Run the action
-                var actionPsi = new ProcessStartInfo
-                {
-                    FileName = "pwsh",
-                    Arguments = $"-NoProfile -NonInteractive -EncodedCommand {EncodeForPowerShell(hook.Action)}",
-                    WorkingDirectory = string.IsNullOrEmpty(planFolder) ? "." : planFolder,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    RedirectStandardInput = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-                actionPsi.Environment["TENDRIL_JOB_ID"] = job.Id;
-                actionPsi.Environment["TENDRIL_JOB_TYPE"] = jobType;
-                actionPsi.Environment["TENDRIL_JOB_STATUS"] = job.Status.ToString();
-                actionPsi.Environment["TENDRIL_PLAN_FOLDER"] = planFolder;
-                actionPsi.Environment["TENDRIL_CONFIG"] = _configService.ConfigPath;
-
-                using var actionProc = Process.Start(actionPsi);
-                var output = actionProc?.StandardOutput.ReadToEnd().Trim() ?? "";
-                var stderr = actionProc?.StandardError.ReadToEnd().Trim() ?? "";
-                actionProc.WaitForExitOrKill(30000);
-
-                if (!string.IsNullOrEmpty(output))
-                    job.EnqueueOutput($"[hook:{hook.Name}] {output}");
-                if (!string.IsNullOrEmpty(stderr))
-                    job.EnqueueOutput($"[hook:{hook.Name}] [stderr] {stderr}");
-
-                if (actionProc?.ExitCode != 0)
-                    job.EnqueueOutput($"[hook:{hook.Name}] Hook failed with exit code {actionProc?.ExitCode}");
-            }
-            catch (Exception ex)
-            {
-                job.EnqueueOutput($"[hook:{hook.Name}] Error: {ex.Message}");
-            }
-    }
-
-    internal async Task RunStaleOutputWatchdog(string id, CancellationTokenSource timeoutCts)
-    {
-        const int checkIntervalSeconds = 60;
-
-        try
-        {
-            while (!timeoutCts.Token.IsCancellationRequested)
-            {
-                for (var i = 0; i < checkIntervalSeconds; i++)
-                {
-                    try
-                    {
-                        await Task.Delay(TimeSpan.FromSeconds(1), timeoutCts.Token);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        return;
-                    }
-
-                    if (timeoutCts.Token.IsCancellationRequested) return;
-                }
-
-                if (!_jobs.TryGetValue(id, out var job) || job.Status != JobStatus.Running)
-                    break;
-
-                if (job.LastOutputAt.HasValue)
-                {
-                    var sinceLastOutput = DateTime.UtcNow - job.LastOutputAt.Value;
-                    if (sinceLastOutput >= _staleOutputTimeout)
-                    {
-                        job.StaleOutputDetected = true;
-                        try { timeoutCts.Cancel(); } catch (ObjectDisposedException) { }
-                        break;
-                    }
-                }
-            }
-        }
-        catch (ObjectDisposedException)
-        {
-        }
-    }
-
-    private void RetryBlockedJobs()
-    {
-        var blockedJobs = _jobs.Values
-            .Where(j => j.Status == JobStatus.Blocked && j.Type == "ExecutePlan")
-            .ToList();
-
-        foreach (var blockedJob in blockedJobs)
-        {
-            var planFolder = blockedJob.Args.Length > 0 ? blockedJob.Args[0] : "";
-            if (string.IsNullOrEmpty(planFolder)) continue;
-
-            var (ok, _) = CheckDependencies(planFolder);
-            if (!ok)
-                continue;
-
-            // Remove the blocked job entry — only one thread succeeds
-            if (!_jobs.TryRemove(blockedJob.Id, out _))
-                continue; // Another thread already handled this job
-
-            // Skip if there's already an active job for this plan
-            if (HasActiveJobForPlan(planFolder))
-                continue;
-
-            // Transition plan to Building before re-launching (ExecutePlan.ps1 requires it)
-            SetPlanStateByFolder(planFolder, "Building");
-
-            // Re-start the job — skip dependency check since we just verified
-            StartJobSkipDepCheck(blockedJob.Type, blockedJob.Args);
-
-            var notification = new JobNotification(
-                "Job Unblocked",
-                $"{blockedJob.PlanFile}: dependencies now satisfied, auto-restarting",
-                true);
-            RaiseNotification(notification);
-        }
-    }
-
-    private bool HasActiveJobForPlan(string planFolder)
-    {
-        return _jobs.Values.Any(j =>
-            j.Type == "ExecutePlan" &&
-            j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
-            j.Args.Length > 0 &&
-            j.Args[0].Equals(planFolder, StringComparison.OrdinalIgnoreCase));
-    }
 
     private void ProcessJobQueue()
     {
@@ -1229,674 +619,37 @@ public class JobService : IJobService
         }
     }
 
-    private static string EncodeForPowerShell(string command)
-    {
-        var bytes = Encoding.Unicode.GetBytes(command);
-        return Convert.ToBase64String(bytes);
-    }
 
     internal static string ExtractFailureReason(List<string> outputLines, string jobType)
-    {
-        if (outputLines.Count == 0)
-            return "Unknown error (exit code non-zero)";
-
-        // 1. Check for PowerShell terminating errors
-        var psError = FindPattern(outputLines, new[] {
-            @"At line:\d+",
-            @"CategoryInfo\s+:",
-            @"TerminatingError\(",
-            "ScriptHalted",
-            @"^\s*\+\s+CategoryInfo",  // PowerShell error location marker
-        });
-        if (psError != null) return psError;
-
-        // 2. Check for Claude API errors (from JSON stream)
-        var apiError = FindPattern(outputLines, new[] {
-            @"""type"":\s*""error""",
-            @"""error"":\s*\{",
-            "rate_limit_error",
-            "overloaded_error",
-            "authentication_error",
-        });
-        if (apiError != null) return ParseClaudeApiError(apiError);
-
-        // 3. Check for CreatePlan-specific failures and failure artifacts
-        if (jobType == "CreatePlan")
-        {
-            var makePlanError = FindPattern(outputLines, new[] {
-                "ERROR: Plan",
-                "WARNING: TENDRIL_HOME",
-                "Failed to parse",
-                "Repository path does not exist",
-            });
-            if (makePlanError != null) return makePlanError;
-
-            // Check for failure artifact
-            var failureArtifactMessage = TryReadFailureArtifact(outputLines);
-            if (failureArtifactMessage != null) return failureArtifactMessage;
-        }
-
-        // 4. Check for validation/assertion failures (from CreatePlan/ExecutePlan)
-        var validationError = FindPattern(outputLines, new[] {
-            @"validation\s+failed",
-            @"assertion\s+failed",
-            "Repository path does not exist",
-            @"\[stderr\].*(?-i)ERROR:",
-        });
-        if (validationError != null) return validationError;
-
-        // 5. Search from end for stderr lines (existing logic)
-        var stderrLines = new List<string>();
-        for (var i = outputLines.Count - 1; i >= 0 && stderrLines.Count < 3; i--)
-        {
-            var line = outputLines[i];
-            if (line.StartsWith("[stderr] "))
-            {
-                var content = line["[stderr] ".Length..].Trim();
-                if (content.Length > 0 && !IsProgressMessage(content))
-                    stderrLines.Insert(0, content);
-            }
-        }
-
-        if (stderrLines.Count > 0)
-            return SanitizeForDisplay(string.Join(" | ", stderrLines));
-
-        // 6. Fall back to last non-progress line
-        for (var i = outputLines.Count - 1; i >= 0; i--)
-        {
-            var trimmed = outputLines[i].Trim();
-            if (trimmed.Length > 0 && !IsProgressMessage(trimmed))
-                return SanitizeForDisplay(trimmed);
-        }
-
-        return "Unknown error (exit code non-zero)";
-    }
-
-    private static bool IsProgressMessage(string line)
-    {
-        // Filter out common progress indicators that aren't errors
-        var progressPatterns = new[] {
-            "Creating Plan", "Executing Plan", "Building", "Researching",
-            "Reading", "Analyzing", "Writing", "Searching",
-            @"^\d+%", @"^\[.*\]\s+(Starting|Running|Completed)",
-        };
-
-        return progressPatterns.Any(p => Regex.IsMatch(line, p, RegexOptions.IgnoreCase));
-    }
-
-    private static string? FindPattern(List<string> lines, string[] patterns)
-    {
-        for (var i = lines.Count - 1; i >= Math.Max(0, lines.Count - 50); i--)
-        {
-            foreach (var pattern in patterns)
-            {
-                if (Regex.IsMatch(lines[i], pattern, RegexOptions.IgnoreCase))
-                {
-                    // Return context: 2 lines before + matching line + 1 line after
-                    var start = Math.Max(0, i - 2);
-                    var end = Math.Min(lines.Count - 1, i + 1);
-                    var context = string.Join(" | ", lines.Skip(start).Take(end - start + 1));
-                    return SanitizeForDisplay(context);
-                }
-            }
-        }
-        return null;
-    }
-
-    private static string ParseClaudeApiError(string jsonErrorLine)
-    {
-        try
-        {
-            // Extract error message from Claude API JSON response
-            var match = Regex.Match(jsonErrorLine, @"""message"":\s*""([^""]+)""");
-            if (match.Success)
-                return $"Claude API: {match.Groups[1].Value}";
-        }
-        catch { }
-
-        return "Claude API error (see output for details)";
-    }
-
-    private static string? TryReadFailureArtifact(List<string> outputLines)
-    {
-        try
-        {
-            // Look for failure artifact path in output (from Get-FailureArtifact.ps1)
-            var artifactLine = outputLines.FirstOrDefault(line =>
-                line.Contains("Failure artifact written:") && line.Contains("Failed"));
-
-            if (artifactLine == null) return null;
-
-            // Extract path from the line: "Failure artifact written: <path>"
-            var pathMatch = Regex.Match(artifactLine, @"Failure artifact written:\s*(.+)");
-            if (!pathMatch.Success) return null;
-
-            var artifactPath = pathMatch.Groups[1].Value.Trim();
-            if (!File.Exists(artifactPath)) return null;
-
-            // Read the failure artifact and extract error summary
-            var lines = File.ReadAllLines(artifactPath);
-            var errorOutputSection = false;
-            var errorLines = new List<string>();
-
-            foreach (var line in lines)
-            {
-                if (line.StartsWith("## Error Output"))
-                {
-                    errorOutputSection = true;
-                    continue;
-                }
-                if (line.StartsWith("## Investigation Steps"))
-                {
-                    break;
-                }
-                if (errorOutputSection && !line.StartsWith("```"))
-                {
-                    errorLines.Add(line.Trim());
-                }
-            }
-
-            if (errorLines.Count > 0)
-            {
-                var summary = string.Join(" | ", errorLines.Take(3).Where(l => l.Length > 0));
-                return string.IsNullOrWhiteSpace(summary) ? null : SanitizeForDisplay(summary);
-            }
-        }
-        catch { }
-
-        return null;
-    }
+        => JobFailureAnalyzer.ExtractFailureReason(outputLines, jobType);
 
     internal static string SanitizeForDisplay(string text)
-    {
-        // Strip ANSI escape codes (color, cursor, formatting)
-        text = Regex.Replace(text, @"\x1B\[[0-9;]*[A-Za-z]", "");
-
-        // Replace control characters (tabs, newlines, carriage returns, null bytes, etc.) with spaces
-        text = Regex.Replace(text, @"[\x00-\x1F]", " ");
-
-        // Collapse multiple consecutive spaces into one
-        text = Regex.Replace(text, " {2,}", " ");
-
-        text = text.Trim();
-
-        if (text.Length > 200)
-            text = text[..200] + "...";
-
-        return text;
-    }
+        => JobFailureAnalyzer.SanitizeForDisplay(text);
 
     internal static string? ReadPlanYamlRaw(string planFolder)
-    {
-        var planYamlPath = Path.Combine(planFolder, "plan.yaml");
-        return File.Exists(planYamlPath) ? FileHelper.ReadAllText(planYamlPath) : null;
-    }
+        => PlanYamlHelper.ReadPlanYamlRaw(planFolder);
 
     internal static PlanYaml? ReadPlanYaml(string planFolder)
-    {
-        var yaml = ReadPlanYamlRaw(planFolder);
-        if (yaml == null) return null;
+        => PlanYamlHelper.ReadPlanYaml(planFolder);
 
-        try
-        {
-            var deserializer = new DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .IgnoreUnmatchedProperties()
-                .Build();
-            return deserializer.Deserialize<PlanYaml>(yaml);
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    /// <summary>
-    ///     Updates one or more fields in plan.yaml using Regex replacement.
-    ///     Preserves YAML formatting and field order.
-    /// </summary>
     internal static void UpdatePlanYamlFields(string planFolder, params (string field, string value)[] updates)
-    {
-        var content = ReadPlanYamlRaw(planFolder);
-        if (content == null) return;
+        => PlanYamlHelper.UpdatePlanYamlFields(planFolder, updates);
 
-        foreach (var (field, value) in updates)
-        {
-            var pattern = $@"(?m)^{Regex.Escape(field)}:\s*.*$";
-            var replacement = $"{field}: {value}";
-            content = Regex.Replace(content, pattern, replacement);
-        }
-
-        var planYamlPath = Path.Combine(planFolder, "plan.yaml");
-        FileHelper.WriteAllText(planYamlPath, content);
-    }
-
-    /// <summary>
-    ///     Updates the state and updated timestamp in plan.yaml.
-    /// </summary>
     internal static void SetPlanStateByFolder(string planFolder, string state)
-    {
-        UpdatePlanYamlFields(planFolder,
-            ("state", state),
-            ("updated", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")));
-    }
+        => PlanYamlHelper.SetPlanStateByFolder(planFolder, state);
 
     private static string? GetNamedArg(string[] args, string name)
-    {
-        for (var i = 0; i < args.Length - 1; i++)
-            if (args[i].Equals(name, StringComparison.OrdinalIgnoreCase))
-                return args[i + 1];
-        return null;
-    }
-
-    private void EnsurePlanStateTransitioned(JobItem job)
-    {
-        try
-        {
-            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
-            var planYaml = ReadPlanYaml(planFolder);
-            if (planYaml == null) return;
-
-            if (planYaml.State is "Executing" or "Building")
-            {
-                var hasIncomplete = planYaml.Verifications?
-                    .Any(v => v.Status is "Pending" or "Fail") ?? false;
-                var targetState = hasIncomplete ? PlanStatus.Failed : PlanStatus.ReadyForReview;
-
-                var folderName = Path.GetFileName(planFolder);
-                if (_planReaderService != null)
-                    _planReaderService.TransitionState(folderName, targetState);
-                else
-                    SetPlanStateByFolder(planFolder, targetState.ToString());
-            }
-        }
-        catch
-        {
-            /* Don't let state transition failures crash job completion */
-        }
-    }
-
-    private void SetPlanState(JobItem job, string state)
-    {
-        try
-        {
-            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
-            if (_planReaderService != null && Enum.TryParse<PlanStatus>(state, true, out var status))
-                _planReaderService.TransitionState(Path.GetFileName(planFolder), status);
-            else
-                SetPlanStateByFolder(planFolder, state);
-        }
-        catch
-        {
-            /* Don't let state transition failures crash job completion */
-        }
-    }
-
-    private void VerifyCreatePlanResult(JobItem job)
-    {
-        try
-        {
-            if (_planReaderService == null) return;
-            var plansDir = _planReaderService.PlansDirectory;
-            if (!Directory.Exists(plansDir)) return;
-
-            var outputText = string.Join("\n", job.OutputLines);
-            var createdMatch = Regex.Match(outputText, @"Plan created:\s*(\S+)");
-            var duplicate = Regex.IsMatch(outputText, "identified as duplicate:");
-
-            if (createdMatch.Success)
-            {
-                job.PlanFile = createdMatch.Groups[1].Value;
-            }
-            else if (!duplicate)
-            {
-                // Fallback: check filesystem for plan folder matching the allocated PlanId
-                var planFolder = FindPlanFolderById(plansDir, job.AllocatedPlanId);
-                if (planFolder != null)
-                {
-                    job.PlanFile = planFolder;
-                }
-                else
-                {
-                    // Check Trash directory for duplicate entries
-                    var trashDir = _configService != null
-                        ? Path.Combine(_configService.TendrilHome, "Trash")
-                        : null;
-                    var trashEntry = trashDir != null && !string.IsNullOrEmpty(job.AllocatedPlanId)
-                        ? FindTrashEntryById(trashDir, job.AllocatedPlanId)
-                        : null;
-
-                    if (trashEntry != null)
-                    {
-                        // Agent trashed as duplicate but didn't output the marker text
-                    }
-                    else
-                    {
-                        job.EnqueueOutput(
-                            "[Tendril] WARNING: CreatePlan completed but no plan folder or trash entry was found.");
-                        job.Status = JobStatus.Failed;
-
-                        var failureMessage = TryReadFailureArtifact(job.OutputLines.ToList());
-                        job.StatusMessage = failureMessage ?? "No plan created";
-                    }
-                }
-            }
-        }
-        catch
-        {
-            /* Don't let verification failures crash job completion */
-        }
-    }
-
-    private static string? FindPlanFolderById(string plansDir, string? planId)
-    {
-        if (string.IsNullOrEmpty(planId)) return null;
-
-        try
-        {
-            var matches = Directory.GetDirectories(plansDir, $"{planId}-*");
-            return matches.Length > 0 ? Path.GetFileName(matches[0]) : null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static string? FindTrashEntryById(string trashDir, string planId)
-    {
-        if (!Directory.Exists(trashDir)) return null;
-
-        try
-        {
-            var matches = Directory.GetFiles(trashDir, $"{planId}-*.md");
-            return matches.Length > 0 ? matches[0] : null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static readonly object PlanIdLock = new();
-
-    private static string AllocatePlanId(string plansDir)
-    {
-        Directory.CreateDirectory(plansDir);
-        var counterFile = Path.Combine(plansDir, ".counter");
-
-        lock (PlanIdLock)
-        {
-            var counter = 1;
-            if (File.Exists(counterFile))
-            {
-                var text = File.ReadAllText(counterFile).Trim();
-                if (int.TryParse(text, out var parsed)) counter = parsed;
-            }
-
-            var id = counter.ToString("D5");
-            File.WriteAllText(counterFile, (counter + 1).ToString());
-            return id;
-        }
-    }
-
-    private void ResetPlanState(JobItem job)
-    {
-        try
-        {
-            if (job.Type is "CreatePlan" or "CreatePr" or "CreateIssue") return;
-
-            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
-            var newState = job.Type == "ExecutePlan" ? "Failed" : "Draft";
-            SetPlanStateByFolder(planFolder, newState);
-        }
-        catch
-        {
-            /* Don't let state reset failures crash job completion */
-        }
-    }
-
-    private void ScheduleWorktreeCleanup(JobItem job)
-    {
-        if (job.Type != "ExecutePlan") return;
-
-        var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
-        if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder)) return;
-
-        var worktreesDir = Path.Combine(planFolder, "worktrees");
-        if (!Directory.Exists(worktreesDir)) return;
-
-        var lifecycleLogger = _worktreeLifecycleLogger;
-
-        Task.Run(async () =>
-        {
-            await Task.Delay(TimeSpan.FromSeconds(30));
-            try
-            {
-                PlanReaderService.RemoveWorktrees(planFolder, lifecycleLogger: lifecycleLogger);
-
-                if (Directory.Exists(worktreesDir) && Directory.GetDirectories(worktreesDir).Length == 0)
-                    Directory.Delete(worktreesDir, false);
-            }
-            catch
-            {
-                // Best-effort: background cleanup service will catch it later
-            }
-        });
-    }
+        => PlanYamlHelper.GetNamedArg(args, name);
 
     private (bool Ok, string? BlockReason) CheckDependencies(string planFolder)
-    {
-        try
-        {
-            var planYaml = ReadPlanYaml(planFolder);
-            if (planYaml?.DependsOn == null || planYaml.DependsOn.Count == 0)
-                return (true, null);
-
-            var plansDir = _planReaderService?.PlansDirectory;
-            if (plansDir == null) return (true, null);
-
-            foreach (var dep in planYaml.DependsOn)
-            {
-                var depFolder = Path.Combine(plansDir, dep);
-                var depPlan = ReadPlanYaml(depFolder);
-
-                if (depPlan == null)
-                    return (false, $"Dependency '{dep}' not found");
-
-                if (!depPlan.State.Equals("Completed", StringComparison.OrdinalIgnoreCase))
-                    return (false, $"Dependency '{dep}' is '{depPlan.State}', not Completed");
-
-                // Check that all PRs are actually merged
-                if (depPlan.Prs.Count == 0)
-                    continue;
-
-                foreach (var prUrl in depPlan.Prs.Where(PullRequestApp.IsValidUrl))
-                    try
-                    {
-                        var psi = new ProcessStartInfo
-                        {
-                            FileName = "gh",
-                            Arguments = $"pr view \"{prUrl}\" --json state -q .state",
-                            RedirectStandardOutput = true,
-                            RedirectStandardError = true,
-                            UseShellExecute = false,
-                            CreateNoWindow = true
-                        };
-                        using var proc = Process.Start(psi);
-                        var output = proc?.StandardOutput.ReadToEnd().Trim() ?? "";
-                        proc.WaitForExitOrKill(10000);
-
-                        if (!output.Equals("MERGED", StringComparison.OrdinalIgnoreCase))
-                            return (false, $"Dependency '{dep}' PR {prUrl} is '{output}', not MERGED");
-                    }
-                    catch (Exception ex)
-                    {
-                        return (false, $"Failed to check PR status for '{dep}': {ex.Message}");
-                    }
-            }
-
-            return (true, null);
-        }
-        catch (Exception ex)
-        {
-            return (false, $"Dependency check failed: {ex.Message}");
-        }
-    }
-
-
-    private void RetryBlockedDependents(string completedPlanFolder)
-    {
-        try
-        {
-            var completedFolderName = Path.GetFileName(completedPlanFolder);
-            var plansDir = _planReaderService?.PlansDirectory;
-            if (string.IsNullOrEmpty(plansDir) || !Directory.Exists(plansDir)) return;
-
-            foreach (var dir in Directory.GetDirectories(plansDir))
-            {
-                var planYaml = ReadPlanYaml(dir);
-                if (planYaml == null) continue;
-                if (!planYaml.State.Equals("Blocked", StringComparison.OrdinalIgnoreCase)) continue;
-                if (!planYaml.DependsOn.Contains(completedFolderName, StringComparer.OrdinalIgnoreCase)) continue;
-
-                // Skip if there's already a blocked or active job for this plan
-                var hasExistingJob = _jobs.Values.Any(j =>
-                    j.Type == "ExecutePlan" &&
-                    j.Status is JobStatus.Blocked or JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
-                    j.Args.Length > 0 &&
-                    j.Args[0].Equals(dir, StringComparison.OrdinalIgnoreCase));
-                if (hasExistingJob) continue;
-
-                var (allMet, _) = CheckDependencies(dir);
-                if (allMet)
-                {
-                    SetPlanStateByFolder(dir, "Building");
-                    StartJobSkipDepCheck("ExecutePlan", dir);
-                }
-            }
-        }
-        catch
-        {
-            /* Don't let auto-retry failures crash job completion */
-        }
-    }
-
-    private void CleanupInboxFile(JobItem job)
-    {
-        if (string.IsNullOrEmpty(job.InboxFile)) return;
-        try
-        {
-            if (File.Exists(job.InboxFile))
-                File.Delete(job.InboxFile);
-        }
-        catch
-        {
-            /* Best-effort cleanup */
-        }
-    }
+        => _completionHandler.CheckDependencies(planFolder);
 
     private void ResetPlanStateToBlocked(JobItem job)
-    {
-        try
-        {
-            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
-            SetPlanStateByFolder(planFolder, "Blocked");
-        }
-        catch
-        {
-            /* Don't let state reset failures crash job completion */
-        }
-    }
-
-
-    internal static void LogCostToCsv(string planFolder, string jobType, int tokens, double cost)
-    {
-        if (!Directory.Exists(planFolder)) return;
-
-        var csvPath = Path.Combine(planFolder, "costs.csv");
-        if (!File.Exists(csvPath)) FileHelper.WriteAllText(csvPath, "Promptware,Tokens,Cost\n");
-
-        var line = $"{jobType},{tokens},{cost:F4}\n";
-        FileHelper.AppendAllText(csvPath, line);
-    }
+        => _completionHandler.ResetPlanStateToBlocked(job);
 
     internal void WriteJobLog(JobItem job)
-    {
-        try
-        {
-            WriteRawOutputLog(job);
-        }
-        catch
-        {
-            // Don't let raw log writing failures block other logging
-        }
+        => _completionHandler.WriteJobLog(job);
 
-        if (_planReaderService == null || string.IsNullOrEmpty(job.PlanFile))
-            return;
-
-        // CreatePlan jobs use the description as PlanFile (no folder exists yet) —
-        // the agent writes its own logs inside the properly-named plan folder.
-        if (job.Type == "CreatePlan")
-            return;
-
-        try
-        {
-            var duration = job.DurationSeconds.HasValue ? $"{job.DurationSeconds}s" : "unknown";
-            var logContent = $"# {job.Type}\n\n" +
-                             $"- **Status:** {job.Status}\n" +
-                             $"- **Started:** {job.StartedAt:u}\n" +
-                             $"- **Completed:** {job.CompletedAt:u}\n" +
-                             $"- **Duration:** {duration}\n";
-
-            if (!string.IsNullOrEmpty(job.SessionId))
-                logContent += $"- **SessionId:** {job.SessionId}\n";
-
-            if (job.Status == JobStatus.Timeout && job.StatusMessage != null)
-                logContent += $"- **Timeout Reason:** {job.StatusMessage}\n";
-
-            _planReaderService.AddLog(job.PlanFile, job.Type, logContent);
-
-            // Persist raw output for failed/timeout jobs
-            if (job.Status is JobStatus.Failed or JobStatus.Timeout && job.OutputLines.Count > 0)
-            {
-                var planFolder = job.Args.Length > 0 ? job.Args[0] : null;
-
-                if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder))
-                {
-                    var logRoot = Path.Combine(
-                        Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? ".",
-                        "Logs", "Jobs");
-                    FileHelper.EnsureDirectory(logRoot);
-                    planFolder = logRoot;
-                }
-
-                var logsDir = Path.Combine(planFolder, "logs");
-                FileHelper.EnsureDirectory(logsDir);
-                var outputFile = Path.Combine(logsDir, $"{job.Type}-{job.Id}.output.log");
-                File.WriteAllLines(outputFile, job.OutputLines);
-
-                job.EnqueueOutput($"[Tendril] Full output saved to: {outputFile}");
-            }
-        }
-        catch
-        {
-            // Don't let log writing failures crash the job completion
-        }
-    }
-
-    private void WriteRawOutputLog(JobItem job)
-    {
-        if (job.OutputLines.Count == 0) return;
-
-        var logsDir = Path.Combine(PromptsRoot, job.Type, "Logs");
-        if (!Directory.Exists(logsDir)) return;
-
-        var logName = !string.IsNullOrEmpty(job.AllocatedPlanId)
-            ? job.AllocatedPlanId
-            : job.Id;
-
-        var rawFile = Path.Combine(logsDir, $"{logName}.raw.jsonl");
-        File.WriteAllLines(rawFile, job.OutputLines);
-    }
+    internal static void LogCostToCsv(string planFolder, string jobType, int tokens, double cost)
+        => PlanYamlHelper.LogCostToCsv(planFolder, jobType, tokens, cost);
 }


### PR DESCRIPTION
Extract four cohesive helper classes from JobService.cs (1902 → 693 lines):
- JobFailureAnalyzer: static failure reason extraction and sanitization
- PlanYamlHelper: static plan YAML read/write/allocation helpers
- JobLauncher: process creation, agent-direct launch, stale output watchdog
- JobCompletionHandler: plan state transitions, hooks, telemetry, logging, dependency retry

Decompose brain methods: CompleteJob (cc=44→6), StartJobInternal (cc=26→5),
TryBuildAgentProcessStart (cc=27→5 smaller methods). Unify ClearCompletedJobs/ClearFailedJobs
into shared ClearJobsByStatus. All 949 passing tests remain green (1 pre-existing failure).
