### PR TITLE
[03474] Update Rustino config reviewActions to use Samples project

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -123,9 +123,9 @@ projects:
     - src/Rustino.Samples/ — demo applications
     Build: `cd src/Rustino.Native && cargo build --release`, then `dotnet build`
   reviewActions:
-  - name: HelloWorld Sample
-    condition: Test-Path "worktrees\Rustino\src\Rustino.Samples\Rustino.Samples.HelloWorld"
-    action: dotnet run --project worktrees\Rustino\src\Rustino.Samples\Rustino.Samples.HelloWorld
+  - name: Samples
+    condition: Test-Path "worktrees\Rustino\src\Rustino.Samples"
+    action: dotnet run --project worktrees\Rustino\src\Rustino.Samples
   hooks:
   - name: SlackNotify
     when: after


### PR DESCRIPTION
# Summary

## Changes

Updated the Rustino project configuration in config.yaml to change the reviewAction from pointing to a specific HelloWorld sample to the general Samples project, aligning with the pattern used by other projects (Framework, Tendril).

## API Changes

None — this is a configuration-only change affecting how the Review app launches Rustino samples.

## Files Modified

- `src/Ivy.Tendril.TeamIvyConfig/config.yaml` — Updated Rustino `reviewActions` section:
  - Changed action name from "HelloWorld Sample" to "Samples"
  - Changed condition to check for general Samples directory
  - Changed action command to run general Samples project


## Commits

- 1328805