### PR TITLE
[03494] Clear failed jobs should exclude blocked jobs

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
@@ -80,11 +80,11 @@ public class JobServiceDeletionTests
 
         Assert.Null(service.GetJob("failed-1"));
         Assert.Null(service.GetJob("timeout-1"));
-        Assert.Null(service.GetJob("blocked-1"));
+        Assert.NotNull(service.GetJob("blocked-1"));
         Assert.NotNull(service.GetJob("completed-1"));
         Assert.Contains("failed-1", db.DeletedJobIds);
         Assert.Contains("timeout-1", db.DeletedJobIds);
-        Assert.Contains("blocked-1", db.DeletedJobIds);
+        Assert.DoesNotContain("blocked-1", db.DeletedJobIds);
         Assert.DoesNotContain("completed-1", db.DeletedJobIds);
     }
 

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -272,7 +272,7 @@ public class JobService : IJobService
         => ClearJobsByStatus(j => j.Status == JobStatus.Completed);
 
     public void ClearFailedJobs()
-        => ClearJobsByStatus(j => j.Status is JobStatus.Failed or JobStatus.Timeout or JobStatus.Blocked);
+        => ClearJobsByStatus(j => j.Status is JobStatus.Failed or JobStatus.Timeout);
 
     private void ClearJobsByStatus(Func<JobItem, bool> predicate)
     {


### PR DESCRIPTION
# Summary

## Changes

Fixed the `ClearFailedJobs()` method to exclude blocked jobs from deletion. The method now only removes jobs with `Failed` or `Timeout` status, preserving jobs with `Blocked` status that are waiting for dependencies.

## API Changes

- `JobService.ClearFailedJobs()` — Behavior changed: no longer removes jobs with `JobStatus.Blocked`

## Files Modified

**Services:**
- `JobService.cs` — Updated `ClearFailedJobs()` predicate to remove `JobStatus.Blocked`

**Tests:**
- `JobServiceDeletionTests.cs` — Updated `ClearFailedJobs_DeletesFromMemoryAndDatabase` test to verify blocked jobs are preserved


## Commits

- 2f91cdc

---

Closes Ivy-Interactive/Ivy-Tendril#45