### PR TITLE
[03499] Window too small on Retina/HiDPI displays

### DIFF
--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -232,6 +232,7 @@ public class Program
             var window = new DesktopWindow(server)
                 .Title("Ivy Tendril")
                 .Size(1400, 900)
+                .UseDpiScaling(false)  // Let the OS handle DPI scaling natively
                 .Icon(typeof(Program), "Ivy.Tendril.Assets.Tendril.ico");
 
             return window.Run();


### PR DESCRIPTION
# Summary

## Changes

Disabled manual DPI scaling in the Tendril window initialization by adding `.UseDpiScaling(false)` to the DesktopWindow configuration. This allows modern operating systems (macOS, Windows 10+) to handle high-DPI scaling natively, fixing the issue where the window appeared too small on Retina and other HiDPI displays.

## API Changes

None. The `UseDpiScaling` method was already available in the `DesktopWindow` class; this change only configures how Tendril uses it.

## Files Modified

- `src/Ivy.Tendril/Program.cs` - Added `.UseDpiScaling(false)` to the window initialization chain

## Commits

- 46abb30 [03499] Disable DPI scaling to fix window size on Retina/HiDPI displays