### PR TITLE
Wire IsInboxFileTracked into InboxWatcher to dedup CreatePlan jobs

### DIFF
--- a/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
@@ -1,3 +1,5 @@
+using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
@@ -137,6 +139,98 @@ public class InboxWatcherServiceTests
             if (Directory.Exists(tempDir))
                 Directory.Delete(tempDir, true);
         }
+    }
+
+    [Fact]
+    public void ProcessFileAsync_AlreadyTrackedByRunningJob_SkipsStartJob()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"inbox-test-{Guid.NewGuid():N}");
+        var inboxDir = Path.Combine(tempDir, "Inbox");
+        Directory.CreateDirectory(inboxDir);
+
+        try
+        {
+            var filePath = Path.Combine(inboxDir, "duplicate-entry.md");
+            File.WriteAllText(filePath, "Fix the bug");
+
+            var config = new ConfigService(new TendrilSettings(), tempDir);
+            var jobService = new TrackedStubJobService { TrackedReturnValue = true };
+            using var watcher = new InboxWatcherService(config, jobService);
+
+            Thread.Sleep(2000);
+
+            // When IsInboxFileTracked returns true, the watcher must not call StartJob
+            // and must leave the .md file untouched (no rename to .processing).
+            Assert.Empty(jobService.StartedJobs);
+            Assert.Single(Directory.GetFiles(inboxDir, "*.md"));
+            Assert.Empty(Directory.GetFiles(inboxDir, "*.md.processing"));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ProcessFileAsync_NotTracked_StartsJobAndRenamesFile()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"inbox-test-{Guid.NewGuid():N}");
+        var inboxDir = Path.Combine(tempDir, "Inbox");
+        Directory.CreateDirectory(inboxDir);
+
+        try
+        {
+            var filePath = Path.Combine(inboxDir, "new-entry.md");
+            File.WriteAllText(filePath, "Fix the bug");
+
+            var config = new ConfigService(new TendrilSettings(), tempDir);
+            var jobService = new TrackedStubJobService { TrackedReturnValue = false };
+            using var watcher = new InboxWatcherService(config, jobService);
+
+            Thread.Sleep(2000);
+
+            Assert.Single(jobService.StartedJobs);
+            Assert.Empty(Directory.GetFiles(inboxDir, "*.md"));
+            Assert.Single(Directory.GetFiles(inboxDir, "*.md.processing"));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    private class TrackedStubJobService : IJobService
+    {
+        public bool TrackedReturnValue { get; set; }
+        public List<(string Type, string[] Args, string? InboxFilePath)> StartedJobs { get; } = new();
+
+        public string StartJob(string type, string[] args, string? inboxFilePath)
+        {
+            StartedJobs.Add((type, args, inboxFilePath));
+            return $"job-{StartedJobs.Count:D3}";
+        }
+
+        public string StartJob(string type, params string[] args) => StartJob(type, args, null);
+
+        public bool IsInboxFileTracked(string filePath) => TrackedReturnValue;
+
+        public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) { }
+        public void StopJob(string id) { }
+        public void DeleteJob(string id) { }
+        public void ClearCompletedJobs() { }
+        public void ClearFailedJobs() { }
+        public List<JobItem> GetJobs() => new();
+        public JobItem? GetJob(string id) => null;
+        public void Dispose() { }
+
+#pragma warning disable CS0067
+        public event Action? JobsChanged;
+        public event Action? JobsStructureChanged;
+        public event Action? JobPropertyChanged;
+        public event Action<JobNotification>? NotificationReady;
+#pragma warning restore CS0067
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Services/InboxWatcherService.cs
+++ b/src/Ivy.Tendril/Services/InboxWatcherService.cs
@@ -112,6 +112,14 @@ public class InboxWatcherService : IInboxWatcherService
             if (!File.Exists(filePath))
                 return;
 
+            // Skip if a CreatePlan job is already tracking this inbox file.
+            // Guards against the FSW firing Created more than once for the same
+            // file, the 30s poll overlapping with an in-flight StartJob, and any
+            // future caller that re-writes an .md into Inbox while its
+            // .md.processing sibling is mid-job.
+            if (_jobService.IsInboxFileTracked(filePath + ".processing"))
+                return;
+
             try
             {
                 await ProcessInboxFileAsync(filePath);

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -298,14 +298,15 @@ public class JobService : IJobService
     }
 
     /// <summary>
-    ///     Checks whether the given inbox file path is already tracked by a running CreatePlan job.
-    ///     Used by InboxWatcherService to avoid re-processing files.
+    ///     Checks whether the given inbox file path is already tracked by a
+    ///     pending, queued, or running CreatePlan job. Used by InboxWatcherService
+    ///     to avoid spawning duplicate CreatePlan jobs for the same inbox file.
     /// </summary>
     public bool IsInboxFileTracked(string filePath)
     {
         return _jobs.Values.Any(j =>
             j.Type == "CreatePlan" &&
-            j.Status == JobStatus.Running &&
+            j.Status is JobStatus.Pending or JobStatus.Queued or JobStatus.Running &&
             j.InboxFile != null &&
             j.InboxFile.Equals(filePath, StringComparison.OrdinalIgnoreCase));
     }


### PR DESCRIPTION
## Summary

`IJobService.IsInboxFileTracked` was declared and implemented but had **no callers** in production code. The InboxWatcher therefore had no guard against starting multiple `CreatePlan` jobs for the same inbox file — `_processing` (the in-memory ConcurrentDictionary) only prevents concurrent re-entry per FSW handler and is cleared synchronously the moment `StartJob` returns, so a second trigger for the same file (replayed FSW event, 30s poll overlap, caller re-writing the `.md`) slips through.

## Motivation

Observed today: dropping **20** `.md` files into `$TENDRIL_HOME/Inbox/` caused job IDs to inflate from the intended 20 to **~80** (`job-079` recorded, additional `job-094` Failed). Several issues got 2–3 CreatePlan jobs each; the redundant ones eventually trashed themselves as duplicates in Step 3 of the CreatePlan promptware, but only after each had spent Opus 4.6 tokens on research. Concrete duplicates from the live run:

- Issue #475 (privacy policy) → `job-020`, `job-060`, `job-079`
- Issue #473 (llms.txt) → `job-005`, `job-077`
- Issue #126 (copy button) → `job-017`, `job-076`
- Issue #17 (dumpster image) → `job-059`, `job-094`

## Changes

- **`InboxWatcherService.ProcessFileAsync`**: before `ProcessInboxFileAsync`, check `_jobService.IsInboxFileTracked(filePath + ".processing")`. If true, return early — don't rename, don't start.
- **`JobService.IsInboxFileTracked`**: broaden the status filter from `Running` only to `Pending | Queued | Running`. CreatePlan jobs sit in `Pending`/`Queued` while waiting on `maxConcurrentJobs` slot availability; a second trigger during that window would previously have slipped past the guard even if the field were wired up.
- **Tests**: two new tests using a stub `IJobService` — one asserts that a `true` tracked signal short-circuits (no StartJob, no rename), the other asserts normal flow when not tracked.

## Test plan

- [x] `dotnet build` clean
- [x] New `InboxWatcherServiceTests` (13 total) all pass
- [x] Full `Ivy.Tendril.Test` suite: 910 passed / 42 failed — the 42 failures are pre-existing on `development` (ModelPricingServiceTests, BackgroundServiceActivatorTests, PlanDownloadHelperTests, ConfigServiceTests) and not touched by this change.
- [ ] Manual repro on the affected remote host after deploy: drop 20 duplicate-named `.md` files and confirm only one CreatePlan fires per unique file.

## Scope / not in this PR

- Plan-ID counter race (concurrent `CreatePlan` jobs producing colliding `NNNNN-` plan folder prefixes) — filed separately as #172.
- Cost-before-dedup issue (CreatePlan agent pays full research cost before Step 3 trashes a duplicate) — would need a cheaper pre-flight check against existing plans; not addressed here.

Related: #166 (Sonnet alias → 4.5 on Bedrock), #172 (PlanId race).