### PR TITLE
Fix unable to remove repo path row in onboarding

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -26,7 +26,17 @@ public class ProjectSetupStepView(IState<int> stepperIndex) : ViewBase
         for (var i = 0; i < currentRepos.Count; i++)
         {
             var ri = i;
-            reposLayout |= new RepoPathInputView(repoPaths, ri);
+            reposLayout |= Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                           | new RepoPathInputView(repoPaths, ri)
+                           | new Button().Icon(Icons.Trash).Ghost()
+                               .OnClick(() =>
+                               {
+                                   var list = new List<string>(repoPaths.Value);
+                                   if (ri < list.Count) list.RemoveAt(ri);
+                                   if (list.Count == 0) list.Add("");
+                                   repoPaths.Set(list);
+                               })
+                               .WithTooltip("Remove repository");
         }
 
         reposLayout |= new Button("Add").Outline().OnClick(() =>


### PR DESCRIPTION
## Summary
- Adds a trash button next to each repository path input in the onboarding `ProjectSetupStepView` so users can remove rows added via the Add button.
- Keeps at least one empty row rendered so the input is always visible.

Closes #110

## Test plan
- [ ] Start onboarding, go to the Project Setup step.
- [ ] Click Add a few times to create extra repo path rows.
- [ ] Verify each row has a trash icon and clicking it removes that row.
- [ ] Verify removing the last row leaves an empty input visible.