### PR TITLE
[03476] Onboarding gets stuck on final step

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -29,23 +29,15 @@ public class CompleteStepView(IState<int> stepperIndex) : ViewBase
                     return;
                 }
 
+                // Step 1: Create directory structure and config
                 await setupService.CompleteSetupAsync(tendrilHome);
 
-                // Redirect first to unblock UI
-                client.Redirect("/", true);
+                // Step 2: Start background services synchronously (may take time)
+                // Run in Task.Run to avoid blocking UI thread, but await completion
+                await Task.Run(() => setupService.StartBackgroundServices());
 
-                // Start background services after redirect (fire-and-forget)
-                _ = Task.Run(() =>
-                {
-                    try
-                    {
-                        setupService.StartBackgroundServices();
-                    }
-                    catch
-                    {
-                        // Already logged by StartBackgroundServices
-                    }
-                });
+                // Step 3: Only redirect after services are ready
+                client.Redirect("/", true);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
# Summary

## Changes

Fixed the onboarding completion flow to wait for background services to initialize before redirecting to the main app, preventing the UI from appearing stuck.

## API Changes

**Modified method signature (behavior change only):**
- `CompleteStepView.OnComplete()` — Now awaits background service initialization instead of fire-and-forget

## Files Modified

**Core changes:**
- `src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs` — Reordered operations to start services before redirect, removed fire-and-forget pattern, added proper async/await handling


## Commits

- 78ea109

---

Closes Ivy-Interactive/Ivy-Tendril#111