### PR TITLE
[00019] Redesign the 'new version available' UI

### DIFF
--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -12,6 +12,8 @@ public class WallpaperApp : ViewBase
         var countsService = UseService<IPlanCountsService>();
         var versionService = UseService<IVersionCheckService>();
         var versionInfo = UseState<VersionInfo?>(null);
+        var dismissedVersion = UseState<string?>(null);
+        var copyToClipboard = UseClipboard();
 
         UseEffect(() =>
         {
@@ -44,15 +46,27 @@ public class WallpaperApp : ViewBase
                 )
         };
 
-        if (versionInfo.Value?.HasUpdate == true)
-            elements.Insert(0, new Box(
-                Callout.Info(
-                    $"**Tendril v{versionInfo.Value.LatestVersion} is available!**\n\n" +
-                    $"You're currently running v{versionInfo.Value.CurrentVersion}.\n\n" +
-                    $"Update with: `tendril --version && dotnet tool update -g Ivy.Tendril`",
-                    "Update Available"
-                )
-            ).Margin(2));
+        if (versionInfo.Value?.HasUpdate == true && versionInfo.Value.LatestVersion != dismissedVersion.Value)
+        {
+            var updateCommand = "dotnet tool update -g Ivy.Tendril";
+            var notification = new FloatingPanel(
+                new Card(
+                    Layout.Vertical().Gap(1)
+                    | Text.P($"**v{versionInfo.Value.LatestVersion}** is available (you have v{versionInfo.Value.CurrentVersion})").Small()
+                    | (Layout.Horizontal().Gap(1)
+                        | new Button("Copy update command", () => copyToClipboard(updateCommand))
+                            .Variant(ButtonVariant.Secondary)
+                            .Small()
+                            .Icon(Icons.Clipboard)
+                        | new Button("Dismiss", () => dismissedVersion.Set(versionInfo.Value.LatestVersion))
+                            .Variant(ButtonVariant.Ghost)
+                            .Small())
+                ).Header("Update Available", null, Icons.CircleArrowUp),
+                Align.BottomRight
+            ).Offset(new Thickness(0, 0, 16, 16));
+
+            elements.Add(notification);
+        }
 
         return new Fragment(elements.ToArray());
     }


### PR DESCRIPTION
## Changes

Redesigned the "new version available" notification in WallpaperApp from an intrusive full-width Callout at the top of the page to a compact FloatingPanel anchored to the bottom-right corner. Added dismiss-per-version support via UseState and a clipboard copy button for the update command via UseClipboard.

## API Changes

None. This is a purely visual/UX change to an internal app view.

## Files Modified

- **src/Ivy.Tendril/Apps/WallpaperApp.cs** — Replaced `Callout.Info` + `Box.Margin(2)` with `FloatingPanel` + `Card` layout; added `dismissedVersion` state and `UseClipboard` hook

## Commits

- `44f03f7` [00019] Redesign version notification as floating panel with dismiss and copy

Closes https://github.com/Ivy-Interactive/Ivy-Tendril/issues/78