### PR TITLE
[03511] Reduce JobsApp output polling interval to 100-200ms for snappier updates

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -71,7 +71,7 @@ public class JobsApp : ViewBase
 
                 lastProcessedIndex.Set(currentLines.Length);
             }
-        }, TimeSpan.FromMilliseconds(300));
+        }, TimeSpan.FromMilliseconds(100));
         var config = UseService<IConfigService>();
         UseEffect(() =>
         {


### PR DESCRIPTION
# Summary

## Changes

Reduced the JobsApp output polling interval from 300ms to 100ms for faster UI updates during long-running jobs. This provides 3x faster responsiveness when viewing job output, with minimal overhead on modern systems.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/JobsApp.cs` — Changed `UseInterval` polling delay from 300ms to 100ms


## Commits

- 67ad427