### PR TITLE
[03512] Make sure the Jobs are listed in the order with the latest new job is on top

### DIFF
--- a/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
@@ -77,7 +77,7 @@ public class AgentProviderFactoryTests
             {
                 ["_default"] = new() { Profile = "quick", AllowedTools = new List<string> { "Read" } },
                 ["ExecutePlan"] = new()
-                    { Profile = "deep", AllowedTools = new List<string> { "Read", "Write", "Bash" } }
+                { Profile = "deep", AllowedTools = new List<string> { "Read", "Write", "Bash" } }
             },
             codingAgents: new List<AgentConfig>
             {

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -798,7 +798,9 @@ public class PlanCliCommandTests : IDisposable
         CreatePlanFolder("20130", "DraftPlan");
         CreatePlanFolder("20131", "FailedPlan", new PlanYaml
         {
-            State = "Failed", Project = "Test", Title = "FailedPlan",
+            State = "Failed",
+            Project = "Test",
+            Title = "FailedPlan",
             Repos = [_tempDir],
             Created = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             Updated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
@@ -815,14 +817,18 @@ public class PlanCliCommandTests : IDisposable
     {
         CreatePlanFolder("20140", "ProjA", new PlanYaml
         {
-            State = "Draft", Project = "Alpha", Title = "ProjA",
+            State = "Draft",
+            Project = "Alpha",
+            Title = "ProjA",
             Repos = [_tempDir],
             Created = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             Updated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
         });
         CreatePlanFolder("20141", "ProjB", new PlanYaml
         {
-            State = "Draft", Project = "Beta", Title = "ProjB",
+            State = "Draft",
+            Project = "Beta",
+            Title = "ProjB",
             Repos = [_tempDir],
             Created = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             Updated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
@@ -839,7 +845,10 @@ public class PlanCliCommandTests : IDisposable
     {
         CreatePlanFolder("20150", "CritPlan", new PlanYaml
         {
-            State = "Draft", Project = "Test", Title = "CritPlan", Level = "Critical",
+            State = "Draft",
+            Project = "Test",
+            Title = "CritPlan",
+            Level = "Critical",
             Repos = [_tempDir],
             Created = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             Updated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
@@ -857,8 +866,11 @@ public class PlanCliCommandTests : IDisposable
     {
         CreatePlanFolder("20160", "WithPr", new PlanYaml
         {
-            State = "Completed", Project = "Test", Title = "WithPr",
-            Repos = [_tempDir], Prs = ["https://github.com/org/repo/pull/1"],
+            State = "Completed",
+            Project = "Test",
+            Title = "WithPr",
+            Repos = [_tempDir],
+            Prs = ["https://github.com/org/repo/pull/1"],
             Created = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             Updated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
         });
@@ -890,14 +902,20 @@ public class PlanCliCommandTests : IDisposable
     {
         CreatePlanFolder("20180", "Match", new PlanYaml
         {
-            State = "Draft", Project = "Tendril", Title = "Match", Level = "Bug",
+            State = "Draft",
+            Project = "Tendril",
+            Title = "Match",
+            Level = "Bug",
             Repos = [_tempDir],
             Created = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             Updated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
         });
         CreatePlanFolder("20181", "NoMatch", new PlanYaml
         {
-            State = "Draft", Project = "Other", Title = "NoMatch", Level = "Bug",
+            State = "Draft",
+            Project = "Other",
+            Title = "NoMatch",
+            Level = "Bug",
             Repos = [_tempDir],
             Created = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             Updated = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)

--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -166,7 +166,7 @@ public class JobsApp : ViewBase
                     : null
             };
         })
-            .OrderBy(r => r.Id)
+            .OrderByDescending(r => r.Id)
             .ToList();
 
         var statusGroups = jobs


### PR DESCRIPTION
# Summary

## Changes

Changed the Jobs table sorting order in JobsApp to display newest jobs first by switching from `.OrderBy(r => r.Id)` to `.OrderByDescending(r => r.Id)`. Fixed pre-existing formatting violations in test files during verification.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/JobsApp.cs` — Changed sort order from ascending to descending
- `src/Ivy.Tendril.Test/AgentProviderFactoryTests.cs` — Fixed whitespace formatting
- `src/Ivy.Tendril.Test/PlanCliCommandTests.cs` — Fixed whitespace formatting

## Commits

- d35c951 [03512] Sort Jobs table by ID descending to show newest jobs first
- e18e39e [03512] Fix formatting violations in test files