### PR TITLE
[03510] Add link format guidance to CreatePlan

### DIFF
--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -347,6 +347,7 @@ If the YOLO flag was detected in Step 1, automatically execute the plan after cr
 - **!CRITICAL: Every CreatePlan execution MUST produce at least one plan folder. Even if the task is an analysis, review, or investigation — always create a plan with actionable steps. Never just analyze and report back without a plan.**
 - The plan must include all paths and information for an LLM coding agent to execute end-to-end without human intervention
 - **!IMPORTANT: Validate all file paths before writing `file:///` links in plans.** Use glob/search to confirm the actual path exists. Do NOT guess paths based on naming conventions — hallucinated paths cause "File not found" errors in the UI.
+- When referencing local files, use markdown links: `[FileName.cs:line](file:///path/to/FileName.cs)` for source files with line numbers, or `[FileName.cs](file:///path/to/FileName.cs)` without. Never use backticks in link text or `#L123` fragments in URLs. Use `![alt](path)` for images.
 - Keep the plan short and concise - the limiting factor of this system is a human that will have to read this.
 - **!IMPORTANT: ONE issue per plan file — if multiple issues, create multiple plan files with separate IDs**
 - **Multiple plans from one execution:** When args contain multiple issues, use the pre-allocated PlanId for the first plan. For additional plans, read `.counter`, use sequential IDs starting from it, and update `.counter` to the next available value after all plans are created.


### PR DESCRIPTION
## Problem

The CreatePlan promptware at Program.md:349 has validation guidance about file paths but lacks the comprehensive link format guidance present in UpdatePlan, SplitPlan, and ExpandPlan.

Current guidance (line 349):
```markdown
- **!IMPORTANT: Validate all file paths before writing `file:///` links in plans.** Use glob/search to confirm the actual path exists. Do NOT guess paths based on naming conventions — hallucinated paths cause "File not found" errors in the UI.
```

Other promptwares have more comprehensive guidance (e.g., UpdatePlan:69):
```markdown
- When referencing local files, use markdown links: `[FileName.cs:line](file:///path/to/FileName.cs)` for source files with line numbers, or `[FileName.cs](file:///path/to/FileName.cs)` without. Never use backticks in link text or `#L123` fragments in URLs. Use `![alt](path)` for images.
```

This creates inconsistency across planning promptwares. CreatePlan should have both validation guidance AND format guidance.

## Solution

Added the comprehensive link format guidance to CreatePlan/Program.md:350 in the Rules section, immediately after the existing validation guidance.

**Specific change:**

After line 349 (the validation guidance), added:
```markdown
- When referencing local files, use markdown links: `[FileName.cs:line](file:///path/to/FileName.cs)` for source files with line numbers, or `[FileName.cs](file:///path/to/FileName.cs)` without. Never use backticks in link text or `#L123` fragments in URLs. Use `![alt](path)` for images.
```

This maintains the existing validation rule while adding the format specification. The two rules complement each other:
1. First rule (existing): VALIDATE paths before writing links
2. Second rule (new): FORMAT links correctly when writing them

## Commits

- 6295bf4a69e76c1c4c801d6e835d1b0b1bcb21aa
