### PR TITLE
[03506] Use FileHelper.ReadAllText in PlanCommandHelpers

### DIFF
--- a/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
@@ -81,7 +81,7 @@ public static class PlanCommandHelpers
         if (!File.Exists(yamlPath))
             throw new FileNotFoundException($"plan.yaml not found at {yamlPath}");
 
-        var content = File.ReadAllText(yamlPath);
+        var content = FileHelper.ReadAllText(yamlPath);
         var plan = YamlHelper.Deserializer.Deserialize<PlanYaml>(content);
         if (plan == null)
             throw new InvalidOperationException($"Failed to deserialize plan.yaml at {yamlPath}");
@@ -108,7 +108,7 @@ public static class PlanCommandHelpers
             FileHelper.WriteAllText(tempPath, yaml);
 
             // Read back and validate
-            var content = File.ReadAllText(tempPath);
+            var content = FileHelper.ReadAllText(tempPath);
             var roundTrip = YamlHelper.Deserializer.Deserialize<PlanYaml>(content);
             if (roundTrip == null)
                 throw new InvalidOperationException("Failed to deserialize temp file after writing");


### PR DESCRIPTION
## Problem

[PlanCommandHelpers.cs:111](file:///D:\Repos\_Ivy\Ivy-Tendril\src\Ivy.Tendril\Helpers\PlanCommandHelpers.cs) uses `File.ReadAllText()` to read back and validate the temp file after writing. This is inconsistent with the fix in Plan 03469 that replaced `File.WriteAllText()` with `FileHelper.WriteAllText()` on line 108 to prevent plan.yaml corruption.

While the read operation is less risky than the write (since the file was just written by this process), using `FileHelper.ReadAllText()` provides:
- **Consistency** with the FileHelper usage on line 108
- **FileShare.ReadWrite semantics** that prevent "file being used by another process" errors if another thread/process accesses the file
- **Retry logic** for transient IO errors
- **Defensive programming** against edge cases

Additionally, [PlanCommandHelpers.cs:84](file:///D:\Repos\_Ivy\Ivy-Tendril\src\Ivy.Tendril\Helpers\PlanCommandHelpers.cs) in the `ReadPlan()` method also uses `File.ReadAllText()` for reading plan.yaml files. This should be converted for the same reasons.

## Solution

Replace both instances of `File.ReadAllText()` with `FileHelper.ReadAllText()`:

1. **[PlanCommandHelpers.cs:111](file:///D:\Repos\_Ivy\Ivy-Tendril\src\Ivy.Tendril\Helpers\PlanCommandHelpers.cs)** — in `WritePlan()` when reading back the temp file for validation
2. **[PlanCommandHelpers.cs:84](file:///D:\Repos\_Ivy\Ivy-Tendril\src\Ivy.Tendril\Helpers\PlanCommandHelpers.cs)** — in `ReadPlan()` when reading plan.yaml

This completes the FileHelper migration started in Plan 03469 and ensures all plan.yaml I/O operations use consistent, defensive file handling.

## Commits

- 98167dd [03506] Replace File.ReadAllText with FileHelper.ReadAllText