### PR TITLE
Prevent plan ID collisions in AllocatePlanId

### DIFF
--- a/src/Ivy.Tendril.Test/PlanYamlHelperAllocateIdTests.cs
+++ b/src/Ivy.Tendril.Test/PlanYamlHelperAllocateIdTests.cs
@@ -1,0 +1,69 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test;
+
+public class PlanYamlHelperAllocateIdTests
+{
+    [Fact]
+    public void AllocatePlanId_SkipsExistingFolders()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, ".counter"), "5");
+            Directory.CreateDirectory(Path.Combine(tempDir, "00005-ExistingPlan"));
+
+            var id = PlanYamlHelper.AllocatePlanId(tempDir);
+
+            Assert.Equal("00006", id);
+            Assert.Equal("7", File.ReadAllText(Path.Combine(tempDir, ".counter")));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void AllocatePlanId_SkipsMultipleConsecutiveCollisions()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, ".counter"), "10");
+            Directory.CreateDirectory(Path.Combine(tempDir, "00010-PlanA"));
+            Directory.CreateDirectory(Path.Combine(tempDir, "00011-PlanB"));
+            Directory.CreateDirectory(Path.Combine(tempDir, "00012-PlanC"));
+
+            var id = PlanYamlHelper.AllocatePlanId(tempDir);
+
+            Assert.Equal("00013", id);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void AllocatePlanId_NoCollision_UsesCounterDirectly()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, ".counter"), "42");
+
+            var id = PlanYamlHelper.AllocatePlanId(tempDir);
+
+            Assert.Equal("00042", id);
+            Assert.Equal("43", File.ReadAllText(Path.Combine(tempDir, ".counter")));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `AllocatePlanId` now skips counter values that already have folders on disk, preventing duplicate plan IDs
- The fix was auto-committed in 98392f3; this PR adds the corresponding tests
- Root cause: when the `.counter` file was reset or two batches of plans were created in quick succession, new plans could reuse IDs already taken by existing plan folders, causing database key conflicts and UI inconsistencies

## Test plan
- [ ] Verify `AllocatePlanId_SkipsExistingFolders` passes
- [ ] Verify `AllocatePlanId_SkipsMultipleConsecutiveCollisions` passes
- [ ] Verify `AllocatePlanId_NoCollision_UsesCounterDirectly` passes