### PR TITLE
[03507] Review dialog state management patterns

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
@@ -82,6 +82,7 @@ public class CreateIssueDialog(
         return new Dialog(
             _ =>
             {
+                isCreating.Set(false);
                 issueCommentState.Set("");
                 issueAssigneeState.Set(null);
                 issueLabelsState.Set(Array.Empty<string>());
@@ -109,6 +110,7 @@ public class CreateIssueDialog(
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() =>
                 {
+                    isCreating.Set(false);
                     issueCommentState.Set("");
                     issueAssigneeState.Set(null);
                     issueLabelsState.Set(Array.Empty<string>());
@@ -132,6 +134,7 @@ public class CreateIssueDialog(
                         }
                     }
 
+                    isCreating.Set(false);
                     issueCommentState.Set("");
                     issueAssigneeState.Set(null);
                     issueLabelsState.Set(Array.Empty<string>());

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -43,6 +43,7 @@ public class CustomPrDialog(
         return new Dialog(
             _ =>
             {
+                isCreating.Set(false);
                 customPrMerge.Set(true);
                 customPrDeleteBranch.Set(true);
                 customPrIncludeArtifacts.Set(true);
@@ -67,6 +68,7 @@ public class CustomPrDialog(
             new DialogFooter(
                 new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() =>
                 {
+                    isCreating.Set(false);
                     customPrMerge.Set(true);
                     customPrDeleteBranch.Set(true);
                     customPrIncludeArtifacts.Set(true);
@@ -95,6 +97,7 @@ public class CustomPrDialog(
                         _jobService.StartJob("CreatePr", _selectedPlan.FolderPath);
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
                         _refreshPlans();
+                        isCreating.Set(false);
                         customPrMerge.Set(true);
                         customPrDeleteBranch.Set(true);
                         customPrIncludeArtifacts.Set(true);

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
@@ -28,7 +28,12 @@ public class RerunDialog(
         if (!_dialogOpen.Value) return null;
 
         return new Dialog(
-            _ => _dialogOpen.Set(false),
+            _ =>
+            {
+                isRerunningClean.Set(false);
+                isRerunningCurrent.Set(false);
+                _dialogOpen.Set(false);
+            },
             new DialogHeader($"Rerun Plan #{_selectedPlan.Id}"),
             new DialogBody(
                 Text.P("How would you like to rerun this plan?")

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
@@ -28,6 +28,7 @@ public class SuggestChangesDialog(
         return new Dialog(
             _ =>
             {
+                isCreating.Set(false);
                 _suggestText.Set("");
                 _dialogOpen.Set(false);
             },
@@ -40,6 +41,7 @@ public class SuggestChangesDialog(
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() =>
                 {
+                    isCreating.Set(false);
                     _suggestText.Set("");
                     _dialogOpen.Set(false);
                 }),
@@ -57,6 +59,7 @@ public class SuggestChangesDialog(
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
                         _jobService.StartJob("UpdatePlan", _selectedPlan.FolderPath);
                         _refreshPlans();
+                        isCreating.Set(false);
                         _suggestText.Set("");
                         _dialogOpen.Set(false);
                     }


### PR DESCRIPTION
# Summary

## Changes

Fixed dialog state persistence bug in four dialog components by ensuring `UseState` boolean flags reset to their initial values when dialogs close. Previously, flags like `isCreating` retained their "true" state across dialog open/close cycles, causing submit buttons to remain disabled on subsequent opens.

## API Changes

None.

## Files Modified

- **SuggestChangesDialog.cs** - Added `isCreating.Set(false)` in dialog onClose handler, Cancel button, and submit handler
- **CustomPrDialog.cs** - Added `isCreating.Set(false)` in dialog onClose handler, Cancel button, and submit handler
- **CreateIssueDialog.cs** - Added `isCreating.Set(false)` in dialog onClose handler, Cancel button, and submit handler
- **RerunDialog.cs** - Added `isRerunningClean.Set(false)` and `isRerunningCurrent.Set(false)` in dialog onClose handler


## Commits

- 6a9a0a819b6bcc6fd176e58686bcdeede5a9957f