### PR TITLE
Stop incremental sync error loop when database is unavailable

### DIFF
--- a/src/Ivy.Tendril/Services/PlanDatabaseSyncService.cs
+++ b/src/Ivy.Tendril/Services/PlanDatabaseSyncService.cs
@@ -14,6 +14,7 @@ public class PlanDatabaseSyncService : IDisposable
     private readonly PlanReaderService _planReader;
     private readonly IPlanWatcherService _watcher;
     private volatile bool _isInitialSyncComplete;
+    private volatile bool _isDatabaseAvailable;
 
     public PlanDatabaseSyncService(
         PlanReaderService planReader,
@@ -68,6 +69,7 @@ public class PlanDatabaseSyncService : IDisposable
 
             // Enable database-backed reads in PlanReaderService
             _planReader.EnableDatabaseReads(_database);
+            _isDatabaseAvailable = true;
 
             stopwatch.Stop();
             _logger.LogInformation("Initial sync complete. Synced {Count} plans in {Ms}ms",
@@ -83,7 +85,7 @@ public class PlanDatabaseSyncService : IDisposable
 
     private void OnPlansChanged(string? changedPlanFolder)
     {
-        if (!_isInitialSyncComplete) return;
+        if (!_isInitialSyncComplete || !_isDatabaseAvailable) return;
 
         try
         {


### PR DESCRIPTION
Add _isDatabaseAvailable flag so OnPlansChanged skips incremental
syncs when the initial sync failed (e.g. readonly SQLite DB),
preventing endless error spam from the file watcher.
