### PR TITLE
Route CreatePlan through CLI commands to eliminate YAML parse errors

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/.shared/Plans.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/.shared/Plans.md
@@ -98,6 +98,12 @@ tendril plan add-commit <plan-id> <sha>
 tendril plan set-verification <plan-id> <name> <status>
 # Valid statuses: Pending, Pass, Fail, Skipped
 
+# Related plans
+tendril plan add-related-plan <plan-id> <folder-name>
+
+# Dependencies
+tendril plan add-depends-on <plan-id> <folder-name>
+
 # Recommendations
 tendril plan rec add <plan-id> <title> -d <description> [--impact Small|Medium|High] [--risk Small|Medium|High]
 tendril plan rec accept <plan-id> <title> [--notes <text>]
@@ -116,8 +122,20 @@ tendril plan validate <plan-id>
 ### Creating a plan
 
 ```bash
-tendril plan create <plan-id> <title>
+tendril plan create <plan-id> <title> [options]
 ```
+
+Options:
+- `--project <name>` — Project name (default: Auto)
+- `--level <level>` — Priority level (default: NiceToHave)
+- `--initial-prompt <text>` — Original user description
+- `--source-url <url>` — GitHub issue or PR URL
+- `--execution-profile <profile>` — deep or balanced
+- `--priority <number>` — Priority (default: 0)
+- `--repo <path>` — Repository path (repeatable)
+- `--verification <Name=Status>` — Verification entry (repeatable)
+- `--related-plan <folder>` — Related plan folder name (repeatable)
+- `--depends-on <folder>` — Dependency plan folder name (repeatable)
 
 ### Writing execution logs
 

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
@@ -156,23 +156,47 @@ This catches stale plans before they enter the review queue, reducing wasted rev
 
 ### 4. Create Plan
 
-Create the plan folder, `plan.yaml`, and `revisions/001.md` according to the structure in `../.shared/Plans.md`.
+Create the plan using CLI commands according to the structure in `../.shared/Plans.md`. **Never write `plan.yaml` directly** — use `tendril plan` commands for all plan metadata.
 
-In `plan.yaml`, populate the `verifications` list with each verification from the project's config, all set to `Pending`:
+#### 4.1. Create the plan folder and revision
 
-```yaml
-verifications:
-  - name: Build
-    status: Pending
-  - name: Test
-    status: Pending
+Create the folder `PlansDirectory/<PlanId>-<SafeTitle>/` and write `revisions/001.md` with the plan content.
+
+#### 4.2. Create plan.yaml via CLI
+
+Use `tendril plan create` with all known fields in a single command:
+
+```bash
+tendril plan create <PlanId> "<Title>" \
+  --project "<Project>" \
+  --level "NiceToHave" \
+  --initial-prompt "<cleaned args text>" \
+  --execution-profile "balanced" \
+  --repo "<repo-path-1>" \
+  --repo "<repo-path-2>" \
+  --verification "Build=Pending" \
+  --verification "Test=Pending"
 ```
 
-If `SourcePath` is present in the firmware header, copy it to `plan.yaml` as `sourcePath`.
+Include optional flags as needed:
+- `--source-url "<url>"` — if a source URL was extracted in Step 1
+- `--related-plan "<folder-name>"` — for each plan referenced via `[number]` syntax in args
+- `--depends-on "<folder-name>"` — for blocking dependencies (see Section 4.4)
+- `--priority <number>` — if non-default priority
 
-If a source URL was extracted in Step 1, add `sourceUrl: "<url>"` to plan.yaml.
+Populate `--verification` flags from the project's `verifications` in config.yaml, all set to `Pending`.
 
-If the plan references other plans (from `[number]` syntax in args), add them to `relatedPlans`.
+#### 4.3. Post-creation adjustments
+
+For any fields that need to be set after initial creation, use individual CLI commands:
+
+```bash
+tendril plan set <PlanId> initialPrompt "<text>"
+tendril plan add-repo <PlanId> "<repo-path>"
+tendril plan set-verification <PlanId> Build Pending
+tendril plan add-related-plan <PlanId> "<folder-name>"
+tendril plan add-depends-on <PlanId> "<folder-name>"
+```
 
 **Validate repo paths**: After determining the project and repos from config.yaml, verify each repo path exists locally:
 - For each repo in the plan's repos list, check `Test-Path <repo-path>`
@@ -188,7 +212,7 @@ If the plan references other plans (from `[number]` syntax in args), add them to
 
 ### 4.5. Recommend Execution Profile
 
-Analyze the task complexity and set `executionProfile` in plan.yaml. Consider:
+Analyze the task complexity and choose an `executionProfile`. This is passed via `--execution-profile` on `tendril plan create` (see Step 4.2).
 
 **Use `deep` (opus/max effort) when:**
 - Plan involves complex cross-cutting changes affecting 10+ files
@@ -203,12 +227,7 @@ Analyze the task complexity and set `executionProfile` in plan.yaml. Consider:
 - Simple changes (docs, typos, version bumps, log statements)
 - When in doubt, use balanced
 
-Add the field to plan.yaml:
-```yaml
-executionProfile: balanced  # or deep
-```
-
-If you cannot determine complexity (e.g., task is too vague), omit the field — ExecutePlan will use the config.yaml default.
+If you cannot determine complexity (e.g., task is too vague), omit `--execution-profile` — ExecutePlan will use the config.yaml default.
 
 ### 4.6. Questions Section
 
@@ -264,7 +283,7 @@ The user can edit the checklist before execution — unchecking a required verif
 If the YOLO flag was detected in Step 1, automatically execute the plan after creation:
 
 1. **Verify plan was created**: Confirm the plan folder exists at `PlansDirectory/<PlanId>-<SafeTitle>/`
-2. **Update plan state**: Change the plan's state from `Draft` to `Building` in `plan.yaml`
+2. **Update plan state**: `tendril plan set <PlanId> state Building`
 3. **Invoke ExecutePlan**: Use `Tools/Invoke-ExecutePlan.ps1` to trigger plan execution:
    ```powershell
    & Tools/Invoke-ExecutePlan.ps1 -PlanPath "PlansDirectory/<PlanId>-<SafeTitle>"

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -1076,6 +1076,176 @@ public class PlanCliCommandTests : IDisposable
         Assert.Contains("Completed all verifications successfully", content);
     }
 
+    // ==================== PlanCreate with optional flags ====================
+
+    [Fact]
+    public void PlanCreate_WithAllOptions_SetsAllFields()
+    {
+        var planDir = Path.Combine(_plansDir, "20200-FullCreate");
+        Directory.CreateDirectory(planDir);
+
+        var plan = new PlanYaml
+        {
+            State = "Draft",
+            Project = "Tendril",
+            Level = "Bug",
+            Title = "FullCreate",
+            InitialPrompt = @"Fix the bug in D:\Repos\Foo",
+            SourceUrl = "https://github.com/org/repo/issues/42",
+            ExecutionProfile = "deep",
+            Priority = 3,
+            Repos = [_tempDir],
+            Verifications =
+            [
+                new PlanVerificationEntry { Name = "DotnetBuild", Status = "Pending" },
+                new PlanVerificationEntry { Name = "DotnetTest", Status = "Pending" }
+            ],
+            RelatedPlans = ["20201-OtherPlan"],
+            DependsOn = ["20202-BasePlan"],
+            Created = DateTime.UtcNow,
+            Updated = DateTime.UtcNow
+        };
+        PlanCommandHelpers.WritePlan(planDir, plan);
+
+        var result = PlanCommandHelpers.ReadPlan(planDir);
+        Assert.Equal("Tendril", result.Project);
+        Assert.Equal("Bug", result.Level);
+        Assert.Equal(@"Fix the bug in D:\Repos\Foo", result.InitialPrompt);
+        Assert.Equal("https://github.com/org/repo/issues/42", result.SourceUrl);
+        Assert.Equal("deep", result.ExecutionProfile);
+        Assert.Equal(3, result.Priority);
+        Assert.Single(result.Repos);
+        Assert.Equal(2, result.Verifications.Count);
+        Assert.Equal("DotnetBuild", result.Verifications[0].Name);
+        Assert.Single(result.RelatedPlans);
+        Assert.Single(result.DependsOn);
+    }
+
+    [Fact]
+    public void PlanCreate_WithWindowsPathInInitialPrompt_RoundTrips()
+    {
+        var planDir = Path.Combine(_plansDir, "20210-WindowsPath");
+        Directory.CreateDirectory(planDir);
+
+        var plan = new PlanYaml
+        {
+            State = "Draft",
+            Project = "Test",
+            Title = "WindowsPath",
+            Repos = [_tempDir],
+            InitialPrompt = @"Show issue in a DataTable D:\Screenshots\2026-04-23_10-25.png",
+            Created = DateTime.UtcNow,
+            Updated = DateTime.UtcNow
+        };
+        PlanCommandHelpers.WritePlan(planDir, plan);
+
+        var result = PlanCommandHelpers.ReadPlan(planDir);
+        Assert.Equal(@"Show issue in a DataTable D:\Screenshots\2026-04-23_10-25.png", result.InitialPrompt);
+    }
+
+    [Fact]
+    public void PlanCreate_VerificationFormat_ParsesCorrectly()
+    {
+        var planDir = Path.Combine(_plansDir, "20220-VerifFormat");
+        Directory.CreateDirectory(planDir);
+
+        var plan = new PlanYaml
+        {
+            State = "Draft",
+            Project = "Test",
+            Title = "VerifFormat",
+            Repos = [_tempDir],
+            Verifications =
+            [
+                new PlanVerificationEntry { Name = "DotnetBuild", Status = "Pending" },
+                new PlanVerificationEntry { Name = "DotnetFormat", Status = "Pending" },
+                new PlanVerificationEntry { Name = "DotnetTest", Status = "Pending" },
+                new PlanVerificationEntry { Name = "CheckResult", Status = "Pending" }
+            ],
+            Created = DateTime.UtcNow,
+            Updated = DateTime.UtcNow
+        };
+        PlanCommandHelpers.WritePlan(planDir, plan);
+
+        var result = PlanCommandHelpers.ReadPlan(planDir);
+        Assert.Equal(4, result.Verifications.Count);
+        Assert.All(result.Verifications, v => Assert.Equal("Pending", v.Status));
+    }
+
+    // ==================== PlanAddRelatedPlan ====================
+
+    [Fact]
+    public void PlanAddRelatedPlan_AddsEntry()
+    {
+        CreatePlanFolder("20230", "AddRelatedTest");
+
+        var folder = PlanCommandHelpers.ResolvePlanFolder("20230");
+        var plan = PlanCommandHelpers.ReadPlan(folder);
+        plan.RelatedPlans.Add("20231-OtherPlan");
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(folder, plan);
+
+        var result = ReadPlan("20230");
+        Assert.Single(result.RelatedPlans);
+        Assert.Equal("20231-OtherPlan", result.RelatedPlans[0]);
+    }
+
+    [Fact]
+    public void PlanAddRelatedPlan_Idempotent()
+    {
+        CreatePlanFolder("20232", "RelatedIdempotent");
+
+        var folder = PlanCommandHelpers.ResolvePlanFolder("20232");
+        var plan = PlanCommandHelpers.ReadPlan(folder);
+        plan.RelatedPlans.Add("20233-OtherPlan");
+        PlanCommandHelpers.WritePlan(folder, plan);
+
+        plan = PlanCommandHelpers.ReadPlan(folder);
+        if (!plan.RelatedPlans.Contains("20233-OtherPlan", StringComparer.OrdinalIgnoreCase))
+            plan.RelatedPlans.Add("20233-OtherPlan");
+        PlanCommandHelpers.WritePlan(folder, plan);
+
+        var result = ReadPlan("20232");
+        Assert.Single(result.RelatedPlans);
+    }
+
+    // ==================== PlanAddDependsOn ====================
+
+    [Fact]
+    public void PlanAddDependsOn_AddsEntry()
+    {
+        CreatePlanFolder("20240", "AddDependsTest");
+
+        var folder = PlanCommandHelpers.ResolvePlanFolder("20240");
+        var plan = PlanCommandHelpers.ReadPlan(folder);
+        plan.DependsOn.Add("20241-BasePlan");
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(folder, plan);
+
+        var result = ReadPlan("20240");
+        Assert.Single(result.DependsOn);
+        Assert.Equal("20241-BasePlan", result.DependsOn[0]);
+    }
+
+    [Fact]
+    public void PlanAddDependsOn_Idempotent()
+    {
+        CreatePlanFolder("20242", "DependsIdempotent");
+
+        var folder = PlanCommandHelpers.ResolvePlanFolder("20242");
+        var plan = PlanCommandHelpers.ReadPlan(folder);
+        plan.DependsOn.Add("20243-BasePlan");
+        PlanCommandHelpers.WritePlan(folder, plan);
+
+        plan = PlanCommandHelpers.ReadPlan(folder);
+        if (!plan.DependsOn.Contains("20243-BasePlan", StringComparer.OrdinalIgnoreCase))
+            plan.DependsOn.Add("20243-BasePlan");
+        PlanCommandHelpers.WritePlan(folder, plan);
+
+        var result = ReadPlan("20242");
+        Assert.Single(result.DependsOn);
+    }
+
     private static string CaptureStdout(Action action)
     {
         var original = Console.Out;

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -410,7 +410,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"Logout failed: {ex}");
+                await Console.Error.WriteLineAsync($"Logout failed: {ex}");
             }
         }
 

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -78,7 +78,7 @@ public class ContentView(
 
         var header = Layout.Horizontal().Width(Size.Full()).Height(Size.Px(40)).Gap(2)
                      | Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold()
-                     | isEditing.ToSwitchInput(Icons.Pencil).Label("Edit")
+                     | isEditing.ToSwitchInput(Icons.Code).Label("Edit")
                      | new Spacer().Width(Size.Grow())
                      | Text.Rich()
                          .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)

--- a/src/Ivy.Tendril/Commands/PlanAddDependsOnCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddDependsOnCommand.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using Ivy.Tendril.Helpers;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class PlanAddDependsOnSettings : CommandSettings
+{
+    [Description("Plan ID (e.g., 03430)")]
+    [CommandArgument(0, "<plan-id>")]
+    public string PlanId { get; set; } = "";
+
+    [Description("Dependency plan folder name (e.g., 01478-WorktreeIsolation)")]
+    [CommandArgument(1, "<depends-on>")]
+    public string DependsOn { get; set; } = "";
+}
+
+public class PlanAddDependsOnCommand : Command<PlanAddDependsOnSettings>
+{
+    protected override int Execute(CommandContext context, PlanAddDependsOnSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            if (plan.DependsOn.Contains(settings.DependsOn, StringComparer.OrdinalIgnoreCase))
+            {
+                Console.WriteLine($"Dependency already present: {settings.DependsOn}");
+                return 0;
+            }
+
+            plan.DependsOn.Add(settings.DependsOn);
+            plan.Updated = DateTime.UtcNow;
+
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+
+            Console.WriteLine($"Added dependency: {settings.DependsOn}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
+    }
+}

--- a/src/Ivy.Tendril/Commands/PlanAddRelatedPlanCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddRelatedPlanCommand.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using Ivy.Tendril.Helpers;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class PlanAddRelatedPlanSettings : CommandSettings
+{
+    [Description("Plan ID (e.g., 03430)")]
+    [CommandArgument(0, "<plan-id>")]
+    public string PlanId { get; set; } = "";
+
+    [Description("Related plan folder name (e.g., 01478-WorktreeIsolation)")]
+    [CommandArgument(1, "<related-plan>")]
+    public string RelatedPlan { get; set; } = "";
+}
+
+public class PlanAddRelatedPlanCommand : Command<PlanAddRelatedPlanSettings>
+{
+    protected override int Execute(CommandContext context, PlanAddRelatedPlanSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            if (plan.RelatedPlans.Contains(settings.RelatedPlan, StringComparer.OrdinalIgnoreCase))
+            {
+                Console.WriteLine($"Related plan already present: {settings.RelatedPlan}");
+                return 0;
+            }
+
+            plan.RelatedPlans.Add(settings.RelatedPlan);
+            plan.Updated = DateTime.UtcNow;
+
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+
+            Console.WriteLine($"Added related plan: {settings.RelatedPlan}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            return 1;
+        }
+    }
+}

--- a/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
@@ -16,6 +16,46 @@ public class PlanCreateSettings : CommandSettings
     [Description("Plan title")]
     [CommandArgument(1, "<title>")]
     public string Title { get; set; } = "";
+
+    [Description("Project name (default: Auto)")]
+    [CommandOption("--project")]
+    public string? Project { get; set; }
+
+    [Description("Priority level (default: NiceToHave)")]
+    [CommandOption("--level")]
+    public string? Level { get; set; }
+
+    [Description("Initial prompt text")]
+    [CommandOption("--initial-prompt")]
+    public string? InitialPrompt { get; set; }
+
+    [Description("Source URL (GitHub issue or PR)")]
+    [CommandOption("--source-url")]
+    public string? SourceUrl { get; set; }
+
+    [Description("Execution profile (deep or balanced)")]
+    [CommandOption("--execution-profile")]
+    public string? ExecutionProfile { get; set; }
+
+    [Description("Priority number (default: 0)")]
+    [CommandOption("--priority")]
+    public int? Priority { get; set; }
+
+    [Description("Repository paths (repeatable)")]
+    [CommandOption("--repo")]
+    public string[]? Repos { get; set; }
+
+    [Description("Verifications in Name=Status format (repeatable)")]
+    [CommandOption("--verification")]
+    public string[]? Verifications { get; set; }
+
+    [Description("Related plan folder names (repeatable)")]
+    [CommandOption("--related-plan")]
+    public string[]? RelatedPlans { get; set; }
+
+    [Description("Dependency plan folder names (repeatable)")]
+    [CommandOption("--depends-on")]
+    public string[]? DependsOn { get; set; }
 }
 
 public class PlanCreateCommand : Command<PlanCreateSettings>
@@ -34,16 +74,44 @@ public class PlanCreateCommand : Command<PlanCreateSettings>
                 return 1;
             }
 
-            // Create new plan with minimal required fields
             var plan = new PlanYaml
             {
                 State = "Draft",
-                Project = "Auto",
-                Level = "NiceToHave",
+                Project = settings.Project ?? "Auto",
+                Level = settings.Level ?? "NiceToHave",
                 Title = settings.Title,
                 Created = DateTime.UtcNow,
-                Updated = DateTime.UtcNow
+                Updated = DateTime.UtcNow,
+                InitialPrompt = settings.InitialPrompt,
+                SourceUrl = settings.SourceUrl,
+                ExecutionProfile = settings.ExecutionProfile,
+                Priority = settings.Priority ?? 0
             };
+
+            if (settings.Repos != null)
+                foreach (var repo in settings.Repos)
+                    plan.Repos.Add(repo);
+
+            if (settings.Verifications != null)
+                foreach (var v in settings.Verifications)
+                {
+                    var eqIdx = v.IndexOf('=');
+                    if (eqIdx < 0)
+                        throw new ArgumentException($"Invalid verification format '{v}'. Expected Name=Status.");
+                    plan.Verifications.Add(new PlanVerificationEntry
+                    {
+                        Name = v[..eqIdx],
+                        Status = v[(eqIdx + 1)..]
+                    });
+                }
+
+            if (settings.RelatedPlans != null)
+                foreach (var rp in settings.RelatedPlans)
+                    plan.RelatedPlans.Add(rp);
+
+            if (settings.DependsOn != null)
+                foreach (var dep in settings.DependsOn)
+                    plan.DependsOn.Add(dep);
 
             PlanCommandHelpers.WritePlan(planFolder, plan);
 

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -99,6 +99,10 @@ public class Program
                         .WithDescription("Add a PR URL");
                     plan.AddCommand<PlanAddCommitCommand>("add-commit")
                         .WithDescription("Add a commit hash");
+                    plan.AddCommand<PlanAddRelatedPlanCommand>("add-related-plan")
+                        .WithDescription("Add a related plan");
+                    plan.AddCommand<PlanAddDependsOnCommand>("add-depends-on")
+                        .WithDescription("Add a plan dependency");
                     plan.AddCommand<PlanSetVerificationCommand>("set-verification")
                         .WithDescription("Update verification status");
                     plan.AddCommand<PlanGetCommand>("get")

--- a/src/Ivy.Tendril/Promptwares/.shared/Plans.md
+++ b/src/Ivy.Tendril/Promptwares/.shared/Plans.md
@@ -98,6 +98,12 @@ tendril plan add-commit <plan-id> <sha>
 tendril plan set-verification <plan-id> <name> <status>
 # Valid statuses: Pending, Pass, Fail, Skipped
 
+# Related plans
+tendril plan add-related-plan <plan-id> <folder-name>
+
+# Dependencies
+tendril plan add-depends-on <plan-id> <folder-name>
+
 # Recommendations
 tendril plan rec add <plan-id> <title> -d <description> [--impact Small|Medium|High] [--risk Small|Medium|High]
 tendril plan rec accept <plan-id> <title> [--notes <text>]
@@ -116,8 +122,20 @@ tendril plan validate <plan-id>
 ### Creating a plan
 
 ```bash
-tendril plan create <plan-id> <title>
+tendril plan create <plan-id> <title> [options]
 ```
+
+Options:
+- `--project <name>` — Project name (default: Auto)
+- `--level <level>` — Priority level (default: NiceToHave)
+- `--initial-prompt <text>` — Original user description
+- `--source-url <url>` — GitHub issue or PR URL
+- `--execution-profile <profile>` — deep or balanced
+- `--priority <number>` — Priority (default: 0)
+- `--repo <path>` — Repository path (repeatable)
+- `--verification <Name=Status>` — Verification entry (repeatable)
+- `--related-plan <folder>` — Related plan folder name (repeatable)
+- `--depends-on <folder>` — Dependency plan folder name (repeatable)
 
 ### Writing execution logs
 

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -149,23 +149,47 @@ This catches stale plans before they enter the review queue, reducing wasted rev
 
 ### 4. Create Plan
 
-Create the plan folder, `plan.yaml`, and `revisions/001.md` according to the structure in `../.shared/Plans.md`.
+Create the plan using CLI commands according to the structure in `../.shared/Plans.md`. **Never write `plan.yaml` directly** — use `tendril plan` commands for all plan metadata.
 
-In `plan.yaml`, populate the `verifications` list with each verification from the project's config, all set to `Pending`:
+#### 4.1. Create the plan folder and revision
 
-```yaml
-verifications:
-  - name: Build
-    status: Pending
-  - name: Test
-    status: Pending
+Create the folder `PlansDirectory/<PlanId>-<SafeTitle>/` and write `revisions/001.md` with the plan content.
+
+#### 4.2. Create plan.yaml via CLI
+
+Use `tendril plan create` with all known fields in a single command:
+
+```bash
+tendril plan create <PlanId> "<Title>" \
+  --project "<Project>" \
+  --level "NiceToHave" \
+  --initial-prompt "<cleaned args text>" \
+  --execution-profile "balanced" \
+  --repo "<repo-path-1>" \
+  --repo "<repo-path-2>" \
+  --verification "Build=Pending" \
+  --verification "Test=Pending"
 ```
 
-If `SourcePath` is present in the firmware header, copy it to `plan.yaml` as `sourcePath`.
+Include optional flags as needed:
+- `--source-url "<url>"` — if a source URL was extracted in Step 1
+- `--related-plan "<folder-name>"` — for each plan referenced via `[number]` syntax in args
+- `--depends-on "<folder-name>"` — for blocking dependencies (see Section 4.4)
+- `--priority <number>` — if non-default priority
 
-If a source URL was extracted in Step 1, add `sourceUrl: "<url>"` to plan.yaml.
+Populate `--verification` flags from the project's `verifications` in config.yaml, all set to `Pending`.
 
-If the plan references other plans (from `[number]` syntax in args), add them to `relatedPlans`.
+#### 4.3. Post-creation adjustments
+
+For any fields that need to be set after initial creation, use individual CLI commands:
+
+```bash
+tendril plan set <PlanId> initialPrompt "<text>"
+tendril plan add-repo <PlanId> "<repo-path>"
+tendril plan set-verification <PlanId> Build Pending
+tendril plan add-related-plan <PlanId> "<folder-name>"
+tendril plan add-depends-on <PlanId> "<folder-name>"
+```
 
 **Validate repo paths**: After determining the project and repos from config.yaml, verify each repo path exists locally:
 - For each repo in the plan's repos list, check `Test-Path <repo-path>`
@@ -255,7 +279,7 @@ When in doubt, **don't use `dependsOn`** — git will surface real conflicts dur
 
 ### 4.5. Recommend Execution Profile
 
-Analyze the task complexity and set `executionProfile` in plan.yaml. Consider:
+Analyze the task complexity and choose an `executionProfile`. This is passed via `--execution-profile` on `tendril plan create` (see Step 4.2).
 
 **Use `deep` (opus/max effort) when:**
 - Plan involves complex cross-cutting changes affecting 10+ files
@@ -270,12 +294,7 @@ Analyze the task complexity and set `executionProfile` in plan.yaml. Consider:
 - Simple changes (docs, typos, version bumps, log statements)
 - When in doubt, use balanced
 
-Add the field to plan.yaml:
-```yaml
-executionProfile: balanced  # or deep
-```
-
-If you cannot determine complexity (e.g., task is too vague), omit the field — ExecutePlan will use the config.yaml default.
+If you cannot determine complexity (e.g., task is too vague), omit `--execution-profile` — ExecutePlan will use the config.yaml default.
 
 ### 4.6. Questions Section
 
@@ -331,7 +350,7 @@ The user can edit the checklist before execution — unchecking a required verif
 If the YOLO flag was detected in Step 1, automatically execute the plan after creation:
 
 1. **Verify plan was created**: Confirm the plan folder exists at `PlansDirectory/<PlanId>-<SafeTitle>/`
-2. **Update plan state**: Change the plan's state from `Draft` to `Building` in `plan.yaml`
+2. **Update plan state**: `tendril plan set <PlanId> state Building`
 3. **Invoke ExecutePlan**: Use `Tools/Invoke-ExecutePlan.ps1` to trigger plan execution:
    ```powershell
    & Tools/Invoke-ExecutePlan.ps1 -PlanPath "PlansDirectory/<PlanId>-<SafeTitle>"


### PR DESCRIPTION
## Summary
- Extend `tendril plan create` with optional flags for all plan.yaml fields so agents never write YAML directly
- Add `tendril plan add-related-plan` and `tendril plan add-depends-on` CLI commands
- Update CreatePlan promptware instructions (both copies) to use CLI exclusively
- Update Plans.md documentation (both copies) with new commands
- Add 7 new tests including Windows path round-trip verification

## Test plan
- [x] All 71 PlanCliCommandTests pass (64 existing + 7 new)
- [x] Windows path in initialPrompt round-trips correctly through serializer
- [x] Verification Name=Status format parses correctly
- [x] Related plan and depends-on add/idempotency verified