### PR TITLE
Scope promptware permissions with path patterns and job context variables

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -257,8 +257,8 @@ promptwares:
     - Glob
     - Grep
     - Bash
-    - Write
-    - Edit
+    - 'Write(%PLANS_DIR%/**)'
+    - 'Edit(%PLANS_DIR%/**)'
   ExecutePlan:
     profile: deep
     allowedTools:
@@ -275,14 +275,16 @@ promptwares:
     - Glob
     - Grep
     - Bash
-    - Write
+    - 'Write(%PLAN_FOLDER%/**)'
   CreatePr:
     profile: balanced
     allowedTools:
     - Read
+    - Glob
+    - Grep
     - Bash
-    - Write
-    - Edit
+    - 'Write(%PLAN_FOLDER%/**)'
+    - 'Edit(%PLAN_FOLDER%/**)'
   UpdatePlan:
     profile: balanced
     allowedTools:
@@ -290,13 +292,13 @@ promptwares:
     - Glob
     - Grep
     - Bash
-    - Write
+    - 'Write(%PLAN_FOLDER%/**)'
   SplitPlan:
     profile: balanced
     allowedTools:
     - Read
     - Bash
-    - Write
+    - 'Write(%PLANS_DIR%/**)'
   CreateIssue:
     profile: balanced
     allowedTools:
@@ -306,7 +308,8 @@ promptwares:
     profile: balanced
     allowedTools:
     - Read
-    - Write
+    - 'Write(%PLAN_FOLDER%/**)'
+    - 'Edit(%PLAN_FOLDER%/**)'
     - Bash
   PlanEvaluator:
     profile: balanced
@@ -315,7 +318,7 @@ promptwares:
     - Glob
     - Grep
     - Bash
-    - Write
+    - 'Write(%TENDRIL_HOME%/Inbox/**)'
 codingAgents:
 - name: claude
   arguments: ''

--- a/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
@@ -268,4 +268,70 @@ public class AgentProviderFactoryTests
         var resolution = AgentProviderFactory.Resolve(settings, "Test");
         Assert.Equal("gemini-2.5-pro", resolution.Model);
     }
+
+    [Fact]
+    public void Resolve_ExpandsJobContextVariables()
+    {
+        var settings = CreateSettings(
+            promptwares: new Dictionary<string, PromptwareConfig>
+            {
+                ["CreatePlan"] = new()
+                {
+                    Profile = "balanced",
+                    AllowedTools = new List<string>
+                    {
+                        "Read", "Bash", "Write(%PLANS_DIR%/**)", "Edit(%PLAN_FOLDER%/**)"
+                    }
+                }
+            });
+
+        var jobContext = new Dictionary<string, string>
+        {
+            ["PLANS_DIR"] = @"D:\Tendril\Plans",
+            ["PLAN_FOLDER"] = @"D:\Tendril\Plans\01234-MyPlan"
+        };
+
+        var resolution = AgentProviderFactory.Resolve(settings, "CreatePlan", jobContext: jobContext);
+
+        Assert.Contains("Read", resolution.AllowedTools);
+        Assert.Contains("Bash", resolution.AllowedTools);
+        Assert.Contains("Write(D:/Tendril/Plans/**)", resolution.AllowedTools);
+        Assert.Contains("Edit(D:/Tendril/Plans/01234-MyPlan/**)", resolution.AllowedTools);
+    }
+
+    [Fact]
+    public void Resolve_JobContextExpansionIsCaseInsensitive()
+    {
+        var settings = CreateSettings(
+            promptwares: new Dictionary<string, PromptwareConfig>
+            {
+                ["Test"] = new()
+                {
+                    AllowedTools = new List<string> { "Write(%plans_dir%/**)" }
+                }
+            });
+
+        var jobContext = new Dictionary<string, string> { ["PLANS_DIR"] = "/home/plans" };
+
+        var resolution = AgentProviderFactory.Resolve(settings, "Test", jobContext: jobContext);
+
+        Assert.Contains("Write(/home/plans/**)", resolution.AllowedTools);
+    }
+
+    [Fact]
+    public void Resolve_NoJobContextLeavesVariablesForEnvExpansion()
+    {
+        var settings = CreateSettings(
+            promptwares: new Dictionary<string, PromptwareConfig>
+            {
+                ["Test"] = new()
+                {
+                    AllowedTools = new List<string> { "Read", "Bash" }
+                }
+            });
+
+        var resolution = AgentProviderFactory.Resolve(settings, "Test");
+
+        Assert.Equal(new[] { "Read", "Bash" }, resolution.AllowedTools);
+    }
 }

--- a/src/Ivy.Tendril.Test/Agents/AgentProviderTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderTests.cs
@@ -225,4 +225,96 @@ public class AgentProviderTests
         Assert.DoesNotContain("--effort", psi.ArgumentList.ToList());
         Assert.DoesNotContain("--reasoning-effort", psi.ArgumentList.ToList());
     }
+
+    // --- ExtractWritableDirs ---
+
+    [Fact]
+    public void ExtractWritableDirs_ParsesWriteAndEditPatterns()
+    {
+        var tools = new[] { "Read", "Bash", "Write(/plans/**)", "Edit(/plans/01234/**)" };
+        var dirs = CodexAgentProvider.ExtractWritableDirs(tools).ToList();
+
+        Assert.Equal(2, dirs.Count);
+        Assert.Equal("/plans", dirs[0]);
+        Assert.Equal("/plans/01234", dirs[1]);
+    }
+
+    [Fact]
+    public void ExtractWritableDirs_DeduplicatesSamePath()
+    {
+        var tools = new[] { "Write(/plans/**)", "Edit(/plans/**)" };
+        var dirs = CodexAgentProvider.ExtractWritableDirs(tools).ToList();
+
+        Assert.Single(dirs);
+        Assert.Equal("/plans", dirs[0]);
+    }
+
+    [Fact]
+    public void ExtractWritableDirs_IgnoresUnscopedTools()
+    {
+        var tools = new[] { "Read", "Write", "Edit", "Bash", "Glob", "Grep" };
+        var dirs = CodexAgentProvider.ExtractWritableDirs(tools).ToList();
+
+        Assert.Empty(dirs);
+    }
+
+    [Fact]
+    public void ExtractWritableDirs_HandlesSingleStar()
+    {
+        var tools = new[] { "Write(/inbox/*)" };
+        var dirs = CodexAgentProvider.ExtractWritableDirs(tools).ToList();
+
+        Assert.Single(dirs);
+        Assert.Equal("/inbox", dirs[0]);
+    }
+
+    // --- Codex writable dirs ---
+
+    [Fact]
+    public void Codex_BuildProcessStart_PassesAddDirForWritableTools()
+    {
+        var provider = new CodexAgentProvider();
+        var psi = provider.BuildProcessStart(CreateInvocation(
+            allowedTools: new[] { "Read", "Write(/plans/**)", "Bash" }));
+
+        var args = psi.ArgumentList.ToList();
+        var idx = args.IndexOf("--add-dir");
+        Assert.True(idx >= 0);
+        Assert.Equal("/plans", args[idx + 1]);
+    }
+
+    [Fact]
+    public void Codex_BuildProcessStart_NoAddDirForUnscopedWrite()
+    {
+        var provider = new CodexAgentProvider();
+        var psi = provider.BuildProcessStart(CreateInvocation(
+            allowedTools: new[] { "Read", "Write", "Bash" }));
+
+        var args = psi.ArgumentList.ToList();
+        Assert.DoesNotContain("--add-dir", args);
+    }
+
+    // --- Gemini writable dirs ---
+
+    [Fact]
+    public void Gemini_BuildProcessStart_PassesIncludeDirectories()
+    {
+        var provider = new GeminiAgentProvider();
+        var psi = provider.BuildProcessStart(CreateInvocation(
+            allowedTools: new[] { "Read", "Edit(/plans/01234/**)", "Bash" }));
+
+        var args = psi.ArgumentList.ToList();
+        var idx = args.IndexOf("--include-directories");
+        Assert.True(idx >= 0);
+        Assert.Equal("/plans/01234", args[idx + 1]);
+    }
+
+    [Fact]
+    public void Gemini_BuildProcessStart_IncludesYoloFlag()
+    {
+        var provider = new GeminiAgentProvider();
+        var psi = provider.BuildProcessStart(CreateInvocation());
+
+        Assert.Contains("--yolo", psi.ArgumentList.ToList());
+    }
 }

--- a/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
+++ b/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
@@ -24,7 +24,11 @@ public class AgentProviderFactory
         throw new ArgumentException($"Unknown agent provider: {name}. Available: {string.Join(", ", Providers.Keys)}");
     }
 
-    public static AgentResolution Resolve(TendrilSettings settings, string promptwareName, string? profileOverride = null)
+    public static AgentResolution Resolve(
+        TendrilSettings settings,
+        string promptwareName,
+        string? profileOverride = null,
+        IReadOnlyDictionary<string, string>? jobContext = null)
     {
         var codingAgent = settings.CodingAgent;
         var provider = GetProvider(codingAgent);
@@ -52,10 +56,16 @@ public class AgentProviderFactory
         if (!string.IsNullOrEmpty(profileOverride))
             profileName = profileOverride;
 
-        // Expand environment variables in allowed tools
+        // Expand job context variables (%PLAN_FOLDER%, %PLANS_DIR%, etc.) then env vars
         for (var i = 0; i < allowedTools.Count; i++)
         {
-            allowedTools[i] = Environment.ExpandEnvironmentVariables(allowedTools[i])
+            var tool = allowedTools[i];
+            if (jobContext != null)
+            {
+                foreach (var (key, value) in jobContext)
+                    tool = tool.Replace($"%{key}%", value, StringComparison.OrdinalIgnoreCase);
+            }
+            allowedTools[i] = Environment.ExpandEnvironmentVariables(tool)
                 .Replace('\\', '/');
         }
 

--- a/src/Ivy.Tendril/Services/Agents/CodexAgentProvider.cs
+++ b/src/Ivy.Tendril/Services/Agents/CodexAgentProvider.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 
 namespace Ivy.Tendril.Services.Agents;
 
@@ -35,6 +36,12 @@ public class CodexAgentProvider : IAgentProvider
             psi.ArgumentList.Add(invocation.Effort);
         }
 
+        foreach (var dir in ExtractWritableDirs(invocation.AllowedTools))
+        {
+            psi.ArgumentList.Add("--add-dir");
+            psi.ArgumentList.Add(dir);
+        }
+
         foreach (var arg in invocation.ExtraArgs)
             psi.ArgumentList.Add(arg);
 
@@ -44,6 +51,18 @@ public class CodexAgentProvider : IAgentProvider
         psi.Environment["TERM"] = "dumb";
 
         return psi;
+    }
+
+    internal static IEnumerable<string> ExtractWritableDirs(IReadOnlyList<string> allowedTools)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var tool in allowedTools)
+        {
+            var match = Regex.Match(tool, @"^(?:Write|Edit)\((.+?)(?:/\*\*?)?\)$", RegexOptions.IgnoreCase);
+            if (!match.Success) continue;
+            var dir = match.Groups[1].Value;
+            if (seen.Add(dir)) yield return dir;
+        }
     }
 
     public string? ExtractResult(IReadOnlyList<string> outputLines)

--- a/src/Ivy.Tendril/Services/Agents/GeminiAgentProvider.cs
+++ b/src/Ivy.Tendril/Services/Agents/GeminiAgentProvider.cs
@@ -22,11 +22,18 @@ public class GeminiAgentProvider : IAgentProvider
         };
 
         psi.ArgumentList.Add("--sandbox");
+        psi.ArgumentList.Add("--yolo");
 
         if (!string.IsNullOrEmpty(invocation.Model))
         {
             psi.ArgumentList.Add("--model");
             psi.ArgumentList.Add(invocation.Model);
+        }
+
+        foreach (var dir in CodexAgentProvider.ExtractWritableDirs(invocation.AllowedTools))
+        {
+            psi.ArgumentList.Add("--include-directories");
+            psi.ArgumentList.Add(dir);
         }
 
         foreach (var arg in invocation.ExtraArgs)

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -223,7 +223,8 @@ internal class JobLauncher
 
         values["Project"] = job.Project;
 
-        var resolution = AgentProviderFactory.Resolve(settings, job.Type, profileOverride);
+        var jobContext = BuildJobContext(job, values);
+        var resolution = AgentProviderFactory.Resolve(settings, job.Type, profileOverride, jobContext);
         var workDir = ResolveWorkingDirectory(job, programFolder);
 
         var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
@@ -314,6 +315,22 @@ internal class JobLauncher
         }
 
         return (values, planYaml, profileOverride);
+    }
+
+    private static Dictionary<string, string> BuildJobContext(JobItem job, Dictionary<string, string> firmwareValues)
+    {
+        var ctx = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (firmwareValues.TryGetValue("PlansDirectory", out var plansDir))
+            ctx["PLANS_DIR"] = plansDir;
+        if (firmwareValues.TryGetValue("PlanFolder", out var planFolder))
+            ctx["PLAN_FOLDER"] = planFolder;
+
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        if (!string.IsNullOrEmpty(tendrilHome))
+            ctx["TENDRIL_HOME"] = tendrilHome;
+
+        return ctx;
     }
 
     private string ResolveWorkingDirectory(JobItem job, string programFolder)

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -61,28 +61,72 @@ codingAgents:
 # The profile determines model and effort from the active coding agent above.
 # _default provides base values. Specific entries override only the fields they define;
 # unspecified fields are inherited from _default.
+#
+# Allowed tools use Claude Code format: Tool, Tool(path-glob), Bash(command-pattern).
+# Read, Glob, Grep are always safe (read-only). Write/Edit can be scoped to directories.
+# Job context variables are expanded at launch time:
+#   %PLANS_DIR%    — the plans directory (e.g., /home/user/tendril/Plans)
+#   %PLAN_FOLDER%  — the specific plan folder (e.g., /home/user/tendril/Plans/01234-MyPlan)
+#   %TENDRIL_HOME% — the TENDRIL_HOME environment variable
+# For Codex: Write/Edit path scopes are translated to --add-dir flags.
+# For Gemini: Write/Edit path scopes are translated to --include-directories flags.
 promptwares:
   CreatePlan:
     profile: balanced
-    allowedTools: [Read, Glob, Grep, Bash, Write, Edit]
+    allowedTools:
+    - Read
+    - Glob
+    - Grep
+    - Bash
+    - 'Write(%PLANS_DIR%/**)'
+    - 'Edit(%PLANS_DIR%/**)'
   ExecutePlan:
     profile: deep
-    allowedTools: [Read, Write, Edit, Glob, Grep, Bash, WebFetch, WebSearch]
+    allowedTools:
+    - Read
+    - Write
+    - Edit
+    - Glob
+    - Grep
+    - Bash
+    - WebFetch
+    - WebSearch
   ExpandPlan:
     profile: balanced
-    allowedTools: [Read, Glob, Grep, Bash, Write, Edit]
+    allowedTools:
+    - Read
+    - Glob
+    - Grep
+    - Bash
+    - 'Write(%PLAN_FOLDER%/**)'
   UpdatePlan:
     profile: balanced
-    allowedTools: [Read, Glob, Grep, Bash, Write]
+    allowedTools:
+    - Read
+    - Glob
+    - Grep
+    - Bash
+    - 'Write(%PLAN_FOLDER%/**)'
   SplitPlan:
     profile: balanced
-    allowedTools: [Read, Bash, Write]
+    allowedTools:
+    - Read
+    - Bash
+    - 'Write(%PLANS_DIR%/**)'
   CreatePr:
     profile: balanced
-    allowedTools: [Read, Glob, Grep, Bash, Write, Edit]
+    allowedTools:
+    - Read
+    - Glob
+    - Grep
+    - Bash
+    - 'Write(%PLAN_FOLDER%/**)'
+    - 'Edit(%PLAN_FOLDER%/**)'
   CreateIssue:
     profile: balanced
-    allowedTools: [Read, Bash]
+    allowedTools:
+    - Read
+    - Bash
 
 # Projects — add your projects here. Each project groups repos, verifications, and context.
 # projects:


### PR DESCRIPTION
## Summary
- Add job context variable expansion (`%PLANS_DIR%`, `%PLAN_FOLDER%`, `%TENDRIL_HOME%`) to allowedTools in AgentProviderFactory
- Scope Write/Edit per promptware so plan-only agents can't write source code
- Codex: extract writable dirs from Write/Edit patterns → `--add-dir` flags
- Gemini: extract writable dirs → `--include-directories` flags, add `--yolo`

## Test plan
- [x] 12 new tests (variable expansion, dir extraction, provider flags)
- [x] All 45 agent provider tests pass
- [x] Full suite: 946 passed, 30 pre-existing flaky failures