### PR TITLE
[00027] Wider Verification Definitions table so Prompt column is not cut off

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
@@ -33,9 +33,12 @@ public class VerificationsSetupView : ViewBase
                     client.Toast($"Verification '{name}' deleted", "Deleted");
                     refreshToken.Refresh();
                 })
-            ));
+            ))
+            .Width(t => t.Name, Size.Px(150))
+            .Width(t => t.Prompt, Size.Auto())
+            .Width(t => t.Index, Size.Px(80));
 
-        return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(120)))
+        return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Verification Definitions").Bold()
                | table
                | new Button("Add Verification").Icon(Icons.Plus).Outline().OnClick(() =>

--- a/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
@@ -34,9 +34,9 @@ public class VerificationsSetupView : ViewBase
                     refreshToken.Refresh();
                 })
             ))
-            .Width(t => t.Name, Size.Px(150))
-            .Width(t => t.Prompt, Size.Auto())
-            .Width(t => t.Index, Size.Px(80));
+            .ColumnWidth(t => t.Name, Size.Px(150))
+            .ColumnWidth(t => t.Prompt, Size.Auto())
+            .ColumnWidth(t => t.Index, Size.Px(80));
 
         return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Verification Definitions").Bold()


### PR DESCRIPTION
## Summary

Enhanced the Verification Definitions table in the Setup view to accommodate longer content by increasing the container width and adding explicit column width definitions. The container max width increased from 120 units to 200 units, and the Prompt column is now configured to use available space while other columns maintain fixed widths.

## API Changes

None

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs` — Added column width definitions and increased container max width

## Commits

- 549e47c
- 2e1a780