### PR TITLE
[00028] Promptware Configuration table Allowed Tools column wider

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
@@ -36,7 +36,8 @@ public class PromptwaresSetupView : ViewBase
                     client.Toast($"Promptware '{row.Name}' deleted", "Deleted");
                     refreshToken.Refresh();
                 })
-            ));
+            ))
+            .ColumnWidth(t => t.AllowedTools, Size.Fraction(0.5f));
 
         return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(120)))
                | Text.Block("Promptware Configuration").Bold()


### PR DESCRIPTION
## Summary

Added explicit column width specification to the AllowedTools column in the Promptware Configuration table. The column now uses 50% of available table width via `Size.Fraction(0.5f)`, allowing complete display of longer tool lists without truncation.

## API Changes

None. This is a UI layout improvement using existing TableBuilder APIs.

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs` — Added `.ColumnWidth(t => t.AllowedTools, Size.Fraction(0.5f))` to table builder chain (line 40)

## Commits

- `54725a0` — [00028] Make AllowedTools column wider in Promptware Configuration table