### PR TITLE
[00030] Consistent edit/delete buttons in setup tables

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
@@ -19,7 +19,7 @@ public class ProjectsSetupView : ViewBase
         var rows = projects.Select((p, i) => new ProjectRow(p.Name, p.Color, p.Repos.Count, p.Verifications.Count, i)).ToList();
 
         var table = new TableBuilder<ProjectRow>(rows)
-            .Header(t => t.Index, "Actions")
+            .Header(t => t.Index, "")
             .Builder(t => t.Index, f => f.Func<ProjectRow, int>(idx =>
                 Layout.Horizontal().Gap(1)
                 | new Button().Icon(Icons.Pencil).Outline().Small().OnClick(() =>


### PR DESCRIPTION
## Changes

Made the edit/delete button headers consistent across all setup tables. Changed ProjectsSetupView to use an empty string header instead of "Actions", matching the pattern already used in PromptwaresSetupView, LevelsSetupView, and VerificationsSetupView.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs` — Changed header from `"Actions"` to `""` for consistency

## Commits

- 9659351 [00030] Consistent edit/delete buttons in setup tables