### PR TITLE
[00031] Fix Projects table width cutoff in Setup

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
@@ -41,7 +41,7 @@ public class LevelsSetupView : ViewBase
                 })
             ));
 
-        return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(120)))
+        return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Priority Levels").Bold()
                | table
                | new Button("Add Level").Icon(Icons.Plus).Outline().OnClick(() =>

--- a/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
@@ -30,7 +30,7 @@ public class ProjectsSetupView : ViewBase
                 | new Button().Icon(Icons.Trash).Outline().Small().OnClick(() => { deleteIndex.Set(idx); })
             ));
 
-        return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(120)))
+        return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Projects").Bold()
                | table
                | new Button("Add Project").Icon(Icons.Plus).Outline().OnClick(() =>

--- a/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
@@ -39,7 +39,7 @@ public class PromptwaresSetupView : ViewBase
                 })
             ));
 
-        return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(120)))
+        return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Promptware Configuration").Bold()
                | Text.Block("Configure agent profile and tool permissions for each promptware.")
                    .Muted().Small()

--- a/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
@@ -35,7 +35,7 @@ public class VerificationsSetupView : ViewBase
                 })
             ));
 
-        return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(120)))
+        return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Verification Definitions").Bold()
                | table
                | new Button("Add Verification").Icon(Icons.Plus).Outline().OnClick(() =>


### PR DESCRIPTION
## Summary

Increased the max width constraint for table-based Setup views from 120 to 200 units. This allows tables with multiple columns to render without being cut off on the right side while maintaining readability constraints on the layout.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs` — Updated max width from 120 to 200 units (line 33)
- `src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs` — Updated max width from 120 to 200 units (line 44)
- `src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs` — Updated max width from 120 to 200 units (line 38)
- `src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs` — Updated max width from 120 to 200 units (line 42)

## Commits

- aa3727d