### PR TITLE
[00033] Taller Plan Template min height in Setup

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/GeneralSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/GeneralSetupView.cs
@@ -27,7 +27,7 @@ public class GeneralSetupView : ViewBase
                        .WithField().Label("Coding Agent")
                    | planTemplate.ToCodeInput("Plan template...")
                        .Language(Languages.Markdown)
-                       .Height(Size.Units(40))
+                       .Height(Size.Units(80))
                        .WithField().Label("Plan Template")
                    | new Button("Save").Primary()
                        .Disabled(!hasChanges)


### PR DESCRIPTION
## Summary

Increased the Plan Template CodeInput min height in the Setup General view from `Size.Units(40)` (10rem) to `Size.Units(80)` (20rem). This provides more vertical space for editing plan template content, reducing the need for excessive scrolling.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/GeneralSetupView.cs` — Updated height property on plan template CodeInput

## Commits

- 79ba408 [00033] Increase Plan Template CodeInput min height from 40 to 80 units