### PR TITLE
Use NewsUrl constant and update CDN path for news

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -478,7 +478,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 | new NewPlanButton()
                 ,
                 Layout.Vertical(
-                    new SidebarNews("https://ivy.app/news.json"),
+                    new SidebarNews(Constants.NewsUrl),
                     settings.Footer,
                     footer
                 ),

--- a/src/Ivy.Tendril/Constants.cs
+++ b/src/Ivy.Tendril/Constants.cs
@@ -21,5 +21,5 @@ public static class Constants
     public const string DocsUrl = "https://tendril.ivy.app";
     public const string DiscordUrl = "https://discord.gg/FHgxkDga3y";
     public const string IssuesUrl = "https://github.com/Ivy-Interactive/Ivy-Tendril/issues/new";
-    public const string NewsUrl = "https://cdn.ivy.app/news.json";
+    public const string NewsUrl = "https://cdn.ivy.app/tendril/news.json";
 }


### PR DESCRIPTION
- Replace hardcoded news URL in TendrilAppShell with Constants.NewsUrl
- Update NewsUrl to use the correct CDN path: cdn.ivy.app/tendril/news.json