### PR TITLE
Make plan/review markdown content scrollable

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -187,7 +187,7 @@ public class ContentView(
                 .Width(Size.Full());
         else
         {
-            var planLayout = Layout.Vertical();
+            var planLayout = Layout.Vertical().Scroll(Scroll.Vertical);
             if (selectedPlan.Status == PlanStatus.Failed) planLayout |= BuildFailureCallout(selectedPlan);
             var annotatedContent = MarkdownHelper.AnnotateAllBrokenLinks(selectedPlan.LatestRevisionContent, planService.PlansDirectory);
             planLayout |= new Markdown(annotatedContent)

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -226,19 +226,20 @@ public class ContentView(
 
         // Plan tab content (not dependent on query — uses in-memory data)
         var reviewAnnotated = MarkdownHelper.AnnotateAllBrokenLinks(selectedPlan.LatestRevisionContent, planService.PlansDirectory);
-        var planTabContent = new Markdown(reviewAnnotated)
-            .DangerouslyAllowLocalFiles()
-            .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile, planId =>
-            {
-                var planFolder = Directory.GetDirectories(planService.PlansDirectory, $"{planId:D5}-*")
-                    .FirstOrDefault();
-                if (planFolder != null)
+        var planTabContent = Layout.Vertical().Scroll(Scroll.Vertical)
+            | new Markdown(reviewAnnotated)
+                .DangerouslyAllowLocalFiles()
+                .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile, planId =>
                 {
-                    var plan = planService.GetPlanByFolder(planFolder);
-                    if (plan != null)
-                        selectedPlanState.Set(plan);
-                }
-            }));
+                    var planFolder = Directory.GetDirectories(planService.PlansDirectory, $"{planId:D5}-*")
+                        .FirstOrDefault();
+                    if (planFolder != null)
+                    {
+                        var plan = planService.GetPlanByFolder(planFolder);
+                        if (plan != null)
+                            selectedPlanState.Set(plan);
+                    }
+                }));
 
         if (planContentQuery.Loading)
         {


### PR DESCRIPTION
## Summary
- The Markdown widget in the Plans and Review apps was rendered inside a non-scrolling `Layout.Vertical`, so long plan content overflowed and wasn't reachable within the tab
- Wrap the markdown in `Layout.Vertical().Scroll(Scroll.Vertical)` so only the content pane scrolls and the rest of the tab chrome stays fixed

## Test plan
- [ ] Open the Plans app with a plan whose markdown is taller than the viewport → verify the content pane scrolls vertically
- [ ] Open the Review app with the same kind of plan → verify the content pane scrolls vertically
- [ ] Check non-markdown tabs (commits, artifacts, etc.) still render and scroll as before (i.e. the scroll is scoped to the plan pane, not the outer layout)
- [ ] In Plans, toggle edit mode → the CodeInput view should continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)