### PR TITLE
[00043] Verification Definitions table full width in Setup

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
@@ -38,7 +38,7 @@ public class VerificationsSetupView : ViewBase
             .ColumnWidth(t => t.Prompt, Size.Auto())
             .ColumnWidth(t => t.Index, Size.Px(80));
 
-        return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(200)))
+        return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(400)))
                | Text.Block("Verification Definitions").Bold()
                | Text.Block("Define verification steps that run after plan execution.").Muted().Small()
                | table


### PR DESCRIPTION
# Summary

## Changes

Increased the maximum width constraint for the Verification Definitions table in the Setup app from 200 to 400 layout units, providing more space for the Prompt column while maintaining responsive layout through `Size.Auto()` constraint.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs` — Changed outer layout width from `Size.Auto().Max(Size.Units(200))` to `Size.Auto().Max(Size.Units(400))` on line 41

## Commits

- `0b29333` [00043] Make Verification Definitions table full width (400 units instead of 200)