### PR TITLE
Fix plans stuck in Draft after ExecutePlan completes

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
@@ -568,7 +568,7 @@ Worktrees are **not** cleaned up by ExecutePlan. They remain on disk so that Cre
 
 ### 9. Plan State
 
-The launcher script handles state transitions (Completed/Failed) based on exit code.
+The JobCompletionHandler in the C# host handles state transitions (ReadyForReview/Failed) based on exit code and verification results.
 
 ### Ambiguity Handling
 

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -283,7 +283,7 @@ internal class JobCompletionHandler
             var planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
             if (planYaml == null) return;
 
-            if (planYaml.State is "Executing" or "Building")
+            if (planYaml.State is "Executing" or "Building" or "Draft")
             {
                 var hasIncomplete = planYaml.Verifications?
                     .Any(v => v.Status is "Pending" or "Fail") ?? false;

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -44,6 +44,9 @@ internal class JobLauncher
         var planFolderForHooks = type != "CreatePlan" && args.Length > 0 ? args[0] : "";
         runHooks("before", type, planFolderForHooks, job.Project, job);
 
+        if (type == "ExecutePlan" && args.Length > 0)
+            PlanYamlHelper.SetPlanStateByFolder(args[0], "Executing");
+
         job.SessionId = Guid.NewGuid().ToString();
 
         var psi = TryBuildAgentProcessStart(job);


### PR DESCRIPTION
## Summary
- Set plan state to `Executing` in `JobLauncher.LaunchJob()` before starting the agent process, so the state machine follows the documented `Draft → Executing → ReadyForReview` path
- Add `Draft` as a fallback in `EnsurePlanStateTransitioned()` guard so plans still transition on completion even if the launch-time write is missed
- Update stale promptware docs referencing removed launcher scripts

## Root cause
Nothing was setting plan state to `Executing` before the job ran. The completion handler only transitioned from `Executing` or `Building`, so plans that were still in `Draft` were silently skipped — they'd complete successfully but never appear in Review.