### PR TITLE
Fix plan search for #ID patterns and sort newest first

### DIFF
--- a/src/Ivy.Tendril/Models/PlanModels.cs
+++ b/src/Ivy.Tendril/Models/PlanModels.cs
@@ -88,15 +88,17 @@ public static class PlanFilters
 
         if (!string.IsNullOrWhiteSpace(textFilter))
         {
-            var search = textFilter.ToLowerInvariant();
+            var search = textFilter.Trim().TrimStart('#').ToLowerInvariant();
+            var isNumericSearch = int.TryParse(search, out var searchId);
             filtered = filtered.Where(p =>
+                (isNumericSearch && p.Id == searchId) ||
                 p.Title.ToLowerInvariant().Contains(search) ||
                 p.Id.ToString().Contains(search) ||
                 p.Project.ToLowerInvariant().Contains(search) ||
                 p.LatestRevisionContent.ToLowerInvariant().Contains(search));
         }
 
-        return filtered;
+        return filtered.OrderByDescending(p => p.Id);
     }
 }
 


### PR DESCRIPTION
## Summary
- Strip `#` prefix from search text so `#03456`, `#3456`, and `03456` all find plan 3456
- Parse numeric searches for exact ID matching (handles zero-padded input)
- Sort all plan lists by descending ID (newest first)
- Applies to all sidebars using `PlanFilters.ApplyFilters()`: Drafts, Review, Icebox

## Test plan
- [ ] Search `#03456` — matches plan 3456
- [ ] Search `#3456` — matches plan 3456
- [ ] Search `3456` — matches plan 3456
- [ ] Search by title still works
- [ ] Plans sorted newest first in all three sidebars