### PR TITLE
Merge worktree Branch/Commit column and fix Git tab badge

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -256,7 +256,7 @@ public class ContentView(
                 new Tab("Verifications", Cap(new VerificationsTabView(
                     selectedPlan.Verifications, planData.VerificationReports,
                     v => openVerification.Set(v)))).Badge(selectedPlan.Verifications.Count.ToString()),
-                new Tab("Git", Cap(gitLayout)).Badge((selectedPlan.Commits.Count + selectedPlan.Prs.Count).ToString()),
+                new Tab("Git", Cap(gitLayout)).Badge((gitData.WorktreeRows.Count + selectedPlan.Commits.Count + selectedPlan.Prs.Count).ToString()),
                 new Tab("Changes", Cap(changesTabView)).Badge(changesTabView.FileCount > 0 ? changesTabView.FileCount.ToString() : ""),
                 new Tab("Artifacts", Cap(new ArtifactsTabView(planData.Artifacts))).Badge(totalArtifacts.ToString())
             ).OnSelect(v => selectedTab.Set(v)).SelectedIndex(selectedTab.Value).Variant(TabsVariant.Content);

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -354,7 +354,7 @@ public class ContentView(
                 new Tab("Verifications", Cap(new VerificationsTabView(
                     selectedPlan.Verifications, planData.VerificationReports,
                     v => openVerification.Set(v)))).Badge(selectedPlan.Verifications.Count.ToString()),
-                new Tab("Git", Cap(gitLayout)).Badge((selectedPlan.Commits.Count + selectedPlan.Prs.Count).ToString()),
+                new Tab("Git", Cap(gitLayout)).Badge((gitData.WorktreeRows.Count + selectedPlan.Commits.Count + selectedPlan.Prs.Count).ToString()),
                 new Tab("Changes", Cap(changesTabView)).Badge(changesTabView.FileCount > 0 ? changesTabView.FileCount.ToString() : ""),
                 new Tab("Artifacts", Cap(new ArtifactsTabView(planData.Artifacts))).Badge(totalArtifacts.ToString()),
                 new Tab("Recommendations", Cap(recommendationsLayout)).Badge(planData.Recommendations.Count.ToString()),

--- a/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
+++ b/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
@@ -87,8 +87,7 @@ public static class GitTabHelper
             var worktreesTable = new Table(
                 new TableRow(
                     new TableCell("Name").IsHeader(),
-                    new TableCell("Branch").IsHeader(),
-                    new TableCell("Commit").IsHeader(),
+                    new TableCell("Branch:Commit").IsHeader(),
                     new TableCell("Actions").IsHeader()
                 )
                 { IsHeader = true }
@@ -111,8 +110,7 @@ public static class GitTabHelper
 
                 worktreesTable |= new TableRow(
                     new TableCell(row.Name),
-                    new TableCell(row.Branch),
-                    new TableCell(row.ShortHash),
+                    new TableCell($"{row.Branch}:{row.ShortHash}"),
                     new TableCell(actionsMenu)
                 );
             }


### PR DESCRIPTION
## Summary
- Combine Branch and Commit columns into a single `Branch:Commit` column in the Worktrees table
- Git tab badge now includes worktree count (worktrees + commits + PRs)
- Applies to both Drafts and Review views