### PR TITLE
[03516] Show issues in a DataTable

### DIFF
--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -254,12 +254,33 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             }
             else
             {
+                var repo = repos.FirstOrDefault(r => r.DisplayName == selectedRepo.Value);
+                var issueRows = issues.Select(i => new
+                {
+                    Number = repo != null ? $"[#{i.Number}](https://github.com/{repo.Owner}/{repo.Name}/issues/{i.Number})" : $"#{i.Number}",
+                    i.Title,
+                    Labels = string.Join(", ", i.Labels),
+                    Assignees = string.Join(", ", i.Assignees)
+                }).ToList();
+
                 issuesList = Layout.Vertical().Gap(1)
-                             | Text.Label($"Found {issues.Count} issue{(issues.Count == 1 ? "" : "s")}")
-                             | (Layout.Vertical().Gap(1)
-                                | issues.Select(i =>
-                                    (object)Text.Muted($"#{i.Number} — {i.Title}")
-                                ).ToArray());
+                    | Text.Label($"Found {issues.Count} issue{(issues.Count == 1 ? "" : "s")}")
+                    | issueRows.AsQueryable()
+                        .ToDataTable(i => i.Number)
+                        .Width(Size.Full())
+                        .Height(Size.Rem(20))
+                        .Header(i => i.Number, "#")
+                        .Header(i => i.Title, "Title")
+                        .Header(i => i.Labels, "Labels")
+                        .Header(i => i.Assignees, "Assignees")
+                        .Width(i => i.Number, Size.Px(80))
+                        .Width(i => i.Title, Size.Auto())
+                        .Width(i => i.Labels, Size.Px(200))
+                        .Width(i => i.Assignees, Size.Px(150))
+                        .Renderer(i => i.Number, new LinkDisplayRenderer())
+                        .Renderer(i => i.Title, new TextDisplayRenderer())
+                        .Renderer(i => i.Labels, new TextDisplayRenderer())
+                        .Renderer(i => i.Assignees, new TextDisplayRenderer());
             }
         }
 


### PR DESCRIPTION
# Summary

## Changes

Replaced the simple text list in ImportIssuesDialog with a structured DataTable component showing GitHub issues in columns (Number, Title, Labels, Assignees). The issue numbers are now clickable links that navigate to the corresponding GitHub issue page.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs** — Replaced vertical text list with DataTable component configured with four columns and appropriate renderers


## Commits

- 0b60099dd8cb84a363b55bfdd92fc88572946d8f