### PR TITLE
Add /api/news proxy endpoint to fix CORS for sidebar news feed

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -478,7 +478,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 | new NewPlanButton()
                 ,
                 Layout.Vertical(
-                    new SidebarNews(Constants.NewsUrl),
+                    new SidebarNews("/api/news", Constants.NewsImageBaseUrl),
                     settings.Footer,
                     footer
                 ),

--- a/src/Ivy.Tendril/Constants.cs
+++ b/src/Ivy.Tendril/Constants.cs
@@ -22,4 +22,5 @@ public static class Constants
     public const string DiscordUrl = "https://discord.gg/FHgxkDga3y";
     public const string IssuesUrl = "https://github.com/Ivy-Interactive/Ivy-Tendril/issues/new";
     public const string NewsUrl = "https://cdn.ivy.app/tendril/news.json";
+    public const string NewsImageBaseUrl = "https://cdn.ivy.app/tendril/";
 }

--- a/src/Ivy.Tendril/Controllers/NewsController.cs
+++ b/src/Ivy.Tendril/Controllers/NewsController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ivy.Tendril.Controllers;
+
+[ApiController]
+[Route("api/news")]
+public class NewsController : ControllerBase
+{
+    private static readonly HttpClient Http = new();
+
+    [HttpGet]
+    public async Task<IActionResult> Get()
+    {
+        try
+        {
+            var json = await Http.GetStringAsync(Constants.NewsUrl);
+            return Content(json, "application/json");
+        }
+        catch
+        {
+            return Ok("[]");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `NewsController` that proxies `https://cdn.ivy.app/tendril/news.json` through `/api/news`
- Point `SidebarNews` feedUrl to `/api/news` (same-origin, no CORS)
- Pass `NewsImageBaseUrl` for CDN image resolution