### PR TITLE
Fix revision number and content not updating after save

### DIFF
--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -53,6 +53,8 @@ public class ContentView(
                 if (plan != null && editContent.Value != originalContent.Value)
                 {
                     planService.SaveRevision(plan.FolderName, editContent.Value);
+                    var updated = planService.GetPlanByFolder(plan.FolderPath);
+                    if (updated != null) selectedPlanState.Set(updated);
                     refreshPlans();
                 }
             }

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -180,6 +180,8 @@ public class ContentView(
                               if (selectedPlan != null && editContent.Value != originalContent.Value)
                               {
                                   planService.SaveRevision(selectedPlan.FolderName, editContent.Value);
+                                  var updated = planService.GetPlanByFolder(selectedPlan.FolderPath);
+                                  if (updated != null) selectedPlanState.Set(updated);
                                   refreshPlans();
                               }
                               isEditing.Set(false);


### PR DESCRIPTION
## Summary
- After `SaveRevision`, re-fetch the plan via `GetPlanByFolder` and update `selectedPlanState`
- Fixes the UI showing stale revision count and content until page reload
- Applied to both Plans and Icebox ContentView

## Test plan
- [ ] Edit a plan, save revision — verify rev count increments immediately
- [ ] Verify the new content is displayed without page reload
- [ ] Test in Icebox view as well