### PR TITLE
[03520] Move Edit button to bottom with shortcut E

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -201,9 +201,6 @@ public class ContentView(
         {
             var planLayout = Layout.Vertical().Scroll(Scroll.Vertical);
             if (selectedPlan.Status == PlanStatus.Failed) planLayout |= BuildFailureCallout(selectedPlan);
-            var editButton = Layout.Horizontal().Padding(0, 0, 2, 0)
-                             | new Button("Edit").Icon(Icons.Pencil).Outline().OnClick(() => isEditing.Set(true));
-            planLayout |= editButton;
             var annotatedContent = MarkdownHelper.AnnotateAllBrokenLinks(selectedPlan.LatestRevisionContent, planService.PlansDirectory);
             planLayout |= new Markdown(annotatedContent)
                 .DangerouslyAllowLocalFiles()
@@ -218,6 +215,9 @@ public class ContentView(
                             selectedPlanState.Set(plan);
                     }
                 }));
+            var editButton = Layout.Horizontal().Padding(0, 0, 2, 0)
+                             | new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E").OnClick(() => isEditing.Set(true));
+            planLayout |= editButton;
             planTabContent = planLayout;
         }
 


### PR DESCRIPTION
# Summary

## Changes

Moved the Edit button from the top to the bottom of the plan content view and added keyboard shortcut "E" for quick access to edit mode.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Plans/ContentView.cs** — Relocated Edit button from line 204-206 to line 218-220 (after Markdown content), added `.ShortcutKey("E")` modifier


## Commits

- 5121aa6