### PR TITLE
[00053] Move Promptware table edit/delete buttons to rightmost column

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
@@ -23,15 +23,16 @@ public class PromptwaresSetupView : ViewBase
         )).ToList();
 
         var table = new TableBuilder<PromptwareRow>(rows)
-            .Header(t => t.Name, "")
-            .Builder(t => t.Name, f => f.Func<PromptwareRow, string>(name =>
+            .Header(t => t.Index, "")
+            .Builder(t => t.Index, f => f.Func<PromptwareRow, int>(idx =>
                 Layout.Horizontal().Gap(1)
                 | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit this promptware").OnClick(() =>
                 {
-                    editKey.Set(name);
+                    editKey.Set(rows[idx].Name);
                 })
                 | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete this promptware").OnClick(() =>
                 {
+                    var name = rows[idx].Name;
                     promptwares.Remove(name);
                     config.SaveSettings();
                     client.Toast($"Promptware '{name}' deleted", "Deleted");


### PR DESCRIPTION
## Summary

Moved the edit/delete action buttons in the Promptware configuration table from the first column (Name) to the last column (Index), matching the consistent pattern used in other Setup tables like LevelsSetupView and ProjectsSetupView.

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs` — Moved action button column from `Name` property to `Index` property, updated button click handlers to access row data via `rows[idx]` instead of direct name parameter.

## Commits

- 8461f2d