### PR TITLE
[00054] Streamline no-content view across all apps

### DIFF
--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Views;
 
 namespace Ivy.Tendril.Apps;
 
@@ -40,16 +41,7 @@ public class DashboardApp : ViewBase
 
         if (stats.TotalCount == 0)
         {
-            return Layout.Vertical()
-                .Padding(16)
-                .Gap(8)
-                .AlignContent(Align.Center)
-                .Height(Size.Full())
-                | Text.Block("No plans yet")
-                    .Large()
-                    .Color(Colors.Muted)
-                | Text.Block("Create your first plan to get started with Tendril.")
-                    .Color(Colors.Muted);
+            return new NoContentView("No plans yet", "Create your first plan to get started.", new NewPlanButton().Width(Size.Fit()));
         }
 
         // Statistics cards

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -1,6 +1,7 @@
 using Ivy.Core;
 using Ivy.Tendril.Apps.Icebox.Dialogs;
 using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Views;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
@@ -73,8 +74,13 @@ public class ContentView(
         }
 
         if (selectedPlan is null)
+        {
+            if (allPlans.Count == 0)
+                return new NoContentView("Icebox is empty", "Plans you put on ice will appear here.");
+
             return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                    | Text.Muted("Select a plan from the sidebar");
+        }
 
         var currentIndex = allPlans.FindIndex(p => p.FolderName == selectedPlan.FolderName);
 

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -118,10 +118,7 @@ public class ContentView(
         if (selectedPlan is null)
         {
             if (allPlans.Count == 0)
-                return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full()).Gap(4).Padding(8)
-                       | new Icon(Icons.Feather).Large().Color(Colors.Gray)
-                       | Text.H3("No draft plans")
-                       | new NewPlanButton().Width(Size.Fit());
+                return new NoContentView("No draft plans", "Plans you create will appear here.", new NewPlanButton().Width(Size.Fit()));
 
             return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                    | Text.Muted("Select a plan from the sidebar");

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Views;
 using Ivy.Tendril.Apps.Recommendations.Dialogs;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
@@ -27,9 +28,7 @@ public class ContentView(
         if (selectedRecommendation is null)
         {
             if (allRecommendations.Count == 0)
-                return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full()).Gap(2)
-                       | new Icon(Icons.Inbox).Large().Color(Colors.Gray)
-                       | Text.Muted("No recommendations yet");
+                return new NoContentView("No recommendations", "Recommendations from completed plans will appear here.");
 
             return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                    | Text.Muted("Select a recommendation from the sidebar");

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -4,6 +4,7 @@ using Ivy.Tendril.Models;
 using Ivy.Tendril.Apps.Review.Dialogs;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Views;
 using Ivy.Tendril.Views.Sheets;
 using Ivy.Tendril.Views.Tabs;
 using Microsoft.Extensions.Logging;
@@ -163,9 +164,7 @@ public class ContentView(
         if (selectedPlan is null)
         {
             if (allPlans.Count == 0)
-                return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full()).Gap(2)
-                       | new Icon(Icons.Inbox).Large().Color(Colors.Gray)
-                       | Text.Muted("No plans to review");
+                return new NoContentView("No plans to review", "Completed plans will appear here for review.");
 
             return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                    | Text.Muted("Select a completed plan to review");

--- a/src/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/Ivy.Tendril/Apps/TrashApp.cs
@@ -2,6 +2,7 @@ using Ivy.Tendril.Apps.Trash;
 using Ivy.Tendril.Apps.Trash.Dialogs;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Views;
 
 namespace Ivy.Tendril.Apps;
 
@@ -61,10 +62,7 @@ public class TrashApp : ViewBase
         object mainContent;
         if (files.Count == 0)
         {
-            mainContent = Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
-                          | new Icon(Icons.Trash2).Size(Size.Units(8)).Color(Colors.Gray)
-                          | Text.Muted("No trash files yet")
-                          | Text.Muted("Duplicate plans will appear here").Small();
+            mainContent = new NoContentView("No trash", "Duplicate plans will appear here.");
         }
         else if (selected is null)
         {

--- a/src/Ivy.Tendril/Views/NoContentView.cs
+++ b/src/Ivy.Tendril/Views/NoContentView.cs
@@ -1,0 +1,16 @@
+namespace Ivy.Tendril.Views;
+
+public class NoContentView(string title, string description, object? cta = null) : ViewBase
+{
+    public override object Build()
+    {
+        var layout = Layout.Vertical().AlignContent(Align.Center).Height(Size.Full()).Gap(4).Padding(8)
+                     | Text.H3(title)
+                     | Text.Muted(description);
+
+        if (cta is not null)
+            layout |= cta;
+
+        return layout;
+    }
+}


### PR DESCRIPTION
## Changes

Created a shared `NoContentView` class under `Views/` and replaced six different inline empty-state implementations across Plans, Review, Icebox, Recommendations, Trash, and Dashboard apps. Each app now uses the unified view with a consistent title + description + optional CTA layout. The Icebox app also gained a new empty-list check it was previously missing.

## API Changes

- **New class:** `Ivy.Tendril.Views.NoContentView(string title, string description, object? cta = null)` extends `ViewBase`

## Files Modified

- **New:** `src/Ivy.Tendril/Views/NoContentView.cs` — shared empty-state view component
- **Modified:** `src/Ivy.Tendril/Apps/Plans/ContentView.cs` — replaced inline empty state with `NoContentView`
- **Modified:** `src/Ivy.Tendril/Apps/Review/ContentView.cs` — replaced inline empty state with `NoContentView`
- **Modified:** `src/Ivy.Tendril/Apps/Icebox/ContentView.cs` — added missing empty-list check + `NoContentView`
- **Modified:** `src/Ivy.Tendril/Apps/Recommendations/ContentView.cs` — replaced inline empty state with `NoContentView`
- **Modified:** `src/Ivy.Tendril/Apps/TrashApp.cs` — replaced inline empty state with `NoContentView`
- **Modified:** `src/Ivy.Tendril/Apps/DashboardApp.cs` — replaced inline empty state with `NoContentView`

## Commits

- `dccb8f2` [00054] Streamline no-content view across all apps