### PR TITLE
[03522] Remove Link Column Renderer from Jobs Prompt/Title Column

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -231,6 +231,7 @@ public class JobsApp : ViewBase
                 BadgeColorMapping = projectColors
             })
             .Renderer(t => t.PlanId, new LinkDisplayRenderer())
+            .Renderer(t => t.Plan, new TextDisplayRenderer())
             .Renderer(t => t.StatusMessage, new TextDisplayRenderer())
             .Hidden(t => t.Id)
             .Hidden(t => t.LastOutputTimestamp)


### PR DESCRIPTION
# Summary

## Changes

Added an explicit `TextDisplayRenderer` to the `Plan` column (header: "Prompt/Title") in the Jobs table to prevent it from being treated as a link column. This removes the unwanted "Ctrl+click to open link" tooltip that was appearing on the column header.

## API Changes

None.

## Files Modified

- `src\Ivy.Tendril\Apps\JobsApp.cs` — Added `.Renderer(t => t.Plan, new TextDisplayRenderer())` to explicitly set the Plan column as text-only

## Commits

- 59146e0
