### PR TITLE
Add Playwright-based E2E test project

### DIFF
--- a/src/Ivy.Tendril.Test.End2End/Configuration/E2ETestSettings.cs
+++ b/src/Ivy.Tendril.Test.End2End/Configuration/E2ETestSettings.cs
@@ -1,0 +1,14 @@
+namespace Ivy.Tendril.Test.End2End.Configuration;
+
+public class E2ETestSettings
+{
+    public string Agent { get; set; } = "claude";
+    public string TestRepo { get; set; } = "octocat/Hello-World";
+    public string TendrilProjectPath { get; set; } = "../Ivy.Tendril/Ivy.Tendril.csproj";
+    public int StartupTimeoutSeconds { get; set; } = 60;
+    public int PlanExecutionTimeoutSeconds { get; set; } = 600;
+    public bool Headless { get; set; } = true;
+    public int SlowMo { get; set; }
+    public bool CleanupFork { get; set; } = true;
+    public bool ScreenshotOnFailure { get; set; } = true;
+}

--- a/src/Ivy.Tendril.Test.End2End/Configuration/TestSettingsProvider.cs
+++ b/src/Ivy.Tendril.Test.End2End/Configuration/TestSettingsProvider.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Ivy.Tendril.Test.End2End.Configuration;
+
+public static class TestSettingsProvider
+{
+    private static E2ETestSettings? _cached;
+
+    public static E2ETestSettings Get()
+    {
+        if (_cached != null) return _cached;
+
+        var config = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("appsettings.e2e.json", optional: true)
+            .AddEnvironmentVariables(prefix: "E2E__")
+            .Build();
+
+        var settings = new E2ETestSettings();
+        config.GetSection("E2E").Bind(settings);
+
+        // Environment variables without the E2E section prefix also bind directly
+        config.Bind(settings);
+
+        // Resolve TendrilProjectPath: default to sibling project relative to source directory
+        if (string.IsNullOrEmpty(settings.TendrilProjectPath))
+        {
+            // Walk up from bin/Debug/net10.0/ to find the src directory
+            var dir = AppContext.BaseDirectory;
+            while (dir != null && !File.Exists(Path.Combine(dir, "Ivy.Tendril.Test.End2End.csproj")))
+                dir = Path.GetDirectoryName(dir);
+
+            if (dir != null)
+                settings.TendrilProjectPath = Path.GetFullPath(
+                    Path.Combine(dir, "..", "Ivy.Tendril", "Ivy.Tendril.csproj"));
+        }
+        else if (!Path.IsPathRooted(settings.TendrilProjectPath))
+        {
+            settings.TendrilProjectPath = Path.GetFullPath(
+                Path.Combine(AppContext.BaseDirectory, settings.TendrilProjectPath));
+        }
+
+        _cached = settings;
+        return settings;
+    }
+
+    public static void Reset() => _cached = null;
+}

--- a/src/Ivy.Tendril.Test.End2End/Fixtures/E2ETestFixture.cs
+++ b/src/Ivy.Tendril.Test.End2End/Fixtures/E2ETestFixture.cs
@@ -1,0 +1,34 @@
+using Ivy.Tendril.Test.End2End.Configuration;
+
+namespace Ivy.Tendril.Test.End2End.Fixtures;
+
+[CollectionDefinition("E2E")]
+public class E2ETestCollection : ICollectionFixture<E2ETestFixture> { }
+
+public class E2ETestFixture : IAsyncLifetime
+{
+    public TendrilProcessFixture Tendril { get; } = new();
+    public PlaywrightFixture Playwright { get; } = new();
+    public TestRepositoryFixture TestRepo { get; } = new();
+    public E2ETestSettings Settings => TestSettingsProvider.Get();
+
+    public bool OnboardingCompleted { get; set; }
+
+    public async Task InitializeAsync()
+    {
+        // Playwright and repo fork can start in parallel
+        var playwrightTask = Playwright.InitializeAsync();
+        var repoTask = TestRepo.InitializeAsync();
+        await Task.WhenAll(playwrightTask, repoTask);
+
+        // Tendril must start after repo is ready (onboarding references repo path)
+        await Tendril.InitializeAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await Tendril.DisposeAsync();
+        await Playwright.DisposeAsync();
+        await TestRepo.DisposeAsync();
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Fixtures/PlaywrightFixture.cs
+++ b/src/Ivy.Tendril.Test.End2End/Fixtures/PlaywrightFixture.cs
@@ -1,0 +1,45 @@
+using Ivy.Tendril.Test.End2End.Configuration;
+using Microsoft.Playwright;
+
+namespace Ivy.Tendril.Test.End2End.Fixtures;
+
+public class PlaywrightFixture : IAsyncLifetime
+{
+    private IPlaywright? _playwright;
+    private IBrowser? _browser;
+
+    public IBrowser Browser => _browser
+        ?? throw new InvalidOperationException("Playwright not initialized");
+
+    public async Task InitializeAsync()
+    {
+        var settings = TestSettingsProvider.Get();
+
+        var exitCode = Microsoft.Playwright.Program.Main(["install", "chromium"]);
+        if (exitCode != 0)
+            throw new InvalidOperationException(
+                $"Playwright browser install failed with exit code {exitCode}");
+
+        _playwright = await Playwright.CreateAsync();
+        _browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
+        {
+            Headless = settings.Headless,
+            SlowMo = settings.SlowMo,
+        });
+    }
+
+    public async Task<IBrowserContext> NewContextAsync()
+    {
+        return await Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            IgnoreHTTPSErrors = true,
+        });
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_browser != null)
+            await _browser.CloseAsync();
+        _playwright?.Dispose();
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Fixtures/TendrilProcessFixture.cs
+++ b/src/Ivy.Tendril.Test.End2End/Fixtures/TendrilProcessFixture.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics;
+using System.Net;
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Test.End2End.Configuration;
+using Xunit.Abstractions;
+
+namespace Ivy.Tendril.Test.End2End.Fixtures;
+
+public class TendrilProcessFixture : IAsyncLifetime
+{
+    private Process? _tendrilProcess;
+    private readonly List<string> _stdoutLines = new();
+    private readonly List<string> _stderrLines = new();
+    private readonly string _runId = Guid.NewGuid().ToString("N")[..12];
+
+    public string TendrilHome { get; private set; } = "";
+    public string TendrilPlans { get; private set; } = "";
+    public string TendrilUrl { get; private set; } = "";
+
+    public IReadOnlyList<string> StdoutLines => _stdoutLines;
+    public IReadOnlyList<string> StderrLines => _stderrLines;
+
+    public async Task InitializeAsync()
+    {
+        var settings = TestSettingsProvider.Get();
+
+        TendrilHome = Path.Combine(Path.GetTempPath(), $"tendril-e2e-{_runId}");
+        TendrilPlans = Path.Combine(TendrilHome, "Plans");
+        Directory.CreateDirectory(TendrilHome);
+        Directory.CreateDirectory(TendrilPlans);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"run --project \"{settings.TendrilProjectPath}\" -- --web --verbose --find-available-port",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        psi.Environment["TENDRIL_HOME"] = TendrilHome;
+        psi.Environment["TENDRIL_PLANS"] = TendrilPlans;
+
+        _tendrilProcess = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start Tendril process");
+
+        TendrilUrl = await WaitForServerUrlAsync(
+            TimeSpan.FromSeconds(settings.StartupTimeoutSeconds));
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_tendrilProcess is { HasExited: false })
+        {
+            try
+            {
+                _tendrilProcess.Kill(entireProcessTree: true);
+                await _tendrilProcess.WaitForExitAsync();
+            }
+            catch
+            {
+                // Best-effort kill
+            }
+        }
+
+        _tendrilProcess?.Dispose();
+
+        await TryDeleteDirectoryAsync(TendrilHome);
+    }
+
+    private async Task<string> WaitForServerUrlAsync(TimeSpan timeout)
+    {
+        // Ivy framework outputs: "Ivy is running on https://localhost:5010 [PID]."
+        // ASP.NET outputs: "Now listening on: https://localhost:5010"
+        var urlPattern = new Regex(@"(?:running on|listening on:?)\s*(https?://[^\s\[\]]+)", RegexOptions.IgnoreCase);
+        var tcs = new TaskCompletionSource<string>();
+        using var cts = new CancellationTokenSource(timeout);
+
+        cts.Token.Register(() =>
+            tcs.TrySetException(new TimeoutException(
+                $"Tendril did not start within {timeout.TotalSeconds}s. " +
+                $"Stdout: {string.Join('\n', _stdoutLines.TakeLast(20))}\n" +
+                $"Stderr: {string.Join('\n', _stderrLines.TakeLast(20))}")));
+
+        _tendrilProcess!.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data == null) return;
+            _stdoutLines.Add(e.Data);
+
+            var match = urlPattern.Match(e.Data);
+            if (match.Success)
+                tcs.TrySetResult(match.Groups[1].Value);
+        };
+
+        _tendrilProcess.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data != null)
+                _stderrLines.Add(e.Data);
+        };
+
+        _tendrilProcess.BeginOutputReadLine();
+        _tendrilProcess.BeginErrorReadLine();
+
+        var url = await tcs.Task;
+
+        // Poll until the server actually responds (bypass SSL for self-signed dev certs)
+        using var handler = new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+        };
+        using var http = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                var response = await http.GetAsync(url);
+                if (response.StatusCode != HttpStatusCode.ServiceUnavailable)
+                    return url;
+            }
+            catch
+            {
+                // Server not ready yet
+            }
+            await Task.Delay(500);
+        }
+
+        return url;
+    }
+
+    private static async Task TryDeleteDirectoryAsync(string path, int maxAttempts = 3)
+    {
+        if (!Directory.Exists(path)) return;
+
+        for (int i = 0; i < maxAttempts; i++)
+        {
+            try
+            {
+                Directory.Delete(path, recursive: true);
+                return;
+            }
+            catch (IOException) when (i < maxAttempts - 1)
+            {
+                await Task.Delay(500 * (i + 1));
+            }
+            catch (UnauthorizedAccessException) when (i < maxAttempts - 1)
+            {
+                await Task.Delay(500 * (i + 1));
+            }
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Fixtures/TestRepositoryFixture.cs
+++ b/src/Ivy.Tendril.Test.End2End/Fixtures/TestRepositoryFixture.cs
@@ -1,0 +1,111 @@
+using Ivy.Tendril.Test.End2End.Configuration;
+using Ivy.Tendril.Test.End2End.Helpers;
+
+namespace Ivy.Tendril.Test.End2End.Fixtures;
+
+public class TestRepositoryFixture : IAsyncLifetime
+{
+    public string ForkedRepoFullName { get; private set; } = "";
+    public string LocalClonePath { get; private set; } = "";
+    public string ForkName { get; private set; } = "";
+
+    public async Task InitializeAsync()
+    {
+        var settings = TestSettingsProvider.Get();
+
+        var whoami = await ProcessHelper.RunAsync("gh", "api user -q .login", timeoutMs: 15_000);
+        if (whoami.ExitCode != 0)
+            throw new InvalidOperationException($"Failed to get GitHub username: {whoami.Error}");
+        var username = whoami.Output.Trim();
+
+        // Try multiple fork names to handle stale forks from previous runs
+        ProcessHelper.ProcessResult? forkResult = null;
+        for (int attempt = 0; attempt < 3; attempt++)
+        {
+            var runId = Guid.NewGuid().ToString("N")[..12];
+            ForkName = $"tendril-e2e-{runId}";
+            LocalClonePath = Path.Combine(Path.GetTempPath(), $"tendril-e2e-repo-{runId}");
+
+            forkResult = await ProcessHelper.RunAsync(
+                "gh",
+                $"repo fork {settings.TestRepo} --clone=false --fork-name {ForkName}",
+                timeoutMs: 60_000);
+
+            if (forkResult.ExitCode == 0) break;
+
+            // Wait for GitHub orchestration to settle before retrying
+            await Task.Delay(5000);
+        }
+
+        if (forkResult == null || forkResult.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"Failed to fork {settings.TestRepo} after 3 attempts: {forkResult?.Error}");
+
+        ForkedRepoFullName = $"{username}/{ForkName}";
+
+        // Wait for GitHub to finish fork orchestration
+        await Task.Delay(3000);
+
+        // Clone to local temp directory
+        var cloneResult = await ProcessHelper.RunAsync(
+            "git",
+            $"clone https://github.com/{ForkedRepoFullName} \"{LocalClonePath}\"",
+            timeoutMs: 60_000);
+
+        if (cloneResult.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"Failed to clone {ForkedRepoFullName}: {cloneResult.Error}");
+    }
+
+    public async Task DisposeAsync()
+    {
+        var settings = TestSettingsProvider.Get();
+
+        await TryDeleteDirectoryAsync(LocalClonePath);
+
+        if (settings.CleanupFork && !string.IsNullOrEmpty(ForkedRepoFullName))
+        {
+            try
+            {
+                await ProcessHelper.RunAsync(
+                    "gh",
+                    $"repo delete {ForkedRepoFullName} --yes",
+                    timeoutMs: 30_000);
+            }
+            catch { /* Best-effort — requires delete_repo scope */ }
+        }
+    }
+
+    private static async Task TryDeleteDirectoryAsync(string path, int maxAttempts = 3)
+    {
+        if (!Directory.Exists(path)) return;
+
+        for (int i = 0; i < maxAttempts; i++)
+        {
+            try
+            {
+                ClearReadOnlyAttributes(path);
+                Directory.Delete(path, recursive: true);
+                return;
+            }
+            catch (IOException) when (i < maxAttempts - 1)
+            {
+                await Task.Delay(500 * (i + 1));
+            }
+            catch (UnauthorizedAccessException) when (i < maxAttempts - 1)
+            {
+                await Task.Delay(500 * (i + 1));
+            }
+        }
+    }
+
+    private static void ClearReadOnlyAttributes(string path)
+    {
+        foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+        {
+            var attrs = File.GetAttributes(file);
+            if ((attrs & FileAttributes.ReadOnly) != 0)
+                File.SetAttributes(file, attrs & ~FileAttributes.ReadOnly);
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Helpers/FileSystemAssertions.cs
+++ b/src/Ivy.Tendril.Test.End2End/Helpers/FileSystemAssertions.cs
@@ -1,0 +1,76 @@
+namespace Ivy.Tendril.Test.End2End.Helpers;
+
+public static class FileSystemAssertions
+{
+    public static void AssertOnboardingComplete(string tendrilHome)
+    {
+        Assert.True(Directory.Exists(tendrilHome), $"TENDRIL_HOME not found: {tendrilHome}");
+        Assert.True(Directory.Exists(Path.Combine(tendrilHome, "Plans")), "Plans/ directory missing");
+        Assert.True(Directory.Exists(Path.Combine(tendrilHome, "Inbox")), "Inbox/ directory missing");
+        Assert.True(Directory.Exists(Path.Combine(tendrilHome, "Trash")), "Trash/ directory missing");
+        Assert.True(Directory.Exists(Path.Combine(tendrilHome, "Promptwares")), "Promptwares/ directory missing");
+        Assert.True(Directory.Exists(Path.Combine(tendrilHome, "Hooks")), "Hooks/ directory missing");
+        Assert.True(File.Exists(Path.Combine(tendrilHome, "config.yaml")), "config.yaml missing");
+    }
+
+    public static string? FindPlanFolder(string plansDir, string titleFragment)
+    {
+        if (!Directory.Exists(plansDir))
+            return null;
+
+        // Normalize by removing hyphens for comparison since folder names
+        // may use CamelCase (e.g., "CreateClaudeLifecycleTxtFile")
+        // while the search term may use hyphens (e.g., "claude-lifecycle")
+        var normalizedFragment = titleFragment.Replace("-", "");
+
+        return Directory.GetDirectories(plansDir)
+            .FirstOrDefault(d =>
+            {
+                var name = Path.GetFileName(d);
+                return name.Contains(titleFragment, StringComparison.OrdinalIgnoreCase) ||
+                       name.Replace("-", "").Contains(normalizedFragment, StringComparison.OrdinalIgnoreCase);
+            });
+    }
+
+    public static void AssertPlanExists(string plansDir, string titleFragment)
+    {
+        var folder = FindPlanFolder(plansDir, titleFragment);
+        Assert.NotNull(folder);
+        Assert.True(File.Exists(Path.Combine(folder!, "plan.yaml")),
+            $"plan.yaml missing in {folder}");
+    }
+
+    public static void AssertPlanYamlState(string planFolder, string expectedState)
+    {
+        var yamlPath = Path.Combine(planFolder, "plan.yaml");
+        Assert.True(File.Exists(yamlPath), $"plan.yaml not found: {yamlPath}");
+
+        var content = File.ReadAllText(yamlPath);
+        Assert.Contains($"state: {expectedState}", content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static void AssertPlanHasRevision(string planFolder, int revisionNumber)
+    {
+        var revisionsDir = Path.Combine(planFolder, "revisions");
+        Assert.True(Directory.Exists(revisionsDir), $"revisions/ directory missing in {planFolder}");
+
+        var revisionFile = Path.Combine(revisionsDir, $"{revisionNumber:D3}.md");
+        Assert.True(File.Exists(revisionFile), $"Revision file missing: {revisionFile}");
+    }
+
+    public static string? GetPlanId(string planFolderPath)
+    {
+        var folderName = Path.GetFileName(planFolderPath);
+        var dashIndex = folderName.IndexOf('-');
+        return dashIndex > 0 ? folderName[..dashIndex] : folderName;
+    }
+
+    public static void AssertConfigContains(string tendrilHome, string expectedText)
+    {
+        var configPath = Path.Combine(tendrilHome, "config.yaml");
+        Assert.True(File.Exists(configPath), "config.yaml not found");
+
+        var content = File.ReadAllText(configPath);
+        Assert.Contains(expectedText, content, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Helpers/LogAssertions.cs
+++ b/src/Ivy.Tendril.Test.End2End/Helpers/LogAssertions.cs
@@ -1,0 +1,85 @@
+namespace Ivy.Tendril.Test.End2End.Helpers;
+
+public static class LogAssertions
+{
+    public static void AssertNoErrors(string tendrilHome)
+    {
+        var logFiles = FindLogFiles(tendrilHome);
+        var errors = new List<string>();
+
+        foreach (var logFile in logFiles)
+        {
+            var lines = File.ReadAllLines(logFile);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                if (line.Contains("ERROR", StringComparison.OrdinalIgnoreCase) ||
+                    line.Contains("FATAL", StringComparison.OrdinalIgnoreCase))
+                {
+                    errors.Add($"{Path.GetFileName(logFile)}:{i + 1}: {line.Trim()}");
+                }
+            }
+        }
+
+        Assert.Empty(errors);
+    }
+
+    public static string? GetJobLog(string tendrilHome, string planId)
+    {
+        var promptwaresDir = Path.Combine(tendrilHome, "Promptwares");
+        if (!Directory.Exists(promptwaresDir))
+            return null;
+
+        foreach (var typeDir in Directory.GetDirectories(promptwaresDir))
+        {
+            var logsDir = Path.Combine(typeDir, "Logs");
+            if (!Directory.Exists(logsDir)) continue;
+
+            var logFile = Path.Combine(logsDir, $"{planId}.md");
+            if (File.Exists(logFile))
+                return File.ReadAllText(logFile);
+
+            var rawLog = Path.Combine(logsDir, $"{planId}.raw.jsonl");
+            if (File.Exists(rawLog))
+                return File.ReadAllText(rawLog);
+        }
+
+        return null;
+    }
+
+    public static void AssertLogContains(string tendrilHome, string planId, string expectedText)
+    {
+        var log = GetJobLog(tendrilHome, planId);
+        Assert.NotNull(log);
+        Assert.Contains(expectedText, log!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<string> FindLogFiles(string tendrilHome)
+    {
+        var files = new List<string>();
+
+        var promptwaresDir = Path.Combine(tendrilHome, "Promptwares");
+        if (Directory.Exists(promptwaresDir))
+        {
+            foreach (var typeDir in Directory.GetDirectories(promptwaresDir))
+            {
+                var logsDir = Path.Combine(typeDir, "Logs");
+                if (Directory.Exists(logsDir))
+                    files.AddRange(Directory.GetFiles(logsDir, "*.md"));
+            }
+        }
+
+        var plansDir = Path.Combine(tendrilHome, "Plans");
+        if (Directory.Exists(plansDir))
+        {
+            foreach (var planDir in Directory.GetDirectories(plansDir))
+            {
+                var logsDir = Path.Combine(planDir, "logs");
+                if (Directory.Exists(logsDir))
+                    files.AddRange(Directory.GetFiles(logsDir));
+            }
+        }
+
+        return files;
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Helpers/ProcessHelper.cs
+++ b/src/Ivy.Tendril.Test.End2End/Helpers/ProcessHelper.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics;
+
+namespace Ivy.Tendril.Test.End2End.Helpers;
+
+public static class ProcessHelper
+{
+    public record ProcessResult(int ExitCode, string Output, string Error);
+
+    public static async Task<ProcessResult> RunAsync(
+        string fileName,
+        string arguments,
+        int timeoutMs = 30_000,
+        string? workingDirectory = null,
+        IDictionary<string, string>? environmentVariables = null)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        if (workingDirectory != null)
+            psi.WorkingDirectory = workingDirectory;
+
+        if (environmentVariables != null)
+            foreach (var (key, value) in environmentVariables)
+                psi.Environment[key] = value;
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException($"Failed to start process: {fileName} {arguments}");
+
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+
+        using var cts = new CancellationTokenSource(timeoutMs);
+        try
+        {
+            await process.WaitForExitAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException(
+                $"Process '{fileName} {arguments}' timed out after {timeoutMs}ms");
+        }
+
+        return new ProcessResult(process.ExitCode, await outputTask, await errorTask);
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Helpers/RetryHelper.cs
+++ b/src/Ivy.Tendril.Test.End2End/Helpers/RetryHelper.cs
@@ -1,0 +1,51 @@
+namespace Ivy.Tendril.Test.End2End.Helpers;
+
+public static class RetryHelper
+{
+    public static async Task WaitUntilAsync(
+        Func<Task<bool>> condition,
+        TimeSpan timeout,
+        TimeSpan? pollInterval = null,
+        string? failureMessage = null)
+    {
+        var interval = pollInterval ?? TimeSpan.FromMilliseconds(500);
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await condition())
+                return;
+            await Task.Delay(interval);
+        }
+
+        throw new TimeoutException(
+            failureMessage ?? $"Condition not met within {timeout.TotalSeconds}s");
+    }
+
+    public static async Task RetryAsync(
+        Func<Task> action,
+        int maxAttempts = 3,
+        TimeSpan? delayBetween = null)
+    {
+        var delay = delayBetween ?? TimeSpan.FromMilliseconds(500);
+        Exception? lastException = null;
+
+        for (int i = 0; i < maxAttempts; i++)
+        {
+            try
+            {
+                await action();
+                return;
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+                if (i < maxAttempts - 1)
+                    await Task.Delay(delay);
+            }
+        }
+
+        throw new AggregateException(
+            $"Action failed after {maxAttempts} attempts", lastException!);
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Ivy.Tendril.Test.End2End.csproj
+++ b/src/Ivy.Tendril.Test.End2End/Ivy.Tendril.Test.End2End.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>CS1591</NoWarn>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Ivy.Tendril.Test.End2End</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Playwright" Version="1.52.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.e2e.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/Ivy.Tendril.Test.End2End/Pages/DashboardPage.cs
+++ b/src/Ivy.Tendril.Test.End2End/Pages/DashboardPage.cs
@@ -1,0 +1,47 @@
+using Microsoft.Playwright;
+
+namespace Ivy.Tendril.Test.End2End.Pages;
+
+public class DashboardPage
+{
+    private readonly IPage _page;
+
+    public DashboardPage(IPage page) => _page = page;
+
+    public async Task WaitForLoaded(int timeoutMs = 30_000)
+    {
+        // Wait for the Ivy SPA to render — initial page load is just an HTML shell,
+        // content renders after the SignalR/WebSocket connection establishes.
+        // Dashboard may show: stats ("Total Plans"), empty state ("No plans yet"),
+        // or loading state ("Loading Dashboard Data...").
+        // Also match "Drafts" which appears in sidebar when dashboard is rendered.
+        await _page.Locator("text=/Total Plans|No plans yet|Create your first plan|Loading Dashboard Data|Drafts/")
+            .First.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeoutMs });
+    }
+
+    public async Task NavigateToDrafts() =>
+        await _page.GetByText("Drafts").First.ClickAsync();
+
+    public async Task NavigateToJobs() =>
+        await _page.GetByText("Jobs").First.ClickAsync();
+
+    public async Task NavigateToReview() =>
+        await _page.GetByText("Review").First.ClickAsync();
+
+    public async Task<string> GetStatValue(string label)
+    {
+        var statCard = _page.GetByText(label).Locator("..");
+        return await statCard.InnerTextAsync();
+    }
+
+    public async Task<int> GetTotalPlans()
+    {
+        var text = await GetStatValue("Total Plans");
+        return int.TryParse(ExtractNumber(text), out var n) ? n : 0;
+    }
+
+    private static string ExtractNumber(string text)
+    {
+        return new string(text.Where(char.IsDigit).ToArray());
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Pages/JobsPage.cs
+++ b/src/Ivy.Tendril.Test.End2End/Pages/JobsPage.cs
@@ -1,0 +1,45 @@
+using Ivy.Tendril.Test.End2End.Helpers;
+using Microsoft.Playwright;
+
+namespace Ivy.Tendril.Test.End2End.Pages;
+
+public class JobsPage
+{
+    private readonly IPage _page;
+
+    public JobsPage(IPage page) => _page = page;
+
+    public async Task WaitForLoaded(int timeoutMs = 10_000)
+    {
+        await _page.GetByText("Jobs").First.WaitForAsync(
+            new() { State = WaitForSelectorState.Visible, Timeout = timeoutMs });
+    }
+
+    public async Task<bool> HasActiveJobs()
+    {
+        try
+        {
+            var hasRunning = await _page.Locator("text=/Running|Queued|Pending/")
+                .First.IsVisibleAsync();
+            return hasRunning;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task WaitForNoActiveJobs(int timeoutSeconds = 300)
+    {
+        await RetryHelper.WaitUntilAsync(
+            async () =>
+            {
+                await _page.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
+                await Task.Delay(2000);
+                return !await HasActiveJobs();
+            },
+            TimeSpan.FromSeconds(timeoutSeconds),
+            pollInterval: TimeSpan.FromSeconds(5),
+            failureMessage: $"Jobs still active after {timeoutSeconds}s");
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Pages/OnboardingPage.cs
+++ b/src/Ivy.Tendril.Test.End2End/Pages/OnboardingPage.cs
@@ -1,0 +1,141 @@
+using Microsoft.Playwright;
+
+namespace Ivy.Tendril.Test.End2End.Pages;
+
+public class OnboardingPage
+{
+    private readonly IPage _page;
+
+    public OnboardingPage(IPage page) => _page = page;
+
+    // Step 0: Welcome
+    public async Task ClickGetStarted() =>
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Get Started" }).ClickAsync();
+
+    // Step 1: Software Check
+    public async Task ClickCheckSoftware() =>
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Check Software" }).ClickAsync();
+
+    public async Task WaitForCheckComplete(int timeoutMs = 60_000) =>
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Continue" })
+            .WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeoutMs });
+
+    public async Task ClickContinue() =>
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Continue" }).ClickAsync();
+
+    // Step 2: Coding Agent — rendered as radio buttons
+    public async Task SelectAgent(string agentName) =>
+        await _page.GetByRole(AriaRole.Radio, new() { Name = agentName }).ClickAsync();
+
+    // Step 3: Tendril Home — pre-filled from TENDRIL_HOME env var
+    public async Task SetTendrilHome(string path)
+    {
+        var input = _page.GetByPlaceholder("Select Tendril data folder...");
+        await input.ClearAsync();
+        await input.FillAsync(path);
+    }
+
+    public async Task ClickNext() =>
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Next" }).ClickAsync();
+
+    // Step 4: Project Setup — Project Name has no a11y label
+    public async Task SetProjectName(string name)
+    {
+        // Wait for the Project Setup heading to appear
+        await _page.GetByRole(AriaRole.Heading, new() { Name = "Project Setup" }).WaitForAsync(
+            new() { State = WaitForSelectorState.Visible, Timeout = 10_000 });
+
+        // Fill the first single-line textbox (not textarea, not placeholder-textbox)
+        // The project name input is the first input[type=text] that isn't the repo path
+        var inputs = _page.Locator("input[type='text']:not([placeholder])");
+        await inputs.First.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 5_000 });
+        await inputs.First.FillAsync(name);
+    }
+
+    public async Task SetRepoPath(string path)
+    {
+        var input = _page.GetByPlaceholder("Select repository folder...");
+        await input.First.ClearAsync();
+        await input.First.FillAsync(path);
+    }
+
+    // Step 5: Complete
+    public async Task ClickCompleteSetup() =>
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Complete Setup" }).ClickAsync();
+
+    public async Task WaitForDashboard(string tendrilHome, int timeoutMs = 60_000)
+    {
+        // After "Complete Setup", the server runs setup + starts background services,
+        // then triggers a full page reload via client.Redirect("/", true).
+        // The Ivy framework's redirect may not always work in headless mode,
+        // so we also poll the filesystem and force a page reload if needed.
+
+        // First, wait for the server to finish setup by checking the filesystem
+        var configPath = Path.Combine(tendrilHome, "config.yaml");
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (File.Exists(configPath))
+            {
+                var content = await File.ReadAllTextAsync(configPath);
+                if (!content.StartsWith("#"))
+                    break;
+            }
+            await Task.Delay(500);
+        }
+
+        // Give the server a moment to finish the redirect
+        await Task.Delay(2000);
+
+        // Check if we're still on the onboarding page
+        var isOnboarding = await _page.GetByRole(AriaRole.Heading, new() { Name = "Ready to Go!" })
+            .IsVisibleAsync();
+        if (isOnboarding)
+        {
+            // Server completed but browser didn't navigate — force a reload
+            await _page.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
+        }
+
+        // Now wait for dashboard content
+        try
+        {
+            await _page.Locator("text=/Loading Dashboard Data|No plans yet|Create your first plan|Dashboard/")
+                .First.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 30_000 });
+        }
+        catch (TimeoutException)
+        {
+            var screenshotPath = Path.Combine(Path.GetTempPath(), "tendril-e2e-complete-timeout.png");
+            await _page.ScreenshotAsync(new PageScreenshotOptions { Path = screenshotPath, FullPage = true });
+            throw new TimeoutException(
+                $"Dashboard did not appear after setup completed. Screenshot: {screenshotPath}");
+        }
+    }
+
+    // Full onboarding flow
+    public async Task CompleteOnboarding(string agent, string tendrilHome, string projectName, string repoPath)
+    {
+        // Step 0: Welcome
+        await ClickGetStarted();
+
+        // Step 1: Software Check
+        await ClickCheckSoftware();
+        await WaitForCheckComplete();
+        await ClickContinue();
+
+        // Step 2: Coding Agent
+        await SelectAgent(agent);
+        await ClickContinue();
+
+        // Step 3: Tendril Home (already pre-filled from env var, just click Next)
+        await ClickNext();
+
+        // Step 4: Project Setup
+        await SetProjectName(projectName);
+        await SetRepoPath(repoPath);
+        await ClickNext();
+
+        // Step 5: Complete
+        await ClickCompleteSetup();
+        await WaitForDashboard(tendrilHome);
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Pages/PlansPage.cs
+++ b/src/Ivy.Tendril.Test.End2End/Pages/PlansPage.cs
@@ -1,0 +1,96 @@
+using Ivy.Tendril.Test.End2End.Helpers;
+using Microsoft.Playwright;
+
+namespace Ivy.Tendril.Test.End2End.Pages;
+
+public class PlansPage
+{
+    private readonly IPage _page;
+
+    public PlansPage(IPage page) => _page = page;
+
+    public async Task ClickNewPlan() =>
+        await _page.GetByRole(AriaRole.Button, new() { Name = "New Plan" }).First.ClickAsync();
+
+    public async Task CreatePlan(string description, string project = "Auto", string priority = "Normal")
+    {
+        await ClickNewPlan();
+
+        // Wait for the Create New Plan dialog
+        await _page.GetByText("Create New Plan").WaitForAsync(
+            new() { State = WaitForSelectorState.Visible, Timeout = 5_000 });
+
+        // Select project if not Auto
+        if (project != "Auto")
+            await _page.GetByText(project).ClickAsync();
+
+        // Select priority if not Normal
+        if (priority != "Normal")
+            await _page.GetByText(priority).ClickAsync();
+
+        // Fill in the task description
+        var textarea = _page.GetByPlaceholder("Enter task description...");
+        await textarea.FillAsync(description);
+
+        // Click Create
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Create" }).ClickAsync();
+    }
+
+    public async Task<bool> PlanExistsInList(string titleFragment)
+    {
+        try
+        {
+            await _page.GetByText(titleFragment).WaitForAsync(
+                new() { State = WaitForSelectorState.Visible, Timeout = 10_000 });
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+    }
+
+    public async Task SelectPlan(string titleFragment) =>
+        await _page.GetByText(titleFragment).First.ClickAsync();
+
+    public async Task SelectPlanById(string planId)
+    {
+        var locator = _page.GetByText($"#{planId}").First;
+        await locator.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 10_000 });
+        await locator.ClickAsync();
+    }
+
+    public async Task ClickExecute() =>
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Execute" }).ClickAsync();
+
+    public async Task ClickUpdate() =>
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Update" }).ClickAsync();
+
+    public async Task ClickSplit() =>
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Split" }).ClickAsync();
+
+    public async Task ClickExpand() =>
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Expand" }).ClickAsync();
+
+    public async Task ClickDelete() =>
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Delete" }).ClickAsync();
+
+    public async Task WaitForPlanState(string plansDir, string titleFragment, string expectedState, int timeoutSeconds = 300)
+    {
+        await RetryHelper.WaitUntilAsync(
+            async () =>
+            {
+                var folder = FileSystemAssertions.FindPlanFolder(plansDir, titleFragment);
+                if (folder == null) return false;
+
+                var yamlPath = Path.Combine(folder, "plan.yaml");
+                if (!File.Exists(yamlPath)) return false;
+
+                var content = await File.ReadAllTextAsync(yamlPath);
+                return content.Contains($"state: {expectedState}", StringComparison.OrdinalIgnoreCase);
+            },
+            TimeSpan.FromSeconds(timeoutSeconds),
+            pollInterval: TimeSpan.FromSeconds(2),
+            failureMessage: $"Plan '{titleFragment}' did not reach state '{expectedState}' within {timeoutSeconds}s");
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Pages/ReviewPage.cs
+++ b/src/Ivy.Tendril.Test.End2End/Pages/ReviewPage.cs
@@ -1,0 +1,48 @@
+using Ivy.Tendril.Test.End2End.Helpers;
+using Microsoft.Playwright;
+
+namespace Ivy.Tendril.Test.End2End.Pages;
+
+public class ReviewPage
+{
+    private readonly IPage _page;
+
+    public ReviewPage(IPage page) => _page = page;
+
+    public async Task WaitForLoaded(int timeoutMs = 10_000) =>
+        await _page.Locator("text=/Ready for Review|No plans|review/i")
+            .First.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeoutMs });
+
+    public async Task SelectPlanById(string planId)
+    {
+        var locator = _page.GetByText($"#{planId}").First;
+        await locator.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 10_000 });
+        await locator.ClickAsync();
+    }
+
+    public async Task ClickCreatePR()
+    {
+        await _page.GetByRole(AriaRole.Button, new() { Name = "Create PR" }).First.ClickAsync();
+
+        // With PrRule "default", a Custom PR dialog opens. Click the dialog's Create PR to confirm.
+        try
+        {
+            await _page.GetByText("Custom PR").First.WaitForAsync(
+                new() { State = WaitForSelectorState.Visible, Timeout = 3_000 });
+            // The dialog's Create PR is the last one on the page
+            var buttons = _page.GetByRole(AriaRole.Button, new() { Name = "Create PR" });
+            var count = await buttons.CountAsync();
+            await buttons.Nth(count - 1).ClickAsync();
+        }
+        catch (TimeoutException)
+        {
+            // No dialog — PrRule is "yolo", PR creation started directly
+        }
+    }
+
+    public async Task WaitForPRCreated(int timeoutMs = 120_000)
+    {
+        await _page.Locator("text=/Pull request|PR created|pull request/i")
+            .First.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = timeoutMs });
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Tests/AgentExecutionTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/AgentExecutionTests.cs
@@ -1,0 +1,237 @@
+using Ivy.Tendril.Test.End2End.Fixtures;
+using Ivy.Tendril.Test.End2End.Helpers;
+using Ivy.Tendril.Test.End2End.Pages;
+using Microsoft.Playwright;
+
+namespace Ivy.Tendril.Test.End2End.Tests;
+
+/// <summary>
+/// Full lifecycle test: CreatePlan → ExecutePlan → CreatePR.
+/// The coding agent is determined by E2E__Agent (default: claude).
+/// Run the suite 3 times with E2E__Agent=claude/codex/gemini to test all agents.
+/// </summary>
+[Collection("E2E")]
+public class AgentExecutionTests : IAsyncLifetime
+{
+    private readonly E2ETestFixture _fixture;
+    private IBrowserContext? _context;
+    private IPage? _page;
+
+    public AgentExecutionTests(E2ETestFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        if (!_fixture.OnboardingCompleted)
+        {
+            var ctx = await _fixture.Playwright.NewContextAsync();
+            var pg = await ctx.NewPageAsync();
+            await pg.GotoAsync(_fixture.Tendril.TendrilUrl);
+
+            var onboarding = new OnboardingPage(pg);
+            var agentDisplayName = _fixture.Settings.Agent switch
+            {
+                "claude" => "Claude",
+                "codex" => "Codex",
+                "gemini" => "Gemini",
+                _ => _fixture.Settings.Agent,
+            };
+            await onboarding.CompleteOnboarding(
+                agentDisplayName,
+                _fixture.Tendril.TendrilHome,
+                "E2ETest",
+                _fixture.TestRepo.LocalClonePath);
+            _fixture.OnboardingCompleted = true;
+            await ctx.CloseAsync();
+        }
+
+        _context = await _fixture.Playwright.NewContextAsync();
+        _page = await _context.NewPageAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_context != null)
+            await _context.CloseAsync();
+    }
+
+    [Fact]
+    public async Task CreatePlan_Execute_CreatePR()
+    {
+        var agent = _fixture.Settings.Agent;
+        var timeout = _fixture.Settings.PlanExecutionTimeoutSeconds;
+        var plansDir = _fixture.Tendril.TendrilPlans;
+        var dashboard = new DashboardPage(_page!);
+        var plans = new PlansPage(_page!);
+        var review = new ReviewPage(_page!);
+
+        // --- Step 1: Create Plan ---
+        await _page!.GotoAsync(_fixture.Tendril.TendrilUrl);
+        await dashboard.WaitForLoaded();
+        await dashboard.NavigateToDrafts();
+        await Task.Delay(1000);
+
+        var planDescription = $"Create a file called {agent}-lifecycle.txt containing 'Hello from {agent}'";
+        await plans.CreatePlan(planDescription);
+
+        await WaitForPlanWithYaml($"{agent}-lifecycle", timeout,
+            $"Step 1 (CreatePlan) failed: agent={agent}");
+
+        var planFolder = FileSystemAssertions.FindPlanFolder(plansDir, $"{agent}-lifecycle")!;
+        var planId = FileSystemAssertions.GetPlanId(planFolder)!;
+        FileSystemAssertions.AssertPlanExists(plansDir, $"{agent}-lifecycle");
+
+        // Wait for the CreatePlan job to fully complete (Jobs badge → 0)
+        await WaitForNoActiveJobs(timeout);
+
+        // --- Step 2: Execute Plan ---
+        await _page!.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
+        await dashboard.WaitForLoaded();
+        await dashboard.NavigateToDrafts();
+
+        // Wait for the plan to appear in the sidebar (sync may still be settling)
+        await WaitForPlanInSidebar(planId, "Drafts");
+
+        await plans.SelectPlanById(planId);
+        await Task.Delay(1000);
+        await plans.ClickExecute();
+
+        await WaitForPlanState($"{agent}-lifecycle", "ReadyForReview", timeout,
+            $"Step 2 (ExecutePlan) failed: plan #{planId} did not reach ReadyForReview, agent={agent}");
+
+        // Wait for the ExecutePlan job to complete
+        await WaitForNoActiveJobs(timeout);
+
+        // --- Step 3: Create PR ---
+        await _page!.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
+        await dashboard.WaitForLoaded();
+        await dashboard.NavigateToReview();
+
+        // Wait for the plan to appear in Review sidebar
+        await WaitForPlanInSidebar(planId, "Review");
+
+        await review.SelectPlanById(planId);
+        await Task.Delay(1000);
+        await review.ClickCreatePR();
+
+        await WaitForPRCreated(planFolder, timeout,
+            $"Step 3 (CreatePR) failed: no PR URL in plan.yaml for #{planId}, agent={agent}");
+    }
+
+    private async Task WaitForPlanWithYaml(string titleFragment, int timeoutSeconds, string context)
+    {
+        var plansDir = _fixture.Tendril.TendrilPlans;
+
+        await RetryHelper.WaitUntilAsync(
+            () =>
+            {
+                var folder = FileSystemAssertions.FindPlanFolder(plansDir, titleFragment);
+                if (folder == null) return Task.FromResult(false);
+                return Task.FromResult(File.Exists(Path.Combine(folder, "plan.yaml")));
+            },
+            TimeSpan.FromSeconds(timeoutSeconds),
+            pollInterval: TimeSpan.FromSeconds(3),
+            failureMessage: $"{context}\n" +
+                $"Plan '{titleFragment}' with plan.yaml not found within {timeoutSeconds}s.\n" +
+                $"Plans dir: {string.Join(", ", Directory.Exists(plansDir) ? Directory.GetFileSystemEntries(plansDir).Select(Path.GetFileName) : [])}\n" +
+                $"Tendril stdout (last 30):\n{string.Join("\n", _fixture.Tendril.StdoutLines.TakeLast(30))}");
+    }
+
+    private async Task WaitForPlanState(string titleFragment, string expectedState, int timeoutSeconds, string context)
+    {
+        var plansDir = _fixture.Tendril.TendrilPlans;
+
+        await RetryHelper.WaitUntilAsync(
+            async () =>
+            {
+                var folder = FileSystemAssertions.FindPlanFolder(plansDir, titleFragment);
+                if (folder == null) return false;
+
+                var yamlPath = Path.Combine(folder, "plan.yaml");
+                if (!File.Exists(yamlPath)) return false;
+
+                var content = await File.ReadAllTextAsync(yamlPath);
+                return content.Contains($"state: {expectedState}", StringComparison.OrdinalIgnoreCase);
+            },
+            TimeSpan.FromSeconds(timeoutSeconds),
+            pollInterval: TimeSpan.FromSeconds(3),
+            failureMessage: $"{context}\n" +
+                $"Tendril stdout (last 30):\n{string.Join("\n", _fixture.Tendril.StdoutLines.TakeLast(30))}");
+    }
+
+    private async Task WaitForPRCreated(string planFolder, int timeoutSeconds, string context)
+    {
+        await RetryHelper.WaitUntilAsync(
+            async () =>
+            {
+                var yamlPath = Path.Combine(planFolder, "plan.yaml");
+                if (!File.Exists(yamlPath)) return false;
+
+                var content = await File.ReadAllTextAsync(yamlPath);
+                return content.Contains("github.com", StringComparison.OrdinalIgnoreCase) &&
+                       content.Contains("pull", StringComparison.OrdinalIgnoreCase);
+            },
+            TimeSpan.FromSeconds(timeoutSeconds),
+            pollInterval: TimeSpan.FromSeconds(3),
+            failureMessage: $"{context}\n" +
+                $"Tendril stdout (last 30):\n{string.Join("\n", _fixture.Tendril.StdoutLines.TakeLast(30))}");
+    }
+
+    private async Task WaitForNoActiveJobs(int timeoutSeconds)
+    {
+        var dashboard = new DashboardPage(_page!);
+
+        await _page!.GotoAsync(_fixture.Tendril.TendrilUrl);
+        await dashboard.WaitForLoaded();
+        await dashboard.NavigateToJobs();
+        await Task.Delay(2000);
+
+        var jobs = new JobsPage(_page!);
+        await jobs.WaitForNoActiveJobs(timeoutSeconds);
+    }
+
+    private async Task WaitForPlanInSidebar(string planId, string tabName)
+    {
+        var dashboard = new DashboardPage(_page!);
+        string lastError = "";
+        int attempt = 0;
+
+        await RetryHelper.WaitUntilAsync(
+            async () =>
+            {
+                attempt++;
+                try
+                {
+                    await _page!.GotoAsync(_fixture.Tendril.TendrilUrl,
+                        new() { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 15_000 });
+                    await dashboard.WaitForLoaded();
+                    if (tabName == "Drafts")
+                        await dashboard.NavigateToDrafts();
+                    else if (tabName == "Review")
+                        await dashboard.NavigateToReview();
+                    await Task.Delay(5000);
+
+                    // Take a screenshot on first and last attempts for debugging
+                    if (attempt == 1 || attempt % 5 == 0)
+                    {
+                        var screenshotPath = Path.Combine(Path.GetTempPath(),
+                            $"tendril-e2e-sidebar-{tabName}-attempt{attempt}.png");
+                        await _page!.ScreenshotAsync(new() { Path = screenshotPath, FullPage = true });
+                    }
+
+                    var visible = await _page!.GetByText($"#{planId}").First.IsVisibleAsync();
+                    return visible;
+                }
+                catch (Exception ex)
+                {
+                    lastError = $"attempt {attempt}: {ex.GetType().Name}: {ex.Message}";
+                    return false;
+                }
+            },
+            TimeSpan.FromSeconds(120),
+            pollInterval: TimeSpan.FromSeconds(10),
+            failureMessage: $"Plan #{planId} not visible in {tabName} sidebar after 120s (attempts: {attempt}).\n" +
+                $"Last error: {lastError}\n" +
+                $"Plans dir: {string.Join(", ", Directory.Exists(_fixture.Tendril.TendrilPlans) ? Directory.GetDirectories(_fixture.Tendril.TendrilPlans).Select(Path.GetFileName) : [])}\n" +
+                $"Tendril URL: {_fixture.Tendril.TendrilUrl}");
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Tests/CleanupTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/CleanupTests.cs
@@ -1,0 +1,63 @@
+using Ivy.Tendril.Test.End2End.Configuration;
+using Ivy.Tendril.Test.End2End.Fixtures;
+using Ivy.Tendril.Test.End2End.Helpers;
+
+namespace Ivy.Tendril.Test.End2End.Tests;
+
+public class CleanupTests
+{
+    [Fact]
+    public async Task TendrilProcessFixture_CleansUpTempDirectories()
+    {
+        var fixture = new TendrilProcessFixture();
+
+        try
+        {
+            await fixture.InitializeAsync();
+            Assert.True(Directory.Exists(fixture.TendrilHome), "TendrilHome should exist during test");
+            Assert.True(Directory.Exists(fixture.TendrilPlans), "TendrilPlans should exist during test");
+        }
+        finally
+        {
+            var homePath = fixture.TendrilHome;
+            await fixture.DisposeAsync();
+
+            // After dispose, the directories should be cleaned up
+            await RetryHelper.WaitUntilAsync(
+                () => Task.FromResult(!Directory.Exists(homePath)),
+                TimeSpan.FromSeconds(10),
+                failureMessage: "TENDRIL_HOME was not cleaned up after dispose");
+        }
+    }
+
+    [Fact]
+    public async Task TestRepositoryFixture_CleansUpFork()
+    {
+        var settings = TestSettingsProvider.Get();
+        var fixture = new TestRepositoryFixture();
+
+        try
+        {
+            await fixture.InitializeAsync();
+            Assert.True(Directory.Exists(fixture.LocalClonePath), "Clone should exist during test");
+            Assert.False(string.IsNullOrEmpty(fixture.ForkedRepoFullName), "Fork name should be set");
+        }
+        finally
+        {
+            var clonePath = fixture.LocalClonePath;
+            var forkName = fixture.ForkedRepoFullName;
+            await fixture.DisposeAsync();
+
+            // Local clone should be removed
+            Assert.False(Directory.Exists(clonePath), "Local clone should be removed after dispose");
+
+            // Fork should be deleted from GitHub (if cleanup is enabled)
+            if (settings.CleanupFork && !string.IsNullOrEmpty(forkName))
+            {
+                var result = await ProcessHelper.RunAsync(
+                    "gh", $"repo view {forkName}", timeoutMs: 15_000);
+                Assert.NotEqual(0, result.ExitCode);
+            }
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Tests/OnboardingTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/OnboardingTests.cs
@@ -1,0 +1,74 @@
+using Ivy.Tendril.Test.End2End.Fixtures;
+using Ivy.Tendril.Test.End2End.Helpers;
+using Ivy.Tendril.Test.End2End.Pages;
+using Microsoft.Playwright;
+
+namespace Ivy.Tendril.Test.End2End.Tests;
+
+[Collection("E2E")]
+public class OnboardingTests : IAsyncLifetime
+{
+    private readonly E2ETestFixture _fixture;
+    private IBrowserContext? _context;
+    private IPage? _page;
+
+    public OnboardingTests(E2ETestFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        _context = await _fixture.Playwright.NewContextAsync();
+        _page = await _context.NewPageAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_context != null)
+            await _context.CloseAsync();
+    }
+
+    [Fact]
+    public async Task Onboarding_CompletesSuccessfully()
+    {
+        if (!_fixture.OnboardingCompleted)
+        {
+            var settings = _fixture.Settings;
+            var onboarding = new OnboardingPage(_page!);
+
+            await _page!.GotoAsync(_fixture.Tendril.TendrilUrl);
+
+            var agentDisplayName = settings.Agent switch
+            {
+                "claude" => "Claude",
+                "codex" => "Codex",
+                "gemini" => "Gemini",
+                _ => settings.Agent,
+            };
+
+            try
+            {
+                await onboarding.CompleteOnboarding(
+                    agent: agentDisplayName,
+                    tendrilHome: _fixture.Tendril.TendrilHome,
+                    projectName: "E2ETest",
+                    repoPath: _fixture.TestRepo.LocalClonePath);
+            }
+            catch (TimeoutException ex)
+            {
+                var stdout = string.Join("\n", _fixture.Tendril.StdoutLines.TakeLast(40));
+                var stderr = string.Join("\n", _fixture.Tendril.StderrLines.TakeLast(20));
+                throw new TimeoutException(
+                    $"{ex.Message}\n\n--- Tendril stdout (last 40 lines) ---\n{stdout}\n\n--- Tendril stderr (last 20 lines) ---\n{stderr}",
+                    ex);
+            }
+
+            _fixture.OnboardingCompleted = true;
+        }
+
+        // Verify filesystem structure
+        FileSystemAssertions.AssertOnboardingComplete(_fixture.Tendril.TendrilHome);
+
+        // Verify config.yaml contains the project and agent
+        FileSystemAssertions.AssertConfigContains(_fixture.Tendril.TendrilHome, "E2ETest");
+        FileSystemAssertions.AssertConfigContains(_fixture.Tendril.TendrilHome, _fixture.Settings.Agent);
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Tests/PlanLifecycleTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/PlanLifecycleTests.cs
@@ -1,0 +1,120 @@
+using Ivy.Tendril.Test.End2End.Fixtures;
+using Ivy.Tendril.Test.End2End.Helpers;
+using Ivy.Tendril.Test.End2End.Pages;
+using Microsoft.Playwright;
+
+namespace Ivy.Tendril.Test.End2End.Tests;
+
+[Collection("E2E")]
+public class PlanLifecycleTests : IAsyncLifetime
+{
+    private readonly E2ETestFixture _fixture;
+    private IBrowserContext? _context;
+    private IPage? _page;
+
+    public PlanLifecycleTests(E2ETestFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        if (!_fixture.OnboardingCompleted)
+        {
+            var ctx = await _fixture.Playwright.NewContextAsync();
+            var pg = await ctx.NewPageAsync();
+            await pg.GotoAsync(_fixture.Tendril.TendrilUrl);
+
+            var onboarding = new OnboardingPage(pg);
+            var agentDisplayName = _fixture.Settings.Agent switch
+            {
+                "claude" => "Claude",
+                "codex" => "Codex",
+                "gemini" => "Gemini",
+                _ => _fixture.Settings.Agent,
+            };
+            await onboarding.CompleteOnboarding(
+                agentDisplayName,
+                _fixture.Tendril.TendrilHome,
+                "E2ETest",
+                _fixture.TestRepo.LocalClonePath);
+            _fixture.OnboardingCompleted = true;
+            await ctx.CloseAsync();
+        }
+
+        _context = await _fixture.Playwright.NewContextAsync();
+        _page = await _context.NewPageAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_context != null)
+            await _context.CloseAsync();
+    }
+
+    [Fact]
+    public async Task CreatePlan_ViaUI_CreatesPlanFolder()
+    {
+        var dashboard = new DashboardPage(_page!);
+        var plans = new PlansPage(_page!);
+        var timeout = _fixture.Settings.PlanExecutionTimeoutSeconds;
+
+        await _page!.GotoAsync(_fixture.Tendril.TendrilUrl);
+        await dashboard.WaitForLoaded();
+        await dashboard.NavigateToDrafts();
+
+        await plans.CreatePlan("Add a README.md file with project description");
+
+        await WaitForPlanWithYaml("README", timeout);
+
+        FileSystemAssertions.AssertPlanExists(_fixture.Tendril.TendrilPlans, "README");
+    }
+
+    [Fact]
+    public async Task PlanList_ShowsCreatedPlans()
+    {
+        var dashboard = new DashboardPage(_page!);
+        var plans = new PlansPage(_page!);
+        var timeout = _fixture.Settings.PlanExecutionTimeoutSeconds;
+
+        await _page!.GotoAsync(_fixture.Tendril.TendrilUrl);
+        await dashboard.WaitForLoaded();
+        await dashboard.NavigateToDrafts();
+
+        await plans.CreatePlan("First test plan for listing");
+        await WaitForPlanWithYaml("First", timeout);
+
+        var firstFolder = FileSystemAssertions.FindPlanFolder(_fixture.Tendril.TendrilPlans, "First")!;
+        var firstId = FileSystemAssertions.GetPlanId(firstFolder)!;
+
+        await plans.CreatePlan("Second test plan for listing");
+        await WaitForPlanWithYaml("Second", timeout);
+
+        var secondFolder = FileSystemAssertions.FindPlanFolder(_fixture.Tendril.TendrilPlans, "Second")!;
+        var secondId = FileSystemAssertions.GetPlanId(secondFolder)!;
+
+        // Reload to pick up both plans in the sidebar
+        await _page!.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
+        await dashboard.WaitForLoaded();
+        await dashboard.NavigateToDrafts();
+        await Task.Delay(2000);
+
+        Assert.True(await plans.PlanExistsInList($"#{firstId}"));
+        Assert.True(await plans.PlanExistsInList($"#{secondId}"));
+    }
+
+    private async Task WaitForPlanWithYaml(string titleFragment, int timeoutSeconds)
+    {
+        var plansDir = _fixture.Tendril.TendrilPlans;
+
+        await RetryHelper.WaitUntilAsync(
+            () =>
+            {
+                var folder = FileSystemAssertions.FindPlanFolder(plansDir, titleFragment);
+                if (folder == null) return Task.FromResult(false);
+                return Task.FromResult(File.Exists(Path.Combine(folder, "plan.yaml")));
+            },
+            TimeSpan.FromSeconds(timeoutSeconds),
+            pollInterval: TimeSpan.FromSeconds(2),
+            failureMessage: $"Plan folder containing '{titleFragment}' with plan.yaml was not created within {timeoutSeconds}s.\n" +
+                $"Plans dir contents: {string.Join(", ", Directory.Exists(plansDir) ? Directory.GetFileSystemEntries(plansDir).Select(Path.GetFileName) : [])}\n" +
+                $"Tendril stdout (last 20 lines):\n{string.Join("\n", _fixture.Tendril.StdoutLines.TakeLast(20))}");
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Tests/VerificationTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/VerificationTests.cs
@@ -1,0 +1,92 @@
+using Ivy.Tendril.Test.End2End.Fixtures;
+using Ivy.Tendril.Test.End2End.Helpers;
+using Ivy.Tendril.Test.End2End.Pages;
+using Microsoft.Playwright;
+
+namespace Ivy.Tendril.Test.End2End.Tests;
+
+[Collection("E2E")]
+public class VerificationTests : IAsyncLifetime
+{
+    private readonly E2ETestFixture _fixture;
+    private IBrowserContext? _context;
+    private IPage? _page;
+
+    public VerificationTests(E2ETestFixture fixture) => _fixture = fixture;
+
+    public async Task InitializeAsync()
+    {
+        if (!_fixture.OnboardingCompleted)
+        {
+            var ctx = await _fixture.Playwright.NewContextAsync();
+            var pg = await ctx.NewPageAsync();
+            await pg.GotoAsync(_fixture.Tendril.TendrilUrl);
+
+            var onboarding = new OnboardingPage(pg);
+            var agentDisplayName = _fixture.Settings.Agent switch
+            {
+                "claude" => "Claude",
+                "codex" => "Codex",
+                "gemini" => "Gemini",
+                _ => _fixture.Settings.Agent,
+            };
+            await onboarding.CompleteOnboarding(
+                agentDisplayName,
+                _fixture.Tendril.TendrilHome,
+                "E2ETest",
+                _fixture.TestRepo.LocalClonePath);
+            _fixture.OnboardingCompleted = true;
+            await ctx.CloseAsync();
+        }
+
+        _context = await _fixture.Playwright.NewContextAsync();
+        _page = await _context.NewPageAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_context != null)
+            await _context.CloseAsync();
+    }
+
+    [Fact]
+    public void OnboardingCreatesValidDirectoryStructure()
+    {
+        FileSystemAssertions.AssertOnboardingComplete(_fixture.Tendril.TendrilHome);
+
+        var counterPath = Path.Combine(_fixture.Tendril.TendrilPlans, ".counter");
+        Assert.True(File.Exists(counterPath), ".counter file missing in Plans/");
+        var counterValue = File.ReadAllText(counterPath).Trim();
+        Assert.True(int.TryParse(counterValue, out var n) && n >= 1,
+            $".counter should be >= 1, got '{counterValue}'");
+    }
+
+    [Fact]
+    public void ConfigYaml_ContainsExpectedSettings()
+    {
+        var configPath = Path.Combine(_fixture.Tendril.TendrilHome, "config.yaml");
+        Assert.True(File.Exists(configPath));
+
+        var content = File.ReadAllText(configPath);
+        Assert.Contains("codingAgent:", content);
+        Assert.Contains("projects:", content);
+        FileSystemAssertions.AssertConfigContains(_fixture.Tendril.TendrilHome, _fixture.Settings.Agent);
+    }
+
+    [Fact]
+    public void Database_ExistsAfterOnboarding()
+    {
+        var dbPath = Path.Combine(_fixture.Tendril.TendrilHome, "tendril.db");
+        Assert.True(File.Exists(dbPath), "tendril.db should exist after onboarding");
+        Assert.True(new FileInfo(dbPath).Length > 0, "tendril.db should not be empty");
+    }
+
+    [Fact]
+    public async Task DashboardLoadsAfterOnboarding()
+    {
+        var dashboard = new DashboardPage(_page!);
+
+        await _page!.GotoAsync(_fixture.Tendril.TendrilUrl);
+        await dashboard.WaitForLoaded();
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/appsettings.e2e.json
+++ b/src/Ivy.Tendril.Test.End2End/appsettings.e2e.json
@@ -1,0 +1,13 @@
+{
+  "E2E": {
+    "Agent": "claude",
+    "TestRepo": "octocat/Hello-World",
+    "TendrilProjectPath": "",
+    "StartupTimeoutSeconds": 60,
+    "PlanExecutionTimeoutSeconds": 600,
+    "Headless": true,
+    "SlowMo": 0,
+    "CleanupFork": true,
+    "ScreenshotOnFailure": true
+  }
+}

--- a/src/Ivy.Tendril/Ivy.Tendril.slnx
+++ b/src/Ivy.Tendril/Ivy.Tendril.slnx
@@ -7,4 +7,5 @@
   <Project Path="Ivy.Tendril.csproj" />
   <Project Path="../Ivy.Tendril.Test/Ivy.Tendril.Test.csproj" />
   <Project Path="../Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj" />
+  <Project Path="../Ivy.Tendril.Test.End2End/Ivy.Tendril.Test.End2End.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary
- Adds new `Ivy.Tendril.Test.End2End` project with Playwright-based E2E tests
- Covers full lifecycle: onboarding, plan creation, agent execution, and PR review flows
- Includes Page Object Model, test fixtures, helpers, and multi-agent support (Claude/Codex/Gemini)
- Adds project reference to solution file

## Details
- **23 files**, **1,685 lines** of new test infrastructure
- **10 tests** across 5 test classes (Onboarding, PlanLifecycle, AgentExecution, Verification, Cleanup)
- Configurable via `appsettings.e2e.json` and environment variable overrides