### PR TITLE
Add reactive watchers and switch E2E tests to Ivy-Templates repo

### DIFF
--- a/src/Ivy.Tendril.Test.End2End/AGENTS.md
+++ b/src/Ivy.Tendril.Test.End2End/AGENTS.md
@@ -1,0 +1,187 @@
+# Ivy.Tendril.Test.End2End
+
+Playwright-based E2E tests that drive Tendril as a black-box subprocess and verify the full lifecycle: onboarding, plan creation, agent execution, PR creation.
+
+## Quick start
+
+```bash
+cd src/Ivy.Tendril.Test.End2End
+dotnet build
+dotnet test --verbosity normal
+```
+
+Individual test classes can be run with `--filter`:
+
+```bash
+dotnet test --filter "FullyQualifiedName~OnboardingTests"
+dotnet test --filter "FullyQualifiedName~VerificationTests"
+dotnet test --filter "FullyQualifiedName~PlanLifecycleTests"
+dotnet test --filter "FullyQualifiedName~AgentExecutionTests"
+dotnet test --filter "FullyQualifiedName~CleanupTests"
+```
+
+To test a specific coding agent:
+
+```bash
+E2E__Agent=codex dotnet test --verbosity normal
+E2E__Agent=gemini dotnet test --verbosity normal
+```
+
+## Architecture
+
+### Fixture lifecycle
+
+```
+E2ETestFixture.InitializeAsync()
+  |
+  ├── PlaywrightFixture  (launches Chromium)     } in parallel
+  ├── TestRepositoryFixture (forks Ivy-Templates) }
+  |
+  └── TendrilProcessFixture (dotnet run --web --verbose --find-available-port)
+        - Uses isolated TENDRIL_HOME in %TEMP%
+        - Captures all stdout/stderr lines for assertions
+        - Polls stdout for server URL via regex
+```
+
+All tests share one `E2ETestFixture` instance via `[Collection("E2E")]`. The fixture forks `Ivy-Interactive/Ivy-Templates` (a dotnet project) to a temporary GitHub fork, clones it locally, and starts Tendril pointing at that clone.
+
+### Test repo
+
+The tests use `Ivy-Interactive/Ivy-Templates` — a real dotnet project with `Program.cs`, `GlobalUsings.cs`, `.csproj`, and solution file. This ensures plan descriptions target actual code (e.g., "Uppercase all string literals in Program.cs").
+
+### Key directories at runtime
+
+```
+%TEMP%/tendril-e2e-{runId}/          ← TENDRIL_HOME
+  config.yaml
+  tendril.db
+  Plans/
+    .counter
+    00001-PlanFolderName/
+      plan.yaml
+      revisions/
+      logs/
+  Promptwares/
+    CreatePlan/Logs/{planId}.md
+    ExecutePlan/Logs/{planId}.md
+    CreatePr/Logs/{planId}.md
+  jobs/
+    {jobId}.status                   ← Status file (JSON)
+  Logs/
+    worktrees.log
+```
+
+## What the tests cover
+
+| Test class | Tests | What it verifies |
+|---|---|---|
+| OnboardingTests | 1 | Full onboarding wizard: welcome → software check → agent selection → home setup → project setup → complete |
+| VerificationTests | 4 | Directory structure, config.yaml, tendril.db, dashboard loads |
+| PlanLifecycleTests | 2 | Plan creation via UI creates plan folder with plan.yaml; multiple plans appear in sidebar |
+| AgentExecutionTests | 1 | Full lifecycle: CreatePlan → Execute → CreatePR (plan reaches ReadyForReview, PR URL in plan.yaml) |
+| CleanupTests | 2 | Fixture teardown, GitHub fork deletion |
+
+## Common gotchas
+
+- **Plan folder names are CamelCase** (e.g., `00001-UppercaseAllStringLiteralsInProgramCs`). `FindPlanFolder` normalizes by removing hyphens for comparison.
+- **Plan IDs in sidebar are unpadded** — sidebar shows `#1`, not `#00001`. `GetPlanId` strips leading zeros.
+- **Plan folders appear before `plan.yaml` is written.** Always wait for `plan.yaml` to exist, not just the folder.
+- **Ivy framework `client.Redirect()` doesn't work reliably in headless Playwright.** After onboarding, the test polls the filesystem for config.yaml then forces `page.ReloadAsync()`.
+- **Duplicate "New Plan" buttons exist** (sidebar + empty state). Use `.First` on all button selectors.
+- **CreatePlan invokes the coding agent** — takes 2-5+ minutes, not seconds.
+- **`--find-available-port`** is required to avoid port conflicts between test runs.
+- **Git pack files are read-only on Windows** — must clear read-only attributes before `Directory.Delete`.
+- **After page reload, the sidebar may not immediately show new plans.** Retry with reloads.
+
+## Troubleshooting test failures
+
+### Step-by-step when a test fails
+
+1. **Check the error message** — timeout errors include the last 20-30 lines of Tendril stdout and the Plans directory contents.
+2. **Check screenshots** — on failure, screenshots are saved to `%TEMP%/tendril-e2e-*.png`. Look at sidebar state, dialog state, etc.
+3. **Check promptware logs** — use `LogAssertions.GetJobLog(tendrilHome, planId)` to read the full agent execution log.
+4. **Check status files** — look in `$TENDRIL_HOME/jobs/*.status` for the last reported job status (JSON with message, planId, planTitle).
+5. **Check Tendril stdout/stderr** — accessible via `_fixture.Tendril.StdoutLines` / `StderrLines` in tests.
+
+### Common failure patterns
+
+- **"Plan not visible in sidebar"** — The plan folder exists but the UI hasn't refreshed. The test retries with reloads for 120s. If it still fails, the sidebar rendering may have changed.
+- **"plan.yaml not created"** — The coding agent failed or timed out. Check promptware logs for the agent's error output.
+- **"state: ReadyForReview not found"** — ExecutePlan didn't complete. Check if the agent errored, if verifications failed, or if the process was killed early.
+- **"PR URL not found in plan.yaml"** — CreatePR promptware failed. Check GitHub auth (`gh auth status`) and fork permissions.
+
+## Promptware CLI status reporting
+
+Promptwares report progress via `tendril job status`:
+
+```
+tendril job status $TENDRIL_JOB_ID --message "Creating plan..." --plan-id 00001 --plan-title "My Plan"
+```
+
+This writes a JSON status file to `$TENDRIL_HOME/jobs/{jobId}.status`, which is polled by JobLauncher every 1 second and forwarded to the Jobs UI.
+
+### Verifiable status fields
+
+- `message` — status text (e.g., "Reading plan...", "Verifying: DotnetBuild", "Creating PR...")
+- `planId` — plan ID being processed
+- `planTitle` — plan title being processed
+
+### How to verify promptware status in tests
+
+```csharp
+// Check that promptware logs contain expected status messages
+LogAssertions.AssertLogContains(tendrilHome, planId, "Creating plan...");
+
+// Check status file directly
+var statusPath = Path.Combine(tendrilHome, "jobs", $"{jobId}.status");
+var json = File.ReadAllText(statusPath);
+// Parse and assert message, planId, planTitle
+
+// Check captured stdout for CLI invocations
+var statusLines = fixture.Tendril.StdoutLines
+    .Where(l => l.Contains("job status"))
+    .ToList();
+```
+
+## What still needs testing
+
+### Multi-agent coverage
+
+Currently the default agent is `claude`. To verify Codex and Gemini work:
+
+```bash
+E2E__Agent=codex dotnet test --filter "FullyQualifiedName~AgentExecutionTests"
+E2E__Agent=gemini dotnet test --filter "FullyQualifiedName~AgentExecutionTests"
+```
+
+Each agent has different CLI invocation patterns and auth requirements:
+- **Claude**: `claude -p "..." --max-turns N` — needs `claude` CLI authenticated
+- **Codex**: `codex -q "..."` — needs `codex` CLI authenticated
+- **Gemini**: `gemini ...` — needs `~/.gemini/oauth_creds.json`
+
+### Promptware CLI verification
+
+We should add tests that verify promptwares properly call `tendril job status` with correct arguments:
+
+1. **Status file assertions** — after a job completes, read `$TENDRIL_HOME/jobs/{jobId}.status` and verify it contains planId and planTitle.
+2. **Log content assertions** — check promptware logs for expected status messages ("Creating plan...", "Reading plan...", "Verifying: DotnetBuild").
+3. **Stdout capture** — search `fixture.Tendril.StdoutLines` for CLI invocation traces.
+
+Consider adding a structured log in Tendril's `JobLauncher.RunStatusFilePoller()` that records every status update received, so tests can assert on the full status progression without relying on the transient status file.
+
+### Reactive wait strategy
+
+Tests use three detection mechanisms (belt-and-suspenders):
+
+1. **`PlanCreationWatcher`** / **`PlanStateWatcher`** — `FileSystemWatcher` + polling fallback. Detects plan.yaml creation or state changes. The watcher fires on filesystem events; polling at 2-3s intervals catches anything the watcher misses (Windows FSW is not 100% reliable with subdirectories).
+2. **`StdoutMonitor.WaitForJobExit()`** — watches Tendril's captured stdout for `"Process exited with code"` or `"Process killed after timeout"` log lines. Detects job completion/failure within 500ms. Also fails fast on agent errors (`"Agent binary not found"`, etc.).
+3. **Timeout** — `PlanExecutionTimeoutSeconds` (default 600s) is the outer safety net if both detection methods fail.
+
+When adding new wait conditions, prefer `PlanStateWatcher` for filesystem state and `StdoutMonitor` for process-level events. Avoid bare `Task.Delay` or fixed sleep durations.
+
+### Recommended test additions
+
+- **PromptwareStatusTests** — verify that each promptware type (CreatePlan, ExecutePlan, CreatePr) reports planId, planTitle, and meaningful status messages
+- **AgentErrorTests** — verify that agent failures (auth errors, network issues) produce clear error messages and don't leave orphaned processes
+- **RecommendationTests** — verify that Tendril's recommendation engine (if applicable) produces output after plan execution
+- **CommitVerificationTests** — after ExecutePlan, verify that the forked repo has new commits on the plan branch

--- a/src/Ivy.Tendril.Test.End2End/Configuration/E2ETestSettings.cs
+++ b/src/Ivy.Tendril.Test.End2End/Configuration/E2ETestSettings.cs
@@ -3,7 +3,7 @@ namespace Ivy.Tendril.Test.End2End.Configuration;
 public class E2ETestSettings
 {
     public string Agent { get; set; } = "claude";
-    public string TestRepo { get; set; } = "octocat/Hello-World";
+    public string TestRepo { get; set; } = "Ivy-Interactive/Ivy-Templates";
     public string TendrilProjectPath { get; set; } = "../Ivy.Tendril/Ivy.Tendril.csproj";
     public int StartupTimeoutSeconds { get; set; } = 60;
     public int PlanExecutionTimeoutSeconds { get; set; } = 600;

--- a/src/Ivy.Tendril.Test.End2End/Helpers/FileSystemAssertions.cs
+++ b/src/Ivy.Tendril.Test.End2End/Helpers/FileSystemAssertions.cs
@@ -62,7 +62,8 @@ public static class FileSystemAssertions
     {
         var folderName = Path.GetFileName(planFolderPath);
         var dashIndex = folderName.IndexOf('-');
-        return dashIndex > 0 ? folderName[..dashIndex] : folderName;
+        var raw = dashIndex > 0 ? folderName[..dashIndex] : folderName;
+        return int.TryParse(raw, out var id) ? id.ToString() : raw;
     }
 
     public static void AssertConfigContains(string tendrilHome, string expectedText)

--- a/src/Ivy.Tendril.Test.End2End/Helpers/PlanCreationWatcher.cs
+++ b/src/Ivy.Tendril.Test.End2End/Helpers/PlanCreationWatcher.cs
@@ -1,0 +1,118 @@
+namespace Ivy.Tendril.Test.End2End.Helpers;
+
+public sealed class PlanCreationWatcher : IDisposable
+{
+    private readonly string _plansDir;
+    private readonly string _titleFragment;
+    private readonly TaskCompletionSource<string> _tcs = new();
+    private FileSystemWatcher? _watcher;
+
+    public PlanCreationWatcher(string plansDir, string titleFragment)
+    {
+        _plansDir = plansDir;
+        _titleFragment = titleFragment;
+
+        try
+        {
+            _watcher = new FileSystemWatcher(plansDir)
+            {
+                Filter = "*.*",
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.FileName | NotifyFilters.LastWrite | NotifyFilters.Size,
+                EnableRaisingEvents = true,
+            };
+            _watcher.Created += OnFileEvent;
+            _watcher.Changed += OnFileEvent;
+        }
+        catch
+        {
+            _watcher = null;
+        }
+    }
+
+    public async Task<string> WaitAsync(TimeSpan timeout, IReadOnlyList<string>? stdoutLines = null)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+
+        if (TryCheckNow(out var folder))
+            return folder!;
+
+        // Race: FileSystemWatcher event vs polling fallback
+        var pollTask = PollUntilFound(cts.Token, stdoutLines);
+        var winnerTask = await Task.WhenAny(_tcs.Task, pollTask);
+        return await winnerTask;
+    }
+
+    private async Task<string> PollUntilFound(CancellationToken ct, IReadOnlyList<string>? stdoutLines)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try { await Task.Delay(TimeSpan.FromSeconds(2), ct); }
+            catch (OperationCanceledException) { break; }
+
+            if (TryCheckNow(out var folder))
+                return folder!;
+        }
+
+        throw BuildTimeoutException(stdoutLines);
+    }
+
+    private void OnFileEvent(object sender, FileSystemEventArgs e)
+    {
+        try
+        {
+            if (!e.FullPath.EndsWith("plan.yaml", StringComparison.OrdinalIgnoreCase)) return;
+            var dir = Path.GetDirectoryName(e.FullPath)!;
+            if (MatchesTitle(Path.GetFileName(dir)))
+                _tcs.TrySetResult(dir);
+        }
+        catch { }
+    }
+
+    private bool TryCheckNow(out string? folder)
+    {
+        folder = null;
+        if (!Directory.Exists(_plansDir)) return false;
+
+        foreach (var dir in Directory.GetDirectories(_plansDir))
+        {
+            if (!MatchesTitle(Path.GetFileName(dir))) continue;
+            if (File.Exists(Path.Combine(dir, "plan.yaml")))
+            {
+                folder = dir;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private bool MatchesTitle(string folderName)
+    {
+        var normalized = _titleFragment.Replace("-", "");
+        return folderName.Contains(_titleFragment, StringComparison.OrdinalIgnoreCase) ||
+               folderName.Replace("-", "").Contains(normalized, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private TimeoutException BuildTimeoutException(IReadOnlyList<string>? stdoutLines)
+    {
+        var entries = Directory.Exists(_plansDir)
+            ? string.Join(", ", Directory.GetFileSystemEntries(_plansDir).Select(Path.GetFileName))
+            : "(dir missing)";
+        var stdout = stdoutLines != null
+            ? string.Join("\n", stdoutLines.TakeLast(30))
+            : "";
+        return new TimeoutException(
+            $"Plan '{_titleFragment}' with plan.yaml not created.\n" +
+            $"Plans dir: {entries}\n" +
+            $"Tendril stdout (last 30):\n{stdout}");
+    }
+
+    public void Dispose()
+    {
+        if (_watcher != null)
+        {
+            _watcher.EnableRaisingEvents = false;
+            _watcher.Dispose();
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Helpers/PlanStateWatcher.cs
+++ b/src/Ivy.Tendril.Test.End2End/Helpers/PlanStateWatcher.cs
@@ -1,0 +1,175 @@
+namespace Ivy.Tendril.Test.End2End.Helpers;
+
+public sealed class PlanStateWatcher : IDisposable
+{
+    private readonly string _plansDir;
+    private readonly TaskCompletionSource<string> _tcs = new();
+    private FileSystemWatcher? _watcher;
+    private readonly string _titleFragment;
+    private readonly string _expectedState;
+    private static readonly HashSet<string> TerminalStates = new(StringComparer.OrdinalIgnoreCase)
+        { "Failed", "Timeout", "Skipped" };
+
+    public PlanStateWatcher(string plansDir, string titleFragment, string expectedState)
+    {
+        _plansDir = plansDir;
+        _titleFragment = titleFragment;
+        _expectedState = expectedState;
+
+        try
+        {
+            _watcher = new FileSystemWatcher(plansDir)
+            {
+                Filter = "plan.yaml",
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime | NotifyFilters.FileName | NotifyFilters.Size,
+                EnableRaisingEvents = true,
+            };
+            _watcher.Changed += OnChanged;
+            _watcher.Created += OnChanged;
+        }
+        catch
+        {
+            _watcher = null;
+        }
+    }
+
+    public async Task<string> WaitAsync(TimeSpan timeout, IReadOnlyList<string>? stdoutLines = null)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+
+        if (TryCheckNow(out var folder))
+            return folder!;
+
+        var pollTask = PollUntilFound(cts.Token, stdoutLines);
+        var winnerTask = await Task.WhenAny(_tcs.Task, pollTask);
+        return await winnerTask;
+    }
+
+    private async Task<string> PollUntilFound(CancellationToken ct, IReadOnlyList<string>? stdoutLines)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try { await Task.Delay(TimeSpan.FromSeconds(3), ct); }
+            catch (OperationCanceledException) { break; }
+
+            if (TryCheckNow(out var folder))
+                return folder!;
+        }
+
+        throw BuildTimeoutException(stdoutLines);
+    }
+
+    private void OnChanged(object sender, FileSystemEventArgs e)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(e.FullPath)!;
+            var folderName = Path.GetFileName(dir);
+            if (!MatchesTitle(folderName)) return;
+
+            var content = ReadFileWithRetry(e.FullPath);
+            if (content == null) return;
+            CheckContent(content, dir);
+        }
+        catch { }
+    }
+
+    private void CheckContent(string content, string dir)
+    {
+        if (content.Contains($"state: {_expectedState}", StringComparison.OrdinalIgnoreCase))
+        {
+            _tcs.TrySetResult(dir);
+            return;
+        }
+
+        foreach (var terminal in TerminalStates)
+        {
+            if (terminal.Equals(_expectedState, StringComparison.OrdinalIgnoreCase)) continue;
+            if (content.Contains($"state: {terminal}", StringComparison.OrdinalIgnoreCase))
+            {
+                _tcs.TrySetException(new InvalidOperationException(
+                    $"Plan reached terminal state '{terminal}' instead of expected '{_expectedState}'."));
+                return;
+            }
+        }
+    }
+
+    private bool TryCheckNow(out string? folder)
+    {
+        folder = null;
+        if (!Directory.Exists(_plansDir)) return false;
+
+        foreach (var dir in Directory.GetDirectories(_plansDir))
+        {
+            if (!MatchesTitle(Path.GetFileName(dir))) continue;
+            var yamlPath = Path.Combine(dir, "plan.yaml");
+            if (!File.Exists(yamlPath)) continue;
+
+            var content = ReadFileWithRetry(yamlPath);
+            if (content == null) continue;
+
+            if (content.Contains($"state: {_expectedState}", StringComparison.OrdinalIgnoreCase))
+            {
+                folder = dir;
+                return true;
+            }
+
+            foreach (var terminal in TerminalStates)
+            {
+                if (terminal.Equals(_expectedState, StringComparison.OrdinalIgnoreCase)) continue;
+                if (content.Contains($"state: {terminal}", StringComparison.OrdinalIgnoreCase))
+                    throw new InvalidOperationException(
+                        $"Plan reached terminal state '{terminal}' instead of expected '{_expectedState}'.");
+            }
+        }
+
+        return false;
+    }
+
+    private bool MatchesTitle(string folderName)
+    {
+        var normalized = _titleFragment.Replace("-", "");
+        return folderName.Contains(_titleFragment, StringComparison.OrdinalIgnoreCase) ||
+               folderName.Replace("-", "").Contains(normalized, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private TimeoutException BuildTimeoutException(IReadOnlyList<string>? stdoutLines)
+    {
+        var entries = Directory.Exists(_plansDir)
+            ? string.Join(", ", Directory.GetFileSystemEntries(_plansDir).Select(Path.GetFileName))
+            : "(dir missing)";
+        var stdout = stdoutLines != null
+            ? string.Join("\n", stdoutLines.TakeLast(30))
+            : "";
+        return new TimeoutException(
+            $"Plan '{_titleFragment}' did not reach state '{_expectedState}'.\n" +
+            $"Plans dir: {entries}\n" +
+            $"Tendril stdout (last 30):\n{stdout}");
+    }
+
+    private static string? ReadFileWithRetry(string path, int attempts = 3)
+    {
+        for (var i = 0; i < attempts; i++)
+        {
+            try
+            {
+                return File.ReadAllText(path);
+            }
+            catch (IOException) when (i < attempts - 1)
+            {
+                Thread.Sleep(50);
+            }
+        }
+        return null;
+    }
+
+    public void Dispose()
+    {
+        if (_watcher != null)
+        {
+            _watcher.EnableRaisingEvents = false;
+            _watcher.Dispose();
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Helpers/StdoutMonitor.cs
+++ b/src/Ivy.Tendril.Test.End2End/Helpers/StdoutMonitor.cs
@@ -1,0 +1,50 @@
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Test.End2End.Fixtures;
+
+namespace Ivy.Tendril.Test.End2End.Helpers;
+
+public static class StdoutMonitor
+{
+    private static readonly Regex JobExitPattern =
+        new(@"Process exited with code\s+(\d+)", RegexOptions.IgnoreCase);
+
+    private static readonly Regex JobKilledPattern =
+        new(@"Process killed after timeout", RegexOptions.IgnoreCase);
+
+    private static readonly Regex AgentErrorPattern =
+        new(@"(Agent binary not found|No agent program found|Failed to start process)", RegexOptions.IgnoreCase);
+
+    private static readonly Regex JobFailedPattern =
+        new(@"Monitor task completed normally|Job.*Failed|Job.*Timeout", RegexOptions.IgnoreCase);
+
+    public static async Task WaitForJobExit(
+        TendrilProcessFixture tendril,
+        TimeSpan timeout,
+        CancellationToken cancellation = default)
+    {
+        var seenCount = tendril.StdoutLines.Count;
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellation.ThrowIfCancellationRequested();
+
+            var lines = tendril.StdoutLines;
+            for (var i = seenCount; i < lines.Count; i++)
+            {
+                var line = lines[i];
+                if (JobExitPattern.IsMatch(line) || JobKilledPattern.IsMatch(line))
+                    return;
+                if (AgentErrorPattern.IsMatch(line))
+                    throw new InvalidOperationException($"Agent error detected: {line}");
+            }
+            seenCount = lines.Count;
+
+            await Task.Delay(500, cancellation);
+        }
+
+        throw new TimeoutException(
+            $"No job exit detected within {timeout.TotalSeconds}s.\n" +
+            $"Tendril stdout (last 30):\n{string.Join("\n", tendril.StdoutLines.TakeLast(30))}");
+    }
+}

--- a/src/Ivy.Tendril.Test.End2End/Tests/AgentExecutionTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/AgentExecutionTests.cs
@@ -70,18 +70,18 @@ public class AgentExecutionTests : IAsyncLifetime
         await dashboard.NavigateToDrafts();
         await Task.Delay(1000);
 
-        var planDescription = $"Create a file called {agent}-lifecycle.txt containing 'Hello from {agent}'";
+        var planDescription = "Uppercase all string literals in Program.cs";
         await plans.CreatePlan(planDescription);
 
-        await WaitForPlanWithYaml($"{agent}-lifecycle", timeout,
+        await WaitForPlanWithYaml("Uppercase", timeout,
             $"Step 1 (CreatePlan) failed: agent={agent}");
 
-        var planFolder = FileSystemAssertions.FindPlanFolder(plansDir, $"{agent}-lifecycle")!;
+        var planFolder = FileSystemAssertions.FindPlanFolder(plansDir, "Uppercase")!;
         var planId = FileSystemAssertions.GetPlanId(planFolder)!;
-        FileSystemAssertions.AssertPlanExists(plansDir, $"{agent}-lifecycle");
+        FileSystemAssertions.AssertPlanExists(plansDir, "Uppercase");
 
-        // Wait for the CreatePlan job to fully complete (Jobs badge → 0)
-        await WaitForNoActiveJobs(timeout);
+        // Wait for the CreatePlan job to finish (detect via stdout)
+        await WaitForJobExit(timeout);
 
         // --- Step 2: Execute Plan ---
         await _page!.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
@@ -95,11 +95,11 @@ public class AgentExecutionTests : IAsyncLifetime
         await Task.Delay(1000);
         await plans.ClickExecute();
 
-        await WaitForPlanState($"{agent}-lifecycle", "ReadyForReview", timeout,
+        await WaitForPlanState("Uppercase", "ReadyForReview", timeout,
             $"Step 2 (ExecutePlan) failed: plan #{planId} did not reach ReadyForReview, agent={agent}");
 
-        // Wait for the ExecutePlan job to complete
-        await WaitForNoActiveJobs(timeout);
+        // Wait for the ExecutePlan job to finish (detect via stdout)
+        await WaitForJobExit(timeout);
 
         // --- Step 3: Create PR ---
         await _page!.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
@@ -119,74 +119,56 @@ public class AgentExecutionTests : IAsyncLifetime
 
     private async Task WaitForPlanWithYaml(string titleFragment, int timeoutSeconds, string context)
     {
-        var plansDir = _fixture.Tendril.TendrilPlans;
-
-        await RetryHelper.WaitUntilAsync(
-            () =>
-            {
-                var folder = FileSystemAssertions.FindPlanFolder(plansDir, titleFragment);
-                if (folder == null) return Task.FromResult(false);
-                return Task.FromResult(File.Exists(Path.Combine(folder, "plan.yaml")));
-            },
-            TimeSpan.FromSeconds(timeoutSeconds),
-            pollInterval: TimeSpan.FromSeconds(3),
-            failureMessage: $"{context}\n" +
-                $"Plan '{titleFragment}' with plan.yaml not found within {timeoutSeconds}s.\n" +
-                $"Plans dir: {string.Join(", ", Directory.Exists(plansDir) ? Directory.GetFileSystemEntries(plansDir).Select(Path.GetFileName) : [])}\n" +
-                $"Tendril stdout (last 30):\n{string.Join("\n", _fixture.Tendril.StdoutLines.TakeLast(30))}");
+        using var watcher = new PlanCreationWatcher(_fixture.Tendril.TendrilPlans, titleFragment);
+        try
+        {
+            await watcher.WaitAsync(
+                TimeSpan.FromSeconds(timeoutSeconds),
+                _fixture.Tendril.StdoutLines);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new TimeoutException($"{context}\n{ex.Message}", ex);
+        }
     }
 
     private async Task WaitForPlanState(string titleFragment, string expectedState, int timeoutSeconds, string context)
     {
-        var plansDir = _fixture.Tendril.TendrilPlans;
-
-        await RetryHelper.WaitUntilAsync(
-            async () =>
-            {
-                var folder = FileSystemAssertions.FindPlanFolder(plansDir, titleFragment);
-                if (folder == null) return false;
-
-                var yamlPath = Path.Combine(folder, "plan.yaml");
-                if (!File.Exists(yamlPath)) return false;
-
-                var content = await File.ReadAllTextAsync(yamlPath);
-                return content.Contains($"state: {expectedState}", StringComparison.OrdinalIgnoreCase);
-            },
-            TimeSpan.FromSeconds(timeoutSeconds),
-            pollInterval: TimeSpan.FromSeconds(3),
-            failureMessage: $"{context}\n" +
-                $"Tendril stdout (last 30):\n{string.Join("\n", _fixture.Tendril.StdoutLines.TakeLast(30))}");
+        using var watcher = new PlanStateWatcher(_fixture.Tendril.TendrilPlans, titleFragment, expectedState);
+        try
+        {
+            await watcher.WaitAsync(
+                TimeSpan.FromSeconds(timeoutSeconds),
+                _fixture.Tendril.StdoutLines);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new TimeoutException($"{context}\n{ex.Message}", ex);
+        }
     }
 
     private async Task WaitForPRCreated(string planFolder, int timeoutSeconds, string context)
     {
-        await RetryHelper.WaitUntilAsync(
-            async () =>
-            {
-                var yamlPath = Path.Combine(planFolder, "plan.yaml");
-                if (!File.Exists(yamlPath)) return false;
-
-                var content = await File.ReadAllTextAsync(yamlPath);
-                return content.Contains("github.com", StringComparison.OrdinalIgnoreCase) &&
-                       content.Contains("pull", StringComparison.OrdinalIgnoreCase);
-            },
-            TimeSpan.FromSeconds(timeoutSeconds),
-            pollInterval: TimeSpan.FromSeconds(3),
-            failureMessage: $"{context}\n" +
-                $"Tendril stdout (last 30):\n{string.Join("\n", _fixture.Tendril.StdoutLines.TakeLast(30))}");
+        using var watcher = new PlanStateWatcher(
+            Path.GetDirectoryName(planFolder)!, Path.GetFileName(planFolder), "Completed");
+        try
+        {
+            // PR creation sets state to Completed and writes the PR URL
+            await watcher.WaitAsync(
+                TimeSpan.FromSeconds(timeoutSeconds),
+                _fixture.Tendril.StdoutLines);
+        }
+        catch (TimeoutException ex)
+        {
+            throw new TimeoutException($"{context}\n{ex.Message}", ex);
+        }
     }
 
-    private async Task WaitForNoActiveJobs(int timeoutSeconds)
+    private async Task WaitForJobExit(int timeoutSeconds)
     {
-        var dashboard = new DashboardPage(_page!);
-
-        await _page!.GotoAsync(_fixture.Tendril.TendrilUrl);
-        await dashboard.WaitForLoaded();
-        await dashboard.NavigateToJobs();
-        await Task.Delay(2000);
-
-        var jobs = new JobsPage(_page!);
-        await jobs.WaitForNoActiveJobs(timeoutSeconds);
+        await StdoutMonitor.WaitForJobExit(
+            _fixture.Tendril,
+            TimeSpan.FromSeconds(timeoutSeconds));
     }
 
     private async Task WaitForPlanInSidebar(string planId, string tabName)
@@ -208,15 +190,7 @@ public class AgentExecutionTests : IAsyncLifetime
                         await dashboard.NavigateToDrafts();
                     else if (tabName == "Review")
                         await dashboard.NavigateToReview();
-                    await Task.Delay(5000);
-
-                    // Take a screenshot on first and last attempts for debugging
-                    if (attempt == 1 || attempt % 5 == 0)
-                    {
-                        var screenshotPath = Path.Combine(Path.GetTempPath(),
-                            $"tendril-e2e-sidebar-{tabName}-attempt{attempt}.png");
-                        await _page!.ScreenshotAsync(new() { Path = screenshotPath, FullPage = true });
-                    }
+                    await Task.Delay(3000);
 
                     var visible = await _page!.GetByText($"#{planId}").First.IsVisibleAsync();
                     return visible;
@@ -228,7 +202,7 @@ public class AgentExecutionTests : IAsyncLifetime
                 }
             },
             TimeSpan.FromSeconds(120),
-            pollInterval: TimeSpan.FromSeconds(10),
+            pollInterval: TimeSpan.FromSeconds(5),
             failureMessage: $"Plan #{planId} not visible in {tabName} sidebar after 120s (attempts: {attempt}).\n" +
                 $"Last error: {lastError}\n" +
                 $"Plans dir: {string.Join(", ", Directory.Exists(_fixture.Tendril.TendrilPlans) ? Directory.GetDirectories(_fixture.Tendril.TendrilPlans).Select(Path.GetFileName) : [])}\n" +

--- a/src/Ivy.Tendril.Test.End2End/Tests/PlanLifecycleTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/PlanLifecycleTests.cs
@@ -60,11 +60,11 @@ public class PlanLifecycleTests : IAsyncLifetime
         await dashboard.WaitForLoaded();
         await dashboard.NavigateToDrafts();
 
-        await plans.CreatePlan("Add a README.md file with project description");
+        await plans.CreatePlan("Uppercase all string literals in Program.cs");
 
-        await WaitForPlanWithYaml("README", timeout);
+        await WaitForPlanWithYaml("Uppercase", timeout);
 
-        FileSystemAssertions.AssertPlanExists(_fixture.Tendril.TendrilPlans, "README");
+        FileSystemAssertions.AssertPlanExists(_fixture.Tendril.TendrilPlans, "Uppercase");
     }
 
     [Fact]
@@ -78,16 +78,16 @@ public class PlanLifecycleTests : IAsyncLifetime
         await dashboard.WaitForLoaded();
         await dashboard.NavigateToDrafts();
 
-        await plans.CreatePlan("First test plan for listing");
-        await WaitForPlanWithYaml("First", timeout);
+        await plans.CreatePlan("Uppercase all string literals in GlobalUsings.cs");
+        await WaitForPlanWithYaml("GlobalUsings", timeout);
 
-        var firstFolder = FileSystemAssertions.FindPlanFolder(_fixture.Tendril.TendrilPlans, "First")!;
+        var firstFolder = FileSystemAssertions.FindPlanFolder(_fixture.Tendril.TendrilPlans, "GlobalUsings")!;
         var firstId = FileSystemAssertions.GetPlanId(firstFolder)!;
 
-        await plans.CreatePlan("Second test plan for listing");
-        await WaitForPlanWithYaml("Second", timeout);
+        await plans.CreatePlan("Add XML documentation comments to Program.cs");
+        await WaitForPlanWithYaml("Documentation", timeout);
 
-        var secondFolder = FileSystemAssertions.FindPlanFolder(_fixture.Tendril.TendrilPlans, "Second")!;
+        var secondFolder = FileSystemAssertions.FindPlanFolder(_fixture.Tendril.TendrilPlans, "Documentation")!;
         var secondId = FileSystemAssertions.GetPlanId(secondFolder)!;
 
         // Reload to pick up both plans in the sidebar
@@ -102,19 +102,9 @@ public class PlanLifecycleTests : IAsyncLifetime
 
     private async Task WaitForPlanWithYaml(string titleFragment, int timeoutSeconds)
     {
-        var plansDir = _fixture.Tendril.TendrilPlans;
-
-        await RetryHelper.WaitUntilAsync(
-            () =>
-            {
-                var folder = FileSystemAssertions.FindPlanFolder(plansDir, titleFragment);
-                if (folder == null) return Task.FromResult(false);
-                return Task.FromResult(File.Exists(Path.Combine(folder, "plan.yaml")));
-            },
+        using var watcher = new PlanCreationWatcher(_fixture.Tendril.TendrilPlans, titleFragment);
+        await watcher.WaitAsync(
             TimeSpan.FromSeconds(timeoutSeconds),
-            pollInterval: TimeSpan.FromSeconds(2),
-            failureMessage: $"Plan folder containing '{titleFragment}' with plan.yaml was not created within {timeoutSeconds}s.\n" +
-                $"Plans dir contents: {string.Join(", ", Directory.Exists(plansDir) ? Directory.GetFileSystemEntries(plansDir).Select(Path.GetFileName) : [])}\n" +
-                $"Tendril stdout (last 20 lines):\n{string.Join("\n", _fixture.Tendril.StdoutLines.TakeLast(20))}");
+            _fixture.Tendril.StdoutLines);
     }
 }

--- a/src/Ivy.Tendril.Test.End2End/appsettings.e2e.json
+++ b/src/Ivy.Tendril.Test.End2End/appsettings.e2e.json
@@ -1,7 +1,7 @@
 {
   "E2E": {
     "Agent": "claude",
-    "TestRepo": "octocat/Hello-World",
+    "TestRepo": "Ivy-Interactive/Ivy-Templates",
     "TendrilProjectPath": "",
     "StartupTimeoutSeconds": 60,
     "PlanExecutionTimeoutSeconds": 600,

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Invoke-TendrilCli.ps1
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Invoke-TendrilCli.ps1
@@ -1,0 +1,12 @@
+param(
+    [Parameter(ValueFromRemainingArguments)]
+    [string[]]$Args
+)
+
+$ErrorActionPreference = "Stop"
+
+# Use dotnet run to invoke Tendril CLI
+$tendrilProject = "D:\Repos\_Ivy\Ivy-Tendril\src\Ivy.Tendril\Ivy.Tendril.csproj"
+
+& dotnet run --project $tendrilProject --no-build -- @Args
+exit $LASTEXITCODE


### PR DESCRIPTION
## Summary
- Replace polling-only waits with `FileSystemWatcher` + polling fallback (`PlanCreationWatcher`, `PlanStateWatcher`) for instant detection of plan.yaml creation and state changes
- Add `StdoutMonitor` to detect job exits via Tendril stdout regex matching
- Fail fast on terminal states (Failed/Timeout/Skipped) instead of waiting for full timeout
- Switch test repo from `octocat/Hello-World` to `Ivy-Interactive/Ivy-Templates` (real dotnet project)
- Fix `GetPlanId` zero-padding mismatch (`00001` → `1` to match sidebar display)
- Add `AGENTS.md` with comprehensive E2E test guide

## Test plan
- [x] OnboardingTests (1 test) — PASS
- [x] VerificationTests (4 tests) — PASS
- [x] PlanLifecycleTests.CreatePlan_ViaUI (1 test) — PASS (~2 min with watchers)
- [ ] AgentExecutionTests — full lifecycle depends on agent completing task successfully