### PR TITLE
Add CLI audit log for promptware invocations

### DIFF
--- a/src/Ivy.Tendril.Test.End2End/Helpers/LogAssertions.cs
+++ b/src/Ivy.Tendril.Test.End2End/Helpers/LogAssertions.cs
@@ -2,6 +2,11 @@ namespace Ivy.Tendril.Test.End2End.Helpers;
 
 public static class LogAssertions
 {
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
+    };
+
     public static void AssertNoErrors(string tendrilHome)
     {
         var logFiles = FindLogFiles(tendrilHome);
@@ -53,6 +58,63 @@ public static class LogAssertions
         Assert.NotNull(log);
         Assert.Contains(expectedText, log!, StringComparison.OrdinalIgnoreCase);
     }
+
+    // --- CLI job log (NNN-{jobType}-job.jsonl) ---
+
+    public static List<CliLogEntry> GetCliLogEntries(string planFolder, string jobType)
+    {
+        var logsDir = Path.Combine(planFolder, "logs");
+        if (!Directory.Exists(logsDir))
+            return [];
+
+        var entries = new List<CliLogEntry>();
+        foreach (var file in Directory.GetFiles(logsDir, $"*-{jobType}-job.jsonl"))
+        {
+            foreach (var line in File.ReadAllLines(file))
+            {
+                if (string.IsNullOrWhiteSpace(line)) continue;
+                try
+                {
+                    var entry = System.Text.Json.JsonSerializer.Deserialize<CliLogEntry>(line, JsonOptions);
+                    if (entry != null) entries.Add(entry);
+                }
+                catch { }
+            }
+        }
+        return entries;
+    }
+
+    public static void AssertCliLogHasEntries(string planFolder, string jobType, int minEntries = 1)
+    {
+        var entries = GetCliLogEntries(planFolder, jobType);
+        Assert.True(entries.Count >= minEntries,
+            $"Expected at least {minEntries} CLI log entries for {jobType} in {planFolder}, found {entries.Count}");
+    }
+
+    public static void AssertCliLogContainsCommand(string planFolder, string jobType, string commandFragment)
+    {
+        var entries = GetCliLogEntries(planFolder, jobType);
+        Assert.True(entries.Count > 0,
+            $"No CLI log entries found for {jobType} in {planFolder}");
+        Assert.Contains(entries, e =>
+            e.Command != null && e.Command.Contains(commandFragment, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static void AssertAllCliCallsSucceeded(string planFolder, string jobType)
+    {
+        var failures = GetCliLogEntries(planFolder, jobType)
+            .Where(e => e.ExitCode != 0)
+            .ToList();
+        Assert.True(failures.Count == 0,
+            $"CLI calls failed for {jobType}:\n" +
+            string.Join("\n", failures.Select(f => $"  [{f.ExitCode}] {f.Command}")));
+    }
+
+    public record CliLogEntry(
+        string? Timestamp,
+        string? Command,
+        int ExitCode,
+        double DurationMs);
 
     private static IEnumerable<string> FindLogFiles(string tendrilHome)
     {

--- a/src/Ivy.Tendril.Test.End2End/Tests/AgentExecutionTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/AgentExecutionTests.cs
@@ -83,6 +83,11 @@ public class AgentExecutionTests : IAsyncLifetime
         // Wait for the CreatePlan job to finish (detect via stdout)
         await WaitForJobExit(timeout);
 
+        // Verify CreatePlan CLI log
+        LogAssertions.AssertCliLogHasEntries(planFolder, "CreatePlan");
+        LogAssertions.AssertCliLogContainsCommand(planFolder, "CreatePlan", "plan");
+        LogAssertions.AssertAllCliCallsSucceeded(planFolder, "CreatePlan");
+
         // --- Step 2: Execute Plan ---
         await _page!.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
         await dashboard.WaitForLoaded();
@@ -101,6 +106,13 @@ public class AgentExecutionTests : IAsyncLifetime
         // Wait for the ExecutePlan job to finish (detect via stdout)
         await WaitForJobExit(timeout);
 
+        // Verify ExecutePlan CLI log
+        LogAssertions.AssertCliLogHasEntries(planFolder, "ExecutePlan");
+        LogAssertions.AssertCliLogContainsCommand(planFolder, "ExecutePlan", "job status");
+        LogAssertions.AssertCliLogContainsCommand(planFolder, "ExecutePlan", "--plan-id");
+        LogAssertions.AssertCliLogContainsCommand(planFolder, "ExecutePlan", "--plan-title");
+        LogAssertions.AssertAllCliCallsSucceeded(planFolder, "ExecutePlan");
+
         // --- Step 3: Create PR ---
         await _page!.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
         await dashboard.WaitForLoaded();
@@ -115,6 +127,11 @@ public class AgentExecutionTests : IAsyncLifetime
 
         await WaitForPRCreated(planFolder, timeout,
             $"Step 3 (CreatePR) failed: no PR URL in plan.yaml for #{planId}, agent={agent}");
+
+        // Verify CreatePr CLI log
+        LogAssertions.AssertCliLogHasEntries(planFolder, "CreatePr");
+        LogAssertions.AssertCliLogContainsCommand(planFolder, "CreatePr", "plan add-pr");
+        LogAssertions.AssertAllCliCallsSucceeded(planFolder, "CreatePr");
     }
 
     private async Task WaitForPlanWithYaml(string titleFragment, int timeoutSeconds, string context)

--- a/src/Ivy.Tendril/Helpers/JobStatusFile.cs
+++ b/src/Ivy.Tendril/Helpers/JobStatusFile.cs
@@ -46,5 +46,51 @@ public static class JobStatusFile
         catch { /* Best-effort */ }
     }
 
+    public static string GetJobLogPath(string statusFilePath) => statusFilePath + ".jsonl";
+
+    public static void AppendCliInvocation(string statusFilePath, string command, int exitCode, double durationMs)
+    {
+        try
+        {
+            var logPath = GetJobLogPath(statusFilePath);
+            var entry = new CliLogEntry(DateTime.UtcNow.ToString("O"), command, exitCode, durationMs);
+            var line = JsonSerializer.Serialize(entry, JsonOptions);
+            File.AppendAllText(logPath, line + "\n");
+        }
+        catch { /* Best-effort */ }
+    }
+
+    public static void MoveLogToPlanFolder(string statusFilePath, string planFolder, string jobType)
+    {
+        try
+        {
+            var logPath = GetJobLogPath(statusFilePath);
+            if (!File.Exists(logPath)) return;
+
+            var logsDir = Path.Combine(planFolder, "logs");
+            FileHelper.EnsureDirectory(logsDir);
+
+            var nextNumber = GetNextLogNumber(logsDir);
+            var dest = Path.Combine(logsDir, $"{nextNumber:D3}-{jobType}-job.jsonl");
+            File.Copy(logPath, dest, overwrite: true);
+            File.Delete(logPath);
+        }
+        catch { /* Best-effort */ }
+    }
+
+    private static int GetNextLogNumber(string logsDir)
+    {
+        var max = 0;
+        foreach (var file in Directory.GetFiles(logsDir))
+        {
+            var name = Path.GetFileNameWithoutExtension(file);
+            var dashIdx = name.IndexOf('-');
+            if (dashIdx > 0 && int.TryParse(name[..dashIdx], out var num) && num > max)
+                max = num;
+        }
+        return max + 1;
+    }
+
     public record StatusPayload(string Message, string? PlanId = null, string? PlanTitle = null);
+    public record CliLogEntry(string Timestamp, string Command, int ExitCode, double DurationMs);
 }

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -161,6 +161,16 @@ public class Program
                 firstArg == "db-reset" || firstArg == "update-promptwares" || firstArg == "job" ||
                 firstArg == "plan" || firstArg == "promptware" || firstArg == "version" || firstArg == "--version")
             {
+                var statusFile = Environment.GetEnvironmentVariable("TENDRIL_STATUS_FILE");
+                if (!string.IsNullOrEmpty(statusFile))
+                {
+                    var commandLine = string.Join(" ", filteredArgs);
+                    var sw = Stopwatch.StartNew();
+                    var exitCode = app.Run(filteredArgs);
+                    sw.Stop();
+                    JobStatusFile.AppendCliInvocation(statusFile, commandLine, exitCode, sw.Elapsed.TotalMilliseconds);
+                    return exitCode;
+                }
                 return app.Run(filteredArgs);
             }
         }

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -594,6 +594,14 @@ internal class JobCompletionHandler
         {
         }
 
+        try
+        {
+            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            if (!string.IsNullOrEmpty(job.StatusFilePath) && !string.IsNullOrEmpty(planFolder) && Directory.Exists(planFolder))
+                JobStatusFile.MoveLogToPlanFolder(job.StatusFilePath, planFolder, job.Type);
+        }
+        catch { }
+
         if (_planReaderService == null || string.IsNullOrEmpty(job.PlanFile))
             return;
 


### PR DESCRIPTION
Log every CLI call made during a promptware job to a JSONL file
(timestamp, command, exitCode, durationMs). On job completion, the
log is moved to the plan's logs/ folder as NNN-{jobType}-job.jsonl,
following the existing sequential naming convention. Each run gets
its own sequence number so retries don't overwrite previous logs.

E2E tests verify CLI entries exist, expected commands appear, and
all calls exited 0.
