### PR TITLE
[00058] Wrap prompt column in Verification Definitions table

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
@@ -36,6 +36,7 @@ public class VerificationsSetupView : ViewBase
             ))
             .ColumnWidth(t => t.Name, Size.Units(32))
             .ColumnWidth(t => t.Prompt, Size.Units(100))
+            .Multiline(t => t.Prompt)
             .ColumnWidth(t => t.Index, Size.Units(20));
 
         return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(400)))


### PR DESCRIPTION
## Summary

Added `.Multiline(t => t.Prompt)` to the TableBuilder chain in the Verification Definitions table view. This enables text wrapping in the Prompt column, allowing long verification prompts to display on multiple lines instead of being truncated.

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs` — Added multiline wrapping to Prompt column in table builder chain

## Commits

- 5a9533578baf4d7bc4b49cf56bc7bf3298f5fd5f