### PR TITLE
[00059] Replace color SelectInput with ColorInput picker in Add Project dialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -240,7 +240,7 @@ public class EditProjectDialog(
             new DialogBody(
                 Layout.Vertical().Gap(4)
                 | editName.ToTextInput("Project name...").WithField().Label("Name")
-                | editColor.ToSelectInput().WithField().Label("Color")
+                | editColor.ToColorInput().WithField().Label("Color")
                 | editContext.ToTextareaInput("Project context or prompt for AI agents (optional)...").Rows(4)
                     .WithField().Label("Context / Prompt (Optional)")
                 | (Layout.Vertical().Gap(2)


### PR DESCRIPTION
## Summary

Replaced the color field's SelectInput dropdown with a ColorInput widget in the Add/Edit Project dialog. This provides a visual color picker/swatch interface instead of plain text options, improving the user experience for color selection in the Setup > Projects dialog.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs` — line 243: changed `editColor.ToSelectInput()` to `editColor.ToColorInput()`

## Commits

- 211bfdee - [00059] Replace color SelectInput with ColorInput picker in Add Project dialog