### PR TITLE
[00061] Project Verifications Switch Inputs

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -1,3 +1,4 @@
+using Ivy.Core.Hooks;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
 
@@ -193,39 +194,45 @@ public class EditProjectDialog(
                            }
                        });
 
-        // Verifications checklist
+        // Verifications switches
         var verificationsLayout = Layout.Vertical().Gap(1);
         foreach (var vName in _allVerifications)
         {
-            var existing = editVerifications.Value.FirstOrDefault(v => v.Name == vName);
-            var isChecked = existing != null;
-            var isRequired = existing?.Required ?? false;
             var capturedName = vName;
 
+            var enabledState = new ConvertedState<List<ProjectVerificationRef>, bool>(
+                editVerifications,
+                list => list.Any(v => v.Name == capturedName),
+                enabled =>
+                {
+                    var list = new List<ProjectVerificationRef>(editVerifications.Value);
+                    if (enabled)
+                        list.Add(new ProjectVerificationRef { Name = capturedName, Required = false });
+                    else
+                        list.RemoveAll(v => v.Name == capturedName);
+                    return list;
+                }
+            );
+
+            var requiredState = new ConvertedState<List<ProjectVerificationRef>, bool>(
+                editVerifications,
+                list => list.FirstOrDefault(v => v.Name == capturedName)?.Required ?? false,
+                required =>
+                {
+                    var list = new List<ProjectVerificationRef>(editVerifications.Value);
+                    var item = list.FirstOrDefault(v => v.Name == capturedName);
+                    if (item != null) item.Required = required;
+                    return list;
+                }
+            );
+
+            var isEnabled = enabledState.Value;
+
             verificationsLayout |= Layout.Horizontal().Gap(2).AlignContent(Align.Center)
-                                   | new Button(isChecked ? "x" : " ")
-                                       .Ghost().Small().OnClick(() =>
-                                       {
-                                           var list = new List<ProjectVerificationRef>(editVerifications.Value);
-                                           if (isChecked)
-                                               list.RemoveAll(v => v.Name == capturedName);
-                                           else
-                                               list.Add(new ProjectVerificationRef
-                                               { Name = capturedName, Required = false });
-                                           editVerifications.Set(list);
-                                       })
-                                   | Text.Block(capturedName).Width(Size.Grow())
-                                   | (isChecked
-                                       ? new Button(isRequired ? "Required" : "Optional")
-                                           .Small()
-                                           .Variant(isRequired ? ButtonVariant.Primary : ButtonVariant.Outline)
-                                           .OnClick(() =>
-                                           {
-                                               var list = new List<ProjectVerificationRef>(editVerifications.Value);
-                                               var item = list.First(v => v.Name == capturedName);
-                                               item.Required = !item.Required;
-                                               editVerifications.Set(list);
-                                           })
+                                   | enabledState.ToSwitchInput(label: capturedName)
+                                   | new Spacer().Width(Size.Grow())
+                                   | (isEnabled
+                                       ? (object)requiredState.ToSwitchInput(label: "Required")
                                        : new Spacer());
         }
 


### PR DESCRIPTION
## Summary

Replaced the manual button-based verification toggle UI in EditProjectDialog with proper `BoolInput` switch widgets. Each verification now has an enabled switch (adds/removes from the list) and a conditionally-shown required switch, both powered by `ConvertedState` to derive per-verification boolean states from the shared `IState<List<ProjectVerificationRef>>`.

## Files Modified

- **src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs** — Added `using Ivy.Core.Hooks`, replaced button-based checklist (lines 196-230) with `ConvertedState` + `ToSwitchInput()` pattern

## Commits

- 414595e [00061] Replace verification button toggles with BoolInput switches