### PR TITLE
Add bash shim for tendril CLI resolution in agent processes

### DIFF
--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -420,9 +420,15 @@ internal class JobLauncher
         {
             var shimDir = Path.Combine(Path.GetTempPath(), "tendril-shim");
             FileHelper.EnsureDirectory(shimDir);
-            var shimPath = Path.Combine(shimDir, "tendril.cmd");
-            if (!File.Exists(shimPath))
-                File.WriteAllText(shimPath, $"@dotnet run --project \"{projectPath}\" --no-build -- %*\r\n");
+
+            var cmdShim = Path.Combine(shimDir, "tendril.cmd");
+            if (!File.Exists(cmdShim))
+                File.WriteAllText(cmdShim, $"@dotnet run --project \"{projectPath}\" --no-build -- %*\r\n");
+
+            var bashShim = Path.Combine(shimDir, "tendril");
+            if (!File.Exists(bashShim))
+                File.WriteAllText(bashShim, $"#!/usr/bin/env bash\ndotnet run --project \"{projectPath}\" --no-build -- \"$@\"\n");
+
             PrependToPath(psi, shimDir);
         }
     }


### PR DESCRIPTION
## Summary
- Agents (Claude CLI) run in bash/git-bash, not cmd.exe, so the existing `.cmd` shim doesn't resolve `tendril` when running from `dotnet run` debug mode
- Creates both `tendril.cmd` and `tendril` (bash) shims in the temp directory so agents can invoke `tendril` CLI regardless of shell

## Test plan
- [ ] E2E: CreatePlan → ExecutePlan → CreatePR lifecycle completes with CLI log entries
- [ ] Verify `tendril` resolves in both installed and debug (`dotnet run`) contexts