### PR TITLE
Fix CLI log move for CreatePlan and E2E test race condition

### DIFF
--- a/src/Ivy.Tendril.Test.End2End/Helpers/StdoutMonitor.cs
+++ b/src/Ivy.Tendril.Test.End2End/Helpers/StdoutMonitor.cs
@@ -20,9 +20,10 @@ public static class StdoutMonitor
     public static async Task WaitForJobExit(
         TendrilProcessFixture tendril,
         TimeSpan timeout,
+        int fromLine = -1,
         CancellationToken cancellation = default)
     {
-        var seenCount = tendril.StdoutLines.Count;
+        var seenCount = fromLine >= 0 ? fromLine : tendril.StdoutLines.Count;
         var deadline = DateTime.UtcNow + timeout;
 
         while (DateTime.UtcNow < deadline)

--- a/src/Ivy.Tendril.Test.End2End/Tests/AgentExecutionTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/AgentExecutionTests.cs
@@ -71,6 +71,7 @@ public class AgentExecutionTests : IAsyncLifetime
         await Task.Delay(1000);
 
         var planDescription = "Uppercase all string literals in Program.cs";
+        var step1StartLine = _fixture.Tendril.StdoutLines.Count;
         await plans.CreatePlan(planDescription);
 
         await WaitForPlanWithYaml("Uppercase", timeout,
@@ -81,9 +82,13 @@ public class AgentExecutionTests : IAsyncLifetime
         FileSystemAssertions.AssertPlanExists(plansDir, "Uppercase");
 
         // Wait for the CreatePlan job to finish (detect via stdout)
-        await WaitForJobExit(timeout);
+        await WaitForJobExit(timeout, step1StartLine);
 
-        // CreatePlan writes files directly — no CLI calls to verify
+        // Verify CreatePlan CLI log
+        LogAssertions.AssertCliLogHasEntries(planFolder, "CreatePlan");
+        LogAssertions.AssertCliLogContainsCommand(planFolder, "CreatePlan", "job status");
+        LogAssertions.AssertCliLogContainsCommand(planFolder, "CreatePlan", "plan create");
+        LogAssertions.AssertAllCliCallsSucceeded(planFolder, "CreatePlan");
 
         // --- Step 2: Execute Plan ---
         await _page!.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
@@ -95,13 +100,14 @@ public class AgentExecutionTests : IAsyncLifetime
 
         await plans.SelectPlanById(planId);
         await Task.Delay(1000);
+        var step2StartLine = _fixture.Tendril.StdoutLines.Count;
         await plans.ClickExecute();
 
         await WaitForPlanState("Uppercase", "ReadyForReview", timeout,
             $"Step 2 (ExecutePlan) failed: plan #{planId} did not reach ReadyForReview, agent={agent}");
 
         // Wait for the ExecutePlan job to finish (detect via stdout)
-        await WaitForJobExit(timeout);
+        await WaitForJobExit(timeout, step2StartLine);
 
         // Verify ExecutePlan CLI log
         LogAssertions.AssertCliLogHasEntries(planFolder, "ExecutePlan");
@@ -178,11 +184,12 @@ public class AgentExecutionTests : IAsyncLifetime
         }
     }
 
-    private async Task WaitForJobExit(int timeoutSeconds)
+    private async Task WaitForJobExit(int timeoutSeconds, int fromLine = -1)
     {
         await StdoutMonitor.WaitForJobExit(
             _fixture.Tendril,
-            TimeSpan.FromSeconds(timeoutSeconds));
+            TimeSpan.FromSeconds(timeoutSeconds),
+            fromLine);
     }
 
     private async Task WaitForPlanInSidebar(string planId, string tabName)

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -584,6 +584,21 @@ internal class JobCompletionHandler
             j.Args[0].Equals(planFolder, StringComparison.OrdinalIgnoreCase));
     }
 
+    private string? ResolvePlanFolder(JobItem job)
+    {
+        if (job.Type != "CreatePlan")
+            return job.Args.Length > 0 ? job.Args[0] : null;
+
+        var planId = job.ReportedPlanId ?? job.AllocatedPlanId;
+        if (string.IsNullOrEmpty(planId)) return null;
+
+        var plansDir = _planReaderService?.PlansDirectory
+                       ?? _configService?.PlanFolder;
+        if (string.IsNullOrEmpty(plansDir)) return null;
+
+        return PlanYamlHelper.FindPlanFolderById(plansDir, planId);
+    }
+
     internal void WriteJobLog(JobItem job)
     {
         try
@@ -596,9 +611,12 @@ internal class JobCompletionHandler
 
         try
         {
-            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
-            if (!string.IsNullOrEmpty(job.StatusFilePath) && !string.IsNullOrEmpty(planFolder) && Directory.Exists(planFolder))
-                JobStatusFile.MoveLogToPlanFolder(job.StatusFilePath, planFolder, job.Type);
+            if (!string.IsNullOrEmpty(job.StatusFilePath))
+            {
+                var planFolder = ResolvePlanFolder(job);
+                if (!string.IsNullOrEmpty(planFolder) && Directory.Exists(planFolder))
+                    JobStatusFile.MoveLogToPlanFolder(job.StatusFilePath, planFolder, job.Type);
+            }
         }
         catch { }
 


### PR DESCRIPTION
## Summary
- **JobCompletionHandler**: Add `ResolvePlanFolder()` to resolve the plan folder for CreatePlan jobs (where `args[0]` is the description, not a folder path). Uses `ReportedPlanId` or `AllocatedPlanId` to find the plan folder via `PlanYamlHelper.FindPlanFolderById`.
- **AgentExecutionTests**: Add CLI log assertions for CreatePlan (it does call `tendril` CLI: `job status`, `plan create`, `plan get`). Previous comment "CreatePlan writes files directly" was wrong.
- **StdoutMonitor**: Fix `WaitForJobExit` race condition — accept `fromLine` parameter so the monitor scans from before the step started, not from the current buffer position (which may already contain the exit message).

## Test plan
- [x] `dotnet build` succeeds for both projects
- [ ] E2E: Full lifecycle CreatePlan → ExecutePlan → CreatePR with CLI log assertions