### PR TITLE
Fix ResolvePlanFolder to return full path

### DIFF
--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -596,7 +596,8 @@ internal class JobCompletionHandler
                        ?? _configService?.PlanFolder;
         if (string.IsNullOrEmpty(plansDir)) return null;
 
-        return PlanYamlHelper.FindPlanFolderById(plansDir, planId);
+        var folderName = PlanYamlHelper.FindPlanFolderById(plansDir, planId);
+        return folderName != null ? Path.Combine(plansDir, folderName) : null;
     }
 
     internal void WriteJobLog(JobItem job)


### PR DESCRIPTION
## Summary
- `FindPlanFolderById` returns just the folder name (e.g., `00001-Title`) but `MoveLogToPlanFolder` needs an absolute path
- Combine `plansDir` with the folder name to produce the correct path
- This fixes CreatePlan CLI audit logs not being moved to the plan folder

## Test plan
- [ ] E2E: CreatePlan CLI log entries found in plan folder after job completion