### PR TITLE
Fix agent providers to use stdin for prompt delivery and add parity tests

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/jobs/job-005.status
+++ b/src/Ivy.Tendril.TeamIvyConfig/jobs/job-005.status
@@ -1,1 +1,0 @@
-{"message":"Validating dependencies...","planId":null,"planTitle":null}

--- a/src/Ivy.Tendril.TeamIvyConfig/jobs/job-005.status.jsonl
+++ b/src/Ivy.Tendril.TeamIvyConfig/jobs/job-005.status.jsonl
@@ -1,3 +1,0 @@
-{"timestamp":"2026-04-24T11:47:32.7646283Z","command":"plan get D:\\Plans\\03528-AddWeatherWidgetToStartPage","exitCode":0,"durationMs":130.1086}
-{"timestamp":"2026-04-24T11:47:37.5956505Z","command":"job status job-005 --message Reading plan... --plan-id 03528 --plan-title Add Weather Widget to Start Page","exitCode":0,"durationMs":80.952}
-{"timestamp":"2026-04-24T11:47:41.2645110Z","command":"job status job-005 --message Validating dependencies...","exitCode":0,"durationMs":80.8391}

--- a/src/Ivy.Tendril.Test/Agents/AgentProviderParityTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderParityTests.cs
@@ -1,0 +1,258 @@
+using System.Diagnostics;
+using Ivy.Tendril.Services.Agents;
+
+namespace Ivy.Tendril.Test.Agents;
+
+/// <summary>
+/// Verifies that all agent providers satisfy the same baseline contract
+/// so that any provider can be swapped in without breaking the job launcher.
+/// </summary>
+public class AgentProviderParityTests
+{
+    private static readonly IAgentProvider[] AllProviders =
+    [
+        new ClaudeAgentProvider(),
+        new CodexAgentProvider(),
+        new GeminiAgentProvider()
+    ];
+
+    private static AgentInvocation CreateInvocation(
+        string prompt = "Test prompt content",
+        string workDir = "/tmp/work",
+        string model = "test-model",
+        string effort = "high",
+        string sessionId = "sess-001",
+        IReadOnlyList<string>? allowedTools = null,
+        IReadOnlyList<string>? extraArgs = null) =>
+        new(prompt, workDir, model, effort, sessionId,
+            allowedTools ?? Array.Empty<string>(),
+            extraArgs ?? Array.Empty<string>());
+
+    public static IEnumerable<object[]> ProviderData =>
+        AllProviders.Select(p => new object[] { p });
+
+    // --- Process configuration ---
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_RedirectStdout(IAgentProvider provider)
+    {
+        var psi = provider.BuildProcessStart(CreateInvocation());
+        Assert.True(psi.RedirectStandardOutput, $"{provider.Name} must redirect stdout");
+    }
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_RedirectStderr(IAgentProvider provider)
+    {
+        var psi = provider.BuildProcessStart(CreateInvocation());
+        Assert.True(psi.RedirectStandardError, $"{provider.Name} must redirect stderr");
+    }
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_RedirectStdin(IAgentProvider provider)
+    {
+        var psi = provider.BuildProcessStart(CreateInvocation());
+        Assert.True(psi.RedirectStandardInput, $"{provider.Name} must redirect stdin");
+    }
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_DisableShellExecute(IAgentProvider provider)
+    {
+        var psi = provider.BuildProcessStart(CreateInvocation());
+        Assert.False(psi.UseShellExecute, $"{provider.Name} must not use shell execute");
+    }
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_CreateNoWindow(IAgentProvider provider)
+    {
+        var psi = provider.BuildProcessStart(CreateInvocation());
+        Assert.True(psi.CreateNoWindow, $"{provider.Name} must set CreateNoWindow");
+    }
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_SetUtf8Encoding(IAgentProvider provider)
+    {
+        var psi = provider.BuildProcessStart(CreateInvocation());
+        Assert.Equal(System.Text.Encoding.UTF8, psi.StandardOutputEncoding);
+        Assert.Equal(System.Text.Encoding.UTF8, psi.StandardErrorEncoding);
+    }
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void StdinProviders_SetUtf8InputEncoding(IAgentProvider provider)
+    {
+        if (!provider.UsesStdinPrompt) return;
+        var psi = provider.BuildProcessStart(CreateInvocation());
+        Assert.Equal(System.Text.Encoding.UTF8, psi.StandardInputEncoding);
+    }
+
+    // --- Working directory ---
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_SetWorkingDirectory(IAgentProvider provider)
+    {
+        var psi = provider.BuildProcessStart(CreateInvocation(workDir: "/custom/dir"));
+        Assert.Equal("/custom/dir", psi.WorkingDirectory);
+    }
+
+    // --- Environment ---
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_SetCIEnvironment(IAgentProvider provider)
+    {
+        var psi = provider.BuildProcessStart(CreateInvocation());
+        Assert.True(psi.Environment.ContainsKey("CI"), $"{provider.Name} must set CI env var");
+        Assert.Equal("true", psi.Environment["CI"]);
+    }
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_SetTermDumb(IAgentProvider provider)
+    {
+        var psi = provider.BuildProcessStart(CreateInvocation());
+        Assert.True(psi.Environment.ContainsKey("TERM"), $"{provider.Name} must set TERM env var");
+        Assert.Equal("dumb", psi.Environment["TERM"]);
+    }
+
+    // --- Model ---
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_PassModel(IAgentProvider provider)
+    {
+        var psi = provider.BuildProcessStart(CreateInvocation(model: "my-model"));
+        var args = psi.ArgumentList.ToList();
+        var idx = args.IndexOf("--model");
+        Assert.True(idx >= 0, $"{provider.Name} must pass --model");
+        Assert.Equal("my-model", args[idx + 1]);
+    }
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_OmitModelWhenEmpty(IAgentProvider provider)
+    {
+        var psi = provider.BuildProcessStart(CreateInvocation(model: ""));
+        Assert.DoesNotContain("--model", psi.ArgumentList.ToList());
+    }
+
+    // --- Extra args ---
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_IncludeExtraArgs(IAgentProvider provider)
+    {
+        var psi = provider.BuildProcessStart(CreateInvocation(extraArgs: new[] { "--custom", "value" }));
+        var args = psi.ArgumentList.ToList();
+        Assert.Contains("--custom", args);
+        Assert.Contains("value", args);
+    }
+
+    // --- Prompt delivery ---
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_HavePromptDeliveryMechanism(IAgentProvider provider)
+    {
+        var promptText = "This is the prompt content for the agent";
+        var psi = provider.BuildProcessStart(CreateInvocation(prompt: promptText));
+        var args = psi.ArgumentList.ToList();
+
+        if (provider.UsesStdinPrompt)
+        {
+            Assert.DoesNotContain(promptText, args);
+        }
+        else
+        {
+            Assert.Contains(promptText, args);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_LargePromptDoesNotExceedArgLimit(IAgentProvider provider)
+    {
+        var largePrompt = new string('x', 20_000);
+        var psi = provider.BuildProcessStart(CreateInvocation(prompt: largePrompt));
+        var args = psi.ArgumentList.ToList();
+
+        if (!provider.UsesStdinPrompt)
+        {
+            // Providers that pass prompt via args should be aware of limits.
+            // Claude and Codex use ArgumentList (not Arguments) so .NET handles
+            // quoting, but the OS limit still applies. This test documents that.
+            Assert.Contains(largePrompt, args);
+        }
+        else
+        {
+            Assert.DoesNotContain(largePrompt, args);
+        }
+    }
+
+    // --- Non-empty name ---
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_HaveNonEmptyName(IAgentProvider provider)
+    {
+        Assert.False(string.IsNullOrWhiteSpace(provider.Name));
+    }
+
+    // --- FileName set ---
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_SetFileName(IAgentProvider provider)
+    {
+        var psi = provider.BuildProcessStart(CreateInvocation());
+        Assert.False(string.IsNullOrWhiteSpace(psi.FileName), $"{provider.Name} must set FileName");
+    }
+
+    // --- ExtractResult handles empty input ---
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_ExtractResult_ReturnsNullForEmptyOutput(IAgentProvider provider)
+    {
+        var result = provider.ExtractResult(Array.Empty<string>());
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_ExtractResult_HandlesWhitespaceOnlyLines(IAgentProvider provider)
+    {
+        var lines = new List<string> { "", "  ", "\t" };
+        var result = provider.ExtractResult(lines);
+        Assert.Null(result);
+    }
+
+    // --- Writable directory passthrough ---
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_HandleWritableDirectoryTools(IAgentProvider provider)
+    {
+        var tools = new[] { "Read", "Write(/plans/**)", "Edit(/plans/01234/**)", "Bash" };
+        var psi = provider.BuildProcessStart(CreateInvocation(allowedTools: tools));
+
+        // Should not throw — all providers should gracefully handle writable tool specs
+        Assert.NotNull(psi);
+    }
+
+    // --- Factory registration ---
+
+    [Theory]
+    [MemberData(nameof(ProviderData))]
+    public void AllProviders_AreRegisteredInFactory(IAgentProvider provider)
+    {
+        var fromFactory = AgentProviderFactory.GetProvider(provider.Name);
+        Assert.Equal(provider.GetType(), fromFactory.GetType());
+    }
+}

--- a/src/Ivy.Tendril.Test/Agents/AgentProviderTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderTests.cs
@@ -165,34 +165,38 @@ public class AgentProviderTests
     }
 
     [Fact]
-    public void Codex_BuildProcessStart_IncludesFullAuto()
+    public void Codex_BuildProcessStart_UsesExecSubcommand()
     {
         var provider = new CodexAgentProvider();
         var psi = provider.BuildProcessStart(CreateInvocation());
 
-        Assert.Contains("--full-auto", psi.ArgumentList.ToList());
+        var args = psi.ArgumentList.ToList();
+        Assert.Equal("exec", args[0]);
+        Assert.Contains("--full-auto", args);
+        Assert.Contains("--json", args);
     }
 
     [Fact]
-    public void Codex_BuildProcessStart_UsesReasoningEffort()
+    public void Codex_BuildProcessStart_DoesNotIncludeEffort()
     {
         var provider = new CodexAgentProvider();
         var psi = provider.BuildProcessStart(CreateInvocation(effort: "medium"));
 
         var args = psi.ArgumentList.ToList();
-        var idx = args.IndexOf("--reasoning-effort");
-        Assert.True(idx >= 0);
-        Assert.Equal("medium", args[idx + 1]);
+        Assert.DoesNotContain("--reasoning-effort", args);
+        Assert.DoesNotContain("--effort", args);
     }
 
     [Fact]
-    public void Codex_BuildProcessStart_PromptIsLastArg()
+    public void Codex_BuildProcessStart_UsesStdinForPrompt()
     {
         var provider = new CodexAgentProvider();
         var psi = provider.BuildProcessStart(CreateInvocation("do the thing"));
 
+        Assert.True(provider.UsesStdinPrompt);
         var args = psi.ArgumentList.ToList();
-        Assert.Equal("do the thing", args[^1]);
+        Assert.Equal("-", args[^1]);
+        Assert.DoesNotContain("do the thing", args);
     }
 
     // --- Gemini Provider ---
@@ -207,12 +211,15 @@ public class AgentProviderTests
     }
 
     [Fact]
-    public void Gemini_BuildProcessStart_IncludesSandbox()
+    public void Gemini_BuildProcessStart_UsesStdinForPrompt()
     {
         var provider = new GeminiAgentProvider();
-        var psi = provider.BuildProcessStart(CreateInvocation());
+        var psi = provider.BuildProcessStart(CreateInvocation("my long prompt"));
 
-        Assert.Contains("--sandbox", psi.ArgumentList.ToList());
+        Assert.True(provider.UsesStdinPrompt);
+        var args = psi.ArgumentList.ToList();
+        Assert.Contains("--prompt", args);
+        Assert.DoesNotContain("my long prompt", args);
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Assets/models.yaml
+++ b/src/Ivy.Tendril/Assets/models.yaml
@@ -3,7 +3,7 @@
 # IMPORTANT: GetPricing() uses longest-match-first ordering to ensure
 # deterministic matching when model names contain multiple keys as substrings.
 # NOTE: Some entries below (gpt-5.4*, gpt-5.3-codex, gemini-3-flash-preview,
-# gemini-2.5-flash-lite) are fictional placeholder models used in example.config.yaml.
+# gemini-3.1-flash-lite-preview, gemini-2.5-flash-lite) are fictional placeholder models used in example.config.yaml.
 # Replace with actual model names and pricing when configuring real agents.
 models:
   # Claude — current generation
@@ -103,6 +103,11 @@ models:
     output: 12.00
     cacheWrite: 0.0
     cacheRead: 0.15
+  gemini-3.1-flash-lite-preview:
+    input: 0.15
+    output: 1.25
+    cacheWrite: 0.0
+    cacheRead: 0.015
   gemini-2.5-flash-lite:
     input: 0.15
     output: 1.25

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -171,6 +171,13 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
             return 1;
         }
 
+        if (resolution.Provider.UsesStdinPrompt && psi.RedirectStandardInput)
+        {
+            process.StandardInput.Write(prompt);
+            process.StandardInput.Flush();
+            process.StandardInput.Close();
+        }
+
         // Stream stdout to our stdout
         var outputTask = Task.Run(() =>
         {

--- a/src/Ivy.Tendril/Services/Agents/CodexAgentProvider.cs
+++ b/src/Ivy.Tendril/Services/Agents/CodexAgentProvider.cs
@@ -6,6 +6,7 @@ namespace Ivy.Tendril.Services.Agents;
 public class CodexAgentProvider : IAgentProvider
 {
     public string Name => "codex";
+    public bool UsesStdinPrompt => true;
 
     public ProcessStartInfo BuildProcessStart(AgentInvocation invocation)
     {
@@ -18,22 +19,19 @@ public class CodexAgentProvider : IAgentProvider
             RedirectStandardInput = true,
             UseShellExecute = false,
             CreateNoWindow = true,
+            StandardInputEncoding = System.Text.Encoding.UTF8,
             StandardOutputEncoding = System.Text.Encoding.UTF8,
             StandardErrorEncoding = System.Text.Encoding.UTF8
         };
 
+        psi.ArgumentList.Add("exec");
         psi.ArgumentList.Add("--full-auto");
+        psi.ArgumentList.Add("--json");
 
         if (!string.IsNullOrEmpty(invocation.Model))
         {
             psi.ArgumentList.Add("--model");
             psi.ArgumentList.Add(invocation.Model);
-        }
-
-        if (!string.IsNullOrEmpty(invocation.Effort))
-        {
-            psi.ArgumentList.Add("--reasoning-effort");
-            psi.ArgumentList.Add(invocation.Effort);
         }
 
         foreach (var dir in ExtractWritableDirs(invocation.AllowedTools))
@@ -45,7 +43,9 @@ public class CodexAgentProvider : IAgentProvider
         foreach (var arg in invocation.ExtraArgs)
             psi.ArgumentList.Add(arg);
 
-        psi.ArgumentList.Add(invocation.PromptContent);
+        // Prompt is read from stdin to avoid Windows command line length limits.
+        // "codex exec" reads from stdin when no positional prompt is given.
+        psi.ArgumentList.Add("-");
 
         psi.Environment["CI"] = "true";
         psi.Environment["TERM"] = "dumb";

--- a/src/Ivy.Tendril/Services/Agents/GeminiAgentProvider.cs
+++ b/src/Ivy.Tendril/Services/Agents/GeminiAgentProvider.cs
@@ -5,6 +5,7 @@ namespace Ivy.Tendril.Services.Agents;
 public class GeminiAgentProvider : IAgentProvider
 {
     public string Name => "gemini";
+    public bool UsesStdinPrompt => true;
 
     public ProcessStartInfo BuildProcessStart(AgentInvocation invocation)
     {
@@ -17,11 +18,11 @@ public class GeminiAgentProvider : IAgentProvider
             RedirectStandardInput = true,
             UseShellExecute = false,
             CreateNoWindow = true,
+            StandardInputEncoding = System.Text.Encoding.UTF8,
             StandardOutputEncoding = System.Text.Encoding.UTF8,
             StandardErrorEncoding = System.Text.Encoding.UTF8
         };
 
-        psi.ArgumentList.Add("--sandbox");
         psi.ArgumentList.Add("--yolo");
 
         if (!string.IsNullOrEmpty(invocation.Model))
@@ -39,7 +40,10 @@ public class GeminiAgentProvider : IAgentProvider
         foreach (var arg in invocation.ExtraArgs)
             psi.ArgumentList.Add(arg);
 
-        psi.ArgumentList.Add(invocation.PromptContent);
+        // Prompt is piped via stdin to avoid Windows command line length limits.
+        // --prompt triggers headless mode; stdin content is read first.
+        psi.ArgumentList.Add("--prompt");
+        psi.ArgumentList.Add(" ");
 
         psi.Environment["CI"] = "true";
         psi.Environment["TERM"] = "dumb";

--- a/src/Ivy.Tendril/Services/Agents/IAgentProvider.cs
+++ b/src/Ivy.Tendril/Services/Agents/IAgentProvider.cs
@@ -5,6 +5,7 @@ namespace Ivy.Tendril.Services.Agents;
 public interface IAgentProvider
 {
     string Name { get; }
+    bool UsesStdinPrompt => false;
     ProcessStartInfo BuildProcessStart(AgentInvocation invocation);
     string? ExtractResult(IReadOnlyList<string> outputLines);
 }

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -49,7 +49,7 @@ internal class JobLauncher
 
         job.SessionId = Guid.NewGuid().ToString();
 
-        var psi = TryBuildAgentProcessStart(job);
+        var (psi, stdinContent) = TryBuildAgentProcessStart(job);
 
         if (psi == null)
         {
@@ -62,6 +62,8 @@ internal class JobLauncher
             raiseStructureChanged();
             return;
         }
+
+        ResolveCommandShim(psi);
 
         var process = new Process { StartInfo = psi };
         AttachOutputHandlers(process, job, id);
@@ -79,6 +81,23 @@ internal class JobLauncher
             jobSlotSemaphore.Release();
             raiseStructureChanged();
             return;
+        }
+
+        if (psi.RedirectStandardInput)
+        {
+            try
+            {
+                if (stdinContent != null)
+                {
+                    process.StandardInput.Write(stdinContent);
+                    process.StandardInput.Flush();
+                }
+                process.StandardInput.Close();
+            }
+            catch (IOException)
+            {
+                // Process exited before stdin could be written — safe to ignore.
+            }
         }
 
         process.BeginOutputReadLine();
@@ -250,12 +269,12 @@ internal class JobLauncher
         };
     }
 
-    private ProcessStartInfo? TryBuildAgentProcessStart(JobItem job)
+    private (ProcessStartInfo? Psi, string? StdinContent) TryBuildAgentProcessStart(JobItem job)
     {
-        if (_configService == null) return null;
+        if (_configService == null) return (null, null);
 
         var programFolder = Path.Combine(_promptsRoot, job.Type);
-        if (!HasAgentDirectProgram(programFolder, job.Type)) return null;
+        if (!HasAgentDirectProgram(programFolder, job.Type)) return (null, null);
 
         var settings = _configService.Settings;
         var (values, planYaml, profileOverride) = BuildFirmwareValues(job, programFolder);
@@ -287,11 +306,13 @@ internal class JobLauncher
         var psi = resolution.Provider.BuildProcessStart(invocation);
         SetTendrilEnvironment(psi, job);
 
+        var stdinContent = resolution.Provider.UsesStdinPrompt ? prompt : null;
+
         _logger.LogInformation(
             "Job {JobId}: Agent-direct launch ({Provider}, model={Model}, effort={Effort})",
             job.Id, resolution.Provider.Name, resolution.Model, resolution.Effort);
 
-        return psi;
+        return (psi, stdinContent);
     }
 
     private static bool HasAgentDirectProgram(string programFolder, string jobType)
@@ -430,6 +451,27 @@ internal class JobLauncher
                 File.WriteAllText(bashShim, $"#!/usr/bin/env bash\ndotnet run --project \"{projectPath}\" --no-build -- \"$@\"\n");
 
             PrependToPath(psi, shimDir);
+        }
+    }
+
+    private static void ResolveCommandShim(ProcessStartInfo psi)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var fileName = psi.FileName;
+        if (Path.IsPathRooted(fileName) || Path.HasExtension(fileName)) return;
+
+        var pathDirs = (psi.Environment.TryGetValue("PATH", out var p) ? p : Environment.GetEnvironmentVariable("PATH"))
+            ?.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries) ?? [];
+
+        foreach (var dir in pathDirs)
+        {
+            var cmdPath = Path.Combine(dir, fileName + ".cmd");
+            if (File.Exists(cmdPath))
+            {
+                psi.FileName = cmdPath;
+                return;
+            }
         }
     }
 

--- a/src/Ivy.Tendril/Services/ModelPricingService.cs
+++ b/src/Ivy.Tendril/Services/ModelPricingService.cs
@@ -235,8 +235,8 @@ public class ModelPricingService : IModelPricingService
                 if (!msg.TryGetProperty("tokens", out var tokens)) continue;
 
                 var model = msg.TryGetProperty("model", out var m)
-                    ? m.GetString() ?? "gemini-2.5-flash"
-                    : "gemini-2.5-flash";
+                    ? m.GetString() ?? "gemini-3-flash-preview"
+                    : "gemini-3-flash-preview";
                 var pricing = GetPricing(model);
 
                 var inputTokens = tokens.TryGetProperty("input", out var it) ? it.GetInt32() : 0;

--- a/src/Ivy.Tendril/Services/OnboardingSetupService.cs
+++ b/src/Ivy.Tendril/Services/OnboardingSetupService.cs
@@ -77,9 +77,9 @@ public class OnboardingSetupService(IConfigService config, IServiceProvider serv
                               "  - name: deep\n" +
                               "    model: gemini-3-flash-preview\n" +
                               "  - name: balanced\n" +
-                              "    model: gemini-2.5-flash\n" +
+                              "    model: gemini-3-flash-preview\n" +
                               "  - name: quick\n" +
-                              "    model: gemini-2.5-flash-lite\n" +
+                              "    model: gemini-3-flash-preview\n" +
                               "projects: []\n" +
                               "verifications: []\n";
             await FileHelper.WriteAllTextAsync(configPath, basicConfig);

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -53,9 +53,9 @@ codingAgents:
   - name: deep
     model: gemini-3-flash-preview
   - name: balanced
-    model: gemini-2.5-flash
+    model: gemini-3-flash-preview
   - name: quick
-    model: gemini-2.5-flash-lite
+    model: gemini-3-flash-preview
 
 # Each promptware is connected to a profile (deep/balanced/quick).
 # The profile determines model and effort from the active coding agent above.


### PR DESCRIPTION
- Codex/Gemini: deliver prompts via stdin instead of CLI args to avoid
  Windows 8191-char command line limit when launched through .cmd shims
- Codex: switch to `codex exec --full-auto --json -` for non-interactive
  mode, remove unsupported --reasoning-effort flag
- Gemini: use `--prompt " "` for headless mode with stdin content,
  remove --sandbox flag, update all profiles to gemini-3-flash-preview
- Add UsesStdinPrompt interface property and UTF-8 stdin encoding
- Add ResolveCommandShim for Windows .cmd PATH resolution
- Add AgentProviderParityTests ensuring all providers satisfy the same
  baseline contract (redirects, encoding, env vars, prompt delivery)
- JobLauncher: write stdin content with IOException safety for fast exits
- PromptwareRunCommand: handle stdin prompt for CLI `run` path
