### PR TITLE
Auto-update promptwares on startup when version changes

### DIFF
--- a/src/Ivy.Tendril.Test/PromptwareDeployerTests.cs
+++ b/src/Ivy.Tendril.Test/PromptwareDeployerTests.cs
@@ -39,4 +39,12 @@ public class PromptwareDeployerTests : IDisposable
         var targetDir = Path.Combine(_tempDir, "Promptwares");
         Assert.Throws<InvalidOperationException>(() => PromptwareDeployer.Deploy(targetDir));
     }
+
+    [Fact]
+    public void NeedsUpdate_ReturnsFalse_WhenNoEmbeddedResource()
+    {
+        var targetDir = Path.Combine(_tempDir, "Promptwares");
+        Directory.CreateDirectory(targetDir);
+        Assert.False(PromptwareDeployer.NeedsUpdate(targetDir));
+    }
 }

--- a/src/Ivy.Tendril/Services/PromptwareCommands.cs
+++ b/src/Ivy.Tendril/Services/PromptwareCommands.cs
@@ -35,6 +35,12 @@ public static class PromptwareCommands
         }
 
         var target = Path.Combine(tendrilHome, "Promptwares");
+        if (!PromptwareDeployer.NeedsUpdate(target))
+        {
+            AnsiConsole.MarkupLine("[green]✓[/] Promptwares are already up to date.");
+            return 0;
+        }
+
         AnsiConsole.MarkupLine($"[bold]Updating promptwares in[/] [blue]{target}[/]...");
         PromptwareDeployer.Deploy(target);
         AnsiConsole.MarkupLine("[green]✓[/] Done.");

--- a/src/Ivy.Tendril/Services/PromptwareDeployer.cs
+++ b/src/Ivy.Tendril/Services/PromptwareDeployer.cs
@@ -10,6 +10,8 @@ internal static class PromptwareDeployer
     /// </summary>
     private const string ResourceName = "Ivy.Tendril.promptwares.zip";
 
+    private const string VersionFileName = ".version";
+
     /// <summary>
     ///     Extracts embedded promptwares.zip to targetDir, preserving existing Logs/ and Memory/ directories.
     /// </summary>
@@ -73,6 +75,9 @@ internal static class PromptwareDeployer
                 var targetFile = Path.Combine(targetDir, Path.GetFileName(sourceFile));
                 File.Copy(sourceFile, targetFile, true);
             }
+
+            // Stamp the deployed version
+            File.WriteAllText(Path.Combine(targetDir, VersionFileName), GetCurrentVersion());
         }
         finally
         {
@@ -85,9 +90,27 @@ internal static class PromptwareDeployer
         }
     }
 
+    public static bool NeedsUpdate(string targetDir)
+    {
+        if (!IsEmbeddedAvailable())
+            return false;
+
+        var versionFile = Path.Combine(targetDir, VersionFileName);
+        if (!File.Exists(versionFile))
+            return true;
+
+        var deployed = File.ReadAllText(versionFile).Trim();
+        return deployed != GetCurrentVersion();
+    }
+
     public static bool IsEmbeddedAvailable()
     {
         var assembly = typeof(PromptwareDeployer).Assembly;
         return assembly.GetManifestResourceNames().Contains(ResourceName);
+    }
+
+    private static string GetCurrentVersion()
+    {
+        return typeof(PromptwareDeployer).Assembly.GetName().Version?.ToString(3) ?? "0.0.0";
     }
 }

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -195,7 +195,18 @@ public static class TendrilServer
                 Environment.SetEnvironmentVariable("TENDRIL_URL", serverUrl);
 
             if (!configService.NeedsOnboarding)
+            {
+                // Auto-update promptwares if the running version is newer than what's deployed
+                var promptwaresDir = Path.Combine(configService.TendrilHome, "Promptwares");
+                if (PromptwareDeployer.NeedsUpdate(promptwaresDir))
+                {
+                    var logger = app.Services.GetRequiredService<ILogger<Server>>();
+                    logger.LogInformation("Promptware update detected, deploying new version");
+                    PromptwareDeployer.Deploy(promptwaresDir);
+                }
+
                 BackgroundServiceActivator.Start(app.Services);
+            }
 
             var telemetryService = app.Services.GetRequiredService<TelemetryService>();
             var appVersion = typeof(TendrilAppShell).Assembly.GetName().Version!.ToString(3);


### PR DESCRIPTION
## Summary
- Write a `.version` file to `TENDRIL_HOME/Promptwares/` after each deployment
- On startup, compare `.version` against the running assembly version and redeploy automatically if they differ
- `update-promptwares` CLI command now short-circuits when already up to date
- Added test for `NeedsUpdate` behavior

## Test plan
- [x] Build succeeds
- [x] Existing promptware deployer tests pass
- [x] New `NeedsUpdate` test passes