### PR TITLE
[00009] Fix null Commits property in plan CLI commands

### DIFF
--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -68,13 +68,14 @@ public class PlanCliCommandTests : IDisposable
 
     private string CreatePlanWithNullLists(string planId)
     {
-        var yaml = """
+        var yaml = $"""
             state: Draft
             project: Tendril
             title: Test Plan
             commits:
             prs:
             repos:
+              - {_tempDir}
             verifications:
             relatedPlans:
             dependsOn:

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -66,6 +66,30 @@ public class PlanCliCommandTests : IDisposable
         return PlanCommandHelpers.ReadPlan(folder);
     }
 
+    private string CreatePlanWithNullLists(string planId)
+    {
+        var yaml = """
+            state: Draft
+            project: Tendril
+            title: Test Plan
+            commits:
+            prs:
+            repos:
+            verifications:
+            relatedPlans:
+            dependsOn:
+            recommendations:
+            created: 2026-04-25T00:00:00Z
+            updated: 2026-04-25T00:00:00Z
+            """;
+
+        var folder = Path.Combine(_plansDir, $"{planId}-TestPlan");
+        Directory.CreateDirectory(Path.Combine(folder, "revisions"));
+        File.WriteAllText(Path.Combine(folder, "plan.yaml"), yaml);
+        File.WriteAllText(Path.Combine(folder, "revisions", "001.md"), "# Test Plan");
+        return folder;
+    }
+
     // ==================== ResolvePlanFolder ====================
 
     [Fact]
@@ -574,6 +598,21 @@ public class PlanCliCommandTests : IDisposable
 
         var result = ReadPlan("20064");
         Assert.Single(result.Commits);
+    }
+
+    [Fact]
+    public void PlanAddCommit_WithNullCommitsList_Succeeds()
+    {
+        var folder = CreatePlanWithNullLists("20099");
+
+        var plan = PlanCommandHelpers.ReadPlan(folder);
+        plan.Commits.Add("abc1234");
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(folder, plan);
+
+        var result = ReadPlan("20099");
+        Assert.Single(result.Commits);
+        Assert.Contains("abc1234", result.Commits);
     }
 
     // ==================== PlanSetVerification ====================

--- a/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
@@ -86,6 +86,16 @@ public static class PlanCommandHelpers
         if (plan == null)
             throw new InvalidOperationException($"Failed to deserialize plan.yaml at {yamlPath}");
 
+        // Initialize null list properties to empty lists
+        // This handles cases where YAML has "commits:" with no items or "commits: null"
+        plan.Commits ??= new();
+        plan.Prs ??= new();
+        plan.Repos ??= new();
+        plan.Verifications ??= new();
+        plan.RelatedPlans ??= new();
+        plan.DependsOn ??= new();
+        plan.Recommendations ??= new();
+
         return plan;
     }
 


### PR DESCRIPTION
# Summary

## Changes

Fixed NullReferenceException in plan CLI commands by initializing all list properties to empty lists when they are null after YAML deserialization. Added test coverage to verify commands handle plans with null list properties.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs` - Added null-coalescing initialization for all list properties in `ReadPlan` method
- `src/Ivy.Tendril.Test/PlanCliCommandTests.cs` - Added helper method `CreatePlanWithNullLists` and test case `PlanAddCommit_WithNullCommitsList_Succeeds`

## Commits

- dd61069 [00009] Fix null Commits property in plan CLI commands