### PR TITLE
Make shipped promptwares fully generic and add AGENTS.md authoring guidelines

### DIFF
--- a/src/Ivy.Tendril/Promptwares/.gitignore
+++ b/src/Ivy.Tendril/Promptwares/.gitignore
@@ -9,3 +9,4 @@
 **/*.md
 !**/Program.md
 !.shared/*.md
+!AGENTS.md

--- a/src/Ivy.Tendril/Promptwares/AGENTS.md
+++ b/src/Ivy.Tendril/Promptwares/AGENTS.md
@@ -1,0 +1,13 @@
+# Promptwares Authoring Guidelines
+
+Shipped promptwares are used by all Tendril customers across different teams, tech stacks, operating systems, and AI agents. Every Program.md must work for everyone out of the box.
+
+## Rules
+
+- **Stack-agnostic.** Never assume a specific language, framework, or package manager. Use config.yaml verifications and project context instead of hard-coded commands. When examples are needed, show multiple stacks as comments (e.g. `.NET`, `JavaScript`, `Python`, `Go`).
+- **Platform-agnostic.** No Windows-only or Unix-only commands, paths, or assumptions. Write shell examples in portable bash. Say "local filesystem path" not "Windows path". Do not reference platform-specific tools (`subst`, `powershell.exe`, etc.).
+- **Agent-agnostic.** Do not reference any specific AI coding agent, its tools, or its capabilities (e.g. "Edit tool", "Grep tool", "Read tool"). Use generic verbs: "edit the file", "search for", "read the file".
+- **Project-agnostic.** No references to internal projects, private packages, internal URLs, proprietary class names, or customer-specific infrastructure. Examples should use generic names (`my-project`, `auth_service`, `user_controller`).
+- **Tool references.** Refer to shipped tools by name without file extension: `Tools/Apply-SyncStrategy`, not `Tools/Apply-SyncStrategy.ps1`. The runtime resolves the correct script format.
+- **Config over convention.** Anything that varies between customers belongs in config.yaml or the firmware header, not in Program.md. If you find yourself writing "if using X, do Y" for a customer-specific X, it should be a config option instead.
+- **Keep it concise.** The limiting factor is a human reading the plan. Every sentence must earn its place.

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -2,7 +2,7 @@
 
 **Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined in `config.yaml` under `verifications`. Examples in this document use multiple tech stacks for illustration.
 
-**🚫 FORBIDDEN: Do NOT modify, create, or delete any source code files (.cs, .ts, .ps1, etc.). Do NOT implement the plan. You are a PLANNER, not an executor. Your ONLY output is plan files (plan.yaml, revisions/*.md) inside PlansDirectory. If you catch yourself writing code to a repo, STOP IMMEDIATELY.**
+**🚫 FORBIDDEN: Do NOT modify, create, or delete any source code files. Do NOT implement the plan. You are a PLANNER, not an executor. Your ONLY output is plan files (plan.yaml, revisions/*.md) inside PlansDirectory. If you catch yourself writing code to a repo, STOP IMMEDIATELY.**
 
 Create an implementation plan for a task described in args.
 
@@ -73,7 +73,7 @@ The plan ID is pre-allocated by the launcher script and provided in the firmware
 
   - **Verify the fix commit exists on main**: Read the existing plan's `commits` list and run `git log --oneline <hash>` to confirm the commit is on the main branch. If the commit is not on main, do NOT trash — create the plan.
   - **Check commit date vs observation time**: If the inbox item describes an issue observed at a specific time, compare against the fix commit date (`git log -1 --format=%ci <hash>`). If the observation is **after** the fix was committed, the fix may not have worked — create the plan instead of trashing.
-  - **Verify in code**: For code fixes, use `Tools/Validate-CodeAssertion.ps1` or grep the actual source to confirm the fix is still present.
+  - **Verify in code**: For code fixes, grep the actual source to confirm the fix is still present.
 
   #### Step 4: Regression detection (for Completed plans)
 
@@ -113,7 +113,7 @@ The plan ID is pre-allocated by the launcher script and provided in the firmware
 
   The Trash directory is at `$env:TENDRIL_HOME/Trash`.
 
-  **Note:** When writing trash files, use `-Force` with `Set-Content` or `Out-File` to ensure synchronous writes, as the parent process checks for the file immediately after exit.
+  **Note:** When writing trash files, ensure the write is flushed/synchronous, as the parent process checks for the file immediately after exit.
 
 - Read relevant source files to understand the codebase areas involved
 - **Search GitHub issues** before creating plans to avoid duplicates or workaround plans for features already being built. Example:
@@ -134,7 +134,7 @@ Before creating the plan, scan the task description (args) for code state assert
 
 For each assertion found:
 1. Extract the referenced file path and optional line range
-2. Use `Tools/Validate-CodeAssertion.ps1` to check if the described code actually exists
+2. Use `Tools/Validate-CodeAssertion` to check if the described code actually exists
 3. If validation fails, investigate:
    - Check `git log --oneline -10 --all -- <file>` for recent changes
    - Check `git blame <file>` to find who/when the code changed
@@ -202,8 +202,8 @@ tendril plan add-depends-on <PlanId> "<folder-name>"
 - This prevents creating plans targeting non-existent repo paths
 
 **Rename/refactor plans (caller enumeration)**: When creating plans that rename functions, change method signatures, extract interfaces, or otherwise require updating callers:
-1. Use `Grep` to search the **entire repo root** (not just the expected directory) for all usage patterns of the symbol being changed
-2. For interface extractions, also search DI-specific patterns: `UseService<ConcreteType>()`, constructor parameter injection, field/property declarations
+1. Search the **entire repo root** (not just the expected directory) for all usage patterns of the symbol being changed
+2. For interface extractions, also search for dependency injection patterns specific to the project's stack (e.g. constructor injection, service registration)
 3. List EVERY caller with file path and line number in the plan revision
 4. Validate count: grep results must match documented callers
 5. Incomplete caller lists cause follow-up fixes during execution (see Memory/caller-audit-pattern.md)
@@ -220,8 +220,8 @@ The `dependsOn` field in plan.yaml declares **true blocking dependencies** betwe
    - Without `dependsOn`, Plan B will fail to compile (symbol doesn't exist yet)
 
 2. **Building on new infrastructure**
-   - Plan A adds a new `IAuthService` interface and implementation
-   - Plan B creates a new feature that depends on `IAuthService`
+   - Plan A adds a new `AuthService` interface and implementation
+   - Plan B creates a new feature that depends on `AuthService`
    - Without `dependsOn`, Plan B references non-existent types
 
 3. **Database schema migrations with data dependencies**
@@ -231,26 +231,26 @@ The `dependsOn` field in plan.yaml declares **true blocking dependencies** betwe
 
 4. **Semantic conflicts (same change, different approaches)**
    - Plan A implements error handling using exceptions
-   - Plan B implements error handling using Result<T> pattern
-   - Both modify the same method signature incompatibly
+   - Plan B implements error handling using a result type pattern
+   - Both modify the same function signature incompatibly
    - Without `dependsOn`, merge conflict is guaranteed but semantically broken
 
 **Do NOT use `dependsOn` when:**
 
 1. **Plans modify different files in same repository**
-   - Plan A: changes `Services/AuthService.cs`
-   - Plan B: changes `Controllers/UserController.cs`
+   - Plan A: changes `services/auth_service`
+   - Plan B: changes `controllers/user_controller`
    - Git handles these independently — no conflict
 
 2. **Plans modify different parts of same file**
-   - Plan A: adds method `GetUserById()` to `UserService.cs`
-   - Plan B: adds method `CreateUser()` to `UserService.cs`
+   - Plan A: adds function `getUserById()` to `user_service`
+   - Plan B: adds function `createUser()` to `user_service`
    - Git auto-merges these changes (different line ranges)
 
 3. **Plans share common ancestor but diverge**
-   - Plan A: adds logging to `ProcessOrder()`
-   - Plan B: adds metrics to `ProcessOrder()`
-   - Both touch same method, but git 3-way merge handles this correctly
+   - Plan A: adds logging to `processOrder()`
+   - Plan B: adds metrics to `processOrder()`
+   - Both touch same function, but git 3-way merge handles this correctly
 
 4. **Hypothetical conflicts (might overlap)**
    - Plan A: "refactor authentication flow"
@@ -286,13 +286,13 @@ When in doubt, **don't use `dependsOn`** — git will surface real conflicts dur
 
 Analyze the task complexity and choose an `executionProfile`. This is passed via `--execution-profile` on `tendril plan create` (see Step 4.2).
 
-**Use `deep` (opus/max effort) when:**
+**Use `deep` (max effort) when:**
 - Plan involves complex cross-cutting changes affecting 10+ files
 - Plan requires architectural decisions or complex refactoring
 - Plan involves new features with significant integration points
 - Plan description mentions "architecture", "refactor", "redesign", "complex"
 
-**Use `balanced` (sonnet/high effort) for everything else:**
+**Use `balanced` (standard effort) for everything else:**
 - Most bug fixes
 - Most new features (unless architectural)
 - Most refactoring (unless cross-cutting)
@@ -315,12 +315,7 @@ The `## Tests` section MUST include two parts:
    To determine scope:
    - Identify the modules/classes being modified
    - Search for existing test classes that cover those areas
-   - **Filters MUST target specific test classes, not broad namespaces/directories.** 
-     Examples:
-     - .NET: `dotnet test --filter "FullyQualifiedName~MyApp.Tests.CommandParserTests"`
-     - JavaScript: `jest --testPathPattern=CommandParser.test.ts`
-     - Python: `pytest tests/test_command_parser.py`
-     - Go: `go test ./pkg/parser/...`
+   - **Filters MUST target specific test classes, not broad namespaces/directories.** Use the project's test runner syntax from config.yaml verifications.
    - **Exclude E2E/integration test classes** unless the plan specifically changes E2E-level behavior. E2E tests are environment-dependent and should only run when explicitly needed.
    - If no existing tests cover the changed code, state: "No existing test coverage for this area."
    - If the change is so broad that all tests are genuinely needed, explicitly state: "Run all tests (broad cross-cutting change)." and justify why.
@@ -357,7 +352,7 @@ The user can edit the checklist before execution — unchecking a required verif
 - **!CRITICAL: Every CreatePlan execution MUST produce at least one plan folder. Even if the task is an analysis, review, or investigation — always create a plan with actionable steps. Never just analyze and report back without a plan.**
 - The plan must include all paths and information for an LLM coding agent to execute end-to-end without human intervention
 - **!IMPORTANT: Validate all file paths before writing `file:///` links in plans.** Use glob/search to confirm the actual path exists. Do NOT guess paths based on naming conventions — hallucinated paths cause "File not found" errors in the UI.
-- When referencing local files, use markdown links: `[FileName.cs:line](file:///path/to/FileName.cs)` for source files with line numbers, or `[FileName.cs](file:///path/to/FileName.cs)` without. Never use backticks in link text or `#L123` fragments in URLs. Use `![alt](path)` for images.
+- When referencing local files, use markdown links: `[filename:line](file:///path/to/filename)` for source files with line numbers, or `[filename](file:///path/to/filename)` without. Never use backticks in link text or `#L123` fragments in URLs. Use `![alt](path)` for images.
 - Keep the plan short and concise - the limiting factor of this system is a human that will have to read this.
 - **!IMPORTANT: ONE issue per plan file — if multiple issues, create multiple plan files with separate IDs**
 - **Multiple plans from one execution:** When args contain multiple issues, use the pre-allocated PlanId for the first plan. For additional plans, read `.counter`, use sequential IDs starting from it, and update `.counter` to the next available value after all plans are created.

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -64,15 +64,11 @@ For each worktree:
 
 ### 2.5. Upload Artifacts
 
-**If custom options exist and `includeArtifacts` is `false`, skip this step entirely** (set `$artifactMarkdown` to empty).
+**If custom options exist and `includeArtifacts` is `false`, skip this step entirely** (set artifact markdown to empty).
 
-Otherwise, run the `Upload-Artifacts.ps1` tool to upload screenshots and videos from `<PlanFolder>/artifacts/` to Azure storage:
+Otherwise, if an artifact upload tool is available in `Tools/`, run it to upload screenshots and videos from `<PlanFolder>/artifacts/` to persistent storage.
 
-```powershell
-$artifactMarkdown = pwsh -NoProfile -File Promptwares/CreatePr/Tools/Upload-Artifacts.ps1 -PlanFolder <PlanFolder>
-```
-
-Capture the returned markdown. If non-empty, it will be appended to the PR body under an `## Artifacts` heading in the next step.
+Capture the returned markdown. If non-empty, it will be appended to the PR body under an `## Artifacts` heading in the next step. If no upload tool is available, skip this step.
 
 ### 3. Create PR
 
@@ -147,7 +143,7 @@ When the PR status is `CONFLICTING`, resolve the conflict locally before retryin
    git merge origin/<default-branch>
    ```
 
-4. **Resolve conflicts**: Read each conflicted file (`git diff --name-only --diff-filter=U`), understand both sides, and resolve using the Edit tool. Prioritize:
+4. **Resolve conflicts**: Read each conflicted file (`git diff --name-only --diff-filter=U`), understand both sides, and edit to resolve. Prioritize:
    - Keep the plan's intentional changes
    - Accept base branch changes for unrelated code
    - When both sides changed the same lines, merge intelligently based on the plan's intent
@@ -161,10 +157,6 @@ When the PR status is `CONFLICTING`, resolve the conflict locally before retryin
 6. **Quick build check** (if build-critical files were involved in conflicts):
    ```bash
    # Run your project's build command from config.yaml verifications
-   # Examples:
-   # - .NET: dotnet build --warnaserror
-   # - JavaScript: npm run build
-   # - Go: go build ./...
    ```
    If the build fails, fix the issue and amend the merge commit.
 
@@ -213,7 +205,7 @@ rm -rf "<PlanFolder>/worktrees"
 
 **Skip cleanup** for repos using the `default` PR rule (or custom options with `merge: false`) — the worktree is still needed for potential review revisions.
 
-If cleanup fails (e.g. locked files on Windows), log a warning but do not fail the overall CreatePr execution.
+If cleanup fails (e.g. locked files), log a warning but do not fail the overall CreatePr execution.
 
 ### 6. Update Plan via CLI
 
@@ -247,4 +239,4 @@ Some plans create new repos and push directly to main (e.g., repo scaffolding). 
 - One PR per repo worktree that has commits
 - Skip worktrees with no commits ahead of the base branch
 - Use `gh` CLI for all GitHub operations
-- NEVER embed images via GitHub branch URLs (`github.com/blob/<branch>/...`) — these 404 after branch deletion. All screenshots/images in PR bodies must use storage URLs from Upload-Artifacts.ps1.
+- NEVER embed images via GitHub branch URLs (`github.com/blob/<branch>/...`) — these 404 after branch deletion. All screenshots/images in PR bodies must use persistent storage URLs (from the artifact upload tool, if available).

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -103,7 +103,7 @@ After reading the plan revision, scan it for code validation markers to detect s
 1. **Extract validation blocks** — Parse the plan revision for sections containing:
    - Headers matching `**Current implementation**`, `**Current implementation in <file>**`, or `**Old implementation**`
    - Fenced code blocks (` ```language ... ``` `) immediately following these headers
-   - Associated file paths (markdown links with `file:///` or inline text like `Utils.ps1:217`)
+   - Associated file paths (markdown links with `file:///` or inline text like `helpers.py:217`)
 
 2. **Validate code exists** — For each validation block found:
    - Extract the file path from the context (header text or preceding paragraph)
@@ -211,7 +211,7 @@ fi
 - Auto-committing and pushing ensures all local work is preserved and visible to worktrees
 - The `WIP:` prefix makes auto-commits easily identifiable for later cleanup (squash/amend)
 - **Revert detection with auto-resolve:** Before committing, each dirty tracked file — whether unstaged (`git diff --name-only HEAD`) or staged (`git diff --cached --name-only`) — is checked against the last 5 commits. If the working tree version matches the file's state *before* a recent commit (i.e., it's stale), the file is automatically restored to its HEAD version via `git checkout HEAD -- <file>`. This prevents silent reverts while keeping the process fully autonomous. Any remaining non-stale dirty files are committed normally.
-- **Backup file exclusion:** After staging all changes with `git add -A`, the command `git reset -- '*.bak_*'` explicitly unstages any files matching the backup pattern. This prevents temporary backup files (created by FileHelper.ReadAllText's defensive copy mechanism in plan 03055) from being committed to version control. Backup files serve only as local recovery points and should not pollute the repository history.
+- **Backup file exclusion:** After staging all changes with `git add -A`, the command `git reset -- '*.bak_*'` explicitly unstages any files matching the backup pattern. This prevents temporary backup files (created by prior plan executions as local recovery points) from being committed to version control. Backup files serve only as local recovery points and should not pollute the repository history.
 
 **Note:** This step runs in the original repo directories, before worktree creation.
 
@@ -264,12 +264,12 @@ git worktree add "<PlanFolder>/worktrees/<RepoName>" -b "tendril/<PlanId>-<SafeT
 **Note on `RepoConfigs`:** The firmware header may include a `RepoConfigs` value injected by Tendril. It contains per-repo configuration from `config.yaml`:
 ```yaml
 RepoConfigs: |
-  - path: D:\Repos\Ivy-Tendril
-    baseBranch: development
+  - path: /home/user/repos/my-project
+    baseBranch: main
     syncStrategy: fetch
     prRule: yolo
-  - path: D:\Repos\Ivy-Framework
-    baseBranch: development
+  - path: /home/user/repos/shared-lib
+    baseBranch: main
     syncStrategy: fetch
     prRule: default
     readOnly: true
@@ -298,10 +298,8 @@ This ensures ExecutePlan fails immediately if worktree creation is incomplete, r
    BASE_BRANCH="<resolved-base-branch>"
    WORKTREE_PATH="<PlanFolder>/worktrees/<repo-folder-name>"
 
-   pwsh -NoProfile -File "$env:TENDRIL_HOME/Promptwares/ExecutePlan/Tools/Apply-SyncStrategy.ps1" \
-     -WorktreePath "$WORKTREE_PATH" \
-     -SyncStrategy "$SYNC_STRATEGY" \
-     -BaseBranch "$BASE_BRANCH"
+   # Invoke the Apply-SyncStrategy tool
+   Tools/Apply-SyncStrategy -WorktreePath "$WORKTREE_PATH" -SyncStrategy "$SYNC_STRATEGY" -BaseBranch "$BASE_BRANCH"
    ```
 
    This tool applies the configured sync strategy (fetch/rebase/merge) to keep the worktree branch synchronized with the base branch. It handles errors and logs each step.
@@ -311,75 +309,48 @@ This ensures ExecutePlan fails immediately if worktree creation is incomplete, r
    **Note:** For `syncStrategy: "rebase"` or `syncStrategy: "merge"`, this operation should also be performed before making commits during plan execution to keep the branch up-to-date with upstream changes. Use the same tool with the same parameters.
 
    **Error handling:**
-   - If `Apply-SyncStrategy.ps1` fails (non-zero exit code), the entire ExecutePlan run should fail
+   - If `Apply-SyncStrategy` fails (non-zero exit code), the entire ExecutePlan run should fail
    - Common failure scenarios:
      - `git fetch` fails → network issue or invalid remote
      - `git rebase` fails → conflicting changes between worktree base and origin
      - `git merge` fails → conflicting changes or uncommitted files
    - On failure, log the error and exit. Do NOT attempt to continue with an out-of-sync worktree.
 
-### 2.5. Setup Frontend Dependencies (JavaScript/TypeScript Projects Only)
+### 2.5. Setup Build Dependencies in Worktrees
 
-**Note:** This section applies only to projects using npm/pnpm. Skip if not applicable.
+**Note:** This section applies only when the project has build-time dependencies (e.g. frontend packages, generated code, pre-built artifacts) that need special handling in worktrees. Skip if not applicable.
 
-**!CRITICAL: Frontend builds in worktrees have known issues with npm package module resolution that cause 15-25 minute timeouts. Follow this workaround to avoid them.**
+Worktrees start with a clean checkout and may be missing build artifacts (e.g. `dist/`, `node_modules/`, generated files) that exist in the original repo. Determine whether the plan modifies these areas:
 
-Frontend directories are detected by the presence of `package.json` files in the repo. Find them by scanning the worktree:
+#### Default Path (No Changes to Build-Dependent Code)
 
-```bash
-find "<worktree-path>" -name "package.json" -not -path "*/node_modules/*" -exec dirname {} \;
-```
+If the plan does **NOT** modify code in directories with build artifacts:
 
-#### Cleanup Leftover Files
-
-Before setting up frontend dependencies, clean up any `.npmrc` files left from previous crashed runs:
+1. **Copy pre-built artifacts** from the original repo into the worktree to avoid unnecessary rebuilds:
 
 ```bash
-pwsh -NoProfile -File "$env:TENDRIL_HOME/Promptwares/ExecutePlan/Tools/Cleanup-WorktreeFrontend.ps1" -WorktreeRoot "<PlanFolder>/worktrees"
-```
-
-This removes temporary `.npmrc` files with auth tokens while preserving tracked files.
-
-#### Default Path (Most Plans)
-
-If the plan does **NOT** modify frontend code (`.tsx`, `.ts`, `.css` files in frontend directories):
-
-1. **Copy pre-built artifacts** from the original repo into each worktree. For each frontend directory that has a `dist/` folder in the original repo, copy it to the corresponding worktree path:
-
-```bash
-# For each frontend dir with dist/ in the original repo, copy to worktree
-for dist_dir in $(find "<original-repo-path>" -name "dist" -path "*/frontend/dist" -type d); do
-  relative_path="${dist_dir#<original-repo-path>/}"
+# Example: copy dist/ directories from original repo to worktree
+for artifact_dir in $(find "<original-repo-path>" -name "dist" -type d -not -path "*/node_modules/*"); do
+  relative_path="${artifact_dir#<original-repo-path>/}"
   parent_dir=$(dirname "$relative_path")
   mkdir -p "<worktree-path>/$parent_dir"
-  cp -r "$dist_dir" "<worktree-path>/$parent_dir/"
+  cp -r "$artifact_dir" "<worktree-path>/$parent_dir/"
 done
 ```
 
-2. **Create `.npmrc`** in each frontend directory preemptively (in case builds need to load frontend resources):
+2. **Skip dependency installation** — the copied artifacts are sufficient for build and tests.
 
-```bash
-for frontend_dir in $(find "<worktree-path>" -name "package.json" -not -path "*/node_modules/*" -exec dirname {} \;); do
-  echo "node-linker=hoisted" > "$frontend_dir/.npmrc"
-done
-```
+#### Exception Path (Build-Dependent Code Changes)
 
-3. **Skip `pnpm install`** entirely — the copied artifacts are sufficient for build and tests.
+If the plan **modifies** build-dependent code, you MUST rebuild:
 
-#### Exception Path (Frontend Code Changes)
-
-If the plan **modifies frontend code** (adding/editing `.tsx`, `.ts`, `.css` files), you MUST rebuild:
-
-1. **Create `.npmrc`** with `node-linker=hoisted` in each frontend directory (required for pnpm in worktrees)
-2. **Run `pnpm install`** in each frontend directory that has a `package.json`
-3. **Run `pnpm run build`** to regenerate `dist/`
-4. Be prepared for resolution failures — if `pnpm install` fails after 2 attempts, document the failure and recommend the user manually fix the lockfile
-
-**Note:** The `Setup-WorktreeFrontend.ps1` tool can automate authentication and `.npmrc` creation, but by default it also runs `pnpm install`. Only use it for the Exception Path when you need a full rebuild.
+1. **Install dependencies** using the project's package manager
+2. **Run the build** to regenerate artifacts
+3. If dependency installation fails after 2 attempts, document the failure and fail the plan
 
 ### 3. Handle Cross-Repo References
 
-Projects may reference other repos via absolute paths in project files (e.g. `.csproj`, `go.mod`, `package.json`).
+Projects may reference other repos via absolute paths in project files (e.g. build files, module manifests, package configs).
 
 These paths point to the original repos, not the worktree copies. Since we only modify files in the worktree, this is usually fine — the build references the original (stable) code.
 
@@ -468,8 +439,8 @@ tendril plan add-commit <plan-id> def5678
 Set verification statuses from the plan revision. Set checked items (`- [x]`) to `Pending` and unchecked items (`- [ ]`) to `Skipped`:
 
 ```bash
-tendril plan set-verification <plan-id> DotnetBuild Pending
-tendril plan set-verification <plan-id> DotnetTest Skipped
+tendril plan set-verification <plan-id> Build Pending
+tendril plan set-verification <plan-id> Test Skipped
 ```
 
 If the plan references other plans (e.g. split-from, follow-up), add them via CLI.
@@ -485,7 +456,7 @@ For each checked verification:
 1. Send a status message: `tendril job status $env:TENDRIL_JOB_ID --message "Verifying: <Name>"`
 2. Look up its `prompt` in the `verifications` list in `config.yaml`
 3. Execute the prompt in the worktree directory
-4. If it fails: diagnose, fix the issue, **commit the fix** (e.g. `[01105] Fix lint errors from DotnetBuild`), and re-run. Repeat until it passes (fail the plan after 3+ failed attempts).
+4. If it fails: diagnose, fix the issue, **commit the fix** (e.g. `[01105] Fix lint errors from Build`), and re-run. Repeat until it passes (fail the plan after 3+ failed attempts).
 5. Document all fix commits via CLI: `tendril plan add-commit <plan-id> <sha>`
 6. Update the verification status via CLI: `tendril plan set-verification <plan-id> <Name> Pass` (or `Fail`)
 
@@ -551,15 +522,9 @@ Do NOT include items that are part of the current plan's scope. Do NOT include r
 
 After all verifications pass:
 
-1. Kill any remaining sample processes from the plan's artifacts directory:
-   ```bash
-   powershell.exe -NoProfile -Command "\$planFolder = '<PlanFolder>'.Replace('\\', '\\\\'); Get-Process -ErrorAction SilentlyContinue | Where-Object { \$_.Path -and \$_.Path -match [regex]::Escape(\$planFolder) -and \$_.Path -match '\\\\artifacts\\\\sample\\\\bin\\\\' } | ForEach-Object { Write-Host \"Killing zombie process: \$(\$_.ProcessName) (PID \$(\$_.Id))\"; \$_ | Stop-Process -Force -ErrorAction SilentlyContinue }"
-   ```
+1. Kill any remaining processes spawned during plan execution (e.g. dev servers, sample apps). Find processes whose working directory or binary path is under the plan folder's artifacts directory and terminate them.
 
-2. Clean up temporary `.npmrc` files created in Step 2.5:
-   ```bash
-   pwsh -NoProfile -File "$env:TENDRIL_HOME/Promptwares/ExecutePlan/Tools/Cleanup-WorktreeFrontend.ps1" -WorktreeRoot "<PlanFolder>/worktrees"
-   ```
+2. Clean up any temporary files created in Step 2.5 (e.g. generated config files, auth tokens).
 
 3. Run `git status` in every worktree. If there are any uncommitted files (from verification fixes, generated files, etc.), commit or discard them. The worktrees must be completely clean before finishing.
 
@@ -594,7 +559,7 @@ You are running in non-interactive mode and CANNOT ask questions. If you are uns
 - Follow the plan instructions exactly as written
 - Do NOT skip tests or pre-commit formatting
 - Commit messages must reference the plan ID
-- All `file:///` paths in plans should be converted to Windows paths when needed
+- Convert `file:///` paths in plans to local filesystem paths appropriate for your OS
 - Do NOT commit artifact files (screenshots, images) to the repo. Test artifacts belong in `<PlanFolder>/artifacts/` only — CreatePr handles uploading them to persistent storage.
-- Private npm packages (like `@ivy-interactive/ivy-design-system`) require authentication via `.npmrc`. The Setup-WorktreeFrontend.ps1 tool handles this automatically. Credentials come from NPM_TOKEN env var or .NET user secrets (Npm:RegistryToken).
-- Do NOT use `subst` to create drive letter mappings for worktree paths. The plans directory is already symlinked to a short path to avoid long-path issues. Using `subst` creates phantom drives that are never cleaned up.
+- If the project uses private package registries, ensure authentication is configured before running dependency installation in worktrees. Credentials should come from environment variables or project-level configuration.
+- Do NOT create filesystem aliases or shortcuts (e.g. symlinks, drive mappings) to worktree paths. The plans directory path is managed by Tendril — additional indirection causes cleanup issues.

--- a/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
@@ -40,8 +40,8 @@ Example:
 **After:**
 ```
 1. Fix dialog content initialization race condition:
-   - In `Dialog.cs`, add immediate content rendering before animation
-   - In `FormBuilder.cs`, ensure UseState hooks execute synchronously in dialog context
+   - In `dialog_component`, add immediate content rendering before animation
+   - In `form_builder`, ensure state hooks execute synchronously in dialog context
 ```
 
 ### 3. Create Expanded Revision
@@ -62,4 +62,4 @@ Example:
 - Do NOT modify any source code — only read files and update the plan
 - Do NOT modify `plan.yaml` — the launcher script handles state and timestamps
 - Keep the plan short and concise — the limiting factor is a human reading it
-- When referencing local files, use markdown links: `[FileName.cs:line](file:///path/to/FileName.cs)` for source files with line numbers, or `[FileName.cs](file:///path/to/FileName.cs)` without. Never use backticks in link text or `#L123` fragments in URLs. Use `![alt](path)` for images.
+- When referencing local files, use markdown links: `[filename:line](file:///path/to/filename)` for source files with line numbers, or `[filename](file:///path/to/filename)` without. Never use backticks in link text or `#L123` fragments in URLs. Use `![alt](path)` for images.

--- a/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -97,4 +97,4 @@ Do NOT modify the original plan — the launcher transitions it to `Skipped` aut
 - Each plan must include all paths and info for an LLM coding agent to execute end-to-end
 - Keep each plan short and concise — the limiting factor is a human reading it
 - Do NOT modify any source code — only read files and create plan folders
-- When referencing local files, use markdown links: `[FileName.cs:line](file:///path/to/FileName.cs)` for source files with line numbers, or `[FileName.cs](file:///path/to/FileName.cs)` without. Never use backticks in link text or `#L123` fragments in URLs. Use `![alt](path)` for images.
+- When referencing local files, use markdown links: `[filename:line](file:///path/to/filename)` for source files with line numbers, or `[filename](file:///path/to/filename)` without. Never use backticks in link text or `#L123` fragments in URLs. Use `![alt](path)` for images.

--- a/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
@@ -67,4 +67,4 @@ If all questions are resolved and no new questions arose, omit the `## Questions
 - Do NOT modify `plan.yaml` — the launcher script handles state and timestamps
 - The plan must remain self-contained with all paths and information for an LLM coding agent
 - Keep the plan short and concise — the limiting factor is a human reading it
-- When referencing local files, use markdown links: `[FileName.cs:line](file:///path/to/FileName.cs)` for source files with line numbers, or `[FileName.cs](file:///path/to/FileName.cs)` without. Never use backticks in link text or `#L123` fragments in URLs. Use `![alt](path)` for images.
+- When referencing local files, use markdown links: `[filename:line](file:///path/to/filename)` for source files with line numbers, or `[filename](file:///path/to/filename)` without. Never use backticks in link text or `#L123` fragments in URLs. Use `![alt](path)` for images.


### PR DESCRIPTION
Remove all stack-specific, platform-specific, agent-specific, and project-specific
references from shipped Program.md files. Add AGENTS.md with authoring rules to
prevent future regressions.
