### PR TITLE
[03531] Move Edit Button to Action Bar Next to Update Button

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -212,9 +212,6 @@ public class ContentView(
                             selectedPlanState.Set(plan);
                     }
                 }));
-            var editButton = Layout.Horizontal().Padding(0, 0, 2, 0)
-                             | new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E").OnClick(() => isEditing.Set(true));
-            planLayout |= editButton;
             planTabContent = planLayout;
         }
 
@@ -282,8 +279,10 @@ public class ContentView(
             j.Args[0].Equals(selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
 
         var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(1)
-                        | new Button("Update").Icon(Icons.Pencil).Outline().ShortcutKey("u")
+                        | new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")
                             .OnClick(() => updateDialogOpen.Set(true))
+                        | new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
+                            .OnClick(() => isEditing.Set(true))
                         | new Button("Split").Icon(Icons.Scissors).Outline().ShortcutKey("s")
                             .Disabled(hasActiveSplitJob)
                             .OnClick(() =>


### PR DESCRIPTION
## Problem

The Edit button for plan revisions is currently rendered inside the Plan tab content area (at the bottom of the markdown display), but it should be positioned in the action bar at the bottom of the screen, next to the Update button.

## Solution

1. Remove the Edit button from the plan tab content
2. Add the Edit button to the action bar, positioned immediately after the Update button
3. Change the Update button icon from `Icons.Pencil` to `Icons.WandSparkles` to better represent AI-powered updates

The Edit button maintains the same styling, shortcut key (E), and onClick handler. The Update button now uses `Icons.WandSparkles` to distinguish it from the Edit button and better represent the AI/wizard-like nature of prompt-based updates.

## Commits

- 717bce2 [03531] Move Edit button to action bar next to Update button