### PR TITLE
Sync plan artifacts from disk when agent skips CLI commands

### DIFF
--- a/src/Ivy.Tendril.Test/PlanYamlHelperVerificationTests.cs
+++ b/src/Ivy.Tendril.Test/PlanYamlHelperVerificationTests.cs
@@ -1,0 +1,147 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test;
+
+public class PlanYamlHelperVerificationTests
+{
+    [Fact]
+    public void ParseVerificationResultFromReport_FrontmatterPass()
+    {
+        var content = """
+            ---
+            result: Pass
+            date: 2026-04-25T13:46:00Z
+            attempts: 1
+            ---
+            # DotnetBuild
+
+            ## Output
+
+            Build succeeded.
+            """;
+
+        Assert.Equal("Pass", PlanYamlHelper.ParseVerificationResultFromReport(content));
+    }
+
+    [Fact]
+    public void ParseVerificationResultFromReport_FrontmatterFail()
+    {
+        var content = """
+            ---
+            result: Fail
+            date: 2026-04-25T13:46:00Z
+            attempts: 3
+            ---
+            # DotnetBuild
+
+            ## Output
+
+            Build failed with 2 errors.
+            """;
+
+        Assert.Equal("Fail", PlanYamlHelper.ParseVerificationResultFromReport(content));
+    }
+
+    [Fact]
+    public void ParseVerificationResultFromReport_FrontmatterSkipped()
+    {
+        var content = """
+            ---
+            result: Skipped
+            date: 2026-04-25T13:46:00Z
+            attempts: 0
+            ---
+            # DotnetTest
+            """;
+
+        Assert.Equal("Skipped", PlanYamlHelper.ParseVerificationResultFromReport(content));
+    }
+
+    [Fact]
+    public void ParseVerificationResultFromReport_LegacyMarkdownFormat()
+    {
+        var content = """
+            # DotnetBuild
+
+            - **Date:** 2026-04-25T13:46:00Z
+            - **Result:** Pass
+            - **Attempts:** 2
+
+            ## Output
+
+            Build succeeded with 0 warnings and 0 errors.
+            """;
+
+        Assert.Equal("Pass", PlanYamlHelper.ParseVerificationResultFromReport(content));
+    }
+
+    [Fact]
+    public void ParseVerificationResultFromReport_LegacyMarkdownFail()
+    {
+        var content = """
+            # DotnetTest
+
+            - **Date:** 2026-04-25T13:46:00Z
+            - **Result:** Fail
+            - **Attempts:** 3
+
+            ## Output
+
+            3 tests failed.
+            """;
+
+        Assert.Equal("Fail", PlanYamlHelper.ParseVerificationResultFromReport(content));
+    }
+
+    [Fact]
+    public void ParseVerificationResultFromReport_InvalidResultReturnsNull()
+    {
+        var content = """
+            ---
+            result: Unknown
+            ---
+            # Test
+            """;
+
+        Assert.Null(PlanYamlHelper.ParseVerificationResultFromReport(content));
+    }
+
+    [Fact]
+    public void ParseVerificationResultFromReport_EmptyContentReturnsNull()
+    {
+        Assert.Null(PlanYamlHelper.ParseVerificationResultFromReport(""));
+        Assert.Null(PlanYamlHelper.ParseVerificationResultFromReport("  "));
+    }
+
+    [Fact]
+    public void ParseVerificationResultFromReport_NoFrontmatterNoMarkdownReturnsNull()
+    {
+        var content = "Just some random text without any result markers.";
+        Assert.Null(PlanYamlHelper.ParseVerificationResultFromReport(content));
+    }
+
+    [Fact]
+    public void ExtractPlanIdFromFolder_StandardFolder()
+    {
+        Assert.Equal("03538", PlanYamlHelper.ExtractPlanIdFromFolder(@"D:\Plans\03538-DataTableCellActions"));
+    }
+
+    [Fact]
+    public void ExtractPlanIdFromFolder_FolderNameOnly()
+    {
+        Assert.Equal("00015", PlanYamlHelper.ExtractPlanIdFromFolder("00015-TestPlan"));
+    }
+
+    [Fact]
+    public void ExtractSafeTitleFromFolder_StandardFolder()
+    {
+        Assert.Equal("DataTableCellActions",
+            PlanYamlHelper.ExtractSafeTitleFromFolder(@"D:\Plans\03538-DataTableCellActions"));
+    }
+
+    [Fact]
+    public void ExtractSafeTitleFromFolder_FolderNameOnly()
+    {
+        Assert.Equal("TestPlan", PlanYamlHelper.ExtractSafeTitleFromFolder("00015-TestPlan"));
+    }
+}

--- a/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
@@ -123,4 +123,50 @@ internal static class PlanYamlHelper
         var line = $"{jobType},{tokens},{cost:F4}\n";
         FileHelper.AppendAllText(csvPath, line);
     }
+
+    /// <summary>
+    ///     Parses the result status from a verification report file.
+    ///     Supports YAML frontmatter format (preferred) and legacy markdown format (fallback).
+    /// </summary>
+    internal static string? ParseVerificationResultFromReport(string reportContent)
+    {
+        if (string.IsNullOrWhiteSpace(reportContent)) return null;
+
+        // Try YAML frontmatter first: ---\nresult: Pass\n---
+        if (reportContent.StartsWith("---"))
+        {
+            var endIndex = reportContent.IndexOf("---", 3, StringComparison.Ordinal);
+            if (endIndex > 0)
+            {
+                var frontmatter = reportContent.Substring(3, endIndex - 3);
+                foreach (var line in frontmatter.Split('\n'))
+                {
+                    var trimmed = line.Trim();
+                    if (trimmed.StartsWith("result:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        var value = trimmed["result:".Length..].Trim();
+                        if (value is "Pass" or "Fail" or "Skipped") return value;
+                    }
+                }
+            }
+        }
+
+        // Fallback: legacy markdown format  - **Result:** Pass
+        var match = Regex.Match(reportContent, @"^-\s+\*\*Result:\*\*\s+(Pass|Fail|Skipped)", RegexOptions.Multiline);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    internal static string? ExtractPlanIdFromFolder(string planFolder)
+    {
+        var folderName = Path.GetFileName(planFolder);
+        var dashIdx = folderName.IndexOf('-');
+        return dashIdx > 0 ? folderName[..dashIdx] : null;
+    }
+
+    internal static string? ExtractSafeTitleFromFolder(string planFolder)
+    {
+        var folderName = Path.GetFileName(planFolder);
+        var dashIdx = folderName.IndexOf('-');
+        return dashIdx > 0 ? folderName[(dashIdx + 1)..] : null;
+    }
 }

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -445,6 +445,8 @@ tendril plan set-verification <plan-id> Test Skipped
 
 If the plan references other plans (e.g. split-from, follow-up), add them via CLI.
 
+**CRITICAL:** The `tendril plan add-commit` and `tendril plan set-verification` CLI commands are the ONLY mechanism that updates plan.yaml. If you skip them, the plan will be marked as Failed even if all verifications pass. You MUST call these commands — do not assume writing verification report files is sufficient.
+
 ### 7. Run Verifications
 
 Create a `verification/` directory in the plan folder if it doesn't exist.
@@ -460,14 +462,17 @@ For each checked verification:
 5. Document all fix commits via CLI: `tendril plan add-commit <plan-id> <sha>`
 6. Update the verification status via CLI: `tendril plan set-verification <plan-id> <Name> Pass` (or `Fail`)
 
-**!IMPORTANT: Every verification MUST produce a report** at `<PlanFolder>/verification/<VerificationName>.md`:
+**CRITICAL:** You MUST call `tendril plan set-verification` after EACH verification. The verification report file alone is NOT sufficient — plan.yaml must also be updated via the CLI. Failing to call this command will result in the plan being marked as Failed.
+
+**!IMPORTANT: Every verification MUST produce a report** at `<PlanFolder>/verification/<VerificationName>.md` using YAML frontmatter:
 
 ```markdown
+---
+result: Pass
+date: <CurrentTime>
+attempts: <number>
+---
 # <VerificationName>
-
-- **Date:** <CurrentTime>
-- **Result:** Pass / Fail
-- **Attempts:** <number>
 
 ## Output
 
@@ -482,7 +487,7 @@ For each checked verification:
 <any remaining issues, or "None">
 ```
 
-A verification is not complete without its report. If the report file does not exist after running a verification, the plan should fail.
+The `result` field in the frontmatter MUST be one of: `Pass`, `Fail`, or `Skipped`. A verification is not complete without both its report file AND the `tendril plan set-verification` CLI call.
 
 ### 7.5. Generate Recommendations
 

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -97,6 +97,7 @@ internal class JobCompletionHandler
         }
         else if (isSuccess && job.Type == "ExecutePlan")
         {
+            SyncPlanArtifacts(job);
             EnsurePlanStateTransitioned(job);
         }
         else if (isSuccess && job.Type == "CreateIssue")
@@ -273,6 +274,171 @@ internal class JobCompletionHandler
     {
         var bytes = Encoding.Unicode.GetBytes(command);
         return Convert.ToBase64String(bytes);
+    }
+
+    private void SyncPlanArtifacts(JobItem job)
+    {
+        var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+        if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder)) return;
+
+        try
+        {
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var changed = false;
+
+            changed |= SyncVerificationsFromReports(planFolder, plan);
+            changed |= SyncCommitsFromWorktrees(planFolder, plan);
+
+            if (changed)
+            {
+                plan.Updated = DateTime.UtcNow;
+                PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcherService);
+                _logger.LogInformation(
+                    "Synced plan artifacts from disk for {PlanFolder} (agent did not call CLI commands)",
+                    Path.GetFileName(planFolder));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to sync plan artifacts for {PlanFolder}", planFolder);
+        }
+    }
+
+    private bool SyncVerificationsFromReports(string planFolder, PlanYaml plan)
+    {
+        var verificationDir = Path.Combine(planFolder, "verification");
+        if (!Directory.Exists(verificationDir)) return false;
+        if (plan.Verifications == null || plan.Verifications.Count == 0) return false;
+
+        var changed = false;
+
+        foreach (var reportFile in Directory.GetFiles(verificationDir, "*.md"))
+        {
+            var reportName = Path.GetFileNameWithoutExtension(reportFile);
+            if (reportName.Equals("PreExecution", StringComparison.OrdinalIgnoreCase)) continue;
+
+            var verification = plan.Verifications.FirstOrDefault(v =>
+                v.Name.Equals(reportName, StringComparison.OrdinalIgnoreCase));
+            if (verification == null) continue;
+            if (verification.Status != "Pending") continue;
+
+            try
+            {
+                var content = FileHelper.ReadAllText(reportFile);
+                var result = PlanYamlHelper.ParseVerificationResultFromReport(content);
+                if (result != null)
+                {
+                    verification.Status = result;
+                    changed = true;
+                }
+            }
+            catch
+            {
+                // Skip unreadable report files
+            }
+        }
+
+        return changed;
+    }
+
+    private bool SyncCommitsFromWorktrees(string planFolder, PlanYaml plan)
+    {
+        if (plan.Commits.Count > 0) return false;
+
+        var worktreesDir = Path.Combine(planFolder, "worktrees");
+        if (!Directory.Exists(worktreesDir)) return false;
+
+        var planId = PlanYamlHelper.ExtractPlanIdFromFolder(planFolder);
+        var safeTitle = PlanYamlHelper.ExtractSafeTitleFromFolder(planFolder);
+        if (planId == null || safeTitle == null) return false;
+
+        var branchName = $"tendril/{planId}-{safeTitle}";
+        var changed = false;
+
+        foreach (var wtDir in Directory.GetDirectories(worktreesDir))
+        {
+            try
+            {
+                var gitFile = Path.Combine(wtDir, ".git");
+                if (!File.Exists(gitFile)) continue;
+
+                var gitContent = FileHelper.ReadAllText(gitFile).Trim();
+                var gitDirMatch = Regex.Match(gitContent, @"gitdir:\s*(.+)");
+                if (!gitDirMatch.Success) continue;
+
+                var gitDir = gitDirMatch.Groups[1].Value.Trim();
+                var repoGitDir = Path.GetFullPath(Path.Combine(gitDir, "..", ".."));
+                var repoRoot = Path.GetDirectoryName(repoGitDir);
+                if (repoRoot == null || !Directory.Exists(repoRoot)) continue;
+
+                // Detect base branch
+                var baseBranch = DetectBaseBranch(repoRoot);
+
+                var psi = new ProcessStartInfo("git",
+                    $"log --format=%H \"{baseBranch}..{branchName}\"")
+                {
+                    WorkingDirectory = repoRoot,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using var process = Process.Start(psi);
+                if (process == null) continue;
+                var output = process.StandardOutput.ReadToEnd().Trim();
+                process.WaitForExitOrKill(10000);
+                if (process.ExitCode != 0 || string.IsNullOrEmpty(output)) continue;
+
+                foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var hash = line.Trim();
+                    if (hash.Length < 7) continue;
+                    var shortHash = hash.Length > 9 ? hash[..9] : hash;
+                    if (!plan.Commits.Contains(shortHash))
+                    {
+                        plan.Commits.Add(shortHash);
+                        changed = true;
+                    }
+                }
+            }
+            catch
+            {
+                // Skip worktrees that can't be read
+            }
+        }
+
+        return changed;
+    }
+
+    private static string DetectBaseBranch(string repoRoot)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("git",
+                "symbolic-ref refs/remotes/origin/HEAD")
+            {
+                WorkingDirectory = repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(psi);
+            if (process == null) return "origin/main";
+            var output = process.StandardOutput.ReadToEnd().Trim();
+            process.WaitForExitOrKill(5000);
+
+            if (process.ExitCode == 0 && !string.IsNullOrEmpty(output))
+                return output.Replace("refs/remotes/", "");
+        }
+        catch
+        {
+            // Fall through to default
+        }
+
+        return "origin/main";
     }
 
     private void EnsurePlanStateTransitioned(JobItem job)


### PR DESCRIPTION
Agents intermittently skip tendril plan set-verification and add-commit
CLI calls after ExecutePlan, leaving plan.yaml stale with all
verifications Pending and no commits. EnsurePlanStateTransitioned then
incorrectly marks the plan as Failed.

Add SyncPlanArtifacts to JobCompletionHandler that runs before the state
transition check. It reads verification/*.md report files and extracts
commits from worktree branches, updating plan.yaml for any entries the
agent missed. Also switch verification reports to YAML frontmatter
format for reliable parsing, with backward-compatible fallback for the
old markdown format.
