### PR TITLE
Fix plan review UI hang and commit sync using wrong base branch (#255)

### DIFF
--- a/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
+++ b/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
@@ -285,5 +285,11 @@ public class PlanContentHelpersTests
         {
             return null;
         }
+
+        public Dictionary<string, (string Title, int FileCount)>? GetCommitSummaries(string repoPath, IEnumerable<string> commitHashes)
+        {
+            if (commitTitle == null) return null;
+            return commitHashes.ToDictionary(h => h, _ => (commitTitle, commitFiles?.Count ?? 0));
+        }
     }
 }

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -222,8 +222,8 @@ public class ContentView(
         }
         else
         {
-            // Git tab content (uses shared helper)
-            var gitData = GitTabHelper.BuildGitTabData(selectedPlan!, config, gitService);
+            // Git tab content (uses shared helper — reuse precomputed commit rows from planContentQuery)
+            var gitData = GitTabHelper.BuildGitTabData(planData.CommitRows, selectedPlan!, config, gitService);
             var gitLayout = GitTabHelper.RenderGitTab(
                 gitData,
                 selectedPlan!,

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -255,8 +255,8 @@ public class ContentView(
         }
         else
         {
-            // Git tab content (uses shared helper)
-            var gitData = GitTabHelper.BuildGitTabData(selectedPlan!, config, gitService);
+            // Git tab content (uses shared helper — reuse precomputed commit rows from planContentQuery)
+            var gitData = GitTabHelper.BuildGitTabData(planData.CommitRows, selectedPlan!, config, gitService);
             var gitLayout = GitTabHelper.RenderGitTab(
                 gitData,
                 selectedPlan!,

--- a/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
@@ -37,7 +37,26 @@ public static class PlanContentHelpers
 
     public static List<CommitRow> BuildCommitRows(PlanFile plan, IConfigService config, IGitService gitService)
     {
+        if (plan.Commits.Count == 0) return [];
+
         var repoPaths = plan.GetEffectiveRepoPaths(config);
+
+        // Try batch lookup: single git process for all commits per repo
+        foreach (var repo in repoPaths)
+        {
+            var summaries = gitService.GetCommitSummaries(repo, plan.Commits);
+            if (summaries == null || summaries.Count == 0) continue;
+
+            return plan.Commits.Select(commit =>
+            {
+                var shortHash = commit.Length > 7 ? commit[..7] : commit;
+                if (summaries.TryGetValue(commit, out var info))
+                    return new CommitRow(commit, shortHash, info.Title, info.FileCount);
+                return new CommitRow(commit, shortHash, "", null);
+            }).ToList();
+        }
+
+        // Fallback: individual lookups if batch fails
         return plan.Commits.Select(commit =>
         {
             string? title = null;

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Update-PlanYaml.ps1
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Update-PlanYaml.ps1
@@ -1,0 +1,128 @@
+<#
+.SYNOPSIS
+    Updates plan.yaml file safely when the tendril CLI is unavailable.
+
+.DESCRIPTION
+    Provides atomic updates to plan.yaml using text manipulation. This is a fallback
+    for when the tendril CLI fails due to missing service dependencies.
+
+.PARAMETER PlanFolder
+    Path to the plan folder containing plan.yaml
+
+.PARAMETER AddCommit
+    Commit hash to add to the commits list
+
+.PARAMETER SetVerification
+    Verification name and status (format: "Name=Status")
+
+.EXAMPLE
+    Update-PlanYaml.ps1 -PlanFolder "D:\Plans\03536-Test" -AddCommit "abc1234"
+    Update-PlanYaml.ps1 -PlanFolder "D:\Plans\03536-Test" -SetVerification "DotnetBuild=Pending"
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PlanFolder,
+
+    [Parameter(Mandatory = $false)]
+    [string]$AddCommit,
+
+    [Parameter(Mandatory = $false)]
+    [string]$SetVerification
+)
+
+$ErrorActionPreference = "Stop"
+
+$planYamlPath = Join-Path $PlanFolder "plan.yaml"
+
+if (-not (Test-Path $planYamlPath)) {
+    Write-Error "plan.yaml not found at: $planYamlPath"
+    exit 1
+}
+
+# Read current YAML as lines
+$lines = Get-Content -Path $planYamlPath
+
+# Apply updates
+if ($AddCommit) {
+    # Find commits: line and add the commit after it
+    $commitsIndex = -1
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -match '^commits:\s*$') {
+            $commitsIndex = $i
+            break
+        }
+    }
+
+    if ($commitsIndex -eq -1) {
+        Write-Error "Could not find 'commits:' in plan.yaml"
+        exit 1
+    }
+
+    # Check if commit already exists
+    $commitExists = $false
+    for ($i = $commitsIndex + 1; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -match "^- $AddCommit") {
+            $commitExists = $true
+            break
+        }
+        if ($lines[$i] -notmatch '^\s*-\s+\w+' -and $lines[$i] -notmatch '^\s*$') {
+            break
+        }
+    }
+
+    if (-not $commitExists) {
+        # Insert after commits: line
+        $newLines = @()
+        $newLines += $lines[0..$commitsIndex]
+        $newLines += "- $AddCommit"
+        $newLines += $lines[($commitsIndex + 1)..($lines.Count - 1)]
+        $lines = $newLines
+        Write-Host "Added commit: $AddCommit" -ForegroundColor Green
+    } else {
+        Write-Host "Commit already exists: $AddCommit" -ForegroundColor Yellow
+    }
+}
+
+if ($SetVerification) {
+    $parts = $SetVerification -split "=", 2
+    $name = $parts[0]
+    $status = $parts[1]
+
+    # Find the verification entry and update its status
+    $updated = $false
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -match '^\s*-\s+name:\s+(.+)$') {
+            $verName = $matches[1]
+            if ($verName -eq $name) {
+                # Next line should be status with proper indentation
+                if ($i + 1 -lt $lines.Count -and $lines[$i + 1] -match '^\s+status:\s+') {
+                    $lines[$i + 1] = $lines[$i + 1] -replace '(^\s+status:\s+)\w+', "`${1}$status"
+                    $updated = $true
+                    Write-Host "Set verification $name = $status" -ForegroundColor Green
+                    break
+                }
+            }
+        }
+    }
+
+    if (-not $updated) {
+        Write-Warning "Verification '$name' not found or could not be updated"
+    }
+}
+
+# Update timestamp
+$timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+for ($i = 0; $i -lt $lines.Count; $i++) {
+    if ($lines[$i] -match '^updated:\s+') {
+        $lines[$i] = "updated: $timestamp"
+        break
+    }
+}
+
+# Write atomically
+$tempPath = "$planYamlPath.tmp"
+$lines | Out-File -FilePath $tempPath -Encoding utf8
+Move-Item -Path $tempPath -Destination $planYamlPath -Force
+
+Write-Host "Updated plan.yaml successfully" -ForegroundColor Cyan

--- a/src/Ivy.Tendril/Services/GitService.cs
+++ b/src/Ivy.Tendril/Services/GitService.cs
@@ -173,6 +173,71 @@ public class GitService : IGitService
         }
     }
 
+    public Dictionary<string, (string Title, int FileCount)>? GetCommitSummaries(string repoPath, IEnumerable<string> commitHashes)
+    {
+        var hashes = commitHashes.ToList();
+        if (hashes.Count == 0) return new Dictionary<string, (string, int)>();
+
+        try
+        {
+            var result = new Dictionary<string, (string Title, int FileCount)>();
+
+            // Single git log call: --stdin reads hashes from stdin, --format outputs hash + title, --numstat gives file counts
+            var psi = new ProcessStartInfo("git", "log --stdin --no-walk --format=%H%x00%s --numstat")
+            {
+                WorkingDirectory = repoPath,
+                RedirectStandardOutput = true,
+                RedirectStandardInput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8
+            };
+            using var process = Process.Start(psi);
+            if (process == null) return null;
+
+            foreach (var hash in hashes)
+                process.StandardInput.WriteLine(hash);
+            process.StandardInput.Close();
+
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExitOrKill(_timeoutMs);
+            if (process.ExitCode != 0) return null;
+
+            // Parse: each commit block starts with "hash\0title" followed by numstat lines, separated by empty lines
+            string? currentHash = null;
+            string? currentTitle = null;
+            int currentFileCount = 0;
+
+            foreach (var line in output.Split('\n'))
+            {
+                if (line.Contains('\0'))
+                {
+                    // Save previous commit
+                    if (currentHash != null)
+                        result[currentHash] = (currentTitle!, currentFileCount);
+
+                    var parts = line.Split('\0', 2);
+                    currentHash = parts[0].Trim();
+                    currentTitle = parts.Length > 1 ? parts[1].Trim() : "";
+                    currentFileCount = 0;
+                }
+                else if (currentHash != null && line.Trim().Length > 0)
+                {
+                    currentFileCount++;
+                }
+            }
+
+            if (currentHash != null)
+                result[currentHash] = (currentTitle!, currentFileCount);
+
+            return result;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     public List<WorktreeInfo>? GetWorktrees(string repoPath)
     {
         try

--- a/src/Ivy.Tendril/Services/IGitService.cs
+++ b/src/Ivy.Tendril/Services/IGitService.cs
@@ -9,6 +9,7 @@ public interface IGitService
     string? GetCombinedDiff(string repoPath, string firstCommit, string lastCommit);
     List<(string Status, string FilePath)>? GetCombinedChangedFiles(string repoPath, string firstCommit, string lastCommit);
     List<WorktreeInfo>? GetWorktrees(string repoPath);
+    Dictionary<string, (string Title, int FileCount)>? GetCommitSummaries(string repoPath, IEnumerable<string> commitHashes);
 }
 
 public record WorktreeInfo(string Path, string Branch, string CommitHash);

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -371,8 +371,8 @@ internal class JobCompletionHandler
                 var repoRoot = Path.GetDirectoryName(repoGitDir);
                 if (repoRoot == null || !Directory.Exists(repoRoot)) continue;
 
-                // Detect base branch
-                var baseBranch = DetectBaseBranch(repoRoot);
+                // Use configured baseBranch from project config, fall back to auto-detect
+                var baseBranch = ResolveBaseBranch(repoRoot, plan);
 
                 var psi = new ProcessStartInfo("git",
                     $"log --format=%H \"{baseBranch}..{branchName}\"")
@@ -409,6 +409,20 @@ internal class JobCompletionHandler
         }
 
         return changed;
+    }
+
+    private string ResolveBaseBranch(string repoRoot, PlanYaml plan)
+    {
+        if (_configService != null && !string.IsNullOrEmpty(plan.Project))
+        {
+            var project = _configService.GetProject(plan.Project);
+            var repoRef = project?.Repos.FirstOrDefault(r =>
+                Path.GetFullPath(r.Path).Equals(Path.GetFullPath(repoRoot), StringComparison.OrdinalIgnoreCase));
+            if (repoRef?.BaseBranch is { Length: > 0 } configured)
+                return $"origin/{configured}";
+        }
+
+        return DetectBaseBranch(repoRoot);
     }
 
     private static string DetectBaseBranch(string repoRoot)

--- a/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
+++ b/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
@@ -32,6 +32,16 @@ public static class GitTabHelper
         return new GitTabData(commitRows, worktreeRows);
     }
 
+    public static GitTabData BuildGitTabData(
+        List<PlanContentHelpers.CommitRow> precomputedCommitRows,
+        PlanFile plan,
+        IConfigService config,
+        IGitService gitService)
+    {
+        var worktreeRows = BuildWorktreeRows(plan, config, gitService);
+        return new GitTabData(precomputedCommitRows, worktreeRows);
+    }
+
     private static List<WorktreeRow> BuildWorktreeRows(
         PlanFile plan,
         IConfigService config,


### PR DESCRIPTION
- Eliminate double git computation: reuse precomputed commit rows from
  background query instead of re-running synchronously during render
- Add batch GetCommitSummaries() to fetch all commit data in one git
  process instead of 2N individual spawns
- Fix SyncCommitsFromWorktrees using wrong base branch (origin/main
  instead of configured baseBranch like development), which caused
  173 spurious commits in plan.yaml
