### PR TITLE
[03539] Show Latest Job on Top in Jobs View

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -236,6 +236,7 @@ public class JobsApp : ViewBase
             .Hidden(t => t.Id)
             .Hidden(t => t.LastOutputTimestamp)
             .Hidden(t => t.ErrorContext)
+            .SortDirection(t => t.Id, SortDirection.Descending)
             .Filterable(t => t.Timer, false)
             .Filterable(t => t.LastOutput, false)
             .Config(c =>


### PR DESCRIPTION
# Summary

## Changes

Added descending sort order by Id to the Jobs DataTable so that the most recent jobs appear at the top when the view loads. The sort is applied to the hidden Id column, ensuring initial ordering without affecting the visible columns.

## API Changes

None.

## Files Modified

- **JobsApp.cs** — Added `.SortDirection(t => t.Id, SortDirection.Descending)` to the Jobs DataTable configuration (line 239).

## Commits

- [03539] Add descending sort by Id to Jobs table (083d345)
