### PR TITLE
Fix 6 ExecutePlan reliability issues from plan 03534 post-mortem

### DIFF
--- a/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
@@ -185,4 +185,29 @@ public class FirmwareCompilerTests : IDisposable
 
         Assert.True(Directory.Exists(Path.Combine(programFolder, "Logs")));
     }
+
+    [Fact]
+    public void GetNextLogFile_ReservesFileOnDisk()
+    {
+        var programFolder = Path.Combine(_tempDir, "ReserveTest");
+        Directory.CreateDirectory(programFolder);
+
+        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
+
+        Assert.True(File.Exists(logFile));
+    }
+
+    [Fact]
+    public void GetNextLogFile_ConcurrentCalls_ProduceDifferentNumbers()
+    {
+        var programFolder = Path.Combine(_tempDir, "ConcurrentTest");
+        Directory.CreateDirectory(programFolder);
+
+        var first = FirmwareCompiler.GetNextLogFile(programFolder);
+        var second = FirmwareCompiler.GetNextLogFile(programFolder);
+
+        Assert.EndsWith("00001.md", first);
+        Assert.EndsWith("00002.md", second);
+        Assert.NotEqual(first, second);
+    }
 }

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -131,7 +131,7 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
         var workDir = settings.WorkingDir ?? programFolder;
 
         // Compile firmware
-        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
+        var logFile = FirmwareCompiler.GetNextLogFile(programFolder, values);
         var sharedDocs = new List<(string Name, string Content)>();
         var plansMdPath = Path.Combine(sharedRoot, "Plans.md");
         if (File.Exists(plansMdPath))

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -453,14 +453,17 @@ Create a `verification/` directory in the plan folder if it doesn't exist.
 
 Check the `## Verification` section in the plan revision for checked items (`- [x]`). Skip unchecked items (`- [ ]`).
 
+**Delegated verifications:** Some verifications are implemented as separate promptwares (e.g., `IvyFrameworkVerification`). A verification is **delegated** if its name matches an entry in the `promptwares` section of `config.yaml`. Delegated verifications MUST be run via `tendril promptware <Name>` — you are FORBIDDEN from writing their report files or setting their status to Pass yourself. If the `tendril` CLI is unavailable and you cannot invoke the sub-promptware, you MUST set the verification to `Fail` with a report explaining the CLI failure. Never self-certify a delegated verification.
+
 For each checked verification:
 
 1. Send a status message: `tendril job status $env:TENDRIL_JOB_ID --message "Verifying: <Name>"`
 2. Look up its `prompt` in the `verifications` list in `config.yaml`
-3. Execute the prompt in the worktree directory
-4. If it fails: diagnose, fix the issue, **commit the fix** (e.g. `[01105] Fix lint errors from Build`), and re-run. Repeat until it passes (fail the plan after 3+ failed attempts).
-5. Document all fix commits via CLI: `tendril plan add-commit <plan-id> <sha>`
-6. Update the verification status via CLI: `tendril plan set-verification <plan-id> <Name> Pass` (or `Fail`)
+3. **Check if delegated:** If the verification name exists in config.yaml's `promptwares` section, it is a delegated verification — follow the prompt's instructions to invoke it as an external process. If the external process cannot be invoked (CLI broken, file lock, etc.), set the verification to `Fail` immediately. Do NOT attempt to do the verification inline or write the report yourself.
+4. Execute the prompt in the worktree directory
+5. If it fails: diagnose, fix the issue, **commit the fix** (e.g. `[01105] Fix lint errors from Build`), and re-run. Repeat until it passes (fail the plan after 3+ failed attempts).
+6. Document all fix commits via CLI: `tendril plan add-commit <plan-id> <sha>`
+7. Update the verification status via CLI: `tendril plan set-verification <plan-id> <Name> Pass` (or `Fail`)
 
 **CRITICAL:** You MUST call `tendril plan set-verification` after EACH verification. The verification report file alone is NOT sufficient — plan.yaml must also be updated via the CLI. Failing to call this command will result in the plan being marked as Failed.
 

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Update-PlanYaml.ps1
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Tools/Update-PlanYaml.ps1
@@ -89,6 +89,24 @@ if ($SetVerification) {
     $name = $parts[0]
     $status = $parts[1]
 
+    # Block self-certification of delegated verifications (those that have their own promptware)
+    if ($status -eq "Pass") {
+        $promptsRoots = @()
+        # From script location: Tools/ -> ExecutePlan/ -> Promptwares/
+        $promptsRoots += Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+        # From TENDRIL_HOME
+        if ($env:TENDRIL_HOME) {
+            $promptsRoots += Join-Path $env:TENDRIL_HOME "Promptwares"
+        }
+        foreach ($root in $promptsRoots) {
+            $promptwareDir = Join-Path $root $name
+            if (Test-Path $promptwareDir) {
+                Write-Error "BLOCKED: '$name' is a delegated verification (has its own promptware at $promptwareDir). It must be run via 'tendril promptware $name' — ExecutePlan cannot self-certify it as Pass. Set it to Fail if the CLI is unavailable."
+                exit 1
+            }
+        }
+    }
+
     # Find the verification entry and update its status
     $updated = $false
     for ($i = 0; $i -lt $lines.Count; $i++) {

--- a/src/Ivy.Tendril/Services/Agents/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/Agents/FirmwareCompiler.cs
@@ -90,7 +90,7 @@ public class FirmwareCompiler
         return firmware;
     }
 
-    public static string GetNextLogFile(string programFolder)
+    public static string GetNextLogFile(string programFolder, Dictionary<string, string>? initialValues = null)
     {
         var logsFolder = Path.Combine(programFolder, "Logs");
         Directory.CreateDirectory(logsFolder);
@@ -106,7 +106,22 @@ public class FirmwareCompiler
             }
         }
 
-        return Path.Combine(logsFolder, $"{maxNumber + 1:D5}.md");
+        var logFile = Path.Combine(logsFolder, $"{maxNumber + 1:D5}.md");
+
+        // Reserve the slot immediately to prevent race conditions with concurrent jobs
+        var header = $"# Execution Log {maxNumber + 1:D5}\n\n## Args\n";
+        if (initialValues != null)
+        {
+            foreach (var kv in initialValues.OrderBy(kv => kv.Key))
+            {
+                var value = kv.Value.Length > 200 ? kv.Value[..200] + "..." : kv.Value;
+                header += $"- **{kv.Key}:** {value}\n";
+            }
+        }
+        header += "\n*Execution in progress...*\n";
+        File.WriteAllText(logFile, header);
+
+        return logFile;
     }
 
     public static string ResolveProgramFolder(string promptsRoot, string promptwareName)

--- a/src/Ivy.Tendril/Services/GitService.cs
+++ b/src/Ivy.Tendril/Services/GitService.cs
@@ -203,6 +203,9 @@ public class GitService : IGitService
             process.WaitForExitOrKill(_timeoutMs);
             if (process.ExitCode != 0) return null;
 
+            // Build a lookup from full hash prefix back to the original input hashes
+            var inputHashSet = new HashSet<string>(hashes, StringComparer.OrdinalIgnoreCase);
+
             // Parse: each commit block starts with "hash\0title" followed by numstat lines, separated by empty lines
             string? currentHash = null;
             string? currentTitle = null;
@@ -212,9 +215,8 @@ public class GitService : IGitService
             {
                 if (line.Contains('\0'))
                 {
-                    // Save previous commit
                     if (currentHash != null)
-                        result[currentHash] = (currentTitle!, currentFileCount);
+                        StoreCommitResult(result, inputHashSet, currentHash, currentTitle!, currentFileCount);
 
                     var parts = line.Split('\0', 2);
                     currentHash = parts[0].Trim();
@@ -228,13 +230,34 @@ public class GitService : IGitService
             }
 
             if (currentHash != null)
-                result[currentHash] = (currentTitle!, currentFileCount);
+                StoreCommitResult(result, inputHashSet, currentHash, currentTitle!, currentFileCount);
 
             return result;
         }
         catch
         {
             return null;
+        }
+    }
+
+    private static void StoreCommitResult(
+        Dictionary<string, (string Title, int FileCount)> result,
+        HashSet<string> inputHashes,
+        string fullHash,
+        string title,
+        int fileCount)
+    {
+        var value = (title, fileCount);
+        result[fullHash] = value;
+
+        // Also store under any abbreviated input hash that matches this full hash
+        foreach (var input in inputHashes)
+        {
+            if (input.Length < fullHash.Length &&
+                fullHash.StartsWith(input, StringComparison.OrdinalIgnoreCase))
+            {
+                result[input] = value;
+            }
         }
     }
 

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -814,13 +814,22 @@ internal class JobCompletionHandler
                              $"- **Status:** {job.Status}\n" +
                              $"- **Started:** {job.StartedAt:u}\n" +
                              $"- **Completed:** {job.CompletedAt:u}\n" +
-                             $"- **Duration:** {duration}\n";
+                             $"- **Duration:** {duration}\n" +
+                             $"- **Provider:** {job.Provider}\n";
 
             if (!string.IsNullOrEmpty(job.SessionId))
                 logContent += $"- **SessionId:** {job.SessionId}\n";
 
+            if (job.Cost.HasValue)
+                logContent += $"- **Cost:** ${job.Cost:F4}\n";
+
+            if (job.Tokens.HasValue)
+                logContent += $"- **Tokens:** {job.Tokens:N0}\n";
+
             if (job.Status == JobStatus.Timeout && job.StatusMessage != null)
                 logContent += $"- **Timeout Reason:** {job.StatusMessage}\n";
+
+            logContent += BuildPlanOutcomeSummary(job);
 
             _planReaderService.AddLog(job.PlanFile, job.Type, logContent);
 
@@ -847,6 +856,54 @@ internal class JobCompletionHandler
         }
         catch
         {
+        }
+    }
+
+    private static string BuildPlanOutcomeSummary(JobItem job)
+    {
+        if (job.Type != "ExecutePlan")
+            return "";
+
+        var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+        if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder))
+            return "";
+
+        try
+        {
+            var plan = PlanYamlHelper.ReadPlanYaml(planFolder);
+            if (plan == null)
+                return "";
+
+            var sb = new StringBuilder();
+            sb.AppendLine("\n## Outcome\n");
+
+            if (plan.Commits.Count > 0)
+            {
+                sb.AppendLine($"**Commits:** {plan.Commits.Count}");
+                foreach (var commit in plan.Commits)
+                    sb.AppendLine($"- `{commit}`");
+                sb.AppendLine();
+            }
+            else
+            {
+                sb.AppendLine("**Commits:** none\n");
+            }
+
+            if (plan.Verifications.Count > 0)
+            {
+                sb.AppendLine("**Verifications:**");
+                foreach (var v in plan.Verifications)
+                    sb.AppendLine($"- {v.Name}: {v.Status}");
+                sb.AppendLine();
+            }
+
+            sb.AppendLine($"**Final State:** {plan.State}");
+
+            return sb.ToString();
+        }
+        catch
+        {
+            return "";
         }
     }
 

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -285,7 +285,7 @@ internal class JobLauncher
         var resolution = AgentProviderFactory.Resolve(settings, job.Type, profileOverride, jobContext);
         var workDir = ResolveWorkingDirectory(job, programFolder);
 
-        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
+        var logFile = FirmwareCompiler.GetNextLogFile(programFolder, values);
         var sharedDocs = new List<(string Name, string Content)>();
         var plansMdPath = Path.Combine(_sharedRoot, "Plans.md");
         if (File.Exists(plansMdPath))
@@ -353,7 +353,12 @@ internal class JobLauncher
             {
                 var folderName = Path.GetFileName(planFolder);
                 var dashIdx = folderName.IndexOf('-');
-                if (dashIdx > 0) values["PlanId"] = folderName[..dashIdx];
+                if (dashIdx > 0)
+                {
+                    var planId = folderName[..dashIdx];
+                    values["PlanId"] = planId;
+                    job.AllocatedPlanId ??= planId;
+                }
                 values["PlanFolder"] = planFolder;
                 values["PlansDirectory"] = Path.GetDirectoryName(planFolder) ?? "";
 
@@ -448,8 +453,11 @@ internal class JobLauncher
             var cmdShim = Path.Combine(shimDir, "tendril.cmd");
             File.WriteAllText(cmdShim, $"@dotnet run --project \"{projectPath}\" {outputArg} -- %*\r\n");
 
+            var bashProjectPath = projectPath.Replace('\\', '/');
+            var bashOutputArg = $"-p:BaseOutputPath='{shimOutputDir.Replace('\\', '/')}/'";
+
             var bashShim = Path.Combine(shimDir, "tendril");
-            File.WriteAllText(bashShim, $"#!/usr/bin/env bash\ndotnet run --project \"{projectPath}\" {outputArg} -- \"$@\"\n");
+            File.WriteAllText(bashShim, $"#!/usr/bin/env bash\ndotnet run --project '{bashProjectPath}' {bashOutputArg} -- \"$@\"\n");
 
             PrependToPath(psi, shimDir);
         }

--- a/src/skills/tendril-debug-plan/SKILL.md
+++ b/src/skills/tendril-debug-plan/SKILL.md
@@ -1,0 +1,248 @@
+***
+
+name: tendril-debug-plan
+description: Debug a Tendril plan by analyzing its execution logs, session JSONL, verification results, and checking infrastructure. Produces actionable bugfix and improvement recommendations. Use when the user wants to investigate why a plan failed, behaved unexpectedly, or to audit plan execution quality.
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+# tendril-debug-plan
+
+Debug and analyze Tendril plan executions end-to-end — from plan creation through checking/verification — and produce a set of concrete bugfix and improvement recommendations.
+
+## Invocation
+
+```
+/tendril-debug-plan <planid> <note>
+```
+
+* **planid** — 5-digit Tendril plan ID (e.g., `03451`)
+* **note** — free-text context about what to look for (e.g., "verification passed but shouldn't have", "took forever", "got stuck in Building state")
+
+## What This Skill Does
+
+1. Gathers all artifacts for a plan: `plan.yaml`, revisions, logs, costs, verification reports, session JSONL
+2. Analyzes the execution timeline, token usage, tool call patterns, and error loops
+3. Cross-references findings with Tendril source code and promptware instructions
+4. Produces a structured recommendations report with concrete fixes
+
+## Execution Steps
+
+### Phase 1 — Gather Plan Artifacts
+
+Resolve paths from environment:
+
+* `TENDRIL_HOME` — base config/data directory
+* `TENDRIL_PLANS` — plans directory (defaults to `$TENDRIL_HOME/Plans`)
+* `REPOS_HOME` — for locating Tendril source code
+
+Read these files from the plan folder (`$TENDRIL_PLANS/{planid}-*/`):
+
+| File                | Purpose                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `plan.yaml`         | Plan metadata: state, repos, commits, PRs, verifications, dependsOn                                        |
+| `revisions/*.md`    | Plan scope, acceptance criteria, verification checkboxes. Last one is the one that is the executable one.  |
+| `logs/*.md`         | Per-step execution logs with outcome data (commits, verifications, cost). Also Tendril CLI logs.           |
+| `costs.csv`         | Token/cost breakdown per promptware (if available)                                                         |
+| `verification/*.md` | Verification reports (PreExecution, IvyFrameworkVerification, etc.)                                        |
+| `worktrees/`        | Check if worktrees were created/cleaned up                                                                 |
+
+Also check promptware-level logs:
+
+* `$TENDRIL_HOME/Promptwares/{Type}/Logs/{PlanId}.md` — agent summary
+* `$TENDRIL_HOME/Promptwares/{Type}/Logs/{PlanId}.raw.jsonl` — full session data
+
+### Phase 2 — Locate and Analyze Session JSONL
+
+Each log entry in `logs/` contains a `SessionId`. The raw Claude session data lives at:
+
+```
+~/.claude/projects/*/{SessionId}.jsonl
+```
+
+Use `find ~/.claude/projects -name "{SessionId}.jsonl"` to locate each file.
+
+For each JSONL session, extract:
+
+**Token Usage:**
+
+* Sum `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens` from `type: "assistant"` messages
+* Cache hit ratio: `cache_read / (cache_read + cache_creation + input)`
+* Flag messages with unusually high `input_tokens` (context bloat)
+
+**Tool Call Patterns:**
+
+* Count each tool type (Read, Write, Edit, Bash, Grep, Glob)
+* Identify repeated reads of the same file (redundant)
+* Identify failed tool calls and their errors
+* Detect thrashing: read-edit-read-edit cycles on the same file
+
+**Error Patterns:**
+
+* Grep for `error`, `failed`, `exception`, `timeout` in tool results
+* Count compilation fix-retry cycles (build → error → edit → build loops)
+* Permission errors, missing files, environmental issues
+
+**Time Analysis:**
+
+* Wall-clock duration from first to last timestamp
+* Long gaps between messages (slow tools, rate limiting)
+* Timeout detection
+
+Use the `Analyze-SessionJsonl.ps1` tool if available at:
+
+```
+$REPOS_HOME/Ivy-Tendril/src/Ivy.Tendril.TeamIvyConfig/Promptwares/PlanEvaluator/Tools/Analyze-SessionJsonl.ps1
+```
+
+### Phase 3 — Analyze the Checking/Verification Pipeline
+
+This is the core debugging focus. Examine:
+
+**Pre-execution checks (ExecutePlan Step 1.5–1.8):**
+
+* Did dependency checking work correctly? (`dependsOn` plans completed, PRs merged)
+* Did worktree validation catch problems? Or miss them?
+* Did code state validation (`**Current implementation**` blocks) match reality?
+* Did auto-commit handle dirty files properly?
+
+**Verification execution (ExecutePlan Step 7):**
+
+* Which verifications ran vs were skipped?
+* Did verifications match what the plan revision checkboxes specified?
+* For each verification: did the prompt execute correctly? Were failures diagnosed?
+* How many fix-retry cycles occurred (max 3 allowed)?
+* Were verification results written to `verification/` correctly?
+* Were plan verification statuses updated via `tendril plan set-verification`?
+
+**Post-verification (ExecutePlan Step 7.5–8):**
+
+* Were recommendations generated?
+* Was the worktree left clean?
+* Were zombie processes detected/killed?
+
+**CheckResult / completion verification (JobService):**
+
+* For CreatePlan: did `VerifyCreatePlanResult` find the plan folder or trash entry?
+* Did `CheckDependencies` correctly evaluate dependency plan states?
+* Did `TryBlockForDependencies` transition appropriately?
+
+Cross-reference each finding with:
+
+* `Promptwares/{Type}/Program.md` — could instructions prevent this?
+* `Promptwares/{Type}/Memory/` — is knowledge missing or ignored?
+* `Services/JobService.cs` — job lifecycle issues
+* `Services/PlanReaderService.cs` — plan state/repair issues
+* `Promptwares/.shared/Plans.md` — schema/CLI issues
+
+### Phase 4 — Produce Recommendations Report
+
+Write the report to `$TENDRIL_PLANS/{planid}-*/debug-report.md` (alongside the plan).
+
+Use this format:
+
+```Markdown
+# Debug Report: {PlanId} — {Title}
+
+- **Analyzed:** {current timestamp}
+- **Plan State:** {state}
+- **User Note:** {the note argument}
+- **Promptwares Run:** {list}
+- **Total Tokens:** {sum}
+- **Wall-Clock Time:** {duration}
+
+## Executive Summary
+
+{3-5 sentences: what happened, what went wrong, what's the root cause}
+
+## Timeline
+
+| # | Step | Promptware | Status | Duration | Tokens | Notes |
+|---|------|------------|--------|----------|--------|-------|
+| 1 | CreatePlan | CreatePlan | Completed | 2m30s | 45k | — |
+| 2 | Execute | ExecutePlan | Failed | 15m | 280k | build loop |
+| ... | | | | | | |
+
+## Checking & Verification Analysis
+
+### Pre-Execution Checks
+{What passed, what failed, what was missed}
+
+### Verification Results
+| Verification | Expected | Actual | Correct? | Notes |
+|-------------|----------|--------|----------|-------|
+| Build | Pass | Pass | Yes | — |
+| IvyFramework | Pass | Pass | No | Should have caught X |
+
+### Completion Verification
+{How JobService verified the result, any gaps}
+
+## Findings
+
+### {Finding Title}
+
+- **Category:** {Token Waste | Error Loop | Missing Knowledge | Instruction Gap | Environmental | Architectural | Verification Gap}
+- **Severity:** {Low | Medium | High | Critical}
+- **Promptware:** {which one}
+- **Evidence:** {specific log lines, timestamps, tool call IDs}
+
+{Description with specific evidence.}
+
+**Root Cause:** {why this happened}
+
+**Recommendation:** {concrete fix — which file to change, what to change, why}
+
+---
+
+{Repeat for each finding}
+
+## Concrete Fixes
+
+Priority-ordered list of specific changes:
+
+1. **[High] {file path}**: {what to change and why}
+2. **[Medium] {file path}**: {what to change and why}
+3. ...
+
+## Skill Self-Improvement Notes
+
+{If this analysis revealed patterns or techniques that would make future debugging faster,
+note them here. These will be incorporated into the skill's references/ directory.}
+```
+
+## Key Tendril Files for Cross-Reference
+
+These are the files most likely to contain the root cause of issues:
+
+| File                                               | What It Controls                                            |
+| -------------------------------------------------- | ----------------------------------------------------------- |
+| `Services/JobService.cs`                           | Job lifecycle, dependency checking, completion verification |
+| `Services/JobLauncher.cs`                          | Job launch, CLI shim generation, firmware value population  |
+| `Services/JobCompletionHandler.cs`                 | Post-completion: logs, raw output, plan state, telemetry    |
+| `Services/PlanReaderService.cs`                    | Plan state transitions, repair logic, stuck plan recovery   |
+| `Services/GitService.cs`                           | Worktree creation/cleanup, commit operations                |
+| `Services/Agents/FirmwareCompiler.cs`              | Prompt compilation, log file allocation                     |
+| `Promptwares/ExecutePlan/Program.md`               | Main execution flow, all verification steps                 |
+| `Promptwares/ExecutePlan/Tools/Update-PlanYaml.ps1`| Fallback plan.yaml updater when CLI unavailable             |
+| `Promptwares/CreatePlan/Program.md`                | Plan creation, folder setup                                 |
+| `Promptwares/.shared/Plans.md`                     | Plan schema, CLI commands, state lifecycle                  |
+| `Promptwares/{Type}/Memory/`                       | Agent knowledge base per promptware                         |
+| `Models/PlanModels.cs`                             | Plan deserialization model                                  |
+| `Helpers/PlanContentHelpers.cs`                    | Commit row building, plan content rendering                 |
+
+## Rules
+
+* **Read-only by default**: do NOT modify source code, promptware instructions, or memory files during analysis. The output is a recommendations report.
+* **Always produce a report**, even if no issues are found — "plan executed cleanly" is a valid finding.
+* **Be specific**: cite file paths, line numbers, log timestamps, tool call sequences.
+* **Focus on the checking pipeline**: verification gaps (things that should have been caught but weren't) are higher priority than token waste.
+* **Use targeted reads**: JSONL files can be huge — use offset/limit or grep rather than reading entire files.
+* **The user's note is your guide**: prioritize investigating what the user flagged.
+
+## Self-Evolution
+
+This skill is designed to improve over time. After producing a report:
+
+1. If you discovered a new debugging pattern or common failure mode not covered here, write it to `references/{topic}.md`
+2. If a cross-reference path was wrong or a file moved, update the paths in this SKILL.md
+3. If the report format could be improved based on what you learned, update the template above
+
+The `references/` directory accumulates knowledge from past debugging sessions.

--- a/src/skills/tendril-debug-plan/references/common-failure-modes.md
+++ b/src/skills/tendril-debug-plan/references/common-failure-modes.md
@@ -1,0 +1,105 @@
+# Common Failure Modes
+
+Patterns observed from past PlanEvaluator runs and debugging sessions.
+
+## Instruction Gap Failures
+
+### Silently Skipped Deliverables
+- **Symptom**: Plan revision lists N components to create, agent only creates N-1
+- **Root cause**: Program.md doesn't enforce a checklist-driven approach per deliverable
+- **Where to look**: Compare revision acceptance criteria against actual file changes in commits
+- **Fix area**: `Promptwares/ExecutePlan/Program.md` — add explicit deliverable tracking
+
+### CheckResult False Positive
+- **Symptom**: Verification marked Pass despite missing files or unmet targets
+- **Root cause**: Verification prompt checks build/test success but doesn't cross-reference the full plan revision
+- **Where to look**: `verification/*.md` reports, compare against revision requirements
+- **Fix area**: Verification prompts in `config.yaml`, `Promptwares/ExecutePlan/Program.md` Step 7
+
+## Token Waste Patterns
+
+### Redundant File Reads
+- **Symptom**: Same file read 4+ times in a single session
+- **Where to look**: JSONL analysis — count Read tool calls per file path
+- **Threshold**: >3 reads of the same file is suspicious, >6 is definitely wasteful
+
+### Context Bloat
+- **Symptom**: Single message with very high `input_tokens` (>50k)
+- **Where to look**: JSONL messages sorted by input_tokens
+- **Root cause**: Usually reading large files when grep would suffice
+
+## Error Loop Patterns
+
+### Build-Fix Cycles
+- **Symptom**: 3+ iterations of build → error → edit → build
+- **Where to look**: JSONL tool call sequences, grep for `dotnet build` or `npm run build`
+- **Root cause**: Agent missing knowledge about API changes, type system, or framework patterns
+- **Fix area**: `Promptwares/{Type}/Memory/` — add knowledge about the specific error pattern
+
+### Type Mismatch Loops
+- **Symptom**: Agent repeatedly tries different type casts/interfaces
+- **Where to look**: JSONL edit tool calls on the same lines
+- **Root cause**: Missing memory about the project's type hierarchy
+- **Example**: IStream→IWriteStream confusion in Ivy framework
+
+## Environmental Failures
+
+### Stuck Plans
+- **Symptom**: Plan stays in Building/Executing state indefinitely
+- **Where to look**: `PlanReaderService.RecoverStuckPlans()` — runs on startup only
+- **Root cause**: Agent process died without cleanup
+- **Fix area**: `Services/PlanReaderService.cs`
+
+### Plan Counter Collisions
+- **Symptom**: Two plans with the same ID
+- **Where to look**: `$TENDRIL_PLANS/.counter`
+- **Root cause**: Multiple Tendril instances running simultaneously
+
+### Missing Logs
+- **Symptom**: No `.raw.jsonl` for a promptware execution
+- **Where to look**: Check if `Logs/` directory exists under the promptware folder
+- **Root cause**: `WriteRawOutputLog` in `JobCompletionHandler.cs` only writes if the directory exists
+
+## CLI / Shim Failures
+
+### Bash Shim Broken Quotes (Fixed 2026-04-26)
+- **Symptom**: Every `tendril` CLI call fails with `unexpected EOF while looking for matching '"'`. Agent falls back to PowerShell tools (`Update-PlanYaml.ps1`) for everything.
+- **Where to look**: Check JSONL for repeated bash errors mentioning the tendril command. Look for the agent switching from CLI to PowerShell fallbacks mid-session.
+- **Root cause**: The bash shim at `/tmp/tendril-shim/tendril` was generated with Windows backslash paths in double quotes. A trailing `\"` was interpreted as an escaped quote by bash.
+- **Fix area**: `Services/JobLauncher.cs` — shim generation. Bash shim now uses single quotes and forward slashes.
+- **Cascading effect**: When the CLI breaks, the agent uses `Update-PlanYaml.ps1` directly, which previously had no guardrails against self-certifying delegated verifications. This was the root cause of the 03534 self-certification incident.
+
+### CLI Process File Lock
+- **Symptom**: `dotnet run --project` fails because another process holds a lock on the output directory
+- **Where to look**: JSONL errors mentioning file locks, `MSB3027`, or `IOException` on `.dll` files
+- **Root cause**: Multiple concurrent agent processes sharing the same shim build output directory
+- **Fix area**: Each agent gets its own `BaseOutputPath` via the shim generation code
+
+## Verification Integrity Failures
+
+### Delegated Verification Self-Certification (Fixed 2026-04-26)
+- **Symptom**: A verification that has its own dedicated promptware (e.g., `IvyFrameworkVerification`) is marked Pass by the ExecutePlan agent without actually running the separate promptware. The verification report contains only a code review, not actual test execution.
+- **Where to look**: Check `verification/{Name}.md` — does it show actual test execution or just a code review? Cross-reference with config.yaml promptwares section.
+- **Root cause**: When the tendril CLI was broken, the agent wrote the verification report manually and called `Update-PlanYaml.ps1 -SetVerification Name=Pass`. There was no enforcement preventing this.
+- **Detection**: If a verification name matches a directory under `Promptwares/`, it's delegated and should NOT be self-certified. The `Update-PlanYaml.ps1` script now blocks this.
+- **Fix area**: `Promptwares/ExecutePlan/Program.md` (instruction-level) + `Promptwares/ExecutePlan/Tools/Update-PlanYaml.ps1` (code-level enforcement)
+
+### Commit Hash Display Mismatch (Fixed 2026-04-26)
+- **Symptom**: All commits show "Potentially corrupted commits" in the UI with no messages or file counts, even though the commits exist.
+- **Where to look**: `plan.yaml` stores abbreviated 9-char hashes, but `GetCommitSummaries` returns full 40-char hashes. The dictionary lookup in `PlanContentHelpers.BuildCommitRows` fails silently.
+- **Root cause**: `GitService.GetCommitSummaries` keyed results by full hash only. The abbreviated hash from plan.yaml never matched.
+- **Fix area**: `Services/GitService.cs` — `StoreCommitResult` now stores under both full and abbreviated hashes.
+
+## Log / Output Failures
+
+### Log File Race Condition (Fixed 2026-04-26)
+- **Symptom**: A plan's execution log in `Promptwares/{Type}/Logs/` is overwritten by another concurrent execution. The original session's log is permanently lost.
+- **Where to look**: Compare the firmware header's log file path (visible in the session JSONL) against what actually exists at that path. If the content is for a different plan, it was overwritten.
+- **Root cause**: `FirmwareCompiler.GetNextLogFile` assigned the next number but didn't create the file, so concurrent calls got the same number.
+- **Fix area**: `Services/Agents/FirmwareCompiler.cs` — now reserves the file on disk immediately.
+
+### Raw JSONL Keyed by Wrong ID (Fixed 2026-04-26)
+- **Symptom**: No `{PlanId}.raw.jsonl` exists, but a `job-{N}.raw.jsonl` does contain the session data.
+- **Where to look**: `Promptwares/{Type}/Logs/` — check for files with job IDs instead of plan IDs.
+- **Root cause**: `job.AllocatedPlanId` was only set for CreatePlan jobs. Other job types (ExecutePlan, etc.) left it null, so `WriteRawOutputLog` used the ephemeral job ID as filename.
+- **Fix area**: `Services/JobLauncher.cs` — now sets `AllocatedPlanId` for all jobs that operate on a plan folder.

--- a/src/skills/tendril-debug-plan/references/jsonl-analysis.md
+++ b/src/skills/tendril-debug-plan/references/jsonl-analysis.md
@@ -1,0 +1,108 @@
+# JSONL Session Analysis Reference
+
+How to efficiently analyze Claude session JSONL files from Tendril plan executions.
+
+## File Location
+
+Session JSONL files are stored at:
+```
+~/.claude/projects/{project-hash}/{SessionId}.jsonl
+```
+
+Find by session ID:
+```bash
+find ~/.claude/projects -name "{SessionId}.jsonl"
+```
+
+The SessionId is found in plan log entries at `{PlanFolder}/logs/*.md`.
+
+## JSONL Structure
+
+Each line is a JSON object. Key message types:
+
+### Assistant Messages (token usage + tool calls)
+```json
+{
+  "type": "assistant",
+  "message": {
+    "usage": {
+      "input_tokens": 12345,
+      "output_tokens": 678,
+      "cache_read_input_tokens": 9000,
+      "cache_creation_input_tokens": 3000
+    },
+    "content": [
+      {"type": "text", "text": "..."},
+      {"type": "tool_use", "id": "toolu_xxx", "name": "Read", "input": {"file_path": "..."}}
+    ]
+  }
+}
+```
+
+### Tool Results
+```json
+{
+  "type": "tool_result",
+  "tool_use_id": "toolu_xxx",
+  "content": "file contents or error..."
+}
+```
+
+## Analysis Techniques
+
+### Quick Token Summary (PowerShell)
+Use the existing tool:
+```powershell
+& "$REPOS_HOME/Ivy-Tendril/src/Ivy.Tendril.TeamIvyConfig/Promptwares/PlanEvaluator/Tools/Analyze-SessionJsonl.ps1" -Path "path/to/session.jsonl"
+```
+
+### Manual JSONL Scanning
+For large files, don't read the whole thing. Instead:
+
+```bash
+# Count total lines (messages)
+wc -l session.jsonl
+
+# Find error patterns
+grep -i '"error\|"failed\|"exception' session.jsonl | head -20
+
+# Count tool types
+grep '"tool_use"' session.jsonl | grep -oP '"name":\s*"\K[^"]+' | sort | uniq -c | sort -rn
+
+# Find duplicate file reads
+grep '"Read"' session.jsonl | grep -oP '"file_path":\s*"\K[^"]+' | sort | uniq -c | sort -rn | head -10
+
+# Token usage per assistant message
+grep '"assistant"' session.jsonl | grep -oP '"input_tokens":\s*\K\d+' | awk '{s+=$1} END {print "Total input:", s}'
+```
+
+### Reading Large JSONL
+Use offset/limit on the Read tool rather than reading entire files:
+- Read first 50 lines for session start context
+- Read last 50 lines for final outcome
+- Grep for specific patterns in between
+
+## Key Metrics
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| Cache hit ratio | >60% | 30-60% | <30% |
+| Duplicate file reads | 0-2 | 3-5 | >5 |
+| Build-fix cycles | 0-1 | 2-3 | >3 |
+| Total tokens (ExecutePlan) | <200k | 200-400k | >400k |
+| Wall-clock time | <10min | 10-20min | >20min |
+| Failed tool calls | 0-3 | 4-8 | >8 |
+
+## Cascading Failure Pattern
+
+A single infrastructure failure (e.g., broken CLI shim) can cascade through the entire execution:
+
+1. **CLI broken** → agent falls back to PowerShell tools
+2. **Fallback tools lack guardrails** → agent self-certifies delegated verifications
+3. **Self-certification** → verification marked Pass without actual testing
+4. **Plan appears complete** → moves to PR creation with unverified code
+
+When analyzing a plan with unexpected results, trace backwards from the symptom:
+- First check if the tendril CLI was available (search JSONL for CLI errors)
+- If CLI failed, check which fallback paths the agent took
+- Check whether those fallback paths have the same enforcement as the CLI

--- a/src/skills/tendril-debug-plan/references/verification-pipeline.md
+++ b/src/skills/tendril-debug-plan/references/verification-pipeline.md
@@ -1,0 +1,104 @@
+# Verification Pipeline Reference
+
+How Tendril's plan verification and checking works end-to-end.
+
+## Verification Lifecycle
+
+```
+Plan Revision checkboxes (- [x] Build, - [ ] Tests)
+    ↓
+config.yaml defines verification prompts
+    ↓
+ExecutePlan Step 7 runs each checked verification
+    ↓
+Up to 3 fix-retry cycles per verification
+    ↓
+Results written to verification/{Name}.md
+    ↓
+Status set via: tendril plan set-verification <id> <name> <status>
+    ↓
+Valid statuses: Pending, Pass, Fail, Skipped
+```
+
+## Pre-Execution Checks (ExecutePlan Steps 1.5–1.8)
+
+### Step 1.5 — Dependency Verification
+- Reads `dependsOn` from plan.yaml
+- For each dependency plan: checks state is `Completed` and PRs are `MERGED`
+- Uses `gh pr view` to verify PR merge status
+- **Common failure**: dependency plan completed but PR not yet merged
+
+### Step 1.6 — Worktree Isolation Validation
+- Ensures target repos are not already worktrees
+- Ensures plans directory is not inside a git worktree
+- **Common failure**: stale worktree from a previous failed execution
+
+### Step 1.7 — Code State Validation
+- Scans plan revisions for `**Current implementation**` code blocks
+- Validates those blocks still match the actual codebase files
+- Writes `verification/PreExecution.md`
+- Also detects self-flagged redundancy (plan says it's already done)
+- **Common failure**: code changed between plan creation and execution
+
+### Step 1.8 — Auto-Commit Uncommitted Changes
+- Detects dirty files in target repos
+- Commits and pushes before worktree creation
+- Includes stale-file detection
+- **Common failure**: uncommitted changes in unexpected repos
+
+## Post-Execution Verification
+
+### JobService.VerifyCreatePlanResult
+- Runs after CreatePlan agent exits with code 0
+- Checks for `"Plan created: <folder>"` marker in agent output
+- Verifies plan folder exists on disk (`FindPlanFolderById`)
+- Falls back to checking trash (`FindTrashEntryById`)
+- Can change `Completed → Failed` if verification fails
+
+### JobService.CheckDependencies
+- Called by `TryBlockForDependencies` for ExecutePlan jobs
+- Delegates to `JobCompletionHandler.CheckDependencies(planFolder)`
+- Verifies dependency plans are `Completed` and PRs are merged
+- Sets job to `Blocked` if unmet, transitions plan to `Blocked` state
+
+### Resume-vs-Redo Logic (ExecutePlan)
+On re-execution, checks if prior run is intact:
+- Commits populated
+- All verifications pass
+- Reports exist
+- Worktree clean
+If all pass → resumes from where it left off rather than redoing
+
+## Inline vs Delegated Verifications
+
+Verifications come in two forms:
+
+### Inline Verifications
+- Defined only in `config.yaml` with a `prompt:` field
+- Executed directly by the ExecutePlan agent within its session
+- Examples: `DotnetBuild`, `DotnetTest`
+
+### Delegated Verifications
+- Have a matching directory under `Promptwares/{VerificationName}/`
+- Must be run as a separate process via `tendril promptware {Name}`
+- The ExecutePlan agent CANNOT self-certify these as Pass
+- Examples: `IvyFrameworkVerification` (creates a sample app, runs Playwright tests)
+
+### How to detect delegation
+Check if a directory exists at `Promptwares/{VerificationName}/` — if it does, it's delegated. This is enforced in:
+- `Update-PlanYaml.ps1` — blocks `-SetVerification Name=Pass` when a matching promptware directory exists
+- `Promptwares/ExecutePlan/Program.md` — instructs the agent to check config.yaml's promptwares section
+
+### Self-certification red flags
+When debugging, if you see a delegated verification marked Pass:
+1. Check `verification/{Name}.md` — does it describe actual test execution or just code review?
+2. Check the JSONL for `tendril promptware {Name}` invocations — were they attempted?
+3. Check for CLI errors that might have prevented the agent from invoking the promptware
+
+## Common Verification Gaps
+
+1. **CheckResult too lenient**: Verification passes despite missing deliverables (e.g., planned file not created)
+2. **Verification doesn't cross-reference plan revision**: Status set to Pass without checking all acceptance criteria
+3. **Stale worktree state**: Worktree from previous failed run not cleaned up properly
+4. **Dependency race**: Plan unblocked before dependency PR is actually merged (GitHub API lag)
+5. **Delegated verification self-certified**: Agent bypasses the separate promptware and marks it Pass directly (see common-failure-modes.md)


### PR DESCRIPTION
- Fix commit hash mismatch: store results under both full and abbreviated hashes in GetCommitSummaries
- Fix bash shim broken quotes: use single quotes and forward slashes for bash paths
- Prevent delegated verification self-certification: instruction + code enforcement in Update-PlanYaml.ps1
- Fix log file race condition: GetNextLogFile now reserves file on disk immediately
- Fix raw.jsonl keyed by wrong ID: set AllocatedPlanId for all plan-operating jobs
- Enrich plan folder logs with provider, cost, tokens, and execution outcome summary
- Update tendril-debug-plan skill with learnings from this investigation
