### PR TITLE
Remove dangerous recursive directory cleanup and add logging to silent catch blocks

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/jobs/job-002.status.jsonl
+++ b/src/Ivy.Tendril.TeamIvyConfig/jobs/job-002.status.jsonl
@@ -1,1 +1,0 @@
-{"timestamp":"2026-04-26T15:40:06.4936940Z","command":"job status job-002 --message Verifying: CheckResult","exitCode":0,"durationMs":79.5159}

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -607,7 +607,6 @@ public static class DoctorCommand
             var yamlPath = Path.Combine(dir, "plan.yaml");
             var (yamlHealthy, yamlError, state) = CheckYamlHealth(yamlPath);
             var worktreeCount = CountWorktrees(dir);
-            var hasNestedWorktrees = HasNestedWorktrees(dir);
             var hasStaleWorktrees = HasStaleWorktrees(dir);
 
             var recsError = CheckRecommendationsHealth(dir);
@@ -617,8 +616,6 @@ public static class DoctorCommand
                 healthIssues.Add($"YAML:{yamlError}");
             if (recsError != null)
                 healthIssues.Add($"Recs:{recsError}");
-            if (hasNestedWorktrees)
-                healthIssues.Add("NestedWorktree");
             if (hasStaleWorktrees)
                 healthIssues.Add("StaleWorktree");
 
@@ -702,28 +699,6 @@ public static class DoctorCommand
             return 0;
 
         return Directory.GetDirectories(worktreesPath).Length;
-    }
-
-    internal static bool HasNestedWorktrees(string planPath)
-    {
-        var worktreesPath = Path.Combine(planPath, "worktrees");
-        if (!Directory.Exists(worktreesPath))
-            return false;
-
-        try
-        {
-            foreach (var wtDir in Directory.GetDirectories(worktreesPath))
-            {
-                var nestedGit = Directory.EnumerateFileSystemEntries(wtDir, ".git", SearchOption.AllDirectories).ToList();
-                if (nestedGit.Count > 1 || (nestedGit.Count == 1 && nestedGit[0] != Path.Combine(wtDir, ".git")))
-                    return true;
-            }
-            return false;
-        }
-        catch
-        {
-            return false;
-        }
     }
 
     internal static bool HasStaleWorktrees(string planPath)
@@ -853,21 +828,6 @@ public static class DoctorCommand
                             Directory.Delete(wtDir, true);
                     }
                     repairs.Add("removed stale worktrees");
-                }
-            }
-
-            if (healthResult.Health.Contains("NestedWorktree"))
-            {
-                var worktreesPath = Path.Combine(planPath, "worktrees");
-                if (Directory.Exists(worktreesPath))
-                {
-                    foreach (var wtDir in Directory.GetDirectories(worktreesPath))
-                    {
-                        var plansSubDir = Path.Combine(wtDir, "Plans");
-                        if (Directory.Exists(plansSubDir))
-                            Directory.Delete(plansSubDir, true);
-                    }
-                    repairs.Add("cleaned nested worktrees");
                 }
             }
 

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -476,8 +476,9 @@ internal class JobCompletionHandler
                     PlanYamlHelper.SetPlanStateByFolder(planFolder, targetState.ToString());
             }
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Failed to ensure plan state transition for job {JobId}", job.Id);
         }
     }
 
@@ -491,8 +492,9 @@ internal class JobCompletionHandler
             else
                 PlanYamlHelper.SetPlanStateByFolder(planFolder, state);
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Failed to set plan state to {State} for job {JobId}", state, job.Id);
         }
     }
 
@@ -555,8 +557,9 @@ internal class JobCompletionHandler
             var failureMessage = JobFailureAnalyzer.TryReadFailureArtifact(job.OutputLines.ToList());
             job.StatusMessage = failureMessage ?? "No plan created";
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Failed to verify CreatePlan result for job {JobId}", job.Id);
         }
     }
 
@@ -570,8 +573,9 @@ internal class JobCompletionHandler
             var newState = job.Type == "ExecutePlan" ? "Failed" : "Draft";
             PlanYamlHelper.SetPlanStateByFolder(planFolder, newState);
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Failed to reset plan state for job {JobId}", job.Id);
         }
     }
 
@@ -582,8 +586,9 @@ internal class JobCompletionHandler
             var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
             PlanYamlHelper.SetPlanStateByFolder(planFolder, "Blocked");
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Failed to reset plan state to Blocked for job {JobId}", job.Id);
         }
     }
 
@@ -611,6 +616,7 @@ internal class JobCompletionHandler
         if (!Directory.Exists(worktreesDir)) return;
 
         var lifecycleLogger = _worktreeLifecycleLogger;
+        var logger = _logger;
 
         Task.Run(async () =>
         {
@@ -622,8 +628,9 @@ internal class JobCompletionHandler
                 if (Directory.Exists(worktreesDir) && Directory.GetDirectories(worktreesDir).Length == 0)
                     Directory.Delete(worktreesDir, false);
             }
-            catch
+            catch (Exception ex)
             {
+                logger.LogWarning(ex, "Failed to cleanup worktrees for {PlanFolder}", Path.GetFileName(planFolder));
             }
         });
     }

--- a/src/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -31,7 +31,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
 
     public void Start()
     {
-        _timer = new Timer(_ => RunCleanup(), null, TimeSpan.Zero, TimerInterval);
+        _timer = new Timer(_ => RunCleanup(), null, TimeSpan.FromMinutes(5), TimerInterval);
     }
 
     public void Dispose()
@@ -45,13 +45,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
         {
             if (!Directory.Exists(_plansDirectory)) return;
 
-            // First pass: remove recursive Plans artifacts within worktrees
-            CleanupRecursiveArtifacts();
-
-            // Clean up legacy .promptwares directories (pre-migration artifacts)
-            CleanupLegacyPromptwaresDirs();
-
-            // Second pass: regular plan-level worktree cleanup
+            // Regular plan-level worktree cleanup
             foreach (var dir in Directory.GetDirectories(_plansDirectory))
             {
                 try
@@ -67,54 +61,6 @@ public class WorktreeCleanupService : IStartable, IDisposable
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Worktree cleanup scan failed");
-        }
-    }
-
-    internal void CleanupRecursiveArtifacts()
-    {
-        try
-        {
-            if (!Directory.Exists(_plansDirectory)) return;
-
-            foreach (var planDir in Directory.GetDirectories(_plansDirectory))
-            {
-                try
-                {
-                    var worktreesDir = Path.Combine(planDir, "worktrees");
-                    if (!Directory.Exists(worktreesDir)) continue;
-
-                    var nestedPlans = Directory.GetDirectories(worktreesDir, "Plans", SearchOption.AllDirectories);
-
-                    foreach (var nestedPlanDir in nestedPlans)
-                    {
-                        try
-                        {
-                            _logger.LogInformation(
-                                "Removing recursive Plans artifact at {Path} (parent: {Parent})",
-                                nestedPlanDir.Replace(_plansDirectory + Path.DirectorySeparatorChar, ""),
-                                Path.GetFileName(planDir));
-
-                            ForceDeleteDirectory(nestedPlanDir, _logger);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex,
-                                "Failed to delete nested Plans directory {Path}",
-                                nestedPlanDir.Replace(_plansDirectory + Path.DirectorySeparatorChar, ""));
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex,
-                        "Failed to scan for recursive artifacts in {PlanFolder}",
-                        Path.GetFileName(planDir));
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Recursive artifact cleanup scan failed");
         }
     }
 
@@ -344,54 +290,6 @@ public class WorktreeCleanupService : IStartable, IDisposable
         catch
         {
             // handle.exe not installed or failed — continue
-        }
-    }
-
-    internal void CleanupLegacyPromptwaresDirs()
-    {
-        try
-        {
-            if (!Directory.Exists(_plansDirectory)) return;
-
-            foreach (var planDir in Directory.GetDirectories(_plansDirectory))
-            {
-                try
-                {
-                    var worktreesDir = Path.Combine(planDir, "worktrees");
-                    if (!Directory.Exists(worktreesDir)) continue;
-
-                    var legacyDirs = Directory.GetDirectories(worktreesDir, ".promptwares", SearchOption.AllDirectories);
-
-                    foreach (var legacyDir in legacyDirs)
-                    {
-                        try
-                        {
-                            _logger.LogInformation(
-                                "Removing legacy .promptwares directory at {Path} (parent: {Parent})",
-                                legacyDir.Replace(_plansDirectory + Path.DirectorySeparatorChar, ""),
-                                Path.GetFileName(planDir));
-
-                            ForceDeleteDirectory(legacyDir, _logger);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogWarning(ex,
-                                "Failed to delete legacy .promptwares directory {Path}",
-                                legacyDir.Replace(_plansDirectory + Path.DirectorySeparatorChar, ""));
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex,
-                        "Failed to scan for legacy .promptwares in {PlanFolder}",
-                        Path.GetFileName(planDir));
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Legacy .promptwares cleanup scan failed");
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove `CleanupRecursiveArtifacts` — was recursively searching worktrees for directories named `Plans` and deleting them, which destroyed `src/Ivy.Tendril/Apps/Plans/` source code
- Remove `CleanupLegacyPromptwaresDirs` — same risky recursive-by-name deletion pattern for `.promptwares`
- Remove `HasNestedWorktrees` detection and repair from `DoctorCommand`
- Delay `WorktreeCleanupService` startup timer from immediate to 5 minutes
- Add `_logger.LogWarning` to 6 bare `catch {}` blocks in `JobCompletionHandler` state transition methods

## Test plan
- [ ] Verify Tendril starts without errors
- [ ] Verify worktrees are no longer missing `Apps/Plans/` after startup
- [ ] Verify review action can build and launch from a plan worktree