### PR TITLE
[03557] Move Edit button first in Plans toolbar

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -171,26 +171,7 @@ public class ContentView(
         object planTabContent;
         if (isEditing.Value)
         {
-            var editBar = Layout.Horizontal().Gap(2).Padding(0, 0, 2, 0)
-                          | new Button("Save Revision").Icon(Icons.Save).Primary().OnClick(() =>
-                          {
-                              if (selectedPlan != null && editContent.Value != originalContent.Value)
-                              {
-                                  planService.SaveRevision(selectedPlan.FolderName, editContent.Value);
-                                  var updated = planService.GetPlanByFolder(selectedPlan.FolderPath);
-                                  if (updated != null) selectedPlanState.Set(updated);
-                                  refreshPlans();
-                              }
-                              isEditing.Set(false);
-                          })
-                          | new Button("Cancel").Outline().OnClick(() =>
-                          {
-                              editContent.Set(originalContent.Value);
-                              isEditing.Set(false);
-                          });
-            planTabContent = Layout.Vertical()
-                            | editBar
-                            | editContent.ToCodeInput()
+            planTabContent = editContent.ToCodeInput()
                                 .Language(Languages.Markdown)
                                 .Width(Size.Full());
         }
@@ -278,11 +259,36 @@ public class ContentView(
             j.Args.Length > 0 &&
             j.Args[0].Equals(selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
 
-        var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(1)
-                        | new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")
-                            .OnClick(() => updateDialogOpen.Set(true))
+        object actionBar;
+        if (isEditing.Value)
+        {
+            // Edit mode: show only Save and Cancel buttons
+            actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(1)
+                        | new Button("Save Revision").Icon(Icons.Save).Primary().ShortcutKey("S").OnClick(() =>
+                        {
+                            if (selectedPlan != null && editContent.Value != originalContent.Value)
+                            {
+                                planService.SaveRevision(selectedPlan.FolderName, editContent.Value);
+                                var updated = planService.GetPlanByFolder(selectedPlan.FolderPath);
+                                if (updated != null) selectedPlanState.Set(updated);
+                                refreshPlans();
+                            }
+                            isEditing.Set(false);
+                        })
+                        | new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() =>
+                        {
+                            editContent.Set(originalContent.Value);
+                            isEditing.Set(false);
+                        });
+        }
+        else
+        {
+            // Normal mode: show all action buttons (Edit first)
+            actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(1)
                         | new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
                             .OnClick(() => isEditing.Set(true))
+                        | new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")
+                            .OnClick(() => updateDialogOpen.Set(true))
                         | new Button("Split").Icon(Icons.Scissors).Outline().ShortcutKey("s")
                             .Disabled(hasActiveSplitJob)
                             .OnClick(() =>
@@ -365,6 +371,7 @@ public class ContentView(
                                 config.OpenInEditor(yamlPath);
                             })
                         );
+        }
 
         var mainLayout = new HeaderLayout(
             header,


### PR DESCRIPTION
# Summary

## Changes

Reordered the Plans app toolbar to place the Edit button first, and relocated the Save Revision and Cancel buttons from a separate edit bar into the main toolbar when in edit mode. The toolbar now dynamically switches between normal mode (showing all action and navigation buttons) and edit mode (showing only Save and Cancel).

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Plans/ContentView.cs` — Reordered action buttons and added conditional toolbar logic for edit mode

## Commits

- 349d398 [03557] Move Edit button first and relocate Save/Cancel to toolbar in edit mode