### PR TITLE
[03559] Clear Completed Jobs on Tendril Restart

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
@@ -1,0 +1,168 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class JobServiceStartupTests
+{
+    [Fact]
+    public void LoadHistoricalJobs_ExcludesCompletedJobs()
+    {
+        // Arrange: seed database with completed and active jobs
+        var db = new FakeDatabaseService
+        {
+            Jobs =
+            {
+                new JobItem { Id = "job-1", Status = JobStatus.Completed },
+                new JobItem { Id = "job-2", Status = JobStatus.Failed },
+                new JobItem { Id = "job-3", Status = JobStatus.Timeout },
+                new JobItem { Id = "job-4", Status = JobStatus.Stopped },
+                new JobItem { Id = "job-5", Status = JobStatus.Running },
+                new JobItem { Id = "job-6", Status = JobStatus.Pending },
+                new JobItem { Id = "job-7", Status = JobStatus.Queued },
+                new JobItem { Id = "job-8", Status = JobStatus.Blocked }
+            }
+        };
+
+        // Act: create JobService (which calls LoadHistoricalJobs)
+        var service = new JobService(
+            TimeSpan.FromMinutes(30),
+            TimeSpan.FromMinutes(10),
+            database: db);
+
+        // Assert: only non-terminal jobs are loaded
+        var jobs = service.GetJobs().ToList();
+        Assert.Equal(4, jobs.Count);
+        Assert.Contains(jobs, j => j.Id == "job-5"); // Running
+        Assert.Contains(jobs, j => j.Id == "job-6"); // Pending
+        Assert.Contains(jobs, j => j.Id == "job-7"); // Queued
+        Assert.Contains(jobs, j => j.Id == "job-8"); // Blocked
+
+        // Terminal jobs should not be loaded
+        Assert.DoesNotContain(jobs, j => j.Id == "job-1"); // Completed
+        Assert.DoesNotContain(jobs, j => j.Id == "job-2"); // Failed
+        Assert.DoesNotContain(jobs, j => j.Id == "job-3"); // Timeout
+        Assert.DoesNotContain(jobs, j => j.Id == "job-4"); // Stopped
+    }
+
+    [Fact]
+    public void LoadHistoricalJobs_NoDatabaseProvided_DoesNotThrow()
+    {
+        // Act & Assert: creating service without database should not throw
+        var exception = Record.Exception(() => new JobService(
+            TimeSpan.FromMinutes(30),
+            TimeSpan.FromMinutes(10),
+            database: null));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void LoadHistoricalJobs_DatabaseThrows_DoesNotBlockStartup()
+    {
+        // Arrange: database that throws on GetRecentJobs
+        var db = new FakeDatabaseService { ThrowOnGetRecentJobs = true };
+
+        // Act & Assert: creating service should not throw
+        var exception = Record.Exception(() => new JobService(
+            TimeSpan.FromMinutes(30),
+            TimeSpan.FromMinutes(10),
+            database: db));
+
+        Assert.Null(exception);
+    }
+
+    private class FakeDatabaseService : IPlanDatabaseService
+    {
+        public List<JobItem> Jobs { get; } = new();
+        public bool ThrowOnGetRecentJobs { get; init; }
+
+        public List<JobItem> GetRecentJobs(int limit = 100)
+        {
+            if (ThrowOnGetRecentJobs) throw new Exception("DB error");
+            return Jobs;
+        }
+
+        public void DeleteJob(string id)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public List<PlanFile> GetPlans(PlanStatus? statusFilter = null)
+        {
+            return new List<PlanFile>();
+        }
+
+        public PlanFile? GetPlanByFolder(string folderPath)
+        {
+            return null;
+        }
+
+        public PlanFile? GetPlanById(int planId)
+        {
+            return null;
+        }
+
+        public PlanReaderService.PlanCountSnapshot ComputePlanCounts()
+        {
+            return new PlanReaderService.PlanCountSnapshot(0, 0, 0, 0, 0, 0);
+        }
+
+        public DashboardModels GetDashboardData(string? projectFilter)
+        {
+            return new DashboardModels(0, 0, 0, 0, 0, 0, 0, new List<DashboardDayStats>(), new List<ProjectCount>());
+        }
+
+        public decimal GetPlanTotalCost(int planId)
+        {
+            return 0;
+        }
+
+        public int GetPlanTotalTokens(int planId)
+        {
+            return 0;
+        }
+
+        public List<LatestJobsPerType> GetLatestJobsByType(int limit = 10)
+        {
+            return new List<LatestJobsPerType>();
+        }
+
+        public void UpsertJob(JobItem job)
+        {
+        }
+
+        public void UpsertPlan(PlanFile plan)
+        {
+        }
+
+        public void PurgeOldJobs(int keepCount = 500)
+        {
+        }
+
+        public Dictionary<string, string> GetAllPrStatuses()
+        {
+            return new Dictionary<string, string>();
+        }
+
+        public void UpsertPrStatus(string prUrl, string status)
+        {
+        }
+
+        public void RemovePrStatus(string prUrl)
+        {
+        }
+
+        public void LogCostEntry(string jobId, decimal inputCost, decimal outputCost, int inputTokens, int outputTokens)
+        {
+        }
+
+        public List<JobCostEntry> GetJobCostEntries(string jobId)
+        {
+            return new List<JobCostEntry>();
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
@@ -126,16 +126,69 @@ public class JobServiceStartupTests
             return 0;
         }
 
-        public List<LatestJobsPerType> GetLatestJobsByType(int limit = 10)
+        public List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7, string? projectFilter = null)
         {
-            return new List<LatestJobsPerType>();
+            return new List<HourlyTokenBurn>();
         }
 
-        public void UpsertJob(JobItem job)
+        public List<Recommendation> GetRecommendations()
+        {
+            return new List<Recommendation>();
+        }
+
+        public int GetPendingRecommendationsCount()
+        {
+            return 0;
+        }
+
+        public List<PlanFile> SearchPlans(string query)
+        {
+            return new List<PlanFile>();
+        }
+
+        public void RebuildFtsIndex()
+        {
+        }
+
+        public void UpdatePlanState(int planId, PlanStatus state)
+        {
+        }
+
+        public void UpdatePlanContent(int planId, string latestRevisionContent, int revisionCount)
+        {
+        }
+
+        public void UpdateRecommendationState(int planId, string recommendationTitle, string newState, string? declineReason)
         {
         }
 
         public void UpsertPlan(PlanFile plan)
+        {
+        }
+
+        public void DeletePlan(int planId)
+        {
+        }
+
+        public void UpsertCosts(int planId, List<CostEntry> costs)
+        {
+        }
+
+        public void UpsertRecommendations(int planId, string folderName, List<RecommendationYaml> recommendations,
+            string project, string planTitle, DateTime updated, PlanStatus status)
+        {
+        }
+
+        public void BulkUpsertPlans(List<PlanFile> plans, bool forceOverwrite = false)
+        {
+        }
+
+        public HashSet<int> GetTerminalPlanIds()
+        {
+            return new HashSet<int>();
+        }
+
+        public void UpsertJob(JobItem job)
         {
         }
 
@@ -148,21 +201,27 @@ public class JobServiceStartupTests
             return new Dictionary<string, string>();
         }
 
-        public void UpsertPrStatus(string prUrl, string status)
+        public void UpsertPrStatus(string prUrl, string owner, string repo, string status, DateTime lastChecked)
         {
         }
 
-        public void RemovePrStatus(string prUrl)
+        public List<string> GetNonMergedPrUrls()
         {
+            return new List<string>();
         }
 
-        public void LogCostEntry(string jobId, decimal inputCost, decimal outputCost, int inputTokens, int outputTokens)
+        public long GetDatabaseSize()
         {
+            return 0;
         }
 
-        public List<JobCostEntry> GetJobCostEntries(string jobId)
+        public DateTime GetLastSyncTime()
         {
-            return new List<JobCostEntry>();
+            return DateTime.UtcNow;
+        }
+
+        public void SetLastSyncTime(DateTime time)
+        {
         }
     }
 }

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -117,6 +117,7 @@ public class JobService : IJobService
         _completionHandler = new JobCompletionHandler(
             null, _logger, null, planReaderService, telemetryService,
             null, null, PromptsRoot);
+        LoadHistoricalJobs();
     }
 
     public event Action? JobsChanged;

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -304,7 +304,11 @@ public class JobService : IJobService
         if (_database == null) return;
         try
         {
-            var historicalJobs = _database.GetRecentJobs();
+            var historicalJobs = _database.GetRecentJobs()
+                .Where(j => j.Status != JobStatus.Completed
+                         && j.Status != JobStatus.Failed
+                         && j.Status != JobStatus.Timeout
+                         && j.Status != JobStatus.Stopped);
             foreach (var job in historicalJobs) _jobs.TryAdd(job.Id, job);
         }
         catch


### PR DESCRIPTION
# Summary

## Changes

Modified `JobService.LoadHistoricalJobs()` to filter out jobs with terminal statuses (Completed, Failed, Timeout, Stopped) when loading from the database on startup. This prevents completed jobs from cluttering the Jobs UI after Tendril restarts. Also ensured `LoadHistoricalJobs()` is called in both constructors for consistent behavior.

## API Changes

None.

## Files Modified

- **JobService.cs** — Added LINQ filter to exclude terminal status jobs in `LoadHistoricalJobs()` and added LoadHistoricalJobs() call in test constructor
- **JobServiceStartupTests.cs** (new) — Added comprehensive test coverage for the filtering behavior with updated FakeDatabaseService implementing new interface methods

## Commits

- [03559] Call LoadHistoricalJobs in test constructor (ba65f34)
- [03559] Update FakeDatabaseService to implement new interface methods (1a69b92)
- [03559] Add tests for LoadHistoricalJobs filtering (ce8622e)
- [03559] Filter out completed jobs on Tendril restart (fbe4796)