### PR TITLE
Remove stale tests for deleted NestedWorktree and recursive cleanup features

### DIFF
--- a/src/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
+++ b/src/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
@@ -101,24 +101,6 @@ public class DoctorCommandPlansTests : IDisposable
     }
 
     [Fact]
-    public void DoctorPlans_NestedWorktree_DetectsIssue()
-    {
-        var planDir = CreatePlan("00005-NestedWt", ValidYaml);
-        var wtRepoDir = Path.Combine(planDir, "worktrees", "SomeRepo");
-        Directory.CreateDirectory(wtRepoDir);
-        File.WriteAllText(Path.Combine(wtRepoDir, ".git"), "gitdir: /some/path");
-        var nestedDir = Path.Combine(wtRepoDir, "subdir");
-        Directory.CreateDirectory(nestedDir);
-        File.WriteAllText(Path.Combine(nestedDir, ".git"), "gitdir: /nested/path");
-
-        var results = DoctorCommand.ScanPlans(_plansDir);
-
-        Assert.Single(results);
-        Assert.False(results[0].IsHealthy);
-        Assert.Contains("NestedWorktree", results[0].Health);
-    }
-
-    [Fact]
     public void DoctorPlans_UnhealthyFlag_FiltersResults()
     {
         CreatePlan("00010-Healthy", ValidYaml);
@@ -173,26 +155,6 @@ public class DoctorCommandPlansTests : IDisposable
         Assert.True(result.Success);
         Assert.Contains("removed stale worktrees", result.Message);
         Assert.False(Directory.Exists(wtDir));
-    }
-
-    [Fact]
-    public void RepairPlan_NestedWorktree_RemovesNested()
-    {
-        var planDir = CreatePlan("00025-RepairNested", ValidYaml);
-        var wtDir = Path.Combine(planDir, "worktrees", "SomeRepo");
-        Directory.CreateDirectory(wtDir);
-        var nestedPlansDir = Path.Combine(wtDir, "Plans");
-        Directory.CreateDirectory(nestedPlansDir);
-        File.WriteAllText(Path.Combine(nestedPlansDir, "dummy.txt"), "test");
-
-        var healthResult = new DoctorCommand.PlanHealthResult(
-            "00025", "RepairNested", "Draft", 1, "NestedWorktree", false);
-
-        var result = DoctorCommand.RepairPlan(planDir, healthResult);
-
-        Assert.True(result.Success);
-        Assert.Contains("cleaned nested worktrees", result.Message);
-        Assert.False(Directory.Exists(nestedPlansDir));
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -439,46 +439,6 @@ public class WorktreeCleanupServiceTests : IDisposable
     }
 
     [Fact]
-    public void CleanupRecursiveArtifacts_Removes_Nested_Plans_In_Worktrees()
-    {
-        var dir = CreatePlan("13000-RecursiveTest", "Executing");
-        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
-        var nestedPlans = Path.Combine(worktreeDir, "src", "tendril", "Plans", "01234-OldPlan");
-        Directory.CreateDirectory(nestedPlans);
-        File.WriteAllText(Path.Combine(nestedPlans, "plan.yaml"), "state: Completed");
-
-        _service.RunCleanup();
-
-        Assert.False(Directory.Exists(Path.Combine(worktreeDir, "src", "tendril", "Plans")),
-            "Nested Plans directory should be deleted");
-        Assert.True(Directory.Exists(worktreeDir),
-            "Worktree repo directory should remain");
-    }
-
-    [Fact]
-    public void CleanupRecursiveArtifacts_Handles_Multiple_Nesting_Levels()
-    {
-        var dir = CreatePlan("13001-MultiLevel", "Executing");
-        var worktreeDir = Path.Combine(dir, "worktrees", "Repo");
-
-        // Level 1: Plans/B inside worktree
-        var level1 = Path.Combine(worktreeDir, "Plans", "B-Plan", "worktrees", "Repo");
-        Directory.CreateDirectory(level1);
-
-        // Level 2: Plans/C nested inside level 1
-        var level2 = Path.Combine(level1, "Plans", "C-Plan");
-        Directory.CreateDirectory(level2);
-        File.WriteAllText(Path.Combine(level2, "plan.yaml"), "state: Failed");
-
-        _service.RunCleanup();
-
-        Assert.False(Directory.Exists(Path.Combine(worktreeDir, "Plans")),
-            "All nested Plans directories should be removed");
-        Assert.True(Directory.Exists(worktreeDir),
-            "Top-level worktree directory should remain");
-    }
-
-    [Fact]
     public void CleanupRecursiveArtifacts_Skips_Plans_With_No_Worktrees()
     {
         CreatePlan("13002-NoWorktrees", "Executing");
@@ -487,36 +447,6 @@ public class WorktreeCleanupServiceTests : IDisposable
         Assert.Null(ex);
     }
 
-    [Fact]
-    public void CleanupRecursiveArtifacts_Logs_On_Delete_Failure()
-    {
-        if (!OperatingSystem.IsWindows()) return;
-
-        var logEntries = new List<string>();
-        var logger = new CapturingLogger(logEntries);
-        var service = new WorktreeCleanupService(_plansDir, new LoggerAdapter(logger));
-
-        var dir = CreatePlan("13003-LockedNested", "Executing");
-        var worktreeDir = Path.Combine(dir, "worktrees", "Repo");
-        var nestedPlans = Path.Combine(worktreeDir, "src", "Plans", "OldPlan");
-        Directory.CreateDirectory(nestedPlans);
-        var lockedFile = Path.Combine(nestedPlans, "locked.txt");
-        File.WriteAllText(lockedFile, "content");
-
-        using (new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
-        {
-            service.RunCleanup();
-        }
-
-        Assert.Contains(logEntries,
-            e => e.Contains("Removing recursive Plans artifact") || e.Contains("Failed to delete nested Plans"));
-
-        // Cleanup
-        if (Directory.Exists(nestedPlans))
-            Directory.Delete(nestedPlans, true);
-
-        service.Dispose();
-    }
 
     [Fact]
     public void RemoveWorktrees_ExtractsSafeTitleFromPlanFolderName()

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
@@ -35,7 +35,7 @@ public class SuggestChangesDialog(
             new DialogHeader($"Suggest Changes for Plan #{_selectedPlan.Id}"),
             new DialogBody(
                 Layout.Vertical()
-                | Text.P("Provide suggestions for changes to this plan before creating the PR.")
+                | Text.P("Provide suggestions for changes to the plan.")
                 | _suggestText.ToTextareaInput("Enter your suggestions...").Rows(6).AutoFocus()
             ),
             new DialogFooter(


### PR DESCRIPTION
## Summary
- Delete 5 stale tests that tested features previously removed from the codebase
- DoctorCommandPlansTests: 2 tests for NestedWorktree detection/repair
- WorktreeCleanupServiceTests: 3 tests for recursive Plans directory cleanup
- Shorten SuggestChangesDialog prompt text

## Test plan
- [x] All 1049 tests pass (1047 passed, 2 skipped, 0 failures)