### PR TITLE
[03646] Fix ReDoS Risk in Config YAML Preprocessing

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1204,4 +1204,34 @@ projects:
             Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void Should_Handle_Pathological_Yaml_Without_Timeout()
+    {
+        // Crafted YAML that would trigger backtracking with the old pattern
+        var pathologicalYaml = @"
+projects:
+  - name: Test
+    repos:
+      - path: " + string.Concat(Enumerable.Repeat("%VAR", 100)) + @"
+";
+
+        var tempDir = CreateTempConfigFile(pathologicalYaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            service.SetTendrilHome(tempDir);
+            sw.Stop();
+
+            // Should complete quickly (< 1s) even with pathological input
+            Assert.True(sw.ElapsedMilliseconds < 1000,
+                $"ReDoS detected: processing took {sw.ElapsedMilliseconds}ms");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -160,6 +160,17 @@ public record ConfigParseError(string Message, string FilePath, Exception? Inner
 
 public class ConfigService : IConfigService
 {
+    // Cached regex patterns to prevent ReDoS and avoid recompilation
+    private static readonly Regex YamlVariableValuePattern = new(
+        @"(?m)(?<=:\s+)(%\w+%.*)$",
+        RegexOptions.NonBacktracking | RegexOptions.Compiled
+    );
+
+    private static readonly Regex YamlVariableListPattern = new(
+        @"(?m)^(\s*-\s+)(%\w+%.*)$",
+        RegexOptions.NonBacktracking | RegexOptions.Compiled
+    );
+
     private readonly bool _explicitHome;
     private readonly ILogger<ConfigService> _logger;
     private string[]? _levelNamesCache;
@@ -167,6 +178,17 @@ public class ConfigService : IConfigService
     private ProjectConfig? _pendingProject;
     private string? _pendingTendrilHome;
     private List<VerificationConfig>? _pendingVerificationDefinitions;
+
+    /// <summary>
+    /// Preprocesses YAML to quote unquoted %VAR% patterns that YAML rejects (% is a directive indicator).
+    /// Uses cached, non-backtracking regexes to prevent ReDoS attacks.
+    /// </summary>
+    private static string PreprocessYamlVariables(string yaml)
+    {
+        yaml = YamlVariableValuePattern.Replace(yaml, "'$1'");
+        yaml = YamlVariableListPattern.Replace(yaml, "$1'$2'");
+        return yaml;
+    }
 
     internal ConfigService(TendrilSettings settings, string? tendrilHome = null, ILogger<ConfigService>? logger = null)
     {
@@ -205,9 +227,7 @@ public class ConfigService : IConfigService
             try
             {
                 var yaml = FileHelper.ReadAllText(ConfigPath);
-                // Quote unquoted %VAR% patterns that YAML rejects (% is a directive indicator)
-                yaml = Regex.Replace(yaml, @"(?m)(?<=:\s+)(%\w+%.*)$", "'$1'");
-                yaml = Regex.Replace(yaml, @"(?m)^(\s*-\s+)(%\w+%.*)$", "$1'$2'");
+                yaml = PreprocessYamlVariables(yaml);
                 Settings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml) ?? new TendrilSettings();
                 MigrateProjectColors();
                 CreateConfigBackup();
@@ -331,8 +351,7 @@ public class ConfigService : IConfigService
         try
         {
             var yaml = FileHelper.ReadAllText(ConfigPath);
-            yaml = Regex.Replace(yaml, @"(?m)(?<=:\s+)(%\w+%.*)$", "'$1'");
-            yaml = Regex.Replace(yaml, @"(?m)^(\s*-\s+)(%\w+%.*)$", "$1'$2'");
+            yaml = PreprocessYamlVariables(yaml);
             Settings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml) ?? new TendrilSettings();
 
             MigrateProjectColors();
@@ -530,8 +549,7 @@ public class ConfigService : IConfigService
         try
         {
             var yaml = FileHelper.ReadAllText(ConfigPath);
-            yaml = Regex.Replace(yaml, @"(?m)(?<=:\s+)(%\w+%.*)$", "'$1'");
-            yaml = Regex.Replace(yaml, @"(?m)^(\s*-\s+)(%\w+%.*)$", "$1'$2'");
+            yaml = PreprocessYamlVariables(yaml);
             Settings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml) ?? new TendrilSettings();
             MigrateProjectColors();
             CreateConfigBackup();


### PR DESCRIPTION
# Summary

## Changes

Fixed ReDoS vulnerability in ConfigService by replacing inline regex patterns with cached, non-backtracking instances. Extracted preprocessing logic into a dedicated helper method.

## API Changes

None — internal implementation change only.

## Files Modified

- **ConfigService.cs** — Added static regex fields with NonBacktracking option, created PreprocessYamlVariables helper method, replaced all inline Regex.Replace calls
- **ConfigServiceTests.cs** — Added test verifying pathological YAML completes quickly (< 1s)

## Commits

- 9092b70 [03646] Fix ReDoS risk in config YAML preprocessing
- 622d9e3 [03646] Add test for ReDoS protection in YAML preprocessing