### PR TITLE
[03648] Extract Job Type Constants

### DIFF
--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -74,7 +74,7 @@ public class ContentView(
                         | new Button("Execute").Icon(Icons.Rocket).Outline().ShortcutKey("e").OnClick(() =>
                         {
                             planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
-                            jobService.StartJob("ExecutePlan", selectedPlan.FolderPath);
+                            jobService.StartJob(Constants.JobTypes.ExecutePlan, selectedPlan.FolderPath);
                             refreshPlans();
                         })
                         | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(

--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -354,18 +354,18 @@ public class JobsApp : ViewBase
                     {
                         if (job.Status is JobStatus.Failed or JobStatus.Timeout or JobStatus.Stopped)
                         {
-                            if (job.Type == "CreatePlan" && !job.Args.Contains("-Description"))
+                            if (job.Type == Constants.JobTypes.CreatePlan && !job.Args.Contains("-Description"))
                             {
                                 client.Toast("Cannot rerun CreatePlan: original description was not preserved.", "Rerun Failed");
                                 return ValueTask.CompletedTask;
                             }
 
-                            if (job.Type is "ExecutePlan" or "ExpandPlan" && job.Args.Length > 0)
+                            if (job.Type is Constants.JobTypes.ExecutePlan or Constants.JobTypes.ExpandPlan && job.Args.Length > 0)
                             {
                                 var folderName = Path.GetFileName(job.Args[0]);
                                 planService.TransitionState(folderName, PlanStatus.Building);
                             }
-                            else if (job is { Type: "UpdatePlan", Args.Length: > 0 })
+                            else if (job is { Type: Constants.JobTypes.UpdatePlan, Args.Length: > 0 })
                             {
                                 var folderName = Path.GetFileName(job.Args[0]);
                                 planService.TransitionState(folderName, PlanStatus.Updating);
@@ -456,7 +456,7 @@ public class JobsApp : ViewBase
 
     private static string? GetFullPrompt(JobItem job)
     {
-        if (job.Type == "CreatePlan")
+        if (job.Type == Constants.JobTypes.CreatePlan)
         {
             for (var i = 0; i < job.Args.Length - 1; i++)
                 if (job.Args[i].Equals("-Description", StringComparison.OrdinalIgnoreCase))
@@ -538,7 +538,7 @@ public class JobsApp : ViewBase
         }
 
         // CreatePlan jobs: use the -Description arg for display when no title is available yet
-        if (j.Type == "CreatePlan")
+        if (j.Type == Constants.JobTypes.CreatePlan)
         {
             var desc = CleanPromptText(GetFullPrompt(j) ?? j.PlanFile);
             return desc.Length > PromptDisplayMaxLength ? desc[..PromptDisplayMaxLength] + "..." : desc;

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -159,7 +159,7 @@ public class ContentView(
             selectedPlanState.Set(optimisticPlan);
 
             planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
-            jobService.StartJob("ExecutePlan", selectedPlan.FolderPath);
+            jobService.StartJob(Constants.JobTypes.ExecutePlan, selectedPlan.FolderPath);
             refreshPlans();
         });
 
@@ -247,14 +247,14 @@ public class ContentView(
 
         // Check for active ExpandPlan job
         var hasActiveExpandJob = jobService.GetJobs().Any(j =>
-            j.Type == "ExpandPlan" &&
+            j.Type == Constants.JobTypes.ExpandPlan &&
             j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
             j.Args.Length > 0 &&
             j.Args[0].Equals(selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
 
         // Check for active SplitPlan job
         var hasActiveSplitJob = jobService.GetJobs().Any(j =>
-            j.Type == "SplitPlan" &&
+            j.Type == Constants.JobTypes.SplitPlan &&
             j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
             j.Args.Length > 0 &&
             j.Args[0].Equals(selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
@@ -303,7 +303,7 @@ public class ContentView(
                             selectedPlanState.Set(optimisticPlan);
 
                             planService.TransitionState(selectedPlan.FolderName, PlanStatus.Updating);
-                            jobService.StartJob("SplitPlan", selectedPlan.FolderPath);
+                            jobService.StartJob(Constants.JobTypes.SplitPlan, selectedPlan.FolderPath);
                             refreshPlans();
                         })
                         | new Button("Expand").Icon(Icons.UnfoldVertical).Outline().ShortcutKey("x")
@@ -321,7 +321,7 @@ public class ContentView(
 
                             planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
                             var planPath = selectedPlan.FolderPath;
-                            jobService.StartJob("ExpandPlan", planPath);
+                            jobService.StartJob(Constants.JobTypes.ExpandPlan, planPath);
                             refreshPlans();
                         })
                         | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
@@ -331,7 +331,7 @@ public class ContentView(
                         | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(() => GoToNext())
                             .ShortcutKey("n")
                         | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
-                            new MenuItem("Create Issue", Icon: Icons.Github, Tag: "CreateIssue").OnSelect(() =>
+                            new MenuItem("Create Issue", Icon: Icons.Github, Tag: Constants.JobTypes.CreateIssue).OnSelect(() =>
                                 createIssueDialogOpen.Set(true)),
                             new MenuItem("Download", Icon: Icons.Download, Tag: "Download").OnSelect(() =>
                             {

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
@@ -129,7 +129,7 @@ public class CreateIssueDialog(
                             var repoPath = selectedRepo.FullName;
                             var assignee = issueAssigneeState.Value ?? "";
                             var selectedLabels = string.Join(",", issueLabelsState.Value);
-                            jobService.StartJob("CreateIssue", selectedPlan.FolderPath, "-Repo", repoPath,
+                            jobService.StartJob(Constants.JobTypes.CreateIssue, selectedPlan.FolderPath, "-Repo", repoPath,
                                 "-Assignee", assignee, "-Comment", issueCommentState.Value, "-Labels", selectedLabels);
                         }
                     }

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
@@ -29,7 +29,7 @@ public class UpdatePlanDialog(
 
         // Check if there's already an UpdatePlan job running for this plan
         var hasActiveJob = _jobService.GetJobs().Any(j =>
-            j.Type == "UpdatePlan" &&
+            j.Type == Constants.JobTypes.UpdatePlan &&
             j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
             j.Args.Length > 0 &&
             j.Args[0].Equals(_selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
@@ -76,7 +76,7 @@ public class UpdatePlanDialog(
                         _planService.SavePlan(_selectedPlan.FolderName, currentContent + "\n\n" + comments + "\n");
 
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
-                        _jobService.StartJob("UpdatePlan", _selectedPlan.FolderPath);
+                        _jobService.StartJob(Constants.JobTypes.UpdatePlan, _selectedPlan.FolderPath);
                         _refreshPlans();
                         _updateText.Set("");
                         isCreating.Set(false);

--- a/src/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -164,7 +164,7 @@ public class PullRequestApp : ViewBase
                 (description, projects, priority) =>
                 {
                     var project = string.Join(",", projects);
-                    jobService.StartJob("CreatePlan", "-Description", description, "-Project", project, "-Priority", priority.ToString());
+                    jobService.StartJob(Constants.JobTypes.CreatePlan, "-Description", description, "-Project", project, "-Priority", priority.ToString());
                 },
                 () =>
                 {

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -52,7 +52,7 @@ public class ContentView(
                      | new Button("Accept").Icon(Icons.Check).Primary().ShortcutKey("a").OnClick(() =>
                      {
                          planService.UpdateRecommendationState(selectedRecommendation.PlanFolderName, selectedRecommendation.Title, "Accepted");
-                         jobService.StartJob("CreatePlan", "-Description", selectedRecommendation.Description, "-Project",
+                         jobService.StartJob(Constants.JobTypes.CreatePlan, "-Description", selectedRecommendation.Description, "-Project",
                              selectedRecommendation.Project);
                          client.Toast($"Started CreatePlan: {selectedRecommendation.Title}", "Recommendation Accepted");
                          refresh();
@@ -142,7 +142,7 @@ public class ContentView(
             {
                 var description = $"[ORIGINAL RECOMMENDATION]\n{selectedRecommendation.Description}\n\n[NOTES]\n{notes}";
                 planService.UpdateRecommendationState(selectedRecommendation.PlanFolderName, selectedRecommendation.Title, "AcceptedWithNotes");
-                jobService.StartJob("CreatePlan", "-Description", description, "-Project", selectedRecommendation.Project);
+                jobService.StartJob(Constants.JobTypes.CreatePlan, "-Description", description, "-Project", selectedRecommendation.Project);
                 client.Toast($"Started CreatePlan: {selectedRecommendation.Title}", "Recommendation Accepted with Notes");
                 refresh();
                 GoToNext();

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -202,7 +202,7 @@ public class ContentView(
                 };
                 selectedPlanState.Set(optimisticPlan);
 
-                jobService.StartJob("CreatePr", selectedPlan.FolderPath);
+                jobService.StartJob(Constants.JobTypes.CreatePr, selectedPlan.FolderPath);
                 planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
                 refreshPlans();
             }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -94,7 +94,7 @@ public class CustomPrDialog(
                             .Build();
                         var optionsPath = Path.Combine(_selectedPlan.FolderPath, ".custom-pr-options.yaml");
                         FileHelper.WriteAllText(optionsPath, serializer.Serialize(options));
-                        _jobService.StartJob("CreatePr", _selectedPlan.FolderPath);
+                        _jobService.StartJob(Constants.JobTypes.CreatePr, _selectedPlan.FolderPath);
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
                         _refreshPlans();
                         isCreating.Set(false);

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
@@ -53,7 +53,7 @@ public class RerunDialog(
                         Task.Run(() =>
                         {
                             CleanPlanState(folderPath, logger);
-                            _jobService.StartJob("ExecutePlan", folderPath, "-Note",
+                            _jobService.StartJob(Constants.JobTypes.ExecutePlan, folderPath, "-Note",
                                 "User requested a clean rerun. All artifacts, logs, and worktrees have been cleaned. Execute this plan from scratch.");
                         });
                     }
@@ -65,7 +65,7 @@ public class RerunDialog(
                         isRerunningCurrent.Set(true);
                         _dialogOpen.Set(false);
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
-                        _jobService.StartJob("ExecutePlan", _selectedPlan.FolderPath, "-Note",
+                        _jobService.StartJob(Constants.JobTypes.ExecutePlan, _selectedPlan.FolderPath, "-Note",
                             "User requested you to execute this plan another time. Go through all code, verifications and artifacts one more time.");
                         _refreshPlans();
                     }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
@@ -57,7 +57,7 @@ public class SuggestChangesDialog(
                         _planService.SavePlan(_selectedPlan.FolderName, currentContent + "\n\n" + comments + "\n");
 
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
-                        _jobService.StartJob("UpdatePlan", _selectedPlan.FolderPath);
+                        _jobService.StartJob(Constants.JobTypes.UpdatePlan, _selectedPlan.FolderPath);
                         _refreshPlans();
                         isCreating.Set(false);
                         _suggestText.Set("");

--- a/src/Ivy.Tendril/Apps/StatusMappings.cs
+++ b/src/Ivy.Tendril/Apps/StatusMappings.cs
@@ -57,12 +57,12 @@ internal static class StatusMappings
     /// </summary>
     public static readonly Dictionary<string, Colors> JobTypeColors = new()
     {
-        ["CreatePlan"] = Colors.Purple,
-        ["ExecutePlan"] = Colors.Blue,
-        ["UpdatePlan"] = Colors.Cyan,
-        ["ExpandPlan"] = Colors.Teal,
-        ["SplitPlan"] = Colors.Indigo,
-        ["CreatePr"] = Colors.Green,
-        ["CreateIssue"] = Colors.Rose
+        [Constants.JobTypes.CreatePlan] = Colors.Purple,
+        [Constants.JobTypes.ExecutePlan] = Colors.Blue,
+        [Constants.JobTypes.UpdatePlan] = Colors.Cyan,
+        [Constants.JobTypes.ExpandPlan] = Colors.Teal,
+        [Constants.JobTypes.SplitPlan] = Colors.Indigo,
+        [Constants.JobTypes.CreatePr] = Colors.Green,
+        [Constants.JobTypes.CreateIssue] = Colors.Rose
     };
 }

--- a/src/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/Ivy.Tendril/Apps/TrashApp.cs
@@ -85,7 +85,7 @@ public class TrashApp : ViewBase
                                 if (!string.IsNullOrEmpty(selected.OriginalRequest))
                                 {
                                     var project = string.IsNullOrEmpty(selected.Project) ? "Auto" : selected.Project;
-                                    jobService.StartJob("CreatePlan", "-Description",
+                                    jobService.StartJob(Constants.JobTypes.CreatePlan, "-Description",
                                         $"{selected.OriginalRequest} [FORCE]", "-Project", project);
                                     client.Toast("CreatePlan job started", "Force Plan");
                                 }

--- a/src/Ivy.Tendril/Constants.cs
+++ b/src/Ivy.Tendril/Constants.cs
@@ -22,4 +22,18 @@ public static class Constants
     public const string DiscordUrl = "https://discord.gg/FHgxkDga3y";
     public const string IssuesUrl = "https://github.com/Ivy-Interactive/Ivy-Tendril/issues/new";
     public const string NewsBaseUrl = "https://cdn.ivy.app/tendril/";
+
+    /// <summary>
+    ///     Job type identifiers for the Tendril promptware execution system.
+    /// </summary>
+    public static class JobTypes
+    {
+        public const string CreatePlan = "CreatePlan";
+        public const string ExecutePlan = "ExecutePlan";
+        public const string ExpandPlan = "ExpandPlan";
+        public const string UpdatePlan = "UpdatePlan";
+        public const string SplitPlan = "SplitPlan";
+        public const string CreatePr = "CreatePr";
+        public const string CreateIssue = "CreateIssue";
+    }
 }

--- a/src/Ivy.Tendril/Controllers/InboxController.cs
+++ b/src/Ivy.Tendril/Controllers/InboxController.cs
@@ -21,7 +21,7 @@ public class InboxController(IJobService jobService) : ControllerBase
             if (!string.IsNullOrEmpty(request.SourcePath))
                 args.AddRange(["-SourcePath", request.SourcePath]);
 
-            var jobId = jobService.StartJob("CreatePlan", args.ToArray(), null);
+            var jobId = jobService.StartJob(Constants.JobTypes.CreatePlan, args.ToArray(), null);
             return Ok(new { jobId, status = "Started", message = "Plan creation job started successfully" });
         }
         catch (Exception ex)

--- a/src/Ivy.Tendril/Services/InboxWatcherService.cs
+++ b/src/Ivy.Tendril/Services/InboxWatcherService.cs
@@ -170,7 +170,7 @@ public class InboxWatcherService : IInboxWatcherService
         var args = new List<string> { "-Description", description, "-Project", project };
         if (!string.IsNullOrEmpty(sourcePath))
             args.AddRange(["-SourcePath", sourcePath]);
-        _jobService.StartJob("CreatePlan", args.ToArray(), processingPath);
+        _jobService.StartJob(Constants.JobTypes.CreatePlan, args.ToArray(), processingPath);
     }
 
     internal static (string project, string description, string? sourcePath) ParseContent(string content)

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -63,10 +63,10 @@ internal class JobCompletionHandler
         if (job.Status is JobStatus.Failed or JobStatus.Timeout)
             ScheduleWorktreeCleanup(job);
 
-        if (isSuccess && job.Type is "ExecutePlan" or "CreatePr")
+        if (isSuccess && job.Type is Constants.JobTypes.ExecutePlan or Constants.JobTypes.CreatePr)
             RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
 
-        if (isSuccess && job.Type is "ExecutePlan" or "CreatePr" or "CreateIssue")
+        if (isSuccess && job.Type is Constants.JobTypes.ExecutePlan or Constants.JobTypes.CreatePr or Constants.JobTypes.CreateIssue)
         {
             var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
             RetryBlockedDependents(planFolder, jobs, startJobSkipDepCheck);
@@ -95,24 +95,24 @@ internal class JobCompletionHandler
         {
             ResetPlanState(job);
         }
-        else if (isSuccess && job.Type == "ExecutePlan")
+        else if (isSuccess && job.Type == Constants.JobTypes.ExecutePlan)
         {
             SyncPlanArtifacts(job);
             EnsurePlanStateTransitioned(job);
         }
-        else if (isSuccess && job.Type == "CreateIssue")
+        else if (isSuccess && job.Type == Constants.JobTypes.CreateIssue)
         {
             SetPlanState(job, "Completed");
         }
-        else if (isSuccess && job.Type is "UpdatePlan" or "ExpandPlan")
+        else if (isSuccess && job.Type is Constants.JobTypes.UpdatePlan or Constants.JobTypes.ExpandPlan)
         {
             SetPlanState(job, "Draft");
         }
-        else if (isSuccess && job.Type == "SplitPlan")
+        else if (isSuccess && job.Type == Constants.JobTypes.SplitPlan)
         {
             SetPlanState(job, "Skipped");
         }
-        else if (isSuccess && job.Type == "CreatePlan")
+        else if (isSuccess && job.Type == Constants.JobTypes.CreatePlan)
         {
             VerifyCreatePlanResult(job);
         }
@@ -120,7 +120,7 @@ internal class JobCompletionHandler
 
     private void TrackTelemetry(JobItem job, bool isSuccess)
     {
-        if (isSuccess && job.Type == "CreatePlan" && job.Status == JobStatus.Completed)
+        if (isSuccess && job.Type == Constants.JobTypes.CreatePlan && job.Status == JobStatus.Completed)
         {
             var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
             var level = "NiceToHave";
@@ -133,7 +133,7 @@ internal class JobCompletionHandler
             _telemetryService?.TrackPlanCreated(new PlanCreatedContext(level, job.DurationSeconds));
         }
 
-        if (isSuccess && job.Type == "CreatePr")
+        if (isSuccess && job.Type == Constants.JobTypes.CreatePr)
         {
             _telemetryService?.TrackPrCreated(new PrCreatedContext(job.DurationSeconds));
         }
@@ -590,10 +590,10 @@ internal class JobCompletionHandler
     {
         try
         {
-            if (job.Type is "CreatePlan" or "CreatePr" or "CreateIssue") return;
+            if (job.Type is Constants.JobTypes.CreatePlan or Constants.JobTypes.CreatePr or Constants.JobTypes.CreateIssue) return;
 
             var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
-            var newState = job.Type == "ExecutePlan" ? "Failed" : "Draft";
+            var newState = job.Type == Constants.JobTypes.ExecutePlan ? "Failed" : "Draft";
             PlanYamlHelper.SetPlanStateByFolder(planFolder, newState);
         }
         catch (Exception ex)
@@ -630,7 +630,7 @@ internal class JobCompletionHandler
 
     private void ScheduleWorktreeCleanup(JobItem job)
     {
-        if (job.Type != "ExecutePlan") return;
+        if (job.Type != Constants.JobTypes.ExecutePlan) return;
 
         var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
         if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder)) return;
@@ -722,7 +722,7 @@ internal class JobCompletionHandler
         Func<string, string[], string> startJobSkipDepCheck)
     {
         var blockedJobs = jobs.Values
-            .Where(j => j.Status == JobStatus.Blocked && j.Type == "ExecutePlan")
+            .Where(j => j.Status == JobStatus.Blocked && j.Type == Constants.JobTypes.ExecutePlan)
             .ToList();
 
         foreach (var blockedJob in blockedJobs)
@@ -766,7 +766,7 @@ internal class JobCompletionHandler
                 if (!planYaml.DependsOn.Contains(completedFolderName, StringComparer.OrdinalIgnoreCase)) continue;
 
                 var hasExistingJob = jobs.Values.Any(j =>
-                    j.Type == "ExecutePlan" &&
+                    j.Type == Constants.JobTypes.ExecutePlan &&
                     j.Status is JobStatus.Blocked or JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
                     j.Args.Length > 0 &&
                     j.Args[0].Equals(dir, StringComparison.OrdinalIgnoreCase));
@@ -776,7 +776,7 @@ internal class JobCompletionHandler
                 if (allMet)
                 {
                     PlanYamlHelper.SetPlanStateByFolder(dir, "Building");
-                    startJobSkipDepCheck("ExecutePlan", new[] { dir });
+                    startJobSkipDepCheck(Constants.JobTypes.ExecutePlan, new[] { dir });
                 }
             }
         }
@@ -788,7 +788,7 @@ internal class JobCompletionHandler
     private static bool HasActiveJobForPlan(string planFolder, ConcurrentDictionary<string, JobItem> jobs)
     {
         return jobs.Values.Any(j =>
-            j.Type == "ExecutePlan" &&
+            j.Type == Constants.JobTypes.ExecutePlan &&
             j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
             j.Args.Length > 0 &&
             j.Args[0].Equals(planFolder, StringComparison.OrdinalIgnoreCase));
@@ -796,7 +796,7 @@ internal class JobCompletionHandler
 
     private string? ResolvePlanFolder(JobItem job)
     {
-        if (job.Type != "CreatePlan")
+        if (job.Type != Constants.JobTypes.CreatePlan)
             return job.Args.Length > 0 ? job.Args[0] : null;
 
         var planId = job.ReportedPlanId ?? job.AllocatedPlanId;
@@ -834,7 +834,7 @@ internal class JobCompletionHandler
         if (_planReaderService == null || string.IsNullOrEmpty(job.PlanFile))
             return;
 
-        if (job.Type == "CreatePlan")
+        if (job.Type == Constants.JobTypes.CreatePlan)
             return;
 
         try
@@ -891,7 +891,7 @@ internal class JobCompletionHandler
 
     private static string BuildPlanOutcomeSummary(JobItem job)
     {
-        if (job.Type != "ExecutePlan")
+        if (job.Type != Constants.JobTypes.ExecutePlan)
             return "";
 
         var planFolder = job.Args.Length > 0 ? job.Args[0] : "";

--- a/src/Ivy.Tendril/Services/JobFailureAnalyzer.cs
+++ b/src/Ivy.Tendril/Services/JobFailureAnalyzer.cs
@@ -31,7 +31,7 @@ internal static class JobFailureAnalyzer
         if (apiError != null) return ParseClaudeApiError(apiError);
 
         // 3. Check for CreatePlan-specific failures and failure artifacts
-        if (jobType == "CreatePlan")
+        if (jobType == Constants.JobTypes.CreatePlan)
         {
             var makePlanError = FindPattern(outputLines, new[] {
                 "ERROR: Plan",

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -39,10 +39,10 @@ internal class JobLauncher
         job.StartedAt = DateTime.UtcNow;
         job.StatusMessage = null;
 
-        var planFolderForHooks = type != "CreatePlan" && args.Length > 0 ? args[0] : "";
+        var planFolderForHooks = type != Constants.JobTypes.CreatePlan && args.Length > 0 ? args[0] : "";
         runHooks("before", type, planFolderForHooks, job.Project, job);
 
-        if (type == "ExecutePlan" && args.Length > 0)
+        if (type == Constants.JobTypes.ExecutePlan && args.Length > 0)
             PlanYamlHelper.SetPlanStateByFolder(args[0], "Executing");
 
         job.SessionId = Guid.NewGuid().ToString();
@@ -327,7 +327,7 @@ internal class JobLauncher
         string? profileOverride = null;
         PlanYaml? planYaml = null;
 
-        if (job.Type == "CreatePlan")
+        if (job.Type == Constants.JobTypes.CreatePlan)
         {
             var description = PlanYamlHelper.GetNamedArg(job.Args, "-Description") ?? string.Join(" ", job.Args);
             values["Args"] = description;
@@ -357,13 +357,13 @@ internal class JobLauncher
 
                 planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
 
-                if (job.Type == "ExecutePlan" && planYaml != null &&
+                if (job.Type == Constants.JobTypes.ExecutePlan && planYaml != null &&
                     !string.IsNullOrEmpty(planYaml.ExecutionProfile))
                 {
                     profileOverride = planYaml.ExecutionProfile;
                 }
 
-                if (job.Type is "ExecutePlan" or "CreatePr" && planYaml != null)
+                if (job.Type is Constants.JobTypes.ExecutePlan or Constants.JobTypes.CreatePr && planYaml != null)
                 {
                     var repoConfigs = BuildRepoConfigsYaml(planYaml, job.Project);
                     if (!string.IsNullOrEmpty(repoConfigs))

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -294,7 +294,7 @@ public class JobService : IJobService
     public bool IsInboxFileTracked(string filePath)
     {
         return _jobs.Values.Any(j =>
-            j.Type == "CreatePlan" &&
+            j.Type == Constants.JobTypes.CreatePlan &&
             j.Status is JobStatus.Pending or JobStatus.Queued or JobStatus.Running &&
             j.InboxFile != null &&
             j.InboxFile.Equals(filePath, StringComparison.OrdinalIgnoreCase));
@@ -394,7 +394,7 @@ public class JobService : IJobService
         if (TryBlockForDependencies(job, skipDependencyCheck))
             return id;
 
-        if (type is "ExecutePlan" or "ExpandPlan" or "UpdatePlan" or "SplitPlan")
+        if (type is Constants.JobTypes.ExecutePlan or Constants.JobTypes.ExpandPlan or Constants.JobTypes.UpdatePlan or Constants.JobTypes.SplitPlan)
             _planReaderService?.FlushPendingWritesAsync().GetAwaiter().GetResult();
 
         if (!_jobSlotSemaphore.Wait(0))
@@ -426,7 +426,7 @@ public class JobService : IJobService
             Priority = priority
         };
 
-        if (type == "CreatePlan")
+        if (type == Constants.JobTypes.CreatePlan)
             SetupInboxTracking(job, id, args, inboxFilePath);
 
         return job;
@@ -434,7 +434,7 @@ public class JobService : IJobService
 
     private static (string PlanFile, string Project, int Priority) ExtractJobMetadata(string type, string[] args)
     {
-        if (type == "CreatePlan")
+        if (type == Constants.JobTypes.CreatePlan)
         {
             var planFile = GetNamedArg(args, "-Description") is { Length: > 0 } desc
                 ? desc.Length > 50 ? desc[..50] + "..." : desc
@@ -479,7 +479,7 @@ public class JobService : IJobService
 
     private bool TryRejectConflictingJob(JobItem job)
     {
-        if (job.Type is not ("ExecutePlan" or "UpdatePlan" or "ExpandPlan" or "SplitPlan"))
+        if (job.Type is not (Constants.JobTypes.ExecutePlan or Constants.JobTypes.UpdatePlan or Constants.JobTypes.ExpandPlan or Constants.JobTypes.SplitPlan))
             return false;
 
         var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
@@ -507,7 +507,7 @@ public class JobService : IJobService
 
     private bool TryBlockForDependencies(JobItem job, bool skipDependencyCheck)
     {
-        if (job.Type != "ExecutePlan" || skipDependencyCheck)
+        if (job.Type != Constants.JobTypes.ExecutePlan || skipDependencyCheck)
             return false;
 
         var planFolder = job.Args.Length > 0 ? job.Args[0] : "";

--- a/src/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs
+++ b/src/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs
@@ -27,7 +27,7 @@ public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : View
                 {
                     lastSelectedProjects.Set(projects);
                     var project = string.Join(",", projects);
-                    jobService.StartJob("CreatePlan", "-Description", $"{description} [FORCE]", "-Project", project, "-Priority", priority.ToString());
+                    jobService.StartJob(Constants.JobTypes.CreatePlan, "-Description", $"{description} [FORCE]", "-Project", project, "-Priority", priority.ToString());
                 },
                 () => dialogOpen.Set(false),
                 lastSelectedProjects.Value


### PR DESCRIPTION
# Summary

## Changes

Extracted hard-coded job type strings into a centralized `Constants.JobTypes` class. All job type string literals (`"ExecutePlan"`, `"CreatePlan"`, etc.) across the codebase have been replaced with their corresponding constant references (`Constants.JobTypes.ExecutePlan`, `Constants.JobTypes.CreatePlan`, etc.).

## API Changes

**New Constants:**
- `Constants.JobTypes.CreatePlan`
- `Constants.JobTypes.ExecutePlan`
- `Constants.JobTypes.ExpandPlan`
- `Constants.JobTypes.UpdatePlan`
- `Constants.JobTypes.SplitPlan`
- `Constants.JobTypes.CreatePr`
- `Constants.JobTypes.CreateIssue`

## Files Modified

**Core Infrastructure:**
- `src/Ivy.Tendril/Constants.cs` — Added `JobTypes` nested class

**Services:**
- `src/Ivy.Tendril/Services/JobService.cs`
- `src/Ivy.Tendril/Services/JobCompletionHandler.cs`
- `src/Ivy.Tendril/Services/JobLauncher.cs`
- `src/Ivy.Tendril/Services/JobFailureAnalyzer.cs`
- `src/Ivy.Tendril/Services/InboxWatcherService.cs`

**Controllers:**
- `src/Ivy.Tendril/Controllers/InboxController.cs`

**UI Components:**
- `src/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs`
- `src/Ivy.Tendril/Apps/StatusMappings.cs`
- `src/Ivy.Tendril/Apps/JobsApp.cs`
- `src/Ivy.Tendril/Apps/Plans/ContentView.cs`
- `src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs`
- `src/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs`
- `src/Ivy.Tendril/Apps/Review/ContentView.cs`
- `src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs`
- `src/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs`
- `src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs`
- `src/Ivy.Tendril/Apps/Icebox/ContentView.cs`
- `src/Ivy.Tendril/Apps/TrashApp.cs`
- `src/Ivy.Tendril/Apps/Recommendations/ContentView.cs`
- `src/Ivy.Tendril/Apps/PullRequestApp.cs`

## Commits

- d844f19 [03648] Extract job type constants to Constants.JobTypes