### PR TITLE
[03645] Track and Cleanup Temp Files in ConfigService

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1234,4 +1234,169 @@ projects:
             Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void PreprocessForEditing_TracksCreatedTempFile()
+    {
+        var yaml = @"
+projects:
+  - name: TestProject
+    repos:
+      - path: D:\Repos\Test
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            // Create a markdown file that needs polishing
+            var mdPath = Path.Combine(tempDir, "test.md");
+            File.WriteAllText(mdPath, "[Plan 12345](plan://12345)");
+
+            var processedPath = service.PreprocessForEditing(mdPath);
+
+            // Should have created a temp file
+            Assert.NotEqual(mdPath, processedPath);
+            Assert.True(File.Exists(processedPath));
+            Assert.Contains("tendril-edit-", processedPath);
+
+            // Clean up the temp file
+            service.Dispose();
+            Assert.False(File.Exists(processedPath));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Dispose_DeletesTrackedTempFiles()
+    {
+        var yaml = @"
+projects:
+  - name: TestProject
+    repos:
+      - path: D:\Repos\Test
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            // Create multiple temp files
+            var mdPath1 = Path.Combine(tempDir, "test1.md");
+            var mdPath2 = Path.Combine(tempDir, "test2.md");
+            File.WriteAllText(mdPath1, "[Plan 1](plan://1)");
+            File.WriteAllText(mdPath2, "[Plan 2](plan://2)");
+
+            var tempPath1 = service.PreprocessForEditing(mdPath1);
+            var tempPath2 = service.PreprocessForEditing(mdPath2);
+
+            Assert.True(File.Exists(tempPath1));
+            Assert.True(File.Exists(tempPath2));
+
+            // Dispose should delete both temp files
+            service.Dispose();
+
+            Assert.False(File.Exists(tempPath1));
+            Assert.False(File.Exists(tempPath2));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Dispose_SuppressesExceptions()
+    {
+        var yaml = @"
+projects:
+  - name: TestProject
+    repos:
+      - path: D:\Repos\Test
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            var mdPath = Path.Combine(tempDir, "test.md");
+            File.WriteAllText(mdPath, "[Plan 1](plan://1)");
+
+            var tempPath = service.PreprocessForEditing(mdPath);
+
+            // Manually delete the temp file before disposal
+            File.Delete(tempPath);
+
+            // Dispose should not throw even if file is already deleted
+            service.Dispose();
+
+            // Calling Dispose again should also not throw
+            service.Dispose();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void PreprocessForEditing_ThreadSafe()
+    {
+        var yaml = @"
+projects:
+  - name: TestProject
+    repos:
+      - path: D:\Repos\Test
+";
+
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            var tempPaths = new System.Collections.Concurrent.ConcurrentBag<string>();
+
+            // Create 10 temp files concurrently
+            Parallel.For(0, 10, i =>
+            {
+                var mdPath = Path.Combine(tempDir, $"test{i}.md");
+                File.WriteAllText(mdPath, $"[Plan {i}](plan://{i})");
+                var tempPath = service.PreprocessForEditing(mdPath);
+                tempPaths.Add(tempPath);
+            });
+
+            // All temp files should exist
+            Assert.Equal(10, tempPaths.Count);
+            foreach (var tempPath in tempPaths)
+            {
+                Assert.True(File.Exists(tempPath));
+            }
+
+            // Dispose should clean up all temp files
+            service.Dispose();
+
+            foreach (var tempPath in tempPaths)
+            {
+                Assert.False(File.Exists(tempPath));
+            }
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -225,9 +225,25 @@ public class Program
             e.SetObserved();
         };
 
+        IServiceProvider? serviceProvider = null;
+
         AppDomain.CurrentDomain.ProcessExit += (_, _) =>
         {
             CrashLog.Write($"[{DateTime.UtcNow:O}] ProcessExit event fired (PID {Environment.ProcessId}) | {GetMemoryStats()}");
+
+            // Clean up tracked temp files
+            if (serviceProvider != null)
+            {
+                try
+                {
+                    var configService = serviceProvider.GetService<ConfigService>();
+                    configService?.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    CrashLog.Write($"[{DateTime.UtcNow:O}] Failed to dispose ConfigService: {ex}");
+                }
+            }
         };
 
         // Periodic memory watchdog — logs a warning when working set exceeds 1 GB
@@ -255,6 +271,7 @@ public class Program
         }
 
         var server = TendrilServer.Create(filteredArgs);
+        serviceProvider = server.Services;
 
         if (useDesktop)
         {

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -27,6 +27,9 @@ public class Program
     // Must be a static field to prevent GC from collecting the delegate
     private static ConsoleCtrlHandlerDelegate? _consoleCtrlHandler;
 
+    // ConfigService reference for cleanup on exit
+    private static ConfigService? _configService;
+
     [STAThread]
     public static async Task<int> Main(string[] args)
     {
@@ -225,24 +228,18 @@ public class Program
             e.SetObserved();
         };
 
-        IServiceProvider? serviceProvider = null;
-
         AppDomain.CurrentDomain.ProcessExit += (_, _) =>
         {
             CrashLog.Write($"[{DateTime.UtcNow:O}] ProcessExit event fired (PID {Environment.ProcessId}) | {GetMemoryStats()}");
 
             // Clean up tracked temp files
-            if (serviceProvider != null)
+            try
             {
-                try
-                {
-                    var configService = serviceProvider.GetService<ConfigService>();
-                    configService?.Dispose();
-                }
-                catch (Exception ex)
-                {
-                    CrashLog.Write($"[{DateTime.UtcNow:O}] Failed to dispose ConfigService: {ex}");
-                }
+                _configService?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                CrashLog.Write($"[{DateTime.UtcNow:O}] Failed to dispose ConfigService: {ex}");
             }
         };
 
@@ -271,7 +268,6 @@ public class Program
         }
 
         var server = TendrilServer.Create(filteredArgs);
-        serviceProvider = server.Services;
 
         if (useDesktop)
         {
@@ -292,6 +288,11 @@ public class Program
             await server.RunAsync();
             return 0;
         }
+    }
+
+    internal static void SetConfigServiceForCleanup(ConfigService configService)
+    {
+        _configService = configService;
     }
 
     private static string GetMemoryStats()

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -158,15 +158,18 @@ public class TendrilSettings
 
 public record ConfigParseError(string Message, string FilePath, Exception? InnerException);
 
-public class ConfigService : IConfigService
+public class ConfigService : IConfigService, IDisposable
 {
     private readonly bool _explicitHome;
     private readonly ILogger<ConfigService> _logger;
+    private readonly HashSet<string> _tempFiles = new();
+    private readonly object _tempFilesLock = new();
     private string[]? _levelNamesCache;
     private string? _pendingCodingAgent;
     private ProjectConfig? _pendingProject;
     private string? _pendingTendrilHome;
     private List<VerificationConfig>? _pendingVerificationDefinitions;
+    private bool _disposed;
 
     internal ConfigService(TendrilSettings settings, string? tendrilHome = null, ILogger<ConfigService>? logger = null)
     {
@@ -448,6 +451,12 @@ public class ConfigService : IConfigService
 
         var tempPath = Path.Combine(Path.GetTempPath(), $"tendril-edit-{Guid.NewGuid()}.md");
         File.WriteAllText(tempPath, polished);
+
+        lock (_tempFilesLock)
+        {
+            _tempFiles.Add(tempPath);
+        }
+
         return tempPath;
     }
 
@@ -792,6 +801,35 @@ public class ConfigService : IConfigService
         if (Settings.Verifications == null) return;
         foreach (var verification in Settings.Verifications)
             verification.Prompt = ExpandVar(verification.Prompt);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        lock (_tempFilesLock)
+        {
+            foreach (var tempFile in _tempFiles)
+            {
+                try
+                {
+                    if (File.Exists(tempFile))
+                    {
+                        File.Delete(tempFile);
+                        _logger.LogDebug("Deleted temp file: {TempFile}", tempFile);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to delete temp file: {TempFile}", tempFile);
+                }
+            }
+
+            _tempFiles.Clear();
+        }
     }
 }
 

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -34,6 +34,9 @@ public static class TendrilServer
         server.Services.AddSingleton<IConfigService>(configService);
         server.Services.AddSingleton<ConfigService>(configService);
 
+        // Store reference for cleanup on process exit
+        Program.SetConfigServiceForCleanup(configService);
+
         if (configService.Settings.Auth != null)
         {
             server.Services.AddHttpContextAccessor();


### PR DESCRIPTION
# Summary

## Changes

Implemented temp file tracking and automatic cleanup in ConfigService to prevent unbounded disk space growth from orphaned markdown editing temp files. ConfigService now implements IDisposable, tracks all temp files created during markdown preprocessing, and cleans them up on process exit.

## API Changes

**ConfigService.cs:**
- Now implements `IDisposable`
- Added `Dispose()` method (public)

**Program.cs:**
- Added `SetConfigServiceForCleanup(ConfigService)` method (internal static)

## Files Modified

**Core Implementation:**
- `src/Ivy.Tendril/Services/ConfigService.cs` — Added temp file tracking, IDisposable implementation
- `src/Ivy.Tendril/Program.cs` — Added ProcessExit cleanup handler
- `src/Ivy.Tendril/TendrilServer.cs` — Register ConfigService for cleanup

**Tests:**
- `src/Ivy.Tendril.Test/ConfigServiceTests.cs` — Added 4 new test methods for temp file lifecycle

## Commits

- 3768814 [03645] Track and cleanup temp files in ConfigService
- 46d3ee6 [03645] Fix service provider access in Program.cs