### PR TITLE
[03647] .Result Access Pattern in SoftwareCheckStepView

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -123,9 +123,11 @@ public class SoftwareCheckStepView(
             var installTasks = SoftwareChecks.Select(s => s.InstallCheck()).ToList();
             await Task.WhenAll(installTasks);
 
-            var results = SoftwareChecks
-                .Zip(installTasks, (check, task) => (check, installed: task.Result))
-                .ToDictionary(x => x.check.Key, x => x.installed);
+            var results = new Dictionary<string, bool>();
+            for (int i = 0; i < SoftwareChecks.Count; i++)
+            {
+                results[SoftwareChecks[i].Key] = await installTasks[i];
+            }
 
             checkResults.Set(results);
 


### PR DESCRIPTION
# Summary

## Changes

Replaced `.Result` access pattern with `await` calls in `SoftwareCheckStepView.CheckSoftware()` method. The code previously used LINQ's `Zip` to pair checks with task results using `.Result`, which could wrap exceptions in `AggregateException`. The new implementation awaits each completed task individually, preserving exception semantics.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs` — Replaced `.Result` with explicit await loop

---

**Commits:**
- f9c72e2