### PR TITLE
[03639] Fix Command Injection via Git Arguments

### DIFF
--- a/src/Ivy.Tendril.Test/GitServiceValidationTests.cs
+++ b/src/Ivy.Tendril.Test/GitServiceValidationTests.cs
@@ -16,7 +16,7 @@ public class GitServiceValidationTests
     [InlineData("abc\n123", false)]                  // newline
     [InlineData("", false)]                          // empty
     [InlineData(null, false)]                        // null
-    public void IsValidCommitHash_ValidatesFormat(string hash, bool expected)
+    public void IsValidCommitHash_ValidatesFormat(string? hash, bool expected)
     {
         var result = GitService.IsValidCommitHash(hash);
         Assert.Equal(expected, result);

--- a/src/Ivy.Tendril.Test/GitServiceValidationTests.cs
+++ b/src/Ivy.Tendril.Test/GitServiceValidationTests.cs
@@ -1,0 +1,24 @@
+using Ivy.Tendril.Services;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class GitServiceValidationTests
+{
+    [Theory]
+    [InlineData("abc1234", true)]                    // 7-char short hash
+    [InlineData("abc1234567890abcdef1234567890abcdef12345678", true)] // 40-char full hash
+    [InlineData("ABC1234", true)]                    // uppercase (git accepts)
+    [InlineData("abc123", false)]                    // too short
+    [InlineData("g123456", false)]                   // invalid character
+    [InlineData("abc123; rm -rf /", false)]          // injection attempt
+    [InlineData("--upload-pack=evil", false)]        // git option injection
+    [InlineData("abc\n123", false)]                  // newline
+    [InlineData("", false)]                          // empty
+    [InlineData(null, false)]                        // null
+    public void IsValidCommitHash_ValidatesFormat(string hash, bool expected)
+    {
+        var result = GitService.IsValidCommitHash(hash);
+        Assert.Equal(expected, result);
+    }
+}

--- a/src/Ivy.Tendril/Commands/PlanAddCommitCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddCommitCommand.cs
@@ -36,6 +36,13 @@ public class PlanAddCommitCommand : Command<PlanAddCommitSettings>
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
+            // Validate commit hash format
+            if (!GitService.IsValidCommitHash(settings.Sha))
+            {
+                _logger.LogError("Invalid commit hash format: {Sha}", settings.Sha);
+                return 1;
+            }
+
             // Check if already present
             if (plan.Commits.Contains(settings.Sha))
             {

--- a/src/Ivy.Tendril/Services/GitService.cs
+++ b/src/Ivy.Tendril/Services/GitService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using System.Text.RegularExpressions;
 using Ivy.Helpers;
 
 namespace Ivy.Tendril.Services;
@@ -13,11 +14,20 @@ public class GitService : IGitService
         _timeoutMs = config.Settings.GitTimeout * 1000;
     }
 
+    public static bool IsValidCommitHash(string hash)
+    {
+        return !string.IsNullOrEmpty(hash) &&
+               Regex.IsMatch(hash, "^[a-fA-F0-9]{7,40}$");
+    }
+
     public string? GetCommitTitle(string repoPath, string commitHash)
     {
+        if (!IsValidCommitHash(commitHash))
+            return null;
+
         try
         {
-            var psi = new ProcessStartInfo("git", $"log -1 --format=%s {commitHash}")
+            var psi = new ProcessStartInfo("git", $"log -1 --format=%s -- {commitHash}")
             {
                 WorkingDirectory = repoPath,
                 RedirectStandardOutput = true,
@@ -38,9 +48,12 @@ public class GitService : IGitService
 
     public string? GetCommitDiff(string repoPath, string commitHash)
     {
+        if (!IsValidCommitHash(commitHash))
+            return null;
+
         try
         {
-            var psi = new ProcessStartInfo("git", $"show --format=\"\" --patch {commitHash}")
+            var psi = new ProcessStartInfo("git", $"show --format=\"\" --patch -- {commitHash}")
             {
                 WorkingDirectory = repoPath,
                 RedirectStandardOutput = true,
@@ -61,9 +74,12 @@ public class GitService : IGitService
 
     public int? GetCommitFileCount(string repoPath, string commitHash)
     {
+        if (!IsValidCommitHash(commitHash))
+            return null;
+
         try
         {
-            var psi = new ProcessStartInfo("git", $"diff-tree --no-commit-id --name-only -r {commitHash}")
+            var psi = new ProcessStartInfo("git", $"diff-tree --no-commit-id --name-only -r -- {commitHash}")
             {
                 WorkingDirectory = repoPath,
                 RedirectStandardOutput = true,
@@ -86,9 +102,12 @@ public class GitService : IGitService
 
     public List<(string Status, string FilePath)>? GetCommitFiles(string repoPath, string commitHash)
     {
+        if (!IsValidCommitHash(commitHash))
+            return null;
+
         try
         {
-            var psi = new ProcessStartInfo("git", $"diff-tree --no-commit-id --name-status -r {commitHash}")
+            var psi = new ProcessStartInfo("git", $"diff-tree --no-commit-id --name-status -r -- {commitHash}")
             {
                 WorkingDirectory = repoPath,
                 RedirectStandardOutput = true,
@@ -119,9 +138,12 @@ public class GitService : IGitService
 
     public string? GetCombinedDiff(string repoPath, string firstCommit, string lastCommit)
     {
+        if (!IsValidCommitHash(firstCommit) || !IsValidCommitHash(lastCommit))
+            return null;
+
         try
         {
-            var psi = new ProcessStartInfo("git", $"diff {firstCommit}^..{lastCommit}")
+            var psi = new ProcessStartInfo("git", $"diff -- {firstCommit}^..{lastCommit}")
             {
                 WorkingDirectory = repoPath,
                 RedirectStandardOutput = true,
@@ -142,9 +164,12 @@ public class GitService : IGitService
 
     public List<(string Status, string FilePath)>? GetCombinedChangedFiles(string repoPath, string firstCommit, string lastCommit)
     {
+        if (!IsValidCommitHash(firstCommit) || !IsValidCommitHash(lastCommit))
+            return null;
+
         try
         {
-            var psi = new ProcessStartInfo("git", $"diff --name-status {firstCommit}^..{lastCommit}")
+            var psi = new ProcessStartInfo("git", $"diff --name-status -- {firstCommit}^..{lastCommit}")
             {
                 WorkingDirectory = repoPath,
                 RedirectStandardOutput = true,
@@ -177,6 +202,10 @@ public class GitService : IGitService
     {
         var hashes = commitHashes.ToList();
         if (hashes.Count == 0) return new Dictionary<string, (string, int)>();
+
+        // Validate all hashes first
+        if (hashes.Any(hash => !IsValidCommitHash(hash)))
+            return null;
 
         try
         {

--- a/src/Ivy.Tendril/Services/GitService.cs
+++ b/src/Ivy.Tendril/Services/GitService.cs
@@ -14,7 +14,7 @@ public class GitService : IGitService
         _timeoutMs = config.Settings.GitTimeout * 1000;
     }
 
-    public static bool IsValidCommitHash(string hash)
+    public static bool IsValidCommitHash(string? hash)
     {
         return !string.IsNullOrEmpty(hash) &&
                Regex.IsMatch(hash, "^[a-fA-F0-9]{7,40}$");


### PR DESCRIPTION
# Summary

## Changes

Fixed command injection vulnerability in GitService by adding input validation for commit hashes and using git's `--` argument separator to prevent malicious input from being interpreted as command options. During verification, fixed nullable parameter handling to satisfy C# nullable reference type requirements.

## API Changes

- **GitService.IsValidCommitHash(string? hash)** — New public static method that validates commit hash format (7-40 hexadecimal characters), accepts nullable parameter
- All GitService methods (`GetCommitTitle`, `GetCommitDiff`, `GetCommitFileCount`, `GetCommitFiles`, `GetCombinedDiff`, `GetCombinedChangedFiles`, `GetCommitSummaries`) now return `null` if provided with invalid commit hashes
- `PlanAddCommitCommand` now rejects invalid commit hashes with exit code 1

## Files Modified

**Security:**
- `src/Ivy.Tendril/Services/GitService.cs` — Added validation method with nullable parameter, updated all git command construction to validate input and use `--` separator
- `src/Ivy.Tendril/Commands/PlanAddCommitCommand.cs` — Added validation before storing commit hashes in plan.yaml

**Tests:**
- `src/Ivy.Tendril.Test/GitServiceValidationTests.cs` — New test file with validation test cases including null handling

## Commits

- e3319f2 [03639] Fix nullable parameter in IsValidCommitHash
- 624227c [03639] Add validation to prevent command injection via git arguments