### PR TITLE
[03635] Race Condition in JobService Queue Processing

### DIFF
--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -590,22 +590,24 @@ public class JobService : IJobService
             if (!_jobSlotSemaphore.Wait(0))
                 break;
 
-            string? queuedId;
+            JobItem? queuedJob = null;
             lock (_queueLock)
             {
-                if (!_jobQueue.TryDequeue(out queuedId, out _))
+                if (!_jobQueue.TryDequeue(out var queuedId, out _))
                 {
                     _jobSlotSemaphore.Release();
                     break;
                 }
+
+                // Check status INSIDE the lock, immediately after dequeue
+                if (!_jobs.TryGetValue(queuedId, out queuedJob) || queuedJob.Status != JobStatus.Queued)
+                {
+                    _jobSlotSemaphore.Release();
+                    continue;
+                }
             }
 
-            if (!_jobs.TryGetValue(queuedId, out var queuedJob) || queuedJob.Status != JobStatus.Queued)
-            {
-                _jobSlotSemaphore.Release();
-                continue;
-            }
-
+            // Launch outside the lock (launching is expensive)
             LaunchJob(queuedJob);
         }
     }


### PR DESCRIPTION
# Summary

## Changes

Fixed a race condition in `JobService.ProcessJobQueue()` where a job's status could change between dequeue and verification. Moved the status check inside the `_queueLock` to ensure atomic dequeue-and-verify operations.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Services/JobService.cs** — Modified `ProcessJobQueue()` to check job status inside the queue lock

## Commits

- 84b755786b306e71c2f983e09fc3e0a6f472e9f2