### PR TITLE
[03637] Flaky Tests — Sleep-Based Timing Patterns

### DIFF
--- a/src/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
+++ b/src/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Test.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -27,7 +28,30 @@ public class BackgroundServiceActivatorTests : IAsyncLifetime
         if (_serviceProvider != null)
         {
             await _serviceProvider.DisposeAsync();
-            await Task.Delay(100);
+
+            // Give services time to complete disposal - use polling instead of fixed delay
+            await RetryHelper.WaitUntilAsync(
+                async () =>
+                {
+                    await Task.Yield();
+                    // Check if temp directory can be safely deleted (no file locks)
+                    try
+                    {
+                        if (Directory.Exists(_tempDir))
+                        {
+                            // Try to enumerate - will fail if services still have locks
+                            _ = Directory.GetFiles(_tempDir, "*", SearchOption.AllDirectories);
+                        }
+                        return true;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                },
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromMilliseconds(50),
+                "Services did not fully dispose within timeout");
         }
 
         try

--- a/src/Ivy.Tendril.Test/Helpers/RetryHelper.cs
+++ b/src/Ivy.Tendril.Test/Helpers/RetryHelper.cs
@@ -1,0 +1,51 @@
+namespace Ivy.Tendril.Test.Helpers;
+
+public static class RetryHelper
+{
+    public static async Task WaitUntilAsync(
+        Func<Task<bool>> condition,
+        TimeSpan timeout,
+        TimeSpan? pollInterval = null,
+        string? failureMessage = null)
+    {
+        var interval = pollInterval ?? TimeSpan.FromMilliseconds(100);
+        var deadline = DateTime.UtcNow + timeout;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await condition())
+                return;
+            await Task.Delay(interval);
+        }
+
+        throw new TimeoutException(
+            failureMessage ?? $"Condition not met within {timeout.TotalSeconds}s");
+    }
+
+    public static async Task RetryAsync(
+        Func<Task> action,
+        int maxAttempts = 3,
+        TimeSpan? delayBetween = null)
+    {
+        var delay = delayBetween ?? TimeSpan.FromMilliseconds(500);
+        Exception? lastException = null;
+
+        for (int i = 0; i < maxAttempts; i++)
+        {
+            try
+            {
+                await action();
+                return;
+            }
+            catch (Exception ex)
+            {
+                lastException = ex;
+                if (i < maxAttempts - 1)
+                    await Task.Delay(delay);
+            }
+        }
+
+        throw new AggregateException(
+            $"Action failed after {maxAttempts} attempts", lastException!);
+    }
+}

--- a/src/Ivy.Tendril.Test/InboxRecoveryTests.cs
+++ b/src/Ivy.Tendril.Test/InboxRecoveryTests.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Test.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ivy.Tendril.Test;
@@ -254,7 +255,7 @@ public class InboxRecoveryTests
     }
 
     [Fact]
-    public void CrashRecovery_EndToEnd_ProcessingFileReprocessedOnStartup()
+    public async Task CrashRecovery_EndToEnd_ProcessingFileReprocessedOnStartup()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"inbox-e2e-{Guid.NewGuid():N}");
         var inboxDir = Path.Combine(tempDir, "Inbox");
@@ -271,8 +272,17 @@ public class InboxRecoveryTests
             var jobService = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), inboxDir);
             using var watcher = new InboxWatcherService(config, jobService, NullLogger<InboxWatcherService>.Instance);
 
-            // Step 3: Wait for async processing
-            Thread.Sleep(2000);
+            // Step 3: Wait for recovery and processing to complete
+            await RetryHelper.WaitUntilAsync(
+                async () =>
+                {
+                    await Task.Yield();
+                    var jobs = jobService.GetJobs();
+                    return jobs.Any(j => j.Type == "CreatePlan" && j.PlanFile.Contains("Crashed task description"));
+                },
+                TimeSpan.FromSeconds(5),
+                TimeSpan.FromMilliseconds(100),
+                "Recovered file was not processed within timeout");
 
             // The .processing file should have been renamed to .md by RecoverProcessingFiles,
             // then picked up by ProcessExistingFiles, renamed back to .processing, and a job started.

--- a/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
@@ -1,6 +1,7 @@
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Test.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ivy.Tendril.Test;
@@ -112,7 +113,7 @@ public class InboxWatcherServiceTests
     }
 
     [Fact]
-    public void ProcessFileAsync_EmptyContent_SkipsJob()
+    public async Task ProcessFileAsync_EmptyContent_SkipsJob()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"inbox-test-{Guid.NewGuid():N}");
         var inboxDir = Path.Combine(tempDir, "Inbox");
@@ -128,8 +129,16 @@ public class InboxWatcherServiceTests
             var jobService = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), inboxDir);
             using var watcher = new InboxWatcherService(config, jobService, NullLogger<InboxWatcherService>.Instance);
 
-            // Wait for async processing
-            Thread.Sleep(2000);
+            // Wait for async processing to complete
+            await RetryHelper.WaitUntilAsync(
+                async () =>
+                {
+                    await Task.Yield();
+                    return Directory.GetFiles(inboxDir, "*.md").Length == 1;
+                },
+                TimeSpan.FromSeconds(5),
+                TimeSpan.FromMilliseconds(100),
+                "Empty file was not skipped within timeout");
 
             // The .md file should still be there (not renamed to .processing) because the description is empty
             Assert.Single(Directory.GetFiles(inboxDir, "*.md"));
@@ -143,7 +152,7 @@ public class InboxWatcherServiceTests
     }
 
     [Fact]
-    public void ProcessFileAsync_AlreadyTrackedByRunningJob_SkipsStartJob()
+    public async Task ProcessFileAsync_AlreadyTrackedByRunningJob_SkipsStartJob()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"inbox-test-{Guid.NewGuid():N}");
         var inboxDir = Path.Combine(tempDir, "Inbox");
@@ -158,7 +167,18 @@ public class InboxWatcherServiceTests
             var jobService = new TrackedStubJobService { TrackedReturnValue = true };
             using var watcher = new InboxWatcherService(config, jobService, NullLogger<InboxWatcherService>.Instance);
 
-            Thread.Sleep(2000);
+            // Wait for processing to be attempted and skipped
+            await RetryHelper.WaitUntilAsync(
+                async () =>
+                {
+                    await Task.Yield();
+                    // Processing should complete (file remains .md, no job started)
+                    return Directory.GetFiles(inboxDir, "*.md").Length == 1 &&
+                           Directory.GetFiles(inboxDir, "*.md.processing").Length == 0;
+                },
+                TimeSpan.FromSeconds(5),
+                TimeSpan.FromMilliseconds(100),
+                "Tracked file was not skipped within timeout");
 
             // When IsInboxFileTracked returns true, the watcher must not call StartJob
             // and must leave the .md file untouched (no rename to .processing).
@@ -174,7 +194,7 @@ public class InboxWatcherServiceTests
     }
 
     [Fact]
-    public void ProcessFileAsync_NotTracked_StartsJobAndRenamesFile()
+    public async Task ProcessFileAsync_NotTracked_StartsJobAndRenamesFile()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"inbox-test-{Guid.NewGuid():N}");
         var inboxDir = Path.Combine(tempDir, "Inbox");
@@ -189,7 +209,17 @@ public class InboxWatcherServiceTests
             var jobService = new TrackedStubJobService { TrackedReturnValue = false };
             using var watcher = new InboxWatcherService(config, jobService, NullLogger<InboxWatcherService>.Instance);
 
-            Thread.Sleep(2000);
+            // Wait for processing to complete (job started, file renamed)
+            await RetryHelper.WaitUntilAsync(
+                async () =>
+                {
+                    await Task.Yield();
+                    return jobService.StartedJobs.Count == 1 &&
+                           Directory.GetFiles(inboxDir, "*.md.processing").Length == 1;
+                },
+                TimeSpan.FromSeconds(5),
+                TimeSpan.FromMilliseconds(100),
+                "File was not processed within timeout");
 
             Assert.Single(jobService.StartedJobs);
             Assert.Empty(Directory.GetFiles(inboxDir, "*.md"));
@@ -235,7 +265,7 @@ public class InboxWatcherServiceTests
     }
 
     [Fact]
-    public void ProcessExistingFiles_PicksUpFilesInInbox()
+    public async Task ProcessExistingFiles_PicksUpFilesInInbox()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"inbox-test-{Guid.NewGuid():N}");
         var inboxDir = Path.Combine(tempDir, "Inbox");
@@ -251,8 +281,17 @@ public class InboxWatcherServiceTests
             using var watcher = new InboxWatcherService(config, jobService, NullLogger<InboxWatcherService>.Instance);
 
             // The constructor calls ProcessExistingFiles, which dispatches async processing.
-            // Wait briefly for the async task to pick up and rename the file to .processing.
-            Thread.Sleep(2000);
+            // Wait for the file to be processed and renamed to .processing.
+            await RetryHelper.WaitUntilAsync(
+                async () =>
+                {
+                    await Task.Yield();
+                    return Directory.GetFiles(inboxDir, "*.md").Length == 0 &&
+                           Directory.GetFiles(inboxDir, "*.md.processing").Length == 1;
+                },
+                TimeSpan.FromSeconds(5),
+                TimeSpan.FromMilliseconds(100),
+                "Existing file was not processed within timeout");
 
             // The .md file should have been renamed to .processing (job started)
             Assert.Empty(Directory.GetFiles(inboxDir, "*.md"));

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -807,12 +807,11 @@ public class PlanCliCommandTests : IDisposable
         CreatePlanFolder("20100", "TimestampTest");
         var before = ReadPlan("20100").Updated;
 
-        Thread.Sleep(50);
-
+        // Explicitly set a later timestamp to avoid timing races
         var folder = PlanCommandHelpers.ResolvePlanFolder("20100");
         var plan = PlanCommandHelpers.ReadPlan(folder);
         plan.Project = "Changed";
-        plan.Updated = DateTime.UtcNow;
+        plan.Updated = before.AddSeconds(1);
         PlanCommandHelpers.WritePlan(folder, plan);
 
         var after = ReadPlan("20100").Updated;

--- a/src/Ivy.Tendril.Test/TimeCacheTests.cs
+++ b/src/Ivy.Tendril.Test/TimeCacheTests.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Test.Helpers;
 
 namespace Ivy.Tendril.Test;
 
@@ -42,7 +43,7 @@ public class TimeCacheTests
     }
 
     [Fact]
-    public void GetOrCompute_RecomputesAfterExpiration()
+    public async Task GetOrCompute_RecomputesAfterExpiration()
     {
         var cache = new TimeCache<int>(TimeSpan.FromMilliseconds(100));
         var callCount = 0;
@@ -52,7 +53,18 @@ public class TimeCacheTests
             callCount++;
             return 42;
         });
-        Thread.Sleep(150);
+
+        // Wait for cache to expire by polling IsValid
+        await RetryHelper.WaitUntilAsync(
+            async () =>
+            {
+                await Task.Yield();
+                return !cache.IsValid;
+            },
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromMilliseconds(50),
+            "Cache did not expire within timeout");
+
         var result = cache.GetOrCompute(() =>
         {
             callCount++;
@@ -95,11 +107,21 @@ public class TimeCacheTests
     }
 
     [Fact]
-    public void IsValid_ReturnsFalseForExpiredCache()
+    public async Task IsValid_ReturnsFalseForExpiredCache()
     {
         var cache = new TimeCache<int>(TimeSpan.FromMilliseconds(50));
         cache.GetOrCompute(() => 42);
-        Thread.Sleep(100);
+
+        // Wait for cache to expire
+        await RetryHelper.WaitUntilAsync(
+            async () =>
+            {
+                await Task.Yield();
+                return !cache.IsValid;
+            },
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromMilliseconds(25),
+            "Cache did not expire within timeout");
 
         Assert.False(cache.IsValid);
     }
@@ -158,7 +180,16 @@ public class TimeCacheTests
             return 42;
         });
 
-        await Task.Delay(150);
+        // Wait for cache to expire by polling IsValid
+        await RetryHelper.WaitUntilAsync(
+            async () =>
+            {
+                await Task.Yield();
+                return !cache.IsValid;
+            },
+            TimeSpan.FromSeconds(2),
+            TimeSpan.FromMilliseconds(50),
+            "Cache did not expire within timeout");
 
         var result = await cache.GetOrComputeAsync(async () =>
         {


### PR DESCRIPTION
# Summary

## Changes

Replaced fixed sleep/delay calls with event-based polling in unit tests to eliminate timing-based flakiness. Added RetryHelper utility for condition-based waiting with configurable timeouts.

## API Changes

None. This is a test-only refactoring with no changes to production code or public APIs.

## Files Modified

**Test Infrastructure:**
- `src/Ivy.Tendril.Test/Helpers/RetryHelper.cs` — Added polling helper with timeout support

**Test Files:**
- `src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs` — Replaced 4 Thread.Sleep(2000) with async polling
- `src/Ivy.Tendril.Test/InboxRecoveryTests.cs` — Replaced Thread.Sleep(2000) with job completion polling
- `src/Ivy.Tendril.Test/TimeCacheTests.cs` — Replaced Thread.Sleep with cache expiration polling (3 tests)
- `src/Ivy.Tendril.Test/PlanCliCommandTests.cs` — Replaced Thread.Sleep(50) with explicit timestamp manipulation
- `src/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs` — Replaced Task.Delay(100) with file lock polling

## Commits

- c3b93dd [03637] Replace sleep-based timing with RetryHelper polling