### PR TITLE
[03628] Log Swallowed Exceptions Across Services

### DIFF
--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -141,7 +141,17 @@ internal class JobCompletionHandler
         _telemetryService?.TrackJobCompleted(job.Type, job.Status, job.DurationSeconds);
 
         if (_telemetryService != null)
-            _ = Task.Run(async () => { try { await _telemetryService.FlushAsync(); } catch { /* best-effort */ } });
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await _telemetryService.FlushAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Failed to flush telemetry (best-effort)");
+                }
+            });
     }
 
     private void NotifyPlanWatcher(JobItem job)
@@ -332,8 +342,9 @@ internal class JobCompletionHandler
                     changed = true;
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogDebug(ex, "Failed to read verification report {ReportPath}", reportFile);
                 // Skip unreadable report files
             }
         }
@@ -424,8 +435,9 @@ internal class JobCompletionHandler
                 }
             }
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogDebug(ex, "Failed to read commits from worktree {Worktree}", wtDir);
             // Skip worktrees that can't be read
         }
 

--- a/src/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -633,8 +633,9 @@ public class PlanDatabaseService : IPlanDatabaseService
                 {
                     plans = ExecuteSearchQuery(ftsCmd);
                 }
-                catch (Microsoft.Data.Sqlite.SqliteException)
+                catch (Microsoft.Data.Sqlite.SqliteException ex)
                 {
+                    _logger?.LogDebug(ex, "FTS5 query syntax error for query '{Query}', falling back to LIKE", sanitizedQuery);
                     // FTS5 syntax error — safety net for edge cases the sanitizer doesn't handle
                     plans = [];
                 }

--- a/src/Ivy.Tendril/Services/PlanWatcherService.cs
+++ b/src/Ivy.Tendril/Services/PlanWatcherService.cs
@@ -1,4 +1,5 @@
 using Ivy.Helpers;
+using Microsoft.Extensions.Logging;
 using Timer = System.Timers.Timer;
 
 namespace Ivy.Tendril.Services;
@@ -8,10 +9,12 @@ public class PlanWatcherService : IPlanWatcherService
     private readonly Timer _debounceTimer;
     private readonly FileSystemWatcher? _watcher;
     private readonly System.Threading.Timer? _pollTimer;
+    private readonly ILogger<PlanWatcherService>? _logger;
     private string? _pendingPlanFolder;
 
-    public PlanWatcherService(IConfigService config)
+    public PlanWatcherService(IConfigService config, ILogger<PlanWatcherService>? logger = null)
     {
+        _logger = logger;
         _debounceTimer = new Timer(500);
         _debounceTimer.AutoReset = false;
         _debounceTimer.Elapsed += (_, _) =>
@@ -22,8 +25,9 @@ public class PlanWatcherService : IPlanWatcherService
                 _pendingPlanFolder = null;
                 PlansChanged?.Invoke(folder);
             }
-            catch
+            catch (Exception ex)
             {
+                _logger?.LogWarning(ex, "Failed to invoke PlansChanged event");
                 // Swallow to prevent unhandled exceptions on the timer's thread-pool
                 // thread from terminating the process.
             }
@@ -61,8 +65,9 @@ public class PlanWatcherService : IPlanWatcherService
             {
                 ScheduleDebounce(null);
             }
-            catch
+            catch (Exception ex)
             {
+                _logger?.LogDebug(ex, "Failed to schedule debounce during poll");
                 // Best-effort polling
             }
         }, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -130,7 +130,8 @@ public static class TendrilServer
         server.Services.AddSingleton<PlanWatcherService>(sp =>
         {
             var config = sp.GetRequiredService<IConfigService>();
-            return new PlanWatcherService(config);
+            var logger = sp.GetService<ILogger<PlanWatcherService>>();
+            return new PlanWatcherService(config, logger);
         });
         server.Services.AddSingleton<IPlanWatcherService>(sp => sp.GetRequiredService<PlanWatcherService>());
         server.Services.AddSingleton<PlanCountsService>(sp =>


### PR DESCRIPTION
# Summary

## Changes

Added `ILogger` instrumentation to all empty catch blocks across JobCompletionHandler, PlanWatcherService, and PlanDatabaseService. Exception details are now logged at Debug or Warning level before being suppressed.

## API Changes

**PlanWatcherService constructor:**
- Added optional `ILogger<PlanWatcherService>? logger = null` parameter

## Files Modified

- **src/Ivy.Tendril/Services/JobCompletionHandler.cs** — Added logging to telemetry flush, verification report parsing, and worktree commit extraction failures
- **src/Ivy.Tendril/Services/PlanWatcherService.cs** — Added ILogger field and logging to timer exception handlers
- **src/Ivy.Tendril/Services/PlanDatabaseService.cs** — Added logging to FTS5 query syntax error fallback
- **src/Ivy.Tendril/TendrilServer.cs** — Updated PlanWatcherService registration to inject logger

## Commits

- 1c8f28e [03628] Add logging to swallowed exceptions across services