### PR TITLE
[03624] CancellationTokenSource Resource Leak in JobLauncher

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceResourceDisposalTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceResourceDisposalTests.cs
@@ -23,7 +23,6 @@ public class JobServiceResourceDisposalTests
         {
             Id = "test-job",
             Type = "ExecutePlan",
-            PlanId = "00001",
             Status = JobStatus.Running
         };
 
@@ -42,7 +41,6 @@ public class JobServiceResourceDisposalTests
         {
             Id = "test-job",
             Type = "ExecutePlan",
-            PlanId = "00001",
             Status = JobStatus.Running
         };
 
@@ -70,7 +68,6 @@ public class JobServiceResourceDisposalTests
         {
             Id = "test-job",
             Type = "ExecutePlan",
-            PlanId = "00001",
             Status = JobStatus.Running
         };
 
@@ -181,7 +178,7 @@ internal class TestLogger : ILogger
         _messages = messages;
     }
 
-    public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+    IDisposable ILogger.BeginScope<TState>(TState state) where TState : default => NullScope.Instance;
 
     public bool IsEnabled(LogLevel logLevel) => true;
 

--- a/src/Ivy.Tendril.Test/JobServiceResourceDisposalTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceResourceDisposalTests.cs
@@ -1,0 +1,198 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test;
+
+public class JobServiceResourceDisposalTests
+{
+    private static JobService CreateService(ILogger<JobService>? logger = null)
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+        return new JobService(
+            jobTimeout: TimeSpan.FromMinutes(30),
+            staleOutputTimeout: TimeSpan.FromMinutes(10),
+            logger: logger);
+    }
+
+    [Fact]
+    public void DisposeResources_WithNullLogger_DoesNotThrow()
+    {
+        var job = new JobItem
+        {
+            Id = "test-job",
+            Type = "ExecutePlan",
+            PlanId = "00001",
+            Status = JobStatus.Running
+        };
+
+        // Should not throw when logger is null
+        job.DisposeResources(null);
+
+        Assert.Null(job.Process);
+        Assert.Null(job.TimeoutCts);
+    }
+
+    [Fact]
+    public void DisposeResources_WithValidResources_DisposesSuccessfully()
+    {
+        var logger = NullLogger<JobService>.Instance;
+        var job = new JobItem
+        {
+            Id = "test-job",
+            Type = "ExecutePlan",
+            PlanId = "00001",
+            Status = JobStatus.Running
+        };
+
+        // Create a CancellationTokenSource that we can dispose
+        job.TimeoutCts = new CancellationTokenSource();
+
+        // Should dispose without exceptions
+        job.DisposeResources(logger);
+
+        Assert.Null(job.Process);
+        Assert.Null(job.TimeoutCts);
+    }
+
+    [Fact]
+    public void DisposeResources_LogsWarningWhenDisposalFails()
+    {
+        var logMessages = new List<string>();
+        var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddProvider(new TestLoggerProvider(logMessages));
+        });
+        var logger = loggerFactory.CreateLogger<JobService>();
+
+        var job = new JobItem
+        {
+            Id = "test-job",
+            Type = "ExecutePlan",
+            PlanId = "00001",
+            Status = JobStatus.Running
+        };
+
+        // Create a CTS and dispose it, so the next dispose call fails
+        job.TimeoutCts = new CancellationTokenSource();
+        job.TimeoutCts.Dispose();
+
+        // Should log a warning when disposal fails
+        job.DisposeResources(logger);
+
+        // Check that a warning was logged (disposal of already-disposed CTS throws ObjectDisposedException)
+        var warningLogs = logMessages.Where(m => m.Contains("Warning") || m.Contains("Failed to dispose")).ToList();
+        Assert.NotEmpty(warningLogs);
+    }
+
+    [Fact]
+    public void CompleteJob_DisposesResources()
+    {
+        var service = CreateService();
+        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+
+        // Start the job
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+
+        // Create a CTS to verify it gets disposed
+        job.TimeoutCts = new CancellationTokenSource();
+
+        // Complete the job
+        service.CompleteJob(id, 0);
+
+        // Verify resources were disposed
+        var completedJob = service.GetJob(id);
+        Assert.NotNull(completedJob);
+        Assert.Null(completedJob.Process);
+        Assert.Null(completedJob.TimeoutCts);
+    }
+
+    [Fact]
+    public void StopJob_DisposesResources()
+    {
+        var service = CreateService();
+        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+
+        // Create a CTS to verify it gets disposed
+        job.TimeoutCts = new CancellationTokenSource();
+
+        // Stop the job
+        service.StopJob(id);
+
+        // Verify resources were disposed
+        var stoppedJob = service.GetJob(id);
+        Assert.NotNull(stoppedJob);
+        Assert.Null(stoppedJob.Process);
+        Assert.Null(stoppedJob.TimeoutCts);
+    }
+
+    [Fact]
+    public void DeleteJob_DisposesResources()
+    {
+        var service = CreateService();
+        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+
+        // Create a CTS to verify it gets disposed
+        job.TimeoutCts = new CancellationTokenSource();
+
+        // Delete the job
+        service.DeleteJob(id);
+
+        // Verify job is removed and resources were disposed
+        var deletedJob = service.GetJob(id);
+        Assert.Null(deletedJob);
+    }
+}
+
+/// <summary>
+/// Simple test logger provider that captures log messages to a list.
+/// </summary>
+internal class TestLoggerProvider : ILoggerProvider
+{
+    private readonly List<string> _messages;
+
+    public TestLoggerProvider(List<string> messages)
+    {
+        _messages = messages;
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new TestLogger(_messages);
+    }
+
+    public void Dispose() { }
+}
+
+internal class TestLogger : ILogger
+{
+    private readonly List<string> _messages;
+
+    public TestLogger(List<string> messages)
+    {
+        _messages = messages;
+    }
+
+    public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        _messages.Add($"{logLevel}: {formatter(state, exception)}");
+    }
+
+    private class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new NullScope();
+        public void Dispose() { }
+    }
+}

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Models;
 
@@ -79,11 +80,41 @@ public record JobItem
             OutputLines.TryDequeue(out _);
     }
 
-    public void DisposeResources()
+    public void DisposeResources(ILogger? logger = null)
     {
-        try { Process?.Dispose(); } catch { }
-        try { TimeoutCts?.Dispose(); } catch { }
-        try { if (StatusFilePath != null && File.Exists(StatusFilePath)) File.Delete(StatusFilePath); } catch { }
+        try
+        {
+            Process?.Dispose();
+            logger?.LogDebug("Job {JobId}: Process disposed successfully", Id);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Job {JobId}: Failed to dispose Process", Id);
+        }
+
+        try
+        {
+            TimeoutCts?.Dispose();
+            logger?.LogDebug("Job {JobId}: TimeoutCts disposed successfully", Id);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Job {JobId}: Failed to dispose TimeoutCts", Id);
+        }
+
+        try
+        {
+            if (StatusFilePath != null && File.Exists(StatusFilePath))
+            {
+                File.Delete(StatusFilePath);
+                logger?.LogDebug("Job {JobId}: Status file deleted successfully", Id);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Job {JobId}: Failed to delete status file at {StatusFilePath}", Id, StatusFilePath);
+        }
+
         Process = null;
         TimeoutCts = null;
     }

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -148,7 +148,7 @@ public class JobService : IJobService
         _completionHandler.HandleCompletion(
             job, _jobs, PersistJob, RaiseNotification, RaiseJobsPropertyChanged, StartJobSkipDepCheck);
 
-        job.DisposeResources();
+        job.DisposeResources(_logger);
         PersistJob(job);
         EvictStaleJobs();
         RaiseJobsStructureChanged();
@@ -204,7 +204,7 @@ public class JobService : IJobService
             /* Process may have already exited */
         }
 
-        job.DisposeResources();
+        job.DisposeResources(_logger);
 
         job.Status = JobStatus.Stopped;
         job.CompletedAt = DateTime.UtcNow;
@@ -228,7 +228,7 @@ public class JobService : IJobService
     {
         if (_jobs.TryRemove(id, out var removed))
         {
-            removed.DisposeResources();
+            removed.DisposeResources(_logger);
             try { _database?.DeleteJob(id); } catch { /* Best-effort */ }
         }
         RaiseJobsStructureChanged();
@@ -254,7 +254,7 @@ public class JobService : IJobService
 
         foreach (var id in staleJobs)
             if (_jobs.TryRemove(id, out var removed))
-                removed.DisposeResources();
+                removed.DisposeResources(_logger);
     }
 
     public void ClearCompletedJobs()
@@ -269,7 +269,7 @@ public class JobService : IJobService
         foreach (var id in ids)
         {
             if (_jobs.TryRemove(id, out var removed))
-                removed.DisposeResources();
+                removed.DisposeResources(_logger);
             try { _database?.DeleteJob(id); } catch { /* Best-effort */ }
         }
         if (ids.Count > 0)


### PR DESCRIPTION
# Summary

## Changes

Added logging to `JobItem.DisposeResources()` to capture disposal failures that were previously silently suppressed. The method now accepts an optional `ILogger` parameter and logs exceptions at Warning level before suppressing them, while successful disposal is logged at Debug level.

## API Changes

- **Modified:** `JobItem.DisposeResources()` now accepts `ILogger? logger = null` parameter
- All call sites in `JobService` updated to pass logger instance

## Files Modified

**Core Changes:**
- `src/Ivy.Tendril/Models/JobModels.cs` — Added logging to DisposeResources method
- `src/Ivy.Tendril/Services/JobService.cs` — Updated 5 call sites to pass logger (CompleteJob, StopJob, DeleteJob, EvictStaleJobs, ClearJobsByStatus)

**Tests:**
- `src/Ivy.Tendril.Test/JobServiceResourceDisposalTests.cs` — New test file with 6 tests verifying disposal behavior and logging

## Commits

- c44024f [03624] Add logging to JobItem.DisposeResources
- 8b86f0c [03624] Fix test compilation errors