### PR TITLE
[03611] No Symlink Detection in FileHelper

### DIFF
--- a/src/Ivy.Tendril.Test/Helpers/FileHelperTest.cs
+++ b/src/Ivy.Tendril.Test/Helpers/FileHelperTest.cs
@@ -1,0 +1,131 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test.Helpers;
+
+public class FileHelperTest : IDisposable
+{
+    private readonly string _tempDir;
+
+    public FileHelperTest()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"FileHelperTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, true);
+        }
+        catch
+        {
+            // Best-effort cleanup
+        }
+    }
+
+    [Fact]
+    public void ReadAllText_SymbolicLink_ThrowsUnauthorizedAccessException()
+    {
+        var targetFile = Path.Combine(_tempDir, "target.txt");
+        var linkFile = Path.Combine(_tempDir, "link.txt");
+        File.WriteAllText(targetFile, "test content");
+
+        try
+        {
+            File.CreateSymbolicLink(linkFile, targetFile);
+        }
+        catch (IOException)
+        {
+            // Skip test if we can't create symlinks (requires admin on Windows)
+            return;
+        }
+
+        var ex = Assert.Throws<UnauthorizedAccessException>(() => FileHelper.ReadAllText(linkFile));
+        Assert.Contains("symbolic link", ex.Message);
+    }
+
+    [Fact]
+    public void WriteAllText_SymbolicLink_ThrowsUnauthorizedAccessException()
+    {
+        var targetFile = Path.Combine(_tempDir, "target.txt");
+        var linkFile = Path.Combine(_tempDir, "link.txt");
+        File.WriteAllText(targetFile, "original content");
+
+        try
+        {
+            File.CreateSymbolicLink(linkFile, targetFile);
+        }
+        catch (IOException)
+        {
+            // Skip test if we can't create symlinks
+            return;
+        }
+
+        var ex = Assert.Throws<UnauthorizedAccessException>(() =>
+            FileHelper.WriteAllText(linkFile, "new content"));
+        Assert.Contains("symbolic link", ex.Message);
+    }
+
+    [Fact]
+    public void ReadAllText_RelativePath_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => FileHelper.ReadAllText("relative/path.txt"));
+        Assert.Contains("fully qualified", ex.Message);
+    }
+
+    [Fact]
+    public void WriteAllText_RelativePath_ThrowsArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            FileHelper.WriteAllText("relative/path.txt", "content"));
+        Assert.Contains("fully qualified", ex.Message);
+    }
+
+    [Fact]
+    public void EnumerateLines_SymbolicLink_ThrowsUnauthorizedAccessException()
+    {
+        var targetFile = Path.Combine(_tempDir, "target.txt");
+        var linkFile = Path.Combine(_tempDir, "link.txt");
+        File.WriteAllText(targetFile, "line1\nline2");
+
+        try
+        {
+            File.CreateSymbolicLink(linkFile, targetFile);
+        }
+        catch (IOException)
+        {
+            // Skip test if we can't create symlinks
+            return;
+        }
+
+        var ex = Assert.Throws<UnauthorizedAccessException>(() =>
+        {
+            // Force enumeration
+            var _ = FileHelper.EnumerateLines(linkFile).ToList();
+        });
+        Assert.Contains("symbolic link", ex.Message);
+    }
+
+    [Fact]
+    public void ReadAllText_ValidPath_Succeeds()
+    {
+        var file = Path.Combine(_tempDir, "valid.txt");
+        File.WriteAllText(file, "test content");
+
+        var content = FileHelper.ReadAllText(file);
+        Assert.Equal("test content", content);
+    }
+
+    [Fact]
+    public void WriteAllText_ValidPath_Succeeds()
+    {
+        var file = Path.Combine(_tempDir, "valid.txt");
+
+        FileHelper.WriteAllText(file, "test content");
+
+        Assert.True(File.Exists(file));
+        Assert.Equal("test content", File.ReadAllText(file));
+    }
+}

--- a/src/Ivy.Tendril/Helpers/FileHelper.cs
+++ b/src/Ivy.Tendril/Helpers/FileHelper.cs
@@ -20,6 +20,46 @@ internal static class FileHelper
     private static readonly int[] RetryDelaysMs = [50, 150, 350, 750, 1500];
 
     /// <summary>
+    ///     Checks if the given path is a symbolic link.
+    ///     On Windows: checks FileAttributes.ReparsePoint.
+    ///     On Linux/macOS: checks FileInfo.LinkTarget.
+    /// </summary>
+    private static bool IsSymbolicLink(string path)
+    {
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                var attrs = File.GetAttributes(path);
+                return (attrs & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+            }
+
+            var fileInfo = new FileInfo(path);
+            return fileInfo.LinkTarget != null;
+        }
+        catch
+        {
+            // If we can't determine, assume it's not a symlink and let the file operation
+            // fail with its natural error
+            return false;
+        }
+    }
+
+    /// <summary>
+    ///     Validates that a path is fully qualified and not a symbolic link.
+    ///     Throws ArgumentException for relative paths.
+    ///     Throws UnauthorizedAccessException for symbolic links.
+    /// </summary>
+    private static void ValidatePath(string path)
+    {
+        if (!Path.IsPathFullyQualified(path))
+            throw new ArgumentException($"Path must be fully qualified: {path}", nameof(path));
+
+        if (IsSymbolicLink(path))
+            throw new UnauthorizedAccessException($"Refusing to operate on symbolic link: {path}");
+    }
+
+    /// <summary>
     ///     Extracts the "**Completed:** &lt;timestamp&gt;" value from a log file.
     ///     Returns null if the file doesn't exist, can't be read, or has no completed timestamp.
     /// </summary>
@@ -52,6 +92,7 @@ internal static class FileHelper
     /// </summary>
     public static string ReadAllText(string path)
     {
+        ValidatePath(path);
         for (var attempt = 0; ; attempt++)
             try
             {
@@ -67,6 +108,7 @@ internal static class FileHelper
 
     public static string[] ReadAllLines(string path)
     {
+        ValidatePath(path);
         for (var attempt = 0; ; attempt++)
             try
             {
@@ -85,6 +127,7 @@ internal static class FileHelper
 
     public static void WriteAllText(string path, string contents)
     {
+        ValidatePath(path);
         ClearReadOnly(path);
         for (var attempt = 0; ; attempt++)
             try
@@ -108,6 +151,7 @@ internal static class FileHelper
     /// <inheritdoc cref="ReadAllText"/>
     public static async Task<string> ReadAllTextAsync(string path)
     {
+        ValidatePath(path);
         for (var attempt = 0; ; attempt++)
             try
             {
@@ -126,6 +170,7 @@ internal static class FileHelper
 
     public static async Task WriteAllTextAsync(string path, string contents)
     {
+        ValidatePath(path);
         ClearReadOnly(path);
         for (var attempt = 0; ; attempt++)
             try
@@ -155,6 +200,7 @@ internal static class FileHelper
     /// </summary>
     public static IEnumerable<string> EnumerateLines(string path)
     {
+        ValidatePath(path);
         FileStream? stream = null;
         for (var attempt = 0; ; attempt++)
             try
@@ -177,6 +223,7 @@ internal static class FileHelper
 
     public static void AppendAllText(string path, string contents)
     {
+        ValidatePath(path);
         ClearReadOnly(path);
         for (var attempt = 0; ; attempt++)
             try
@@ -259,10 +306,11 @@ internal static class FileHelper
                 info.SetAccessControl(security);
             }
         }
-        catch
+        catch (Exception ex)
         {
             // Best-effort: if we can't fix the ACL (e.g. not owner), the caller will
             // get the original UnauthorizedAccessException on the next retry.
+            Console.Error.WriteLine($"Failed to grant access to {path}: {ex.Message}");
         }
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Added symlink detection and path validation to all FileHelper file operations to prevent security vulnerabilities. Added logging to permission grant failures for better visibility into access control issues.

## API Changes

**Modified methods** (internal):
- `FileHelper.ReadAllText(string path)` — now validates path is fully qualified and not a symlink before reading
- `FileHelper.ReadAllTextAsync(string path)` — now validates path is fully qualified and not a symlink before reading
- `FileHelper.ReadAllLines(string path)` — now validates path is fully qualified and not a symlink before reading
- `FileHelper.WriteAllText(string path, string contents)` — now validates path is fully qualified and not a symlink before writing
- `FileHelper.WriteAllTextAsync(string path, string contents)` — now validates path is fully qualified and not a symlink before writing
- `FileHelper.AppendAllText(string path, string contents)` — now validates path is fully qualified and not a symlink before appending
- `FileHelper.EnumerateLines(string path)` — now validates path is fully qualified and not a symlink before enumerating

**New exceptions thrown**:
- `ArgumentException` — when path is not fully qualified (relative path)
- `UnauthorizedAccessException` — when path is a symbolic link

**Internal utilities added**:
- `IsSymbolicLink(string path)` — checks if path is a symlink (cross-platform)
- `ValidatePath(string path)` — validates path is fully qualified and not a symlink

## Files Modified

**Implementation:**
- `src/Ivy.Tendril/Helpers/FileHelper.cs` — added symlink detection, path validation, and permission grant logging

**Tests:**
- `src/Ivy.Tendril.Test/Helpers/FileHelperTest.cs` — new test file with 7 test cases covering symlink detection, relative path rejection, and valid path handling

## Commits

- 2dab1e43a0e6a87471303e61a0e42bea24a0c925 [03611] Add symlink detection and path validation to FileHelper