### PR TITLE
[03622] Refactor GitService to reduce code duplication and complexity

### DIFF
--- a/src/Ivy.Tendril.Test/GitOutputParserTests.cs
+++ b/src/Ivy.Tendril.Test/GitOutputParserTests.cs
@@ -1,0 +1,135 @@
+using Ivy.Tendril.Services;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class GitOutputParserTests
+{
+    [Fact]
+    public void ParseNameStatusOutput_WithValidInput_ReturnsCorrectFiles()
+    {
+        var output = "M\tsrc/file1.cs\nA\tsrc/file2.cs\nD\tsrc/file3.cs";
+
+        var result = GitOutputParser.ParseNameStatusOutput(output);
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(("M", "src/file1.cs"), result[0]);
+        Assert.Equal(("A", "src/file2.cs"), result[1]);
+        Assert.Equal(("D", "src/file3.cs"), result[2]);
+    }
+
+    [Fact]
+    public void ParseNameStatusOutput_WithEmptyInput_ReturnsEmptyList()
+    {
+        var output = "";
+
+        var result = GitOutputParser.ParseNameStatusOutput(output);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ParseNameStatusOutput_WithInvalidLines_SkipsThem()
+    {
+        var output = "M\tsrc/file1.cs\nInvalidLine\nA\tsrc/file2.cs";
+
+        var result = GitOutputParser.ParseNameStatusOutput(output);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(("M", "src/file1.cs"), result[0]);
+        Assert.Equal(("A", "src/file2.cs"), result[1]);
+    }
+
+    [Fact]
+    public void ParseWorktreeList_WithValidInput_ReturnsCorrectWorktrees()
+    {
+        var output = @"worktree /path/to/main
+HEAD abc123
+branch refs/heads/main
+
+worktree /path/to/feature
+HEAD def456
+branch refs/heads/feature/test
+
+worktree /path/to/another
+HEAD ghi789
+branch refs/heads/another-branch
+";
+
+        var result = GitOutputParser.ParseWorktreeList(output);
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal("/path/to/main", result[0].Path);
+        Assert.Equal("main", result[0].Branch);
+        Assert.Equal("abc123", result[0].Hash);
+
+        Assert.Equal("/path/to/feature", result[1].Path);
+        Assert.Equal("feature/test", result[1].Branch);
+        Assert.Equal("def456", result[1].Hash);
+
+        Assert.Equal("/path/to/another", result[2].Path);
+        Assert.Equal("another-branch", result[2].Branch);
+        Assert.Equal("ghi789", result[2].Hash);
+    }
+
+    [Fact]
+    public void ParseWorktreeList_WithIncompleteWorktree_SkipsIt()
+    {
+        var output = @"worktree /path/to/main
+HEAD abc123
+
+worktree /path/to/feature
+HEAD def456
+branch refs/heads/feature
+";
+
+        var result = GitOutputParser.ParseWorktreeList(output);
+
+        Assert.Single(result);
+        Assert.Equal("/path/to/feature", result[0].Path);
+        Assert.Equal("feature", result[0].Branch);
+        Assert.Equal("def456", result[0].Hash);
+    }
+
+    [Fact]
+    public void ParseCommitSummaries_WithValidInput_ReturnsCorrectSummaries()
+    {
+        var output = "abc123\0First commit title\n10\t5\tfile1.cs\n20\t10\tfile2.cs\n\ndef456\0Second commit title\n5\t3\tfile3.cs\n";
+        var inputHashes = new HashSet<string> { "abc123", "def456" };
+
+        var result = GitOutputParser.ParseCommitSummaries(output, inputHashes);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("First commit title", result["abc123"].Title);
+        Assert.Equal(2, result["abc123"].FileCount);
+        Assert.Equal("Second commit title", result["def456"].Title);
+        Assert.Equal(1, result["def456"].FileCount);
+    }
+
+    [Fact]
+    public void ParseCommitSummaries_WithAbbreviatedHash_MapsToFullHash()
+    {
+        var output = "abc123def456\0Commit title\n10\t5\tfile1.cs\n";
+        var inputHashes = new HashSet<string> { "abc123" };
+
+        var result = GitOutputParser.ParseCommitSummaries(output, inputHashes);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Commit title", result["abc123def456"].Title);
+        Assert.Equal("Commit title", result["abc123"].Title);
+        Assert.Equal(1, result["abc123"].FileCount);
+    }
+
+    [Fact]
+    public void ParseCommitSummaries_WithEmptyTitle_StoresEmptyString()
+    {
+        var output = "abc123\0\n10\t5\tfile1.cs\n";
+        var inputHashes = new HashSet<string> { "abc123" };
+
+        var result = GitOutputParser.ParseCommitSummaries(output, inputHashes);
+
+        Assert.Single(result);
+        Assert.Equal("", result["abc123"].Title);
+        Assert.Equal(1, result["abc123"].FileCount);
+    }
+}

--- a/src/Ivy.Tendril/Services/GitOutputParser.cs
+++ b/src/Ivy.Tendril/Services/GitOutputParser.cs
@@ -1,0 +1,107 @@
+namespace Ivy.Tendril.Services;
+
+internal static class GitOutputParser
+{
+    public static List<(string Status, string FilePath)> ParseNameStatusOutput(string output)
+    {
+        var files = new List<(string Status, string FilePath)>();
+        foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = line.Split('\t', 2);
+            if (parts.Length == 2)
+                files.Add((parts[0].Trim(), parts[1].Trim()));
+        }
+        return files;
+    }
+
+    public static List<WorktreeInfo> ParseWorktreeList(string output)
+    {
+        var worktrees = new List<WorktreeInfo>();
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        string? currentPath = null;
+        string? currentBranch = null;
+        string? currentHash = null;
+
+        foreach (var line in lines)
+        {
+            if (line.StartsWith("worktree "))
+            {
+                if (IsWorktreeComplete(currentPath, currentBranch, currentHash))
+                    worktrees.Add(new WorktreeInfo(currentPath!, currentBranch!, currentHash!));
+
+                currentPath = line.Substring(9).Trim();
+                currentBranch = null;
+                currentHash = null;
+            }
+            else if (line.StartsWith("HEAD "))
+                currentHash = line.Substring(5).Trim();
+            else if (line.StartsWith("branch "))
+            {
+                var branchRef = line.Substring(7).Trim();
+                currentBranch = branchRef.Replace("refs/heads/", "");
+            }
+        }
+
+        if (IsWorktreeComplete(currentPath, currentBranch, currentHash))
+            worktrees.Add(new WorktreeInfo(currentPath!, currentBranch!, currentHash!));
+
+        return worktrees;
+    }
+
+    private static bool IsWorktreeComplete(string? path, string? branch, string? hash)
+        => path != null && branch != null && hash != null;
+
+    public static Dictionary<string, (string Title, int FileCount)> ParseCommitSummaries(
+        string output,
+        HashSet<string> inputHashes)
+    {
+        var result = new Dictionary<string, (string Title, int FileCount)>();
+        string? currentHash = null;
+        string? currentTitle = null;
+        int currentFileCount = 0;
+
+        foreach (var line in output.Split('\n'))
+        {
+            if (line.Contains('\0'))
+            {
+                if (currentHash != null)
+                    StoreCommitResult(result, inputHashes, currentHash, currentTitle!, currentFileCount);
+
+                var parts = line.Split('\0', 2);
+                currentHash = parts[0].Trim();
+                currentTitle = parts.Length > 1 ? parts[1].Trim() : "";
+                currentFileCount = 0;
+            }
+            else if (currentHash != null && line.Trim().Length > 0)
+            {
+                currentFileCount++;
+            }
+        }
+
+        if (currentHash != null)
+            StoreCommitResult(result, inputHashes, currentHash, currentTitle!, currentFileCount);
+
+        return result;
+    }
+
+    private static void StoreCommitResult(
+        Dictionary<string, (string Title, int FileCount)> result,
+        HashSet<string> inputHashes,
+        string fullHash,
+        string title,
+        int fileCount)
+    {
+        var value = (title, fileCount);
+        result[fullHash] = value;
+
+        foreach (var input in inputHashes)
+        {
+            if (input.Length < fullHash.Length &&
+                fullHash.StartsWith(input, StringComparison.OrdinalIgnoreCase))
+            {
+                result[input] = value;
+            }
+        }
+    }
+}

--- a/src/Ivy.Tendril/Services/GitService.cs
+++ b/src/Ivy.Tendril/Services/GitService.cs
@@ -13,11 +13,11 @@ public class GitService : IGitService
         _timeoutMs = config.Settings.GitTimeout * 1000;
     }
 
-    public string? GetCommitTitle(string repoPath, string commitHash)
+    private T? RunGitCommand<T>(string repoPath, string args, Func<string, T?> parser)
     {
         try
         {
-            var psi = new ProcessStartInfo("git", $"log -1 --format=%s {commitHash}")
+            var psi = new ProcessStartInfo("git", args)
             {
                 WorkingDirectory = repoPath,
                 RedirectStandardOutput = true,
@@ -26,152 +26,37 @@ public class GitService : IGitService
                 StandardOutputEncoding = Encoding.UTF8
             };
             using var process = Process.Start(psi);
-            var title = process?.StandardOutput.ReadLine();
+            var output = process?.StandardOutput.ReadToEnd();
             process.WaitForExitOrKill(_timeoutMs);
-            return process?.ExitCode == 0 ? title : null;
+            return process?.ExitCode == 0 ? parser(output ?? "") : default;
         }
         catch
         {
-            return null; /* git may not be installed, or repo path invalid */
+            return default;
         }
     }
+
+    public string? GetCommitTitle(string repoPath, string commitHash)
+        => RunGitCommand(repoPath, $"log -1 --format=%s {commitHash}",
+            output => output.Split('\n', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault());
 
     public string? GetCommitDiff(string repoPath, string commitHash)
-    {
-        try
-        {
-            var psi = new ProcessStartInfo("git", $"show --format=\"\" --patch {commitHash}")
-            {
-                WorkingDirectory = repoPath,
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                StandardOutputEncoding = Encoding.UTF8
-            };
-            using var process = Process.Start(psi);
-            var output = process?.StandardOutput.ReadToEnd();
-            process.WaitForExitOrKill(_timeoutMs);
-            return process?.ExitCode == 0 ? output : null;
-        }
-        catch
-        {
-            return null; /* git may not be installed, or repo path invalid */
-        }
-    }
+        => RunGitCommand(repoPath, $"show --format=\"\" --patch {commitHash}", output => output);
 
     public int? GetCommitFileCount(string repoPath, string commitHash)
-    {
-        try
-        {
-            var psi = new ProcessStartInfo("git", $"diff-tree --no-commit-id --name-only -r {commitHash}")
-            {
-                WorkingDirectory = repoPath,
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                StandardOutputEncoding = Encoding.UTF8
-            };
-            using var process = Process.Start(psi);
-            var output = process?.StandardOutput.ReadToEnd();
-            process.WaitForExitOrKill(_timeoutMs);
-            if (process?.ExitCode != 0 || output == null) return null;
-
-            return output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length;
-        }
-        catch
-        {
-            return null;
-        }
-    }
+        => RunGitCommand(repoPath, $"diff-tree --no-commit-id --name-only -r {commitHash}",
+            output => output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Length);
 
     public List<(string Status, string FilePath)>? GetCommitFiles(string repoPath, string commitHash)
-    {
-        try
-        {
-            var psi = new ProcessStartInfo("git", $"diff-tree --no-commit-id --name-status -r {commitHash}")
-            {
-                WorkingDirectory = repoPath,
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                StandardOutputEncoding = Encoding.UTF8
-            };
-            using var process = Process.Start(psi);
-            var output = process?.StandardOutput.ReadToEnd();
-            process.WaitForExitOrKill(_timeoutMs);
-            if (process?.ExitCode != 0 || output == null) return null;
-
-            var files = new List<(string Status, string FilePath)>();
-            foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-            {
-                var parts = line.Split('\t', 2);
-                if (parts.Length == 2)
-                    files.Add((parts[0].Trim(), parts[1].Trim()));
-            }
-
-            return files;
-        }
-        catch
-        {
-            return null; /* git may not be installed, or repo path invalid */
-        }
-    }
+        => RunGitCommand(repoPath, $"diff-tree --no-commit-id --name-status -r {commitHash}",
+            GitOutputParser.ParseNameStatusOutput);
 
     public string? GetCombinedDiff(string repoPath, string firstCommit, string lastCommit)
-    {
-        try
-        {
-            var psi = new ProcessStartInfo("git", $"diff {firstCommit}^..{lastCommit}")
-            {
-                WorkingDirectory = repoPath,
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                StandardOutputEncoding = Encoding.UTF8
-            };
-            using var process = Process.Start(psi);
-            var output = process?.StandardOutput.ReadToEnd();
-            process.WaitForExitOrKill(_timeoutMs);
-            return process?.ExitCode == 0 ? output : null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
+        => RunGitCommand(repoPath, $"diff {firstCommit}^..{lastCommit}", output => output);
 
     public List<(string Status, string FilePath)>? GetCombinedChangedFiles(string repoPath, string firstCommit, string lastCommit)
-    {
-        try
-        {
-            var psi = new ProcessStartInfo("git", $"diff --name-status {firstCommit}^..{lastCommit}")
-            {
-                WorkingDirectory = repoPath,
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                StandardOutputEncoding = Encoding.UTF8
-            };
-            using var process = Process.Start(psi);
-            var output = process?.StandardOutput.ReadToEnd();
-            process.WaitForExitOrKill(_timeoutMs);
-            if (process?.ExitCode != 0 || output == null) return null;
-
-            var files = new List<(string Status, string FilePath)>();
-            foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-            {
-                var parts = line.Split('\t', 2);
-                if (parts.Length == 2)
-                    files.Add((parts[0].Trim(), parts[1].Trim()));
-            }
-
-            return files;
-        }
-        catch
-        {
-            return null;
-        }
-    }
+        => RunGitCommand(repoPath, $"diff --name-status {firstCommit}^..{lastCommit}",
+            GitOutputParser.ParseNameStatusOutput);
 
     public Dictionary<string, (string Title, int FileCount)>? GetCommitSummaries(string repoPath, IEnumerable<string> commitHashes)
     {
@@ -180,9 +65,6 @@ public class GitService : IGitService
 
         try
         {
-            var result = new Dictionary<string, (string Title, int FileCount)>();
-
-            // Single git log call: --stdin reads hashes from stdin, --format outputs hash + title, --numstat gives file counts
             var psi = new ProcessStartInfo("git", "log --stdin --no-walk --format=%H%x00%s --numstat")
             {
                 WorkingDirectory = repoPath,
@@ -203,36 +85,8 @@ public class GitService : IGitService
             process.WaitForExitOrKill(_timeoutMs);
             if (process.ExitCode != 0) return null;
 
-            // Build a lookup from full hash prefix back to the original input hashes
             var inputHashSet = new HashSet<string>(hashes, StringComparer.OrdinalIgnoreCase);
-
-            // Parse: each commit block starts with "hash\0title" followed by numstat lines, separated by empty lines
-            string? currentHash = null;
-            string? currentTitle = null;
-            int currentFileCount = 0;
-
-            foreach (var line in output.Split('\n'))
-            {
-                if (line.Contains('\0'))
-                {
-                    if (currentHash != null)
-                        StoreCommitResult(result, inputHashSet, currentHash, currentTitle!, currentFileCount);
-
-                    var parts = line.Split('\0', 2);
-                    currentHash = parts[0].Trim();
-                    currentTitle = parts.Length > 1 ? parts[1].Trim() : "";
-                    currentFileCount = 0;
-                }
-                else if (currentHash != null && line.Trim().Length > 0)
-                {
-                    currentFileCount++;
-                }
-            }
-
-            if (currentHash != null)
-                StoreCommitResult(result, inputHashSet, currentHash, currentTitle!, currentFileCount);
-
-            return result;
+            return GitOutputParser.ParseCommitSummaries(output, inputHashSet);
         }
         catch
         {
@@ -240,87 +94,6 @@ public class GitService : IGitService
         }
     }
 
-    private static void StoreCommitResult(
-        Dictionary<string, (string Title, int FileCount)> result,
-        HashSet<string> inputHashes,
-        string fullHash,
-        string title,
-        int fileCount)
-    {
-        var value = (title, fileCount);
-        result[fullHash] = value;
-
-        // Also store under any abbreviated input hash that matches this full hash
-        foreach (var input in inputHashes)
-        {
-            if (input.Length < fullHash.Length &&
-                fullHash.StartsWith(input, StringComparison.OrdinalIgnoreCase))
-            {
-                result[input] = value;
-            }
-        }
-    }
-
     public List<WorktreeInfo>? GetWorktrees(string repoPath)
-    {
-        try
-        {
-            var psi = new ProcessStartInfo("git", "worktree list --porcelain")
-            {
-                WorkingDirectory = repoPath,
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                StandardOutputEncoding = Encoding.UTF8
-            };
-            using var process = Process.Start(psi);
-            var output = process?.StandardOutput.ReadToEnd();
-            process.WaitForExitOrKill(_timeoutMs);
-            if (process?.ExitCode != 0 || output == null) return null;
-
-            var worktrees = new List<WorktreeInfo>();
-            var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-
-            string? currentPath = null;
-            string? currentBranch = null;
-            string? currentHash = null;
-
-            foreach (var line in lines)
-            {
-                if (line.StartsWith("worktree "))
-                {
-                    // Save previous worktree if complete
-                    if (currentPath != null && currentBranch != null && currentHash != null)
-                    {
-                        worktrees.Add(new WorktreeInfo(currentPath, currentBranch, currentHash));
-                    }
-
-                    currentPath = line.Substring(9).Trim();
-                    currentBranch = null;
-                    currentHash = null;
-                }
-                else if (line.StartsWith("HEAD "))
-                {
-                    currentHash = line.Substring(5).Trim();
-                }
-                else if (line.StartsWith("branch "))
-                {
-                    var branchRef = line.Substring(7).Trim();
-                    currentBranch = branchRef.Replace("refs/heads/", "");
-                }
-            }
-
-            // Save last worktree
-            if (currentPath != null && currentBranch != null && currentHash != null)
-            {
-                worktrees.Add(new WorktreeInfo(currentPath, currentBranch, currentHash));
-            }
-
-            return worktrees;
-        }
-        catch
-        {
-            return null; /* git may not be installed, or repo path invalid */
-        }
-    }
+        => RunGitCommand(repoPath, "worktree list --porcelain", GitOutputParser.ParseWorktreeList);
 }


### PR DESCRIPTION
# Summary

## Changes

Refactored GitService to eliminate code duplication and reduce complexity. Extracted a generic `RunGitCommand<T>` helper to handle boilerplate process execution, and created a new `GitOutputParser` class to centralize all git output parsing logic. This reduced GitService from 325 lines to 98 lines (~70% reduction) while maintaining all functionality.

## API Changes

**New internal class:**
- `GitOutputParser` with three static parsing methods:
  - `ParseNameStatusOutput(string output)` - parses git name-status output
  - `ParseWorktreeList(string output)` - parses git worktree list --porcelain output
  - `ParseCommitSummaries(string output, HashSet<string> inputHashes)` - parses git log output with commit summaries

**No changes to public API** - all public methods in `GitService` retain the same signatures.

## Files Modified

**New files:**
- `src/Ivy.Tendril/Services/GitOutputParser.cs` - centralized git output parsing
- `src/Ivy.Tendril.Test/GitOutputParserTests.cs` - unit tests for parsers

**Modified files:**
- `src/Ivy.Tendril/Services/GitService.cs` - refactored to use generic helper and parsers

## Commits

- 72f987f [03622] Extract git command execution and parsing into separate helpers
- 91fd605 [03622] Add unit tests for GitOutputParser