### PR TITLE
[03606] Fix ReaderWriterLockSlim Deadlock Risk in PlanDatabaseService

### DIFF
--- a/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -1198,4 +1198,24 @@ public class PlanDatabaseServiceTests : IDisposable
         var frameworkCount = stats.ProjectCounts.FirstOrDefault(pc => pc.Project == "Framework");
         Assert.Null(frameworkCount); // Framework has no plans in 7-day window
     }
+
+    [Fact]
+    public void ConcurrentOperations_DoNotDeadlock()
+    {
+        // Setup: Insert initial plans
+        _db.UpsertPlan(CreateTestPlan(1500, "Plan A"));
+        _db.UpsertPlan(CreateTestPlan(1501, "Plan B"));
+
+        // Execute: Run 100 concurrent read/write operations
+        var tasks = new List<Task>();
+        for (int i = 0; i < 50; i++)
+        {
+            tasks.Add(Task.Run(() => _db.GetPlans()));
+            tasks.Add(Task.Run(() => _db.UpdatePlanState(1500, PlanStatus.Building)));
+        }
+
+        // Verify: All operations complete without deadlock (5 second timeout)
+        var allCompleted = Task.WaitAll(tasks.ToArray(), TimeSpan.FromSeconds(5));
+        Assert.True(allCompleted, "Operations deadlocked");
+    }
 }

--- a/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -1200,7 +1200,7 @@ public class PlanDatabaseServiceTests : IDisposable
     }
 
     [Fact]
-    public void ConcurrentOperations_DoNotDeadlock()
+    public async Task ConcurrentOperations_DoNotDeadlock()
     {
         // Setup: Insert initial plans
         _db.UpsertPlan(CreateTestPlan(1500, "Plan A"));
@@ -1215,7 +1215,8 @@ public class PlanDatabaseServiceTests : IDisposable
         }
 
         // Verify: All operations complete without deadlock (5 second timeout)
-        var allCompleted = Task.WaitAll(tasks.ToArray(), TimeSpan.FromSeconds(5));
-        Assert.True(allCompleted, "Operations deadlocked");
+        var allCompletedTask = Task.WhenAll(tasks);
+        var completedInTime = await Task.WhenAny(allCompletedTask, Task.Delay(TimeSpan.FromSeconds(5))) == allCompletedTask;
+        Assert.True(completedInTime, "Operations deadlocked");
     }
 }

--- a/src/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -22,6 +22,28 @@ public class PlanDatabaseService : IPlanDatabaseService
     private readonly ILogger<PlanDatabaseService> _logger;
     private readonly ReaderWriterLockSlim _lock = new();
 
+    private sealed class ReadLockHandle : IDisposable
+    {
+        private readonly ReaderWriterLockSlim _lock;
+        public ReadLockHandle(ReaderWriterLockSlim rwLock)
+        {
+            _lock = rwLock;
+            _lock.EnterReadLock();
+        }
+        public void Dispose() => _lock.ExitReadLock();
+    }
+
+    private sealed class WriteLockHandle : IDisposable
+    {
+        private readonly ReaderWriterLockSlim _lock;
+        public WriteLockHandle(ReaderWriterLockSlim rwLock)
+        {
+            _lock = rwLock;
+            _lock.EnterWriteLock();
+        }
+        public void Dispose() => _lock.ExitWriteLock();
+    }
+
     public PlanDatabaseService(string databasePath, ILogger<PlanDatabaseService> logger)
     {
         _logger = logger;
@@ -72,8 +94,7 @@ public class PlanDatabaseService : IPlanDatabaseService
 
     public List<PlanFile> GetPlans(PlanStatus? statusFilter = null)
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             var sql = """
                       SELECT Id, Title, Project, Level, State, FolderPath, FolderName,
@@ -136,16 +157,11 @@ public class PlanDatabaseService : IPlanDatabaseService
 
             return plans;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public PlanFile? GetPlanByFolder(string folderPath)
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
@@ -161,16 +177,11 @@ public class PlanDatabaseService : IPlanDatabaseService
 
             return null;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public PlanFile? GetPlanById(int planId)
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
@@ -186,16 +197,11 @@ public class PlanDatabaseService : IPlanDatabaseService
 
             return null;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public PlanReaderService.PlanCountSnapshot ComputePlanCounts()
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
@@ -231,16 +237,11 @@ public class PlanDatabaseService : IPlanDatabaseService
 
             return new PlanReaderService.PlanCountSnapshot(0, 0, 0, 0, 0, 0);
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public DashboardModels GetDashboardData(string? projectFilter)
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             var cutoff = DateTime.UtcNow.Date.AddDays(-6).ToString("yyyy-MM-dd");
             var pf = projectFilter != null ? " AND Project = @project" : "";
@@ -395,16 +396,11 @@ public class PlanDatabaseService : IPlanDatabaseService
                 totalCount, draftCount, inProgressCount, reviewCount, completedCount, failedCount,
                 avgCost, dailyStats, projectCounts);
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public decimal GetPlanTotalCost(int planId)
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "SELECT COALESCE(SUM(Cost), 0) FROM Costs WHERE PlanId = @planId";
@@ -412,16 +408,11 @@ public class PlanDatabaseService : IPlanDatabaseService
             var result = cmd.ExecuteScalar();
             return result != null ? Convert.ToDecimal(result, CultureInfo.InvariantCulture) : 0m;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public int GetPlanTotalTokens(int planId)
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "SELECT COALESCE(SUM(Tokens), 0) FROM Costs WHERE PlanId = @planId";
@@ -429,16 +420,11 @@ public class PlanDatabaseService : IPlanDatabaseService
             var result = cmd.ExecuteScalar();
             return result != null ? Convert.ToInt32(result, CultureInfo.InvariantCulture) : 0;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7, string? projectFilter = null)
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             var cutoff = DateTime.UtcNow.AddDays(-days);
 
@@ -489,16 +475,11 @@ public class PlanDatabaseService : IPlanDatabaseService
 
             return result;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public List<Recommendation> GetRecommendations()
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
@@ -564,24 +545,15 @@ public class PlanDatabaseService : IPlanDatabaseService
 
             return result;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public int GetPendingRecommendationsCount()
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "SELECT COUNT(*) FROM Recommendations WHERE State = 'Pending'";
             return Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
-        }
-        finally
-        {
-            _lock.ExitReadLock();
         }
     }
 
@@ -608,8 +580,7 @@ public class PlanDatabaseService : IPlanDatabaseService
 
     public List<PlanFile> SearchPlans(string query)
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             // Try FTS5 first with sanitized query
             var sanitizedQuery = SanitizeFts5Query(query);
@@ -660,16 +631,11 @@ public class PlanDatabaseService : IPlanDatabaseService
 
             return plans;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public void UpsertPlan(PlanFile plan)
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             using var transaction = _connection.BeginTransaction();
             try
@@ -683,32 +649,22 @@ public class PlanDatabaseService : IPlanDatabaseService
                 throw;
             }
         }
-        finally
-        {
-            _lock.ExitWriteLock();
-        }
     }
 
     public void DeletePlan(int planId)
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "DELETE FROM Plans WHERE Id = @id";
             cmd.Parameters.AddWithValue("@id", planId);
             cmd.ExecuteNonQuery();
         }
-        finally
-        {
-            _lock.ExitWriteLock();
-        }
     }
 
     public void UpdatePlanState(int planId, PlanStatus state)
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "UPDATE Plans SET State = @state, Updated = @updated WHERE Id = @id";
@@ -717,16 +673,11 @@ public class PlanDatabaseService : IPlanDatabaseService
             cmd.Parameters.AddWithValue("@id", planId);
             cmd.ExecuteNonQuery();
         }
-        finally
-        {
-            _lock.ExitWriteLock();
-        }
     }
 
     public void UpdatePlanContent(int planId, string latestRevisionContent, int revisionCount)
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText =
@@ -737,17 +688,12 @@ public class PlanDatabaseService : IPlanDatabaseService
             cmd.Parameters.AddWithValue("@id", planId);
             cmd.ExecuteNonQuery();
         }
-        finally
-        {
-            _lock.ExitWriteLock();
-        }
     }
 
     public void UpdateRecommendationState(int planId, string recommendationTitle, string newState,
         string? declineReason)
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
@@ -760,16 +706,11 @@ public class PlanDatabaseService : IPlanDatabaseService
             cmd.Parameters.AddWithValue("@title", recommendationTitle);
             cmd.ExecuteNonQuery();
         }
-        finally
-        {
-            _lock.ExitWriteLock();
-        }
     }
 
     public void UpsertCosts(int planId, List<CostEntry> costs)
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             using var deleteCmd = _connection.CreateCommand();
             deleteCmd.CommandText = "DELETE FROM Costs WHERE PlanId = @planId";
@@ -801,17 +742,12 @@ public class PlanDatabaseService : IPlanDatabaseService
                 insertCmd.ExecuteNonQuery();
             }
         }
-        finally
-        {
-            _lock.ExitWriteLock();
-        }
     }
 
     public void UpsertRecommendations(int planId, string folderName, List<RecommendationYaml> recommendations,
         string project, string planTitle, DateTime updated, PlanStatus status)
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             using var deleteCmd = _connection.CreateCommand();
             deleteCmd.CommandText = "DELETE FROM Recommendations WHERE PlanId = @planId";
@@ -859,16 +795,11 @@ public class PlanDatabaseService : IPlanDatabaseService
                 insertCmd.ExecuteNonQuery();
             }
         }
-        finally
-        {
-            _lock.ExitWriteLock();
-        }
     }
 
     public HashSet<int> GetTerminalPlanIds()
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "SELECT Id FROM Plans WHERE State IN ('Completed', 'Skipped')";
@@ -878,16 +809,11 @@ public class PlanDatabaseService : IPlanDatabaseService
                 ids.Add(reader.GetInt32(0));
             return ids;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public void BulkUpsertPlans(List<PlanFile> plans, bool forceOverwrite = false)
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             if (plans.Count == 0) return;
 
@@ -904,16 +830,11 @@ public class PlanDatabaseService : IPlanDatabaseService
                 throw;
             }
         }
-        finally
-        {
-            _lock.ExitWriteLock();
-        }
     }
 
     public void UpsertJob(JobItem job)
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
@@ -938,16 +859,11 @@ public class PlanDatabaseService : IPlanDatabaseService
             cmd.Parameters.AddWithValue("@args", job.Args.Length > 0 ? JsonSerializer.Serialize(job.Args) : (object)DBNull.Value);
             cmd.ExecuteNonQuery();
         }
-        finally
-        {
-            _lock.ExitWriteLock();
-        }
     }
 
     public List<JobItem> GetRecentJobs(int limit = 100)
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "SELECT * FROM Jobs ORDER BY CompletedAt DESC LIMIT @limit";
@@ -993,16 +909,11 @@ public class PlanDatabaseService : IPlanDatabaseService
                 });
             return jobs;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public void PurgeOldJobs(int keepCount = 500)
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
@@ -1016,48 +927,33 @@ public class PlanDatabaseService : IPlanDatabaseService
             cmd.Parameters.AddWithValue("@keepCount", keepCount);
             cmd.ExecuteNonQuery();
         }
-        finally
-        {
-            _lock.ExitWriteLock();
-        }
     }
 
     public void DeleteJob(string id)
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "DELETE FROM Jobs WHERE Id = @id";
             cmd.Parameters.AddWithValue("@id", id);
             cmd.ExecuteNonQuery();
         }
-        finally
-        {
-            _lock.ExitWriteLock();
-        }
     }
 
     public long GetDatabaseSize()
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()";
             var result = cmd.ExecuteScalar();
             return result != null ? Convert.ToInt64(result, CultureInfo.InvariantCulture) : 0;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public DateTime GetLastSyncTime()
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "SELECT Value FROM SyncMetadata WHERE Key = 'LastSyncTime'";
@@ -1067,16 +963,11 @@ public class PlanDatabaseService : IPlanDatabaseService
                 return dt;
             return DateTime.MinValue;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public void SetLastSyncTime(DateTime time)
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
@@ -1086,16 +977,11 @@ public class PlanDatabaseService : IPlanDatabaseService
             cmd.Parameters.AddWithValue("@value", time.ToString("O", CultureInfo.InvariantCulture));
             cmd.ExecuteNonQuery();
         }
-        finally
-        {
-            _lock.ExitWriteLock();
-        }
     }
 
     public Dictionary<string, string> GetAllPrStatuses()
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "SELECT PrUrl, Status FROM PrStatuses";
@@ -1105,16 +991,11 @@ public class PlanDatabaseService : IPlanDatabaseService
                 result[reader.GetString(0)] = reader.GetString(1);
             return result;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public void UpsertPrStatus(string prUrl, string owner, string repo, string status, DateTime lastChecked)
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
@@ -1131,16 +1012,11 @@ public class PlanDatabaseService : IPlanDatabaseService
             cmd.Parameters.AddWithValue("@checked", lastChecked.ToString("O", CultureInfo.InvariantCulture));
             cmd.ExecuteNonQuery();
         }
-        finally
-        {
-            _lock.ExitWriteLock();
-        }
     }
 
     public List<string> GetNonMergedPrUrls()
     {
-        _lock.EnterReadLock();
-        try
+        using (new ReadLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "SELECT PrUrl FROM PrStatuses WHERE Status != 'Merged'";
@@ -1150,16 +1026,11 @@ public class PlanDatabaseService : IPlanDatabaseService
                 result.Add(reader.GetString(0));
             return result;
         }
-        finally
-        {
-            _lock.ExitReadLock();
-        }
     }
 
     public void RebuildFtsIndex()
     {
-        _lock.EnterWriteLock();
-        try
+        using (new WriteLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "INSERT INTO PlanSearch(PlanSearch) VALUES('delete-all');";
@@ -1171,10 +1042,6 @@ public class PlanDatabaseService : IPlanDatabaseService
                               FROM Plans;
                               """;
             cmd.ExecuteNonQuery();
-        }
-        finally
-        {
-            _lock.ExitWriteLock();
         }
     }
 


### PR DESCRIPTION
# Summary

## Changes

Replaced the manual `EnterReadLock()/EnterWriteLock()` + `try/finally` + `ExitReadLock()/ExitWriteLock()` pattern with disposable lock handle classes (`ReadLockHandle` and `WriteLockHandle`) across all 31 lock-protected methods in `PlanDatabaseService`. Added a concurrency test to verify that concurrent read/write operations do not deadlock.

## API Changes

None — all public methods retain the same signatures and behavior.

## Files Modified

**Services:**
- `src/Ivy.Tendril/Services/PlanDatabaseService.cs` — Added `ReadLockHandle` and `WriteLockHandle` nested classes; replaced 31 lock patterns with disposable handles

**Tests:**
- `src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs` — Added `ConcurrentOperations_DoNotDeadlock` test

## Commits

- 13fc089 [03606] Fix xUnit1031 warning by making test async
- e151a0f [03606] Replace ReaderWriterLockSlim pattern with disposable lock handles