### PR TITLE
[03659] Extract ExtractPlanRecommendations Helper

### DIFF
--- a/src/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/PlanReaderService.cs
@@ -828,6 +828,38 @@ public class PlanReaderService(
         return (totalCost, totalTokens);
     }
 
+    private IEnumerable<Recommendation> ExtractPlanRecommendations(string folderName, string planYamlPath)
+    {
+        var planYaml = FileHelper.ReadAllText(planYamlPath);
+        var plan = YamlHelper.Deserializer.Deserialize<PlanYaml>(planYaml);
+        if (plan == null) yield break;
+
+        var match = FolderNameRegex.Match(folderName);
+        var planId = match.Groups[1].Value;
+
+        if (!Enum.TryParse<PlanStatus>(plan.State, true, out var status))
+            status = PlanStatus.Draft;
+
+        var items = plan.Recommendations;
+        if (items == null) yield break;
+
+        foreach (var item in items)
+            yield return new Recommendation(
+                item.Title,
+                item.Description,
+                string.IsNullOrWhiteSpace(item.State) ? "Pending" : item.State,
+                planId,
+                plan.Title ?? "",
+                folderName,
+                plan.Project ?? "",
+                plan.Updated,
+                status,
+                item.DeclineReason,
+                item.Impact,
+                item.Risk
+            );
+    }
+
     private List<Recommendation> ComputeRecommendations()
     {
         var recommendations = new List<Recommendation>();
@@ -836,36 +868,7 @@ public class PlanReaderService(
         {
             try
             {
-                var planYaml = FileHelper.ReadAllText(planYamlPath);
-                var plan = YamlHelper.Deserializer.Deserialize<PlanYaml>(planYaml);
-                if (plan == null) continue;
-
-                var match = FolderNameRegex.Match(folderName);
-                var planId = match.Groups[1].Value;
-
-                if (!Enum.TryParse<PlanStatus>(plan.State, true, out var status))
-                    status = PlanStatus.Draft;
-
-                var items = plan.Recommendations;
-
-                if (items != null)
-                {
-                    foreach (var item in items)
-                        recommendations.Add(new Recommendation(
-                            item.Title,
-                            item.Description,
-                            string.IsNullOrWhiteSpace(item.State) ? "Pending" : item.State,
-                            planId,
-                            plan.Title ?? "",
-                            folderName,
-                            plan.Project ?? "",
-                            plan.Updated,
-                            status,
-                            item.DeclineReason,
-                            item.Impact,
-                            item.Risk
-                        ));
-                }
+                recommendations.AddRange(ExtractPlanRecommendations(folderName, planYamlPath));
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
# Summary

## Changes

Extracted per-plan recommendation processing logic from `ComputeRecommendations` into a new `ExtractPlanRecommendations` helper method. This refactoring reduces cyclomatic complexity from 11 to ~5 and separates orchestration from data extraction.

## API Changes

None — this is an internal refactoring of private methods in `PlanReaderService`.

## Files Modified

- `src/Ivy.Tendril/Services/PlanReaderService.cs` — extracted `ExtractPlanRecommendations` helper method

## Commits

- fba41f2aedaa808ad54bba2ffa67e9e4b7330ded