### PR TITLE
[03669] Reduce cyclomatic complexity in GetPromptDisplay method

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
@@ -70,31 +70,45 @@ public partial class JobsApp
 
     private static string GetPromptDisplay(JobItem j, IPlanReaderService planService)
     {
-        if (!string.IsNullOrEmpty(j.PlanFile))
-        {
-            var fullPath = Path.Combine(planService.PlansDirectory, j.PlanFile);
-            var plan = planService.GetPlanByFolder(fullPath);
-            if (plan != null && !string.IsNullOrEmpty(plan.Title))
-            {
-                var title = CleanPromptText(plan.Title);
-                return title.Length > PromptDisplayMaxLength ? title[..PromptDisplayMaxLength] + "..." : title;
-            }
-        }
+        // Try loading plan title from service
+        if (TryGetPlanTitle(j.PlanFile, planService, out var planTitle))
+            return TruncatePrompt(planTitle);
 
+        // Try reported title
         if (!string.IsNullOrEmpty(j.ReportedPlanTitle))
-        {
-            var title = CleanPromptText(j.ReportedPlanTitle);
-            return title.Length > PromptDisplayMaxLength ? title[..PromptDisplayMaxLength] + "..." : title;
-        }
+            return TruncatePrompt(j.ReportedPlanTitle);
 
+        // Try CreatePlan description
         if (j.Type == "CreatePlan")
+            return TruncatePrompt(GetFullPrompt(j) ?? j.PlanFile);
+
+        // Fallback to plan file
+        return TruncatePrompt(j.PlanFile);
+    }
+
+    private static bool TryGetPlanTitle(string? planFile, IPlanReaderService planService, out string title)
+    {
+        title = string.Empty;
+        if (string.IsNullOrEmpty(planFile)) return false;
+
+        var fullPath = Path.Combine(planService.PlansDirectory, planFile);
+        var plan = planService.GetPlanByFolder(fullPath);
+
+        if (plan != null && !string.IsNullOrEmpty(plan.Title))
         {
-            var desc = CleanPromptText(GetFullPrompt(j) ?? j.PlanFile);
-            return desc.Length > PromptDisplayMaxLength ? desc[..PromptDisplayMaxLength] + "..." : desc;
+            title = plan.Title;
+            return true;
         }
 
-        var pf = CleanPromptText(j.PlanFile);
-        return pf.Length > PromptDisplayMaxLength ? pf[..PromptDisplayMaxLength] + "..." : pf;
+        return false;
+    }
+
+    private static string TruncatePrompt(string? text)
+    {
+        var cleaned = CleanPromptText(text ?? string.Empty);
+        return cleaned.Length > PromptDisplayMaxLength
+            ? cleaned[..PromptDisplayMaxLength] + "..."
+            : cleaned;
     }
 
     private static string GetStatusMessage(JobItem job)


### PR DESCRIPTION
# Summary

## Changes

Refactored the `GetPromptDisplay` method in `JobsApp.Helpers.cs` to reduce cyclomatic complexity from 11 to approximately 3-4. This was achieved by extracting two helper methods (`TryGetPlanTitle` and `TruncatePrompt`) and replacing nested if-else chains with guard clauses. The refactoring eliminates four instances of duplicated truncation logic while preserving identical behavior.

## API Changes

**New private methods:**
- `TryGetPlanTitle(string? planFile, IPlanReaderService planService, out string title)` - Encapsulates plan loading logic
- `TruncatePrompt(string? text)` - Combines text cleaning and length truncation

**Modified private methods:**
- `GetPromptDisplay(JobItem j, IPlanReaderService planService)` - Simplified from nested conditionals to guard clauses

No public API changes - all modifications are to private helper methods.

## Files Modified

**Core changes:**
- `src/Ivy.Tendril/Apps/JobsApp.Helpers.cs` - Refactored GetPromptDisplay and added helper methods

## Commits

- aa53f61 [03669] Refactor GetPromptDisplay to reduce cyclomatic complexity