### PR TITLE
[03661] Add IClassFixture Pattern for Expensive Test Setup

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigServiceFixture.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceFixture.cs
@@ -1,0 +1,34 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class ConfigServiceFixture : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("ivy-config-test");
+
+    public ConfigService Service { get; }
+
+    public ConfigServiceFixture()
+    {
+        var yaml = @"
+projects:
+  - name: TestProject
+    repos:
+      - path: D:\Repos\Test
+    context: Test context
+verifications: []
+";
+        var configPath = Path.Combine(_tempDir.Path, "config.yaml");
+        File.WriteAllText(configPath, yaml);
+
+        Service = new ConfigService(new TendrilSettings());
+        Service.SetTendrilHome(_tempDir.Path);
+    }
+
+    public void Dispose()
+    {
+        (Service as IDisposable)?.Dispose();
+        _tempDir.Dispose();
+    }
+}

--- a/src/Ivy.Tendril.Test/ConfigServiceFixtureTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceFixtureTests.cs
@@ -1,0 +1,40 @@
+namespace Ivy.Tendril.Test;
+
+public class ConfigServiceFixtureTests : IClassFixture<ConfigServiceFixture>
+{
+    private readonly ConfigServiceFixture _fixture;
+
+    public ConfigServiceFixtureTests(ConfigServiceFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void Fixture_Creates_Valid_ConfigService()
+    {
+        Assert.NotNull(_fixture.Service);
+        Assert.NotNull(_fixture.Service.Settings);
+    }
+
+    [Fact]
+    public void Fixture_Loads_Test_Project()
+    {
+        var projects = _fixture.Service.Settings.Projects;
+        Assert.NotEmpty(projects);
+        Assert.Equal("TestProject", projects[0].Name);
+    }
+
+    [Fact]
+    public void Fixture_Sets_Tendril_Home()
+    {
+        Assert.NotEmpty(_fixture.Service.TendrilHome);
+        Assert.True(Directory.Exists(_fixture.Service.TendrilHome));
+    }
+
+    [Fact]
+    public void Fixture_Cleans_Up_After_All_Tests()
+    {
+        var tempPath = _fixture.Service.TendrilHome;
+        Assert.True(Directory.Exists(tempPath));
+    }
+}

--- a/src/Ivy.Tendril.Test/DatabaseFixture.cs
+++ b/src/Ivy.Tendril.Test/DatabaseFixture.cs
@@ -1,0 +1,27 @@
+using Ivy.Tendril.Database;
+using Microsoft.Data.Sqlite;
+
+namespace Ivy.Tendril.Test;
+
+public class DatabaseFixture : IDisposable
+{
+    public SqliteConnection Connection { get; }
+
+    public DatabaseFixture()
+    {
+        Connection = new SqliteConnection("Data Source=:memory:");
+        Connection.Open();
+
+        using var pragmaCmd = Connection.CreateCommand();
+        pragmaCmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;";
+        pragmaCmd.ExecuteNonQuery();
+
+        var migrator = new DatabaseMigrator(Connection);
+        migrator.ApplyMigrations();
+    }
+
+    public void Dispose()
+    {
+        Connection.Dispose();
+    }
+}

--- a/src/Ivy.Tendril.Test/DatabaseFixtureTests.cs
+++ b/src/Ivy.Tendril.Test/DatabaseFixtureTests.cs
@@ -1,0 +1,46 @@
+namespace Ivy.Tendril.Test;
+
+public class DatabaseFixtureTests : IClassFixture<DatabaseFixture>
+{
+    private readonly DatabaseFixture _fixture;
+
+    public DatabaseFixtureTests(DatabaseFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void Fixture_Creates_Open_Connection()
+    {
+        Assert.NotNull(_fixture.Connection);
+        Assert.Equal(System.Data.ConnectionState.Open, _fixture.Connection.State);
+    }
+
+    [Fact]
+    public void Fixture_Applies_Migrations()
+    {
+        using var cmd = _fixture.Connection.CreateCommand();
+        cmd.CommandText = "PRAGMA user_version;";
+        var version = Convert.ToInt32(cmd.ExecuteScalar());
+        Assert.True(version > 0, "Database should have migrations applied");
+    }
+
+    [Fact]
+    public void Fixture_Creates_Plans_Table()
+    {
+        using var cmd = _fixture.Connection.CreateCommand();
+        cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name='Plans';";
+        var result = cmd.ExecuteScalar();
+        Assert.NotNull(result);
+        Assert.Equal("Plans", result);
+    }
+
+    [Fact]
+    public void Fixture_Enables_Foreign_Keys()
+    {
+        using var cmd = _fixture.Connection.CreateCommand();
+        cmd.CommandText = "PRAGMA foreign_keys;";
+        var result = Convert.ToInt32(cmd.ExecuteScalar());
+        Assert.Equal(1, result);
+    }
+}

--- a/src/Ivy.Tendril.Test/README.md
+++ b/src/Ivy.Tendril.Test/README.md
@@ -1,0 +1,158 @@
+# Ivy.Tendril.Test
+
+## Test Fixtures Guide
+
+This project uses xUnit's fixture patterns to manage test setup and teardown. Choose the appropriate fixture based on your test's isolation requirements.
+
+### Per-Test Fixtures
+
+**`TempDirectoryFixture`** — Creates a temporary directory for each test
+
+**When to use:**
+- Tests need isolated file system state
+- Tests modify files or directories
+- Tests create config files or other artifacts
+
+**Example:**
+```csharp
+public class MyTest : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("my-test");
+
+    public void Dispose()
+    {
+        _tempDir.Dispose();
+    }
+
+    [Fact]
+    public void Should_Write_File()
+    {
+        var path = Path.Combine(_tempDir.Path, "test.txt");
+        File.WriteAllText(path, "content");
+        Assert.True(File.Exists(path));
+    }
+}
+```
+
+### Per-Class Fixtures (IClassFixture<T>)
+
+**`ConfigServiceFixture`** — Shares a ConfigService instance across all tests in a class
+
+**When to use:**
+- Multiple tests need to read the same config structure
+- Tests don't modify config state
+- Expensive config initialization (file writes, YAML parsing)
+
+**Example:**
+```csharp
+public class MyConfigTests : IClassFixture<ConfigServiceFixture>
+{
+    private readonly ConfigServiceFixture _fixture;
+
+    public MyConfigTests(ConfigServiceFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void Should_Read_Projects()
+    {
+        var projects = _fixture.Service.Settings.Projects;
+        Assert.NotEmpty(projects);
+    }
+}
+```
+
+**`DatabaseFixture`** — Shares an in-memory SQLite database with migrations applied
+
+**When to use:**
+- Multiple tests need database schema but not shared data
+- Tests modify database state but wrap operations in transactions
+- Expensive migration setup (schema creation, indexes)
+
+**Example:**
+```csharp
+public class MyDatabaseTests : IClassFixture<DatabaseFixture>
+{
+    private readonly DatabaseFixture _fixture;
+
+    public MyDatabaseTests(DatabaseFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void Should_Insert_Plan()
+    {
+        using var transaction = _fixture.Connection.BeginTransaction();
+        try
+        {
+            using var cmd = _fixture.Connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO Plans (...) VALUES (...)";
+            cmd.ExecuteNonQuery();
+            
+            // Test assertions here
+            
+            transaction.Rollback(); // Keep database clean for next test
+        }
+        catch
+        {
+            transaction.Rollback();
+            throw;
+        }
+    }
+}
+```
+
+### Choosing the Right Fixture
+
+| Requirement | Use |
+|-------------|-----|
+| Need isolated file system per test | `TempDirectoryFixture` (per-test) |
+| Multiple tests read same config | `ConfigServiceFixture` (per-class) |
+| Need database schema, isolated data | `DatabaseFixture` (per-class) + transactions |
+| Need to modify config between tests | `TempDirectoryFixture` (per-test) |
+
+### Migration Guide
+
+If your test class currently uses per-test setup that could be shared:
+
+**Before (per-test setup):**
+```csharp
+public class ConfigServiceTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("ivy-config-test");
+
+    public void Dispose()
+    {
+        _tempDir.Dispose();
+    }
+
+    [Fact]
+    public void Test1() { /* uses _tempDir */ }
+
+    [Fact]
+    public void Test2() { /* uses _tempDir */ }
+}
+```
+
+**After (per-class fixture):**
+```csharp
+public class ConfigServiceTests : IClassFixture<ConfigServiceFixture>
+{
+    private readonly ConfigServiceFixture _fixture;
+
+    public ConfigServiceTests(ConfigServiceFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void Test1() { /* uses _fixture.Service */ }
+
+    [Fact]
+    public void Test2() { /* uses _fixture.Service */ }
+}
+```
+
+**Note:** Only migrate to per-class fixtures if tests don't need isolation. If tests modify state, keep per-test fixtures.


### PR DESCRIPTION
# Summary

## Changes

Added xUnit IClassFixture<T> pattern support for expensive test setup scenarios. Created two new fixture classes: ConfigServiceFixture for shared config loading across test classes, and DatabaseFixture for shared in-memory database schema setup. Included comprehensive documentation explaining when to use per-test vs per-class fixtures.

## API Changes

**New public classes:**
- `ConfigServiceFixture` — Per-class fixture providing a shared ConfigService instance with sample config
- `DatabaseFixture` — Per-class fixture providing a shared SQLite connection with migrations applied

**New test classes:**
- `ConfigServiceFixtureTests` — Verifies ConfigServiceFixture lifecycle and behavior
- `DatabaseFixtureTests` — Verifies DatabaseFixture connection, migrations, and schema

## Files Modified

**Added:**
- `src/Ivy.Tendril.Test/ConfigServiceFixture.cs` — Fixture for shared ConfigService
- `src/Ivy.Tendril.Test/ConfigServiceFixtureTests.cs` — Tests for ConfigServiceFixture
- `src/Ivy.Tendril.Test/DatabaseFixture.cs` — Fixture for shared database connection
- `src/Ivy.Tendril.Test/DatabaseFixtureTests.cs` — Tests for DatabaseFixture
- `src/Ivy.Tendril.Test/README.md` — Documentation on fixture patterns, usage guide, migration examples

## Commits

- 5532bbb [03661] Add IClassFixture pattern with ConfigServiceFixture and DatabaseFixture