### PR TITLE
[00076] Replace color picker with TextAndPicker variant in setup

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -247,7 +247,7 @@ public class EditProjectDialog(
             new DialogBody(
                 Layout.Vertical().Gap(4)
                 | editName.ToTextInput("Project name...").WithField().Label("Name")
-                | editColor.ToColorInput().WithField().Label("Color")
+                | editColor.ToColorInput().Variant(ColorInputVariant.TextAndPicker).Suffix("hex").WithField().Label("Color")
                 | editContext.ToTextareaInput("Project context or prompt for AI agents (optional)...").Rows(4)
                     .WithField().Label("Context / Prompt (Optional)")
                 | (Layout.Vertical().Gap(2)


### PR DESCRIPTION
## Changes

Updated the color input in the EditProjectDialog's Add/Edit Project dialog to use the `TextAndPicker` variant instead of the default `Swatch` variant. This displays a color picker and text input side-by-side with a "hex" suffix label, providing users with both visual and text-based color selection methods.

## API Changes

None. This is a UI variant change to an existing widget without public API modifications.

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs` — Updated color input variant and added `using Ivy.Widgets.Inputs;`

## Commits

- f696509 [00076] Replace color picker with TextAndPicker variant in setup