### PR TITLE
[00077] Fix Setup dialog field gap spacing

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditLevelDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditLevelDialog.cs
@@ -43,7 +43,7 @@ public class EditLevelDialog(
             _ => { _editIndex.Set(-1); },
             new DialogHeader(isNew ? "Add Level" : "Edit Level"),
             new DialogBody(
-                Layout.Vertical().Gap(2)
+                Layout.Vertical().Gap(4)
                 | editName.ToTextInput("Level name...").WithField().Label("Name")
                 | editBadge.ToSelectInput(badgeOptions).WithField().Label("Badge Variant")
             ),

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditPromptwareDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditPromptwareDialog.cs
@@ -40,7 +40,7 @@ public class EditPromptwareDialog(
             _ => editKey.Set("__closed__"),
             new DialogHeader(isNew ? "Add Promptware" : "Edit Promptware"),
             new DialogBody(
-                Layout.Vertical().Gap(2)
+                Layout.Vertical().Gap(4)
                 | editName.ToTextInput("Promptware name (e.g. CreatePlan)...").WithField().Label("Name")
                 | editProfile.ToTextInput("Profile name (e.g. deep, balanced, quick)...").WithField().Label("Profile")
                 | editAllowedTools.ToTextInput("Comma-separated tools (e.g. Read, Write, Edit)...").WithField()

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditVerificationDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditVerificationDialog.cs
@@ -42,7 +42,7 @@ public class EditVerificationDialog(
             _ => _editIndex.Set(-1),
             new DialogHeader(isNew ? "Add Verification" : "Edit Verification"),
             new DialogBody(
-                Layout.Vertical().Gap(2)
+                Layout.Vertical().Gap(4)
                 | editName.ToTextInput("Verification name...").WithField().Label("Name")
                 | editPrompt.ToTextareaInput("Verification prompt...").Rows(8).WithField().Label("Prompt")
             ),


### PR DESCRIPTION
# Summary

## Changes

Fixed vertical field spacing in three Setup dialogs by changing `Layout.Vertical().Gap(2)` to `Layout.Vertical().Gap(4)`. This aligns them with the established spacing pattern used in other working setup views and dialogs, resolving insufficient vertical spacing between form fields wrapped with `.WithField()`.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/Dialogs/EditLevelDialog.cs` — Changed Gap(2) to Gap(4)
- `src/Ivy.Tendril/Apps/Setup/Dialogs/EditVerificationDialog.cs` — Changed Gap(2) to Gap(4)
- `src/Ivy.Tendril/Apps/Setup/Dialogs/EditPromptwareDialog.cs` — Changed Gap(2) to Gap(4)

## Commits

- 22ff0a89b3f61424dbb4d80fd2383ef0e3cb59c5