### PR TITLE
[03678] Fix DashboardRepository Logger Dependency

### DIFF
--- a/src/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -94,11 +94,7 @@ public class PlanDatabaseService : IPlanDatabaseService
         migrator.ApplyMigrations();
         _logger.LogInformation("Database migrations applied");
 
-        // Create a logger adapter for DashboardRepository
-        // In practice, DashboardRepository should accept ILogger (non-generic) or use ILoggerFactory
-        // but for now we create a simple adapter
-        var dashboardLogger = new DashboardLoggerAdapter(logger);
-        _dashboardRepository = new DashboardRepository(_connection, _lock, dashboardLogger);
+        _dashboardRepository = new DashboardRepository(_connection, _lock, _logger);
     }
 
     public List<PlanFile> GetPlans(PlanStatus? statusFilter = null)
@@ -1295,27 +1291,4 @@ public class PlanDatabaseService : IPlanDatabaseService
         int InitialPrompt,
         int SourceUrl);
 
-    /// <summary>
-    /// Adapter to bridge ILogger&lt;PlanDatabaseService&gt; to ILogger&lt;DashboardRepository&gt;.
-    /// This is a workaround for the constructor type mismatch.
-    /// </summary>
-    private sealed class DashboardLoggerAdapter : ILogger<DashboardRepository>
-    {
-        private readonly ILogger _innerLogger;
-
-        public DashboardLoggerAdapter(ILogger innerLogger)
-        {
-            _innerLogger = innerLogger;
-        }
-
-        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
-            => _innerLogger.BeginScope(state);
-
-        public bool IsEnabled(LogLevel logLevel)
-            => _innerLogger.IsEnabled(logLevel);
-
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
-            Exception? exception, Func<TState, Exception?, string> formatter)
-            => _innerLogger.Log(logLevel, eventId, state, exception, formatter);
-    }
 }


### PR DESCRIPTION
# Summary

## Changes

Removed the `DashboardLoggerAdapter` workaround class and updated `PlanDatabaseService` to pass the logger directly to `DashboardRepository`. The adapter was unnecessary since `DashboardRepository` already accepts non-generic `ILogger`.

## API Changes

None — this is an internal refactoring that doesn't affect public APIs.

## Files Modified

- **src/Ivy.Tendril/Services/PlanDatabaseService.cs** — Removed adapter usage (lines 97-101) and deleted `DashboardLoggerAdapter` class (lines 1298-1320)

## Commits

- e327a16387ea6276d54feecacd02aa62efb95b47 [03678] Remove DashboardLoggerAdapter and use logger directly