### PR TITLE
[03667] Extract AppShellRouter from OpenApp method

### DIFF
--- a/src/Ivy.Tendril.Test/AppShell/AppShellRouterTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/AppShellRouterTests.cs
@@ -1,0 +1,112 @@
+using System.Collections.Immutable;
+using Ivy.Core.Apps;
+using Ivy.Tendril.AppShell;
+
+namespace Ivy.Tendril.Test.AppShell;
+
+public class AppShellRouterTests
+{
+    [Fact]
+    public void RouteForPages_WithAppId_ReturnsOpenPage()
+    {
+        var router = new AppShellRouter();
+        var result = router.Route(
+            new NavigateArgs("plans"),
+            AppShellNavigation.Pages,
+            "default",
+            ImmutableArray<TabState>.Empty,
+            null,
+            false);
+
+        Assert.Equal(AppShellRouter.RouteAction.OpenPage, result.Action);
+        Assert.Equal("plans", result.EffectiveAppId);
+    }
+
+    [Fact]
+    public void RouteForPages_WithoutAppId_UsesDefault()
+    {
+        var router = new AppShellRouter();
+        var result = router.Route(
+            new NavigateArgs(null),
+            AppShellNavigation.Pages,
+            "default",
+            ImmutableArray<TabState>.Empty,
+            null,
+            false);
+
+        Assert.Equal(AppShellRouter.RouteAction.OpenPage, result.Action);
+        Assert.Equal("default", result.EffectiveAppId);
+    }
+
+    [Fact]
+    public void RouteForTabs_ExistingTabId_ReturnsSwitchToExistingTab()
+    {
+        var tabs = ImmutableArray.Create(
+            new TabState("tab1", "plans", "Plans", null, null, "key1"));
+        var router = new AppShellRouter();
+
+        var result = router.Route(
+            new NavigateArgs(null, null, "tab1"),
+            AppShellNavigation.Tabs,
+            null,
+            tabs,
+            null,
+            false);
+
+        Assert.Equal(AppShellRouter.RouteAction.SwitchToExistingTab, result.Action);
+        Assert.Equal(0, result.TabIndex);
+        Assert.Equal("tab1", result.TabId);
+    }
+
+    [Fact]
+    public void RouteForTabs_MissingTabIdWithPopOp_ReturnsError()
+    {
+        var router = new AppShellRouter();
+        var result = router.Route(
+            new NavigateArgs(null, null, "nonexistent", HistoryOp.Pop),
+            AppShellNavigation.Tabs,
+            null,
+            ImmutableArray<TabState>.Empty,
+            null,
+            false);
+
+        Assert.Equal(AppShellRouter.RouteAction.Error, result.Action);
+        Assert.Equal("Tab no longer exists.", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void RouteForTabs_DuplicateAppId_ReturnsSwitchToExistingTab()
+    {
+        var tabs = ImmutableArray.Create(
+            new TabState("tab1", "plans", "Plans", null, null, "key1"));
+        var appDescriptor = new AppDescriptor { AllowDuplicateTabs = false };
+        var router = new AppShellRouter();
+
+        var result = router.Route(
+            new NavigateArgs("plans"),
+            AppShellNavigation.Tabs,
+            null,
+            tabs,
+            appDescriptor,
+            true);
+
+        Assert.Equal(AppShellRouter.RouteAction.SwitchToExistingTab, result.Action);
+        Assert.Equal(0, result.TabIndex);
+    }
+
+    [Fact]
+    public void RouteForTabs_NewAppId_ReturnsCreateNewTab()
+    {
+        var router = new AppShellRouter();
+        var result = router.Route(
+            new NavigateArgs("review"),
+            AppShellNavigation.Tabs,
+            null,
+            ImmutableArray<TabState>.Empty,
+            null,
+            false);
+
+        Assert.Equal(AppShellRouter.RouteAction.CreateNewTab, result.Action);
+        Assert.Equal("review", result.EffectiveAppId);
+    }
+}

--- a/src/Ivy.Tendril/AppShell/AppShellRouter.cs
+++ b/src/Ivy.Tendril/AppShell/AppShellRouter.cs
@@ -27,7 +27,7 @@ internal class AppShellRouter
         NavigateArgs navigateArgs,
         AppShellNavigation navigationMode,
         string? defaultAppId,
-        ImmutableArray<TabState> currentTabs,
+        ImmutableArray<TendrilAppShell.TabState> currentTabs,
         AppDescriptor? appDescriptor,
         bool preventTabDuplicates)
     {
@@ -48,7 +48,7 @@ internal class AppShellRouter
 
     private RouteResult RouteForTabs(
         NavigateArgs navigateArgs,
-        ImmutableArray<TabState> currentTabs,
+        ImmutableArray<TendrilAppShell.TabState> currentTabs,
         AppDescriptor? appDescriptor,
         bool preventTabDuplicates)
     {
@@ -104,14 +104,14 @@ internal class AppShellRouter
         };
     }
 
-    private static int FindTabIndex(ImmutableArray<TabState> tabs, string tabId)
+    private static int FindTabIndex(ImmutableArray<TendrilAppShell.TabState> tabs, string tabId)
     {
         for (var i = 0; i < tabs.Length; i++)
             if (tabs[i].Id == tabId) return i;
         return -1;
     }
 
-    private static int FindTabIndexByAppId(ImmutableArray<TabState> tabs, string appId)
+    private static int FindTabIndexByAppId(ImmutableArray<TendrilAppShell.TabState> tabs, string appId)
     {
         for (var i = 0; i < tabs.Length; i++)
             if (tabs[i].AppId == appId) return i;

--- a/src/Ivy.Tendril/AppShell/AppShellRouter.cs
+++ b/src/Ivy.Tendril/AppShell/AppShellRouter.cs
@@ -1,0 +1,120 @@
+using System.Collections.Immutable;
+using Ivy.Core.Apps;
+
+namespace Ivy.Tendril.AppShell;
+
+internal class AppShellRouter
+{
+    internal record RouteResult
+    {
+        public required RouteAction Action { get; init; }
+        public string? TabId { get; init; }
+        public int? TabIndex { get; init; }
+        public string? EffectiveAppId { get; init; }
+        public string? ErrorMessage { get; init; }
+    }
+
+    internal enum RouteAction
+    {
+        OpenPage,
+        SwitchToExistingTab,
+        CreateNewTab,
+        Error,
+        Noop
+    }
+
+    internal RouteResult Route(
+        NavigateArgs navigateArgs,
+        AppShellNavigation navigationMode,
+        string? defaultAppId,
+        ImmutableArray<TabState> currentTabs,
+        AppDescriptor? appDescriptor,
+        bool preventTabDuplicates)
+    {
+        return navigationMode == AppShellNavigation.Pages
+            ? RouteForPages(navigateArgs, defaultAppId)
+            : RouteForTabs(navigateArgs, currentTabs, appDescriptor, preventTabDuplicates);
+    }
+
+    private RouteResult RouteForPages(NavigateArgs navigateArgs, string? defaultAppId)
+    {
+        var effectiveAppId = navigateArgs.AppId ?? defaultAppId;
+        return new RouteResult
+        {
+            Action = RouteAction.OpenPage,
+            EffectiveAppId = effectiveAppId
+        };
+    }
+
+    private RouteResult RouteForTabs(
+        NavigateArgs navigateArgs,
+        ImmutableArray<TabState> currentTabs,
+        AppDescriptor? appDescriptor,
+        bool preventTabDuplicates)
+    {
+        // Handle TabId lookup
+        if (!string.IsNullOrEmpty(navigateArgs.TabId))
+        {
+            var tabIndex = FindTabIndex(currentTabs, navigateArgs.TabId);
+            if (tabIndex >= 0)
+            {
+                return new RouteResult
+                {
+                    Action = RouteAction.SwitchToExistingTab,
+                    TabIndex = tabIndex,
+                    TabId = navigateArgs.TabId
+                };
+            }
+
+            if (navigateArgs.HistoryOp is HistoryOp.Pop)
+            {
+                return new RouteResult
+                {
+                    Action = RouteAction.Error,
+                    ErrorMessage = "Tab no longer exists."
+                };
+            }
+        }
+
+        if (navigateArgs.AppId == null)
+        {
+            return new RouteResult { Action = RouteAction.Noop };
+        }
+
+        // Check for duplicate tabs
+        if (preventTabDuplicates)
+        {
+            var existingTabIndex = FindTabIndexByAppId(currentTabs, navigateArgs.AppId);
+            if (existingTabIndex >= 0 && appDescriptor?.AllowDuplicateTabs != true)
+            {
+                return new RouteResult
+                {
+                    Action = RouteAction.SwitchToExistingTab,
+                    TabIndex = existingTabIndex,
+                    TabId = currentTabs[existingTabIndex].Id
+                };
+            }
+        }
+
+        // Create new tab
+        return new RouteResult
+        {
+            Action = RouteAction.CreateNewTab,
+            EffectiveAppId = navigateArgs.AppId
+        };
+    }
+
+    private static int FindTabIndex(ImmutableArray<TabState> tabs, string tabId)
+    {
+        for (var i = 0; i < tabs.Length; i++)
+            if (tabs[i].Id == tabId) return i;
+        return -1;
+    }
+
+    private static int FindTabIndexByAppId(ImmutableArray<TabState> tabs, string appId)
+    {
+        for (var i = 0; i < tabs.Length; i++)
+            if (tabs[i].AppId == appId) return i;
+        return -1;
+    }
+}

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -187,97 +187,92 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         {
             try
             {
-                if (settings.Navigation == AppShellNavigation.Pages)
+                var router = new AppShellRouter();
+                var appDescriptor = navigateArgs.AppId != null
+                    ? appRepository.GetApp(navigateArgs.AppId)
+                    : null;
+
+                var routeResult = router.Route(
+                    navigateArgs,
+                    settings.Navigation,
+                    settings.DefaultAppId,
+                    tabs.Value,
+                    appDescriptor,
+                    settings.PreventTabDuplicates);
+
+                switch (routeResult.Action)
                 {
-                    var previousApp = currentApp.Value?.AppId;
-                    var effectiveNavigateArgs = navigateArgs.AppId == null
-                        ? navigateArgs with { AppId = settings.DefaultAppId }
-                        : navigateArgs;
+                    case AppShellRouter.RouteAction.OpenPage:
+                        HandleOpenPage(navigateArgs, routeResult.EffectiveAppId, replaceHistory);
+                        break;
 
-                    var appHost = effectiveNavigateArgs.AppId != null
-                        ? effectiveNavigateArgs.ToAppHost(args.ConnectionId)
-                        : null;
+                    case AppShellRouter.RouteAction.SwitchToExistingTab:
+                        HandleSwitchToExistingTab(navigateArgs, routeResult.TabIndex!.Value,
+                            routeResult.TabId!, replaceHistory);
+                        break;
 
-                    currentApp.Set(appHost);
+                    case AppShellRouter.RouteAction.CreateNewTab:
+                        HandleCreateNewTab(navigateArgs, routeResult.EffectiveAppId!, replaceHistory);
+                        break;
 
-                    if (effectiveNavigateArgs.AppId != null) SetAppTitle(effectiveNavigateArgs.AppId);
+                    case AppShellRouter.RouteAction.Error:
+                        client.Error(new InvalidOperationException(routeResult.ErrorMessage));
+                        break;
 
-                    if (effectiveNavigateArgs.HistoryOp is HistoryOp.Push && previousApp != effectiveNavigateArgs.AppId)
-                        RedirectToAppIfNotError(effectiveNavigateArgs, replaceHistory);
-                }
-                else
-                {
-                    if (!string.IsNullOrEmpty(navigateArgs.TabId))
-                    {
-                        var tabIndex = tabs.Value.ToList().FindIndex(t => t.Id == navigateArgs.TabId);
-                        if (tabIndex >= 0)
-                        {
-                            selectedIndex.Set(tabIndex);
-                            var tab = tabs.Value[tabIndex];
-                            SetAppTitle(tab.AppId);
-
-                            if (navigateArgs.HistoryOp is HistoryOp.Push)
-                                RedirectToAppIfNotError(navigateArgs, replaceHistory, tab.Id);
-                            return;
-                        }
-
-                        if (navigateArgs.HistoryOp is HistoryOp.Pop)
-                        {
-                            client.Error(new InvalidOperationException("Tab no longer exists."));
-                            return;
-                        }
-                    }
-
-                    if (navigateArgs.AppId == null) return;
-
-                    var tabId = Guid.NewGuid().ToString();
-                    var appHost = navigateArgs.ToAppHost(args.ConnectionId);
-
-                    if (settings.PreventTabDuplicates)
-                    {
-                        var targetAppId = navigateArgs.AppId;
-                        var appDescriptor = appRepository.GetApp(targetAppId);
-                        if (appDescriptor?.AllowDuplicateTabs != true)
-                        {
-                            var existingTabIndex = -1;
-                            for (var i = 0; i < tabs.Value.Length; i++)
-                                if (tabs.Value[i].AppId == targetAppId)
-                                {
-                                    existingTabIndex = i;
-                                    break;
-                                }
-
-                            if (existingTabIndex >= 0)
-                            {
-                                var previousSelectedIndex = selectedIndex.Value;
-                                selectedIndex.Set(existingTabIndex);
-                                var existingTabId = tabs.Value[existingTabIndex].Id;
-                                SetAppTitle(targetAppId);
-
-                                if (navigateArgs.HistoryOp is HistoryOp.Push &&
-                                    previousSelectedIndex != existingTabIndex)
-                                    RedirectToAppIfNotError(navigateArgs, replaceHistory, existingTabId);
-                                return;
-                            }
-                        }
-                    }
-
-                    if (navigateArgs.HistoryOp is HistoryOp.Push)
-                    {
-                        var app = appRepository!.GetAppOrDefault(navigateArgs.AppId);
-                        var newTabs = tabs.Value.Add(new TabState(tabId, app.Id, app.Title, appHost, app.Icon,
-                            Guid.NewGuid().ToString()));
-                        tabs.Set(newTabs);
-                        selectedIndex.Set(newTabs.Length - 1);
-                        SetAppTitle(app.Id);
-                        RedirectToAppIfNotError(navigateArgs, replaceHistory, tabId);
-                    }
+                    case AppShellRouter.RouteAction.Noop:
+                        break;
                 }
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "TendrilAppShell.OpenApp failed for {AppId}", navigateArgs.AppId);
             }
+        }
+
+        private void HandleOpenPage(NavigateArgs navigateArgs, string? effectiveAppId, bool replaceHistory)
+        {
+            var previousApp = currentApp.Value?.AppId;
+            var effectiveNavigateArgs = navigateArgs with { AppId = effectiveAppId };
+
+            var appHost = effectiveAppId != null
+                ? effectiveNavigateArgs.ToAppHost(args.ConnectionId)
+                : null;
+
+            currentApp.Set(appHost);
+
+            if (effectiveAppId != null) SetAppTitle(effectiveAppId);
+
+            if (navigateArgs.HistoryOp is HistoryOp.Push && previousApp != effectiveAppId)
+                RedirectToAppIfNotError(effectiveNavigateArgs, replaceHistory);
+        }
+
+        private void HandleSwitchToExistingTab(NavigateArgs navigateArgs, int tabIndex,
+            string tabId, bool replaceHistory)
+        {
+            var previousSelectedIndex = selectedIndex.Value;
+            selectedIndex.Set(tabIndex);
+            var tab = tabs.Value[tabIndex];
+            SetAppTitle(tab.AppId);
+
+            if (navigateArgs.HistoryOp is HistoryOp.Push && previousSelectedIndex != tabIndex)
+                RedirectToAppIfNotError(navigateArgs, replaceHistory, tabId);
+        }
+
+        private void HandleCreateNewTab(NavigateArgs navigateArgs, string effectiveAppId,
+            bool replaceHistory)
+        {
+            if (navigateArgs.HistoryOp is not HistoryOp.Push) return;
+
+            var tabId = Guid.NewGuid().ToString();
+            var appHost = navigateArgs.ToAppHost(args.ConnectionId);
+            var app = appRepository.GetAppOrDefault(effectiveAppId);
+
+            var newTabs = tabs.Value.Add(new TabState(tabId, app.Id, app.Title, appHost,
+                app.Icon, Guid.NewGuid().ToString()));
+            tabs.Set(newTabs);
+            selectedIndex.Set(newTabs.Length - 1);
+            SetAppTitle(app.Id);
+            RedirectToAppIfNotError(navigateArgs, replaceHistory, tabId);
         }
 
         bool CheckTabExists(int tabId)
@@ -529,7 +524,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         );
     }
 
-    private record TabState(string Id, string AppId, string Title, AppHost AppHost, Icons? Icon, string RefreshToken)
+    internal record TabState(string Id, string AppId, string Title, AppHost AppHost, Icons? Icon, string RefreshToken)
     {
         public Tab ToTab()
         {

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -229,7 +229,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             }
         }
 
-        private void HandleOpenPage(NavigateArgs navigateArgs, string? effectiveAppId, bool replaceHistory)
+        void HandleOpenPage(NavigateArgs navigateArgs, string? effectiveAppId, bool replaceHistory)
         {
             var previousApp = currentApp.Value?.AppId;
             var effectiveNavigateArgs = navigateArgs with { AppId = effectiveAppId };
@@ -246,7 +246,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 RedirectToAppIfNotError(effectiveNavigateArgs, replaceHistory);
         }
 
-        private void HandleSwitchToExistingTab(NavigateArgs navigateArgs, int tabIndex,
+        void HandleSwitchToExistingTab(NavigateArgs navigateArgs, int tabIndex,
             string tabId, bool replaceHistory)
         {
             var previousSelectedIndex = selectedIndex.Value;
@@ -258,7 +258,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 RedirectToAppIfNotError(navigateArgs, replaceHistory, tabId);
         }
 
-        private void HandleCreateNewTab(NavigateArgs navigateArgs, string effectiveAppId,
+        void HandleCreateNewTab(NavigateArgs navigateArgs, string effectiveAppId,
             bool replaceHistory)
         {
             if (navigateArgs.HistoryOp is not HistoryOp.Push) return;


### PR DESCRIPTION
## Summary

Extracted routing logic from the OpenApp method into a new AppShellRouter class, reducing cyclomatic complexity from 20 to approximately 5-8 across multiple focused methods.

## Changes

Created AppShellRouter class that encapsulates navigation decision logic for both Pages and Tabs navigation modes. Refactored OpenApp method to delegate routing decisions to the router and handle the results via dedicated handler methods.

## API Changes

**New Types:**
- `AppShellRouter` (internal class)
- `AppShellRouter.RouteResult` (internal record)
- `AppShellRouter.RouteAction` (internal enum: OpenPage, SwitchToExistingTab, CreateNewTab, Error, Noop)

**Modified Types:**
- `TendrilAppShell.TabState` - changed from `private` to `internal` for router access

**New Methods:**
- `AppShellRouter.Route()` - main routing decision method
- `TendrilAppShell.HandleOpenPage()` - local function for page navigation
- `TendrilAppShell.HandleSwitchToExistingTab()` - local function for tab switching
- `TendrilAppShell.HandleCreateNewTab()` - local function for new tab creation

**Refactored Methods:**
- `TendrilAppShell.OpenApp()` - simplified to routing delegation + switch statement

## Files Modified

**Core Implementation:**
- `src/Ivy.Tendril/AppShell/AppShellRouter.cs` (new)
- `src/Ivy.Tendril/AppShell/TendrilAppShell.cs` (refactored OpenApp method)

**Tests:**
- `src/Ivy.Tendril.Test/AppShell/AppShellRouterTests.cs` (new - 6 test cases)

## Commits

- b0e1fdb [03667] Extract AppShellRouter from OpenApp method
- 8dddb98 [03667] Fix TabState reference in AppShellRouter and handler method access modifiers