### PR TITLE
[03658] Reduce ParsePlanFolder Complexity

### DIFF
--- a/src/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/PlanReaderService.cs
@@ -727,24 +727,7 @@ public class PlanReaderService(
                 return null;
             }
 
-            var yamlContent = FileHelper.ReadAllText(planYamlPath);
-            PlanYaml? planYaml;
-
-            try
-            {
-                planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yamlContent);
-            }
-            catch (Exception ex)
-            {
-                // Fall back to the repair pass for malformed agent-generated YAML.
-                _logger.LogWarning(ex, "Failed to parse plan YAML {PlanYamlPath}, attempting repair", planYamlPath);
-                var repaired = PlanYamlRepairService.RepairPlanYaml(yamlContent);
-                if (repaired != yamlContent)
-                    FileHelper.WriteAllText(planYamlPath, repaired);
-
-                planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(repaired);
-            }
-
+            var planYaml = ParsePlanYaml(planYamlPath);
             if (planYaml == null) return null;
 
             var folderName = Path.GetFileName(folderPath);
@@ -773,13 +756,10 @@ public class PlanReaderService(
                 planYaml.InitialPrompt,
                 planYaml.SourceUrl
             );
-            var latestContent = ReadLatestRevisionFromFileSystem(folderName);
 
-            var revisionsDir = Path.Combine(folderPath, "revisions");
-            var revisionCount = Directory.Exists(revisionsDir)
-                ? Directory.GetFiles(revisionsDir, "*.md").Length
-                : 1;
-            if (revisionCount == 0) revisionCount = 1;
+            var latestContent = ReadLatestRevisionFromFileSystem(folderName);
+            var yamlContent = FileHelper.ReadAllText(planYamlPath);
+            var revisionCount = GetLatestRevisionNumber(folderPath);
 
             return new PlanFile(metadata, latestContent, folderPath, yamlContent, revisionCount);
         }
@@ -788,6 +768,39 @@ public class PlanReaderService(
             _logger.LogWarning(ex, "Failed to parse plan folder: {FolderPath}", folderPath);
             return null;
         }
+    }
+
+    private PlanYaml? ParsePlanYaml(string planYamlPath)
+    {
+        var yamlContent = FileHelper.ReadAllText(planYamlPath);
+        PlanYaml? planYaml;
+
+        try
+        {
+            planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yamlContent);
+        }
+        catch (Exception ex)
+        {
+            // Fall back to the repair pass for malformed agent-generated YAML.
+            _logger.LogWarning(ex, "Failed to parse plan YAML {PlanYamlPath}, attempting repair", planYamlPath);
+            var repaired = PlanYamlRepairService.RepairPlanYaml(yamlContent);
+            if (repaired != yamlContent)
+                FileHelper.WriteAllText(planYamlPath, repaired);
+
+            planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(repaired);
+        }
+
+        return planYaml;
+    }
+
+    private static int GetLatestRevisionNumber(string folderPath)
+    {
+        var revisionsDir = Path.Combine(folderPath, "revisions");
+        var revisionCount = Directory.Exists(revisionsDir)
+            ? Directory.GetFiles(revisionsDir, "*.md").Length
+            : 1;
+        if (revisionCount == 0) revisionCount = 1;
+        return revisionCount;
     }
 
     private static int? ExtractPlanId(string folderPath)


### PR DESCRIPTION
# Summary

## Changes

Extracted two helper methods from `ParsePlanFolder` in `PlanReaderService.cs`: `ParsePlanYaml` for YAML parsing with repair fallback, and `GetLatestRevisionNumber` for revision enumeration. This refactoring reduces the cyclomatic complexity of `ParsePlanFolder` from 19 to approximately 8-10.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Services/PlanReaderService.cs** — Added `ParsePlanYaml()` and `GetLatestRevisionNumber()` helper methods, simplified `ParsePlanFolder()`

## Commits

- 9ace8d7 [03658] Reduce ParsePlanFolder complexity by extracting helper methods