### PR TITLE
[03662] Last Output column displays dash for running jobs

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
@@ -29,10 +29,14 @@ public partial class JobsApp
 
     private static string FormatLastOutput(JobItem job)
     {
-        if (job.LastOutputAt.HasValue && job.Status == JobStatus.Running)
+        if (job.Status == JobStatus.Running)
         {
-            var elapsed = DateTime.UtcNow - job.LastOutputAt.Value;
-            return FormatTimeSpan(elapsed);
+            if (job.LastOutputAt.HasValue)
+            {
+                var elapsed = DateTime.UtcNow - job.LastOutputAt.Value;
+                return FormatTimeSpan(elapsed);
+            }
+            return "Starting...";
         }
 
         return "-";


### PR DESCRIPTION
## Problem

The "Last Output" column in the Jobs table shows a dash (`-`) even for jobs that are currently running. This appears inconsistent with the expected behavior where running jobs should display their last output.

**Expected:** Running jobs should display their last output in the "Last Output" column.

**Actual:** Running jobs display a dash (`-`) in the "Last Output" column, same as completed jobs without output.

The issue is reported in [GitHub issue #258](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/258).

## Solution

The root cause is in `JobsApp.Helpers.cs:30-39` (`FormatLastOutput` method):

The problem is that the method returns "-" in two distinct cases:
1. **Running job with no output yet** — `job.LastOutputAt` is null (hasn't produced output)
2. **Completed job** — regardless of whether it produced output

For running jobs, it now displays "Starting..." when `LastOutputAt` is null and status is Running, providing clearer feedback about job state.

## Commits

- e2033a9 — [03662] Display "Starting..." for running jobs without output