### PR TITLE
[00080] Setup projects list layout and verification navigation

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -98,7 +98,7 @@ public class EditProjectDialog(
                                        .WithTooltip(!pathExists
                                            ? $"Path does not exist: {expandedPath}"
                                            : $"Not a git repository: {expandedPath}")
-                                   : new Spacer().Width(Size.Units(4)))
+                                   : null!)
                                | editingRepoPath
                                    .ToTextInput("Your repository folder")
                                    .Width(Size.Grow())
@@ -139,7 +139,7 @@ public class EditProjectDialog(
             }
             else
             {
-                var pathText = Text.Block(repo.Path).Width(Size.Grow());
+                var pathText = Text.Block(repo.Path);
                 if (!isGitRepo) pathText = pathText.Color(Colors.Red);
 
                 reposLayout |= Layout.Horizontal().Gap(2).AlignContent(Align.Center)
@@ -148,9 +148,10 @@ public class EditProjectDialog(
                                        .WithTooltip(!pathExists
                                            ? $"Path does not exist: {expandedPath}"
                                            : $"Not a git repository: {expandedPath}")
-                                   : new Spacer().Width(Size.Units(4)))
+                                   : null!)
                                | pathText
                                | new Badge(repo.PrRule).Variant(BadgeVariant.Outline)
+                               | new Spacer().Width(Size.Grow())
                                | new Button().Icon(Icons.Pencil).Ghost().Small()
                                    .OnClick(() =>
                                    {

--- a/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
@@ -17,24 +17,37 @@ public class ProjectsSetupView : ViewBase
         var projects = config.Settings.Projects;
         var allVerifications = config.Settings.Verifications.Select(v => v.Name).ToList();
 
-        var rows = projects.Select((p, i) => new ProjectRow(p.Name, p.Color, p.Repos.Count, p.Verifications.Count, i)).ToList();
+        var projectList = Layout.Vertical().Gap(2);
+        for (var i = 0; i < projects.Count; i++)
+        {
+            var idx = i;
+            var project = projects[idx];
 
-        var table = new TableBuilder<ProjectRow>(rows)
-            .Header(t => t.Index, "")
-            .Builder(t => t.Index, f => f.Func<ProjectRow, int>(idx =>
-                Layout.Horizontal().Gap(1)
-                | new Button().Icon(Icons.Pencil).Outline().Small().OnClick(() =>
-                {
-                    editIndex.Set(idx);
-                })
-                | new Button().Icon(Icons.Trash).Outline().Small().OnClick(() => { deleteIndex.Set(idx); })
-            ))
-            .ColumnWidth(t => t.Index, Size.Px(88));
+            var repoInfo = Layout.Horizontal().Gap(2).AlignContent(Align.Center);
+            foreach (var repo in project.Repos)
+            {
+                repoInfo |= Text.Block(repo.Path).Muted().Small();
+                repoInfo |= new Badge(repo.PrRule).Variant(BadgeVariant.Outline).Small();
+            }
+
+            var row = Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                      | Text.Block(project.Name).Bold()
+                      | repoInfo
+                      | new Spacer().Width(Size.Grow())
+                      | new Button().Icon(Icons.Pencil).Ghost().Small()
+                          .OnClick(() => editIndex.Set(idx))
+                          .WithTooltip("Edit project")
+                      | new Button().Icon(Icons.Trash).Ghost().Small()
+                          .OnClick(() => deleteIndex.Set(idx));
+
+            projectList |= new Button().Inline().OnClick(() => editIndex.Set(idx))
+                               .Content(row);
+        }
 
         return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Projects").Bold()
                | Text.Block("Manage projects, their repositories, and verification assignments.").Muted().Small()
-               | table
+               | projectList
                | new Button("Add Project").Icon(Icons.Plus).Outline().OnClick(() =>
                {
                    editIndex.Set(null);
@@ -42,6 +55,4 @@ public class ProjectsSetupView : ViewBase
                | new EditProjectDialog(editIndex, projects, allVerifications, config, client, refreshToken)
                | new DeleteProjectDialog(deleteIndex, projects, config, client, refreshToken);
     }
-
-    private record ProjectRow(string Name, string Color, int RepoCount, int VerificationCount, int Index);
 }


### PR DESCRIPTION
## Changes

Replaced the `TableBuilder` in `ProjectsSetupView` with a clickable vertical list of project rows. Each row shows the project name, repo paths with PrRule badges positioned directly next to each path, and edit/delete buttons. Clicking a project row opens the `EditProjectDialog` for that project. In `EditProjectDialog`, removed unnecessary spacers to the left of repo paths (both in view and edit modes), moved the PrRule badge next to the path name, and added a grow spacer to push action buttons to the right edge.

## Files Modified

- **src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs** — Replaced `TableBuilder<ProjectRow>` with vertical list of clickable `Button().Inline()` rows showing project name + repo info; removed `ProjectRow` record
- **src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs** — Removed `Spacer().Width(Size.Units(4))` fallback in both edit and view modes, replaced with `null!`; removed `Width(Size.Grow())` from view-mode path text; added `Spacer().Width(Size.Grow())` before action buttons