### PR TITLE
Fix 15 unit test failures across 7 test classes

### DIFF
--- a/src/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
+++ b/src/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
@@ -3,6 +3,7 @@ using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.SessionParsers;
 using Ivy.Tendril.Test.Helpers;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ivy.Tendril.Test;
@@ -144,6 +145,7 @@ public class BackgroundServiceActivatorTests : IAsyncLifetime
         var config = new FreshInstallConfigService(settings);
 
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton<IConfigService>(config);
         services.AddSingleton<ISessionParser, ClaudeSessionParser>();
         services.AddSingleton<ISessionParser, CodexSessionParser>();

--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -884,9 +884,13 @@ editor:
     [Fact]
     public void SetTendrilHome_Should_Handle_Malformed_Config_Gracefully()
     {
-        var validYaml = "codingAgent: testAgent\njobTimeout: 99";
-        var validDir = CreateTempConfigFile(validYaml);
-        var malformedDir = CreateTempConfigFile("invalid: yaml: [unclosed");
+        var validDir = Path.Combine(Path.GetTempPath(), $"ivy-config-test-valid-{Guid.NewGuid():N}");
+        var malformedDir = Path.Combine(Path.GetTempPath(), $"ivy-config-test-malformed-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(validDir);
+        Directory.CreateDirectory(malformedDir);
+        File.WriteAllText(Path.Combine(validDir, "config.yaml"), "codingAgent: testAgent\njobTimeout: 99");
+        File.WriteAllText(Path.Combine(malformedDir, "config.yaml"), "projects:\n  - name: [invalid");
+
         var service = new ConfigService(new TendrilSettings());
 
         try
@@ -905,8 +909,8 @@ editor:
         }
         finally
         {
-            Directory.Delete(validDir, true);
-            Directory.Delete(malformedDir, true);
+            if (Directory.Exists(validDir)) Directory.Delete(validDir, true);
+            if (Directory.Exists(malformedDir)) Directory.Delete(malformedDir, true);
         }
     }
 
@@ -1250,9 +1254,9 @@ projects:
         {
             service.SetTendrilHome(tempDir);
 
-            // Create a markdown file that needs polishing
+            // Create a markdown file that needs polishing (backtick link text gets polished)
             var mdPath = Path.Combine(tempDir, "test.md");
-            File.WriteAllText(mdPath, "[Plan 12345](plan://12345)");
+            File.WriteAllText(mdPath, "[`Button.cs`](file:///D:/Repos/Test/Button.cs)");
 
             var processedPath = service.PreprocessForEditing(mdPath);
 
@@ -1291,8 +1295,8 @@ projects:
             // Create multiple temp files
             var mdPath1 = Path.Combine(tempDir, "test1.md");
             var mdPath2 = Path.Combine(tempDir, "test2.md");
-            File.WriteAllText(mdPath1, "[Plan 1](plan://1)");
-            File.WriteAllText(mdPath2, "[Plan 2](plan://2)");
+            File.WriteAllText(mdPath1, "[`File1.cs`](file:///D:/Repos/Test/File1.cs)");
+            File.WriteAllText(mdPath2, "[`File2.cs`](file:///D:/Repos/Test/File2.cs)");
 
             var tempPath1 = service.PreprocessForEditing(mdPath1);
             var tempPath2 = service.PreprocessForEditing(mdPath2);
@@ -1330,7 +1334,7 @@ projects:
             service.SetTendrilHome(tempDir);
 
             var mdPath = Path.Combine(tempDir, "test.md");
-            File.WriteAllText(mdPath, "[Plan 1](plan://1)");
+            File.WriteAllText(mdPath, "[`Button.cs`](file:///D:/Repos/Test/Button.cs)");
 
             var tempPath = service.PreprocessForEditing(mdPath);
 
@@ -1372,7 +1376,7 @@ projects:
             Parallel.For(0, 10, i =>
             {
                 var mdPath = Path.Combine(tempDir, $"test{i}.md");
-                File.WriteAllText(mdPath, $"[Plan {i}](plan://{i})");
+                File.WriteAllText(mdPath, $"[`File{i}.cs`](file:///D:/Repos/Test/File{i}.cs)");
                 var tempPath = service.PreprocessForEditing(mdPath);
                 tempPaths.Add(tempPath);
             });

--- a/src/Ivy.Tendril.Test/GitServiceValidationTests.cs
+++ b/src/Ivy.Tendril.Test/GitServiceValidationTests.cs
@@ -10,7 +10,7 @@ public class GitServiceValidationTests
 
     [Theory]
     [InlineData("abc1234", true)]                    // 7-char short hash
-    [InlineData("abc1234567890abcdef1234567890abcdef12345678", true)] // 40-char full hash
+    [InlineData("abc1234567890abcdef1234567890abcdef12345", true)] // 40-char full hash
     [InlineData("ABC1234", true)]                    // uppercase (git accepts)
     [InlineData("abc123", false)]                    // too short
     [InlineData("g123456", false)]                   // invalid character

--- a/src/Ivy.Tendril.Test/JobServiceResourceDisposalTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceResourceDisposalTests.cs
@@ -55,35 +55,6 @@ public class JobServiceResourceDisposalTests
     }
 
     [Fact]
-    public void DisposeResources_LogsWarningWhenDisposalFails()
-    {
-        var logMessages = new List<string>();
-        var loggerFactory = LoggerFactory.Create(builder =>
-        {
-            builder.AddProvider(new TestLoggerProvider(logMessages));
-        });
-        var logger = loggerFactory.CreateLogger<JobService>();
-
-        var job = new JobItem
-        {
-            Id = "test-job",
-            Type = "ExecutePlan",
-            Status = JobStatus.Running
-        };
-
-        // Create a CTS and dispose it, so the next dispose call fails
-        job.TimeoutCts = new CancellationTokenSource();
-        job.TimeoutCts.Dispose();
-
-        // Should log a warning when disposal fails
-        job.DisposeResources(logger);
-
-        // Check that a warning was logged (disposal of already-disposed CTS throws ObjectDisposedException)
-        var warningLogs = logMessages.Where(m => m.Contains("Warning") || m.Contains("Failed to dispose")).ToList();
-        Assert.NotEmpty(warningLogs);
-    }
-
-    [Fact]
     public void CompleteJob_DisposesResources()
     {
         var service = CreateService();

--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -221,17 +221,19 @@ public class JobServiceRetryBlockedTests : IDisposable
         var completingId = service.CreateTestJob("CreatePr", Path.GetTempPath());
         service.CompleteJob(completingId, 0);
 
-        // The blocked job should have been removed (TryRemove succeeds)
-        Assert.Null(service.GetJob(blockedId));
+        // The blocked job should remain because an active job exists for the same plan
+        var stillBlocked = service.GetJob(blockedId);
+        Assert.NotNull(stillBlocked);
+        Assert.Equal(JobStatus.Blocked, stillBlocked.Status);
 
-        // But no NEW ExecutePlan job should be created because HasActiveJobForPlan returns true
+        // The active job should still be running
         var executePlanJobs = service.GetJobs()
             .Where(j => j.Type == "ExecutePlan" && j.Args.Length > 0 && j.Args[0] == dependentPlan)
             .ToList();
 
-        // Only the original active job should exist
-        Assert.Single(executePlanJobs);
-        Assert.Equal(activeId, executePlanJobs[0].Id);
+        Assert.Equal(2, executePlanJobs.Count);
+        Assert.Contains(executePlanJobs, j => j.Id == activeId && j.Status == JobStatus.Running);
+        Assert.Contains(executePlanJobs, j => j.Id == blockedId && j.Status == JobStatus.Blocked);
 
         // Cleanup
         Directory.Delete(dependentPlan, true);

--- a/src/Ivy.Tendril.Test/Mcp/AuthenticatedToolBaseTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/AuthenticatedToolBaseTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ivy.Tendril.Test.Mcp;
 
+[Collection("EnvironmentVariableTests")]
 public class AuthenticatedToolBaseTests : IDisposable
 {
     private readonly string? _originalToken;

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -158,10 +158,12 @@ public class TendrilSettings
 
 public record ConfigParseError(string Message, string FilePath, Exception? InnerException);
 
-public class ConfigService : IConfigService
+public class ConfigService : IConfigService, IDisposable
 {
     private readonly bool _explicitHome;
     private readonly ILogger<ConfigService> _logger;
+    private readonly List<string> _trackedTempFiles = new();
+    private readonly object _tempFileLock = new();
     private string[]? _levelNamesCache;
     private string? _pendingCodingAgent;
     private ProjectConfig? _pendingProject;
@@ -485,7 +487,20 @@ public class ConfigService : IConfigService
 
         var tempPath = Path.Combine(Path.GetTempPath(), $"tendril-edit-{Guid.NewGuid()}.md");
         File.WriteAllText(tempPath, polished);
+        lock (_tempFileLock) { _trackedTempFiles.Add(tempPath); }
         return tempPath;
+    }
+
+    public void Dispose()
+    {
+        lock (_tempFileLock)
+        {
+            foreach (var path in _trackedTempFiles)
+            {
+                try { if (File.Exists(path)) File.Delete(path); } catch { }
+            }
+            _trackedTempFiles.Clear();
+        }
     }
 
     public void CompleteOnboarding(string tendrilHome)
@@ -738,6 +753,7 @@ public class ConfigService : IConfigService
             }
         }
 
+        ValidateSettings();
         MigrateProjectColors();
         _levelNamesCache = null;
         VariableExpansion.InitializeUserSecrets(TendrilHome, _logger);

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -756,6 +756,12 @@ internal class JobCompletionHandler
         }
     }
 
+    internal void HandleRetryBlockedJobs(
+        ConcurrentDictionary<string, JobItem> jobs,
+        Action<JobNotification> raiseNotification,
+        Func<string, string[], string> startJobSkipDepCheck)
+        => RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
+
     private void RetryBlockedJobs(
         ConcurrentDictionary<string, JobItem> jobs,
         Action<JobNotification> raiseNotification,
@@ -773,9 +779,9 @@ internal class JobCompletionHandler
             var (ok, _) = CheckDependencies(planFolder);
             if (!ok) continue;
 
-            if (!jobs.TryRemove(blockedJob.Id, out _)) continue;
-
             if (HasActiveJobForPlan(planFolder, jobs)) continue;
+
+            if (!jobs.TryRemove(blockedJob.Id, out _)) continue;
 
             PlanYamlHelper.SetPlanStateByFolder(planFolder, "Building");
             startJobSkipDepCheck(blockedJob.Type, blockedJob.Args);
@@ -827,11 +833,27 @@ internal class JobCompletionHandler
 
     private static bool HasActiveJobForPlan(string planFolder, ConcurrentDictionary<string, JobItem> jobs)
     {
+        var planRepos = PlanYamlHelper.ReadPlanYaml(planFolder)?.Repos;
+
         return jobs.Values.Any(j =>
-            j.Type == Constants.JobTypes.ExecutePlan &&
-            j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
-            j.Args.Length > 0 &&
-            j.Args[0].Equals(planFolder, StringComparison.OrdinalIgnoreCase));
+        {
+            if (j.Type != Constants.JobTypes.ExecutePlan) return false;
+            if (j.Status is not (JobStatus.Running or JobStatus.Queued or JobStatus.Pending)) return false;
+            if (j.Args.Length == 0) return false;
+
+            var otherFolder = j.Args[0];
+            if (otherFolder.Equals(planFolder, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (planRepos is { Count: > 0 })
+            {
+                var otherRepos = PlanYamlHelper.ReadPlanYaml(otherFolder)?.Repos;
+                if (otherRepos != null && planRepos.Any(r => otherRepos.Contains(r, StringComparer.OrdinalIgnoreCase)))
+                    return true;
+            }
+
+            return false;
+        });
     }
 
     private string? ResolvePlanFolder(JobItem job)

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -217,6 +217,10 @@ public class JobService : IJobService
 
         JobCompletionHandler.CleanupInboxFile(job);
         _completionHandler.ResetPlanState(job);
+
+        if (job.Type is Constants.JobTypes.ExecutePlan or Constants.JobTypes.CreatePr)
+            _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck);
+
         RaiseJobsStructureChanged();
 
         // Try to start queued jobs now that a slot is free

--- a/src/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -887,13 +887,13 @@ public class PlanDatabaseService : IPlanDatabaseService
         if (_disposed)
             return;
 
+        _disposed = true;
+
         if (disposing)
         {
-            _connection?.Dispose();
-            _lock?.Dispose();
+            try { _connection?.Dispose(); } catch { }
+            try { _lock?.Dispose(); } catch { }
         }
-
-        _disposed = true;
     }
 
     ~PlanDatabaseService()


### PR DESCRIPTION
Source fixes:
- ConfigService: add ValidateSettings() call in SetTendrilHome, implement
  IDisposable with thread-safe temp file tracking/cleanup
- JobCompletionHandler: move TryRemove after HasActiveJobForPlan check to
  prevent blocked job leak, add repo-overlap detection
- JobService: call RetryBlockedJobs from StopJob for ExecutePlan/CreatePr
- PlanDatabaseService: fix Dispose race condition

Test fixes:
- GitServiceValidationTests: correct 42-char hash to 40
- BackgroundServiceActivatorTests: add missing AddLogging() DI registration
- ConfigServiceTests: use separate temp dirs, use polishable markdown content
- AuthenticatedToolBaseTests: add Collection attribute for env var isolation
- Remove DisposeResources_LogsWarningWhenDisposalFails (CTS.Dispose is idempotent)
- Update RetryBlocked test expectations to match corrected behavior
