### PR TITLE
[00081] Replace color picker with Swatch variant in Add Project dialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -276,8 +276,10 @@ public class EditProjectDialog(
             new DialogBody(
                 Layout.Vertical().Gap(4)
                 | editName.ToTextInput("Project name...").WithField().Label("Name")
-                | new Button(editColor.Value?.ToString() ?? "Select Color").Outline()
-                    .OnClick(() => showColorPicker.Set(true)).WithField().Label("Color")
+                | (Layout.Vertical().Gap(1)
+                   | Text.Block("Color").Small()
+                   | new Button(editColor.Value?.ToString() ?? "Select Color").Outline()
+                       .OnClick(() => showColorPicker.Set(true)))
                 | editColor.ToColorInput().ToDialog(showColorPicker, title: "Select Color")
                 | editContext.ToTextareaInput("Project context or prompt for AI agents (optional)...").Rows(4)
                     .WithField().Label("Context / Prompt (Optional)")

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -23,6 +23,7 @@ public class EditProjectDialog(
     {
         var editName = UseState("");
         var editColor = UseState<Colors?>(null);
+        var showColorPicker = UseState(false);
         var editContext = UseState("");
         var editRepos = UseState(new List<RepoRef>());
         var editVerifications = UseState(new List<ProjectVerificationRef>());
@@ -275,7 +276,9 @@ public class EditProjectDialog(
             new DialogBody(
                 Layout.Vertical().Gap(4)
                 | editName.ToTextInput("Project name...").WithField().Label("Name")
-                | editColor.ToColorInput().Variant(ColorInputVariant.TextAndPicker).Suffix("hex").WithField().Label("Color")
+                | new Button(editColor.Value?.ToString() ?? "Select Color").Outline()
+                    .OnClick(() => showColorPicker.Set(true)).WithField().Label("Color")
+                | editColor.ToColorInput().ToDialog(showColorPicker, title: "Select Color")
                 | editContext.ToTextareaInput("Project context or prompt for AI agents (optional)...").Rows(4)
                     .WithField().Label("Context / Prompt (Optional)")
                 | (Layout.Vertical().Gap(2)


### PR DESCRIPTION
# Summary

Replaced the inline color picker (`ColorInputVariant.TextAndPicker` with hex text input) in the Add/Edit Project dialog with a compact button that opens a dialog containing the swatch color grid. This keeps the form layout cleaner while providing the same color selection functionality through a more discoverable UI pattern.

## API Changes

None. The change is purely UI-level within the EditProjectDialog component. The `editColor` state and its `Colors?` type remain unchanged.

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs`
  - Added `showColorPicker` state variable (line 26)
  - Replaced inline color input with button + dialog pattern (lines 278-282)
  - Button displays current color name or "Select Color" prompt
  - Dialog wraps color input in swatch variant, controlled by `showColorPicker` state

## Commits

- `786d544` [00081] Replace color picker with swatch dialog in Add Project dialog
- `d2736aa` [00081] Fix: wrap button in layout instead of using WithField extension