### PR TITLE
Fix CTS disposal race in job watchdog and status poller

### DIFF
--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -244,8 +244,19 @@ internal class JobLauncher
                     {
                         return;
                     }
+                    catch (ObjectDisposedException)
+                    {
+                        return;
+                    }
 
-                    if (timeoutCts.Token.IsCancellationRequested) return;
+                    try
+                    {
+                        if (timeoutCts.Token.IsCancellationRequested) return;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        return;
+                    }
                 }
 
                 if (!jobs.TryGetValue(id, out var job) || job.Status != JobStatus.Running)
@@ -282,6 +293,7 @@ internal class JobLauncher
                     await Task.Delay(TimeSpan.FromSeconds(1), timeoutCts.Token);
                 }
                 catch (OperationCanceledException) { return; }
+                catch (ObjectDisposedException) { return; }
 
                 if (!jobs.TryGetValue(id, out var job) || job.Status != JobStatus.Running)
                     break;


### PR DESCRIPTION
RunStaleOutputWatchdog and RunStatusFilePoller shared a CancellationTokenSource
with the monitor task. When the monitor disposed the CTS on job completion, the
other tasks could throw ObjectDisposedException from Task.Delay or Token access.
Only OperationCanceledException was caught, leaving a window for unobserved
task exceptions.
