### PR TITLE
[03674] Job timeout of 30 minutes not being enforced

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -157,25 +157,20 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void CompleteJob_CreatePlan_LeavesPlanFileUnchangedOnDuplicate()
     {
         var service = CreateServiceWithPlanReader(_tempDir.Path);
-            var id = service.CreateTestJob("CreatePlan", "-Description", "Fix login bug", "-Project", "Tendril");
+        var id = service.CreateTestJob("CreatePlan", "-Description", "Fix login bug", "-Project", "Tendril");
 
-            var job = service.GetJob(id);
-            Assert.NotNull(job);
-            var originalPlanFile = job.PlanFile;
-            job.EnqueueOutput("Processing...");
-            job.EnqueueOutput("identified as duplicate: 01234-ExistingPlan");
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+        var originalPlanFile = job.PlanFile;
+        job.EnqueueOutput("Processing...");
+        job.EnqueueOutput("identified as duplicate: 01234-ExistingPlan");
 
-            service.CompleteJob(id, 0);
+        service.CompleteJob(id, 0);
 
-            job = service.GetJob(id);
-            Assert.NotNull(job);
-            Assert.Equal(originalPlanFile, job.PlanFile);
-            Assert.Equal(JobStatus.Completed, job.Status);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        job = service.GetJob(id);
+        Assert.NotNull(job);
+        Assert.Equal(originalPlanFile, job.PlanFile);
+        Assert.Equal(JobStatus.Completed, job.Status);
     }
 
     private class StubPlanReaderService(string plansDirectory) : IPlanReaderService

--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -139,18 +139,18 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void CompleteJob_CreatePlan_UpdatesPlanFileWhenOutputContainsPlanCreated()
     {
         var service = CreateServiceWithPlanReader(_tempDir.Path);
-            var id = service.CreateTestJob("CreatePlan", "-Description", "Fix login bug", "-Project", "Tendril");
+        var id = service.CreateTestJob("CreatePlan", "-Description", "Fix login bug", "-Project", "Tendril");
 
-            var job = service.GetJob(id);
-            Assert.NotNull(job);
-            job.EnqueueOutput("Processing...");
-            job.EnqueueOutput("Plan created: 02353-FixLoginBug");
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+        job.EnqueueOutput("Processing...");
+        job.EnqueueOutput("Plan created: 02353-FixLoginBug");
 
-            service.CompleteJob(id, 0);
+        service.CompleteJob(id, 0);
 
-            job = service.GetJob(id);
-            Assert.NotNull(job);
-            Assert.Equal("02353-FixLoginBug", job.PlanFile);
+        job = service.GetJob(id);
+        Assert.NotNull(job);
+        Assert.Equal("02353-FixLoginBug", job.PlanFile);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
@@ -17,7 +17,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         _tempDir.Dispose();
     }
-{
+
     private static JobService CreateService(
         TimeSpan jobTimeout,
         TimeSpan staleOutputTimeout,

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -176,28 +176,61 @@ internal class JobLauncher
         var cts = new CancellationTokenSource(ctx.JobTimeout);
         job.TimeoutCts = cts;
 
+        // Hard timeout guard - ensures the job is completed even if WaitForExitOrKillAsync hangs
+        var hardTimeout = ctx.JobTimeout + TimeSpan.FromMinutes(5);
+        var hardTimeoutCts = new CancellationTokenSource(hardTimeout);
+
         Task.Run(async () =>
         {
             _logger.LogDebug("Job {JobId}: Monitor task started", id);
 
             try
             {
-                if (await process.WaitForExitOrKillAsync(cts.Token))
+                var waitTask = process.WaitForExitOrKillAsync(cts.Token);
+                var completedTask = await Task.WhenAny(waitTask, Task.Delay(hardTimeout, hardTimeoutCts.Token));
+
+                if (completedTask == waitTask)
                 {
-                    if (ctx.Jobs.TryGetValue(id, out var j) && j.StaleOutputDetected)
+                    var normalExit = await waitTask;
+                    if (normalExit)
                     {
-                        _logger.LogInformation("Job {JobId}: Process exited, stale output detected", id);
-                        ctx.CompleteJob(id, null, true, true);
+                        if (ctx.Jobs.TryGetValue(id, out var j) && j.StaleOutputDetected)
+                        {
+                            _logger.LogInformation("Job {JobId}: Process exited, stale output detected", id);
+                            ctx.CompleteJob(id, null, true, true);
+                        }
+                        else
+                        {
+                            _logger.LogInformation("Job {JobId}: Process exited with code {ExitCode}", id, process.ExitCode);
+                            ctx.CompleteJob(id, process.ExitCode, false, false);
+                        }
                     }
                     else
                     {
-                        _logger.LogInformation("Job {JobId}: Process exited with code {ExitCode}", id, process.ExitCode);
-                        ctx.CompleteJob(id, process.ExitCode, false, false);
+                        _logger.LogWarning("Job {JobId}: Process killed after timeout", id);
+                        ctx.CompleteJob(id, null, true, false);
                     }
                 }
                 else
                 {
-                    _logger.LogWarning("Job {JobId}: Process killed after timeout", id);
+                    _logger.LogError("Job {JobId}: HARD TIMEOUT after {Minutes} minutes - process may still be running",
+                        id, hardTimeout.TotalMinutes);
+                    CrashLog.Write($"[{DateTime.UtcNow:O}] Job {id} hit hard timeout after {hardTimeout.TotalMinutes} minutes - WaitForExitOrKillAsync did not complete");
+
+                    // Try one last forceful kill
+                    try
+                    {
+                        if (!process.HasExited)
+                        {
+                            _logger.LogWarning("Job {JobId}: Attempting emergency kill", id);
+                            process.Kill(entireProcessTree: true);
+                        }
+                    }
+                    catch (Exception killEx)
+                    {
+                        _logger.LogError(killEx, "Job {JobId}: Emergency kill failed", id);
+                    }
+
                     ctx.CompleteJob(id, null, true, false);
                 }
 
@@ -212,6 +245,10 @@ internal class JobLauncher
                 _logger.LogError(ex, "Job {JobId}: Monitor task exception", id);
                 CrashLog.Write($"[{DateTime.UtcNow:O}] JobService process monitor exception for job {id}: {ex}");
                 ctx.CompleteJob(id, null, false, false);
+            }
+            finally
+            {
+                hardTimeoutCts.Dispose();
             }
         });
 


### PR DESCRIPTION
# Summary

## Changes

Added a hard timeout guard to the job monitoring system in `JobLauncher.cs`. The guard ensures that jobs are terminated even if the soft timeout mechanism (`WaitForExitOrKillAsync`) hangs. The hard timeout is set to the configured job timeout plus 5 minutes. If triggered, it logs an error, attempts an emergency kill of the process tree, and completes the job.

## API Changes

None — internal implementation change only.

## Files Modified

### Core Implementation
- `src/Ivy.Tendril/Services/JobLauncher.cs` — Added hard timeout guard to `InitializeJobMonitoring` method

### Test Fixes (Pre-existing Issues)
- `src/Ivy.Tendril.Test/JobServiceTimeoutTests.cs` — Fixed duplicate brace syntax error
- `src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs` — Removed orphaned `finally` block, fixed whitespace formatting

## Commits

- da88792 [03674] Fix formatting (whitespace)
- 7446ff6 [03674] Fix test compilation errors (pre-existing issues)
- 677eaad [03674] Add hard timeout guard to prevent hung job processes