### PR TITLE
[03668] Group Authentication and Navigation Effects Setup

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -83,37 +83,8 @@ public class ContentView(
                 new Dictionary<string, List<string>>(), new List<PlanContentHelpers.CommitRow>(), new Dictionary<string, bool>(), null)
         );
 
-        UseEffect(() =>
-        {
-            var plan = selectedPlanRef.Value;
-            if (isEditing.Value && !isEditingPrev.Value)
-            {
-                if (plan != null)
-                {
-                    var raw = planService.ReadRawPlan(plan.FolderName);
-                    editContent.Set(raw);
-                    originalContent.Set(raw);
-                }
-                else
-                {
-                    isEditing.Set(false);
-                }
-            }
-
-            isEditingPrev.Set(isEditing.Value);
-        }, isEditing);
-
-        UseEffect(() => { selectedTab.Set(0); }, selectedPlanState);
-
-#pragma warning disable CS8601
-        selectedPlanRef.Value = selectedPlan;
-#pragma warning restore CS8601
-
-        if (lastPlanId.Value != (selectedPlan?.Id ?? -1))
-        {
-            lastPlanId.Set(selectedPlan?.Id ?? -1);
-            isEditing.Set(false);
-        }
+        UseAuthenticationEffects(isEditing, isEditingPrev, editContent, originalContent, selectedPlanRef, planService);
+        UseNavigationEffects(selectedTab, selectedPlanState, isEditing, lastPlanId, selectedPlanRef, selectedPlan);
 
         if (selectedPlan is null)
         {
@@ -376,6 +347,56 @@ public class ContentView(
         var currentIndex = allPlans.FindIndex(p => p.FolderName == selectedPlan?.FolderName);
         var prevIndex = (currentIndex - 1 + allPlans.Count) % allPlans.Count;
         selectedPlanState.Set(allPlans[prevIndex]);
+    }
+
+    private void UseAuthenticationEffects(
+        IState<bool> isEditing,
+        IState<bool> isEditingPrev,
+        IState<string> editContent,
+        IState<string> originalContent,
+        IRef<PlanFile?> selectedPlanRef,
+        IPlanReaderService planService)
+    {
+        UseEffect(() =>
+        {
+            var plan = selectedPlanRef.Value;
+            if (isEditing.Value && !isEditingPrev.Value)
+            {
+                if (plan != null)
+                {
+                    var raw = planService.ReadRawPlan(plan.FolderName);
+                    editContent.Set(raw);
+                    originalContent.Set(raw);
+                }
+                else
+                {
+                    isEditing.Set(false);
+                }
+            }
+
+            isEditingPrev.Set(isEditing.Value);
+        }, isEditing);
+    }
+
+    private void UseNavigationEffects(
+        IState<int> selectedTab,
+        IState<PlanFile?> selectedPlanState,
+        IState<bool> isEditing,
+        IState<int> lastPlanId,
+        IRef<PlanFile?> selectedPlanRef,
+        PlanFile? selectedPlan)
+    {
+        UseEffect(() => { selectedTab.Set(0); }, selectedPlanState);
+
+#pragma warning disable CS8601
+        selectedPlanRef.Value = selectedPlan;
+#pragma warning restore CS8601
+
+        if (lastPlanId.Value != (selectedPlan?.Id ?? -1))
+        {
+            lastPlanId.Set(selectedPlan?.Id ?? -1);
+            isEditing.Set(false);
+        }
     }
 
     private record PlanContentData(


### PR DESCRIPTION
# Summary

## Changes

**No changes were made during this execution.** The plan was rejected during PreExecution validation without creating new commits.

### Execution History

1. **First execution (2026-04-27T09:02:39Z):** Implemented the refactoring as specified, creating commit `fa6cddc`. Failed during DotnetBuild with IVYHOOK001 analyzer errors.

2. **Second execution (2026-04-27T11:49:51Z):** Rejected during PreExecution validation per Program.md Step 1.7.5 - avoided creating duplicate commits for an architecturally invalid design.

## API Changes

None.

## Files Modified

None in this execution. The previous execution's commit `fa6cddc` modified `ContentView.cs` but cannot pass verification.

## Reason for Rejection

The plan specifies extracting `UseEffect` hook calls into **private instance methods** (`SetupAuthenticationEffects` and `SetupNavigationEffects`). This pattern is architecturally invalid because:

1. The Ivy Framework requires hooks to be called at the top level of the `Build()` method
2. Extracting hooks into private methods breaks the framework's hook execution order tracking  
3. The IVYHOOK001 analyzer correctly rejects this pattern at build time

A valid alternative would be to use **IViewContext extension methods** (like the referenced `UseStartJob` example), but that's a fundamentally different design than what was specified in the plan.

## Recommendations

Two recommendations were generated from the first execution attempt:

1. **Revise plan to use IViewContext extension methods** (Medium impact, Small risk) - addresses the architectural issue
2. **Document hook extraction patterns in AGENTS.md** (Small impact, Small risk) - prevents similar invalid plans in the future

Both recommendations remain valid and are tracked in plan.yaml.

## Commits

- fa6cddc [03668] Group authentication and navigation effects setup into separate methods