### PR TITLE
[00087] Remove inline Add repo button in Edit Project dialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -239,8 +239,7 @@ public class EditProjectDialog(
                                .Width(Size.Percent(100))
                                .OnClick(() => showFolderDialog(_ => { }))
                            | newRepoPrRule.ToSelectInput(new List<string> { "default", "yolo" })
-                               .Width(Size.Units(20))
-                           | new Button("Add").Outline().Small().OnClick(addRepoAction))
+                               .Width(Size.Units(20)))
                            | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
                            | newRepoBaseBranch.ToTextInput("Base branch (optional)")
                                .Width(Size.Grow()));
@@ -251,8 +250,7 @@ public class EditProjectDialog(
                            | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
                            | newRepoPath.ToTextInput("Your repository folder")
                                .Suffix(newRepoPrRule.ToSelectInput(new List<string> { "default", "yolo" }).Ghost())
-                               .Width(Size.Grow())
-                           | new Button("Add").Outline().Small().OnClick(addRepoAction))
+                               .Width(Size.Grow()))
                            | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
                            | newRepoBaseBranch.ToTextInput("Base branch (optional)")
                                .Width(Size.Grow()));
@@ -339,6 +337,7 @@ public class EditProjectDialog(
                 }),
                 new Button(isNew ? "Add" : "Save").Primary().OnClick(() =>
                 {
+                    addRepoAction();
                     if (string.IsNullOrWhiteSpace(editName.Value)) return;
                     var project = isNew ? new ProjectConfig() : _projects[_editIndex.Value!.Value];
                     project.Name = editName.Value;


### PR DESCRIPTION
## Changes

Removed the redundant inline "Add" button from the Edit/Add Project dialog in Setup. Since each dialog adds one project with its repos, the inline "Add" button duplicated the footer "Add"/"Save" button's functionality. The repo is now added when the user clicks the footer button to complete the project creation.

## API Changes

None. This is a UI behavior change only.

## Files Modified

- `src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs`
  - Removed inline "Add" button from desktop repo input layout
  - Removed inline "Add" button from non-desktop repo input layout
  - Integrated `addRepoAction()` logic into the footer "Add"/"Save" button's OnClick handler

## Commits

- 260fe8f [00087] Remove inline Add repo button in Edit Project dialog