### PR TITLE
[03682] Make Prompt/Title clickable and remove right-side buttons in Jobs UI

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -117,6 +117,20 @@ public partial class JobsApp
                         }
                     }
                 }
+                else if (e.Value.ColumnName == "Prompt/Title")
+                {
+                    var id = e.Value.RowId?.ToString();
+                    if (!string.IsNullOrEmpty(id))
+                    {
+                        var job = jobs.FirstOrDefault(j => j.Id == id);
+                        if (job != null)
+                        {
+                            var fullPrompt = GetFullPrompt(job);
+                            if (!string.IsNullOrEmpty(fullPrompt))
+                                showPrompt.Set(fullPrompt);
+                        }
+                    }
+                }
 
                 return ValueTask.CompletedTask;
             })
@@ -224,21 +238,6 @@ public partial class JobsApp
                 }
 
                 return ValueTask.CompletedTask;
-            })
-            .HeaderRight(_ => Layout.Horizontal().Gap(2)
-                              | jobsProgress
-                              | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
-                                  new MenuItem("Clear Completed", Icon: Icons.Trash, Tag: "ClearCompleted")
-                                      .OnSelect(() =>
-                                      {
-                                          jobService.ClearCompletedJobs();
-                                          refreshToken.Refresh();
-                                      }),
-                                  new MenuItem("Clear Failed", Icon: Icons.Trash, Tag: "ClearFailed").OnSelect(() =>
-                                  {
-                                      jobService.ClearFailedJobs();
-                                      refreshToken.Refresh();
-                                  })
-                              ));
+            });
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Modified JobsApp.DataTable.cs to make the Prompt/Title column clickable for viewing full prompts in a sheet, and removed the HeaderRight section that contained the job progress indicator and dropdown menu button.

## API Changes

None - Internal UI behavior changes only.

## Files Modified

- **src/Ivy.Tendril/Apps/JobsApp.DataTable.cs**
  - Added OnCellClick handler for "Prompt/Title" column to display full prompt in sheet
  - Removed HeaderRight section (removed job progress display and dropdown menu with Clear Completed/Failed actions)

## Commits

- [03682] Make Prompt/Title clickable and remove HeaderRight buttons (8b77d1a)