### PR TITLE
Fix delegated verification invocation syntax causing IvyFrameworkVerification failures

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -168,10 +168,18 @@ verifications:
   prompt: >
     Visually verify UI changes by delegating to the IvyFrameworkVerification promptware.
     You MUST run this as an external process — do NOT attempt to do the verification yourself or write the report directly.
+
+    COPY THE COMMAND BELOW EXACTLY — only replace angle-bracketed placeholders with actual paths.
+    The plan folder is a POSITIONAL argument (NOT `--plan-folder`). The `--value` flags are REQUIRED.
+
     Execute: `tendril promptware IvyFrameworkVerification "<PlanFolder>" --value VerificationDir="<PlanFolder>\verification" --value ArtifactsDir="<PlanFolder>\artifacts" --value IvyFrameworkPath="<worktree path to Ivy-Framework>"`
+
+    Example with real paths: `tendril promptware IvyFrameworkVerification "D:\Plans\03683-Example" --value VerificationDir="D:\Plans\03683-Example\verification" --value ArtifactsDir="D:\Plans\03683-Example\artifacts" --value IvyFrameworkPath="D:\Plans\03683-Example\worktrees\Ivy-Framework"`
+
     Wait for the process to complete (it may take several minutes).
-    If exit code is 0, read `<PlanFolder>\verification\IvyFrameworkVerification.md` and set status based on the Result field.
-    If exit code is non-zero or the report file was not created, set status to Fail.
+    After the process exits, IMMEDIATELY check if `<PlanFolder>\verification\IvyFrameworkVerification.md` exists.
+    If the file exists, read it and set status based on the Result field in its YAML frontmatter.
+    If exit code is non-zero OR the report file does not exist, set status to Fail immediately — do not poll or wait.
     Do NOT write the verification report yourself — the promptware creates it.
 - name: CheckResult
   prompt: >

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -30,6 +30,14 @@ public class PromptwareRunSettings : CommandSettings
     [CommandOption("--value")]
     [Description("Additional firmware header values (key=value, repeatable)")]
     public string[]? Values { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        if (Args.Length > 0 && !Directory.Exists(Args[0]) && !File.Exists(Args[0]))
+            return Spectre.Console.ValidationResult.Error($"First argument '{Args[0]}' is not a valid path.");
+
+        return Spectre.Console.ValidationResult.Success();
+    }
 }
 
 public class PromptwareRunCommand : Command<PromptwareRunSettings>

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -455,6 +455,8 @@ Check the `## Verification` section in the plan revision for checked items (`- [
 
 **Delegated verifications:** Some verifications are implemented as separate promptwares (e.g., `IvyFrameworkVerification`). A verification is **delegated** if its name matches an entry in the `promptwares` section of `config.yaml`. Delegated verifications MUST be run via `tendril promptware <Name>` — you are FORBIDDEN from writing their report files or setting their status to Pass yourself. If the `tendril` CLI is unavailable and you cannot invoke the sub-promptware, you MUST set the verification to `Fail` with a report explaining the CLI failure. Never self-certify a delegated verification.
 
+**IMPORTANT — delegated invocation syntax:** The `tendril promptware` CLI takes the plan folder as a **positional argument** (NOT a named flag like `--plan-folder`). You MUST also pass `--value` flags for each required firmware value. The exact command is in the verification's `prompt` field in config.yaml — copy it character-for-character, only replacing angle-bracketed placeholders with actual paths. If the command is wrong, the child promptware receives no arguments and silently fails.
+
 For each checked verification:
 
 1. Send a status message: `tendril job status $env:TENDRIL_JOB_ID --message "Verifying: <Name>"`


### PR DESCRIPTION
## Summary

- **config.yaml**: Strengthened IvyFrameworkVerification prompt with explicit warnings about positional argument syntax, a concrete filled-in example, and immediate-fail-on-missing-report instruction (no polling)
- **ExecutePlan/Program.md**: Added guidance clarifying that `tendril promptware` takes plan folder as a positional argument with required `--value` flags
- **PromptwareRunCommand.cs**: Added `Validate()` override to reject invocations where the first argument is not a valid path

## Context

Plan 03683 failed because the ExecutePlan agent used `--plan-folder` (non-existent option) instead of a positional argument, and omitted all `--value` flags. The child IvyFrameworkVerification promptware received an empty firmware header and silently failed with exit code 0.

## Test plan

- [x] `dotnet build` passes (0 errors)
- [x] PromptwareRunCommand tests pass (6/6)