### PR TITLE
[03693] Propagate background service initialization errors during onboarding

### DIFF
--- a/src/Ivy.Tendril/Services/BackgroundServiceActivator.cs
+++ b/src/Ivy.Tendril/Services/BackgroundServiceActivator.cs
@@ -21,6 +21,7 @@ public static class BackgroundServiceActivator
             {
                 logger?.LogError(ex, "Failed to initialize background services");
                 CrashLog.Write($"[{DateTime.UtcNow:O}] BackgroundServiceActivator.StartAsync failed: {ex}");
+                throw; // Re-throw so caller (CompleteStepView) can handle it
             }
         });
     }


### PR DESCRIPTION
# Summary

## Changes

Restored exception propagation in `BackgroundServiceActivator.StartAsync()` by re-adding the `throw;` statement after logging. This ensures initialization failures are propagated to the caller instead of being silently swallowed.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Services/BackgroundServiceActivator.cs** — Added `throw;` statement in catch block at line 24

## Commits

- 64771e4 [03693] Propagate background service initialization errors during onboarding