### PR TITLE
[03695] Investigate and fix missing Tendril application window icon

### DIFF
--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -115,9 +115,9 @@ public class Program
 
         if (useDesktop)
         {
-            var iconResource = OperatingSystem.IsWindows() ? "Ivy.Tendril.Assets.Tendril.ico"
-                : OperatingSystem.IsMacOS() ? "Ivy.Tendril.Assets.Tendril.icns"
-                : "Ivy.Tendril.Assets.Tendril.png";
+            var iconResource = OperatingSystem.IsWindows() ? "Ivy.Tendril.Assets.icon.ico"
+                : OperatingSystem.IsMacOS() ? "Ivy.Tendril.Assets.icon.icns"
+                : "Ivy.Tendril.Assets.icon.png";
 
             var window = new DesktopWindow(server)
                 .Title("Ivy Tendril")


### PR DESCRIPTION
# Summary

## Changes

Updated the application icon resource names in Program.cs to reference the renamed icon files. The icon files were renamed from `Tendril.*` to `icon.*` in a previous commit, but the code still referenced the old filenames, causing the window icon to not display in the title bar and taskbar.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Program.cs** — Updated icon resource name strings to match renamed asset files

## Commits

- 41fa444 [03695] Fix missing application window icon by updating resource names