### PR TITLE
[03696] Restore bulk clear actions menu in Jobs UI

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -238,6 +238,21 @@ public partial class JobsApp
                 }
 
                 return ValueTask.CompletedTask;
-            });
+            })
+            .HeaderRight(_ => Layout.Horizontal().Gap(2)
+                              | jobsProgress
+                              | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
+                                  new MenuItem("Clear Completed", Icon: Icons.Trash, Tag: "ClearCompleted")
+                                      .OnSelect(() =>
+                                      {
+                                          jobService.ClearCompletedJobs();
+                                          refreshToken.Refresh();
+                                      }),
+                                  new MenuItem("Clear Failed", Icon: Icons.Trash, Tag: "ClearFailed").OnSelect(() =>
+                                  {
+                                      jobService.ClearFailedJobs();
+                                      refreshToken.Refresh();
+                                  })
+                              ));
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Restored the header-right menu button in the Jobs UI that provides bulk clear operations. This functionality was mistakenly removed in plan 03682.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/JobsApp.DataTable.cs** — Added `.HeaderRight()` method with dropdown menu for bulk operations

## Commits

- a0a4568 [03696] Restore bulk clear actions menu in Jobs UI