### PR TITLE
[03698] Fix incomplete 'You have .' message in WallpaperApp

### DIFF
--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -82,6 +82,8 @@ public class WallpaperApp : ViewBase
         if (counts.Reviews > 0)
             parts.Add($"{counts.Reviews} {(counts.Reviews == 1 ? "review" : "reviews")} waiting");
 
-        return "You have " + string.Join(", ", parts) + ".";
+        return parts.Count > 0
+            ? "You have " + string.Join(", ", parts) + "."
+            : "No current drafts, jobs or reviews.";
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Fixed the `BuildSummary` method in `WallpaperApp` to return a meaningful fallback message ("No current drafts, jobs or reviews.") when there are no items to display, preventing the incomplete "You have ." message.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/WallpaperApp.cs` — Updated `BuildSummary` to handle empty parts list

---

## Commits

- 9a1be3a [03698] Fix incomplete 'You have .' message in WallpaperApp