### PR TITLE
[00002] Stop filtering out completed jobs on restart

### DIFF
--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -319,11 +319,7 @@ public class JobService : IJobService
         if (_database == null) return;
         try
         {
-            var historicalJobs = _database.GetRecentJobs()
-                .Where(j => j.Status != JobStatus.Completed
-                         && j.Status != JobStatus.Failed
-                         && j.Status != JobStatus.Timeout
-                         && j.Status != JobStatus.Stopped);
+            var historicalJobs = _database.GetRecentJobs();
             foreach (var job in historicalJobs) _jobs.TryAdd(job.Id, job);
         }
         catch


### PR DESCRIPTION
# Summary

## Changes

Removed the status filter from `LoadHistoricalJobs()` in `JobService.cs` to restore all recent jobs from the database on startup, instead of only loading jobs that are not Completed, Failed, Timeout, or Stopped. This preserves job history visibility across application restarts.

## API Changes

**Modified:**
- `JobService.LoadHistoricalJobs()` — Now loads all recent jobs instead of filtering by status

## Files Modified

**Core Services:**
- `src/Ivy.Tendril/Services/JobService.cs` — Removed status filter from LoadHistoricalJobs()

## Commits

- [00002] Stop filtering out completed jobs on restart (bb59b88)