### PR TITLE
[00102] Add 'Add' button to repo section in EditProjectDialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -284,6 +284,8 @@ public class EditProjectDialog(
                                .Width(Size.Grow()));
         }
 
+        reposLayout |= new Button("Add").Icon(Icons.Plus).Outline().OnClick(() => addRepoAction());
+
         // Verifications switches
         var verificationsLayout = Layout.Vertical().Gap(1);
         foreach (var vName in _allVerifications)

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -241,30 +241,30 @@ public class EditProjectDialog(
                                .OnClick(async () =>
                                {
                                    var tcs = new TaskCompletionSource<string[]?>();
-                                       var thread = new Thread(() =>
+                                   var thread = new Thread(() =>
+                                   {
+                                       try
                                        {
-                                           try
-                                           {
-                                               var folders = desktop.ShowSelectFolderDialog("Select Repository Folder");
-                                               tcs.SetResult(folders);
-                                           }
-                                           catch (Exception ex)
-                                           {
-                                               tcs.SetException(ex);
-                                           }
-                                       });
-                                       
-                                       if (OperatingSystem.IsWindows())
-                                       {
-                                           thread.SetApartmentState(ApartmentState.STA);
+                                           var folders = desktop.ShowSelectFolderDialog("Select Repository Folder");
+                                           tcs.SetResult(folders);
                                        }
-                                       thread.Start();
+                                       catch (Exception ex)
+                                       {
+                                           tcs.SetException(ex);
+                                       }
+                                   });
 
-                                       var result = await tcs.Task;
-                                       if (result != null && result.Length > 0)
-                                       {
-                                           newRepoPath.Set(result[0]);
-                                       }
+                                   if (OperatingSystem.IsWindows())
+                                   {
+                                       thread.SetApartmentState(ApartmentState.STA);
+                                   }
+                                   thread.Start();
+
+                                   var result = await tcs.Task;
+                                   if (result != null && result.Length > 0)
+                                   {
+                                       newRepoPath.Set(result[0]);
+                                   }
                                })
                            | newRepoPrRule.ToSelectInput(new List<string> { "default", "yolo" })
                                .Width(Size.Units(20)))


### PR DESCRIPTION
# Summary

## Changes

Added an "Add" button with a Plus icon to the repo section of `EditProjectDialog`. The button appears below the new-repo input fields (path, PR rule, base branch) in both desktop and web environments, allowing users to add multiple repositories one at a time before saving the project.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs** — Added `Button("Add")` that calls the existing `addRepoAction` delegate

## Commits

- `aec39f5` [00102] Add 'Add' button to repo section in EditProjectDialog
- `bad8712` [00102] Apply dotnet format