### PR TITLE
[00103] Per-file diff view with file tree in Changes tab

### DIFF
--- a/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
+++ b/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
@@ -243,6 +243,128 @@ public class PlanContentHelpersTests
         Assert.Null(result);
     }
 
+    [Fact]
+    public void SplitDiffByFile_MultiFileDiff_SplitsCorrectly()
+    {
+        var diff = "diff --git a/src/Foo.cs b/src/Foo.cs\n"
+                   + "index abc1234..def5678 100644\n"
+                   + "--- a/src/Foo.cs\n"
+                   + "+++ b/src/Foo.cs\n"
+                   + "@@ -1,3 +1,4 @@\n"
+                   + " using System;\n"
+                   + "+using System.Linq;\n"
+                   + " namespace Foo;\n"
+                   + "diff --git a/src/Bar.cs b/src/Bar.cs\n"
+                   + "new file mode 100644\n"
+                   + "index 0000000..abc1234\n"
+                   + "--- /dev/null\n"
+                   + "+++ b/src/Bar.cs\n"
+                   + "@@ -0,0 +1,2 @@\n"
+                   + "+namespace Bar;\n"
+                   + "+public class Bar { }\n"
+                   + "diff --git a/src/Baz.cs b/src/Baz.cs\n"
+                   + "deleted file mode 100644\n"
+                   + "index abc1234..0000000\n"
+                   + "--- a/src/Baz.cs\n"
+                   + "+++ /dev/null\n"
+                   + "@@ -1,2 +0,0 @@\n"
+                   + "-namespace Baz;\n"
+                   + "-public class Baz { }\n";
+
+        var files = new List<(string Status, string FilePath)>
+        {
+            ("M", "src/Foo.cs"),
+            ("A", "src/Bar.cs"),
+            ("D", "src/Baz.cs")
+        };
+
+        var changesData = new PlanContentHelpers.AllChangesData(diff, files, 1, 1, 1);
+        var result = PlanContentHelpers.SplitDiffByFile(changesData);
+
+        Assert.Equal(3, result.Count);
+
+        Assert.Equal("src/Foo.cs", result[0].FilePath);
+        Assert.Equal("M", result[0].Status);
+        Assert.Contains("using System.Linq", result[0].Diff);
+
+        Assert.Equal("src/Bar.cs", result[1].FilePath);
+        Assert.Equal("A", result[1].Status);
+        Assert.Contains("namespace Bar", result[1].Diff);
+
+        Assert.Equal("src/Baz.cs", result[2].FilePath);
+        Assert.Equal("D", result[2].Status);
+        Assert.Contains("namespace Baz", result[2].Diff);
+    }
+
+    [Fact]
+    public void SplitDiffByFile_EmptyDiff_ReturnsEmptyList()
+    {
+        var files = new List<(string Status, string FilePath)>();
+        var changesData = new PlanContentHelpers.AllChangesData("", files, 0, 0, 0);
+
+        var result = PlanContentHelpers.SplitDiffByFile(changesData);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void SplitDiffByFile_NullDiff_ReturnsEmptyList()
+    {
+        var files = new List<(string Status, string FilePath)>();
+        var changesData = new PlanContentHelpers.AllChangesData(null, files, 0, 0, 0);
+
+        var result = PlanContentHelpers.SplitDiffByFile(changesData);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void SplitDiffByFile_SingleFileDiff_ReturnsSingleItem()
+    {
+        var diff = "diff --git a/README.md b/README.md\n"
+                   + "index abc1234..def5678 100644\n"
+                   + "--- a/README.md\n"
+                   + "+++ b/README.md\n"
+                   + "@@ -1,2 +1,3 @@\n"
+                   + " # Project\n"
+                   + "+New line added\n";
+
+        var files = new List<(string Status, string FilePath)>
+        {
+            ("M", "README.md")
+        };
+
+        var changesData = new PlanContentHelpers.AllChangesData(diff, files, 0, 1, 0);
+        var result = PlanContentHelpers.SplitDiffByFile(changesData);
+
+        Assert.Single(result);
+        Assert.Equal("README.md", result[0].FilePath);
+        Assert.Equal("M", result[0].Status);
+        Assert.Contains("New line added", result[0].Diff);
+    }
+
+    [Fact]
+    public void SplitDiffByFile_UnknownFileStatus_DefaultsToModified()
+    {
+        var diff = "diff --git a/unknown.txt b/unknown.txt\n"
+                   + "index abc1234..def5678 100644\n"
+                   + "--- a/unknown.txt\n"
+                   + "+++ b/unknown.txt\n"
+                   + "@@ -1 +1 @@\n"
+                   + "-old\n"
+                   + "+new\n";
+
+        // File not in the files list — should default to "M"
+        var files = new List<(string Status, string FilePath)>();
+        var changesData = new PlanContentHelpers.AllChangesData(diff, files, 0, 0, 0);
+
+        var result = PlanContentHelpers.SplitDiffByFile(changesData);
+
+        Assert.Single(result);
+        Assert.Equal("unknown.txt", result[0].FilePath);
+        Assert.Equal("M", result[0].Status);
+    }
+
     private class StubGitService(
         string? commitTitle = null,
         List<(string Status, string FilePath)>? commitFiles = null,

--- a/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Ivy.Tendril.Models;
 using Ivy.Widgets.DiffView;
 
@@ -7,6 +8,42 @@ namespace Ivy.Tendril.Helpers;
 public static class PlanContentHelpers
 {
     public record CommitRow(string Hash, string ShortHash, string Title, int? FileCount);
+
+    public record FileDiff(string FilePath, string Status, string Diff);
+
+    public static List<FileDiff> SplitDiffByFile(AllChangesData changesData)
+    {
+        var result = new List<FileDiff>();
+        if (string.IsNullOrWhiteSpace(changesData.Diff))
+            return result;
+
+        // Split on "diff --git " boundaries
+        var chunks = Regex.Split(changesData.Diff, @"(?=^diff --git )", RegexOptions.Multiline);
+
+        // Build a lookup from file path to status
+        var statusLookup = new Dictionary<string, string>();
+        foreach (var (status, filePath) in changesData.Files)
+        {
+            statusLookup[filePath] = status;
+        }
+
+        foreach (var chunk in chunks)
+        {
+            if (string.IsNullOrWhiteSpace(chunk) || !chunk.StartsWith("diff --git "))
+                continue;
+
+            // Extract file path from "diff --git a/path b/path"
+            var headerMatch = Regex.Match(chunk, @"^diff --git a/(.+?) b/(.+?)$", RegexOptions.Multiline);
+            if (!headerMatch.Success)
+                continue;
+
+            var filePath = headerMatch.Groups[2].Value;
+            var status = statusLookup.GetValueOrDefault(filePath, "M");
+            result.Add(new FileDiff(filePath, status, chunk.TrimEnd()));
+        }
+
+        return result;
+    }
 
     public record CommitDetailData(
         string Title,
@@ -96,7 +133,8 @@ public static class PlanContentHelpers
     }
 
     public static object RenderCommitDetailSheet(CommitDetailData? data, bool loading, string? commitHash,
-        Action closeSheet, Exception? error = null)
+        Action closeSheet, HashSet<string>? expandedFiles = null, Action<string>? onToggleFile = null,
+        Exception? error = null)
     {
         if (commitHash is null) return new Empty();
 
@@ -119,7 +157,44 @@ public static class PlanContentHelpers
         {
             var commitSheetContent = Layout.Vertical().Gap(4).Padding(2);
 
-            if (data.Files is { Count: > 0 })
+            if (!string.IsNullOrWhiteSpace(data.Diff) && data.Files is { Count: > 0 })
+            {
+                // Build AllChangesData to reuse SplitDiffByFile
+                var changesData = new AllChangesData(data.Diff, data.Files, 0, 0, 0);
+                var fileDiffs = SplitDiffByFile(changesData);
+
+                foreach (var fileDiff in fileDiffs)
+                {
+                    var isExpanded = expandedFiles?.Contains(fileDiff.FilePath) ?? false;
+                    var chevronIcon = isExpanded ? Icons.ChevronDown : Icons.ChevronRight;
+                    var (statusIcon, statusColor) = GetFileStatusIconAndColor(fileDiff.Status);
+                    var fileName = Path.GetFileName(fileDiff.FilePath);
+
+                    var header = Layout.Horizontal().Gap(2)
+                        | new Icon(chevronIcon).Small()
+                        | new Icon(statusIcon).Small().Color(statusColor)
+                        | Text.Block(fileName).Bold()
+                        | Text.Muted(fileDiff.FilePath);
+
+                    if (onToggleFile != null)
+                    {
+                        var path = fileDiff.FilePath;
+                        commitSheetContent |= new Box(header)
+                            .BorderThickness(0).Padding(0)
+                            .OnClick(() => onToggleFile(path));
+                    }
+                    else
+                    {
+                        commitSheetContent |= header;
+                    }
+
+                    if (isExpanded)
+                    {
+                        commitSheetContent |= new DiffView().Diff(fileDiff.Diff).Split();
+                    }
+                }
+            }
+            else if (data.Files is { Count: > 0 })
             {
                 var filesLayout = Layout.Vertical().Gap(1);
                 filesLayout |= Text.Block("Changed Files").Bold();
@@ -136,12 +211,12 @@ public static class PlanContentHelpers
                         | Text.Block(filePath);
                 }
                 commitSheetContent |= filesLayout;
-            }
 
-            if (!string.IsNullOrWhiteSpace(data.Diff))
-            {
-                commitSheetContent |= Text.Block("Diff").Bold();
-                commitSheetContent |= new DiffView().Diff(data.Diff).Split();
+                if (!string.IsNullOrWhiteSpace(data.Diff))
+                {
+                    commitSheetContent |= Text.Block("Diff").Bold();
+                    commitSheetContent |= new DiffView().Diff(data.Diff).Split();
+                }
             }
 
             sheetContent = commitSheetContent;
@@ -153,6 +228,13 @@ public static class PlanContentHelpers
             title: $"Commit {shortHash} — {data?.Title ?? ""}"
         ).Width(Size.Half()).Resizable();
     }
+
+    internal static (Icons Icon, Colors Color) GetFileStatusIconAndColor(string status) => status switch
+    {
+        "A" => (Icons.FilePlus, Colors.Success),
+        "D" => (Icons.FileMinus, Colors.Destructive),
+        _ => (Icons.FilePen, Colors.Neutral)
+    };
 
     public record AllChangesData(
         string? Diff,

--- a/src/Ivy.Tendril/Views/Sheets/CommitDetailSheet.cs
+++ b/src/Ivy.Tendril/Views/Sheets/CommitDetailSheet.cs
@@ -13,6 +13,8 @@ public class CommitDetailSheet(
 {
     public override object Build()
     {
+        var expandedFiles = UseState(new HashSet<string>());
+
         var commitQuery = UseQuery<PlanContentHelpers.CommitDetailData?, string>(
             openCommit.Value ?? "",
             async (hash, ct) =>
@@ -43,11 +45,20 @@ public class CommitDetailSheet(
         if (openCommit.Value is not { } commitHash || selectedPlan is null)
             return new Empty();
 
+        void ToggleFile(string path)
+        {
+            var files = new HashSet<string>(expandedFiles.Value);
+            if (!files.Add(path)) files.Remove(path);
+            expandedFiles.Set(files);
+        }
+
         return PlanContentHelpers.RenderCommitDetailSheet(
             commitQuery.Value,
             commitQuery.Loading || commitQuery.Value is null && !string.IsNullOrEmpty(openCommit.Value),
             commitHash,
             () => openCommit.Set(null),
+            expandedFiles.Value,
+            ToggleFile,
             commitQuery.Error);
     }
 }

--- a/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
@@ -12,6 +12,9 @@ public class ChangesTabView(
 
     public override object Build()
     {
+        var expandedFiles = UseState(new HashSet<string>());
+        var selectedFile = UseState<string?>(null);
+
         if (loading)
             return Text.Muted("Loading...");
 
@@ -23,36 +26,82 @@ public class ChangesTabView(
             return Text.Muted(errorMsg);
         }
 
-        var layout = Layout.Vertical().Gap(4).Padding(2);
+        var fileDiffs = PlanContentHelpers.SplitDiffByFile(changesData);
 
+        if (fileDiffs.Count == 0 && changesData.Files.Count == 0)
+            return Text.Muted("No file changes.");
+
+        // Build tree items from file list
+        var treeItems = fileDiffs.Select(fd =>
+        {
+            var fileName = Path.GetFileName(fd.FilePath);
+            var (icon, color) = PlanContentHelpers.GetFileStatusIconAndColor(fd.Status);
+            return new MenuItem(fileName)
+                .Icon(icon)
+                .Color(color)
+                .Tag(fd.FilePath)
+                .Tooltip(fd.FilePath);
+        }).ToArray();
+
+        var tree = new Tree(treeItems)
+            .OnSelect(e =>
+            {
+                var path = e.Value?.ToString();
+                if (path is null) return;
+                selectedFile.Set(path);
+                // Also expand the file when selected from tree
+                if (!expandedFiles.Value.Contains(path))
+                {
+                    var files = new HashSet<string>(expandedFiles.Value) { path };
+                    expandedFiles.Set(files);
+                }
+            });
+
+        // Stats header
         var statsText =
             $"{changesData.Files.Count} files changed ({changesData.AddedCount} added, {changesData.ModifiedCount} modified, {changesData.DeletedCount} deleted)";
-        layout |= Text.Block(statsText).Bold();
 
-        if (changesData.Files.Count > 0)
+        // Build per-file collapsible diff sections
+        var diffsLayout = Layout.Vertical().Gap(2);
+        diffsLayout |= Text.Block(statsText).Bold();
+
+        foreach (var fileDiff in fileDiffs)
         {
-            var filesLayout = Layout.Vertical().Gap(1);
-            foreach (var (status, filePath) in changesData.Files)
-            {
-                var (label, variant) = status switch
+            var isExpanded = expandedFiles.Value.Contains(fileDiff.FilePath);
+            var chevronIcon = isExpanded ? Icons.ChevronDown : Icons.ChevronRight;
+            var (statusIcon, statusColor) = PlanContentHelpers.GetFileStatusIconAndColor(fileDiff.Status);
+            var fileName = Path.GetFileName(fileDiff.FilePath);
+
+            var header = Layout.Horizontal()
+                .Gap(2)
+                | new Icon(chevronIcon).Small()
+                | new Icon(statusIcon).Small().Color(statusColor)
+                | Text.Block(fileName).Bold()
+                | Text.Muted(Path.GetDirectoryName(fileDiff.FilePath)?.Replace('\\', '/') ?? "");
+
+            var path = fileDiff.FilePath;
+            diffsLayout |= new Box(header)
+                .BorderThickness(0).Padding(1)
+                .OnClick(() =>
                 {
-                    "A" => ("Added", BadgeVariant.Success),
-                    "D" => ("Deleted", BadgeVariant.Destructive),
-                    _ => ("Modified", BadgeVariant.Outline)
-                };
-                filesLayout |= Layout.Horizontal().Gap(2)
-                    | new Badge(label).Variant(variant).Small()
-                    | Text.Block(filePath);
+                    var files = new HashSet<string>(expandedFiles.Value);
+                    if (!files.Add(path)) files.Remove(path);
+                    expandedFiles.Set(files);
+                });
+
+            if (isExpanded)
+            {
+                diffsLayout |= new DiffView().Diff(fileDiff.Diff).Split();
             }
-
-            layout |= filesLayout;
         }
 
-        if (!string.IsNullOrWhiteSpace(changesData.Diff))
-        {
-            layout |= new DiffView().Diff(changesData.Diff).Split();
-        }
+        var sidebarContent = Layout.Vertical().Gap(2).Padding(1)
+            | tree;
 
-        return layout;
+        return new SidebarLayout(
+            mainContent: diffsLayout,
+            sidebarContent: sidebarContent,
+            width: Size.Rem(16)
+        ).Resizable();
     }
 }


### PR DESCRIPTION
## Summary

Replaced the monolithic diff view and flat file list in the Changes tab with a sidebar file tree and per-file collapsible diff sections. Added a `SplitDiffByFile` helper that splits unified diffs on `diff --git` boundaries and maps each chunk to its file status. Applied the same per-file collapsible pattern to the commit detail sheet.

## API Changes

- `PlanContentHelpers.FileDiff` — new record: `FileDiff(string FilePath, string Status, string Diff)`
- `PlanContentHelpers.SplitDiffByFile(AllChangesData)` — new static method returning `List<FileDiff>`
- `PlanContentHelpers.GetFileStatusIconAndColor(string status)` — new internal helper returning `(Icons, Colors)`
- `PlanContentHelpers.RenderCommitDetailSheet` — added optional parameters: `HashSet<string>? expandedFiles`, `Action<string>? onToggleFile`

## Files Modified

- **src/Ivy.Tendril/Helpers/PlanContentHelpers.cs** — Added `FileDiff` record, `SplitDiffByFile` method, `GetFileStatusIconAndColor` helper; updated `RenderCommitDetailSheet` for per-file collapsible diffs
- **src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs** — Rewrote to use `SidebarLayout` with `Tree` widget + per-file collapsible diff sections
- **src/Ivy.Tendril/Views/Sheets/CommitDetailSheet.cs** — Added `expandedFiles` state and toggle callback for per-file diffs in commit detail sheet
- **src/Ivy.Tendril.Test/PlanContentHelpersTests.cs** — Added 5 tests for `SplitDiffByFile` (multi-file, empty, null, single-file, unknown status)

## Commits

- `3b2b744` [00103] Add per-file diff view with file tree in Changes tab

---
Source: https://github.com/Ivy-Interactive/Ivy-Tendril/issues/262