### PR TITLE
[00107] Full-width scroll with max-width markdown in plan views

### DIFF
--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -44,7 +44,7 @@ public class ContentView(
                          .Muted("plans", word: true)
             ;
 
-        var scrollableContent = Layout.Vertical().Width(Size.Auto().Max(Size.Units(200)))
+        var scrollableContent = Layout.Vertical().Width(Size.Full().Max(Size.Units(200)))
                                 |
                                 new Markdown(MarkdownHelper.AnnotateAllBrokenLinks(selectedPlan.LatestRevisionContent, planService.PlansDirectory))
                                     .DangerouslyAllowLocalFiles()
@@ -96,7 +96,7 @@ public class ContentView(
                             })
                         );
 
-        var mainContent = Layout.Vertical()
+        var mainContent = Layout.Vertical().Scroll(Scroll.Auto).Width(Size.Full())
                           | scrollableContent;
 
         var mainLayout = new HeaderLayout(

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -287,7 +287,8 @@ public class ContentView(
 
         return new Fragment(elements.ToArray());
 
-        object Cap(object inner) => Layout.Vertical().Width(Size.Auto().Max(Size.Units(200))).Height(Size.Full()) | inner;
+        object Cap(object inner) => Layout.Vertical().Scroll(Scroll.Auto).Width(Size.Full()).Height(Size.Full())
+            | (Layout.Vertical().Width(Size.Full().Max(Size.Units(200))) | inner);
     }
 
     internal static object BuildFailureCallout(PlanFile plan)

--- a/src/Ivy.Tendril/Apps/Plans/PlanTabView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/PlanTabView.cs
@@ -23,7 +23,7 @@ public class PlanTabView(
         }
         else
         {
-            var planLayout = Layout.Vertical().Scroll(Scroll.Auto).Height(Size.Full());
+            var planLayout = Layout.Vertical().Height(Size.Full());
             if (selectedPlan.Status == PlanStatus.Failed)
                 planLayout |= ContentView.BuildFailureCallout(selectedPlan);
 

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -334,7 +334,7 @@ public class ContentView(
         }
 
         var reviewAnnotated = MarkdownHelper.AnnotateAllBrokenLinks(selectedPlan.LatestRevisionContent, planService.PlansDirectory);
-        var planTabContent = Layout.Vertical().Scroll(Scroll.Vertical).Height(Size.Full())
+        var planTabContent = Layout.Vertical().Height(Size.Full())
             | new Markdown(reviewAnnotated)
                 .DangerouslyAllowLocalFiles()
                 .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile, planId =>
@@ -502,7 +502,8 @@ public class ContentView(
 
         object Cap(object inner)
         {
-            return Layout.Vertical().Width(Size.Auto().Max(Size.Units(200))).Height(Size.Full()) | inner;
+            return Layout.Vertical().Scroll(Scroll.Auto).Width(Size.Full()).Height(Size.Full())
+                | (Layout.Vertical().Width(Size.Full().Max(Size.Units(200))) | inner);
         }
     }
 

--- a/src/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/Ivy.Tendril/Apps/TrashApp.cs
@@ -92,16 +92,18 @@ public class TrashApp : ViewBase
                             });
 
             var annotatedContent = MarkdownHelper.AnnotateAllBrokenLinks(selected.Content, planService.PlansDirectory);
-            var scrollableContent = Layout.Vertical().Width(Size.Auto().Max(Size.Units(200)))
+            var scrollableContent = Layout.Vertical().Width(Size.Full().Max(Size.Units(200)))
                                     | new Markdown(annotatedContent)
                                         .DangerouslyAllowLocalFiles()
                                         .OnLinkClick(FileLinkHelper.CreateFileLinkClickHandler(openFile));
 
+            var scrollWrapper = Layout.Vertical().Scroll(Scroll.Auto).Width(Size.Full())
+                                | scrollableContent;
             mainContent = new HeaderLayout(
                 header,
                 new FooterLayout(
                     actionBar,
-                    scrollableContent
+                    scrollWrapper
                 ).Size(Size.Full())
             ).Scroll(Scroll.None).Size(Size.Full());
         }


### PR DESCRIPTION
# Summary

## Changes

Restructured the layout pattern across Plans, Review, Icebox, and Trash views so that the scrollable container is full-width (scrollbar at viewport edge) while the markdown content area remains constrained to a max-width of 200 units. Removed redundant inner scroll containers from PlanTabView and Review's planTabContent that are now handled by the outer Cap/scroll wrapper.

## Files Modified

- **Apps/Plans/ContentView.cs** — Updated `Cap()` to use full-width scroll outer with max-width inner content
- **Apps/Plans/PlanTabView.cs** — Removed `.Scroll(Scroll.Auto)` from planLayout
- **Apps/Review/ContentView.cs** — Updated `Cap()` same pattern; removed `.Scroll(Scroll.Vertical)` from planTabContent
- **Apps/Icebox/ContentView.cs** — Changed scrollableContent width to `Size.Full().Max(...)` and added scroll wrapper to mainContent
- **Apps/TrashApp.cs** — Changed scrollableContent width to `Size.Full().Max(...)` and added scrollWrapper

## Commits

- 4272f8f [00107] Full-width scroll with max-width markdown in plan views