### PR TITLE
Fix link in docs

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/01_Introduction.md
+++ b/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/01_Introduction.md
@@ -43,7 +43,7 @@ Plans flow through the following pipeline:
 
 At [Ivy Interactive](https://ivy.app), we experimented with many different systems of architecture in order to improve our workflow and take advantage of the advancements in AI/agentic coding capabilities. Working with the incredible capabilities of Claude and others was great, but it quickly became messy managing a dozen terminal windows.
 
-Therefore, we created this system to streamline the experience of working with different agents. Through the [Promptware](/concepts/promptwares) architecture, we have created a feedback loop that ensures agents are not only organized and structured, but also self-improving according to the needs and context of the projects they work with. By centering the entire process on a **Plan**, you maintain the "Source of Truth" while specialized agents handle the heavy lifting.
+Therefore, we created this system to streamline the experience of working with different agents. Through the [Promptware](../Concepts/Promptwares) architecture, we have created a feedback loop that ensures agents are not only organized and structured, but also self-improving according to the needs and context of the projects they work with. By centering the entire process on a **Plan**, you maintain the "Source of Truth" while specialized agents handle the heavy lifting.
 
 <Callout type="tip">
 We LOVE hearing from you! You are always welcome to report issues, bugs, and suggestions on our **[GitHub repository](https://github.com/Ivy-Interactive/Ivy-Tendril)**.  If you need direct help or would like to connect with the community, please join us on **[Discord](https://discord.gg/FHgxkDga3y)** — we'd love to see you there!


### PR DESCRIPTION
Fixes this error:

```
Ivy.Tendril.Docs net10.0 failed with 1 error(s) (1.1s)
    /Users/zachwolfe/Code/ivy-root/Ivy-Tendril/src/Ivy.Tendril.Docs/Generated/GettingStarted/Introduction.g.cs(58,43): error CS0234: The type or namespace name 'concepts' does not exist in the namespace 'Ivy.Tendril.Docs.Apps.GettingStarted' (are you missing an assembly reference?)
```