### PR TITLE
[00111] Fix Update Available toast spacing and position

### DIFF
--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -51,7 +51,7 @@ public class WallpaperApp : ViewBase
             var updateCommand = "dotnet tool update -g Ivy.Tendril";
             var notification = new FloatingPanel(
                 new Card(
-                    Layout.Vertical().Gap(2)
+                    Layout.Vertical().Gap(4)
                     | Text.Rich()
                         .Bold($"v{versionInfo.Value.LatestVersion}")
                         .Run($" is available (you have v{versionInfo.Value.CurrentVersion})")
@@ -66,7 +66,7 @@ public class WallpaperApp : ViewBase
                             .Small())
                 ).Header("Update Available", null, Icons.CircleArrowUp),
                 Align.BottomRight
-            ).Offset(new Thickness(0, 0, 20, 20));
+            ).Offset(new Thickness(0, 0, 8, 8));
 
             elements.Add(notification);
         }


### PR DESCRIPTION
## Summary

Increased the vertical gap between the version text and action buttons in the "Update Available" floating toast from `Gap(2)` to `Gap(4)`, and reduced the corner offset from `Thickness(0, 0, 20, 20)` to `Thickness(0, 0, 8, 8)` to position the toast closer to the bottom-right corner.

## Files Modified

- **src/Ivy.Tendril/Apps/WallpaperApp.cs** — Updated `FloatingPanel` layout gap and offset values

## Commits

- 94ed493 [00111] Fix Update Available toast spacing and position