### PR TITLE
[00115] Fix job output rendered twice when job completes

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
@@ -32,8 +32,20 @@ public class OutputSheet(
                     .Height(Size.Full());
             }
         }
+        else if (job is not null && hasStreamContent.Value)
+        {
+            // Job finished while user was watching the stream — keep using stream renderer
+            // (switching to JsonStream would duplicate content since streamedLines persists in React state)
+            outputContent = new ClaudeJsonRenderer()
+                .Stream(outputStream)
+                .ShowThinking(false)
+                .ShowSystemEvents(false)
+                .AutoScroll(false)
+                .Height(Size.Full());
+        }
         else if (job is not null && job.OutputLines.Count > 0)
         {
+            // Job completed before user opened sheet — load from stored output
             var jsonStream = string.Join("\n", job.OutputLines);
             outputContent = new ClaudeJsonRenderer()
                 .JsonStream(jsonStream)


### PR DESCRIPTION
## Summary

Fixed the job output being rendered twice when a job transitions from Running to Completed. Added a new branch in `OutputSheet.Build()` that detects when the user was already watching the live stream and keeps using the stream-based renderer instead of switching to `JsonStream`, which prevented the React `ClaudeJsonRenderer` component from combining both data sources.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs** — Added intermediate branch for `hasStreamContent.Value` when job is no longer Running, keeping the stream renderer active with `AutoScroll(false)`

## Commits

- de6716b [00115] Fix job output rendered twice when job completes

Closes #384