### PR TITLE
[00120] Fix ExecutePlan jobs showing truncated prompt instead of full text

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -125,7 +125,7 @@ public partial class JobsApp
                         var job = jobs.FirstOrDefault(j => j.Id == id);
                         if (job != null)
                         {
-                            var fullPrompt = GetFullPrompt(job);
+                            var fullPrompt = GetFullPrompt(job, planService);
                             if (!string.IsNullOrEmpty(fullPrompt))
                                 showPrompt.Set(fullPrompt);
                         }
@@ -186,7 +186,7 @@ public partial class JobsApp
                     }
                     else if (tag == "show-prompt")
                     {
-                        var fullPrompt = GetFullPrompt(job);
+                        var fullPrompt = GetFullPrompt(job, planService);
                         if (!string.IsNullOrEmpty(fullPrompt))
                             showPrompt.Set(fullPrompt);
                     }

--- a/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
@@ -8,13 +8,26 @@ public partial class JobsApp
 {
     private const int PromptDisplayMaxLength = 500;
 
-    private static string? GetFullPrompt(JobItem job)
+    private static string? GetFullPrompt(JobItem job, IPlanReaderService? planService = null)
     {
         if (job.Type == "CreatePlan")
         {
             for (var i = 0; i < job.Args.Length - 1; i++)
                 if (job.Args[i].Equals("-Description", StringComparison.OrdinalIgnoreCase))
                     return job.Args[i + 1];
+        }
+
+        if (planService != null && !string.IsNullOrEmpty(job.PlanFile))
+        {
+            var fullPath = Path.Combine(planService.PlansDirectory, job.PlanFile);
+            var plan = planService.GetPlanByFolder(fullPath);
+            if (plan != null)
+            {
+                if (!string.IsNullOrEmpty(plan.InitialPrompt))
+                    return plan.InitialPrompt;
+                if (!string.IsNullOrEmpty(plan.Title))
+                    return plan.Title;
+            }
         }
 
         return job.PlanFile;
@@ -86,8 +99,8 @@ public partial class JobsApp
         if (j.Type == "CreatePlan")
             return TruncatePrompt(GetFullPrompt(j) ?? j.PlanFile);
 
-        // Fallback to plan file
-        return TruncatePrompt(j.PlanFile);
+        // Fallback to full prompt (resolves InitialPrompt/Title from plan.yaml) or plan file
+        return TruncatePrompt(GetFullPrompt(j, planService) ?? j.PlanFile);
     }
 
     private static bool TryGetPlanTitle(string? planFile, IPlanReaderService planService, out string title)


### PR DESCRIPTION
## Summary

Updated `GetFullPrompt()` in `JobsApp.Helpers.cs` to resolve the full `InitialPrompt` text from `plan.yaml` for non-CreatePlan job types (ExecutePlan, ExpandPlan, etc.), instead of returning the truncated plan folder name. Also updated the `GetPromptDisplay()` fallback and both "Show Prompt" call sites in `JobsApp.DataTable.cs` to pass the `IPlanReaderService` dependency.

## API Changes

None. Internal static helper methods only — no public API surface changed.

## Files Modified

- **src/Ivy.Tendril/Apps/JobsApp.Helpers.cs** — Added `IPlanReaderService?` parameter to `GetFullPrompt()`, added InitialPrompt/Title lookup logic, updated `GetPromptDisplay()` fallback
- **src/Ivy.Tendril/Apps/JobsApp.DataTable.cs** — Updated two `GetFullPrompt()` call sites (cell click and row action handlers) to pass `planService`

## Commits

- 27d4518 [00120] Fix ExecutePlan jobs showing truncated prompt instead of full text

Closes https://github.com/Ivy-Interactive/Ivy-Tendril/issues/406