### PR TITLE
[00121] Disable filter on DataTable in JobsApp

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -71,12 +71,10 @@ public partial class JobsApp
             .Hidden(t => t.LastOutputTimestamp)
             .Hidden(t => t.ErrorContext)
             .SortDirection(t => t.Id, SortDirection.Descending)
-            .Filterable(t => t.Timer, false)
-            .Filterable(t => t.LastOutput, false)
             .Config(c =>
             {
                 c.AllowSorting = true;
-                c.AllowFiltering = true;
+                c.AllowFiltering = false;
                 c.ShowSearch = false;
                 c.SelectionMode = SelectionModes.None;
                 c.ShowIndexColumn = false;


### PR DESCRIPTION
## Changes

Disabled filtering on the DataTable widget in JobsApp by setting `AllowFiltering = false` in the config and removing the per-column `.Filterable()` calls for Timer and LastOutput columns that were no longer needed.

## Files Modified

- **src/Ivy.Tendril/Apps/JobsApp.DataTable.cs** — Changed `AllowFiltering` from `true` to `false`, removed two `.Filterable()` calls

## Commits

- e73b9c1