### PR TITLE
[00122] Review UI: Remove centered text alignment from recommendations

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -423,7 +423,7 @@ public class ContentView(
             else
                 foreach (var rec in planData.Recommendations)
                 {
-                    var titleRow = Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                    var titleRow = Layout.Horizontal().Gap(2).AlignContent(Align.Left)
                                    | Text.Block(rec.Title).Bold();
 
                     if (rec.Impact is { } impact)


### PR DESCRIPTION
## Changes

Changed the recommendation title row alignment in the Review UI from `Align.Center` to `Align.Left` in `ContentView.cs`. This fixes the visually incorrect centered text alignment on recommendation titles, badges, and descriptions.

## Files Modified

- **src/Ivy.Tendril/Apps/Review/ContentView.cs** — Changed `AlignContent(Align.Center)` to `AlignContent(Align.Left)` on the recommendation title row layout (line 426)

## Commits

- ee0e538 — Change recommendation title row alignment from Center to Left

Resolves https://github.com/Ivy-Interactive/Ivy-Tendril/issues/410