### PR TITLE
Add crash.log to TeamIvyConfig .gitignore

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/.gitignore
+++ b/src/Ivy.Tendril.TeamIvyConfig/.gitignore
@@ -6,3 +6,4 @@ Trash/
 *.db
 *.db-shm
 *.db-wal
+crash.log


### PR DESCRIPTION
## Summary
- Add `crash.log` to `src/Ivy.Tendril.TeamIvyConfig/.gitignore` to prevent it from being tracked

## Test plan
- [x] Verify `crash.log` is listed in the `.gitignore` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)