### PR TITLE
[00020] Fix Jobs table sorting to show newest jobs first

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Data.cs
@@ -43,8 +43,15 @@ public partial class JobsApp
                     : null
             };
         })
-            .OrderByDescending(r => r.Id)
+            .OrderByDescending(r => ExtractJobNumber(r.Id))
             .ToList();
+    }
+
+    private static int ExtractJobNumber(string jobId)
+    {
+        if (string.IsNullOrEmpty(jobId)) return 0;
+        var parts = jobId.Split('-');
+        return parts.Length > 1 && int.TryParse(parts[^1], out var num) ? num : 0;
     }
 
     private StackedProgress BuildStatusProgress(List<JobItem> jobs, IConfigService config)


### PR DESCRIPTION
# Summary

## Changes

Fixed the Jobs table sorting to show the newest jobs first by extracting the numeric portion of job IDs and sorting numerically instead of lexicographically. Added a helper method `ExtractJobNumber` that parses the numeric suffix from job IDs like "job-042" to enable proper descending order.

## API Changes

- **Private method added**: `ExtractJobNumber(string jobId)` in `JobsApp` partial class - extracts the numeric suffix from job IDs for sorting purposes.

## Files Modified

- **src/Ivy.Tendril/Apps/JobsApp.Data.cs** - Modified `BuildJobRows` method to use numeric sorting via `ExtractJobNumber` helper method.

## Commits

- 5cfa087