### PR TITLE
[00125] Scroll to file in diff tree on click

### DIFF
--- a/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
@@ -72,6 +72,7 @@ public class ChangesTabView(
 
             var path = fileDiff.FilePath;
             diffsLayout |= new Box(header)
+                .TestId(fileDiff.FilePath)
                 .BorderThickness(0).Padding(1)
                 .Hover(HoverEffect.Pointer)
                 .OnClick(() =>
@@ -86,6 +87,8 @@ public class ChangesTabView(
                 diffsLayout |= new DiffView().Diff(fileDiff.Diff).Split().Width(Size.Full());
             }
         }
+
+        diffsLayout.ScrollTarget(selectedFile.Value);
 
         var sidebarContent = Layout.Vertical().Gap(2).Padding(1)
             | tree;


### PR DESCRIPTION
## Summary

Added a `ScrollTarget` prop to the Ivy Framework's `StackLayout` widget that triggers a smooth scroll to a child element matching a `data-testid` value. Used this new prop in Tendril's `ChangesTabView` so that clicking a file in the diff tree sidebar scrolls the main content area to that file's diff section.

## API Changes

- `StackLayout` (record): Added `[Prop] public string? ScrollTarget { get; set; }`
- `LayoutView` (builder): Added `LayoutView ScrollTarget(string? target)` method
- `StackLayoutWidget` (React): Added `scrollTarget?: string | null` prop with `useEffect` scroll behavior

## Files Modified

**Ivy-Tendril:**
- `src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs` — Added `TestId` on file header boxes and `ScrollTarget` on diffs layout

## Commits

- `022839c` [00125] Wire ScrollTarget into ChangesTabView for scroll-on-click

Closes #421