### PR TITLE
[00022] Integrate Console.Error.WriteLine with ILogger system

### DIFF
--- a/src/Ivy.Tendril/Commands/PlanGetCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanGetCommand.cs
@@ -2,6 +2,7 @@ using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
+using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -19,6 +20,13 @@ public class PlanGetSettings : CommandSettings
 
 public class PlanGetCommand : Command<PlanGetSettings>
 {
+    private readonly ILogger<PlanGetCommand> _logger;
+
+    public PlanGetCommand(ILogger<PlanGetCommand> logger)
+    {
+        _logger = logger;
+    }
+
     protected override int Execute(CommandContext context, PlanGetSettings settings, CancellationToken cancellationToken)
     {
         try
@@ -86,6 +94,7 @@ public class PlanGetCommand : Command<PlanGetSettings>
         }
         catch (Exception ex)
         {
+            _logger.LogError(ex, "Failed to get plan {PlanId}", settings.PlanId);
             Console.Error.WriteLine($"Error: {ex.Message}");
             return 1;
         }

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -192,6 +192,7 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
             while (!process.StandardError.EndOfStream)
             {
                 var line = process.StandardError.ReadLine();
+                // Passthrough stderr from child process — not logged to avoid polluting parent logs
                 if (line != null) Console.Error.WriteLine(line);
             }
         }, cancellationToken);

--- a/src/Ivy.Tendril/Helpers/FileHelper.cs
+++ b/src/Ivy.Tendril/Helpers/FileHelper.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Helpers;
 
@@ -278,7 +279,7 @@ internal static class FileHelper
     ///     (e.g. Tendril running as Administrator) and the current non-elevated user
     ///     only has read access via BUILTIN\Users.
     /// </summary>
-    private static void TryGrantCurrentUserAccess(string path)
+    private static void TryGrantCurrentUserAccess(string path, ILogger? logger = null)
     {
         if (!OperatingSystem.IsWindows()) return;
         try
@@ -310,7 +311,11 @@ internal static class FileHelper
         {
             // Best-effort: if we can't fix the ACL (e.g. not owner), the caller will
             // get the original UnauthorizedAccessException on the next retry.
-            Console.Error.WriteLine($"Failed to grant access to {path}: {ex.Message}");
+            var message = $"Failed to grant access to {path}: {ex.Message}";
+            if (logger != null)
+                logger.LogWarning(ex, "Failed to grant access to {Path}", path);
+            else
+                Console.Error.WriteLine(message);
         }
     }
 }

--- a/src/Ivy.Tendril/Mcp/TendrilMcpServer.cs
+++ b/src/Ivy.Tendril/Mcp/TendrilMcpServer.cs
@@ -45,8 +45,8 @@ public class TendrilMcpServer
         }
         catch (Exception ex)
         {
-            // Logger may not be available if host build itself failed; fall back is acceptable
-            Console.Error.WriteLine($"MCP server error: {ex.Message}");
+            // Logger unavailable when host build fails; use stderr fallback
+            Console.Error.WriteLine($"MCP server error: {ex}");
             return 1;
         }
     }


### PR DESCRIPTION
# Summary

## Changes

Integrated Console.Error.WriteLine calls with the application's ILogger system to improve log routing, filtering, and observability. Added structured logging where dependency injection is available while maintaining Console.Error fallbacks for bootstrap scenarios.

## API Changes

- `FileHelper.TryGrantCurrentUserAccess(string path, ILogger? logger = null)` — Added optional ILogger parameter (breaking change at signature level, but backward compatible due to optional parameter)
- `PlanGetCommand` constructor — Now requires `ILogger<PlanGetCommand>` via dependency injection

## Files Modified

**Commands:**
- `src/Ivy.Tendril/Commands/PlanGetCommand.cs` — Added ILogger injection and structured error logging
- `src/Ivy.Tendril/Commands/PromptwareRunCommand.cs` — Added clarifying comment for stderr passthrough

**Helpers:**
- `src/Ivy.Tendril/Helpers/FileHelper.cs` — Enhanced TryGrantCurrentUserAccess with optional ILogger parameter

**MCP:**
- `src/Ivy.Tendril/Mcp/TendrilMcpServer.cs` — Improved error message to include full exception stack trace

## Commits

- 0c16efa [00022] Integrate Console.Error.WriteLine with ILogger system