### PR TITLE
[00012] Post PRs in draft mode

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -32,6 +32,7 @@ public class CustomPrDialog(
         var customPrIncludeArtifacts = UseState(false);
         var customPrAssignee = UseState<string?>(null);
         var customPrComment = UseState("");
+        var customPrDraft = UseState(false);
 
         UseEffect(() =>
         {
@@ -49,6 +50,7 @@ public class CustomPrDialog(
                 customPrIncludeArtifacts.Set(true);
                 customPrAssignee.Set(null);
                 customPrComment.Set("");
+                customPrDraft.Set(false);
                 _dialogOpen.Set(false);
             },
             new DialogHeader($"Custom PR for #{_selectedPlan.Id}"),
@@ -58,6 +60,7 @@ public class CustomPrDialog(
                 | customPrDeleteBranch.ToBoolInput("Delete Branch")
                     .Disabled(!customPrMerge.Value)
                 | customPrIncludeArtifacts.ToBoolInput("Include Artifacts")
+                | customPrDraft.ToBoolInput("Create as Draft")
                 | customPrAssignee.ToSelectInput((_assigneesQuery.Value ?? Array.Empty<string>()).ToOptions())
                     .Nullable().WithField().Label("Assignee")
                 | (_assigneesError.Value is { } err
@@ -74,6 +77,7 @@ public class CustomPrDialog(
                     customPrIncludeArtifacts.Set(true);
                     customPrAssignee.Set(null);
                     customPrComment.Set("");
+                    customPrDraft.Set(false);
                     _dialogOpen.Set(false);
                 }),
                 new Button("Create PR").Primary().Disabled(isCreating.Value).ShortcutKey("Ctrl+Enter").OnClick(() =>
@@ -87,7 +91,8 @@ public class CustomPrDialog(
                             ["deleteBranch"] = customPrDeleteBranch.Value && customPrMerge.Value,
                             ["includeArtifacts"] = customPrIncludeArtifacts.Value,
                             ["assignee"] = customPrAssignee.Value ?? "",
-                            ["comment"] = customPrComment.Value
+                            ["comment"] = customPrComment.Value,
+                            ["draft"] = customPrDraft.Value
                         };
                         var serializer = new SerializerBuilder()
                             .WithNamingConvention(CamelCaseNamingConvention.Instance)
@@ -103,6 +108,7 @@ public class CustomPrDialog(
                         customPrIncludeArtifacts.Set(true);
                         customPrAssignee.Set(null);
                         customPrComment.Set("");
+                        customPrDraft.Set(false);
                         _dialogOpen.Set(false);
                     }
                 }).WithConfetti(AnimationTrigger.Click)

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -40,6 +40,7 @@ Before processing, read `plan.yaml` and check the `state` field. After reading, 
   includeArtifacts: true/false
   assignee: "username"
   comment: "Review comment text"
+  draft: true/false
   ```
   These flags override the default behavior in subsequent steps. If the file does not exist, all flags default to the behavior defined by the repo's `prRule`. **Delete the file after reading** so it doesn't affect future runs.
 
@@ -75,7 +76,7 @@ Capture the returned markdown. If non-empty, it will be appended to the PR body 
 For each pushed branch:
 
 ```bash
-gh pr create --repo <owner/repo> --base <default-branch> --head <branch> --title "<title>" --body "$(cat <<'EOF'
+gh pr create [--draft] --repo <owner/repo> --base <default-branch> --head <branch> --title "<title>" --body "$(cat <<'EOF'
 <body content>
 EOF
 )"
@@ -88,6 +89,7 @@ EOF
   4. Otherwise, auto-detect via: `gh repo view <owner/repo> --json defaultBranchRef -q .defaultBranchRef.name`
 - **Title:** `[<planId>] <plan title>`
 - **Body:** If `<PlanFolder>/artifacts/summary.md` exists, use its content as the PR body (followed by list of commits). Otherwise, fall back to summary from Problem + Solution sections. If `$artifactMarkdown` from step 2.5 is non-empty, append it under an `## Artifacts` heading after the commits list.
+- **Draft (custom options):** If custom options exist and `draft` is `true`, add `--draft` to the `gh pr create` command to create the PR in draft mode. If no custom options or `draft` is `false`, create as ready for review (default behavior).
 - **Assignee (custom options):** If custom options exist and `assignee` is non-empty, add `--assignee <assignee>` to the `gh pr create` command.
 
 ### 3.5. Add PR Comment (custom options)


### PR DESCRIPTION
# Summary

## Changes

Added a "Create as Draft" option to the Custom PR dialog in the Review app. When enabled, PRs are created in draft mode, allowing human review before marking them ready. The CreatePr promptware now supports the `--draft` flag conditionally based on the custom options YAML.

## API Changes

**CustomPrDialog.cs:**
- Added `customPrDraft` state variable (boolean)
- Added "Create as Draft" checkbox to dialog body
- Added `["draft"]` entry to custom PR options dictionary

**CreatePr/Program.md:**
- Updated custom options schema to include `draft: true/false`
- Updated `gh pr create` command to conditionally include `--draft` flag
- Added documentation for draft behavior (defaults to `false`)

## Files Modified

**UI Changes:**
- `src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs` — Added draft checkbox and state management

**Documentation:**
- `src/Ivy.Tendril/Promptwares/CreatePr/Program.md` — Added draft flag to custom options schema and command template

## Commits

- 9af44a8bf44cfc86597894605f38fb185bb04b20 — [00012] Add draft mode option to PR creation