### PR TITLE
[00019] Fix yolo mode detection in Create PR button

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1507,4 +1507,57 @@ maxConcurrentJobs: 10
             Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void GetRepoRef_WithTrailingSlash_ShouldMatch()
+    {
+        var project = new ProjectConfig
+        {
+            Repos = new List<RepoRef>
+            {
+                new RepoRef { Path = @"D:\Repos\MyRepo", PrRule = "yolo" }
+            }
+        };
+
+        var result = project.GetRepoRef(@"D:\Repos\MyRepo\");
+        Assert.NotNull(result);
+        Assert.Equal("yolo", result.PrRule);
+    }
+
+    [Fact]
+    public void GetRepoRef_WithMixedSlashes_ShouldMatch()
+    {
+        var project = new ProjectConfig
+        {
+            Repos = new List<RepoRef>
+            {
+                new RepoRef { Path = @"D:\Repos\MyRepo", PrRule = "yolo" }
+            }
+        };
+
+        var result = project.GetRepoRef(@"D:/Repos/MyRepo");
+        Assert.NotNull(result);
+        Assert.Equal("yolo", result.PrRule);
+    }
+
+    [Fact]
+    public void GetRepoRef_WithRelativePath_ShouldMatch()
+    {
+        // Arrange: create a RepoRef with absolute path
+        var absolutePath = Path.Combine(Directory.GetCurrentDirectory(), "TestRepo");
+        var project = new ProjectConfig
+        {
+            Repos = new List<RepoRef>
+            {
+                new RepoRef { Path = absolutePath, PrRule = "yolo" }
+            }
+        };
+
+        // Act: query with relative path
+        var result = project.GetRepoRef("TestRepo");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("yolo", result.PrRule);
+    }
 }

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -41,9 +41,34 @@ public record ProjectConfig
         return Meta.TryGetValue(key, out var v) ? v?.ToString() : null;
     }
 
+    /// <summary>
+    /// Finds a repository reference by path.
+    /// Normalizes paths before comparison to handle trailing slashes, mixed separators, and relative paths.
+    /// </summary>
+    /// <param name="path">The repository path to find.</param>
+    /// <returns>The matching RepoRef, or null if not found.</returns>
     public RepoRef? GetRepoRef(string path)
     {
-        return Repos.FirstOrDefault(r => r.Path.Equals(path, StringComparison.OrdinalIgnoreCase));
+        var normalizedPath = NormalizePath(path);
+        return Repos.FirstOrDefault(r =>
+            NormalizePath(r.Path).Equals(normalizedPath, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizePath(string path)
+    {
+        if (string.IsNullOrEmpty(path)) return path;
+
+        try
+        {
+            // Get full path and remove trailing directory separators
+            var normalized = Path.GetFullPath(path);
+            return normalized.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+        catch
+        {
+            // If Path.GetFullPath fails (e.g., invalid path), return original with trimmed separators
+            return path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
     }
 }
 


### PR DESCRIPTION
# Summary

## Changes

Fixed the "Create PR" button yolo mode detection by normalizing repository paths before comparison. The bug occurred when path formats differed (trailing slashes, mixed separators, or relative vs absolute paths), causing the dialog to show even when all repos had `prRule: yolo`.

## API Changes

**Modified methods:**
- `ProjectConfig.GetRepoRef(string path)` — Now normalizes paths before comparison and includes XML documentation
  
**New private methods:**
- `ProjectConfig.NormalizePath(string path)` — Normalizes paths by resolving to full path and trimming directory separators

## Files Modified

**Implementation:**
- `src/Ivy.Tendril/Services/ConfigService.cs` — Added path normalization logic to `GetRepoRef` method

**Tests:**
- `src/Ivy.Tendril.Test/ConfigServiceTests.cs` — Added three unit tests for path normalization scenarios (trailing slash, mixed slashes, relative paths)

## Commits

- 4f82d54 [00019] Fix yolo mode detection by normalizing paths in GetRepoRef