### PR TITLE
[00006] Clarify config file naming - config.yaml vs tendril-config.yaml

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
+++ b/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
@@ -53,6 +53,8 @@ On macOS/Linux, if you've never used .NET tools before, you may need to add the 
 tendril
 ```
 
+The first time you run Tendril, you'll be guided through an onboarding wizard. During setup, Tendril will create a configuration file at `$TENDRIL_HOME/config.yaml` (default: `~/.tendril/config.yaml`).
+
 ## Update
 
 You can update Ivy Tendril at anytime after the initial install using the dotnet tool update command:

--- a/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/05_Troubleshooting.md
+++ b/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/05_Troubleshooting.md
@@ -21,6 +21,7 @@ Common issues and how to fix them. If you're still stuck, run <code>tendril doct
 | Symptom | Fix |
 |---------|-----|
 | `TENDRIL_HOME` not found | Set the environment variable and restart your terminal |
+| `config.yaml` not found | Ensure the file exists at `$TENDRIL_HOME/config.yaml` (default: `~/.tendril/config.yaml`). The filename must be `config.yaml`, not `tendril-config.yaml`. Run `tendril doctor` to see the expected path. |
 | `gh` not authenticated | Run `gh auth login` |
 | `pwsh` not found | Install [PowerShell 7](https://github.com/PowerShell/PowerShell) — required on all platforms |
 | `git` not found | Install Git and ensure it's on your `PATH` |

--- a/src/Ivy.Tendril.Docs/Docs/03_Configuration/01_Setup.md
+++ b/src/Ivy.Tendril.Docs/Docs/03_Configuration/01_Setup.md
@@ -27,7 +27,9 @@ From Tendril, open setup without hand-editing YAML. Sections include:
 
 ## `config.yaml`
 
-Same data lives in `TENDRIL_HOME/config.yaml`. Changes in the UI write here immediately.
+Same data lives in `$TENDRIL_HOME/config.yaml` (default: `~/.tendril/config.yaml`). Changes in the UI write here immediately.
+
+**Note:** The configuration file must be named `config.yaml` (not `tendril-config.yaml`). The `TENDRIL_CONFIG` environment variable points to this file's full path.
 
 ### Example
 

--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Test;
 
@@ -1505,6 +1506,71 @@ maxConcurrentJobs: 10
         finally
         {
             Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void LoadConfig_WhenFileNotFound_LogsExpectedPath()
+    {
+        var tempDir = _tempDir.Path;
+        var configPath = Path.Combine(tempDir, "config.yaml");
+
+        // Ensure no config file exists
+        if (File.Exists(configPath))
+            File.Delete(configPath);
+
+        var logMessages = new List<string>();
+        var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddProvider(new TestLoggerProvider((level, message) =>
+            {
+                if (level == LogLevel.Warning)
+                    logMessages.Add(message);
+            }));
+        });
+        var logger = loggerFactory.CreateLogger<ConfigService>();
+
+        var service = new ConfigService(logger, tempDir);
+
+        Assert.Contains(logMessages, msg =>
+            msg.Contains("Configuration file not found") &&
+            msg.Contains(configPath) &&
+            msg.Contains("config.yaml"));
+    }
+
+    private class TestLoggerProvider : ILoggerProvider
+    {
+        private readonly Action<LogLevel, string> _logAction;
+
+        public TestLoggerProvider(Action<LogLevel, string> logAction)
+        {
+            _logAction = logAction;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new TestLogger(_logAction);
+        }
+
+        public void Dispose() { }
+    }
+
+    private class TestLogger : ILogger
+    {
+        private readonly Action<LogLevel, string> _logAction;
+
+        public TestLogger(Action<LogLevel, string> logAction)
+        {
+            _logAction = logAction;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) => null!;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            _logAction(logLevel, formatter(state, exception));
         }
     }
 }

--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1530,7 +1530,7 @@ maxConcurrentJobs: 10
         });
         var logger = loggerFactory.CreateLogger<ConfigService>();
 
-        var service = new ConfigService(logger, tempDir);
+        var service = new ConfigService(new TendrilSettings(), tempDir, logger);
 
         Assert.Contains(logMessages, msg =>
             msg.Contains("Configuration file not found") &&
@@ -1564,7 +1564,7 @@ maxConcurrentJobs: 10
             _logAction = logAction;
         }
 
-        public IDisposable BeginScope<TState>(TState state) => null!;
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
 
         public bool IsEnabled(LogLevel logLevel) => true;
 

--- a/src/Ivy.Tendril.Test/DoctorChecksTests.cs
+++ b/src/Ivy.Tendril.Test/DoctorChecksTests.cs
@@ -14,7 +14,7 @@ public class DoctorChecksTests : IDisposable
     }
 
     [Fact]
-    public void EnvironmentCheck_MissingConfigFile_ShowsFullPath()
+    public async Task EnvironmentCheck_MissingConfigFile_ShowsFullPath()
     {
         var tempDir = _tempDir.Path;
         var expectedConfigPath = Path.Combine(tempDir, "config.yaml");
@@ -28,9 +28,9 @@ public class DoctorChecksTests : IDisposable
         try
         {
             var check = new EnvironmentCheck();
-            var result = check.Run();
+            var result = await check.RunAsync();
 
-            var configStatus = result.Statuses.FirstOrDefault(s => s.Name == "config.yaml");
+            var configStatus = result.Statuses.FirstOrDefault(s => s.Label == "config.yaml");
             Assert.NotNull(configStatus);
             Assert.Equal(StatusKind.Error, configStatus.Kind);
             Assert.Contains("Not found at", configStatus.Value);

--- a/src/Ivy.Tendril.Test/DoctorChecksTests.cs
+++ b/src/Ivy.Tendril.Test/DoctorChecksTests.cs
@@ -1,0 +1,44 @@
+using Ivy.Tendril.Commands.DoctorChecks;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class DoctorChecksTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("ivy-doctor-test");
+
+    public void Dispose()
+    {
+        _tempDir.Dispose();
+    }
+
+    [Fact]
+    public void EnvironmentCheck_MissingConfigFile_ShowsFullPath()
+    {
+        var tempDir = _tempDir.Path;
+        var expectedConfigPath = Path.Combine(tempDir, "config.yaml");
+
+        // Ensure no config file exists
+        if (File.Exists(expectedConfigPath))
+            File.Delete(expectedConfigPath);
+
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", tempDir);
+
+        try
+        {
+            var check = new EnvironmentCheck();
+            var result = check.Run();
+
+            var configStatus = result.Statuses.FirstOrDefault(s => s.Name == "config.yaml");
+            Assert.NotNull(configStatus);
+            Assert.Equal(StatusKind.Error, configStatus.Kind);
+            Assert.Contains("Not found at", configStatus.Value);
+            Assert.Contains(expectedConfigPath, configStatus.Value);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TENDRIL_HOME", null);
+        }
+    }
+}

--- a/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
@@ -16,11 +16,13 @@ public class TendrilHomeStepView(IState<int> stepperIndex) : ViewBase
             )
         );
         var error = UseState<string?>(null);
+        var configInfo = UseState<string?>(null);
         var config = UseService<IConfigService>();
 
         return Layout.Vertical().Margin(0, 0, 0, 20)
                | Text.H2("Tendril Data Location")
                | Text.Muted("This folder will store your plans, inbox, trash, and other Tendril data.")
+               | (configInfo.Value != null ? Text.Muted(configInfo.Value) : null!)
                | (error.Value != null ? Text.Danger(error.Value) : null!)
                | folderPath.ToTextInput("Select Tendril data folder...")
                    .WithField().Label("Tendril Home")
@@ -61,6 +63,8 @@ public class TendrilHomeStepView(IState<int> stepperIndex) : ViewBase
                            tendrilHome = Path.GetFullPath(tendrilHome);
 
                            config.SetPendingTendrilHome(tendrilHome);
+                           var expectedConfigPath = Path.Combine(tendrilHome, "config.yaml");
+                           configInfo.Set($"Configuration will be stored at {expectedConfigPath}");
                            error.Set(null);
                            stepperIndex.Set(stepperIndex.Value + 1);
                        }

--- a/src/Ivy.Tendril/Commands/DoctorChecks/EnvironmentCheck.cs
+++ b/src/Ivy.Tendril/Commands/DoctorChecks/EnvironmentCheck.cs
@@ -32,7 +32,7 @@ internal class EnvironmentCheck : IDoctorCheck
         }
         else
         {
-            statuses.Add(new CheckStatus("config.yaml", "Not found", StatusKind.Error));
+            statuses.Add(new CheckStatus("config.yaml", $"Not found at {configPath}", StatusKind.Error));
             hasErrors = true;
         }
 

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -230,7 +230,10 @@ public class ConfigService : IConfigService, IDisposable
     private (bool Success, TendrilSettings Config) TryLoadConfig()
     {
         if (!File.Exists(ConfigPath))
+        {
+            _logger.LogWarning("Configuration file not found at {ConfigPath}. Expected filename: config.yaml", ConfigPath);
             return (false, new TendrilSettings());
+        }
 
         try
         {


### PR DESCRIPTION
# Summary

## Changes

Added logging and improved error messages to clarify the expected configuration filename (`config.yaml` not `tendril-config.yaml`). Updated documentation to explicitly state the naming requirement and added troubleshooting guidance.

## API Changes

None.

## Files Modified

### Code Changes
- `src/Ivy.Tendril/Services/ConfigService.cs` — Added warning log when config file not found, including full path and expected filename
- `src/Ivy.Tendril/Commands/DoctorChecks/EnvironmentCheck.cs` — Enhanced error message to show full path when config.yaml missing
- `src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs` — Added info message showing where config.yaml will be created

### Documentation Updates
- `src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md` — Added note about config.yaml filename after Run section
- `src/Ivy.Tendril.Docs/Docs/03_Configuration/01_Setup.md` — Clarified config filename requirement with note about TENDRIL_CONFIG env var
- `src/Ivy.Tendril.Docs/Docs/01_GettingStarted/05_Troubleshooting.md` — Added troubleshooting entry for missing config.yaml

### Tests
- `src/Ivy.Tendril.Test/ConfigServiceTests.cs` — Added test verifying warning log includes full path and filename
- `src/Ivy.Tendril.Test/DoctorChecksTests.cs` — New file with test for EnvironmentCheck error message format

---

**Commits:**
- c74fed9 [00006] Clarify config file naming and improve error messages
- c0a95d9 [00006] Fix test compilation errors