### PR TITLE
[00123] Fix 'Copy update command' button in update notification

### DIFF
--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -13,7 +13,6 @@ public class WallpaperApp : ViewBase
         var versionService = UseService<IVersionCheckService>();
         var versionInfo = UseState<VersionInfo?>(null);
         var dismissedVersion = UseState<string?>(null);
-        var copyToClipboard = UseClipboard();
 
         UseEffect(() =>
         {
@@ -56,14 +55,10 @@ public class WallpaperApp : ViewBase
                         .Bold($"v{versionInfo.Value.LatestVersion}")
                         .Run($" is available (you have v{versionInfo.Value.CurrentVersion})")
                         .Small()
-                    | (Layout.Horizontal().Gap(1)
-                        | new Button("Copy update command", () => copyToClipboard(updateCommand))
-                            .Variant(ButtonVariant.Primary)
-                            .Small()
-                            .Icon(Icons.Clipboard)
-                        | new Button("Dismiss", () => dismissedVersion.Set(versionInfo.Value.LatestVersion))
-                            .Variant(ButtonVariant.Ghost)
-                            .Small())
+                    | new CodeBlock(updateCommand, Languages.Bash)
+                    | new Button("Dismiss", () => dismissedVersion.Set(versionInfo.Value.LatestVersion))
+                        .Variant(ButtonVariant.Ghost)
+                        .Small()
                 ).Header("Update Available", null, Icons.CircleArrowUp),
                 Align.BottomRight
             ).Offset(new Thickness(0, 0, 8, 8));


### PR DESCRIPTION
## Summary

Replaced the `UseClipboard()` server-roundtrip approach in WallpaperApp's update notification with a `CodeBlock` widget that has a built-in client-side copy button. The `UseClipboard()` hook sent a SignalR message to the server which then sent a `CopyToClipboard` message back to the frontend — this async roundtrip lost the browser's user gesture context required for `navigator.clipboard.writeText()`. The `CodeBlock` widget handles clipboard entirely on the frontend within the click handler's user gesture context.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/WallpaperApp.cs** — Removed `UseClipboard()` hook, replaced "Copy update command" Button with `CodeBlock(updateCommand, Languages.Bash)` that displays the command with a built-in copy button

## Commits

- 8d2ba28 [00123] Replace UseClipboard server roundtrip with CodeBlock client-side copy button

---
Closes https://github.com/Ivy-Interactive/Ivy-Tendril/issues/422