### PR TITLE
[00131] Add color indicators to Changes tab tree view folders

### DIFF
--- a/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
@@ -153,7 +153,37 @@ public class ChangesTabView(
             node = only;
         }
 
-        return new MenuItem(label, ChildItems(node)).Icon(Icons.Folder).Expanded();
+        var item = new MenuItem(label, ChildItems(node)).Icon(Icons.Folder).Expanded();
+        var folderColor = GetFolderColor(node);
+        return folderColor is not null ? item.Color(folderColor.Value) : item;
+    }
+
+    private static Colors? GetFolderColor(TreeNode node)
+    {
+        var hasAdded = false;
+        var hasDeleted = false;
+        var hasOther = false;
+        CollectStatuses(node);
+        if (!hasAdded && !hasDeleted && !hasOther) return null;
+        if (hasAdded && !hasDeleted && !hasOther) return Colors.Success;
+        if (hasDeleted && !hasAdded && !hasOther) return Colors.Destructive;
+        return Colors.Neutral;
+
+        void CollectStatuses(TreeNode n)
+        {
+            foreach (var f in n.Files)
+            {
+                switch (f.Status)
+                {
+                    case "A": hasAdded = true; break;
+                    case "D": hasDeleted = true; break;
+                    default: hasOther = true; break;
+                }
+                if (hasAdded && hasDeleted) return;
+            }
+            foreach (var folder in n.Folders.Values)
+                CollectStatuses(folder);
+        }
     }
 
     private sealed class TreeNode(string name)


### PR DESCRIPTION
# Summary

Added color indicators to folder items in the Changes tab tree view sidebar. Folders now display green (all files added), red (all files deleted), or gray (mixed statuses) color indicators matching the existing file-level color scheme. Added a recursive `GetFolderColor` static method that walks all descendant files to determine the appropriate folder color.

## Files Modified

- **src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs** — Added `GetFolderColor(TreeNode)` method with local `CollectStatuses` function; updated `FolderItem()` to apply computed color via `.Color()`.

## Commits

- 7cffbde [00131] Add color indicators to Changes tab tree view folders

Closes https://github.com/Ivy-Interactive/Ivy-Tendril/issues/434