### PR TITLE
[00132] Configure global gitignore during onboarding to prevent OS metadata files in repos

### DIFF
--- a/src/Ivy.Tendril.Test/OnboardingGitignoreTests.cs
+++ b/src/Ivy.Tendril.Test/OnboardingGitignoreTests.cs
@@ -1,0 +1,145 @@
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test;
+
+public class OnboardingGitignoreTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("gitignore-test");
+    private readonly OnboardingSetupService _service;
+    private readonly string _tendrilHome;
+
+    public OnboardingGitignoreTests()
+    {
+        _tendrilHome = Path.Combine(_tempDir.Path, "tendril-home");
+        Directory.CreateDirectory(_tendrilHome);
+        var config = new ConfigService(new TendrilSettings());
+        _service = new OnboardingSetupService(
+            config,
+            null!,
+            NullLogger<OnboardingSetupService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        // Restore git global config to original state if we changed it
+        try
+        {
+            var gitignorePath = Path.Combine(_tempDir.Path, "test-gitignore");
+            if (File.Exists(gitignorePath))
+                File.Delete(gitignorePath);
+        }
+        catch { /* best effort */ }
+
+        _tempDir.Dispose();
+    }
+
+    [Fact]
+    public async Task EnsureGlobalGitignore_CreatesFileWhenNoneExists()
+    {
+        // The method uses git config and XDG path, so we test the marker file behavior
+        // and the overall flow without mocking git
+        await _service.EnsureGlobalGitignoreAsync(_tendrilHome);
+
+        // Marker file should be created
+        var markerPath = Path.Combine(_tendrilHome, ".gitignore-configured");
+        Assert.True(File.Exists(markerPath), "Marker file should be created after running");
+    }
+
+    [Fact]
+    public async Task EnsureGlobalGitignore_IsIdempotent()
+    {
+        await _service.EnsureGlobalGitignoreAsync(_tendrilHome);
+
+        // Get the global gitignore path (XDG default or custom)
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var xdgPath = Path.Combine(home, ".config", "git", "ignore");
+
+        string? gitignoreContent = null;
+        if (File.Exists(xdgPath))
+            gitignoreContent = await File.ReadAllTextAsync(xdgPath);
+
+        // Run again
+        await _service.EnsureGlobalGitignoreAsync(_tendrilHome);
+
+        // Content should not be duplicated
+        if (File.Exists(xdgPath))
+        {
+            var afterContent = await File.ReadAllTextAsync(xdgPath);
+            var dsStoreCount = afterContent.Split('\n').Count(l => l.Trim() == ".DS_Store");
+            Assert.True(dsStoreCount <= 1, $".DS_Store pattern should appear at most once, found {dsStoreCount} times");
+        }
+    }
+
+    [Fact]
+    public async Task EnsureGlobalGitignore_AppendsToExistingContent()
+    {
+        // Get the current global gitignore path
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var xdgPath = Path.Combine(home, ".config", "git", "ignore");
+        var dir = Path.GetDirectoryName(xdgPath)!;
+        Directory.CreateDirectory(dir);
+
+        // Save original content for restoration
+        string? originalContent = null;
+        if (File.Exists(xdgPath))
+            originalContent = await File.ReadAllTextAsync(xdgPath);
+
+        try
+        {
+            // Write some pre-existing content
+            var preExisting = "# My custom ignores\n*.log\n";
+            if (originalContent != null)
+                preExisting = originalContent;
+
+            await File.WriteAllTextAsync(xdgPath, preExisting);
+
+            await _service.EnsureGlobalGitignoreAsync(_tendrilHome);
+
+            var content = await File.ReadAllTextAsync(xdgPath);
+
+            // Original content should be preserved
+            Assert.Contains(preExisting.TrimEnd(), content);
+
+            // OS metadata patterns should be present
+            Assert.Contains(".DS_Store", content);
+            Assert.Contains("Thumbs.db", content);
+            Assert.Contains("desktop.ini", content);
+        }
+        finally
+        {
+            // Restore original content
+            if (originalContent != null)
+                await File.WriteAllTextAsync(xdgPath, originalContent);
+        }
+    }
+
+    [Fact]
+    public async Task EnsureGlobalGitignoreOnStartup_SkipsWhenMarkerExists()
+    {
+        // Create marker file
+        var markerPath = Path.Combine(_tendrilHome, ".gitignore-configured");
+        await File.WriteAllTextAsync(markerPath, DateTime.UtcNow.ToString("O"));
+        var markerTime = File.GetLastWriteTimeUtc(markerPath);
+
+        // Short delay to distinguish timestamps
+        await Task.Delay(50);
+
+        await _service.EnsureGlobalGitignoreOnStartupAsync(_tendrilHome);
+
+        // Marker file should not have been rewritten
+        Assert.Equal(markerTime, File.GetLastWriteTimeUtc(markerPath));
+    }
+
+    [Fact]
+    public async Task EnsureGlobalGitignoreOnStartup_RunsWhenNoMarker()
+    {
+        var markerPath = Path.Combine(_tendrilHome, ".gitignore-configured");
+        Assert.False(File.Exists(markerPath));
+
+        await _service.EnsureGlobalGitignoreOnStartupAsync(_tendrilHome);
+
+        Assert.True(File.Exists(markerPath), "Marker file should be created when migration runs");
+    }
+}

--- a/src/Ivy.Tendril/Services/OnboardingSetupService.cs
+++ b/src/Ivy.Tendril/Services/OnboardingSetupService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Ivy.Tendril.Helpers;
 using Microsoft.Extensions.Logging;
 
@@ -5,6 +6,16 @@ namespace Ivy.Tendril.Services;
 
 public class OnboardingSetupService(IConfigService config, IServiceProvider services, ILogger<OnboardingSetupService> logger) : IOnboardingSetupService
 {
+    private const string GitignoreMarkerFileName = ".gitignore-configured";
+
+    private static readonly string[] OsMetadataPatterns =
+    [
+        ".DS_Store",
+        "._*",
+        "Thumbs.db",
+        "desktop.ini"
+    ];
+
     private readonly ILogger<OnboardingSetupService> _logger = logger;
 
     public async Task CompleteSetupAsync(string tendrilHome)
@@ -98,6 +109,9 @@ public class OnboardingSetupService(IConfigService config, IServiceProvider serv
 
         _logger.LogInformation("Config file written");
 
+        // Configure global gitignore for OS metadata files
+        await EnsureGlobalGitignoreAsync(tendrilHome);
+
         // Set environment variable for current session
         _logger.LogInformation("Setting environment variable TENDRIL_HOME={Value}", tendrilHome);
         Environment.SetEnvironmentVariable("TENDRIL_HOME", tendrilHome);
@@ -161,5 +175,118 @@ public class OnboardingSetupService(IConfigService config, IServiceProvider serv
     {
         _logger.LogInformation("Starting background services (deferred)");
         await BackgroundServiceActivator.StartAsync(services, _logger);
+    }
+
+    /// <summary>
+    ///     Ensures a global gitignore is configured with OS metadata patterns (.DS_Store, Thumbs.db, etc.).
+    ///     Called during onboarding and as a one-time migration for existing installations.
+    /// </summary>
+    internal async Task EnsureGlobalGitignoreAsync(string tendrilHome)
+    {
+        try
+        {
+            var gitignorePath = await ResolveGlobalGitignorePathAsync();
+            var dir = Path.GetDirectoryName(gitignorePath);
+            if (dir != null)
+                Directory.CreateDirectory(dir);
+
+            var existingContent = File.Exists(gitignorePath)
+                ? await File.ReadAllTextAsync(gitignorePath)
+                : "";
+
+            var missingPatterns = OsMetadataPatterns
+                .Where(p => !ContainsPattern(existingContent, p))
+                .ToList();
+
+            if (missingPatterns.Count == 0)
+            {
+                _logger.LogInformation("Global gitignore at {Path} already contains all OS metadata patterns", gitignorePath);
+            }
+            else
+            {
+                var block = "\n# OS metadata (added by Tendril)\n" + string.Join("\n", missingPatterns) + "\n";
+                await File.AppendAllTextAsync(gitignorePath, block);
+                _logger.LogInformation("Appended {Count} OS metadata pattern(s) to global gitignore at {Path}",
+                    missingPatterns.Count, gitignorePath);
+            }
+
+            // Write marker file so startup migration doesn't re-run
+            var markerPath = Path.Combine(tendrilHome, GitignoreMarkerFileName);
+            if (!File.Exists(markerPath))
+                await File.WriteAllTextAsync(markerPath, DateTime.UtcNow.ToString("O"));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to configure global gitignore");
+        }
+    }
+
+    /// <summary>
+    ///     One-time startup migration: ensures global gitignore is configured for existing installations
+    ///     that completed onboarding before this feature was added.
+    /// </summary>
+    public async Task EnsureGlobalGitignoreOnStartupAsync(string tendrilHome)
+    {
+        var markerPath = Path.Combine(tendrilHome, GitignoreMarkerFileName);
+        if (File.Exists(markerPath))
+            return;
+
+        _logger.LogInformation("Running one-time global gitignore migration for existing installation");
+        await EnsureGlobalGitignoreAsync(tendrilHome);
+    }
+
+    private static async Task<string> ResolveGlobalGitignorePathAsync()
+    {
+        // Check if the user has a custom core.excludesFile configured
+        var customPath = await GetGitConfigValueAsync("core.excludesFile");
+        if (!string.IsNullOrWhiteSpace(customPath))
+        {
+            // Expand ~ to home directory
+            if (customPath.StartsWith('~'))
+                customPath = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    customPath[2..]);
+            return customPath;
+        }
+
+        // Fall back to XDG default: ~/.config/git/ignore
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".config", "git", "ignore");
+    }
+
+    private static async Task<string?> GetGitConfigValueAsync(string key)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("git", $"config --global {key}")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var process = Process.Start(psi);
+            if (process == null) return null;
+            var output = await process.StandardOutput.ReadToEndAsync();
+            await process.WaitForExitAsync();
+            return process.ExitCode == 0 ? output.Trim() : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool ContainsPattern(string content, string pattern)
+    {
+        // Check each line for an exact match (ignoring comments and whitespace)
+        using var reader = new StringReader(content);
+        while (reader.ReadLine() is { } line)
+        {
+            var trimmed = line.Trim();
+            if (trimmed == pattern)
+                return true;
+        }
+        return false;
     }
 }

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -214,6 +214,20 @@ public static class TendrilServer
                     PromptwareDeployer.Deploy(promptwaresDir);
                 }
 
+                // One-time migration: ensure global gitignore has OS metadata patterns
+                var onboarding = app.Services.GetRequiredService<OnboardingSetupService>();
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await onboarding.EnsureGlobalGitignoreOnStartupAsync(configService.TendrilHome);
+                    }
+                    catch (Exception ex)
+                    {
+                        CrashLog.Write($"[{DateTime.UtcNow:O}] Global gitignore migration failed: {ex}");
+                    }
+                });
+
                 BackgroundServiceActivator.Start(app.Services);
             }
 

--- a/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
@@ -88,8 +88,6 @@ public class ChangesTabView(
             }
         }
 
-        diffsLayout.ScrollTarget(selectedFile.Value);
-
         var sidebarContent = Layout.Vertical().Gap(2).Padding(1)
             | tree;
 


### PR DESCRIPTION
## Summary

Added global gitignore configuration to prevent OS metadata files (.DS_Store, Thumbs.db, desktop.ini, ._*) from appearing in git repos. The setup runs during onboarding (`CompleteSetupAsync`) and as a one-time startup migration for existing installations using a marker file (`$TENDRIL_HOME/.gitignore-configured`).

Also fixed a pre-existing build break where `ChangesTabView.cs` called `ScrollTarget` which doesn't exist in the current Ivy NuGet package (1.2.50).

## API Changes

- `OnboardingSetupService.EnsureGlobalGitignoreAsync(string tendrilHome)` — new internal method that configures the global gitignore
- `OnboardingSetupService.EnsureGlobalGitignoreOnStartupAsync(string tendrilHome)` — new public method for one-time startup migration

## Files Modified

- **src/Ivy.Tendril/Services/OnboardingSetupService.cs** — Added `EnsureGlobalGitignoreAsync`, `EnsureGlobalGitignoreOnStartupAsync`, `ResolveGlobalGitignorePathAsync`, `GetGitConfigValueAsync`, and `ContainsPattern` methods. Called from `CompleteSetupAsync`.
- **src/Ivy.Tendril/TendrilServer.cs** — Added startup migration call to `EnsureGlobalGitignoreOnStartupAsync` for existing installations.
- **src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs** — Removed broken `ScrollTarget` call (pre-existing build fix).
- **src/Ivy.Tendril.Test/OnboardingGitignoreTests.cs** — New test class with 5 tests verifying creation, idempotency, append behavior, and marker file logic.

## Commits

- `0bc7d8a` [00132] Remove ScrollTarget call missing from Ivy NuGet package
- `5b3e7be` [00132] Configure global gitignore during onboarding and startup migration

## Source

Closes https://github.com/Ivy-Interactive/Ivy-Tendril/issues/268

---
🤖 Generated by [Tendril](https://github.com/Ivy-Interactive/Ivy-Tendril)