### PR TITLE
[00130] Sort diff viewers to match file tree order in ReviewApp changes tab

### DIFF
--- a/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
@@ -35,7 +35,9 @@ public class ChangesTabView(
         var currentlyExpanded = expandedFiles.Value
             ?? new HashSet<string>(fileDiffs.Select(fd => fd.FilePath));
 
-        var treeItems = BuildFileTree(fileDiffs);
+        var root = BuildFileTree(fileDiffs);
+        var treeItems = ChildItems(root);
+        var sortedFileDiffs = SortByTreeOrder(fileDiffs, root);
 
         var tree = new Tree(treeItems)
             .OnSelect(e =>
@@ -56,7 +58,7 @@ public class ChangesTabView(
         var diffsLayout = Layout.Vertical().Gap(2).Width(Size.Full());
         diffsLayout |= Text.Block(statsText).Bold();
 
-        foreach (var fileDiff in fileDiffs)
+        foreach (var fileDiff in sortedFileDiffs)
         {
             var isExpanded = currentlyExpanded.Contains(fileDiff.FilePath);
             var chevronIcon = isExpanded ? Icons.ChevronDown : Icons.ChevronRight;
@@ -100,7 +102,7 @@ public class ChangesTabView(
         ).Resizable();
     }
 
-    private static MenuItem[] BuildFileTree(IReadOnlyList<PlanContentHelpers.FileDiff> fileDiffs)
+    private static TreeNode BuildFileTree(IReadOnlyList<PlanContentHelpers.FileDiff> fileDiffs)
     {
         var root = new TreeNode("");
         foreach (var fd in fileDiffs)
@@ -119,7 +121,7 @@ public class ChangesTabView(
             }
             node.Files.Add(fd);
         }
-        return ChildItems(root);
+        return root;
     }
 
     private static MenuItem[] ChildItems(TreeNode node)
@@ -139,6 +141,32 @@ public class ChangesTabView(
                 .Tooltip(file.FilePath));
         }
         return items.ToArray();
+    }
+
+    private static List<string> FlattenTreeOrder(TreeNode node)
+    {
+        var result = new List<string>();
+        FlattenTreeOrderRecursive(node, result);
+        return result;
+    }
+
+    private static void FlattenTreeOrderRecursive(TreeNode node, List<string> result)
+    {
+        foreach (var folder in node.Folders.Values.OrderBy(f => f.Name, StringComparer.OrdinalIgnoreCase))
+            FlattenTreeOrderRecursive(folder, result);
+        foreach (var file in node.Files.OrderBy(f => Path.GetFileName(f.FilePath), StringComparer.OrdinalIgnoreCase))
+            result.Add(file.FilePath);
+    }
+
+    private static List<PlanContentHelpers.FileDiff> SortByTreeOrder(
+        IReadOnlyList<PlanContentHelpers.FileDiff> fileDiffs, TreeNode root)
+    {
+        var orderedPaths = FlattenTreeOrder(root);
+        var lookup = fileDiffs.ToDictionary(fd => fd.FilePath);
+        return orderedPaths
+            .Where(lookup.ContainsKey)
+            .Select(p => lookup[p])
+            .ToList();
     }
 
     // Collapse single-child folder chains (e.g. "src/components" if src has only the components folder)


### PR DESCRIPTION
## Changes

Sorted the diff viewer list in the ReviewApp's Changes tab to match the file tree sidebar ordering. The `BuildFileTree` method now returns the raw `TreeNode` root, allowing both the tree widget and a new `SortByTreeOrder` helper to derive consistent alphabetical folder-then-file ordering. The diff viewer `foreach` loop now iterates `sortedFileDiffs` instead of raw git output order.

## Files Modified

- **src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs** — Changed `BuildFileTree` return type from `MenuItem[]` to `TreeNode`; added `FlattenTreeOrder`, `FlattenTreeOrderRecursive`, and `SortByTreeOrder` private methods; updated `Build()` to sort diffs before rendering.

## Commits

- 1a7bf9c [00130] Sort diff viewers to match file tree order in ReviewApp changes tab