### PR TITLE
[00125] Use Anchor instead of TestId for diff-tree scroll target

### DIFF
--- a/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
@@ -74,7 +74,7 @@ public class ChangesTabView(
 
             var path = fileDiff.FilePath;
             diffsLayout |= new Box(header)
-                .TestId(fileDiff.FilePath)
+                .Anchor(fileDiff.FilePath)
                 .BorderThickness(0).Padding(1)
                 .Hover(HoverEffect.Pointer)
                 .OnClick(() =>


### PR DESCRIPTION
## Summary

Companion to Ivy-Interactive/Ivy-Framework#4352.

`ChangesTabView` (shared by both `PlansApp` and `ReviewApp`) marked file diff sections with `.TestId(filePath)` so `StackLayout.ScrollTarget(...)` could locate them. `data-testid` is stripped in production bundles, so the scroll never landed on the right file in deployed Tendril — clicking a file in the diff tree did nothing visible.

Switch to `.Anchor(filePath)`, which emits a prod-safe `data-anchor` attribute on the widget wrapper. Pairs with the framework change that switches `StackLayout`'s `ScrollTarget` query from `[data-testid=...]` to `[data-anchor=...]`.

This single change covers both apps because `ContentView`s in `Apps/Plans` and `Apps/Review` share `Views/Tabs/ChangesTabView.cs`.

## Dependency

Requires Ivy NuGet **1.2.51+** (with the new `WidgetBase.Anchor` extension method from Ivy-Framework#4352). CI on this branch will fail until the framework PR merges and a new Ivy NuGet is published. Local builds with `IvySource=true` work today.

## Test plan

- [x] `dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj -c Release -p:IvySource=true` succeeds
- [ ] Manual (after NuGet update): open PlansApp Changes tab, click file in tree → main pane scrolls to that file's diff
- [ ] Manual (after NuGet update): same in ReviewApp Changes tab
- [ ] Manual: verify the production Tendril build (not just dev) actually scrolls — that's the regression this fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)