### PR TITLE
[JobsAppDataTable]: Apply responsive density — Large on tablet, Medium on desktop

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -23,6 +23,7 @@ public partial class JobsApp
     {
         return rows.AsQueryable()
             .ToDataTable(t => t.Id)
+            .Density(Density.Large.At(Breakpoint.Tablet).And(Breakpoint.Desktop, Density.Medium))
             .RefreshToken(refreshToken)
             .UpdateStream(updateStream)
             .Width(Size.Full())


### PR DESCRIPTION
# Apply Responsive Density to Jobs DataTable

Closes #256

## Related

- **Depends on:** Ivy-Framework PR must be merged first and a new NuGet package version published.

## Problem

On iPad and mobile devices, the Jobs DataTable has small text and compact touch targets, making it difficult to read and interact with. The UI feels too small on touch screens where users hold the device at arm's length.

## Solution

Applied responsive density to the Jobs DataTable using the new `Responsive<Density?>` support added in the Ivy-Framework PR:

```csharp
.Density(Density.Large.At(Breakpoint.Tablet).And(Breakpoint.Desktop, Density.Medium))
```

This sets:
- **Tablet and below (< 768px):** `Large` density — bigger text, larger padding, touch-friendly controls
- **Desktop and above (≥ 1024px):** `Medium` density — standard compact view, no visual changes

### Changed Files

- `src/Ivy.Tendril/Apps/JobsApp.DataTable.cs` — Added `.Density(...)` call to the DataTable builder chain

## Testing

Tested manually with Chrome DevTools Device Toolbar:
- ✅ iPad (768px) — Large density applied, text and controls visibly bigger
- ✅ Desktop (1920px) — Medium density, standard view unchanged
- ✅ Density transition occurs at the correct breakpoint (~768px)

https://github.com/user-attachments/assets/5aa5e686-3111-416f-a174-c28f2fd54497

