### PR TITLE
[JobsAppDataTable]: fix responsive density fallback

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -23,7 +23,7 @@ public partial class JobsApp
     {
         return rows.AsQueryable()
             .ToDataTable(t => t.Id)
-            .Density(Density.Large.At(Breakpoint.Tablet).And(Breakpoint.Desktop, Density.Medium))
+            .Density(new Responsive<Density?> { Default = Density.Large, Desktop = Density.Medium })
             .RefreshToken(refreshToken)
             .UpdateStream(updateStream)
             .Width(Size.Full())


### PR DESCRIPTION
fixed bug where responsive UI wasn't applying for small width




https://github.com/user-attachments/assets/c711bbb8-1751-481a-9446-36085b637080

