### PR TITLE
[auth]: fix gh auth status failing with multiple accounts

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -13,7 +13,7 @@ public class SoftwareCheckStepView(
     {
         new("GitHub CLI", "gh", "https://cli.github.com/", true,
             () => CheckCommand("gh", "--version"),
-            () => CheckHealth("gh", "auth status"),
+            () => CheckHealth("gh", "auth status --active"),
             "Run `gh auth login` to authenticate"),
         new("Claude CLI", "claude", "https://docs.anthropic.com/en/docs/claude-code", false,
             () => CheckCommand("claude", "--version"),

--- a/src/Ivy.Tendril/Commands/DoctorChecks/SoftwareCheck.cs
+++ b/src/Ivy.Tendril/Commands/DoctorChecks/SoftwareCheck.cs
@@ -21,7 +21,7 @@ internal class SoftwareCheck : IDoctorCheck
 
     private static readonly Dictionary<string, string> HealthArgs = new()
     {
-        ["gh"] = "auth status",
+        ["gh"] = "auth status --active",
         ["claude"] = "-p \"ping\" --max-turns 1",
         ["codex"] = "login status",
         ["copilot"] = "-p \"ping\" --allow-all -s"

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -27,7 +27,7 @@ public static class DoctorCommand
 
     private static readonly Dictionary<string, string> HealthArgs = new()
     {
-        ["gh"] = "auth status",
+        ["gh"] = "auth status --active",
         ["claude"] = "-p \"ping\" --max-turns 1",
         ["codex"] = "login status"
     };


### PR DESCRIPTION
## Issue

When a user has **multiple GitHub accounts** configured in the GitHub CLI and at least one of them has an expired or invalid token, Tendril incorrectly reports the user as **not authenticated** — even though the **active** account is fully valid.

This affects both the **onboarding software check** and the **`tendril doctor`** command.

## Root Cause

Tendril checks GitHub authentication by running `gh auth status` and inspecting the exit code. The problem is that `gh auth status` (without flags) validates **all** configured accounts. If **any** account has an invalid token, the command returns exit code `1` — regardless of whether the active account is healthy.

For example, a user with two accounts:
```
✓ Logged in to github.com account main-user (keyring)
  - Active account: true              ← Working fine

✗ Failed to log in to github.com account old-user (keyring)
  - Active account: false             ← Expired token
  - The token in keyring is invalid.
```

Here `gh auth status` returns exit code `1`, and Tendril interprets this as "user is not authenticated".

## Testing

### Reproducing the bug

1. Verified current auth state — single account, `gh auth status` returns exit code `0`:
   ```
   github.com
     ✓ Logged in to github.com account defymecobra (keyring)
     - Active account: true
   ```

2. Added a fake second user entry (`fake-expired-user`) directly to `%APPDATA%\GitHub CLI\hosts.yml` to simulate a second account with no valid token in the keyring (backed up original config first):
   ```yaml
   github.com:
       git_protocol: https
       users:
           defymecobra:
           fake-expired-user:
       user: defymecobra
   ```

3. Confirmed the bug — `gh auth status` now returns exit code `1`:
   ```
   ✓ Logged in to github.com account defymecobra (keyring)
     - Active account: true

   ✗ Failed to log in to github.com account fake-expired-user (default)
     - Active account: false
     - The token in default is invalid.

   EXIT CODE: 1
   ```

4. Launched Tendril (`dotnet watch`) and ran the onboarding software check — GitHub CLI showed **"⚠️ Installed but not authenticated"**, confirming the bug.

### Verifying the fix

5. Applied the fix (`auth status` → `auth status --active`) in all 3 locations.

6. Confirmed `gh auth status --active` returns exit code `0` with the same multi-account config:
   ```
   github.com
     ✓ Logged in to github.com account defymecobra (keyring)
     - Active account: true

   EXIT CODE: 0
   ```

7. Hot-reloaded Tendril and re-ran the onboarding software check — GitHub CLI now shows **"✅ Ready"**.

8. Cleaned up — restored the original `hosts.yml` config and removed the backup file.

## Changes

Changed `gh auth status` to `gh auth status --active` in 3 files:

| File | Location |
|------|----------|
| `Apps/Onboarding/SoftwareCheckStepView.cs` | Onboarding health check |
| `Commands/DoctorCommand.cs` | `tendril doctor` health args |
| `Commands/DoctorChecks/SoftwareCheck.cs` | Doctor checks health args |

The `--active` flag tells `gh auth status` to only validate the **currently active** account, ignoring any other configured accounts that may have expired tokens.
