### PR TITLE
[JobsAppSheets]: fix datatable flicker on sheet open by stabilizing tree position

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.Sheets.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Sheets.cs
@@ -19,7 +19,7 @@ public partial class JobsApp
         IState<bool> hasStreamContent,
         LayoutView layout)
     {
-        layout |= dataTable;
+        object? activeSheet = null;
 
         if (showPlan.Value is { } planPath)
         {
@@ -32,14 +32,15 @@ public partial class JobsApp
                 planSheetView.GetSheetTitle()
             ).Width(Size.Half()).Resizable();
 
-            layout |= planSheet;
-            if (fileLinkSheet is not null) layout |= fileLinkSheet;
+            activeSheet = fileLinkSheet is not null
+                ? new Fragment(planSheet, fileLinkSheet)
+                : planSheet;
         }
         else if (showOutput.Value is { } jobId)
         {
             var outputSheetView = new OutputSheet(jobId, jobService, outputStream, hasStreamContent);
 
-            layout |= new Sheet(
+            activeSheet = new Sheet(
                 () => showOutput.Set(null),
                 outputSheetView.Build(),
                 outputSheetView.GetSheetTitle()
@@ -49,13 +50,13 @@ public partial class JobsApp
         {
             var promptSheetView = new PromptSheet(promptText);
 
-            layout |= new Sheet(
+            activeSheet = new Sheet(
                 () => showPrompt.Set(null),
                 promptSheetView.Build(),
                 "Full Prompt"
             ).Width(Size.Half()).Resizable();
         }
 
-        return layout;
+        return layout | new Fragment(dataTable, activeSheet);
     }
 }

--- a/src/Ivy.Tendril/Apps/JobsApp.Sheets.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Sheets.cs
@@ -19,6 +19,8 @@ public partial class JobsApp
         IState<bool> hasStreamContent,
         LayoutView layout)
     {
+        layout |= dataTable;
+
         if (showPlan.Value is { } planPath)
         {
             var planSheetView = new PlanSheet(planPath, planService, config, openFile);
@@ -30,37 +32,30 @@ public partial class JobsApp
                 planSheetView.GetSheetTitle()
             ).Width(Size.Half()).Resizable();
 
-            if (fileLinkSheet is not null) return layout | new Fragment(dataTable, planSheet, fileLinkSheet);
-
-            return layout | new Fragment(dataTable, planSheet);
+            layout |= planSheet;
+            if (fileLinkSheet is not null) layout |= fileLinkSheet;
         }
-
-        if (showOutput.Value is { } jobId)
+        else if (showOutput.Value is { } jobId)
         {
             var outputSheetView = new OutputSheet(jobId, jobService, outputStream, hasStreamContent);
 
-            var outputSheet = new Sheet(
+            layout |= new Sheet(
                 () => showOutput.Set(null),
                 outputSheetView.Build(),
                 outputSheetView.GetSheetTitle()
             ).Width(Size.Half()).Resizable();
-
-            return layout | new Fragment(dataTable, outputSheet);
         }
-
-        if (showPrompt.Value is { } promptText)
+        else if (showPrompt.Value is { } promptText)
         {
             var promptSheetView = new PromptSheet(promptText);
 
-            var promptSheet = new Sheet(
+            layout |= new Sheet(
                 () => showPrompt.Set(null),
                 promptSheetView.Build(),
                 "Full Prompt"
             ).Width(Size.Half()).Resizable();
-
-            return layout | new Fragment(dataTable, promptSheet);
         }
 
-        return layout | dataTable;
+        return layout;
     }
 }


### PR DESCRIPTION
## Problem

When opening a Sheet in the Jobs page (e.g. clicking on PlanId, LastOutput, or Prompt/Title), the DataTable would visually flicker — disappearing for a moment and reappearing with fresh state (scroll position and column widths lost).

### Root Cause

`RenderWithSheets` returned structurally different widget trees depending on whether a sheet was open:

```csharp
// No sheet — DataTable is a direct child of Layout
return layout | dataTable;                          // DataTable at Layout[0]

// With sheet — DataTable wrapped inside Fragment
return layout | new Fragment(dataTable, sheet);     // DataTable at Layout[0]/Fragment[0]
```

The Ivy Framework generates widget IDs from `TreePath` (position in the widget tree). When the DataTable moved from `Layout[0]` to `Layout[0]/Fragment[0]`, its ID changed. React treats a changed `key` as a completely different component — unmounting the old DataTable and mounting a new one, causing the flicker.

## Solution

Add the DataTable and Sheet as **separate direct children** of the Layout instead of wrapping them in a Fragment:

```csharp
layout |= dataTable;           // Always Layout[0] — stable TreePath
if (sheet != null)
    layout |= sheet;           // Layout[1] — appears/disappears independently
return layout;
```

The DataTable is always at `Layout[0]` regardless of sheet state, so its widget ID remains stable. React recognizes it as the same component and preserves its internal state. The Sheet is added/removed as a sibling at `Layout[1]` without affecting the DataTable's position.

## Changes

- **`JobsApp.Sheets.cs`** — Refactored `RenderWithSheets` to add DataTable and sheets as separate layout children instead of using `Fragment` wrapping. Converted early-return branches to `else if` chain with a single `return layout` at the end.

## Before

https://github.com/user-attachments/assets/5f078933-9bc1-478b-b01f-21f964fc07bb

## After

https://github.com/user-attachments/assets/b3b27969-68bd-4719-b162-d4ce803ba90f

