### PR TITLE
[00025] Fix cleanup of preserved directories during promptware deployment

### DIFF
--- a/src/Ivy.Tendril.Test/PromptwareDeployerTests.cs
+++ b/src/Ivy.Tendril.Test/PromptwareDeployerTests.cs
@@ -192,4 +192,37 @@ public class PromptwareDeployerTests : IDisposable
             }
         }
     }
+
+    [Fact]
+    public void CleanupOrphanedPreservedDirectories_RemovesPreservedDirectories()
+    {
+        // Arrange
+        var promptwaresDir = Path.Combine(_tempDir, "Promptwares");
+        var updatePlanDir = Path.Combine(promptwaresDir, "UpdatePlan");
+        var orphanedDir = Path.Combine(updatePlanDir, "Logs-preserved-abc123");
+        Directory.CreateDirectory(orphanedDir);
+        File.WriteAllText(Path.Combine(orphanedDir, "test.md"), "orphaned content");
+
+        // Act
+        PromptwareDeployer.CleanupOrphanedPreservedDirectories(promptwaresDir);
+
+        // Assert
+        Assert.False(Directory.Exists(orphanedDir));
+    }
+
+    [Fact]
+    public void CleanupOrphanedPreservedDirectories_IgnoresNormalDirectories()
+    {
+        // Arrange
+        var promptwaresDir = Path.Combine(_tempDir, "Promptwares");
+        var normalDir = Path.Combine(promptwaresDir, "UpdatePlan", "Logs");
+        Directory.CreateDirectory(normalDir);
+        File.WriteAllText(Path.Combine(normalDir, "test.md"), "normal content");
+
+        // Act
+        PromptwareDeployer.CleanupOrphanedPreservedDirectories(promptwaresDir);
+
+        // Assert
+        Assert.True(Directory.Exists(normalDir));
+    }
 }

--- a/src/Ivy.Tendril/Services/PromptwareDeployer.cs
+++ b/src/Ivy.Tendril/Services/PromptwareDeployer.cs
@@ -51,21 +51,37 @@ internal static class PromptwareDeployer
                     }
                 }
 
-                // Delete old promptware files (if target exists)
-                if (Directory.Exists(targetSubDir))
-                    Directory.Delete(targetSubDir, true);
-
-                // Move new files from temp
-                Directory.Move(sourceSubDir, targetSubDir);
-
-                // Restore preserved directories
-                foreach (var (original, aside) in preservedDirs)
+                try
                 {
-                    // Remove empty placeholder if it was created by the zip
-                    if (Directory.Exists(original))
-                        Directory.Delete(original, true);
+                    // Delete old promptware files (if target exists)
+                    if (Directory.Exists(targetSubDir))
+                        Directory.Delete(targetSubDir, true);
 
-                    Directory.Move(aside, original);
+                    // Move new files from temp
+                    Directory.Move(sourceSubDir, targetSubDir);
+
+                    // Restore preserved directories
+                    foreach (var (original, aside) in preservedDirs)
+                    {
+                        // Remove empty placeholder if it was created by the zip
+                        if (Directory.Exists(original))
+                            Directory.Delete(original, true);
+
+                        Directory.Move(aside, original);
+                    }
+                }
+                catch
+                {
+                    // If deployment fails after preservation, clean up preserved dirs
+                    foreach (var (_, aside) in preservedDirs)
+                    {
+                        if (Directory.Exists(aside))
+                        {
+                            try { Directory.Delete(aside, true); }
+                            catch { /* Best effort */ }
+                        }
+                    }
+                    throw;
                 }
             }
 
@@ -86,6 +102,35 @@ internal static class PromptwareDeployer
             {
                 try { Directory.Delete(tempDir, true); }
                 catch { /* Best effort */ }
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Removes orphaned *-preserved-* directories from previous failed deployments.
+    /// </summary>
+    public static void CleanupOrphanedPreservedDirectories(string targetDir)
+    {
+        if (!Directory.Exists(targetDir))
+            return;
+
+        foreach (var subDir in Directory.GetDirectories(targetDir))
+        {
+            // Scan each promptware subfolder for preserved directories
+            foreach (var dir in Directory.GetDirectories(subDir))
+            {
+                var dirName = Path.GetFileName(dir);
+                if (dirName.Contains("-preserved-"))
+                {
+                    try
+                    {
+                        Directory.Delete(dir, recursive: true);
+                    }
+                    catch
+                    {
+                        // Best effort — log but don't block startup
+                    }
+                }
             }
         }
     }

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -207,6 +207,7 @@ public static class TendrilServer
             {
                 // Auto-update promptwares if the running version is newer than what's deployed
                 var promptwaresDir = Path.Combine(configService.TendrilHome, "Promptwares");
+                PromptwareDeployer.CleanupOrphanedPreservedDirectories(promptwaresDir);
                 if (PromptwareDeployer.NeedsUpdate(promptwaresDir))
                 {
                     var logger = app.Services.GetRequiredService<ILogger<Server>>();


### PR DESCRIPTION
# Summary

## Changes

Added cleanup logic for orphaned preserved directories that remain after failed promptware deployments. The fix includes error handling during deployment to clean up on failures, a startup cleanup method to remove leftover directories, and test coverage for the cleanup behavior.

## API Changes

- **`PromptwareDeployer.CleanupOrphanedPreservedDirectories(string targetDir)`** — New public static method that scans and removes orphaned `-preserved-*` directories from the promptwares folder.

## Files Modified

**Services:**
- `src/Ivy.Tendril/Services/PromptwareDeployer.cs` — Added try-catch around preservation/restore logic to clean up on error, added CleanupOrphanedPreservedDirectories method
- `src/Ivy.Tendril/TendrilServer.cs` — Added cleanup call before promptware update check

**Tests:**
- `src/Ivy.Tendril.Test/PromptwareDeployerTests.cs` — Added two tests for cleanup method

## Commits

- d8c768a [00025] Add cleanup logic for orphaned preserved directories