### PR TITLE
[00027] Fix PromptwareDeployer preserved directory deletion bug

### DIFF
--- a/src/Ivy.Tendril/Services/PromptwareDeployer.cs
+++ b/src/Ivy.Tendril/Services/PromptwareDeployer.cs
@@ -45,7 +45,10 @@ internal static class PromptwareDeployer
                     var existingDir = Path.Combine(targetSubDir, preserve);
                     if (Directory.Exists(existingDir))
                     {
-                        var asideDir = existingDir + "-preserved-" + Guid.NewGuid().ToString("N")[..8];
+                        // IMPORTANT: Move preserved dirs to temp directory (not as subdirs of targetSubDir)
+                        // so they aren't deleted when we recursively delete targetSubDir
+                        var asideDir = Path.Combine(Path.GetTempPath(),
+                            $"{subDirName}-{preserve}-preserved-" + Guid.NewGuid().ToString("N")[..8]);
                         Directory.Move(existingDir, asideDir);
                         preservedDirs.Add((existingDir, asideDir));
                     }


### PR DESCRIPTION
# Summary

## Changes

Fixed the PromptwareDeployer bug where preserved `Logs/` and `Memory/` directories were being deleted during promptware deployment. The fix moves preserved directories to `Path.GetTempPath()` instead of creating them as subdirectories of the target folder, preventing them from being deleted when the target folder is recursively deleted.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Services/PromptwareDeployer.cs** — Updated preserved directory location logic to use temp directory

## Commits

- dd87b59 [00027] Fix preserved directory deletion in PromptwareDeployer