### PR TITLE
Fix output sheet showing empty panel for completed jobs

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
@@ -9,7 +9,8 @@ public class OutputSheet(
     string jobId,
     IJobService jobService,
     IWriteStream<string> outputStream,
-    IState<bool> hasStreamContent) : ViewBase
+    IState<bool> hasStreamContent,
+    IState<string?> streamingJobId) : ViewBase
 {
     public override object Build()
     {
@@ -32,10 +33,8 @@ public class OutputSheet(
                     .Height(Size.Full());
             }
         }
-        else if (job is not null && hasStreamContent.Value)
+        else if (job is not null && hasStreamContent.Value && streamingJobId.Value == jobId)
         {
-            // Job finished while user was watching the stream — keep using stream renderer
-            // (switching to JsonStream would duplicate content since streamedLines persists in React state)
             outputContent = new ClaudeJsonRenderer()
                 .Stream(outputStream)
                 .ShowThinking(false)

--- a/src/Ivy.Tendril/Apps/JobsApp.Sheets.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Sheets.cs
@@ -17,6 +17,7 @@ public partial class JobsApp
         IJobService jobService,
         IWriteStream<string> outputStream,
         IState<bool> hasStreamContent,
+        IState<string?> streamingJobId,
         LayoutView layout)
     {
         object? activeSheet = null;
@@ -38,7 +39,7 @@ public partial class JobsApp
         }
         else if (showOutput.Value is { } jobId)
         {
-            var outputSheetView = new OutputSheet(jobId, jobService, outputStream, hasStreamContent);
+            var outputSheetView = new OutputSheet(jobId, jobService, outputStream, hasStreamContent, streamingJobId);
 
             activeSheet = new Sheet(
                 () => showOutput.Set(null),

--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -43,6 +43,6 @@ public partial class JobsApp : ViewBase
         var layout = Layout.Vertical().Height(Size.Full());
 
         return RenderWithSheets(dataTable, showPlan, showOutput, showPrompt, planService,
-            config, openFile, jobService, outputStream, hasStreamContent, layout);
+            config, openFile, jobService, outputStream, hasStreamContent, streamingJobId, layout);
     }
 }


### PR DESCRIPTION
The stream branch in OutputSheet used a session-wide `hasStreamContent` flag, so clicking Last Output on a completed job that wasn't the one being streamed would show an empty panel. Now gates the stream path on `streamingJobId` matching the current job so it falls through to `OutputLines` for other jobs.