### PR TITLE
(docker): non-root `tendril` user, Copilot CLI, PATH/HOME fixes

### DIFF
--- a/.github/docker/Dockerfile.tendril
+++ b/.github/docker/Dockerfile.tendril
@@ -1,4 +1,4 @@
-# Ivy Tendril image for Sliplane (or similar). Includes Node CLIs: claude-code, codex, gemini;
+# Ivy Tendril image for Sliplane (or similar). Includes Node CLIs: claude-code, codex, gemini, copilot;
 # git, gh, pwsh, pandoc. Required: ANTHROPIC_API_KEY, GITHUB_TOKEN. Optional: OPENAI_API_KEY,
 # Gemini auth, PORT (8000), TENDRIL_HOME (/data/tendril). Mount /data/tendril to persist data.
 
@@ -12,20 +12,26 @@ RUN --mount=type=cache,id=nuget-tendril,target=/root/.nuget/packages \
 # ── Stage 2: runtime image with all CLI dependencies ──────────────────────────
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
 
+# Non-root user so Claude Code accepts --dangerously-skip-permissions
+RUN useradd --create-home --shell /bin/bash tendril
+
 # aspnet:10.0 puts the runtime at /usr/share/dotnet — tools must point there
 ENV DOTNET_ROOT=/usr/share/dotnet
-ENV PATH="$PATH:/root/.dotnet/tools"
+ENV PATH="$PATH:/home/tendril/.dotnet/tools"
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV DOTNET_NOLOGO=1
 ENV CLAUDE_CODE_SKIP_SETUP=1
-ENV HOME=/root
+ENV HOME=/home/tendril
+# HOMEDIR is read by the clone bootstrap prelude: HOME="${HOMEDIR:-/root}"
+# Without this, HOME gets reset to /root and non-root tools (gh, claude) fail.
+ENV HOMEDIR=/home/tendril
 
 # Tendril runtime config
 ENV TENDRIL_HOME=/data/tendril
 ENV PORT=8000
 
-# Copy Tendril + PowerShell global tools from build stage
-COPY --from=build /root/.dotnet/tools /root/.dotnet/tools
+# Copy Tendril + PowerShell global tools from build stage (root → tendril user home)
+COPY --from=build --chown=tendril:tendril /root/.dotnet/tools /home/tendril/.dotnet/tools
 
 # Copy Node.js from official image (avoids flaky apt mirrors — same pattern as Dockerfile.tendril-docs)
 COPY --from=node:22-bookworm-slim /usr/local/bin/node /usr/local/bin/node
@@ -38,7 +44,8 @@ RUN --mount=type=cache,id=npm-tendril,target=/root/.npm \
     npm install -g \
       @anthropic-ai/claude-code \
       @openai/codex \
-      @google/gemini-cli
+      @google/gemini-cli \
+      @github/copilot
 
 # Install git + GitHub CLI + Pandoc (PDF export)
 RUN apt-get update \
@@ -53,10 +60,18 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends gh \
  && rm -rf /var/lib/apt/lists/*
 
-# git: allow operations on any mounted repo volume
+# git: allow operations on any mounted repo volume (for both root and tendril user)
 RUN git config --global --add safe.directory '*' \
  && git config --global user.name  "Tendril" \
- && git config --global user.email "tendril@localhost"
+ && git config --global user.email "tendril@localhost" \
+ && chown tendril:tendril /home/tendril/.gitconfig
+
+# Ensure dotnet tools path and /usr/local/bin survive login-shell PATH reinit
+RUN echo 'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/tendril/.dotnet/tools"' \
+    > /etc/profile.d/tendril-path.sh
+
+# Ensure tendril user owns the data volume mount point
+RUN mkdir -p /data/tendril && chown tendril:tendril /data/tendril
 
 # Default config template (copied to TENDRIL_HOME on first start by Tendril itself)
 COPY src/Ivy.Tendril/example.config.yaml /etc/tendril/example.config.yaml
@@ -64,5 +79,7 @@ COPY src/Ivy.Tendril/example.config.yaml /etc/tendril/example.config.yaml
 VOLUME ["/data/tendril"]
 
 EXPOSE 8000
+
+USER tendril
 
 CMD ["tendril", "--web"]


### PR DESCRIPTION
### Summary
- Run the image as user `tendril` instead of `root` (better for tools that expect a real home dir, e.g. Claude Code with `--dangerously-skip-permissions`).
- Add `@github/copilot` to the global Node CLIs next to claude-code, codex, and gemini-cli; refresh the Dockerfile header comment.
- Set `HOME`, `HOMEDIR`, and `PATH` so login shells and non-root CLIs (`gh`, Node globals, `dotnet` tools) resolve correctly.
- Copy build-stage `dotnet` global tools into `/home/tendril/.dotnet/tools` with `chown tendril:tendril`.
- Configure global `git` safe directory and identity for the tendril user; create `/data/tendril` and `chown` for the volume mount.
- Add `/etc/profile.d/tendril-path.sh` so `/usr/local/bin` and `~/.dotnet/tools` stay on `PATH` for login shells.

### Why
Aligns the runtime with a non-root security posture and fixes HOME-related failures for GitHub CLI and similar tools. Brings GitHub Copilot CLI in line with other agent CLIs already in the image.
