### PR TITLE
release

### DIFF
--- a/.github/docker/Dockerfile.tendril
+++ b/.github/docker/Dockerfile.tendril
@@ -1,29 +1,6 @@
-# Dockerfile.tendril — builds and runs Ivy Tendril for one-click Sliplane deploy.
-#
-# Runtime dependencies installed in the final image:
-#   - Claude Code  (@anthropic-ai/claude-code) — AI agent CLI
-#   - Codex CLI    (@openai/codex)             — OpenAI coding agent (`codex` on PATH)
-#   - Gemini CLI   (@google/gemini-cli)        — Google coding agent (`gemini` on PATH)
-#   - GitHub CLI   (gh)                        — PR creation / branch management
-#   - PowerShell   (pwsh)                      — hooks and verification scripts
-#   - Git                                        — worktree / commit operations
-#   - Pandoc       (pandoc)                    — optional PDF export (Tendril onboarding / PlanPdf)
-#
-# Required env vars at runtime:
-#   ANTHROPIC_API_KEY  — Anthropic API key passed to Claude Code
-#   GITHUB_TOKEN       — GitHub token used automatically by gh CLI
-#
-# Agent auth (set in Sliplane / your orchestrator as needed):
-#   OPENAI_API_KEY     — Codex CLI (or use `codex login` interactively where possible)
-#   GEMINI_API_KEY / Google auth — see Gemini CLI docs for headless/container setup
-#
-# Optional env vars:
-#   PORT               — web server port         (default: 8000)
-#   TENDRIL_HOME       — config + data directory (default: /data/tendril)
-#
-# Persistent volume:
-#   Mount a volume at /data/tendril to persist config.yaml, plans, and SQLite DB.
-#   On first start the example config.yaml is copied there automatically.
+# Ivy Tendril image for Sliplane (or similar). Includes Node CLIs: claude-code, codex, gemini;
+# git, gh, pwsh, pandoc. Required: ANTHROPIC_API_KEY, GITHUB_TOKEN. Optional: OPENAI_API_KEY,
+# Gemini auth, PORT (8000), TENDRIL_HOME (/data/tendril). Mount /data/tendril to persist data.
 
 # ── Stage 1: install Tendril + PowerShell as dotnet global tools ───────────────
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build

--- a/.github/docker/Dockerfile.tendril
+++ b/.github/docker/Dockerfile.tendril
@@ -1,0 +1,91 @@
+# Dockerfile.tendril — builds and runs Ivy Tendril for one-click Sliplane deploy.
+#
+# Runtime dependencies installed in the final image:
+#   - Claude Code  (@anthropic-ai/claude-code) — AI agent CLI
+#   - Codex CLI    (@openai/codex)             — OpenAI coding agent (`codex` on PATH)
+#   - Gemini CLI   (@google/gemini-cli)        — Google coding agent (`gemini` on PATH)
+#   - GitHub CLI   (gh)                        — PR creation / branch management
+#   - PowerShell   (pwsh)                      — hooks and verification scripts
+#   - Git                                        — worktree / commit operations
+#   - Pandoc       (pandoc)                    — optional PDF export (Tendril onboarding / PlanPdf)
+#
+# Required env vars at runtime:
+#   ANTHROPIC_API_KEY  — Anthropic API key passed to Claude Code
+#   GITHUB_TOKEN       — GitHub token used automatically by gh CLI
+#
+# Agent auth (set in Sliplane / your orchestrator as needed):
+#   OPENAI_API_KEY     — Codex CLI (or use `codex login` interactively where possible)
+#   GEMINI_API_KEY / Google auth — see Gemini CLI docs for headless/container setup
+#
+# Optional env vars:
+#   PORT               — web server port         (default: 8000)
+#   TENDRIL_HOME       — config + data directory (default: /data/tendril)
+#
+# Persistent volume:
+#   Mount a volume at /data/tendril to persist config.yaml, plans, and SQLite DB.
+#   On first start the example config.yaml is copied there automatically.
+
+# ── Stage 1: install Tendril + PowerShell as dotnet global tools ───────────────
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+
+RUN --mount=type=cache,id=nuget-tendril,target=/root/.nuget/packages \
+    dotnet tool install --global Ivy.Tendril \
+ && dotnet tool install --global PowerShell
+
+# ── Stage 2: runtime image with all CLI dependencies ──────────────────────────
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
+
+# aspnet:10.0 puts the runtime at /usr/share/dotnet — tools must point there
+ENV DOTNET_ROOT=/usr/share/dotnet
+ENV PATH="$PATH:/root/.dotnet/tools"
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_NOLOGO=1
+ENV CLAUDE_CODE_SKIP_SETUP=1
+ENV HOME=/root
+
+# Tendril runtime config
+ENV TENDRIL_HOME=/data/tendril
+ENV PORT=8000
+
+# Copy Tendril + PowerShell global tools from build stage
+COPY --from=build /root/.dotnet/tools /root/.dotnet/tools
+
+# Copy Node.js from official image (avoids flaky apt mirrors — same pattern as Dockerfile.tendril-docs)
+COPY --from=node:22-bookworm-slim /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:22-bookworm-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+ && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+# Coding agent CLIs (npm cache speeds rebuilds on the same builder)
+RUN --mount=type=cache,id=npm-tendril,target=/root/.npm \
+    npm install -g \
+      @anthropic-ai/claude-code \
+      @openai/codex \
+      @google/gemini-cli
+
+# Install git + GitHub CLI + Pandoc (PDF export)
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git curl ca-certificates gnupg pandoc \
+ && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+        https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends gh \
+ && rm -rf /var/lib/apt/lists/*
+
+# git: allow operations on any mounted repo volume
+RUN git config --global --add safe.directory '*' \
+ && git config --global user.name  "Tendril" \
+ && git config --global user.email "tendril@localhost"
+
+# Default config template (copied to TENDRIL_HOME on first start by Tendril itself)
+COPY src/Ivy.Tendril/example.config.yaml /etc/tendril/example.config.yaml
+
+VOLUME ["/data/tendril"]
+
+EXPOSE 8000
+
+CMD ["tendril", "--web"]

--- a/.github/docker/Dockerfile.tendril
+++ b/.github/docker/Dockerfile.tendril
@@ -1,4 +1,4 @@
-# Ivy Tendril image for Sliplane (or similar). Includes Node CLIs: claude-code, codex, gemini;
+# Ivy Tendril image for Sliplane (or similar). Includes Node CLIs: claude-code, codex, gemini, copilot;
 # git, gh, pwsh, pandoc. Required: ANTHROPIC_API_KEY, GITHUB_TOKEN. Optional: OPENAI_API_KEY,
 # Gemini auth, PORT (8000), TENDRIL_HOME (/data/tendril). Mount /data/tendril to persist data.
 
@@ -12,20 +12,26 @@ RUN --mount=type=cache,id=nuget-tendril,target=/root/.nuget/packages \
 # ── Stage 2: runtime image with all CLI dependencies ──────────────────────────
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
 
+# Non-root user so Claude Code accepts --dangerously-skip-permissions
+RUN useradd --create-home --shell /bin/bash tendril
+
 # aspnet:10.0 puts the runtime at /usr/share/dotnet — tools must point there
 ENV DOTNET_ROOT=/usr/share/dotnet
-ENV PATH="$PATH:/root/.dotnet/tools"
+ENV PATH="$PATH:/home/tendril/.dotnet/tools"
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV DOTNET_NOLOGO=1
 ENV CLAUDE_CODE_SKIP_SETUP=1
-ENV HOME=/root
+ENV HOME=/home/tendril
+# HOMEDIR is read by the clone bootstrap prelude: HOME="${HOMEDIR:-/root}"
+# Without this, HOME gets reset to /root and non-root tools (gh, claude) fail.
+ENV HOMEDIR=/home/tendril
 
 # Tendril runtime config
 ENV TENDRIL_HOME=/data/tendril
 ENV PORT=8000
 
-# Copy Tendril + PowerShell global tools from build stage
-COPY --from=build /root/.dotnet/tools /root/.dotnet/tools
+# Copy Tendril + PowerShell global tools from build stage (root → tendril user home)
+COPY --from=build --chown=tendril:tendril /root/.dotnet/tools /home/tendril/.dotnet/tools
 
 # Copy Node.js from official image (avoids flaky apt mirrors — same pattern as Dockerfile.tendril-docs)
 COPY --from=node:22-bookworm-slim /usr/local/bin/node /usr/local/bin/node
@@ -38,7 +44,8 @@ RUN --mount=type=cache,id=npm-tendril,target=/root/.npm \
     npm install -g \
       @anthropic-ai/claude-code \
       @openai/codex \
-      @google/gemini-cli
+      @google/gemini-cli \
+      @github/copilot
 
 # Install git + GitHub CLI + Pandoc (PDF export)
 RUN apt-get update \
@@ -53,10 +60,18 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends gh \
  && rm -rf /var/lib/apt/lists/*
 
-# git: allow operations on any mounted repo volume
+# git: allow operations on any mounted repo volume (for both root and tendril user)
 RUN git config --global --add safe.directory '*' \
  && git config --global user.name  "Tendril" \
- && git config --global user.email "tendril@localhost"
+ && git config --global user.email "tendril@localhost" \
+ && chown tendril:tendril /home/tendril/.gitconfig
+
+# Ensure dotnet tools path and /usr/local/bin survive login-shell PATH reinit
+RUN echo 'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/tendril/.dotnet/tools"' \
+    > /etc/profile.d/tendril-path.sh
+
+# Ensure tendril user owns the data volume mount point
+RUN mkdir -p /data/tendril && chown tendril:tendril /data/tendril
 
 # Default config template (copied to TENDRIL_HOME on first start by Tendril itself)
 COPY src/Ivy.Tendril/example.config.yaml /etc/tendril/example.config.yaml
@@ -64,5 +79,7 @@ COPY src/Ivy.Tendril/example.config.yaml /etc/tendril/example.config.yaml
 VOLUME ["/data/tendril"]
 
 EXPOSE 8000
+
+USER tendril
 
 CMD ["tendril", "--web"]

--- a/src/Ivy.Tendril.Docs/Dockerfile
+++ b/src/Ivy.Tendril.Docs/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
 # Install Node.js + pnpm + vite-plus (Ivy.csproj MSBuild targets run "vp install/build")
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
-    npm install -g pnpm@10.33.0 vite-plus@0.1.13
+    npm install -g pnpm@10.33.0 vite-plus@0.1.20
 
 RUN git clone --depth 1 --branch $IVY_FRAMEWORK_REF \
     https://github.com/Ivy-Interactive/Ivy-Framework.git /src/Ivy-Framework

--- a/src/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
+++ b/src/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
@@ -17,9 +17,9 @@
     </ItemGroup>
     <ItemGroup Condition="'$(IvySource)' != 'true'">
         <PackageReference Include="Ivy" Version="$(IvyPackageVersion)" Condition="'$(IvyPackageVersion)' != ''" />
-        <PackageReference Include="Ivy" Version="1.2.54" Condition="'$(IvyPackageVersion)' == ''" />
+        <PackageReference Include="Ivy" Version="1.2.55" Condition="'$(IvyPackageVersion)' == ''" />
         <PackageReference Include="Ivy.Docs.Helpers" Version="$(IvyPackageVersion)" Condition="'$(IvyPackageVersion)' != ''" />
-        <PackageReference Include="Ivy.Docs.Helpers" Version="1.2.54" Condition="'$(IvyPackageVersion)' == ''" />
+        <PackageReference Include="Ivy.Docs.Helpers" Version="1.2.55" Condition="'$(IvyPackageVersion)' == ''" />
     </ItemGroup>
 
     <ItemGroup>
@@ -64,7 +64,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Ivy.Analyser" Version="1.2.54" Condition="'$(IvyPackageVersion)' == ''">
+        <PackageReference Include="Ivy.Analyser" Version="1.2.55" Condition="'$(IvyPackageVersion)' == ''">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
+++ b/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
@@ -38,7 +38,7 @@
     <ProjectReference Include="..\..\..\Ivy-Framework\src\Ivy\Ivy.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy" Version="1.2.54" />
+    <PackageReference Include="Ivy" Version="1.2.55" />
   </ItemGroup>
 
 </Project>

--- a/src/Ivy.Tendril.Test/PlanYamlCorruptionTests.cs
+++ b/src/Ivy.Tendril.Test/PlanYamlCorruptionTests.cs
@@ -1,0 +1,158 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Test;
+
+public class PlanYamlCorruptionTests : IClassFixture<ConfigServiceFixture>
+{
+    private readonly ConfigServiceFixture _fixture;
+    private readonly string _testPlansDir;
+
+    public PlanYamlCorruptionTests(ConfigServiceFixture fixture)
+    {
+        _fixture = fixture;
+        _testPlansDir = Path.Combine(Path.GetTempPath(), $"test-plans-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testPlansDir);
+    }
+
+    private string CreateTestPlan(string initialPrompt = "Test plan", string title = "Test Plan")
+    {
+        var planId = PlanYamlHelper.AllocatePlanId(_testPlansDir);
+        var safeTitle = PlanYamlHelper.ToSafeTitle(title);
+        var planFolder = Path.Combine(_testPlansDir, $"{planId}-{safeTitle}");
+        Directory.CreateDirectory(planFolder);
+        Directory.CreateDirectory(Path.Combine(planFolder, "revisions"));
+
+        var plan = new PlanYaml
+        {
+            State = "Draft",
+            Project = "Test",
+            Level = "NiceToHave",
+            Title = title,
+            Repos = [],
+            Created = DateTime.UtcNow,
+            Updated = DateTime.UtcNow,
+            InitialPrompt = initialPrompt,
+            Prs = [],
+            Commits = [],
+            Verifications = [],
+            RelatedPlans = [],
+            DependsOn = []
+        };
+
+        PlanCommandHelpers.WritePlan(planFolder, plan, watcher: null);
+
+        // Create initial revision
+        var revisionPath = Path.Combine(planFolder, "revisions", "001.md");
+        File.WriteAllText(revisionPath, "# Test Plan\n\n## Problem\n\nTest problem");
+
+        return planFolder;
+    }
+
+    [Fact]
+    public void SetPlanStateByFolder_WithLargeInitialPrompt_DoesNotCorruptYaml()
+    {
+        // Arrange: Create a plan with a very long initialPrompt (>10KB)
+        var largePrompt = new string('x', 50000);
+        var planFolder = CreateTestPlan(initialPrompt: largePrompt);
+
+        // Act: Change state multiple times
+        PlanYamlHelper.SetPlanStateByFolder(planFolder, "Building");
+        PlanYamlHelper.SetPlanStateByFolder(planFolder, "Draft");
+
+        // Assert: plan.yaml is valid and intact
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        Assert.NotNull(plan);
+        Assert.Equal("Draft", plan.State);
+        Assert.Equal(largePrompt, plan.InitialPrompt);
+
+        // Verify the file can be parsed without errors
+        var raw = File.ReadAllText(Path.Combine(planFolder, "plan.yaml"));
+        var roundTrip = YamlHelper.Deserializer.Deserialize<PlanYaml>(raw);
+        Assert.NotNull(roundTrip);
+        Assert.Equal(largePrompt, roundTrip.InitialPrompt);
+
+        // Cleanup
+        Directory.Delete(planFolder, true);
+    }
+
+    [Fact]
+    public async Task ConcurrentStateChanges_DoNotCorruptPlanYaml()
+    {
+        // Arrange: Create a plan
+        var planFolder = CreateTestPlan();
+
+        // Act: Rapidly change state multiple times concurrently
+        var tasks = Enumerable.Range(0, 10).Select(async i =>
+        {
+            await Task.Delay(Random.Shared.Next(0, 50));
+            var state = i % 2 == 0 ? "Draft" : "Building";
+            PlanYamlHelper.SetPlanStateByFolder(planFolder, state);
+        });
+
+        await Task.WhenAll(tasks);
+
+        // Assert: plan.yaml is still valid and can be read
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        Assert.NotNull(plan);
+        Assert.Contains(plan.State, new[] { "Draft", "Building" });
+
+        // Verify no corruption - file should still be valid YAML
+        var raw = File.ReadAllText(Path.Combine(planFolder, "plan.yaml"));
+        var roundTrip = YamlHelper.Deserializer.Deserialize<PlanYaml>(raw);
+        Assert.NotNull(roundTrip);
+        Assert.NotNull(roundTrip.State);
+        Assert.NotNull(roundTrip.Title);
+
+        // Cleanup
+        Directory.Delete(planFolder, true);
+    }
+
+    [Fact]
+    public void SetPlanStateByFolder_UsesAtomicWrite()
+    {
+        // Arrange: Create a plan
+        var planFolder = CreateTestPlan();
+        var planYamlPath = Path.Combine(planFolder, "plan.yaml");
+
+        // Act: Change state
+        var beforeModTime = File.GetLastWriteTimeUtc(planYamlPath);
+        Thread.Sleep(10); // Ensure timestamp difference
+        PlanYamlHelper.SetPlanStateByFolder(planFolder, "Building");
+
+        // Assert: File was modified
+        var afterModTime = File.GetLastWriteTimeUtc(planYamlPath);
+        Assert.True(afterModTime > beforeModTime);
+
+        // Verify no temporary files left behind
+        var tempFiles = Directory.GetFiles(planFolder, "plan.yaml.tmp.*");
+        Assert.Empty(tempFiles);
+
+        // Verify content is valid
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        Assert.Equal("Building", plan.State);
+
+        // Cleanup
+        Directory.Delete(planFolder, true);
+    }
+
+    [Fact]
+    public void SetPlanStateByFolder_UpdatesTimestamp()
+    {
+        // Arrange: Create a plan
+        var planFolder = CreateTestPlan();
+        var originalPlan = PlanCommandHelpers.ReadPlan(planFolder);
+        var originalUpdated = originalPlan.Updated;
+
+        // Act: Wait briefly then change state
+        Thread.Sleep(100);
+        PlanYamlHelper.SetPlanStateByFolder(planFolder, "Building");
+
+        // Assert: Updated timestamp changed
+        var updatedPlan = PlanCommandHelpers.ReadPlan(planFolder);
+        Assert.True(updatedPlan.Updated > originalUpdated);
+
+        // Cleanup
+        Directory.Delete(planFolder, true);
+    }
+}

--- a/src/Ivy.Tendril.Test/PromptwareDeployerTests.cs
+++ b/src/Ivy.Tendril.Test/PromptwareDeployerTests.cs
@@ -192,4 +192,37 @@ public class PromptwareDeployerTests : IDisposable
             }
         }
     }
+
+    [Fact]
+    public void CleanupOrphanedPreservedDirectories_RemovesPreservedDirectories()
+    {
+        // Arrange
+        var promptwaresDir = Path.Combine(_tempDir, "Promptwares");
+        var updatePlanDir = Path.Combine(promptwaresDir, "UpdatePlan");
+        var orphanedDir = Path.Combine(updatePlanDir, "Logs-preserved-abc123");
+        Directory.CreateDirectory(orphanedDir);
+        File.WriteAllText(Path.Combine(orphanedDir, "test.md"), "orphaned content");
+
+        // Act
+        PromptwareDeployer.CleanupOrphanedPreservedDirectories(promptwaresDir);
+
+        // Assert
+        Assert.False(Directory.Exists(orphanedDir));
+    }
+
+    [Fact]
+    public void CleanupOrphanedPreservedDirectories_IgnoresNormalDirectories()
+    {
+        // Arrange
+        var promptwaresDir = Path.Combine(_tempDir, "Promptwares");
+        var normalDir = Path.Combine(promptwaresDir, "UpdatePlan", "Logs");
+        Directory.CreateDirectory(normalDir);
+        File.WriteAllText(Path.Combine(normalDir, "test.md"), "normal content");
+
+        // Act
+        PromptwareDeployer.CleanupOrphanedPreservedDirectories(promptwaresDir);
+
+        // Assert
+        Assert.True(Directory.Exists(normalDir));
+    }
 }

--- a/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
@@ -9,7 +9,8 @@ public class OutputSheet(
     string jobId,
     IJobService jobService,
     IWriteStream<string> outputStream,
-    IState<bool> hasStreamContent) : ViewBase
+    IState<bool> hasStreamContent,
+    IState<string?> streamingJobId) : ViewBase
 {
     public override object Build()
     {
@@ -32,10 +33,8 @@ public class OutputSheet(
                     .Height(Size.Full());
             }
         }
-        else if (job is not null && hasStreamContent.Value)
+        else if (job is not null && hasStreamContent.Value && streamingJobId.Value == jobId)
         {
-            // Job finished while user was watching the stream — keep using stream renderer
-            // (switching to JsonStream would duplicate content since streamedLines persists in React state)
             outputContent = new ClaudeJsonRenderer()
                 .Stream(outputStream)
                 .ShowThinking(false)

--- a/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
@@ -44,7 +44,7 @@ public class OutputSheet(
         }
         else if (job is not null && job.OutputLines.Count > 0)
         {
-            // Job completed before user opened sheet — load from stored output
+            // Job completed before user opened sheet load from stored output
             var jsonStream = string.Join("\n", job.OutputLines);
             outputContent = new ClaudeJsonRenderer()
                 .JsonStream(jsonStream)
@@ -64,7 +64,7 @@ public class OutputSheet(
     public string GetSheetTitle()
     {
         var job = jobService.GetJob(jobId);
-        return job is not null ? $"{job.Type} — {ExtractPlanId(job.PlanFile)}" : "Job Output";
+        return job is not null ? $"{job.Type} {ExtractPlanId(job.PlanFile)}" : "Job Output";
     }
 
     private static string ExtractPlanId(string planFile)

--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -134,14 +134,7 @@ public partial class JobsApp
             .RowActions(row =>
             {
                 var job = jobs.FirstOrDefault(j => j.Id == row.Id);
-                var actions = new List<MenuItem>
-                {
-                    new MenuItem("View Plan", Icon: Icons.FileText, Tag: "view-plan").Tooltip("Open the associated plan"),
-                    new MenuItem("View Output", Icon: Icons.Terminal, Tag: "view-output").Tooltip(
-                        "View job output with Claude JSON rendering"),
-                    new MenuItem("Show Prompt", Icon: Icons.MessageSquare, Tag: "show-prompt").Tooltip(
-                        "Show the full prompt text"),
-                };
+                var actions = new List<MenuItem> { };
 
                 if (job?.Status is JobStatus.Running or JobStatus.Queued)
                 {
@@ -168,26 +161,8 @@ public partial class JobsApp
 
                 if (job != null)
                 {
-                    if (tag == "view-plan")
-                    {
-                        if (!string.IsNullOrEmpty(job.PlanFile))
-                        {
-                            var fullPath = Path.Combine(planService.PlansDirectory, job.PlanFile);
-                            if (Directory.Exists(fullPath))
-                                showPlan.Set(fullPath);
-                        }
-                    }
-                    else if (tag == "view-output")
-                    {
-                        showOutput.Set(job.Id);
-                    }
-                    else if (tag == "show-prompt")
-                    {
-                        var fullPrompt = GetFullPrompt(job, planService);
-                        if (!string.IsNullOrEmpty(fullPrompt))
-                            showPrompt.Set(fullPrompt);
-                    }
-                    else if (tag == "stop-job")
+                  
+                    if (tag == "stop-job")
                     {
                         if (job.Status is JobStatus.Running or JobStatus.Queued)
                         {
@@ -236,7 +211,7 @@ public partial class JobsApp
 
                 return ValueTask.CompletedTask;
             })
-            .HeaderRight(_ => Layout.Horizontal().Gap(2)
+            .HeaderRight(_ => Layout.Horizontal()
                               | jobsProgress
                               | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
                                   new MenuItem("Clear Completed", Icon: Icons.Trash, Tag: "ClearCompleted")

--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -80,57 +80,55 @@ public partial class JobsApp
                 c.SelectionMode = SelectionModes.None;
                 c.ShowIndexColumn = false;
                 c.BatchSize = 50;
-                c.EnableCellClickEvents = true;
             })
-            .OnCellClick(e =>
+            .OnCellAction(t => t.PlanId, e =>
             {
-                if (e.Value.ColumnName == "PlanId")
+                var planId = e.Value.CellValue?.ToString();
+                if (!string.IsNullOrEmpty(planId))
                 {
-                    var planId = e.Value.CellValue?.ToString();
-                    if (!string.IsNullOrEmpty(planId))
+                    var job = jobs.FirstOrDefault(j => ExtractPlanId(j.PlanFile) == planId);
+                    if (job != null && !string.IsNullOrEmpty(job.PlanFile))
                     {
-                        var job = jobs.FirstOrDefault(j => ExtractPlanId(j.PlanFile) == planId);
-                        if (job != null && !string.IsNullOrEmpty(job.PlanFile))
-                        {
-                            var fullPath = Path.Combine(planService.PlansDirectory, job.PlanFile);
-                            if (Directory.Exists(fullPath))
-                                showPlan.Set(fullPath);
-                        }
+                        var fullPath = Path.Combine(planService.PlansDirectory, job.PlanFile);
+                        if (Directory.Exists(fullPath))
+                            showPlan.Set(fullPath);
                     }
                 }
-                else if (e.Value.ColumnName == "LastOutput")
+                return ValueTask.CompletedTask;
+            })
+            .OnCellAction(t => t.LastOutput, e =>
+            {
+                var id = e.Value.RowId?.ToString();
+                if (!string.IsNullOrEmpty(id))
+                    showOutput.Set(id);
+                return ValueTask.CompletedTask;
+            })
+            .OnCellAction(t => t.StatusMessage, e =>
+            {
+                var id = e.Value.RowId?.ToString();
+                if (!string.IsNullOrEmpty(id))
                 {
-                    var id = e.Value.RowId?.ToString();
-                    if (!string.IsNullOrEmpty(id))
+                    var job = jobs.FirstOrDefault(j => j.Id == id);
+                    if (job?.Status is JobStatus.Failed or JobStatus.Timeout)
+                    {
                         showOutput.Set(id);
-                }
-                else if (e.Value.ColumnName == "StatusMessage")
-                {
-                    var id = e.Value.RowId?.ToString();
-                    if (!string.IsNullOrEmpty(id))
-                    {
-                        var job = jobs.FirstOrDefault(j => j.Id == id);
-                        if (job?.Status is JobStatus.Failed or JobStatus.Timeout)
-                        {
-                            showOutput.Set(id);
-                        }
                     }
                 }
-                else if (e.Value.ColumnName == "Prompt/Title")
+                return ValueTask.CompletedTask;
+            })
+            .OnCellAction(t => t.Plan, e =>
+            {
+                var id = e.Value.RowId?.ToString();
+                if (!string.IsNullOrEmpty(id))
                 {
-                    var id = e.Value.RowId?.ToString();
-                    if (!string.IsNullOrEmpty(id))
+                    var job = jobs.FirstOrDefault(j => j.Id == id);
+                    if (job != null)
                     {
-                        var job = jobs.FirstOrDefault(j => j.Id == id);
-                        if (job != null)
-                        {
-                            var fullPrompt = GetFullPrompt(job, planService);
-                            if (!string.IsNullOrEmpty(fullPrompt))
-                                showPrompt.Set(fullPrompt);
-                        }
+                        var fullPrompt = GetFullPrompt(job, planService);
+                        if (!string.IsNullOrEmpty(fullPrompt))
+                            showPrompt.Set(fullPrompt);
                     }
                 }
-
                 return ValueTask.CompletedTask;
             })
             .RowActions(row =>

--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -23,7 +23,7 @@ public partial class JobsApp
     {
         return rows.AsQueryable()
             .ToDataTable(t => t.Id)
-            .Density(Density.Large.At(Breakpoint.Tablet).And(Breakpoint.Desktop, Density.Medium))
+            .Density(new Responsive<Density?> { Default = Density.Large, Desktop = Density.Medium })
             .RefreshToken(refreshToken)
             .UpdateStream(updateStream)
             .Width(Size.Full())

--- a/src/Ivy.Tendril/Apps/JobsApp.Sheets.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Sheets.cs
@@ -19,7 +19,7 @@ public partial class JobsApp
         IState<bool> hasStreamContent,
         LayoutView layout)
     {
-        layout |= dataTable;
+        object? activeSheet = null;
 
         if (showPlan.Value is { } planPath)
         {
@@ -32,14 +32,15 @@ public partial class JobsApp
                 planSheetView.GetSheetTitle()
             ).Width(Size.Half()).Resizable();
 
-            layout |= planSheet;
-            if (fileLinkSheet is not null) layout |= fileLinkSheet;
+            activeSheet = fileLinkSheet is not null
+                ? new Fragment(planSheet, fileLinkSheet)
+                : planSheet;
         }
         else if (showOutput.Value is { } jobId)
         {
             var outputSheetView = new OutputSheet(jobId, jobService, outputStream, hasStreamContent);
 
-            layout |= new Sheet(
+            activeSheet = new Sheet(
                 () => showOutput.Set(null),
                 outputSheetView.Build(),
                 outputSheetView.GetSheetTitle()
@@ -49,13 +50,13 @@ public partial class JobsApp
         {
             var promptSheetView = new PromptSheet(promptText);
 
-            layout |= new Sheet(
+            activeSheet = new Sheet(
                 () => showPrompt.Set(null),
                 promptSheetView.Build(),
                 "Full Prompt"
             ).Width(Size.Half()).Resizable();
         }
 
-        return layout;
+        return layout | new Fragment(dataTable, activeSheet);
     }
 }

--- a/src/Ivy.Tendril/Apps/JobsApp.Sheets.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Sheets.cs
@@ -19,6 +19,8 @@ public partial class JobsApp
         IState<bool> hasStreamContent,
         LayoutView layout)
     {
+        layout |= dataTable;
+
         if (showPlan.Value is { } planPath)
         {
             var planSheetView = new PlanSheet(planPath, planService, config, openFile);
@@ -30,37 +32,30 @@ public partial class JobsApp
                 planSheetView.GetSheetTitle()
             ).Width(Size.Half()).Resizable();
 
-            if (fileLinkSheet is not null) return layout | new Fragment(dataTable, planSheet, fileLinkSheet);
-
-            return layout | new Fragment(dataTable, planSheet);
+            layout |= planSheet;
+            if (fileLinkSheet is not null) layout |= fileLinkSheet;
         }
-
-        if (showOutput.Value is { } jobId)
+        else if (showOutput.Value is { } jobId)
         {
             var outputSheetView = new OutputSheet(jobId, jobService, outputStream, hasStreamContent);
 
-            var outputSheet = new Sheet(
+            layout |= new Sheet(
                 () => showOutput.Set(null),
                 outputSheetView.Build(),
                 outputSheetView.GetSheetTitle()
             ).Width(Size.Half()).Resizable();
-
-            return layout | new Fragment(dataTable, outputSheet);
         }
-
-        if (showPrompt.Value is { } promptText)
+        else if (showPrompt.Value is { } promptText)
         {
             var promptSheetView = new PromptSheet(promptText);
 
-            var promptSheet = new Sheet(
+            layout |= new Sheet(
                 () => showPrompt.Set(null),
                 promptSheetView.Build(),
                 "Full Prompt"
             ).Width(Size.Half()).Resizable();
-
-            return layout | new Fragment(dataTable, promptSheet);
         }
 
-        return layout | dataTable;
+        return layout;
     }
 }

--- a/src/Ivy.Tendril/Apps/JobsApp.Sheets.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Sheets.cs
@@ -17,6 +17,7 @@ public partial class JobsApp
         IJobService jobService,
         IWriteStream<string> outputStream,
         IState<bool> hasStreamContent,
+        IState<string?> streamingJobId,
         LayoutView layout)
     {
         object? activeSheet = null;
@@ -38,7 +39,7 @@ public partial class JobsApp
         }
         else if (showOutput.Value is { } jobId)
         {
-            var outputSheetView = new OutputSheet(jobId, jobService, outputStream, hasStreamContent);
+            var outputSheetView = new OutputSheet(jobId, jobService, outputStream, hasStreamContent, streamingJobId);
 
             activeSheet = new Sheet(
                 () => showOutput.Set(null),

--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -43,6 +43,6 @@ public partial class JobsApp : ViewBase
         var layout = Layout.Vertical().Height(Size.Full());
 
         return RenderWithSheets(dataTable, showPlan, showOutput, showPrompt, planService,
-            config, openFile, jobService, outputStream, hasStreamContent, layout);
+            config, openFile, jobService, outputStream, hasStreamContent, streamingJobId, layout);
     }
 }

--- a/src/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/SoftwareCheckStepView.cs
@@ -13,7 +13,7 @@ public class SoftwareCheckStepView(
     {
         new("GitHub CLI", "gh", "https://cli.github.com/", true,
             () => CheckCommand("gh", "--version"),
-            () => CheckHealth("gh", "auth status"),
+            () => CheckHealth("gh", "auth status --active"),
             "Run `gh auth login` to authenticate"),
         new("Claude CLI", "claude", "https://docs.anthropic.com/en/docs/claude-code", false,
             () => CheckCommand("claude", "--version"),

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -185,7 +185,7 @@ public class ContentView(
         }
         else
         {
-            // Git tab content (uses shared helper — reuse precomputed commit rows from planContentQuery)
+            // Git tab content (uses shared helper reuse precomputed commit rows from planContentQuery)
             var gitData = GitTabHelper.BuildGitTabData(planData.CommitRows, selectedPlan!, config, gitService);
             var gitLayout = GitTabHelper.RenderGitTab(
                 gitData,
@@ -306,7 +306,7 @@ public class ContentView(
                 var reportPath = Path.Combine(verificationDir, $"{v.Name}.md");
                 if (!File.Exists(reportPath))
                 {
-                    parts.Add($"**{v.Name}** — {v.Status}, no report generated");
+                    parts.Add($"**{v.Name}** {v.Status}, no report generated");
                     continue;
                 }
 
@@ -327,7 +327,7 @@ public class ContentView(
                     : null;
 
                 var detail = output ?? issues ?? "See verification report for details";
-                parts.Add($"**{v.Name}** — {detail}");
+                parts.Add($"**{v.Name}** {detail}");
             }
 
             return Callout.Destructive(string.Join("\n\n", parts), "Execution Failed");

--- a/src/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -95,17 +95,13 @@ public class PullRequestApp : ViewBase
                 c.SelectionMode = SelectionModes.None;
                 c.ShowIndexColumn = false;
                 c.BatchSize = 50;
-                c.EnableCellClickEvents = true;
             })
-            .OnCellClick(e =>
+            .OnCellAction(t => t.Plan, e =>
             {
-                if (e.Value.ColumnName == "Plan")
-                {
-                    var row = rows.ElementAtOrDefault(e.Value.RowIndex);
-                    if (row != null && !string.IsNullOrEmpty(row.PlanFolderPath) &&
-                        Directory.Exists(row.PlanFolderPath))
-                        showPlan.Set(row.PlanFolderPath);
-                }
+                var row = rows.ElementAtOrDefault(e.Value.RowIndex);
+                if (row != null && !string.IsNullOrEmpty(row.PlanFolderPath) &&
+                    Directory.Exists(row.PlanFolderPath))
+                    showPlan.Set(row.PlanFolderPath);
 
                 return ValueTask.CompletedTask;
             })

--- a/src/Ivy.Tendril/Commands/DoctorChecks/SoftwareCheck.cs
+++ b/src/Ivy.Tendril/Commands/DoctorChecks/SoftwareCheck.cs
@@ -21,7 +21,7 @@ internal class SoftwareCheck : IDoctorCheck
 
     private static readonly Dictionary<string, string> HealthArgs = new()
     {
-        ["gh"] = "auth status",
+        ["gh"] = "auth status --active",
         ["claude"] = "-p \"ping\" --max-turns 1",
         ["codex"] = "login status",
         ["copilot"] = "-p \"ping\" --allow-all -s"

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -27,7 +27,7 @@ public static class DoctorCommand
 
     private static readonly Dictionary<string, string> HealthArgs = new()
     {
-        ["gh"] = "auth status",
+        ["gh"] = "auth status --active",
         ["claude"] = "-p \"ping\" --max-turns 1",
         ["codex"] = "login status"
     };

--- a/src/Ivy.Tendril/Helpers/FileHelper.cs
+++ b/src/Ivy.Tendril/Helpers/FileHelper.cs
@@ -136,6 +136,8 @@ internal static class FileHelper
                 using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read);
                 using var writer = new StreamWriter(stream);
                 writer.Write(contents);
+                writer.Flush();
+                stream.Flush(flushToDisk: true);
                 return;
             }
             catch (UnauthorizedAccessException) when (attempt < MaxRetries)

--- a/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
@@ -9,7 +9,7 @@ public static class PlanContentHelpers
 {
     public record CommitRow(string Hash, string ShortHash, string Title, int? FileCount);
 
-    public record FileDiff(string FilePath, string Status, string Diff);
+    public record FileDiff(string FilePath, string Status, string Diff, string? OldFilePath = null);
 
     public static List<FileDiff> SplitDiffByFile(AllChangesData changesData)
     {
@@ -38,8 +38,10 @@ public static class PlanContentHelpers
                 continue;
 
             var filePath = headerMatch.Groups[2].Value;
+            var oldFilePath = headerMatch.Groups[1].Value;
             var status = statusLookup.GetValueOrDefault(filePath, "M");
-            result.Add(new FileDiff(filePath, status, chunk.TrimEnd()));
+            var oldPath = oldFilePath != filePath ? oldFilePath : null;
+            result.Add(new FileDiff(filePath, status, chunk.TrimEnd(), oldPath));
         }
 
         return result;
@@ -169,12 +171,25 @@ public static class PlanContentHelpers
                     var chevronIcon = isExpanded ? Icons.ChevronDown : Icons.ChevronRight;
                     var (statusIcon, statusColor) = GetFileStatusIconAndColor(fileDiff.Status);
                     var fileName = Path.GetFileName(fileDiff.FilePath);
+                    var isRenamed = fileDiff.OldFilePath != null;
+                    var oldFileName = isRenamed ? Path.GetFileName(fileDiff.OldFilePath!) : null;
 
                     var header = Layout.Horizontal().Gap(2)
                         | new Icon(chevronIcon).Small()
-                        | new Icon(statusIcon).Small().Color(statusColor)
-                        | Text.Block(fileName).Bold()
-                        | Text.Muted(fileDiff.FilePath);
+                        | new Icon(statusIcon).Small().Color(statusColor);
+
+                    if (isRenamed)
+                    {
+                        header |= Text.Block(oldFileName!).Bold();
+                        header |= Text.Muted("→");
+                        header |= Text.Block(fileName).Bold();
+                        header |= Text.Muted(fileDiff.FilePath);
+                    }
+                    else
+                    {
+                        header |= Text.Block(fileName).Bold();
+                        header |= Text.Muted(fileDiff.FilePath);
+                    }
 
                     if (onToggleFile != null)
                     {
@@ -190,7 +205,7 @@ public static class PlanContentHelpers
 
                     if (isExpanded)
                     {
-                        commitSheetContent |= new DiffView().Diff(fileDiff.Diff).Split();
+                        commitSheetContent |= new DiffView().Diff(fileDiff.Diff).Split().ShowHeader(false);
                     }
                 }
             }
@@ -215,7 +230,7 @@ public static class PlanContentHelpers
                 if (!string.IsNullOrWhiteSpace(data.Diff))
                 {
                     commitSheetContent |= Text.Block("Diff").Bold();
-                    commitSheetContent |= new DiffView().Diff(data.Diff).Split();
+                    commitSheetContent |= new DiffView().Diff(data.Diff).Split().ShowHeader(false);
                 }
             }
 

--- a/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
@@ -205,7 +205,7 @@ public static class PlanContentHelpers
 
                     if (isExpanded)
                     {
-                        commitSheetContent |= new DiffView().Diff(fileDiff.Diff).Split().ShowHeader(false);
+                        commitSheetContent |= new DiffView().Diff(fileDiff.Diff).Split();
                     }
                 }
             }
@@ -230,7 +230,7 @@ public static class PlanContentHelpers
                 if (!string.IsNullOrWhiteSpace(data.Diff))
                 {
                     commitSheetContent |= Text.Block("Diff").Bold();
-                    commitSheetContent |= new DiffView().Diff(data.Diff).Split().ShowHeader(false);
+                    commitSheetContent |= new DiffView().Diff(data.Diff).Split();
                 }
             }
 

--- a/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
@@ -44,9 +44,10 @@ internal static class PlanYamlHelper
 
     internal static void SetPlanStateByFolder(string planFolder, string state)
     {
-        UpdatePlanYamlFields(planFolder,
-            ("state", state),
-            ("updated", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")));
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        plan.State = state;
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(planFolder, plan, watcher: null);
     }
 
     internal static string? GetNamedArg(string[] args, string name)

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -51,12 +51,12 @@
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Desktop/Ivy.Desktop.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy" Version="1.2.54" />
-    <PackageReference Include="Ivy.Hooks.Pty" Version="1.2.54" />
-    <PackageReference Include="Ivy.Widgets.Xterm" Version="1.2.54" />
-    <PackageReference Include="Ivy.Widgets.DiffView" Version="1.2.54" />
-    <PackageReference Include="Ivy.Widgets.ClaudeJsonRenderer" Version="1.2.54" />
-    <PackageReference Include="Ivy.Desktop" Version="1.2.54" />
+    <PackageReference Include="Ivy" Version="1.2.55" />
+    <PackageReference Include="Ivy.Hooks.Pty" Version="1.2.55" />
+    <PackageReference Include="Ivy.Widgets.Xterm" Version="1.2.55" />
+    <PackageReference Include="Ivy.Widgets.DiffView" Version="1.2.55" />
+    <PackageReference Include="Ivy.Widgets.ClaudeJsonRenderer" Version="1.2.55" />
+    <PackageReference Include="Ivy.Desktop" Version="1.2.55" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' == 'true'">
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Analyser/Ivy.Analyser.csproj">
@@ -67,7 +67,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy.Analyser" Version="1.2.54">
+    <PackageReference Include="Ivy.Analyser" Version="1.2.55">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -11,6 +11,7 @@ Create GitHub pull requests and apply PR rules.
 The firmware header contains:
 - **PlanFolder** — path to the plan folder
 - **CurrentTime** — current UTC timestamp
+- **SourceUrl** — (optional) GitHub issue or PR URL from plan.yaml
 
 The plan structure and CLI commands are in the **Reference Documents** section of your firmware.
 Project configuration (repos, `prRule` settings) is available from the firmware header.
@@ -88,7 +89,25 @@ EOF
   3. If configured, use that value
   4. Otherwise, auto-detect via: `gh repo view <owner/repo> --json defaultBranchRef -q .defaultBranchRef.name`
 - **Title:** `[<planId>] <plan title>`
-- **Body:** If `<PlanFolder>/artifacts/summary.md` exists, use its content as the PR body (followed by list of commits). Otherwise, fall back to summary from Problem + Solution sections. If `$artifactMarkdown` from step 2.5 is non-empty, append it under an `## Artifacts` heading after the commits list.
+- **Body:** 
+  1. **If SourceUrl is present in firmware header** and it's a GitHub issue URL (format: `https://github.com/owner/repo/issues/NUMBER`), prepend `Fixes #NUMBER\n\n` to the body
+  2. If `<PlanFolder>/artifacts/summary.md` exists, use its content as the PR body (after the issue link)
+  3. Otherwise, fall back to summary from Problem + Solution sections
+  4. Append commit list
+  5. If `$artifactMarkdown` from step 2.5 is non-empty, append it under an `## Artifacts` heading
+
+  **Issue linking logic:**
+  ```bash
+  # Extract issue number from SourceUrl (if present in firmware header)
+  issueLink=""
+  if [[ -n "$SOURCE_URL" && "$SOURCE_URL" =~ github\.com/.*/issues/([0-9]+) ]]; then
+    issueNumber="${BASH_REMATCH[1]}"
+    issueLink="Fixes #${issueNumber}\n\n"
+  fi
+
+  # Construct body with issue link prepended
+  body="${issueLink}${summaryContent}\n\n---\n${commitsList}${artifactMarkdown}"
+  ```
 - **Draft (custom options):** If custom options exist and `draft` is `true`, add `--draft` to the `gh pr create` command to create the PR in draft mode. If no custom options or `draft` is `false`, create as ready for review (default behavior).
 - **Assignee (custom options):** If custom options exist and `assignee` is non-empty, add `--assignee <assignee>` to the `gh pr create` command.
 

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -550,6 +550,10 @@ internal class JobCompletionHandler
         try
         {
             var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+
+            _logger.LogDebug("SetPlanState: Setting {PlanFolder} to {State} for job {JobId}",
+                Path.GetFileName(planFolder), state, job.Id);
+
             if (_planReaderService != null && Enum.TryParse<PlanStatus>(state, true, out var status))
                 _planReaderService.TransitionState(Path.GetFileName(planFolder), status);
             else

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -573,8 +573,6 @@ internal class JobCompletionHandler
             var plansDir = _planReaderService.PlansDirectory;
             if (!Directory.Exists(plansDir)) return;
 
-            var planId = job.ReportedPlanId ?? job.AllocatedPlanId;
-
             // 1. Agent reported a plan ID via the status API
             if (!string.IsNullOrEmpty(job.ReportedPlanId))
             {
@@ -584,7 +582,15 @@ internal class JobCompletionHandler
                     job.PlanFile = reportedFolder;
                     return;
                 }
+
+                // Reported ID doesn't match any plan folder — clear it so the
+                // bogus value doesn't leak into the UI (e.g. agent copied the
+                // example "01234" from documentation instead of calling the CLI).
+                job.ReportedPlanId = null;
+                job.ReportedPlanTitle = null;
             }
+
+            var planId = job.ReportedPlanId ?? job.AllocatedPlanId;
 
             // 2. Check output regex (backward compat)
             var outputText = string.Join("\n", job.OutputLines);

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -483,6 +483,10 @@ internal class JobLauncher
         if (planYaml == null)
             return (values, null, null);
 
+        // Add sourceUrl to firmware header if present
+        if (!string.IsNullOrEmpty(planYaml.SourceUrl))
+            values["SourceUrl"] = planYaml.SourceUrl;
+
         var profileOverride = ExtractExecutionProfile(job, planYaml);
         AddRepoConfigsIfNeeded(job, planYaml, values);
 

--- a/src/Ivy.Tendril/Services/PromptwareDeployer.cs
+++ b/src/Ivy.Tendril/Services/PromptwareDeployer.cs
@@ -51,21 +51,37 @@ internal static class PromptwareDeployer
                     }
                 }
 
-                // Delete old promptware files (if target exists)
-                if (Directory.Exists(targetSubDir))
-                    Directory.Delete(targetSubDir, true);
-
-                // Move new files from temp
-                Directory.Move(sourceSubDir, targetSubDir);
-
-                // Restore preserved directories
-                foreach (var (original, aside) in preservedDirs)
+                try
                 {
-                    // Remove empty placeholder if it was created by the zip
-                    if (Directory.Exists(original))
-                        Directory.Delete(original, true);
+                    // Delete old promptware files (if target exists)
+                    if (Directory.Exists(targetSubDir))
+                        Directory.Delete(targetSubDir, true);
 
-                    Directory.Move(aside, original);
+                    // Move new files from temp
+                    Directory.Move(sourceSubDir, targetSubDir);
+
+                    // Restore preserved directories
+                    foreach (var (original, aside) in preservedDirs)
+                    {
+                        // Remove empty placeholder if it was created by the zip
+                        if (Directory.Exists(original))
+                            Directory.Delete(original, true);
+
+                        Directory.Move(aside, original);
+                    }
+                }
+                catch
+                {
+                    // If deployment fails after preservation, clean up preserved dirs
+                    foreach (var (_, aside) in preservedDirs)
+                    {
+                        if (Directory.Exists(aside))
+                        {
+                            try { Directory.Delete(aside, true); }
+                            catch { /* Best effort */ }
+                        }
+                    }
+                    throw;
                 }
             }
 
@@ -86,6 +102,35 @@ internal static class PromptwareDeployer
             {
                 try { Directory.Delete(tempDir, true); }
                 catch { /* Best effort */ }
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Removes orphaned *-preserved-* directories from previous failed deployments.
+    /// </summary>
+    public static void CleanupOrphanedPreservedDirectories(string targetDir)
+    {
+        if (!Directory.Exists(targetDir))
+            return;
+
+        foreach (var subDir in Directory.GetDirectories(targetDir))
+        {
+            // Scan each promptware subfolder for preserved directories
+            foreach (var dir in Directory.GetDirectories(subDir))
+            {
+                var dirName = Path.GetFileName(dir);
+                if (dirName.Contains("-preserved-"))
+                {
+                    try
+                    {
+                        Directory.Delete(dir, recursive: true);
+                    }
+                    catch
+                    {
+                        // Best effort — log but don't block startup
+                    }
+                }
             }
         }
     }

--- a/src/Ivy.Tendril/Services/PromptwareDeployer.cs
+++ b/src/Ivy.Tendril/Services/PromptwareDeployer.cs
@@ -45,7 +45,10 @@ internal static class PromptwareDeployer
                     var existingDir = Path.Combine(targetSubDir, preserve);
                     if (Directory.Exists(existingDir))
                     {
-                        var asideDir = existingDir + "-preserved-" + Guid.NewGuid().ToString("N")[..8];
+                        // IMPORTANT: Move preserved dirs to temp directory (not as subdirs of targetSubDir)
+                        // so they aren't deleted when we recursively delete targetSubDir
+                        var asideDir = Path.Combine(Path.GetTempPath(),
+                            $"{subDirName}-{preserve}-preserved-" + Guid.NewGuid().ToString("N")[..8]);
                         Directory.Move(existingDir, asideDir);
                         preservedDirs.Add((existingDir, asideDir));
                     }

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -207,6 +207,7 @@ public static class TendrilServer
             {
                 // Auto-update promptwares if the running version is newer than what's deployed
                 var promptwaresDir = Path.Combine(configService.TendrilHome, "Promptwares");
+                PromptwareDeployer.CleanupOrphanedPreservedDirectories(promptwaresDir);
                 if (PromptwareDeployer.NeedsUpdate(promptwaresDir))
                 {
                     var logger = app.Services.GetRequiredService<ILogger<Server>>();

--- a/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
@@ -67,13 +67,26 @@ public class ChangesTabView(
             var chevronIcon = isExpanded ? Icons.ChevronDown : Icons.ChevronRight;
             var (statusIcon, statusColor) = PlanContentHelpers.GetFileStatusIconAndColor(fileDiff.Status);
             var fileName = Path.GetFileName(fileDiff.FilePath);
+            var isRenamed = fileDiff.OldFilePath != null;
+            var oldFileName = isRenamed ? Path.GetFileName(fileDiff.OldFilePath!) : null;
 
             var header = Layout.Horizontal()
                 .Gap(2)
                 | new Icon(chevronIcon).Small()
-                | new Icon(statusIcon).Small().Color(statusColor)
-                | Text.Block(fileName).Bold()
-                | Text.Muted(Path.GetDirectoryName(fileDiff.FilePath)?.Replace('\\', '/') ?? "");
+                | new Icon(statusIcon).Small().Color(statusColor);
+
+            if (isRenamed)
+            {
+                header |= Text.Block(oldFileName!).Bold();
+                header |= Text.Muted("→");
+                header |= Text.Block(fileName).Bold();
+                header |= Text.Muted(Path.GetDirectoryName(fileDiff.FilePath)?.Replace('\\', '/') ?? "");
+            }
+            else
+            {
+                header |= Text.Block(fileName).Bold();
+                header |= Text.Muted(Path.GetDirectoryName(fileDiff.FilePath)?.Replace('\\', '/') ?? "");
+            }
 
             var path = fileDiff.FilePath;
             
@@ -91,7 +104,7 @@ public class ChangesTabView(
 
             if (isExpanded)
             {
-                diffsLayout |= new DiffView().Diff(fileDiff.Diff).Split().Width(Size.Full());
+                diffsLayout |= new DiffView().Diff(fileDiff.Diff).Split().Width(Size.Full()).ShowHeader(false);
             }
         }
 

--- a/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
@@ -104,7 +104,7 @@ public class ChangesTabView(
 
             if (isExpanded)
             {
-                diffsLayout |= new DiffView().Diff(fileDiff.Diff).Split().Width(Size.Full()).ShowHeader(false);
+                diffsLayout |= new DiffView().Diff(fileDiff.Diff).Split().Width(Size.Full());
             }
         }
 


### PR DESCRIPTION
This pull request introduces several improvements and updates across the Docker build process, dependency versions, job output handling, and test coverage for the Tendril project. The main highlights include a new Dockerfile for a comprehensive Tendril runtime image, updated package and tool versions, enhanced UI logic for job output streaming, and expanded automated tests to ensure data integrity and cleanup.

**Docker and Dependency Updates:**

- Added a new `.github/docker/Dockerfile.tendril` to build a runtime image for Tendril with all necessary CLI tools (Claude, Codex, Gemini, Copilot, git, gh, pwsh, pandoc), supporting both required and optional environment variables, and improved non-root user setup for better CLI compatibility.
- Updated dependencies in `Ivy.Tendril.Docs.csproj` and `Ivy.Tendril.Test.csproj` to use Ivy packages version `1.2.55` (was `1.2.54`), ensuring the latest features and bug fixes are included. [[1]](diffhunk://#diff-5f7784529861d13bb6477b8d078d410b3cd0a120caa53b87c08335c2aacab5cfL20-R22) [[2]](diffhunk://#diff-5f7784529861d13bb6477b8d078d410b3cd0a120caa53b87c08335c2aacab5cfL67-R67) [[3]](diffhunk://#diff-44be015ff2a882bec59e801b762fc859723b86a453a9a8478f20b2a56bdc47a7L41-R41)
- Upgraded the global install of `vite-plus` from `0.1.13` to `0.1.20` in the documentation Dockerfile for improved build tooling.

**Job Output and UI Improvements:**

- Enhanced the `OutputSheet` class to track the currently streaming job ID, preventing duplicate output when switching between streaming and completed job views. [[1]](diffhunk://#diff-3350a66d3f01e8d8d129053562ab5da3d052f40c833ed40bfaeb2d3478f5863dL12-R13) [[2]](diffhunk://#diff-3350a66d3f01e8d8d129053562ab5da3d052f40c833ed40bfaeb2d3478f5863dL35-L38)
- Refined the jobs data table UI to use more granular cell action handlers (`OnCellAction`) instead of generic cell click events, improving clarity and maintainability. Also adjusted responsive density settings for better display across devices. [[1]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L26-R26) [[2]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L83-R84) [[3]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L100-R106) [[4]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L118-R119) [[5]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L132-R137) [[6]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L173-R165) [[7]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L241-R214)
- Minor UI tweaks, such as removing the em dash from job sheet titles and improving comments for clarity. [[1]](diffhunk://#diff-3350a66d3f01e8d8d129053562ab5da3d052f40c833ed40bfaeb2d3478f5863dL68-R67) [[2]](diffhunk://#diff-3350a66d3f01e8d8d129053562ab5da3d052f40c833ed40bfaeb2d3478f5863dL48-R47)

**Test Coverage and Reliability:**

- Added comprehensive tests in `PlanYamlCorruptionTests` to ensure atomic writes and concurrent state changes do not corrupt `plan.yaml`, even with large payloads or rapid updates.
- Introduced tests for `PromptwareDeployer` to verify that orphaned preserved directories are correctly cleaned up, and normal directories are left untouched.

These changes collectively improve the reliability, maintainability, and usability of the Tendril system.

**References:**
- [[1]](diffhunk://#diff-220145fd175f6232ed5850069837fa28820ed52738a5486cdf2a582b18a3e7e6R1-R85) [[2]](diffhunk://#diff-5f7784529861d13bb6477b8d078d410b3cd0a120caa53b87c08335c2aacab5cfL20-R22) [[3]](diffhunk://#diff-5f7784529861d13bb6477b8d078d410b3cd0a120caa53b87c08335c2aacab5cfL67-R67) [[4]](diffhunk://#diff-44be015ff2a882bec59e801b762fc859723b86a453a9a8478f20b2a56bdc47a7L41-R41) [[5]](diffhunk://#diff-58ca142b747072d7338913c967ee81e08f015e0c0a51d43f179315b46a3b0441L17-R17) [[6]](diffhunk://#diff-3350a66d3f01e8d8d129053562ab5da3d052f40c833ed40bfaeb2d3478f5863dL12-R13) [[7]](diffhunk://#diff-3350a66d3f01e8d8d129053562ab5da3d052f40c833ed40bfaeb2d3478f5863dL35-L38) [[8]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L26-R26) [[9]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L83-R84) [[10]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L100-R106) [[11]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L118-R119) [[12]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L132-R137) [[13]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L173-R165) [[14]](diffhunk://#diff-b27c80e3d3e57b9fa033d08a2de48f9d55a618721f22075de01b0d9d26058741L241-R214) [[15]](diffhunk://#diff-3350a66d3f01e8d8d129053562ab5da3d052f40c833ed40bfaeb2d3478f5863dL68-R67) [[16]](diffhunk://#diff-3350a66d3f01e8d8d129053562ab5da3d052f40c833ed40bfaeb2d3478f5863dL48-R47) [[17]](diffhunk://#diff-2213fb86eb6b5a6ad85077e67d143ce898f15b57da9785949fd0c09ca9f0f879R1-R158) [[18]](diffhunk://#diff-78aa9c084bddeb04a36d9230ddd3ff585bb2d56047300e439dd405f3b35499c2R195-R227)