### PR TITLE
[00010] Add Playwright screenshot verification for frontend changes

### DIFF
--- a/src/Ivy.Tendril/Templates/README.md
+++ b/src/Ivy.Tendril/Templates/README.md
@@ -1,0 +1,95 @@
+# Playwright Visual Verification Templates
+
+This directory contains templates for setting up Playwright visual verification in your projects.
+
+## Files
+
+- **playwright.config.js** - Playwright configuration template that automatically saves screenshots to the plan's artifacts folder
+- **example.visual.spec.js** - Example test demonstrating screenshot capture patterns
+
+## Usage
+
+### 1. Add VisualCheck Verification to Your Project
+
+In your `config.yaml`, add the `VisualCheck` verification to your project:
+
+```yaml
+projects:
+  - name: MyProject
+    verifications:
+      - name: VisualCheck
+        required: false  # Optional by default
+```
+
+### 2. Setup Playwright in Your Project
+
+If you don't have Playwright installed:
+
+```bash
+npm init playwright@latest
+```
+
+Or add to an existing project:
+
+```bash
+npm install -D @playwright/test
+npx playwright install
+```
+
+### 3. Copy Templates
+
+Copy the configuration and example test to your project:
+
+```bash
+# Copy config to your project root
+cp Templates/playwright.config.js <your-project>/playwright.config.js
+
+# Copy example test to your tests directory
+cp Templates/example.visual.spec.js <your-project>/tests/
+```
+
+### 4. Create Your Visual Tests
+
+Edit the example test to match your components:
+
+```javascript
+test('my component', async ({ page }) => {
+  await page.goto('http://localhost:3000/my-page');
+  
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  
+  // Capture screenshot
+  await page.screenshot({
+    path: path.join(screenshotDir, `my-component-${timestamp}.png`),
+    fullPage: true,
+  });
+});
+```
+
+### 5. Run Visual Verification
+
+During plan execution, the `VisualCheck` verification will:
+
+1. Set the `PLAN_FOLDER` environment variable
+2. Run your Playwright tests
+3. Collect screenshots in `<PlanFolder>/artifacts/screenshots/`
+4. Generate a visual comparison report
+
+## Screenshot Naming Conventions
+
+Use descriptive filenames that include:
+- Component/page name
+- State (before/after, default/hover/active)
+- Timestamp for uniqueness
+
+Examples:
+- `login-page-before-2026-05-05.png`
+- `button-hover-state-2026-05-05.png`
+- `dashboard-after-filter-applied-2026-05-05.png`
+
+## Tips
+
+- Use `fullPage: true` to capture the entire page scroll
+- Capture screenshots at key interaction points (before/after actions)
+- Test multiple viewport sizes if responsive design is important
+- Use the generated `report.md` to document what each screenshot shows

--- a/src/Ivy.Tendril/Templates/example.visual.spec.js
+++ b/src/Ivy.Tendril/Templates/example.visual.spec.js
@@ -1,0 +1,101 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+
+/**
+ * Example Playwright test demonstrating screenshot capture for visual verification.
+ *
+ * This test shows how to:
+ * 1. Navigate to a page
+ * 2. Capture "before" and "after" screenshots
+ * 3. Save screenshots to the plan's artifacts folder
+ * 4. Generate a markdown report
+ */
+
+// Get plan folder and screenshot directory from environment
+const planFolder = process.env.PLAN_FOLDER || process.cwd();
+const screenshotDir = path.join(planFolder, 'artifacts', 'screenshots');
+
+// Ensure screenshot directory exists
+if (!fs.existsSync(screenshotDir)) {
+  fs.mkdirSync(screenshotDir, { recursive: true });
+}
+
+test.describe('Visual Regression Example', () => {
+  test('capture component screenshots', async ({ page }) => {
+    // Navigate to the page under test
+    // await page.goto('http://localhost:3000');
+
+    // Example: Capture a "before" screenshot
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const componentName = 'example-component';
+
+    await page.screenshot({
+      path: path.join(screenshotDir, `${componentName}-${timestamp}.png`),
+      fullPage: true,
+    });
+
+    // Example: Interact with the page
+    // await page.click('button#submit');
+
+    // Example: Capture an "after" screenshot
+    // await page.screenshot({
+    //   path: path.join(screenshotDir, `${componentName}-after-${timestamp}.png`),
+    //   fullPage: true,
+    // });
+
+    // Verify the page is loaded (example assertion)
+    // await expect(page.locator('h1')).toBeVisible();
+  });
+
+  test('capture multiple component states', async ({ page }) => {
+    // Example: Test multiple states of a component
+    const componentName = 'multi-state-component';
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+
+    // State 1: Default
+    // await page.goto('http://localhost:3000/component');
+    // await page.screenshot({
+    //   path: path.join(screenshotDir, `${componentName}-default-${timestamp}.png`),
+    // });
+
+    // State 2: Hover
+    // await page.hover('button.primary');
+    // await page.screenshot({
+    //   path: path.join(screenshotDir, `${componentName}-hover-${timestamp}.png`),
+    // });
+
+    // State 3: Active/Clicked
+    // await page.click('button.primary');
+    // await page.screenshot({
+    //   path: path.join(screenshotDir, `${componentName}-active-${timestamp}.png`),
+    // });
+  });
+});
+
+// After all tests, generate a report
+test.afterAll(async () => {
+  // List all screenshots in the directory
+  const screenshots = fs.readdirSync(screenshotDir)
+    .filter(file => file.endsWith('.png'))
+    .sort();
+
+  // Generate markdown report
+  const reportPath = path.join(screenshotDir, 'report.md');
+  let reportContent = '# Visual Verification Report\n\n';
+  reportContent += `Generated: ${new Date().toISOString()}\n\n`;
+  reportContent += `## Screenshots Captured\n\n`;
+
+  if (screenshots.length === 0) {
+    reportContent += 'No screenshots captured.\n';
+  } else {
+    screenshots.forEach(screenshot => {
+      reportContent += `### ${screenshot}\n\n`;
+      reportContent += `![${screenshot}](${screenshot})\n\n`;
+    });
+  }
+
+  fs.writeFileSync(reportPath, reportContent);
+  console.log(`Visual verification report generated at: ${reportPath}`);
+});

--- a/src/Ivy.Tendril/Templates/playwright.config.js
+++ b/src/Ivy.Tendril/Templates/playwright.config.js
@@ -1,0 +1,98 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+const path = require('path');
+
+/**
+ * Playwright configuration template for Tendril visual verification.
+ *
+ * This configuration is designed to capture screenshots of frontend changes
+ * and store them in the plan's artifacts folder for review.
+ *
+ * Usage:
+ * 1. Copy this file to your project's test directory
+ * 2. Set the PLAN_FOLDER environment variable to your plan's folder path
+ * 3. Run: npx playwright test
+ *
+ * Screenshots will be saved to: <PLAN_FOLDER>/artifacts/screenshots/
+ */
+
+// Get plan folder from environment variable (set by VisualCheck verification)
+const planFolder = process.env.PLAN_FOLDER || process.cwd();
+const screenshotDir = path.join(planFolder, 'artifacts', 'screenshots');
+
+module.exports = defineConfig({
+  testDir: './tests',
+
+  // Maximum time one test can run
+  timeout: 30 * 1000,
+
+  // Run tests in files in parallel
+  fullyParallel: true,
+
+  // Fail the build on CI if you accidentally left test.only in the source code
+  forbidOnly: !!process.env.CI,
+
+  // Retry on CI only
+  retries: process.env.CI ? 2 : 0,
+
+  // Reporter configuration
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: path.join(screenshotDir, 'report-html') }]
+  ],
+
+  // Shared settings for all projects
+  use: {
+    // Base URL for navigation
+    // baseURL: 'http://localhost:3000',
+
+    // Collect trace on failure
+    trace: 'on-first-retry',
+
+    // Screenshot on failure
+    screenshot: 'only-on-failure',
+
+    // Video on failure
+    video: 'retain-on-failure',
+  },
+
+  // Configure projects for major browsers
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        // Custom screenshot path for this browser
+        screenshot: {
+          mode: 'on',
+          fullPage: true,
+        },
+      },
+    },
+
+    // Uncomment to test on Firefox
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // Uncomment to test on Safari
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+
+    // Uncomment to test on mobile viewports
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+  ],
+
+  // Configure output folders
+  outputDir: path.join(screenshotDir, 'test-results'),
+});

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -240,6 +240,14 @@ verifications:
     2. Review all commits made by this execution
     3. Compare the plan's Problem and Solution sections against the actual changes
     4. Write the verification report to `<PlanFolder>/verification/CheckResult.md`
+- name: VisualCheck
+  prompt: >
+    Run Playwright tests for changed frontend components and capture screenshots.
+    1. Read the plan revision's **## Tests** section.
+    2. If the plan involves frontend changes, identify affected pages/components.
+    3. Run Playwright tests with screenshot capture enabled.
+    4. Save screenshots to `<PlanFolder>/artifacts/screenshots/` with descriptive filenames (e.g., `login-page-before.png`, `login-page-after.png`).
+    5. Create a visual comparison report at `<PlanFolder>/artifacts/screenshots/report.md` listing all captured screenshots.
 
 # Stack-specific verification examples (uncomment and customize for your stack):
 
@@ -274,6 +282,16 @@ verifications:
 #   prompt: Run `go build ./...` and verify it succeeds.
 # - name: GoTest
 #   prompt: Run `go test <packages>` with the filter from the plan's **## Tests** section.
+
+# Frontend Visual Testing:
+# - name: VisualCheck
+#   prompt: >
+#     Run Playwright tests for changed frontend components and capture screenshots.
+#     1. Read the plan revision's **## Tests** section.
+#     2. If the plan involves frontend changes, identify affected pages/components.
+#     3. Run Playwright tests with screenshot capture enabled.
+#     4. Save screenshots to `<PlanFolder>/artifacts/screenshots/` with descriptive filenames (e.g., `login-page-before.png`, `login-page-after.png`).
+#     5. Create a visual comparison report at `<PlanFolder>/artifacts/screenshots/report.md` listing all captured screenshots.
 
 levels:
   - name: Bug


### PR DESCRIPTION
# Summary

## Changes

Added Playwright screenshot verification support for frontend changes. The implementation includes a new `VisualCheck` verification definition in the config, reusable Playwright templates, and example tests demonstrating screenshot capture patterns.

## API Changes

- **New verification: `VisualCheck`** - Verification step that runs Playwright tests and captures screenshots to `<PlanFolder>/artifacts/screenshots/`

## Files Modified

**Configuration:**
- `src/Ivy.Tendril/example.config.yaml` - Added VisualCheck verification definition and example

**Templates (new):**
- `src/Ivy.Tendril/Templates/playwright.config.js` - Playwright configuration template
- `src/Ivy.Tendril/Templates/example.visual.spec.js` - Example test demonstrating screenshot capture
- `src/Ivy.Tendril/Templates/README.md` - Documentation for using the templates

---

## Commits

- [00010] Add Playwright screenshot verification for frontend changes (688fab9)
- Merge pull request #476 from Ivy-Interactive/main (166d91a)
- Bump version from 1.0.32 to 1.0.33 (0a8cd09)
- Merge pull request #475 from Ivy-Interactive/development (1649482)