### PR TITLE
[00141] Show No Projects dialog when creating plan with empty config

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/NoProjectsDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/NoProjectsDialog.cs
@@ -1,0 +1,23 @@
+namespace Ivy.Tendril.Apps.Plans.Dialogs;
+
+public class NoProjectsDialog(Action onClose, Action onGoToProjects) : ViewBase
+{
+    public override object Build()
+    {
+        return new Dialog(
+            _ => onClose(),
+            new DialogHeader("No Projects"),
+            new DialogBody(
+                Text.P("No projects are configured. Add a project to get started with creating plans.")
+            ),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(onClose),
+                new Button("Go to Projects").Primary().OnClick(() =>
+                {
+                    onGoToProjects();
+                    onClose();
+                })
+            )
+        );
+    }
+}

--- a/src/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs
+++ b/src/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Apps;
 using Ivy.Tendril.Apps.Plans.Dialogs;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
@@ -10,6 +11,7 @@ public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : View
     {
         var jobService = UseService<IJobService>();
         var configService = UseService<IConfigService>();
+        var navigator = UseService<INavigator>();
         var dialogOpen = UseState(false);
         var lastSelectedProjects = UseState<string[]>(["Auto"]);
 
@@ -21,17 +23,25 @@ public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : View
         };
 
         if (dialogOpen.Value)
-            elements.Add(new CreatePlanDialog(
-                projectNames,
-                (description, projects, priority) =>
-                {
-                    lastSelectedProjects.Set(projects);
-                    var project = string.Join(",", projects);
-                    jobService.StartJob(Constants.JobTypes.CreatePlan, "-Description", $"{description} [FORCE]", "-Project", project, "-Priority", priority.ToString());
-                },
-                () => dialogOpen.Set(false),
-                lastSelectedProjects.Value
-            ));
+        {
+            if (projectNames.Count == 0)
+                elements.Add(new NoProjectsDialog(
+                    () => dialogOpen.Set(false),
+                    () => navigator.Navigate<SetupApp>()
+                ));
+            else
+                elements.Add(new CreatePlanDialog(
+                    projectNames,
+                    (description, projects, priority) =>
+                    {
+                        lastSelectedProjects.Set(projects);
+                        var project = string.Join(",", projects);
+                        jobService.StartJob(Constants.JobTypes.CreatePlan, "-Description", $"{description} [FORCE]", "-Project", project, "-Priority", priority.ToString());
+                    },
+                    () => dialogOpen.Set(false),
+                    lastSelectedProjects.Value
+                ));
+        }
 
         return new Fragment(elements.ToArray());
     }


### PR DESCRIPTION
# Summary

## Changes

Added a `NoProjectsDialog` that is shown when the user clicks "New Plan" but no projects are configured in `config.yaml`. The dialog explains the issue and provides a "Go to Projects" button that navigates to the Setup app's Projects tab.

## API Changes

- **New class:** `Ivy.Tendril.Apps.Plans.Dialogs.NoProjectsDialog` — a dialog component taking `onClose` and `onGoToProjects` callbacks.

## Files Modified

- **src/Ivy.Tendril/Apps/Plans/Dialogs/NoProjectsDialog.cs** — new dialog component
- **src/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs** — added empty-projects check and INavigator usage

## Commits

- e61b0ac