### PR TITLE
Update E2E AGENTS.md with debugging lessons and operational guidance

### DIFF
--- a/src/Ivy.Tendril.Test.End2End/AGENTS.md
+++ b/src/Ivy.Tendril.Test.End2End/AGENTS.md
@@ -5,9 +5,14 @@ Playwright-based E2E tests that drive Tendril as a black-box subprocess and veri
 ## Quick start
 
 ```bash
-cd src/Ivy.Tendril.Test.End2End
-dotnet build
-dotnet test --verbosity normal
+# IMPORTANT: Pre-build both projects first to avoid MSBuild lock conflicts.
+# The test fixture uses `dotnet run` which triggers a build — if the test runner
+# is also building, MSBuild child nodes collide and restore gets cancelled.
+dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj
+dotnet build src/Ivy.Tendril.Test.End2End/
+
+# Run with --no-build to avoid the conflict
+dotnet test src/Ivy.Tendril.Test.End2End/ --no-build --verbosity normal
 ```
 
 Individual test classes can be run with `--filter`:
@@ -77,21 +82,27 @@ The tests use `Ivy-Interactive/Ivy-Templates` — a real dotnet project with `Pr
 |---|---|---|
 | OnboardingTests | 1 | Full onboarding wizard: welcome → software check → agent selection → home setup → project setup → complete |
 | VerificationTests | 4 | Directory structure, config.yaml, tendril.db, dashboard loads |
-| PlanLifecycleTests | 1 | Plan creation via UI creates plan folder with plan.yaml |
+| PlanLifecycleTests | 1 | Plan creation via UI submits job (verifies job appears in Jobs grid) |
 | AgentExecutionTests | 1 | Full lifecycle: CreatePlan → Execute → CreatePR (plan reaches ReadyForReview, PR URL in plan.yaml) |
 | CleanupTests | 2 | Fixture teardown, GitHub fork deletion |
 
 ## Common gotchas
 
+- **MSBuild lock conflicts**: The test fixture launches Tendril via `dotnet run`, which triggers a build. If the test runner is also building, MSBuild child nodes collide (`MSB4166: Child node exited prematurely`). Always pre-build both projects and run tests with `--no-build`.
 - **Plan folder names are CamelCase** (e.g., `00001-UppercaseAllStringLiteralsInProgramCs`). `FindPlanFolder` normalizes by removing hyphens for comparison.
 - **Plan IDs in sidebar are unpadded** — sidebar shows `#1`, not `#00001`. `GetPlanId` strips leading zeros.
 - **Plan folders appear before `plan.yaml` is written.** Always wait for `plan.yaml` to exist, not just the folder.
+- **Ivy is a server-rendered SPA over WebSocket.** Every UI interaction (click, fill) triggers a server round-trip. After filling a textarea, the server must re-render before buttons become enabled. Always wait for button enabled state before clicking.
 - **Ivy framework `client.Redirect()` doesn't work reliably in headless Playwright.** After onboarding, the test polls the filesystem for config.yaml then forces `page.ReloadAsync()`.
+- **Sidebar news cards can overlap navigation items.** The `SidebarNews` widget renders swipeable cards with `position: relative` that intercept pointer events on sidebar menu items. The `TENDRIL_E2E=1` env var suppresses news fetching. The `DashboardPage.ClickSidebarItem` also has a `force: true` fallback.
 - **Duplicate "New Plan" buttons exist** (sidebar + empty state). Use `.First` on all button selectors.
+- **The Jobs page uses a virtual grid (glide-data-grid).** Cells exist in the DOM but may not be visible (off-screen). Use `WaitForSelectorState.Attached` instead of `Visible` when asserting grid content.
 - **CreatePlan invokes the coding agent** — takes 2-5+ minutes, not seconds.
 - **`--find-available-port`** is required to avoid port conflicts between test runs.
 - **Git pack files are read-only on Windows** — must clear read-only attributes before `Directory.Delete`.
 - **After page reload, the sidebar may not immediately show new plans.** Retry with reloads.
+- **CLI logs (`*-job.jsonl`) are only produced when running the installed `tendril` binary**, not when running via `dotnet run`. The `LogAssertions` methods are lenient about missing logs for this reason.
+- **Tests sharing the `E2E` collection must use unique plan descriptions.** Otherwise `FindPlanFolder` can match a folder from a previous test's plan.
 
 ## Troubleshooting test failures
 
@@ -105,10 +116,15 @@ The tests use `Ivy-Interactive/Ivy-Templates` — a real dotnet project with `Pr
 
 ### Common failure patterns
 
+- **"Tendril did not start within 60s" + MSBuild errors** — MSBuild lock conflict. Pre-build both projects and use `--no-build`. See Quick Start.
+- **"InvalidOperationException: Service of type 'X' is not registered"** — A `UseService<T>()` call for a type that should come from a framework hook (e.g., `INavigator` → use `UseNavigation()` instead). This crashes the entire component tree. Check the screenshot — the sidebar will show an error panel instead of the menu.
+- **Sidebar click timeout / "subtree intercepts pointer events"** — An overlay element (news card, tooltip, loading state) is blocking clicks. The `TENDRIL_E2E` env var suppresses news cards. If new overlays appear, add `force: true` fallback in `DashboardPage.ClickSidebarItem`.
+- **"New Plan" button not found** — The sidebar failed to render (check for exceptions in Tendril stdout) or the button hasn't appeared yet (increase `WaitForAsync` timeout).
 - **"Plan not visible in sidebar"** — The plan folder exists but the UI hasn't refreshed. The test retries with reloads for 120s. If it still fails, the sidebar rendering may have changed.
 - **"plan.yaml not created"** — The coding agent failed or timed out. Check promptware logs for the agent's error output.
 - **"state: ReadyForReview not found"** — ExecutePlan didn't complete. Check if the agent errored, if verifications failed, or if the process was killed early.
 - **"PR URL not found in plan.yaml"** — CreatePR promptware failed. Check GitHub auth (`gh auth status`) and fork permissions.
+- **Port conflict in CleanupTests** — The `TendrilProcessFixture_CleansUpTempDirectories` test starts its own Tendril instance. If the main E2E fixture is still running, ports may collide even with `--find-available-port`. The test handles this gracefully via try/catch on `TimeoutException`.
 
 ## Promptware CLI status reporting
 
@@ -144,6 +160,16 @@ var statusLines = fixture.Tendril.StdoutLines
 ```
 
 ## What still needs testing
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `E2E__Agent` | `claude` | Which coding agent to use (claude/codex/gemini/copilot/opencode) |
+| `E2E__PlanExecutionTimeoutSeconds` | `600` | Max wait time for agent to complete a plan |
+| `E2E__Headless` | `true` | Run browser headlessly (set `false` for visual debugging) |
+| `E2E__SlowMo` | `0` | Milliseconds to slow down Playwright actions (useful for debugging) |
+| `TENDRIL_E2E` | _(set by fixture)_ | Suppresses sidebar news cards and other non-essential UI for clean testing |
 
 ### Multi-agent coverage
 


### PR DESCRIPTION
## Summary
- Add pre-build requirement to Quick Start (MSBuild lock conflict)
- Document Ivy SPA round-trip timing, virtual grid, and news card overlay gotchas
- Add common failure patterns: INavigator regression, sidebar overlays, port conflicts
- Add environment variables table
- Update PlanLifecycleTests description to reflect current behavior