### PR TITLE
[README]: Add deployment instructions for Sliplane in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Tendril is a web application built on [Ivy Framework](https://github.com/Ivy-Int
 - **GitHub PR integration** — Automated pull request creation from completed plans
 - **Plan review workflow** — Review diffs, run sample apps, approve or send back for revision
 
+## Deploy on Sliplane
+
+<p align="center">
+  <a href="https://ivy-tendril-deployment.sliplane.app">
+    <img src="https://raw.githubusercontent.com/Ivy-Interactive/Ivy-Examples/development/project-demos/tendril-deploy/Assets/deploy-button.svg" alt="Deploy your Tendril on Sliplane" />
+  </a>
+</p>
+
 ## Installation
 
 ### Quick Install


### PR DESCRIPTION

## Summary

Adds a **Deploy on Sliplane** section to `README.md`: centered deploy button linking to the Ivy Tendril deployment on Sliplane, using the shared button asset from Ivy-Examples (`deploy-button.svg`).

## Changes

- New README subsection with centered HTML link + image

<p align="center">
  <a href="https://ivy-tendril-deployment.sliplane.app">
    <img src="https://raw.githubusercontent.com/Ivy-Interactive/Ivy-Examples/development/project-demos/tendril-deploy/Assets/deploy-button.svg" alt="Deploy your Tendril on Sliplane" />
  </a>
</p>