### PR TITLE
[00032] Review Action command schema mismatch and macOS background crash

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -160,12 +160,12 @@ projects:
 
             Assert.Equal("Sample", project.ReviewActions[0].Name);
             Assert.Contains("Test-Path", project.ReviewActions[0].Condition);
-            Assert.Equal("dotnet run --browse", project.ReviewActions[0].Action);
+            Assert.Equal("dotnet run --browse", project.ReviewActions[0].Command);
 
             Assert.Equal("Open Docs", project.ReviewActions[1].Name);
             Assert.Empty(project.ReviewActions[1].Condition);
-            Assert.Contains("start docs", project.ReviewActions[1].Action);
-            Assert.Contains("index.html", project.ReviewActions[1].Action);
+            Assert.Contains("start docs", project.ReviewActions[1].Command);
+            Assert.Contains("index.html", project.ReviewActions[1].Command);
         }
         finally
         {

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -402,7 +402,7 @@ public class ContentView(
                         var actionCapture = action;
                         btn = btn.OnClick(() =>
                         {
-                            if (!PlatformHelper.RunPowerShellAction(actionCapture.Action, selectedPlan.FolderPath, logger))
+                            if (!PlatformHelper.RunPowerShellAction(actionCapture.Command, selectedPlan.FolderPath, logger))
                             {
                                 logger.LogWarning("Failed to run review action {ActionName}: pwsh not found", actionCapture.Name);
                             }

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -459,7 +459,8 @@ public class ContentView(
                 new Tab("Artifacts", Cap(new ArtifactsTabView(planData.Artifacts))).Badge(totalArtifacts.ToString()),
                 new Tab("Recommendations", Cap(recommendationsLayout)).Badge(planData.Recommendations.Count.ToString()),
                 new Tab("Plan", Cap(planTabContent))
-            ).OnSelect(v => {
+            ).OnSelect(v =>
+            {
                 if (v >= 0 && v < tabNames.Length && selectedPlanState.Value != null)
                     nav.Navigate<ReviewApp>(new ReviewAppArgs(selectedPlanState.Value.FolderName, tabNames[v]));
             }).SelectedIndex(selectedTabIndex).Variant(TabsVariant.Content);

--- a/src/Ivy.Tendril/Helpers/PlatformHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlatformHelper.cs
@@ -48,6 +48,36 @@ public static class PlatformHelper
     {
         try
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // On macOS, create a temporary .command script and open it in Terminal.app
+                // This ensures the terminal window is visible and interactive
+                var scriptPath = Path.Combine(Path.GetTempPath(), $"tendril-action-{Guid.NewGuid():N}.command");
+                var scriptContent = $"#!/bin/bash\ncd \"{workingDirectory}\"\npwsh -NoExit -NoProfile -Command \"{action.Replace("\"", "\\\"")}\"\nrm \"{scriptPath}\"\n";
+                File.WriteAllText(scriptPath, scriptContent);
+
+                // Make the script executable
+                var chmodPsi = new ProcessStartInfo("chmod", $"+x \"{scriptPath}\"")
+                {
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                using (var chmodProc = Process.Start(chmodPsi))
+                {
+                    chmodProc?.WaitForExit();
+                }
+
+                // Open the script in Terminal.app
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "open",
+                    Arguments = $"-a Terminal \"{scriptPath}\"",
+                    UseShellExecute = true
+                });
+                return true;
+            }
+
+            // Windows and Linux: run pwsh directly
             Process.Start(new ProcessStartInfo
             {
                 FileName = "pwsh",

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -854,7 +854,7 @@ public class ConfigService : IConfigService, IDisposable
         foreach (var action in actions)
         {
             action.Condition = ExpandVar(action.Condition);
-            action.Action = ExpandVar(action.Action);
+            action.Command = ExpandVar(action.Command);
         }
     }
 

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -94,7 +94,7 @@ public record ReviewActionConfig
 {
     public string Name { get; set; } = "";
     public string Condition { get; set; } = "";
-    public string Action { get; set; } = "";
+    public string Command { get; set; } = "";
 }
 
 public record PromptwareHookConfig


### PR DESCRIPTION
Fixes #480

# Summary

## Changes

Renamed the `ReviewActionConfig.Action` property to `Command` to fix schema mismatch where users wrote `command:` in config.yaml. Fixed macOS background crash by creating executable `.command` scripts that Terminal.app can properly launch instead of spawning backgrounded pwsh processes without TTY.

## API Changes

**Changed:**
- `ReviewActionConfig.Action` → `ReviewActionConfig.Command` in ConfigService.cs

## Files Modified

- **src/Ivy.Tendril/Services/ConfigService.cs** — Renamed `Action` property to `Command`
- **src/Ivy.Tendril/Apps/Review/ContentView.cs** — Updated to use `Command` property
- **src/Ivy.Tendril/Helpers/PlatformHelper.cs** — Added macOS-specific terminal spawning via `.command` scripts

---

## Commits

- 1ad96e3a520793005e9edc5bab8a0b5ae9664e72 — [00032] Rename ReviewActionConfig.Action to Command and fix macOS terminal spawning
- 73202a351dcf1b9aeda2fb4d61f9f26f79ef0dc6 — [00032] Fix remaining Action references in tests and variable expansion
- 1fcbec5010a35cfce68a42b03d05dc23e58deaee — [00032] Apply dotnet format