### PR TITLE
Add CLI CRUD commands for verifications and projects

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -141,10 +141,10 @@ projects:
     reviewActions:
       - name: Sample
         condition: 'Test-Path ""artifacts\sample\*.csproj""'
-        action: 'dotnet run --browse'
+        command: 'dotnet run --browse'
       - name: Open Docs
         condition: ''
-        action: 'start docs/index.html'
+        command: 'start docs/index.html'
 ";
 
         var tempDir = CreateTempConfigFile(yaml);

--- a/src/Ivy.Tendril.Test/PlanVerificationCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanVerificationCommandTests.cs
@@ -1,0 +1,234 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Test;
+
+[Collection("TendrilHome")]
+public class PlanVerificationCommandTests : IDisposable
+{
+    private readonly string _originalTendrilHome;
+    private readonly string? _originalTendrilPlans;
+    private readonly string _plansDir;
+    private readonly string _tempDir;
+
+    public PlanVerificationCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"tendril-planver-test-{Guid.NewGuid():N}");
+        _plansDir = Path.Combine(_tempDir, "Plans");
+        Directory.CreateDirectory(_plansDir);
+
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        _originalTendrilPlans = Environment.GetEnvironmentVariable("TENDRIL_PLANS");
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", null);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", _originalTendrilPlans);
+        if (Directory.Exists(_tempDir))
+            try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    private void CreatePlan(string id, string title, List<PlanVerificationEntry>? verifications = null)
+    {
+        var folderName = $"{id}-{title}";
+        var planDir = Path.Combine(_plansDir, folderName);
+        Directory.CreateDirectory(planDir);
+
+        var plan = new PlanYaml
+        {
+            State = "Draft",
+            Project = "TestProject",
+            Title = title,
+            Repos = [_tempDir],
+            Created = DateTime.UtcNow,
+            Updated = DateTime.UtcNow,
+            Verifications = verifications ?? []
+        };
+
+        var yaml = YamlHelper.Serializer.Serialize(plan);
+        File.WriteAllText(Path.Combine(planDir, "plan.yaml"), yaml);
+    }
+
+    private PlanYaml ReadPlan(string planId)
+    {
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+        return PlanCommandHelpers.ReadPlan(planFolder);
+    }
+
+    // --- Add Verification ---
+
+    [Fact]
+    public void AddVerification_CreatesNewEntry()
+    {
+        CreatePlan("30001", "AddVerTest");
+
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder("30001");
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        plan.Verifications.Add(new PlanVerificationEntry { Name = "UnitTests", Status = "Pending" });
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(planFolder, plan);
+
+        var result = ReadPlan("30001");
+        Assert.Single(result.Verifications);
+        Assert.Equal("UnitTests", result.Verifications[0].Name);
+        Assert.Equal("Pending", result.Verifications[0].Status);
+    }
+
+    [Fact]
+    public void AddVerification_MultipleEntries()
+    {
+        CreatePlan("30002", "MultiVerTest");
+
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder("30002");
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        plan.Verifications.Add(new PlanVerificationEntry { Name = "UnitTests", Status = "Pending" });
+        plan.Verifications.Add(new PlanVerificationEntry { Name = "Integration", Status = "Pass" });
+        PlanCommandHelpers.WritePlan(planFolder, plan);
+
+        var result = ReadPlan("30002");
+        Assert.Equal(2, result.Verifications.Count);
+        Assert.Equal("UnitTests", result.Verifications[0].Name);
+        Assert.Equal("Integration", result.Verifications[1].Name);
+    }
+
+    [Fact]
+    public void AddVerification_PreservesExisting()
+    {
+        CreatePlan("30003", "PreserveVerTest", [
+            new PlanVerificationEntry { Name = "Existing", Status = "Pass" }
+        ]);
+
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder("30003");
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        plan.Verifications.Add(new PlanVerificationEntry { Name = "New", Status = "Pending" });
+        PlanCommandHelpers.WritePlan(planFolder, plan);
+
+        var result = ReadPlan("30003");
+        Assert.Equal(2, result.Verifications.Count);
+        Assert.Equal("Existing", result.Verifications[0].Name);
+        Assert.Equal("Pass", result.Verifications[0].Status);
+        Assert.Equal("New", result.Verifications[1].Name);
+    }
+
+    // --- Remove Verification ---
+
+    [Fact]
+    public void RemoveVerification_RemovesEntry()
+    {
+        CreatePlan("30010", "RemoveVerTest", [
+            new PlanVerificationEntry { Name = "ToRemove", Status = "Pending" },
+            new PlanVerificationEntry { Name = "ToKeep", Status = "Pass" }
+        ]);
+
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder("30010");
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var match = plan.Verifications.First(v =>
+            v.Name.Equals("ToRemove", StringComparison.OrdinalIgnoreCase));
+        plan.Verifications.Remove(match);
+        PlanCommandHelpers.WritePlan(planFolder, plan);
+
+        var result = ReadPlan("30010");
+        Assert.Single(result.Verifications);
+        Assert.Equal("ToKeep", result.Verifications[0].Name);
+    }
+
+    [Fact]
+    public void RemoveVerification_LastEntry_LeavesEmptyList()
+    {
+        CreatePlan("30011", "RemoveLastVer", [
+            new PlanVerificationEntry { Name = "Only", Status = "Fail" }
+        ]);
+
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder("30011");
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        plan.Verifications.RemoveAt(0);
+        PlanCommandHelpers.WritePlan(planFolder, plan);
+
+        var result = ReadPlan("30011");
+        Assert.Empty(result.Verifications);
+    }
+
+    // --- Set Verification Status ---
+
+    [Fact]
+    public void SetVerificationStatus_UpdatesExisting()
+    {
+        CreatePlan("30020", "SetStatusTest", [
+            new PlanVerificationEntry { Name = "UnitTests", Status = "Pending" }
+        ]);
+
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder("30020");
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        plan.Verifications[0].Status = "Pass";
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(planFolder, plan);
+
+        var result = ReadPlan("30020");
+        Assert.Equal("Pass", result.Verifications[0].Status);
+    }
+
+    [Fact]
+    public void SetVerificationStatus_AllStatuses()
+    {
+        foreach (var status in new[] { "Pass", "Fail", "Pending", "Skipped" })
+        {
+            var id = $"3003{Array.IndexOf(new[] { "Pass", "Fail", "Pending", "Skipped" }, status)}";
+            CreatePlan(id, $"Status{status}", [
+                new PlanVerificationEntry { Name = "Test", Status = "Pending" }
+            ]);
+
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(id);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            plan.Verifications[0].Status = status;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+
+            var result = ReadPlan(id);
+            Assert.Equal(status, result.Verifications[0].Status);
+        }
+    }
+
+    // --- Timestamp ---
+
+    [Fact]
+    public void ModifyingVerification_UpdatesTimestamp()
+    {
+        CreatePlan("30040", "TimestampTest");
+        var before = ReadPlan("30040").Updated;
+
+        Thread.Sleep(50);
+
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder("30040");
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        plan.Verifications.Add(new PlanVerificationEntry { Name = "New", Status = "Pending" });
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(planFolder, plan);
+
+        var after = ReadPlan("30040").Updated;
+        Assert.True(after > before);
+    }
+
+    // --- Roundtrip ---
+
+    [Fact]
+    public void Verifications_SurviveRoundtrip()
+    {
+        CreatePlan("30050", "RoundtripTest", [
+            new PlanVerificationEntry { Name = "UnitTests", Status = "Pass" },
+            new PlanVerificationEntry { Name = "Integration", Status = "Fail" },
+            new PlanVerificationEntry { Name = "E2E", Status = "Skipped" }
+        ]);
+
+        var result = ReadPlan("30050");
+        Assert.Equal(3, result.Verifications.Count);
+        Assert.Equal("UnitTests", result.Verifications[0].Name);
+        Assert.Equal("Pass", result.Verifications[0].Status);
+        Assert.Equal("Integration", result.Verifications[1].Name);
+        Assert.Equal("Fail", result.Verifications[1].Status);
+        Assert.Equal("E2E", result.Verifications[2].Name);
+        Assert.Equal("Skipped", result.Verifications[2].Status);
+    }
+}

--- a/src/Ivy.Tendril.Test/ProjectCommandTests.cs
+++ b/src/Ivy.Tendril.Test/ProjectCommandTests.cs
@@ -1,0 +1,262 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+[Collection("TendrilHome")]
+public class ProjectCommandTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("tendril-proj-cmd-test");
+    private readonly string _originalTendrilHome;
+
+    public ProjectCommandTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+
+        var yaml = @"
+projects: []
+verifications: []
+";
+        File.WriteAllText(Path.Combine(_tempDir.Path, "config.yaml"), yaml);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+    }
+
+    private ConfigService CreateConfig() => new();
+
+    // --- Add Project ---
+
+    [Fact]
+    public void AddProject_CreatesNewProject()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig { Name = "MyProject", Color = "Blue", Context = "Test context" });
+        config.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Single(reloaded.Settings.Projects);
+        Assert.Equal("MyProject", reloaded.Settings.Projects[0].Name);
+        Assert.Equal("Blue", reloaded.Settings.Projects[0].Color);
+        Assert.Equal("Test context", reloaded.Settings.Projects[0].Context);
+    }
+
+    [Fact]
+    public void AddProject_MultipleProjects()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig { Name = "Alpha" });
+        config.Settings.Projects.Add(new ProjectConfig { Name = "Beta" });
+        config.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal(2, reloaded.Settings.Projects.Count);
+        Assert.Equal("Alpha", reloaded.Settings.Projects[0].Name);
+        Assert.Equal("Beta", reloaded.Settings.Projects[1].Name);
+    }
+
+    // --- Remove Project ---
+
+    [Fact]
+    public void RemoveProject_RemovesExisting()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig { Name = "ToRemove" });
+        config.Settings.Projects.Add(new ProjectConfig { Name = "ToKeep" });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        var match = config2.Settings.Projects.First(p => p.Name.Equals("ToRemove", StringComparison.OrdinalIgnoreCase));
+        config2.Settings.Projects.Remove(match);
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Single(reloaded.Settings.Projects);
+        Assert.Equal("ToKeep", reloaded.Settings.Projects[0].Name);
+    }
+
+    // --- Set Project Fields ---
+
+    [Fact]
+    public void SetProject_UpdatesName()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig { Name = "Original" });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        config2.Settings.Projects[0].Name = "Renamed";
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal("Renamed", reloaded.Settings.Projects[0].Name);
+    }
+
+    [Fact]
+    public void SetProject_UpdatesColor()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig { Name = "Test", Color = "Red" });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        config2.Settings.Projects[0].Color = "Green";
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal("Green", reloaded.Settings.Projects[0].Color);
+    }
+
+    [Fact]
+    public void SetProject_UpdatesContext()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig { Name = "Test", Context = "Old" });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        config2.Settings.Projects[0].Context = "New context";
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal("New context", reloaded.Settings.Projects[0].Context);
+    }
+
+    // --- Add/Remove Repo ---
+
+    [Fact]
+    public void AddRepo_AddsToProject()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig { Name = "Test" });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        config2.Settings.Projects[0].Repos.Add(new RepoRef
+        {
+            Path = @"D:\Repos\MyRepo",
+            PrRule = "default",
+            SyncStrategy = "fetch"
+        });
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Single(reloaded.Settings.Projects[0].Repos);
+        Assert.Equal(@"D:\Repos\MyRepo", reloaded.Settings.Projects[0].Repos[0].Path);
+    }
+
+    [Fact]
+    public void RemoveRepo_RemovesFromProject()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Test",
+            Repos = [
+                new RepoRef { Path = @"D:\Repos\Keep" },
+                new RepoRef { Path = @"D:\Repos\Remove" }
+            ]
+        });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        var match = config2.Settings.Projects[0].GetRepoRef(@"D:\Repos\Remove");
+        Assert.NotNull(match);
+        config2.Settings.Projects[0].Repos.Remove(match);
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Single(reloaded.Settings.Projects[0].Repos);
+        Assert.Equal(@"D:\Repos\Keep", reloaded.Settings.Projects[0].Repos[0].Path);
+    }
+
+    // --- Add/Remove Verification ---
+
+    [Fact]
+    public void AddVerification_AddsToProject()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig { Name = "Test" });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        config2.Settings.Projects[0].Verifications.Add(new ProjectVerificationRef
+        {
+            Name = "UnitTests",
+            Required = true
+        });
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Single(reloaded.Settings.Projects[0].Verifications);
+        Assert.Equal("UnitTests", reloaded.Settings.Projects[0].Verifications[0].Name);
+        Assert.True(reloaded.Settings.Projects[0].Verifications[0].Required);
+    }
+
+    [Fact]
+    public void RemoveVerification_RemovesFromProject()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Test",
+            Verifications = [
+                new ProjectVerificationRef { Name = "Keep" },
+                new ProjectVerificationRef { Name = "Remove" }
+            ]
+        });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        var match = config2.Settings.Projects[0].Verifications
+            .First(v => v.Name.Equals("Remove", StringComparison.OrdinalIgnoreCase));
+        config2.Settings.Projects[0].Verifications.Remove(match);
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Single(reloaded.Settings.Projects[0].Verifications);
+        Assert.Equal("Keep", reloaded.Settings.Projects[0].Verifications[0].Name);
+    }
+
+    // --- Add/Remove Build Dependency ---
+
+    [Fact]
+    public void AddBuildDep_AddsToProject()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig { Name = "Test" });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        config2.Settings.Projects[0].BuildDependencies.Add("Framework");
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Single(reloaded.Settings.Projects[0].BuildDependencies);
+        Assert.Equal("Framework", reloaded.Settings.Projects[0].BuildDependencies[0]);
+    }
+
+    [Fact]
+    public void RemoveBuildDep_RemovesFromProject()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Test",
+            BuildDependencies = ["Keep", "Remove"]
+        });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        config2.Settings.Projects[0].BuildDependencies.RemoveAll(
+            d => d.Equals("Remove", StringComparison.OrdinalIgnoreCase));
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Single(reloaded.Settings.Projects[0].BuildDependencies);
+        Assert.Equal("Keep", reloaded.Settings.Projects[0].BuildDependencies[0]);
+    }
+}

--- a/src/Ivy.Tendril.Test/VerificationCommandTests.cs
+++ b/src/Ivy.Tendril.Test/VerificationCommandTests.cs
@@ -1,0 +1,145 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+[Collection("TendrilHome")]
+public class VerificationCommandTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("tendril-ver-cmd-test");
+    private readonly string _originalTendrilHome;
+
+    public VerificationCommandTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+
+        var yaml = @"
+projects: []
+verifications: []
+";
+        File.WriteAllText(Path.Combine(_tempDir.Path, "config.yaml"), yaml);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+    }
+
+    private ConfigService CreateConfig() => new();
+
+    // --- Add Verification Definition ---
+
+    [Fact]
+    public void AddVerification_CreatesDefinition()
+    {
+        var config = CreateConfig();
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "UnitTests", Prompt = "Run unit tests" });
+        config.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Single(reloaded.Settings.Verifications);
+        Assert.Equal("UnitTests", reloaded.Settings.Verifications[0].Name);
+        Assert.Equal("Run unit tests", reloaded.Settings.Verifications[0].Prompt);
+    }
+
+    [Fact]
+    public void AddVerification_MultipleDefinitions()
+    {
+        var config = CreateConfig();
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "UnitTests", Prompt = "Run units" });
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "Lint", Prompt = "Run linter" });
+        config.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal(2, reloaded.Settings.Verifications.Count);
+        Assert.Equal("UnitTests", reloaded.Settings.Verifications[0].Name);
+        Assert.Equal("Lint", reloaded.Settings.Verifications[1].Name);
+    }
+
+    // --- Remove Verification Definition ---
+
+    [Fact]
+    public void RemoveVerification_RemovesDefinition()
+    {
+        var config = CreateConfig();
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "ToRemove", Prompt = "x" });
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "ToKeep", Prompt = "y" });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        var match = config2.Settings.Verifications
+            .First(v => v.Name.Equals("ToRemove", StringComparison.OrdinalIgnoreCase));
+        config2.Settings.Verifications.Remove(match);
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Single(reloaded.Settings.Verifications);
+        Assert.Equal("ToKeep", reloaded.Settings.Verifications[0].Name);
+    }
+
+    [Fact]
+    public void RemoveVerification_LastEntry_LeavesEmptyList()
+    {
+        var config = CreateConfig();
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "Only", Prompt = "x" });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        config2.Settings.Verifications.RemoveAt(0);
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Empty(reloaded.Settings.Verifications);
+    }
+
+    // --- Set Verification Fields ---
+
+    [Fact]
+    public void SetVerification_UpdatesName()
+    {
+        var config = CreateConfig();
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "Original", Prompt = "test" });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        config2.Settings.Verifications[0].Name = "Renamed";
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal("Renamed", reloaded.Settings.Verifications[0].Name);
+    }
+
+    [Fact]
+    public void SetVerification_UpdatesPrompt()
+    {
+        var config = CreateConfig();
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "Test", Prompt = "Old prompt" });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        config2.Settings.Verifications[0].Prompt = "New prompt";
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal("New prompt", reloaded.Settings.Verifications[0].Prompt);
+    }
+
+    // --- Roundtrip ---
+
+    [Fact]
+    public void Verifications_SurviveRoundtrip()
+    {
+        var config = CreateConfig();
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "UnitTests", Prompt = "Run all unit tests and report" });
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "Build", Prompt = "Verify the project builds" });
+        config.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal(2, reloaded.Settings.Verifications.Count);
+        Assert.Equal("UnitTests", reloaded.Settings.Verifications[0].Name);
+        Assert.Equal("Run all unit tests and report", reloaded.Settings.Verifications[0].Prompt);
+        Assert.Equal("Build", reloaded.Settings.Verifications[1].Name);
+        Assert.Equal("Verify the project builds", reloaded.Settings.Verifications[1].Prompt);
+    }
+}

--- a/src/Ivy.Tendril/Commands/PlanVerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanVerificationCommand.cs
@@ -1,0 +1,173 @@
+using System.ComponentModel;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class PlanVerificationListSettings : CommandSettings
+{
+    [Description("Plan ID (e.g., 03430)")]
+    [CommandArgument(0, "<plan-id>")]
+    public string PlanId { get; set; } = "";
+
+    [CommandOption("--status")]
+    [Description("Filter by status (Pending, Pass, Fail, Skipped)")]
+    public string? Status { get; set; }
+}
+
+public class PlanVerificationAddSettings : CommandSettings
+{
+    [Description("Plan ID (e.g., 03430)")]
+    [CommandArgument(0, "<plan-id>")]
+    public string PlanId { get; set; } = "";
+
+    [Description("Verification name")]
+    [CommandArgument(1, "<name>")]
+    public string Name { get; set; } = "";
+
+    [CommandOption("--status")]
+    [Description("Initial status (default: Pending)")]
+    public string? Status { get; set; }
+}
+
+public class PlanVerificationRemoveSettings : CommandSettings
+{
+    [Description("Plan ID (e.g., 03430)")]
+    [CommandArgument(0, "<plan-id>")]
+    public string PlanId { get; set; } = "";
+
+    [Description("Verification name")]
+    [CommandArgument(1, "<name>")]
+    public string Name { get; set; } = "";
+}
+
+public class PlanVerificationListCommand : Command<PlanVerificationListSettings>
+{
+    private readonly ILogger<PlanVerificationListCommand> _logger;
+
+    public PlanVerificationListCommand(ILogger<PlanVerificationListCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, PlanVerificationListSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var verifications = plan.Verifications;
+
+            if (!string.IsNullOrEmpty(settings.Status))
+                verifications = verifications.Where(v => v.Status.Equals(settings.Status, StringComparison.OrdinalIgnoreCase)).ToList();
+
+            if (verifications.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[dim]No verifications found.[/]");
+                return 0;
+            }
+
+            var table = new Spectre.Console.Table();
+            table.AddColumn("Name");
+            table.AddColumn("Status");
+
+            foreach (var v in verifications)
+                table.AddRow(v.Name.EscapeMarkup(), v.Status.EscapeMarkup());
+
+            AnsiConsole.Write(table);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to list verifications for plan {PlanId}", settings.PlanId);
+            return 1;
+        }
+    }
+}
+
+public class PlanVerificationAddCommand : Command<PlanVerificationAddSettings>
+{
+    private readonly ILogger<PlanVerificationAddCommand> _logger;
+    private readonly IPlanWatcherService _planWatcher;
+
+    public PlanVerificationAddCommand(ILogger<PlanVerificationAddCommand> logger, IPlanWatcherService planWatcher)
+    {
+        _logger = logger;
+        _planWatcher = planWatcher;
+    }
+
+    protected override int Execute(CommandContext context, PlanVerificationAddSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            if (plan.Verifications.Any(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                _logger.LogError("Verification already exists: {Name}", settings.Name);
+                return 1;
+            }
+
+            plan.Verifications.Add(new PlanVerificationEntry
+            {
+                Name = settings.Name,
+                Status = settings.Status ?? "Pending"
+            });
+
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+            _logger.LogInformation("Added verification: {Name}", settings.Name);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add verification to plan {PlanId}", settings.PlanId);
+            return 1;
+        }
+    }
+}
+
+public class PlanVerificationRemoveCommand : Command<PlanVerificationRemoveSettings>
+{
+    private readonly ILogger<PlanVerificationRemoveCommand> _logger;
+    private readonly IPlanWatcherService _planWatcher;
+
+    public PlanVerificationRemoveCommand(ILogger<PlanVerificationRemoveCommand> logger, IPlanWatcherService planWatcher)
+    {
+        _logger = logger;
+        _planWatcher = planWatcher;
+    }
+
+    protected override int Execute(CommandContext context, PlanVerificationRemoveSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            var match = plan.Verifications
+                .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null)
+            {
+                _logger.LogError("Verification not found: {Name}", settings.Name);
+                return 1;
+            }
+
+            plan.Verifications.Remove(match);
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+            _logger.LogInformation("Removed verification: {Name}", settings.Name);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to remove verification from plan {PlanId}", settings.PlanId);
+            return 1;
+        }
+    }
+}

--- a/src/Ivy.Tendril/Commands/ProjectCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectCommand.cs
@@ -1,0 +1,543 @@
+using System.ComponentModel;
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+// --- Settings ---
+
+public class ProjectListSettings : CommandSettings { }
+
+public class ProjectAddSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<name>")]
+    public string Name { get; set; } = "";
+
+    [CommandOption("--color")]
+    [Description("Project color")]
+    public string? Color { get; set; }
+
+    [CommandOption("--context")]
+    [Description("Project context/prompt")]
+    public string? Context { get; set; }
+}
+
+public class ProjectRemoveSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<name>")]
+    public string Name { get; set; } = "";
+}
+
+public class ProjectSetSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<name>")]
+    public string Name { get; set; } = "";
+
+    [Description("Field name (name, color, context)")]
+    [CommandArgument(1, "<field>")]
+    public string Field { get; set; } = "";
+
+    [Description("Field value")]
+    [CommandArgument(2, "<value>")]
+    public string Value { get; set; } = "";
+}
+
+public class ProjectAddRepoSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<project-name>")]
+    public string ProjectName { get; set; } = "";
+
+    [Description("Repository path")]
+    [CommandArgument(1, "<repo-path>")]
+    public string RepoPath { get; set; } = "";
+
+    [CommandOption("--pr-rule")]
+    [Description("PR rule (default, yolo)")]
+    public string? PrRule { get; set; }
+
+    [CommandOption("--base-branch")]
+    [Description("Base branch name")]
+    public string? BaseBranch { get; set; }
+
+    [CommandOption("--sync-strategy")]
+    [Description("Sync strategy (fetch, pull)")]
+    public string? SyncStrategy { get; set; }
+}
+
+public class ProjectRemoveRepoSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<project-name>")]
+    public string ProjectName { get; set; } = "";
+
+    [Description("Repository path")]
+    [CommandArgument(1, "<repo-path>")]
+    public string RepoPath { get; set; } = "";
+}
+
+public class ProjectAddVerificationSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<project-name>")]
+    public string ProjectName { get; set; } = "";
+
+    [Description("Verification name")]
+    [CommandArgument(1, "<verification-name>")]
+    public string VerificationName { get; set; } = "";
+
+    [CommandOption("--required")]
+    [Description("Whether the verification is required")]
+    public bool Required { get; set; }
+}
+
+public class ProjectRemoveVerificationSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<project-name>")]
+    public string ProjectName { get; set; } = "";
+
+    [Description("Verification name")]
+    [CommandArgument(1, "<verification-name>")]
+    public string VerificationName { get; set; } = "";
+}
+
+public class ProjectAddBuildDepSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<project-name>")]
+    public string ProjectName { get; set; } = "";
+
+    [Description("Build dependency")]
+    [CommandArgument(1, "<dependency>")]
+    public string Dependency { get; set; } = "";
+}
+
+public class ProjectRemoveBuildDepSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<project-name>")]
+    public string ProjectName { get; set; } = "";
+
+    [Description("Build dependency")]
+    [CommandArgument(1, "<dependency>")]
+    public string Dependency { get; set; } = "";
+}
+
+// --- Commands ---
+
+public class ProjectListCommand : Command<ProjectListSettings>
+{
+    private readonly ILogger<ProjectListCommand> _logger;
+
+    public ProjectListCommand(ILogger<ProjectListCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, ProjectListSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+            var projects = config.Settings.Projects;
+
+            if (projects.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[dim]No projects found.[/]");
+                return 0;
+            }
+
+            var table = new Spectre.Console.Table();
+            table.AddColumn("Name");
+            table.AddColumn("Color");
+            table.AddColumn("Repos");
+            table.AddColumn("Verifications");
+
+            foreach (var p in projects)
+                table.AddRow(
+                    p.Name.EscapeMarkup(),
+                    (p.Color ?? "-").EscapeMarkup(),
+                    p.Repos.Count.ToString(),
+                    p.Verifications.Count.ToString());
+
+            AnsiConsole.Write(table);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to list projects");
+            return 1;
+        }
+    }
+}
+
+public class ProjectAddCommand : Command<ProjectAddSettings>
+{
+    private readonly ILogger<ProjectAddCommand> _logger;
+
+    public ProjectAddCommand(ILogger<ProjectAddCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, ProjectAddSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+
+            if (config.Settings.Projects.Any(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                _logger.LogError("Project already exists: {Name}", settings.Name);
+                return 1;
+            }
+
+            config.Settings.Projects.Add(new ProjectConfig
+            {
+                Name = settings.Name,
+                Color = settings.Color ?? "",
+                Context = settings.Context ?? ""
+            });
+
+            config.SaveSettings();
+            _logger.LogInformation("Added project: {Name}", settings.Name);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add project");
+            return 1;
+        }
+    }
+}
+
+public class ProjectRemoveCommand : Command<ProjectRemoveSettings>
+{
+    private readonly ILogger<ProjectRemoveCommand> _logger;
+
+    public ProjectRemoveCommand(ILogger<ProjectRemoveCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, ProjectRemoveSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+            var match = config.Settings.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null)
+            {
+                _logger.LogError("Project not found: {Name}", settings.Name);
+                return 1;
+            }
+
+            config.Settings.Projects.Remove(match);
+            config.SaveSettings();
+            _logger.LogInformation("Removed project: {Name}", settings.Name);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to remove project");
+            return 1;
+        }
+    }
+}
+
+public class ProjectSetCommand : Command<ProjectSetSettings>
+{
+    private readonly ILogger<ProjectSetCommand> _logger;
+
+    public ProjectSetCommand(ILogger<ProjectSetCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, ProjectSetSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+            var match = config.Settings.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null)
+            {
+                _logger.LogError("Project not found: {Name}", settings.Name);
+                return 1;
+            }
+
+            switch (settings.Field.ToLower())
+            {
+                case "name":
+                    match.Name = settings.Value;
+                    break;
+                case "color":
+                    match.Color = settings.Value;
+                    break;
+                case "context":
+                    match.Context = settings.Value;
+                    break;
+                default:
+                    _logger.LogError("Unknown field: {Field}. Valid fields: name, color, context", settings.Field);
+                    return 1;
+            }
+
+            config.SaveSettings();
+            _logger.LogInformation("Updated project {Field} to '{Value}'", settings.Field, settings.Value);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update project");
+            return 1;
+        }
+    }
+}
+
+public class ProjectAddRepoCommand : Command<ProjectAddRepoSettings>
+{
+    private readonly ILogger<ProjectAddRepoCommand> _logger;
+
+    public ProjectAddRepoCommand(ILogger<ProjectAddRepoCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, ProjectAddRepoSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+            var project = config.Settings.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+            {
+                _logger.LogError("Project not found: {Name}", settings.ProjectName);
+                return 1;
+            }
+
+            if (project.GetRepoRef(settings.RepoPath) != null)
+            {
+                _logger.LogError("Repository already exists in project: {Path}", settings.RepoPath);
+                return 1;
+            }
+
+            project.Repos.Add(new RepoRef
+            {
+                Path = settings.RepoPath,
+                PrRule = settings.PrRule ?? "default",
+                BaseBranch = settings.BaseBranch,
+                SyncStrategy = settings.SyncStrategy ?? "fetch"
+            });
+
+            config.SaveSettings();
+            _logger.LogInformation("Added repository: {Path}", settings.RepoPath);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add repository to project");
+            return 1;
+        }
+    }
+}
+
+public class ProjectRemoveRepoCommand : Command<ProjectRemoveRepoSettings>
+{
+    private readonly ILogger<ProjectRemoveRepoCommand> _logger;
+
+    public ProjectRemoveRepoCommand(ILogger<ProjectRemoveRepoCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, ProjectRemoveRepoSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+            var project = config.Settings.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+            {
+                _logger.LogError("Project not found: {Name}", settings.ProjectName);
+                return 1;
+            }
+
+            var match = project.GetRepoRef(settings.RepoPath);
+            if (match == null)
+            {
+                _logger.LogError("Repository not found in project: {Path}", settings.RepoPath);
+                return 1;
+            }
+
+            project.Repos.Remove(match);
+            config.SaveSettings();
+            _logger.LogInformation("Removed repository: {Path}", settings.RepoPath);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to remove repository from project");
+            return 1;
+        }
+    }
+}
+
+public class ProjectAddVerificationCommand : Command<ProjectAddVerificationSettings>
+{
+    private readonly ILogger<ProjectAddVerificationCommand> _logger;
+
+    public ProjectAddVerificationCommand(ILogger<ProjectAddVerificationCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, ProjectAddVerificationSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+            var project = config.Settings.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+            {
+                _logger.LogError("Project not found: {Name}", settings.ProjectName);
+                return 1;
+            }
+
+            if (project.Verifications.Any(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase)))
+            {
+                _logger.LogError("Verification already exists in project: {Name}", settings.VerificationName);
+                return 1;
+            }
+
+            project.Verifications.Add(new ProjectVerificationRef
+            {
+                Name = settings.VerificationName,
+                Required = settings.Required
+            });
+
+            config.SaveSettings();
+            _logger.LogInformation("Added verification: {Name}", settings.VerificationName);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add verification to project");
+            return 1;
+        }
+    }
+}
+
+public class ProjectRemoveVerificationCommand : Command<ProjectRemoveVerificationSettings>
+{
+    private readonly ILogger<ProjectRemoveVerificationCommand> _logger;
+
+    public ProjectRemoveVerificationCommand(ILogger<ProjectRemoveVerificationCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, ProjectRemoveVerificationSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+            var project = config.Settings.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+            {
+                _logger.LogError("Project not found: {Name}", settings.ProjectName);
+                return 1;
+            }
+
+            var match = project.Verifications
+                .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null)
+            {
+                _logger.LogError("Verification not found in project: {Name}", settings.VerificationName);
+                return 1;
+            }
+
+            project.Verifications.Remove(match);
+            config.SaveSettings();
+            _logger.LogInformation("Removed verification: {Name}", settings.VerificationName);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to remove verification from project");
+            return 1;
+        }
+    }
+}
+
+public class ProjectAddBuildDepCommand : Command<ProjectAddBuildDepSettings>
+{
+    private readonly ILogger<ProjectAddBuildDepCommand> _logger;
+
+    public ProjectAddBuildDepCommand(ILogger<ProjectAddBuildDepCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, ProjectAddBuildDepSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+            var project = config.Settings.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+            {
+                _logger.LogError("Project not found: {Name}", settings.ProjectName);
+                return 1;
+            }
+
+            if (project.BuildDependencies.Contains(settings.Dependency, StringComparer.OrdinalIgnoreCase))
+            {
+                _logger.LogError("Build dependency already exists: {Dependency}", settings.Dependency);
+                return 1;
+            }
+
+            project.BuildDependencies.Add(settings.Dependency);
+            config.SaveSettings();
+            _logger.LogInformation("Added build dependency: {Dependency}", settings.Dependency);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add build dependency to project");
+            return 1;
+        }
+    }
+}
+
+public class ProjectRemoveBuildDepCommand : Command<ProjectRemoveBuildDepSettings>
+{
+    private readonly ILogger<ProjectRemoveBuildDepCommand> _logger;
+
+    public ProjectRemoveBuildDepCommand(ILogger<ProjectRemoveBuildDepCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, ProjectRemoveBuildDepSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+            var project = config.Settings.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+            {
+                _logger.LogError("Project not found: {Name}", settings.ProjectName);
+                return 1;
+            }
+
+            var removed = project.BuildDependencies.RemoveAll(d => d.Equals(settings.Dependency, StringComparison.OrdinalIgnoreCase));
+            if (removed == 0)
+            {
+                _logger.LogError("Build dependency not found: {Dependency}", settings.Dependency);
+                return 1;
+            }
+
+            config.SaveSettings();
+            _logger.LogInformation("Removed build dependency: {Dependency}", settings.Dependency);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to remove build dependency from project");
+            return 1;
+        }
+    }
+}

--- a/src/Ivy.Tendril/Commands/VerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/VerificationCommand.cs
@@ -1,0 +1,207 @@
+using System.ComponentModel;
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class VerificationListSettings : CommandSettings { }
+
+public class VerificationAddSettings : CommandSettings
+{
+    [Description("Verification name")]
+    [CommandArgument(0, "<name>")]
+    public string Name { get; set; } = "";
+
+    [CommandOption("-p|--prompt")]
+    [Description("Verification prompt (reads from stdin if omitted)")]
+    public string? Prompt { get; set; }
+}
+
+public class VerificationRemoveSettings : CommandSettings
+{
+    [Description("Verification name")]
+    [CommandArgument(0, "<name>")]
+    public string Name { get; set; } = "";
+}
+
+public class VerificationSetSettings : CommandSettings
+{
+    [Description("Verification name")]
+    [CommandArgument(0, "<name>")]
+    public string Name { get; set; } = "";
+
+    [Description("Field name (name, prompt)")]
+    [CommandArgument(1, "<field>")]
+    public string Field { get; set; } = "";
+
+    [Description("Field value")]
+    [CommandArgument(2, "<value>")]
+    public string Value { get; set; } = "";
+}
+
+public class VerificationListCommand : Command<VerificationListSettings>
+{
+    private readonly ILogger<VerificationListCommand> _logger;
+
+    public VerificationListCommand(ILogger<VerificationListCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, VerificationListSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+            var verifications = config.Settings.Verifications;
+
+            if (verifications.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[dim]No verification definitions found.[/]");
+                return 0;
+            }
+
+            var table = new Spectre.Console.Table();
+            table.AddColumn("Name");
+            table.AddColumn("Prompt");
+
+            foreach (var v in verifications)
+            {
+                var prompt = v.Prompt.Length > 60 ? v.Prompt[..60] + "..." : v.Prompt;
+                table.AddRow(v.Name.EscapeMarkup(), prompt.EscapeMarkup());
+            }
+
+            AnsiConsole.Write(table);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to list verification definitions");
+            return 1;
+        }
+    }
+}
+
+public class VerificationAddCommand : Command<VerificationAddSettings>
+{
+    private readonly ILogger<VerificationAddCommand> _logger;
+
+    public VerificationAddCommand(ILogger<VerificationAddCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, VerificationAddSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+
+            if (config.Settings.Verifications.Any(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                _logger.LogError("Verification already exists: {Name}", settings.Name);
+                return 1;
+            }
+
+            var prompt = settings.Prompt;
+            if (string.IsNullOrEmpty(prompt))
+            {
+                if (!Console.IsInputRedirected)
+                {
+                    _logger.LogError("Provide --prompt or pipe content via stdin");
+                    return 1;
+                }
+                prompt = Console.In.ReadToEnd().Trim();
+            }
+
+            config.Settings.Verifications.Add(new VerificationConfig
+            {
+                Name = settings.Name,
+                Prompt = prompt
+            });
+
+            config.SaveSettings();
+            _logger.LogInformation("Added verification definition: {Name}", settings.Name);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add verification definition");
+            return 1;
+        }
+    }
+}
+
+public class VerificationRemoveCommand : Command<VerificationRemoveSettings>
+{
+    private readonly ILogger<VerificationRemoveCommand> _logger;
+
+    public VerificationRemoveCommand(ILogger<VerificationRemoveCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, VerificationRemoveSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+            var match = config.Settings.Verifications
+                .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null)
+            {
+                _logger.LogError("Verification not found: {Name}", settings.Name);
+                return 1;
+            }
+
+            config.Settings.Verifications.Remove(match);
+            config.SaveSettings();
+            _logger.LogInformation("Removed verification definition: {Name}", settings.Name);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to remove verification definition");
+            return 1;
+        }
+    }
+}
+
+public class VerificationSetCommand : Command<VerificationSetSettings>
+{
+    private readonly ILogger<VerificationSetCommand> _logger;
+
+    public VerificationSetCommand(ILogger<VerificationSetCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, VerificationSetSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+            var match = config.Settings.Verifications
+                .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null)
+            {
+                _logger.LogError("Verification not found: {Name}", settings.Name);
+                return 1;
+            }
+
+            switch (settings.Field.ToLower())
+            {
+                case "name":
+                    match.Name = settings.Value;
+                    break;
+                case "prompt":
+                    match.Prompt = settings.Value;
+                    break;
+                default:
+                    _logger.LogError("Unknown field: {Field}. Valid fields: name, prompt", settings.Field);
+                    return 1;
+            }
+
+            config.SaveSettings();
+            _logger.LogInformation("Updated verification {Field} to '{Value}'", settings.Field, settings.Value);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update verification definition");
+            return 1;
+        }
+    }
+}

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -162,6 +162,7 @@ public class Program
         {
             "doctor", "db-version", "db-migrate", "db-reset",
             "update-promptwares", "job", "plan", "promptware",
+            "verification", "project",
             "version", "--version"
         };
         return cliCommands.Contains(firstArg);
@@ -257,6 +258,52 @@ public class Program
                     rec.AddCommand<PlanRecDeclineCommand>("decline")
                         .WithDescription("Decline a recommendation");
                 });
+
+                plan.AddBranch("verification", verification =>
+                {
+                    verification.AddCommand<PlanVerificationListCommand>("list")
+                        .WithDescription("List verifications on a plan");
+                    verification.AddCommand<PlanVerificationAddCommand>("add")
+                        .WithDescription("Add a verification to a plan");
+                    verification.AddCommand<PlanVerificationRemoveCommand>("remove")
+                        .WithDescription("Remove a verification from a plan");
+                });
+            });
+
+            config.AddBranch("verification", verification =>
+            {
+                verification.AddCommand<VerificationListCommand>("list")
+                    .WithDescription("List global verification definitions");
+                verification.AddCommand<VerificationAddCommand>("add")
+                    .WithDescription("Add a verification definition");
+                verification.AddCommand<VerificationRemoveCommand>("remove")
+                    .WithDescription("Remove a verification definition");
+                verification.AddCommand<VerificationSetCommand>("set")
+                    .WithDescription("Update a verification definition field");
+            });
+
+            config.AddBranch("project", project =>
+            {
+                project.AddCommand<ProjectListCommand>("list")
+                    .WithDescription("List all projects");
+                project.AddCommand<ProjectAddCommand>("add")
+                    .WithDescription("Add a project");
+                project.AddCommand<ProjectRemoveCommand>("remove")
+                    .WithDescription("Remove a project");
+                project.AddCommand<ProjectSetCommand>("set")
+                    .WithDescription("Set a project field");
+                project.AddCommand<ProjectAddRepoCommand>("add-repo")
+                    .WithDescription("Add a repository to a project");
+                project.AddCommand<ProjectRemoveRepoCommand>("remove-repo")
+                    .WithDescription("Remove a repository from a project");
+                project.AddCommand<ProjectAddVerificationCommand>("add-verification")
+                    .WithDescription("Add a verification to a project");
+                project.AddCommand<ProjectRemoveVerificationCommand>("remove-verification")
+                    .WithDescription("Remove a verification from a project");
+                project.AddCommand<ProjectAddBuildDepCommand>("add-build-dep")
+                    .WithDescription("Add a build dependency to a project");
+                project.AddCommand<ProjectRemoveBuildDepCommand>("remove-build-dep")
+                    .WithDescription("Remove a build dependency from a project");
             });
         });
         return app;


### PR DESCRIPTION
- verification list/add/remove/set for global definitions
- plan verification list/add/remove for per-plan entries
- project list/add/remove/set/add-repo/remove-repo/add-verification/remove-verification/add-build-dep/remove-build-dep
- Fix ConfigServiceTests to use renamed 'command' key
