### PR TITLE
[00156] Remove token consumption note from onboarding

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -187,12 +187,7 @@ public class CodingAgentStepView(IState<int> stepperIndex) : ViewBase
                | Text.Markdown(
                    "Tendril is a coding orchestrator powered by AI agents. Pick the agent you'd like to use — we'll check the required software and sign you in.")
                | (errorMessage != null ? Text.Danger(errorMessage) : null!)
-               | grid
-               | Text.Markdown(
-                   """
-                   >[!NOTE]
-                   >Tendril runs agents at scale and can consume tokens rapidly.
-                   """);
+               | grid;
     }
 
     private static List<SoftwareCheck> BuildChecks(string agentKey)


### PR DESCRIPTION
## Changes

Removed the token consumption warning note from the onboarding coding agent step view. The `Text.Markdown` block containing "> [!NOTE] > Tendril runs agents at scale and can consume tokens rapidly." was deleted, and the expression chain now terminates cleanly after the agent selection grid.

## Files Modified

- `src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs` — removed 6 lines (the trailing note block)

---

**Commits:** 32b9e0a