### PR TITLE
Replace --agent-cmd with --agent to use agent providers properly

### DIFF
--- a/src/Ivy.Tendril.Test/Commands/PromptwareDryRunTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareDryRunTests.cs
@@ -351,7 +351,7 @@ public class PromptwareDryRunTests : IDisposable
                 DryRun = true,
                 ConfigPath = _configPath,
                 PromptwarePath = _promptwarePath,
-                AgentCmd = "nonexistent-binary-that-should-not-run",
+                Agent = "claude",
                 Values = ["PlansDirectory=/tmp"]
             });
             Assert.Equal(0, exitCode);

--- a/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
@@ -46,7 +46,7 @@ public class PromptwareRunCommandTests : IDisposable
         Assert.Null(settings.Values);
         Assert.Null(settings.Plan);
         Assert.Null(settings.ConfigPath);
-        Assert.Null(settings.AgentCmd);
+        Assert.Null(settings.Agent);
         Assert.False(settings.DryRun);
     }
 
@@ -93,12 +93,12 @@ public class PromptwareRunCommandTests : IDisposable
         {
             Promptware = "TestPromptware",
             ConfigPath = "/tmp/test-config.yaml",
-            AgentCmd = "echo",
+            Agent = "gemini",
             DryRun = true
         };
 
         Assert.Equal("/tmp/test-config.yaml", settings.ConfigPath);
-        Assert.Equal("echo", settings.AgentCmd);
+        Assert.Equal("gemini", settings.Agent);
         Assert.True(settings.DryRun);
     }
 

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -42,9 +42,9 @@ public class PromptwareRunSettings : CommandSettings
     [Description("Override config.yaml path (for testing)")]
     public string? ConfigPath { get; init; }
 
-    [CommandOption("--agent-cmd")]
-    [Description("Override agent CLI command (for testing, e.g. 'echo' to dry-run)")]
-    public string? AgentCmd { get; init; }
+    [CommandOption("--agent")]
+    [Description("Override agent provider (claude, gemini, codex, copilot, opencode)")]
+    public string? Agent { get; init; }
 
     [CommandOption("--dry-run")]
     [Description("Print the compiled firmware and exit without launching the agent")]
@@ -119,7 +119,9 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
 
         var values = BuildFirmwareValues(settings, configService);
 
-        var resolution = AgentProviderFactory.Resolve(tendrilSettings, settings.Promptware, settings.Profile);
+        var resolution = !string.IsNullOrEmpty(settings.Agent)
+            ? AgentProviderFactory.Resolve(tendrilSettings, settings.Promptware, settings.Profile, agentOverride: settings.Agent)
+            : AgentProviderFactory.Resolve(tendrilSettings, settings.Promptware, settings.Profile);
 
         var workDir = settings.WorkingDir ?? programFolder;
 
@@ -172,9 +174,6 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
             ExtraArgs: resolution.ExtraArgs);
 
         var psi = resolution.Provider.BuildProcessStart(invocation);
-
-        if (!string.IsNullOrEmpty(settings.AgentCmd))
-            psi.FileName = settings.AgentCmd;
 
         var tendrilHome = configService.TendrilHome;
         if (!string.IsNullOrEmpty(tendrilHome))

--- a/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
+++ b/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
@@ -30,9 +30,10 @@ public class AgentProviderFactory
         TendrilSettings settings,
         string promptwareName,
         string? profileOverride = null,
-        IReadOnlyDictionary<string, string>? jobContext = null)
+        IReadOnlyDictionary<string, string>? jobContext = null,
+        string? agentOverride = null)
     {
-        var codingAgent = settings.CodingAgent;
+        var codingAgent = agentOverride ?? settings.CodingAgent;
         var provider = GetProvider(codingAgent);
 
         // Layer promptware config: _default → specific → profileOverride


### PR DESCRIPTION
## Summary
- Replaces the `--agent-cmd` hack (which overrode `psi.FileName` after provider built ProcessStartInfo) with `--agent` that selects a proper agent provider (`claude|gemini|codex|copilot|opencode`)
- Adds `agentOverride` parameter to `AgentProviderFactory.Resolve()` so the CLI flag flows through the provider abstraction
- Updates tests to use the new `Agent` property

## Test plan
- [x] Zero CS compilation errors
- [x] Dry-run tests updated to use `Agent = "claude"` instead of `AgentCmd = "nonexistent-binary"`