### PR TITLE
[00159] Reduce onboarding agent logo size to match sidebar

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -226,7 +226,7 @@ public class CodingAgentStepView(
         {
             grid |= new Card(
                 Layout.Horizontal().Gap(2).AlignContent(Align.Center).Padding(1)
-                | a.Logo.ToIcon().Width(Size.Px(32)).Height(Size.Px(32))
+                | a.Logo.ToIcon().Width(Size.Units(15)).Height(Size.Auto())
                 | Text.Block(a.Label)
             ).OnClick(() => onSelect(a.Key));
         }


### PR DESCRIPTION
## Changes

Changed the coding agent logo sizing in the onboarding picker from fixed pixel values (`Size.Px(32)` width and height) to responsive units (`Size.Units(15)` width, `Size.Auto()` height) to match the sidebar header logo approach.

## Files Modified

- **src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs** — Updated logo sizing from `Size.Px(32)` to `Size.Units(15)` width and `Size.Auto()` height

---

**Commits:**
- 3ce5466