### PR TITLE
[00160] Remove project name from verifications header in onboarding

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -21,7 +21,6 @@ public class CompleteStepView(
         var error = UseState<string?>(null);
         var refreshToken = UseState(0);
         var isFinishing = UseState(false);
-        var currentProject = UseState<string?>((string?)null);
 
         UseEffect(async () =>
         {
@@ -43,7 +42,6 @@ public class CompleteStepView(
 
                 foreach (var name in projectsNeedingVerifications)
                 {
-                    currentProject.Set(name);
                     var handle = runner.Run(new PromptwareRunOptions
                     {
                         Promptware = "UpdateProject",
@@ -65,7 +63,6 @@ public class CompleteStepView(
             }
             finally
             {
-                currentProject.Set((string?)null);
                 running.Set(false);
             }
         }, [EffectTrigger.OnMount()]);
@@ -124,9 +121,7 @@ public class CompleteStepView(
         }
 
         var headerText = running.Value
-            ? (currentProject.Value != null
-                ? $"Setting up verifications for {currentProject.Value}…"
-                : "Setting up verifications…")
+            ? "Setting up verifications…"
             : "Ready to Go!";
 
         var subText = running.Value


### PR DESCRIPTION
Removed the project name from the onboarding verifications header. The text now always shows "Setting up verifications..." instead of conditionally appending the project name. Also removed the unused `currentProject` state and its associated set/clear calls.

## Files Modified

- **src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs** — Removed `currentProject` state declaration, its usage in the loop and finally block, and simplified the `headerText` conditional.

---

Commits: ac0e3f4