### PR TITLE
Add opencode to the coding agent options in settings menu

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/GeneralSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/GeneralSetupView.cs
@@ -5,7 +5,7 @@ namespace Ivy.Tendril.Apps.Setup;
 
 public class GeneralSetupView : ViewBase
 {
-    private static readonly string[] CodingAgentOptions = ["claude", "codex", "gemini", "copilot"];
+    private static readonly string[] CodingAgentOptions = ["claude", "codex", "gemini", "copilot", "opencode"];
 
     public override object Build()
     {


### PR DESCRIPTION
## Summary
- Adds `opencode` to the `CodingAgentOptions` array in `GeneralSetupView.cs` so it can be selected in the settings UI

## Test plan
- [ ] Open settings, verify opencode appears in the coding agent dropdown