### PR TITLE
Capitalize repos directory to TENDRIL_HOME\Repos

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -130,7 +130,7 @@ public class ProjectSetupStepView(
                                             ?? Path.Combine(
                                                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                                                 ".tendril");
-                          var reposDir = Path.Combine(tendrilHome, "repos");
+                          var reposDir = Path.Combine(tendrilHome, "Repos");
                           Directory.CreateDirectory(reposDir);
 
                           var refs = new List<RepoRef>();

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -125,7 +125,7 @@ public class EditProjectDialog(
                 isFetching.Set(true);
 
                 var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril");
-                var reposDir = Path.Combine(tendrilHome, "repos");
+                var reposDir = Path.Combine(tendrilHome, "Repos");
                 Directory.CreateDirectory(reposDir);
 
                 var url = newRepoPath.Value;


### PR DESCRIPTION
Renames the cloned repos directory from `TENDRIL_HOME\repos` to `TENDRIL_HOME\Repos`.