### PR TITLE
Add delete confirmation dialogs to Levels and Verifications setup views

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
@@ -12,6 +12,7 @@ public class LevelsSetupView : ViewBase
         var client = UseService<IClientProvider>();
         var refreshToken = UseRefreshToken();
         var editIndex = UseState<int?>(-1);
+        var (alertView, showAlert) = UseAlert();
 
         // Use levels in config.yaml order (not alphabetically sorted).
         var levels = config.Settings.Levels;
@@ -34,10 +35,16 @@ public class LevelsSetupView : ViewBase
                 | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete this level").OnClick(() =>
                 {
                     var name = levels[idx].Name;
-                    levels.RemoveAt(idx);
-                    config.SaveSettings();
-                    client.Toast($"Level '{name}' deleted", "Deleted");
-                    refreshToken.Refresh();
+                    showAlert($"Are you sure you want to delete '{name}'?", result =>
+                    {
+                        if (result == AlertResult.Ok)
+                        {
+                            levels.RemoveAt(idx);
+                            config.SaveSettings();
+                            client.Toast($"Level '{name}' deleted", "Deleted");
+                            refreshToken.Refresh();
+                        }
+                    }, "Delete Level", AlertButtonSet.OkCancel);
                 })
             ))
             .ColumnWidth(t => t.Index, Size.Px(88));
@@ -50,7 +57,8 @@ public class LevelsSetupView : ViewBase
                {
                    editIndex.Set(null);
                })
-               | new EditLevelDialog(editIndex, levels, config, client, refreshToken);
+               | new EditLevelDialog(editIndex, levels, config, client, refreshToken)
+               | alertView;
     }
 
     private record LevelRow(string Name, string Badge, int Index);

--- a/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
@@ -12,6 +12,7 @@ public class VerificationsSetupView : ViewBase
         var client = UseService<IClientProvider>();
         var refreshToken = UseRefreshToken();
         var editIndex = UseState<int?>(-1);
+        var (alertView, showAlert) = UseAlert();
 
         var verifications = config.Settings.Verifications;
 
@@ -28,10 +29,16 @@ public class VerificationsSetupView : ViewBase
                 | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete this verification").OnClick(() =>
                 {
                     var name = verifications[idx].Name;
-                    verifications.RemoveAt(idx);
-                    config.SaveSettings();
-                    client.Toast($"Verification '{name}' deleted", "Deleted");
-                    refreshToken.Refresh();
+                    showAlert($"Are you sure you want to delete '{name}'?", result =>
+                    {
+                        if (result == AlertResult.Ok)
+                        {
+                            verifications.RemoveAt(idx);
+                            config.SaveSettings();
+                            client.Toast($"Verification '{name}' deleted", "Deleted");
+                            refreshToken.Refresh();
+                        }
+                    }, "Delete Verification", AlertButtonSet.OkCancel);
                 })
             ))
             .ColumnWidth(t => t.Name, Size.Units(32))
@@ -47,7 +54,8 @@ public class VerificationsSetupView : ViewBase
                {
                    editIndex.Set(null);
                })
-               | new EditVerificationDialog(editIndex, verifications, config, client, refreshToken);
+               | new EditVerificationDialog(editIndex, verifications, config, client, refreshToken)
+               | alertView;
     }
 
     private record VerificationRow(string Name, string Prompt, int Index);


### PR DESCRIPTION
## Summary
- Add UseAlert confirmation before deleting levels in LevelsSetupView
- Add UseAlert confirmation before deleting verifications in VerificationsSetupView
- Ensures all destructive actions in setup views now require user confirmation