### PR TITLE
[00167] Wrap repo paths to one per line in Setup/Projects table

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
@@ -22,13 +22,15 @@ public class ProjectsSetupView : ViewBase
         var table = new TableBuilder<ProjectRow>(rows)
             .Builder(t => t.Repos, f => f.Func<ProjectRow, List<RepoRef>>(repos =>
             {
-                var layout = Layout.Horizontal().Gap(2).AlignContent(Align.Left);
+                var layout = Layout.Vertical().Gap(1);
                 foreach (var repo in repos)
                 {
-                    layout |= Text.Block(repo.Path).Muted().Small();
-                    layout |= new Badge(repo.PrRule).Variant(BadgeVariant.Outline).Small();
+                    var row = Layout.Horizontal().Gap(2).AlignContent(Align.Left);
+                    row |= Text.Block(repo.Path).Muted().Small();
+                    row |= new Badge(repo.PrRule).Variant(BadgeVariant.Outline).Small();
                     if (!string.IsNullOrEmpty(repo.BaseBranch))
-                        layout |= new Badge(repo.BaseBranch).Variant(BadgeVariant.Secondary).Small();
+                        row |= new Badge(repo.BaseBranch).Variant(BadgeVariant.Secondary).Small();
+                    layout |= row;
                 }
                 return layout;
             }))


### PR DESCRIPTION
## Changes

Changed the repos cell in the Setup/Projects table from a single horizontal layout (where all repo paths ran together) to a vertical layout with one repo per line. Each line still shows the repo path followed by its prRule and baseBranch badges in a horizontal arrangement.

## Files Modified

- **src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs** — Changed repos builder from `Layout.Horizontal()` to `Layout.Vertical()` with per-repo horizontal rows

---

### Commits
- fdc0101 [00167] Change repos cell layout from horizontal to vertical in Setup/Projects table