### PR TITLE
[00168] Resize onboarding logo to match sidebar size

### DIFF
--- a/src/Ivy.Tendril/Apps/OnboardingApp.cs
+++ b/src/Ivy.Tendril/Apps/OnboardingApp.cs
@@ -62,7 +62,7 @@ public class OnboardingApp : ViewBase
 
         return Layout.TopCenter() |
                (Layout.Vertical().Margin(0, 20).Width(150)
-                | new Image("/tendril/assets/Tendril.svg").Width(Size.Units(20)).Height(Size.Auto())
+                | new Image("/tendril/assets/Tendril.svg").Width(Size.Units(15)).Height(Size.Auto())
                 | new Stepper(OnSelect, stepperIndex.Value, steps).Width(Size.Full())
                 | GetStepViews(stepperIndex, ghOwners, ghReposByOwner,
                                commonChecksPassed, homeBootstrapped, reposFetched, completedAgentKey,


### PR DESCRIPTION
# Summary

## Changes

Resized the Tendril logo in the onboarding screen from `Size.Units(20)` (80px) to `Size.Units(15)` (60px) to match the sidebar logo size (~40-50px height).

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/OnboardingApp.cs` — changed logo width from 20 to 15 units

---

**Commits:**
- 1d63859