### PR TITLE
[00166] Use SwatchPicker variant in EditProjectDialog for colors

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -24,7 +24,7 @@ public class EditProjectDialog(
     {
         var editName = UseState("");
         var editColor = UseState<Colors?>(null);
-        var showColorPicker = UseState(false);
+
         var editContext = UseState("");
         var editRepos = UseState(new List<RepoRef>());
         var editVerifications = UseState(new List<ProjectVerificationRef>());
@@ -126,15 +126,7 @@ public class EditProjectDialog(
             new DialogBody(
                 Layout.Vertical().Gap(4)
                 | editName.ToTextInput("Project name...").WithField().Label("Name")
-                | (Layout.Vertical().Gap(1)
-                   | Text.Block("Color").Small()
-                   | (Layout.Horizontal().Gap(2).AlignContent(Align.TopLeft)
-                      | new Button(editColor.Value?.ToString() ?? "Select Color").Outline()
-                          .OnClick(() => showColorPicker.Set(true))
-                      | (editColor.Value != null
-                          ? (object)new Box().Background(editColor.Value.Value).Width(Size.Units(8)).Height(Size.Units(8))
-                          : null!)))
-                | editColor.ToColorInput().ToDialog(showColorPicker, title: "Select Color")
+                | editColor.ToColorInput().Variant(ColorInputVariant.SwatchPicker).Nullable().WithField().Label("Color")
                 | editContext.ToTextareaInput("Project context or prompt for AI agents (optional)...").Rows(4)
                     .WithField().Label("Context / Prompt (Optional)")
                 | (Layout.Vertical().Gap(2)


### PR DESCRIPTION
## Changes

Replaced the button + dialog color picker pattern in EditProjectDialog with an inline `ColorInput` using `ColorInputVariant.SwatchPicker`. Removed the unused `showColorPicker` state variable. The dialog is now simpler (10 lines reduced to 1) while providing a better UX with an inline color swatch grid.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs** — Replaced color selection UI with SwatchPicker variant, removed unused state

---

### Commits

- 5c61cc1 [00166] Use SwatchPicker variant in EditProjectDialog for colors