### PR TITLE
[00171] Remove bold styling from onboarding progress status text

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -174,7 +174,7 @@ public class CodingAgentStepView(
         var missing = missingCheck.Value;
 
         return Layout.Vertical().Margin(0, 0, 0, 20).Gap(4)
-               | Text.Bold(progressMessage.Value ?? $"Setting Up {selected.Label}")
+               | Text.Block(progressMessage.Value ?? $"Setting Up {selected.Label}")
                | (progressValue.Value != null
                    ? new Progress(progressValue.Value.Value)
                    : null!)

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -30,7 +30,7 @@ public class ProjectSetupStepView(
         if (isCloning.Value)
         {
             return Layout.Vertical().Margin(0, 0, 0, 20).Gap(4)
-                   | Text.Bold(progressMessage.Value ?? "Setting up your project...")
+                   | Text.Block(progressMessage.Value ?? "Setting up your project...")
                    | (progressValue.Value != null
                        ? new Progress(progressValue.Value.Value)
                        : null!)


### PR DESCRIPTION
# Summary

## Changes

Replaced `Text.Bold(...)` with `Text.Block(...)` in two onboarding progress views to remove bold styling from progress status text above progress bars.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs` — line 177: `Text.Bold` → `Text.Block`
- `src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs` — line 33: `Text.Bold` → `Text.Block`

---

Commits: 2e9e3d8