### PR TITLE
[00170] Move default path hint to placeholder in onboarding data-location step

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
@@ -29,9 +29,8 @@ public class TendrilHomeStepView(
                    "you want this data on a different drive, synced via Dropbox/iCloud, or shared " +
                    "between machines.")
                | (error.Value != null ? Text.Danger(error.Value) : null!)
-               | tendrilHomePath.ToTextInput("Path to data folder...")
+               | tendrilHomePath.ToTextInput(defaultHome)
                    .WithField().Label("Tendril Home")
-               | Text.Muted($"Default: {defaultHome}")
                | (Layout.Horizontal().Width(Size.Full())
                   | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
                       .Disabled(isBootstrapping.Value)


### PR DESCRIPTION
## Changes

Moved the default Tendril home path hint from a separate `Text.Muted` line below the text input to the input's placeholder text. This makes the UI cleaner — the default path disappears once the user starts typing.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs** — Changed placeholder from static string to `defaultHome` variable, removed redundant `Text.Muted` line

---

### Commits

- 02c5247 [00170] Move default path hint to placeholder in onboarding data-location step