### PR TITLE
[00172] Change selected repo boxes in onboarding to borderless with 4% black background

### DIFF
--- a/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
@@ -293,7 +293,7 @@ public class ProjectRepoPickerView(
                              repos.Set(list);
                          }).WithTooltip("Remove");
 
-            listLayout |= new Box(row).Padding(4, 2, 2, 2).Width(Size.Full());
+            listLayout |= new Box(row).BorderStyle(BorderStyle.None).Background(Colors.Black, 0.04f).Padding(4, 2, 2, 2).Width(Size.Full());
         }
 
         var helperText = isRemote


### PR DESCRIPTION
## Summary

Changed selected repo boxes in the onboarding repo picker to use a borderless style with a 4% black background color instead of the default bordered box.

## Files Modified

- **src/Ivy.Tendril/Views/ProjectRepoPickerView.cs** — Added `.BorderStyle(BorderStyle.None).Background(Colors.Black, 0.04f)` to the Box wrapping each selected repo row

---

**Commits:**
- 140a749 — [00172] Change selected repo boxes to borderless with 4% black background