### PR TITLE
[00175] Use theme-aware enum colors for selected repo boxes in onboarding

### DIFF
--- a/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
@@ -265,7 +265,7 @@ public class ProjectRepoPickerView(
                 var isGitRepo = pathExists && Path.Exists(Path.Combine(expanded, ".git"));
                 if (!isGitRepo)
                 {
-                    pathLabel = Text.Block(item.Path).Color(Colors.Red);
+                    pathLabel = Text.Block(item.Path).Color(Colors.Destructive);
                     validityIcon = new Icon(Icons.TriangleAlert, Colors.Warning).Small()
                         .WithTooltip(!pathExists
                             ? $"Path does not exist: {expanded}"
@@ -293,7 +293,7 @@ public class ProjectRepoPickerView(
                              repos.Set(list);
                          }).WithTooltip("Remove");
 
-            listLayout |= new Box(row).BorderStyle(BorderStyle.None).Background(Colors.Black, 0.04f).Padding(4, 2, 2, 2).Width(Size.Full());
+            listLayout |= new Box(row).BorderStyle(BorderStyle.None).Background(Colors.Muted, 0.15f).Padding(4, 2, 2, 2).Width(Size.Full());
         }
 
         var helperText = isRemote


### PR DESCRIPTION
Replace hardcoded `Colors.Black` with theme-aware `Colors.Muted` for the selected repo box background in onboarding, ensuring proper adaptation to light/dark mode. Also updated invalid path label to use `Colors.Destructive` instead of `Colors.Red` for full theme awareness.

**Changes:**
- `ProjectRepoPickerView.cs`: `.Background(Colors.Black, 0.04f)` → `.Background(Colors.Muted, 0.15f)`
- `ProjectRepoPickerView.cs`: `.Color(Colors.Red)` → `.Color(Colors.Destructive)`

---
Commits:
- b9c80b8 [00175] Use theme-aware enum colors for selected repo boxes in onboarding