### PR TITLE
[00174] Default branch in repo picker branch selector should use remote GitHub default branch

### DIFF
--- a/src/Ivy.Tendril/Helpers/GitHubCliHelper.cs
+++ b/src/Ivy.Tendril/Helpers/GitHubCliHelper.cs
@@ -64,6 +64,15 @@ public static class GitHubCliHelper
         return await RunCommandAsync(cmd);
     }
 
+    public static async Task<string?> GetDefaultBranchAsync(string owner, string repo)
+    {
+        var safeOwner = owner.Replace("'", "").Replace("\"", "");
+        var safeRepo = repo.Replace("'", "").Replace("\"", "");
+        var cmd = $"gh api repos/{safeOwner}/{safeRepo} --jq '.default_branch'";
+        var result = await RunCommandAsync(cmd);
+        return result.Length > 0 ? result[0] : null;
+    }
+
     public static async Task<bool> CloneRepositoryAsync(string url, string destinationPath)
     {
         try

--- a/src/Ivy.Tendril/Helpers/GitHubCliHelper.cs
+++ b/src/Ivy.Tendril/Helpers/GitHubCliHelper.cs
@@ -79,10 +79,10 @@ public static class GitHubCliHelper
         {
             var isWindows = OperatingSystem.IsWindows();
             var shell = isWindows ? "pwsh" : "pwsh";
-            
+
             // Validate arguments somewhat to prevent injection
             if (url.Contains('\'') || url.Contains('"')) return false;
-            
+
             string cmd;
             if (System.IO.Directory.Exists(destinationPath))
             {
@@ -92,7 +92,7 @@ public static class GitHubCliHelper
             {
                 cmd = $"git clone '{url}' '{destinationPath}'";
             }
-            
+
             var psi = new ProcessStartInfo
             {
                 FileName = shell,

--- a/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
@@ -87,7 +87,18 @@ public class ProjectRepoPickerView(
             loadingBranches.Set(true);
             try
             {
-                var fetched = await GitHubCliHelper.GetBranchesAsync(selectedOwner.Value, selectedRepo.Value);
+                var branchesTask = GitHubCliHelper.GetBranchesAsync(selectedOwner.Value, selectedRepo.Value);
+                var defaultBranchTask = GitHubCliHelper.GetDefaultBranchAsync(selectedOwner.Value, selectedRepo.Value);
+                await Task.WhenAll(branchesTask, defaultBranchTask);
+
+                var fetched = branchesTask.Result;
+                var defaultBranch = defaultBranchTask.Result;
+
+                if (!string.IsNullOrEmpty(defaultBranch) && fetched.Contains(defaultBranch))
+                {
+                    fetched = new[] { defaultBranch }.Concat(fetched.Where(b => b != defaultBranch)).ToArray();
+                }
+
                 var next = new Dictionary<string, string[]>(branchesByRepo.Value) { [key] = fetched };
                 branchesByRepo.Set(next);
                 if (fetched.Length > 0) selectedBranch.Set(fetched[0]);


### PR DESCRIPTION
## Changes

Added `GetDefaultBranchAsync` to `GitHubCliHelper` to fetch a repository's configured default branch via the GitHub API. Updated `ProjectRepoPickerView` to call this concurrently with the branch list fetch and reorder the results so the default branch appears first (and is therefore auto-selected).

## API Changes

- **New method:** `GitHubCliHelper.GetDefaultBranchAsync(string owner, string repo)` — returns the repo's default branch name or `null` on failure.

## Files Modified

- `src/Ivy.Tendril/Helpers/GitHubCliHelper.cs` — added `GetDefaultBranchAsync` method
- `src/Ivy.Tendril/Views/ProjectRepoPickerView.cs` — updated branch-fetch effect to use concurrent default branch lookup and reorder

---

### Commits

- `282e7f0` [00174] Fix formatting in GitHubCliHelper
- `60e56d8` [00174] Use remote default branch in repo picker branch selector