### PR TITLE
[00176] Disable back navigation from last onboarding step

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -86,13 +86,6 @@ public class CompleteStepView(
             }
         }
 
-        void OnBack()
-        {
-            selectedRepos.Set(new List<RepoRef>());
-            projectName.Set("");
-            stepperIndex.Set(stepperIndex.Value - 1);
-        }
-
         var projects = config.Settings.Projects;
         var totalVerifications = projects.Sum(p => p.Verifications?.Count ?? 0);
 
@@ -155,9 +148,6 @@ public class CompleteStepView(
                    : null!)
                | (!running.Value && totalVerifications > 0 ? (object)listLayout : null!)
                | (Layout.Horizontal().Width(Size.Full())
-                  | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
-                      .Disabled(running.Value || isFinishing.Value)
-                      .OnClick(OnBack)
                   | new Spacer()
                   | new Button("Finish").Primary().Large().Icon(Icons.Check, Align.Right)
                       .Disabled(running.Value || isFinishing.Value)

--- a/src/Ivy.Tendril/Apps/OnboardingApp.cs
+++ b/src/Ivy.Tendril/Apps/OnboardingApp.cs
@@ -71,6 +71,7 @@ public class OnboardingApp : ViewBase
 
         ValueTask OnSelect(Event<Stepper, int> e)
         {
+            if (stepperIndex.Value == 3) return ValueTask.CompletedTask;
             stepperIndex.Set(e.Value);
             return ValueTask.CompletedTask;
         }


### PR DESCRIPTION
## Summary

## Changes

Removed the "Back" button and `OnBack()` method from `CompleteStepView.cs`, and added a guard in `OnboardingApp.cs` to prevent the Stepper's `OnSelect` callback from navigating away when on the final step (index 3).

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs` — Removed Back button, OnBack method
- `src/Ivy.Tendril/Apps/OnboardingApp.cs` — Added early return guard in OnSelect when on step 3

---

### Commits

- 66c1a3b