### PR TITLE
Inject customInstructions into promptware execution

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/02_Concepts/02_Promptwares.md
+++ b/src/Ivy.Tendril.Docs/Docs/02_Concepts/02_Promptwares.md
@@ -36,9 +36,39 @@ Tendril runs them through the configured AI stack (e.g. Claude Code) for focused
 | **CreatePr** | GitHub PR from the worktree diff (`gh`). |
 | **CreateIssue** | Push plan failure/state to GitHub for triage. |
 
+## Configuration
+
+Each promptware is configured in `config.yaml` under the `promptwares:` key:
+
+```yaml
+promptwares:
+  CreatePlan:
+    profile: balanced
+    allowedTools:
+      - Read
+      - Glob
+      - Grep
+      - Bash
+      - Write(%PLANS_DIR%/**)
+    customInstructions: |
+      Always include acceptance criteria in the plan.
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `profile` | Yes | Agent profile to use (`balanced`, `deep`, `quick`). |
+| `allowedTools` | Yes | Tools the agent may call. Supports `%PLAN_FOLDER%` and `%PLANS_DIR%` variables. |
+| `customInstructions` | No | Free-text instructions injected into the agent prompt. Takes precedence over Firmware and Program.md. |
+
+A special `_default` entry applies as a baseline to all promptwares; specific entries override it.
+
+### Custom Instructions
+
+When `customInstructions` is set, Tendril appends them to the end of the Firmware prompt with an explicit priority marker. The agent is instructed to follow these over both the Firmware template and the promptware's `Program.md`. Use this for per-promptware behavioral overrides without editing the shared program files.
+
 ## Execution Flow
 
-1. **Context** — Load `Program.md`; attach project context from `config.yaml`.
+1. **Context** — Load `Program.md`; attach project context and custom instructions from `config.yaml`.
 2. **Tools** — Expose `Tools/` via the tool protocol.
 3. **Run** — Agent runs in the background with isolated state.
 4. **Capture** — Stream to `logs/`; tokens and cost – `costs.csv`.

--- a/src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
@@ -44,10 +44,10 @@ public class LevelsSetupView : ViewBase
                             client.Toast($"Level '{name}' deleted", "Deleted");
                             refreshToken.Refresh();
                         }
-                    }, "Delete Level", AlertButtonSet.OkCancel);
+                    }, "Delete Level");
                 })
             ))
-            .ColumnWidth(t => t.Index, Size.Px(88));
+            .Width(Size.Fit());
 
         return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Priority Levels").Bold()

--- a/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
@@ -56,8 +56,7 @@ public class ProjectsSetupView : ViewBase
                     }, "Delete Project", AlertButtonSet.OkCancel);
                 })
             ))
-            .ColumnWidth(t => t.Repos, Size.Grow())
-            .ColumnWidth(t => t.Index, Size.Px(88));
+            .Width(Size.Fit());
 
         return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Projects").Bold()

--- a/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
@@ -28,9 +28,6 @@ public class PromptwaresSetupView : ViewBase
                     ? Layout.Horizontal().Gap(2) | name | new Badge("Tendril").Variant(BadgeVariant.Secondary).Small()
                     : name))
             .Header(t => t.Index, "")
-            .ColumnWidth(c => c.Name, Size.Fit())
-            .ColumnWidth(c => c.Profile, Size.Fit())
-            .ColumnWidth(c => c.Index, Size.Fit())
             .Builder(t => t.Index, f => f.Func<PromptwareRow, int>(idx =>
             {
                 var name = rows[idx].Name;

--- a/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
@@ -16,7 +16,7 @@ public class VerificationsSetupView : ViewBase
 
         var verifications = config.Settings.Verifications;
 
-        var rows = verifications.Select((v, i) => new VerificationRow(v.Name, v.Prompt, i)).ToList();
+        var rows = verifications.Select((v, i) => new VerificationRow(v.Name, i)).ToList();
 
         var table = new TableBuilder<VerificationRow>(rows)
             .Header(t => t.Index, "")
@@ -41,10 +41,7 @@ public class VerificationsSetupView : ViewBase
                     }, "Delete Verification", AlertButtonSet.OkCancel);
                 })
             ))
-            .ColumnWidth(t => t.Name, Size.Units(32))
-            .ColumnWidth(t => t.Prompt, Size.Units(100))
-            .Multiline(t => t.Prompt)
-            .ColumnWidth(t => t.Index, Size.Px(88));
+            .Width(Size.Fit());
 
         return Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(400)))
                | Text.Block("Verification Definitions").Bold()
@@ -58,7 +55,7 @@ public class VerificationsSetupView : ViewBase
                | alertView;
     }
 
-    private record VerificationRow(string Name, string Prompt, int Index);
+    private record VerificationRow(string Name, int Index);
 }
 
 file class EditVerificationDialogContent(

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -129,8 +129,15 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
 
         var workDir = settings.WorkingDir ?? programFolder;
 
+        string? customInstructions = null;
+        if (tendrilSettings.Promptwares.TryGetValue("_default", out var defaultCfg))
+            customInstructions = defaultCfg.CustomInstructions;
+        if (tendrilSettings.Promptwares.TryGetValue(settings.Promptware, out var specificCfg)
+            && !string.IsNullOrWhiteSpace(specificCfg.CustomInstructions))
+            customInstructions = specificCfg.CustomInstructions;
+
         var logFile = FirmwareCompiler.GetNextLogFile(programFolder, values);
-        var firmwareContext = new FirmwareContext(programFolder, logFile, values);
+        var firmwareContext = new FirmwareContext(programFolder, logFile, values, customInstructions);
         var prompt = FirmwareCompiler.Compile(firmwareContext);
 
         // Emit resolved context as YAML for testability/debugging

--- a/src/Ivy.Tendril/Services/Agents/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/Agents/FirmwareCompiler.cs
@@ -95,6 +95,13 @@ public class FirmwareCompiler
             firmware += $"\n### Plans\n\n{plansContent}\n";
         }
 
+        if (!string.IsNullOrWhiteSpace(context.CustomInstructions))
+        {
+            firmware += "\n\n## Custom Instructions\n\n";
+            firmware += "IMPORTANT: The following instructions are provided by the user and take precedence over the Firmware template and Program.md instructions. Follow them even if they conflict with other instructions.\n\n";
+            firmware += context.CustomInstructions + "\n";
+        }
+
         return firmware;
     }
 
@@ -141,4 +148,5 @@ public class FirmwareCompiler
 public record FirmwareContext(
     string ProgramFolder,
     string LogFile,
-    Dictionary<string, string> Values);
+    Dictionary<string, string> Values,
+    string? CustomInstructions = null);

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -401,8 +401,15 @@ internal class JobLauncher
         var resolution = AgentProviderFactory.Resolve(settings, job.Type, profileOverride, jobContext);
         var workDir = ResolveWorkingDirectory(job, programFolder);
 
+        string? customInstructions = null;
+        if (settings.Promptwares.TryGetValue("_default", out var defaultCfg))
+            customInstructions = defaultCfg.CustomInstructions;
+        if (settings.Promptwares.TryGetValue(job.Type, out var specificCfg)
+            && !string.IsNullOrWhiteSpace(specificCfg.CustomInstructions))
+            customInstructions = specificCfg.CustomInstructions;
+
         var logFile = FirmwareCompiler.GetNextLogFile(programFolder, values);
-        var context = new FirmwareContext(programFolder, logFile, values);
+        var context = new FirmwareContext(programFolder, logFile, values, customInstructions);
         var prompt = FirmwareCompiler.Compile(context);
 
         var invocation = new AgentInvocation(


### PR DESCRIPTION
## Summary
- Wire up `CustomInstructions` from `PromptwareConfig` into the firmware prompt at runtime
- Instructions appended with explicit priority marker (precedence over Firmware and Program.md)
- Layered resolution: `_default` → specific promptware config
- Updated Promptwares docs with Configuration section and field reference