### PR TITLE
[00179] Simplify onboarding repo picker - remove versioning tool dependency

### DIFF
--- a/src/Ivy.Tendril.Test/Helpers/RepoPathValidatorTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/RepoPathValidatorTests.cs
@@ -1,0 +1,136 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test.Helpers;
+
+public class RepoPathValidatorTests
+{
+    [Theory]
+    [InlineData("git@github.com:owner/repo.git", RepoPathKind.SshUrl)]
+    [InlineData("git@gitlab.com:org/repo", RepoPathKind.SshUrl)]
+    [InlineData("git@bitbucket.org:team/repo.git", RepoPathKind.SshUrl)]
+    [InlineData("git@custom-host.example.com:user/project.git", RepoPathKind.SshUrl)]
+    public void Classify_SshUrl_ReturnsCorrect(string input, RepoPathKind expected)
+    {
+        Assert.Equal(expected, RepoPathValidator.Classify(input));
+    }
+
+    [Theory]
+    [InlineData("https://github.com/owner/repo.git", RepoPathKind.HttpUrl)]
+    [InlineData("https://github.com/owner/repo", RepoPathKind.HttpUrl)]
+    [InlineData("http://gitlab.com/org/repo", RepoPathKind.HttpUrl)]
+    [InlineData("https://bitbucket.org/team/project.git", RepoPathKind.HttpUrl)]
+    public void Classify_HttpUrl_ReturnsCorrect(string input, RepoPathKind expected)
+    {
+        Assert.Equal(expected, RepoPathValidator.Classify(input));
+    }
+
+    [Theory]
+    [InlineData("/home/user/repos/myapp", RepoPathKind.LocalPath)]
+    [InlineData("~/code/project", RepoPathKind.LocalPath)]
+    [InlineData("/var/lib/repos/test", RepoPathKind.LocalPath)]
+    public void Classify_LocalPath_ReturnsCorrect(string input, RepoPathKind expected)
+    {
+        Assert.Equal(expected, RepoPathValidator.Classify(input));
+    }
+
+    [Theory]
+    [InlineData("", RepoPathKind.Invalid)]
+    [InlineData("   ", RepoPathKind.Invalid)]
+    [InlineData("relative/path", RepoPathKind.Invalid)]
+    [InlineData("just-a-name", RepoPathKind.Invalid)]
+    public void Classify_Invalid_ReturnsInvalid(string input, RepoPathKind expected)
+    {
+        Assert.Equal(expected, RepoPathValidator.Classify(input));
+    }
+
+    [Theory]
+    [InlineData("git@github.com:owner/repo.git", "repo")]
+    [InlineData("git@gitlab.com:org/my-project", "my-project")]
+    [InlineData("https://github.com/owner/repo.git", "repo")]
+    [InlineData("https://github.com/owner/repo", "repo")]
+    [InlineData("http://gitlab.com/org/my-lib.git", "my-lib")]
+    [InlineData("/home/user/repos/myapp", "myapp")]
+    [InlineData("~/code/project", "project")]
+    public void ExtractRepoName_VariousFormats(string input, string expected)
+    {
+        Assert.Equal(expected, RepoPathValidator.ExtractRepoName(input));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void ExtractRepoName_InvalidInput_ReturnsNull(string? input)
+    {
+        Assert.Null(RepoPathValidator.ExtractRepoName(input!));
+    }
+
+    [Theory]
+    [InlineData("git@github.com:owner/repo.git")]
+    [InlineData("https://github.com/owner/repo")]
+    [InlineData("/home/user/repos/myapp")]
+    [InlineData("~/code/project")]
+    public void IsValid_ValidInputs_ReturnsTrue(string input)
+    {
+        Assert.True(RepoPathValidator.IsValid(input));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("relative/path")]
+    [InlineData("just-a-name")]
+    public void IsValid_InvalidInputs_ReturnsFalse(string input)
+    {
+        Assert.False(RepoPathValidator.IsValid(input));
+    }
+
+    [Theory]
+    [InlineData("git@github.com:owner/repo.git")]
+    [InlineData("git@gitlab.com:org/repo")]
+    public void IsSshUrl_ValidSsh_ReturnsTrue(string input)
+    {
+        Assert.True(RepoPathValidator.IsSshUrl(input));
+    }
+
+    [Theory]
+    [InlineData("https://github.com/owner/repo")]
+    [InlineData("/home/user/repos/myapp")]
+    public void IsSshUrl_NonSsh_ReturnsFalse(string input)
+    {
+        Assert.False(RepoPathValidator.IsSshUrl(input));
+    }
+
+    [Theory]
+    [InlineData("https://github.com/owner/repo.git")]
+    [InlineData("http://gitlab.com/org/repo")]
+    public void IsHttpUrl_ValidHttp_ReturnsTrue(string input)
+    {
+        Assert.True(RepoPathValidator.IsHttpUrl(input));
+    }
+
+    [Theory]
+    [InlineData("git@github.com:owner/repo.git")]
+    [InlineData("/home/user/repos/myapp")]
+    public void IsHttpUrl_NonHttp_ReturnsFalse(string input)
+    {
+        Assert.False(RepoPathValidator.IsHttpUrl(input));
+    }
+
+    [Theory]
+    [InlineData("/home/user/repos/myapp")]
+    [InlineData("~/code/project")]
+    public void IsLocalPath_ValidPath_ReturnsTrue(string input)
+    {
+        Assert.True(RepoPathValidator.IsLocalPath(input));
+    }
+
+    [Theory]
+    [InlineData("git@github.com:owner/repo.git")]
+    [InlineData("https://github.com/owner/repo")]
+    [InlineData("relative/path")]
+    public void IsLocalPath_NonPath_ReturnsFalse(string input)
+    {
+        Assert.False(RepoPathValidator.IsLocalPath(input));
+    }
+}

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using Ivy.Helpers;
-using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
@@ -8,10 +7,7 @@ namespace Ivy.Tendril.Apps.Onboarding;
 
 public class CodingAgentStepView(
     IState<int> stepperIndex,
-    IState<string[]> ghOwners,
-    IState<Dictionary<string, string[]>> ghReposByOwner,
     IState<bool> commonChecksPassed,
-    IState<bool> reposFetched,
     IState<string?> completedAgentKey) : ViewBase
 {
     private record AgentInfo(string Key, string Label, Icons Logo);
@@ -126,21 +122,6 @@ public class CodingAgentStepView(
                 config.Settings.CodingAgent = agentKey;
                 config.SetPendingCodingAgent(agentKey);
 
-                if (!reposFetched.Value)
-                {
-                    progressMessage.Set("Fetching Your GitHub Repositories...");
-                    var owners = await GitHubCliHelper.GetOwnersAsync();
-                    ghOwners.Set(owners);
-
-                    var repoFetches = owners.Select(async o => (Owner: o, Repos: await GitHubCliHelper.GetRepositoriesAsync(o)));
-                    var results = await Task.WhenAll(repoFetches);
-                    var byOwner = new Dictionary<string, string[]>();
-                    foreach (var (owner, ownerRepos) in results)
-                        byOwner[owner] = ownerRepos;
-                    ghReposByOwner.Set(byOwner);
-                    reposFetched.Set(true);
-                }
-
                 completedAgentKey.Set(agentKey);
 
                 progressCts.Cancel();
@@ -233,11 +214,7 @@ public class CodingAgentStepView(
             new("Git", "git", "https://git-scm.com/downloads", true,
                 () => CheckCommand("git", "--version")),
             new("PowerShell", "powershell", "https://github.com/PowerShell/PowerShell", true,
-                CheckPowerShell),
-            new("GitHub CLI", "gh", "https://cli.github.com/", true,
-                () => CheckCommand("gh", "--version"),
-                () => CheckHealth("gh", "auth status --active"),
-                "Sign in to GitHub")
+                CheckPowerShell)
         };
         list.Add(BuildAgentCheck(agentKey));
         return list;

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -7,8 +7,6 @@ namespace Ivy.Tendril.Apps.Onboarding;
 
 public class ProjectSetupStepView(
     IState<int> stepperIndex,
-    IState<string[]> ghOwners,
-    IState<Dictionary<string, string[]>> ghReposByOwner,
     IState<List<RepoRef>> selectedRepos,
     IState<string> projectName) : ViewBase
 {
@@ -43,9 +41,7 @@ public class ProjectSetupStepView(
         return Layout.Vertical().Gap(4).Margin(0, 0, 0, 20)
                | Text.H2("Setup your first project")
                | (error.Value != null ? Text.Danger(error.Value) : null!)
-               | new ProjectRepoPickerView(selectedRepos, projectName,
-                                           preFetchedOwners: ghOwners,
-                                           preFetchedReposByOwner: ghReposByOwner)
+               | new ProjectRepoPickerView(selectedRepos, projectName)
                | projectName.ToTextInput().WithField().Required().Label("Project Name")
                | (Layout.Horizontal().Width(Size.Full())
                   | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
@@ -87,7 +83,8 @@ public class ProjectSetupStepView(
                               foreach (var repo in selectedRepos.Value)
                               {
                                   i++;
-                                  if (!LooksLikeUrl(repo.Path))
+                                  var kind = RepoPathValidator.Classify(repo.Path);
+                                  if (kind == RepoPathKind.LocalPath)
                                   {
                                       progressMessage.Set($"Adding {repo.Path} ({i}/{total})...");
                                       var trimmed = repo.Path.Trim();
@@ -97,7 +94,7 @@ public class ProjectSetupStepView(
                                   else
                                   {
                                       Directory.CreateDirectory(reposDir);
-                                      var repoName = ExtractRepoName(repo.Path);
+                                      var repoName = RepoPathValidator.ExtractRepoName(repo.Path) ?? Guid.NewGuid().ToString();
                                       progressMessage.Set($"Fetching {repoName} ({i}/{total})...");
                                       var destPath = Path.Combine(reposDir, repoName);
                                       var success = await GitHubCliHelper.CloneRepositoryAsync(repo.Path, destPath);
@@ -145,21 +142,6 @@ public class ProjectSetupStepView(
                               isCloning.Set(false);
                           }
                       }));
-    }
-
-    private static bool LooksLikeUrl(string path)
-        => !string.IsNullOrEmpty(path)
-           && (path.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
-               || path.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
-               || path.StartsWith("git@", StringComparison.OrdinalIgnoreCase));
-
-    private static string ExtractRepoName(string url)
-    {
-        var trimmed = url;
-        if (trimmed.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
-            trimmed = trimmed[..^4];
-        var parts = trimmed.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        return parts.Length > 0 ? parts[^1] : Guid.NewGuid().ToString();
     }
 
     private static async Task DriveProgressAsync(IState<int?> value, CancellationToken ct)

--- a/src/Ivy.Tendril/Apps/OnboardingApp.cs
+++ b/src/Ivy.Tendril/Apps/OnboardingApp.cs
@@ -23,11 +23,8 @@ public class OnboardingApp : ViewBase
 
     private static object GetStepViews(
         IState<int> stepperIndex,
-        IState<string[]> ghOwners,
-        IState<Dictionary<string, string[]>> ghReposByOwner,
         IState<bool> commonChecksPassed,
         IState<bool> homeBootstrapped,
-        IState<bool> reposFetched,
         IState<string?> completedAgentKey,
         IState<string> tendrilHomePath,
         IState<List<RepoRef>> selectedRepos,
@@ -35,10 +32,9 @@ public class OnboardingApp : ViewBase
     {
         return stepperIndex.Value switch
         {
-            0 => new CodingAgentStepView(stepperIndex, ghOwners, ghReposByOwner,
-                                         commonChecksPassed, reposFetched, completedAgentKey),
+            0 => new CodingAgentStepView(stepperIndex, commonChecksPassed, completedAgentKey),
             1 => new TendrilHomeStepView(stepperIndex, tendrilHomePath, homeBootstrapped),
-            2 => new ProjectSetupStepView(stepperIndex, ghOwners, ghReposByOwner, selectedRepos, projectName),
+            2 => new ProjectSetupStepView(stepperIndex, selectedRepos, projectName),
             3 => new CompleteStepView(stepperIndex, selectedRepos, projectName),
             _ => throw new ArgumentOutOfRangeException()
         };
@@ -47,11 +43,8 @@ public class OnboardingApp : ViewBase
     public override object Build()
     {
         var stepperIndex = UseState(0);
-        var ghOwners = UseState<string[]>(Array.Empty<string>);
-        var ghReposByOwner = UseState<Dictionary<string, string[]>>(() => new Dictionary<string, string[]>());
         var commonChecksPassed = UseState(false);
         var homeBootstrapped = UseState(false);
-        var reposFetched = UseState(false);
         var completedAgentKey = UseState<string?>((string?)null);
         var tendrilHomePath = UseState(() =>
             Environment.GetEnvironmentVariable("TENDRIL_HOME")
@@ -64,8 +57,8 @@ public class OnboardingApp : ViewBase
                (Layout.Vertical().Margin(0, 20).Width(150)
                 | new Image("/tendril/assets/Tendril.svg").Width(Size.Units(15)).Height(Size.Auto())
                 | new Stepper(OnSelect, stepperIndex.Value, steps).Width(Size.Full())
-                | GetStepViews(stepperIndex, ghOwners, ghReposByOwner,
-                               commonChecksPassed, homeBootstrapped, reposFetched, completedAgentKey,
+                | GetStepViews(stepperIndex,
+                               commonChecksPassed, homeBootstrapped, completedAgentKey,
                                tendrilHomePath, selectedRepos, projectName)
                );
 

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -59,14 +59,15 @@ public class EditProjectDialog(
 
         Func<RepoRef, Task<RepoRef?>> cloneRemoteOnAdd = async draft =>
         {
-            if (!LooksLikeUrl(draft.Path)) return draft;
+            var kind = RepoPathValidator.Classify(draft.Path);
+            if (kind == RepoPathKind.LocalPath || kind == RepoPathKind.Invalid) return draft;
 
             var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME")
                               ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril");
             var reposDir = Path.Combine(tendrilHome, "Repos");
             Directory.CreateDirectory(reposDir);
 
-            var repoName = ExtractRepoName(draft.Path);
+            var repoName = RepoPathValidator.ExtractRepoName(draft.Path) ?? Guid.NewGuid().ToString();
             var destPath = Path.Combine(reposDir, repoName);
 
             var success = await GitHubCliHelper.CloneRepositoryAsync(draft.Path, destPath);
@@ -157,18 +158,4 @@ public class EditProjectDialog(
         ).Width(Size.Rem(40));
     }
 
-    private static bool LooksLikeUrl(string path)
-        => !string.IsNullOrEmpty(path)
-           && (path.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
-               || path.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
-               || path.StartsWith("git@", StringComparison.OrdinalIgnoreCase));
-
-    private static string ExtractRepoName(string url)
-    {
-        var trimmed = url;
-        if (trimmed.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
-            trimmed = trimmed[..^4];
-        var parts = trimmed.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        return parts.Length > 0 ? parts[^1] : Guid.NewGuid().ToString();
-    }
 }

--- a/src/Ivy.Tendril/Helpers/GitHubCliHelper.cs
+++ b/src/Ivy.Tendril/Helpers/GitHubCliHelper.cs
@@ -1,90 +1,20 @@
 using System.Diagnostics;
-using System.Text.Json;
 
 namespace Ivy.Tendril.Helpers;
 
 public static class GitHubCliHelper
 {
-    private static async Task<string[]> RunCommandAsync(string arguments)
-    {
-        try
-        {
-            var isWindows = OperatingSystem.IsWindows();
-            var shell = isWindows ? "pwsh" : "pwsh"; // Using pwsh on all platforms as requested by assumption
-            var psi = new ProcessStartInfo
-            {
-                FileName = shell,
-                Arguments = $"-NoProfile -Command \"{arguments}\"",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            using var process = Process.Start(psi);
-            if (process == null) return [];
-
-            var output = await process.StandardOutput.ReadToEndAsync();
-            await process.WaitForExitAsync();
-
-            if (process.ExitCode != 0)
-            {
-                var error = await process.StandardError.ReadToEndAsync();
-                return [];
-            }
-
-            return output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-        }
-        catch
-        {
-            return [];
-        }
-    }
-
-    public static async Task<string[]> GetOwnersAsync()
-    {
-        // Get both user and organizations
-        var cmd = "gh api graphql -F query='query { viewer { login organizations(first:100) { nodes { login } } } }' --jq '.data.viewer.login, .data.viewer.organizations.nodes[].login'";
-        return await RunCommandAsync(cmd);
-    }
-
-    public static async Task<string[]> GetRepositoriesAsync(string owner)
-    {
-        // Ensure owner string doesn't contain malicious quotes
-        var safeOwner = owner.Replace("'", "").Replace("\"", "");
-        var cmd = $"gh repo list {safeOwner} --json name --jq '.[].name' -L 100";
-        return await RunCommandAsync(cmd);
-    }
-
-    public static async Task<string[]> GetBranchesAsync(string owner, string repo)
-    {
-        var safeOwner = owner.Replace("'", "").Replace("\"", "");
-        var safeRepo = repo.Replace("'", "").Replace("\"", "");
-        var cmd = $"gh api repos/{safeOwner}/{safeRepo}/branches --jq '.[].name'";
-        return await RunCommandAsync(cmd);
-    }
-
-    public static async Task<string?> GetDefaultBranchAsync(string owner, string repo)
-    {
-        var safeOwner = owner.Replace("'", "").Replace("\"", "");
-        var safeRepo = repo.Replace("'", "").Replace("\"", "");
-        var cmd = $"gh api repos/{safeOwner}/{safeRepo} --jq '.default_branch'";
-        var result = await RunCommandAsync(cmd);
-        return result.Length > 0 ? result[0] : null;
-    }
-
     public static async Task<bool> CloneRepositoryAsync(string url, string destinationPath)
     {
         try
         {
-            var isWindows = OperatingSystem.IsWindows();
-            var shell = isWindows ? "pwsh" : "pwsh";
+            var shell = "pwsh";
 
             // Validate arguments somewhat to prevent injection
             if (url.Contains('\'') || url.Contains('"')) return false;
 
             string cmd;
-            if (System.IO.Directory.Exists(destinationPath))
+            if (Directory.Exists(destinationPath))
             {
                 cmd = $"git -C '{destinationPath}' pull";
             }

--- a/src/Ivy.Tendril/Helpers/RepoPathValidator.cs
+++ b/src/Ivy.Tendril/Helpers/RepoPathValidator.cs
@@ -1,0 +1,93 @@
+using System.Text.RegularExpressions;
+
+namespace Ivy.Tendril.Helpers;
+
+public enum RepoPathKind { SshUrl, HttpUrl, LocalPath, Invalid }
+
+public static class RepoPathValidator
+{
+    // git@<host>:<owner>/<repo>(.git)?
+    private static readonly Regex SshPattern = new(
+        @"^git@[\w.\-]+:[\w.\-]+/[\w.\-]+(?:\.git)?$",
+        RegexOptions.Compiled);
+
+    // http(s)://<host>/<path>(.git)?
+    private static readonly Regex HttpPattern = new(
+        @"^https?://[\w.\-]+(:\d+)?(/[\w.\-~%]+)+(?:\.git)?$",
+        RegexOptions.Compiled);
+
+    public static RepoPathKind Classify(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return RepoPathKind.Invalid;
+
+        input = input.Trim();
+
+        if (IsSshUrl(input)) return RepoPathKind.SshUrl;
+        if (IsHttpUrl(input)) return RepoPathKind.HttpUrl;
+        if (IsLocalPath(input)) return RepoPathKind.LocalPath;
+
+        return RepoPathKind.Invalid;
+    }
+
+    public static bool IsValid(string input) => Classify(input) != RepoPathKind.Invalid;
+
+    public static bool IsSshUrl(string input)
+        => !string.IsNullOrWhiteSpace(input) && SshPattern.IsMatch(input.Trim());
+
+    public static bool IsHttpUrl(string input)
+        => !string.IsNullOrWhiteSpace(input) && HttpPattern.IsMatch(input.Trim());
+
+    public static bool IsLocalPath(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return false;
+        var trimmed = input.Trim();
+
+        // Absolute Linux/macOS path
+        if (trimmed.StartsWith('/')) return true;
+        // Home-relative path
+        if (trimmed.StartsWith('~')) return true;
+        // Windows drive letter (e.g. C:\...)
+        if (trimmed.Length >= 2 && char.IsLetter(trimmed[0]) && trimmed[1] == ':') return true;
+
+        return false;
+    }
+
+    public static string? ExtractRepoName(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return null;
+        input = input.Trim();
+
+        var kind = Classify(input);
+
+        switch (kind)
+        {
+            case RepoPathKind.SshUrl:
+            {
+                // git@host:owner/repo.git -> repo
+                var colonIdx = input.IndexOf(':');
+                if (colonIdx < 0) return null;
+                var path = input[(colonIdx + 1)..];
+                if (path.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+                    path = path[..^4];
+                var parts = path.Split('/');
+                return parts.Length > 0 ? parts[^1] : null;
+            }
+            case RepoPathKind.HttpUrl:
+            {
+                var trimmed = input;
+                if (trimmed.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+                    trimmed = trimmed[..^4];
+                var parts = trimmed.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                return parts.Length > 0 ? parts[^1] : null;
+            }
+            case RepoPathKind.LocalPath:
+            {
+                var trimmed = input.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                return Path.GetFileName(trimmed);
+            }
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Ivy.Tendril/Helpers/RepoPathValidator.cs
+++ b/src/Ivy.Tendril/Helpers/RepoPathValidator.cs
@@ -63,29 +63,29 @@ public static class RepoPathValidator
         switch (kind)
         {
             case RepoPathKind.SshUrl:
-            {
-                // git@host:owner/repo.git -> repo
-                var colonIdx = input.IndexOf(':');
-                if (colonIdx < 0) return null;
-                var path = input[(colonIdx + 1)..];
-                if (path.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
-                    path = path[..^4];
-                var parts = path.Split('/');
-                return parts.Length > 0 ? parts[^1] : null;
-            }
+                {
+                    // git@host:owner/repo.git -> repo
+                    var colonIdx = input.IndexOf(':');
+                    if (colonIdx < 0) return null;
+                    var path = input[(colonIdx + 1)..];
+                    if (path.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+                        path = path[..^4];
+                    var parts = path.Split('/');
+                    return parts.Length > 0 ? parts[^1] : null;
+                }
             case RepoPathKind.HttpUrl:
-            {
-                var trimmed = input;
-                if (trimmed.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
-                    trimmed = trimmed[..^4];
-                var parts = trimmed.Split('/', StringSplitOptions.RemoveEmptyEntries);
-                return parts.Length > 0 ? parts[^1] : null;
-            }
+                {
+                    var trimmed = input;
+                    if (trimmed.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+                        trimmed = trimmed[..^4];
+                    var parts = trimmed.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                    return parts.Length > 0 ? parts[^1] : null;
+                }
             case RepoPathKind.LocalPath:
-            {
-                var trimmed = input.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-                return Path.GetFileName(trimmed);
-            }
+                {
+                    var trimmed = input.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+                    return Path.GetFileName(trimmed);
+                }
             default:
                 return null;
         }

--- a/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
@@ -10,168 +10,41 @@ public class ProjectRepoPickerView(
     IState<List<RepoRef>> repos,
     IState<string>? projectName = null,
     Func<RepoRef, Task<RepoRef?>>? onAdd = null,
-    bool showPrRule = false,
-    IState<string[]>? preFetchedOwners = null,
-    IState<Dictionary<string, string[]>>? preFetchedReposByOwner = null) : ViewBase
+    bool showPrRule = false) : ViewBase
 {
     public override object Build()
     {
-        var mode = UseState("remote"); // "remote" | "local"
-        var ownersInternal = UseState<string[]>(Array.Empty<string>);
-        var reposByOwnerInternal = UseState<Dictionary<string, string[]>>(() => new Dictionary<string, string[]>());
-        var branchesByRepo = UseState<Dictionary<string, string[]>>(() => new Dictionary<string, string[]>());
-        var fetchingRepos = UseState(preFetchedOwners == null || preFetchedReposByOwner == null);
-
-        var selectedOwner = UseState("");
-        var selectedRepo = UseState("");
-        var selectedBranch = UseState("");
-        var loadingBranches = UseState(false);
-
-        var newLocalPath = UseState("");
+        var inputValue = UseState("");
         var addingError = UseState<string?>(null);
         var isAdding = UseState(false);
 
-        UseEffect(async () =>
-        {
-            if (preFetchedOwners != null && preFetchedReposByOwner != null)
-            {
-                fetchingRepos.Set(false);
-                var pfOwners = preFetchedOwners.Value;
-                if (pfOwners.Length > 0 && string.IsNullOrEmpty(selectedOwner.Value))
-                    selectedOwner.Set(pfOwners[0]);
-                return;
-            }
-
-            try
-            {
-                fetchingRepos.Set(true);
-                var ownersList = await GitHubCliHelper.GetOwnersAsync();
-                ownersInternal.Set(ownersList);
-
-                var fetches = ownersList.Select(async o => (Owner: o, Repos: await GitHubCliHelper.GetRepositoriesAsync(o)));
-                var results = await Task.WhenAll(fetches);
-                var byOwner = new Dictionary<string, string[]>();
-                foreach (var (owner, ownerRepos) in results)
-                    byOwner[owner] = ownerRepos;
-                reposByOwnerInternal.Set(byOwner);
-
-                if (ownersList.Length > 0 && string.IsNullOrEmpty(selectedOwner.Value))
-                    selectedOwner.Set(ownersList[0]);
-            }
-            finally
-            {
-                fetchingRepos.Set(false);
-            }
-        }, [EffectTrigger.OnMount()]);
-
-        UseEffect(() =>
-        {
-            selectedRepo.Set("");
-            selectedBranch.Set("");
-        }, selectedOwner);
-
-        UseEffect(async () =>
-        {
-            selectedBranch.Set("");
-            if (string.IsNullOrEmpty(selectedOwner.Value) || string.IsNullOrEmpty(selectedRepo.Value))
-                return;
-
-            var key = $"{selectedOwner.Value}/{selectedRepo.Value}";
-            var cache = branchesByRepo.Value;
-            if (cache.TryGetValue(key, out var cached))
-            {
-                if (cached.Length > 0) selectedBranch.Set(cached[0]);
-                return;
-            }
-
-            loadingBranches.Set(true);
-            try
-            {
-                var branchesTask = GitHubCliHelper.GetBranchesAsync(selectedOwner.Value, selectedRepo.Value);
-                var defaultBranchTask = GitHubCliHelper.GetDefaultBranchAsync(selectedOwner.Value, selectedRepo.Value);
-                await Task.WhenAll(branchesTask, defaultBranchTask);
-
-                var fetched = branchesTask.Result;
-                var defaultBranch = defaultBranchTask.Result;
-
-                if (!string.IsNullOrEmpty(defaultBranch) && fetched.Contains(defaultBranch))
-                {
-                    fetched = new[] { defaultBranch }.Concat(fetched.Where(b => b != defaultBranch)).ToArray();
-                }
-
-                var next = new Dictionary<string, string[]>(branchesByRepo.Value) { [key] = fetched };
-                branchesByRepo.Set(next);
-                if (fetched.Length > 0) selectedBranch.Set(fetched[0]);
-            }
-            finally
-            {
-                loadingBranches.Set(false);
-            }
-        }, selectedRepo);
-
         Context.TryUseService<DesktopWindow>(out var desktop);
         var isDesktop = desktop != null;
-        var isRemote = mode.Value == "remote";
-        var hasPreFetched = preFetchedOwners != null && preFetchedReposByOwner != null;
 
         IConfigService? configService = null;
         Context.TryUseService<IConfigService>(out configService);
         var tendrilHome = configService?.TendrilHome;
 
-        var modeToggle = Layout.Horizontal().Gap(2).AlignContent(Align.Left)
-                         | Text.Block("Remote")
-                         | new ConvertedState<string, bool>(
-                                 mode,
-                                 m => m == "local",
-                                 v => v ? "local" : "remote")
-                             .ToSwitchInput()
-                         | Text.Block("Local");
-
-        async Task AddRemoteAsync()
+        async Task AddAsync()
         {
-            var owner = selectedOwner.Value;
-            var name = selectedRepo.Value;
-            var branch = selectedBranch.Value;
-            if (string.IsNullOrEmpty(owner) || string.IsNullOrEmpty(name)) return;
+            var path = (inputValue.Value ?? "").Trim();
+            if (string.IsNullOrWhiteSpace(path)) return;
 
-            var url = $"https://github.com/{owner}/{name}.git";
-            if (repos.Value.Any(r => string.Equals(r.Path, url, StringComparison.OrdinalIgnoreCase)))
+            if (!RepoPathValidator.IsValid(path))
             {
-                selectedRepo.Set("");
+                addingError.Set("Invalid input. Enter an SSH URL, HTTPS URL, or local path.");
                 return;
             }
 
-            var draft = new RepoRef
-            {
-                Path = url,
-                PrRule = "default",
-                BaseBranch = string.IsNullOrEmpty(branch) ? null : branch,
-            };
-
-            await AppendAsync(draft, name);
-            selectedRepo.Set("");
-        }
-
-        async Task AddLocalAsync()
-        {
-            var path = (newLocalPath.Value ?? "").Trim();
-            if (string.IsNullOrWhiteSpace(path)) return;
             if (repos.Value.Any(r => string.Equals(r.Path, path, StringComparison.OrdinalIgnoreCase)))
             {
-                newLocalPath.Set("");
+                inputValue.Set("");
                 return;
             }
 
             var draft = new RepoRef { Path = path, PrRule = "default" };
-            var leaf = Path.GetFileName(path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-            if (string.IsNullOrEmpty(leaf)) leaf = path;
+            var suggestedName = RepoPathValidator.ExtractRepoName(path) ?? path;
 
-            await AppendAsync(draft, leaf);
-            newLocalPath.Set("");
-        }
-
-        async Task AppendAsync(RepoRef draft, string suggestedName)
-        {
             addingError.Set(null);
             isAdding.Set(true);
             try
@@ -188,6 +61,8 @@ public class ProjectRepoPickerView(
 
                 if (projectName != null && string.IsNullOrEmpty(projectName.Value) && !string.IsNullOrEmpty(suggestedName))
                     projectName.Set(SanitizeProjectName(suggestedName));
+
+                inputValue.Set("");
             }
             catch (Exception ex)
             {
@@ -199,64 +74,42 @@ public class ProjectRepoPickerView(
             }
         }
 
-        var ownersValue = hasPreFetched ? preFetchedOwners!.Value : ownersInternal.Value;
-        var reposByOwnerValue = hasPreFetched ? preFetchedReposByOwner!.Value : reposByOwnerInternal.Value;
+        var kind = RepoPathValidator.Classify(inputValue.Value ?? "");
+        object? validationBadge = kind switch
+        {
+            RepoPathKind.SshUrl => new Badge("SSH").Variant(BadgeVariant.Secondary),
+            RepoPathKind.HttpUrl => new Badge("HTTPS").Variant(BadgeVariant.Secondary),
+            RepoPathKind.LocalPath => new Badge("Local").Variant(BadgeVariant.Secondary),
+            _ => null
+        };
 
         object pickerControls;
-        if (isRemote)
-        {
-            if (fetchingRepos.Value)
-            {
-                pickerControls = Layout.Horizontal().Gap(2).AlignContent(Align.Center).Width(Size.Full()).Padding(4)
-                                 | Icons.LoaderCircle.ToIcon().WithAnimation(AnimationType.Rotate).Duration(1)
-                                 | Text.Muted("Fetching your GitHub repositories...");
-            }
-            else
-            {
-                var ownerRepos = reposByOwnerValue.TryGetValue(selectedOwner.Value, out var r) ? r : Array.Empty<string>();
-                var key = $"{selectedOwner.Value}/{selectedRepo.Value}";
-                var availableBranches = branchesByRepo.Value.TryGetValue(key, out var b) ? b : Array.Empty<string>();
-
-                pickerControls = Layout.Horizontal().Gap(2).Width(Size.Full())
-                                 | selectedOwner.ToSelectInput(ownersValue)
-                                     .Placeholder("Owner")
-                                     .Width(Size.Fraction(0.25f))
-                                 | selectedRepo.ToSelectInput(ownerRepos, disabled: string.IsNullOrEmpty(selectedOwner.Value))
-                                     .Placeholder("Repository")
-                                     .Width(Size.Grow())
-                                 | selectedBranch.ToSelectInput(availableBranches,
-                                         disabled: string.IsNullOrEmpty(selectedRepo.Value) || loadingBranches.Value)
-                                     .Placeholder(loadingBranches.Value ? "Loading..." : "Branch")
-                                     .Width(Size.Fraction(0.25f))
-                                 | new Button(isAdding.Value ? "Adding..." : "Add").Icon(Icons.Plus)
-                                     .Disabled(string.IsNullOrEmpty(selectedRepo.Value) || isAdding.Value)
-                                     .OnClick(() => { _ = AddRemoteAsync(); });
-            }
-        }
-        else if (isDesktop)
+        if (isDesktop)
         {
             pickerControls = Layout.Horizontal().Gap(2).Width(Size.Full())
-                             | newLocalPath.ToTextInput("Repository path")
+                             | inputValue.ToTextInput("SSH URL, HTTPS URL, or local path")
                                  .Width(Size.Grow())
+                             | (validationBadge ?? null!)
                              | new Button("Browse").Icon(Icons.FolderOpen).Outline()
                                  .OnClick(() =>
                                  {
                                      var picked = desktop!.ShowSelectFolderDialog("Select repository folder");
                                      if (picked != null && picked.Length > 0 && !string.IsNullOrEmpty(picked[0]))
-                                         newLocalPath.Set(picked[0]);
+                                         inputValue.Set(picked[0]);
                                  })
                              | new Button(isAdding.Value ? "Adding..." : "Add").Icon(Icons.Plus)
-                                 .Disabled(string.IsNullOrWhiteSpace(newLocalPath.Value) || isAdding.Value)
-                                 .OnClick(() => { _ = AddLocalAsync(); });
+                                 .Disabled(string.IsNullOrWhiteSpace(inputValue.Value) || isAdding.Value)
+                                 .OnClick(() => { _ = AddAsync(); });
         }
         else
         {
             pickerControls = Layout.Horizontal().Gap(2).Width(Size.Full())
-                             | newLocalPath.ToTextInput("Absolute path to local repository (e.g. /Users/you/code/myrepo)")
+                             | inputValue.ToTextInput("SSH URL, HTTPS URL, or local path")
                                  .Width(Size.Grow())
+                             | (validationBadge ?? null!)
                              | new Button(isAdding.Value ? "Adding..." : "Add").Icon(Icons.Plus)
-                                 .Disabled(string.IsNullOrWhiteSpace(newLocalPath.Value) || isAdding.Value)
-                                 .OnClick(() => { _ = AddLocalAsync(); });
+                                 .Disabled(string.IsNullOrWhiteSpace(inputValue.Value) || isAdding.Value)
+                                 .OnClick(() => { _ = AddAsync(); });
         }
 
         var listLayout = Layout.Vertical().Gap(2);
@@ -265,7 +118,8 @@ public class ProjectRepoPickerView(
         {
             var idx = i;
             var item = current[idx];
-            var isLocal = !LooksLikeUrl(item.Path);
+            var itemKind = RepoPathValidator.Classify(item.Path);
+            var isLocal = itemKind == RepoPathKind.LocalPath;
 
             object? validityIcon = null;
             object pathLabel = Text.Block(GetDisplayLabel(item));
@@ -284,15 +138,18 @@ public class ProjectRepoPickerView(
                 }
             }
 
+            var kindBadge = itemKind switch
+            {
+                RepoPathKind.SshUrl => (object)new Badge("SSH").Variant(BadgeVariant.Outline),
+                RepoPathKind.HttpUrl => (object)new Badge("HTTPS").Variant(BadgeVariant.Outline),
+                RepoPathKind.LocalPath => (object)new Badge("Local").Variant(BadgeVariant.Outline),
+                _ => (object)new Badge("Remote").Variant(BadgeVariant.Outline)
+            };
+
             object row = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.Center).Gap(2)
                          | (validityIcon ?? null!)
                          | pathLabel
-                         | (isLocal
-                             ? (object)new Badge("Local").Variant(BadgeVariant.Outline)
-                             : new Badge("Remote").Variant(BadgeVariant.Outline))
-                         | (!isLocal && !string.IsNullOrEmpty(item.BaseBranch)
-                             ? (object)new Badge(item.BaseBranch!).Variant(BadgeVariant.Secondary)
-                             : null!)
+                         | kindBadge
                          | new Spacer()
                          | (showPrRule
                              ? (object)BuildPrRuleSelector(repos, idx)
@@ -307,15 +164,8 @@ public class ProjectRepoPickerView(
             listLayout |= new Box(row).BorderStyle(BorderStyle.None).Background(Colors.Muted, 0.15f).Padding(4, 2, 2, 2).Width(Size.Full());
         }
 
-        var helperText = isRemote
-            ? "Pick the GitHub repositories this project will work with."
-            : (isDesktop
-                ? "Select folders containing local git repositories."
-                : "Add absolute paths to local git repositories on the server.");
-
         return Layout.Vertical().Gap(4).Width(Size.Full())
-               | Text.Muted(helperText)
-               | modeToggle
+               | Text.Muted("Add repositories by SSH URL, HTTPS URL, or local path.")
                | (addingError.Value != null ? Text.Danger(addingError.Value) : null!)
                | pickerControls
                | (current.Count > 0 ? new Separator() : null!)
@@ -338,23 +188,32 @@ public class ProjectRepoPickerView(
         return bridge.ToSelectInput(new List<string> { "default", "yolo" }).Width(Size.Units(20));
     }
 
-    private static bool LooksLikeUrl(string path)
-        => !string.IsNullOrEmpty(path)
-           && (path.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
-               || path.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
-               || path.StartsWith("git@", StringComparison.OrdinalIgnoreCase));
-
     private static string GetDisplayLabel(RepoRef repo)
     {
-        if (LooksLikeUrl(repo.Path))
+        var name = RepoPathValidator.ExtractRepoName(repo.Path);
+        if (name != null)
         {
-            var trimmed = repo.Path;
-            if (trimmed.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
-                trimmed = trimmed[..^4];
-            var parts = trimmed.Split('/');
-            if (parts.Length >= 2)
-                return $"{parts[^2]}/{parts[^1]}";
-            return trimmed;
+            var kind = RepoPathValidator.Classify(repo.Path);
+            if (kind == RepoPathKind.HttpUrl || kind == RepoPathKind.SshUrl)
+            {
+                // Show owner/repo for remote URLs
+                var trimmed = repo.Path;
+                if (trimmed.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+                    trimmed = trimmed[..^4];
+                if (kind == RepoPathKind.SshUrl)
+                {
+                    var colonIdx = trimmed.IndexOf(':');
+                    if (colonIdx >= 0)
+                        return trimmed[(colonIdx + 1)..];
+                }
+                else
+                {
+                    var parts = trimmed.Split('/');
+                    if (parts.Length >= 2)
+                        return $"{parts[^2]}/{parts[^1]}";
+                }
+            }
+            return name;
         }
         return repo.Path;
     }


### PR DESCRIPTION
# Summary

## Changes

Removed the GitHub CLI dependency from the onboarding flow by replacing the dual-mode remote/local repo picker (which used `gh` to fetch GitHub owners, repos, and branches) with a single text input that accepts SSH URLs, HTTPS URLs, or local paths. Created a centralized `RepoPathValidator` helper to handle string validation across the codebase.

## API Changes

- **New:** `RepoPathValidator` static class with `Classify()`, `IsValid()`, `IsSshUrl()`, `IsHttpUrl()`, `IsLocalPath()`, `ExtractRepoName()` methods
- **New:** `RepoPathKind` enum (`SshUrl`, `HttpUrl`, `LocalPath`, `Invalid`)
- **Changed:** `ProjectRepoPickerView` constructor — removed `preFetchedOwners` and `preFetchedReposByOwner` parameters
- **Changed:** `CodingAgentStepView` constructor — removed `ghOwners`, `ghReposByOwner`, `reposFetched` parameters
- **Changed:** `ProjectSetupStepView` constructor — removed `ghOwners`, `ghReposByOwner` parameters
- **Removed:** `GitHubCliHelper.GetOwnersAsync()`, `GetRepositoriesAsync()`, `GetBranchesAsync()`, `GetDefaultBranchAsync()`
- **Removed:** GitHub CLI entry from onboarding software checks

## Files Modified

- **New:** `src/Ivy.Tendril/Helpers/RepoPathValidator.cs` — centralized validation
- **New:** `src/Ivy.Tendril.Test/Helpers/RepoPathValidatorTests.cs` — 46 unit tests
- **Modified:** `src/Ivy.Tendril/Views/ProjectRepoPickerView.cs` — simplified to single text input
- **Modified:** `src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs` — removed gh check and repo pre-fetching
- **Modified:** `src/Ivy.Tendril/Apps/OnboardingApp.cs` — removed unused state
- **Modified:** `src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs` — uses RepoPathValidator
- **Modified:** `src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs` — uses RepoPathValidator
- **Modified:** `src/Ivy.Tendril/Helpers/GitHubCliHelper.cs` — stripped to only CloneRepositoryAsync

---

**Commits:**
- `2b145dc` [00179] Simplify onboarding repo picker - remove versioning tool dependency
- `c9b2ca6` [00179] Fix formatting in RepoPathValidator