### PR TITLE
[00180] Rename GitHubCliHelper to GitHelper

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -97,7 +97,7 @@ public class ProjectSetupStepView(
                                       var repoName = RepoPathValidator.ExtractRepoName(repo.Path) ?? Guid.NewGuid().ToString();
                                       progressMessage.Set($"Fetching {repoName} ({i}/{total})...");
                                       var destPath = Path.Combine(reposDir, repoName);
-                                      var success = await GitHubCliHelper.CloneRepositoryAsync(repo.Path, destPath);
+                                      var success = await GitHelper.CloneRepositoryAsync(repo.Path, destPath);
                                       if (!success)
                                       {
                                           progressCts.Cancel();

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -70,7 +70,7 @@ public class EditProjectDialog(
             var repoName = RepoPathValidator.ExtractRepoName(draft.Path) ?? Guid.NewGuid().ToString();
             var destPath = Path.Combine(reposDir, repoName);
 
-            var success = await GitHubCliHelper.CloneRepositoryAsync(draft.Path, destPath);
+            var success = await GitHelper.CloneRepositoryAsync(draft.Path, destPath);
             if (!success)
             {
                 _client.Toast($"Failed to fetch repository: {draft.Path}", "Error");

--- a/src/Ivy.Tendril/Helpers/GitHelper.cs
+++ b/src/Ivy.Tendril/Helpers/GitHelper.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 
 namespace Ivy.Tendril.Helpers;
 
-public static class GitHubCliHelper
+public static class GitHelper
 {
     public static async Task<bool> CloneRepositoryAsync(string url, string destinationPath)
     {


### PR DESCRIPTION
## Summary

Renamed `GitHubCliHelper` class and file to `GitHelper` to accurately reflect that it uses plain `git` commands rather than the GitHub CLI (`gh`). Updated both callers.

## Changes

- **Renamed:** `src/Ivy.Tendril/Helpers/GitHubCliHelper.cs` → `src/Ivy.Tendril/Helpers/GitHelper.cs`
- **Updated callers:**
  - `src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs`
  - `src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs`

---

**Commits:**
- cc451dc [00180] Rename GitHubCliHelper to GitHelper