### PR TITLE
[00184] Fix onboarding repo list item background invisible in light theme

### DIFF
--- a/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
@@ -161,7 +161,7 @@ public class ProjectRepoPickerView(
                              repos.Set(list);
                          }).WithTooltip("Remove");
 
-            listLayout |= new Box(row).BorderStyle(BorderStyle.None).Background(Colors.Muted, 0.15f).Padding(4, 2, 2, 2).Width(Size.Full());
+            listLayout |= new Box(row).BorderStyle(BorderStyle.None).Background(Colors.Muted).Padding(4, 2, 2, 2).Width(Size.Full());
         }
 
         return Layout.Vertical().Gap(4).Width(Size.Full())


### PR DESCRIPTION
Removed the opacity parameter from the `Background()` call on the onboarding repo list item box, changing from `Background(Colors.Muted, 0.15f)` to `Background(Colors.Muted)`. This ensures the muted background color is visible in both light and dark themes.

## Files Modified

- **src/Ivy.Tendril/Views/ProjectRepoPickerView.cs** — Removed opacity parameter from Background call at line 164

---

### Commits

- fcb0f69 [00184] Fix repo list item background invisible in light theme