### PR TITLE
[00183] Generate Project Verifications button - move icon to left side

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -47,7 +47,7 @@ public class ProjectSetupStepView(
                   | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
                       .OnClick(() => stepperIndex.Set(stepperIndex.Value - 1))
                   | new Spacer()
-                  | new Button("Generate Project Verifications").Primary().Large().Icon(Icons.Sparkles, Align.Right)
+                  | new Button("Generate Project Verifications").Primary().Large().Icon(Icons.Sparkles)
                       .Disabled(!canContinue)
                       .OnClick(async () =>
                       {


### PR DESCRIPTION
# Summary

## Changes

Moved the Sparkles icon from the right side to the left side on the "Generate Project Verifications" button in the onboarding project setup step. Removed the `Align.Right` parameter from the `.Icon()` call, defaulting to left alignment.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs** — Removed `Align.Right` from button icon call

---

## Commits

- 1fc3201 [00183] Move Sparkles icon to left side on Generate Project Verifications button