### PR TITLE
[00202] Fix onboarding loading indicator disappearing before JSON output renders

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -174,10 +174,16 @@ public class CompleteStepView(
 
         public void Write(T data)
         {
-            if (!_notified)
+            if (!_notified && data is string json)
             {
-                _notified = true;
-                _onFirstWrite();
+                var trimmed = json.TrimStart();
+                // Only hide loading indicator for events that produce visible output
+                // System and user events are filtered out by the renderer
+                if (!trimmed.StartsWith("{\"type\":\"system\"") && !trimmed.StartsWith("{\"type\":\"user\""))
+                {
+                    _notified = true;
+                    _onFirstWrite();
+                }
             }
             _inner.Write(data);
         }


### PR DESCRIPTION
## Summary

Modified `NotifyingStream<T>.Write()` in `CompleteStepView.cs` to only dismiss the loading spinner when a visible event arrives. Previously, any stream write (including filtered `system` events) would hide the loading indicator, causing a ~2 second empty box before actual content rendered.

## Files Modified

- **src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs** — Updated `Write()` method to check event type before triggering `_onFirstWrite()`

---

**Commits:**
- 46ff628 [00202] Fix loading indicator hiding on non-visible stream events