### PR TITLE
[00204] Onboarding repo box path text should use primary foreground

### DIFF
--- a/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
@@ -111,7 +111,7 @@ public class ProjectRepoPickerView(
             var isLocal = itemKind == RepoPathKind.LocalPath;
 
             object? validityIcon = null;
-            object pathLabel = Text.Block(GetDisplayLabel(item));
+            object pathLabel = Text.Block(GetDisplayLabel(item)).Color(Colors.Primary);
             if (isLocal)
             {
                 var expanded = VariableExpansion.ExpandVariables(item.Path, tendrilHome);


### PR DESCRIPTION
# Summary

## Changes

Added explicit `.Color(Colors.Primary)` to the repo path label text in `ProjectRepoPickerView.cs` so it renders with primary foreground color instead of inheriting muted foreground from the parent Box's background.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Views/ProjectRepoPickerView.cs** — Added `.Color(Colors.Primary)` to path label Text.Block call (line 114)

---

Commits:
- 832ebba