### PR TITLE
[00203] Onboarding verifications as collapsible items with prompt

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -100,8 +100,10 @@ public class CompleteStepView(
             {
                 var capturedProjectName = project.Name;
                 var capturedVerificationName = v.Name;
-                listLayout |= new Box(
-                    Layout.Horizontal().Width(Size.Full()).AlignContent(Align.Center)
+                var prompt = config.Settings.Verifications
+                    .FirstOrDefault(vc => vc.Name == v.Name)?.Prompt ?? "";
+
+                var header = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.Center)
                     | Text.Block(v.Name)
                     | (v.Required ? (object)new Badge("required").Variant(BadgeVariant.Outline) : null!)
                     | new Spacer()
@@ -109,8 +111,11 @@ public class CompleteStepView(
                     {
                         await setupService.RemoveProjectVerificationAsync(capturedProjectName, capturedVerificationName);
                         refreshToken.Set(refreshToken.Value + 1);
-                    }).WithTooltip("Remove")
-                ).Padding(4, 2, 2, 2).Width(Size.Full());
+                    }).WithTooltip("Remove");
+
+                listLayout |= new Expandable(header, Text.Muted(prompt))
+                    .Ghost()
+                    .Width(Size.Full());
             }
         }
 


### PR DESCRIPTION
## Summary

Replaced flat verification rows in the onboarding final step (`CompleteStepView.cs`) with `Expandable` widgets from Ivy Framework. Each verification is now a collapsible item where the header shows the existing row (name + required badge + delete button) and the expandable content shows the verification's prompt text.

## Files Modified

- **src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs** — Replaced `Box` wrapper with `Expandable` widget, added prompt lookup from `config.Settings.Verifications`

---

## Commits

- 3ea0afe [00203] Replace flat verification rows with Expandable widgets in onboarding