### PR TITLE
[00205] Rearrange onboarding project setup step button layout

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -59,7 +59,6 @@ public class ProjectSetupStepView(
                | (Layout.Horizontal().Width(Size.Full())
                   | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
                       .OnClick(() => stepperIndex.Set(stepperIndex.Value - 1))
-                  | new Spacer()
                   | new Button("Continue without verifications").Ghost().Large()
                       .Disabled(!canContinue)
                       .OnClick(async () =>
@@ -95,6 +94,7 @@ public class ProjectSetupStepView(
                           await setupService.StartBackgroundServicesAsync();
                           clientProvider.ReloadPage();
                       })
+                  | new Spacer()
                   | new Button("Generate Project Verifications").Primary().Large().Icon(Icons.Sparkles)
                       .Disabled(!canContinue)
                       .OnClick(async () =>


### PR DESCRIPTION
Rearranged the button layout in the onboarding project setup step. The Skip button ("Continue without verifications") now sits immediately after the Back button on the left side, with the Spacer pushing the Generate button to the right side.

## Files Modified

- **src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs** — Reordered Spacer and Skip button elements within the horizontal layout

---

## Commits

- e181e32 [00205] Rearrange onboarding project setup step button layout