### PR TITLE
[ci/cd]: Remove NuGet cache mount for dotnet tool install in Tendril Docker image

### DIFF
--- a/.github/docker/Dockerfile.tendril
+++ b/.github/docker/Dockerfile.tendril
@@ -5,8 +5,7 @@
 # ── Stage 1: install Tendril + PowerShell as dotnet global tools ───────────────
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
-RUN --mount=type=cache,id=nuget-tendril,target=/root/.nuget/packages \
-    dotnet tool install --global Ivy.Tendril \
+RUN dotnet tool install --global Ivy.Tendril \
  && dotnet tool install --global PowerShell
 
 # ── Stage 2: runtime image with all CLI dependencies ──────────────────────────


### PR DESCRIPTION
## What changed

- Removed BuildKit cache mount (`--mount=type=cache,id=nuget-tendril,target=/root/.nuget/packages`) from the .NET tools install step in `.github/docker/Dockerfile.tendril`.
- Kept the same tool install commands:
  - `dotnet tool install --global Ivy.Tendril`
  - `dotnet tool install --global PowerShell`

## Why

- To avoid reusing cached NuGet packages during image builds.
- Ensures each build resolves and installs the freshest available tool version from the package source.

## Impact

- Docker builds may be slower for this step.
- Improves version freshness and reduces risk of stale cached packages.
