### PR TITLE
Grant promptwares Write/Edit/Bash permissions for their own directory; rename PLAN_FOLDER → PLAN_DIR

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/02_Concepts/02_Promptwares.md
+++ b/src/Ivy.Tendril.Docs/Docs/02_Concepts/02_Promptwares.md
@@ -57,7 +57,7 @@ promptwares:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `profile` | Yes | Agent profile to use (`balanced`, `deep`, `quick`). |
-| `allowedTools` | Yes | Tools the agent may call. Supports `%PLAN_FOLDER%` and `%PLANS_DIR%` variables. |
+| `allowedTools` | No | Additional tools beyond the built-in defaults. Supports `%PROMPTWARE_DIR%`, `%PLAN_DIR%`, and `%PLANS_DIR%` variables. |
 | `customInstructions` | No | Free-text instructions injected into the agent prompt. Takes precedence over Firmware and Program.md. |
 
 A special `_default` entry applies as a baseline to all promptwares; specific entries override it.

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -263,8 +263,8 @@ promptwares:
   IvyFrameworkVerification:
     profile: balanced
     allowedTools:
-    - Write(%PLAN_FOLDER%\**)
-    - Edit(%PLAN_FOLDER%\**)
+    - Write(%PLAN_DIR%\**)
+    - Edit(%PLAN_DIR%\**)
 codingAgents:
 - name: claude
   arguments: ''

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml.backup
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml.backup
@@ -263,8 +263,8 @@ promptwares:
   IvyFrameworkVerification:
     profile: balanced
     allowedTools:
-    - Write(%PLAN_FOLDER%\**)
-    - Edit(%PLAN_FOLDER%\**)
+    - Write(%PLAN_DIR%\**)
+    - Edit(%PLAN_DIR%\**)
 codingAgents:
 - name: claude
   arguments: ''

--- a/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
@@ -62,15 +62,22 @@ public class AgentProviderFactoryTests
                 }
             });
 
-        var resolution = AgentProviderFactory.Resolve(settings, "UnknownPromptware");
+        var jobContext = new Dictionary<string, string>
+        {
+            ["PROMPTWARE_DIR"] = "/promptwares/UnknownPromptware"
+        };
+        var resolution = AgentProviderFactory.Resolve(settings, "UnknownPromptware", jobContext: jobContext);
 
         Assert.IsType<ClaudeAgentProvider>(resolution.Provider);
         Assert.Equal("sonnet", resolution.Model);
         Assert.Equal("high", resolution.Effort);
-        // Base tools + _default's Write
+        // Base tools + _default's Write (unrestricted)
         Assert.Contains("Read", resolution.AllowedTools);
         Assert.Contains("Write", resolution.AllowedTools);
         Assert.Contains("Bash(tendril*)", resolution.AllowedTools);
+        // Promptware-scoped tools
+        Assert.Contains("Write(/promptwares/UnknownPromptware/**)", resolution.AllowedTools);
+        Assert.Contains("Edit(/promptwares/UnknownPromptware/**)", resolution.AllowedTools);
     }
 
     [Fact]
@@ -94,7 +101,11 @@ public class AgentProviderFactoryTests
                 }
             });
 
-        var resolution = AgentProviderFactory.Resolve(settings, "ExecutePlan");
+        var jobContext = new Dictionary<string, string>
+        {
+            ["PROMPTWARE_DIR"] = "/promptwares/ExecutePlan"
+        };
+        var resolution = AgentProviderFactory.Resolve(settings, "ExecutePlan", jobContext: jobContext);
 
         Assert.Equal("opus", resolution.Model);
         Assert.Equal("max", resolution.Effort);
@@ -166,7 +177,11 @@ public class AgentProviderFactoryTests
     public void Resolve_NoConfigStillReturnsBaseTools()
     {
         var settings = CreateSettings();
-        var resolution = AgentProviderFactory.Resolve(settings, "SomePromptware");
+        var jobContext = new Dictionary<string, string>
+        {
+            ["PROMPTWARE_DIR"] = "/promptwares/SomePromptware"
+        };
+        var resolution = AgentProviderFactory.Resolve(settings, "SomePromptware", jobContext: jobContext);
 
         Assert.IsType<ClaudeAgentProvider>(resolution.Provider);
         Assert.Equal("", resolution.Model);
@@ -177,6 +192,9 @@ public class AgentProviderFactoryTests
         Assert.Contains("Bash(tendril*)", resolution.AllowedTools);
         Assert.Contains("WebFetch", resolution.AllowedTools);
         Assert.Contains("WebSearch", resolution.AllowedTools);
+        Assert.Contains("Write(/promptwares/SomePromptware/**)", resolution.AllowedTools);
+        Assert.Contains("Edit(/promptwares/SomePromptware/**)", resolution.AllowedTools);
+        Assert.Contains("Bash(/promptwares/SomePromptware/Tools/*)", resolution.AllowedTools);
         Assert.DoesNotContain("Bash", resolution.AllowedTools.Where(t => t == "Bash"));
         Assert.Empty(resolution.ExtraArgs);
     }
@@ -318,15 +336,16 @@ public class AgentProviderFactoryTests
                     Profile = "balanced",
                     AllowedTools = new List<string>
                     {
-                        "Write(%PLANS_DIR%/**)", "Edit(%PLAN_FOLDER%/**)"
+                        "Write(%PLANS_DIR%/**)", "Edit(%PLAN_DIR%/**)"
                     }
                 }
             });
 
         var jobContext = new Dictionary<string, string>
         {
+            ["PROMPTWARE_DIR"] = @"D:\Tendril\Promptwares\CreatePlan",
             ["PLANS_DIR"] = @"D:\Tendril\Plans",
-            ["PLAN_FOLDER"] = @"D:\Tendril\Plans\01234-MyPlan"
+            ["PLAN_DIR"] = @"D:\Tendril\Plans\01234-MyPlan"
         };
 
         var resolution = AgentProviderFactory.Resolve(settings, "CreatePlan", jobContext: jobContext);
@@ -335,6 +354,10 @@ public class AgentProviderFactoryTests
         Assert.Contains("Read", resolution.AllowedTools);
         Assert.Contains("Bash(tendril*)", resolution.AllowedTools);
         Assert.Contains("WebFetch", resolution.AllowedTools);
+        // Promptware self-modification tools
+        Assert.Contains("Write(D:/Tendril/Promptwares/CreatePlan/**)", resolution.AllowedTools);
+        Assert.Contains("Edit(D:/Tendril/Promptwares/CreatePlan/**)", resolution.AllowedTools);
+        Assert.Contains("Bash(D:/Tendril/Promptwares/CreatePlan/Tools/*)", resolution.AllowedTools);
         // Config extras with expanded variables
         Assert.Contains("Write(D:/Tendril/Plans/**)", resolution.AllowedTools);
         Assert.Contains("Edit(D:/Tendril/Plans/01234-MyPlan/**)", resolution.AllowedTools);
@@ -391,7 +414,8 @@ public class AgentProviderFactoryTests
 
         var jobContext = new Dictionary<string, string>
         {
-            ["PLAN_FOLDER"] = "/plans/01234-Test"
+            ["PROMPTWARE_DIR"] = "/promptwares/ExecutePlan",
+            ["PLAN_DIR"] = "/plans/01234-Test"
         };
 
         var resolution = AgentProviderFactory.Resolve(settings, "ExecutePlan", jobContext: jobContext);
@@ -400,6 +424,9 @@ public class AgentProviderFactoryTests
         Assert.Contains("Bash", resolution.AllowedTools);
         Assert.Contains("Write(/plans/01234-Test/worktrees/**)", resolution.AllowedTools);
         Assert.Contains("Edit(/plans/01234-Test/worktrees/**)", resolution.AllowedTools);
+        // Also gets promptware self-modification
+        Assert.Contains("Write(/promptwares/ExecutePlan/**)", resolution.AllowedTools);
+        Assert.Contains("Edit(/promptwares/ExecutePlan/**)", resolution.AllowedTools);
     }
 
     [Fact]
@@ -426,7 +453,7 @@ public class AgentProviderFactoryTests
     [InlineData("gemini", typeof(GeminiAgentProvider))]
     [InlineData("copilot", typeof(CopilotAgentProvider))]
     [InlineData("opencode", typeof(OpenCodeAgentProvider))]
-    public void Resolve_UpdateProject_GetsOnlyBaseToolsForAllAgents(string agent, Type expectedProviderType)
+    public void Resolve_UpdateProject_GetsBaseToolsWithPromptwareDirForAllAgents(string agent, Type expectedProviderType)
     {
         var settings = CreateSettings(
             agent,
@@ -446,13 +473,18 @@ public class AgentProviderFactoryTests
                 }
             });
 
-        var resolution = AgentProviderFactory.Resolve(settings, "UpdateProject");
+        var jobContext = new Dictionary<string, string>
+        {
+            ["PROMPTWARE_DIR"] = "/promptwares/UpdateProject"
+        };
+
+        var resolution = AgentProviderFactory.Resolve(settings, "UpdateProject", jobContext: jobContext);
 
         Assert.IsType(expectedProviderType, resolution.Provider);
         Assert.Equal("test-model", resolution.Model);
         Assert.Equal("max", resolution.Effort);
 
-        // UpdateProject gets exactly base tools — no Write, Edit, or unrestricted Bash
+        // Base read-only tools
         Assert.Contains("Read", resolution.AllowedTools);
         Assert.Contains("Glob", resolution.AllowedTools);
         Assert.Contains("Grep", resolution.AllowedTools);
@@ -460,11 +492,14 @@ public class AgentProviderFactoryTests
         Assert.Contains("WebFetch", resolution.AllowedTools);
         Assert.Contains("WebSearch", resolution.AllowedTools);
 
-        // Must NOT have unrestricted Bash, Write, or Edit
-        Assert.DoesNotContain("Bash", resolution.AllowedTools.Where(t => t == "Bash"));
-        Assert.DoesNotContain(resolution.AllowedTools, t => t.StartsWith("Write", StringComparison.OrdinalIgnoreCase));
-        Assert.DoesNotContain(resolution.AllowedTools, t => t.StartsWith("Edit", StringComparison.OrdinalIgnoreCase));
+        // Promptware self-modification tools (scoped to own directory)
+        Assert.Contains("Write(/promptwares/UpdateProject/**)", resolution.AllowedTools);
+        Assert.Contains("Edit(/promptwares/UpdateProject/**)", resolution.AllowedTools);
+        Assert.Contains("Bash(/promptwares/UpdateProject/Tools/*)", resolution.AllowedTools);
 
-        Assert.Equal(6, resolution.AllowedTools.Count);
+        // Must NOT have unrestricted Bash
+        Assert.DoesNotContain("Bash", resolution.AllowedTools.Where(t => t == "Bash"));
+
+        Assert.Equal(9, resolution.AllowedTools.Count);
     }
 }

--- a/src/Ivy.Tendril.Test/Agents/AgentProviderTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderTests.cs
@@ -481,12 +481,12 @@ public class AgentProviderTests
     [Fact]
     public void ExtractWritableDirs_HandlesBackslashPaths()
     {
-        var tools = new[] { @"Write(D:\Plans\00123\**)", @"Edit(%PLAN_FOLDER%\**)" };
+        var tools = new[] { @"Write(D:\Plans\00123\**)", @"Edit(%PLAN_DIR%\**)" };
         var dirs = CodexAgentProvider.ExtractWritableDirs(tools).ToList();
 
         Assert.Equal(2, dirs.Count);
         Assert.Equal(@"D:\Plans\00123", dirs[0]);
-        Assert.Equal(@"%PLAN_FOLDER%", dirs[1]);
+        Assert.Equal(@"%PLAN_DIR%", dirs[1]);
     }
 
     // --- Codex writable dirs ---

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -123,9 +123,18 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
 
         var values = BuildFirmwareValues(settings, configService);
 
+        var jobContext = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["PROMPTWARE_DIR"] = programFolder
+        };
+        if (values.TryGetValue("PlansDirectory", out var plansDir))
+            jobContext["PLANS_DIR"] = plansDir;
+        if (values.TryGetValue("PlanFolder", out var planFolder2))
+            jobContext["PLAN_DIR"] = planFolder2;
+
         var resolution = !string.IsNullOrEmpty(settings.Agent)
-            ? AgentProviderFactory.Resolve(tendrilSettings, settings.Promptware, settings.Profile, agentOverride: settings.Agent)
-            : AgentProviderFactory.Resolve(tendrilSettings, settings.Promptware, settings.Profile);
+            ? AgentProviderFactory.Resolve(tendrilSettings, settings.Promptware, settings.Profile, jobContext, settings.Agent)
+            : AgentProviderFactory.Resolve(tendrilSettings, settings.Promptware, settings.Profile, jobContext);
 
         var workDir = settings.WorkingDir ?? programFolder;
 

--- a/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
+++ b/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
@@ -19,12 +19,13 @@ public class AgentProviderFactory
     };
 
     internal static readonly IReadOnlyList<string> BaseTools =
-        ["Read", "Glob", "Grep", "Bash(tendril*)", "WebFetch", "WebSearch"];
+        ["Read", "Glob", "Grep", "Bash(tendril*)", "WebFetch", "WebSearch",
+         "Write(%PROMPTWARE_DIR%/**)", "Edit(%PROMPTWARE_DIR%/**)", "Bash(%PROMPTWARE_DIR%/Tools/*)"];
 
     private static readonly Dictionary<string, IReadOnlyList<string>> BuiltInExtraTools =
         new(StringComparer.OrdinalIgnoreCase)
         {
-            ["ExecutePlan"] = ["Bash", "Write(%PLAN_FOLDER%/worktrees/**)", "Edit(%PLAN_FOLDER%/worktrees/**)"]
+            ["ExecutePlan"] = ["Bash", "Write(%PLAN_DIR%/worktrees/**)", "Edit(%PLAN_DIR%/worktrees/**)"]
         };
 
     public static IAgentProvider GetProvider(string name)
@@ -73,7 +74,7 @@ public class AgentProviderFactory
         if (!string.IsNullOrEmpty(profileOverride))
             profileName = profileOverride;
 
-        // Expand job context variables (%PLAN_FOLDER%, %PLANS_DIR%, etc.) then env vars
+        // Expand job context variables (%PLAN_DIR%, %PLANS_DIR%, etc.) then env vars
         for (var i = 0; i < allowedTools.Count; i++)
         {
             var tool = allowedTools[i];

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -400,7 +400,7 @@ internal class JobLauncher
 
         values["Project"] = job.Project;
 
-        var jobContext = BuildJobContext(job, values);
+        var jobContext = BuildJobContext(job, values, programFolder);
         var resolution = AgentProviderFactory.Resolve(settings, job.Type, profileOverride, jobContext);
         var workDir = ResolveWorkingDirectory(job, programFolder);
 
@@ -527,14 +527,16 @@ internal class JobLauncher
             values["RepoConfigs"] = repoConfigs;
     }
 
-    private static Dictionary<string, string> BuildJobContext(JobItem job, Dictionary<string, string> firmwareValues)
+    private static Dictionary<string, string> BuildJobContext(JobItem job, Dictionary<string, string> firmwareValues, string programFolder)
     {
         var ctx = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        ctx["PROMPTWARE_DIR"] = programFolder;
 
         if (firmwareValues.TryGetValue("PlansDirectory", out var plansDir))
             ctx["PLANS_DIR"] = plansDir;
         if (firmwareValues.TryGetValue("PlanFolder", out var planFolder))
-            ctx["PLAN_FOLDER"] = planFolder;
+            ctx["PLAN_DIR"] = planFolder;
 
         var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
         if (!string.IsNullOrEmpty(tendrilHome))

--- a/src/Ivy.Tendril/Services/PromptwareRunner.cs
+++ b/src/Ivy.Tendril/Services/PromptwareRunner.cs
@@ -67,7 +67,13 @@ public class PromptwareRunner : IPromptwareRunner
             throw new FileNotFoundException($"Program.md not found at {programMd}", programMd);
 
         var values = new Dictionary<string, string>(options.Values);
-        var resolution = AgentProviderFactory.Resolve(settings, options.Promptware, options.Profile);
+
+        var jobContext = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["PROMPTWARE_DIR"] = programFolder
+        };
+
+        var resolution = AgentProviderFactory.Resolve(settings, options.Promptware, options.Profile, jobContext);
         var workDir = options.WorkingDir ?? programFolder;
 
         var logFile = FirmwareCompiler.GetNextLogFile(programFolder, values);

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -72,15 +72,17 @@ codingAgents:
 # The profile determines model and effort from the active coding agent above.
 #
 # All promptwares receive these base tools automatically:
-#   Read, Glob, Grep, Bash(tendril*), WebFetch, WebSearch
-# ExecutePlan additionally gets: Bash, Write(%PLAN_FOLDER%/worktrees/**), Edit(%PLAN_FOLDER%/worktrees/**)
+#   Read, Glob, Grep, Bash(tendril*), WebFetch, WebSearch,
+#   Write(%PROMPTWARE_DIR%/**), Edit(%PROMPTWARE_DIR%/**), Bash(%PROMPTWARE_DIR%/Tools/*)
+# ExecutePlan additionally gets: Bash, Write(%PLAN_DIR%/worktrees/**), Edit(%PLAN_DIR%/worktrees/**)
 #
 # Only specify allowedTools if you need ADDITIONAL tools beyond the defaults.
 # Tool format uses Claude Code syntax: Tool, Tool(path-glob).
 # Job context variables are expanded at launch time:
-#   %PLANS_DIR%    — the plans directory (e.g., /home/user/tendril/Plans)
-#   %PLAN_FOLDER%  — the specific plan folder (e.g., /home/user/tendril/Plans/01234-MyPlan)
-#   %TENDRIL_HOME% — the TENDRIL_HOME environment variable
+#   %PROMPTWARE_DIR% — the promptware's own directory (Program.md, Logs/, Tools/, Memory/)
+#   %PLANS_DIR%      — the plans directory (e.g., /home/user/tendril/Plans)
+#   %PLAN_DIR%       — the specific plan folder (e.g., /home/user/tendril/Plans/01234-MyPlan)
+#   %TENDRIL_HOME%   — the TENDRIL_HOME environment variable
 # For Codex: Write/Edit path scopes are translated to --add-dir flags.
 # For Gemini: Write/Edit path scopes are translated to --include-directories flags.
 # For Copilot: Write/Edit path scopes are translated to --add-dir flags.


### PR DESCRIPTION
## Summary
- All promptwares now get `Write(%PROMPTWARE_DIR%/**)`, `Edit(%PROMPTWARE_DIR%/**)`, and `Bash(%PROMPTWARE_DIR%/Tools/*)` as base tools, enabling them to modify their own Program.md, Logs/, Tools/, and Memory/ directories
- All three launch paths (JobLauncher, PromptwareRunCommand, PromptwareRunner) pass `PROMPTWARE_DIR` in the job context
- Standardized job context variable naming to `_DIR` convention: `PLAN_FOLDER` → `PLAN_DIR`

## Test plan
- [x] All 1408 existing tests pass
- [x] AgentProviderFactoryTests updated to verify promptware-scoped tools are resolved
- [x] No remaining `%PLAN_FOLDER%` references in codebase (env var `TENDRIL_PLAN_FOLDER` intentionally kept)