### PR TITLE
Inline Program.md into firmware prompt instead of requiring agent to read it

### DIFF
--- a/src/Ivy.Tendril.Test/Agents/TryBuildAgentProcessStartTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/TryBuildAgentProcessStartTests.cs
@@ -48,7 +48,7 @@ public class TryBuildAgentProcessStartTests : IDisposable
         var result = FirmwareCompiler.Compile(context);
 
         Assert.Contains("Tools/", result);
-        Assert.Contains("reusable tools", result);
+        Assert.Contains("Memory/", result);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Commands/PromptwareDryRunTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareDryRunTests.cs
@@ -137,7 +137,7 @@ public class PromptwareDryRunTests : IDisposable
 
         Assert.Contains("PlansDirectory: /tmp/plans", output);
         Assert.Contains("Project: TestProject", output);
-        Assert.Contains("Program.md", output);
+        Assert.Contains("## Program", output);
     }
 
     [Fact]
@@ -157,7 +157,7 @@ public class PromptwareDryRunTests : IDisposable
         var output = RunDryRun("ExecutePlan", ["PlanFolder=/tmp/plans/00001-Test"]);
 
         Assert.Contains("PlanFolder: /tmp/plans/00001-Test", output);
-        Assert.Contains("Program.md", output);
+        Assert.Contains("## Program", output);
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public class PromptwareDryRunTests : IDisposable
         var output = RunDryRun("ExpandPlan", ["PlanFolder=/tmp/plans/00002-Expand"]);
 
         Assert.Contains("PlanFolder: /tmp/plans/00002-Expand", output);
-        Assert.Contains("Program.md", output);
+        Assert.Contains("## Program", output);
     }
 
     [Fact]
@@ -205,7 +205,7 @@ public class PromptwareDryRunTests : IDisposable
         var output = RunDryRun("UpdatePlan", ["PlanFolder=/tmp/plans/00003-Update"]);
 
         Assert.Contains("PlanFolder: /tmp/plans/00003-Update", output);
-        Assert.Contains("Program.md", output);
+        Assert.Contains("## Program", output);
     }
 
     [Fact]
@@ -224,7 +224,7 @@ public class PromptwareDryRunTests : IDisposable
         var output = RunDryRun("SplitPlan", ["PlanFolder=/tmp/plans/00004-Split"]);
 
         Assert.Contains("PlanFolder: /tmp/plans/00004-Split", output);
-        Assert.Contains("Program.md", output);
+        Assert.Contains("## Program", output);
     }
 
     [Fact]
@@ -243,7 +243,7 @@ public class PromptwareDryRunTests : IDisposable
         var output = RunDryRun("CreatePr", ["PlanFolder=/tmp/plans/00005-PR"]);
 
         Assert.Contains("PlanFolder: /tmp/plans/00005-PR", output);
-        Assert.Contains("Program.md", output);
+        Assert.Contains("## Program", output);
     }
 
     [Fact]
@@ -271,7 +271,7 @@ public class PromptwareDryRunTests : IDisposable
 
         Assert.Contains("PlanFolder: /tmp/plans/00006-Issue", output);
         Assert.Contains("Repo: /repos/myapp", output);
-        Assert.Contains("Program.md", output);
+        Assert.Contains("## Program", output);
     }
 
     [Fact]
@@ -300,7 +300,7 @@ public class PromptwareDryRunTests : IDisposable
 
         Assert.Contains("ProjectName: TestProject", output);
         Assert.Contains("Instructions: Setup verifications", output);
-        Assert.Contains("Program.md", output);
+        Assert.Contains("## Program", output);
     }
 
     [Fact]
@@ -322,7 +322,7 @@ public class PromptwareDryRunTests : IDisposable
         foreach (var name in promptwares)
         {
             var output = RunDryRun(name, ["Args=test"]);
-            Assert.Contains("Program.md", output);
+            Assert.Contains("## Program", output);
             Assert.Contains($"promptware: {name}", output);
         }
     }

--- a/src/Ivy.Tendril.Test/UpdateProjectPromptwareTests.cs
+++ b/src/Ivy.Tendril.Test/UpdateProjectPromptwareTests.cs
@@ -113,7 +113,7 @@ public class UpdateProjectPromptwareTests : IDisposable
 
         Assert.Contains("ProjectName: MyApp", output);
         Assert.Contains("Instructions: Setup verifications and review actions", output);
-        Assert.Contains("Program.md", output);
+        Assert.Contains("## Program", output);
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Services/Agents/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/Agents/FirmwareCompiler.cs
@@ -42,34 +42,26 @@ public class FirmwareCompiler
 
         ## Goal
 
-        You are to execute the instructions in {PROGRAMFOLDER}/Program.md
-
-        Your goal is to complete these instructions with the following priority:
+        Your goal is to complete the instructions in the **Program** section below (inlined from {PROGRAMFOLDER}/Program.md) with the following priority:
 
         1. Completeness
         2. Speed
         3. Token efficiency
         4. Improvement over time
 
-        To complete your task you have powershell tools stored in {PROGRAMFOLDER}/Tools/. You are urged to create and maintain reusable tools to better achieve your goals during this session and over time.
+        **Tools:** {PROGRAMFOLDER}/Tools/
+        **Memory:** {PROGRAMFOLDER}/Memory/
 
-        You can store memory in {PROGRAMFOLDER}/Memory/ as markdown files.
+        List memory files at the start of execution for relevant context.
 
-        Always start with:
-
-        - Read {PROGRAMFOLDER}/Program.md
-        - List tools in {PROGRAMFOLDER}/Tools/
-        - List memory in {PROGRAMFOLDER}/Memory/
-
-        Complete you task and present the user with a summary.
+        Complete your task and present the user with a summary.
 
         ## Reflection
 
-        Every execution needs to end with a reflection step. This is your oppurtunity to improve over time. What did we learn during this session. Save this in a applicable markdown file under {PROGRAMFOLDER}/Memory/. Create new tools if applicable. Add instuctions to {PROGRAMFOLDER}/Program.md.
+        Every execution needs to end with a reflection step. This is your opportunity to improve over time. What did we learn during this session. Save this in an applicable markdown file under {PROGRAMFOLDER}/Memory/.
 
         - Note that learnings might be falsified over time. Pruning memory is just as important as storing new memory.
-        - Many session don't have any new learnings. Only store memory when you need it.
-        - Only store general knowledge in Program.md - this is shared between multiple users of this system. In Memory you should store specifics about this user's system.
+        - Many sessions don't have any new learnings. Only store memory when you need it.
         """;
 
     public static string Compile(FirmwareContext context)
@@ -87,6 +79,14 @@ public class FirmwareCompiler
             .Replace("{HEADER}", header)
             .Replace("{LOGFILE}", context.LogFile)
             .Replace("{PROGRAMFOLDER}", context.ProgramFolder);
+
+        // Include Program.md inline
+        var programFile = Path.Combine(context.ProgramFolder, "Program.md");
+        if (File.Exists(programFile))
+        {
+            firmware += "\n\n## Program\n\n";
+            firmware += File.ReadAllText(programFile) + "\n";
+        }
 
         var plansContent = PlansReference.Value;
         if (plansContent != null)


### PR DESCRIPTION
## Summary

- Program.md content is now compiled directly into the firmware prompt at launch time
- Removes the "Always start with: Read Program.md" instruction that wasted a turn
- Removes stale "powershell tools" and "reusable tools" references from firmware template
- Lists Tools/ and Memory/ paths explicitly in the firmware

Fixes a bug where CreatePlan attempted to edit source files directly because it saw the task args before reading the FORBIDDEN constraint in Program.md.

## Test plan

- [x] All 1408 tests pass
- [x] PromptwareDryRunTests updated to assert `## Program` section presence