### PR TITLE
Fix Windows command line length limit for agent prompts

### DIFF
--- a/src/Ivy.Tendril.Test/Agents/AgentProviderTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderTests.cs
@@ -12,11 +12,13 @@ public class AgentProviderTests
         string effort = "high",
         string sessionId = "sess-123",
         IReadOnlyList<string>? allowedTools = null,
-        IReadOnlyList<string>? extraArgs = null)
+        IReadOnlyList<string>? extraArgs = null,
+        string? promptFilePath = null)
     {
         return new AgentInvocation(prompt, workDir, model, effort, sessionId,
             allowedTools ?? Array.Empty<string>(),
-            extraArgs ?? Array.Empty<string>());
+            extraArgs ?? Array.Empty<string>(),
+            promptFilePath);
     }
 
     // --- Claude Provider ---
@@ -100,15 +102,18 @@ public class AgentProviderTests
     }
 
     [Fact]
-    public void Claude_BuildProcessStart_PromptAfterDoubleDash()
+    public void Claude_BuildProcessStart_PromptViaStdin()
     {
         var provider = new ClaudeAgentProvider();
-        var psi = provider.BuildProcessStart(CreateInvocation("hello world"));
+        Assert.True(provider.UsesStdinPrompt);
 
+        var psi = provider.BuildProcessStart(CreateInvocation("hello world"));
         var args = psi.ArgumentList.ToList();
-        var dashIdx = args.IndexOf("--");
-        Assert.True(dashIdx >= 0);
-        Assert.Equal("hello world", args[dashIdx + 1]);
+
+        // Prompt read from stdin (indicated by "-"), not as a CLI argument
+        Assert.Contains("-", args);
+        Assert.DoesNotContain("--", args);
+        Assert.DoesNotContain("hello world", args);
     }
 
     [Fact]
@@ -361,6 +366,24 @@ public class AgentProviderTests
         var pIdx = args.IndexOf("-p");
         Assert.True(pIdx >= 0);
         Assert.Equal("hello world", args[pIdx + 1]);
+    }
+
+    [Fact]
+    public void Copilot_BuildProcessStart_UsesPromptFileWhenProvided()
+    {
+        var provider = new CopilotAgentProvider();
+        var psi = provider.BuildProcessStart(CreateInvocation(
+            "long prompt content",
+            promptFilePath: "/plans/00123-Test/temp/prompt-job-001.md"));
+
+        var args = psi.ArgumentList.ToList();
+        var pIdx = args.IndexOf("-p");
+        Assert.True(pIdx >= 0);
+        Assert.Contains("/plans/00123-Test/temp/prompt-job-001.md", args[pIdx + 1]);
+        Assert.DoesNotContain("long prompt content", args);
+        Assert.Contains("--add-dir", args);
+        var addDirIdx = args.IndexOf("--add-dir");
+        Assert.Contains("temp", args[addDirIdx + 1]);
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Services/Agents/ClaudeAgentProvider.cs
+++ b/src/Ivy.Tendril/Services/Agents/ClaudeAgentProvider.cs
@@ -6,6 +6,7 @@ namespace Ivy.Tendril.Services.Agents;
 public class ClaudeAgentProvider : IAgentProvider
 {
     public string Name => "claude";
+    public bool UsesStdinPrompt => true;
 
     public ProcessStartInfo BuildProcessStart(AgentInvocation invocation)
     {
@@ -18,6 +19,7 @@ public class ClaudeAgentProvider : IAgentProvider
             RedirectStandardInput = true,
             UseShellExecute = false,
             CreateNoWindow = true,
+            StandardInputEncoding = System.Text.Encoding.UTF8,
             StandardOutputEncoding = System.Text.Encoding.UTF8,
             StandardErrorEncoding = System.Text.Encoding.UTF8
         };
@@ -56,8 +58,8 @@ public class ClaudeAgentProvider : IAgentProvider
         foreach (var arg in invocation.ExtraArgs)
             psi.ArgumentList.Add(arg);
 
-        psi.ArgumentList.Add("--");
-        psi.ArgumentList.Add(invocation.PromptContent);
+        // Prompt is read from stdin to avoid Windows command line length limits.
+        psi.ArgumentList.Add("-");
 
         psi.Environment["CI"] = "true";
         psi.Environment["TERM"] = "dumb";

--- a/src/Ivy.Tendril/Services/Agents/CopilotAgentProvider.cs
+++ b/src/Ivy.Tendril/Services/Agents/CopilotAgentProvider.cs
@@ -39,8 +39,18 @@ public class CopilotAgentProvider : IAgentProvider
             StandardErrorEncoding = System.Text.Encoding.UTF8
         };
 
-        psi.ArgumentList.Add("-p");
-        psi.ArgumentList.Add(invocation.PromptContent);
+        if (invocation.PromptFilePath != null)
+        {
+            psi.ArgumentList.Add("-p");
+            psi.ArgumentList.Add($"Read and execute all instructions in the file: {invocation.PromptFilePath}");
+            psi.ArgumentList.Add("--add-dir");
+            psi.ArgumentList.Add(Path.GetDirectoryName(invocation.PromptFilePath)!);
+        }
+        else
+        {
+            psi.ArgumentList.Add("-p");
+            psi.ArgumentList.Add(invocation.PromptContent);
+        }
         psi.ArgumentList.Add("--allow-all-paths");
         psi.ArgumentList.Add("--allow-all-urls");
         psi.ArgumentList.Add("--output-format");

--- a/src/Ivy.Tendril/Services/Agents/IAgentProvider.cs
+++ b/src/Ivy.Tendril/Services/Agents/IAgentProvider.cs
@@ -17,4 +17,5 @@ public record AgentInvocation(
     string Effort,
     string SessionId,
     IReadOnlyList<string> AllowedTools,
-    IReadOnlyList<string> ExtraArgs);
+    IReadOnlyList<string> ExtraArgs,
+    string? PromptFilePath = null);

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -415,6 +415,17 @@ internal class JobLauncher
         var context = new FirmwareContext(programFolder, logFile, values, customInstructions);
         var prompt = FirmwareCompiler.Compile(context);
 
+        string? promptFilePath = null;
+        if (!resolution.Provider.UsesStdinPrompt)
+        {
+            var tempDir = values.TryGetValue("PlanFolder", out var pf)
+                ? Path.Combine(pf, "temp")
+                : Path.GetTempPath();
+            Directory.CreateDirectory(tempDir);
+            promptFilePath = Path.Combine(tempDir, $"prompt-{job.Id}.md");
+            File.WriteAllText(promptFilePath, prompt);
+        }
+
         var invocation = new AgentInvocation(
             PromptContent: prompt,
             WorkingDirectory: workDir,
@@ -422,7 +433,8 @@ internal class JobLauncher
             Effort: resolution.Effort,
             SessionId: job.SessionId ?? "",
             AllowedTools: resolution.AllowedTools,
-            ExtraArgs: resolution.ExtraArgs);
+            ExtraArgs: resolution.ExtraArgs,
+            PromptFilePath: promptFilePath);
 
         var psi = resolution.Provider.BuildProcessStart(invocation);
         SetTendrilEnvironment(psi, job);


### PR DESCRIPTION
Claude: pass prompt via stdin (-) instead of CLI argument (-- <prompt>).
Copilot: write prompt to temp file when PromptFilePath is set, since
copilot CLI doesn't support stdin input.
JobLauncher: write prompt to plan temp/ for non-stdin providers.
