### PR TITLE
Refactor StartJob to use typed POCO args instead of params string[]

### DIFF
--- a/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
+++ b/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
@@ -41,13 +41,15 @@ public class UseStartJobTests
 
         // Act
         var (startJob, _) = ctx.UseStartJob();
-        startJob("CreatePlan", new[] { "-Description", "Test Plan", "-Project", "TestProject" });
+        startJob("CreatePlan", new CreatePlanArgs("Test Plan", "TestProject"));
 
         // Assert
         Assert.Single(jobService.StartedJobs);
         var (type, args) = jobService.StartedJobs[0];
         Assert.Equal("CreatePlan", type);
-        Assert.Equal(new[] { "-Description", "Test Plan", "-Project", "TestProject" }, args);
+        var createPlanArgs = Assert.IsType<CreatePlanArgs>(args);
+        Assert.Equal("Test Plan", createPlanArgs.Description);
+        Assert.Equal("TestProject", createPlanArgs.Project);
     }
 
     [Fact]
@@ -59,9 +61,9 @@ public class UseStartJobTests
         var (startJob, _) = ctx.UseStartJob();
 
         // Act
-        startJob("TestJob1", new[] { "arg1" });
-        startJob("TestJob2", new[] { "arg2" });
-        startJob("TestJob3", new[] { "arg3" });
+        startJob("TestJob1", new CreatePlanArgs("task1", "Auto"));
+        startJob("TestJob2", new CreatePlanArgs("task2", "Auto"));
+        startJob("TestJob3", new CreatePlanArgs("task3", "Auto"));
 
         // Assert - only the first call should have triggered StartJob
         Assert.Single(jobService.StartedJobs);
@@ -79,7 +81,7 @@ public class UseStartJobTests
         var (startJob, isStartingBefore) = ctx.UseStartJob();
         Assert.False(isStartingBefore);
 
-        startJob("TestJob", new[] { "arg1" });
+        startJob("TestJob", new CreatePlanArgs("task", "Auto"));
 
         // Second render - reset context and call hook again
         ctx.Reset();
@@ -91,15 +93,9 @@ public class UseStartJobTests
 
     private class TestJobService : IJobService
     {
-        public List<(string Type, string[] Args)> StartedJobs { get; } = new();
+        public List<(string Type, JobArgsBase Args)> StartedJobs { get; } = new();
 
-        public string StartJob(string type, string[] args, string? inboxFilePath)
-        {
-            StartedJobs.Add((type, args));
-            return Guid.NewGuid().ToString();
-        }
-
-        public string StartJob(string type, params string[] args)
+        public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
         {
             StartedJobs.Add((type, args));
             return Guid.NewGuid().ToString();

--- a/src/Ivy.Tendril.Test/InboxControllerTests.cs
+++ b/src/Ivy.Tendril.Test/InboxControllerTests.cs
@@ -46,8 +46,8 @@ public class InboxControllerTests
 
         Assert.IsType<OkObjectResult>(result);
         var job = Assert.Single(jobService.StartedJobs);
-        Assert.Contains("-SourcePath", job.Args);
-        Assert.Contains(@"D:\Tests\Session1", job.Args);
+        var cpArgs = Assert.IsType<CreatePlanArgs>(job.Args);
+        Assert.Equal(@"D:\Tests\Session1", cpArgs.SourcePath);
     }
 
     [Fact]
@@ -60,7 +60,8 @@ public class InboxControllerTests
 
         Assert.IsType<OkObjectResult>(result);
         var job = Assert.Single(jobService.StartedJobs);
-        Assert.Contains("Auto", job.Args);
+        var cpArgs = Assert.IsType<CreatePlanArgs>(job.Args);
+        Assert.Equal("Auto", cpArgs.Project);
     }
 
     private static InboxController CreateController(IJobService jobService)
@@ -75,18 +76,13 @@ public class InboxControllerTests
 
     private class StubJobService : IJobService
     {
-        public List<(string Type, string[] Args)> StartedJobs { get; } = new();
+        public List<(string Type, JobArgsBase Args)> StartedJobs { get; } = new();
 
-        public string StartJob(string type, string[] args, string? inboxFilePath)
+        public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
         {
             var id = $"job-{StartedJobs.Count + 1}";
             StartedJobs.Add((type, args));
             return id;
-        }
-
-        public string StartJob(string type, params string[] args)
-        {
-            return StartJob(type, args, null);
         }
 
         public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false)

--- a/src/Ivy.Tendril.Test/InboxRecoveryTests.cs
+++ b/src/Ivy.Tendril.Test/InboxRecoveryTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Test.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -108,9 +109,7 @@ public class InboxRecoveryTests
         {
             var jobService = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), inboxDir);
 
-            var id = jobService.StartJob("CreatePlan",
-                "-Description", "Test plan description",
-                "-Project", "Tendril");
+            var id = jobService.StartJob("CreatePlan", new CreatePlanArgs("Test plan description", "Tendril"));
 
             var job = jobService.GetJob(id);
             Assert.NotNull(job);
@@ -145,9 +144,7 @@ public class InboxRecoveryTests
         {
             var jobService = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), inboxDir);
 
-            var id = jobService.StartJob("CreatePlan",
-                "-Description", "Failing plan",
-                "-Project", "Tendril");
+            var id = jobService.StartJob("CreatePlan", new CreatePlanArgs("Failing plan", "Tendril"));
 
             var job = jobService.GetJob(id);
             Assert.NotNull(job?.InboxFile);
@@ -175,9 +172,7 @@ public class InboxRecoveryTests
         {
             var jobService = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), inboxDir);
 
-            var id = jobService.StartJob("CreatePlan",
-                "-Description", "Stopped plan",
-                "-Project", "Tendril");
+            var id = jobService.StartJob("CreatePlan", new CreatePlanArgs("Stopped plan", "Tendril"));
 
             var job = jobService.GetJob(id);
             Assert.NotNull(job?.InboxFile);
@@ -210,7 +205,7 @@ public class InboxRecoveryTests
             var jobService = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), inboxDir);
 
             var id = jobService.StartJob("CreatePlan",
-                ["-Description", "Some request", "-Project", "Agent"],
+                new CreatePlanArgs("Some request", "Agent"),
                 processingFile);
 
             var job = jobService.GetJob(id);
@@ -246,7 +241,7 @@ public class InboxRecoveryTests
             File.WriteAllText(Path.Combine(planFolder, "plan.yaml"),
                 $"state: Draft\nproject: TestProject\nlevel: NiceToHave\ntitle: Test Plan\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\nrepos:\n- {repoDir}\nprs: []\ncommits: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\n");
 
-            var id = jobService.StartJob("ExecutePlan", planFolder);
+            var id = jobService.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
             var job = jobService.GetJob(id);
             Assert.NotNull(job);
             Assert.Null(job.InboxFile);

--- a/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
@@ -214,15 +214,13 @@ public class InboxWatcherServiceTests : IDisposable
     private class TrackedStubJobService : IJobService
     {
         public bool TrackedReturnValue { get; set; }
-        public List<(string Type, string[] Args, string? InboxFilePath)> StartedJobs { get; } = new();
+        public List<(string Type, JobArgsBase Args, string? InboxFilePath)> StartedJobs { get; } = new();
 
-        public string StartJob(string type, string[] args, string? inboxFilePath)
+        public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
         {
             StartedJobs.Add((type, args, inboxFilePath));
             return $"job-{StartedJobs.Count:D3}";
         }
-
-        public string StartJob(string type, params string[] args) => StartJob(type, args, null);
 
         public bool IsInboxFileTracked(string filePath) => TrackedReturnValue;
 
@@ -347,20 +345,18 @@ public class InboxWatcherServiceTests : IDisposable
     private class DeleteBeforeRenameJobService : IJobService
     {
         private readonly string _fileToDelete;
-        public List<(string Type, string[] Args, string? InboxFilePath)> StartedJobs { get; } = new();
+        public List<(string Type, JobArgsBase Args, string? InboxFilePath)> StartedJobs { get; } = new();
 
         public DeleteBeforeRenameJobService(string fileToDelete)
         {
             _fileToDelete = fileToDelete;
         }
 
-        public string StartJob(string type, string[] args, string? inboxFilePath)
+        public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
         {
             StartedJobs.Add((type, args, inboxFilePath));
             return $"job-{StartedJobs.Count:D3}";
         }
-
-        public string StartJob(string type, params string[] args) => StartJob(type, args, null);
 
         public bool IsInboxFileTracked(string filePath)
         {
@@ -392,17 +388,15 @@ public class InboxWatcherServiceTests : IDisposable
 
     private class TimestampedJobService : IJobService
     {
-        public List<(string Type, string[] Args, string? InboxFilePath)> StartedJobs { get; } = new();
+        public List<(string Type, JobArgsBase Args, string? InboxFilePath)> StartedJobs { get; } = new();
         public List<DateTime> StartJobTimestamps { get; } = new();
 
-        public string StartJob(string type, string[] args, string? inboxFilePath)
+        public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
         {
             StartJobTimestamps.Add(DateTime.UtcNow);
             StartedJobs.Add((type, args, inboxFilePath));
             return $"job-{StartedJobs.Count:D3}";
         }
-
-        public string StartJob(string type, params string[] args) => StartJob(type, args, null);
 
         public bool IsInboxFileTracked(string filePath) => false;
 

--- a/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
@@ -27,7 +27,7 @@ public class JobServiceConcurrencyTests
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var id = service.StartJob("CreatePlan", "-Description", "Test Job");
+        var id = service.StartJob("CreatePlan", new CreatePlanArgs("Test Job", "Auto"));
         var job = service.GetJob(id);
 
         Assert.NotNull(job);
@@ -47,7 +47,7 @@ public class JobServiceConcurrencyTests
         // but the initial status should be "Running" not "Queued"
         try
         {
-            var id = service.StartJob("CreatePlan", "-Description", "Test Job");
+            var id = service.StartJob("CreatePlan", new CreatePlanArgs("Test Job", "Auto"));
             var job = service.GetJob(id);
             Assert.NotNull(job);
             Assert.NotEqual(JobStatus.Queued, job.Status);
@@ -65,8 +65,8 @@ public class JobServiceConcurrencyTests
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        service.StartJob("CreatePlan", "-Description", "Job 1");
-        service.StartJob("CreatePlan", "-Description", "Job 2");
+        service.StartJob("CreatePlan", new CreatePlanArgs("Job 1", "Auto"));
+        service.StartJob("CreatePlan", new CreatePlanArgs("Job 2", "Auto"));
 
         var jobs = service.GetJobs();
         Assert.Equal(2, jobs.Count);
@@ -80,7 +80,7 @@ public class JobServiceConcurrencyTests
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var id = service.StartJob("CreatePlan", "-Description", "Test Job");
+        var id = service.StartJob("CreatePlan", new CreatePlanArgs("Test Job", "Auto"));
         service.StopJob(id);
 
         var job = service.GetJob(id);

--- a/src/Ivy.Tendril.Test/JobServiceConcurrentPlanModificationTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceConcurrentPlanModificationTests.cs
@@ -51,7 +51,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
         Assert.Equal(JobStatus.Running, firstJob.Status);
 
         // Try to start second UpdatePlan job for the same plan
-        var secondJobId = service.StartJob("UpdatePlan", _planFolder);
+        var secondJobId = service.StartJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
         // Second job should fail immediately with conflict message
@@ -69,7 +69,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         _ = service.CreateTestJob("ExpandPlan", _planFolder);
-        var secondJobId = service.StartJob("ExpandPlan", _planFolder);
+        var secondJobId = service.StartJob("ExpandPlan", new ExpandPlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
         Assert.NotNull(secondJob);
@@ -85,7 +85,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         _ = service.CreateTestJob("SplitPlan", _planFolder);
-        var secondJobId = service.StartJob("SplitPlan", _planFolder);
+        var secondJobId = service.StartJob("SplitPlan", new SplitPlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
         Assert.NotNull(secondJob);
@@ -110,7 +110,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
         // Second job should be allowed (will fail to launch process, but should attempt)
         try
         {
-            var secondJobId = service.StartJob("UpdatePlan", _planFolder);
+            var secondJobId = service.StartJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
             var secondJob = service.GetJob(secondJobId);
             Assert.NotNull(secondJob);
             // Should not be Failed due to conflict (might be Failed due to process launch, but that's OK)
@@ -132,13 +132,13 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var firstJobId = service.StartJob("UpdatePlan", _planFolder);
+        var firstJobId = service.StartJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
         var firstJob = service.GetJob(firstJobId);
         Assert.NotNull(firstJob);
         Assert.Equal(JobStatus.Queued, firstJob.Status);
 
         // Second job should fail even though first is only queued
-        var secondJobId = service.StartJob("UpdatePlan", _planFolder);
+        var secondJobId = service.StartJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
         Assert.NotNull(secondJob);
@@ -160,7 +160,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
         firstJob.Status = JobStatus.Pending;
 
         // Second job should fail
-        var secondJobId = service.StartJob("UpdatePlan", _planFolder);
+        var secondJobId = service.StartJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
         Assert.NotNull(secondJob);
@@ -198,7 +198,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
         // Start UpdatePlan for different plan — should be allowed
         try
         {
-            var secondJobId = service.StartJob("UpdatePlan", otherPlanFolder);
+            var secondJobId = service.StartJob("UpdatePlan", new UpdatePlanArgs(otherPlanFolder));
             var secondJob = service.GetJob(secondJobId);
             Assert.NotNull(secondJob);
             // Should not fail due to conflict
@@ -225,7 +225,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
         // ExecutePlan should not be blocked by UpdatePlan (they're different job types)
         try
         {
-            var executeJobId = service.StartJob("ExecutePlan", _planFolder);
+            var executeJobId = service.StartJob("ExecutePlan", new ExecutePlanArgs(_planFolder));
             var executeJob = service.GetJob(executeJobId);
             Assert.NotNull(executeJob);
             // Should not fail due to plan modification conflict
@@ -253,7 +253,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
         Assert.Equal(JobStatus.Running, firstJob.Status);
 
         // Try to start second ExecutePlan job for the same plan
-        var secondJobId = service.StartJob("ExecutePlan", _planFolder);
+        var secondJobId = service.StartJob("ExecutePlan", new ExecutePlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
         // Second job should fail immediately with conflict message
@@ -281,7 +281,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             _ = service.CreateTestJob("UpdatePlan", _planFolder);
 
             // Try to start conflicting second job
-            _ = service.StartJob("UpdatePlan", _planFolder);
+            _ = service.StartJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
 
             // Should have received a notification
             Assert.NotNull(receivedNotification);

--- a/src/Ivy.Tendril.Test/JobServiceCostTrackingTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCostTrackingTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
@@ -67,7 +68,7 @@ public class JobServiceCostTrackingTests : IDisposable
         var service = CreateService();
         var planFolder = CreateValidPlanFolder();
 
-        var id = service.StartJob("ExecutePlan", planFolder);
+        var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
         var job = service.GetJob(id);
 
         Assert.NotNull(job);
@@ -83,8 +84,8 @@ public class JobServiceCostTrackingTests : IDisposable
         var planFolder1 = CreateValidPlanFolder();
         var planFolder2 = CreateValidPlanFolder();
 
-        var id1 = service.StartJob("ExecutePlan", planFolder1);
-        var id2 = service.StartJob("ExecutePlan", planFolder2);
+        var id1 = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder1));
+        var id2 = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder2));
 
         var job1 = service.GetJob(id1);
         var job2 = service.GetJob(id2);
@@ -102,7 +103,7 @@ public class JobServiceCostTrackingTests : IDisposable
         var service = new JobService(configService);
         var planFolder = CreateValidPlanFolder();
 
-        var id = service.StartJob("ExecutePlan", planFolder);
+        var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
         var job = service.GetJob(id);
 
         Assert.NotNull(job);
@@ -121,7 +122,7 @@ public class JobServiceCostTrackingTests : IDisposable
             var service = new JobService(configService);
             var planFolder = CreateValidPlanFolder(tempDir);
 
-            var id = service.StartJob("ExecutePlan", planFolder);
+            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
             var job = service.GetJob(id);
 
             Assert.NotNull(job);

--- a/src/Ivy.Tendril.Test/JobServiceCreateIssueTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCreateIssueTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
@@ -49,7 +50,7 @@ public class JobServiceCreateIssueTests : IDisposable
         WritePlanYaml("Draft");
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", _tempDir.Path, "-Repo", "owner/repo", "-Assignee", "", "-Labels", "");
+        var id = service.StartJob("CreateIssue", new CreateIssueArgs(_tempDir.Path, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         var content = File.ReadAllText(_planYamlPath);
@@ -62,7 +63,7 @@ public class JobServiceCreateIssueTests : IDisposable
         WritePlanYaml("Draft");
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", _tempDir.Path, "-Repo", "owner/repo", "-Assignee", "", "-Labels", "");
+        var id = service.StartJob("CreateIssue", new CreateIssueArgs(_tempDir.Path, "owner/repo", "", "", ""));
         service.CompleteJob(id, 1);
 
         var content = File.ReadAllText(_planYamlPath);

--- a/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
@@ -75,12 +75,12 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         };
 
         // Simulate CreateIssue completing for PlanB
-        var id = service.StartJob("CreateIssue", planB, "-Repo", "owner/repo", "-Assignee", "", "-Labels", "");
+        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         // PlanA should have been auto-queued
         var jobs = service.GetJobs();
-        Assert.Contains(jobs, j => j.Type == "ExecutePlan" && j.Args.Contains(planA));
+        Assert.Contains(jobs, j => j.Type == "ExecutePlan" && j.TypedArgs?.PlanFolder == planA);
     }
 
     [Fact]
@@ -92,11 +92,11 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
 
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", planB, "-Repo", "owner/repo", "-Assignee", "", "-Labels", "");
+        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         var jobs = service.GetJobs();
-        Assert.DoesNotContain(jobs, j => j.Type == "ExecutePlan" && j.Args.Contains(planA));
+        Assert.DoesNotContain(jobs, j => j.Type == "ExecutePlan" && j.TypedArgs?.PlanFolder == planA);
     }
 
     [Fact]
@@ -108,11 +108,11 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
 
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", planB, "-Repo", "owner/repo", "-Assignee", "", "-Labels", "");
+        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         var jobs = service.GetJobs();
-        Assert.DoesNotContain(jobs, j => j.Type == "ExecutePlan" && j.Args.Contains(planA));
+        Assert.DoesNotContain(jobs, j => j.Type == "ExecutePlan" && j.TypedArgs?.PlanFolder == planA);
     }
 
     [Fact]
@@ -123,7 +123,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
 
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", planB, "-Repo", "owner/repo", "-Assignee", "", "-Labels", "");
+        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         // Verify plan.yaml was updated — Building then immediately Executing when job launches
@@ -141,7 +141,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         var service = CreateService();
 
         // Start ExecutePlan — dependencies aren't met, so ResetPlanStateToBlocked should fire
-        service.StartJob("ExecutePlan", planA);
+        service.StartJob("ExecutePlan", new ExecutePlanArgs(planA));
 
         // Verify plan.yaml was updated to Blocked (not Draft)
         var planYamlContent = File.ReadAllText(Path.Combine(planA, "plan.yaml"));
@@ -156,11 +156,11 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
 
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", planB, "-Repo", "owner/repo", "-Assignee", "", "-Labels", "");
+        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         var jobs = service.GetJobs();
-        Assert.DoesNotContain(jobs, j => j.Type == "ExecutePlan" && j.Args.Contains(planA));
+        Assert.DoesNotContain(jobs, j => j.Type == "ExecutePlan" && j.TypedArgs?.PlanFolder == planA);
     }
 
     [Fact]
@@ -171,11 +171,11 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
 
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", planB, "-Repo", "owner/repo", "-Assignee", "", "-Labels", "");
+        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         var jobs = service.GetJobs();
-        Assert.DoesNotContain(jobs, j => j.Type == "ExecutePlan" && j.Args.Contains(planA));
+        Assert.DoesNotContain(jobs, j => j.Type == "ExecutePlan" && j.TypedArgs?.PlanFolder == planA);
     }
 
     [Fact]
@@ -186,7 +186,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
 
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", planB, "-Repo", "owner/repo", "-Assignee", "", "-Labels", "");
+        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         var jobs = service.GetJobs();
@@ -204,27 +204,27 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         var service = CreateService();
 
         // Start ExecutePlan for planC — it will be blocked because DepPlan is not Completed
-        service.StartJob("ExecutePlan", planC);
+        service.StartJob("ExecutePlan", new ExecutePlanArgs(planC));
 
         var blockedJobsBefore = service.GetJobs().Count(j =>
             j.Type == "ExecutePlan" &&
             j.Status == JobStatus.Blocked &&
-            j.Args.Length > 0 &&
-            j.Args[0] == planC);
+            j.TypedArgs?.PlanFolder != null &&
+            j.TypedArgs.PlanFolder == planC);
         Assert.Equal(1, blockedJobsBefore);
 
         // Complete a CreateIssue job for PlanB — triggers RetryBlockedDependents
         // planC depends on both DepPlan (not met) and PlanB (met), so it stays blocked
         // But the duplicate-job guard should prevent creating another blocked job entry
-        var id = service.StartJob("CreateIssue", planB, "-Repo", "owner/repo", "-Assignee", "", "-Labels", "");
+        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         // Should still have exactly one blocked job for planC (not two)
         var blockedJobsAfter = service.GetJobs().Count(j =>
             j.Type == "ExecutePlan" &&
             j.Status == JobStatus.Blocked &&
-            j.Args.Length > 0 &&
-            j.Args[0] == planC);
+            j.TypedArgs?.PlanFolder != null &&
+            j.TypedArgs.PlanFolder == planC);
         Assert.Equal(1, blockedJobsAfter);
     }
 
@@ -238,11 +238,11 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         var service = CreateService();
 
         // Start ExecutePlan — dependencies are met, so it should NOT be blocked
-        service.StartJob("ExecutePlan", planA);
+        service.StartJob("ExecutePlan", new ExecutePlanArgs(planA));
 
         // Verify the job is not blocked (deps are met, no redundant CheckDependencies to fail)
         var jobs = service.GetJobs();
-        var planAJob = jobs.FirstOrDefault(j => j.Type == "ExecutePlan" && j.Args.Contains(planA));
+        var planAJob = jobs.FirstOrDefault(j => j.Type == "ExecutePlan" && j.TypedArgs?.PlanFolder == planA);
         Assert.NotNull(planAJob);
         Assert.NotEqual(JobStatus.Blocked, planAJob.Status);
     }
@@ -260,12 +260,12 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         Assert.Equal(JobStatus.Running, service.GetJob(activeId)!.Status);
 
         // Trigger RetryBlockedDependents by completing a job for PlanB
-        var id = service.StartJob("CreateIssue", planB, "-Repo", "owner/repo", "-Assignee", "", "-Labels", "");
+        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         // Should NOT create a duplicate ExecutePlan job for planA
         var executePlanJobs = service.GetJobs()
-            .Where(j => j.Type == "ExecutePlan" && j.Args.Length > 0 && j.Args[0] == planA)
+            .Where(j => j.Type == "ExecutePlan" && j.TypedArgs?.PlanFolder == planA)
             .ToList();
 
         // Only the original active job should exist
@@ -286,12 +286,12 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         service.GetJob(blockedId)!.Status = JobStatus.Blocked;
 
         // Trigger RetryBlockedDependents by completing a CreateIssue job for PlanB
-        var id = service.StartJob("CreateIssue", planB, "-Repo", "owner/repo", "-Assignee", "", "-Labels", "");
+        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         // Should have at most one ExecutePlan job for planA (not two)
         var executePlanJobs = service.GetJobs()
-            .Where(j => j.Type == "ExecutePlan" && j.Args.Length > 0 && j.Args[0] == planA)
+            .Where(j => j.Type == "ExecutePlan" && j.TypedArgs?.PlanFolder == planA)
             .ToList();
         Assert.True(executePlanJobs.Count <= 1,
             $"Expected at most 1 ExecutePlan job for planA, found {executePlanJobs.Count}");

--- a/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
@@ -129,7 +129,7 @@ public class JobServiceFailureReasonTests : IDisposable
     {
         var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
         var planFolder = CreateValidPlanFolder();
-        var id = service.StartJob("ExecutePlan", planFolder);
+        var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
 
         service.CompleteJob(id, 0);
 
@@ -169,7 +169,7 @@ public class JobServiceFailureReasonTests : IDisposable
     {
         var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
         var planFolder = CreateValidPlanFolder();
-        var id = service.StartJob("ExecutePlan", planFolder);
+        var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
         var job = service.GetJob(id)!;
         job.StatusMessage = "Execution failed (exit code: 1)";
         job.OutputLines.Enqueue("[stderr] some raw stderr output");

--- a/src/Ivy.Tendril.Test/JobServiceHookTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceHookTests.cs
@@ -56,7 +56,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("ExecutePlan", planFolder);
+            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
             var job = service.GetJob(id)!;
 
             // Before hooks should have run during StartJob
@@ -89,7 +89,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("CreatePr", planFolder);
+            var id = service.StartJob("CreatePr", new CreatePrArgs(planFolder));
             var job = service.GetJob(id)!;
 
             Assert.Contains(job.OutputLines, l => l.Contains("[hook:Global Hook]"));
@@ -121,7 +121,7 @@ public class JobServiceHookTests : IDisposable
         try
         {
             // Start a CreatePr job — the hook should NOT match
-            var id = service.StartJob("CreatePr", planFolder);
+            var id = service.StartJob("CreatePr", new CreatePrArgs(planFolder));
             var job = service.GetJob(id)!;
 
             Assert.DoesNotContain(job.OutputLines, l => l.Contains("[hook:Execute Only]"));
@@ -151,7 +151,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("ExecutePlan", planFolder);
+            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
             var job = service.GetJob(id)!;
 
             // Job should not be blocked/pending — the failing hook must not prevent launch.
@@ -184,7 +184,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("ExecutePlan", planFolder);
+            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
             var job = service.GetJob(id)!;
 
             Assert.Contains(job.OutputLines,
@@ -248,7 +248,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("ExecutePlan", planFolder);
+            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
             service.CompleteJob(id, 0);
 
             var job = service.GetJob(id)!;
@@ -285,7 +285,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("ExecutePlan", planFolder);
+            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
             service.CompleteJob(id, 1);
 
             var job = service.GetJob(id)!;
@@ -316,7 +316,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("ExecutePlan", planFolder);
+            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
             service.CompleteJob(id, 0);
 
             var job = service.GetJob(id)!;

--- a/src/Ivy.Tendril.Test/JobServiceNotificationThreadSafetyTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceNotificationThreadSafetyTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
@@ -37,7 +38,7 @@ public class JobServiceNotificationThreadSafetyTests : IDisposable
             service.NotificationReady += n => received = n;
 
             // Start a job and complete it to trigger notification
-            var id = service.StartJob("CreatePr", _tempDir.Path);
+            var id = service.StartJob("CreatePr", new CreatePrArgs(_tempDir.Path));
             service.CompleteJob(id, 0);
 
             // The notification should have been posted to the sync context, not invoked directly
@@ -68,7 +69,7 @@ public class JobServiceNotificationThreadSafetyTests : IDisposable
         JobNotification? received = null;
         service.NotificationReady += n => received = n;
 
-        var id = service.StartJob("CreatePr", _tempDir.Path);
+        var id = service.StartJob("CreatePr", new CreatePrArgs(_tempDir.Path));
         service.CompleteJob(id, 0);
 
         Assert.NotNull(received);
@@ -90,7 +91,7 @@ public class JobServiceNotificationThreadSafetyTests : IDisposable
 
         // Complete multiple jobs rapidly
         var ids = new List<string>();
-        for (var i = 0; i < 5; i++) ids.Add(service.StartJob("CreatePr", _tempDir.Path));
+        for (var i = 0; i < 5; i++) ids.Add(service.StartJob("CreatePr", new CreatePrArgs(_tempDir.Path)));
 
         foreach (var id in ids) service.CompleteJob(id, 0);
 
@@ -117,7 +118,7 @@ public class JobServiceNotificationThreadSafetyTests : IDisposable
         service.NotificationReady += n => received = n;
 
         var planFolder = CreateValidPlanFolder();
-        var id = service.StartJob("ExecutePlan", planFolder);
+        var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
         service.CompleteJob(id, 1);
 
         Assert.NotNull(received);

--- a/src/Ivy.Tendril.Test/JobServicePriorityTests.cs
+++ b/src/Ivy.Tendril.Test/JobServicePriorityTests.cs
@@ -19,7 +19,7 @@ public class JobServicePriorityTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var id = service.StartJob("CreatePlan", "-Description", "Test", "-Project", "Framework", "-Priority", "2");
+        var id = service.StartJob("CreatePlan", new CreatePlanArgs("Test", "Framework", Priority: 2));
         var job = service.GetJob(id);
 
         Assert.NotNull(job);
@@ -33,7 +33,7 @@ public class JobServicePriorityTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var id = service.StartJob("CreatePlan", "-Description", "Test", "-Project", "Framework");
+        var id = service.StartJob("CreatePlan", new CreatePlanArgs("Test", "Framework"));
         var job = service.GetJob(id);
 
         Assert.NotNull(job);
@@ -47,7 +47,7 @@ public class JobServicePriorityTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var id = service.StartJob("CreatePlan", "-Description", "Test", "-Priority", "notanumber");
+        var id = service.StartJob("CreatePlan", new CreatePlanArgs("Test", "Auto"));
         var job = service.GetJob(id);
 
         Assert.NotNull(job);
@@ -62,9 +62,9 @@ public class JobServicePriorityTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var lowId = service.StartJob("CreatePlan", "-Description", "Low priority", "-Priority", "0");
-        var highId = service.StartJob("CreatePlan", "-Description", "High priority", "-Priority", "2");
-        var medId = service.StartJob("CreatePlan", "-Description", "Med priority", "-Priority", "1");
+        var lowId = service.StartJob("CreatePlan", new CreatePlanArgs("Low priority", "Auto", Priority: 0));
+        var highId = service.StartJob("CreatePlan", new CreatePlanArgs("High priority", "Auto", Priority: 2));
+        var medId = service.StartJob("CreatePlan", new CreatePlanArgs("Med priority", "Auto", Priority: 1));
 
         // All should be queued
         Assert.Equal(JobStatus.Queued, service.GetJob(lowId)!.Status);

--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -186,7 +186,7 @@ public class JobServiceRetryBlockedTests : IDisposable
         // Since the blocked job was already removed, no new ExecutePlan job should be created for it
         var jobs = service.GetJobs();
         var executePlanJobs =
-            jobs.Where(j => j.Type == "ExecutePlan" && j.Args.Length > 0 && j.Args[0] == dependentPlan1).ToList();
+            jobs.Where(j => j.Type == "ExecutePlan" && j.TypedArgs?.PlanFolder == dependentPlan1).ToList();
         Assert.Empty(executePlanJobs);
 
         // Cleanup
@@ -232,7 +232,7 @@ public class JobServiceRetryBlockedTests : IDisposable
 
         // The active job should still be running
         var executePlanJobs = service.GetJobs()
-            .Where(j => j.Type == "ExecutePlan" && j.Args.Length > 0 && j.Args[0] == dependentPlan)
+            .Where(j => j.Type == "ExecutePlan" && j.TypedArgs?.PlanFolder == dependentPlan)
             .ToList();
 
         Assert.Equal(2, executePlanJobs.Count);
@@ -289,7 +289,7 @@ public class JobServiceRetryBlockedTests : IDisposable
 
         // A new job should have been created (the restarted job B)
         var jobs = service.GetJobs();
-        var restartedJob = jobs.FirstOrDefault(j => j.Id != jobAId && j.Type == "ExecutePlan" && j.Args.Length > 0 && j.Args[0] == planB);
+        var restartedJob = jobs.FirstOrDefault(j => j.Id != jobAId && j.Type == "ExecutePlan" && j.TypedArgs?.PlanFolder == planB);
         Assert.NotNull(restartedJob);
         Assert.NotEqual(JobStatus.Blocked, restartedJob.Status);
 
@@ -342,7 +342,7 @@ public class JobServiceRetryBlockedTests : IDisposable
 
         // A new job should have been created (the restarted job B)
         var jobs = service.GetJobs();
-        var restartedJob = jobs.FirstOrDefault(j => j.Id != jobAId && j.Type == "ExecutePlan" && j.Args.Length > 0 && j.Args[0] == planB);
+        var restartedJob = jobs.FirstOrDefault(j => j.Id != jobAId && j.Type == "ExecutePlan" && j.TypedArgs?.PlanFolder == planB);
         Assert.NotNull(restartedJob);
         Assert.NotEqual(JobStatus.Blocked, restartedJob.Status);
 

--- a/src/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs
@@ -18,7 +18,7 @@ public class JobServiceThreadSafetyTests
         string id;
         try
         {
-            id = service.StartJob("CreatePlan", "-Description", "Slot filler");
+            id = service.StartJob("CreatePlan", new CreatePlanArgs("Slot filler", "Auto"));
         }
         catch
         {

--- a/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -186,12 +186,7 @@ public class PlanCountsServiceTests : IDisposable
             return _jobs.FirstOrDefault(j => j.Id == id);
         }
 
-        public string StartJob(string type, string[] args, string? inboxFilePath)
-        {
-            throw new NotImplementedException();
-        }
-
-        public string StartJob(string type, params string[] args)
+        public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
         {
             throw new NotImplementedException();
         }

--- a/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
@@ -133,7 +133,7 @@ projects:
         {
             Id = "test-1",
             Type = "CreatePlan",
-            Args = new[] { "Test" },
+            TypedArgs = new CreatePlanArgs("Test", "Auto"),
             Project = "TestProject",
             Status = JobStatus.Running,
             LastOutputAt = DateTime.UtcNow
@@ -163,7 +163,7 @@ projects:
         {
             Id = "test-1",
             Type = "CreatePlan",
-            Args = new[] { "Test" },
+            TypedArgs = new CreatePlanArgs("Test", "Auto"),
             Project = "TestProject",
             Status = JobStatus.Running,
             StatusFilePath = Path.Combine(_tempTendrilHome, "status-test-1.json")

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -74,7 +74,7 @@ public class ContentView(
                         | new Button("Execute").Icon(Icons.Rocket).Outline().ShortcutKey("e").OnClick(() =>
                         {
                             planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
-                            jobService.StartJob(Constants.JobTypes.ExecutePlan, selectedPlan.FolderPath);
+                            jobService.StartJob(Constants.JobTypes.ExecutePlan, new ExecutePlanArgs(selectedPlan.FolderPath));
                             refreshPlans();
                         })
                         | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(

--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -176,25 +176,24 @@ public partial class JobsApp
                     {
                         if (job.Status is JobStatus.Failed or JobStatus.Timeout or JobStatus.Stopped)
                         {
-                            if (job.Type == "CreatePlan" && !job.Args.Contains("-Description"))
+                            if (job.TypedArgs == null)
                             {
-                                client.Toast("Cannot rerun CreatePlan: original description was not preserved.", "Rerun Failed");
+                                client.Toast("Cannot rerun: original args were not preserved.", "Rerun Failed");
                                 return ValueTask.CompletedTask;
                             }
 
-                            if (job.Type is "ExecutePlan" or "ExpandPlan" && job.Args.Length > 0)
+                            var folder = job.TypedArgs.PlanFolder;
+                            if (job.Type is "ExecutePlan" or "ExpandPlan" && folder != null)
                             {
-                                var folderName = Path.GetFileName(job.Args[0]);
-                                planService.TransitionState(folderName, PlanStatus.Building);
+                                planService.TransitionState(Path.GetFileName(folder), PlanStatus.Building);
                             }
-                            else if (job is { Type: "UpdatePlan", Args.Length: > 0 })
+                            else if (job.Type == "UpdatePlan" && folder != null)
                             {
-                                var folderName = Path.GetFileName(job.Args[0]);
-                                planService.TransitionState(folderName, PlanStatus.Updating);
+                                planService.TransitionState(Path.GetFileName(folder), PlanStatus.Updating);
                             }
 
                             jobService.DeleteJob(job.Id);
-                            jobService.StartJob(job.Type, job.Args);
+                            jobService.StartJob(job.Type, job.TypedArgs);
 
                             refreshToken.Refresh();
                         }

--- a/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
@@ -10,12 +10,8 @@ public partial class JobsApp
 
     private static string? GetFullPrompt(JobItem job, IPlanReaderService? planService = null)
     {
-        if (job.Type == "CreatePlan")
-        {
-            for (var i = 0; i < job.Args.Length - 1; i++)
-                if (job.Args[i].Equals("-Description", StringComparison.OrdinalIgnoreCase))
-                    return job.Args[i + 1];
-        }
+        if (job.TypedArgs is CreatePlanArgs cp)
+            return cp.Description;
 
         if (planService != null && !string.IsNullOrEmpty(job.PlanFile))
         {

--- a/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
@@ -73,7 +73,7 @@ public class ActionBarView(
                     selectedPlanState.Set(optimisticPlan);
 
                     planService.TransitionState(selectedPlan.FolderName, PlanStatus.Updating);
-                    jobService.StartJob("SplitPlan", selectedPlan.FolderPath);
+                    jobService.StartJob("SplitPlan", new SplitPlanArgs(selectedPlan.FolderPath));
                     refreshPlans();
                 })
                 | new Button("Expand").Icon(Icons.UnfoldVertical).Outline().ShortcutKey("x")
@@ -91,7 +91,7 @@ public class ActionBarView(
 
                     planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
                     var planPath = selectedPlan.FolderPath;
-                    jobService.StartJob("ExpandPlan", planPath);
+                    jobService.StartJob("ExpandPlan", new ExpandPlanArgs(planPath));
                     refreshPlans();
                 })
                 | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -161,7 +161,7 @@ public class ContentView(
             selectedPlanState.Set(optimisticPlan);
 
             planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
-            jobService.StartJob("ExecutePlan", selectedPlan.FolderPath);
+            jobService.StartJob("ExecutePlan", new ExecutePlanArgs(selectedPlan.FolderPath));
             refreshPlans();
         });
 
@@ -225,15 +225,15 @@ public class ContentView(
         var hasActiveExpandJob = jobService.GetJobs().Any(j =>
             j.Type == "ExpandPlan" &&
             j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
-            j.Args.Length > 0 &&
-            j.Args[0].Equals(selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
+            j.TypedArgs?.PlanFolder != null &&
+            j.TypedArgs.PlanFolder.Equals(selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
 
         // Check for active SplitPlan job
         var hasActiveSplitJob = jobService.GetJobs().Any(j =>
             j.Type == "SplitPlan" &&
             j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
-            j.Args.Length > 0 &&
-            j.Args[0].Equals(selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
+            j.TypedArgs?.PlanFolder != null &&
+            j.TypedArgs.PlanFolder.Equals(selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
 
         var actionBar = new ActionBarView(
             selectedPlan,

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
@@ -129,8 +129,7 @@ public class CreateIssueDialog(
                             var repoPath = selectedRepo.FullName;
                             var assignee = issueAssigneeState.Value ?? "";
                             var selectedLabels = string.Join(",", issueLabelsState.Value);
-                            jobService.StartJob(Constants.JobTypes.CreateIssue, selectedPlan.FolderPath, "-Repo", repoPath,
-                                "-Assignee", assignee, "-Comment", issueCommentState.Value, "-Labels", selectedLabels);
+                            jobService.StartJob(Constants.JobTypes.CreateIssue, new CreateIssueArgs(selectedPlan.FolderPath, repoPath, assignee, issueCommentState.Value, selectedLabels));
                         }
                     }
 

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
@@ -31,8 +31,8 @@ public class UpdatePlanDialog(
         var hasActiveJob = _jobService.GetJobs().Any(j =>
             j.Type == Constants.JobTypes.UpdatePlan &&
             j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
-            j.Args.Length > 0 &&
-            j.Args[0].Equals(_selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
+            j.TypedArgs?.PlanFolder != null &&
+            j.TypedArgs.PlanFolder.Equals(_selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
 
         return new Dialog(
             _ =>
@@ -76,7 +76,7 @@ public class UpdatePlanDialog(
                         _planService.SavePlan(_selectedPlan.FolderName, currentContent + "\n\n" + comments + "\n");
 
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
-                        _jobService.StartJob(Constants.JobTypes.UpdatePlan, _selectedPlan.FolderPath);
+                        _jobService.StartJob(Constants.JobTypes.UpdatePlan, new UpdatePlanArgs(_selectedPlan.FolderPath));
                         _refreshPlans();
                         _updateText.Set("");
                         isCreating.Set(false);

--- a/src/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -166,7 +166,7 @@ public class PullRequestApp : ViewBase
                 (description, projects, priority) =>
                 {
                     var project = string.Join(",", projects);
-                    jobService.StartJob(Constants.JobTypes.CreatePlan, "-Description", description, "-Project", project, "-Priority", priority.ToString());
+                    jobService.StartJob(Constants.JobTypes.CreatePlan, new CreatePlanArgs(description, project, priority));
                 },
                 () =>
                 {

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -52,8 +52,7 @@ public class ContentView(
                      | new Button("Accept").Icon(Icons.Check).Primary().ShortcutKey("a").OnClick(() =>
                      {
                          planService.UpdateRecommendationState(selectedRecommendation.PlanFolderName, selectedRecommendation.Title, "Accepted");
-                         jobService.StartJob(Constants.JobTypes.CreatePlan, "-Description", selectedRecommendation.Description, "-Project",
-                             selectedRecommendation.Project);
+                         jobService.StartJob(Constants.JobTypes.CreatePlan, new CreatePlanArgs(selectedRecommendation.Description, selectedRecommendation.Project));
                          client.Toast($"Started CreatePlan: {selectedRecommendation.Title}", "Recommendation Accepted");
                          refresh();
                          GoToNext();
@@ -142,7 +141,7 @@ public class ContentView(
             {
                 var description = $"[ORIGINAL RECOMMENDATION]\n{selectedRecommendation.Description}\n\n[NOTES]\n{notes}";
                 planService.UpdateRecommendationState(selectedRecommendation.PlanFolderName, selectedRecommendation.Title, "AcceptedWithNotes");
-                jobService.StartJob(Constants.JobTypes.CreatePlan, "-Description", description, "-Project", selectedRecommendation.Project);
+                jobService.StartJob(Constants.JobTypes.CreatePlan, new CreatePlanArgs(description, selectedRecommendation.Project));
                 client.Toast($"Started CreatePlan: {selectedRecommendation.Title}", "Recommendation Accepted with Notes");
                 refresh();
                 GoToNext();

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -226,7 +226,7 @@ public class ContentView(
 
             if (allYolo)
             {
-                jobService.StartJob(Constants.JobTypes.CreatePr, selectedPlan.FolderPath);
+                jobService.StartJob(Constants.JobTypes.CreatePr, new CreatePrArgs(selectedPlan.FolderPath));
                 planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
                 refreshPlans();
             }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -99,7 +99,7 @@ public class CustomPrDialog(
                             .Build();
                         var optionsPath = Path.Combine(_selectedPlan.FolderPath, ".custom-pr-options.yaml");
                         FileHelper.WriteAllText(optionsPath, serializer.Serialize(options));
-                        _jobService.StartJob(Constants.JobTypes.CreatePr, _selectedPlan.FolderPath);
+                        _jobService.StartJob(Constants.JobTypes.CreatePr, new CreatePrArgs(_selectedPlan.FolderPath));
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
                         _refreshPlans();
                         isCreating.Set(false);

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
@@ -53,8 +53,7 @@ public class RerunDialog(
                         Task.Run(() =>
                         {
                             CleanPlanState(folderPath, logger);
-                            _jobService.StartJob(Constants.JobTypes.ExecutePlan, folderPath, "-Note",
-                                "User requested a clean rerun. All artifacts, logs, and worktrees have been cleaned. Execute this plan from scratch.");
+                            _jobService.StartJob(Constants.JobTypes.ExecutePlan, new ExecutePlanArgs(folderPath, Note: "User requested a clean rerun. All artifacts, logs, and worktrees have been cleaned. Execute this plan from scratch."));
                         });
                     }
                 }),
@@ -65,8 +64,7 @@ public class RerunDialog(
                         isRerunningCurrent.Set(true);
                         _dialogOpen.Set(false);
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
-                        _jobService.StartJob(Constants.JobTypes.ExecutePlan, _selectedPlan.FolderPath, "-Note",
-                            "User requested you to execute this plan another time. Go through all code, verifications and artifacts one more time.");
+                        _jobService.StartJob(Constants.JobTypes.ExecutePlan, new ExecutePlanArgs(_selectedPlan.FolderPath, Note: "User requested you to execute this plan another time. Go through all code, verifications and artifacts one more time."));
                         _refreshPlans();
                     }
                 })

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
@@ -57,7 +57,7 @@ public class SuggestChangesDialog(
                         _planService.SavePlan(_selectedPlan.FolderName, currentContent + "\n\n" + comments + "\n");
 
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
-                        _jobService.StartJob(Constants.JobTypes.UpdatePlan, _selectedPlan.FolderPath);
+                        _jobService.StartJob(Constants.JobTypes.UpdatePlan, new UpdatePlanArgs(_selectedPlan.FolderPath));
                         _refreshPlans();
                         isCreating.Set(false);
                         _suggestText.Set("");

--- a/src/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/Ivy.Tendril/Apps/TrashApp.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Trash;
 using Ivy.Tendril.Apps.Trash.Dialogs;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Views;
@@ -85,8 +86,7 @@ public class TrashApp : ViewBase
                                 if (!string.IsNullOrEmpty(selected.OriginalRequest))
                                 {
                                     var project = string.IsNullOrEmpty(selected.Project) ? "Auto" : selected.Project;
-                                    jobService.StartJob(Constants.JobTypes.CreatePlan, "-Description",
-                                        selected.OriginalRequest, "-Project", project, "-Force");
+                                    jobService.StartJob(Constants.JobTypes.CreatePlan, new CreatePlanArgs(selected.OriginalRequest, project, Force: true));
                                     client.Toast("CreatePlan job started", "Force Plan");
                                 }
                             });

--- a/src/Ivy.Tendril/Controllers/InboxController.cs
+++ b/src/Ivy.Tendril/Controllers/InboxController.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Ivy.Tendril.Controllers;
@@ -17,11 +18,8 @@ public class InboxController(IJobService jobService) : ControllerBase
         try
         {
             var project = request.Project ?? "Auto";
-            var args = new List<string> { "-Description", request.Description, "-Project", project };
-            if (!string.IsNullOrEmpty(request.SourcePath))
-                args.AddRange(["-SourcePath", request.SourcePath]);
-
-            var jobId = jobService.StartJob(Constants.JobTypes.CreatePlan, args.ToArray(), null);
+            var args = new CreatePlanArgs(request.Description, project, SourcePath: request.SourcePath);
+            var jobId = jobService.StartJob(Constants.JobTypes.CreatePlan, args);
             return Ok(new { jobId, status = "Started", message = "Plan creation job started successfully" });
         }
         catch (Exception ex)

--- a/src/Ivy.Tendril/Database/Migrations/Migration_011_JobsTypedArgs.cs
+++ b/src/Ivy.Tendril/Database/Migrations/Migration_011_JobsTypedArgs.cs
@@ -1,0 +1,21 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Database.Migrations;
+
+public class Migration_011_JobsTypedArgs : IMigration
+{
+    public int Version => 11;
+    public string Description => "Add TypedArgs column to Jobs table";
+
+    public void Apply(SqliteConnection connection, ILogger? logger = null)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "ALTER TABLE Jobs ADD COLUMN TypedArgs TEXT;";
+        cmd.ExecuteNonQuery();
+
+        using var setVersionCmd = connection.CreateCommand();
+        setVersionCmd.CommandText = "PRAGMA user_version = 11;";
+        setVersionCmd.ExecuteNonQuery();
+    }
+}

--- a/src/Ivy.Tendril/Hooks/UseStartJob.cs
+++ b/src/Ivy.Tendril/Hooks/UseStartJob.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Hooks;
 
@@ -11,13 +12,13 @@ public static class UseStartJobExtensions
     /// </summary>
     /// <param name="context">The view context</param>
     /// <returns>A tuple containing the startJob action and isStarting flag</returns>
-    public static (Action<string, string[]> StartJob, bool IsStarting) UseStartJob(
+    public static (Action<string, JobArgsBase> StartJob, bool IsStarting) UseStartJob(
         this IViewContext context)
     {
         var jobService = context.UseService<IJobService>();
         var isStarting = context.UseState(false);
 
-        Action<string, string[]> startJob = (type, args) =>
+        Action<string, JobArgsBase> startJob = (type, args) =>
         {
             if (!isStarting.Value)
             {

--- a/src/Ivy.Tendril/Models/JobArgs.cs
+++ b/src/Ivy.Tendril/Models/JobArgs.cs
@@ -1,0 +1,105 @@
+using System.Text.Json.Serialization;
+
+namespace Ivy.Tendril.Models;
+
+[JsonDerivedType(typeof(CreatePlanArgs), "CreatePlan")]
+[JsonDerivedType(typeof(ExecutePlanArgs), "ExecutePlan")]
+[JsonDerivedType(typeof(ExpandPlanArgs), "ExpandPlan")]
+[JsonDerivedType(typeof(UpdatePlanArgs), "UpdatePlan")]
+[JsonDerivedType(typeof(SplitPlanArgs), "SplitPlan")]
+[JsonDerivedType(typeof(CreatePrArgs), "CreatePr")]
+[JsonDerivedType(typeof(CreateIssueArgs), "CreateIssue")]
+[JsonDerivedType(typeof(UpdateProjectArgs), "UpdateProject")]
+public abstract record JobArgsBase
+{
+    public virtual string? PlanFolder => null;
+    internal static JobArgsBase? FromLegacy(string type, string[] args)
+    {
+        if (args.Length == 0) return null;
+
+        return type switch
+        {
+            Constants.JobTypes.CreatePlan => new CreatePlanArgs(
+                GetNamedArg(args, "-Description") ?? string.Join(" ", args),
+                GetNamedArg(args, "-Project") ?? "Auto",
+                int.TryParse(GetNamedArg(args, "-Priority"), out var p) ? p : 0,
+                args.Contains("-Force", StringComparer.OrdinalIgnoreCase),
+                GetNamedArg(args, "-SourcePath")),
+            Constants.JobTypes.ExecutePlan => new ExecutePlanArgs(args[0], GetNamedArg(args, "-Note")),
+            Constants.JobTypes.ExpandPlan => new ExpandPlanArgs(args[0]),
+            Constants.JobTypes.UpdatePlan => new UpdatePlanArgs(args[0]),
+            Constants.JobTypes.SplitPlan => new SplitPlanArgs(args[0]),
+            Constants.JobTypes.CreatePr => new CreatePrArgs(args[0]),
+            Constants.JobTypes.CreateIssue => new CreateIssueArgs(
+                args[0],
+                GetNamedArg(args, "-Repo") ?? "",
+                GetNamedArg(args, "-Assignee"),
+                GetNamedArg(args, "-Comment"),
+                GetNamedArg(args, "-Labels")),
+            Constants.JobTypes.UpdateProject => new UpdateProjectArgs(args[0]),
+            _ => null
+        };
+    }
+
+    private static string? GetNamedArg(string[] args, string name)
+    {
+        for (var i = 0; i < args.Length - 1; i++)
+            if (args[i].Equals(name, StringComparison.OrdinalIgnoreCase))
+                return args[i + 1];
+        return null;
+    }
+}
+
+public record CreatePlanArgs(
+    string Description,
+    string Project,
+    int Priority = 0,
+    bool Force = false,
+    string? SourcePath = null) : JobArgsBase;
+
+public record ExecutePlanArgs(
+    string FolderPath,
+    string? Note = null) : JobArgsBase
+{
+    public override string PlanFolder => FolderPath;
+}
+
+public record ExpandPlanArgs(
+    string FolderPath) : JobArgsBase
+{
+    public override string PlanFolder => FolderPath;
+}
+
+public record UpdatePlanArgs(
+    string FolderPath) : JobArgsBase
+{
+    public override string PlanFolder => FolderPath;
+}
+
+public record SplitPlanArgs(
+    string FolderPath) : JobArgsBase
+{
+    public override string PlanFolder => FolderPath;
+}
+
+public record CreatePrArgs(
+    string FolderPath) : JobArgsBase
+{
+    public override string PlanFolder => FolderPath;
+}
+
+public record CreateIssueArgs(
+    string FolderPath,
+    string Repo,
+    string? Assignee = null,
+    string? Comment = null,
+    string? Labels = null) : JobArgsBase
+{
+    public override string PlanFolder => FolderPath;
+}
+
+public record UpdateProjectArgs(
+    string FolderPath) : JobArgsBase
+{
+    public override string PlanFolder => FolderPath;
+}

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -40,7 +40,7 @@ public record JobItem
     public DateTime? StartedAt { get; set; }
     public DateTime? CompletedAt { get; set; }
     public int? DurationSeconds { get; set; }
-    public string[] Args { get; init; } = [];
+    public JobArgsBase? TypedArgs { get; init; }
     public bool CancellationRequested { get; set; }
     public string? SessionId { get; set; }
     public string Provider { get; init; } = "claude";

--- a/src/Ivy.Tendril/Services/IJobService.cs
+++ b/src/Ivy.Tendril/Services/IJobService.cs
@@ -10,8 +10,7 @@ public interface IJobService : IDisposable
     event Action? JobPropertyChanged;    // Only properties changed (cost, tokens)
     event Action<JobNotification>? NotificationReady;
 
-    string StartJob(string type, string[] args, string? inboxFilePath);
-    string StartJob(string type, params string[] args);
+    string StartJob(string type, JobArgsBase args, string? inboxFilePath = null);
     void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false);
     void StopJob(string id);
     void DeleteJob(string id);

--- a/src/Ivy.Tendril/Services/InboxWatcherService.cs
+++ b/src/Ivy.Tendril/Services/InboxWatcherService.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
 using System.Collections.Concurrent;
 using System.Linq;
 using Ivy.Helpers;
@@ -191,10 +192,8 @@ public class InboxWatcherService : IInboxWatcherService
             return;
         }
 
-        var args = new List<string> { "-Description", description, "-Project", project };
-        if (!string.IsNullOrEmpty(sourcePath))
-            args.AddRange(["-SourcePath", sourcePath]);
-        _jobService.StartJob(Constants.JobTypes.CreatePlan, args.ToArray(), processingPath);
+        var args = new CreatePlanArgs(description, project, SourcePath: sourcePath);
+        _jobService.StartJob(Constants.JobTypes.CreatePlan, args, processingPath);
     }
 
     internal static (string project, string description, string? sourcePath) ParseContent(string content)

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -47,7 +47,7 @@ internal class JobCompletionHandler
         Action<JobItem> persistJob,
         Action<JobNotification> raiseNotification,
         Action raisePropertyChanged,
-        Func<string, string[], string> startJobSkipDepCheck)
+        Func<string, JobArgsBase, string> startJobSkipDepCheck)
     {
         var isSuccess = job.Status == JobStatus.Completed;
 
@@ -68,14 +68,14 @@ internal class JobCompletionHandler
 
         if (isSuccess && job.Type is Constants.JobTypes.ExecutePlan or Constants.JobTypes.CreatePr or Constants.JobTypes.CreateIssue)
         {
-            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            var planFolder = job.TypedArgs?.PlanFolder ?? "";
             RetryBlockedDependents(planFolder, jobs, startJobSkipDepCheck);
         }
     }
 
     private void RunAfterHooks(JobItem job)
     {
-        var planFolderForHooks = job.Args.Length > 0 ? job.Args[0] : "";
+        var planFolderForHooks = job.TypedArgs?.PlanFolder ?? "";
         RunHooks("after", job.Type, planFolderForHooks, job.Project, job);
     }
 
@@ -122,7 +122,7 @@ internal class JobCompletionHandler
     {
         if (isSuccess && job.Type == Constants.JobTypes.CreatePlan && job.Status == JobStatus.Completed)
         {
-            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            var planFolder = job.TypedArgs?.PlanFolder ?? "";
             var level = "NiceToHave";
             if (Directory.Exists(planFolder))
             {
@@ -156,7 +156,7 @@ internal class JobCompletionHandler
 
     private void NotifyPlanWatcher(JobItem job)
     {
-        var notifyFolder = job.Args.Length > 0 ? job.Args[0] : null;
+        var notifyFolder = job.TypedArgs?.PlanFolder;
         _planWatcherService?.NotifyChanged(Directory.Exists(notifyFolder) ? notifyFolder : null);
     }
 
@@ -171,7 +171,7 @@ internal class JobCompletionHandler
             return;
 
         var sessionId = job.SessionId;
-        var jobArgs = job.Args;
+        var jobPlanFolder = job.TypedArgs?.PlanFolder;
         var jobType = job.Type;
         var jobId = job.Id;
         var provider = job.Provider;
@@ -193,8 +193,8 @@ internal class JobCompletionHandler
                         raisePropertyChanged();
                     }
 
-                    if (jobArgs.Length > 0)
-                        PlanYamlHelper.LogCostToCsv(jobArgs[0], jobType, costCalc.TotalTokens, costCalc.TotalCost);
+                    if (jobPlanFolder != null)
+                        PlanYamlHelper.LogCostToCsv(jobPlanFolder, jobType, costCalc.TotalTokens, costCalc.TotalCost);
                 }
             }
             catch (Exception ex)
@@ -288,7 +288,7 @@ internal class JobCompletionHandler
 
     private void SyncPlanArtifacts(JobItem job)
     {
-        var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+        var planFolder = job.TypedArgs?.PlanFolder ?? "";
         if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder)) return;
 
         try
@@ -522,7 +522,7 @@ internal class JobCompletionHandler
     {
         try
         {
-            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            var planFolder = job.TypedArgs?.PlanFolder ?? "";
             var planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
             if (planYaml == null) return;
 
@@ -549,7 +549,7 @@ internal class JobCompletionHandler
     {
         try
         {
-            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            var planFolder = job.TypedArgs?.PlanFolder ?? "";
 
             _logger.LogDebug("SetPlanState: Setting {PlanFolder} to {State} for job {JobId}",
                 Path.GetFileName(planFolder), state, job.Id);
@@ -642,7 +642,7 @@ internal class JobCompletionHandler
         {
             if (job.Type is Constants.JobTypes.CreatePlan or Constants.JobTypes.CreatePr or Constants.JobTypes.CreateIssue) return;
 
-            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            var planFolder = job.TypedArgs?.PlanFolder ?? "";
             var newState = job.Type == Constants.JobTypes.ExecutePlan ? "Failed" : "Draft";
             PlanYamlHelper.SetPlanStateByFolder(planFolder, newState);
         }
@@ -656,7 +656,7 @@ internal class JobCompletionHandler
     {
         try
         {
-            var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+            var planFolder = job.TypedArgs?.PlanFolder ?? "";
             PlanYamlHelper.SetPlanStateByFolder(planFolder, "Blocked");
         }
         catch (Exception ex)
@@ -682,7 +682,7 @@ internal class JobCompletionHandler
     {
         if (job.Type != Constants.JobTypes.ExecutePlan) return;
 
-        var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+        var planFolder = job.TypedArgs?.PlanFolder ?? "";
         if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder)) return;
 
         var worktreesDir = Path.Combine(planFolder, "worktrees");
@@ -769,13 +769,13 @@ internal class JobCompletionHandler
     internal void HandleRetryBlockedJobs(
         ConcurrentDictionary<string, JobItem> jobs,
         Action<JobNotification> raiseNotification,
-        Func<string, string[], string> startJobSkipDepCheck)
+        Func<string, JobArgsBase, string> startJobSkipDepCheck)
         => RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
 
     private void RetryBlockedJobs(
         ConcurrentDictionary<string, JobItem> jobs,
         Action<JobNotification> raiseNotification,
-        Func<string, string[], string> startJobSkipDepCheck)
+        Func<string, JobArgsBase, string> startJobSkipDepCheck)
     {
         var blockedJobs = jobs.Values
             .Where(j => j.Status == JobStatus.Blocked && j.Type == Constants.JobTypes.ExecutePlan)
@@ -783,7 +783,7 @@ internal class JobCompletionHandler
 
         foreach (var blockedJob in blockedJobs)
         {
-            var planFolder = blockedJob.Args.Length > 0 ? blockedJob.Args[0] : "";
+            var planFolder = blockedJob.TypedArgs?.PlanFolder ?? "";
             if (string.IsNullOrEmpty(planFolder)) continue;
 
             var (ok, _) = CheckDependencies(planFolder);
@@ -794,7 +794,7 @@ internal class JobCompletionHandler
             if (!jobs.TryRemove(blockedJob.Id, out _)) continue;
 
             PlanYamlHelper.SetPlanStateByFolder(planFolder, "Building");
-            startJobSkipDepCheck(blockedJob.Type, blockedJob.Args);
+            startJobSkipDepCheck(blockedJob.Type, blockedJob.TypedArgs!);
 
             raiseNotification(new JobNotification(
                 "Job Unblocked",
@@ -806,7 +806,7 @@ internal class JobCompletionHandler
     private void RetryBlockedDependents(
         string completedPlanFolder,
         ConcurrentDictionary<string, JobItem> jobs,
-        Func<string, string[], string> startJobSkipDepCheck)
+        Func<string, JobArgsBase, string> startJobSkipDepCheck)
     {
         try
         {
@@ -824,15 +824,15 @@ internal class JobCompletionHandler
                 var hasExistingJob = jobs.Values.Any(j =>
                     j.Type == Constants.JobTypes.ExecutePlan &&
                     j.Status is JobStatus.Blocked or JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
-                    j.Args.Length > 0 &&
-                    j.Args[0].Equals(dir, StringComparison.OrdinalIgnoreCase));
+                    j.TypedArgs?.PlanFolder != null &&
+                    j.TypedArgs.PlanFolder.Equals(dir, StringComparison.OrdinalIgnoreCase));
                 if (hasExistingJob) continue;
 
                 var (allMet, _) = CheckDependencies(dir);
                 if (allMet)
                 {
                     PlanYamlHelper.SetPlanStateByFolder(dir, "Building");
-                    startJobSkipDepCheck(Constants.JobTypes.ExecutePlan, new[] { dir });
+                    startJobSkipDepCheck(Constants.JobTypes.ExecutePlan, new ExecutePlanArgs(dir));
                 }
             }
         }
@@ -849,9 +849,10 @@ internal class JobCompletionHandler
         {
             if (j.Type != Constants.JobTypes.ExecutePlan) return false;
             if (j.Status is not (JobStatus.Running or JobStatus.Queued or JobStatus.Pending)) return false;
-            if (j.Args.Length == 0) return false;
 
-            var otherFolder = j.Args[0];
+            var otherFolder = j.TypedArgs?.PlanFolder;
+            if (otherFolder == null) return false;
+
             if (otherFolder.Equals(planFolder, StringComparison.OrdinalIgnoreCase))
                 return true;
 
@@ -869,7 +870,7 @@ internal class JobCompletionHandler
     private string? ResolvePlanFolder(JobItem job)
     {
         if (job.Type != Constants.JobTypes.CreatePlan)
-            return job.Args.Length > 0 ? job.Args[0] : null;
+            return job.TypedArgs?.PlanFolder;
 
         var planId = job.ReportedPlanId ?? job.AllocatedPlanId;
         if (string.IsNullOrEmpty(planId)) return null;
@@ -956,7 +957,7 @@ internal class JobCompletionHandler
         if (job.Status is not JobStatus.Failed and not JobStatus.Timeout || job.OutputLines.Count == 0)
             return;
 
-        var planFolder = job.Args.Length > 0 ? job.Args[0] : null;
+        var planFolder = job.TypedArgs?.PlanFolder;
 
         if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder))
         {
@@ -980,7 +981,7 @@ internal class JobCompletionHandler
         if (job.Type != Constants.JobTypes.ExecutePlan)
             return "";
 
-        var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+        var planFolder = job.TypedArgs?.PlanFolder ?? "";
         if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder))
             return "";
 

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -68,17 +68,16 @@ internal class JobLauncher
     {
         var job = ctx.Job;
         var type = job.Type;
-        var args = job.Args;
 
         job.Status = JobStatus.Running;
         job.StartedAt = DateTime.UtcNow;
         job.StatusMessage = null;
 
-        var planFolderForHooks = type != Constants.JobTypes.CreatePlan && args.Length > 0 ? args[0] : "";
+        var planFolderForHooks = type != Constants.JobTypes.CreatePlan ? (job.TypedArgs?.PlanFolder ?? "") : "";
         ctx.RunHooks("before", type, planFolderForHooks, job.Project, job);
 
-        if (type == Constants.JobTypes.ExecutePlan && args.Length > 0)
-            PlanYamlHelper.SetPlanStateByFolder(args[0], "Executing");
+        if (type == Constants.JobTypes.ExecutePlan && !string.IsNullOrEmpty(job.TypedArgs?.PlanFolder))
+            PlanYamlHelper.SetPlanStateByFolder(job.TypedArgs!.PlanFolder!, "Executing");
 
         job.SessionId = Guid.NewGuid().ToString();
     }
@@ -477,18 +476,19 @@ internal class JobLauncher
     private void BuildCreatePlanFirmware(JobLaunchContext ctx, Dictionary<string, string> values)
     {
         var job = ctx.Job;
-        var description = PlanYamlHelper.GetNamedArg(job.Args, "-Description") ?? string.Join(" ", job.Args);
+        var cp = job.TypedArgs as CreatePlanArgs;
+        var description = cp?.Description ?? "";
         values["Args"] = description;
         values["PlansDirectory"] = _configService!.PlanFolder;
 
-        if (job.Args.Contains("-Force", StringComparer.OrdinalIgnoreCase))
+        if (cp?.Force == true)
             values["Force"] = "true";
     }
 
     private (Dictionary<string, string> Values, PlanYaml? PlanYaml, string? ProfileOverride)
         BuildNonCreatePlanFirmware(JobItem job, Dictionary<string, string> values)
     {
-        var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+        var planFolder = job.TypedArgs?.PlanFolder ?? "";
         values["Args"] = planFolder;
 
         if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder))

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -107,14 +107,9 @@ public class JobService : IJobService
     public event Action? JobPropertyChanged;
     public event Action<JobNotification>? NotificationReady;
 
-    public string StartJob(string type, string[] args, string? inboxFilePath)
+    public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
     {
         return StartJobInternal(type, args, inboxFilePath);
-    }
-
-    public string StartJob(string type, params string[] args)
-    {
-        return StartJobInternal(type, args, null);
     }
 
     public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false)
@@ -368,12 +363,12 @@ public class JobService : IJobService
             NotificationReady?.Invoke(notification);
     }
 
-    private string StartJobSkipDepCheck(string type, params string[] args)
+    private string StartJobSkipDepCheck(string type, JobArgsBase args)
     {
         return StartJobInternal(type, args, inboxFilePath: null, skipDependencyCheck: true);
     }
 
-    private string StartJobInternal(string type, string[] args, string? inboxFilePath, bool skipDependencyCheck = false)
+    private string StartJobInternal(string type, JobArgsBase args, string? inboxFilePath, bool skipDependencyCheck = false)
     {
         var id = $"job-{Interlocked.Increment(ref _counter):D3}";
         var job = BuildJobItem(id, type, args, inboxFilePath);
@@ -402,7 +397,7 @@ public class JobService : IJobService
         return id;
     }
 
-    private JobItem BuildJobItem(string id, string type, string[] args, string? inboxFilePath)
+    private JobItem BuildJobItem(string id, string type, JobArgsBase args, string? inboxFilePath)
     {
         var (planFile, project, priority) = ExtractJobMetadata(type, args);
 
@@ -413,7 +408,7 @@ public class JobService : IJobService
             PlanFile = planFile,
             Project = project,
             Status = JobStatus.Pending,
-            Args = args,
+            TypedArgs = args,
             Provider = _configService?.Settings.CodingAgent ?? "claude",
             Priority = priority
         };
@@ -424,19 +419,15 @@ public class JobService : IJobService
         return job;
     }
 
-    private static (string PlanFile, string Project, int Priority) ExtractJobMetadata(string type, string[] args)
+    private static (string PlanFile, string Project, int Priority) ExtractJobMetadata(string type, JobArgsBase args)
     {
-        if (type == Constants.JobTypes.CreatePlan)
+        if (args is CreatePlanArgs cp)
         {
-            var planFile = GetNamedArg(args, "-Description") is { Length: > 0 } desc
-                ? desc.Length > 50 ? desc[..50] + "..." : desc
-                : "New Plan";
-            var project = GetNamedArg(args, "-Project") ?? "Auto";
-            int.TryParse(GetNamedArg(args, "-Priority"), out var priority);
-            return (planFile, project, priority);
+            var planFile = cp.Description.Length > 50 ? cp.Description[..50] + "..." : cp.Description;
+            return (planFile, cp.Project, cp.Priority);
         }
 
-        var folder = args.Length > 0 ? args[0] : "";
+        var folder = args.PlanFolder ?? "";
         var file = Path.GetFileName(folder);
         if (!Directory.Exists(folder))
             return (file, "Auto", 0);
@@ -447,7 +438,7 @@ public class JobService : IJobService
             : (file, "Auto", 0);
     }
 
-    private void SetupInboxTracking(JobItem job, string id, string[] args, string? inboxFilePath)
+    private void SetupInboxTracking(JobItem job, string id, JobArgsBase args, string? inboxFilePath)
     {
         if (inboxFilePath != null)
         {
@@ -458,8 +449,9 @@ public class JobService : IJobService
             try
             {
                 FileHelper.EnsureDirectory(_inboxPath);
-                var description = GetNamedArg(args, "-Description") ?? "New Plan";
-                var inboxProject = GetNamedArg(args, "-Project") ?? "Auto";
+                var cp = args as CreatePlanArgs;
+                var description = cp?.Description ?? "New Plan";
+                var inboxProject = cp?.Project ?? "Auto";
                 var pendingFile = Path.Combine(_inboxPath, $"pending-{id}.md.processing");
                 var content = $"---\nproject: {inboxProject}\n---\n{description}";
                 FileHelper.WriteAllText(pendingFile, content);
@@ -474,12 +466,12 @@ public class JobService : IJobService
         if (job.Type is not (Constants.JobTypes.ExecutePlan or Constants.JobTypes.UpdatePlan or Constants.JobTypes.ExpandPlan or Constants.JobTypes.SplitPlan))
             return false;
 
-        var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+        var planFolder = job.TypedArgs?.PlanFolder ?? "";
         var conflictingJob = _jobs.Values.FirstOrDefault(j =>
             j.Type == job.Type &&
             j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
-            j.Args.Length > 0 &&
-            j.Args[0].Equals(planFolder, StringComparison.OrdinalIgnoreCase));
+            !string.IsNullOrEmpty(j.TypedArgs?.PlanFolder) &&
+            j.TypedArgs!.PlanFolder!.Equals(planFolder, StringComparison.OrdinalIgnoreCase));
 
         if (conflictingJob == null)
             return false;
@@ -502,7 +494,7 @@ public class JobService : IJobService
         if (job.Type != Constants.JobTypes.ExecutePlan || skipDependencyCheck)
             return false;
 
-        var planFolder = job.Args.Length > 0 ? job.Args[0] : "";
+        var planFolder = job.TypedArgs?.PlanFolder ?? "";
         var (ok, blockReason) = CheckDependencies(planFolder);
         if (ok)
             return false;
@@ -531,7 +523,7 @@ public class JobService : IJobService
             PlanFile = args.Length > 0 ? args[0] : type,
             Status = JobStatus.Running,
             StartedAt = DateTime.UtcNow,
-            Args = args,
+            TypedArgs = JobArgsBase.FromLegacy(type, args),
             TimeoutCts = new CancellationTokenSource()
         };
         _jobs[id] = job;
@@ -646,8 +638,6 @@ public class JobService : IJobService
     internal static void SetPlanStateByFolder(string planFolder, string state)
         => PlanYamlHelper.SetPlanStateByFolder(planFolder, state);
 
-    private static string? GetNamedArg(string[] args, string name)
-        => PlanYamlHelper.GetNamedArg(args, name);
 
     private (bool Ok, string? BlockReason) CheckDependencies(string planFolder)
         => _completionHandler.CheckDependencies(planFolder);

--- a/src/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -644,8 +644,8 @@ public class PlanDatabaseService : IPlanDatabaseService
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
-                              INSERT OR REPLACE INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, SessionId, StartedAt, CompletedAt, DurationSeconds, Cost, Tokens, StatusMessage, Args)
-                              VALUES (@id, @type, @planFile, @project, @status, @provider, @sessionId, @startedAt, @completedAt, @durationSeconds, @cost, @tokens, @statusMessage, @args)
+                              INSERT OR REPLACE INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, SessionId, StartedAt, CompletedAt, DurationSeconds, Cost, Tokens, StatusMessage, Args, TypedArgs)
+                              VALUES (@id, @type, @planFile, @project, @status, @provider, @sessionId, @startedAt, @completedAt, @durationSeconds, @cost, @tokens, @statusMessage, @args, @typedArgs)
                               """;
             cmd.Parameters.AddWithValue("@id", job.Id);
             cmd.Parameters.AddWithValue("@type", job.Type);
@@ -662,7 +662,10 @@ public class PlanDatabaseService : IPlanDatabaseService
             cmd.Parameters.AddWithValue("@cost", job.Cost.HasValue ? (double)job.Cost.Value : DBNull.Value);
             cmd.Parameters.AddWithValue("@tokens", (object?)job.Tokens ?? DBNull.Value);
             cmd.Parameters.AddWithValue("@statusMessage", (object?)job.StatusMessage ?? DBNull.Value);
-            cmd.Parameters.AddWithValue("@args", job.Args.Length > 0 ? JsonSerializer.Serialize(job.Args) : (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@args", DBNull.Value);
+            cmd.Parameters.AddWithValue("@typedArgs", job.TypedArgs != null
+                ? JsonSerializer.Serialize<JobArgsBase>(job.TypedArgs)
+                : DBNull.Value);
             cmd.ExecuteNonQuery();
         }
     }
@@ -703,9 +706,7 @@ public class PlanDatabaseService : IPlanDatabaseService
                     StatusMessage = reader.IsDBNull(reader.GetOrdinal("StatusMessage"))
                         ? null
                         : reader.GetString(reader.GetOrdinal("StatusMessage")),
-                    Args = reader.IsDBNull(reader.GetOrdinal("Args"))
-                        ? []
-                        : JsonSerializer.Deserialize<string[]>(reader.GetString(reader.GetOrdinal("Args"))) ?? []
+                    TypedArgs = ReadTypedArgs(reader)
                 },
                 new SqliteParameter("@limit", limit));
         }
@@ -848,6 +849,24 @@ public class PlanDatabaseService : IPlanDatabaseService
     /// <summary>
     /// Executes a query and maps each row to T using the provided mapper function. Must be called within a lock.
     /// </summary>
+    private static JobArgsBase? ReadTypedArgs(SqliteDataReader reader)
+    {
+        var typedOrd = reader.GetOrdinal("TypedArgs");
+        if (!reader.IsDBNull(typedOrd))
+        {
+            var json = reader.GetString(typedOrd);
+            return JsonSerializer.Deserialize<JobArgsBase>(json);
+        }
+
+        // Legacy fallback: parse old Args column
+        var argsOrd = reader.GetOrdinal("Args");
+        if (reader.IsDBNull(argsOrd)) return null;
+        var legacyArgs = JsonSerializer.Deserialize<string[]>(reader.GetString(argsOrd));
+        if (legacyArgs == null || legacyArgs.Length == 0) return null;
+        var type = reader.GetString(reader.GetOrdinal("Type"));
+        return JobArgsBase.FromLegacy(type, legacyArgs);
+    }
+
     private List<T> ReadList<T>(string sql, Func<SqliteDataReader, T> mapper, params SqliteParameter[] parameters)
     {
         using var cmd = _connection.CreateCommand();

--- a/src/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs
+++ b/src/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps;
 using Ivy.Tendril.Apps.Plans.Dialogs;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
 
@@ -36,7 +37,7 @@ public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : View
                     {
                         lastSelectedProjects.Set(projects);
                         var project = string.Join(",", projects);
-                        jobService.StartJob(Constants.JobTypes.CreatePlan, "-Description", description, "-Project", project, "-Priority", priority.ToString(), "-Force");
+                        jobService.StartJob(Constants.JobTypes.CreatePlan, new CreatePlanArgs(description, project, priority, Force: true));
                     },
                     () => dialogOpen.Set(false),
                     lastSelectedProjects.Value


### PR DESCRIPTION
## Summary
- Replace legacy PowerShell-style `params string[]` args with strongly-typed POCO records per promptware type
- Each promptware gets its own record: `CreatePlanArgs`, `ExecutePlanArgs`, `ExpandPlanArgs`, `UpdatePlanArgs`, `SplitPlanArgs`, `CreatePrArgs`, `CreateIssueArgs`, `UpdateProjectArgs`
- Add SQLite migration (v11) for `TypedArgs` column with backward-compat shim via `JobArgsBase.FromLegacy()`

## Test plan
- [x] `dotnet build --warnaserror` passes (0 errors, 0 warnings)
- [x] All 1410 tests pass
- [x] Old persisted jobs load correctly via the compat shim