### PR TITLE
Move CustomPr options from sidecar YAML into CreatePrArgs

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -2,8 +2,6 @@ using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 
 namespace Ivy.Tendril.Apps.Review.Dialogs;
 
@@ -85,21 +83,14 @@ public class CustomPrDialog(
                     if (!isCreating.Value)
                     {
                         isCreating.Set(true);
-                        var options = new Dictionary<string, object>
-                        {
-                            ["merge"] = customPrMerge.Value,
-                            ["deleteBranch"] = customPrDeleteBranch.Value && customPrMerge.Value,
-                            ["includeArtifacts"] = customPrIncludeArtifacts.Value,
-                            ["assignee"] = customPrAssignee.Value ?? "",
-                            ["comment"] = customPrComment.Value,
-                            ["draft"] = customPrDraft.Value
-                        };
-                        var serializer = new SerializerBuilder()
-                            .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                            .Build();
-                        var optionsPath = Path.Combine(_selectedPlan.FolderPath, ".custom-pr-options.yaml");
-                        FileHelper.WriteAllText(optionsPath, serializer.Serialize(options));
-                        _jobService.StartJob(Constants.JobTypes.CreatePr, new CreatePrArgs(_selectedPlan.FolderPath));
+                        _jobService.StartJob(Constants.JobTypes.CreatePr, new CreatePrArgs(
+                            _selectedPlan.FolderPath,
+                            Merge: customPrMerge.Value,
+                            DeleteBranch: customPrDeleteBranch.Value && customPrMerge.Value,
+                            IncludeArtifacts: customPrIncludeArtifacts.Value,
+                            Assignee: customPrAssignee.Value,
+                            Comment: string.IsNullOrEmpty(customPrComment.Value) ? null : customPrComment.Value,
+                            Draft: customPrDraft.Value));
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
                         _refreshPlans();
                         isCreating.Set(false);

--- a/src/Ivy.Tendril/Models/JobArgs.cs
+++ b/src/Ivy.Tendril/Models/JobArgs.cs
@@ -83,7 +83,13 @@ public record SplitPlanArgs(
 }
 
 public record CreatePrArgs(
-    string FolderPath) : JobArgsBase
+    string FolderPath,
+    bool Merge = true,
+    bool DeleteBranch = true,
+    bool IncludeArtifacts = true,
+    string? Assignee = null,
+    string? Comment = null,
+    bool Draft = false) : JobArgsBase
 {
     public override string PlanFolder => FolderPath;
 }

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -34,16 +34,13 @@ Before processing, read `plan.yaml` and check the `state` field. After reading, 
 - Read `plan.yaml` from the plan folder (project, commits, repos)
 - Read the latest revision for the plan title and description
 - Find the `prRule` for each repo from the firmware header
-- **Check for custom options:** If `<PlanFolder>/.custom-pr-options.yaml` exists, read it. The file contains:
-  ```yaml
-  merge: true/false
-  deleteBranch: true/false
-  includeArtifacts: true/false
-  assignee: "username"
-  comment: "Review comment text"
-  draft: true/false
-  ```
-  These flags override the default behavior in subsequent steps. If the file does not exist, all flags default to the behavior defined by the repo's `prRule`. **Delete the file after reading** so it doesn't affect future runs.
+- **Check for custom options:** Read the following firmware header values (if present). These override the default behavior in subsequent steps. If not present, all flags default to the behavior defined by the repo's `prRule`.
+  - `PrMerge` — `true`/`false` (default: `true`)
+  - `PrDeleteBranch` — `true`/`false` (default: `true`)
+  - `PrIncludeArtifacts` — `true`/`false` (default: `true`)
+  - `PrAssignee` — GitHub username (default: none)
+  - `PrComment` — Review comment text (default: none)
+  - `PrDraft` — `true`/`false` (default: `false`)
 
 ### 2. For Each Worktree
 

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -514,6 +514,7 @@ internal class JobLauncher
 
         var profileOverride = ExtractExecutionProfile(job, planYaml);
         AddRepoConfigsIfNeeded(job, planYaml, values);
+        AddCreatePrOptions(job, values);
 
         return (values, planYaml, profileOverride);
     }
@@ -540,6 +541,21 @@ internal class JobLauncher
         var repoConfigs = BuildRepoConfigsYaml(planYaml, job.Project);
         if (!string.IsNullOrEmpty(repoConfigs))
             values["RepoConfigs"] = repoConfigs;
+    }
+
+    private static void AddCreatePrOptions(JobItem job, Dictionary<string, string> values)
+    {
+        if (job.Type != Constants.JobTypes.CreatePr || job.TypedArgs is not CreatePrArgs pr)
+            return;
+
+        values["PrMerge"] = pr.Merge.ToString().ToLowerInvariant();
+        values["PrDeleteBranch"] = pr.DeleteBranch.ToString().ToLowerInvariant();
+        values["PrIncludeArtifacts"] = pr.IncludeArtifacts.ToString().ToLowerInvariant();
+        values["PrDraft"] = pr.Draft.ToString().ToLowerInvariant();
+        if (!string.IsNullOrEmpty(pr.Assignee))
+            values["PrAssignee"] = pr.Assignee;
+        if (!string.IsNullOrEmpty(pr.Comment))
+            values["PrComment"] = pr.Comment;
     }
 
     private static Dictionary<string, string> BuildJobContext(JobItem job, Dictionary<string, string> firmwareValues, string programFolder)


### PR DESCRIPTION
## Summary
- Expand `CreatePrArgs` with Merge, DeleteBranch, IncludeArtifacts, Assignee, Comment, Draft fields
- `CustomPrDialog` passes options directly through typed args instead of writing `.custom-pr-options.yaml`
- `JobLauncher` injects them as firmware headers (`PrMerge`, `PrDeleteBranch`, etc.)
- Updated `CreatePr/Program.md` to read from firmware headers instead of the sidecar file

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] All 1410 tests pass
- [ ] Manual: create a custom PR and verify options are respected