### PR TITLE
Remove legacy string[] args support from JobService

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -30,7 +30,7 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void CompleteJob_ConcurrentCalls_OnlyFirstCompletes()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         var notificationCount = 0;
         service.NotificationReady += _ => Interlocked.Increment(ref notificationCount);
@@ -69,7 +69,7 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void StopJob_RacingWithCompleteJob_OnlyOneWins()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         var notificationCount = 0;
         service.NotificationReady += _ => Interlocked.Increment(ref notificationCount);
@@ -103,7 +103,7 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void CompleteJob_AfterStopJob_IsNoOp()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         service.StopJob(id);
         var job = service.GetJob(id);
@@ -121,7 +121,7 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void CompleteJob_StaleOutputDetected_SetsTimeoutWithStaleReason()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         var job = service.GetJob(id);
         Assert.NotNull(job);
@@ -139,7 +139,7 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void CompleteJob_CreatePlan_UpdatesPlanFileWhenOutputContainsPlanCreated()
     {
         var service = CreateServiceWithPlanReader(_tempDir.Path);
-        var id = service.CreateTestJob("CreatePlan", "-Description", "Fix login bug", "-Project", "Tendril");
+        var id = service.CreateTestJob("CreatePlan", new CreatePlanArgs("Fix login bug", "Tendril"));
 
         var job = service.GetJob(id);
         Assert.NotNull(job);
@@ -157,7 +157,7 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void CompleteJob_CreatePlan_LeavesPlanFileUnchangedOnDuplicate()
     {
         var service = CreateServiceWithPlanReader(_tempDir.Path);
-        var id = service.CreateTestJob("CreatePlan", "-Description", "Fix login bug", "-Project", "Tendril");
+        var id = service.CreateTestJob("CreatePlan", new CreatePlanArgs("Fix login bug", "Tendril"));
 
         var job = service.GetJob(id);
         Assert.NotNull(job);

--- a/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
@@ -96,8 +96,8 @@ public class JobServiceConcurrencyTests
         var jobService = new JobService(configService);
 
         // Create 2 test jobs that will run (consume the 2 slots)
-        var job1Id = jobService.CreateTestJob("ExecutePlan", "plan1");
-        var job2Id = jobService.CreateTestJob("ExecutePlan", "plan2");
+        var job1Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan1"));
+        var job2Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan2"));
 
         // Verify we can only have 2 running jobs
         Assert.Equal(JobStatus.Running, jobService.GetJob(job1Id)!.Status);
@@ -108,8 +108,8 @@ public class JobServiceConcurrencyTests
         configService.TriggerSettingsReloaded();
 
         // Assert: Should now be able to create 2 more running jobs
-        var job3Id = jobService.CreateTestJob("ExecutePlan", "plan3");
-        var job4Id = jobService.CreateTestJob("ExecutePlan", "plan4");
+        var job3Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan3"));
+        var job4Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan4"));
 
         Assert.Equal(JobStatus.Running, jobService.GetJob(job3Id)!.Status);
         Assert.Equal(JobStatus.Running, jobService.GetJob(job4Id)!.Status);
@@ -123,10 +123,10 @@ public class JobServiceConcurrencyTests
         var jobService = new JobService(configService);
 
         // Create 4 test jobs that will run
-        var job1Id = jobService.CreateTestJob("ExecutePlan", "plan1");
-        var job2Id = jobService.CreateTestJob("ExecutePlan", "plan2");
-        var job3Id = jobService.CreateTestJob("ExecutePlan", "plan3");
-        var job4Id = jobService.CreateTestJob("ExecutePlan", "plan4");
+        var job1Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan1"));
+        var job2Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan2"));
+        var job3Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan3"));
+        var job4Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan4"));
 
         // Act: Decrease max to 2
         configService.MaxConcurrentJobs = 2;
@@ -149,7 +149,7 @@ public class JobServiceConcurrencyTests
         jobService.CompleteJob(job3Id, 0);
 
         // Now we should have 1 available slot (1 running < limit of 2)
-        var job5Id = jobService.CreateTestJob("ExecutePlan", "plan5");
+        var job5Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan5"));
         Assert.Equal(JobStatus.Running, jobService.GetJob(job5Id)!.Status);
     }
 
@@ -160,7 +160,7 @@ public class JobServiceConcurrencyTests
         var configService = new TestConfigService { MaxConcurrentJobs = 5 };
         var jobService = new JobService(configService);
 
-        var job1Id = jobService.CreateTestJob("ExecutePlan", "plan1");
+        var job1Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan1"));
         Assert.Equal(JobStatus.Running, jobService.GetJob(job1Id)!.Status);
 
         // Act: Reload with same value
@@ -170,7 +170,7 @@ public class JobServiceConcurrencyTests
         Assert.Equal(JobStatus.Running, jobService.GetJob(job1Id)!.Status);
 
         // Can still create new test jobs
-        var job2Id = jobService.CreateTestJob("ExecutePlan", "plan2");
+        var job2Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan2"));
         Assert.Equal(JobStatus.Running, jobService.GetJob(job2Id)!.Status);
     }
 

--- a/src/Ivy.Tendril.Test/JobServiceConcurrentPlanModificationTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceConcurrentPlanModificationTests.cs
@@ -45,7 +45,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         // Start first UpdatePlan job (will be in Running state after CreateTestJob)
-        var firstJobId = service.CreateTestJob("UpdatePlan", _planFolder);
+        var firstJobId = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
         var firstJob = service.GetJob(firstJobId);
         Assert.NotNull(firstJob);
         Assert.Equal(JobStatus.Running, firstJob.Status);
@@ -68,7 +68,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 10);
 
-        _ = service.CreateTestJob("ExpandPlan", _planFolder);
+        _ = service.CreateTestJob("ExpandPlan", new ExpandPlanArgs(_planFolder));
         var secondJobId = service.StartJob("ExpandPlan", new ExpandPlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
@@ -84,7 +84,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 10);
 
-        _ = service.CreateTestJob("SplitPlan", _planFolder);
+        _ = service.CreateTestJob("SplitPlan", new SplitPlanArgs(_planFolder));
         var secondJobId = service.StartJob("SplitPlan", new SplitPlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
@@ -101,7 +101,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         // Start and complete first job
-        var firstJobId = service.CreateTestJob("UpdatePlan", _planFolder);
+        var firstJobId = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
         service.CompleteJob(firstJobId, 0);
         var firstJob = service.GetJob(firstJobId);
         Assert.NotNull(firstJob);
@@ -154,7 +154,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         // Create a job manually in Pending state
-        var firstJobId = service.CreateTestJob("UpdatePlan", _planFolder);
+        var firstJobId = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
         var firstJob = service.GetJob(firstJobId);
         Assert.NotNull(firstJob);
         firstJob.Status = JobStatus.Pending;
@@ -190,7 +190,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         // Start UpdatePlan for first plan
-        var firstJobId = service.CreateTestJob("UpdatePlan", _planFolder);
+        var firstJobId = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
         var firstJob = service.GetJob(firstJobId);
         Assert.NotNull(firstJob);
         Assert.Equal(JobStatus.Running, firstJob.Status);
@@ -220,7 +220,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         // Start UpdatePlan
-        _ = service.CreateTestJob("UpdatePlan", _planFolder);
+        _ = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
 
         // ExecutePlan should not be blocked by UpdatePlan (they're different job types)
         try
@@ -247,7 +247,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         // Start first ExecutePlan job
-        var firstJobId = service.CreateTestJob("ExecutePlan", _planFolder);
+        var firstJobId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_planFolder));
         var firstJob = service.GetJob(firstJobId);
         Assert.NotNull(firstJob);
         Assert.Equal(JobStatus.Running, firstJob.Status);
@@ -278,7 +278,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             service.NotificationReady += n => receivedNotification = n;
 
             // Start first job
-            _ = service.CreateTestJob("UpdatePlan", _planFolder);
+            _ = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
 
             // Try to start conflicting second job
             _ = service.StartJob("UpdatePlan", new UpdatePlanArgs(_planFolder));

--- a/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
@@ -256,7 +256,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         var service = CreateService();
 
         // Create a Running ExecutePlan job for planA (simulating an already active job)
-        var activeId = service.CreateTestJob("ExecutePlan", planA);
+        var activeId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planA));
         Assert.Equal(JobStatus.Running, service.GetJob(activeId)!.Status);
 
         // Trigger RetryBlockedDependents by completing a job for PlanB
@@ -282,7 +282,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         var service = CreateService();
 
         // Create a Blocked ExecutePlan job for planA (simulating StartJob that found unmet deps earlier)
-        var blockedId = service.CreateTestJob("ExecutePlan", planA);
+        var blockedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planA));
         service.GetJob(blockedId)!.Status = JobStatus.Blocked;
 
         // Trigger RetryBlockedDependents by completing a CreateIssue job for PlanB

--- a/src/Ivy.Tendril.Test/JobServiceEventSplitTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceEventSplitTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
@@ -14,7 +15,7 @@ public class JobServiceEventSplitTests
     public void CompleteJob_RaisesJobsStructureChanged()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         var structureChangedFired = false;
         var propertyChangedFired = false;
@@ -31,7 +32,7 @@ public class JobServiceEventSplitTests
     public void CompleteJob_AlsoRaisesJobsChanged_ForBackwardCompatibility()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         var jobsChangedFired = false;
         service.JobsChanged += () => jobsChangedFired = true;
@@ -45,7 +46,7 @@ public class JobServiceEventSplitTests
     public void DeleteJob_RaisesJobsStructureChanged()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
         service.CompleteJob(id, 0);
 
         var structureChangedFired = false;
@@ -63,7 +64,7 @@ public class JobServiceEventSplitTests
     public void StopJob_RaisesJobsStructureChanged()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         var structureChangedFired = false;
         var propertyChangedFired = false;
@@ -80,7 +81,7 @@ public class JobServiceEventSplitTests
     public void ClearCompletedJobs_RaisesJobsStructureChanged()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
         service.CompleteJob(id, 0);
 
         var structureChangedFired = false;
@@ -95,7 +96,7 @@ public class JobServiceEventSplitTests
     public void ClearFailedJobs_RaisesJobsStructureChanged()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
         service.CompleteJob(id, 1);
 
         var structureChangedFired = false;

--- a/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
@@ -112,7 +112,7 @@ public class JobServiceFailureReasonTests : IDisposable
     public void CompleteJob_NonZeroExitCode_PopulatesStatusMessage()
     {
         var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
-        var id = service.CreateTestJob("ExecutePlan", Path.GetTempPath());
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(Path.GetTempPath()));
         var job = service.GetJob(id)!;
         job.OutputLines.Enqueue("[stderr] something went wrong");
 

--- a/src/Ivy.Tendril.Test/JobServiceHookTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceHookTests.cs
@@ -334,7 +334,7 @@ public class JobServiceHookTests : IDisposable
         // Use the constructor that doesn't take ConfigService
         var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", Path.GetTempPath());
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(Path.GetTempPath()));
         var job = service.GetJob(id)!;
 
         // Should not throw, just silently skip hooks

--- a/src/Ivy.Tendril.Test/JobServiceJobsChangedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceJobsChangedTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
@@ -14,7 +15,7 @@ public class JobServiceJobsChangedTests
     public void CompleteJob_RaisesJobsChangedEvent()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         var fired = false;
         service.JobsChanged += () => fired = true;
@@ -27,7 +28,7 @@ public class JobServiceJobsChangedTests
     public void CompleteJob_Failure_RaisesJobsChangedEvent()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         var fired = false;
         service.JobsChanged += () => fired = true;
@@ -40,7 +41,7 @@ public class JobServiceJobsChangedTests
     public void StopJob_RaisesJobsChangedEvent()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         var fired = false;
         service.JobsChanged += () => fired = true;

--- a/src/Ivy.Tendril.Test/JobServiceNotificationTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceNotificationTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
@@ -21,7 +22,7 @@ public class JobServiceNotificationTests : IDisposable
     public void CompleteJob_Success_NotificationTitleIncludesJobType()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("CreatePr", _tempDir.Path);
+        var id = service.CreateTestJob("CreatePr", new CreatePrArgs(_tempDir.Path));
 
         JobNotification? notification = null;
         service.NotificationReady += n => notification = n;
@@ -36,7 +37,7 @@ public class JobServiceNotificationTests : IDisposable
     public void CompleteJob_Failure_NotificationTitleIncludesJobType()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
 
         JobNotification? notification = null;
         service.NotificationReady += n => notification = n;
@@ -51,7 +52,7 @@ public class JobServiceNotificationTests : IDisposable
     public void CompleteJob_Timeout_NotificationTitleIncludesJobType()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExpandPlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExpandPlan", new ExpandPlanArgs(_tempDir.Path));
 
         JobNotification? notification = null;
         service.NotificationReady += n => notification = n;

--- a/src/Ivy.Tendril.Test/JobServiceResourceDisposalTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceResourceDisposalTests.cs
@@ -58,7 +58,7 @@ public class JobServiceResourceDisposalTests
     public void CompleteJob_DisposesResources()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         // Start the job
         var job = service.GetJob(id);
@@ -81,7 +81,7 @@ public class JobServiceResourceDisposalTests
     public void StopJob_DisposesResources()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         var job = service.GetJob(id);
         Assert.NotNull(job);
@@ -103,7 +103,7 @@ public class JobServiceResourceDisposalTests
     public void DeleteJob_DisposesResources()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", "test-plan");
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         var job = service.GetJob(id);
         Assert.NotNull(job);

--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -74,12 +74,12 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Manually create a blocked job (simulating what StartJob does when dependencies aren't met)
-        var blockedId = service.CreateTestJob("ExecutePlan", dependentPlan);
+        var blockedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(dependentPlan));
         var blockedJob = service.GetJob(blockedId)!;
         blockedJob.Status = JobStatus.Blocked;
 
         // Create a completing CreatePr job to trigger RetryBlockedJobs
-        var completingId = service.CreateTestJob("CreatePr", Path.GetTempPath());
+        var completingId = service.CreateTestJob("CreatePr", new CreatePrArgs(Path.GetTempPath()));
 
         var notifications = new List<JobNotification>();
         service.NotificationReady += n => notifications.Add(n);
@@ -124,12 +124,12 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Create a blocked job
-        var blockedId = service.CreateTestJob("ExecutePlan", dependentPlan);
+        var blockedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(dependentPlan));
         var blockedJob = service.GetJob(blockedId)!;
         blockedJob.Status = JobStatus.Blocked;
 
         // Create a completing job
-        var completingId = service.CreateTestJob("CreatePr", Path.GetTempPath());
+        var completingId = service.CreateTestJob("CreatePr", new CreatePrArgs(Path.GetTempPath()));
 
         var notifications = new List<JobNotification>();
         service.NotificationReady += n => notifications.Add(n);
@@ -169,7 +169,7 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Create a blocked job for plan1
-        var blockedId = service.CreateTestJob("ExecutePlan", dependentPlan1);
+        var blockedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(dependentPlan1));
         var blockedJob = service.GetJob(blockedId)!;
         blockedJob.Status = JobStatus.Blocked;
 
@@ -180,7 +180,7 @@ public class JobServiceRetryBlockedTests : IDisposable
         Assert.True(removed);
 
         // Create a completing job to trigger RetryBlockedJobs
-        var completingId = service.CreateTestJob("CreatePr", Path.GetTempPath());
+        var completingId = service.CreateTestJob("CreatePr", new CreatePrArgs(Path.GetTempPath()));
         service.CompleteJob(completingId, 0);
 
         // Since the blocked job was already removed, no new ExecutePlan job should be created for it
@@ -213,16 +213,16 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Create a Running ExecutePlan job for the same plan folder (simulating an already active job)
-        var activeId = service.CreateTestJob("ExecutePlan", dependentPlan);
+        var activeId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(dependentPlan));
         Assert.Equal(JobStatus.Running, service.GetJob(activeId)!.Status);
 
         // Create a blocked job for the same plan folder
-        var blockedId = service.CreateTestJob("ExecutePlan", dependentPlan);
+        var blockedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(dependentPlan));
         var blockedJob = service.GetJob(blockedId)!;
         blockedJob.Status = JobStatus.Blocked;
 
         // Create a completing job to trigger RetryBlockedJobs
-        var completingId = service.CreateTestJob("CreatePr", Path.GetTempPath());
+        var completingId = service.CreateTestJob("CreatePr", new CreatePrArgs(Path.GetTempPath()));
         service.CompleteJob(completingId, 0);
 
         // The blocked job should remain because an active job exists for the same plan
@@ -270,11 +270,11 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Start job A (this will hold the repo lock)
-        var jobAId = service.CreateTestJob("ExecutePlan", planA);
+        var jobAId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planA));
         Assert.Equal(JobStatus.Running, service.GetJob(jobAId)!.Status);
 
         // Attempt to start job B (should get blocked due to repo concurrency)
-        var jobBId = service.CreateTestJob("ExecutePlan", planB);
+        var jobBId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planB));
         var blockedJob = service.GetJob(jobBId)!;
         blockedJob.Status = JobStatus.Blocked;
 
@@ -323,11 +323,11 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Start job A (this will hold the repo lock)
-        var jobAId = service.CreateTestJob("ExecutePlan", planA);
+        var jobAId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planA));
         Assert.Equal(JobStatus.Running, service.GetJob(jobAId)!.Status);
 
         // Attempt to start job B (should get blocked due to repo concurrency)
-        var jobBId = service.CreateTestJob("ExecutePlan", planB);
+        var jobBId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planB));
         var blockedJob = service.GetJob(jobBId)!;
         blockedJob.Status = JobStatus.Blocked;
 
@@ -379,16 +379,16 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Start job A (this will hold the repo lock)
-        var jobAId = service.CreateTestJob("ExecutePlan", planA);
+        var jobAId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planA));
         Assert.Equal(JobStatus.Running, service.GetJob(jobAId)!.Status);
 
         // Attempt to start job B (should get blocked due to repo concurrency)
-        var jobBId = service.CreateTestJob("ExecutePlan", planB);
+        var jobBId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planB));
         var blockedJob = service.GetJob(jobBId)!;
         blockedJob.Status = JobStatus.Blocked;
 
         // Start job C on the same repo (simulating a new job starting before job A completes)
-        var jobCId = service.CreateTestJob("ExecutePlan", planC);
+        var jobCId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planC));
         Assert.Equal(JobStatus.Running, service.GetJob(jobCId)!.Status);
 
         var notifications = new List<JobNotification>();

--- a/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
@@ -19,7 +19,7 @@ public class JobServiceSplitPlanCompletionTests
     public void CompleteJob_SplitPlan_TransitionsToSkipped()
     {
         var (service, recorder) = CreateService();
-        var id = service.CreateTestJob("SplitPlan", "/plans/03500-OriginalPlan");
+        var id = service.CreateTestJob("SplitPlan", new SplitPlanArgs("/plans/03500-OriginalPlan"));
 
         service.CompleteJob(id, 0);
 
@@ -31,7 +31,7 @@ public class JobServiceSplitPlanCompletionTests
     public void CompleteJob_UpdatePlan_TransitionsToDraft()
     {
         var (service, recorder) = CreateService();
-        var id = service.CreateTestJob("UpdatePlan", "/plans/03501-SomePlan");
+        var id = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs("/plans/03501-SomePlan"));
 
         service.CompleteJob(id, 0);
 
@@ -43,7 +43,7 @@ public class JobServiceSplitPlanCompletionTests
     public void CompleteJob_ExpandPlan_TransitionsToDraft()
     {
         var (service, recorder) = CreateService();
-        var id = service.CreateTestJob("ExpandPlan", "/plans/03502-SomePlan");
+        var id = service.CreateTestJob("ExpandPlan", new ExpandPlanArgs("/plans/03502-SomePlan"));
 
         service.CompleteJob(id, 0);
 

--- a/src/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs
@@ -121,7 +121,7 @@ public class JobServiceThreadSafetyTests
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 2);
 
-        var jobId = service.CreateTestJob("ExecutePlan", "test-plan");
+        var jobId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
 
         // First call should succeed and transition the job out of Running
         service.CompleteJob(jobId, 0);
@@ -144,7 +144,7 @@ public class JobServiceThreadSafetyTests
 
         // Pre-populate with some jobs
         for (var i = 0; i < 5; i++)
-            service.CreateTestJob("ExecutePlan", $"plan-{i}");
+            service.CreateTestJob("ExecutePlan", new ExecutePlanArgs($"plan-{i}"));
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
         var exceptions = new ConcurrentBag<Exception>();
@@ -171,7 +171,7 @@ public class JobServiceThreadSafetyTests
             var counter = 100;
             while (!cts.Token.IsCancellationRequested)
             {
-                var id = service.CreateTestJob("CreatePlan", $"concurrent-{counter++}");
+                var id = service.CreateTestJob("CreatePlan", new CreatePlanArgs($"concurrent-{counter++}", "Auto"));
                 Thread.Sleep(1);
                 service.DeleteJob(id);
             }

--- a/src/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
@@ -32,7 +32,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
         var job = service.GetJob(id);
         Assert.NotNull(job);
         Assert.Equal(JobStatus.Running, job.Status);
@@ -58,7 +58,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
 
         JobNotification? notification = null;
         service.NotificationReady += n => notification = n;
@@ -79,7 +79,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
 
         JobNotification? notification = null;
         service.NotificationReady += n => notification = n;
@@ -100,7 +100,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
 
         JobNotification? notification = null;
         service.NotificationReady += n => notification = n;
@@ -120,7 +120,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
 
         service.CompleteJob(id, 0);
         var job = service.GetJob(id);
@@ -138,7 +138,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
         var job = service.GetJob(id);
         var cts = job!.TimeoutCts;
         Assert.NotNull(cts);
@@ -154,10 +154,10 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var runningId = service.CreateTestJob("ExecutePlan", _tempDir.Path);
-        var completedId = service.CreateTestJob("ExecutePlan", _tempDir.Path);
-        var failedId = service.CreateTestJob("ExecutePlan", _tempDir.Path);
-        var timeoutId = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var runningId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var completedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var failedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var timeoutId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
 
         service.CompleteJob(completedId, 0);
         service.CompleteJob(failedId, 1);
@@ -176,7 +176,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
         service.CompleteJob(id, 0);
 
         service.ClearFailedJobs();
@@ -223,7 +223,7 @@ codingAgent: claude
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
         var job = service.GetJob(id);
         Assert.NotNull(job);
 
@@ -243,7 +243,7 @@ codingAgent: claude
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
         var job = service.GetJob(id);
         Assert.NotNull(job);
 
@@ -285,7 +285,7 @@ codingAgent: claude
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromSeconds(5));
 
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
         var job = service.GetJob(id);
         Assert.NotNull(job);
 
@@ -304,7 +304,7 @@ codingAgent: claude
     public void ProcessId_CapturedOnJobItem()
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
         var job = service.GetJob(id);
         Assert.NotNull(job);
 
@@ -333,7 +333,7 @@ codingAgent: claude
         var logger = NullLogger<JobService>.Instance;
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), logger);
 
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
         service.CompleteJob(id, 0);
 
         var job = service.GetJob(id);
@@ -348,7 +348,7 @@ codingAgent: claude
         var logger = new CapturingLogger<JobService>(logEntries);
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), logger);
 
-        var id = service.CreateTestJob("ExecutePlan", _tempDir.Path);
+        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
         service.CompleteJob(id, 0);
 
         var job = service.GetJob(id);

--- a/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
@@ -50,13 +50,6 @@ internal static class PlanYamlHelper
         PlanCommandHelpers.WritePlan(planFolder, plan, watcher: null);
     }
 
-    internal static string? GetNamedArg(string[] args, string name)
-    {
-        for (var i = 0; i < args.Length - 1; i++)
-            if (args[i].Equals(name, StringComparison.OrdinalIgnoreCase))
-                return args[i + 1];
-        return null;
-    }
 
     private static readonly object CounterLock = new();
 

--- a/src/Ivy.Tendril/Models/JobArgs.cs
+++ b/src/Ivy.Tendril/Models/JobArgs.cs
@@ -13,41 +13,6 @@ namespace Ivy.Tendril.Models;
 public abstract record JobArgsBase
 {
     public virtual string? PlanFolder => null;
-    internal static JobArgsBase? FromLegacy(string type, string[] args)
-    {
-        if (args.Length == 0) return null;
-
-        return type switch
-        {
-            Constants.JobTypes.CreatePlan => new CreatePlanArgs(
-                GetNamedArg(args, "-Description") ?? string.Join(" ", args),
-                GetNamedArg(args, "-Project") ?? "Auto",
-                int.TryParse(GetNamedArg(args, "-Priority"), out var p) ? p : 0,
-                args.Contains("-Force", StringComparer.OrdinalIgnoreCase),
-                GetNamedArg(args, "-SourcePath")),
-            Constants.JobTypes.ExecutePlan => new ExecutePlanArgs(args[0], GetNamedArg(args, "-Note")),
-            Constants.JobTypes.ExpandPlan => new ExpandPlanArgs(args[0]),
-            Constants.JobTypes.UpdatePlan => new UpdatePlanArgs(args[0]),
-            Constants.JobTypes.SplitPlan => new SplitPlanArgs(args[0]),
-            Constants.JobTypes.CreatePr => new CreatePrArgs(args[0]),
-            Constants.JobTypes.CreateIssue => new CreateIssueArgs(
-                args[0],
-                GetNamedArg(args, "-Repo") ?? "",
-                GetNamedArg(args, "-Assignee"),
-                GetNamedArg(args, "-Comment"),
-                GetNamedArg(args, "-Labels")),
-            Constants.JobTypes.UpdateProject => new UpdateProjectArgs(args[0]),
-            _ => null
-        };
-    }
-
-    private static string? GetNamedArg(string[] args, string name)
-    {
-        for (var i = 0; i < args.Length - 1; i++)
-            if (args[i].Equals(name, StringComparison.OrdinalIgnoreCase))
-                return args[i + 1];
-        return null;
-    }
 }
 
 public record CreatePlanArgs(

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -513,17 +513,17 @@ public class JobService : IJobService
     ///     Creates a job in "Running" state without launching a real process.
     ///     Used by tests to exercise CompleteJob without background monitor races.
     /// </summary>
-    internal string CreateTestJob(string type, params string[] args)
+    internal string CreateTestJob(string type, JobArgsBase args)
     {
         var id = $"job-{Interlocked.Increment(ref _counter):D3}";
         var job = new JobItem
         {
             Id = id,
             Type = type,
-            PlanFile = args.Length > 0 ? args[0] : type,
+            PlanFile = args.PlanFolder ?? type,
             Status = JobStatus.Running,
             StartedAt = DateTime.UtcNow,
-            TypedArgs = JobArgsBase.FromLegacy(type, args),
+            TypedArgs = args,
             TimeoutCts = new CancellationTokenSource()
         };
         _jobs[id] = job;

--- a/src/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -858,13 +858,41 @@ public class PlanDatabaseService : IPlanDatabaseService
             return JsonSerializer.Deserialize<JobArgsBase>(json);
         }
 
-        // Legacy fallback: parse old Args column
+        // Legacy fallback: parse old Args column for rows written before migration 011
         var argsOrd = reader.GetOrdinal("Args");
         if (reader.IsDBNull(argsOrd)) return null;
         var legacyArgs = JsonSerializer.Deserialize<string[]>(reader.GetString(argsOrd));
         if (legacyArgs == null || legacyArgs.Length == 0) return null;
         var type = reader.GetString(reader.GetOrdinal("Type"));
-        return JobArgsBase.FromLegacy(type, legacyArgs);
+        return ParseLegacyArgs(type, legacyArgs);
+    }
+
+    private static JobArgsBase? ParseLegacyArgs(string type, string[] args)
+    {
+        return type switch
+        {
+            Constants.JobTypes.CreatePlan => new CreatePlanArgs(
+                GetLegacyArg(args, "-Description") ?? string.Join(" ", args),
+                GetLegacyArg(args, "-Project") ?? "Auto"),
+            Constants.JobTypes.ExecutePlan => new ExecutePlanArgs(args[0]),
+            Constants.JobTypes.ExpandPlan => new ExpandPlanArgs(args[0]),
+            Constants.JobTypes.UpdatePlan => new UpdatePlanArgs(args[0]),
+            Constants.JobTypes.SplitPlan => new SplitPlanArgs(args[0]),
+            Constants.JobTypes.CreatePr => new CreatePrArgs(args[0]),
+            Constants.JobTypes.CreateIssue => new CreateIssueArgs(
+                args[0],
+                GetLegacyArg(args, "-Repo") ?? ""),
+            Constants.JobTypes.UpdateProject => new UpdateProjectArgs(args[0]),
+            _ => null
+        };
+
+        static string? GetLegacyArg(string[] a, string name)
+        {
+            for (var i = 0; i < a.Length - 1; i++)
+                if (a[i].Equals(name, StringComparison.OrdinalIgnoreCase))
+                    return a[i + 1];
+            return null;
+        }
     }
 
     private List<T> ReadList<T>(string sql, Func<SqliteDataReader, T> mapper, params SqliteParameter[] parameters)


### PR DESCRIPTION
## Summary
- `CreateTestJob` now takes `JobArgsBase` directly instead of `params string[]`
- `FromLegacy` parser moved into `PlanDatabaseService` as private `ParseLegacyArgs` (only needed for reading old DB rows)
- Removed `FromLegacy`/`GetNamedArg` from `JobArgsBase` model — keeps the model clean
- Removed dead `GetNamedArg` from `PlanYamlHelper`

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] All 1410 tests pass