### PR TITLE
Remove redundant type string from StartJob/CreateTestJob

### DIFF
--- a/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
+++ b/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
@@ -41,12 +41,11 @@ public class UseStartJobTests
 
         // Act
         var (startJob, _) = ctx.UseStartJob();
-        startJob("CreatePlan", new CreatePlanArgs("Test Plan", "TestProject"));
+        startJob(new CreatePlanArgs("Test Plan", "TestProject"));
 
         // Assert
         Assert.Single(jobService.StartedJobs);
-        var (type, args) = jobService.StartedJobs[0];
-        Assert.Equal("CreatePlan", type);
+        var args = jobService.StartedJobs[0];
         var createPlanArgs = Assert.IsType<CreatePlanArgs>(args);
         Assert.Equal("Test Plan", createPlanArgs.Description);
         Assert.Equal("TestProject", createPlanArgs.Project);
@@ -61,13 +60,12 @@ public class UseStartJobTests
         var (startJob, _) = ctx.UseStartJob();
 
         // Act
-        startJob("TestJob1", new CreatePlanArgs("task1", "Auto"));
-        startJob("TestJob2", new CreatePlanArgs("task2", "Auto"));
-        startJob("TestJob3", new CreatePlanArgs("task3", "Auto"));
+        startJob(new CreatePlanArgs("task1", "Auto"));
+        startJob(new CreatePlanArgs("task2", "Auto"));
+        startJob(new CreatePlanArgs("task3", "Auto"));
 
         // Assert - only the first call should have triggered StartJob
         Assert.Single(jobService.StartedJobs);
-        Assert.Equal("TestJob1", jobService.StartedJobs[0].Type);
     }
 
     [Fact]
@@ -81,7 +79,7 @@ public class UseStartJobTests
         var (startJob, isStartingBefore) = ctx.UseStartJob();
         Assert.False(isStartingBefore);
 
-        startJob("TestJob", new CreatePlanArgs("task", "Auto"));
+        startJob(new CreatePlanArgs("task", "Auto"));
 
         // Second render - reset context and call hook again
         ctx.Reset();
@@ -93,11 +91,11 @@ public class UseStartJobTests
 
     private class TestJobService : IJobService
     {
-        public List<(string Type, JobArgsBase Args)> StartedJobs { get; } = new();
+        public List<JobArgsBase> StartedJobs { get; } = new();
 
-        public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null)
         {
-            StartedJobs.Add((type, args));
+            StartedJobs.Add(args);
             return Guid.NewGuid().ToString();
         }
 

--- a/src/Ivy.Tendril.Test/InboxControllerTests.cs
+++ b/src/Ivy.Tendril.Test/InboxControllerTests.cs
@@ -46,7 +46,7 @@ public class InboxControllerTests
 
         Assert.IsType<OkObjectResult>(result);
         var job = Assert.Single(jobService.StartedJobs);
-        var cpArgs = Assert.IsType<CreatePlanArgs>(job.Args);
+        var cpArgs = Assert.IsType<CreatePlanArgs>(job);
         Assert.Equal(@"D:\Tests\Session1", cpArgs.SourcePath);
     }
 
@@ -60,7 +60,7 @@ public class InboxControllerTests
 
         Assert.IsType<OkObjectResult>(result);
         var job = Assert.Single(jobService.StartedJobs);
-        var cpArgs = Assert.IsType<CreatePlanArgs>(job.Args);
+        var cpArgs = Assert.IsType<CreatePlanArgs>(job);
         Assert.Equal("Auto", cpArgs.Project);
     }
 
@@ -76,12 +76,12 @@ public class InboxControllerTests
 
     private class StubJobService : IJobService
     {
-        public List<(string Type, JobArgsBase Args)> StartedJobs { get; } = new();
+        public List<JobArgsBase> StartedJobs { get; } = new();
 
-        public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null)
         {
             var id = $"job-{StartedJobs.Count + 1}";
-            StartedJobs.Add((type, args));
+            StartedJobs.Add(args);
             return id;
         }
 

--- a/src/Ivy.Tendril.Test/InboxRecoveryTests.cs
+++ b/src/Ivy.Tendril.Test/InboxRecoveryTests.cs
@@ -109,7 +109,7 @@ public class InboxRecoveryTests
         {
             var jobService = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), inboxDir);
 
-            var id = jobService.StartJob("CreatePlan", new CreatePlanArgs("Test plan description", "Tendril"));
+            var id = jobService.StartJob(new CreatePlanArgs("Test plan description", "Tendril"));
 
             var job = jobService.GetJob(id);
             Assert.NotNull(job);
@@ -144,7 +144,7 @@ public class InboxRecoveryTests
         {
             var jobService = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), inboxDir);
 
-            var id = jobService.StartJob("CreatePlan", new CreatePlanArgs("Failing plan", "Tendril"));
+            var id = jobService.StartJob(new CreatePlanArgs("Failing plan", "Tendril"));
 
             var job = jobService.GetJob(id);
             Assert.NotNull(job?.InboxFile);
@@ -172,7 +172,7 @@ public class InboxRecoveryTests
         {
             var jobService = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), inboxDir);
 
-            var id = jobService.StartJob("CreatePlan", new CreatePlanArgs("Stopped plan", "Tendril"));
+            var id = jobService.StartJob(new CreatePlanArgs("Stopped plan", "Tendril"));
 
             var job = jobService.GetJob(id);
             Assert.NotNull(job?.InboxFile);
@@ -204,7 +204,7 @@ public class InboxRecoveryTests
 
             var jobService = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), inboxDir);
 
-            var id = jobService.StartJob("CreatePlan",
+            var id = jobService.StartJob(
                 new CreatePlanArgs("Some request", "Agent"),
                 processingFile);
 
@@ -241,7 +241,7 @@ public class InboxRecoveryTests
             File.WriteAllText(Path.Combine(planFolder, "plan.yaml"),
                 $"state: Draft\nproject: TestProject\nlevel: NiceToHave\ntitle: Test Plan\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\nrepos:\n- {repoDir}\nprs: []\ncommits: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\n");
 
-            var id = jobService.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
+            var id = jobService.StartJob(new ExecutePlanArgs(planFolder));
             var job = jobService.GetJob(id);
             Assert.NotNull(job);
             Assert.Null(job.InboxFile);

--- a/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
@@ -214,11 +214,11 @@ public class InboxWatcherServiceTests : IDisposable
     private class TrackedStubJobService : IJobService
     {
         public bool TrackedReturnValue { get; set; }
-        public List<(string Type, JobArgsBase Args, string? InboxFilePath)> StartedJobs { get; } = new();
+        public List<(JobArgsBase Args, string? InboxFilePath)> StartedJobs { get; } = new();
 
-        public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null)
         {
-            StartedJobs.Add((type, args, inboxFilePath));
+            StartedJobs.Add((args, inboxFilePath));
             return $"job-{StartedJobs.Count:D3}";
         }
 
@@ -345,16 +345,16 @@ public class InboxWatcherServiceTests : IDisposable
     private class DeleteBeforeRenameJobService : IJobService
     {
         private readonly string _fileToDelete;
-        public List<(string Type, JobArgsBase Args, string? InboxFilePath)> StartedJobs { get; } = new();
+        public List<(JobArgsBase Args, string? InboxFilePath)> StartedJobs { get; } = new();
 
         public DeleteBeforeRenameJobService(string fileToDelete)
         {
             _fileToDelete = fileToDelete;
         }
 
-        public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null)
         {
-            StartedJobs.Add((type, args, inboxFilePath));
+            StartedJobs.Add((args, inboxFilePath));
             return $"job-{StartedJobs.Count:D3}";
         }
 
@@ -388,13 +388,13 @@ public class InboxWatcherServiceTests : IDisposable
 
     private class TimestampedJobService : IJobService
     {
-        public List<(string Type, JobArgsBase Args, string? InboxFilePath)> StartedJobs { get; } = new();
+        public List<(JobArgsBase Args, string? InboxFilePath)> StartedJobs { get; } = new();
         public List<DateTime> StartJobTimestamps { get; } = new();
 
-        public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null)
         {
             StartJobTimestamps.Add(DateTime.UtcNow);
-            StartedJobs.Add((type, args, inboxFilePath));
+            StartedJobs.Add((args, inboxFilePath));
             return $"job-{StartedJobs.Count:D3}";
         }
 

--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -30,7 +30,7 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void CompleteJob_ConcurrentCalls_OnlyFirstCompletes()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         var notificationCount = 0;
         service.NotificationReady += _ => Interlocked.Increment(ref notificationCount);
@@ -69,7 +69,7 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void StopJob_RacingWithCompleteJob_OnlyOneWins()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         var notificationCount = 0;
         service.NotificationReady += _ => Interlocked.Increment(ref notificationCount);
@@ -103,7 +103,7 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void CompleteJob_AfterStopJob_IsNoOp()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         service.StopJob(id);
         var job = service.GetJob(id);
@@ -121,7 +121,7 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void CompleteJob_StaleOutputDetected_SetsTimeoutWithStaleReason()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         var job = service.GetJob(id);
         Assert.NotNull(job);
@@ -139,7 +139,7 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void CompleteJob_CreatePlan_UpdatesPlanFileWhenOutputContainsPlanCreated()
     {
         var service = CreateServiceWithPlanReader(_tempDir.Path);
-        var id = service.CreateTestJob("CreatePlan", new CreatePlanArgs("Fix login bug", "Tendril"));
+        var id = service.CreateTestJob(new CreatePlanArgs("Fix login bug", "Tendril"));
 
         var job = service.GetJob(id);
         Assert.NotNull(job);
@@ -157,7 +157,7 @@ public class JobServiceCompletionGuardTests : IDisposable
     public void CompleteJob_CreatePlan_LeavesPlanFileUnchangedOnDuplicate()
     {
         var service = CreateServiceWithPlanReader(_tempDir.Path);
-        var id = service.CreateTestJob("CreatePlan", new CreatePlanArgs("Fix login bug", "Tendril"));
+        var id = service.CreateTestJob(new CreatePlanArgs("Fix login bug", "Tendril"));
 
         var job = service.GetJob(id);
         Assert.NotNull(job);

--- a/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
@@ -27,7 +27,7 @@ public class JobServiceConcurrencyTests
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var id = service.StartJob("CreatePlan", new CreatePlanArgs("Test Job", "Auto"));
+        var id = service.StartJob(new CreatePlanArgs("Test Job", "Auto"));
         var job = service.GetJob(id);
 
         Assert.NotNull(job);
@@ -47,7 +47,7 @@ public class JobServiceConcurrencyTests
         // but the initial status should be "Running" not "Queued"
         try
         {
-            var id = service.StartJob("CreatePlan", new CreatePlanArgs("Test Job", "Auto"));
+            var id = service.StartJob(new CreatePlanArgs("Test Job", "Auto"));
             var job = service.GetJob(id);
             Assert.NotNull(job);
             Assert.NotEqual(JobStatus.Queued, job.Status);
@@ -65,8 +65,8 @@ public class JobServiceConcurrencyTests
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        service.StartJob("CreatePlan", new CreatePlanArgs("Job 1", "Auto"));
-        service.StartJob("CreatePlan", new CreatePlanArgs("Job 2", "Auto"));
+        service.StartJob(new CreatePlanArgs("Job 1", "Auto"));
+        service.StartJob(new CreatePlanArgs("Job 2", "Auto"));
 
         var jobs = service.GetJobs();
         Assert.Equal(2, jobs.Count);
@@ -80,7 +80,7 @@ public class JobServiceConcurrencyTests
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var id = service.StartJob("CreatePlan", new CreatePlanArgs("Test Job", "Auto"));
+        var id = service.StartJob(new CreatePlanArgs("Test Job", "Auto"));
         service.StopJob(id);
 
         var job = service.GetJob(id);
@@ -96,8 +96,8 @@ public class JobServiceConcurrencyTests
         var jobService = new JobService(configService);
 
         // Create 2 test jobs that will run (consume the 2 slots)
-        var job1Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan1"));
-        var job2Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan2"));
+        var job1Id = jobService.CreateTestJob(new ExecutePlanArgs("plan1"));
+        var job2Id = jobService.CreateTestJob(new ExecutePlanArgs("plan2"));
 
         // Verify we can only have 2 running jobs
         Assert.Equal(JobStatus.Running, jobService.GetJob(job1Id)!.Status);
@@ -108,8 +108,8 @@ public class JobServiceConcurrencyTests
         configService.TriggerSettingsReloaded();
 
         // Assert: Should now be able to create 2 more running jobs
-        var job3Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan3"));
-        var job4Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan4"));
+        var job3Id = jobService.CreateTestJob(new ExecutePlanArgs("plan3"));
+        var job4Id = jobService.CreateTestJob(new ExecutePlanArgs("plan4"));
 
         Assert.Equal(JobStatus.Running, jobService.GetJob(job3Id)!.Status);
         Assert.Equal(JobStatus.Running, jobService.GetJob(job4Id)!.Status);
@@ -123,10 +123,10 @@ public class JobServiceConcurrencyTests
         var jobService = new JobService(configService);
 
         // Create 4 test jobs that will run
-        var job1Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan1"));
-        var job2Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan2"));
-        var job3Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan3"));
-        var job4Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan4"));
+        var job1Id = jobService.CreateTestJob(new ExecutePlanArgs("plan1"));
+        var job2Id = jobService.CreateTestJob(new ExecutePlanArgs("plan2"));
+        var job3Id = jobService.CreateTestJob(new ExecutePlanArgs("plan3"));
+        var job4Id = jobService.CreateTestJob(new ExecutePlanArgs("plan4"));
 
         // Act: Decrease max to 2
         configService.MaxConcurrentJobs = 2;
@@ -149,7 +149,7 @@ public class JobServiceConcurrencyTests
         jobService.CompleteJob(job3Id, 0);
 
         // Now we should have 1 available slot (1 running < limit of 2)
-        var job5Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan5"));
+        var job5Id = jobService.CreateTestJob(new ExecutePlanArgs("plan5"));
         Assert.Equal(JobStatus.Running, jobService.GetJob(job5Id)!.Status);
     }
 
@@ -160,7 +160,7 @@ public class JobServiceConcurrencyTests
         var configService = new TestConfigService { MaxConcurrentJobs = 5 };
         var jobService = new JobService(configService);
 
-        var job1Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan1"));
+        var job1Id = jobService.CreateTestJob(new ExecutePlanArgs("plan1"));
         Assert.Equal(JobStatus.Running, jobService.GetJob(job1Id)!.Status);
 
         // Act: Reload with same value
@@ -170,7 +170,7 @@ public class JobServiceConcurrencyTests
         Assert.Equal(JobStatus.Running, jobService.GetJob(job1Id)!.Status);
 
         // Can still create new test jobs
-        var job2Id = jobService.CreateTestJob("ExecutePlan", new ExecutePlanArgs("plan2"));
+        var job2Id = jobService.CreateTestJob(new ExecutePlanArgs("plan2"));
         Assert.Equal(JobStatus.Running, jobService.GetJob(job2Id)!.Status);
     }
 

--- a/src/Ivy.Tendril.Test/JobServiceConcurrentPlanModificationTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceConcurrentPlanModificationTests.cs
@@ -45,13 +45,13 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         // Start first UpdatePlan job (will be in Running state after CreateTestJob)
-        var firstJobId = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
+        var firstJobId = service.CreateTestJob(new UpdatePlanArgs(_planFolder));
         var firstJob = service.GetJob(firstJobId);
         Assert.NotNull(firstJob);
         Assert.Equal(JobStatus.Running, firstJob.Status);
 
         // Try to start second UpdatePlan job for the same plan
-        var secondJobId = service.StartJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
+        var secondJobId = service.StartJob(new UpdatePlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
         // Second job should fail immediately with conflict message
@@ -68,8 +68,8 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 10);
 
-        _ = service.CreateTestJob("ExpandPlan", new ExpandPlanArgs(_planFolder));
-        var secondJobId = service.StartJob("ExpandPlan", new ExpandPlanArgs(_planFolder));
+        _ = service.CreateTestJob(new ExpandPlanArgs(_planFolder));
+        var secondJobId = service.StartJob(new ExpandPlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
         Assert.NotNull(secondJob);
@@ -84,8 +84,8 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 10);
 
-        _ = service.CreateTestJob("SplitPlan", new SplitPlanArgs(_planFolder));
-        var secondJobId = service.StartJob("SplitPlan", new SplitPlanArgs(_planFolder));
+        _ = service.CreateTestJob(new SplitPlanArgs(_planFolder));
+        var secondJobId = service.StartJob(new SplitPlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
         Assert.NotNull(secondJob);
@@ -101,7 +101,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         // Start and complete first job
-        var firstJobId = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
+        var firstJobId = service.CreateTestJob(new UpdatePlanArgs(_planFolder));
         service.CompleteJob(firstJobId, 0);
         var firstJob = service.GetJob(firstJobId);
         Assert.NotNull(firstJob);
@@ -110,7 +110,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
         // Second job should be allowed (will fail to launch process, but should attempt)
         try
         {
-            var secondJobId = service.StartJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
+            var secondJobId = service.StartJob(new UpdatePlanArgs(_planFolder));
             var secondJob = service.GetJob(secondJobId);
             Assert.NotNull(secondJob);
             // Should not be Failed due to conflict (might be Failed due to process launch, but that's OK)
@@ -132,13 +132,13 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var firstJobId = service.StartJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
+        var firstJobId = service.StartJob(new UpdatePlanArgs(_planFolder));
         var firstJob = service.GetJob(firstJobId);
         Assert.NotNull(firstJob);
         Assert.Equal(JobStatus.Queued, firstJob.Status);
 
         // Second job should fail even though first is only queued
-        var secondJobId = service.StartJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
+        var secondJobId = service.StartJob(new UpdatePlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
         Assert.NotNull(secondJob);
@@ -154,13 +154,13 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         // Create a job manually in Pending state
-        var firstJobId = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
+        var firstJobId = service.CreateTestJob(new UpdatePlanArgs(_planFolder));
         var firstJob = service.GetJob(firstJobId);
         Assert.NotNull(firstJob);
         firstJob.Status = JobStatus.Pending;
 
         // Second job should fail
-        var secondJobId = service.StartJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
+        var secondJobId = service.StartJob(new UpdatePlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
         Assert.NotNull(secondJob);
@@ -190,7 +190,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         // Start UpdatePlan for first plan
-        var firstJobId = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
+        var firstJobId = service.CreateTestJob(new UpdatePlanArgs(_planFolder));
         var firstJob = service.GetJob(firstJobId);
         Assert.NotNull(firstJob);
         Assert.Equal(JobStatus.Running, firstJob.Status);
@@ -198,7 +198,7 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
         // Start UpdatePlan for different plan — should be allowed
         try
         {
-            var secondJobId = service.StartJob("UpdatePlan", new UpdatePlanArgs(otherPlanFolder));
+            var secondJobId = service.StartJob(new UpdatePlanArgs(otherPlanFolder));
             var secondJob = service.GetJob(secondJobId);
             Assert.NotNull(secondJob);
             // Should not fail due to conflict
@@ -220,12 +220,12 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         // Start UpdatePlan
-        _ = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
+        _ = service.CreateTestJob(new UpdatePlanArgs(_planFolder));
 
         // ExecutePlan should not be blocked by UpdatePlan (they're different job types)
         try
         {
-            var executeJobId = service.StartJob("ExecutePlan", new ExecutePlanArgs(_planFolder));
+            var executeJobId = service.StartJob(new ExecutePlanArgs(_planFolder));
             var executeJob = service.GetJob(executeJobId);
             Assert.NotNull(executeJob);
             // Should not fail due to plan modification conflict
@@ -247,13 +247,13 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             null, 10);
 
         // Start first ExecutePlan job
-        var firstJobId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_planFolder));
+        var firstJobId = service.CreateTestJob(new ExecutePlanArgs(_planFolder));
         var firstJob = service.GetJob(firstJobId);
         Assert.NotNull(firstJob);
         Assert.Equal(JobStatus.Running, firstJob.Status);
 
         // Try to start second ExecutePlan job for the same plan
-        var secondJobId = service.StartJob("ExecutePlan", new ExecutePlanArgs(_planFolder));
+        var secondJobId = service.StartJob(new ExecutePlanArgs(_planFolder));
         var secondJob = service.GetJob(secondJobId);
 
         // Second job should fail immediately with conflict message
@@ -278,10 +278,10 @@ public class JobServiceConcurrentPlanModificationTests : IDisposable
             service.NotificationReady += n => receivedNotification = n;
 
             // Start first job
-            _ = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
+            _ = service.CreateTestJob(new UpdatePlanArgs(_planFolder));
 
             // Try to start conflicting second job
-            _ = service.StartJob("UpdatePlan", new UpdatePlanArgs(_planFolder));
+            _ = service.StartJob(new UpdatePlanArgs(_planFolder));
 
             // Should have received a notification
             Assert.NotNull(receivedNotification);

--- a/src/Ivy.Tendril.Test/JobServiceCostTrackingTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCostTrackingTests.cs
@@ -68,7 +68,7 @@ public class JobServiceCostTrackingTests : IDisposable
         var service = CreateService();
         var planFolder = CreateValidPlanFolder();
 
-        var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
+        var id = service.StartJob(new ExecutePlanArgs(planFolder));
         var job = service.GetJob(id);
 
         Assert.NotNull(job);
@@ -84,8 +84,8 @@ public class JobServiceCostTrackingTests : IDisposable
         var planFolder1 = CreateValidPlanFolder();
         var planFolder2 = CreateValidPlanFolder();
 
-        var id1 = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder1));
-        var id2 = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder2));
+        var id1 = service.StartJob(new ExecutePlanArgs(planFolder1));
+        var id2 = service.StartJob(new ExecutePlanArgs(planFolder2));
 
         var job1 = service.GetJob(id1);
         var job2 = service.GetJob(id2);
@@ -103,7 +103,7 @@ public class JobServiceCostTrackingTests : IDisposable
         var service = new JobService(configService);
         var planFolder = CreateValidPlanFolder();
 
-        var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
+        var id = service.StartJob(new ExecutePlanArgs(planFolder));
         var job = service.GetJob(id);
 
         Assert.NotNull(job);
@@ -122,7 +122,7 @@ public class JobServiceCostTrackingTests : IDisposable
             var service = new JobService(configService);
             var planFolder = CreateValidPlanFolder(tempDir);
 
-            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
+            var id = service.StartJob(new ExecutePlanArgs(planFolder));
             var job = service.GetJob(id);
 
             Assert.NotNull(job);

--- a/src/Ivy.Tendril.Test/JobServiceCreateIssueTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCreateIssueTests.cs
@@ -50,7 +50,7 @@ public class JobServiceCreateIssueTests : IDisposable
         WritePlanYaml("Draft");
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", new CreateIssueArgs(_tempDir.Path, "owner/repo", "", "", ""));
+        var id = service.StartJob(new CreateIssueArgs(_tempDir.Path, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         var content = File.ReadAllText(_planYamlPath);
@@ -63,7 +63,7 @@ public class JobServiceCreateIssueTests : IDisposable
         WritePlanYaml("Draft");
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", new CreateIssueArgs(_tempDir.Path, "owner/repo", "", "", ""));
+        var id = service.StartJob(new CreateIssueArgs(_tempDir.Path, "owner/repo", "", "", ""));
         service.CompleteJob(id, 1);
 
         var content = File.ReadAllText(_planYamlPath);

--- a/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
@@ -75,7 +75,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         };
 
         // Simulate CreateIssue completing for PlanB
-        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
+        var id = service.StartJob(new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         // PlanA should have been auto-queued
@@ -92,7 +92,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
 
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
+        var id = service.StartJob(new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         var jobs = service.GetJobs();
@@ -108,7 +108,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
 
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
+        var id = service.StartJob(new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         var jobs = service.GetJobs();
@@ -123,7 +123,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
 
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
+        var id = service.StartJob(new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         // Verify plan.yaml was updated — Building then immediately Executing when job launches
@@ -141,7 +141,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         var service = CreateService();
 
         // Start ExecutePlan — dependencies aren't met, so ResetPlanStateToBlocked should fire
-        service.StartJob("ExecutePlan", new ExecutePlanArgs(planA));
+        service.StartJob(new ExecutePlanArgs(planA));
 
         // Verify plan.yaml was updated to Blocked (not Draft)
         var planYamlContent = File.ReadAllText(Path.Combine(planA, "plan.yaml"));
@@ -156,7 +156,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
 
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
+        var id = service.StartJob(new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         var jobs = service.GetJobs();
@@ -171,7 +171,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
 
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
+        var id = service.StartJob(new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         var jobs = service.GetJobs();
@@ -186,7 +186,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
 
         var service = CreateService();
 
-        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
+        var id = service.StartJob(new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         var jobs = service.GetJobs();
@@ -204,7 +204,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         var service = CreateService();
 
         // Start ExecutePlan for planC — it will be blocked because DepPlan is not Completed
-        service.StartJob("ExecutePlan", new ExecutePlanArgs(planC));
+        service.StartJob(new ExecutePlanArgs(planC));
 
         var blockedJobsBefore = service.GetJobs().Count(j =>
             j.Type == "ExecutePlan" &&
@@ -216,7 +216,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         // Complete a CreateIssue job for PlanB — triggers RetryBlockedDependents
         // planC depends on both DepPlan (not met) and PlanB (met), so it stays blocked
         // But the duplicate-job guard should prevent creating another blocked job entry
-        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
+        var id = service.StartJob(new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         // Should still have exactly one blocked job for planC (not two)
@@ -238,7 +238,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         var service = CreateService();
 
         // Start ExecutePlan — dependencies are met, so it should NOT be blocked
-        service.StartJob("ExecutePlan", new ExecutePlanArgs(planA));
+        service.StartJob(new ExecutePlanArgs(planA));
 
         // Verify the job is not blocked (deps are met, no redundant CheckDependencies to fail)
         var jobs = service.GetJobs();
@@ -256,11 +256,11 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         var service = CreateService();
 
         // Create a Running ExecutePlan job for planA (simulating an already active job)
-        var activeId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planA));
+        var activeId = service.CreateTestJob(new ExecutePlanArgs(planA));
         Assert.Equal(JobStatus.Running, service.GetJob(activeId)!.Status);
 
         // Trigger RetryBlockedDependents by completing a job for PlanB
-        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
+        var id = service.StartJob(new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         // Should NOT create a duplicate ExecutePlan job for planA
@@ -282,11 +282,11 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         var service = CreateService();
 
         // Create a Blocked ExecutePlan job for planA (simulating StartJob that found unmet deps earlier)
-        var blockedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planA));
+        var blockedId = service.CreateTestJob(new ExecutePlanArgs(planA));
         service.GetJob(blockedId)!.Status = JobStatus.Blocked;
 
         // Trigger RetryBlockedDependents by completing a CreateIssue job for PlanB
-        var id = service.StartJob("CreateIssue", new CreateIssueArgs(planB, "owner/repo", "", "", ""));
+        var id = service.StartJob(new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
         // Should have at most one ExecutePlan job for planA (not two)

--- a/src/Ivy.Tendril.Test/JobServiceEventSplitTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceEventSplitTests.cs
@@ -15,7 +15,7 @@ public class JobServiceEventSplitTests
     public void CompleteJob_RaisesJobsStructureChanged()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         var structureChangedFired = false;
         var propertyChangedFired = false;
@@ -32,7 +32,7 @@ public class JobServiceEventSplitTests
     public void CompleteJob_AlsoRaisesJobsChanged_ForBackwardCompatibility()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         var jobsChangedFired = false;
         service.JobsChanged += () => jobsChangedFired = true;
@@ -46,7 +46,7 @@ public class JobServiceEventSplitTests
     public void DeleteJob_RaisesJobsStructureChanged()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
         service.CompleteJob(id, 0);
 
         var structureChangedFired = false;
@@ -64,7 +64,7 @@ public class JobServiceEventSplitTests
     public void StopJob_RaisesJobsStructureChanged()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         var structureChangedFired = false;
         var propertyChangedFired = false;
@@ -81,7 +81,7 @@ public class JobServiceEventSplitTests
     public void ClearCompletedJobs_RaisesJobsStructureChanged()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
         service.CompleteJob(id, 0);
 
         var structureChangedFired = false;
@@ -96,7 +96,7 @@ public class JobServiceEventSplitTests
     public void ClearFailedJobs_RaisesJobsStructureChanged()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
         service.CompleteJob(id, 1);
 
         var structureChangedFired = false;

--- a/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
@@ -112,7 +112,7 @@ public class JobServiceFailureReasonTests : IDisposable
     public void CompleteJob_NonZeroExitCode_PopulatesStatusMessage()
     {
         var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(Path.GetTempPath()));
+        var id = service.CreateTestJob(new ExecutePlanArgs(Path.GetTempPath()));
         var job = service.GetJob(id)!;
         job.OutputLines.Enqueue("[stderr] something went wrong");
 
@@ -129,7 +129,7 @@ public class JobServiceFailureReasonTests : IDisposable
     {
         var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
         var planFolder = CreateValidPlanFolder();
-        var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
+        var id = service.StartJob(new ExecutePlanArgs(planFolder));
 
         service.CompleteJob(id, 0);
 
@@ -169,7 +169,7 @@ public class JobServiceFailureReasonTests : IDisposable
     {
         var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
         var planFolder = CreateValidPlanFolder();
-        var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
+        var id = service.StartJob(new ExecutePlanArgs(planFolder));
         var job = service.GetJob(id)!;
         job.StatusMessage = "Execution failed (exit code: 1)";
         job.OutputLines.Enqueue("[stderr] some raw stderr output");

--- a/src/Ivy.Tendril.Test/JobServiceHookTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceHookTests.cs
@@ -56,7 +56,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
+            var id = service.StartJob(new ExecutePlanArgs(planFolder));
             var job = service.GetJob(id)!;
 
             // Before hooks should have run during StartJob
@@ -89,7 +89,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("CreatePr", new CreatePrArgs(planFolder));
+            var id = service.StartJob(new CreatePrArgs(planFolder));
             var job = service.GetJob(id)!;
 
             Assert.Contains(job.OutputLines, l => l.Contains("[hook:Global Hook]"));
@@ -121,7 +121,7 @@ public class JobServiceHookTests : IDisposable
         try
         {
             // Start a CreatePr job — the hook should NOT match
-            var id = service.StartJob("CreatePr", new CreatePrArgs(planFolder));
+            var id = service.StartJob(new CreatePrArgs(planFolder));
             var job = service.GetJob(id)!;
 
             Assert.DoesNotContain(job.OutputLines, l => l.Contains("[hook:Execute Only]"));
@@ -151,7 +151,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
+            var id = service.StartJob(new ExecutePlanArgs(planFolder));
             var job = service.GetJob(id)!;
 
             // Job should not be blocked/pending — the failing hook must not prevent launch.
@@ -184,7 +184,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
+            var id = service.StartJob(new ExecutePlanArgs(planFolder));
             var job = service.GetJob(id)!;
 
             Assert.Contains(job.OutputLines,
@@ -248,7 +248,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
+            var id = service.StartJob(new ExecutePlanArgs(planFolder));
             service.CompleteJob(id, 0);
 
             var job = service.GetJob(id)!;
@@ -285,7 +285,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
+            var id = service.StartJob(new ExecutePlanArgs(planFolder));
             service.CompleteJob(id, 1);
 
             var job = service.GetJob(id)!;
@@ -316,7 +316,7 @@ public class JobServiceHookTests : IDisposable
 
         try
         {
-            var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
+            var id = service.StartJob(new ExecutePlanArgs(planFolder));
             service.CompleteJob(id, 0);
 
             var job = service.GetJob(id)!;
@@ -334,7 +334,7 @@ public class JobServiceHookTests : IDisposable
         // Use the constructor that doesn't take ConfigService
         var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(Path.GetTempPath()));
+        var id = service.CreateTestJob(new ExecutePlanArgs(Path.GetTempPath()));
         var job = service.GetJob(id)!;
 
         // Should not throw, just silently skip hooks

--- a/src/Ivy.Tendril.Test/JobServiceJobsChangedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceJobsChangedTests.cs
@@ -15,7 +15,7 @@ public class JobServiceJobsChangedTests
     public void CompleteJob_RaisesJobsChangedEvent()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         var fired = false;
         service.JobsChanged += () => fired = true;
@@ -28,7 +28,7 @@ public class JobServiceJobsChangedTests
     public void CompleteJob_Failure_RaisesJobsChangedEvent()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         var fired = false;
         service.JobsChanged += () => fired = true;
@@ -41,7 +41,7 @@ public class JobServiceJobsChangedTests
     public void StopJob_RaisesJobsChangedEvent()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         var fired = false;
         service.JobsChanged += () => fired = true;

--- a/src/Ivy.Tendril.Test/JobServiceNotificationTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceNotificationTests.cs
@@ -22,7 +22,7 @@ public class JobServiceNotificationTests : IDisposable
     public void CompleteJob_Success_NotificationTitleIncludesJobType()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("CreatePr", new CreatePrArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new CreatePrArgs(_tempDir.Path));
 
         JobNotification? notification = null;
         service.NotificationReady += n => notification = n;
@@ -37,7 +37,7 @@ public class JobServiceNotificationTests : IDisposable
     public void CompleteJob_Failure_NotificationTitleIncludesJobType()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
 
         JobNotification? notification = null;
         service.NotificationReady += n => notification = n;
@@ -52,7 +52,7 @@ public class JobServiceNotificationTests : IDisposable
     public void CompleteJob_Timeout_NotificationTitleIncludesJobType()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExpandPlan", new ExpandPlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExpandPlanArgs(_tempDir.Path));
 
         JobNotification? notification = null;
         service.NotificationReady += n => notification = n;

--- a/src/Ivy.Tendril.Test/JobServiceNotificationThreadSafetyTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceNotificationThreadSafetyTests.cs
@@ -38,7 +38,7 @@ public class JobServiceNotificationThreadSafetyTests : IDisposable
             service.NotificationReady += n => received = n;
 
             // Start a job and complete it to trigger notification
-            var id = service.StartJob("CreatePr", new CreatePrArgs(_tempDir.Path));
+            var id = service.StartJob(new CreatePrArgs(_tempDir.Path));
             service.CompleteJob(id, 0);
 
             // The notification should have been posted to the sync context, not invoked directly
@@ -69,7 +69,7 @@ public class JobServiceNotificationThreadSafetyTests : IDisposable
         JobNotification? received = null;
         service.NotificationReady += n => received = n;
 
-        var id = service.StartJob("CreatePr", new CreatePrArgs(_tempDir.Path));
+        var id = service.StartJob(new CreatePrArgs(_tempDir.Path));
         service.CompleteJob(id, 0);
 
         Assert.NotNull(received);
@@ -91,7 +91,7 @@ public class JobServiceNotificationThreadSafetyTests : IDisposable
 
         // Complete multiple jobs rapidly
         var ids = new List<string>();
-        for (var i = 0; i < 5; i++) ids.Add(service.StartJob("CreatePr", new CreatePrArgs(_tempDir.Path)));
+        for (var i = 0; i < 5; i++) ids.Add(service.StartJob(new CreatePrArgs(_tempDir.Path)));
 
         foreach (var id in ids) service.CompleteJob(id, 0);
 
@@ -118,7 +118,7 @@ public class JobServiceNotificationThreadSafetyTests : IDisposable
         service.NotificationReady += n => received = n;
 
         var planFolder = CreateValidPlanFolder();
-        var id = service.StartJob("ExecutePlan", new ExecutePlanArgs(planFolder));
+        var id = service.StartJob(new ExecutePlanArgs(planFolder));
         service.CompleteJob(id, 1);
 
         Assert.NotNull(received);

--- a/src/Ivy.Tendril.Test/JobServicePriorityTests.cs
+++ b/src/Ivy.Tendril.Test/JobServicePriorityTests.cs
@@ -19,7 +19,7 @@ public class JobServicePriorityTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var id = service.StartJob("CreatePlan", new CreatePlanArgs("Test", "Framework", Priority: 2));
+        var id = service.StartJob(new CreatePlanArgs("Test", "Framework", Priority: 2));
         var job = service.GetJob(id);
 
         Assert.NotNull(job);
@@ -33,7 +33,7 @@ public class JobServicePriorityTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var id = service.StartJob("CreatePlan", new CreatePlanArgs("Test", "Framework"));
+        var id = service.StartJob(new CreatePlanArgs("Test", "Framework"));
         var job = service.GetJob(id);
 
         Assert.NotNull(job);
@@ -47,7 +47,7 @@ public class JobServicePriorityTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var id = service.StartJob("CreatePlan", new CreatePlanArgs("Test", "Auto"));
+        var id = service.StartJob(new CreatePlanArgs("Test", "Auto"));
         var job = service.GetJob(id);
 
         Assert.NotNull(job);
@@ -62,9 +62,9 @@ public class JobServicePriorityTests : IDisposable
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 0);
 
-        var lowId = service.StartJob("CreatePlan", new CreatePlanArgs("Low priority", "Auto", Priority: 0));
-        var highId = service.StartJob("CreatePlan", new CreatePlanArgs("High priority", "Auto", Priority: 2));
-        var medId = service.StartJob("CreatePlan", new CreatePlanArgs("Med priority", "Auto", Priority: 1));
+        var lowId = service.StartJob(new CreatePlanArgs("Low priority", "Auto", Priority: 0));
+        var highId = service.StartJob(new CreatePlanArgs("High priority", "Auto", Priority: 2));
+        var medId = service.StartJob(new CreatePlanArgs("Med priority", "Auto", Priority: 1));
 
         // All should be queued
         Assert.Equal(JobStatus.Queued, service.GetJob(lowId)!.Status);

--- a/src/Ivy.Tendril.Test/JobServiceResourceDisposalTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceResourceDisposalTests.cs
@@ -58,7 +58,7 @@ public class JobServiceResourceDisposalTests
     public void CompleteJob_DisposesResources()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         // Start the job
         var job = service.GetJob(id);
@@ -81,7 +81,7 @@ public class JobServiceResourceDisposalTests
     public void StopJob_DisposesResources()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         var job = service.GetJob(id);
         Assert.NotNull(job);
@@ -103,7 +103,7 @@ public class JobServiceResourceDisposalTests
     public void DeleteJob_DisposesResources()
     {
         var service = CreateService();
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         var job = service.GetJob(id);
         Assert.NotNull(job);

--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -74,12 +74,12 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Manually create a blocked job (simulating what StartJob does when dependencies aren't met)
-        var blockedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(dependentPlan));
+        var blockedId = service.CreateTestJob(new ExecutePlanArgs(dependentPlan));
         var blockedJob = service.GetJob(blockedId)!;
         blockedJob.Status = JobStatus.Blocked;
 
         // Create a completing CreatePr job to trigger RetryBlockedJobs
-        var completingId = service.CreateTestJob("CreatePr", new CreatePrArgs(Path.GetTempPath()));
+        var completingId = service.CreateTestJob(new CreatePrArgs(Path.GetTempPath()));
 
         var notifications = new List<JobNotification>();
         service.NotificationReady += n => notifications.Add(n);
@@ -124,12 +124,12 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Create a blocked job
-        var blockedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(dependentPlan));
+        var blockedId = service.CreateTestJob(new ExecutePlanArgs(dependentPlan));
         var blockedJob = service.GetJob(blockedId)!;
         blockedJob.Status = JobStatus.Blocked;
 
         // Create a completing job
-        var completingId = service.CreateTestJob("CreatePr", new CreatePrArgs(Path.GetTempPath()));
+        var completingId = service.CreateTestJob(new CreatePrArgs(Path.GetTempPath()));
 
         var notifications = new List<JobNotification>();
         service.NotificationReady += n => notifications.Add(n);
@@ -169,7 +169,7 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Create a blocked job for plan1
-        var blockedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(dependentPlan1));
+        var blockedId = service.CreateTestJob(new ExecutePlanArgs(dependentPlan1));
         var blockedJob = service.GetJob(blockedId)!;
         blockedJob.Status = JobStatus.Blocked;
 
@@ -180,7 +180,7 @@ public class JobServiceRetryBlockedTests : IDisposable
         Assert.True(removed);
 
         // Create a completing job to trigger RetryBlockedJobs
-        var completingId = service.CreateTestJob("CreatePr", new CreatePrArgs(Path.GetTempPath()));
+        var completingId = service.CreateTestJob(new CreatePrArgs(Path.GetTempPath()));
         service.CompleteJob(completingId, 0);
 
         // Since the blocked job was already removed, no new ExecutePlan job should be created for it
@@ -213,16 +213,16 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Create a Running ExecutePlan job for the same plan folder (simulating an already active job)
-        var activeId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(dependentPlan));
+        var activeId = service.CreateTestJob(new ExecutePlanArgs(dependentPlan));
         Assert.Equal(JobStatus.Running, service.GetJob(activeId)!.Status);
 
         // Create a blocked job for the same plan folder
-        var blockedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(dependentPlan));
+        var blockedId = service.CreateTestJob(new ExecutePlanArgs(dependentPlan));
         var blockedJob = service.GetJob(blockedId)!;
         blockedJob.Status = JobStatus.Blocked;
 
         // Create a completing job to trigger RetryBlockedJobs
-        var completingId = service.CreateTestJob("CreatePr", new CreatePrArgs(Path.GetTempPath()));
+        var completingId = service.CreateTestJob(new CreatePrArgs(Path.GetTempPath()));
         service.CompleteJob(completingId, 0);
 
         // The blocked job should remain because an active job exists for the same plan
@@ -270,11 +270,11 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Start job A (this will hold the repo lock)
-        var jobAId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planA));
+        var jobAId = service.CreateTestJob(new ExecutePlanArgs(planA));
         Assert.Equal(JobStatus.Running, service.GetJob(jobAId)!.Status);
 
         // Attempt to start job B (should get blocked due to repo concurrency)
-        var jobBId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planB));
+        var jobBId = service.CreateTestJob(new ExecutePlanArgs(planB));
         var blockedJob = service.GetJob(jobBId)!;
         blockedJob.Status = JobStatus.Blocked;
 
@@ -323,11 +323,11 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Start job A (this will hold the repo lock)
-        var jobAId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planA));
+        var jobAId = service.CreateTestJob(new ExecutePlanArgs(planA));
         Assert.Equal(JobStatus.Running, service.GetJob(jobAId)!.Status);
 
         // Attempt to start job B (should get blocked due to repo concurrency)
-        var jobBId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planB));
+        var jobBId = service.CreateTestJob(new ExecutePlanArgs(planB));
         var blockedJob = service.GetJob(jobBId)!;
         blockedJob.Status = JobStatus.Blocked;
 
@@ -379,16 +379,16 @@ public class JobServiceRetryBlockedTests : IDisposable
             planReaderService: planReader);
 
         // Start job A (this will hold the repo lock)
-        var jobAId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planA));
+        var jobAId = service.CreateTestJob(new ExecutePlanArgs(planA));
         Assert.Equal(JobStatus.Running, service.GetJob(jobAId)!.Status);
 
         // Attempt to start job B (should get blocked due to repo concurrency)
-        var jobBId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planB));
+        var jobBId = service.CreateTestJob(new ExecutePlanArgs(planB));
         var blockedJob = service.GetJob(jobBId)!;
         blockedJob.Status = JobStatus.Blocked;
 
         // Start job C on the same repo (simulating a new job starting before job A completes)
-        var jobCId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(planC));
+        var jobCId = service.CreateTestJob(new ExecutePlanArgs(planC));
         Assert.Equal(JobStatus.Running, service.GetJob(jobCId)!.Status);
 
         var notifications = new List<JobNotification>();

--- a/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
@@ -19,7 +19,7 @@ public class JobServiceSplitPlanCompletionTests
     public void CompleteJob_SplitPlan_TransitionsToSkipped()
     {
         var (service, recorder) = CreateService();
-        var id = service.CreateTestJob("SplitPlan", new SplitPlanArgs("/plans/03500-OriginalPlan"));
+        var id = service.CreateTestJob(new SplitPlanArgs("/plans/03500-OriginalPlan"));
 
         service.CompleteJob(id, 0);
 
@@ -31,7 +31,7 @@ public class JobServiceSplitPlanCompletionTests
     public void CompleteJob_UpdatePlan_TransitionsToDraft()
     {
         var (service, recorder) = CreateService();
-        var id = service.CreateTestJob("UpdatePlan", new UpdatePlanArgs("/plans/03501-SomePlan"));
+        var id = service.CreateTestJob(new UpdatePlanArgs("/plans/03501-SomePlan"));
 
         service.CompleteJob(id, 0);
 
@@ -43,7 +43,7 @@ public class JobServiceSplitPlanCompletionTests
     public void CompleteJob_ExpandPlan_TransitionsToDraft()
     {
         var (service, recorder) = CreateService();
-        var id = service.CreateTestJob("ExpandPlan", new ExpandPlanArgs("/plans/03502-SomePlan"));
+        var id = service.CreateTestJob(new ExpandPlanArgs("/plans/03502-SomePlan"));
 
         service.CompleteJob(id, 0);
 

--- a/src/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceThreadSafetyTests.cs
@@ -18,7 +18,7 @@ public class JobServiceThreadSafetyTests
         string id;
         try
         {
-            id = service.StartJob("CreatePlan", new CreatePlanArgs("Slot filler", "Auto"));
+            id = service.StartJob(new CreatePlanArgs("Slot filler", "Auto"));
         }
         catch
         {
@@ -121,7 +121,7 @@ public class JobServiceThreadSafetyTests
             TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
             null, 2);
 
-        var jobId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs("test-plan"));
+        var jobId = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         // First call should succeed and transition the job out of Running
         service.CompleteJob(jobId, 0);
@@ -144,7 +144,7 @@ public class JobServiceThreadSafetyTests
 
         // Pre-populate with some jobs
         for (var i = 0; i < 5; i++)
-            service.CreateTestJob("ExecutePlan", new ExecutePlanArgs($"plan-{i}"));
+            service.CreateTestJob(new ExecutePlanArgs($"plan-{i}"));
 
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
         var exceptions = new ConcurrentBag<Exception>();
@@ -171,7 +171,7 @@ public class JobServiceThreadSafetyTests
             var counter = 100;
             while (!cts.Token.IsCancellationRequested)
             {
-                var id = service.CreateTestJob("CreatePlan", new CreatePlanArgs($"concurrent-{counter++}", "Auto"));
+                var id = service.CreateTestJob(new CreatePlanArgs($"concurrent-{counter++}", "Auto"));
                 Thread.Sleep(1);
                 service.DeleteJob(id);
             }

--- a/src/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
@@ -32,7 +32,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
         var job = service.GetJob(id);
         Assert.NotNull(job);
         Assert.Equal(JobStatus.Running, job.Status);
@@ -58,7 +58,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
 
         JobNotification? notification = null;
         service.NotificationReady += n => notification = n;
@@ -79,7 +79,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
 
         JobNotification? notification = null;
         service.NotificationReady += n => notification = n;
@@ -100,7 +100,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
 
         JobNotification? notification = null;
         service.NotificationReady += n => notification = n;
@@ -120,7 +120,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
 
         service.CompleteJob(id, 0);
         var job = service.GetJob(id);
@@ -138,7 +138,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
         var job = service.GetJob(id);
         var cts = job!.TimeoutCts;
         Assert.NotNull(cts);
@@ -154,10 +154,10 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var runningId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
-        var completedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
-        var failedId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
-        var timeoutId = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var runningId = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
+        var completedId = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
+        var failedId = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
+        var timeoutId = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
 
         service.CompleteJob(completedId, 0);
         service.CompleteJob(failedId, 1);
@@ -176,7 +176,7 @@ public class JobServiceTimeoutTests : IDisposable
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
         service.CompleteJob(id, 0);
 
         service.ClearFailedJobs();
@@ -223,7 +223,7 @@ codingAgent: claude
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
         var job = service.GetJob(id);
         Assert.NotNull(job);
 
@@ -243,7 +243,7 @@ codingAgent: claude
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
         var job = service.GetJob(id);
         Assert.NotNull(job);
 
@@ -285,7 +285,7 @@ codingAgent: claude
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromSeconds(5));
 
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
         var job = service.GetJob(id);
         Assert.NotNull(job);
 
@@ -304,7 +304,7 @@ codingAgent: claude
     public void ProcessId_CapturedOnJobItem()
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
         var job = service.GetJob(id);
         Assert.NotNull(job);
 
@@ -333,7 +333,7 @@ codingAgent: claude
         var logger = NullLogger<JobService>.Instance;
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), logger);
 
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
         service.CompleteJob(id, 0);
 
         var job = service.GetJob(id);
@@ -348,7 +348,7 @@ codingAgent: claude
         var logger = new CapturingLogger<JobService>(logEntries);
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), logger);
 
-        var id = service.CreateTestJob("ExecutePlan", new ExecutePlanArgs(_tempDir.Path));
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
         service.CompleteJob(id, 0);
 
         var job = service.GetJob(id);

--- a/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -186,7 +186,7 @@ public class PlanCountsServiceTests : IDisposable
             return _jobs.FirstOrDefault(j => j.Id == id);
         }
 
-        public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null)
         {
             throw new NotImplementedException();
         }

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -74,7 +74,7 @@ public class ContentView(
                         | new Button("Execute").Icon(Icons.Rocket).Outline().ShortcutKey("e").OnClick(() =>
                         {
                             planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
-                            jobService.StartJob(Constants.JobTypes.ExecutePlan, new ExecutePlanArgs(selectedPlan.FolderPath));
+                            jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath));
                             refreshPlans();
                         })
                         | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(

--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -193,7 +193,7 @@ public partial class JobsApp
                             }
 
                             jobService.DeleteJob(job.Id);
-                            jobService.StartJob(job.Type, job.TypedArgs);
+                            jobService.StartJob(job.TypedArgs);
 
                             refreshToken.Refresh();
                         }

--- a/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
@@ -73,7 +73,7 @@ public class ActionBarView(
                     selectedPlanState.Set(optimisticPlan);
 
                     planService.TransitionState(selectedPlan.FolderName, PlanStatus.Updating);
-                    jobService.StartJob("SplitPlan", new SplitPlanArgs(selectedPlan.FolderPath));
+                    jobService.StartJob(new SplitPlanArgs(selectedPlan.FolderPath));
                     refreshPlans();
                 })
                 | new Button("Expand").Icon(Icons.UnfoldVertical).Outline().ShortcutKey("x")
@@ -91,7 +91,7 @@ public class ActionBarView(
 
                     planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
                     var planPath = selectedPlan.FolderPath;
-                    jobService.StartJob("ExpandPlan", new ExpandPlanArgs(planPath));
+                    jobService.StartJob(new ExpandPlanArgs(planPath));
                     refreshPlans();
                 })
                 | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -161,7 +161,7 @@ public class ContentView(
             selectedPlanState.Set(optimisticPlan);
 
             planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
-            jobService.StartJob("ExecutePlan", new ExecutePlanArgs(selectedPlan.FolderPath));
+            jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath));
             refreshPlans();
         });
 

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/CreateIssueDialog.cs
@@ -129,7 +129,7 @@ public class CreateIssueDialog(
                             var repoPath = selectedRepo.FullName;
                             var assignee = issueAssigneeState.Value ?? "";
                             var selectedLabels = string.Join(",", issueLabelsState.Value);
-                            jobService.StartJob(Constants.JobTypes.CreateIssue, new CreateIssueArgs(selectedPlan.FolderPath, repoPath, assignee, issueCommentState.Value, selectedLabels));
+                            jobService.StartJob(new CreateIssueArgs(selectedPlan.FolderPath, repoPath, assignee, issueCommentState.Value, selectedLabels));
                         }
                     }
 

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
@@ -76,7 +76,7 @@ public class UpdatePlanDialog(
                         _planService.SavePlan(_selectedPlan.FolderName, currentContent + "\n\n" + comments + "\n");
 
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
-                        _jobService.StartJob(Constants.JobTypes.UpdatePlan, new UpdatePlanArgs(_selectedPlan.FolderPath));
+                        _jobService.StartJob(new UpdatePlanArgs(_selectedPlan.FolderPath));
                         _refreshPlans();
                         _updateText.Set("");
                         isCreating.Set(false);

--- a/src/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -166,7 +166,7 @@ public class PullRequestApp : ViewBase
                 (description, projects, priority) =>
                 {
                     var project = string.Join(",", projects);
-                    jobService.StartJob(Constants.JobTypes.CreatePlan, new CreatePlanArgs(description, project, priority));
+                    jobService.StartJob(new CreatePlanArgs(description, project, priority));
                 },
                 () =>
                 {

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -52,7 +52,7 @@ public class ContentView(
                      | new Button("Accept").Icon(Icons.Check).Primary().ShortcutKey("a").OnClick(() =>
                      {
                          planService.UpdateRecommendationState(selectedRecommendation.PlanFolderName, selectedRecommendation.Title, "Accepted");
-                         jobService.StartJob(Constants.JobTypes.CreatePlan, new CreatePlanArgs(selectedRecommendation.Description, selectedRecommendation.Project));
+                         jobService.StartJob(new CreatePlanArgs(selectedRecommendation.Description, selectedRecommendation.Project));
                          client.Toast($"Started CreatePlan: {selectedRecommendation.Title}", "Recommendation Accepted");
                          refresh();
                          GoToNext();
@@ -141,7 +141,7 @@ public class ContentView(
             {
                 var description = $"[ORIGINAL RECOMMENDATION]\n{selectedRecommendation.Description}\n\n[NOTES]\n{notes}";
                 planService.UpdateRecommendationState(selectedRecommendation.PlanFolderName, selectedRecommendation.Title, "AcceptedWithNotes");
-                jobService.StartJob(Constants.JobTypes.CreatePlan, new CreatePlanArgs(description, selectedRecommendation.Project));
+                jobService.StartJob(new CreatePlanArgs(description, selectedRecommendation.Project));
                 client.Toast($"Started CreatePlan: {selectedRecommendation.Title}", "Recommendation Accepted with Notes");
                 refresh();
                 GoToNext();

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -226,7 +226,7 @@ public class ContentView(
 
             if (allYolo)
             {
-                jobService.StartJob(Constants.JobTypes.CreatePr, new CreatePrArgs(selectedPlan.FolderPath));
+                jobService.StartJob(new CreatePrArgs(selectedPlan.FolderPath));
                 planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
                 refreshPlans();
             }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -83,7 +83,7 @@ public class CustomPrDialog(
                     if (!isCreating.Value)
                     {
                         isCreating.Set(true);
-                        _jobService.StartJob(Constants.JobTypes.CreatePr, new CreatePrArgs(
+                        _jobService.StartJob(new CreatePrArgs(
                             _selectedPlan.FolderPath,
                             Merge: customPrMerge.Value,
                             DeleteBranch: customPrDeleteBranch.Value && customPrMerge.Value,

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/RerunDialog.cs
@@ -53,7 +53,7 @@ public class RerunDialog(
                         Task.Run(() =>
                         {
                             CleanPlanState(folderPath, logger);
-                            _jobService.StartJob(Constants.JobTypes.ExecutePlan, new ExecutePlanArgs(folderPath, Note: "User requested a clean rerun. All artifacts, logs, and worktrees have been cleaned. Execute this plan from scratch."));
+                            _jobService.StartJob(new ExecutePlanArgs(folderPath, Note: "User requested a clean rerun. All artifacts, logs, and worktrees have been cleaned. Execute this plan from scratch."));
                         });
                     }
                 }),
@@ -64,7 +64,7 @@ public class RerunDialog(
                         isRerunningCurrent.Set(true);
                         _dialogOpen.Set(false);
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
-                        _jobService.StartJob(Constants.JobTypes.ExecutePlan, new ExecutePlanArgs(_selectedPlan.FolderPath, Note: "User requested you to execute this plan another time. Go through all code, verifications and artifacts one more time."));
+                        _jobService.StartJob(new ExecutePlanArgs(_selectedPlan.FolderPath, Note: "User requested you to execute this plan another time. Go through all code, verifications and artifacts one more time."));
                         _refreshPlans();
                     }
                 })

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
@@ -57,7 +57,7 @@ public class SuggestChangesDialog(
                         _planService.SavePlan(_selectedPlan.FolderName, currentContent + "\n\n" + comments + "\n");
 
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
-                        _jobService.StartJob(Constants.JobTypes.UpdatePlan, new UpdatePlanArgs(_selectedPlan.FolderPath));
+                        _jobService.StartJob(new UpdatePlanArgs(_selectedPlan.FolderPath));
                         _refreshPlans();
                         isCreating.Set(false);
                         _suggestText.Set("");

--- a/src/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/Ivy.Tendril/Apps/TrashApp.cs
@@ -86,7 +86,7 @@ public class TrashApp : ViewBase
                                 if (!string.IsNullOrEmpty(selected.OriginalRequest))
                                 {
                                     var project = string.IsNullOrEmpty(selected.Project) ? "Auto" : selected.Project;
-                                    jobService.StartJob(Constants.JobTypes.CreatePlan, new CreatePlanArgs(selected.OriginalRequest, project, Force: true));
+                                    jobService.StartJob(new CreatePlanArgs(selected.OriginalRequest, project, Force: true));
                                     client.Toast("CreatePlan job started", "Force Plan");
                                 }
                             });

--- a/src/Ivy.Tendril/Controllers/InboxController.cs
+++ b/src/Ivy.Tendril/Controllers/InboxController.cs
@@ -19,7 +19,7 @@ public class InboxController(IJobService jobService) : ControllerBase
         {
             var project = request.Project ?? "Auto";
             var args = new CreatePlanArgs(request.Description, project, SourcePath: request.SourcePath);
-            var jobId = jobService.StartJob(Constants.JobTypes.CreatePlan, args);
+            var jobId = jobService.StartJob(args);
             return Ok(new { jobId, status = "Started", message = "Plan creation job started successfully" });
         }
         catch (Exception ex)

--- a/src/Ivy.Tendril/Hooks/UseStartJob.cs
+++ b/src/Ivy.Tendril/Hooks/UseStartJob.cs
@@ -12,20 +12,18 @@ public static class UseStartJobExtensions
     /// </summary>
     /// <param name="context">The view context</param>
     /// <returns>A tuple containing the startJob action and isStarting flag</returns>
-    public static (Action<string, JobArgsBase> StartJob, bool IsStarting) UseStartJob(
+    public static (Action<JobArgsBase> StartJob, bool IsStarting) UseStartJob(
         this IViewContext context)
     {
         var jobService = context.UseService<IJobService>();
         var isStarting = context.UseState(false);
 
-        Action<string, JobArgsBase> startJob = (type, args) =>
+        Action<JobArgsBase> startJob = args =>
         {
             if (!isStarting.Value)
             {
                 isStarting.Set(true);
-                jobService.StartJob(type, args);
-                // Note: isStarting stays true - dialogs close immediately after StartJob,
-                // so resetting to false is not needed
+                jobService.StartJob(args);
             }
         };
 

--- a/src/Ivy.Tendril/Models/JobArgs.cs
+++ b/src/Ivy.Tendril/Models/JobArgs.cs
@@ -12,6 +12,9 @@ namespace Ivy.Tendril.Models;
 [JsonDerivedType(typeof(UpdateProjectArgs), "UpdateProject")]
 public abstract record JobArgsBase
 {
+    [JsonIgnore]
+    public abstract string Type { get; }
+    [JsonIgnore]
     public virtual string? PlanFolder => null;
 }
 
@@ -20,30 +23,37 @@ public record CreatePlanArgs(
     string Project,
     int Priority = 0,
     bool Force = false,
-    string? SourcePath = null) : JobArgsBase;
+    string? SourcePath = null) : JobArgsBase
+{
+    public override string Type => Constants.JobTypes.CreatePlan;
+}
 
 public record ExecutePlanArgs(
     string FolderPath,
     string? Note = null) : JobArgsBase
 {
+    public override string Type => Constants.JobTypes.ExecutePlan;
     public override string PlanFolder => FolderPath;
 }
 
 public record ExpandPlanArgs(
     string FolderPath) : JobArgsBase
 {
+    public override string Type => Constants.JobTypes.ExpandPlan;
     public override string PlanFolder => FolderPath;
 }
 
 public record UpdatePlanArgs(
     string FolderPath) : JobArgsBase
 {
+    public override string Type => Constants.JobTypes.UpdatePlan;
     public override string PlanFolder => FolderPath;
 }
 
 public record SplitPlanArgs(
     string FolderPath) : JobArgsBase
 {
+    public override string Type => Constants.JobTypes.SplitPlan;
     public override string PlanFolder => FolderPath;
 }
 
@@ -56,6 +66,7 @@ public record CreatePrArgs(
     string? Comment = null,
     bool Draft = false) : JobArgsBase
 {
+    public override string Type => Constants.JobTypes.CreatePr;
     public override string PlanFolder => FolderPath;
 }
 
@@ -66,11 +77,13 @@ public record CreateIssueArgs(
     string? Comment = null,
     string? Labels = null) : JobArgsBase
 {
+    public override string Type => Constants.JobTypes.CreateIssue;
     public override string PlanFolder => FolderPath;
 }
 
 public record UpdateProjectArgs(
     string FolderPath) : JobArgsBase
 {
+    public override string Type => Constants.JobTypes.UpdateProject;
     public override string PlanFolder => FolderPath;
 }

--- a/src/Ivy.Tendril/Services/IJobService.cs
+++ b/src/Ivy.Tendril/Services/IJobService.cs
@@ -10,7 +10,7 @@ public interface IJobService : IDisposable
     event Action? JobPropertyChanged;    // Only properties changed (cost, tokens)
     event Action<JobNotification>? NotificationReady;
 
-    string StartJob(string type, JobArgsBase args, string? inboxFilePath = null);
+    string StartJob(JobArgsBase args, string? inboxFilePath = null);
     void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false);
     void StopJob(string id);
     void DeleteJob(string id);

--- a/src/Ivy.Tendril/Services/InboxWatcherService.cs
+++ b/src/Ivy.Tendril/Services/InboxWatcherService.cs
@@ -193,7 +193,7 @@ public class InboxWatcherService : IInboxWatcherService
         }
 
         var args = new CreatePlanArgs(description, project, SourcePath: sourcePath);
-        _jobService.StartJob(Constants.JobTypes.CreatePlan, args, processingPath);
+        _jobService.StartJob(args, processingPath);
     }
 
     internal static (string project, string description, string? sourcePath) ParseContent(string content)

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -47,7 +47,7 @@ internal class JobCompletionHandler
         Action<JobItem> persistJob,
         Action<JobNotification> raiseNotification,
         Action raisePropertyChanged,
-        Func<string, JobArgsBase, string> startJobSkipDepCheck)
+        Func<JobArgsBase, string> startJobSkipDepCheck)
     {
         var isSuccess = job.Status == JobStatus.Completed;
 
@@ -769,13 +769,13 @@ internal class JobCompletionHandler
     internal void HandleRetryBlockedJobs(
         ConcurrentDictionary<string, JobItem> jobs,
         Action<JobNotification> raiseNotification,
-        Func<string, JobArgsBase, string> startJobSkipDepCheck)
+        Func<JobArgsBase, string> startJobSkipDepCheck)
         => RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
 
     private void RetryBlockedJobs(
         ConcurrentDictionary<string, JobItem> jobs,
         Action<JobNotification> raiseNotification,
-        Func<string, JobArgsBase, string> startJobSkipDepCheck)
+        Func<JobArgsBase, string> startJobSkipDepCheck)
     {
         var blockedJobs = jobs.Values
             .Where(j => j.Status == JobStatus.Blocked && j.Type == Constants.JobTypes.ExecutePlan)
@@ -794,7 +794,7 @@ internal class JobCompletionHandler
             if (!jobs.TryRemove(blockedJob.Id, out _)) continue;
 
             PlanYamlHelper.SetPlanStateByFolder(planFolder, "Building");
-            startJobSkipDepCheck(blockedJob.Type, blockedJob.TypedArgs!);
+            startJobSkipDepCheck(blockedJob.TypedArgs!);
 
             raiseNotification(new JobNotification(
                 "Job Unblocked",
@@ -806,7 +806,7 @@ internal class JobCompletionHandler
     private void RetryBlockedDependents(
         string completedPlanFolder,
         ConcurrentDictionary<string, JobItem> jobs,
-        Func<string, JobArgsBase, string> startJobSkipDepCheck)
+        Func<JobArgsBase, string> startJobSkipDepCheck)
     {
         try
         {
@@ -832,7 +832,7 @@ internal class JobCompletionHandler
                 if (allMet)
                 {
                     PlanYamlHelper.SetPlanStateByFolder(dir, "Building");
-                    startJobSkipDepCheck(Constants.JobTypes.ExecutePlan, new ExecutePlanArgs(dir));
+                    startJobSkipDepCheck(new ExecutePlanArgs(dir));
                 }
             }
         }

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -107,9 +107,9 @@ public class JobService : IJobService
     public event Action? JobPropertyChanged;
     public event Action<JobNotification>? NotificationReady;
 
-    public string StartJob(string type, JobArgsBase args, string? inboxFilePath = null)
+    public string StartJob(JobArgsBase args, string? inboxFilePath = null)
     {
-        return StartJobInternal(type, args, inboxFilePath);
+        return StartJobInternal(args, inboxFilePath);
     }
 
     public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false)
@@ -363,15 +363,15 @@ public class JobService : IJobService
             NotificationReady?.Invoke(notification);
     }
 
-    private string StartJobSkipDepCheck(string type, JobArgsBase args)
+    private string StartJobSkipDepCheck(JobArgsBase args)
     {
-        return StartJobInternal(type, args, inboxFilePath: null, skipDependencyCheck: true);
+        return StartJobInternal(args, inboxFilePath: null, skipDependencyCheck: true);
     }
 
-    private string StartJobInternal(string type, JobArgsBase args, string? inboxFilePath, bool skipDependencyCheck = false)
+    private string StartJobInternal(JobArgsBase args, string? inboxFilePath, bool skipDependencyCheck = false)
     {
         var id = $"job-{Interlocked.Increment(ref _counter):D3}";
-        var job = BuildJobItem(id, type, args, inboxFilePath);
+        var job = BuildJobItem(id, args, inboxFilePath);
 
         if (TryRejectConflictingJob(job))
             return id;
@@ -381,7 +381,7 @@ public class JobService : IJobService
         if (TryBlockForDependencies(job, skipDependencyCheck))
             return id;
 
-        if (type is Constants.JobTypes.ExecutePlan or Constants.JobTypes.ExpandPlan or Constants.JobTypes.UpdatePlan or Constants.JobTypes.SplitPlan)
+        if (job.Type is Constants.JobTypes.ExecutePlan or Constants.JobTypes.ExpandPlan or Constants.JobTypes.UpdatePlan or Constants.JobTypes.SplitPlan)
             _planReaderService?.FlushPendingWritesAsync().GetAwaiter().GetResult();
 
         if (!_jobSlotSemaphore.Wait(0))
@@ -397,14 +397,14 @@ public class JobService : IJobService
         return id;
     }
 
-    private JobItem BuildJobItem(string id, string type, JobArgsBase args, string? inboxFilePath)
+    private JobItem BuildJobItem(string id, JobArgsBase args, string? inboxFilePath)
     {
-        var (planFile, project, priority) = ExtractJobMetadata(type, args);
+        var (planFile, project, priority) = ExtractJobMetadata(args);
 
         var job = new JobItem
         {
             Id = id,
-            Type = type,
+            Type = args.Type,
             PlanFile = planFile,
             Project = project,
             Status = JobStatus.Pending,
@@ -413,13 +413,13 @@ public class JobService : IJobService
             Priority = priority
         };
 
-        if (type == Constants.JobTypes.CreatePlan)
+        if (args is CreatePlanArgs)
             SetupInboxTracking(job, id, args, inboxFilePath);
 
         return job;
     }
 
-    private static (string PlanFile, string Project, int Priority) ExtractJobMetadata(string type, JobArgsBase args)
+    private static (string PlanFile, string Project, int Priority) ExtractJobMetadata(JobArgsBase args)
     {
         if (args is CreatePlanArgs cp)
         {
@@ -513,14 +513,14 @@ public class JobService : IJobService
     ///     Creates a job in "Running" state without launching a real process.
     ///     Used by tests to exercise CompleteJob without background monitor races.
     /// </summary>
-    internal string CreateTestJob(string type, JobArgsBase args)
+    internal string CreateTestJob(JobArgsBase args)
     {
         var id = $"job-{Interlocked.Increment(ref _counter):D3}";
         var job = new JobItem
         {
             Id = id,
-            Type = type,
-            PlanFile = args.PlanFolder ?? type,
+            Type = args.Type,
+            PlanFile = args.PlanFolder ?? args.Type,
             Status = JobStatus.Running,
             StartedAt = DateTime.UtcNow,
             TypedArgs = args,

--- a/src/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs
+++ b/src/Ivy.Tendril/Views/CreatePlanDialogLauncher.cs
@@ -37,7 +37,7 @@ public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : View
                     {
                         lastSelectedProjects.Set(projects);
                         var project = string.Join(",", projects);
-                        jobService.StartJob(Constants.JobTypes.CreatePlan, new CreatePlanArgs(description, project, priority, Force: true));
+                        jobService.StartJob(new CreatePlanArgs(description, project, priority, Force: true));
                     },
                     () => dialogOpen.Set(false),
                     lastSelectedProjects.Value


### PR DESCRIPTION
## Summary
- Add abstract `Type` property to `JobArgsBase` — each POCO returns its constant (e.g. `ExecutePlanArgs.Type => "ExecutePlan"`)
- Remove the `type` parameter from `StartJob`, `StartJobInternal`, `StartJobSkipDepCheck`, `BuildJobItem`, `ExtractJobMetadata`, and `CreateTestJob`
- Callers now just pass the args: `jobService.StartJob(new ExecutePlanArgs(folder))`
- Eliminates potential bugs where type string and POCO could mismatch
- `[JsonIgnore]` on `Type` and `PlanFolder` to keep serialization clean

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] All 1410 tests pass