### PR TITLE
Replace string-based job type checks with pattern matching on TypedArgs

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -183,11 +183,11 @@ public partial class JobsApp
                             }
 
                             var folder = job.TypedArgs.PlanFolder;
-                            if (job.Type is "ExecutePlan" or "ExpandPlan" && folder != null)
+                            if (job.TypedArgs is ExecutePlanArgs or ExpandPlanArgs && folder != null)
                             {
                                 planService.TransitionState(Path.GetFileName(folder), PlanStatus.Building);
                             }
-                            else if (job.Type == "UpdatePlan" && folder != null)
+                            else if (job.TypedArgs is UpdatePlanArgs && folder != null)
                             {
                                 planService.TransitionState(Path.GetFileName(folder), PlanStatus.Updating);
                             }

--- a/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
@@ -92,7 +92,7 @@ public partial class JobsApp
             return TruncatePrompt(j.ReportedPlanTitle);
 
         // Try CreatePlan description
-        if (j.Type == "CreatePlan")
+        if (j.TypedArgs is CreatePlanArgs)
             return TruncatePrompt(GetFullPrompt(j) ?? j.PlanFile);
 
         // Fallback to full prompt (resolves InitialPrompt/Title from plan.yaml) or plan file

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -223,14 +223,14 @@ public class ContentView(
 
         // Check for active ExpandPlan job
         var hasActiveExpandJob = jobService.GetJobs().Any(j =>
-            j.Type == "ExpandPlan" &&
+            j.TypedArgs is ExpandPlanArgs &&
             j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
             j.TypedArgs?.PlanFolder != null &&
             j.TypedArgs.PlanFolder.Equals(selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
 
         // Check for active SplitPlan job
         var hasActiveSplitJob = jobService.GetJobs().Any(j =>
-            j.Type == "SplitPlan" &&
+            j.TypedArgs is SplitPlanArgs &&
             j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
             j.TypedArgs?.PlanFolder != null &&
             j.TypedArgs.PlanFolder.Equals(selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
@@ -29,7 +29,7 @@ public class UpdatePlanDialog(
 
         // Check if there's already an UpdatePlan job running for this plan
         var hasActiveJob = _jobService.GetJobs().Any(j =>
-            j.Type == Constants.JobTypes.UpdatePlan &&
+            j.TypedArgs is UpdatePlanArgs &&
             j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
             j.TypedArgs?.PlanFolder != null &&
             j.TypedArgs.PlanFolder.Equals(_selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -63,10 +63,10 @@ internal class JobCompletionHandler
         if (job.Status is JobStatus.Failed or JobStatus.Timeout)
             ScheduleWorktreeCleanup(job);
 
-        if (job.Type is Constants.JobTypes.ExecutePlan or Constants.JobTypes.CreatePr)
+        if (job.TypedArgs is ExecutePlanArgs or CreatePrArgs)
             RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
 
-        if (isSuccess && job.Type is Constants.JobTypes.ExecutePlan or Constants.JobTypes.CreatePr or Constants.JobTypes.CreateIssue)
+        if (isSuccess && job.TypedArgs is ExecutePlanArgs or CreatePrArgs or CreateIssueArgs)
         {
             var planFolder = job.TypedArgs?.PlanFolder ?? "";
             RetryBlockedDependents(planFolder, jobs, startJobSkipDepCheck);
@@ -95,24 +95,24 @@ internal class JobCompletionHandler
         {
             ResetPlanState(job);
         }
-        else if (isSuccess && job.Type == Constants.JobTypes.ExecutePlan)
+        else if (isSuccess && job.TypedArgs is ExecutePlanArgs)
         {
             SyncPlanArtifacts(job);
             EnsurePlanStateTransitioned(job);
         }
-        else if (isSuccess && job.Type == Constants.JobTypes.CreateIssue)
+        else if (isSuccess && job.TypedArgs is CreateIssueArgs)
         {
             SetPlanState(job, "Completed");
         }
-        else if (isSuccess && job.Type is Constants.JobTypes.UpdatePlan or Constants.JobTypes.ExpandPlan)
+        else if (isSuccess && job.TypedArgs is UpdatePlanArgs or ExpandPlanArgs)
         {
             SetPlanState(job, "Draft");
         }
-        else if (isSuccess && job.Type == Constants.JobTypes.SplitPlan)
+        else if (isSuccess && job.TypedArgs is SplitPlanArgs)
         {
             SetPlanState(job, "Skipped");
         }
-        else if (isSuccess && job.Type == Constants.JobTypes.CreatePlan)
+        else if (isSuccess && job.TypedArgs is CreatePlanArgs)
         {
             VerifyCreatePlanResult(job);
         }
@@ -120,7 +120,7 @@ internal class JobCompletionHandler
 
     private void TrackTelemetry(JobItem job, bool isSuccess)
     {
-        if (isSuccess && job.Type == Constants.JobTypes.CreatePlan && job.Status == JobStatus.Completed)
+        if (isSuccess && job.TypedArgs is CreatePlanArgs && job.Status == JobStatus.Completed)
         {
             var planFolder = job.TypedArgs?.PlanFolder ?? "";
             var level = "NiceToHave";
@@ -133,7 +133,7 @@ internal class JobCompletionHandler
             _telemetryService?.TrackPlanCreated(new PlanCreatedContext(level, job.DurationSeconds));
         }
 
-        if (isSuccess && job.Type == Constants.JobTypes.CreatePr)
+        if (isSuccess && job.TypedArgs is CreatePrArgs)
         {
             _telemetryService?.TrackPrCreated(new PrCreatedContext(job.DurationSeconds));
         }
@@ -640,10 +640,10 @@ internal class JobCompletionHandler
     {
         try
         {
-            if (job.Type is Constants.JobTypes.CreatePlan or Constants.JobTypes.CreatePr or Constants.JobTypes.CreateIssue) return;
+            if (job.TypedArgs is CreatePlanArgs or CreatePrArgs or CreateIssueArgs) return;
 
             var planFolder = job.TypedArgs?.PlanFolder ?? "";
-            var newState = job.Type == Constants.JobTypes.ExecutePlan ? "Failed" : "Draft";
+            var newState = job.TypedArgs is ExecutePlanArgs ? "Failed" : "Draft";
             PlanYamlHelper.SetPlanStateByFolder(planFolder, newState);
         }
         catch (Exception ex)
@@ -680,7 +680,7 @@ internal class JobCompletionHandler
 
     private void ScheduleWorktreeCleanup(JobItem job)
     {
-        if (job.Type != Constants.JobTypes.ExecutePlan) return;
+        if (job.TypedArgs is not ExecutePlanArgs) return;
 
         var planFolder = job.TypedArgs?.PlanFolder ?? "";
         if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder)) return;
@@ -778,7 +778,7 @@ internal class JobCompletionHandler
         Func<JobArgsBase, string> startJobSkipDepCheck)
     {
         var blockedJobs = jobs.Values
-            .Where(j => j.Status == JobStatus.Blocked && j.Type == Constants.JobTypes.ExecutePlan)
+            .Where(j => j.Status == JobStatus.Blocked && j.TypedArgs is ExecutePlanArgs)
             .ToList();
 
         foreach (var blockedJob in blockedJobs)
@@ -822,7 +822,7 @@ internal class JobCompletionHandler
                 if (!planYaml.DependsOn.Contains(completedFolderName, StringComparer.OrdinalIgnoreCase)) continue;
 
                 var hasExistingJob = jobs.Values.Any(j =>
-                    j.Type == Constants.JobTypes.ExecutePlan &&
+                    j.TypedArgs is ExecutePlanArgs &&
                     j.Status is JobStatus.Blocked or JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
                     j.TypedArgs?.PlanFolder != null &&
                     j.TypedArgs.PlanFolder.Equals(dir, StringComparison.OrdinalIgnoreCase));
@@ -847,7 +847,7 @@ internal class JobCompletionHandler
 
         return jobs.Values.Any(j =>
         {
-            if (j.Type != Constants.JobTypes.ExecutePlan) return false;
+            if (j.TypedArgs is not ExecutePlanArgs) return false;
             if (j.Status is not (JobStatus.Running or JobStatus.Queued or JobStatus.Pending)) return false;
 
             var otherFolder = j.TypedArgs?.PlanFolder;
@@ -869,7 +869,7 @@ internal class JobCompletionHandler
 
     private string? ResolvePlanFolder(JobItem job)
     {
-        if (job.Type != Constants.JobTypes.CreatePlan)
+        if (job.TypedArgs is not CreatePlanArgs)
             return job.TypedArgs?.PlanFolder;
 
         var planId = job.ReportedPlanId ?? job.AllocatedPlanId;
@@ -902,7 +902,7 @@ internal class JobCompletionHandler
         if (_planReaderService == null || string.IsNullOrEmpty(job.PlanFile))
             return;
 
-        if (job.Type == Constants.JobTypes.CreatePlan)
+        if (job.TypedArgs is CreatePlanArgs)
             return;
 
         try
@@ -978,7 +978,7 @@ internal class JobCompletionHandler
 
     private static string BuildPlanOutcomeSummary(JobItem job)
     {
-        if (job.Type != Constants.JobTypes.ExecutePlan)
+        if (job.TypedArgs is not ExecutePlanArgs)
             return "";
 
         var planFolder = job.TypedArgs?.PlanFolder ?? "";

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -73,10 +73,10 @@ internal class JobLauncher
         job.StartedAt = DateTime.UtcNow;
         job.StatusMessage = null;
 
-        var planFolderForHooks = type != Constants.JobTypes.CreatePlan ? (job.TypedArgs?.PlanFolder ?? "") : "";
+        var planFolderForHooks = job.TypedArgs is not CreatePlanArgs ? (job.TypedArgs?.PlanFolder ?? "") : "";
         ctx.RunHooks("before", type, planFolderForHooks, job.Project, job);
 
-        if (type == Constants.JobTypes.ExecutePlan && !string.IsNullOrEmpty(job.TypedArgs?.PlanFolder))
+        if (job.TypedArgs is ExecutePlanArgs && !string.IsNullOrEmpty(job.TypedArgs?.PlanFolder))
             PlanYamlHelper.SetPlanStateByFolder(job.TypedArgs!.PlanFolder!, "Executing");
 
         job.SessionId = Guid.NewGuid().ToString();
@@ -464,7 +464,7 @@ internal class JobLauncher
             ["ClaudeSessionId"] = job.SessionId ?? ""
         };
 
-        if (job.Type == Constants.JobTypes.CreatePlan)
+        if (job.TypedArgs is CreatePlanArgs)
         {
             BuildCreatePlanFirmware(ctx, values);
             return (values, null, null);
@@ -528,14 +528,14 @@ internal class JobLauncher
 
     private static string? ExtractExecutionProfile(JobItem job, PlanYaml planYaml)
     {
-        if (job.Type == Constants.JobTypes.ExecutePlan && !string.IsNullOrEmpty(planYaml.ExecutionProfile))
+        if (job.TypedArgs is ExecutePlanArgs && !string.IsNullOrEmpty(planYaml.ExecutionProfile))
             return planYaml.ExecutionProfile;
         return null;
     }
 
     private void AddRepoConfigsIfNeeded(JobItem job, PlanYaml planYaml, Dictionary<string, string> values)
     {
-        if (job.Type is not (Constants.JobTypes.ExecutePlan or Constants.JobTypes.CreatePr))
+        if (job.TypedArgs is not (ExecutePlanArgs or CreatePrArgs))
             return;
 
         var repoConfigs = BuildRepoConfigsYaml(planYaml, job.Project);
@@ -545,7 +545,7 @@ internal class JobLauncher
 
     private static void AddCreatePrOptions(JobItem job, Dictionary<string, string> values)
     {
-        if (job.Type != Constants.JobTypes.CreatePr || job.TypedArgs is not CreatePrArgs pr)
+        if (job.TypedArgs is not CreatePrArgs pr)
             return;
 
         values["PrMerge"] = pr.Merge.ToString().ToLowerInvariant();

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -205,7 +205,7 @@ public class JobService : IJobService
         JobCompletionHandler.CleanupInboxFile(job);
         _completionHandler.ResetPlanState(job);
 
-        if (job.Type is Constants.JobTypes.ExecutePlan or Constants.JobTypes.CreatePr)
+        if (job.TypedArgs is ExecutePlanArgs or CreatePrArgs)
             _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck);
 
         RaiseJobsStructureChanged();
@@ -285,7 +285,7 @@ public class JobService : IJobService
     public bool IsInboxFileTracked(string filePath)
     {
         return _jobs.Values.Any(j =>
-            j.Type == Constants.JobTypes.CreatePlan &&
+            j.TypedArgs is CreatePlanArgs &&
             j.Status is JobStatus.Pending or JobStatus.Queued or JobStatus.Running &&
             j.InboxFile != null &&
             j.InboxFile.Equals(filePath, StringComparison.OrdinalIgnoreCase));
@@ -381,7 +381,7 @@ public class JobService : IJobService
         if (TryBlockForDependencies(job, skipDependencyCheck))
             return id;
 
-        if (job.Type is Constants.JobTypes.ExecutePlan or Constants.JobTypes.ExpandPlan or Constants.JobTypes.UpdatePlan or Constants.JobTypes.SplitPlan)
+        if (job.TypedArgs is ExecutePlanArgs or ExpandPlanArgs or UpdatePlanArgs or SplitPlanArgs)
             _planReaderService?.FlushPendingWritesAsync().GetAwaiter().GetResult();
 
         if (!_jobSlotSemaphore.Wait(0))
@@ -463,7 +463,7 @@ public class JobService : IJobService
 
     private bool TryRejectConflictingJob(JobItem job)
     {
-        if (job.Type is not (Constants.JobTypes.ExecutePlan or Constants.JobTypes.UpdatePlan or Constants.JobTypes.ExpandPlan or Constants.JobTypes.SplitPlan))
+        if (job.TypedArgs is not (ExecutePlanArgs or UpdatePlanArgs or ExpandPlanArgs or SplitPlanArgs))
             return false;
 
         var planFolder = job.TypedArgs?.PlanFolder ?? "";
@@ -491,7 +491,7 @@ public class JobService : IJobService
 
     private bool TryBlockForDependencies(JobItem job, bool skipDependencyCheck)
     {
-        if (job.Type != Constants.JobTypes.ExecutePlan || skipDependencyCheck)
+        if (job.TypedArgs is not ExecutePlanArgs || skipDependencyCheck)
             return false;
 
         var planFolder = job.TypedArgs?.PlanFolder ?? "";


### PR DESCRIPTION
## Summary
- Replace `job.Type == Constants.JobTypes.X` with `job.TypedArgs is XArgs` across JobCompletionHandler, JobService, JobLauncher, and UI files
- Type-safe: compile error if a POCO is renamed/removed, unlike silent string mismatch
- `Constants.JobTypes` retained for DB persistence, StatusMappings, and POCO Type properties

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] All 1410 tests pass