### PR TITLE
[00219] Fix onboarding Skip Verifications not writing project to config file

### DIFF
--- a/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
@@ -1,0 +1,52 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test;
+
+public class OnboardingSetupServiceTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("ivy-onboarding-test");
+
+    public void Dispose()
+    {
+        _tempDir.Dispose();
+    }
+
+    [Fact]
+    public async Task FinalizeOnboardingAsync_Should_Persist_Project_To_Config_File()
+    {
+        // Arrange: create a bootstrapped config.yaml at the tendril home path (no projects)
+        var tendrilHome = Path.Combine(_tempDir.Path, "tendril-home");
+        Directory.CreateDirectory(tendrilHome);
+        var configPath = Path.Combine(tendrilHome, "config.yaml");
+        File.WriteAllText(configPath, "codingAgent: claude\nprojects: []\n");
+
+        // Create a ConfigService in onboarding mode (no TENDRIL_HOME set)
+        var configService = new ConfigService(new TendrilSettings());
+        configService.SetPendingTendrilHome(tendrilHome);
+        configService.SetPendingProject(new ProjectConfig
+        {
+            Name = "TestProject",
+            Repos = new List<RepoRef> { new() { Path = "/tmp/test-repo" } }
+        });
+
+        // Create the OnboardingSetupService
+        var onboardingService = new OnboardingSetupService(
+            configService,
+            null!,
+            NullLogger<OnboardingSetupService>.Instance);
+
+        // Act
+        await onboardingService.FinalizeOnboardingAsync();
+
+        // Assert: re-read the config file at the tendril home path
+        var savedYaml = File.ReadAllText(configPath);
+        var savedSettings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(savedYaml);
+
+        Assert.NotNull(savedSettings);
+        Assert.Single(savedSettings.Projects);
+        Assert.Equal("TestProject", savedSettings.Projects[0].Name);
+        Assert.Equal("/tmp/test-repo", savedSettings.Projects[0].Repos[0].Path);
+    }
+}

--- a/src/Ivy.Tendril/Services/OnboardingSetupService.cs
+++ b/src/Ivy.Tendril/Services/OnboardingSetupService.cs
@@ -167,10 +167,10 @@ public class OnboardingSetupService(IConfigService config, IServiceProvider serv
         if (string.IsNullOrEmpty(tendrilHome))
             throw new InvalidOperationException("Tendril home path not set; cannot finalize onboarding.");
 
-        await CommitPendingProjectAsync();
-
         _logger.LogInformation("Marking onboarding complete");
         config.CompleteOnboarding(tendrilHome);
+
+        await CommitPendingProjectAsync();
 
         _logger.LogInformation("Configuration saved");
     }


### PR DESCRIPTION
Fixes #551

## Summary

Fixed the onboarding "Skip Verifications" flow losing the newly created project by reordering `CommitPendingProjectAsync()` to run after `CompleteOnboarding()` in `FinalizeOnboardingAsync`. This ensures the project is written to the correct `config.yaml` path after `SetTendrilHome` switches the config location.

## Files Modified

- **src/Ivy.Tendril/Services/OnboardingSetupService.cs** — Reordered method calls in `FinalizeOnboardingAsync`
- **src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs** — New test verifying project persistence after finalization

---

## Commits

- 077b6b0 [00219] Fix onboarding skip verifications not persisting project to config