### PR TITLE
[00220] Fix project deletion from setup not persisting to config file

### DIFF
--- a/src/Ivy.Tendril.Test/IConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/IConfigServiceTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
@@ -120,5 +121,38 @@ public class IConfigServiceTests
         var names = config.LevelNames;
 
         Assert.Equal(new[] { "Bug", "Critical", "NiceToHave" }, names);
+    }
+
+    [Fact]
+    public void SaveSettings_PersistsProjectDeletion()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"tendril-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var config = new ConfigService(new TendrilSettings
+            {
+                Projects = new List<ProjectConfig>
+                {
+                    new() { Name = "ProjectA", Color = "Blue" },
+                    new() { Name = "ProjectB", Color = "Red" }
+                }
+            }, tempDir);
+
+            // Delete the first project
+            config.Settings.Projects.RemoveAt(0);
+            config.SaveSettings();
+
+            // Reload from file and verify
+            var yaml = File.ReadAllText(config.ConfigPath);
+            var reloaded = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml);
+
+            Assert.Single(reloaded.Projects);
+            Assert.Equal("ProjectB", reloaded.Projects[0].Name);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
     }
 }

--- a/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
@@ -48,10 +48,20 @@ public class ProjectsSetupView : ViewBase
                     {
                         if (result == AlertResult.Ok)
                         {
+                            var removedProject = projects[idx];
                             projects.RemoveAt(idx);
-                            config.SaveSettings();
-                            refreshToken.Refresh();
-                            client.Toast($"Project '{name}' deleted", "Deleted");
+                            try
+                            {
+                                config.SaveSettings();
+                                refreshToken.Refresh();
+                                client.Toast($"Project '{name}' deleted", "Deleted");
+                            }
+                            catch (Exception ex)
+                            {
+                                projects.Insert(idx, removedProject);
+                                refreshToken.Refresh();
+                                client.Toast($"Failed to delete project: {ex.Message}", "Error");
+                            }
                         }
                     }, "Delete Project", AlertButtonSet.OkCancel);
                 })

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -34,6 +34,7 @@ public record ProjectConfig
     public List<ReviewActionConfig> ReviewActions { get; set; } = new();
     public List<PromptwareHookConfig> Hooks { get; set; } = new();
     public List<string> BuildDependencies { get; set; } = new();
+    [YamlIgnore]
     public List<string> RepoPaths => Repos.Select(r => r.Path).ToList();
 
     public string? GetMeta(string key)


### PR DESCRIPTION
Fixes #552

## Summary

Added `[YamlIgnore]` attribute to `ProjectConfig.RepoPaths` computed property to prevent it from being serialized into config YAML (which caused deserialization issues on reload). Wrapped the project delete handler in a try-catch that rolls back the in-memory removal and shows an error toast if `SaveSettings()` fails. Added a unit test that verifies project deletion actually persists to the config file on disk.

## Files Modified

- **src/Ivy.Tendril/Services/ConfigService.cs** — Added `[YamlIgnore]` to `RepoPaths` property
- **src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs** — Wrapped delete logic in try-catch with rollback
- **src/Ivy.Tendril.Test/IConfigServiceTests.cs** — Added `SaveSettings_PersistsProjectDeletion` test

---

### Commits

- a7f805d [00220] Fix project deletion from setup not persisting to config file