### PR TITLE
Make promptware logging fully automatic (#580)

### DIFF
--- a/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
@@ -23,7 +23,6 @@ public class FirmwareCompilerTests : IDisposable
     {
         var context = new FirmwareContext(
             "/programs/CreatePlan",
-            "/programs/CreatePlan/Logs/00001.md",
             new Dictionary<string, string> { ["PlanId"] = "03456", ["Project"] = "Tendril" });
 
         var result = FirmwareCompiler.Compile(context);
@@ -37,7 +36,6 @@ public class FirmwareCompilerTests : IDisposable
     {
         var context = new FirmwareContext(
             "/programs/Test",
-            "/programs/Test/Logs/00001.md",
             new Dictionary<string, string>());
 
         var result = FirmwareCompiler.Compile(context);
@@ -50,7 +48,6 @@ public class FirmwareCompilerTests : IDisposable
     {
         var context = new FirmwareContext(
             "/programs/Test",
-            "/programs/Test/Logs/00001.md",
             new Dictionary<string, string> { ["CurrentTime"] = "2026-01-01T00:00:00Z" });
 
         var result = FirmwareCompiler.Compile(context);
@@ -63,7 +60,6 @@ public class FirmwareCompilerTests : IDisposable
     {
         var context = new FirmwareContext(
             "/my/programs/ExecutePlan",
-            "/my/programs/ExecutePlan/Logs/00003.md",
             new Dictionary<string, string>());
 
         var result = FirmwareCompiler.Compile(context);
@@ -73,17 +69,16 @@ public class FirmwareCompilerTests : IDisposable
     }
 
     [Fact]
-    public void Compile_ReplacesLogFile()
+    public void Compile_DoesNotContainLogFilePlaceholder()
     {
         var context = new FirmwareContext(
             "/programs/Test",
-            "/programs/Test/Logs/00042.md",
             new Dictionary<string, string>());
 
         var result = FirmwareCompiler.Compile(context);
 
-        Assert.Contains("/programs/Test/Logs/00042.md", result);
         Assert.DoesNotContain("{LOGFILE}", result);
+        Assert.DoesNotContain("In the log file you are to maintain", result);
     }
 
     [Fact]
@@ -91,7 +86,6 @@ public class FirmwareCompilerTests : IDisposable
     {
         var context = new FirmwareContext(
             "/programs/Test",
-            "/programs/Test/Logs/00001.md",
             new Dictionary<string, string>());
 
         var result = FirmwareCompiler.Compile(context);
@@ -107,7 +101,6 @@ public class FirmwareCompilerTests : IDisposable
     {
         var context = new FirmwareContext(
             "/programs/Test",
-            "/programs/Test/Logs/00001.md",
             new Dictionary<string, string> { ["Zebra"] = "last", ["Alpha"] = "first" });
 
         var result = FirmwareCompiler.Compile(context);
@@ -122,7 +115,6 @@ public class FirmwareCompilerTests : IDisposable
     {
         var context = new FirmwareContext(
             "/programs/Test",
-            "/programs/Test/Logs/00001.md",
             new Dictionary<string, string>());
 
         var result = FirmwareCompiler.Compile(context);
@@ -130,8 +122,8 @@ public class FirmwareCompilerTests : IDisposable
         Assert.Contains("You are an agentic application", result);
         Assert.Contains("Program.md", result);
         Assert.Contains("Reflection", result);
-        Assert.Contains("Memory/", result);
-        Assert.Contains("Tools/", result);
+        Assert.Contains("**Memory:**", result);
+        Assert.Contains("**Tools:**", result);
     }
 
     // --- GetNextLogFile ---

--- a/src/Ivy.Tendril.Test/Agents/TryBuildAgentProcessStartTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/TryBuildAgentProcessStartTests.cs
@@ -27,7 +27,6 @@ public class TryBuildAgentProcessStartTests : IDisposable
     {
         var context = new FirmwareContext(
             "/programs/Test",
-            "/programs/Test/Logs/00001.md",
             new Dictionary<string, string>());
 
         var result = FirmwareCompiler.Compile(context);
@@ -42,13 +41,12 @@ public class TryBuildAgentProcessStartTests : IDisposable
     {
         var context = new FirmwareContext(
             "/programs/Test",
-            "/programs/Test/Logs/00001.md",
             new Dictionary<string, string>());
 
         var result = FirmwareCompiler.Compile(context);
 
-        Assert.Contains("Tools/", result);
-        Assert.Contains("Memory/", result);
+        Assert.Contains("**Tools:**", result);
+        Assert.Contains("**Memory:**", result);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
@@ -118,8 +118,8 @@ public class PromptwareRunCommandTests : IDisposable
             ["ArtifactsDir"] = "/plans/00123-Test/artifacts"
         };
 
-        var logFile = FirmwareCompiler.GetNextLogFile(promptwareDir);
-        var context = new FirmwareContext(promptwareDir, logFile, values);
+        FirmwareCompiler.GetNextLogFile(promptwareDir);
+        var context = new FirmwareContext(promptwareDir, values);
         var prompt = FirmwareCompiler.Compile(context);
 
         Assert.Contains(promptwareDir, prompt);
@@ -142,8 +142,8 @@ public class PromptwareRunCommandTests : IDisposable
             ["Instructions"] = "Setup verifications"
         };
 
-        var logFile = FirmwareCompiler.GetNextLogFile(promptwareDir);
-        var context = new FirmwareContext(promptwareDir, logFile, values);
+        FirmwareCompiler.GetNextLogFile(promptwareDir);
+        var context = new FirmwareContext(promptwareDir, values);
         var prompt = FirmwareCompiler.Compile(context);
 
         Assert.Contains("ProjectName: MyProject", prompt);
@@ -162,8 +162,8 @@ public class PromptwareRunCommandTests : IDisposable
             ["Args"] = "Setup verifications and review actions for this project."
         };
 
-        var logFile = FirmwareCompiler.GetNextLogFile(promptwareDir);
-        var context = new FirmwareContext(promptwareDir, logFile, values);
+        FirmwareCompiler.GetNextLogFile(promptwareDir);
+        var context = new FirmwareContext(promptwareDir, values);
         var prompt = FirmwareCompiler.Compile(context);
 
         Assert.Contains("Args: Setup verifications and review actions for this project.", prompt);

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -145,8 +145,8 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
             && !string.IsNullOrWhiteSpace(specificCfg.CustomInstructions))
             customInstructions = specificCfg.CustomInstructions;
 
-        var logFile = FirmwareCompiler.GetNextLogFile(programFolder, values);
-        var firmwareContext = new FirmwareContext(programFolder, logFile, values, customInstructions);
+        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
+        var firmwareContext = new FirmwareContext(programFolder, values, customInstructions);
         var prompt = FirmwareCompiler.Compile(firmwareContext);
 
         // Emit resolved context as YAML for testability/debugging

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -78,6 +78,12 @@ public record JobItem
     // Path to the status file used for cross-process status updates
     public string? StatusFilePath { get; set; }
 
+    // Automatic logging metadata (transient, not persisted)
+    [JsonIgnore] public string? LogFilePath { get; set; }
+    [JsonIgnore] public string? CompiledPrompt { get; set; }
+    [JsonIgnore] public string? CliCommand { get; set; }
+    [JsonIgnore] public int? ExitCode { get; set; }
+
     public void EnqueueOutput(string line)
     {
         OutputLines.Enqueue(line);

--- a/src/Ivy.Tendril/Services/Agents/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/Agents/FirmwareCompiler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reflection;
 
 namespace Ivy.Tendril.Services.Agents;
@@ -24,21 +25,6 @@ public class FirmwareCompiler
         In the header above your arguments is specified.
 
         Your program folder is: {PROGRAMFOLDER}
-
-        ## Logs
-
-        In {PROGRAMFOLDER}/Logs/ we maintain logs for all executions of this application.
-
-        A file for this session has already been created: {LOGFILE}
-
-        It currently only have the args written to it.
-
-        In the log file you are to maintain a record:
-
-        - The outcome of the execution
-        - Any tools created or changed
-        - Any memory created or changed
-        - And changes to the program during reflection
 
         ## Goal
 
@@ -78,7 +64,6 @@ public class FirmwareCompiler
 
         var firmware = FirmwareTemplate
             .Replace("{HEADER}", header)
-            .Replace("{LOGFILE}", context.LogFile)
             .Replace("{PROGRAMFOLDER}", context.ProgramFolder)
             .Replace("{TOOLS_LISTING}", toolsListing)
             .Replace("{MEMORY_LISTING}", memoryListing);
@@ -122,38 +107,32 @@ public class FirmwareCompiler
         return files.Count == 0 ? "(none)" : string.Join(", ", files);
     }
 
-    public static string GetNextLogFile(string programFolder, Dictionary<string, string>? initialValues = null)
+    public static string GetNextLogFile(string programFolder)
     {
         var logsFolder = Path.Combine(programFolder, "Logs");
         Directory.CreateDirectory(logsFolder);
 
         var maxNumber = 0;
-        if (Directory.Exists(logsFolder))
+        foreach (var file in Directory.GetFiles(logsFolder, "*.md"))
         {
-            foreach (var file in Directory.GetFiles(logsFolder, "*.md"))
-            {
-                var baseName = Path.GetFileNameWithoutExtension(file);
-                if (int.TryParse(baseName, out var num) && num > maxNumber)
-                    maxNumber = num;
-            }
+            var baseName = Path.GetFileNameWithoutExtension(file);
+            if (int.TryParse(baseName, out var num) && num > maxNumber)
+                maxNumber = num;
         }
 
         var logFile = Path.Combine(logsFolder, $"{maxNumber + 1:D5}.md");
 
         // Reserve the slot immediately to prevent race conditions with concurrent jobs
-        var header = $"# Execution Log {maxNumber + 1:D5}\n\n## Args\n";
-        if (initialValues != null)
-        {
-            foreach (var kv in initialValues.OrderBy(kv => kv.Key))
-            {
-                var value = kv.Value.Length > 200 ? kv.Value[..200] + "..." : kv.Value;
-                header += $"- **{kv.Key}:** {value}\n";
-            }
-        }
-        header += "\n*Execution in progress...*\n";
-        File.WriteAllText(logFile, header);
+        File.WriteAllText(logFile, "*Execution in progress...*\n");
 
         return logFile;
+    }
+
+    public static string FormatCliCommand(ProcessStartInfo psi)
+    {
+        var parts = new List<string> { psi.FileName };
+        parts.AddRange(psi.ArgumentList);
+        return string.Join(" ", parts.Select(p => p.Contains(' ') ? $"\"{p}\"" : p));
     }
 
     public static string ResolveProgramFolder(string promptsRoot, string promptwareName)
@@ -164,6 +143,5 @@ public class FirmwareCompiler
 
 public record FirmwareContext(
     string ProgramFolder,
-    string LogFile,
     Dictionary<string, string> Values,
     string? CustomInstructions = null);

--- a/src/Ivy.Tendril/Services/Agents/PromptwareLogWriter.cs
+++ b/src/Ivy.Tendril/Services/Agents/PromptwareLogWriter.cs
@@ -1,0 +1,79 @@
+using System.Text;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Services.Agents;
+
+public static class PromptwareLogWriter
+{
+    public static void WriteLog(JobItem job)
+    {
+        if (string.IsNullOrEmpty(job.LogFilePath)) return;
+
+        var logNumber = Path.GetFileNameWithoutExtension(job.LogFilePath);
+        var sb = new StringBuilder();
+        sb.AppendLine($"# Execution Log {logNumber}");
+        sb.AppendLine();
+        sb.AppendLine($"- **Status:** {job.Status}");
+        sb.AppendLine($"- **Exit Code:** {job.ExitCode?.ToString() ?? "N/A"}");
+        sb.AppendLine($"- **Started:** {job.StartedAt:u}");
+        sb.AppendLine($"- **Completed:** {job.CompletedAt:u}");
+        sb.AppendLine($"- **Duration:** {(job.DurationSeconds.HasValue ? $"{job.DurationSeconds}s" : "unknown")}");
+        sb.AppendLine($"- **Provider:** {job.Provider}");
+        sb.AppendLine();
+
+        if (!string.IsNullOrEmpty(job.CliCommand))
+        {
+            sb.AppendLine("## CLI Command");
+            sb.AppendLine();
+            sb.AppendLine("```");
+            sb.AppendLine(job.CliCommand);
+            sb.AppendLine("```");
+            sb.AppendLine();
+        }
+
+        if (!string.IsNullOrEmpty(job.CompiledPrompt))
+        {
+            sb.AppendLine("## Compiled Prompt");
+            sb.AppendLine();
+            sb.AppendLine("````markdown");
+            sb.AppendLine(job.CompiledPrompt);
+            sb.AppendLine("````");
+            sb.AppendLine();
+        }
+
+        var result = ExtractFinalOutput(job);
+        if (!string.IsNullOrEmpty(result))
+        {
+            sb.AppendLine("## Final Output");
+            sb.AppendLine();
+            sb.AppendLine(result);
+            sb.AppendLine();
+        }
+
+        File.WriteAllText(job.LogFilePath, sb.ToString());
+
+        job.CompiledPrompt = null;
+        job.CliCommand = null;
+    }
+
+    public static void WriteRawLog(string logFilePath, IEnumerable<string> outputLines)
+    {
+        var rawFile = Path.ChangeExtension(logFilePath, ".raw.jsonl");
+        File.WriteAllLines(rawFile, outputLines);
+    }
+
+    private static string? ExtractFinalOutput(JobItem job)
+    {
+        if (job.OutputLines.Count == 0) return null;
+
+        try
+        {
+            var provider = AgentProviderFactory.GetProvider(job.Provider);
+            return provider.ExtractResult(job.OutputLines.ToArray());
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -6,6 +6,7 @@ using Ivy.Helpers;
 using Ivy.Tendril.Apps;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Agents;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Services;
@@ -887,6 +888,12 @@ internal class JobCompletionHandler
     {
         try
         {
+            PromptwareLogWriter.WriteLog(job);
+        }
+        catch { }
+
+        try
+        {
             WriteRawOutputLog(job);
         }
         catch
@@ -1032,18 +1039,12 @@ internal class JobCompletionHandler
         sb.AppendLine();
     }
 
-    private void WriteRawOutputLog(JobItem job)
+    private static void WriteRawOutputLog(JobItem job)
     {
         if (job.OutputLines.Count == 0) return;
+        if (string.IsNullOrEmpty(job.LogFilePath)) return;
 
-        var logsDir = Path.Combine(_promptsRoot, job.Type, "Logs");
-        if (!Directory.Exists(logsDir)) return;
-
-        var logName = !string.IsNullOrEmpty(job.AllocatedPlanId)
-            ? job.AllocatedPlanId
-            : job.Id;
-
-        var rawFile = Path.Combine(logsDir, $"{logName}.raw.jsonl");
+        var rawFile = Path.ChangeExtension(job.LogFilePath, ".raw.jsonl");
         File.WriteAllLines(rawFile, job.OutputLines);
     }
 }

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -202,6 +202,8 @@ internal class JobLauncher
                         else
                         {
                             _logger.LogInformation("Job {JobId}: Process exited with code {ExitCode}", id, process.ExitCode);
+                            if (ctx.Jobs.TryGetValue(id, out var exitJob))
+                                exitJob.ExitCode = process.ExitCode;
                             ctx.CompleteJob(id, process.ExitCode, false, false);
                         }
                     }
@@ -410,9 +412,12 @@ internal class JobLauncher
             && !string.IsNullOrWhiteSpace(specificCfg.CustomInstructions))
             customInstructions = specificCfg.CustomInstructions;
 
-        var logFile = FirmwareCompiler.GetNextLogFile(programFolder, values);
-        var context = new FirmwareContext(programFolder, logFile, values, customInstructions);
+        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
+        job.LogFilePath = logFile;
+
+        var context = new FirmwareContext(programFolder, values, customInstructions);
         var prompt = FirmwareCompiler.Compile(context);
+        job.CompiledPrompt = prompt;
 
         string? promptFilePath = null;
         if (!resolution.Provider.UsesStdinPrompt)
@@ -437,6 +442,7 @@ internal class JobLauncher
 
         var psi = resolution.Provider.BuildProcessStart(invocation);
         SetTendrilEnvironment(psi, job);
+        job.CliCommand = FirmwareCompiler.FormatCliCommand(psi);
 
         var stdinContent = resolution.Provider.UsesStdinPrompt ? prompt : null;
 

--- a/src/Ivy.Tendril/Services/PromptwareRunner.cs
+++ b/src/Ivy.Tendril/Services/PromptwareRunner.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services.Agents;
 using Microsoft.Extensions.Logging;
 
@@ -18,6 +19,10 @@ public record PromptwareRunHandle : IDisposable
 {
     internal Process? Process { get; init; }
     internal CancellationTokenSource Cts { get; init; } = new();
+    internal string? LogFilePath { get; init; }
+    internal string? CompiledPrompt { get; set; }
+    internal string? CliCommand { get; set; }
+    internal string Provider { get; init; } = "claude";
 
     public bool IsRunning => Process is { HasExited: false };
     public int? ExitCode => Process is { HasExited: true } ? Process.ExitCode : null;
@@ -76,8 +81,8 @@ public class PromptwareRunner : IPromptwareRunner
         var resolution = AgentProviderFactory.Resolve(settings, options.Promptware, options.Profile, jobContext);
         var workDir = options.WorkingDir ?? programFolder;
 
-        var logFile = FirmwareCompiler.GetNextLogFile(programFolder, values);
-        var firmwareContext = new FirmwareContext(programFolder, logFile, values);
+        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
+        var firmwareContext = new FirmwareContext(programFolder, values);
         var prompt = FirmwareCompiler.Compile(firmwareContext);
 
         var invocation = new AgentInvocation(
@@ -113,28 +118,46 @@ public class PromptwareRunner : IPromptwareRunner
             process.StandardInput.Close();
         }
 
-        var cts = new CancellationTokenSource();
-        var completion = Task.Run(() => PipeOutput(process, outputStream, cts.Token), cts.Token);
+        var cliCommand = FirmwareCompiler.FormatCliCommand(psi);
 
-        return new PromptwareRunHandle
+        var cts = new CancellationTokenSource();
+        var handle = new PromptwareRunHandle
         {
             Process = process,
             Cts = cts,
-            Completion = completion
+            LogFilePath = logFile,
+            CompiledPrompt = prompt,
+            CliCommand = cliCommand,
+            Provider = resolution.Provider.Name
         };
+
+        handle = handle with
+        {
+            Completion = Task.Run(() => PipeOutputAndLog(process, outputStream, handle, cts.Token), cts.Token)
+        };
+
+        return handle;
     }
 
-    private static async Task PipeOutput(Process process, IWriteStream<string> stream, CancellationToken ct)
+    private static async Task PipeOutputAndLog(Process process, IWriteStream<string> stream, PromptwareRunHandle handle, CancellationToken ct)
     {
+        var outputLines = new List<string>();
+
         process.OutputDataReceived += (_, e) =>
         {
             if (e.Data != null)
+            {
                 stream.Write(e.Data);
+                outputLines.Add(e.Data);
+            }
         };
         process.ErrorDataReceived += (_, e) =>
         {
             if (e.Data != null)
+            {
                 stream.Write($"[stderr] {e.Data}");
+                outputLines.Add($"[stderr] {e.Data}");
+            }
         };
         process.EnableRaisingEvents = true;
 
@@ -144,10 +167,36 @@ public class PromptwareRunner : IPromptwareRunner
         try
         {
             await process.WaitForExitAsync(ct);
-            // Give output handlers a moment to flush
             await Task.Delay(100, ct);
         }
         catch (OperationCanceledException) { }
+
+        if (!string.IsNullOrEmpty(handle.LogFilePath))
+        {
+            try
+            {
+                var job = new JobItem
+                {
+                    Provider = handle.Provider,
+                    Status = process.HasExited && process.ExitCode == 0 ? JobStatus.Completed : JobStatus.Failed,
+                    StartedAt = null,
+                    CompletedAt = DateTime.UtcNow,
+                    ExitCode = process.HasExited ? process.ExitCode : null,
+                    LogFilePath = handle.LogFilePath,
+                    CompiledPrompt = handle.CompiledPrompt,
+                    CliCommand = handle.CliCommand
+                };
+                foreach (var line in outputLines)
+                    job.EnqueueOutput(line);
+
+                PromptwareLogWriter.WriteLog(job);
+                PromptwareLogWriter.WriteRawLog(handle.LogFilePath, outputLines);
+            }
+            catch { }
+
+            handle.CompiledPrompt = null;
+            handle.CliCommand = null;
+        }
     }
 
     private static string ResolvePromptwareFolder(string promptwareName, string? tendrilHome, string? promptwarePath)


### PR DESCRIPTION
Agents no longer maintain their own log files. Each invocation now
produces a co-located pair (00001.md + 00001.raw.jsonl) written
automatically after execution with CLI command, compiled prompt,
final output, and exit code.
