### PR TITLE
[00221] Fix GetRepoRef path tests failing on Linux

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1541,6 +1541,8 @@ maxConcurrentJobs: 10
     [Fact]
     public void GetRepoRef_WithTrailingSlash_ShouldMatch()
     {
+        if (!OperatingSystem.IsWindows()) return; // Backslash is not a path separator on Linux
+
         var project = new ProjectConfig
         {
             Repos = new List<RepoRef>
@@ -1557,6 +1559,8 @@ maxConcurrentJobs: 10
     [Fact]
     public void GetRepoRef_WithMixedSlashes_ShouldMatch()
     {
+        if (!OperatingSystem.IsWindows()) return; // Mixed slashes only relevant on Windows
+
         var project = new ProjectConfig
         {
             Repos = new List<RepoRef>


### PR DESCRIPTION
# Summary

## Changes

Added `OperatingSystem.IsWindows()` platform guards to two test methods in ConfigServiceTests.cs that assert Windows-specific path normalization behavior (backslash handling and mixed slash resolution). Tests now early-return on Linux instead of failing.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril.Test/ConfigServiceTests.cs** — Added platform guards to `GetRepoRef_WithTrailingSlash_ShouldMatch` and `GetRepoRef_WithMixedSlashes_ShouldMatch`

---

**Commits:**
- aa35ad6 [00221] Add Windows platform guards to path tests