### PR TITLE
[00222] Add try-catch rollback to Setup dialog SaveSettings calls

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -144,16 +144,39 @@ public class EditProjectDialog(
                 {
                     if (string.IsNullOrWhiteSpace(editName.Value)) return;
                     var project = isNew ? new ProjectConfig() : _projects[_editIndex.Value!.Value];
+                    var oldName = project.Name;
+                    var oldColor = project.Color;
+                    var oldContext = project.Context;
+                    var oldRepos = project.Repos;
+                    var oldVerifications = project.Verifications;
                     project.Name = editName.Value;
                     project.Color = editColor.Value?.ToString() ?? "";
                     project.Context = editContext.Value;
                     project.Repos = new List<RepoRef>(editRepos.Value);
                     project.Verifications = new List<ProjectVerificationRef>(editVerifications.Value);
                     if (isNew) _projects.Add(project);
-                    _config.SaveSettings();
-                    _editIndex.Set(-1);
-                    _refreshToken.Refresh();
-                    _client.Toast($"Project '{editName.Value}' saved", "Saved");
+                    try
+                    {
+                        _config.SaveSettings();
+                        _editIndex.Set(-1);
+                        _refreshToken.Refresh();
+                        _client.Toast($"Project '{editName.Value}' saved", "Saved");
+                    }
+                    catch (Exception ex)
+                    {
+                        if (isNew)
+                            _projects.Remove(project);
+                        else
+                        {
+                            project.Name = oldName;
+                            project.Color = oldColor;
+                            project.Context = oldContext;
+                            project.Repos = oldRepos;
+                            project.Verifications = oldVerifications;
+                        }
+                        _refreshToken.Refresh();
+                        _client.Toast($"Failed to save project: {ex.Message}", "Error");
+                    }
                 })
             )
         ).Width(Size.Rem(40));

--- a/src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
@@ -39,10 +39,20 @@ public class LevelsSetupView : ViewBase
                     {
                         if (result == AlertResult.Ok)
                         {
+                            var removed = levels[idx];
                             levels.RemoveAt(idx);
-                            config.SaveSettings();
-                            client.Toast($"Level '{name}' deleted", "Deleted");
-                            refreshToken.Refresh();
+                            try
+                            {
+                                config.SaveSettings();
+                                client.Toast($"Level '{name}' deleted", "Deleted");
+                                refreshToken.Refresh();
+                            }
+                            catch (Exception ex)
+                            {
+                                levels.Insert(idx, removed);
+                                refreshToken.Refresh();
+                                client.Toast($"Failed to delete level: {ex.Message}", "Error");
+                            }
                         }
                     }, "Delete Level");
                 })
@@ -102,6 +112,8 @@ file class EditLevelDialogContent(
                 new Button(isNew ? "Add" : "Save").Primary().OnClick(() =>
                 {
                     if (string.IsNullOrWhiteSpace(editName.Value)) return;
+                    var oldLevelName = isNew ? null : levels[existingIndex!.Value].Name;
+                    var oldBadge = isNew ? null : levels[existingIndex!.Value].Badge;
                     if (isNew)
                     {
                         levels.Add(new LevelConfig { Name = editName.Value, Badge = editBadge.Value });
@@ -113,10 +125,26 @@ file class EditLevelDialogContent(
                         level.Badge = editBadge.Value;
                     }
 
-                    config.SaveSettings();
-                    isOpen.Set(false);
-                    refreshToken.Refresh();
-                    client.Toast("Level saved", "Saved");
+                    try
+                    {
+                        config.SaveSettings();
+                        isOpen.Set(false);
+                        refreshToken.Refresh();
+                        client.Toast("Level saved", "Saved");
+                    }
+                    catch (Exception ex)
+                    {
+                        if (isNew)
+                            levels.RemoveAt(levels.Count - 1);
+                        else
+                        {
+                            var level = levels[existingIndex!.Value];
+                            level.Name = oldLevelName!;
+                            level.Badge = oldBadge!;
+                        }
+                        refreshToken.Refresh();
+                        client.Toast($"Failed to save level: {ex.Message}", "Error");
+                    }
                 })
             )
         ).Width(Size.Rem(25));

--- a/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
@@ -44,10 +44,20 @@ public class PromptwaresSetupView : ViewBase
                                showAlert($"Are you sure you want to delete '{name}'?", result =>
                                {
                                    if (result != AlertResult.Ok) return;
+                                   var removedValue = promptwares[name];
                                    promptwares.Remove(name);
-                                   config.SaveSettings();
-                                   client.Toast($"Promptware '{name}' deleted", "Deleted");
-                                   refreshToken.Refresh();
+                                   try
+                                   {
+                                       config.SaveSettings();
+                                       client.Toast($"Promptware '{name}' deleted", "Deleted");
+                                       refreshToken.Refresh();
+                                   }
+                                   catch (Exception ex)
+                                   {
+                                       promptwares[name] = removedValue;
+                                       refreshToken.Refresh();
+                                       client.Toast($"Failed to delete promptware: {ex.Message}", "Error");
+                                   }
                                }, "Delete Promptware");
                            }));
             }))
@@ -135,14 +145,36 @@ file class EditPromptwareDialogContent(
                             : editCustomInstructions.Value
                     };
 
-                    if (!isNew && existingKey != editName.Value)
+                    var wasRenamed = !isNew && existingKey != editName.Value;
+                    PromptwareConfig? oldValue = null;
+                    if (wasRenamed)
+                    {
+                        oldValue = promptwares[existingKey!];
                         promptwares.Remove(existingKey!);
+                    }
+                    else if (!isNew)
+                    {
+                        oldValue = promptwares[existingKey!];
+                    }
 
                     promptwares[editName.Value] = pwConfig;
-                    config.SaveSettings();
-                    isOpen.Set(false);
-                    refreshToken.Refresh();
-                    client.Toast("Promptware saved", "Saved");
+                    try
+                    {
+                        config.SaveSettings();
+                        isOpen.Set(false);
+                        refreshToken.Refresh();
+                        client.Toast("Promptware saved", "Saved");
+                    }
+                    catch (Exception ex)
+                    {
+                        promptwares.Remove(editName.Value);
+                        if (wasRenamed)
+                            promptwares[existingKey!] = oldValue!;
+                        else if (!isNew)
+                            promptwares[existingKey!] = oldValue!;
+                        refreshToken.Refresh();
+                        client.Toast($"Failed to save promptware: {ex.Message}", "Error");
+                    }
                 })
             )
         ).Width(Size.Rem(35));

--- a/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
@@ -33,10 +33,20 @@ public class VerificationsSetupView : ViewBase
                     {
                         if (result == AlertResult.Ok)
                         {
+                            var removed = verifications[idx];
                             verifications.RemoveAt(idx);
-                            config.SaveSettings();
-                            client.Toast($"Verification '{name}' deleted", "Deleted");
-                            refreshToken.Refresh();
+                            try
+                            {
+                                config.SaveSettings();
+                                client.Toast($"Verification '{name}' deleted", "Deleted");
+                                refreshToken.Refresh();
+                            }
+                            catch (Exception ex)
+                            {
+                                verifications.Insert(idx, removed);
+                                refreshToken.Refresh();
+                                client.Toast($"Failed to delete verification: {ex.Message}", "Error");
+                            }
                         }
                     }, "Delete Verification", AlertButtonSet.OkCancel);
                 })
@@ -95,6 +105,8 @@ file class EditVerificationDialogContent(
                 new Button(isNew ? "Add" : "Save").Primary().OnClick(() =>
                 {
                     if (string.IsNullOrWhiteSpace(editName.Value)) return;
+                    var oldName = isNew ? null : verifications[existingIndex!.Value].Name;
+                    var oldPrompt = isNew ? null : verifications[existingIndex!.Value].Prompt;
                     if (isNew)
                     {
                         verifications.Add(new VerificationConfig
@@ -109,10 +121,25 @@ file class EditVerificationDialogContent(
                         verifications[existingIndex!.Value].Prompt = editPrompt.Value;
                     }
 
-                    config.SaveSettings();
-                    isOpen.Set(false);
-                    refreshToken.Refresh();
-                    client.Toast("Verification saved", "Saved");
+                    try
+                    {
+                        config.SaveSettings();
+                        isOpen.Set(false);
+                        refreshToken.Refresh();
+                        client.Toast("Verification saved", "Saved");
+                    }
+                    catch (Exception ex)
+                    {
+                        if (isNew)
+                            verifications.RemoveAt(verifications.Count - 1);
+                        else
+                        {
+                            verifications[existingIndex!.Value].Name = oldName!;
+                            verifications[existingIndex!.Value].Prompt = oldPrompt!;
+                        }
+                        refreshToken.Refresh();
+                        client.Toast($"Failed to save verification: {ex.Message}", "Error");
+                    }
                 })
             )
         ).Width(Size.Rem(35));


### PR DESCRIPTION
## Summary

Added try-catch rollback protection to all 7 `SaveSettings()` call sites in Setup dialogs (EditProjectDialog, VerificationsSetupView, LevelsSetupView, PromptwaresSetupView). On save failure, in-memory state is rolled back to its pre-mutation value and an error toast is shown, preventing silent data loss on app restart.

## Files Modified

- **src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs** — Add/Edit project save with rollback
- **src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs** — Delete and Add/Edit verification save with rollback
- **src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs** — Delete and Add/Edit level save with rollback
- **src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs** — Delete and Add/Edit promptware save with rollback (including rename handling)

---

- 44f6285 [00222] Add try-catch rollback to Setup dialog SaveSettings calls