### PR TITLE
[00223] Move Generate Verifications to separate content block in onboarding project step

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -61,7 +61,7 @@ public class ProjectSetupStepView(
                 | new Button("Back").Outline().Icon(Icons.ArrowLeft)
                     .OnClick(() => stepperIndex.Set(stepperIndex.Value - 1))
                 | new Spacer()
-                | new Button("Skip").Secondary()
+                | new Button("Finish").Secondary()
                     .OnClick(async () =>
                     {
                         await setupService.FinalizeOnboardingAsync();
@@ -74,7 +74,8 @@ public class ProjectSetupStepView(
             buttonArea = Layout.Horizontal().Width(Size.Full())
                 | new Button("Back").Outline().Icon(Icons.ArrowLeft)
                     .OnClick(() => stepperIndex.Set(stepperIndex.Value - 1))
-                | new Button("Skip").Secondary()
+                | new Spacer()
+                | new Button("Finish").Secondary()
                     .OnClick(async () =>
                     {
                         var name = SanitizeProjectName(projectName.Value);
@@ -108,8 +109,13 @@ public class ProjectSetupStepView(
                         await setupService.FinalizeOnboardingAsync();
                         await setupService.StartBackgroundServicesAsync();
                         clientProvider.ReloadPage();
-                    })
-                | new Spacer()
+                    });
+        }
+
+        var generateBlock = canContinue
+            ? (object)(Layout.Vertical().Gap(2)
+                | Text.Bold("Generate Verifications")
+                | Text.Muted("Automatically detect your project's tech stack and configure verification steps (build, test, lint, etc.) that run after each plan execution.")
                 | new Button("Generate Verifications").Primary().Large().Icon(Icons.Sparkles)
                     .OnClick(async () =>
                     {
@@ -173,14 +179,15 @@ public class ProjectSetupStepView(
                             isCloning.Set(false);
                             isStepLoading.Set(false);
                         }
-                    });
-        }
+                    }))
+            : null!;
 
         return Layout.Vertical().Gap(4).Margin(0, 0, 0, 20)
                | Text.H2("Setup your first project")
                | (error.Value != null ? Text.Danger(error.Value) : null!)
                | new ProjectRepoPickerView(selectedRepos, projectName)
                | projectName.ToTextInput().WithField().Required().Label("Project Name")
+               | generateBlock
                | buttonArea;
     }
 

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -187,7 +187,9 @@ public class ProjectSetupStepView(
                | (error.Value != null ? Text.Danger(error.Value) : null!)
                | new ProjectRepoPickerView(selectedRepos, projectName)
                | projectName.ToTextInput().WithField().Required().Label("Project Name")
+               | (canContinue ? new Separator() : null!)
                | generateBlock
+               | (canContinue ? new Separator() : null!)
                | buttonArea;
     }
 


### PR DESCRIPTION
## Summary

Moved the "Generate Verifications" button from the footer into a dedicated content block with a title and description, rendered conditionally when a valid project is configured. Simplified both footer states to show only "Back" and "Finish" buttons.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs** — Restructured `Build()` method to extract `generateBlock` as a separate layout section with explanatory text; renamed "Skip"/"Skip Verifications" buttons to "Finish"

---

### Commits
- 5843aca [00223] Move Generate Verifications to separate content block in onboarding project step