### PR TITLE
Refactor JobLauncher and JobCompletionHandler — extract focused classes

### DIFF
--- a/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -53,24 +54,14 @@ projects:
     [Fact]
     public void ExtractPlanIdFromFolder_ReturnsCorrectId()
     {
-        var launcher = new JobLauncher(null, NullLogger.Instance, _tempPromptsRoot);
-        var method = typeof(JobLauncher).GetMethod("ExtractPlanIdFromFolder",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-
-        var result = method?.Invoke(null, new object[] { "D:\\Plans\\01234-TestPlan" });
-
+        var result = PlanYamlHelper.ExtractPlanIdFromFolder("D:\\Plans\\01234-TestPlan");
         Assert.Equal("01234", result);
     }
 
     [Fact]
     public void ExtractPlanIdFromFolder_HandlesNoDash()
     {
-        var launcher = new JobLauncher(null, NullLogger.Instance, _tempPromptsRoot);
-        var method = typeof(JobLauncher).GetMethod("ExtractPlanIdFromFolder",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-
-        var result = method?.Invoke(null, new object[] { "D:\\Plans\\SomePlan" });
-
+        var result = PlanYamlHelper.ExtractPlanIdFromFolder("D:\\Plans\\SomePlan");
         Assert.Null(result);
     }
 
@@ -128,7 +119,6 @@ projects:
         var configService = new ConfigService(new TendrilSettings());
         configService.SetTendrilHome(_tempTendrilHome);
 
-        var launcher = new JobLauncher(configService, NullLogger.Instance, _tempPromptsRoot);
         var job = new JobItem
         {
             Id = "test-1",
@@ -142,7 +132,7 @@ projects:
         jobs[job.Id] = job;
 
         var cts = new CancellationTokenSource();
-        var watchdogTask = launcher.RunStaleOutputWatchdog(
+        var watchdogTask = JobMonitor.RunStaleOutputWatchdog(
             job.Id,
             cts,
             jobs,
@@ -172,7 +162,7 @@ projects:
         jobs[job.Id] = job;
 
         var cts = new CancellationTokenSource();
-        var pollerTask = JobLauncher.RunStatusFilePoller(job.Id, cts, jobs);
+        var pollerTask = JobMonitor.RunStatusFilePoller(job.Id, cts, jobs);
 
         job.Status = JobStatus.Completed;
         await Task.Delay(TimeSpan.FromSeconds(2));

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -75,35 +75,6 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
         }
     }
 
-    private static string ResolvePromptwareFolder(string promptwareName, string? tendrilHome, string? promptwarePath)
-    {
-        // 1. --promptware-path override (highest priority)
-        if (!string.IsNullOrEmpty(promptwarePath))
-        {
-            var overrideFolder = Path.Combine(promptwarePath, promptwareName);
-            if (File.Exists(Path.Combine(overrideFolder, "Program.md")))
-                return overrideFolder;
-        }
-
-        // 2. Source/debug mode (AppContext.BaseDirectory relative)
-        var sourceRoot = PromptwareHelper.ResolvePromptsRoot(tendrilHome);
-        var sourceFolder = Path.Combine(sourceRoot, promptwareName);
-
-        if (File.Exists(Path.Combine(sourceFolder, "Program.md")))
-            return sourceFolder;
-
-        // 3. TENDRIL_HOME/Promptwares (deployed mode)
-        tendrilHome ??= Environment.GetEnvironmentVariable("TENDRIL_HOME");
-        if (!string.IsNullOrEmpty(tendrilHome))
-        {
-            var deployedRoot = Path.Combine(tendrilHome, "Promptwares");
-            var deployedFolder = Path.Combine(deployedRoot, promptwareName);
-            if (File.Exists(Path.Combine(deployedFolder, "Program.md")))
-                return deployedFolder;
-        }
-
-        return sourceFolder;
-    }
 
     internal int Run(PromptwareRunSettings settings, CancellationToken cancellationToken = default)
     {
@@ -113,7 +84,7 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
 
         var tendrilSettings = configService.Settings;
 
-        var programFolder = ResolvePromptwareFolder(settings.Promptware, configService.TendrilHome, settings.PromptwarePath);
+        var programFolder = PromptwareHelper.ResolvePromptwareFolder(settings.Promptware, configService.TendrilHome, settings.PromptwarePath);
         var programMd = Path.Combine(programFolder, "Program.md");
 
         if (!File.Exists(programMd))
@@ -214,13 +185,13 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
         if (!string.IsNullOrEmpty(settings.CliLog))
             psi.Environment["TENDRIL_CLI_LOG"] = settings.CliLog;
 
-        JobLauncher.EnsureTendrilOnPath(psi);
-        JobLauncher.ResolveCommandShim(psi);
+        AgentProcessHelper.EnsureTendrilOnPath(psi);
+        AgentProcessHelper.ResolveCommandShim(psi);
 
         if (verbosityService.Level != VerbosityLevel.Quiet)
             _logger.LogInformation("Running {Promptware} via {ProviderName} (model={Model}, effort={Effort})", settings.Promptware, resolution.Provider.Name, resolution.Model, resolution.Effort);
 
-        var cliCommand = FirmwareCompiler.FormatCliCommand(psi);
+        var cliCommand = AgentProcessHelper.FormatCliCommand(psi);
 
         using var process = Process.Start(psi);
         if (process == null)

--- a/src/Ivy.Tendril/Helpers/AgentProcessHelper.cs
+++ b/src/Ivy.Tendril/Helpers/AgentProcessHelper.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+
+namespace Ivy.Tendril.Helpers;
+
+public static class AgentProcessHelper
+{
+    public static void EnsureTendrilOnPath(ProcessStartInfo psi)
+    {
+        var processPath = Environment.ProcessPath;
+        if (!string.IsNullOrEmpty(processPath) &&
+            Path.GetFileNameWithoutExtension(processPath).Equals("tendril", StringComparison.OrdinalIgnoreCase))
+        {
+            PrependToPath(psi, Path.GetDirectoryName(processPath)!);
+            return;
+        }
+
+        var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+        var dllPath = Path.Combine(baseDir, "Ivy.Tendril.dll");
+        if (File.Exists(dllPath))
+        {
+            var shimDir = Path.Combine(Path.GetTempPath(), "tendril-shim");
+            FileHelper.EnsureDirectory(shimDir);
+
+            var cmdShim = Path.Combine(shimDir, "tendril.cmd");
+            File.WriteAllText(cmdShim, $"@dotnet exec \"{dllPath}\" %*\r\n");
+
+            var bashDllPath = dllPath.Replace('\\', '/');
+            var bashShim = Path.Combine(shimDir, "tendril");
+            File.WriteAllText(bashShim, $"#!/usr/bin/env bash\ndotnet exec '{bashDllPath}' \"$@\"\n");
+
+            PrependToPath(psi, shimDir);
+        }
+    }
+
+    public static void ResolveCommandShim(ProcessStartInfo psi)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var fileName = psi.FileName;
+        if (Path.IsPathRooted(fileName) || Path.HasExtension(fileName)) return;
+
+        var pathDirs = (psi.Environment.TryGetValue("PATH", out var p) ? p : Environment.GetEnvironmentVariable("PATH"))
+            ?.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries) ?? [];
+
+        foreach (var dir in pathDirs)
+        {
+            var cmdPath = Path.Combine(dir, fileName + ".cmd");
+            if (File.Exists(cmdPath))
+            {
+                psi.FileName = cmdPath;
+                return;
+            }
+        }
+    }
+
+    public static string FormatCliCommand(ProcessStartInfo psi)
+    {
+        var parts = new List<string> { psi.FileName };
+        parts.AddRange(psi.ArgumentList);
+        return string.Join(" ", parts.Select(p => p.Contains(' ') ? $"\"{p}\"" : p));
+    }
+
+    internal static void PrependToPath(ProcessStartInfo psi, string dir)
+    {
+        var current = psi.Environment.TryGetValue("PATH", out var p) ? p : Environment.GetEnvironmentVariable("PATH");
+        psi.Environment["PATH"] = $"{dir}{Path.PathSeparator}{current}";
+    }
+}

--- a/src/Ivy.Tendril/Helpers/PromptwareHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PromptwareHelper.cs
@@ -2,6 +2,33 @@ namespace Ivy.Tendril.Helpers;
 
 public static class PromptwareHelper
 {
+    public static string ResolvePromptwareFolder(string promptwareName, string? tendrilHome, string? promptwarePath = null)
+    {
+        if (!string.IsNullOrEmpty(promptwarePath))
+        {
+            var overrideFolder = Path.Combine(promptwarePath, promptwareName);
+            if (File.Exists(Path.Combine(overrideFolder, "Program.md")))
+                return overrideFolder;
+        }
+
+        var sourceRoot = ResolvePromptsRoot(tendrilHome);
+        var sourceFolder = Path.Combine(sourceRoot, promptwareName);
+
+        if (File.Exists(Path.Combine(sourceFolder, "Program.md")))
+            return sourceFolder;
+
+        tendrilHome ??= Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        if (!string.IsNullOrEmpty(tendrilHome))
+        {
+            var deployedRoot = Path.Combine(tendrilHome, "Promptwares");
+            var deployedFolder = Path.Combine(deployedRoot, promptwareName);
+            if (File.Exists(Path.Combine(deployedFolder, "Program.md")))
+                return deployedFolder;
+        }
+
+        return sourceFolder;
+    }
+
     public static string ResolvePromptsRoot(string? tendrilHome = null)
     {
         // 1. Debug/source mode: check if Promptwares exists relative to BaseDirectory

--- a/src/Ivy.Tendril/Services/DependencyChecker.cs
+++ b/src/Ivy.Tendril/Services/DependencyChecker.cs
@@ -1,0 +1,190 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Ivy.Helpers;
+using Ivy.Tendril.Apps;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Services;
+
+internal class DependencyChecker
+{
+    private readonly IPlanReaderService? _planReaderService;
+
+    internal DependencyChecker(IPlanReaderService? planReaderService)
+    {
+        _planReaderService = planReaderService;
+    }
+
+    internal (bool Ok, string? BlockReason) CheckDependencies(string planFolder)
+    {
+        try
+        {
+            var planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
+            if (planYaml?.DependsOn == null || planYaml.DependsOn.Count == 0)
+                return (true, null);
+
+            var plansDir = _planReaderService?.PlansDirectory;
+            if (plansDir == null) return (true, null);
+
+            foreach (var dep in planYaml.DependsOn)
+            {
+                var result = CheckSingleDependency(dep, plansDir);
+                if (!result.Ok) return result;
+            }
+
+            return (true, null);
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Dependency check failed: {ex.Message}");
+        }
+    }
+
+    private static (bool Ok, string? BlockReason) CheckSingleDependency(string dep, string plansDir)
+    {
+        var depFolder = Path.Combine(plansDir, dep);
+        var depPlan = PlanYamlHelper.ReadPlanYaml(depFolder);
+
+        if (depPlan == null)
+            return (false, $"Dependency '{dep}' not found");
+
+        if (!depPlan.State.Equals("Completed", StringComparison.OrdinalIgnoreCase))
+            return (false, $"Dependency '{dep}' is '{depPlan.State}', not Completed");
+
+        foreach (var prUrl in depPlan.Prs.Where(PullRequestApp.IsValidUrl))
+        {
+            var prState = GetPrState(prUrl);
+            if (prState != null && !prState.Equals("MERGED", StringComparison.OrdinalIgnoreCase))
+                return (false, $"Dependency '{dep}' PR {prUrl} is '{prState}', not MERGED");
+        }
+
+        return (true, null);
+    }
+
+    private static string? GetPrState(string prUrl)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "gh",
+                Arguments = $"pr view \"{prUrl}\" --json state -q .state",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var proc = Process.Start(psi);
+            var output = proc?.StandardOutput.ReadToEnd().Trim() ?? "";
+            proc.WaitForExitOrKill(10000);
+            return output;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to check PR status: {ex.Message}", ex);
+        }
+    }
+
+    internal void RetryBlockedJobs(
+        ConcurrentDictionary<string, JobItem> jobs,
+        Action<JobNotification> raiseNotification,
+        Func<JobArgsBase, string> startJobSkipDepCheck)
+    {
+        var blockedJobs = jobs.Values
+            .Where(j => j.Status == JobStatus.Blocked && j.TypedArgs is ExecutePlanArgs)
+            .ToList();
+
+        foreach (var blockedJob in blockedJobs)
+        {
+            var planFolder = blockedJob.TypedArgs?.PlanFolder ?? "";
+            if (string.IsNullOrEmpty(planFolder)) continue;
+
+            var (ok, _) = CheckDependencies(planFolder);
+            if (!ok) continue;
+
+            if (HasActiveJobForPlan(planFolder, jobs)) continue;
+            if (!jobs.TryRemove(blockedJob.Id, out _)) continue;
+
+            PlanYamlHelper.SetPlanStateByFolder(planFolder, "Building");
+            startJobSkipDepCheck(blockedJob.TypedArgs!);
+
+            raiseNotification(new JobNotification(
+                "Job Unblocked",
+                $"{blockedJob.PlanFile}: dependencies now satisfied, auto-restarting",
+                true));
+        }
+    }
+
+    internal void RetryBlockedDependents(
+        string completedPlanFolder,
+        ConcurrentDictionary<string, JobItem> jobs,
+        Func<JobArgsBase, string> startJobSkipDepCheck)
+    {
+        try
+        {
+            var completedFolderName = Path.GetFileName(completedPlanFolder);
+            var plansDir = _planReaderService?.PlansDirectory;
+            if (string.IsNullOrEmpty(plansDir) || !Directory.Exists(plansDir)) return;
+
+            foreach (var dir in Directory.GetDirectories(plansDir))
+            {
+                if (!ShouldRetryDependentPlan(dir, completedFolderName, jobs))
+                    continue;
+
+                var (allMet, _) = CheckDependencies(dir);
+                if (allMet)
+                {
+                    PlanYamlHelper.SetPlanStateByFolder(dir, "Building");
+                    startJobSkipDepCheck(new ExecutePlanArgs(dir));
+                }
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private static bool ShouldRetryDependentPlan(
+        string dir,
+        string completedFolderName,
+        ConcurrentDictionary<string, JobItem> jobs)
+    {
+        var planYaml = PlanYamlHelper.ReadPlanYaml(dir);
+        if (planYaml == null) return false;
+        if (!planYaml.State.Equals("Blocked", StringComparison.OrdinalIgnoreCase)) return false;
+        if (!planYaml.DependsOn.Contains(completedFolderName, StringComparer.OrdinalIgnoreCase)) return false;
+
+        return !jobs.Values.Any(j =>
+            j.TypedArgs is ExecutePlanArgs &&
+            j.Status is JobStatus.Blocked or JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
+            j.TypedArgs?.PlanFolder != null &&
+            j.TypedArgs.PlanFolder.Equals(dir, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool HasActiveJobForPlan(string planFolder, ConcurrentDictionary<string, JobItem> jobs)
+    {
+        var planRepos = PlanYamlHelper.ReadPlanYaml(planFolder)?.Repos;
+
+        return jobs.Values.Any(j =>
+        {
+            if (j.TypedArgs is not ExecutePlanArgs) return false;
+            if (j.Status is not (JobStatus.Running or JobStatus.Queued or JobStatus.Pending)) return false;
+
+            var otherFolder = j.TypedArgs?.PlanFolder;
+            if (otherFolder == null) return false;
+
+            if (otherFolder.Equals(planFolder, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            if (planRepos is { Count: > 0 })
+            {
+                var otherRepos = PlanYamlHelper.ReadPlanYaml(otherFolder)?.Repos;
+                if (otherRepos != null && planRepos.Any(r => otherRepos.Contains(r, StringComparer.OrdinalIgnoreCase)))
+                    return true;
+            }
+
+            return false;
+        });
+    }
+}

--- a/src/Ivy.Tendril/Services/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/FirmwareCompiler.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Reflection;
 
 namespace Ivy.Tendril.Services;
@@ -35,8 +34,11 @@ public static class FirmwareCompiler
         3. Token efficiency
         4. Improvement over time
 
-        **Tools:** {TOOLS_LISTING}
-        **Memory:** {MEMORY_LISTING}
+        **Tools:** 
+        {TOOLS}
+        
+        **Memory:** 
+        {MEMORY}
 
         Complete your task and present the user with a summary.
 
@@ -65,8 +67,8 @@ public static class FirmwareCompiler
         var firmware = FirmwareTemplate
             .Replace("{HEADER}", header)
             .Replace("{PROGRAMFOLDER}", context.ProgramFolder)
-            .Replace("{TOOLS_LISTING}", toolsListing)
-            .Replace("{MEMORY_LISTING}", memoryListing);
+            .Replace("{TOOLS}", toolsListing)
+            .Replace("{MEMORY}", memoryListing);
 
         // Include Program.md inline
         var programFile = Path.Combine(context.ProgramFolder, "Program.md");
@@ -143,17 +145,6 @@ public static class FirmwareCompiler
         return fallback;
     }
 
-    public static string FormatCliCommand(ProcessStartInfo psi)
-    {
-        var parts = new List<string> { psi.FileName };
-        parts.AddRange(psi.ArgumentList);
-        return string.Join(" ", parts.Select(p => p.Contains(' ') ? $"\"{p}\"" : p));
-    }
-
-    public static string ResolveProgramFolder(string promptsRoot, string promptwareName)
-    {
-        return Path.Combine(promptsRoot, promptwareName);
-    }
 }
 
 public record FirmwareContext(

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 using Ivy.Helpers;
-using Ivy.Tendril.Apps;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services.Agents;
@@ -21,6 +20,8 @@ internal class JobCompletionHandler
     private readonly ITelemetryService? _telemetryService;
     private readonly IWorktreeLifecycleLogger? _worktreeLifecycleLogger;
     private readonly string _promptsRoot;
+    private readonly PlanArtifactSyncer _artifactSyncer;
+    private readonly DependencyChecker _dependencyChecker;
 
     internal JobCompletionHandler(
         IConfigService? configService,
@@ -40,6 +41,8 @@ internal class JobCompletionHandler
         _planWatcherService = planWatcherService;
         _worktreeLifecycleLogger = worktreeLifecycleLogger;
         _promptsRoot = promptsRoot;
+        _artifactSyncer = new PlanArtifactSyncer(configService, logger, planWatcherService);
+        _dependencyChecker = new DependencyChecker(planReaderService);
     }
 
     internal void HandleCompletion(
@@ -65,12 +68,12 @@ internal class JobCompletionHandler
             ScheduleWorktreeCleanup(job);
 
         if (job.TypedArgs is ExecutePlanArgs or CreatePrArgs)
-            RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
+            _dependencyChecker.RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
 
         if (isSuccess && job.TypedArgs is ExecutePlanArgs or CreatePrArgs or CreateIssueArgs)
         {
             var planFolder = job.TypedArgs?.PlanFolder ?? "";
-            RetryBlockedDependents(planFolder, jobs, startJobSkipDepCheck);
+            _dependencyChecker.RetryBlockedDependents(planFolder, jobs, startJobSkipDepCheck);
         }
     }
 
@@ -95,33 +98,44 @@ internal class JobCompletionHandler
         if (job.Status is JobStatus.Failed or JobStatus.Timeout)
         {
             ResetPlanState(job);
+            return;
         }
-        else if (isSuccess && job.TypedArgs is ExecutePlanArgs)
+
+        if (!isSuccess) return;
+
+        switch (job.TypedArgs)
         {
-            SyncPlanArtifacts(job);
-            EnsurePlanStateTransitioned(job);
-        }
-        else if (isSuccess && job.TypedArgs is CreateIssueArgs)
-        {
-            SetPlanState(job, "Completed");
-        }
-        else if (isSuccess && job.TypedArgs is UpdatePlanArgs or ExpandPlanArgs)
-        {
-            SetPlanState(job, "Draft");
-        }
-        else if (isSuccess && job.TypedArgs is SplitPlanArgs)
-        {
-            SetPlanState(job, "Skipped");
-        }
-        else if (isSuccess && job.TypedArgs is CreatePlanArgs)
-        {
-            VerifyCreatePlanResult(job);
+            case ExecutePlanArgs:
+                _artifactSyncer.SyncPlanArtifacts(job);
+                EnsurePlanStateTransitioned(job);
+                break;
+            case CreateIssueArgs:
+                SetPlanState(job, "Completed");
+                break;
+            case UpdatePlanArgs or ExpandPlanArgs:
+                SetPlanState(job, "Draft");
+                break;
+            case SplitPlanArgs:
+                SetPlanState(job, "Skipped");
+                break;
+            case CreatePlanArgs:
+                VerifyCreatePlanResult(job);
+                break;
         }
     }
 
     private void TrackTelemetry(JobItem job, bool isSuccess)
     {
-        if (isSuccess && job.TypedArgs is CreatePlanArgs && job.Status == JobStatus.Completed)
+        if (isSuccess)
+            TrackSuccessTelemetry(job);
+
+        _telemetryService?.TrackJobCompleted(job.Type, job.Status, job.DurationSeconds);
+        FlushTelemetryAsync();
+    }
+
+    private void TrackSuccessTelemetry(JobItem job)
+    {
+        if (job.TypedArgs is CreatePlanArgs)
         {
             var planFolder = job.TypedArgs?.PlanFolder ?? "";
             var level = "NiceToHave";
@@ -130,29 +144,23 @@ internal class JobCompletionHandler
                 var plan = PlanYamlHelper.ReadPlanYaml(planFolder);
                 if (plan != null) level = plan.Level;
             }
-
             _telemetryService?.TrackPlanCreated(new PlanCreatedContext(level, job.DurationSeconds));
         }
-
-        if (isSuccess && job.TypedArgs is CreatePrArgs)
+        else if (job.TypedArgs is CreatePrArgs)
         {
             _telemetryService?.TrackPrCreated(new PrCreatedContext(job.DurationSeconds));
         }
+    }
 
-        _telemetryService?.TrackJobCompleted(job.Type, job.Status, job.DurationSeconds);
+    private void FlushTelemetryAsync()
+    {
+        if (_telemetryService == null) return;
 
-        if (_telemetryService != null)
-            _ = Task.Run(async () =>
-            {
-                try
-                {
-                    await _telemetryService.FlushAsync();
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex, "Failed to flush telemetry (best-effort)");
-                }
-            });
+        _ = Task.Run(async () =>
+        {
+            try { await _telemetryService.FlushAsync(); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Failed to flush telemetry (best-effort)"); }
+        });
     }
 
     private void NotifyPlanWatcher(JobItem job)
@@ -218,305 +226,90 @@ internal class JobCompletionHandler
             .ToList();
 
         foreach (var hook in hooks)
-            try
-            {
-                if (!string.IsNullOrWhiteSpace(hook.Condition))
-                {
-                    var condPsi = new ProcessStartInfo
-                    {
-                        FileName = "pwsh",
-                        Arguments = $"-NoProfile -NonInteractive -EncodedCommand {EncodeForPowerShell(hook.Condition)}",
-                        WorkingDirectory = string.IsNullOrEmpty(planFolder) ? "." : planFolder,
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true,
-                        RedirectStandardInput = true,
-                        UseShellExecute = false,
-                        CreateNoWindow = true
-                    };
-                    using var condProc = Process.Start(condPsi);
-                    var condOutput = condProc?.StandardOutput.ReadToEnd().Trim() ?? "";
-                    condProc.WaitForExitOrKill(10000);
+            ExecuteSingleHook(hook, planFolder, job, jobType);
+    }
 
-                    if (condProc?.ExitCode != 0 ||
-                        condOutput.Equals("False", StringComparison.OrdinalIgnoreCase))
-                    {
-                        job.EnqueueOutput($"[hook:{hook.Name}] Condition not met, skipping");
-                        continue;
-                    }
-                }
+    private void ExecuteSingleHook(PromptwareHookConfig hook, string planFolder, JobItem job, string jobType)
+    {
+        try
+        {
+            if (!EvaluateHookCondition(hook, planFolder, job))
+                return;
 
-                var actionPsi = new ProcessStartInfo
-                {
-                    FileName = "pwsh",
-                    Arguments = $"-NoProfile -NonInteractive -EncodedCommand {EncodeForPowerShell(hook.Action)}",
-                    WorkingDirectory = string.IsNullOrEmpty(planFolder) ? "." : planFolder,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    RedirectStandardInput = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-                actionPsi.Environment["TENDRIL_JOB_ID"] = job.Id;
-                actionPsi.Environment["TENDRIL_JOB_TYPE"] = jobType;
-                actionPsi.Environment["TENDRIL_JOB_STATUS"] = job.Status.ToString();
-                actionPsi.Environment["TENDRIL_PLAN_FOLDER"] = planFolder;
-                actionPsi.Environment["TENDRIL_CONFIG"] = _configService.ConfigPath;
+            RunHookAction(hook, planFolder, job, jobType);
+        }
+        catch (Exception ex)
+        {
+            job.EnqueueOutput($"[hook:{hook.Name}] Error: {ex.Message}");
+        }
+    }
 
-                using var actionProc = Process.Start(actionPsi);
-                var output = actionProc?.StandardOutput.ReadToEnd().Trim() ?? "";
-                var stderr = actionProc?.StandardError.ReadToEnd().Trim() ?? "";
-                actionProc.WaitForExitOrKill(30000);
+    private static bool EvaluateHookCondition(PromptwareHookConfig hook, string planFolder, JobItem job)
+    {
+        if (string.IsNullOrWhiteSpace(hook.Condition))
+            return true;
 
-                if (!string.IsNullOrEmpty(output))
-                    job.EnqueueOutput($"[hook:{hook.Name}] {output}");
-                if (!string.IsNullOrEmpty(stderr))
-                    job.EnqueueOutput($"[hook:{hook.Name}] [stderr] {stderr}");
+        var condPsi = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            Arguments = $"-NoProfile -NonInteractive -EncodedCommand {EncodeForPowerShell(hook.Condition)}",
+            WorkingDirectory = string.IsNullOrEmpty(planFolder) ? "." : planFolder,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        using var condProc = Process.Start(condPsi);
+        var condOutput = condProc?.StandardOutput.ReadToEnd().Trim() ?? "";
+        condProc.WaitForExitOrKill(10000);
 
-                if (actionProc?.ExitCode != 0)
-                    job.EnqueueOutput($"[hook:{hook.Name}] Hook failed with exit code {actionProc?.ExitCode}");
-            }
-            catch (Exception ex)
-            {
-                job.EnqueueOutput($"[hook:{hook.Name}] Error: {ex.Message}");
-            }
+        if (condProc?.ExitCode != 0 || condOutput.Equals("False", StringComparison.OrdinalIgnoreCase))
+        {
+            job.EnqueueOutput($"[hook:{hook.Name}] Condition not met, skipping");
+            return false;
+        }
+
+        return true;
+    }
+
+    private void RunHookAction(PromptwareHookConfig hook, string planFolder, JobItem job, string jobType)
+    {
+        var actionPsi = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            Arguments = $"-NoProfile -NonInteractive -EncodedCommand {EncodeForPowerShell(hook.Action)}",
+            WorkingDirectory = string.IsNullOrEmpty(planFolder) ? "." : planFolder,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        actionPsi.Environment["TENDRIL_JOB_ID"] = job.Id;
+        actionPsi.Environment["TENDRIL_JOB_TYPE"] = jobType;
+        actionPsi.Environment["TENDRIL_JOB_STATUS"] = job.Status.ToString();
+        actionPsi.Environment["TENDRIL_PLAN_FOLDER"] = planFolder;
+        actionPsi.Environment["TENDRIL_CONFIG"] = _configService!.ConfigPath;
+
+        using var actionProc = Process.Start(actionPsi);
+        var output = actionProc?.StandardOutput.ReadToEnd().Trim() ?? "";
+        var stderr = actionProc?.StandardError.ReadToEnd().Trim() ?? "";
+        actionProc.WaitForExitOrKill(30000);
+
+        if (!string.IsNullOrEmpty(output))
+            job.EnqueueOutput($"[hook:{hook.Name}] {output}");
+        if (!string.IsNullOrEmpty(stderr))
+            job.EnqueueOutput($"[hook:{hook.Name}] [stderr] {stderr}");
+
+        if (actionProc?.ExitCode != 0)
+            job.EnqueueOutput($"[hook:{hook.Name}] Hook failed with exit code {actionProc?.ExitCode}");
     }
 
     private static string EncodeForPowerShell(string command)
     {
         var bytes = Encoding.Unicode.GetBytes(command);
         return Convert.ToBase64String(bytes);
-    }
-
-    private void SyncPlanArtifacts(JobItem job)
-    {
-        var planFolder = job.TypedArgs?.PlanFolder ?? "";
-        if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder)) return;
-
-        try
-        {
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-            var changed = false;
-
-            changed |= SyncVerificationsFromReports(planFolder, plan);
-            changed |= SyncCommitsFromWorktrees(planFolder, plan);
-
-            if (changed)
-            {
-                plan.Updated = DateTime.UtcNow;
-                PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcherService);
-                _logger.LogInformation(
-                    "Synced plan artifacts from disk for {PlanFolder} (agent did not call CLI commands)",
-                    Path.GetFileName(planFolder));
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to sync plan artifacts for {PlanFolder}", planFolder);
-        }
-    }
-
-    private bool SyncVerificationsFromReports(string planFolder, PlanYaml plan)
-    {
-        var verificationDir = Path.Combine(planFolder, "verification");
-        if (!Directory.Exists(verificationDir)) return false;
-        if (plan.Verifications == null || plan.Verifications.Count == 0) return false;
-
-        var changed = false;
-
-        foreach (var reportFile in Directory.GetFiles(verificationDir, "*.md"))
-        {
-            var reportName = Path.GetFileNameWithoutExtension(reportFile);
-            if (reportName.Equals("PreExecution", StringComparison.OrdinalIgnoreCase)) continue;
-
-            var verification = plan.Verifications.FirstOrDefault(v =>
-                v.Name.Equals(reportName, StringComparison.OrdinalIgnoreCase));
-            if (verification == null) continue;
-            if (verification.Status != "Pending") continue;
-
-            try
-            {
-                var content = FileHelper.ReadAllText(reportFile);
-                var result = PlanYamlHelper.ParseVerificationResultFromReport(content);
-                if (result != null)
-                {
-                    verification.Status = result;
-                    changed = true;
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Failed to read verification report {ReportPath}", reportFile);
-                // Skip unreadable report files
-            }
-        }
-
-        return changed;
-    }
-
-    private bool SyncCommitsFromWorktrees(string planFolder, PlanYaml plan)
-    {
-        if (plan.Commits.Count > 0) return false;
-
-        var worktreesDir = Path.Combine(planFolder, "worktrees");
-        if (!Directory.Exists(worktreesDir)) return false;
-
-        var planId = PlanYamlHelper.ExtractPlanIdFromFolder(planFolder);
-        var safeTitle = PlanYamlHelper.ExtractSafeTitleFromFolder(planFolder);
-        if (planId == null || safeTitle == null) return false;
-
-        var branchName = $"tendril/{planId}-{safeTitle}";
-        var planRepoNames = new HashSet<string>(
-            plan.Repos.Select(r => Path.GetFileName(Environment.ExpandEnvironmentVariables(r))),
-            StringComparer.OrdinalIgnoreCase);
-
-        var changed = false;
-        foreach (var wtDir in IterateWorktrees(worktreesDir, planRepoNames))
-        {
-            var commits = ExtractCommitsFromWorktree(wtDir, branchName, plan);
-            changed |= AddCommitsToPlan(plan, commits);
-        }
-
-        return changed;
-    }
-
-    private IEnumerable<string> IterateWorktrees(string worktreesDir, HashSet<string> planRepoNames)
-    {
-        foreach (var wtDir in Directory.GetDirectories(worktreesDir))
-        {
-            var wtName = Path.GetFileName(wtDir);
-            if (planRepoNames.Count > 0 && !planRepoNames.Contains(wtName))
-                continue;
-
-            var gitFile = Path.Combine(wtDir, ".git");
-            if (File.Exists(gitFile))
-                yield return wtDir;
-        }
-    }
-
-    private List<string> ExtractCommitsFromWorktree(string wtDir, string branchName, PlanYaml plan)
-    {
-        var commits = new List<string>();
-        try
-        {
-            var gitFile = Path.Combine(wtDir, ".git");
-            var gitContent = FileHelper.ReadAllText(gitFile).Trim();
-            var gitDirMatch = Regex.Match(gitContent, @"gitdir:\s*(.+)");
-            if (!gitDirMatch.Success) return commits;
-
-            var gitDir = gitDirMatch.Groups[1].Value.Trim();
-            var repoGitDir = Path.GetFullPath(Path.Combine(gitDir, "..", ".."));
-            var repoRoot = Path.GetDirectoryName(repoGitDir);
-            if (repoRoot == null || !Directory.Exists(repoRoot)) return commits;
-
-            var baseBranch = ResolveBaseBranch(repoRoot, plan);
-
-            var psi = new ProcessStartInfo("git",
-                $"log --format=%H \"{baseBranch}..{branchName}\"")
-            {
-                WorkingDirectory = repoRoot,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            using var process = Process.Start(psi);
-            if (process == null) return commits;
-            var output = process.StandardOutput.ReadToEnd().Trim();
-            process.WaitForExitOrKill(10000);
-            if (process.ExitCode != 0 || string.IsNullOrEmpty(output)) return commits;
-
-            foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-            {
-                var hash = line.Trim();
-                if (hash.Length >= 7)
-                {
-                    var shortHash = hash.Length > 9 ? hash[..9] : hash;
-                    commits.Add(shortHash);
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to read commits from worktree {Worktree}", wtDir);
-            // Skip worktrees that can't be read
-        }
-
-        return commits;
-    }
-
-    private static bool AddCommitsToPlan(PlanYaml plan, IEnumerable<string> commits)
-    {
-        var changed = false;
-        foreach (var commit in commits)
-        {
-            if (!plan.Commits.Contains(commit))
-            {
-                plan.Commits.Add(commit);
-                changed = true;
-            }
-        }
-        return changed;
-    }
-
-    private string ResolveBaseBranch(string repoRoot, PlanYaml plan)
-    {
-        var configured = TryGetConfiguredBaseBranch(repoRoot, plan);
-        return configured ?? DetectBaseBranch(repoRoot);
-    }
-
-    private string? TryGetConfiguredBaseBranch(string repoRoot, PlanYaml plan)
-    {
-        if (_configService == null) return null;
-
-        if (!string.IsNullOrEmpty(plan.Project))
-        {
-            var project = _configService.GetProject(plan.Project);
-            var repoRef = project?.Repos.FirstOrDefault(r =>
-                Path.GetFullPath(r.Path).Equals(Path.GetFullPath(repoRoot), StringComparison.OrdinalIgnoreCase));
-            if (repoRef?.BaseBranch is { Length: > 0 } configured)
-                return $"origin/{configured}";
-        }
-
-        foreach (var proj in _configService.Projects)
-        {
-            var repoRef = proj.Repos.FirstOrDefault(r =>
-                Path.GetFullPath(r.Path).Equals(Path.GetFullPath(repoRoot), StringComparison.OrdinalIgnoreCase));
-            if (repoRef?.BaseBranch is { Length: > 0 } found)
-                return $"origin/{found}";
-        }
-
-        return null;
-    }
-
-    private static string DetectBaseBranch(string repoRoot)
-    {
-        try
-        {
-            var psi = new ProcessStartInfo("git",
-                "symbolic-ref refs/remotes/origin/HEAD")
-            {
-                WorkingDirectory = repoRoot,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            using var process = Process.Start(psi);
-            if (process == null) return "origin/main";
-            var output = process.StandardOutput.ReadToEnd().Trim();
-            process.WaitForExitOrKill(5000);
-
-            if (process.ExitCode == 0 && !string.IsNullOrEmpty(output))
-                return output.Replace("refs/remotes/", "");
-        }
-        catch
-        {
-            // Fall through to default
-        }
-
-        return "origin/main";
     }
 
     private void EnsurePlanStateTransitioned(JobItem job)
@@ -570,71 +363,87 @@ internal class JobCompletionHandler
     {
         try
         {
-            if (_planReaderService == null) return;
-            var plansDir = _planReaderService.PlansDirectory;
-            if (!Directory.Exists(plansDir)) return;
+            var plansDir = _planReaderService?.PlansDirectory;
+            if (plansDir == null || !Directory.Exists(plansDir)) return;
 
-            // 1. Agent reported a plan ID via the status API
-            if (!string.IsNullOrEmpty(job.ReportedPlanId))
-            {
-                var reportedFolder = PlanYamlHelper.FindPlanFolderById(plansDir, job.ReportedPlanId);
-                if (reportedFolder != null)
-                {
-                    job.PlanFile = reportedFolder;
-                    return;
-                }
+            if (TryVerifyByReportedId(job, plansDir)) return;
+            if (TryVerifyByOutputRegex(job)) return;
+            if (IsDuplicatePlan(job)) return;
+            if (TryVerifyByFilesystem(job, plansDir)) return;
+            if (IsInTrash(job)) return;
 
-                // Reported ID doesn't match any plan folder — clear it so the
-                // bogus value doesn't leak into the UI (e.g. agent copied the
-                // example "01234" from documentation instead of calling the CLI).
-                job.ReportedPlanId = null;
-                job.ReportedPlanTitle = null;
-            }
-
-            var planId = job.ReportedPlanId ?? job.AllocatedPlanId;
-
-            // 2. Check output regex (backward compat)
-            var outputText = string.Join("\n", job.OutputLines);
-            var createdMatch = Regex.Match(outputText, @"Plan created:\s*(\S+)");
-            if (createdMatch.Success)
-            {
-                job.PlanFile = createdMatch.Groups[1].Value;
-                return;
-            }
-
-            // 3. Duplicate detection
-            var duplicate = Regex.IsMatch(outputText, "identified as duplicate:");
-            if (duplicate) return;
-
-            // 4. Filesystem fallback using allocated or reported ID
-            var planFolder = PlanYamlHelper.FindPlanFolderById(plansDir, planId);
-            if (planFolder != null)
-            {
-                job.PlanFile = planFolder;
-                return;
-            }
-
-            // 5. Check trash
-            var trashDir = _configService != null
-                ? Path.Combine(_configService.TendrilHome, "Trash")
-                : null;
-            var trashEntry = trashDir != null && !string.IsNullOrEmpty(planId)
-                ? PlanYamlHelper.FindTrashEntryById(trashDir, planId)
-                : null;
-            if (trashEntry != null) return;
-
-            // 6. Nothing found — mark as failed
-            job.EnqueueOutput(
-                "[Tendril] WARNING: CreatePlan completed but no plan folder or trash entry was found.");
-            job.Status = JobStatus.Failed;
-
-            var failureMessage = JobFailureAnalyzer.TryReadFailureArtifact(job.OutputLines.ToList());
-            job.StatusMessage = failureMessage ?? "No plan created";
+            MarkCreatePlanFailed(job);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to verify CreatePlan result for job {JobId}", job.Id);
         }
+    }
+
+    private static void MarkCreatePlanFailed(JobItem job)
+    {
+        job.EnqueueOutput(
+            "[Tendril] WARNING: CreatePlan completed but no plan folder or trash entry was found.");
+        job.Status = JobStatus.Failed;
+        job.StatusMessage = JobFailureAnalyzer.TryReadFailureArtifact(job.OutputLines.ToList()) ?? "No plan created";
+    }
+
+    private static bool TryVerifyByReportedId(JobItem job, string plansDir)
+    {
+        if (string.IsNullOrEmpty(job.ReportedPlanId)) return false;
+
+        var reportedFolder = PlanYamlHelper.FindPlanFolderById(plansDir, job.ReportedPlanId);
+        if (reportedFolder != null)
+        {
+            job.PlanFile = reportedFolder;
+            return true;
+        }
+
+        job.ReportedPlanId = null;
+        job.ReportedPlanTitle = null;
+        return false;
+    }
+
+    private static bool TryVerifyByOutputRegex(JobItem job)
+    {
+        var outputText = string.Join("\n", job.OutputLines);
+        var createdMatch = Regex.Match(outputText, @"Plan created:\s*(\S+)");
+        if (createdMatch.Success)
+        {
+            job.PlanFile = createdMatch.Groups[1].Value;
+            return true;
+        }
+        return false;
+    }
+
+    private static bool IsDuplicatePlan(JobItem job)
+    {
+        var outputText = string.Join("\n", job.OutputLines);
+        return Regex.IsMatch(outputText, "identified as duplicate:");
+    }
+
+    private static bool TryVerifyByFilesystem(JobItem job, string plansDir)
+    {
+        var planId = job.ReportedPlanId ?? job.AllocatedPlanId;
+        var planFolder = PlanYamlHelper.FindPlanFolderById(plansDir, planId);
+        if (planFolder != null)
+        {
+            job.PlanFile = planFolder;
+            return true;
+        }
+        return false;
+    }
+
+    private bool IsInTrash(JobItem job)
+    {
+        var planId = job.ReportedPlanId ?? job.AllocatedPlanId;
+        var trashDir = _configService != null
+            ? Path.Combine(_configService.TendrilHome, "Trash")
+            : null;
+        var trashEntry = trashDir != null && !string.IsNullOrEmpty(planId)
+            ? PlanYamlHelper.FindTrashEntryById(trashDir, planId)
+            : null;
+        return trashEntry != null;
     }
 
     internal void ResetPlanState(JobItem job)
@@ -689,6 +498,11 @@ internal class JobCompletionHandler
         var worktreesDir = Path.Combine(planFolder, "worktrees");
         if (!Directory.Exists(worktreesDir)) return;
 
+        ScheduleWorktreeRemoval(planFolder, worktreesDir);
+    }
+
+    private void ScheduleWorktreeRemoval(string planFolder, string worktreesDir)
+    {
         var lifecycleLogger = _worktreeLifecycleLogger;
         var logger = _logger;
 
@@ -710,163 +524,13 @@ internal class JobCompletionHandler
     }
 
     internal (bool Ok, string? BlockReason) CheckDependencies(string planFolder)
-    {
-        try
-        {
-            var planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
-            if (planYaml?.DependsOn == null || planYaml.DependsOn.Count == 0)
-                return (true, null);
-
-            var plansDir = _planReaderService?.PlansDirectory;
-            if (plansDir == null) return (true, null);
-
-            foreach (var dep in planYaml.DependsOn)
-            {
-                var depFolder = Path.Combine(plansDir, dep);
-                var depPlan = PlanYamlHelper.ReadPlanYaml(depFolder);
-
-                if (depPlan == null)
-                    return (false, $"Dependency '{dep}' not found");
-
-                if (!depPlan.State.Equals("Completed", StringComparison.OrdinalIgnoreCase))
-                    return (false, $"Dependency '{dep}' is '{depPlan.State}', not Completed");
-
-                if (depPlan.Prs.Count == 0)
-                    continue;
-
-                foreach (var prUrl in depPlan.Prs.Where(PullRequestApp.IsValidUrl))
-                    try
-                    {
-                        var psi = new ProcessStartInfo
-                        {
-                            FileName = "gh",
-                            Arguments = $"pr view \"{prUrl}\" --json state -q .state",
-                            RedirectStandardOutput = true,
-                            RedirectStandardError = true,
-                            UseShellExecute = false,
-                            CreateNoWindow = true
-                        };
-                        using var proc = Process.Start(psi);
-                        var output = proc?.StandardOutput.ReadToEnd().Trim() ?? "";
-                        proc.WaitForExitOrKill(10000);
-
-                        if (!output.Equals("MERGED", StringComparison.OrdinalIgnoreCase))
-                            return (false, $"Dependency '{dep}' PR {prUrl} is '{output}', not MERGED");
-                    }
-                    catch (Exception ex)
-                    {
-                        return (false, $"Failed to check PR status for '{dep}': {ex.Message}");
-                    }
-            }
-
-            return (true, null);
-        }
-        catch (Exception ex)
-        {
-            return (false, $"Dependency check failed: {ex.Message}");
-        }
-    }
+        => _dependencyChecker.CheckDependencies(planFolder);
 
     internal void HandleRetryBlockedJobs(
         ConcurrentDictionary<string, JobItem> jobs,
         Action<JobNotification> raiseNotification,
         Func<JobArgsBase, string> startJobSkipDepCheck)
-        => RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
-
-    private void RetryBlockedJobs(
-        ConcurrentDictionary<string, JobItem> jobs,
-        Action<JobNotification> raiseNotification,
-        Func<JobArgsBase, string> startJobSkipDepCheck)
-    {
-        var blockedJobs = jobs.Values
-            .Where(j => j.Status == JobStatus.Blocked && j.TypedArgs is ExecutePlanArgs)
-            .ToList();
-
-        foreach (var blockedJob in blockedJobs)
-        {
-            var planFolder = blockedJob.TypedArgs?.PlanFolder ?? "";
-            if (string.IsNullOrEmpty(planFolder)) continue;
-
-            var (ok, _) = CheckDependencies(planFolder);
-            if (!ok) continue;
-
-            if (HasActiveJobForPlan(planFolder, jobs)) continue;
-
-            if (!jobs.TryRemove(blockedJob.Id, out _)) continue;
-
-            PlanYamlHelper.SetPlanStateByFolder(planFolder, "Building");
-            startJobSkipDepCheck(blockedJob.TypedArgs!);
-
-            raiseNotification(new JobNotification(
-                "Job Unblocked",
-                $"{blockedJob.PlanFile}: dependencies now satisfied, auto-restarting",
-                true));
-        }
-    }
-
-    private void RetryBlockedDependents(
-        string completedPlanFolder,
-        ConcurrentDictionary<string, JobItem> jobs,
-        Func<JobArgsBase, string> startJobSkipDepCheck)
-    {
-        try
-        {
-            var completedFolderName = Path.GetFileName(completedPlanFolder);
-            var plansDir = _planReaderService?.PlansDirectory;
-            if (string.IsNullOrEmpty(plansDir) || !Directory.Exists(plansDir)) return;
-
-            foreach (var dir in Directory.GetDirectories(plansDir))
-            {
-                var planYaml = PlanYamlHelper.ReadPlanYaml(dir);
-                if (planYaml == null) continue;
-                if (!planYaml.State.Equals("Blocked", StringComparison.OrdinalIgnoreCase)) continue;
-                if (!planYaml.DependsOn.Contains(completedFolderName, StringComparer.OrdinalIgnoreCase)) continue;
-
-                var hasExistingJob = jobs.Values.Any(j =>
-                    j.TypedArgs is ExecutePlanArgs &&
-                    j.Status is JobStatus.Blocked or JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
-                    j.TypedArgs?.PlanFolder != null &&
-                    j.TypedArgs.PlanFolder.Equals(dir, StringComparison.OrdinalIgnoreCase));
-                if (hasExistingJob) continue;
-
-                var (allMet, _) = CheckDependencies(dir);
-                if (allMet)
-                {
-                    PlanYamlHelper.SetPlanStateByFolder(dir, "Building");
-                    startJobSkipDepCheck(new ExecutePlanArgs(dir));
-                }
-            }
-        }
-        catch
-        {
-        }
-    }
-
-    private static bool HasActiveJobForPlan(string planFolder, ConcurrentDictionary<string, JobItem> jobs)
-    {
-        var planRepos = PlanYamlHelper.ReadPlanYaml(planFolder)?.Repos;
-
-        return jobs.Values.Any(j =>
-        {
-            if (j.TypedArgs is not ExecutePlanArgs) return false;
-            if (j.Status is not (JobStatus.Running or JobStatus.Queued or JobStatus.Pending)) return false;
-
-            var otherFolder = j.TypedArgs?.PlanFolder;
-            if (otherFolder == null) return false;
-
-            if (otherFolder.Equals(planFolder, StringComparison.OrdinalIgnoreCase))
-                return true;
-
-            if (planRepos is { Count: > 0 })
-            {
-                var otherRepos = PlanYamlHelper.ReadPlanYaml(otherFolder)?.Repos;
-                if (otherRepos != null && planRepos.Any(r => otherRepos.Contains(r, StringComparer.OrdinalIgnoreCase)))
-                    return true;
-            }
-
-            return false;
-        });
-    }
+        => _dependencyChecker.RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
 
     private string? ResolvePlanFolder(JobItem job)
     {
@@ -1032,5 +696,4 @@ internal class JobCompletionHandler
             sb.AppendLine($"- {v.Name}: {v.Status}");
         sb.AppendLine();
     }
-
 }

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Text.RegularExpressions;
 using Ivy.Helpers;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
@@ -18,6 +17,13 @@ internal record JobLaunchContext(
     Action<string, string, string, string, JobItem> RunHooks,
     Action<string, int?, bool, bool> CompleteJob,
     Action RaiseStructureChanged);
+
+internal record RepoConfigEntry(
+    string Path,
+    string BaseBranch,
+    string SyncStrategy,
+    string PrRule,
+    bool ReadOnly);
 
 internal class JobLauncher
 {
@@ -49,7 +55,7 @@ internal class JobLauncher
         LaunchJob(ctx);
     }
 
-    internal void LaunchJob(JobLaunchContext ctx)
+    private void LaunchJob(JobLaunchContext ctx)
     {
         PrepareJobForLaunch(ctx);
 
@@ -170,188 +176,8 @@ internal class JobLauncher
 
     private void InitializeJobMonitoring(JobLaunchContext ctx, Process process)
     {
-        var job = ctx.Job;
-        var id = job.Id;
-
-        var cts = new CancellationTokenSource(ctx.JobTimeout);
-        job.TimeoutCts = cts;
-
-        // Hard timeout guard - ensures the job is completed even if WaitForExitOrKillAsync hangs
-        var hardTimeout = ctx.JobTimeout + TimeSpan.FromMinutes(5);
-        var hardTimeoutCts = new CancellationTokenSource(hardTimeout);
-
-        Task.Run(async () =>
-        {
-            _logger.LogDebug("Job {JobId}: Monitor task started", id);
-
-            try
-            {
-                var waitTask = process.WaitForExitOrKillAsync(cts.Token);
-                var completedTask = await Task.WhenAny(waitTask, Task.Delay(hardTimeout, hardTimeoutCts.Token));
-
-                if (completedTask == waitTask)
-                {
-                    var normalExit = await waitTask;
-                    if (normalExit)
-                    {
-                        if (ctx.Jobs.TryGetValue(id, out var j) && j.StaleOutputDetected)
-                        {
-                            _logger.LogInformation("Job {JobId}: Process exited, stale output detected", id);
-                            ctx.CompleteJob(id, null, true, true);
-                        }
-                        else
-                        {
-                            _logger.LogInformation("Job {JobId}: Process exited with code {ExitCode}", id, process.ExitCode);
-                            if (ctx.Jobs.TryGetValue(id, out var exitJob))
-                                exitJob.ExitCode = process.ExitCode;
-                            ctx.CompleteJob(id, process.ExitCode, false, false);
-                        }
-                    }
-                    else
-                    {
-                        _logger.LogWarning("Job {JobId}: Process killed after timeout", id);
-                        ctx.CompleteJob(id, null, true, false);
-                    }
-                }
-                else
-                {
-                    _logger.LogError("Job {JobId}: HARD TIMEOUT after {Minutes} minutes - process may still be running",
-                        id, hardTimeout.TotalMinutes);
-                    CrashLog.Write($"[{DateTime.UtcNow:O}] Job {id} hit hard timeout after {hardTimeout.TotalMinutes} minutes - WaitForExitOrKillAsync did not complete");
-
-                    // Try one last forceful kill
-                    try
-                    {
-                        if (!process.HasExited)
-                        {
-                            _logger.LogWarning("Job {JobId}: Attempting emergency kill", id);
-                            process.Kill(entireProcessTree: true);
-                        }
-                    }
-                    catch (Exception killEx)
-                    {
-                        _logger.LogError(killEx, "Job {JobId}: Emergency kill failed", id);
-                    }
-
-                    ctx.CompleteJob(id, null, true, false);
-                }
-
-                _logger.LogDebug("Job {JobId}: Monitor task completed normally", id);
-            }
-            catch (ObjectDisposedException)
-            {
-                _logger.LogDebug("Job {JobId}: Monitor task exiting (CTS disposed, job completed elsewhere)", id);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Job {JobId}: Monitor task exception", id);
-                CrashLog.Write($"[{DateTime.UtcNow:O}] JobService process monitor exception for job {id}: {ex}");
-                ctx.CompleteJob(id, null, false, false);
-            }
-            finally
-            {
-                hardTimeoutCts.Dispose();
-            }
-        });
-
-        if (ctx.StaleOutputTimeout > TimeSpan.Zero)
-            _ = RunStaleOutputWatchdog(id, cts, ctx.Jobs, ctx.StaleOutputTimeout);
-
-        if (!string.IsNullOrEmpty(job.StatusFilePath))
-            _ = RunStatusFilePoller(id, cts, ctx.Jobs);
-    }
-
-    internal async Task RunStaleOutputWatchdog(
-        string id,
-        CancellationTokenSource timeoutCts,
-        ConcurrentDictionary<string, JobItem> jobs,
-        TimeSpan staleOutputTimeout)
-    {
-        const int checkIntervalSeconds = 60;
-
-        try
-        {
-            while (!timeoutCts.Token.IsCancellationRequested)
-            {
-                for (var i = 0; i < checkIntervalSeconds; i++)
-                {
-                    try
-                    {
-                        await Task.Delay(TimeSpan.FromSeconds(1), timeoutCts.Token);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        return;
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        return;
-                    }
-
-                    try
-                    {
-                        if (timeoutCts.Token.IsCancellationRequested) return;
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        return;
-                    }
-                }
-
-                if (!jobs.TryGetValue(id, out var job) || job.Status != JobStatus.Running)
-                    break;
-
-                if (job.LastOutputAt.HasValue)
-                {
-                    var sinceLastOutput = DateTime.UtcNow - job.LastOutputAt.Value;
-                    if (sinceLastOutput >= staleOutputTimeout)
-                    {
-                        job.StaleOutputDetected = true;
-                        try { timeoutCts.Cancel(); } catch (ObjectDisposedException) { }
-                        break;
-                    }
-                }
-            }
-        }
-        catch (ObjectDisposedException)
-        {
-        }
-    }
-
-    internal static async Task RunStatusFilePoller(
-        string id,
-        CancellationTokenSource timeoutCts,
-        ConcurrentDictionary<string, JobItem> jobs)
-    {
-        try
-        {
-            while (!timeoutCts.Token.IsCancellationRequested)
-            {
-                try
-                {
-                    await Task.Delay(TimeSpan.FromSeconds(1), timeoutCts.Token);
-                }
-                catch (OperationCanceledException) { return; }
-                catch (ObjectDisposedException) { return; }
-
-                if (!jobs.TryGetValue(id, out var job) || job.Status != JobStatus.Running)
-                    break;
-
-                if (string.IsNullOrEmpty(job.StatusFilePath)) break;
-
-                var payload = JobStatusFile.Read(job.StatusFilePath);
-                if (payload == null) continue;
-
-                job.StatusMessage = payload.Message;
-                if (!string.IsNullOrEmpty(payload.PlanId)
-                    && Regex.IsMatch(payload.PlanId, @"^\d{5}$")
-                    && payload.PlanId != "01234")
-                    job.ReportedPlanId = payload.PlanId;
-                if (!string.IsNullOrEmpty(payload.PlanTitle))
-                    job.ReportedPlanTitle = payload.PlanTitle;
-            }
-        }
-        catch (ObjectDisposedException) { }
+        var monitor = new JobMonitor(ctx.Job.Id, ctx, process, _logger);
+        monitor.Start();
     }
 
     private static void AttachOutputHandlers(Process process, JobItem job, string id)
@@ -398,37 +224,20 @@ internal class JobLauncher
 
         var settings = _configService.Settings;
         var (values, planYaml, profileOverride) = BuildFirmwareValues(ctx, programFolder);
-
         values["Project"] = job.Project;
 
         var jobContext = BuildJobContext(job, values, programFolder);
         var resolution = AgentProviderFactory.Resolve(settings, job.Type, profileOverride, jobContext);
         var workDir = ResolveWorkingDirectory(job, programFolder);
 
-        string? customInstructions = null;
-        if (settings.Promptwares.TryGetValue("_default", out var defaultCfg))
-            customInstructions = defaultCfg.CustomInstructions;
-        if (settings.Promptwares.TryGetValue(job.Type, out var specificCfg)
-            && !string.IsNullOrWhiteSpace(specificCfg.CustomInstructions))
-            customInstructions = specificCfg.CustomInstructions;
-
         var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
         job.LogFilePath = logFile;
 
-        var context = new FirmwareContext(programFolder, values, customInstructions);
-        var prompt = FirmwareCompiler.Compile(context);
+        var customInstructions = ResolveCustomInstructions(job.Type);
+        var prompt = FirmwareCompiler.Compile(new FirmwareContext(programFolder, values, customInstructions));
         job.CompiledPrompt = prompt;
 
-        string? promptFilePath = null;
-        if (!resolution.Provider.UsesStdinPrompt)
-        {
-            var tempDir = values.TryGetValue("PlanFolder", out var pf)
-                ? Path.Combine(pf, "temp")
-                : Path.GetTempPath();
-            Directory.CreateDirectory(tempDir);
-            promptFilePath = Path.Combine(tempDir, $"prompt-{job.Id}.md");
-            File.WriteAllText(promptFilePath, prompt);
-        }
+        var promptFilePath = WritePromptFileIfNeeded(resolution, prompt, job.Id, values);
 
         var invocation = new AgentInvocation(
             PromptContent: prompt,
@@ -442,15 +251,40 @@ internal class JobLauncher
 
         var psi = resolution.Provider.BuildProcessStart(invocation);
         SetTendrilEnvironment(psi, job);
-        job.CliCommand = FirmwareCompiler.FormatCliCommand(psi);
-
-        var stdinContent = resolution.Provider.UsesStdinPrompt ? prompt : null;
+        job.CliCommand = AgentProcessHelper.FormatCliCommand(psi);
 
         _logger.LogInformation(
             "Job {JobId}: Agent-direct launch ({Provider}, model={Model}, effort={Effort})",
             job.Id, resolution.Provider.Name, resolution.Model, resolution.Effort);
 
-        return (psi, stdinContent);
+        return (psi, resolution.Provider.UsesStdinPrompt ? prompt : null);
+    }
+
+    private string? ResolveCustomInstructions(string promptwareName)
+    {
+        var settings = _configService!.Settings;
+        string? instructions = null;
+        if (settings.Promptwares.TryGetValue("_default", out var defaultCfg))
+            instructions = defaultCfg.CustomInstructions;
+        if (settings.Promptwares.TryGetValue(promptwareName, out var specificCfg)
+            && !string.IsNullOrWhiteSpace(specificCfg.CustomInstructions))
+            instructions = specificCfg.CustomInstructions;
+        return instructions;
+    }
+
+    private static string? WritePromptFileIfNeeded(
+        AgentResolution resolution, string prompt, string jobId, Dictionary<string, string> values)
+    {
+        if (resolution.Provider.UsesStdinPrompt)
+            return null;
+
+        var tempDir = values.TryGetValue("PlanFolder", out var pf)
+            ? Path.Combine(pf, "temp")
+            : Path.GetTempPath();
+        Directory.CreateDirectory(tempDir);
+        var path = Path.Combine(tempDir, $"prompt-{jobId}.md");
+        File.WriteAllText(path, prompt);
+        return path;
     }
 
     private static bool HasAgentDirectProgram(string programFolder, string jobType)
@@ -500,7 +334,7 @@ internal class JobLauncher
         if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder))
             return (values, null, null);
 
-        var planId = ExtractPlanIdFromFolder(planFolder);
+        var planId = PlanYamlHelper.ExtractPlanIdFromFolder(planFolder);
         if (planId != null)
         {
             values["PlanId"] = planId;
@@ -525,12 +359,6 @@ internal class JobLauncher
         return (values, planYaml, profileOverride);
     }
 
-    private static string? ExtractPlanIdFromFolder(string planFolder)
-    {
-        var folderName = Path.GetFileName(planFolder);
-        var dashIdx = folderName.IndexOf('-');
-        return dashIdx > 0 ? folderName[..dashIdx] : null;
-    }
 
     private static string? ExtractExecutionProfile(JobItem job, PlanYaml planYaml)
     {
@@ -566,9 +394,10 @@ internal class JobLauncher
 
     private static Dictionary<string, string> BuildJobContext(JobItem job, Dictionary<string, string> firmwareValues, string programFolder)
     {
-        var ctx = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-        ctx["PROMPTWARE_DIR"] = programFolder;
+        var ctx = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["PROMPTWARE_DIR"] = programFolder
+        };
 
         if (firmwareValues.TryGetValue("PlansDirectory", out var plansDir))
             ctx["PLANS_DIR"] = plansDir;
@@ -615,62 +444,10 @@ internal class JobLauncher
     }
 
     internal static void EnsureTendrilOnPath(ProcessStartInfo psi)
-    {
-        var processPath = Environment.ProcessPath;
-        if (!string.IsNullOrEmpty(processPath) &&
-            Path.GetFileNameWithoutExtension(processPath).Equals("tendril", StringComparison.OrdinalIgnoreCase))
-        {
-            var dir = Path.GetDirectoryName(processPath)!;
-            PrependToPath(psi, dir);
-            return;
-        }
-
-        // Dev mode: create a shim that uses `dotnet exec` on the already-built DLL
-        // instead of `dotnet run` which triggers a build and fails when DLLs are locked.
-        var baseDir = AppDomain.CurrentDomain.BaseDirectory;
-        var dllPath = Path.Combine(baseDir, "Ivy.Tendril.dll");
-        if (File.Exists(dllPath))
-        {
-            var shimDir = Path.Combine(Path.GetTempPath(), "tendril-shim");
-            FileHelper.EnsureDirectory(shimDir);
-
-            var cmdShim = Path.Combine(shimDir, "tendril.cmd");
-            File.WriteAllText(cmdShim, $"@dotnet exec \"{dllPath}\" %*\r\n");
-
-            var bashDllPath = dllPath.Replace('\\', '/');
-            var bashShim = Path.Combine(shimDir, "tendril");
-            File.WriteAllText(bashShim, $"#!/usr/bin/env bash\ndotnet exec '{bashDllPath}' \"$@\"\n");
-
-            PrependToPath(psi, shimDir);
-        }
-    }
+        => AgentProcessHelper.EnsureTendrilOnPath(psi);
 
     internal static void ResolveCommandShim(ProcessStartInfo psi)
-    {
-        if (!OperatingSystem.IsWindows()) return;
-
-        var fileName = psi.FileName;
-        if (Path.IsPathRooted(fileName) || Path.HasExtension(fileName)) return;
-
-        var pathDirs = (psi.Environment.TryGetValue("PATH", out var p) ? p : Environment.GetEnvironmentVariable("PATH"))
-            ?.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries) ?? [];
-
-        foreach (var dir in pathDirs)
-        {
-            var cmdPath = Path.Combine(dir, fileName + ".cmd");
-            if (File.Exists(cmdPath))
-            {
-                psi.FileName = cmdPath;
-                return;
-            }
-        }
-    }
-
-    internal static void PrependToPath(ProcessStartInfo psi, string dir)
-    {
-        var current = psi.Environment.TryGetValue("PATH", out var p) ? p : Environment.GetEnvironmentVariable("PATH");
-        psi.Environment["PATH"] = $"{dir}{Path.PathSeparator}{current}";
-    }
+        => AgentProcessHelper.ResolveCommandShim(psi);
 
     private string? BuildRepoConfigsYaml(PlanYaml plan, string project)
     {
@@ -696,11 +473,13 @@ internal class JobLauncher
         {
             var expanded = Environment.ExpandEnvironmentVariables(repoPath);
             var repoRef = FindProjectRepoConfig(projectConfig, Path.GetFileName(expanded));
-            AddRepoToConfigLines(lines, expanded,
+            var entry = new RepoConfigEntry(
+                expanded,
                 repoRef?.BaseBranch ?? "main",
                 repoRef?.SyncStrategy ?? "fetch",
                 repoRef?.PrRule ?? "default",
-                false);
+                ReadOnly: false);
+            AddRepoToConfigLines(lines, entry);
         }
     }
 
@@ -716,24 +495,23 @@ internal class JobLauncher
             if (planRepoNames.Contains(repoName))
                 continue;
 
-            var depBaseBranch = FindBaseBranchAcrossProjects(repoName);
-            AddRepoToConfigLines(lines, expanded, depBaseBranch, "fetch", "default", true);
+            var entry = new RepoConfigEntry(
+                expanded,
+                FindBaseBranchAcrossProjects(repoName),
+                "fetch",
+                "default",
+                ReadOnly: true);
+            AddRepoToConfigLines(lines, entry);
         }
     }
 
-    private static void AddRepoToConfigLines(
-        List<string> lines,
-        string path,
-        string baseBranch,
-        string syncStrategy,
-        string prRule,
-        bool readOnly)
+    private static void AddRepoToConfigLines(List<string> lines, RepoConfigEntry entry)
     {
-        lines.Add($"- path: {path}");
-        lines.Add($"  baseBranch: {baseBranch}");
-        lines.Add($"  syncStrategy: {syncStrategy}");
-        lines.Add($"  prRule: {prRule}");
-        if (readOnly)
+        lines.Add($"- path: {entry.Path}");
+        lines.Add($"  baseBranch: {entry.BaseBranch}");
+        lines.Add($"  syncStrategy: {entry.SyncStrategy}");
+        lines.Add($"  prRule: {entry.PrRule}");
+        if (entry.ReadOnly)
             lines.Add("  readOnly: true");
     }
 

--- a/src/Ivy.Tendril/Services/JobMonitor.cs
+++ b/src/Ivy.Tendril/Services/JobMonitor.cs
@@ -1,0 +1,183 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Ivy.Helpers;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services;
+
+internal class JobMonitor
+{
+    private readonly string _id;
+    private readonly JobLaunchContext _ctx;
+    private readonly Process _process;
+    private readonly ILogger _logger;
+    private readonly CancellationTokenSource _timeoutCts;
+    private readonly TimeSpan _hardTimeout;
+
+    internal JobMonitor(string id, JobLaunchContext ctx, Process process, ILogger logger)
+    {
+        _id = id;
+        _ctx = ctx;
+        _process = process;
+        _logger = logger;
+        _timeoutCts = new CancellationTokenSource(ctx.JobTimeout);
+        _hardTimeout = ctx.JobTimeout + TimeSpan.FromMinutes(5);
+    }
+
+    internal void Start()
+    {
+        var job = _ctx.Jobs.GetValueOrDefault(_id);
+        if (job != null)
+            job.TimeoutCts = _timeoutCts;
+
+        Task.Run(MonitorProcessAsync);
+
+        if (_ctx.StaleOutputTimeout > TimeSpan.Zero)
+            _ = RunStaleOutputWatchdog(_id, _timeoutCts, _ctx.Jobs, _ctx.StaleOutputTimeout);
+
+        if (job != null && !string.IsNullOrEmpty(job.StatusFilePath))
+            _ = RunStatusFilePoller(_id, _timeoutCts, _ctx.Jobs);
+    }
+
+    private async Task MonitorProcessAsync()
+    {
+        var hardTimeoutCts = new CancellationTokenSource(_hardTimeout);
+        _logger.LogDebug("Job {JobId}: Monitor task started", _id);
+
+        try
+        {
+            var waitTask = _process.WaitForExitOrKillAsync(_timeoutCts.Token);
+            var completedTask = await Task.WhenAny(waitTask, Task.Delay(_hardTimeout, hardTimeoutCts.Token));
+
+            if (completedTask == waitTask)
+                HandleNormalExit(await waitTask);
+            else
+                HandleHardTimeout();
+        }
+        catch (ObjectDisposedException)
+        {
+            _logger.LogDebug("Job {JobId}: Monitor task exiting (CTS disposed, job completed elsewhere)", _id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Job {JobId}: Monitor task exception", _id);
+            CrashLog.Write($"[{DateTime.UtcNow:O}] JobService process monitor exception for job {_id}: {ex}");
+            _ctx.CompleteJob(_id, null, false, false);
+        }
+        finally
+        {
+            hardTimeoutCts.Dispose();
+        }
+    }
+
+    private void HandleNormalExit(bool normalExit)
+    {
+        if (!normalExit)
+        {
+            _logger.LogWarning("Job {JobId}: Process killed after timeout", _id);
+            _ctx.CompleteJob(_id, null, true, false);
+            return;
+        }
+
+        if (_ctx.Jobs.TryGetValue(_id, out var j) && j.StaleOutputDetected)
+        {
+            _logger.LogInformation("Job {JobId}: Process exited, stale output detected", _id);
+            _ctx.CompleteJob(_id, null, true, true);
+            return;
+        }
+
+        _logger.LogInformation("Job {JobId}: Process exited with code {ExitCode}", _id, _process.ExitCode);
+        if (_ctx.Jobs.TryGetValue(_id, out var exitJob))
+            exitJob.ExitCode = _process.ExitCode;
+        _ctx.CompleteJob(_id, _process.ExitCode, false, false);
+    }
+
+    private void HandleHardTimeout()
+    {
+        _logger.LogError("Job {JobId}: HARD TIMEOUT after {Minutes} minutes - process may still be running",
+            _id, _hardTimeout.TotalMinutes);
+        CrashLog.Write($"[{DateTime.UtcNow:O}] Job {_id} hit hard timeout after {_hardTimeout.TotalMinutes} minutes - WaitForExitOrKillAsync did not complete");
+
+        try
+        {
+            if (!_process.HasExited)
+            {
+                _logger.LogWarning("Job {JobId}: Attempting emergency kill", _id);
+                _process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (Exception killEx)
+        {
+            _logger.LogError(killEx, "Job {JobId}: Emergency kill failed", _id);
+        }
+
+        _ctx.CompleteJob(_id, null, true, false);
+    }
+
+    internal static async Task RunStaleOutputWatchdog(
+        string id,
+        CancellationTokenSource timeoutCts,
+        ConcurrentDictionary<string, JobItem> jobs,
+        TimeSpan staleOutputTimeout)
+    {
+        try
+        {
+            while (!timeoutCts.Token.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1), timeoutCts.Token);
+                if (!jobs.TryGetValue(id, out var job) || job.Status != JobStatus.Running)
+                    return;
+                if (!job.LastOutputAt.HasValue)
+                    continue;
+                if (DateTime.UtcNow - job.LastOutputAt.Value < staleOutputTimeout)
+                    continue;
+
+                job.StaleOutputDetected = true;
+                try { timeoutCts.Cancel(); } catch (ObjectDisposedException) { }
+                return;
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }
+    }
+
+    internal static async Task RunStatusFilePoller(
+        string id,
+        CancellationTokenSource timeoutCts,
+        ConcurrentDictionary<string, JobItem> jobs)
+    {
+        try
+        {
+            while (!timeoutCts.Token.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1), timeoutCts.Token);
+                if (!jobs.TryGetValue(id, out var job) || job.Status != JobStatus.Running)
+                    return;
+                if (string.IsNullOrEmpty(job.StatusFilePath))
+                    return;
+
+                var payload = JobStatusFile.Read(job.StatusFilePath);
+                if (payload == null)
+                    continue;
+
+                job.StatusMessage = payload.Message;
+                if (IsValidPlanId(payload.PlanId))
+                    job.ReportedPlanId = payload.PlanId;
+                if (!string.IsNullOrEmpty(payload.PlanTitle))
+                    job.ReportedPlanTitle = payload.PlanTitle;
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { }
+    }
+
+    private static bool IsValidPlanId(string? planId)
+    {
+        return !string.IsNullOrEmpty(planId)
+            && Regex.IsMatch(planId, @"^\d{5}$")
+            && planId != "01234";
+    }
+}

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -12,14 +12,11 @@ public record JobNotification(string Title, string Message, bool IsSuccess);
 
 public class JobService : IJobService
 {
-
-
     private readonly IConfigService? _configService;
     private readonly IPlanDatabaseService? _database;
-
     private readonly string? _inboxPath;
     private readonly PriorityQueue<string, int> _jobQueue = new();
-    private readonly object _queueLock = new();
+    private readonly Lock _queueLock = new();
     private SemaphoreSlim _jobSlotSemaphore;
     private TimeSpan _jobTimeout;
     private readonly ConcurrentDictionary<string, JobItem> _jobs = new();
@@ -34,7 +31,6 @@ public class JobService : IJobService
     private readonly ILogger<JobService> _logger;
     private readonly JobLauncher _jobLauncher;
     private readonly JobCompletionHandler _completionHandler;
-    private readonly string _promptsRoot;
     private int _counter;
 
     public JobService(
@@ -63,11 +59,11 @@ public class JobService : IJobService
             ? new SemaphoreSlim(_maxConcurrentJobs, _maxConcurrentJobs)
             : new SemaphoreSlim(0, 1);
         _inboxPath = Path.Combine(configService.TendrilHome, "Inbox");
-        _promptsRoot = Ivy.Tendril.Helpers.PromptwareHelper.ResolvePromptsRoot(configService.TendrilHome);
-        _jobLauncher = new JobLauncher(configService, _logger, _promptsRoot);
+        var promptsRoot = Ivy.Tendril.Helpers.PromptwareHelper.ResolvePromptsRoot(configService.TendrilHome);
+        _jobLauncher = new JobLauncher(configService, _logger, promptsRoot);
         _completionHandler = new JobCompletionHandler(
             configService, _logger, modelPricingService, planReaderService,
-            telemetryService, planWatcherService, worktreeLifecycleLogger, _promptsRoot);
+            telemetryService, planWatcherService, worktreeLifecycleLogger, promptsRoot);
         configService.SettingsReloaded += OnSettingsReloaded;
         LoadHistoricalJobs();
     }
@@ -94,11 +90,11 @@ public class JobService : IJobService
         _planReaderService = planReaderService;
         _telemetryService = telemetryService;
         _database = database;
-        _promptsRoot = Ivy.Tendril.Helpers.PromptwareHelper.ResolvePromptsRoot();
-        _jobLauncher = new JobLauncher(null, _logger, _promptsRoot);
+        var promptsRoot = Ivy.Tendril.Helpers.PromptwareHelper.ResolvePromptsRoot();
+        _jobLauncher = new JobLauncher(null, _logger, promptsRoot);
         _completionHandler = new JobCompletionHandler(
             null, _logger, null, planReaderService, telemetryService,
-            null, null, _promptsRoot);
+            null, null, promptsRoot);
         LoadHistoricalJobs();
     }
 
@@ -587,7 +583,7 @@ public class JobService : IJobService
         => _completionHandler.RunHooks(when, jobType, planFolder, project, job);
 
     internal Task RunStaleOutputWatchdog(string id, CancellationTokenSource timeoutCts)
-        => _jobLauncher.RunStaleOutputWatchdog(id, timeoutCts, _jobs, _staleOutputTimeout);
+        => JobMonitor.RunStaleOutputWatchdog(id, timeoutCts, _jobs, _staleOutputTimeout);
 
 
     private void ProcessJobQueue()

--- a/src/Ivy.Tendril/Services/PlanArtifactSyncer.cs
+++ b/src/Ivy.Tendril/Services/PlanArtifactSyncer.cs
@@ -1,0 +1,255 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Ivy.Helpers;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services;
+
+internal class PlanArtifactSyncer
+{
+    private readonly IConfigService? _configService;
+    private readonly ILogger _logger;
+    private readonly IPlanWatcherService? _planWatcherService;
+
+    internal PlanArtifactSyncer(IConfigService? configService, ILogger logger, IPlanWatcherService? planWatcherService)
+    {
+        _configService = configService;
+        _logger = logger;
+        _planWatcherService = planWatcherService;
+    }
+
+    internal void SyncPlanArtifacts(JobItem job)
+    {
+        var planFolder = job.TypedArgs?.PlanFolder ?? "";
+        if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder)) return;
+
+        try
+        {
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var changed = false;
+
+            changed |= SyncVerificationsFromReports(planFolder, plan);
+            changed |= SyncCommitsFromWorktrees(planFolder, plan);
+
+            if (changed)
+            {
+                plan.Updated = DateTime.UtcNow;
+                PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcherService);
+                _logger.LogInformation(
+                    "Synced plan artifacts from disk for {PlanFolder} (agent did not call CLI commands)",
+                    Path.GetFileName(planFolder));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to sync plan artifacts for {PlanFolder}", planFolder);
+        }
+    }
+
+    private bool SyncVerificationsFromReports(string planFolder, PlanYaml plan)
+    {
+        var verificationDir = Path.Combine(planFolder, "verification");
+        if (!Directory.Exists(verificationDir)) return false;
+        if (plan.Verifications == null || plan.Verifications.Count == 0) return false;
+
+        var changed = false;
+
+        foreach (var reportFile in Directory.GetFiles(verificationDir, "*.md"))
+        {
+            var reportName = Path.GetFileNameWithoutExtension(reportFile);
+            if (reportName.Equals("PreExecution", StringComparison.OrdinalIgnoreCase)) continue;
+
+            var verification = plan.Verifications.FirstOrDefault(v =>
+                v.Name.Equals(reportName, StringComparison.OrdinalIgnoreCase));
+            if (verification == null || verification.Status != "Pending") continue;
+
+            try
+            {
+                var content = FileHelper.ReadAllText(reportFile);
+                var result = PlanYamlHelper.ParseVerificationResultFromReport(content);
+                if (result != null)
+                {
+                    verification.Status = result;
+                    changed = true;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to read verification report {ReportPath}", reportFile);
+            }
+        }
+
+        return changed;
+    }
+
+    private bool SyncCommitsFromWorktrees(string planFolder, PlanYaml plan)
+    {
+        if (plan.Commits.Count > 0) return false;
+
+        var worktreesDir = Path.Combine(planFolder, "worktrees");
+        if (!Directory.Exists(worktreesDir)) return false;
+
+        var planId = PlanYamlHelper.ExtractPlanIdFromFolder(planFolder);
+        var safeTitle = PlanYamlHelper.ExtractSafeTitleFromFolder(planFolder);
+        if (planId == null || safeTitle == null) return false;
+
+        var branchName = $"tendril/{planId}-{safeTitle}";
+        var planRepoNames = new HashSet<string>(
+            plan.Repos.Select(r => Path.GetFileName(Environment.ExpandEnvironmentVariables(r))),
+            StringComparer.OrdinalIgnoreCase);
+
+        var changed = false;
+        foreach (var wtDir in IterateWorktrees(worktreesDir, planRepoNames))
+        {
+            var commits = ExtractCommitsFromWorktree(wtDir, branchName, plan);
+            changed |= AddCommitsToPlan(plan, commits);
+        }
+
+        return changed;
+    }
+
+    private static IEnumerable<string> IterateWorktrees(string worktreesDir, HashSet<string> planRepoNames)
+    {
+        foreach (var wtDir in Directory.GetDirectories(worktreesDir))
+        {
+            var wtName = Path.GetFileName(wtDir);
+            if (planRepoNames.Count > 0 && !planRepoNames.Contains(wtName))
+                continue;
+
+            var gitFile = Path.Combine(wtDir, ".git");
+            if (File.Exists(gitFile))
+                yield return wtDir;
+        }
+    }
+
+    private List<string> ExtractCommitsFromWorktree(string wtDir, string branchName, PlanYaml plan)
+    {
+        var commits = new List<string>();
+        try
+        {
+            var repoRoot = ResolveRepoRootFromWorktree(wtDir);
+            if (repoRoot == null) return commits;
+
+            var baseBranch = ResolveBaseBranch(repoRoot, plan);
+            var output = RunGitLog(repoRoot, baseBranch, branchName);
+            if (output == null) return commits;
+
+            foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var hash = line.Trim();
+                if (hash.Length >= 7)
+                    commits.Add(hash.Length > 9 ? hash[..9] : hash);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to read commits from worktree {Worktree}", wtDir);
+        }
+
+        return commits;
+    }
+
+    private static string? ResolveRepoRootFromWorktree(string wtDir)
+    {
+        var gitFile = Path.Combine(wtDir, ".git");
+        var gitContent = FileHelper.ReadAllText(gitFile).Trim();
+        var gitDirMatch = Regex.Match(gitContent, @"gitdir:\s*(.+)");
+        if (!gitDirMatch.Success) return null;
+
+        var gitDir = gitDirMatch.Groups[1].Value.Trim();
+        var repoGitDir = Path.GetFullPath(Path.Combine(gitDir, "..", ".."));
+        var repoRoot = Path.GetDirectoryName(repoGitDir);
+        return repoRoot != null && Directory.Exists(repoRoot) ? repoRoot : null;
+    }
+
+    private static string? RunGitLog(string repoRoot, string baseBranch, string branchName)
+    {
+        var psi = new ProcessStartInfo("git", $"log --format=%H \"{baseBranch}..{branchName}\"")
+        {
+            WorkingDirectory = repoRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = Process.Start(psi);
+        if (process == null) return null;
+        var output = process.StandardOutput.ReadToEnd().Trim();
+        process.WaitForExitOrKill(10000);
+        return process.ExitCode == 0 && !string.IsNullOrEmpty(output) ? output : null;
+    }
+
+    private static bool AddCommitsToPlan(PlanYaml plan, IEnumerable<string> commits)
+    {
+        var changed = false;
+        foreach (var commit in commits)
+        {
+            if (!plan.Commits.Contains(commit))
+            {
+                plan.Commits.Add(commit);
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    private string ResolveBaseBranch(string repoRoot, PlanYaml plan)
+    {
+        return TryGetConfiguredBaseBranch(repoRoot, plan) ?? DetectBaseBranch(repoRoot);
+    }
+
+    private string? TryGetConfiguredBaseBranch(string repoRoot, PlanYaml plan)
+    {
+        if (_configService == null) return null;
+
+        if (!string.IsNullOrEmpty(plan.Project))
+        {
+            var project = _configService.GetProject(plan.Project);
+            var repoRef = project?.Repos.FirstOrDefault(r =>
+                Path.GetFullPath(r.Path).Equals(Path.GetFullPath(repoRoot), StringComparison.OrdinalIgnoreCase));
+            if (repoRef?.BaseBranch is { Length: > 0 } configured)
+                return $"origin/{configured}";
+        }
+
+        foreach (var proj in _configService.Projects)
+        {
+            var repoRef = proj.Repos.FirstOrDefault(r =>
+                Path.GetFullPath(r.Path).Equals(Path.GetFullPath(repoRoot), StringComparison.OrdinalIgnoreCase));
+            if (repoRef?.BaseBranch is { Length: > 0 } found)
+                return $"origin/{found}";
+        }
+
+        return null;
+    }
+
+    private static string DetectBaseBranch(string repoRoot)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("git", "symbolic-ref refs/remotes/origin/HEAD")
+            {
+                WorkingDirectory = repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(psi);
+            if (process == null) return "origin/main";
+            var output = process.StandardOutput.ReadToEnd().Trim();
+            process.WaitForExitOrKill(5000);
+
+            if (process.ExitCode == 0 && !string.IsNullOrEmpty(output))
+                return output.Replace("refs/remotes/", "");
+        }
+        catch
+        {
+        }
+
+        return "origin/main";
+    }
+}

--- a/src/Ivy.Tendril/Services/PromptwareRunner.cs
+++ b/src/Ivy.Tendril/Services/PromptwareRunner.cs
@@ -65,7 +65,7 @@ public class PromptwareRunner : IPromptwareRunner
     public PromptwareRunHandle Run(PromptwareRunOptions options, IWriteStream<string> outputStream)
     {
         var settings = _configService.Settings;
-        var programFolder = ResolvePromptwareFolder(options.Promptware, _configService.TendrilHome, options.PromptwarePath);
+        var programFolder = PromptwareHelper.ResolvePromptwareFolder(options.Promptware, _configService.TendrilHome, options.PromptwarePath);
         var programMd = Path.Combine(programFolder, "Program.md");
 
         if (!File.Exists(programMd))
@@ -111,7 +111,7 @@ public class PromptwareRunner : IPromptwareRunner
         psi.Environment["TENDRIL_CONFIG"] = _configService.ConfigPath;
         psi.Environment["TENDRIL_PLANS"] = _configService.PlanFolder;
 
-        JobLauncher.EnsureTendrilOnPath(psi);
+        AgentProcessHelper.EnsureTendrilOnPath(psi);
 
         _logger.LogInformation("PromptwareRunner: launching {Promptware} via {Provider} (model={Model}, effort={Effort})",
             options.Promptware, resolution.Provider.Name, resolution.Model, resolution.Effort);
@@ -127,7 +127,7 @@ public class PromptwareRunner : IPromptwareRunner
             process.StandardInput.Close();
         }
 
-        var cliCommand = FirmwareCompiler.FormatCliCommand(psi);
+        var cliCommand = AgentProcessHelper.FormatCliCommand(psi);
 
         var cts = new CancellationTokenSource();
         var handle = new PromptwareRunHandle
@@ -208,30 +208,4 @@ public class PromptwareRunner : IPromptwareRunner
         }
     }
 
-    private static string ResolvePromptwareFolder(string promptwareName, string? tendrilHome, string? promptwarePath)
-    {
-        if (!string.IsNullOrEmpty(promptwarePath))
-        {
-            var overrideFolder = Path.Combine(promptwarePath, promptwareName);
-            if (File.Exists(Path.Combine(overrideFolder, "Program.md")))
-                return overrideFolder;
-        }
-
-        var sourceRoot = PromptwareHelper.ResolvePromptsRoot(tendrilHome);
-        var sourceFolder = Path.Combine(sourceRoot, promptwareName);
-
-        if (File.Exists(Path.Combine(sourceFolder, "Program.md")))
-            return sourceFolder;
-
-        tendrilHome ??= Environment.GetEnvironmentVariable("TENDRIL_HOME");
-        if (!string.IsNullOrEmpty(tendrilHome))
-        {
-            var deployedRoot = Path.Combine(tendrilHome, "Promptwares");
-            var deployedFolder = Path.Combine(deployedRoot, promptwareName);
-            if (File.Exists(Path.Combine(deployedFolder, "Program.md")))
-                return deployedFolder;
-        }
-
-        return sourceFolder;
-    }
 }


### PR DESCRIPTION
Extract monitoring, dependency checking, artifact syncing, and process
helpers into dedicated classes to reduce complexity scores:

- JobLauncher.cs: 6.98 → 9.38 (green)
- JobCompletionHandler.cs: 5.89 → 8.28

New files:
- Services/JobMonitor.cs — process monitoring, stale output watchdog, status polling
- Services/DependencyChecker.cs — plan dependency validation and blocked job retry
- Services/PlanArtifactSyncer.cs — post-execution plan artifact syncing
- Helpers/AgentProcessHelper.cs — process start utilities (PATH, shim resolution)

Also consolidates duplicated ResolvePromptwareFolder into PromptwareHelper
and removes duplicate ExtractPlanIdFromFolder from JobLauncher.
