### PR TITLE
Fix UTF-8 mojibake in CLI stdin reading (CP437 → UTF-8)

### DIFF
--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -35,6 +35,9 @@ public class Program
     [STAThread]
     public static async Task<int> Main(string[] args)
     {
+        Console.InputEncoding = System.Text.Encoding.UTF8;
+        Console.OutputEncoding = System.Text.Encoding.UTF8;
+
         VelopackApp.Build().Run();
 
         var (verbose, quiet, forceDesktop, forceWeb, filteredArgs) = ParseGlobalFlags(args);


### PR DESCRIPTION
Console.In.ReadToEnd() used the system default CP437 encoding,
corrupting multi-byte characters (e.g. em-dash → ΓÇö) piped from bash.
