### PR TITLE
Fix output sheet showing empty content on reopen

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -40,6 +40,9 @@ public partial class JobsApp : ViewBase
             if (!isOpen.Value)
             {
                 activeOutputJobId.Set(null);
+                streamingJobId.Set(null);
+                hasStreamContent.Set(false);
+                lastProcessedIndex.Set(0);
                 return null;
             }
             activeOutputJobId.Set(jobId);


### PR DESCRIPTION
## Summary
- Reset all streaming state when output sheet closes so reopening always shows full output
- Fixes: close sheet while job is running → reopen → content was blank

## Test plan
- [ ] Open a running job's output → close → reopen while still running → full output visible
- [ ] Open a running job's output → close → wait for completion → reopen → full output visible
- [ ] Open a completed job's output → full output visible