### PR TITLE
Add gh CLI to base tools and diagnostic toasts to clear actions

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -218,13 +218,17 @@ public partial class JobsApp
                                   new MenuItem("Clear Completed", Icon: Icons.Trash, Tag: "ClearCompleted")
                                       .OnSelect(() =>
                                       {
+                                          var count = jobService.GetJobs().Count(j => j.Status == JobStatus.Completed);
                                           jobService.ClearCompletedJobs();
                                           refreshToken.Refresh();
+                                          client.Toast($"Cleared {count} completed job(s)", "Clear Completed");
                                       }),
                                   new MenuItem("Clear Failed", Icon: Icons.Trash, Tag: "ClearFailed").OnSelect(() =>
                                   {
+                                      var count = jobService.GetJobs().Count(j => j.Status is JobStatus.Failed or JobStatus.Timeout);
                                       jobService.ClearFailedJobs();
                                       refreshToken.Refresh();
+                                      client.Toast($"Cleared {count} failed job(s)", "Clear Failed");
                                   })
                               ));
     }

--- a/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
+++ b/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
@@ -19,7 +19,7 @@ public class AgentProviderFactory
     };
 
     internal static readonly IReadOnlyList<string> BaseTools =
-        ["Read", "Glob", "Grep", "Bash(tendril*)", "Bash(git *)", "WebFetch", "WebSearch",
+        ["Read", "Glob", "Grep", "Bash(tendril*)", "Bash(git *)", "Bash(gh *)", "WebFetch", "WebSearch",
          "Write(%PROMPTWARE_DIR%/**)", "Edit(%PROMPTWARE_DIR%/**)", "Bash(%PROMPTWARE_DIR%/Tools/*)"];
 
     private static readonly Dictionary<string, IReadOnlyList<string>> BuiltInExtraTools =


### PR DESCRIPTION
## Summary
- Add `Bash(gh *)` to promptware base tools — agents can now run `gh issue view`, `gh pr view` etc. to resolve GitHub URLs
- Add confirmation toasts to Clear Completed/Failed dropdown actions for debugging

## Test plan
- [ ] Create a plan from a GitHub issue URL via inbox — agent should be able to fetch issue content
- [ ] Click Clear Failed — toast shows count
- [ ] Click Clear Completed — toast shows count