### PR TITLE
[00053] SimplifyFollowUpPlanDialog

### DIFF
--- a/src/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
+++ b/src/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
@@ -1,49 +1,23 @@
-using Ivy.Core.Hooks;
 using Ivy.Tendril.Apps.Plans.Dialogs;
 
 namespace Ivy.Tendril.Apps.PullRequest.Dialogs;
 
 public class FollowUpDialog(
     string planId,
-    string planTitle,
-    List<string> projectNames,
+    string project,
     Action<string, string[], int> onCreatePlan,
     Action onClose) : ViewBase
 {
     public override object Build()
     {
         var followUpText = UseState("");
-        var selectedProjects = UseState<string[]>(["Auto"]);
         var selectedPriority = UseState("Normal");
-
-        var exclusiveProjects = new ConvertedState<string[], string[]>(
-            selectedProjects,
-            forward: v => v,
-            backward: newValue =>
-            {
-                var current = selectedProjects.Value;
-                if (newValue.Contains("Auto") && !current.Contains("Auto"))
-                    return ["Auto"];
-                if (newValue.Contains("Auto") && newValue.Any(p => p != "Auto"))
-                    return newValue.Where(p => p != "Auto").ToArray();
-                return newValue;
-            }
-        );
-
-        var options = new List<string> { "Auto" };
-        options.AddRange(projectNames);
 
         return new Dialog(
             _ => onClose(),
             new DialogHeader("Create Follow-Up Plan"),
             new DialogBody(
                 Layout.Vertical()
-                | Text.P($"Creating a follow-up plan for:").Muted()
-                | Text.P($"#{planId} {planTitle}").Bold()
-                | exclusiveProjects.ToSelectInput(options)
-                    .Variant(SelectInputVariant.Toggle)
-                    .WithField()
-                    .Label("Select project(s)")
                 | selectedPriority.ToSelectInput(CreatePlanDialog.PriorityOptions)
                     .Variant(SelectInputVariant.Toggle)
                     .WithField()
@@ -60,9 +34,8 @@ public class FollowUpDialog(
                 {
                     if (!string.IsNullOrWhiteSpace(followUpText.Value))
                     {
-                        var projects = selectedProjects.Value.Any() ? selectedProjects.Value : ["Auto"];
                         var descriptionWithReference = $"{followUpText.Value} [Follows up on plan [{planId}]]";
-                        onCreatePlan(descriptionWithReference, projects, CreatePlanDialog.ParsePriority(selectedPriority.Value));
+                        onCreatePlan(descriptionWithReference, [project], CreatePlanDialog.ParsePriority(selectedPriority.Value));
                         onClose();
                     }
                 })

--- a/src/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -55,17 +55,15 @@ public class PullRequestApp : ViewBase
         var (followUpDialog, showFollowUpDialog) = UseTrigger<PrRow>((isOpen, selectedRow) =>
         {
             if (!isOpen.Value) return null;
-            var projectNames = config.Projects.Select(p => p.Name).ToList();
             var planFolder = selectedRow.PlanFolderPath;
             var planData = !string.IsNullOrEmpty(planFolder) && Directory.Exists(planFolder)
                 ? planService.GetPlanByFolder(planFolder)
                 : null;
-            var planTitle = planData?.Title ?? selectedRow.Plan;
+            var project = planData?.Project ?? "Auto";
 
             return new FollowUpDialog(
                 selectedRow.PlanId,
-                planTitle,
-                projectNames,
+                project,
                 (description, projects, priority) =>
                 {
                     var project = string.Join(",", projects);


### PR DESCRIPTION
# Summary

## Changes

Simplified the "Create Follow-Up Plan" dialog by removing three unnecessary UI elements: the project selector (follow-up plans now inherit the project from the original plan), the plan ID/title display, and the "Creating a follow-up plan for:" label text.

## API Changes

**FollowUpDialog.cs (constructor signature changed):**
- Removed `planTitle` parameter
- Changed `List<string> projectNames` parameter to `string project` parameter
- Now: `FollowUpDialog(string planId, string project, Action<string, string[], int> onCreatePlan, Action onClose)`

**PullRequestApp.cs (call site updated):**
- Call site now passes `project` string instead of `planTitle` and `projectNames` list

## Files Modified

**Dialog implementation:**
- `src/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs` — Simplified constructor, removed project selection UI and plan display

**Call site:**
- `src/Ivy.Tendril/Apps/PullRequestApp.cs` — Updated to pass inherited project instead of project list and title

---

**Commits:**
- 421eaea — [00053] Simplify Follow-Up Plan dialog