### PR TITLE
Rename firmware headers, add --file flag to write-revision, cleanup temp folders

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -171,18 +171,18 @@ verifications:
 
     COPY THE COMMAND BELOW EXACTLY — only replace angle-bracketed placeholders with actual paths. The plan folder is a POSITIONAL argument (NOT `--plan-folder`). The `--value` flags are REQUIRED.
 
-    Execute: `tendril promptware IvyFrameworkVerification "<PlanFolder>" --value VerificationDir="<PlanFolder>\verification" --value ArtifactsDir="<PlanFolder>\artifacts" --value IvyFrameworkPath="<worktree path to Ivy-Framework>"`
+    Execute: `tendril promptware IvyFrameworkVerification "<TendrilPlanFolder>" --value VerificationDir="<TendrilPlanFolder>\verification" --value ArtifactsDir="<TendrilPlanFolder>\artifacts" --value IvyFrameworkPath="<worktree path to Ivy-Framework>"`
 
     Example with real paths: `tendril promptware IvyFrameworkVerification "D:\Plans\03683-Example" --value VerificationDir="D:\Plans\03683-Example\verification" --value ArtifactsDir="D:\Plans\03683-Example\artifacts" --value IvyFrameworkPath="D:\Plans\03683-Example\worktrees\Ivy-Framework"`
 
-    Wait for the process to complete (it may take several minutes). After the process exits, IMMEDIATELY check if `<PlanFolder>\verification\IvyFrameworkVerification.md` exists. If the file exists, read it and set status based on the Result field in its YAML frontmatter. If exit code is non-zero OR the report file does not exist, set status to Fail immediately — do not poll or wait. Do NOT write the verification report yourself — the promptware creates it.
+    Wait for the process to complete (it may take several minutes). After the process exits, IMMEDIATELY check if `<TendrilPlanFolder>\verification\IvyFrameworkVerification.md` exists. If the file exists, read it and set status based on the Result field in its YAML frontmatter. If exit code is non-zero OR the report file does not exist, set status to Fail immediately — do not poll or wait. Do NOT write the verification report yourself — the promptware creates it.
 - name: CheckResult
   prompt: >
-    Verify the implementation matches what was requested in the plan. 1. Read the plan revision from `<PlanFolder>\revisions\` (latest numbered .md file) 2. Read all commits made by this execution from `plan.yaml` `commits` list 3. For each commit, review the diff (`git show <hash>`) in the worktree 4. Compare the plan's **Problem** and **Solution** sections against the actual changes:
+    Verify the implementation matches what was requested in the plan. 1. Read the plan revision from `<TendrilPlanFolder>\revisions\` (latest numbered .md file) 2. Read all commits made by this execution from `plan.yaml` `commits` list 3. For each commit, review the diff (`git show <hash>`) in the worktree 4. Compare the plan's **Problem** and **Solution** sections against the actual changes:
        - Are all described changes present?
        - Are there unexpected\unrelated changes?
        - Do the changes solve the stated problem?
-    5. If the plan has a **Tests** section, verify those tests were actually written 6. Write the verification report to `<PlanFolder>\verification\CheckResult.md` Report format: ``` # CheckResult
+    5. If the plan has a **Tests** section, verify those tests were actually written 6. Write the verification report to `<TendrilPlanFolder>\verification\CheckResult.md` Report format: ``` # CheckResult
 
     - **Date:** <CurrentTime> - **Result:** Pass \ Fail - **Attempts:** 1
 

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml.backup
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml.backup
@@ -171,18 +171,18 @@ verifications:
 
     COPY THE COMMAND BELOW EXACTLY — only replace angle-bracketed placeholders with actual paths. The plan folder is a POSITIONAL argument (NOT `--plan-folder`). The `--value` flags are REQUIRED.
 
-    Execute: `tendril promptware IvyFrameworkVerification "<PlanFolder>" --value VerificationDir="<PlanFolder>\verification" --value ArtifactsDir="<PlanFolder>\artifacts" --value IvyFrameworkPath="<worktree path to Ivy-Framework>"`
+    Execute: `tendril promptware IvyFrameworkVerification "<TendrilPlanFolder>" --value VerificationDir="<TendrilPlanFolder>\verification" --value ArtifactsDir="<TendrilPlanFolder>\artifacts" --value IvyFrameworkPath="<worktree path to Ivy-Framework>"`
 
     Example with real paths: `tendril promptware IvyFrameworkVerification "D:\Plans\03683-Example" --value VerificationDir="D:\Plans\03683-Example\verification" --value ArtifactsDir="D:\Plans\03683-Example\artifacts" --value IvyFrameworkPath="D:\Plans\03683-Example\worktrees\Ivy-Framework"`
 
-    Wait for the process to complete (it may take several minutes). After the process exits, IMMEDIATELY check if `<PlanFolder>\verification\IvyFrameworkVerification.md` exists. If the file exists, read it and set status based on the Result field in its YAML frontmatter. If exit code is non-zero OR the report file does not exist, set status to Fail immediately — do not poll or wait. Do NOT write the verification report yourself — the promptware creates it.
+    Wait for the process to complete (it may take several minutes). After the process exits, IMMEDIATELY check if `<TendrilPlanFolder>\verification\IvyFrameworkVerification.md` exists. If the file exists, read it and set status based on the Result field in its YAML frontmatter. If exit code is non-zero OR the report file does not exist, set status to Fail immediately — do not poll or wait. Do NOT write the verification report yourself — the promptware creates it.
 - name: CheckResult
   prompt: >
-    Verify the implementation matches what was requested in the plan. 1. Read the plan revision from `<PlanFolder>\revisions\` (latest numbered .md file) 2. Read all commits made by this execution from `plan.yaml` `commits` list 3. For each commit, review the diff (`git show <hash>`) in the worktree 4. Compare the plan's **Problem** and **Solution** sections against the actual changes:
+    Verify the implementation matches what was requested in the plan. 1. Read the plan revision from `<TendrilPlanFolder>\revisions\` (latest numbered .md file) 2. Read all commits made by this execution from `plan.yaml` `commits` list 3. For each commit, review the diff (`git show <hash>`) in the worktree 4. Compare the plan's **Problem** and **Solution** sections against the actual changes:
        - Are all described changes present?
        - Are there unexpected\unrelated changes?
        - Do the changes solve the stated problem?
-    5. If the plan has a **Tests** section, verify those tests were actually written 6. Write the verification report to `<PlanFolder>\verification\CheckResult.md` Report format: ``` # CheckResult
+    5. If the plan has a **Tests** section, verify those tests were actually written 6. Write the verification report to `<TendrilPlanFolder>\verification\CheckResult.md` Report format: ``` # CheckResult
 
     - **Date:** <CurrentTime> - **Result:** Pass \ Fail - **Attempts:** 1
 

--- a/src/Ivy.Tendril.Test.End2End/Tests/Promptware/CreatePlanTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/Promptware/CreatePlanTests.cs
@@ -24,8 +24,8 @@ public class CreatePlanTests
             extraValues: new Dictionary<string, string>
             {
                 ["Args"] = description,
-                ["PlansDirectory"] = _fixture.PlansDir,
-                ["Project"] = "E2ETest"
+                ["TendrilPlansFolder"] = _fixture.PlansDir,
+                ["TendrilProject"] = "E2ETest"
             });
 
         PromptwareAssertions.AssertExitSuccess(result, $"CreatePlan ({agent})");
@@ -62,8 +62,8 @@ public class CreatePlanTests
                 extraValues: new Dictionary<string, string>
                 {
                     ["Args"] = "",
-                    ["PlansDirectory"] = _fixture.PlansDir,
-                    ["Project"] = "E2ETest"
+                    ["TendrilPlansFolder"] = _fixture.PlansDir,
+                    ["TendrilProject"] = "E2ETest"
                 },
                 timeout: TimeSpan.FromSeconds(120));
 

--- a/src/Ivy.Tendril.Test.End2End/Tests/Promptware/SplitPlanTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/Promptware/SplitPlanTests.cs
@@ -41,7 +41,7 @@ public class SplitPlanTests
             cliLogPath: cliLog,
             extraValues: new Dictionary<string, string>
             {
-                ["PlansDirectory"] = _fixture.PlansDir
+                ["TendrilPlansFolder"] = _fixture.PlansDir
             });
 
         PromptwareAssertions.AssertExitSuccess(result, $"SplitPlan ({agent})");

--- a/src/Ivy.Tendril.Test.End2End/Tests/Promptware/UpdateProjectTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/Promptware/UpdateProjectTests.cs
@@ -25,7 +25,7 @@ public class UpdateProjectTests
             extraValues: new Dictionary<string, string>
             {
                 ["Args"] = "Setup verifications for the E2ETest project. Add a dotnet build verification.",
-                ["Project"] = "E2ETest"
+                ["TendrilProject"] = "E2ETest"
             });
 
         PromptwareAssertions.AssertExitSuccess(result, $"UpdateProject ({agent})");

--- a/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
@@ -491,6 +491,9 @@ public class AgentProviderFactoryTests
         Assert.Contains("Bash(tendril*)", resolution.AllowedTools);
         Assert.Contains("Bash(git *)", resolution.AllowedTools);
         Assert.Contains("Bash(gh *)", resolution.AllowedTools);
+        Assert.Contains("Bash(ls *)", resolution.AllowedTools);
+        Assert.Contains("Bash(find *)", resolution.AllowedTools);
+        Assert.Contains("Bash(cat *)", resolution.AllowedTools);
         Assert.Contains("WebFetch", resolution.AllowedTools);
         Assert.Contains("WebSearch", resolution.AllowedTools);
 
@@ -502,6 +505,6 @@ public class AgentProviderFactoryTests
         // Must NOT have unrestricted Bash
         Assert.DoesNotContain("Bash", resolution.AllowedTools.Where(t => t == "Bash"));
 
-        Assert.Equal(11, resolution.AllowedTools.Count);
+        Assert.Equal(14, resolution.AllowedTools.Count);
     }
 }

--- a/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
@@ -24,12 +24,12 @@ public class FirmwareCompilerTests : IDisposable
     {
         var context = new FirmwareContext(
             "/programs/CreatePlan",
-            new Dictionary<string, string> { ["PlanId"] = "03456", ["Project"] = "Tendril" });
+            new Dictionary<string, string> { ["TendrilPlanId"] = "03456", ["TendrilProject"] = "Tendril" });
 
         var result = FirmwareCompiler.Compile(context);
 
-        Assert.Contains("PlanId: 03456", result);
-        Assert.Contains("Project: Tendril", result);
+        Assert.Contains("TendrilPlanId: 03456", result);
+        Assert.Contains("TendrilProject: Tendril", result);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
@@ -114,7 +114,7 @@ public class PromptwareRunCommandTests : IDisposable
 
         var values = new Dictionary<string, string>
         {
-            ["PlanFolder"] = "/plans/00123-Test",
+            ["TendrilPlanFolder"] = "/plans/00123-Test",
             ["VerificationDir"] = "/plans/00123-Test/verification",
             ["ArtifactsDir"] = "/plans/00123-Test/artifacts"
         };

--- a/src/Ivy.Tendril/Assets/Plans.md
+++ b/src/Ivy.Tendril/Assets/Plans.md
@@ -112,9 +112,6 @@ tendril plan rec set <plan-id> <title> <field> <value>
 tendril plan rec remove <plan-id> <title>
 tendril plan rec list <plan-id> [--state Pending|Accepted|Declined]
 
-# Replace entire plan YAML (reads from stdin)
-tendril plan update <plan-id> < revised.yaml
-
 # Validate plan health
 tendril plan validate <plan-id>
 ```
@@ -128,7 +125,7 @@ tendril plan create <title> [options]
 Auto-allocates a plan ID, creates the folder, and writes `plan.yaml`. Outputs:
 ```
 PlanId: <ID>
-Directory: <PlansDirectory>/<ID>-<SafeTitle>
+Directory: <TendrilPlansFolder>/<ID>-<SafeTitle>
 Plan created: <ID>-<SafeTitle>
 ```
 
@@ -147,10 +144,12 @@ Options:
 ### Writing revisions
 
 ```bash
-echo "<content>" | tendril plan write-revision <plan-id>
+tendril plan write-revision <plan-id> --file <path-to-file>
 ```
 
-Writes STDIN content to `revisions/<NNN>.md` in the plan folder. Auto-increments from the highest existing revision. Outputs the file path.
+Reads content from `<path-to-file>` and writes it to `revisions/<NNN>.md` in the plan folder. Auto-increments from the highest existing revision. Outputs the file path.
+
+Workflow: write revision content to `temp/<short-random>.md` inside the plan folder using the `Write` tool, then run the command above referencing that file.
 
 ### Writing execution logs
 

--- a/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
@@ -10,6 +10,10 @@ public class PlanWriteRevisionSettings : CommandSettings
     [Description("Plan ID or folder path")]
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
+
+    [Description("Read content from file instead of STDIN")]
+    [CommandOption("--file|-f")]
+    public string? FilePath { get; set; }
 }
 
 public class PlanWriteRevisionCommand : Command<PlanWriteRevisionSettings>
@@ -30,9 +34,11 @@ public class PlanWriteRevisionCommand : Command<PlanWriteRevisionSettings>
             var filename = $"{number:D3}.md";
             var filePath = Path.Combine(revisionsDir, filename);
 
-            var content = Console.In.ReadToEnd();
+            var content = !string.IsNullOrEmpty(settings.FilePath)
+                ? File.ReadAllText(settings.FilePath)
+                : Console.In.ReadToEnd();
             if (string.IsNullOrWhiteSpace(content))
-                throw new ArgumentException("No content provided on STDIN");
+                throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
 
             File.WriteAllText(filePath, content);
             Console.WriteLine(filePath);

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -32,7 +32,7 @@ public class PromptwareRunSettings : CommandSettings
     public string[]? Values { get; init; }
 
     [CommandOption("--plan")]
-    [Description("Plan ID or folder path — populates PlanFolder, PlansDirectory, PlanId")]
+    [Description("Plan ID or folder path — populates TendrilPlanFolder, TendrilPlansFolder, TendrilPlanId")]
     public string? Plan { get; init; }
 
     [CommandOption("--promptware-path")]
@@ -99,9 +99,9 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
         {
             ["PROMPTWARE_DIR"] = programFolder
         };
-        if (values.TryGetValue("PlansDirectory", out var plansDir))
+        if (values.TryGetValue("TendrilPlansFolder", out var plansDir))
             jobContext["PLANS_DIR"] = plansDir;
-        if (values.TryGetValue("PlanFolder", out var planFolder2))
+        if (values.TryGetValue("TendrilPlanFolder", out var planFolder2))
             jobContext["PLAN_DIR"] = planFolder2;
 
         var resolution = !string.IsNullOrEmpty(settings.Agent)
@@ -131,9 +131,9 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
             Console.WriteLine($"configPath: {configService.ConfigPath}");
             Console.WriteLine($"tendrilHome: {configService.TendrilHome}");
             Console.WriteLine($"plansDirectory: {configService.PlanFolder}");
-            if (values.TryGetValue("PlanId", out var planId))
+            if (values.TryGetValue("TendrilPlanId", out var planId))
                 Console.WriteLine($"planId: {planId}");
-            if (values.TryGetValue("PlanFolder", out var planPath))
+            if (values.TryGetValue("TendrilPlanFolder", out var planPath))
                 Console.WriteLine($"planPath: {planPath}");
             Console.WriteLine($"workingDirectory: {workDir}");
             Console.WriteLine($"logFile: {logFile}");
@@ -275,17 +275,17 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
             try
             {
                 var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.Plan);
-                values["PlanFolder"] = planFolder;
-                values["PlansDirectory"] = Path.GetDirectoryName(planFolder) ?? "";
+                values["TendrilPlanFolder"] = planFolder;
+                values["TendrilPlansFolder"] = Path.GetDirectoryName(planFolder) ?? "";
                 var folderName = Path.GetFileName(planFolder);
                 var dashIdx = folderName.IndexOf('-');
-                if (dashIdx > 0) values["PlanId"] = folderName[..dashIdx];
+                if (dashIdx > 0) values["TendrilPlanId"] = folderName[..dashIdx];
             }
             catch (DirectoryNotFoundException)
             {
                 // If it looks like a direct folder path, use it as-is (for testing)
-                values["PlanFolder"] = settings.Plan;
-                values["PlansDirectory"] = Path.GetDirectoryName(settings.Plan) ?? "";
+                values["TendrilPlanFolder"] = settings.Plan;
+                values["TendrilPlansFolder"] = Path.GetDirectoryName(settings.Plan) ?? "";
             }
         }
 

--- a/src/Ivy.Tendril/Promptwares/CreateIssue/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreateIssue/Program.md
@@ -5,7 +5,7 @@ Create a GitHub issue from a plan.
 ## Context
 
 The firmware header contains:
-- **PlanFolder** — path to the plan folder
+- **TendrilPlanFolder** — path to the plan folder
 - **CurrentTime** — current UTC timestamp
 - **Repo** — target repository path (local path)
 - **Assignee** — GitHub username to assign (optional, may be empty)
@@ -17,7 +17,7 @@ The firmware header contains:
 
 - Read `plan.yaml` from the plan folder
 - Read the latest revision for the plan title and Problem section
-- Report plan context to Jobs UI: `tendril job status $env:TENDRIL_JOB_ID --message "Creating issue..." --plan-id <plan-id> --plan-title "<title>"`
+- Report plan context to Jobs UI: `tendril job status TendrilJobId --message "Creating issue..." --plan-id <plan-id> --plan-title "<title>"`
 
 ### 2. Identify GitHub Repository
 

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -2,28 +2,31 @@
 
 **Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined in `config.yaml` under `verifications`. Examples in this document use multiple tech stacks for illustration.
 
-**🚫 FORBIDDEN: Do NOT modify, create, or delete any source code files. Do NOT implement the plan. You are a PLANNER, not an executor. Your ONLY output is plan files (plan.yaml, revisions/*.md) inside PlansDirectory. If you catch yourself writing code to a repo, STOP IMMEDIATELY.**
+**🚫 FORBIDDEN: Do NOT modify, create, or delete any source code files. Do NOT implement the plan. You are a PLANNER, not an executor. Your ONLY output is plan files (plan.yaml, revisions/*.md) inside TendrilPlansFolder. If you catch yourself writing code to a repo, STOP IMMEDIATELY.**
 
-**⚠️ SCOPE ENFORCEMENT: You have READ access to source code for research. You do NOT have WRITE/EDIT access to any files outside PlansDirectory and the Trash folder. Any attempt to Write or Edit source code will be DENIED by the permission system. Do not attempt it — plan the changes instead and let the executor handle implementation.**
+**⚠️ SCOPE ENFORCEMENT: You have READ access to source code for research. You do NOT have WRITE/EDIT access to any files outside TendrilPlansFolder and the Trash folder. Any attempt to Write or Edit source code will be DENIED by the permission system. Do not attempt it — plan the changes instead and let the executor handle implementation.**
 
 Create an implementation plan for a task described in args.
 
 ## Context
 
 The firmware header contains these key values:
-- **PlansDirectory** — where plan folders are created
-- **Project** — selected project name, or `Auto` if not specified
+- **TendrilPlansFolder** — where plan folders are created
+- **TendrilProject** — selected project name, or `Auto` if not specified
 - **Force** (optional) — if `true`, skip duplicate detection entirely (see Step 3)
 - **SourcePath** (optional) — absolute path to the source that generated this plan (e.g. test working directory)
+- **TendrilJobId** — your job ID for status reporting (use this literal value in `tendril job status` commands)
+- **TendrilConfigPath** — absolute path to config.yaml (use `Read` tool directly on this path)
+- **TendrilHome** — the Tendril home directory (use for Trash path: `<TendrilHome>/Trash/`)
 
 The plan folder structure and CLI commands are in the **Reference Documents** section of your firmware.
-Project configuration is available from `config.yaml` (referenced via `$TENDRIL_CONFIG` env var).
+Project configuration is available from `config.yaml` — read it using the `Read` tool at the `TendrilConfigPath` path from the firmware header.
 
 ## Execution Steps
 
 ### 1. Parse Args
 
-Args contains the user's task description. If it references related plans with `[number]` syntax (e.g. `[01205]`), find and read those plan files from `PlansDirectory` for context.
+Args contains the user's task description. If it references related plans with `[number]` syntax (e.g. `[01205]`), find and read those plan files from `TendrilPlansFolder` for context.
 
 **Extract Source URL**: Check if the args contain a GitHub PR URL (`https://github.com/{owner}/{repo}/pull/{number}`) or issue URL (`https://github.com/{owner}/{repo}/issues/{number}`). If found, store it as `sourceUrl` in plan.yaml. Use `gh pr view <url> --json title,body` or `gh issue view <url> --json title,body` to fetch the title and body for additional context when writing the plan.
 
@@ -33,10 +36,10 @@ Args contains the user's task description. If it references related plans with `
 
 Read `config.yaml` to understand all available projects, their repos, and context.
 
-**If `Project` is set to a specific project name** (not `Auto`):
+**If `TendrilProject` is set to a specific project name** (not `Auto`):
 - Find that project in `config.yaml` and use its repos and context to scope your research
 
-**If `Project: Auto`**:
+**If `TendrilProject: Auto`**:
 - Analyze the task description to infer the correct project from `config.yaml`
 - Match based on keywords, repo paths, or component names in the description
 - If no project matches, set `project: Auto` in plan.yaml and leave `repos: []` empty
@@ -86,7 +89,7 @@ Do NOT read or modify `.counter` directly. Plan IDs are allocated by the `tendri
 
   #### Step 5: Write trash file (when trashing)
 
-  Write a file to `$env:TENDRIL_HOME/Trash/<SafeTitle>.md` (where `<SafeTitle>` is the title with spaces replaced by hyphens and special characters removed) with the following format, then exit without creating a plan folder:
+  Write a file to `TendrilHome/Trash/<SafeTitle>.md` (where `<SafeTitle>` is the title with spaces replaced by hyphens and special characters removed) with the following format, then exit without creating a plan folder:
 
   ```markdown
   ---
@@ -109,7 +112,7 @@ Do NOT read or modify `.counter` directly. Plan IDs are allocated by the `tendri
   **Reason:** <brief explanation of why it's a duplicate>
   ```
 
-  The Trash directory is at `$env:TENDRIL_HOME/Trash`.
+  The Trash directory is at `TendrilHome/Trash`.
 
   **Note:** When writing trash files, ensure the write is flushed/synchronous, as the parent process checks for the file immediately after exit.
 
@@ -140,7 +143,7 @@ For each assertion found:
 
 **Decision:**
 - **All validations pass** → Proceed to Step 4, include validated code blocks in plan with `**Current implementation**` headers
-- **Any validation fails** → Write trash file to `$env:TENDRIL_HOME/Trash/<SafeTitle>.md` explaining the validation failure, then exit without creating a plan
+- **Any validation fails** → Write trash file to `TendrilHome/Trash/<SafeTitle>.md` explaining the validation failure, then exit without creating a plan
 
 This catches stale plans before they enter the review queue, reducing wasted review time.
 
@@ -154,8 +157,8 @@ Use `tendril plan create` to allocate a plan ID, create the folder, and write `p
 
 ```bash
 tendril plan create "<Title>" \
-  --plans-dir "<PlansDirectory>" \
-  --project "<Project>" \
+  --plans-dir "<TendrilPlansFolder>" \
+  --project "<TendrilProject>" \
   --level "NiceToHave" \
   --initial-prompt "<cleaned args text>" \
   --execution-profile "balanced" \
@@ -165,12 +168,12 @@ tendril plan create "<Title>" \
   --verification "Test=Pending"
 ```
 
-**IMPORTANT:** Always pass `--plans-dir` with the `PlansDirectory` firmware value. This ensures the plan is created in the correct directory regardless of environment variable inheritance.
+**IMPORTANT:** Always pass `--plans-dir` with the `TendrilPlansFolder` firmware value. This ensures the plan is created in the correct directory regardless of environment variable inheritance.
 
 The command outputs:
 ```
 PlanId: <ID>
-Directory: <PlansDirectory>/<ID>-<SafeTitle>
+Directory: <TendrilPlansFolder>/<ID>-<SafeTitle>
 Plan created: <ID>-<SafeTitle>
 ```
 
@@ -186,26 +189,17 @@ Populate `--verification` flags from the project's `verifications` in config.yam
 
 #### 4.2. Write the revision
 
-Write the revision content via the CLI (heredoc on stdin):
+Write the revision content to a temp file, then commit it via CLI:
 
-```bash
-tendril plan write-revision <PlanId> <<'EOF'
-# Plan Title
+1. Write the revision markdown to `<Directory>/temp/<short-random>.md` using the `Write` tool (e.g. `temp/r7x.md`)
+2. Run: `tendril plan write-revision <PlanId> --file "<path-to-temp-file>"`
 
-## Problem
-...
-
-## Solution
-...
-EOF
-```
-
-This auto-creates `revisions/001.md` (or the next sequential number) in the plan folder. Do NOT use the Write or Edit tools to create revision files — always use the `tendril plan write-revision` command.
+This auto-creates `revisions/001.md` (or the next sequential number) in the plan folder. Do NOT use the Write or Edit tools to create revision files directly in `revisions/` — always use the `tendril plan write-revision` command with `--file`.
 
 After creating the plan, report the plan ID and title to the Jobs UI so it can display progress:
 
 ```bash
-tendril job status $env:TENDRIL_JOB_ID --message "Creating plan..." --plan-id <PlanId> --plan-title "<Title>"
+tendril job status <TendrilJobId> --message "Creating plan..." --plan-id <PlanId> --plan-title "<Title>"
 ```
 
 **CRITICAL: Never call `tendril job status --plan-id` with a value you did not receive from `tendril plan create` stdout. Never use example IDs from documentation. If you have not successfully created a plan, do NOT report any plan-id.**
@@ -374,7 +368,7 @@ The user can edit the checklist before execution — unchecking a required verif
 ### Rules
 
 - **Diagrams**: Markdown supports Graphviz/DOT (```dot or ```graphviz code blocks) and Mermaid (```mermaid code blocks). **Prefer Graphviz/DOT over Mermaid** — it produces cleaner layouts for architecture and flow diagrams. Use diagrams sparingly — only when a visual genuinely clarifies the concept. Most plans don't need diagrams.
-- **🚫 NEVER modify source code. NEVER implement changes. You READ source code for research, you WRITE only to PlansDirectory and TENDRIL_HOME/Trash. Any file write outside these directories is a critical violation that wastes the entire session. The permission system WILL block you and you WILL fail.**
+- **🚫 NEVER modify source code. NEVER implement changes. You READ source code for research, you WRITE only to TendrilPlansFolder and TendrilHome/Trash. Any file write outside these directories is a critical violation that wastes the entire session. The permission system WILL block you and you WILL fail.**
 - **!CRITICAL: Every CreatePlan execution MUST produce at least one plan folder. Even if the task is an analysis, review, or investigation — always create a plan with actionable steps. Never just analyze and report back without a plan.**
 - The plan must include all paths and information for an LLM coding agent to execute end-to-end without human intervention
 - **!IMPORTANT: Validate all file paths before writing `file:///` links in plans.** Use glob/search to confirm the actual path exists. Do NOT guess paths based on naming conventions — hallucinated paths cause "File not found" errors in the UI.

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -9,7 +9,7 @@ Create GitHub pull requests and apply PR rules.
 ## Context
 
 The firmware header contains:
-- **PlanFolder** — path to the plan folder
+- **TendrilPlanFolder** — path to the plan folder
 - **CurrentTime** — current UTC timestamp
 - **SourceUrl** — (optional) GitHub issue or PR URL from plan.yaml
 
@@ -25,7 +25,7 @@ Project configuration (repos, `prRule` settings) is available from the firmware 
 
 ### 0. Check Plan State
 
-Before processing, read `plan.yaml` and check the `state` field. After reading, report plan context: `tendril job status $env:TENDRIL_JOB_ID --message "Creating PR..." --plan-id <plan-id> --plan-title "<title>"`
+Before processing, read `plan.yaml` and check the `state` field. After reading, report plan context: `tendril job status TendrilJobId --message "Creating PR..." --plan-id <plan-id> --plan-title "<title>"`
 - If `state: Completed`, the plan was already processed. Exit early with a message indicating the plan is already completed and showing the existing PR URLs from the `prs` list.
 - Otherwise, proceed with step 1.
 
@@ -44,7 +44,7 @@ Before processing, read `plan.yaml` and check the `state` field. After reading, 
 
 ### 2. For Each Worktree
 
-Check `<PlanFolder>/worktrees/` for each repo worktree.
+Check `<TendrilPlanFolder>/worktrees/` for each repo worktree.
 
 > **Worktree already removed:** If the worktrees/ directory is empty (worktree was already cleaned up), fall back to `plan.yaml` to get the repo path and branch name (format: `tendril/<planId>-<SafeTitle>`, where SafeTitle is extracted from the plan folder name: e.g. `03158-ChangeBranchNaming` → `ChangeBranchNaming`). The commit objects may still exist in the original repo's object store. Use `git cat-file -t <sha>` to verify, then create or force-update the local branch: `git branch -f <branch-name> <sha>` (use `-f` because the branch may already exist from a WIP auto-commit) and push from the original repo path.
 >
@@ -65,7 +65,7 @@ For each worktree:
 
 **If custom options exist and `includeArtifacts` is `false`, skip this step entirely** (set artifact markdown to empty).
 
-Otherwise, if an artifact upload tool is available in `Tools/`, run it to upload screenshots and videos from `<PlanFolder>/artifacts/` to persistent storage.
+Otherwise, if an artifact upload tool is available in `Tools/`, run it to upload screenshots and videos from `<TendrilPlanFolder>/artifacts/` to persistent storage.
 
 Capture the returned markdown. If non-empty, it will be appended to the PR body under an `## Artifacts` heading in the next step. If no upload tool is available, skip this step.
 
@@ -88,7 +88,7 @@ EOF
 - **Title:** `[<planId>] <plan title>`
 - **Body:** 
   1. **If SourceUrl is present in firmware header** and it's a GitHub issue URL (format: `https://github.com/owner/repo/issues/NUMBER`), prepend `Fixes #NUMBER\n\n` to the body
-  2. If `<PlanFolder>/artifacts/summary.md` exists, use its content as the PR body (after the issue link)
+  2. If `<TendrilPlanFolder>/artifacts/summary.md` exists, use its content as the PR body (after the issue link)
   3. Otherwise, fall back to summary from Problem + Solution sections
   4. Append commit list
   5. If `$artifactMarkdown` from step 2.5 is non-empty, append it under an `## Artifacts` heading
@@ -150,7 +150,7 @@ done
 
 When the PR status is `CONFLICTING`, resolve the conflict locally before retrying:
 
-1. **Locate the worktree** for this repo. If the worktree still exists in `<PlanFolder>/worktrees/<repo-folder-name>`, use it. If the worktree was already removed, use the original repo path — create or force-update the local branch first: `git branch -f <branch-name> <sha>` and `git checkout <branch-name>`.
+1. **Locate the worktree** for this repo. If the worktree still exists in `<TendrilPlanFolder>/worktrees/<repo-folder-name>`, use it. If the worktree was already removed, use the original repo path — create or force-update the local branch first: `git branch -f <branch-name> <sha>` and `git checkout <branch-name>`.
 
 2. **Read the plan revision** to understand the intent of the plan's changes (what matters, what can be safely adapted).
 
@@ -206,7 +206,7 @@ After successful `yolo` merges (or custom options with `merge: true`), clean up 
 For each repo where the PR was merged:
 
 ```bash
-tendril plan remove-worktree <PlanId> <repo-folder-name>
+tendril plan remove-worktree <TendrilPlanId> <repo-folder-name>
 ```
 
 **Skip cleanup** for repos using the `default` PR rule (or custom options with `merge: false`) — the worktree is still needed for potential review revisions.

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -8,12 +8,12 @@ Execute an approved plan in isolated git worktrees.
 
 The firmware header contains:
 
-- **Args** / **PlanFolder** — path to the plan folder
+- **Args** / **TendrilPlanFolder** — path to the plan folder
 - **CurrentTime** — current UTC timestamp
 - **Note** (optional) — Additional instructions from the reviewer. If present, follow these instructions in addition to the plan.
 
 The plan structure and CLI commands are in the **Reference Documents** section of your firmware.
-Read the project configuration from `config.yaml` (referenced via `$TENDRIL_CONFIG` env var) for project repos and context.
+Read the project configuration from `config.yaml` (use `Read` tool with the `TendrilConfigPath` from the firmware header) for project repos and context.
 
 The launcher sets the working directory to the project's primary repo.
 
@@ -40,7 +40,7 @@ Focus on making progress, not achieving perfect understanding. A working impleme
 - Read `plan.yaml` from the plan folder (project, repos, title)
 - Read the latest revision from `revisions/` (highest numbered .md file)
 - Extract the plan ID from the folder name (e.g. `01105` from `01105-TestPlan`)
-- Report plan context to Jobs UI: `tendril job status $env:TENDRIL_JOB_ID --message "Reading plan..." --plan-id <plan-id> --plan-title "<title>"`
+- Report plan context to Jobs UI: `tendril job status TendrilJobId --message "Reading plan..." --plan-id <plan-id> --plan-title "<title>"`
 
 ### 1.5. Verify Dependencies
 
@@ -119,7 +119,7 @@ After reading the plan revision, scan it for code validation markers to detect s
    - **If all validation blocks pass** → Proceed to worktree creation
    - **If any validation fails** → Fail the plan immediately with a detailed report
 
-4. **Write validation report** — Create `<PlanFolder>/verification/PreExecution.md`:
+4. **Write validation report** — Create `<TendrilPlanFolder>/verification/PreExecution.md`:
 
 ```markdown
 # PreExecution
@@ -227,7 +227,7 @@ For each repo in `RepoConfigs` (this includes both the plan's repos AND any read
 3. If the worktree or branch already exists from a prior execution, remove it first:
 
 ```bash
-tendril plan remove-worktree <PlanId> <repo-folder-name>
+tendril plan remove-worktree <TendrilPlanId> <repo-folder-name>
 ```
 
 This handles stale directories, locked files, and branch cleanup automatically with fallback strategies.
@@ -239,11 +239,11 @@ This handles stale directories, locked files, and branch cleanup automatically w
 ```bash
 cd <original-repo-path>
 git fetch origin
-PLAN_FOLDER_NAME=$(basename "<PlanFolder>")
+PLAN_FOLDER_NAME=$(basename "<TendrilPlanFolder>")
 PLAN_ID=$(echo "$PLAN_FOLDER_NAME" | grep -oP '^\d+')
 SAFE_TITLE=$(echo "$PLAN_FOLDER_NAME" | sed 's/^[0-9]\+-//')
 BRANCH_NAME="tendril/$PLAN_ID-$SAFE_TITLE"
-git worktree add "<PlanFolder>/worktrees/<repo-folder-name>" -b "$BRANCH_NAME" "origin/<resolved-base-branch>"
+git worktree add "<TendrilPlanFolder>/worktrees/<repo-folder-name>" -b "$BRANCH_NAME" "origin/<resolved-base-branch>"
 ```
 
 Example:
@@ -251,7 +251,7 @@ Example:
 ```bash
 cd <RepoPath>
 git fetch origin
-git worktree add "<PlanFolder>/worktrees/<RepoName>" -b "tendril/<PlanId>-<SafeTitle>" origin/<resolved-base-branch>
+git worktree add "<TendrilPlanFolder>/worktrees/<RepoName>" -b "tendril/<TendrilPlanId>-<SafeTitle>" origin/<resolved-base-branch>
 ```
 
 **Important:** Always branch from `origin/<resolved-base-branch>`, not local HEAD. This ensures the PR only contains the plan's commits, not any unpushed local work. The `<resolved-base-branch>` comes from either the `RepoConfigs` firmware header (if `baseBranch` is configured) or auto-detection.
@@ -276,12 +276,12 @@ If `baseBranch` is present for a repo, use it instead of auto-detecting. If abse
 4. After creating the worktree, **verify the `.git` file exists** and fail fast if it's missing:
 
 ```bash
-if [ ! -f "<PlanFolder>/worktrees/<repo-folder-name>/.git" ]; then
-    echo "ERROR: Worktree creation failed - .git file missing at <PlanFolder>/worktrees/<repo-folder-name>/.git"
+if [ ! -f "<TendrilPlanFolder>/worktrees/<repo-folder-name>/.git" ]; then
+    echo "ERROR: Worktree creation failed - .git file missing at <TendrilPlanFolder>/worktrees/<repo-folder-name>/.git"
     echo "This indicates git worktree add did not fully initialize the worktree."
     exit 1
 fi
-cat "<PlanFolder>/worktrees/<repo-folder-name>/.git"
+cat "<TendrilPlanFolder>/worktrees/<repo-folder-name>/.git"
 ```
 
 This ensures ExecutePlan fails immediately if worktree creation is incomplete, rather than leaving orphaned directories that trigger warnings during cleanup.
@@ -291,7 +291,7 @@ This ensures ExecutePlan fails immediately if worktree creation is incomplete, r
    ```bash
    SYNC_STRATEGY="<from RepoConfigs or 'fetch' if not specified>"
    BASE_BRANCH="<resolved-base-branch>"
-   WORKTREE_PATH="<PlanFolder>/worktrees/<repo-folder-name>"
+   WORKTREE_PATH="<TendrilPlanFolder>/worktrees/<repo-folder-name>"
 
    tendril plan sync-worktree "$WORKTREE_PATH" --strategy "$SYNC_STRATEGY" --base-branch "$BASE_BRANCH"
    ```
@@ -395,7 +395,7 @@ If there are uncommitted changes, either commit them or discard them with a clea
 
 ### 5.5. Generate Summary
 
-After all implementation commits are made, create `<PlanFolder>/artifacts/summary.md` summarizing what was done.
+After all implementation commits are made, create `<TendrilPlanFolder>/artifacts/summary.md` summarizing what was done.
 
 The summary should follow this structure:
 
@@ -453,7 +453,7 @@ Check the `## Verification` section in the plan revision for checked items (`- [
 
 For each checked verification:
 
-1. Send a status message: `tendril job status $env:TENDRIL_JOB_ID --message "Verifying: <Name>"`
+1. Send a status message: `tendril job status TendrilJobId --message "Verifying: <Name>"`
 2. Look up its `prompt` in the `verifications` list in `config.yaml`
 3. **Check if delegated:** If the verification name exists in config.yaml's `promptwares` section, it is a delegated verification — follow the prompt's instructions to invoke it as an external process. If the external process cannot be invoked (CLI broken, file lock, etc.), set the verification to `Fail` immediately. Do NOT attempt to do the verification inline or write the report yourself.
 4. Execute the prompt in the worktree directory
@@ -463,7 +463,7 @@ For each checked verification:
 
 **CRITICAL:** You MUST call `tendril plan set-verification` after EACH verification. The verification report file alone is NOT sufficient — plan.yaml must also be updated via the CLI. Failing to call this command will result in the plan being marked as Failed.
 
-**!IMPORTANT: Every verification MUST produce a report** at `<PlanFolder>/verification/<VerificationName>.md` using YAML frontmatter:
+**!IMPORTANT: Every verification MUST produce a report** at `<TendrilPlanFolder>/verification/<VerificationName>.md` using YAML frontmatter:
 
 ```markdown
 ---
@@ -507,7 +507,7 @@ tendril plan rec add <plan-id> "Short descriptive title" -d "Markdown descriptio
 
 Do NOT include items that are part of the current plan's scope. Do NOT include recommendations about code formatting, linting, or style issues — those are handled by verifications.
 
-**After registering any recommendations via the CLI**, create `<PlanFolder>/artifacts/recommendations.md`. Having zero recommendations is fine — but the file must still be created:
+**After registering any recommendations via the CLI**, create `<TendrilPlanFolder>/artifacts/recommendations.md`. Having zero recommendations is fine — but the file must still be created:
 
 ~~~markdown
 # Recommendations
@@ -532,7 +532,7 @@ After all verifications pass:
 
 3. Run `git status` in every worktree. If there are any uncommitted files (from verification fixes, generated files, etc.), commit or discard them. The worktrees must be completely clean before finishing.
 
-4. Verify `<PlanFolder>/artifacts/recommendations.md` exists. If missing, the plan **must fail** — go back to Step 7.5.
+4. Verify `<TendrilPlanFolder>/artifacts/recommendations.md` exists. If missing, the plan **must fail** — go back to Step 7.5.
 
 ### 8.5. Worktree Lifecycle
 
@@ -564,6 +564,6 @@ You are running in non-interactive mode and CANNOT ask questions. If you are uns
 - Do NOT skip tests or pre-commit formatting
 - Commit messages must reference the plan ID
 - Convert `file:///` paths in plans to local filesystem paths appropriate for your OS
-- Do NOT commit artifact files (screenshots, images) to the repo. Test artifacts belong in `<PlanFolder>/artifacts/` only — CreatePr handles uploading them to persistent storage.
+- Do NOT commit artifact files (screenshots, images) to the repo. Test artifacts belong in `<TendrilPlanFolder>/artifacts/` only — CreatePr handles uploading them to persistent storage.
 - If the project uses private package registries, ensure authentication is configured before running dependency installation in worktrees. Credentials should come from environment variables or project-level configuration.
 - Do NOT create filesystem aliases or shortcuts (e.g. symlinks, drive mappings) to worktree paths. The plans directory path is managed by Tendril — additional indirection causes cleanup issues.

--- a/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
@@ -5,7 +5,7 @@ Transform investigation-heavy plans into concrete implementation plans.
 ## Context
 
 The firmware header contains:
-- **Args** / **PlanFolder** — path to the plan folder
+- **Args** / **TendrilPlanFolder** — path to the plan folder
 - **CurrentTime** — current UTC timestamp
 
 The plan structure and CLI commands are in the **Reference Documents** section of your firmware.
@@ -18,7 +18,7 @@ Project configuration is available from the firmware header.
 - Read `plan.yaml` from the plan folder
 - Read the latest revision from `revisions/` (highest numbered .md file)
 - Identify sections with investigative/exploratory language ("Investigate...", "Check if...", "Research...", "Explore...")
-- Report plan context to Jobs UI: `tendril job status $env:TENDRIL_JOB_ID --message "Expanding plan..." --plan-id <plan-id> --plan-title "<title>"`
+- Report plan context to Jobs UI: `tendril job status TendrilJobId --message "Expanding plan..." --plan-id <plan-id> --plan-title "<title>"`
 
 ### 2. Research and Resolve
 
@@ -47,12 +47,10 @@ Example:
 ### 3. Create Expanded Revision
 
 - Write the new revision via CLI (number auto-incremented):
-  ```bash
-  tendril plan write-revision <plan-id> <<'EOF'
-  <expanded revision content>
-  EOF
-  ```
-  Do NOT use the Write or Edit tools to create revision files.
+  1. Write the expanded revision content to `<TendrilPlanFolder>/temp/<short-random>.md` using the `Write` tool
+  2. Run: `tendril plan write-revision <plan-id> --file "<path-to-temp-file>"`
+
+  Do NOT use the Write or Edit tools to create revision files directly in `revisions/` — always use `tendril plan write-revision` with `--file`.
 - Replace all investigative/exploratory language with specific actions
 - Include exact file paths for changes
 - Specify concrete code modifications or additions

--- a/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -5,7 +5,7 @@ Split a multi-issue plan into separate, self-contained plans.
 ## Context
 
 The firmware header contains:
-- **Args** / **PlanFolder** — path to the plan folder to split
+- **Args** / **TendrilPlanFolder** — path to the plan folder to split
 - **CurrentTime** — current UTC timestamp
 
 The plan structure and CLI commands are in the **Reference Documents** section of your firmware.
@@ -20,7 +20,7 @@ The plans directory path can be derived from the plan folder's parent directory.
 - Read `plan.yaml` via `tendril plan get <plan-id>` from the plan folder
 - Read the latest revision from `revisions/` (highest numbered .md file)
 - Identify distinct issues/tasks that should be separate plans
-- Report plan context to Jobs UI: `tendril job status $env:TENDRIL_JOB_ID --message "Splitting plan..." --plan-id <plan-id> --plan-title "<title>"`
+- Report plan context to Jobs UI: `tendril job status TendrilJobId --message "Splitting plan..." --plan-id <plan-id> --plan-title "<title>"`
 
 ### 2. Create Split Plans
 
@@ -28,8 +28,8 @@ For each distinct issue, use `tendril plan create` to allocate an ID, create the
 
 ```bash
 tendril plan create "<Title>" \
-  --plans-dir "<PlansDirectory>" \
-  --project "<Project>" \
+  --plans-dir "<TendrilPlansFolder>" \
+  --project "<TendrilProject>" \
   --level "<Level>" \
   --initial-prompt "<original plan's initialPrompt>" \
   --execution-profile "balanced" \
@@ -53,12 +53,11 @@ Populate `--verification` flags from the project's verifications in config.yaml,
 Do NOT read or modify `.counter` directly — `tendril plan create` handles ID allocation.
 
 After creating each plan, write the revision via CLI:
-```bash
-tendril plan write-revision <PlanId> <<'EOF'
-<revision content>
-EOF
-```
-Fill in Problem, Solution, Remaining Design Questions, Tests sections. Each plan must be fully self-contained. Do NOT use the Write or Edit tools to create revision files.
+
+1. Write revision content to `<TendrilPlansFolder>/<NewPlanFolder>/temp/<short-random>.md` using the `Write` tool
+2. Run: `tendril plan write-revision <PlanId> --file "<path-to-temp-file>"`
+
+Fill in Problem, Solution, Remaining Design Questions, Tests sections. Each plan must be fully self-contained. Do NOT use the Write or Edit tools to create revision files directly in `revisions/`.
 
 #### Project Assignment
 

--- a/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
@@ -5,7 +5,7 @@ Update an existing plan by applying user comments (lines prefixed with `>>`).
 ## Context
 
 The firmware header contains:
-- **Args** / **PlanFolder** — path to the plan folder
+- **Args** / **TendrilPlanFolder** — path to the plan folder
 - **CurrentTime** — current UTC timestamp
 
 The plan structure and CLI commands are in the **Reference Documents** section of your firmware.
@@ -18,7 +18,7 @@ Project configuration is available from the firmware header.
 - Read `plan.yaml` from the plan folder
 - Read the latest revision from `revisions/` (highest numbered .md file)
 - The latest revision contains `>>` comment lines — these are user instructions
-- Report plan context to Jobs UI: `tendril job status $env:TENDRIL_JOB_ID --message "Updating plan..." --plan-id <plan-id> --plan-title "<title>"`
+- Report plan context to Jobs UI: `tendril job status TendrilJobId --message "Updating plan..." --plan-id <plan-id> --plan-title "<title>"`
 
 ### 2. Parse Comments
 
@@ -49,12 +49,10 @@ If all questions are resolved and no new questions arose, omit the `## Questions
 ### 4. Apply Changes
 
 - Write the new revision via CLI (number auto-incremented):
-  ```bash
-  tendril plan write-revision <plan-id> <<'EOF'
-  <updated revision content>
-  EOF
-  ```
-  Do NOT use the Write or Edit tools to create revision files.
+  1. Write the updated revision content to `<TendrilPlanFolder>/temp/<short-random>.md` using the `Write` tool
+  2. Run: `tendril plan write-revision <plan-id> --file "<path-to-temp-file>"`
+
+  Do NOT use the Write or Edit tools to create revision files directly in `revisions/` — always use `tendril plan write-revision` with `--file`.
 - Incorporate the intent of each `>>` instruction into the updated plan
 - Maintain the `## Questions` section (placed after the title, before `## Problem`) using `<details>` tags: (1) Existing questions answered by `>>` comments or research should be collapsed into `<details>` blocks with the answer. (2) New `>>` questions become new `<details>` blocks with answers. (3) Unanswered questions from prior revisions remain as open items (not in `<details>`). (4) If all questions are resolved and no new ones arose, omit the section entirely. Format:
   ```html

--- a/src/Ivy.Tendril/Promptwares/UpdateProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdateProject/Program.md
@@ -9,7 +9,7 @@ The firmware header contains:
 - **Instructions** — what to do (e.g. "Setup verifications and review actions for this project.")
 - **CurrentTime** — current UTC timestamp
 
-Project and verification configuration is available via `tendril project list`, `tendril verification list`, and by reading the config file at `$TENDRIL_CONFIG`.
+Project and verification configuration is available via `tendril project list`, `tendril verification list`, and by reading the config file at the `TendrilConfigPath` from the firmware header (use `Read` tool).
 
 ## Rules
 

--- a/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
+++ b/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
@@ -19,13 +19,17 @@ public class AgentProviderFactory
     };
 
     internal static readonly IReadOnlyList<string> BaseTools =
-        ["Read", "Glob", "Grep", "Bash(tendril*)", "Bash(git *)", "Bash(gh *)", "WebFetch", "WebSearch",
-         "Write(%PROMPTWARE_DIR%/**)", "Edit(%PROMPTWARE_DIR%/**)", "Bash(%PROMPTWARE_DIR%/Tools/*)"];
+        ["Read", "Glob", "Grep", "Bash(tendril*)", "Bash(git *)", "Bash(gh *)", "Bash(ls *)", "Bash(find *)", "Bash(cat *)",
+         "WebFetch", "WebSearch", "Write(%PROMPTWARE_DIR%/**)", "Edit(%PROMPTWARE_DIR%/**)", "Bash(%PROMPTWARE_DIR%/Tools/*)"];
 
     private static readonly Dictionary<string, IReadOnlyList<string>> BuiltInExtraTools =
         new(StringComparer.OrdinalIgnoreCase)
         {
             ["ExecutePlan"] = ["Bash", "Write(%PLAN_DIR%/**)", "Edit(%PLAN_DIR%/**)"],
+            ["CreatePlan"] = ["Write(%PLANS_DIR%/**)"],
+            ["SplitPlan"] = ["Write(%PLANS_DIR%/**)"],
+            ["UpdatePlan"] = ["Write(%PLAN_DIR%/**)"],
+            ["ExpandPlan"] = ["Write(%PLAN_DIR%/**)"],
             ["CreatePr"] = ["Bash"],
             ["CreateIssue"] = ["Bash"]
         };

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -61,6 +61,7 @@ internal class JobCompletionHandler
         HandlePlanStateTransition(job, isSuccess);
         TrackTelemetry(job, isSuccess);
         CleanupInboxFile(job);
+        CleanupTempFolder(job);
         WriteJobLog(job);
         NotifyPlanWatcher(job);
         ScheduleCostCalculation(job, jobs, persistJob, raisePropertyChanged);
@@ -516,6 +517,23 @@ internal class JobCompletionHandler
         {
             if (File.Exists(job.InboxFile))
                 File.Delete(job.InboxFile);
+        }
+        catch
+        {
+        }
+    }
+
+    private static void CleanupTempFolder(JobItem job)
+    {
+        var planFolder = job.TypedArgs?.PlanFolder ?? "";
+        if (string.IsNullOrEmpty(planFolder)) return;
+
+        var tempDir = Path.Combine(planFolder, "temp");
+        if (!Directory.Exists(tempDir)) return;
+
+        try
+        {
+            Directory.Delete(tempDir, recursive: true);
         }
         catch
         {

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -224,7 +224,7 @@ internal class JobLauncher
 
         var settings = _configService.Settings;
         var (values, planYaml, profileOverride) = BuildFirmwareValues(ctx, programFolder);
-        values["Project"] = job.Project;
+        values["TendrilProject"] = job.Project;
 
         var jobContext = BuildJobContext(job, values, programFolder);
         var resolution = AgentProviderFactory.Resolve(settings, job.Type, profileOverride, jobContext);
@@ -278,7 +278,7 @@ internal class JobLauncher
         if (resolution.Provider.UsesStdinPrompt)
             return null;
 
-        var tempDir = values.TryGetValue("PlanFolder", out var pf)
+        var tempDir = values.TryGetValue("TendrilPlanFolder", out var pf)
             ? Path.Combine(pf, "temp")
             : Path.GetTempPath();
         Directory.CreateDirectory(tempDir);
@@ -301,7 +301,10 @@ internal class JobLauncher
         var job = ctx.Job;
         var values = new Dictionary<string, string>
         {
-            ["ClaudeSessionId"] = job.SessionId ?? ""
+            ["AgentSessionId"] = job.SessionId ?? "",
+            ["TendrilJobId"] = job.Id,
+            ["TendrilConfigPath"] = _configService!.ConfigPath,
+            ["TendrilHome"] = _configService.TendrilHome ?? ""
         };
 
         if (job.TypedArgs is CreatePlanArgs)
@@ -319,7 +322,7 @@ internal class JobLauncher
         var cp = job.TypedArgs as CreatePlanArgs;
         var description = cp?.Description ?? "";
         values["Args"] = description;
-        values["PlansDirectory"] = _configService!.PlanFolder;
+        values["TendrilPlansFolder"] = _configService!.PlanFolder;
 
         if (cp?.Force == true)
             values["Force"] = "true";
@@ -337,12 +340,12 @@ internal class JobLauncher
         var planId = PlanYamlHelper.ExtractPlanIdFromFolder(planFolder);
         if (planId != null)
         {
-            values["PlanId"] = planId;
+            values["TendrilPlanId"] = planId;
             job.AllocatedPlanId ??= planId;
         }
 
-        values["PlanFolder"] = planFolder;
-        values["PlansDirectory"] = Path.GetDirectoryName(planFolder) ?? "";
+        values["TendrilPlanFolder"] = planFolder;
+        values["TendrilPlansFolder"] = Path.GetDirectoryName(planFolder) ?? "";
 
         var planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
         if (planYaml == null)
@@ -399,9 +402,9 @@ internal class JobLauncher
             ["PROMPTWARE_DIR"] = programFolder
         };
 
-        if (firmwareValues.TryGetValue("PlansDirectory", out var plansDir))
+        if (firmwareValues.TryGetValue("TendrilPlansFolder", out var plansDir))
             ctx["PLANS_DIR"] = plansDir;
-        if (firmwareValues.TryGetValue("PlanFolder", out var planFolder))
+        if (firmwareValues.TryGetValue("TendrilPlanFolder", out var planFolder))
             ctx["PLAN_DIR"] = planFolder;
 
         var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -72,10 +72,15 @@ codingAgents:
 # The profile determines model and effort from the active coding agent above.
 #
 # All promptwares receive these base tools automatically:
-#   Read, Glob, Grep, Bash(tendril*), Bash(git *), Bash(gh *), WebFetch, WebSearch,
-#   Write(%PROMPTWARE_DIR%/**), Edit(%PROMPTWARE_DIR%/**), Bash(%PROMPTWARE_DIR%/Tools/*)
-# ExecutePlan additionally gets: Bash, Write(%PLAN_DIR%/worktrees/**), Edit(%PLAN_DIR%/worktrees/**)
+#   Read, Glob, Grep, Bash(tendril*), Bash(git *), Bash(gh *), Bash(ls *), Bash(find *), Bash(cat *),
+#   WebFetch, WebSearch, Write(%PROMPTWARE_DIR%/**), Edit(%PROMPTWARE_DIR%/**), Bash(%PROMPTWARE_DIR%/Tools/*)
+# ExecutePlan additionally gets: Bash, Write(%PLAN_DIR%/**), Edit(%PLAN_DIR%/**)
+# CreatePlan additionally gets: Write(%PLANS_DIR%/**) (for temp files used by --file flag)
+# SplitPlan additionally gets: Write(%PLANS_DIR%/**) (creates child plans with --file flag)
+# UpdatePlan additionally gets: Write(%PLAN_DIR%/**) (for temp files used by --file flag)
+# ExpandPlan additionally gets: Write(%PLAN_DIR%/**) (for temp files used by --file flag)
 # CreatePr additionally gets: Bash (needs unrestricted shell for git/gh in worktrees)
+# CreateIssue additionally gets: Bash (needs unrestricted shell for gh in repo directories)
 #
 # Only specify allowedTools if you need ADDITIONAL tools beyond the defaults.
 # Tool format uses Claude Code syntax: Tool, Tool(path-glob).
@@ -178,10 +183,10 @@ verifications:
 - name: CheckResult
   prompt: >
     Verify the implementation matches what was requested in the plan.
-    1. Read the plan revision from `<PlanFolder>/revisions/` (latest numbered .md file)
+    1. Read the plan revision from `<TendrilPlanFolder>/revisions/` (latest numbered .md file)
     2. Review all commits made by this execution
     3. Compare the plan's Problem and Solution sections against the actual changes
-    4. Write the verification report to `<PlanFolder>/verification/CheckResult.md`
+    4. Write the verification report to `<TendrilPlanFolder>/verification/CheckResult.md`
 
 # Stack-specific verification examples (uncomment and customize for your stack):
 


### PR DESCRIPTION
- Rename firmware header keys for consistency: ClaudeSessionId→AgentSessionId,
  PlanId→TendrilPlanId, PlanFolder→TendrilPlanFolder, PlansDirectory→TendrilPlansFolder,
  Project→TendrilProject
- Add --file option to `tendril plan write-revision` to eliminate heredoc usage
- Add TendrilJobId, TendrilConfigPath, TendrilHome to common firmware values
- Update all promptware Program.md files to use --file pattern and new header names
- Add Write(%PLANS_DIR%/**) for SplitPlan, Write(%PLAN_DIR%/**) for UpdatePlan/ExpandPlan
- Add Bash(ls/find/cat) to base tools for all promptwares
- Clean up plan temp/ folder on job completion
