### PR TITLE
[00228] Rename Skip Verification to Skip in onboarding first project step

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -57,10 +57,10 @@ public class ProjectSetupStepView(
         if (!canContinue)
         {
             buttonArea = Layout.Horizontal().Width(Size.Full())
-                | new Button("Back").Outline().Small().Icon(Icons.ArrowLeft)
+                | new Button("Back").Outline().Icon(Icons.ArrowLeft)
                     .OnClick(() => stepperIndex.Set(stepperIndex.Value - 1))
                 | new Spacer()
-                | new Button("Skip").Ghost().Small()
+                | new Button("Skip").Secondary()
                     .OnClick(async () =>
                     {
                         await setupService.FinalizeOnboardingAsync();
@@ -71,9 +71,9 @@ public class ProjectSetupStepView(
         else
         {
             buttonArea = Layout.Horizontal().Width(Size.Full())
-                | new Button("Back").Outline().Small().Icon(Icons.ArrowLeft)
+                | new Button("Back").Outline().Icon(Icons.ArrowLeft)
                     .OnClick(() => stepperIndex.Set(stepperIndex.Value - 1))
-                | new Button("Skip Verifications").Ghost().Small()
+                | new Button("Skip").Secondary()
                     .OnClick(async () =>
                     {
                         var name = SanitizeProjectName(projectName.Value);


### PR DESCRIPTION
## Changes

Renamed "Skip Verifications" button to "Skip" with Secondary style in the onboarding first project step. Removed `.Small()` from both Back buttons to make them normal size.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs** — Updated button styling in the `!canContinue` and `canContinue` branches

---

**Commits:**
- a8cd6b6