### PR TITLE
[00229] Make finish button normal size on onboarding complete step

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -184,7 +184,7 @@ public class CompleteStepView(
                       .Disabled(isFinishing.Value)
                       .OnClick(OnBack)
                   | new Spacer()
-                  | new Button("Finish").Primary().Large().Icon(Icons.Check, Align.Right)
+                  | new Button("Finish").Primary().Icon(Icons.Check, Align.Right)
                       .Disabled(running || isFinishing.Value)
                       .Loading(isFinishing.Value)
                       .OnClick(async () => await OnFinish()));


### PR DESCRIPTION
# Summary

## Changes

Removed `.Large()` from the "Finish" button in the onboarding wizard's `CompleteStepView`, so the button renders at normal/default size instead of being oversized.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs` — removed `.Large()` from Finish button chain (line 187)

---

## Commits

- e4187dd [00229] Remove .Large() from Finish button on onboarding complete step