### PR TITLE
[00234] Make Files Tree Container Narrower in ReviewApp Changes Tab

### DIFF
--- a/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
@@ -109,7 +109,7 @@ public class ChangesTabView(
         }
 
         var treePanel = Layout.Vertical().Gap(2).Padding(1)
-            .Width(Size.Rem(16).Min(Size.Rem(16))).Scroll(Scroll.Auto).Height(Size.Full())
+            .Width(Size.Rem(12).Min(Size.Rem(12))).Scroll(Scroll.Auto).Height(Size.Full())
             | tree;
 
         return Layout.Horizontal().Height(Size.Full())

--- a/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
@@ -13,7 +13,7 @@ public class ChangesTabView(
     public override object Build()
     {
         var client = UseService<IClientProvider>();
-        
+
         // null sentinel = "user hasn't toggled yet, default to all expanded"
         var expandedFiles = UseState<HashSet<string>?>(() => null);
         var selectedFile = UseState<string?>(null);
@@ -89,7 +89,7 @@ public class ChangesTabView(
             }
 
             var path = fileDiff.FilePath;
-            
+
             diffsLayout |= Text.Block("").Anchor(path);
 
             diffsLayout |= new Box(header)


### PR DESCRIPTION
Reduce the width of the files tree panel in the Changes tab from 16rem to 12rem, giving more horizontal space to the diffs panel.

---

**Commits:**
- d5b554c
- da7b86c