### PR TITLE
[00233] Disable stepper navigation during loading in onboarding flow

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -8,7 +8,8 @@ namespace Ivy.Tendril.Apps.Onboarding;
 public class CodingAgentStepView(
     IState<int> stepperIndex,
     IState<bool> commonChecksPassed,
-    IState<string?> completedAgentKey) : ViewBase
+    IState<string?> completedAgentKey,
+    IState<bool> isStepLoading) : ViewBase
 {
     private record AgentInfo(string Key, string Label, Icons Logo);
 
@@ -46,6 +47,7 @@ public class CodingAgentStepView(
                 return;
             }
 
+            isStepLoading.Set(true);
             var progressCts = new CancellationTokenSource();
             _ = DriveProgressAsync(progressValue, progressCts.Token);
 
@@ -84,6 +86,7 @@ public class CodingAgentStepView(
 
                     if (!resumed)
                     {
+                        isStepLoading.Set(false);
                         selectedAgent.Set(null);
                         return;
                     }
@@ -111,6 +114,7 @@ public class CodingAgentStepView(
                         progressCts.Cancel();
                         progressValue.Set(null);
                         progressMessage.Set(null);
+                        isStepLoading.Set(false);
                         error.Set($"Could not authenticate {c.Name}. Please try again.");
                         selectedAgent.Set(null);
                         return;
@@ -131,6 +135,7 @@ public class CodingAgentStepView(
 
                 progressValue.Set(null);
                 progressMessage.Set(null);
+                isStepLoading.Set(false);
                 stepperIndex.Set(stepperIndex.Value + 1);
             }
             catch
@@ -138,6 +143,7 @@ public class CodingAgentStepView(
                 progressCts.Cancel();
                 progressValue.Set(null);
                 progressMessage.Set(null);
+                isStepLoading.Set(false);
                 throw;
             }
         }

--- a/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -7,6 +7,7 @@ public class CompleteStepView(
     IState<int> stepperIndex,
     IState<List<RepoRef>> selectedRepos,
     IState<string> projectName,
+    IState<bool> isStepLoading,
     OnboardingVerificationSession session) : ViewBase
 {
     public override object Build()
@@ -44,6 +45,7 @@ public class CompleteStepView(
 
                 session.Started.Set(true);
                 session.Running.Set(true);
+                isStepLoading.Set(true);
 
                 foreach (var name in projectsNeedingVerifications)
                 {
@@ -83,6 +85,7 @@ public class CompleteStepView(
             finally
             {
                 session.Running.Set(false);
+                isStepLoading.Set(false);
             }
         }, [EffectTrigger.OnMount()]);
 
@@ -95,6 +98,7 @@ public class CompleteStepView(
         async Task OnFinish()
         {
             isFinishing.Set(true);
+            isStepLoading.Set(true);
             session.Error.Set(null);
             try
             {
@@ -106,6 +110,7 @@ public class CompleteStepView(
             {
                 session.Error.Set($"Failed to complete setup: {ex.Message}");
                 isFinishing.Set(false);
+                isStepLoading.Set(false);
             }
         }
 

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -10,6 +10,7 @@ public class ProjectSetupStepView(
     IState<int> stepperIndex,
     IState<List<RepoRef>> selectedRepos,
     IState<string> projectName,
+    IState<bool> isStepLoading,
     OnboardingVerificationSession session) : ViewBase
 {
     public override object Build()
@@ -86,6 +87,7 @@ public class ProjectSetupStepView(
                         {
                             error.Set(null);
                             isCloning.Set(true);
+                            isStepLoading.Set(true);
 
                             var refs = await ResolveReposAsync(config, progressMessage, error, isCloning);
                             if (refs == null) return;
@@ -120,6 +122,7 @@ public class ProjectSetupStepView(
 
                         error.Set(null);
                         isCloning.Set(true);
+                        isStepLoading.Set(true);
 
                         var progressCts = new CancellationTokenSource();
                         _ = DriveProgressAsync(progressValue, progressCts.Token);
@@ -158,6 +161,7 @@ public class ProjectSetupStepView(
                             progressValue.Set(null);
                             progressMessage.Set(null);
                             isCloning.Set(false);
+                            isStepLoading.Set(false);
                             stepperIndex.Set(stepperIndex.Value + 1);
                         }
                         catch (Exception ex)
@@ -167,6 +171,7 @@ public class ProjectSetupStepView(
                             progressMessage.Set(null);
                             error.Set($"Failed to set up project: {ex.Message}");
                             isCloning.Set(false);
+                            isStepLoading.Set(false);
                         }
                     });
         }
@@ -272,6 +277,7 @@ public class ProjectSetupStepView(
                 {
                     error.Set($"Failed to fetch repository: {repo.Path}.");
                     isCloning.Set(false);
+                    isStepLoading.Set(false);
                     return null;
                 }
                 refs.Add(repo with { Path = destPath });

--- a/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
@@ -7,7 +7,8 @@ namespace Ivy.Tendril.Apps.Onboarding;
 public class TendrilHomeStepView(
     IState<int> stepperIndex,
     IState<string> tendrilHomePath,
-    IState<bool> homeBootstrapped) : ViewBase
+    IState<bool> homeBootstrapped,
+    IState<bool> isStepLoading) : ViewBase
 {
     public override object Build()
     {
@@ -60,6 +61,7 @@ public class TendrilHomeStepView(
 
                           error.Set(null);
                           isBootstrapping.Set(true);
+                          isStepLoading.Set(true);
                           try
                           {
                               config.SetPendingTendrilHome(resolved);
@@ -75,6 +77,7 @@ public class TendrilHomeStepView(
                           finally
                           {
                               isBootstrapping.Set(false);
+                              isStepLoading.Set(false);
                           }
                       }));
     }

--- a/src/Ivy.Tendril/Apps/OnboardingApp.cs
+++ b/src/Ivy.Tendril/Apps/OnboardingApp.cs
@@ -29,14 +29,15 @@ public class OnboardingApp : ViewBase
         IState<string> tendrilHomePath,
         IState<List<RepoRef>> selectedRepos,
         IState<string> projectName,
+        IState<bool> isStepLoading,
         OnboardingVerificationSession session)
     {
         return stepperIndex.Value switch
         {
-            0 => new CodingAgentStepView(stepperIndex, commonChecksPassed, completedAgentKey),
-            1 => new TendrilHomeStepView(stepperIndex, tendrilHomePath, homeBootstrapped),
-            2 => new ProjectSetupStepView(stepperIndex, selectedRepos, projectName, session),
-            3 => new CompleteStepView(stepperIndex, selectedRepos, projectName, session),
+            0 => new CodingAgentStepView(stepperIndex, commonChecksPassed, completedAgentKey, isStepLoading),
+            1 => new TendrilHomeStepView(stepperIndex, tendrilHomePath, homeBootstrapped, isStepLoading),
+            2 => new ProjectSetupStepView(stepperIndex, selectedRepos, projectName, isStepLoading, session),
+            3 => new CompleteStepView(stepperIndex, selectedRepos, projectName, isStepLoading, session),
             _ => throw new ArgumentOutOfRangeException()
         };
     }
@@ -52,6 +53,7 @@ public class OnboardingApp : ViewBase
             ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril"));
         var selectedRepos = UseState(() => new List<RepoRef>());
         var projectName = UseState("");
+        var isStepLoading = UseState(false);
 
         var verificationStream = UseStream<string>();
         var verificationHandle = UseState<PromptwareRunHandle?>((PromptwareRunHandle?)null);
@@ -76,14 +78,15 @@ public class OnboardingApp : ViewBase
         return Layout.TopCenter() |
                (Layout.Vertical().Margin(0, 20).Width(150)
                 | new Image("/tendril/assets/Tendril.svg").Width(Size.Units(15)).Height(Size.Auto())
-                | new Stepper(OnSelect, stepperIndex.Value, steps).Width(Size.Full())
+                | new Stepper(OnSelect, stepperIndex.Value, steps).Width(Size.Full()).Disabled(isStepLoading.Value || verificationRunning.Value)
                 | GetStepViews(stepperIndex,
                                commonChecksPassed, homeBootstrapped, completedAgentKey,
-                               tendrilHomePath, selectedRepos, projectName, session)
+                               tendrilHomePath, selectedRepos, projectName, isStepLoading, session)
                );
 
         ValueTask OnSelect(Event<Stepper, int> e)
         {
+            if (isStepLoading.Value || verificationRunning.Value) return ValueTask.CompletedTask;
             if (e.Value < stepperIndex.Value)
             {
                 stepperIndex.Set(e.Value);


### PR DESCRIPTION
Fixes #585

# Summary

## Changes

Added a shared `isStepLoading` state to the onboarding flow that disables stepper navigation (both the Stepper widget's step buttons and the OnSelect handler) during any async operation across all steps.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/OnboardingApp.cs** — Added `isStepLoading` state, applied `.Disabled()` to Stepper, guarded OnSelect, updated GetStepViews signature
- **src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs** — Accepts `isStepLoading`, sets it during agent checks
- **src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs** — Accepts `isStepLoading`, sets it during home bootstrapping
- **src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs** — Accepts `isStepLoading`, sets it during repo cloning
- **src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs** — Accepts `isStepLoading`, sets it during verification session and finishing

---

Commits:
- d14f231 [00233] Disable stepper navigation during loading in onboarding flow