### PR TITLE
[Docs]: simplify hosted BasicAuth secrets in Setup

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/03_Configuration/01_Setup.md
+++ b/src/Ivy.Tendril.Docs/Docs/03_Configuration/01_Setup.md
@@ -7,6 +7,12 @@ searchHints:
   - settings
   - projects
   - gui
+  - deployment
+  - docker
+  - secrets
+  - BasicAuth
+  - password
+  - hosted
 ---
 
 # Setup & Settings
@@ -62,6 +68,20 @@ projects:
 | `maxConcurrentJobs` | Cap on parallel agent runs (worktrees). |
 | `projects` | Registered repositories and their settings. |
 | `api.apiKey` | Protect the REST API with a shared secret (see [REST API](../07_Advanced/02_REST.md)). |
+
+## Password on a server (env secrets)
+
+Set **`TENDRIL_HOME`** to your data directory. For a password on the web UI, set these env vars (double underscore is normal on hosts like Sliplane):
+
+**`BasicAuth__Users`** — login in plain text, e.g. `you:your-password`. No colon = password only.
+
+**`BasicAuth__HashSecret`** — one random **base64** line (`openssl rand -base64 32`). Used to hash the password.
+
+**`BasicAuth__JwtSecret`** — same base64 as `BasicAuth__HashSecret` if your host shows three secrets and you want to fill all three. Otherwise optional: it is a second **name** for the same value, not a second secret.
+
+You can use `TENDRIL_AUTH_PASSWORD`, `TENDRIL_AUTH_USERNAME`, and `TENDRIL_AUTH_HASH_SECRET` instead of the `BasicAuth__*` names if you prefer.
+
+REST uses **`api.apiKey`** in config, not these vars — see [REST API](../07_Advanced/02_REST.md). **Settings** in the app still edits `config.yaml` after startup.
 
 ## Verifications
 


### PR DESCRIPTION
## Summary

Updates **Setup & Settings** docs with a short, layout-friendly section on enabling **browser login** when Tendril runs on a host that injects secrets as environment variables (e.g. Sliplane).

## What changed

- Documents **`TENDRIL_HOME`** plus **`BasicAuth__Users`**, **`BasicAuth__HashSecret`**, and **`BasicAuth__JwtSecret`**: what each is for, and that `JwtSecret` is an alternate env name for the same base64 value as `HashSecret`, not a separate secret.
- Mentions **`TENDRIL_AUTH_*`** as optional equivalents.
- Notes that the **REST API** uses **`api.apiKey`**, not these variables (with a link to the REST page).
- Replaces a wide three-column table with short paragraphs so the docs page does not overflow horizontally.

## Why

Operators need a **accurate, scannable** reference that matches what the platform UI shows (`BasicAuth__*`) without long unbroken lines in tables.

<img width="1726" height="1006" alt="Знімок екрана 2026-05-12 о 12 31 13" src="https://github.com/user-attachments/assets/df3cc1d0-c33c-4d85-aa1e-b68c748338b3" />
