### PR TITLE
[00237] Simplify ChangesTabView and PlanContentHelpers to use DiffView native collapse

### DIFF
--- a/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
@@ -135,8 +135,7 @@ public static class PlanContentHelpers
     }
 
     public static object RenderCommitDetailSheet(CommitDetailData? data, bool loading, string? commitHash,
-        Action closeSheet, HashSet<string>? expandedFiles = null, Action<string>? onToggleFile = null,
-        Exception? error = null)
+        Action closeSheet, Exception? error = null)
     {
         if (commitHash is null) return new Empty();
 
@@ -167,46 +166,11 @@ public static class PlanContentHelpers
 
                 foreach (var fileDiff in fileDiffs)
                 {
-                    var isExpanded = expandedFiles?.Contains(fileDiff.FilePath) ?? false;
-                    var chevronIcon = isExpanded ? Icons.ChevronDown : Icons.ChevronRight;
-                    var (statusIcon, statusColor) = GetFileStatusIconAndColor(fileDiff.Status);
-                    var fileName = Path.GetFileName(fileDiff.FilePath);
-                    var isRenamed = fileDiff.OldFilePath != null;
-                    var oldFileName = isRenamed ? Path.GetFileName(fileDiff.OldFilePath!) : null;
-
-                    var header = Layout.Horizontal().Gap(2)
-                        | new Icon(chevronIcon).Small()
-                        | new Icon(statusIcon).Small().Color(statusColor);
-
-                    if (isRenamed)
-                    {
-                        header |= Text.Block(oldFileName!).Bold();
-                        header |= Text.Muted("→");
-                        header |= Text.Block(fileName).Bold();
-                        header |= Text.Muted(fileDiff.FilePath);
-                    }
-                    else
-                    {
-                        header |= Text.Block(fileName).Bold();
-                        header |= Text.Muted(fileDiff.FilePath);
-                    }
-
-                    if (onToggleFile != null)
-                    {
-                        var path = fileDiff.FilePath;
-                        commitSheetContent |= new Box(header)
-                            .BorderThickness(0).Padding(0)
-                            .OnClick(() => onToggleFile(path));
-                    }
-                    else
-                    {
-                        commitSheetContent |= header;
-                    }
-
-                    if (isExpanded)
-                    {
-                        commitSheetContent |= new DiffView().Diff(fileDiff.Diff).Split();
-                    }
+                    commitSheetContent |= new DiffView()
+                        .Diff(fileDiff.Diff)
+                        .Split()
+                        .Collapsible()
+                        .DefaultCollapsed();
                 }
             }
             else if (data.Files is { Count: > 0 })

--- a/src/Ivy.Tendril/Views/Sheets/CommitDetailSheet.cs
+++ b/src/Ivy.Tendril/Views/Sheets/CommitDetailSheet.cs
@@ -13,8 +13,6 @@ public class CommitDetailSheet(
 {
     public override object Build()
     {
-        var expandedFiles = UseState(new HashSet<string>());
-
         var commitQuery = UseQuery<PlanContentHelpers.CommitDetailData?, string>(
             openCommit.Value ?? "",
             async (hash, ct) =>
@@ -45,20 +43,11 @@ public class CommitDetailSheet(
         if (openCommit.Value is not { } commitHash || selectedPlan is null)
             return new Empty();
 
-        void ToggleFile(string path)
-        {
-            var files = new HashSet<string>(expandedFiles.Value);
-            if (!files.Add(path)) files.Remove(path);
-            expandedFiles.Set(files);
-        }
-
         return PlanContentHelpers.RenderCommitDetailSheet(
             commitQuery.Value,
             commitQuery.Loading || commitQuery.Value is null && !string.IsNullOrEmpty(openCommit.Value),
             commitHash,
             () => openCommit.Set(null),
-            expandedFiles.Value,
-            ToggleFile,
             commitQuery.Error);
     }
 }

--- a/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
@@ -14,10 +14,6 @@ public class ChangesTabView(
     {
         var client = UseService<IClientProvider>();
 
-        // null sentinel = "user hasn't toggled yet, default to all expanded"
-        var expandedFiles = UseState<HashSet<string>?>(() => null);
-        var selectedFile = UseState<string?>(null);
-
         if (loading)
             return Text.Muted("Loading...");
 
@@ -34,9 +30,6 @@ public class ChangesTabView(
         if (fileDiffs.Count == 0 && changesData.Files.Count == 0)
             return Text.Muted("No file changes.");
 
-        var currentlyExpanded = expandedFiles.Value
-            ?? new HashSet<string>(fileDiffs.Select(fd => fd.FilePath));
-
         var root = BuildFileTree(fileDiffs);
         var treeItems = ChildItems(root);
         var sortedFileDiffs = SortByTreeOrder(fileDiffs, root);
@@ -46,12 +39,6 @@ public class ChangesTabView(
             {
                 var path = e.Value?.ToString();
                 if (path is null) return;
-                selectedFile.Set(path);
-                if (!currentlyExpanded.Contains(path))
-                {
-                    var files = new HashSet<string>(currentlyExpanded) { path };
-                    expandedFiles.Set(files);
-                }
                 client.Redirect($"#{path}");
             });
 
@@ -63,49 +50,13 @@ public class ChangesTabView(
 
         foreach (var fileDiff in sortedFileDiffs)
         {
-            var isExpanded = currentlyExpanded.Contains(fileDiff.FilePath);
-            var chevronIcon = isExpanded ? Icons.ChevronDown : Icons.ChevronRight;
-            var (statusIcon, statusColor) = PlanContentHelpers.GetFileStatusIconAndColor(fileDiff.Status);
-            var fileName = Path.GetFileName(fileDiff.FilePath);
-            var isRenamed = fileDiff.OldFilePath != null;
-            var oldFileName = isRenamed ? Path.GetFileName(fileDiff.OldFilePath!) : null;
-
-            var header = Layout.Horizontal()
-                .Gap(2)
-                | new Icon(chevronIcon).Small()
-                | new Icon(statusIcon).Small().Color(statusColor);
-
-            if (isRenamed)
-            {
-                header |= Text.Block(oldFileName!).Bold();
-                header |= Text.Muted("→");
-                header |= Text.Block(fileName).Bold();
-                header |= Text.Muted(Path.GetDirectoryName(fileDiff.FilePath)?.Replace('\\', '/') ?? "");
-            }
-            else
-            {
-                header |= Text.Block(fileName).Bold();
-                header |= Text.Muted(Path.GetDirectoryName(fileDiff.FilePath)?.Replace('\\', '/') ?? "");
-            }
-
             var path = fileDiff.FilePath;
-
             diffsLayout |= Text.Block("").Anchor(path);
-
-            diffsLayout |= new Box(header)
-                .BorderThickness(0).Padding(1)
-                .Hover(HoverEffect.Pointer)
-                .OnClick(() =>
-                {
-                    var files = new HashSet<string>(currentlyExpanded);
-                    if (!files.Add(path)) files.Remove(path);
-                    expandedFiles.Set(files);
-                });
-
-            if (isExpanded)
-            {
-                diffsLayout |= new DiffView().Diff(fileDiff.Diff).Split().Width(Size.Full());
-            }
+            diffsLayout |= new DiffView()
+                .Diff(fileDiff.Diff)
+                .Split()
+                .Collapsible()
+                .Width(Size.Full());
         }
 
         var treePanel = Layout.Vertical().Gap(2).Padding(1)


### PR DESCRIPTION
## Changes

Removed custom expand/collapse logic from ChangesTabView and PlanContentHelpers, replacing it with DiffView's native `Collapsible()` and `DefaultCollapsed()` properties. This eliminated ~100 lines of state management, chevron icons, clickable Box wrappers, and conditional rendering across 3 files.

## API Changes

- `PlanContentHelpers.RenderCommitDetailSheet` — removed `expandedFiles` and `onToggleFile` parameters (breaking change for callers, all updated)

## Files Modified

- **src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs** — Removed expandedFiles state, chevron/header/toggle logic, replaced with `DiffView().Collapsible()`
- **src/Ivy.Tendril/Helpers/PlanContentHelpers.cs** — Simplified RenderCommitDetailSheet to use `DiffView().Collapsible().DefaultCollapsed()`
- **src/Ivy.Tendril/Views/Sheets/CommitDetailSheet.cs** — Removed expandedFiles state and ToggleFile callback, updated call signature

---

Commits:
- e162947 [00237] Simplify ChangesTabView and PlanContentHelpers to use DiffView native collapse