### PR TITLE
Pass UpdatePlan instructions via firmware header, tighten permissions, normalize paths

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
@@ -67,15 +67,8 @@ public class UpdatePlanDialog(
                         };
                         _selectedPlanState.Set(optimisticPlan);
 
-                        // Append >> comments to the latest revision so UpdatePlan can process them
-                        var currentContent = _planService.ReadLatestRevision(_selectedPlan.FolderName);
-                        var comments = string.Join("\n", updateText.Value
-                            .Split('\n')
-                            .Select(line => $">> {line}"));
-                        _planService.SavePlan(_selectedPlan.FolderName, currentContent + "\n\n" + comments + "\n");
-
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
-                        _jobService.StartJob(new UpdatePlanArgs(_selectedPlan.FolderPath));
+                        _jobService.StartJob(new UpdatePlanArgs(_selectedPlan.FolderPath, updateText.Value));
                         _refreshPlans();
                         updateText.Set("");
                         isCreating.Set(false);

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
@@ -49,14 +49,9 @@ public class SuggestChangesDialog(
                     if (!string.IsNullOrWhiteSpace(suggestText.Value) && !isCreating.Value)
                     {
                         isCreating.Set(true);
-                        var currentContent = _planService.ReadLatestRevision(_selectedPlan.FolderName);
-                        var comments = string.Join("\n", suggestText.Value
-                            .Split('\n')
-                            .Select(line => $">> {line}"));
-                        _planService.SavePlan(_selectedPlan.FolderName, currentContent + "\n\n" + comments + "\n");
 
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
-                        _jobService.StartJob(new UpdatePlanArgs(_selectedPlan.FolderPath));
+                        _jobService.StartJob(new UpdatePlanArgs(_selectedPlan.FolderPath, suggestText.Value));
                         _refreshPlans();
                         isCreating.Set(false);
                         suggestText.Set("");

--- a/src/Ivy.Tendril/Assets/Plans.md
+++ b/src/Ivy.Tendril/Assets/Plans.md
@@ -26,7 +26,6 @@ Plans live under `planFolder` from `config.yaml`.
 │   │   ├── DotnetTest.md
 │   │   └── ...
 │   ├── worktrees/                    # Git worktrees used during execution
-│   ├── temp/                         # Scratch space for promptware agents
 └── ...
 ```
 
@@ -149,7 +148,7 @@ tendril plan write-revision <plan-id> --file <path-to-file>
 
 Reads content from `<path-to-file>` and writes it to `revisions/<NNN>.md` in the plan folder. Auto-increments from the highest existing revision. Outputs the file path.
 
-Workflow: write revision content to `temp/<short-random>.md` inside the plan folder using the `Write` tool, then run the command above referencing that file.
+Workflow: write revision content to `<TendrilHome>/Temp/<short-random>.md` using the `Write` tool, then run the command above referencing that file.
 
 ### Writing execution logs
 
@@ -260,10 +259,6 @@ Subsequent revisions are written by ExpandPlan, UpdatePlan, or SplitPlan agents.
 ## Logs
 
 `logs/{NNN}-{Action}.md` per promptware run (Completed time, status, …).
-
-## temp/
-
-Scratch for clones, downloads, intermediates. Safe to delete after the plan finishes.
 
 ## .counter
 

--- a/src/Ivy.Tendril/Models/JobArgs.cs
+++ b/src/Ivy.Tendril/Models/JobArgs.cs
@@ -44,7 +44,8 @@ public record ExpandPlanArgs(
 }
 
 public record UpdatePlanArgs(
-    string FolderPath) : JobArgsBase
+    string FolderPath,
+    string? Instructions = null) : JobArgsBase
 {
     public override string Type => Constants.JobTypes.UpdatePlan;
     public override string PlanFolder => FolderPath;

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -191,7 +191,7 @@ Populate `--verification` flags from the project's `verifications` in config.yam
 
 Write the revision content to a temp file, then commit it via CLI:
 
-1. Write the revision markdown to `<Directory>/temp/<short-random>.md` using the `Write` tool (e.g. `temp/r7x.md`)
+1. Write the revision markdown to `<TendrilHome>/Temp/<short-random>.md` using the `Write` tool
 2. Run: `tendril plan write-revision <PlanId> --file "<path-to-temp-file>"`
 
 This auto-creates `revisions/001.md` (or the next sequential number) in the plan folder. Do NOT use the Write or Edit tools to create revision files directly in `revisions/` — always use the `tendril plan write-revision` command with `--file`.

--- a/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
@@ -47,7 +47,7 @@ Example:
 ### 3. Create Expanded Revision
 
 - Write the new revision via CLI (number auto-incremented):
-  1. Write the expanded revision content to `<TendrilPlanFolder>/temp/<short-random>.md` using the `Write` tool
+  1. Write the expanded revision content to `<TendrilHome>/Temp/<short-random>.md` using the `Write` tool
   2. Run: `tendril plan write-revision <plan-id> --file "<path-to-temp-file>"`
 
   Do NOT use the Write or Edit tools to create revision files directly in `revisions/` — always use `tendril plan write-revision` with `--file`.

--- a/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -54,7 +54,7 @@ Do NOT read or modify `.counter` directly — `tendril plan create` handles ID a
 
 After creating each plan, write the revision via CLI:
 
-1. Write revision content to `<TendrilPlansFolder>/<NewPlanFolder>/temp/<short-random>.md` using the `Write` tool
+1. Write revision content to `<TendrilHome>/Temp/<short-random>.md` using the `Write` tool
 2. Run: `tendril plan write-revision <PlanId> --file "<path-to-temp-file>"`
 
 Fill in Problem, Solution, Remaining Design Questions, Tests sections. Each plan must be fully self-contained. Do NOT use the Write or Edit tools to create revision files directly in `revisions/`.

--- a/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
@@ -1,11 +1,12 @@
 # UpdatePlan
 
-Update an existing plan by applying user comments (lines prefixed with `>>`).
+Update an existing plan by applying user instructions from the firmware header.
 
 ## Context
 
 The firmware header contains:
 - **Args** / **TendrilPlanFolder** — path to the plan folder
+- **UpdateInstructions** — the user's update instructions (what to change)
 - **CurrentTime** — current UTC timestamp
 
 The plan structure and CLI commands are in the **Reference Documents** section of your firmware.
@@ -15,55 +16,52 @@ Project configuration is available from the firmware header.
 
 ### 1. Read the Plan
 
-- Read `plan.yaml` from the plan folder
 - Read the latest revision from `revisions/` (highest numbered .md file)
-- The latest revision contains `>>` comment lines — these are user instructions
+- Get the plan title: `tendril plan get <TendrilPlanId> title`
 - Report plan context to Jobs UI: `tendril job status TendrilJobId --message "Updating plan..." --plan-id <plan-id> --plan-title "<title>"`
 
-### 2. Parse Comments
+### 2. Parse Instructions
 
-Look for lines prefixed with `>>`. These are either:
+Read the `UpdateInstructions` value from the firmware header. Instructions are either:
 - **Questions** (contain `?` or start with question words) — research and answer them
 - **Instructions** — changes to incorporate into the plan
 
-If no `>>` lines exist, report "No comments found" and stop.
-
 ### 3. Research and Answer Questions
 
-For each question in the `>>` lines:
+For each question in the instructions:
 1. Read relevant source files to find the answer
 2. Use the firmware header for project context if needed
 
 ### 3.5. Resolve Answered Questions
 
 Compare each existing question in `## Questions` against:
-- The `>>` comments (user may have directly answered a question)
+- The user's instructions (user may have directly answered a question)
 - Your research findings from step 3
 
-For each question, determine if it has been answered — either explicitly by a `>>` comment or implicitly by a decision made in the updated plan. If answered:
+For each question, determine if it has been answered — either explicitly by the user's instructions or implicitly by a decision made in the updated plan. If answered:
 - Wrap the question in a `<details>` block (collapsed) with the answer as the body
-- The answer should reference the user's comment or the design decision that resolves it
+- The answer should reference the user's instruction or the design decision that resolves it
 
 If all questions are resolved and no new questions arose, omit the `## Questions` section entirely.
 
 ### 4. Apply Changes
 
 - Write the new revision via CLI (number auto-incremented):
-  1. Write the updated revision content to `<TendrilPlanFolder>/temp/<short-random>.md` using the `Write` tool
+  1. Write the updated revision content to `<TendrilHome>/Temp/<short-random>.md` using the `Write` tool
   2. Run: `tendril plan write-revision <plan-id> --file "<path-to-temp-file>"`
 
   Do NOT use the Write or Edit tools to create revision files directly in `revisions/` — always use `tendril plan write-revision` with `--file`.
-- Incorporate the intent of each `>>` instruction into the updated plan
-- Maintain the `## Questions` section (placed after the title, before `## Problem`) using `<details>` tags: (1) Existing questions answered by `>>` comments or research should be collapsed into `<details>` blocks with the answer. (2) New `>>` questions become new `<details>` blocks with answers. (3) Unanswered questions from prior revisions remain as open items (not in `<details>`). (4) If all questions are resolved and no new ones arose, omit the section entirely. Format:
+- Incorporate the intent of each instruction into the updated plan
+- Maintain the `## Questions` section (placed after the title, before `## Problem`) using `<details>` tags: (1) Existing questions answered by the user's instructions or research should be collapsed into `<details>` blocks with the answer. (2) New questions become new `<details>` blocks with answers. (3) Unanswered questions from prior revisions remain as open items (not in `<details>`). (4) If all questions are resolved and no new ones arose, omit the section entirely. Format:
   ```html
   <details>
   <summary>Question</summary>
   Answer
   </details>
   ```
-- Remove all `>>` lines — they've been processed
 - Preserve the plan template structure
 - The updated plan must be at least as comprehensive as the original
+
 ### Rules
 
 - Do NOT modify any source code — only read files and update the plan

--- a/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
+++ b/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
@@ -20,16 +20,14 @@ public class AgentProviderFactory
 
     internal static readonly IReadOnlyList<string> BaseTools =
         ["Read", "Glob", "Grep", "Bash(tendril*)", "Bash(git *)", "Bash(gh *)", "Bash(ls *)", "Bash(find *)", "Bash(cat *)",
-         "WebFetch", "WebSearch", "Write(%PROMPTWARE_DIR%/**)", "Edit(%PROMPTWARE_DIR%/**)", "Bash(%PROMPTWARE_DIR%/Tools/*)"];
+         "WebFetch", "WebSearch", "Write(%PROMPTWARE_DIR%/**)", "Edit(%PROMPTWARE_DIR%/**)", "Bash(%PROMPTWARE_DIR%/Tools/*)",
+         "Write(%TENDRIL_HOME%/Temp/**)"];
 
     private static readonly Dictionary<string, IReadOnlyList<string>> BuiltInExtraTools =
         new(StringComparer.OrdinalIgnoreCase)
         {
             ["ExecutePlan"] = ["Bash", "Write(%PLAN_DIR%/**)", "Edit(%PLAN_DIR%/**)"],
-            ["CreatePlan"] = ["Write(%PLANS_DIR%/**)"],
-            ["SplitPlan"] = ["Write(%PLANS_DIR%/**)"],
-            ["UpdatePlan"] = ["Write(%PLAN_DIR%/**)"],
-            ["ExpandPlan"] = ["Write(%PLAN_DIR%/**)"],
+            ["CreatePlan"] = ["Write(%TENDRIL_HOME%/Trash/**)"],
             ["CreatePr"] = ["Bash"],
             ["CreateIssue"] = ["Bash"]
         };

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -311,10 +311,32 @@ public class ConfigService : IConfigService, IDisposable
     {
         Directory.CreateDirectory(TendrilHome);
         Directory.CreateDirectory(Path.Combine(TendrilHome, "Inbox"));
-        Directory.CreateDirectory(PlanFolder);
         Directory.CreateDirectory(Path.Combine(TendrilHome, "Trash"));
+        Directory.CreateDirectory(PlanFolder);
         Directory.CreateDirectory(Path.Combine(TendrilHome, "Promptwares"));
         Directory.CreateDirectory(Path.Combine(TendrilHome, "Hooks"));
+        CleanAndCreateTempDirectory();
+    }
+
+    private void CleanAndCreateTempDirectory()
+    {
+        var tempDir = Path.Combine(TendrilHome, "Temp");
+        try
+        {
+            if (Directory.Exists(tempDir))
+            {
+                foreach (var file in Directory.GetFiles(tempDir))
+                    File.Delete(file);
+            }
+            else
+            {
+                Directory.CreateDirectory(tempDir);
+            }
+        }
+        catch
+        {
+            Directory.CreateDirectory(tempDir);
+        }
     }
 
     private void ValidateSettings()

--- a/src/Ivy.Tendril/Services/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/FirmwareCompiler.cs
@@ -59,10 +59,10 @@ public static class FirmwareCompiler
 
         var header = string.Join("\n", headerValues
             .OrderBy(kv => kv.Key)
-            .Select(kv => $"{kv.Key}: {kv.Value}"));
+            .Select(kv => $"{kv.Key}: {NormalizeHeaderValue(kv.Key, kv.Value)}"));
 
-        var toolsListing = ListDirectoryFiles(Path.Combine(context.ProgramFolder, "Tools"));
-        var memoryListing = ListDirectoryFiles(Path.Combine(context.ProgramFolder, "Memory"));
+        var toolsListing = ListDirectoryFiles(Path.Combine(context.ProgramFolder, "Tools"), "(no tools yet)");
+        var memoryListing = ListDirectoryFiles(Path.Combine(context.ProgramFolder, "Memory"), "(no memory yet)");
 
         var firmware = FirmwareTemplate
             .Replace("{HEADER}", header)
@@ -95,18 +95,27 @@ public static class FirmwareCompiler
         return firmware;
     }
 
-    private static string ListDirectoryFiles(string directory)
+    private static readonly HashSet<string> PathKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Args", "TendrilConfigPath", "TendrilHome", "TendrilPlanFolder",
+        "TendrilPlansFolder", "SourceUrl", "SourcePath"
+    };
+
+    private static string NormalizeHeaderValue(string key, string value) =>
+        PathKeys.Contains(key) ? value.Replace('\\', '/') : value;
+
+    private static string ListDirectoryFiles(string directory, string emptyLabel = "(none)")
     {
         if (!Directory.Exists(directory))
-            return "(none)";
+            return emptyLabel;
 
         var files = Directory.GetFiles(directory)
             .Select(Path.GetFileName)
-            .Where(f => f != null)
+            .Where(f => f != null && !f.StartsWith('.'))
             .OrderBy(f => f)
             .ToList();
 
-        return files.Count == 0 ? "(none)" : string.Join(", ", files);
+        return files.Count == 0 ? emptyLabel : string.Join(", ", files);
     }
 
     public static string GetNextLogFile(string programFolder)

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -61,7 +61,7 @@ internal class JobCompletionHandler
         HandlePlanStateTransition(job, isSuccess);
         TrackTelemetry(job, isSuccess);
         CleanupInboxFile(job);
-        CleanupTempFolder(job);
+        CleanupOldTrashFiles();
         WriteJobLog(job);
         NotifyPlanWatcher(job);
         ScheduleCostCalculation(job, jobs, persistJob, raisePropertyChanged);
@@ -523,17 +523,22 @@ internal class JobCompletionHandler
         }
     }
 
-    private static void CleanupTempFolder(JobItem job)
+    private static void CleanupOldTrashFiles()
     {
-        var planFolder = job.TypedArgs?.PlanFolder ?? "";
-        if (string.IsNullOrEmpty(planFolder)) return;
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        if (string.IsNullOrEmpty(tendrilHome)) return;
 
-        var tempDir = Path.Combine(planFolder, "temp");
-        if (!Directory.Exists(tempDir)) return;
+        var trashDir = Path.Combine(tendrilHome, "Trash");
+        if (!Directory.Exists(trashDir)) return;
 
         try
         {
-            Directory.Delete(tempDir, recursive: true);
+            var cutoff = DateTime.UtcNow - TimeSpan.FromDays(7);
+            foreach (var file in Directory.GetFiles(trashDir))
+            {
+                if (File.GetLastWriteTimeUtc(file) < cutoff)
+                    File.Delete(file);
+            }
         }
         catch
         {

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -355,6 +355,9 @@ internal class JobLauncher
         if (!string.IsNullOrEmpty(planYaml.SourceUrl))
             values["SourceUrl"] = planYaml.SourceUrl;
 
+        if (job.TypedArgs is UpdatePlanArgs { Instructions: not null } updateArgs)
+            values["UpdateInstructions"] = updateArgs.Instructions;
+
         var profileOverride = ExtractExecutionProfile(job, planYaml);
         AddRepoConfigsIfNeeded(job, planYaml, values);
         AddCreatePrOptions(job, values);

--- a/src/Ivy.Tendril/Services/PromptwareRunner.cs
+++ b/src/Ivy.Tendril/Services/PromptwareRunner.cs
@@ -75,7 +75,8 @@ public class PromptwareRunner : IPromptwareRunner
 
         var jobContext = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["PROMPTWARE_DIR"] = programFolder
+            ["PROMPTWARE_DIR"] = programFolder,
+            ["TENDRIL_HOME"] = _configService.TendrilHome
         };
 
         var resolution = AgentProviderFactory.Resolve(settings, options.Promptware, options.Profile, jobContext);


### PR DESCRIPTION
- Pass update instructions as a firmware header value instead of appending >> lines to revision files
- Move temp file writes to TendrilHome/Temp/ (shared scratch space) with startup cleanup
- Tighten promptware Write permissions to only TendrilHome/Temp and Trash
- Normalize only path-valued firmware header values to forward slashes
- Add TENDRIL_HOME to PromptwareRunner job context
- Filter dotfiles from Tools/Memory listings in firmware
- Auto-cleanup Trash files older than 7 days
