### PR TITLE
Fix ghosted PR rule selector in Edit Project dialog (#584)

### DIFF
--- a/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
@@ -165,7 +165,9 @@ public class ProjectRepoPickerView(
                 return list;
             });
 
-        return bridge.ToSelectInput(new List<string> { "default", "yolo" }).Width(Size.Units(20));
+        return bridge.ToSelectInput(new List<string> { "default", "yolo" })
+            .Variant(SelectInputVariant.Toggle)
+            .Width(Size.Units(28));
     }
 
     private static string GetDisplayLabel(RepoRef repo)


### PR DESCRIPTION
## Summary
- Switches the PR rule selector inside `ProjectRepoPickerView` to the `Toggle` variant so it renders as a visible segmented pill instead of a single trigger that blended into the row's muted background.
- No change to the repo URL text input or any other field in the Edit Project dialog.

## Why
The selector sits inside a row wrapped in `Background(Colors.Muted)`. The default `Select` variant's trigger uses muted styling too, which on top of a muted row read as "disabled" even though the control was fully interactive. Toggle renders both options as buttons, so the state is unambiguous and the disabled-look is gone.

Closes #584.

## Test plan
- [ ] Open the Edit Project dialog on an existing project with one or more repositories
- [ ] Confirm the PR rule selector reads as a two-option segmented control (default / yolo), not a single trigger
- [ ] Toggle between the two values; verify the saved project picks up the change
- [ ] Same check in the onboarding repo picker (shares this view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)