### PR TITLE
[00054] ShowFullPathInFileViewerSheet

### DIFF
--- a/src/Ivy.Tendril/Helpers/FileLinkHelper.cs
+++ b/src/Ivy.Tendril/Helpers/FileLinkHelper.cs
@@ -69,13 +69,17 @@ public static class FileLinkHelper
             }
         }
 
+        var contentWithPath = Layout.Vertical().Gap(1);
+        contentWithPath |= Text.Block(filePath).Muted().Small();
+        contentWithPath |= sheetContent;
+
         var finalContent = File.Exists(filePath)
             ? new HeaderLayout(
                 new Button($"Open in {config.Editor.Label}").Icon(Icons.ExternalLink).Outline().OnClick(() =>
                 {
                     config.OpenInEditor(filePath);
                 }),
-                sheetContent
+                contentWithPath
             )
             : sheetContent;
 


### PR DESCRIPTION
# Summary

## Changes

Modified the file viewer sheet to display the full file path above the content. When users click a file link in the Plans view, they now see the complete path in small, muted text before the file content.

## API Changes

- Modified `FileLinkHelper.BuildFileLinkSheet()` — now creates a vertical layout with the file path displayed above the content

## Files Modified

- `src/Ivy.Tendril/Helpers/FileLinkHelper.cs` — added Layout.Vertical() with Text.Block for path display

---

## Commits

- 6d4db37 [00054] Show full file path in file viewer sheet