### PR TITLE
[Setup]: move user profile from sidebar footer to Settings

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -93,8 +93,6 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var selectedIndex = UseState<int?>();
         var appRepository = UseService<IAppRepository>();
         var client = UseService<IClientProvider>();
-        Context.TryUseService<IAuthService>(out var auth);
-        var user = UseState<UserInfo?>();
         var currentApp = UseState<AppHost?>();
         var countsService = UseService<IPlanCountsService>();
         var menuItems = UseState(() => BuildMenuItems(appRepository, countsService.Current));
@@ -136,12 +134,6 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         UseEffect(async () =>
         {
             if (config.NeedsOnboarding) return;
-
-            if (auth != null)
-            {
-                var userInfo = await auth.GetUserInfoAsync();
-                user.Set(userInfo);
-            }
 
             var initialAppId = args.NavigationAppId ?? settings.DefaultAppId;
             var targetAppId = initialAppId;
@@ -420,25 +412,6 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 .OnSelect(() => importIssuesDialogOpen.Set(true))
         };
 
-        void OnLogout()
-        {
-            _ = LogoutAsync();
-        }
-
-        async Task LogoutAsync()
-        {
-            if (auth == null) return;
-
-            try
-            {
-                await auth.LogoutAsync();
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Logout failed");
-            }
-        }
-
         var settingsTrigger = new Button("Settings")
             .Content(
                 Layout.Horizontal().AlignContent(Align.Left)
@@ -453,36 +426,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             .Top()
             .Items(settings.FooterMenuItemsTransformer(settingsMenuItems, navigator));
 
-        object? footer;
-        if (user.Value != null)
-        {
-            var profileTrigger = new Button().Variant(ButtonVariant.Ghost)
-                .Content(
-                    Layout.Horizontal().AlignContent(Align.Left).Width(Size.Full())
-                    | new Avatar(user.Value.Initials, user.Value.AvatarUrl)
-                    | (Layout.Vertical().Gap(1)
-                       | (user.Value.FullName != null
-                           ? Text.Muted(user.Value.FullName!).Overflow(Overflow.Ellipsis)
-                           : null!)
-                       | Text.Label(user.Value.Email).Overflow(Overflow.Ellipsis))
-                    .Grow()
-                    .Size(Size.Full().Min(0))
-                ).Width(Size.Full());
-
-            var profileMenu = new DropDownMenu(
-                    DropDownMenu.DefaultSelectHandler(),
-                    profileTrigger)
-                .Top()
-                .Items(settings.FooterMenuItemsTransformer(
-                    [MenuItem.Default("Logout").Tag("$logout").Icon(Icons.LogOut).OnSelect(OnLogout)],
-                    navigator));
-
-            footer = Layout.Vertical().Gap(1) | settingsMenu | profileMenu;
-        }
-        else
-        {
-            footer = settingsMenu;
-        }
+        object? footer = settingsMenu;
 
         if (config.ParseError != null)
             return new ConfigErrorApp(config);

--- a/src/Ivy.Tendril/Apps/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/SettingsApp.cs
@@ -18,6 +18,7 @@ public class SettingsApp : ViewBase
     private const string TagAdvanced = "advanced";
     private const string TagTheme = "theme";
     private const string TagOpenConfig = "open-config";
+    private const string TagAccount = "account";
 
     public override object Build()
     {
@@ -48,6 +49,12 @@ public class SettingsApp : ViewBase
                 .Children(
                     MenuItem.Default("Theme", TagTheme).Icon(Icons.SunMoon),
                     MenuItem.Default("Open config.yaml", TagOpenConfig).Icon(Icons.FileText)
+                ),
+            MenuItem.Default("Account")
+                .Icon(Icons.User)
+                .Expanded()
+                .Children(
+                    MenuItem.Default("Profile", TagAccount).Icon(Icons.CircleUser)
                 )
         };
 
@@ -77,6 +84,7 @@ public class SettingsApp : ViewBase
             TagProjects => new ProjectsSetupView(),
             TagAdvanced => new AdvancedSetupView(),
             TagTheme => new ThemeSettingsView(),
+            TagAccount => new AccountSetupView(),
             _ => new GeneralSetupView()
         };
 

--- a/src/Ivy.Tendril/Apps/Setup/AccountSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/AccountSetupView.cs
@@ -1,0 +1,57 @@
+using Ivy.Desktop;
+
+namespace Ivy.Tendril.Apps.Setup;
+
+public class AccountSetupView : ViewBase
+{
+    public override object Build()
+    {
+        // Hooks first, then Context.TryUseService, then UseEffect — matches analyzer rules
+        var client = UseService<IClientProvider>();
+        var user = UseState<UserInfo?>();
+        Context.TryUseService<IAuthService>(out var auth);
+
+        UseEffect(async () =>
+        {
+            if (auth != null)
+                user.Set(await auth.GetUserInfoAsync());
+        });
+
+        async Task OnLogout()
+        {
+            if (auth == null) return;
+            try { await auth.LogoutAsync(); }
+            catch { /* ignore */ }
+        }
+
+        var form = Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(120)))
+                   | Text.Block("Account").Bold()
+                   | Text.Block("Your account details.").Muted().Small();
+
+        if (user.Value != null)
+        {
+            form |= Layout.Horizontal().Gap(3).AlignContent(Align.Center)
+                    | new Avatar(user.Value.Initials, user.Value.AvatarUrl)
+                    | (Layout.Vertical().Gap(1)
+                       | (user.Value.FullName != null ? (object)Text.Block(user.Value.FullName!) : null!)
+                       | Text.Muted(user.Value.Email));
+
+            form |= new Separator();
+
+            form |= new Button("Logout")
+                .Secondary()
+                .Icon(Icons.LogOut)
+                .OnClick(async () => await OnLogout());
+        }
+        else if (auth == null)
+        {
+            form |= Text.Muted("Authentication is not configured.");
+        }
+        else
+        {
+            form |= Text.Muted("Loading…");
+        }
+
+        return form;
+    }
+}


### PR DESCRIPTION
Moves the user profile widget (avatar + username) out of the sidebar footer and into a dedicated **Settings → Account → Profile** page.

### Why

The sidebar footer was getting crowded. The profile is more at home in Settings, where other app-wide configuration lives.

### Changes

- **`TendrilAppShell.cs`** — removed profile dropdown, `user` state, auth loading, and logout logic from the app shell
- **`SettingsApp.cs`** — added "Account" section with a "Profile" menu item
- **`AccountSetupView.cs`** — new view: shows avatar, name, email, user ID (with graceful fallbacks) and a "Sign out" button; handles unauthenticated state 

<img width="1333" height="843" alt="Знімок екрана 2026-05-13 о 02 17 40" src="https://github.com/user-attachments/assets/28386da7-1cb5-48e3-8e4a-ca8d96cd181e" />
