### PR TITLE
[00243] Move add button below repo input

### DIFF
--- a/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
@@ -86,20 +86,18 @@ public class ProjectRepoPickerView(
                                      var picked = desktop!.ShowSelectFolderDialog("Select repository folder");
                                      if (picked != null && picked.Length > 0 && !string.IsNullOrEmpty(picked[0]))
                                          inputValue.Set(picked[0]);
-                                 })
-                             | new Button(isAdding.Value ? "Adding..." : "Add").Icon(Icons.Plus)
-                                 .Disabled(string.IsNullOrWhiteSpace(inputValue.Value) || isAdding.Value)
-                                 .OnClick(() => { _ = AddAsync(); });
+                                 });
         }
         else
         {
             pickerControls = Layout.Horizontal().Gap(2).Width(Size.Full())
                              | inputValue.ToTextInput("Repository URL or local path")
-                                 .Width(Size.Grow())
-                             | new Button(isAdding.Value ? "Adding..." : "Add").Icon(Icons.Plus)
-                                 .Disabled(string.IsNullOrWhiteSpace(inputValue.Value) || isAdding.Value)
-                                 .OnClick(() => { _ = AddAsync(); });
+                                 .Width(Size.Grow());
         }
+
+        var addButton = new Button(isAdding.Value ? "Adding..." : "Add").Icon(Icons.Plus)
+            .Disabled(string.IsNullOrWhiteSpace(inputValue.Value) || isAdding.Value)
+            .OnClick(() => { _ = AddAsync(); });
 
         var listLayout = Layout.Vertical().Gap(2);
         var current = repos.Value;
@@ -148,6 +146,7 @@ public class ProjectRepoPickerView(
                | Text.Muted("Add repositories to this project (optional).")
                | (addingError.Value != null ? Text.Danger(addingError.Value) : null!)
                | pickerControls
+               | addButton
                | (current.Count > 0 ? new Separator() : null!)
                | (current.Count > 0 ? listLayout : null!);
     }


### PR DESCRIPTION
Fixes #625

## Summary

Moved the "Add" button from inline (horizontal) position next to the text input/Browse button to a separate row below the input controls in `ProjectRepoPickerView`. The button is now left-aligned below the input row in the vertical layout, affecting both the onboarding project setup step and the settings Edit Project dialog.

## Files Modified

- **src/Ivy.Tendril/Views/ProjectRepoPickerView.cs** — Extracted Add button from both desktop and non-desktop horizontal layouts into a standalone `addButton` variable, inserted it in the vertical return layout between `pickerControls` and the separator.

---

Commits: 70624d1