### PR TITLE
[00244] Add animated status label to Last Output cell in JobsApp

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -37,6 +37,14 @@ public partial class JobsApp
             .Header(t => t.Cost, "Cost")
             .Header(t => t.Tokens, "Tokens")
             .Header(t => t.LastOutput, "Last Output")
+            .Renderer(t => t.LastOutput, new LabelsDisplayRenderer
+            {
+                BadgeColorMapping = new Dictionary<string, string>
+                {
+                    ["Done"] = Colors.Green.ToString(),
+                    ["Starting..."] = Colors.Amber.ToString()
+                }
+            })
             .Header(t => t.StatusMessage, "Status")
             .Width(t => t.Status, Size.Px(100))
             .Width(t => t.PlanId, Size.Px(100))

--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -37,14 +37,7 @@ public partial class JobsApp
             .Header(t => t.Cost, "Cost")
             .Header(t => t.Tokens, "Tokens")
             .Header(t => t.LastOutput, "Last Output")
-            .Renderer(t => t.LastOutput, new LabelsDisplayRenderer
-            {
-                BadgeColorMapping = new Dictionary<string, string>
-                {
-                    ["Done"] = Colors.Green.ToString(),
-                    ["Starting..."] = Colors.Amber.ToString()
-                }
-            })
+            .Renderer(t => t.LastOutput, new AnimatedStatusLabelDisplayRenderer())
             .Header(t => t.StatusMessage, "Status")
             .Width(t => t.Status, Size.Px(100))
             .Width(t => t.PlanId, Size.Px(100))

--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -171,7 +171,7 @@ public partial class JobsApp
 
                 if (job != null)
                 {
-                  
+
                     if (tag == "stop-job")
                     {
                         if (job.Status is JobStatus.Running or JobStatus.Queued)

--- a/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
@@ -40,6 +40,8 @@ public partial class JobsApp
     {
         if (job.Status == JobStatus.Running)
         {
+            if (!string.IsNullOrEmpty(job.StatusMessage))
+                return job.StatusMessage;
             if (job.LastOutputAt.HasValue)
             {
                 var elapsed = DateTime.UtcNow - job.LastOutputAt.Value;
@@ -47,6 +49,9 @@ public partial class JobsApp
             }
             return "Starting...";
         }
+
+        if (job.Status == JobStatus.Completed)
+            return "Done";
 
         return "-";
     }

--- a/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
@@ -41,19 +41,19 @@ public partial class JobsApp
         if (job.Status == JobStatus.Running)
         {
             if (!string.IsNullOrEmpty(job.StatusMessage))
-                return job.StatusMessage;
+                return AnimatedStatusValue.Running(job.StatusMessage);
             if (job.LastOutputAt.HasValue)
             {
                 var elapsed = DateTime.UtcNow - job.LastOutputAt.Value;
-                return FormatTimeSpan(elapsed);
+                return AnimatedStatusValue.Running(FormatTimeSpan(elapsed));
             }
-            return "Starting...";
+            return AnimatedStatusValue.Running("Starting...");
         }
 
         if (job.Status == JobStatus.Completed)
-            return "Done";
+            return AnimatedStatusValue.Done("Done");
 
-        return "-";
+        return AnimatedStatusValue.Idle("-");
     }
 
     private static string FormatTimer(JobItem job)


### PR DESCRIPTION
Fixes #627

## Changes

The Last Output cell now renders a real animated status label: a spinner + shimmering status text while the job runs, and a check + static text when the job completes. Implemented as a new reusable DataTable cell renderer in Ivy-Framework so other tables can adopt the same pattern.

- **`src/Ivy.Tendril/Apps/JobsApp.DataTable.cs`** — switched the `LastOutput` column renderer from `LabelsDisplayRenderer` to `AnimatedStatusLabelDisplayRenderer`.
- **`src/Ivy.Tendril/Apps/JobsApp.Helpers.cs`** — `FormatLastOutput` now returns values via `AnimatedStatusValue.Running(...)` / `.Done(...)` / `.Idle(...)` so the cell renderer knows which animation state to draw.

## Dependency

Requires the new symbols `AnimatedStatusLabelDisplayRenderer` and `AnimatedStatusValue` from Ivy-Framework (added on `development`). The local checkout builds via `ProjectReference`. CI here builds against the `Ivy` NuGet package — a version bump in `Directory.Packages.props` will be needed once a new Ivy package is published.

## API Changes

None on the Tendril side. Ivy-Framework adds `ColType.AnimatedStatus`, `AnimatedStatusLabelDisplayRenderer`, and `AnimatedStatusValue` (all additive).

## Why the previous approach didn't work

The earlier commit applied `LabelsDisplayRenderer` to a literal-string column, which only colored two known strings ("Done", "Starting...") and showed the raw timer/status text otherwise. The DataTable cells are rendered into a canvas by `@glideapps/glide-data-grid`, so the existing React `AnimatedStatusLabel` widget cannot be mounted inside a cell. The new framework renderer is a canvas-side equivalent that produces the same look efficiently for any row count.