### PR TITLE
Inject project context via FirmwareCompiler, remove config.yaml reads from promptwares

### DIFF
--- a/.claude/skills/tendril-review/SKILL.md
+++ b/.claude/skills/tendril-review/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: tendril-review
+description: Comprehensive post-change review of all modified files. Checks for code smells, cleanup opportunities, unnecessary legacy support, missing tests, broken tests, and obsolete tests. Use after a big change to leave the codebase in better health.
+---
+
+# tendril-review
+
+Perform a thorough review of all changes in the current working tree (or a specified branch/PR). The goal is to leave every touched file in better code health than before.
+
+## Invocation
+
+```
+/tendril-review
+```
+
+No arguments required — operates on the current git diff against the base branch.
+
+## What This Skill Does
+
+1. Identifies ALL changed files (staged, unstaged, and committed on branch)
+2. Reviews each file for code smells, cleanup opportunities, and quality issues
+3. Flags unnecessary legacy/backwards-compatibility code (asks before removing)
+4. Checks test coverage — missing tests, broken tests, obsolete tests
+5. Runs the test suite and reports failures
+6. Produces actionable recommendations
+
+## Execution Steps
+
+### Phase 1 — Scope the Changes
+
+1. Run `git diff --name-only` against the base branch to get all changed files
+2. Run `git status` to capture any uncommitted changes
+3. Categorize files: source code, tests, config, promptware, other
+4. Flag any files that seem unrelated to the main change — **ask the user** if there's confusion about why they changed
+
+### Phase 2 — Code Quality Review
+
+For each changed source file:
+
+1. Read the full file content
+2. Check for:
+   - Dead code or unused imports
+   - Code duplication
+   - Overly complex methods (consider cyclomatic complexity)
+   - Poor naming or unclear intent
+   - Missing error handling at system boundaries
+   - Inconsistent patterns vs. the rest of the codebase
+   - Unnecessary abstractions or over-engineering
+   - Legacy/backwards-compatibility code that may no longer be needed
+
+3. Use `mcp__codescene__code_health_review` on each changed source file to get an objective code health assessment
+
+**Important:** For any legacy support or backwards-compatibility code identified for removal — **ASK the user before removing**. Do not auto-delete.
+
+### Phase 3 — Test Review
+
+1. Identify tests related to changed code
+2. Run the full test suite: `dotnet test` (or appropriate command)
+3. Report:
+   - **Failing tests** — investigate root cause
+   - **Missing tests** — suggest what should be covered
+   - **Obsolete tests** — tests that exercise removed/changed behavior and are no longer relevant
+4. For obsolete tests — **ASK the user** before suggesting removal
+
+### Phase 4 — Summary Report
+
+Produce a structured report:
+
+```
+## Review Summary
+
+### Changes Reviewed
+- List of all files reviewed, grouped by category
+
+### Issues Found
+- [ ] Issue 1 — severity, file, description
+- [ ] Issue 2 — ...
+
+### Cleanup Opportunities
+- [ ] Opportunity 1 — what and why
+
+### Legacy Code Questions
+- [ ] "This code appears to exist for backwards compat with X — still needed?"
+
+### Test Status
+- Passing: N
+- Failing: N (with details)
+- Missing coverage: list
+- Potentially obsolete: list
+
+### Recommendations
+Prioritized list of actions to take
+```
+
+## Principles
+
+- **Leave it better than you found it** — every touched file should improve in code health
+- **Ask, don't assume** — when in doubt about whether something is still needed, ask
+- **Unrelated changes are normal** — the user may have made parallel manual edits; clarify rather than flag as errors
+- **Be thorough** — this is a big change review, not a quick scan

--- a/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
@@ -190,4 +190,78 @@ public class FirmwareCompilerTests : IDisposable
         Assert.EndsWith("00002.md", second);
         Assert.NotEqual(first, second);
     }
+
+    // --- Projects Section ---
+
+    [Fact]
+    public void Compile_RendersProjectsSection()
+    {
+        var projects = new[]
+        {
+            new ProjectInfo("MyProject", "A test project",
+                new List<ProjectRepoInfo> { new("D:\\Repos\\my-app", "org/my-app") },
+                new List<ProjectVerificationInfo> { new("Build", true, false), new("Lint", false, true) })
+        };
+
+        var context = new FirmwareContext("/programs/Test", new Dictionary<string, string>(), Projects: projects);
+        var result = FirmwareCompiler.Compile(context);
+
+        Assert.Contains("## Projects", result);
+        Assert.Contains("### MyProject", result);
+        Assert.Contains("A test project", result);
+        Assert.Contains("org/my-app", result);
+        Assert.Contains("Build (required)", result);
+        Assert.Contains("Lint (optional, delegated)", result);
+    }
+
+    [Fact]
+    public void Compile_RendersMultipleProjects()
+    {
+        var projects = new[]
+        {
+            new ProjectInfo("Alpha", "", new List<ProjectRepoInfo>(), new List<ProjectVerificationInfo>()),
+            new ProjectInfo("Beta", "Beta context", new List<ProjectRepoInfo>(), new List<ProjectVerificationInfo>())
+        };
+
+        var context = new FirmwareContext("/programs/Test", new Dictionary<string, string>(), Projects: projects);
+        var result = FirmwareCompiler.Compile(context);
+
+        Assert.Contains("### Alpha", result);
+        Assert.Contains("### Beta", result);
+        Assert.Contains("Beta context", result);
+    }
+
+    [Fact]
+    public void Compile_OmitsProjectsSection_WhenNull()
+    {
+        var context = new FirmwareContext("/programs/Test", new Dictionary<string, string>());
+        var result = FirmwareCompiler.Compile(context);
+
+        Assert.DoesNotContain("## Projects", result);
+    }
+
+    [Fact]
+    public void Compile_OmitsProjectsSection_WhenEmpty()
+    {
+        var context = new FirmwareContext("/programs/Test", new Dictionary<string, string>(), Projects: Array.Empty<ProjectInfo>());
+        var result = FirmwareCompiler.Compile(context);
+
+        Assert.DoesNotContain("## Projects", result);
+    }
+
+    [Fact]
+    public void Compile_ProjectsSectionAppearsBeforeReferenceDocuments()
+    {
+        var projects = new[]
+        {
+            new ProjectInfo("TestProj", "ctx", new List<ProjectRepoInfo>(), new List<ProjectVerificationInfo>())
+        };
+
+        var context = new FirmwareContext("/programs/Test", new Dictionary<string, string>(), Projects: projects);
+        var result = FirmwareCompiler.Compile(context);
+
+        var projectsIdx = result.IndexOf("## Projects");
+        var referenceIdx = result.IndexOf("## Reference Documents");
+        Assert.True(projectsIdx < referenceIdx);
+    }
 }

--- a/src/Ivy.Tendril.Test/VerificationCommandTests.cs
+++ b/src/Ivy.Tendril.Test/VerificationCommandTests.cs
@@ -125,6 +125,37 @@ verifications: []
         Assert.Equal("New prompt", reloaded.Settings.Verifications[0].Prompt);
     }
 
+    // --- Get Verification Definition ---
+
+    [Fact]
+    public void GetVerification_FindsByName_CaseInsensitive()
+    {
+        var config = CreateConfig();
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "Build", Prompt = "dotnet build --warnaserror" });
+        config.SaveSettings();
+
+        var reloaded = CreateConfig();
+        var match = reloaded.Settings.Verifications
+            .FirstOrDefault(v => v.Name.Equals("build", StringComparison.OrdinalIgnoreCase));
+
+        Assert.NotNull(match);
+        Assert.Equal("dotnet build --warnaserror", match.Prompt);
+    }
+
+    [Fact]
+    public void GetVerification_ReturnsNull_WhenNotFound()
+    {
+        var config = CreateConfig();
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "Build", Prompt = "x" });
+        config.SaveSettings();
+
+        var reloaded = CreateConfig();
+        var match = reloaded.Settings.Verifications
+            .FirstOrDefault(v => v.Name.Equals("NonExistent", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Null(match);
+    }
+
     // --- Roundtrip ---
 
     [Fact]

--- a/src/Ivy.Tendril/Commands/VerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/VerificationCommand.cs
@@ -26,6 +26,13 @@ public class VerificationRemoveSettings : CommandSettings
     public string Name { get; set; } = "";
 }
 
+public class VerificationGetSettings : CommandSettings
+{
+    [Description("Verification name")]
+    [CommandArgument(0, "<name>")]
+    public string Name { get; set; } = "";
+}
+
 public class VerificationSetSettings : CommandSettings
 {
     [Description("Verification name")]
@@ -76,6 +83,37 @@ public class VerificationListCommand : Command<VerificationListSettings>
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to list verification definitions");
+            return 1;
+        }
+    }
+}
+
+public class VerificationGetCommand : Command<VerificationGetSettings>
+{
+    private readonly ILogger<VerificationGetCommand> _logger;
+
+    public VerificationGetCommand(ILogger<VerificationGetCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, VerificationGetSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = new ConfigService();
+            var match = config.Settings.Verifications
+                .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+
+            if (match == null)
+            {
+                _logger.LogError("Verification not found: {Name}", settings.Name);
+                return 1;
+            }
+
+            Console.Write(match.Prompt);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get verification definition");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -358,6 +358,8 @@ public class Program
             {
                 verification.AddCommand<VerificationListCommand>("list")
                     .WithDescription("List global verification definitions");
+                verification.AddCommand<VerificationGetCommand>("get")
+                    .WithDescription("Get the full prompt for a verification definition");
                 verification.AddCommand<VerificationAddCommand>("add")
                     .WithDescription("Add a verification definition");
                 verification.AddCommand<VerificationRemoveCommand>("remove")

--- a/src/Ivy.Tendril/Promptwares/AGENTS.md
+++ b/src/Ivy.Tendril/Promptwares/AGENTS.md
@@ -4,10 +4,10 @@ Shipped promptwares are used by all Tendril customers across different teams, te
 
 ## Rules
 
-- **Stack-agnostic.** Never assume a specific language, framework, or package manager. Use config.yaml verifications and project context instead of hard-coded commands. When examples are needed, show multiple stacks as comments (e.g. `.NET`, `JavaScript`, `Python`, `Go`).
+- **Stack-agnostic.** Never assume a specific language, framework, or package manager. Use project verifications and context (from the **Projects** firmware section) instead of hard-coded commands. When examples are needed, show multiple stacks as comments (e.g. `.NET`, `JavaScript`, `Python`, `Go`).
 - **Platform-agnostic.** No Windows-only or Unix-only commands, paths, or assumptions. Write shell examples in portable bash. Say "local filesystem path" not "Windows path". Do not reference platform-specific tools (`subst`, `powershell.exe`, etc.).
 - **Agent-agnostic.** Do not reference any specific AI coding agent, its tools, or its capabilities (e.g. "Edit tool", "Grep tool", "Read tool"). Use generic verbs: "edit the file", "search for", "read the file".
 - **Project-agnostic.** No references to internal projects, private packages, internal URLs, proprietary class names, or customer-specific infrastructure. Examples should use generic names (`my-project`, `auth_service`, `user_controller`).
 - **CLI over scripts.** Prefer `tendril` CLI commands over PowerShell/Bash scripts in Tools/. The agent's base permissions include `Bash(tendril*)`, making CLI commands always accessible.
-- **Config over convention.** Anything that varies between customers belongs in config.yaml or the firmware header, not in Program.md. If you find yourself writing "if using X, do Y" for a customer-specific X, it should be a config option instead.
+- **Config over convention.** Anything that varies between customers belongs in configuration (injected via the firmware header or **Projects** section), not in Program.md. If you find yourself writing "if using X, do Y" for a customer-specific X, it should be a config option instead.
 - **Keep it concise.** The limiting factor is a human reading the plan. Every sentence must earn its place.

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -1,6 +1,6 @@
 # CreatePlan
 
-**Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined in `config.yaml` under `verifications`. Examples in this document use multiple tech stacks for illustration.
+**Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined as verifications in the project configuration. Examples in this document use multiple tech stacks for illustration.
 
 **🚫 FORBIDDEN: Do NOT modify, create, or delete any source code files. Do NOT implement the plan. You are a PLANNER, not an executor. Your ONLY output is plan files (plan.yaml, revisions/*.md) inside TendrilPlansFolder. If you catch yourself writing code to a repo, STOP IMMEDIATELY.**
 
@@ -16,11 +16,10 @@ The firmware header contains these key values:
 - **Force** (optional) — if `true`, skip duplicate detection entirely (see Step 3)
 - **SourcePath** (optional) — absolute path to the source that generated this plan (e.g. test working directory)
 - **TendrilJobId** — your job ID for status reporting (use this literal value in `tendril job status` commands)
-- **TendrilConfigPath** — absolute path to config.yaml (use `Read` tool directly on this path)
 - **TendrilHome** — the Tendril home directory (use for Trash path: `<TendrilHome>/Trash/`)
 
 The plan folder structure and CLI commands are in the **Reference Documents** section of your firmware.
-Project configuration is available from `config.yaml` — read it using the `Read` tool at the `TendrilConfigPath` path from the firmware header.
+Project information (repos, verifications, context) is in the **Projects** section of your firmware.
 
 ## Execution Steps
 
@@ -32,15 +31,15 @@ Args contains the user's task description. If it references related plans with `
 
 **Format screenshot paths**: If the description contains file paths to images (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`), include them in the plan revision as markdown images using `file:///` URLs. Convert backslashes to forward slashes. Example: a path like `D:\Screenshots\2026-05-07_17-16.png` in the description becomes `![screenshot](file:///D:/Screenshots/2026-05-07_17-16.png)` in the revision.
 
-### 1.5. Load Project Context
+### 1.5. Select Project
 
-Read `config.yaml` to understand all available projects, their repos, and context.
+The **Projects** section of your firmware lists all available projects with their repos, verifications, and context.
 
 **If `TendrilProject` is set to a specific project name** (not `Auto`):
-- Find that project in `config.yaml` and use its repos and context to scope your research
+- Use that project's repos and context from the **Projects** section to scope your research
 
 **If `TendrilProject: Auto`**:
-- Analyze the task description to infer the correct project from `config.yaml`
+- Analyze the task description to infer the correct project from the **Projects** section
 - Match based on keywords, repo paths, or component names in the description
 - If no project matches, set `project: Auto` in plan.yaml and leave `repos: []` empty
 - Use the matched project's context to scope your research
@@ -119,7 +118,7 @@ Do NOT read or modify `.counter` directly. Plan IDs are allocated by the `tendri
   ```bash
   gh search issues "<keyword>" --repo <owner>/<repo> --json title,url,number,state
   ```
-  Derive the repo owner/name from the repos in `config.yaml`. If an issue already covers the task, reference it in the plan and avoid creating workaround plans.
+  Derive the repo owner/name from the **Projects** section repos. If an issue already covers the task, reference it in the plan and avoid creating workaround plans.
 
 ### 3.5. Validate Code State
 
@@ -183,7 +182,7 @@ Include optional flags as needed:
 - `--depends-on "<folder-name>"` — for blocking dependencies (see Section 4.4)
 - `--priority <number>` — if non-default priority
 
-Populate `--verification` flags from the project's `verifications` in config.yaml, all set to `Pending`.
+Populate `--verification` flags from the project's verifications in the **Projects** section, all set to `Pending`.
 
 #### 4.2. Write the revision
 
@@ -217,9 +216,9 @@ tendril plan add-related-plan <PlanId> "<folder-name>"
 tendril plan add-depends-on <PlanId> "<folder-name>"
 ```
 
-**Validate repo paths**: After determining the project and repos from config.yaml, verify each repo path exists locally:
+**Validate repo paths**: After determining the project and repos from the **Projects** section, verify each repo path exists locally:
 - For each repo in the plan's repos list, check `Test-Path <repo-path>`
-- If any repo path doesn't exist, fail with error: "Repository path does not exist: `<path>`. Check config.yaml project configuration."
+- If any repo path doesn't exist, fail with error: "Repository path does not exist: `<path>`. Check project configuration."
 - This prevents creating plans targeting non-existent repo paths
 
 **Rename/refactor plans (caller enumeration)**: When creating plans that rename functions, change method signatures, extract interfaces, or otherwise require updating callers:
@@ -320,7 +319,7 @@ Analyze the task complexity and choose an `executionProfile`. This is passed via
 - Simple changes (docs, typos, version bumps, log statements)
 - When in doubt, use balanced
 
-If you cannot determine complexity (e.g., task is too vague), omit `--execution-profile` — ExecutePlan will use the config.yaml default.
+If you cannot determine complexity (e.g., task is too vague), omit `--execution-profile` — ExecutePlan will use the configured default.
 
 ### 4.6. Questions Section
 
@@ -336,7 +335,7 @@ The `## Tests` section MUST include two parts:
    To determine scope:
    - Identify the modules/classes being modified
    - Search for existing test classes that cover those areas
-   - **Filters MUST target specific test classes, not broad namespaces/directories.** Use the project's test runner syntax from config.yaml verifications.
+   - **Filters MUST target specific test classes, not broad namespaces/directories.** Use the project's test runner syntax from its verifications (fetch full prompts with `tendril verification get <name>` if needed).
    - **Exclude E2E/integration test classes** unless the plan specifically changes E2E-level behavior. E2E tests are environment-dependent and should only run when explicitly needed.
    - If no existing tests cover the changed code, state: "No existing test coverage for this area."
    - If the change is so broad that all tests are genuinely needed, explicitly state: "Run all tests (broad cross-cutting change)." and justify why.
@@ -345,13 +344,13 @@ The `## Tests` section MUST include two parts:
 
 ### 5. Verification Checklist
 
-In the `## Verification` section of the plan revision, generate a checklist from the project's `verifications` in `config.yaml`.
+In the `## Verification` section of the plan revision, generate a checklist from the project's verifications in the **Projects** section.
 
 For each verification assigned to the project:
-- **Required** (`required: true`) → `- [x] VerificationName`
-- **Optional** (`required: false`) → `- [ ] VerificationName`
+- **Required** → `- [x] VerificationName`
+- **Optional** → `- [ ] VerificationName`
 
-Example (verification names come from config.yaml):
+Example:
 ```markdown
 ## Verification
 

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -1,6 +1,6 @@
 # CreatePr
 
-**Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined in `config.yaml` under `verifications`. Examples in this document use multiple tech stacks for illustration.
+**Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined as verifications in the project configuration. Examples in this document use multiple tech stacks for illustration.
 
 Create GitHub pull requests and apply PR rules.
 
@@ -16,7 +16,7 @@ The firmware header contains:
 The plan structure and CLI commands are in the **Reference Documents** section of your firmware.
 Project configuration (repos, `prRule` settings) is available from the firmware header.
 
-## PR Rules (from config.yaml per repo)
+## PR Rules (per repo, from RepoConfigs header)
 
 - **`default`** — Create the PR and stop
 - **`yolo`** — Create PR → auto-merge with `--admin` → delete remote branch → pull default branch into the original local repo
@@ -120,7 +120,7 @@ If no custom options or `comment` is empty, skip this step.
 
 ### 4. Apply PR Rule
 
-**!MANDATORY** — look up the `prRule` for this repo in config.yaml under the project's repos list.
+**!MANDATORY** — look up the `prRule` for this repo in the `RepoConfigs` firmware header.
 
 **Custom options override:** If custom options exist, the flags override the yolo behavior:
 - If `merge` is `false`: skip the entire merge step (treat as `default` rule regardless of prRule)
@@ -174,7 +174,7 @@ When the PR status is `CONFLICTING`, resolve the conflict locally before retryin
 
 6. **Quick build check** (if build-critical files were involved in conflicts):
    ```bash
-   # Run your project's build command from config.yaml verifications
+   # Fetch build command: tendril verification get Build
    ```
    If the build fails, fix the issue and amend the merge commit.
 

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -1,6 +1,6 @@
 # ExecutePlan
 
-**Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined in `config.yaml` under `verifications`. Examples in this document use multiple tech stacks for illustration.
+**Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined as verifications in the project configuration. Examples in this document use multiple tech stacks for illustration.
 
 Execute an approved plan in isolated git worktrees.
 
@@ -13,7 +13,7 @@ The firmware header contains:
 - **Note** (optional) — Additional instructions from the reviewer. If present, follow these instructions in addition to the plan.
 
 The plan structure and CLI commands are in the **Reference Documents** section of your firmware.
-Read the project configuration from `config.yaml` (use `Read` tool with the `TendrilConfigPath` from the firmware header) for project repos and context.
+Project repos, verifications, and context are in the **Projects** section of your firmware. Use `tendril verification get <name>` to fetch the full prompt for each verification at execution time.
 
 The launcher sets the working directory to the project's primary repo.
 
@@ -64,7 +64,7 @@ If `plan.yaml` has a `dependsOn` list, for each entry:
 Before creating worktrees, verify the execution environment is safe:
 
 1. **Check each repo is not itself a worktree** — If `<repo-path>/.git` is a file containing `gitdir:`, the repo is a worktree. Fail with error:
-   > ERROR: Repository at <repo-path> is itself a worktree. ExecutePlan cannot create worktrees inside worktrees. Update config.yaml to use the main repo path.
+   > ERROR: Repository at <repo-path> is itself a worktree. ExecutePlan cannot create worktrees inside worktrees. Update project configuration to use the main repo path.
 
 2. **Check Plans directory is not inside a worktree** — If `$TENDRIL_HOME` or its parent contains a worktree `.git` file, fail with error:
    > ERROR: TENDRIL_HOME is inside a git worktree. Move your Tendril installation or change the Plans directory.
@@ -77,7 +77,7 @@ cd <repo-path>
 if [ -f .git ] && grep -q "gitdir:" .git; then
     echo "ERROR: Repository at <repo-path> is itself a worktree."
     echo "ExecutePlan cannot create worktrees inside worktrees."
-    echo "Check that config.yaml repo paths point to main repositories, not worktrees."
+    echo "Check that project repo paths point to main repositories, not worktrees."
     exit 1
 fi
 
@@ -154,7 +154,7 @@ After reading the plan revision, scan it for code validation markers to detect s
 
 Before creating worktrees, check each repo for uncommitted changes and automatically commit them. This prevents silent data loss when worktrees are created from `origin/<default-branch>` and later merged back.
 
-For each repo listed in `plan.yaml` `repos` (or the project's repos from `config.yaml` if empty):
+For each repo listed in `plan.yaml` `repos` (or the project's repos from the **Projects** section if empty):
 
 ```bash
 cd <repo-path>
@@ -256,7 +256,7 @@ git worktree add "<TendrilPlanFolder>/worktrees/<RepoName>" -b "tendril/<Tendril
 
 **Important:** Always branch from `origin/<resolved-base-branch>`, not local HEAD. This ensures the PR only contains the plan's commits, not any unpushed local work. The `<resolved-base-branch>` comes from either the `RepoConfigs` firmware header (if `baseBranch` is configured) or auto-detection.
 
-**Note on `RepoConfigs`:** The firmware header may include a `RepoConfigs` value injected by Tendril. It contains per-repo configuration from `config.yaml`:
+**Note on `RepoConfigs`:** The firmware header may include a `RepoConfigs` value injected by Tendril. It contains per-repo configuration:
 ```yaml
 RepoConfigs: |
   - path: /home/user/repos/my-project
@@ -362,9 +362,9 @@ Work exclusively in the worktree directories. Follow the plan's latest revision:
 
 Make logically grouped commits in the worktree(s). Each commit should be a coherent unit of work.
 
-Before each commit, run formatting/linting as defined by the project's verifications in `config.yaml`. The exact commands depend on your stack's verification definitions.
+Before each commit, run formatting/linting as defined by the project's verifications. Fetch the full prompt for a verification with `tendril verification get <name>`.
 
-**Example patterns** (actual commands come from config.yaml verifications):
+**Example patterns** (actual commands come from verification prompts):
 
 ```bash
 # Get changed files from this execution's commits
@@ -447,15 +447,15 @@ Create a `verification/` directory in the plan folder if it doesn't exist.
 
 Check the `## Verification` section in the plan revision for checked items (`- [x]`). Skip unchecked items (`- [ ]`).
 
-**Delegated verifications:** Some verifications are implemented as separate promptwares (e.g., `IvyFrameworkVerification`). A verification is **delegated** if its name matches an entry in the `promptwares` section of `config.yaml`. Delegated verifications MUST be run via `tendril promptware run <Name>` — you are FORBIDDEN from writing their report files or setting their status to Pass yourself. If the `tendril` CLI is unavailable and you cannot invoke the sub-promptware, you MUST set the verification to `Fail` with a report explaining the CLI failure. Never self-certify a delegated verification.
+**Delegated verifications:** Some verifications are implemented as separate promptwares (e.g., `IvyFrameworkVerification`). The **Projects** section marks delegated verifications. Delegated verifications MUST be run via `tendril promptware run <Name>` — you are FORBIDDEN from writing their report files or setting their status to Pass yourself. If the `tendril` CLI is unavailable and you cannot invoke the sub-promptware, you MUST set the verification to `Fail` with a report explaining the CLI failure. Never self-certify a delegated verification.
 
-**IMPORTANT — delegated invocation syntax:** The `tendril promptware run` CLI takes the plan folder as a **positional argument** (NOT a named flag like `--plan-folder`). You MUST also pass `--value` flags for each required firmware value. The exact command is in the verification's `prompt` field in config.yaml — copy it character-for-character, only replacing angle-bracketed placeholders with actual paths. If the command is wrong, the child promptware receives no arguments and silently fails.
+**IMPORTANT — delegated invocation syntax:** The `tendril promptware run` CLI takes the plan folder as a **positional argument** (NOT a named flag like `--plan-folder`). You MUST also pass `--value` flags for each required firmware value. The exact command is in the verification's prompt (fetched via `tendril verification get <Name>`) — copy it character-for-character, only replacing angle-bracketed placeholders with actual paths. If the command is wrong, the child promptware receives no arguments and silently fails.
 
 For each checked verification:
 
 1. Send a status message: `tendril job status TendrilJobId --message "Verifying: <Name>"`
-2. Look up its `prompt` in the `verifications` list in `config.yaml`
-3. **Check if delegated:** If the verification name exists in config.yaml's `promptwares` section, it is a delegated verification — follow the prompt's instructions to invoke it as an external process. If the external process cannot be invoked (CLI broken, file lock, etc.), set the verification to `Fail` immediately. Do NOT attempt to do the verification inline or write the report yourself.
+2. Fetch its full prompt: `tendril verification get <Name>`
+3. **Check if delegated:** The **Projects** section indicates which verifications are delegated — follow the prompt's instructions to invoke it as an external process. If the external process cannot be invoked (CLI broken, file lock, etc.), set the verification to `Fail` immediately. Do NOT attempt to do the verification inline or write the report yourself.
 4. Execute the prompt in the worktree directory
 5. If it fails: diagnose, fix the issue, **commit the fix** (e.g. `[01105] Fix lint errors from Build`), and re-run. Repeat until it passes (fail the plan after 3+ failed attempts).
 6. Document all fix commits via CLI: `tendril plan add-commit <plan-id> <sha>`

--- a/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
@@ -58,7 +58,7 @@ Example:
 - Include exact file paths for changes
 - Specify concrete code modifications or additions
 - Maintain all original context and problem description
-- Preserve the plan template structure (from `planTemplate` in config.yaml)
+- Preserve the plan template structure
 
 ### Rules
 

--- a/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -48,7 +48,7 @@ Include optional flags as needed:
 - `--depends-on "<sibling-plan-folder>"` — only when a sibling plan has a true blocking dependency (see Section 3)
 - `--priority <number>` — if non-default priority
 
-Populate `--verification` flags from the project's verifications in config.yaml, all set to `Pending`.
+Populate `--verification` flags from the project's verifications in the **Projects** section, all set to `Pending`.
 
 Do NOT read or modify `.counter` directly — `tendril plan create` handles ID allocation.
 
@@ -65,7 +65,7 @@ The command reads from STDIN and auto-creates the next numbered revision file. F
 #### Project Assignment
 
 Each new plan may belong to a different project than the original. For each split plan:
-- Analyze which project(s) from `config.yaml` are relevant based on the files/repos involved
+- Analyze which project(s) from the **Projects** section are relevant based on the files/repos involved
 - Use the matching project's repos and verifications in the `tendril plan create` command
 - If a sub-plan spans multiple projects, prefer the primary project (where most changes occur)
 

--- a/src/Ivy.Tendril/Services/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/FirmwareCompiler.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text;
 
 namespace Ivy.Tendril.Services;
 
@@ -87,6 +88,12 @@ public static class FirmwareCompiler
             firmware += File.ReadAllText(programFile) + "\n";
         }
 
+        if (context.Projects is { Length: > 0 })
+        {
+            firmware += "\n\n## Projects\n\n";
+            firmware += RenderProjects(context.Projects);
+        }
+
         var plansContent = PlansReference.Value;
         if (plansContent != null)
         {
@@ -102,6 +109,45 @@ public static class FirmwareCompiler
         }
 
         return firmware;
+    }
+
+    private static string RenderProjects(ProjectInfo[] projects)
+    {
+        var sb = new StringBuilder();
+
+        foreach (var project in projects)
+        {
+            sb.AppendLine($"### {project.Name}");
+            sb.AppendLine();
+
+            if (!string.IsNullOrWhiteSpace(project.Context))
+            {
+                sb.AppendLine(project.Context);
+                sb.AppendLine();
+            }
+
+            if (project.Repos.Count > 0)
+            {
+                sb.AppendLine("**Repos:**");
+                foreach (var repo in project.Repos)
+                    sb.AppendLine($"- {repo.OwnerName} (`{repo.Path}`)");
+                sb.AppendLine();
+            }
+
+            if (project.Verifications.Count > 0)
+            {
+                sb.AppendLine("**Verifications:**");
+                foreach (var v in project.Verifications)
+                {
+                    var flag = v.Required ? "required" : "optional";
+                    if (v.Delegated) flag += ", delegated";
+                    sb.AppendLine($"- {v.Name} ({flag})");
+                }
+                sb.AppendLine();
+            }
+        }
+
+        return sb.ToString();
     }
 
     private static readonly HashSet<string> PathKeys = new(StringComparer.OrdinalIgnoreCase)
@@ -168,4 +214,20 @@ public static class FirmwareCompiler
 public record FirmwareContext(
     string ProgramFolder,
     Dictionary<string, string> Values,
-    string? CustomInstructions = null);
+    string? CustomInstructions = null,
+    ProjectInfo[]? Projects = null);
+
+public record ProjectInfo(
+    string Name,
+    string Context,
+    List<ProjectRepoInfo> Repos,
+    List<ProjectVerificationInfo> Verifications);
+
+public record ProjectRepoInfo(
+    string Path,
+    string OwnerName);
+
+public record ProjectVerificationInfo(
+    string Name,
+    bool Required,
+    bool Delegated);

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -234,7 +234,8 @@ internal class JobLauncher
         job.LogFilePath = logFile;
 
         var customInstructions = ResolveCustomInstructions(job.Type);
-        var prompt = FirmwareCompiler.Compile(new FirmwareContext(programFolder, values, customInstructions));
+        var projects = BuildProjectInfos(job);
+        var prompt = FirmwareCompiler.Compile(new FirmwareContext(programFolder, values, customInstructions, projects));
         job.CompiledPrompt = prompt;
 
         var promptFilePath = WritePromptFileIfNeeded(resolution, prompt, job.Id, values);
@@ -303,9 +304,11 @@ internal class JobLauncher
         {
             ["AgentSessionId"] = job.SessionId ?? "",
             ["TendrilJobId"] = job.Id,
-            ["TendrilConfigPath"] = _configService!.ConfigPath,
             ["TendrilHome"] = _configService.TendrilHome ?? ""
         };
+
+        if (job.Type == Constants.JobTypes.UpdateProject)
+            values["TendrilConfigPath"] = _configService!.ConfigPath;
 
         if (job.TypedArgs is CreatePlanArgs)
         {
@@ -542,5 +545,55 @@ internal class JobLauncher
         }
 
         return "main";
+    }
+
+    private ProjectInfo[]? BuildProjectInfos(JobItem job)
+    {
+        if (_configService == null) return null;
+
+        var projectNames = ProjectHelper.ParseProjects(job.Project);
+
+        if (projectNames.Length == 0 || (projectNames.Length == 1 && projectNames[0].Equals("Auto", StringComparison.OrdinalIgnoreCase)))
+            return BuildAllProjectInfos();
+
+        var result = projectNames
+            .Select(BuildSingleProjectInfo)
+            .Where(p => p != null)
+            .Select(p => p!)
+            .ToArray();
+
+        return result.Length > 0 ? result : null;
+    }
+
+    private ProjectInfo[] BuildAllProjectInfos()
+    {
+        return _configService!.Projects
+            .Select(BuildProjectInfoFromConfig)
+            .ToArray();
+    }
+
+    private ProjectInfo? BuildSingleProjectInfo(string name)
+    {
+        var config = _configService!.GetProject(name);
+        return config == null ? null : BuildProjectInfoFromConfig(config);
+    }
+
+    private ProjectInfo BuildProjectInfoFromConfig(ProjectConfig config)
+    {
+        var repos = config.Repos.Select(r =>
+        {
+            var expanded = Environment.ExpandEnvironmentVariables(r.Path);
+            var repoName = Path.GetFileName(expanded);
+            var ownerDir = Path.GetFileName(Path.GetDirectoryName(expanded) ?? "");
+            return new ProjectRepoInfo(expanded, $"{ownerDir}/{repoName}");
+        }).ToList();
+
+        var verifications = config.Verifications.Select(v =>
+        {
+            var delegated = _configService!.Settings.Promptwares.ContainsKey(v.Name);
+            return new ProjectVerificationInfo(v.Name, v.Required, delegated);
+        }).ToList();
+
+        return new ProjectInfo(config.Name, config.Context, repos, verifications);
     }
 }


### PR DESCRIPTION
## Summary

- Add `ProjectInfo` records and render a `## Projects` section in compiled firmware with project name, context, repos, and verifications
- Add `tendril verification get <name>` CLI command to fetch full verification prompts at runtime
- JobLauncher resolves project(s) from comma-separated `job.Project` and injects `ProjectInfo[]` into `FirmwareContext`
- Remove `TendrilConfigPath` from firmware header for all non-UpdateProject jobs
- Update all Program.md files (CreatePlan, ExecutePlan, CreatePr, SplitPlan, ExpandPlan, AGENTS.md) to reference the firmware Projects section instead of reading config.yaml
- Add 7 new tests covering RenderProjects rendering, section ordering, and verification get logic

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 1415 tests pass
- [x] No config.yaml references remain in operational promptwares (verified via grep)