### PR TITLE
[00247] Put theme option back in settings dropdown

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -419,7 +419,16 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             MenuItem.Default("Import Issues from GitHub")
                 .Tag("$import-issues")
                 .Icon(Icons.Download)
-                .OnSelect(() => importIssuesDialogOpen.Set(true))
+                .OnSelect(() => importIssuesDialogOpen.Set(true)),
+            MenuItem.Default("Theme")
+                .Tag("$theme")
+                .Icon(Icons.SunMoon)
+                .Children(
+                    MenuItem.Checkbox("Light").Icon(Icons.Sun).OnSelect(() => client.SetThemeMode(ThemeMode.Light)),
+                    MenuItem.Checkbox("Dark").Icon(Icons.Moon).OnSelect(() => client.SetThemeMode(ThemeMode.Dark)),
+                    MenuItem.Checkbox("System").Icon(Icons.SunMoon)
+                        .OnSelect(() => client.SetThemeMode(ThemeMode.System))
+                )
         };
 
         void OnLogout()


### PR DESCRIPTION
## Summary

### Changes

Added a "Theme" menu item with Light/Dark/System checkbox children back to the footer Settings dropdown in `TendrilAppShell.cs`. This restores quick theme switching without navigating into the full Settings app.

### API Changes

None.

### Files Modified

- `src/Ivy.Tendril/AppShell/TendrilAppShell.cs` — Added Theme submenu to `settingsMenuItems` array

---

### Commits

- d1674f0 [00247] Add Theme submenu back to settings dropdown