### PR TITLE
[00253] Fix animated status label still spinning after stopping a job

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Data.cs
@@ -87,8 +87,6 @@ public partial class JobsApp
                 new DataTableCellUpdate(j.Id, "Cost", j.Cost.HasValue ? $"${j.Cost.Value:F2}" : ""),
                 new DataTableCellUpdate(j.Id, "Tokens", j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : ""),
                 new DataTableCellUpdate(j.Id, "LastOutput", FormatLastOutput(j)),
-                new DataTableCellUpdate(j.Id, "Status", FormatStatusBadge(j.Status)),
-                new DataTableCellUpdate(j.Id, "StatusMessage", GetStatusMessage(j))
             });
     }
 }


### PR DESCRIPTION
After stopping a running job in JobsApp, the Status badge continued to shimmer because stale streaming overrides persisted in the frontend's `useCellUpdates` ref, taking precedence over the refreshed base data.

**Fix:** Remove Status and StatusMessage from `BuildDataTableUpdates()` in `JobsApp.Data.cs`. These columns only change on state transitions which already trigger a table refresh — streaming them created stale overrides that delayed the visual update.

---

**Commits:**
- e282e32 — [00253] Remove Status and StatusMessage from DataTable stream updates