### PR TITLE
Add JobDebugSheet row action to JobsApp (debug mode only)

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
@@ -1,0 +1,167 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Agents;
+
+namespace Ivy.Tendril.Apps.Jobs;
+
+public class JobDebugSheet(
+    string jobId,
+    IJobService jobService,
+    IPlanReaderService planService,
+    IConfigService config) : ViewBase
+{
+    public override object Build()
+    {
+        var copyToClipboard = UseClipboard();
+        var client = UseService<IClientProvider>();
+
+        var job = jobService.GetJob(jobId);
+        if (job is null)
+            return Text.P("Job not found.");
+
+        var layout = Layout.Vertical().Gap(4).Padding(4);
+
+        layout |= BuildSection("Job Id", job.Id);
+        layout |= BuildSection("Prompt/Title", JobsApp.GetFullPrompt(job, planService));
+        layout |= BuildSection("Status", $"{job.Status}{(job.StatusMessage != null ? $" — {job.StatusMessage}" : "")}");
+        layout |= BuildSection("Type", job.Type);
+        layout |= BuildSection("Project", job.Project);
+        layout |= BuildSection("Provider", job.Provider);
+        layout |= BuildSection("Session Id", job.SessionId ?? "-");
+
+        if (job.StartedAt.HasValue)
+            layout |= BuildSection("Started", job.StartedAt.Value.ToString("u"));
+        if (job.CompletedAt.HasValue)
+            layout |= BuildSection("Completed", job.CompletedAt.Value.ToString("u"));
+        if (job.DurationSeconds.HasValue)
+            layout |= BuildSection("Duration", $"{job.DurationSeconds}s");
+        if (job.Cost.HasValue)
+            layout |= BuildSection("Cost", $"${job.Cost:F4}");
+        if (job.Tokens.HasValue)
+            layout |= BuildSection("Tokens", $"{job.Tokens:N0}");
+
+        layout |= BuildPermissionDenials(job);
+        layout |= BuildPathSection("Plan Folder", GetPlanFolderPath(job), copyToClipboard, client);
+        layout |= BuildPathSection("Plan Log", GetPlanLogPath(job), copyToClipboard, client);
+        layout |= BuildPromptwareLogPaths(job, copyToClipboard, client);
+
+        if (job.ExitCode.HasValue)
+            layout |= BuildSection("Exit Code", job.ExitCode.Value.ToString());
+
+        return layout;
+    }
+
+    private static object BuildSection(string label, string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return new Empty();
+
+        return Layout.Vertical().Gap(1)
+               | Text.Block(label).Bold()
+               | Text.Block(value).Muted();
+    }
+
+    private static object BuildPermissionDenials(JobItem job)
+    {
+        if (job.OutputLines.Count == 0)
+            return BuildSection("Permission Denials", "None");
+
+        try
+        {
+            var provider = AgentProviderFactory.GetProvider(job.Provider);
+            var denials = provider.ExtractPermissionDenials(job.OutputLines.ToArray());
+            if (denials.Count == 0)
+                return BuildSection("Permission Denials", "None");
+
+            var layout = Layout.Vertical().Gap(1);
+            layout |= Text.Block("Permission Denials").Bold();
+            foreach (var d in denials)
+            {
+                var detail = d.InputSummary != null
+                    ? $"{d.ToolName}({d.InputSummary})"
+                    : d.ToolName;
+                layout |= Text.Block($"  - {detail}").Muted();
+            }
+            return layout;
+        }
+        catch
+        {
+            return BuildSection("Permission Denials", "Error parsing denials");
+        }
+    }
+
+    private object BuildPathSection(string label, string? path, Action<string> copy, IClientProvider client)
+    {
+        if (string.IsNullOrEmpty(path)) return new Empty();
+
+        return Layout.Vertical().Gap(1)
+               | Text.Block(label).Bold()
+               | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                  | Text.Block(path).Muted()
+                  | new Button("Copy").Icon(Icons.ClipboardCopy).Ghost().OnClick(() =>
+                  {
+                      copy(path);
+                      client.Toast($"Copied to clipboard", label);
+                  }));
+    }
+
+    private object BuildPromptwareLogPaths(JobItem job, Action<string> copy, IClientProvider client)
+    {
+        var promptsRoot = PromptwareHelper.ResolvePromptsRoot(config.TendrilHome);
+        var programFolder = Path.Combine(promptsRoot, job.Type);
+        var logsFolder = Path.Combine(programFolder, "Logs");
+
+        if (!Directory.Exists(logsFolder))
+            return BuildSection("Promptware Logs", "No logs directory");
+
+        var logFile = job.LogFilePath;
+        if (string.IsNullOrEmpty(logFile))
+            return BuildSection("Promptware Logs", "No log file recorded");
+
+        var rawFile = Path.ChangeExtension(logFile, ".raw.jsonl");
+
+        var layout = Layout.Vertical().Gap(1);
+        layout |= Text.Block("Promptware Logs").Bold();
+
+        layout |= Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                   | Text.Block(logFile).Muted()
+                   | new Button("Copy").Icon(Icons.ClipboardCopy).Ghost().OnClick(() =>
+                   {
+                       copy(logFile);
+                       client.Toast("Copied to clipboard", "Log Path");
+                   });
+
+        layout |= Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                   | Text.Block(rawFile).Muted()
+                   | new Button("Copy").Icon(Icons.ClipboardCopy).Ghost().OnClick(() =>
+                   {
+                       copy(rawFile);
+                       client.Toast("Copied to clipboard", "Raw Log Path");
+                   });
+
+        return layout;
+    }
+
+    private string? GetPlanFolderPath(JobItem job)
+    {
+        if (string.IsNullOrEmpty(job.PlanFile)) return null;
+        var fullPath = Path.Combine(planService.PlansDirectory, job.PlanFile);
+        return Directory.Exists(fullPath) ? fullPath : job.TypedArgs?.PlanFolder;
+    }
+
+    private string? GetPlanLogPath(JobItem job)
+    {
+        var folder = GetPlanFolderPath(job);
+        if (string.IsNullOrEmpty(folder)) return null;
+
+        var logsDir = Path.Combine(folder, "logs");
+        if (!Directory.Exists(logsDir)) return null;
+
+        var latestLog = Directory.GetFiles(logsDir, "*.md")
+            .OrderByDescending(File.GetLastWriteTimeUtc)
+            .FirstOrDefault();
+
+        return latestLog;
+    }
+
+}

--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -17,6 +17,7 @@ public partial class JobsApp
         Action<string> showPlan,
         Action<string> showOutput,
         Action<string> showPrompt,
+        Action<string>? showDebug,
         List<JobItem> jobs,
         Dictionary<string, string> projectColors,
         StackedProgress jobsProgress)
@@ -150,6 +151,12 @@ public partial class JobsApp
                         .Tooltip("Rerun this job"));
                 }
 
+                if (showDebug != null)
+                {
+                    actions.Add(new MenuItem("Debug", Icon: Icons.Bug, Tag: "debug-job")
+                        .Tooltip("Show debug details for this job"));
+                }
+
                 actions.Add(new MenuItem("Delete", Icon: Icons.Trash, Tag: "delete-job")
                     .Tooltip("Delete this job"));
 
@@ -197,6 +204,10 @@ public partial class JobsApp
 
                             refreshToken.Refresh();
                         }
+                    }
+                    else if (tag == "debug-job")
+                    {
+                        showDebug?.Invoke(job.Id);
                     }
                     else if (tag == "delete-job")
                     {

--- a/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
@@ -8,7 +8,7 @@ public partial class JobsApp
 {
     private const int PromptDisplayMaxLength = 500;
 
-    private static string? GetFullPrompt(JobItem job, IPlanReaderService? planService = null)
+    internal static string? GetFullPrompt(JobItem job, IPlanReaderService? planService = null)
     {
         if (job.TypedArgs is CreatePlanArgs cp)
             return cp.Description;

--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -65,6 +65,19 @@ public partial class JobsApp : ViewBase
             ).Width(Size.Half()).Resizable();
         });
 
+#if DEBUG
+        var (debugSheet, showDebug) = UseTrigger<string>((isOpen, jobId) =>
+        {
+            if (!isOpen.Value) return null;
+            var debugSheetView = new JobDebugSheet(jobId, jobService, planService, config);
+            return new Sheet(
+                () => isOpen.Set(false),
+                debugSheetView.Build(),
+                "Job Debug"
+            ).Width(Size.Half()).Resizable();
+        });
+#endif
+
         UseInterval(() => StreamOutputLines(jobService, activeOutputJobId, streamingJobId, lastProcessedIndex, hasStreamContent, outputStream),
             TimeSpan.FromMilliseconds(100));
         UseEffect(() => NotificationHookDisposable(jobService, client));
@@ -80,11 +93,20 @@ public partial class JobsApp : ViewBase
         var rows = BuildJobRows(jobs, planService);
         var jobsProgress = BuildStatusProgress(jobs, config);
 
+#if DEBUG
         var dataTable = BuildDataTable(rows, refreshToken, updateStream, config, planService,
-            jobService, client, showPlan, showOutput, showPrompt, jobs, projectColors, jobsProgress);
+            jobService, client, showPlan, showOutput, showPrompt, showDebug, jobs, projectColors, jobsProgress);
+#else
+        var dataTable = BuildDataTable(rows, refreshToken, updateStream, config, planService,
+            jobService, client, showPlan, showOutput, showPrompt, null, jobs, projectColors, jobsProgress);
+#endif
 
         var layout = Layout.Vertical().Height(Size.Full());
 
+#if DEBUG
+        return layout | new Fragment(dataTable, planSheet, outputSheet, promptSheet, debugSheet);
+#else
         return layout | new Fragment(dataTable, planSheet, outputSheet, promptSheet);
+#endif
     }
 }


### PR DESCRIPTION
## Summary
- Adds a "Debug" row action (bug icon) to JobsApp, visible only in debug builds
- Opens a JobDebugSheet showing: job ID, full prompt/title, status with details, permission denials with full tool+input info, plan folder path, plan log path, and promptware log paths — all with copy-to-clipboard buttons
- Extracts `GetFullPrompt` to `internal static` to remove duplication between JobsApp.Helpers and the new sheet

## Test plan
- [x] Build succeeds with 0 warnings/errors
- [x] All 1415 unit tests pass
- [ ] Manual: run `dotnet run`, open Jobs, click Debug row action on a completed job, verify paths and copy buttons work