### PR TITLE
Fix: "Open config.yaml" not opening when editor path is invalid or when accessed remotely

### DIFF
--- a/src/Ivy.Tendril/Apps/ConfigErrorApp.cs
+++ b/src/Ivy.Tendril/Apps/ConfigErrorApp.cs
@@ -15,6 +15,7 @@ public class ConfigErrorApp(IConfigService config) : ViewBase
         var httpContextAccessor = UseService<IHttpContextAccessor>();
         Context.TryUseService<DesktopWindow>(out var desktopWindow);
         var isDesktopShell = desktopWindow != null;
+        var capturedHost = ConfigYamlUiHelper.CaptureHost(httpContextAccessor);
         var parseError = config.ParseError;
 
         if (parseError == null)
@@ -40,7 +41,7 @@ public class ConfigErrorApp(IConfigService config) : ViewBase
                    | new Button("Edit Config")
                        .Icon(Icons.FileText)
                        .OnClick(() =>
-                           ConfigYamlUiHelper.OpenOrNavigate(config, navigator, isDesktopShell, httpContextAccessor))
+                           ConfigYamlUiHelper.OpenOrNavigate(config, navigator, isDesktopShell, capturedHost))
                    | new Button("Reload Config")
                        .Icon(Icons.RefreshCw)
                        .Variant(ButtonVariant.Outline)

--- a/src/Ivy.Tendril/Apps/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/SettingsApp.cs
@@ -27,6 +27,7 @@ public class SettingsApp : ViewBase
         var selected = UseState(TagGeneral);
         Context.TryUseService<DesktopWindow>(out var desktopWindow);
         var isDesktop = desktopWindow != null;
+        var capturedHost = ConfigYamlUiHelper.CaptureHost(httpContextAccessor);
 
         var menuItems = new[]
         {
@@ -57,7 +58,7 @@ public class SettingsApp : ViewBase
             switch (tag)
             {
                 case TagOpenConfig:
-                    ConfigYamlUiHelper.OpenOrNavigate(config, navigator, isDesktop, httpContextAccessor);
+                    ConfigYamlUiHelper.OpenOrNavigate(config, navigator, isDesktop, capturedHost);
                     break;
                 default:
                     selected.Set(tag);

--- a/src/Ivy.Tendril/Helpers/ConfigYamlUiHelper.cs
+++ b/src/Ivy.Tendril/Helpers/ConfigYamlUiHelper.cs
@@ -11,25 +11,43 @@ namespace Ivy.Tendril.Helpers;
 /// </summary>
 public static class ConfigYamlUiHelper
 {
+    /// <summary>
+    /// Call this overload only from <c>Build()</c> — HttpContext is available there.
+    /// Captures the host immediately so the click handler doesn't rely on HttpContext.
+    /// </summary>
     public static void OpenOrNavigate(
         IConfigService config,
         INavigator navigator,
         bool isDesktopShell,
         IHttpContextAccessor? httpContextAccessor = null)
     {
-        if (isDesktopShell || IsLikelyLocalLoopbackBrowser(httpContextAccessor))
+        var capturedHost = httpContextAccessor?.HttpContext?.Request.Host.Host;
+        OpenOrNavigate(config, navigator, isDesktopShell, capturedHost);
+    }
+
+    /// <summary>
+    /// Use this overload inside click handlers — pass the host captured during <c>Build()</c>.
+    /// </summary>
+    public static void OpenOrNavigate(
+        IConfigService config,
+        INavigator navigator,
+        bool isDesktopShell,
+        string? capturedHost)
+    {
+        if (isDesktopShell || IsLoopbackHost(capturedHost))
             config.OpenInEditor(config.ConfigPath);
         else
             navigator.Navigate<ConfigEditorApp>();
     }
 
     /// <summary>
-    /// True when the HTTP Host is loopback (e.g. user opened <c>http://localhost:5010/</c> on the same machine
-    /// that runs Tendril, so spawning <c>code</c> / the configured editor is meaningful).
+    /// Captures the request host during Build/render so it can be safely used inside click handlers.
     /// </summary>
-    public static bool IsLikelyLocalLoopbackBrowser(IHttpContextAccessor? httpContextAccessor)
+    public static string? CaptureHost(IHttpContextAccessor? httpContextAccessor) =>
+        httpContextAccessor?.HttpContext?.Request.Host.Host;
+
+    public static bool IsLoopbackHost(string? host)
     {
-        var host = httpContextAccessor?.HttpContext?.Request.Host.Host;
         if (string.IsNullOrEmpty(host)) return false;
 
         if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase)) return true;

--- a/src/Ivy.Tendril/Helpers/PlatformHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlatformHelper.cs
@@ -139,11 +139,13 @@ public static class PlatformHelper
     {
         try
         {
+            // UseShellExecute = false prevents the OS from printing "The file X does not exist"
+            // to the terminal before .NET gets a chance to catch the exception.
             Process.Start(new ProcessStartInfo
             {
                 FileName = editorCommand,
                 Arguments = $"\"{target}\"",
-                UseShellExecute = true
+                UseShellExecute = false
             });
             return true;
         }


### PR DESCRIPTION
## Summary
- Capture the request host during `Build()` via `ConfigYamlUiHelper.CaptureHost` and pass it into `OpenOrNavigate` from click handlers, so loopback detection does not depend on `HttpContext` when the handler runs.
- Add an overload of `OpenOrNavigate` that takes `string? capturedHost`; rename loopback detection to `IsLoopbackHost`.
- Update `ConfigErrorApp` and `SettingsApp` to use the captured host.
- When launching the external editor from `PlatformHelper`, set `UseShellExecute = false` so the OS does not print a “file does not exist” style message to the terminal before .NET can handle the failure.

## Testing
- [ ] Manual: open Settings / config error UI, click “Edit config” / open config from localhost vs remote host (desktop shell vs browser) as applicable.