### PR TITLE
Introduce global JobId allocator for unified log identification

### DIFF
--- a/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
@@ -127,68 +127,41 @@ public class FirmwareCompilerTests : IDisposable
         Assert.Contains("**Tools:**", result);
     }
 
-    // --- GetNextLogFile ---
+    // --- GetLogFile ---
 
     [Fact]
-    public void GetNextLogFile_ReturnsFirst_WhenEmpty()
+    public void GetLogFile_CreatesFileWithJobId()
     {
         var programFolder = Path.Combine(_tempDir, "TestProgram");
         Directory.CreateDirectory(programFolder);
 
-        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
+        var logFile = FirmwareCompiler.GetLogFile(programFolder, "00042");
 
-        Assert.EndsWith("00001.md", logFile);
+        Assert.EndsWith("00042.md", logFile);
         Assert.Contains("Logs", logFile);
     }
 
     [Fact]
-    public void GetNextLogFile_IncrementsExisting()
-    {
-        var programFolder = Path.Combine(_tempDir, "TestProgram");
-        var logsFolder = Path.Combine(programFolder, "Logs");
-        Directory.CreateDirectory(logsFolder);
-        File.WriteAllText(Path.Combine(logsFolder, "00001.md"), "log 1");
-        File.WriteAllText(Path.Combine(logsFolder, "00002.md"), "log 2");
-
-        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
-
-        Assert.EndsWith("00003.md", logFile);
-    }
-
-    [Fact]
-    public void GetNextLogFile_CreatesLogsDirectory()
+    public void GetLogFile_CreatesLogsDirectory()
     {
         var programFolder = Path.Combine(_tempDir, "NewProgram");
         Directory.CreateDirectory(programFolder);
 
-        FirmwareCompiler.GetNextLogFile(programFolder);
+        FirmwareCompiler.GetLogFile(programFolder, "00001");
 
         Assert.True(Directory.Exists(Path.Combine(programFolder, "Logs")));
     }
 
     [Fact]
-    public void GetNextLogFile_ReservesFileOnDisk()
+    public void GetLogFile_WritesPlaceholderContent()
     {
         var programFolder = Path.Combine(_tempDir, "ReserveTest");
         Directory.CreateDirectory(programFolder);
 
-        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
+        var logFile = FirmwareCompiler.GetLogFile(programFolder, "00001");
 
         Assert.True(File.Exists(logFile));
-    }
-
-    [Fact]
-    public void GetNextLogFile_ConcurrentCalls_ProduceDifferentNumbers()
-    {
-        var programFolder = Path.Combine(_tempDir, "ConcurrentTest");
-        Directory.CreateDirectory(programFolder);
-
-        var first = FirmwareCompiler.GetNextLogFile(programFolder);
-        var second = FirmwareCompiler.GetNextLogFile(programFolder);
-
-        Assert.EndsWith("00001.md", first);
-        Assert.EndsWith("00002.md", second);
-        Assert.NotEqual(first, second);
+        Assert.Contains("Execution in progress", File.ReadAllText(logFile));
     }
 
     // --- Projects Section ---

--- a/src/Ivy.Tendril.Test/Agents/JobIdAllocatorTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/JobIdAllocatorTests.cs
@@ -1,0 +1,173 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test.Agents;
+
+public class JobIdAllocatorTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public JobIdAllocatorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"jobid-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, true); }
+        catch { }
+    }
+
+    [Fact]
+    public void AllocateJobId_ReturnsFirstId()
+    {
+        var id = JobIdAllocator.AllocateJobId(_tempDir);
+
+        Assert.Equal("00001", id);
+    }
+
+    [Fact]
+    public void AllocateJobId_IncrementsSequentially()
+    {
+        var first = JobIdAllocator.AllocateJobId(_tempDir);
+        var second = JobIdAllocator.AllocateJobId(_tempDir);
+        var third = JobIdAllocator.AllocateJobId(_tempDir);
+
+        Assert.Equal("00001", first);
+        Assert.Equal("00002", second);
+        Assert.Equal("00003", third);
+    }
+
+    [Fact]
+    public void AllocateJobId_CreatesCounterFile()
+    {
+        JobIdAllocator.AllocateJobId(_tempDir);
+
+        var counterFile = Path.Combine(_tempDir, "Jobs", ".counter");
+        Assert.True(File.Exists(counterFile));
+    }
+
+    [Fact]
+    public void AllocateJobId_PersistsAcrossCalls()
+    {
+        JobIdAllocator.AllocateJobId(_tempDir);
+        JobIdAllocator.AllocateJobId(_tempDir);
+
+        var counterFile = Path.Combine(_tempDir, "Jobs", ".counter");
+        var content = File.ReadAllText(counterFile).Trim();
+        Assert.Equal("3", content);
+    }
+
+    [Fact]
+    public void SeedIfNeeded_DoesNothingWhenCounterExists()
+    {
+        var jobsDir = Path.Combine(_tempDir, "Jobs");
+        Directory.CreateDirectory(jobsDir);
+        File.WriteAllText(Path.Combine(jobsDir, ".counter"), "50");
+
+        var promptwaresRoot = Path.Combine(_tempDir, "Promptwares");
+        var logsDir = Path.Combine(promptwaresRoot, "ExecutePlan", "Logs");
+        Directory.CreateDirectory(logsDir);
+        File.WriteAllText(Path.Combine(logsDir, "00100.md"), "log");
+
+        JobIdAllocator.SeedIfNeeded(_tempDir, promptwaresRoot);
+
+        var content = File.ReadAllText(Path.Combine(jobsDir, ".counter")).Trim();
+        Assert.Equal("50", content);
+    }
+
+    [Fact]
+    public void SeedIfNeeded_SeedsFromExistingLogs()
+    {
+        var promptwaresRoot = Path.Combine(_tempDir, "Promptwares");
+        var logsDir = Path.Combine(promptwaresRoot, "ExecutePlan", "Logs");
+        Directory.CreateDirectory(logsDir);
+        File.WriteAllText(Path.Combine(logsDir, "00042.md"), "log");
+        File.WriteAllText(Path.Combine(logsDir, "00010.md"), "log");
+
+        JobIdAllocator.SeedIfNeeded(_tempDir, promptwaresRoot);
+
+        var counterFile = Path.Combine(_tempDir, "Jobs", ".counter");
+        var content = File.ReadAllText(counterFile).Trim();
+        Assert.Equal("43", content);
+    }
+
+    [Fact]
+    public void SeedIfNeeded_ScansMultiplePromptwareFolders()
+    {
+        var promptwaresRoot = Path.Combine(_tempDir, "Promptwares");
+        var logs1 = Path.Combine(promptwaresRoot, "ExecutePlan", "Logs");
+        var logs2 = Path.Combine(promptwaresRoot, "CreatePlan", "Logs");
+        Directory.CreateDirectory(logs1);
+        Directory.CreateDirectory(logs2);
+        File.WriteAllText(Path.Combine(logs1, "00020.md"), "log");
+        File.WriteAllText(Path.Combine(logs2, "00055.md"), "log");
+
+        JobIdAllocator.SeedIfNeeded(_tempDir, promptwaresRoot);
+
+        var counterFile = Path.Combine(_tempDir, "Jobs", ".counter");
+        var content = File.ReadAllText(counterFile).Trim();
+        Assert.Equal("56", content);
+    }
+
+    [Fact]
+    public void SeedIfNeeded_IgnoresNonNumericFiles()
+    {
+        var promptwaresRoot = Path.Combine(_tempDir, "Promptwares");
+        var logsDir = Path.Combine(promptwaresRoot, "ExecutePlan", "Logs");
+        Directory.CreateDirectory(logsDir);
+        File.WriteAllText(Path.Combine(logsDir, "readme.md"), "not a log");
+        File.WriteAllText(Path.Combine(logsDir, "00005.md"), "log");
+
+        JobIdAllocator.SeedIfNeeded(_tempDir, promptwaresRoot);
+
+        var counterFile = Path.Combine(_tempDir, "Jobs", ".counter");
+        var content = File.ReadAllText(counterFile).Trim();
+        Assert.Equal("6", content);
+    }
+
+    [Fact]
+    public void SeedIfNeeded_NoOpWhenNoLogs()
+    {
+        var promptwaresRoot = Path.Combine(_tempDir, "Promptwares");
+        Directory.CreateDirectory(promptwaresRoot);
+
+        JobIdAllocator.SeedIfNeeded(_tempDir, promptwaresRoot);
+
+        var counterFile = Path.Combine(_tempDir, "Jobs", ".counter");
+        Assert.False(File.Exists(counterFile));
+    }
+
+    [Fact]
+    public void AllocateJobId_StartsAfterSeed()
+    {
+        var promptwaresRoot = Path.Combine(_tempDir, "Promptwares");
+        var logsDir = Path.Combine(promptwaresRoot, "ExecutePlan", "Logs");
+        Directory.CreateDirectory(logsDir);
+        File.WriteAllText(Path.Combine(logsDir, "00090.md"), "log");
+
+        JobIdAllocator.SeedIfNeeded(_tempDir, promptwaresRoot);
+        var id = JobIdAllocator.AllocateJobId(_tempDir);
+
+        Assert.Equal("00091", id);
+    }
+
+    [Fact]
+    public void ScanMaxLogNumber_ReturnsZeroForEmptyDirectory()
+    {
+        var root = Path.Combine(_tempDir, "Empty");
+        Directory.CreateDirectory(root);
+
+        var max = JobIdAllocator.ScanMaxLogNumber(root);
+
+        Assert.Equal(0, max);
+    }
+
+    [Fact]
+    public void ScanMaxLogNumber_ReturnsZeroForNonExistentDirectory()
+    {
+        var max = JobIdAllocator.ScanMaxLogNumber(Path.Combine(_tempDir, "NoSuchDir"));
+
+        Assert.Equal(0, max);
+    }
+}

--- a/src/Ivy.Tendril.Test/Agents/TryBuildAgentProcessStartTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/TryBuildAgentProcessStartTests.cs
@@ -162,18 +162,14 @@ public class TryBuildAgentProcessStartTests : IDisposable
     }
 
     [Fact]
-    public void FirmwareCompiler_GetNextLogFile_HandlesNonNumericFiles()
+    public void FirmwareCompiler_GetLogFile_CreatesNamedLogFile()
     {
         var programFolder = Path.Combine(_tempDir, "TestProgram");
-        var logsFolder = Path.Combine(programFolder, "Logs");
-        Directory.CreateDirectory(logsFolder);
+        Directory.CreateDirectory(programFolder);
 
-        // Create files that don't match the numeric pattern
-        File.WriteAllText(Path.Combine(logsFolder, "readme.md"), "ignore me");
-        File.WriteAllText(Path.Combine(logsFolder, "00003.md"), "log 3");
-
-        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
-        Assert.EndsWith("00004.md", logFile);
+        var logFile = FirmwareCompiler.GetLogFile(programFolder, "00099");
+        Assert.EndsWith("00099.md", logFile);
+        Assert.True(File.Exists(logFile));
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
@@ -119,7 +119,7 @@ public class PromptwareRunCommandTests : IDisposable
             ["ArtifactsDir"] = "/plans/00123-Test/artifacts"
         };
 
-        FirmwareCompiler.GetNextLogFile(promptwareDir);
+        FirmwareCompiler.GetLogFile(promptwareDir, "test");
         var context = new FirmwareContext(promptwareDir, values);
         var prompt = FirmwareCompiler.Compile(context);
 
@@ -143,7 +143,7 @@ public class PromptwareRunCommandTests : IDisposable
             ["Instructions"] = "Setup verifications"
         };
 
-        FirmwareCompiler.GetNextLogFile(promptwareDir);
+        FirmwareCompiler.GetLogFile(promptwareDir, "test");
         var context = new FirmwareContext(promptwareDir, values);
         var prompt = FirmwareCompiler.Compile(context);
 
@@ -163,7 +163,7 @@ public class PromptwareRunCommandTests : IDisposable
             ["Args"] = "Setup verifications and review actions for this project."
         };
 
-        FirmwareCompiler.GetNextLogFile(promptwareDir);
+        FirmwareCompiler.GetLogFile(promptwareDir, "test");
         var context = new FirmwareContext(promptwareDir, values);
         var prompt = FirmwareCompiler.Compile(context);
 

--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -222,7 +222,7 @@ public class JobServiceCompletionGuardTests : IDisposable
             return [];
         }
 
-        public void AddLog(string folderName, string action, string content)
+        public void AddLog(string folderName, string action, string content, string? jobId = null)
         {
         }
 

--- a/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
@@ -351,7 +351,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
             return [];
         }
 
-        public void AddLog(string folderName, string action, string content)
+        public void AddLog(string folderName, string action, string content, string? jobId = null)
         {
         }
 

--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -464,7 +464,7 @@ public class JobServiceRetryBlockedTests : IDisposable
             return [];
         }
 
-        public void AddLog(string folderName, string action, string content)
+        public void AddLog(string folderName, string action, string content, string? jobId = null)
         {
         }
 

--- a/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
@@ -74,7 +74,7 @@ public class JobServiceSplitPlanCompletionTests
         public void SaveRevision(string folderName, string content) { }
         public string ReadLatestRevision(string folderName) => "";
         public List<(int Number, string Content, DateTime Modified)> GetRevisions(string folderName) => [];
-        public void AddLog(string folderName, string action, string content) { }
+        public void AddLog(string folderName, string action, string content, string? jobId = null) { }
         public void DeletePlan(string folderName) { }
         public string ReadRawPlan(string folderName) => "";
         public void SavePlan(string folderName, string fullContent) { }

--- a/src/Ivy.Tendril/AGENTS.md
+++ b/src/Ivy.Tendril/AGENTS.md
@@ -187,4 +187,4 @@ tendril plan get <id>       # Show plan details
 - **Plan counter collisions**: `$TENDRIL_PLANS/.counter` is protected by file-based locking in `tendril plan create`. If plans get duplicate IDs, check for concurrent access issues.
 - **Plans not appearing in UI**: Run `tendril doctor plans` to check for malformed `plan.yaml` files. `PlanReaderService.RepairPlans()` runs on startup but silently skips plans it can't fix.
 - **Build errors from locked files**: Tendril locks its own exe while running. Use `--no-dependencies` or stop the running instance before building.
-- **Missing `.raw.jsonl` logs**: These are written by `PromptwareLogWriter.WriteRawLog` on job completion. The Logs directory is created automatically by `GetNextLogFile`.
+- **Missing `.raw.jsonl` logs**: These are written by `PromptwareLogWriter.WriteRawLog` on job completion. The Logs directory is created automatically by `FirmwareCompiler.GetLogFile`.

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -117,7 +117,8 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
             && !string.IsNullOrWhiteSpace(specificCfg.CustomInstructions))
             customInstructions = specificCfg.CustomInstructions;
 
-        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
+        var jobId = JobIdAllocator.AllocateJobId(configService.TendrilHome);
+        var logFile = FirmwareCompiler.GetLogFile(programFolder, jobId);
         var firmwareContext = new FirmwareContext(programFolder, values, customInstructions);
         var prompt = FirmwareCompiler.Compile(firmwareContext);
 

--- a/src/Ivy.Tendril/Helpers/JobIdAllocator.cs
+++ b/src/Ivy.Tendril/Helpers/JobIdAllocator.cs
@@ -1,0 +1,127 @@
+namespace Ivy.Tendril.Helpers;
+
+public static class JobIdAllocator
+{
+    private static readonly object CounterLock = new();
+
+    public static string AllocateJobId(string tendrilHome)
+    {
+        var jobsDir = Path.Combine(tendrilHome, "Jobs");
+        Directory.CreateDirectory(jobsDir);
+        var counterFile = Path.Combine(jobsDir, ".counter");
+
+        lock (CounterLock)
+        {
+            var timeout = TimeSpan.FromSeconds(10);
+            var startTime = DateTime.UtcNow;
+            var retryDelay = 50;
+
+            while (true)
+            {
+                try
+                {
+                    using var stream = new FileStream(
+                        counterFile,
+                        FileMode.OpenOrCreate,
+                        FileAccess.ReadWrite,
+                        FileShare.None,
+                        bufferSize: 4096,
+                        FileOptions.None);
+
+                    var counter = 1;
+                    if (stream.Length > 0)
+                    {
+                        using var reader = new StreamReader(stream, leaveOpen: true);
+                        var text = reader.ReadToEnd().Trim();
+                        if (int.TryParse(text, out var parsed))
+                            counter = parsed;
+                    }
+
+                    var id = counter.ToString("D5");
+
+                    stream.SetLength(0);
+                    stream.Position = 0;
+                    using (var writer = new StreamWriter(stream, leaveOpen: true))
+                    {
+                        writer.Write((counter + 1).ToString());
+                        writer.Flush();
+                    }
+
+                    return id;
+                }
+                catch (IOException) when (DateTime.UtcNow - startTime < timeout)
+                {
+                    Thread.Sleep(retryDelay);
+                    retryDelay = Math.Min(retryDelay * 2, 500);
+                }
+                catch (IOException)
+                {
+                    throw new TimeoutException(
+                        $"Failed to acquire lock on {counterFile} after {timeout.TotalSeconds} seconds.");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Seeds the counter from existing promptware logs so new IDs don't collide with old ones.
+    /// Call once at startup if the counter file doesn't exist yet.
+    /// </summary>
+    public static void SeedIfNeeded(string tendrilHome, string promptwaresRoot)
+    {
+        var jobsDir = Path.Combine(tendrilHome, "Jobs");
+        Directory.CreateDirectory(jobsDir);
+        var counterFile = Path.Combine(jobsDir, ".counter");
+
+        if (File.Exists(counterFile)) return;
+
+        var max = ScanMaxLogNumber(promptwaresRoot);
+        if (max <= 0) return;
+
+        lock (CounterLock)
+        {
+            if (File.Exists(counterFile)) return;
+
+            try
+            {
+                using var stream = new FileStream(
+                    counterFile,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None);
+                using var writer = new StreamWriter(stream);
+                writer.Write((max + 1).ToString());
+            }
+            catch (IOException)
+            {
+                // Another process created it first — that's fine
+            }
+        }
+    }
+
+    internal static int ScanMaxLogNumber(string promptwaresRoot)
+    {
+        var max = 0;
+        try
+        {
+            if (Directory.Exists(promptwaresRoot))
+            {
+                foreach (var logsDir in Directory.GetDirectories(promptwaresRoot, "Logs", SearchOption.AllDirectories))
+                {
+                    foreach (var file in Directory.GetFiles(logsDir, "*.md"))
+                    {
+                        var baseName = Path.GetFileNameWithoutExtension(file);
+                        if (int.TryParse(baseName, out var num) && num > max)
+                            max = num;
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Best-effort scan
+        }
+
+        return max;
+    }
+}

--- a/src/Ivy.Tendril/Helpers/JobStatusFile.cs
+++ b/src/Ivy.Tendril/Helpers/JobStatusFile.cs
@@ -74,7 +74,7 @@ public static class JobStatusFile
         catch { /* Best-effort */ }
     }
 
-    public static void MoveLogToPlanFolder(string statusFilePath, string planFolder, string jobType)
+    public static void MoveLogToPlanFolder(string statusFilePath, string planFolder, string jobType, string? jobId = null)
     {
         try
         {
@@ -84,25 +84,14 @@ public static class JobStatusFile
             var logsDir = Path.Combine(planFolder, "logs");
             FileHelper.EnsureDirectory(logsDir);
 
-            var nextNumber = GetNextLogNumber(logsDir);
-            var dest = Path.Combine(logsDir, $"{nextNumber:D3}-{jobType}-job.jsonl");
+            var filename = !string.IsNullOrEmpty(jobId)
+                ? $"{jobId}-{jobType}.cli.jsonl"
+                : $"{jobType}.cli.jsonl";
+            var dest = Path.Combine(logsDir, filename);
             File.Copy(logPath, dest, overwrite: true);
             File.Delete(logPath);
         }
         catch { /* Best-effort */ }
-    }
-
-    private static int GetNextLogNumber(string logsDir)
-    {
-        var max = 0;
-        foreach (var file in Directory.GetFiles(logsDir))
-        {
-            var name = Path.GetFileNameWithoutExtension(file);
-            var dashIdx = name.IndexOf('-');
-            if (dashIdx > 0 && int.TryParse(name[..dashIdx], out var num) && num > max)
-                max = num;
-        }
-        return max + 1;
     }
 
     public record StatusPayload(string Message, string? PlanId = null, string? PlanTitle = null);

--- a/src/Ivy.Tendril/Services/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/FirmwareCompiler.cs
@@ -173,40 +173,13 @@ public static class FirmwareCompiler
         return files.Count == 0 ? emptyLabel : string.Join(", ", files);
     }
 
-    public static string GetNextLogFile(string programFolder)
+    public static string GetLogFile(string programFolder, string jobId)
     {
         var logsFolder = Path.Combine(programFolder, "Logs");
         Directory.CreateDirectory(logsFolder);
-
-        var maxNumber = 0;
-        foreach (var file in Directory.GetFiles(logsFolder, "*.md"))
-        {
-            var baseName = Path.GetFileNameWithoutExtension(file);
-            if (int.TryParse(baseName, out var num) && num > maxNumber)
-                maxNumber = num;
-        }
-
-        // Use CreateNew to atomically claim the slot; retry on collision
-        for (var attempt = maxNumber + 1; attempt < maxNumber + 100; attempt++)
-        {
-            var logFile = Path.Combine(logsFolder, $"{attempt:D5}.md");
-            try
-            {
-                using var fs = new FileStream(logFile, FileMode.CreateNew, FileAccess.Write);
-                using var writer = new StreamWriter(fs);
-                writer.Write("*Execution in progress...*\n");
-                return logFile;
-            }
-            catch (IOException)
-            {
-                // File already exists (race with another process), try next number
-            }
-        }
-
-        // Fallback: should never reach here
-        var fallback = Path.Combine(logsFolder, $"{maxNumber + 1:D5}.md");
-        File.WriteAllText(fallback, "*Execution in progress...*\n");
-        return fallback;
+        var logFile = Path.Combine(logsFolder, $"{jobId}.md");
+        File.WriteAllText(logFile, "*Execution in progress...*\n");
+        return logFile;
     }
 
 }

--- a/src/Ivy.Tendril/Services/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/IPlanReaderService.cs
@@ -17,7 +17,7 @@ public interface IPlanReaderService
     void SaveRevision(string folderName, string content);
     string ReadLatestRevision(string folderName);
     List<(int Number, string Content, DateTime Modified)> GetRevisions(string folderName);
-    void AddLog(string folderName, string action, string content);
+    void AddLog(string folderName, string action, string content, string? jobId = null);
     void DeletePlan(string folderName);
     string ReadRawPlan(string folderName);
     void SavePlan(string folderName, string fullContent);

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -630,7 +630,7 @@ internal class JobCompletionHandler
         try
         {
             var logContent = BuildJobLogContent(job);
-            _planReaderService.AddLog(job.PlanFile, job.Type, logContent);
+            _planReaderService.AddLog(job.PlanFile, job.Type, logContent, job.Id);
             WriteFailedJobOutputIfNeeded(job);
         }
         catch
@@ -644,13 +644,14 @@ internal class JobCompletionHandler
 
         var planFolder = ResolvePlanFolder(job);
         if (!string.IsNullOrEmpty(planFolder) && Directory.Exists(planFolder))
-            JobStatusFile.MoveLogToPlanFolder(job.StatusFilePath, planFolder, job.Type);
+            JobStatusFile.MoveLogToPlanFolder(job.StatusFilePath, planFolder, job.Type, job.Id);
     }
 
     private string BuildJobLogContent(JobItem job)
     {
         var duration = job.DurationSeconds.HasValue ? $"{job.DurationSeconds}s" : "unknown";
         var logContent = $"# {job.Type}\n\n" +
+                         $"- **JobId:** {job.Id}\n" +
                          $"- **Status:** {job.Status}\n" +
                          $"- **Started:** {job.StartedAt:u}\n" +
                          $"- **Completed:** {job.CompletedAt:u}\n" +

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -230,7 +230,7 @@ internal class JobLauncher
         var resolution = AgentProviderFactory.Resolve(settings, job.Type, profileOverride, jobContext);
         var workDir = ResolveWorkingDirectory(job, programFolder);
 
-        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
+        var logFile = FirmwareCompiler.GetLogFile(programFolder, job.Id);
         job.LogFilePath = logFile;
 
         var customInstructions = ResolveCustomInstructions(job.Type);

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -31,8 +31,6 @@ public class JobService : IJobService
     private readonly ILogger<JobService> _logger;
     private readonly JobLauncher _jobLauncher;
     private readonly JobCompletionHandler _completionHandler;
-    private int _counter;
-
     public JobService(
         IConfigService configService,
         ILogger<JobService>? logger = null,
@@ -65,6 +63,7 @@ public class JobService : IJobService
             configService, _logger, modelPricingService, planReaderService,
             telemetryService, planWatcherService, worktreeLifecycleLogger, promptsRoot);
         configService.SettingsReloaded += OnSettingsReloaded;
+        JobIdAllocator.SeedIfNeeded(configService.TendrilHome, promptsRoot);
         LoadHistoricalJobs();
     }
 
@@ -366,7 +365,9 @@ public class JobService : IJobService
 
     private string StartJobInternal(JobArgsBase args, string? inboxFilePath, bool skipDependencyCheck = false)
     {
-        var id = $"job-{Interlocked.Increment(ref _counter):D3}";
+        var id = _configService != null
+            ? JobIdAllocator.AllocateJobId(_configService.TendrilHome)
+            : Guid.NewGuid().ToString("N")[..5];
         var job = BuildJobItem(id, args, inboxFilePath);
 
         if (TryRejectConflictingJob(job))
@@ -511,7 +512,9 @@ public class JobService : IJobService
     /// </summary>
     internal string CreateTestJob(JobArgsBase args)
     {
-        var id = $"job-{Interlocked.Increment(ref _counter):D3}";
+        var id = _configService != null
+            ? JobIdAllocator.AllocateJobId(_configService.TendrilHome)
+            : $"test-{Guid.NewGuid().ToString("N")[..5]}";
         var job = new JobItem
         {
             Id = id,

--- a/src/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/PlanReaderService.cs
@@ -314,26 +314,14 @@ public class PlanReaderService(
     /// <param name="folderName">Name of the plan folder.</param>
     /// <param name="action">Action name used in the log filename (e.g. <c>ExecutePlan</c>).</param>
     /// <param name="content">Markdown content of the log entry.</param>
-    public void AddLog(string folderName, string action, string content)
+    public void AddLog(string folderName, string action, string content, string? jobId = null)
     {
         var logsDir = Path.Combine(PlansDirectory, folderName, "logs");
         FileHelper.EnsureDirectory(logsDir);
 
-        var nextNumber = 1;
-        var existingLogs = Directory.GetFiles(logsDir, "*.md");
-        if (existingLogs.Length > 0)
-            nextNumber = existingLogs
-                .Select(f => Path.GetFileNameWithoutExtension(f))
-                .Select(n =>
-                {
-                    var dashIdx = n.IndexOf('-');
-                    var numPart = dashIdx >= 0 ? n.Substring(0, dashIdx) : n;
-                    return int.TryParse(numPart, out var num) ? num : 0;
-                })
-                .DefaultIfEmpty(0)
-                .Max() + 1;
-
-        var logPath = Path.Combine(logsDir, $"{nextNumber:D3}-{action}.md");
+        var logPath = !string.IsNullOrEmpty(jobId)
+            ? Path.Combine(logsDir, $"{jobId}-{action}.md")
+            : Path.Combine(logsDir, $"{action}.md");
         FileHelper.WriteAllText(logPath, content);
     }
 

--- a/src/Ivy.Tendril/Services/PromptwareRunner.cs
+++ b/src/Ivy.Tendril/Services/PromptwareRunner.cs
@@ -82,7 +82,8 @@ public class PromptwareRunner : IPromptwareRunner
         var resolution = AgentProviderFactory.Resolve(settings, options.Promptware, options.Profile, jobContext);
         var workDir = options.WorkingDir ?? programFolder;
 
-        var logFile = FirmwareCompiler.GetNextLogFile(programFolder);
+        var jobId = JobIdAllocator.AllocateJobId(_configService.TendrilHome);
+        var logFile = FirmwareCompiler.GetLogFile(programFolder, jobId);
         var firmwareContext = new FirmwareContext(programFolder, values);
         var prompt = FirmwareCompiler.Compile(firmwareContext);
 


### PR DESCRIPTION
## Summary
- Adds `JobIdAllocator` with file-locked counter at `{TENDRIL_HOME}/Jobs/.counter` for globally unique 5-digit job IDs
- Replaces per-session in-memory counter (`job-001`) and per-promptware log sequences (`00095`)
- All log artifacts (promptware logs, plan logs, CLI invocation logs) now share the same job ID

## Test plan
- [x] All 1425 tests pass (12 new for `JobIdAllocator`)
- [x] CodeScene health: 9.38 on all changed files
- [ ] Manual: start Tendril, trigger plan execution, verify `.counter` file and log filenames use global ID