### PR TITLE
Add Plan Id, CLI log link, and path dropdown menu to JobDebugSheet

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
@@ -13,6 +14,8 @@ public class JobDebugSheet(
 {
     public override object Build()
     {
+        var copyToClipboard = UseClipboard();
+
         var job = jobService.GetJob(jobId);
         if (job is null)
             return Text.P("Job not found.");
@@ -20,6 +23,7 @@ public class JobDebugSheet(
         var data = new
         {
             JobId = job.Id,
+            PlanId = GetPlanId(job),
             PromptTitle = JobsApp.GetFullPrompt(job, planService) ?? "",
             Status = $"{job.Status}{(job.StatusMessage != null ? $" — {job.StatusMessage}" : "")}",
             job.Type,
@@ -34,37 +38,57 @@ public class JobDebugSheet(
             PermissionDenials = FormatPermissionDenials(job),
             PlanFolder = GetPlanFolderPath(job) ?? "",
             PlanLog = GetPlanLogPath(job) ?? "",
+            PlanCliLog = GetPlanCliLogPath(job) ?? "",
             PromptwareLog = GetPromptwareLogPath(job) ?? "",
             PromptwareRawLog = GetPromptwareRawLogPath(job) ?? "",
             ExitCode = job.ExitCode?.ToString() ?? ""
         };
 
         return data.ToDetails()
-            .Multiline(x => x.PromptTitle, x => x.PermissionDenials)
+            .Multiline(x => x.PromptTitle)
             .Label(x => x.PromptTitle, "Prompt/Title")
+            .Label(x => x.PlanId, "Plan Id")
             .Label(x => x.SessionId, "Session Id")
             .Label(x => x.PlanFolder, "Plan Folder")
             .Label(x => x.PlanLog, "Plan Log")
+            .Label(x => x.PlanCliLog, "Plan CLI Log")
             .Label(x => x.PromptwareLog, "Promptware Log")
             .Label(x => x.PromptwareRawLog, "Promptware Raw Log")
+            .Label(x => x.PermissionDenials, "Permission Denials")
             .Label(x => x.ExitCode, "Exit Code")
             .Label(x => x.JobId, "Job Id")
-            .Builder(x => x.PlanFolder, f => f.CopyToClipboard())
-            .Builder(x => x.PlanLog, f => f.CopyToClipboard())
-            .Builder(x => x.PromptwareLog, f => f.CopyToClipboard())
-            .Builder(x => x.PromptwareRawLog, f => f.CopyToClipboard())
+            .Builder(x => x.PermissionDenials, f => f.Func((string denials) =>
+                new CodeBlock(denials)))
+            .Builder(x => x.PlanFolder, f => f.Func((string path) => PathDropDown(path, copyToClipboard)))
+            .Builder(x => x.PlanLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard)))
+            .Builder(x => x.PlanCliLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard)))
+            .Builder(x => x.PromptwareLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard)))
+            .Builder(x => x.PromptwareRawLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard)))
             .RemoveEmpty();
+    }
+
+    private object PathDropDown(string path, Action<string> copyToClipboard)
+    {
+        return Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+            | Text.Block(path)
+            | new Button().Icon(Icons.EllipsisVertical).Ghost().Small()
+                .WithDropDown(
+                    new MenuItem("Copy to Clipboard", Icon: Icons.ClipboardCopy, Tag: "Copy")
+                        .OnSelect(() => copyToClipboard(path)),
+                    new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
+                        .OnSelect(() => config.OpenInEditor(path))
+                );
     }
 
     private static string FormatPermissionDenials(JobItem job)
     {
-        if (job.OutputLines.Count == 0) return "None";
+        if (job.OutputLines.Count == 0) return "";
 
         try
         {
             var provider = AgentProviderFactory.GetProvider(job.Provider);
             var denials = provider.ExtractPermissionDenials(job.OutputLines.ToArray());
-            if (denials.Count == 0) return "None";
+            if (denials.Count == 0) return "";
 
             return string.Join("\n", denials.Select(d =>
                 d.InputSummary != null ? $"{d.ToolName}({d.InputSummary})" : d.ToolName));
@@ -75,6 +99,17 @@ public class JobDebugSheet(
         }
     }
 
+    private static string GetPlanId(JobItem job)
+    {
+        if (!string.IsNullOrEmpty(job.PlanFile))
+        {
+            var match = Regex.Match(job.PlanFile, @"^(\d{5})-");
+            if (match.Success) return match.Groups[1].Value;
+        }
+
+        return job.ReportedPlanId ?? job.AllocatedPlanId ?? "";
+    }
+
     private string? GetPlanFolderPath(JobItem job)
     {
         if (string.IsNullOrEmpty(job.PlanFile)) return null;
@@ -82,7 +117,11 @@ public class JobDebugSheet(
         return Directory.Exists(fullPath) ? fullPath : job.TypedArgs?.PlanFolder;
     }
 
-    private string? GetPlanLogPath(JobItem job)
+    private string? GetPlanLogPath(JobItem job) => FindInLogsDir(job, "*.md");
+
+    private string? GetPlanCliLogPath(JobItem job) => FindInLogsDir(job, $"{job.Id}-*.cli.jsonl", orderByLatest: false);
+
+    private string? FindInLogsDir(JobItem job, string pattern, bool orderByLatest = true)
     {
         var folder = GetPlanFolderPath(job);
         if (string.IsNullOrEmpty(folder)) return null;
@@ -90,9 +129,10 @@ public class JobDebugSheet(
         var logsDir = Path.Combine(folder, "logs");
         if (!Directory.Exists(logsDir)) return null;
 
-        return Directory.GetFiles(logsDir, "*.md")
-            .OrderByDescending(File.GetLastWriteTimeUtc)
-            .FirstOrDefault();
+        var files = Directory.GetFiles(logsDir, pattern);
+        return orderByLatest
+            ? files.OrderByDescending(File.GetLastWriteTimeUtc).FirstOrDefault()
+            : files.FirstOrDefault();
     }
 
     private string? GetPromptwareLogPath(JobItem job)


### PR DESCRIPTION
- Show Plan Id field (extracted from PlanFile or reported/allocated IDs)
- Add Plan CLI Log field linking to the job-specific cli.jsonl
- Render permission denials in a CodeBlock instead of plain text
- Replace CopyToClipboard buttons with a dropdown menu offering both "Copy to Clipboard" and "Open in Editor"
- Extract shared logs directory lookup to reduce duplication