### PR TITLE
Fix ExecutePlan permission denials on Windows

### DIFF
--- a/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
@@ -189,7 +189,6 @@ public class AgentProviderFactoryTests
         Assert.Contains("Bash(tendril*)", resolution.AllowedTools);
         Assert.Contains("WebFetch", resolution.AllowedTools);
         Assert.Contains("WebSearch", resolution.AllowedTools);
-        Assert.Contains("Bash(/promptwares/SomePromptware/Tools/*)", resolution.AllowedTools);
         Assert.DoesNotContain("Bash", resolution.AllowedTools.Where(t => t == "Bash"));
         Assert.Empty(resolution.ExtraArgs);
     }
@@ -349,8 +348,6 @@ public class AgentProviderFactoryTests
         Assert.Contains("Read", resolution.AllowedTools);
         Assert.Contains("Bash(tendril*)", resolution.AllowedTools);
         Assert.Contains("WebFetch", resolution.AllowedTools);
-        // Promptware tool execution (scoped to own directory)
-        Assert.Contains("Bash(D:/Tendril/Promptwares/CreatePlan/Tools/*)", resolution.AllowedTools);
         // Config extras with expanded variables
         Assert.Contains("Write(D:/Tendril/Plans/**)", resolution.AllowedTools);
         Assert.Contains("Edit(D:/Tendril/Plans/01234-MyPlan/**)", resolution.AllowedTools);
@@ -415,8 +412,8 @@ public class AgentProviderFactoryTests
 
         Assert.Contains("Read", resolution.AllowedTools);
         Assert.Contains("Bash", resolution.AllowedTools);
-        Assert.Contains("Write(/plans/01234-Test/**)", resolution.AllowedTools);
-        Assert.Contains("Edit(/plans/01234-Test/**)", resolution.AllowedTools);
+        Assert.Contains("Write", resolution.AllowedTools);
+        Assert.Contains("Edit", resolution.AllowedTools);
     }
 
     [Fact]
@@ -487,12 +484,9 @@ public class AgentProviderFactoryTests
         Assert.Contains("WebFetch", resolution.AllowedTools);
         Assert.Contains("WebSearch", resolution.AllowedTools);
 
-        // Promptware tool execution (scoped to own directory)
-        Assert.Contains("Bash(/promptwares/UpdateProject/Tools/*)", resolution.AllowedTools);
-
         // Must NOT have unrestricted Bash
         Assert.DoesNotContain("Bash", resolution.AllowedTools.Where(t => t == "Bash"));
 
-        Assert.Equal(12, resolution.AllowedTools.Count);
+        Assert.Equal(11, resolution.AllowedTools.Count);
     }
 }

--- a/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
+++ b/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
@@ -20,12 +20,12 @@ public class AgentProviderFactory
 
     internal static readonly IReadOnlyList<string> BaseTools =
         ["Read", "Glob", "Grep", "Bash(tendril*)", "Bash(git *)", "Bash(gh *)", "Bash(ls *)", "Bash(find *)", "Bash(cat *)",
-         "WebFetch", "WebSearch", "Bash(%PROMPTWARE_DIR%/Tools/*)"];
+         "WebFetch", "WebSearch"];
 
     private static readonly Dictionary<string, IReadOnlyList<string>> BuiltInExtraTools =
         new(StringComparer.OrdinalIgnoreCase)
         {
-            ["ExecutePlan"] = ["Bash", "Write(%PLAN_DIR%/**)", "Edit(%PLAN_DIR%/**)"],
+            ["ExecutePlan"] = ["Bash", "Write", "Edit"],
             ["CreatePr"] = ["Bash"],
             ["CreateIssue"] = ["Bash"]
         };


### PR DESCRIPTION
## Summary
- Give ExecutePlan unrestricted `Write` and `Edit` — glob patterns like `Write(%PLAN_DIR%/**)` don't resolve correctly through worktree paths on Windows
- Remove `Bash(%PROMPTWARE_DIR%/Tools/*)` from base tools (never worked — glob expansion fails)
- Update AgentProviderFactory tests to match

## Test plan
- [x] All 1424 unit tests pass
- [x] Build succeeds