### PR TITLE
JobDebugSheet path validation, ReviewApp Details tab, StopJob log writing

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
@@ -115,7 +115,9 @@ public class JobDebugSheet(
     {
         if (string.IsNullOrEmpty(job.PlanFile)) return null;
         var fullPath = Path.Combine(planService.PlansDirectory, job.PlanFile);
-        return Directory.Exists(fullPath) ? fullPath : job.TypedArgs?.PlanFolder;
+        if (Directory.Exists(fullPath)) return fullPath;
+        var fallback = job.TypedArgs?.PlanFolder;
+        return !string.IsNullOrEmpty(fallback) && Directory.Exists(fallback) ? fallback : null;
     }
 
     private string? GetPlanLogPath(JobItem job) => FindInLogsDir(job, "*.md");
@@ -139,7 +141,7 @@ public class JobDebugSheet(
     private string? GetPromptwareLogPath(JobItem job)
     {
         var logFile = job.LogFilePath;
-        if (!string.IsNullOrEmpty(logFile)) return logFile;
+        if (!string.IsNullOrEmpty(logFile) && File.Exists(logFile)) return logFile;
 
         var promptsRoot = PromptwareHelper.ResolvePromptsRoot(config.TendrilHome);
         var logsFolder = Path.Combine(promptsRoot, job.Type, "Logs");
@@ -153,6 +155,8 @@ public class JobDebugSheet(
     private string? GetPromptwareRawLogPath(JobItem job)
     {
         var logPath = GetPromptwareLogPath(job);
-        return logPath != null ? Path.ChangeExtension(logPath, ".raw.jsonl") : null;
+        if (logPath == null) return null;
+        var rawPath = Path.ChangeExtension(logPath, ".raw.jsonl");
+        return File.Exists(rawPath) ? rawPath : null;
     }
 }

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -179,7 +179,7 @@ public class ContentView(
                 new List<(string Name, bool ConditionMet)>(), null)
         );
 
-        var tabNames = new[] { "summary", "verifications", "git", "changes", "artifacts", "recommendations", "plan" };
+        var tabNames = new[] { "summary", "plan", "details", "verifications", "git", "changes", "artifacts", "recommendations" };
         var selectedTabIndex = Array.IndexOf(tabNames, args?.Tab ?? "summary");
         if (selectedTabIndex < 0) selectedTabIndex = 0;
 
@@ -467,14 +467,15 @@ public class ContentView(
 
             var tabs = Layout.Tabs(
                 new Tab("Summary", Cap(new SummaryTabView(planData.SummaryMarkdown))),
+                new Tab("Plan", Cap(planTabContent)),
+                new Tab("Details", Cap(new DetailsTabView(selectedPlan))),
                 new Tab("Verifications", Cap(new VerificationsTabView(
                     selectedPlan.Verifications, planData.VerificationReports,
                     v => openVerification.Set(v)))).Badge(selectedPlan.Verifications.Count.ToString()),
                 new Tab("Git", Cap(gitLayout)).Badge((gitData.WorktreeRows.Count + selectedPlan.Commits.Count + selectedPlan.Prs.Count).ToString()),
                 new Tab("Changes", Layout.Vertical().Width(Size.Full()).Height(Size.Full()) | changesTabView).Badge(changesTabView.FileCount > 0 ? changesTabView.FileCount.ToString() : ""),
                 new Tab("Artifacts", Cap(new ArtifactsTabView(planData.Artifacts))).Badge(totalArtifacts.ToString()),
-                new Tab("Recommendations", Cap(recommendationsLayout)).Badge(planData.Recommendations.Count.ToString()),
-                new Tab("Plan", Cap(planTabContent))
+                new Tab("Recommendations", Cap(recommendationsLayout)).Badge(planData.Recommendations.Count.ToString())
             ).OnSelect(v =>
             {
                 if (v >= 0 && v < tabNames.Length && selectedPlanState.Value != null)

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -193,6 +193,8 @@ public class JobService : IJobService
         if (job.StartedAt.HasValue)
             job.DurationSeconds = (int)(job.CompletedAt.Value - job.StartedAt.Value).TotalSeconds;
 
+        _completionHandler.WriteJobLog(job);
+
         // Release job slot if the job was running
         if (wasRunning)
             _jobSlotSemaphore.Release();


### PR DESCRIPTION
## Summary
- JobDebugSheet: verify file/directory existence before presenting paths (fixes showing non-existent files)
- ReviewApp: add shared Details tab (reuses `DetailsTabView`), reorder tabs to: Summary, Plan, Details, Verifications, Git, Changes, Artifacts, Recommendations
- JobService.StopJob: write execution log so stopped jobs preserve their `.md` and `.raw.jsonl` for debugging

## Test plan
- [x] All 1424 unit tests pass
- [x] Build succeeds