### PR TITLE
Replace generic Args with named firmware headers and grant unrestricted Bash (#652)

### DIFF
--- a/src/Ivy.Tendril.Test.End2End/Tests/Promptware/CreatePlanTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/Promptware/CreatePlanTests.cs
@@ -23,7 +23,7 @@ public class CreatePlanTests
             agent: agent,
             extraValues: new Dictionary<string, string>
             {
-                ["Args"] = description,
+                ["TaskDescription"] = description,
                 ["TendrilPlansFolder"] = _fixture.PlansDir,
                 ["TendrilProject"] = "E2ETest"
             });
@@ -61,7 +61,7 @@ public class CreatePlanTests
                 agent: agent,
                 extraValues: new Dictionary<string, string>
                 {
-                    ["Args"] = "",
+                    ["TaskDescription"] = "",
                     ["TendrilPlansFolder"] = _fixture.PlansDir,
                     ["TendrilProject"] = "E2ETest"
                 },

--- a/src/Ivy.Tendril.Test.End2End/Tests/Promptware/UpdateProjectTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/Promptware/UpdateProjectTests.cs
@@ -24,7 +24,7 @@ public class UpdateProjectTests
             cliLogPath: cliLog,
             extraValues: new Dictionary<string, string>
             {
-                ["Args"] = "Setup verifications for the E2ETest project. Add a dotnet build verification.",
+                ["Instructions"] = "Setup verifications for the E2ETest project. Add a dotnet build verification.",
                 ["TendrilProject"] = "E2ETest"
             });
 

--- a/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
@@ -74,7 +74,7 @@ public class AgentProviderFactoryTests
         // Base tools + _default's Write (unrestricted)
         Assert.Contains("Read", resolution.AllowedTools);
         Assert.Contains("Write", resolution.AllowedTools);
-        Assert.Contains("Bash(tendril*)", resolution.AllowedTools);
+        Assert.Contains("Bash", resolution.AllowedTools);
     }
 
     [Fact]
@@ -109,7 +109,6 @@ public class AgentProviderFactoryTests
         // Base tools + built-in ExecutePlan extras + config extras
         Assert.Contains("Read", resolution.AllowedTools);
         Assert.Contains("Bash", resolution.AllowedTools);
-        Assert.Contains("Bash(tendril*)", resolution.AllowedTools);
         Assert.Contains("WebFetch", resolution.AllowedTools);
         Assert.Contains("Write(/extra/**)", resolution.AllowedTools);
     }
@@ -186,10 +185,9 @@ public class AgentProviderFactoryTests
         Assert.Contains("Read", resolution.AllowedTools);
         Assert.Contains("Glob", resolution.AllowedTools);
         Assert.Contains("Grep", resolution.AllowedTools);
-        Assert.Contains("Bash(tendril*)", resolution.AllowedTools);
+        Assert.Contains("Bash", resolution.AllowedTools);
         Assert.Contains("WebFetch", resolution.AllowedTools);
         Assert.Contains("WebSearch", resolution.AllowedTools);
-        Assert.DoesNotContain("Bash", resolution.AllowedTools.Where(t => t == "Bash"));
         Assert.Empty(resolution.ExtraArgs);
     }
 
@@ -346,7 +344,7 @@ public class AgentProviderFactoryTests
 
         // Base tools always present
         Assert.Contains("Read", resolution.AllowedTools);
-        Assert.Contains("Bash(tendril*)", resolution.AllowedTools);
+        Assert.Contains("Bash", resolution.AllowedTools);
         Assert.Contains("WebFetch", resolution.AllowedTools);
         // Config extras with expanded variables
         Assert.Contains("Write(D:/Tendril/Plans/**)", resolution.AllowedTools);
@@ -390,7 +388,7 @@ public class AgentProviderFactoryTests
         Assert.Contains("Read", resolution.AllowedTools);
         Assert.Contains("Glob", resolution.AllowedTools);
         Assert.Contains("Grep", resolution.AllowedTools);
-        Assert.Contains("Bash(tendril*)", resolution.AllowedTools);
+        Assert.Contains("Bash", resolution.AllowedTools);
         Assert.Contains("WebFetch", resolution.AllowedTools);
         Assert.Contains("WebSearch", resolution.AllowedTools);
         // Config extra
@@ -440,7 +438,7 @@ public class AgentProviderFactoryTests
     [InlineData("gemini", typeof(GeminiAgentProvider))]
     [InlineData("copilot", typeof(CopilotAgentProvider))]
     [InlineData("opencode", typeof(OpenCodeAgentProvider))]
-    public void Resolve_UpdateProject_GetsBaseToolsWithPromptwareDirForAllAgents(string agent, Type expectedProviderType)
+    public void Resolve_UpdateProject_GetsBaseToolsForAllAgents(string agent, Type expectedProviderType)
     {
         var settings = CreateSettings(
             agent,
@@ -471,22 +469,14 @@ public class AgentProviderFactoryTests
         Assert.Equal("test-model", resolution.Model);
         Assert.Equal("max", resolution.Effort);
 
-        // Base read-only tools
+        // Base tools
         Assert.Contains("Read", resolution.AllowedTools);
         Assert.Contains("Glob", resolution.AllowedTools);
         Assert.Contains("Grep", resolution.AllowedTools);
-        Assert.Contains("Bash(tendril*)", resolution.AllowedTools);
-        Assert.Contains("Bash(git *)", resolution.AllowedTools);
-        Assert.Contains("Bash(gh *)", resolution.AllowedTools);
-        Assert.Contains("Bash(ls *)", resolution.AllowedTools);
-        Assert.Contains("Bash(find *)", resolution.AllowedTools);
-        Assert.Contains("Bash(cat *)", resolution.AllowedTools);
+        Assert.Contains("Bash", resolution.AllowedTools);
         Assert.Contains("WebFetch", resolution.AllowedTools);
         Assert.Contains("WebSearch", resolution.AllowedTools);
 
-        // Must NOT have unrestricted Bash
-        Assert.DoesNotContain("Bash", resolution.AllowedTools.Where(t => t == "Bash"));
-
-        Assert.Equal(11, resolution.AllowedTools.Count);
+        Assert.Equal(6, resolution.AllowedTools.Count);
     }
 }

--- a/src/Ivy.Tendril.Test/Agents/TryBuildAgentProcessStartTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/TryBuildAgentProcessStartTests.cs
@@ -157,7 +157,7 @@ public class TryBuildAgentProcessStartTests : IDisposable
         // Base tools + _default's Write should still be present
         Assert.Contains("Read", resolution.AllowedTools);
         Assert.Contains("Write", resolution.AllowedTools);
-        Assert.Contains("Bash(tendril*)", resolution.AllowedTools);
+        Assert.Contains("Bash", resolution.AllowedTools);
         Assert.Equal("haiku", resolution.Model);
     }
 

--- a/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
@@ -160,14 +160,14 @@ public class PromptwareRunCommandTests : IDisposable
 
         var values = new Dictionary<string, string>
         {
-            ["Args"] = "Setup verifications and review actions for this project."
+            ["TaskDescription"] = "Setup verifications and review actions for this project."
         };
 
         FirmwareCompiler.GetLogFile(promptwareDir, "test");
         var context = new FirmwareContext(promptwareDir, values);
         var prompt = FirmwareCompiler.Compile(context);
 
-        Assert.Contains("Args: Setup verifications and review actions for this project.", prompt);
+        Assert.Contains("TaskDescription: Setup verifications and review actions for this project.", prompt);
     }
 
     // --- Plan Resolution ---

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -266,9 +266,9 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
     {
         var values = new Dictionary<string, string>();
 
-        // Free-form args joined into a single Args value
+        // Free-form args joined into TaskDescription header value
         if (settings.Args.Length > 0)
-            values["Args"] = string.Join(" ", settings.Args);
+            values["TaskDescription"] = string.Join(" ", settings.Args);
 
         // --plan resolves plan context
         if (!string.IsNullOrEmpty(settings.Plan))

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -2,15 +2,16 @@
 
 **Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined as verifications in the project configuration. Examples in this document use multiple tech stacks for illustration.
 
-**🚫 FORBIDDEN: Do NOT modify, create, or delete any source code files. Do NOT implement the plan. You are a PLANNER, not an executor. Your ONLY output is plan files (plan.yaml, revisions/*.md) inside TendrilPlansFolder. If you catch yourself writing code to a repo, STOP IMMEDIATELY.**
+**🚫 FORBIDDEN: Do NOT modify, create, or delete any source code files. Do NOT implement the plan. You are a PLANNER, not an executor. Your ONLY output is executing CLI commands. If you catch yourself writing code to a repo, STOP IMMEDIATELY.**
 
-**⚠️ SCOPE ENFORCEMENT: You have READ access to source code for research. You do NOT have WRITE/EDIT access to any files. All writes go through `tendril` CLI commands (plan commands, trash write, memory write). Any attempt to Write or Edit source code will be DENIED by the permission system. Do not attempt it — plan the changes instead and let the executor handle implementation.**
+**⚠️ SCOPE ENFORCEMENT: You have READ access to source code for research. You do NOT have WRITE/EDIT access to any files. All writes go through `tendril` CLI commands (plan commands, trash write, memory write). Any attempt to Write or Edit source code will be DENIED by the permission system. Do not attempt it — plan the changes instead and let the following steps handle implementation.**
 
-Create an implementation plan for a task described in args.
+Create an implementation plan for a task described in the `TaskDescription` header value.
 
 ## Context
 
 The firmware header contains these key values:
+- **TaskDescription** — the user's task description (what to plan)
 - **TendrilPlansFolder** — where plan folders are created
 - **TendrilProject** — selected project name, or `Auto` if not specified
 - **Force** (optional) — if `true`, skip duplicate detection entirely (see Step 3)
@@ -23,15 +24,15 @@ Project information (repos, verifications, context) is in the **Projects** secti
 
 ## Execution Steps
 
-### 1. Parse Args
+### 1. Parse Task Description
 
-Args contains the user's task description. If it references related plans with `[number]` syntax (e.g. `[01205]`), find and read those plan files from `TendrilPlansFolder` for context.
+The `TaskDescription` header value contains the user's task description. If it references related plans with `[number]` syntax (e.g. `[01205]`), find and read those plan files from `TendrilPlansFolder` for context.
 
-**Extract Source URL**: Check if the args contain a GitHub PR URL (`https://github.com/{owner}/{repo}/pull/{number}`) or issue URL (`https://github.com/{owner}/{repo}/issues/{number}`). If found, store it as `sourceUrl` in plan.yaml. Use `gh pr view <url> --json title,body` or `gh issue view <url> --json title,body` to fetch the title and body for additional context when writing the plan.
+**Extract Source URL**: Check if the task description contains a GitHub PR URL (`https://github.com/{owner}/{repo}/pull/{number}`) or issue URL (`https://github.com/{owner}/{repo}/issues/{number}`). If found, store it as `sourceUrl` in plan.yaml. Use `gh pr view <url> --json title,body` or `gh issue view <url> --json title,body` to fetch the title and body for additional context when writing the plan.
 
-**Format screenshot paths**: If the description contains file paths to images (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`), include them in the plan revision as markdown images using `file:///` URLs. Convert backslashes to forward slashes. Example: a path like `D:\Screenshots\2026-05-07_17-16.png` in the description becomes `![screenshot](file:///D:/Screenshots/2026-05-07_17-16.png)` in the revision.
+**Format screenshot paths**: If the task description contains file paths to images (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`), include them in the plan revision as markdown images using `file:///` URLs. Convert backslashes to forward slashes. Example: a path like `D:\Screenshots\2026-05-07_17-16.png` in the description becomes `![screenshot](file:///D:/Screenshots/2026-05-07_17-16.png)` in the revision.
 
-### 1.5. Select Project
+### 1.1. Select Project
 
 The **Projects** section of your firmware lists all available projects with their repos, verifications, and context.
 
@@ -94,7 +95,7 @@ Do NOT read or modify `.counter` directly. Plan IDs are allocated by the `tendri
   tendril trash write <SafeTitle>.md <<'EOF'
   ---
   date: <CurrentTime>
-  originalRequest: "<the args/request text>"
+  originalRequest: "<the task description text>"
   duplicateOf: "<existing plan folder name>"
   project: "<project name>"
   existingPlanState: "<state from the existing plan's plan.yaml>"
@@ -105,7 +106,7 @@ Do NOT read or modify `.counter` directly. Plan IDs are allocated by the `tendri
 
   This request was identified as a duplicate of plan [<existing plan ID>](<path to existing plan>).
 
-  **Original request:** <args text>
+  **Original request:** <task description text>
 
   **Existing plan state:** <state>
 
@@ -122,7 +123,7 @@ Do NOT read or modify `.counter` directly. Plan IDs are allocated by the `tendri
 
 ### 3.5. Validate Code State
 
-Before creating the plan, scan the task description (args) for code state assertions — statements about what the code currently does or how it currently looks.
+Before creating the plan, scan the task description for code state assertions — statements about what the code currently does or how it currently looks.
 
 **Patterns to detect:**
 - "currently does/has/is/returns"
@@ -157,7 +158,7 @@ tendril plan create "<Title>" \
   --plans-dir "<TendrilPlansFolder>" \
   --project "<TendrilProject>" \
   --level "NiceToHave" \
-  --initial-prompt "<cleaned args text>" \
+  --initial-prompt "<cleaned task description>" \
   --execution-profile "balanced" \
   --repo "<repo-path-1>" \
   --repo "<repo-path-2>" \
@@ -178,7 +179,7 @@ Parse `PlanId` and `Directory` from the output — use these for all subsequent 
 
 Include optional flags as needed:
 - `--source-url "<url>"` — if a source URL was extracted in Step 1
-- `--related-plan "<folder-name>"` — for each plan referenced via `[number]` syntax in args
+- `--related-plan "<folder-name>"` — for each plan referenced via `[number]` syntax in the task description
 - `--depends-on "<folder-name>"` — for blocking dependencies (see Section 4.4)
 - `--priority <number>` — if non-default priority
 
@@ -375,4 +376,5 @@ The user can edit the checklist before execution — unchecking a required verif
 - When referencing local files, use markdown links: `[filename:line](file:///path/to/filename)` for source files with line numbers, or `[filename](file:///path/to/filename)` without. Never use backticks in link text or `#L123` fragments in URLs. Use `![alt](path)` for images.
 - Keep the plan short and concise - the limiting factor of this system is a human that will have to read this.
 - **!IMPORTANT: ONE issue per plan file — if multiple issues, create multiple plan files with separate IDs**
-- **Multiple plans from one execution:** When args contain multiple issues, call `tendril plan create` once per plan. Each call auto-allocates a unique ID. Do NOT read or modify `.counter` directly.
+- **Multiple plans from one execution:** When the task description contains multiple issues, call `tendril plan create` once per plan. Each call auto-allocates a unique ID. Do NOT read or modify `.counter` directly.
+- **🚫 ABSOLUTE PROHIBITION: You are NEVER allowed to fix code directly in the source repository. Under NO circumstances may you Write, Edit, or create files in the source repos. Not "just this once", not "to save time", not "it's a one-liner". Your ONLY job is to produce plans via `tendril` CLI commands. If you feel tempted to "just fix it quickly" — STOP. Write a plan instead. Violations waste the entire execution and break the workflow.**

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -8,7 +8,7 @@ Execute an approved plan in isolated git worktrees.
 
 The firmware header contains:
 
-- **Args** / **TendrilPlanFolder** — path to the plan folder
+- **TendrilPlanFolder** — path to the plan folder
 - **CurrentTime** — current UTC timestamp
 - **Note** (optional) — Additional instructions from the reviewer. If present, follow these instructions in addition to the plan.
 

--- a/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
@@ -5,7 +5,7 @@ Transform investigation-heavy plans into concrete implementation plans.
 ## Context
 
 The firmware header contains:
-- **Args** / **TendrilPlanFolder** — path to the plan folder
+- **TendrilPlanFolder** — path to the plan folder
 - **CurrentTime** — current UTC timestamp
 
 The plan structure and CLI commands are in the **Reference Documents** section of your firmware.

--- a/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -5,7 +5,7 @@ Split a multi-issue plan into separate, self-contained plans.
 ## Context
 
 The firmware header contains:
-- **Args** / **TendrilPlanFolder** — path to the plan folder to split
+- **TendrilPlanFolder** — path to the plan folder to split
 - **CurrentTime** — current UTC timestamp
 
 The plan structure and CLI commands are in the **Reference Documents** section of your firmware.

--- a/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
@@ -5,7 +5,7 @@ Update an existing plan by applying user instructions from the firmware header.
 ## Context
 
 The firmware header contains:
-- **Args** / **TendrilPlanFolder** — path to the plan folder
+- **TendrilPlanFolder** — path to the plan folder
 - **UpdateInstructions** — the user's update instructions (what to change)
 - **CurrentTime** — current UTC timestamp
 

--- a/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
+++ b/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
@@ -19,15 +19,12 @@ public class AgentProviderFactory
     };
 
     internal static readonly IReadOnlyList<string> BaseTools =
-        ["Read", "Glob", "Grep", "Bash(tendril*)", "Bash(git *)", "Bash(gh *)", "Bash(ls *)", "Bash(find *)", "Bash(cat *)",
-         "WebFetch", "WebSearch"];
+        ["Read", "Glob", "Grep", "Bash", "WebFetch", "WebSearch"];
 
     private static readonly Dictionary<string, IReadOnlyList<string>> BuiltInExtraTools =
         new(StringComparer.OrdinalIgnoreCase)
         {
-            ["ExecutePlan"] = ["Bash", "Write", "Edit"],
-            ["CreatePr"] = ["Bash"],
-            ["CreateIssue"] = ["Bash"]
+            ["ExecutePlan"] = ["Write", "Edit"],
         };
 
     public static IAgentProvider GetProvider(string name)

--- a/src/Ivy.Tendril/Services/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/FirmwareCompiler.cs
@@ -22,7 +22,7 @@ public static class FirmwareCompiler
 
         This prompt is your Firmware and is never allowed to change.
 
-        In the header above your arguments is specified.
+        The header above contains your named parameters for this execution.
 
         Your program folder is: {PROGRAMFOLDER}
 
@@ -152,7 +152,7 @@ public static class FirmwareCompiler
 
     private static readonly HashSet<string> PathKeys = new(StringComparer.OrdinalIgnoreCase)
     {
-        "Args", "TendrilConfigPath", "TendrilHome", "TendrilPlanFolder",
+        "TendrilConfigPath", "TendrilHome", "TendrilPlanFolder",
         "TendrilPlansFolder", "SourceUrl", "SourcePath"
     };
 

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -324,7 +324,7 @@ internal class JobLauncher
         var job = ctx.Job;
         var cp = job.TypedArgs as CreatePlanArgs;
         var description = cp?.Description ?? "";
-        values["Args"] = description;
+        values["TaskDescription"] = description;
         values["TendrilPlansFolder"] = _configService!.PlanFolder;
 
         if (cp?.Force == true)
@@ -335,7 +335,6 @@ internal class JobLauncher
         BuildNonCreatePlanFirmware(JobItem job, Dictionary<string, string> values)
     {
         var planFolder = job.TypedArgs?.PlanFolder ?? "";
-        values["Args"] = planFolder;
 
         if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder))
             return (values, null, null);


### PR DESCRIPTION
- Rename Args → TaskDescription for CreatePlan firmware header
- Remove redundant Args for non-CreatePlan promptwares (already have TendrilPlanFolder)
- Grant unrestricted Bash to all promptwares (fixes non-deterministic heredoc permission denials)
- Simplify BuiltInExtraTools to only ExecutePlan → [Write, Edit]
- Add strict no-direct-fix policy to CreatePlan Program.md
- Update firmware template text to reference "named parameters"
- Remove TaskDescription from PathKeys (it's free text, not a path)
