### PR TITLE
Fix OutputSheet UseState crash by moving snapshot to JobsApp (#652)

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
@@ -9,13 +9,12 @@ public partial class OutputSheet(
     IJobService jobService,
     IWriteStream<string> outputStream,
     IState<bool> hasStreamContent,
-    IState<string?> streamingJobId) : ViewBase
+    IState<string?> streamingJobId,
+    IState<string?> initialContent) : ViewBase
 {
     public override object Build()
     {
         var job = jobService.GetJob(jobId);
-        var initialContent = UseState(() => job is not null && !job.OutputLines.IsEmpty
-            ? string.Join("\n", job.OutputLines) : null);
         object agentOutputView;
 
         if (job is { Status: JobStatus.Running })

--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -35,6 +35,7 @@ public partial class JobsApp : ViewBase
             return new Fragment(sheet, new FileSheet(openFile, config));
         });
 
+        var outputInitialContent = UseState<string?>(null);
         var (outputSheet, showOutput) = UseTrigger<string>((isOpen, jobId) =>
         {
             if (!isOpen.Value)
@@ -43,10 +44,15 @@ public partial class JobsApp : ViewBase
                 streamingJobId.Set(null);
                 hasStreamContent.Set(false);
                 lastProcessedIndex.Set(0);
+                outputInitialContent.Set(null);
                 return null;
             }
             activeOutputJobId.Set(jobId);
-            var outputSheetView = new OutputSheet(jobId, jobService, outputStream, hasStreamContent, streamingJobId);
+            var job = jobService.GetJob(jobId);
+            var snapshot = job is not null && !job.OutputLines.IsEmpty
+                ? string.Join("\n", job.OutputLines) : null;
+            outputInitialContent.Set(snapshot);
+            var outputSheetView = new OutputSheet(jobId, jobService, outputStream, hasStreamContent, streamingJobId, outputInitialContent);
             return new Sheet(
                 () => isOpen.Set(false),
                 outputSheetView.Build(),


### PR DESCRIPTION
OutputSheet.Build() is called directly from UseTrigger, not mounted as
a stateful child — UseState is unavailable there. Capture the initial
content snapshot in JobsApp where hooks are valid and pass it in.
