### PR TITLE
[00072] Add Clear All option to Jobs toolbar menu

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -245,6 +245,13 @@ public partial class JobsApp
                                       jobService.ClearFailedJobs();
                                       refreshToken.Refresh();
                                       client.Toast($"Cleared {count} failed {(count == 1 ? "job" : "jobs")}.", "Clear Failed");
+                                  }),
+                                  new MenuItem("Clear All", Icon: Icons.Trash, Tag: "ClearAll").OnSelect(() =>
+                                  {
+                                      var count = jobService.GetJobs().Count(j => j.Status is not JobStatus.Running and not JobStatus.Queued);
+                                      jobService.ClearAllJobs();
+                                      refreshToken.Refresh();
+                                      client.Toast($"Cleared {count} {(count == 1 ? "job" : "jobs")}.", "Clear All");
                                   })
                               ));
     }

--- a/src/Ivy.Tendril/Services/IJobService.cs
+++ b/src/Ivy.Tendril/Services/IJobService.cs
@@ -16,6 +16,7 @@ public interface IJobService : IDisposable
     void DeleteJob(string id);
     void ClearCompletedJobs();
     void ClearFailedJobs();
+    void ClearAllJobs();
     List<JobItem> GetJobs();
     JobItem? GetJob(string id);
     bool IsInboxFileTracked(string filePath);

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -251,6 +251,9 @@ public class JobService : IJobService
     public void ClearFailedJobs()
         => ClearJobsByStatus(j => j.Status is JobStatus.Failed or JobStatus.Timeout);
 
+    public void ClearAllJobs()
+        => ClearJobsByStatus(j => j.Status is not JobStatus.Running and not JobStatus.Queued);
+
     private void ClearJobsByStatus(Func<JobItem, bool> predicate)
     {
         var ids = _jobs.Values.Where(predicate).Select(j => j.Id).ToList();


### PR DESCRIPTION
# Summary

## Changes

Added a "Clear All" option to the Jobs toolbar ellipsis menu that removes all non-running and non-queued jobs with a single click.

## API Changes

- **Added:** `IJobService.ClearAllJobs()` — public method to clear all jobs except Running and Queued
- **Added:** `JobService.ClearAllJobs()` — implementation delegates to existing `ClearJobsByStatus` helper

## Files Modified

**Services:**
- `src/Ivy.Tendril/Services/IJobService.cs` — added interface method
- `src/Ivy.Tendril/Services/JobService.cs` — added implementation

**UI:**
- `src/Ivy.Tendril/Apps/JobsApp.DataTable.cs` — added third menu item to toolbar dropdown

---

**Commits:**
- e9faa41 [00072] Add Clear All option to Jobs toolbar menu