### PR TITLE
[00074] Add AI Wizard icon to Auto project option

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs
@@ -43,10 +43,10 @@ public class CreatePlanDialog(
             }
         );
 
-        var options = new List<string>();
+        var options = new List<IAnyOption>();
         if (projectNames.Count > 1)
-            options.Add("Auto");
-        options.AddRange(projectNames);
+            options.Add(new Option<string>("Auto", "Auto", icon: Icons.WandSparkles));
+        options.AddRange(projectNames.Select(p => new Option<string>(p, p)));
 
         return new Dialog(
             _ => onClose(),


### PR DESCRIPTION
# Summary

## Changes

Added WandSparkles icon to the "Auto" project option in the Create Plan dialog. The Auto option now uses `Option<string>` with icon support to visually distinguish it from named projects.

## API Changes

**CreatePlanDialog.cs:**
- Changed `options` variable type from `List<string>` to `List<IAnyOption>`
- Auto option now created as `new Option<string>("Auto", "Auto", icon: Icons.WandSparkles)`
- Project names converted to `Option<string>` instances via `.Select(p => new Option<string>(p, p))`

## Files Modified

**Core Changes:**
- `src/Ivy.Tendril/Apps/Plans/Dialogs/CreatePlanDialog.cs` — Added icon to Auto option

---

**Commits:**
- 1aa8cbb