### PR TITLE
[00076] Add Reset to Draft button in Review app

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -82,10 +82,11 @@ public class ContentView(
                 assigneesQuery, assigneesError);
         });
 
-        var (rerunDialog, showRerunDialog) = UseTrigger((isOpen) =>
+        var (resetToDraftDialog, showResetToDraftDialog) = UseTrigger((isOpen) =>
         {
             if (!isOpen.Value) return null;
-            return new RerunDialog(isOpen, selectedPlanState.Value!, jobService, planService, refreshPlans);
+            return new ResetToDraftDialog(isOpen, selectedPlanState.Value!, planService, refreshPlans,
+                UseService<ILogger<ResetToDraftDialog>>());
         });
 
         var artifactContentQuery = UseQuery<string, string>(
@@ -213,7 +214,7 @@ public class ContentView(
             ).Scroll(Scroll.None).Size(Size.Full())
         ).Scroll(Scroll.None).Size(Size.Full()).Key(selectedPlanState.Value.Id);
 
-        return new Fragment(mainLayout, discardDialog, suggestChangesDialog, customPrDialog, rerunDialog);
+        return new Fragment(mainLayout, discardDialog, suggestChangesDialog, customPrDialog, resetToDraftDialog);
     }
 
     private object BuildHeader(
@@ -273,9 +274,9 @@ public class ContentView(
         ReviewAppArgs? args)
     {
         return Layout.Horizontal().AlignContent(Align.Left).Gap(1)
-                | new Button("Rerun").Icon(Icons.RotateCw).Outline().ShortcutKey("r").OnClick(() =>
+                | new Button("Reset to Draft").Icon(Icons.RotateCcw).Outline().ShortcutKey("r").OnClick(() =>
                 {
-                    showRerunDialog();
+                    showResetToDraftDialog();
                 })
                 | new Button("Suggest Changes").Icon(Icons.MessageSquare).Outline().OnClick(() =>
                 {

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -82,11 +82,12 @@ public class ContentView(
                 assigneesQuery, assigneesError);
         });
 
+        var resetToDraftLogger = UseService<ILogger<ResetToDraftDialog>>();
         var (resetToDraftDialog, showResetToDraftDialog) = UseTrigger((isOpen) =>
         {
             if (!isOpen.Value) return null;
             return new ResetToDraftDialog(isOpen, selectedPlanState.Value!, planService, refreshPlans,
-                UseService<ILogger<ResetToDraftDialog>>());
+                resetToDraftLogger);
         });
 
         var artifactContentQuery = UseQuery<string, string>(
@@ -198,7 +199,7 @@ public class ContentView(
 
         var header = BuildHeader(selectedPlanState.Value, allPlans, currentIndex, client, showCustomPrDialog, nav, args);
         var actionBar = BuildActionBar(
-            selectedPlanState.Value, showRerunDialog, showSuggestChangesDialog, showDiscardDialog,
+            selectedPlanState.Value, showResetToDraftDialog, showSuggestChangesDialog, showDiscardDialog,
             showCustomPrDialog, copyToClipboard, client, logger, nav, args);
         var content = BuildContent(
             selectedPlanState.Value, planData, planContentQuery, selectedTabIndex, tabNames, openVerification,
@@ -263,7 +264,7 @@ public class ContentView(
 
     private object BuildActionBar(
         PlanFile selectedPlan,
-        Action showRerunDialog,
+        Action showResetToDraftDialog,
         Action showSuggestChangesDialog,
         Action showDiscardDialog,
         Action showCustomPrDialog,

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
@@ -6,66 +6,51 @@ using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Apps.Review.Dialogs;
 
-public class RerunDialog(
+public class ResetToDraftDialog(
     IState<bool> dialogOpen,
     PlanFile selectedPlan,
-    IJobService jobService,
     IPlanReaderService planService,
-    Action refreshPlans) : ViewBase
+    Action refreshPlans,
+    ILogger<ResetToDraftDialog> logger) : ViewBase
 {
     private readonly IState<bool> _dialogOpen = dialogOpen;
-    private readonly IJobService _jobService = jobService;
     private readonly IPlanReaderService _planService = planService;
     private readonly Action _refreshPlans = refreshPlans;
     private readonly PlanFile _selectedPlan = selectedPlan;
+    private readonly ILogger<ResetToDraftDialog> _logger = logger;
 
     public override object? Build()
     {
-        var isRerunningClean = UseState(false);
-        var isRerunningCurrent = UseState(false);
-        var logger = UseService<ILogger<RerunDialog>>();
+        var isResetting = UseState(false);
 
         if (!_dialogOpen.Value) return null;
 
         return new Dialog(
             _ =>
             {
-                isRerunningClean.Set(false);
-                isRerunningCurrent.Set(false);
+                isResetting.Set(false);
                 _dialogOpen.Set(false);
             },
-            new DialogHeader($"Rerun Plan #{_selectedPlan.Id}"),
+            new DialogHeader($"Reset Plan #{_selectedPlan.Id} to Draft"),
             new DialogBody(
-                Text.P("How would you like to rerun this plan?")
+                Text.P("Are you sure you want to reset this plan? Will remove all worktrees and artifacts.")
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() => _dialogOpen.Set(false)),
-                new Button("Rerun from Scratch").Warning().Disabled(isRerunningClean.Value).OnClick(() =>
+                new Button("Reset to Draft").Warning().Disabled(isResetting.Value).ShortcutKey("Enter").AutoFocus().OnClick(() =>
                 {
-                    if (!isRerunningClean.Value)
+                    if (!isResetting.Value)
                     {
-                        isRerunningClean.Set(true);
+                        isResetting.Set(true);
                         _dialogOpen.Set(false);
-                        _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
-                        _refreshPlans();
 
                         var folderPath = _selectedPlan.FolderPath;
                         Task.Run(() =>
                         {
-                            CleanPlanState(folderPath, logger);
-                            _jobService.StartJob(new ExecutePlanArgs(folderPath, Note: "User requested a clean rerun. All artifacts, logs, and worktrees have been cleaned. Execute this plan from scratch."));
+                            CleanPlanState(folderPath, _logger);
+                            _planService.ResetToDraft(_selectedPlan.FolderName);
+                            _refreshPlans();
                         });
-                    }
-                }),
-                new Button("Rerun with Current").Primary().Disabled(isRerunningCurrent.Value).ShortcutKey("Enter").AutoFocus().OnClick(() =>
-                {
-                    if (!isRerunningCurrent.Value)
-                    {
-                        isRerunningCurrent.Set(true);
-                        _dialogOpen.Set(false);
-                        _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
-                        _jobService.StartJob(new ExecutePlanArgs(_selectedPlan.FolderPath, Note: "User requested you to execute this plan another time. Go through all code, verifications and artifacts one more time."));
-                        _refreshPlans();
                     }
                 })
             )

--- a/src/Ivy.Tendril/Services/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/IPlanReaderService.cs
@@ -14,6 +14,7 @@ public interface IPlanReaderService
     PlanFile? GetPlanByFolder(string folderPath);
     List<PlanFile> GetIceboxPlans();
     void TransitionState(string folderName, PlanStatus newState);
+    void ResetToDraft(string folderName);
     void SaveRevision(string folderName, string content);
     string ReadLatestRevision(string folderName);
     List<(int Number, string Content, DateTime Modified)> GetRevisions(string folderName);

--- a/src/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/PlanReaderService.cs
@@ -221,6 +221,39 @@ public class PlanReaderService(
     }
 
     /// <summary>
+    ///     Resets a plan to Draft state, clearing commits, recommendations, and verification statuses.
+    /// </summary>
+    /// <param name="folderName">Name of the plan folder (e.g. <c>01105-TestPlan</c>).</param>
+    public void ResetToDraft(string folderName)
+    {
+        var planId = ExtractPlanId(folderName);
+
+        if (planId.HasValue && _database != null)
+            _database.UpdatePlanState(planId.Value, PlanStatus.Draft);
+
+        _planCountsCache.Invalidate();
+        _recommendationsCache.Invalidate();
+        CountsInvalidated?.Invoke();
+        _planWatcherService?.NotifyChanged(folderName);
+
+        WriteFileInBackground(() =>
+        {
+            var planYamlPath = Path.Combine(PlansDirectory, folderName, "plan.yaml");
+            if (!File.Exists(planYamlPath)) return;
+
+            var yaml = FileHelper.ReadAllText(planYamlPath);
+            var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
+            planYaml.State = PlanStatus.Draft.ToString();
+            planYaml.Updated = DateTime.UtcNow;
+            planYaml.Commits = new List<string>();
+            planYaml.Recommendations = null;
+            foreach (var v in planYaml.Verifications)
+                v.Status = "Pending";
+            FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
+        });
+    }
+
+    /// <summary>
     ///     Creates a new revision file for a plan and updates the plan's timestamp.
     /// </summary>
     /// <param name="folderName">Name of the plan folder.</param>


### PR DESCRIPTION
# Summary

## Changes

Replaced the "Rerun" button in the Review app with a "Reset to Draft" button that shows a confirmation dialog before resetting a plan back to Draft state. The reset clears all execution artifacts (worktrees, artifacts, logs, verifications) while preserving the plan itself.

## API Changes

**Added:**
- `IPlanReaderService.ResetToDraft(string folderName)` - Resets plan state to Draft, clears commits/recommendations, resets verifications to Pending

**Removed:**
- `RerunDialog` class (replaced by `ResetToDraftDialog`)

## Files Modified

**Apps/Review:**
- `Dialogs/ResetToDraftDialog.cs` - New dialog with confirmation prompt
- `ContentView.cs` - Updated to use ResetToDraftDialog instead of RerunDialog

**Services:**
- `IPlanReaderService.cs` - Added ResetToDraft method signature
- `PlanReaderService.cs` - Implemented ResetToDraft method

---

## Commits

- [00076] Fix build errors in ContentView (79de467)
- [00076] Replace Rerun button with Reset to Draft button (6123337)