### PR TITLE
[00260] Align Delete button on same line as other action buttons

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs
@@ -28,42 +28,40 @@ public class DeletePlanDialog(
                 Text.P($"What would you like to do with plan #{_selectedPlan.Id}?")
             ),
             new DialogFooter(
-                Layout.Vertical().Gap(2)
-                | (Layout.Horizontal().Gap(2).Right()
-                   | new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() => _dialogOpen.Set(false))
-                   | new Button("Move to Skipped").Outline().ShortcutKey("s").OnClick(() =>
-                   {
-                       // Optimistically update UI state before disk I/O
-                       var optimisticPlan = _selectedPlan with
-                       {
-                           Metadata = _selectedPlan.Metadata with { State = PlanStatus.Skipped }
-                       };
-                       _selectedPlanState.Set(optimisticPlan);
+                Layout.Horizontal().Gap(2).Right()
+                | new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() => _dialogOpen.Set(false))
+                | new Button("Move to Skipped").Outline().ShortcutKey("s").OnClick(() =>
+                {
+                    // Optimistically update UI state before disk I/O
+                    var optimisticPlan = _selectedPlan with
+                    {
+                        Metadata = _selectedPlan.Metadata with { State = PlanStatus.Skipped }
+                    };
+                    _selectedPlanState.Set(optimisticPlan);
 
-                       _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Skipped);
-                       _refreshPlans();
-                       _dialogOpen.Set(false);
-                   })
-                   | new Button("Move to Icebox").Outline().ShortcutKey("b").OnClick(() =>
-                   {
-                       // Optimistically update UI state before disk I/O
-                       var optimisticPlan = _selectedPlan with
-                       {
-                           Metadata = _selectedPlan.Metadata with { State = PlanStatus.Icebox }
-                       };
-                       _selectedPlanState.Set(optimisticPlan);
+                    _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Skipped);
+                    _refreshPlans();
+                    _dialogOpen.Set(false);
+                })
+                | new Button("Move to Icebox").Outline().ShortcutKey("b").OnClick(() =>
+                {
+                    // Optimistically update UI state before disk I/O
+                    var optimisticPlan = _selectedPlan with
+                    {
+                        Metadata = _selectedPlan.Metadata with { State = PlanStatus.Icebox }
+                    };
+                    _selectedPlanState.Set(optimisticPlan);
 
-                       _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Icebox);
-                       _refreshPlans();
-                       _dialogOpen.Set(false);
-                   }))
-                | (Layout.Horizontal().Right()
-                   | new Button("Delete").Destructive().ShortcutKey("Enter").AutoFocus().OnClick(() =>
-                   {
-                       _planService.DeletePlan(_selectedPlan.FolderName);
-                       _refreshPlans();
-                       _dialogOpen.Set(false);
-                   }))
+                    _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Icebox);
+                    _refreshPlans();
+                    _dialogOpen.Set(false);
+                })
+                | new Button("Delete").Destructive().ShortcutKey("Enter").AutoFocus().OnClick(() =>
+                {
+                    _planService.DeletePlan(_selectedPlan.FolderName);
+                    _refreshPlans();
+                    _dialogOpen.Set(false);
+                })
             )
         ).Width(Size.Rem(40));
     }


### PR DESCRIPTION
Fixes #660

## Changes

Replaced the two-row vertical layout in DeletePlanDialog's footer with a single horizontal row. All four buttons (Cancel, Move to Skipped, Move to Icebox, Delete) now appear on the same line.

## Files Modified

- `src/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs` — Replaced `Layout.Vertical().Gap(2)` with single `Layout.Horizontal().Gap(2).Right()` containing all buttons

---

**Commits:**
- 7ddc8d9 [00260] Align Delete button on same line as other action buttons