### PR TITLE
[00264] Add padding to onboarding last step output container

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -174,7 +174,7 @@ public class CompleteStepView(
                      )
                        .Width(Size.Full())
                        .Height(Size.Units(100).Max(Size.Fraction(0.6f)))
-                       .Padding(0)
+                       .Padding(4)
                    : null!)
                | (!running && totalVerifications > 0 ? (object)listLayout : null!)
                | (Layout.Horizontal().Width(Size.Full())


### PR DESCRIPTION
## Changes

Added padding to the onboarding Complete step's output container. Changed `.Padding(0)` to `.Padding(4)` on the Box wrapping the AgentOutputView, giving the JSON output stream breathing room from the container border.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs** — Changed Box padding from 0 to 4

---

### Commits

- 5c0d7a2 [00264] Add padding to onboarding last step output container