### PR TITLE
Fix premature plan visibility in Review/Drafts while jobs are still running

### DIFF
--- a/src/Ivy.Tendril/Apps/PlansApp.cs
+++ b/src/Ivy.Tendril/Apps/PlansApp.cs
@@ -36,8 +36,25 @@ public class PlansApp : ViewBase
 
         var previousPlans = UseRef(new List<PlanFile>());
 
+        var activeJobs = jobService.GetJobs()
+            .Where(j => j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending or JobStatus.Blocked)
+            .ToList();
+
+        var activePlanFolders = activeJobs
+            .Select(j => j.TypedArgs?.PlanFolder)
+            .Where(f => f != null)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var activeCreatePlanIds = activeJobs
+            .Where(j => j.TypedArgs is CreatePlanArgs)
+            .Select(j => j.ReportedPlanId ?? j.AllocatedPlanId)
+            .Where(id => id != null)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         var plans = planService.GetPlans()
             .Where(p => p.Status is PlanStatus.Draft or PlanStatus.Blocked)
+            .Where(p => !activePlanFolders.Contains(p.FolderPath) &&
+                        !activeCreatePlanIds.Any(id => p.FolderName.StartsWith(id + "-", StringComparison.OrdinalIgnoreCase)))
             .ToList();
         var filteredPlans = PlanFilters.ApplyFilters(plans, projectFilter.Value, levelFilter.Value, textFilter.Value)
             .ToList();

--- a/src/Ivy.Tendril/Apps/ReviewApp.cs
+++ b/src/Ivy.Tendril/Apps/ReviewApp.cs
@@ -65,10 +65,17 @@ public class ReviewApp : ViewBase
 
         var previousPlans = UseRef(new List<PlanFile>());
 
+        var activePlanFolders = jobService.GetJobs()
+            .Where(j => j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending or JobStatus.Blocked)
+            .Select(j => j.TypedArgs?.PlanFolder)
+            .Where(f => f != null)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         var plans = planService.GetPlans()
             .Where(p => showCompleted.Value
                 ? p.Status is PlanStatus.ReadyForReview or PlanStatus.Failed or PlanStatus.Completed
                 : p.Status is PlanStatus.ReadyForReview or PlanStatus.Failed)
+            .Where(p => !activePlanFolders.Contains(p.FolderPath))
             .ToList();
         var filteredPlans = PlanFilters.ApplyFilters(plans, projectFilter.Value, levelFilter.Value, textFilter.Value).ToList();
 

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -548,7 +548,7 @@ Worktrees are **not** cleaned up by ExecutePlan. They remain on disk so that Cre
 
 ### 9. Plan State
 
-The launcher script handles state transitions (Completed/Failed) based on exit code.
+**🚫 FORBIDDEN:** Do NOT call `tendril plan set <plan-id> state <anything>`. The Tendril server handles all state transitions automatically based on your exit code and verification statuses. Setting state manually causes the plan to appear in Review prematurely while your job is still running.
 
 ### Ambiguity Handling
 

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -350,18 +350,15 @@ internal class JobCompletionHandler
             var planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
             if (planYaml == null) return;
 
-            if (planYaml.State is "Executing" or "Building" or "Draft")
-            {
-                var hasIncomplete = planYaml.Verifications?
-                    .Any(v => v.Status is "Pending" or "Fail") ?? false;
-                var targetState = hasIncomplete ? PlanStatus.Failed : PlanStatus.ReadyForReview;
+            var hasIncomplete = planYaml.Verifications?
+                .Any(v => v.Status is "Pending" or "Fail") ?? false;
+            var targetState = hasIncomplete ? PlanStatus.Failed : PlanStatus.ReadyForReview;
 
-                var folderName = Path.GetFileName(planFolder);
-                if (_planReaderService != null)
-                    _planReaderService.TransitionState(folderName, targetState);
-                else
-                    PlanYamlHelper.SetPlanStateByFolder(planFolder, targetState.ToString());
-            }
+            var folderName = Path.GetFileName(planFolder);
+            if (_planReaderService != null)
+                _planReaderService.TransitionState(folderName, targetState);
+            else
+                PlanYamlHelper.SetPlanStateByFolder(planFolder, targetState.ToString());
         }
         catch (Exception ex)
         {

--- a/src/Ivy.Tendril/Services/PlanCountsService.cs
+++ b/src/Ivy.Tendril/Services/PlanCountsService.cs
@@ -86,10 +86,43 @@ public class PlanCountsService : IPlanCountsService
         var snapshot = _planReaderService.ComputePlanCounts();
         var jobs = _jobService.GetJobs();
 
+        var activeJobs = jobs
+            .Where(j => j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending or JobStatus.Blocked)
+            .ToList();
+
+        var activePlanFolders = activeJobs
+            .Select(j => j.TypedArgs?.PlanFolder)
+            .Where(f => f != null)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var activeCreatePlanIds = activeJobs
+            .Where(j => j.TypedArgs is CreatePlanArgs)
+            .Select(j => j.ReportedPlanId ?? j.AllocatedPlanId)
+            .Where(id => id != null)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var prematureReviews = 0;
+        var prematureDrafts = 0;
+
+        if (activePlanFolders.Count > 0 || activeCreatePlanIds.Count > 0)
+        {
+            foreach (var p in _planReaderService.GetPlans())
+            {
+                var hasActiveJob = activePlanFolders.Contains(p.FolderPath) ||
+                    activeCreatePlanIds.Any(id => p.FolderName.StartsWith(id + "-", StringComparison.OrdinalIgnoreCase));
+                if (!hasActiveJob) continue;
+
+                if (p.Status is PlanStatus.ReadyForReview or PlanStatus.Failed)
+                    prematureReviews++;
+                else if (p.Status is PlanStatus.Draft or PlanStatus.Blocked)
+                    prematureDrafts++;
+            }
+        }
+
         return new PlanCounts(
-            snapshot.Drafts,
+            Math.Max(0, snapshot.Drafts - prematureDrafts),
             jobs.Count(j => j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Blocked),
-            snapshot.ReadyForReview + snapshot.Failed,
+            Math.Max(0, snapshot.ReadyForReview + snapshot.Failed - prematureReviews),
             snapshot.Icebox,
             snapshot.PendingRecommendations,
             snapshot.TotalPlans


### PR DESCRIPTION
## Summary

- Hide plans from Review and Drafts apps when they have an active job (Running/Queued/Pending/Blocked)
- Correct PlanCountsService side menu counters to subtract plans with active jobs
- Self-heal premature state changes in JobCompletionHandler by always overriding on completion
- Strengthen ExecutePlan Program.md to explicitly forbid manual state changes

## Test plan

- [x] All 1429 unit tests pass
- [x] Build succeeds