### PR TITLE
[00269] Keep theme selector open when selecting a theme

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -105,12 +105,12 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var navigator = UseNavigation();
         var importIssuesDialogOpen = UseState(false);
         var newsArticles = UseState(Array.Empty<SidebarNewsArticle>());
-        
+
         UseEffect(async () =>
         {
             newsArticles.Set(await FetchNewsAsync());
         });
-        
+
         UseEffect(() =>
         {
             void OnChanged()

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -461,6 +461,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 DropDownMenu.DefaultSelectHandler(),
                 settingsTrigger)
             .Top()
+            .StayOpen()
             .Items(settings.FooterMenuItemsTransformer(settingsMenuItems, navigator));
 
         object? footer;


### PR DESCRIPTION
Added a `StayOpen` property to the `DropDownMenu` widget that prevents the menu from closing when an item is selected. Applied this to the Tendril settings menu so users can cycle through theme options (Light/Dark/System) without the menu closing after each selection.

## Commits

- `2299915` [00269] Apply StayOpen to settings menu for theme selection
- `ef9de91` [00269] Fix formatting in TendrilAppShell.cs