### PR TITLE
[00270] Add Enter key submit to repo path input in add project dialog and onboarding

### DIFF
--- a/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
@@ -78,6 +78,7 @@ public class ProjectRepoPickerView(
             pickerControls = Layout.Horizontal().Gap(2).Width(Size.Full())
                              | inputValue.ToTextInput("Repository URL or local path")
                                  .Width(Size.Grow())
+                                 .OnSubmit(() => { _ = AddAsync(); })
                              | new Button("Browse").Icon(Icons.FolderOpen).Outline()
                                  .OnClick(() =>
                                  {
@@ -90,7 +91,8 @@ public class ProjectRepoPickerView(
         {
             pickerControls = Layout.Horizontal().Gap(2).Width(Size.Full())
                              | inputValue.ToTextInput("Repository URL or local path")
-                                 .Width(Size.Grow());
+                                 .Width(Size.Grow())
+                                 .OnSubmit(() => { _ = AddAsync(); });
         }
 
         var addButton = new Button(isAdding.Value ? "Adding..." : "Add").Icon(Icons.Plus)


### PR DESCRIPTION
## Summary

Added `.OnSubmit(() => { _ = AddAsync(); })` to both text input instances in `ProjectRepoPickerView.cs` — the desktop mode input (with Browse button) and the non-desktop mode input. Pressing Enter in the "Repository URL or local path" field now triggers the same `AddAsync()` logic as clicking the "Add" button.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Views/ProjectRepoPickerView.cs** — Added `.OnSubmit()` handler to both text input fluent chains

---

- 02f6b87 [00270] Add Enter key submit to repo path text input in ProjectRepoPickerView