### PR TITLE
Fix Review tab refresh stuck in Loading state

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using Ivy.Core;
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
@@ -107,7 +108,7 @@ public class ContentView(
         );
 
         var planContentQuery = UseQuery<PlanContentData, string>(
-            selectedPlanState.Value?.FolderPath ?? "",
+            selectedPlanState.Value?.FolderPath,
             async (folderPath, ct) =>
             {
                 return await Task.Run(() =>
@@ -180,6 +181,23 @@ public class ContentView(
                 new Dictionary<string, List<string>>(), new List<PlanContentHelpers.CommitRow>(), new Dictionary<string, bool>(),
                 new List<(string Name, bool ConditionMet)>(), null)
         );
+
+        var planWatcher = UseService<IPlanWatcherService>();
+        var localRefresh = UseRefreshToken();
+
+        UseEffect(() =>
+        {
+            void OnChanged(string? _) => localRefresh.Refresh();
+            planWatcher.PlansChanged += OnChanged;
+            return Disposable.Create(() => planWatcher.PlansChanged -= OnChanged);
+        });
+
+        UseEffect(() =>
+        {
+            if (localRefresh.IsRefreshed)
+                planContentQuery.Mutator.Revalidate();
+            return Disposable.Empty;
+        }, [localRefresh]);
 
         var tabNames = new[] { "summary", "plan", "details", "verifications", "git", "changes", "artifacts", "recommendations" };
         var selectedTabIndex = Array.IndexOf(tabNames, args?.Tab ?? "summary");
@@ -365,7 +383,7 @@ public class ContentView(
                     }
                 }));
 
-        if (planContentQuery.Loading)
+        if (planContentQuery.Loading && planData is null)
         {
             content |= Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                        | Text.Muted("Loading...");

--- a/src/Ivy.Tendril/Services/GitService.cs
+++ b/src/Ivy.Tendril/Services/GitService.cs
@@ -96,15 +96,17 @@ public class GitService : IGitService
                 return GitResult<string>.Failure(GitError.GitNotFound, "Failed to start git process");
             }
 
-            var output = process.StandardOutput.ReadToEnd();
+            var outputTask = process.StandardOutput.ReadToEndAsync();
             var timedOut = !process.WaitForExit(_timeoutMs);
 
             if (timedOut)
             {
-                process.Kill();
+                try { process.Kill(); } catch { }
                 _logger.LogWarning("Git command timed out after {Timeout}ms", _timeoutMs);
                 return GitResult<string>.Failure(GitError.Timeout, $"Git command timed out after {_timeoutMs}ms");
             }
+
+            var output = outputTask.GetAwaiter().GetResult();
 
             if (process.ExitCode != 0)
             {
@@ -151,15 +153,17 @@ public class GitService : IGitService
                 return GitResult<int>.Failure(GitError.GitNotFound, "Failed to start git process");
             }
 
-            var output = process.StandardOutput.ReadToEnd();
+            var outputTask = process.StandardOutput.ReadToEndAsync();
             var timedOut = !process.WaitForExit(_timeoutMs);
 
             if (timedOut)
             {
-                process.Kill();
+                try { process.Kill(); } catch { }
                 _logger.LogWarning("Git command timed out after {Timeout}ms", _timeoutMs);
                 return GitResult<int>.Failure(GitError.Timeout, $"Git command timed out after {_timeoutMs}ms");
             }
+
+            var output = outputTask.GetAwaiter().GetResult();
 
             if (process.ExitCode != 0)
             {
@@ -207,15 +211,17 @@ public class GitService : IGitService
                 return GitResult<List<(string Status, string FilePath)>>.Failure(GitError.GitNotFound, "Failed to start git process");
             }
 
-            var output = process.StandardOutput.ReadToEnd();
+            var outputTask = process.StandardOutput.ReadToEndAsync();
             var timedOut = !process.WaitForExit(_timeoutMs);
 
             if (timedOut)
             {
-                process.Kill();
+                try { process.Kill(); } catch { }
                 _logger.LogWarning("Git command timed out after {Timeout}ms", _timeoutMs);
                 return GitResult<List<(string Status, string FilePath)>>.Failure(GitError.Timeout, $"Git command timed out after {_timeoutMs}ms");
             }
+
+            var output = outputTask.GetAwaiter().GetResult();
 
             if (process.ExitCode != 0)
             {
@@ -270,15 +276,17 @@ public class GitService : IGitService
                 return GitResult<string>.Failure(GitError.GitNotFound, "Failed to start git process");
             }
 
-            var output = process.StandardOutput.ReadToEnd();
+            var outputTask = process.StandardOutput.ReadToEndAsync();
             var timedOut = !process.WaitForExit(_timeoutMs);
 
             if (timedOut)
             {
-                process.Kill();
+                try { process.Kill(); } catch { }
                 _logger.LogWarning("Git command timed out after {Timeout}ms", _timeoutMs);
                 return GitResult<string>.Failure(GitError.Timeout, $"Git command timed out after {_timeoutMs}ms");
             }
+
+            var output = outputTask.GetAwaiter().GetResult();
 
             if (process.ExitCode != 0)
             {
@@ -325,15 +333,17 @@ public class GitService : IGitService
                 return GitResult<List<(string Status, string FilePath)>>.Failure(GitError.GitNotFound, "Failed to start git process");
             }
 
-            var output = process.StandardOutput.ReadToEnd();
+            var outputTask = process.StandardOutput.ReadToEndAsync();
             var timedOut = !process.WaitForExit(_timeoutMs);
 
             if (timedOut)
             {
-                process.Kill();
+                try { process.Kill(); } catch { }
                 _logger.LogWarning("Git command timed out after {Timeout}ms", _timeoutMs);
                 return GitResult<List<(string Status, string FilePath)>>.Failure(GitError.Timeout, $"Git command timed out after {_timeoutMs}ms");
             }
+
+            var output = outputTask.GetAwaiter().GetResult();
 
             if (process.ExitCode != 0)
             {
@@ -400,15 +410,17 @@ public class GitService : IGitService
                 process.StandardInput.WriteLine(hash);
             process.StandardInput.Close();
 
-            var output = process.StandardOutput.ReadToEnd();
+            var outputTask = process.StandardOutput.ReadToEndAsync();
             var timedOut = !process.WaitForExit(_timeoutMs);
 
             if (timedOut)
             {
-                process.Kill();
+                try { process.Kill(); } catch { }
                 _logger.LogWarning("Git command timed out after {Timeout}ms", _timeoutMs);
                 return GitResult<Dictionary<string, (string Title, int FileCount)>>.Failure(GitError.Timeout, $"Git command timed out after {_timeoutMs}ms");
             }
+
+            var output = outputTask.GetAwaiter().GetResult();
 
             if (process.ExitCode != 0)
             {
@@ -505,15 +517,17 @@ public class GitService : IGitService
                 return GitResult<List<WorktreeInfo>>.Failure(GitError.GitNotFound, "Failed to start git process");
             }
 
-            var output = process.StandardOutput.ReadToEnd();
+            var outputTask = process.StandardOutput.ReadToEndAsync();
             var timedOut = !process.WaitForExit(_timeoutMs);
 
             if (timedOut)
             {
-                process.Kill();
+                try { process.Kill(); } catch { }
                 _logger.LogWarning("Git command timed out after {Timeout}ms", _timeoutMs);
                 return GitResult<List<WorktreeInfo>>.Failure(GitError.Timeout, $"Git command timed out after {_timeoutMs}ms");
             }
+
+            var output = outputTask.GetAwaiter().GetResult();
 
             if (process.ExitCode != 0)
             {


### PR DESCRIPTION
## Summary
- Use `Revalidate()` instead of full remount so existing content stays visible while data refreshes in background
- Change query key from empty string to `null` for idle state when no plan is selected
- Fix GitService timeout pattern: `ReadToEndAsync()` before `WaitForExit()` so timeouts actually fire instead of blocking forever

## Test plan
- [x] All 36 GitService tests pass
- [x] All 18 PlanContentHelper tests pass
- [ ] Manual: open Review app, select a plan, click tab refresh — content stays visible, refreshes in background
- [ ] Manual: verify initial load of a plan still shows "Loading..." correctly