### PR TITLE
Fix Reset to Draft not deleting the worktrees directory

### DIFF
--- a/src/Ivy.Tendril.Test/RerunDialogTests.cs
+++ b/src/Ivy.Tendril.Test/RerunDialogTests.cs
@@ -103,4 +103,27 @@ public class ResetToDraftDialogTests
                 Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void CleanPlanState_DeletesWorktreesDirectory()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-test-{Guid.NewGuid()}");
+        try
+        {
+            var planDir = Path.Combine(tempDir, "00001-TestPlan");
+            var worktreesDir = Path.Combine(planDir, "worktrees");
+            var repoDir = Path.Combine(worktreesDir, "Ivy-Framework");
+            Directory.CreateDirectory(repoDir);
+            File.WriteAllText(Path.Combine(repoDir, "dummy.txt"), "test");
+
+            ResetToDraftDialog.CleanPlanState(planDir);
+
+            Assert.False(Directory.Exists(worktreesDir));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
@@ -81,5 +81,12 @@ public class ResetToDraftDialog(
         }
 
         WorktreeCleanupService.RemoveWorktrees(planFolderPath, logger);
+
+        var worktreesDir = Path.Combine(planFolderPath, "worktrees");
+        if (Directory.Exists(worktreesDir))
+        {
+            logger?.LogInformation("Cleaning worktrees directory: {Path}", worktreesDir);
+            WorktreeCleanupService.ForceDeleteDirectory(worktreesDir, logger);
+        }
     }
 }


### PR DESCRIPTION
RemoveWorktrees unregisters git worktrees and deletes subdirectories
but leaves the parent worktrees/ folder behind. Add explicit deletion
of the directory after cleanup, matching CleanupPlanWorktrees behavior.
