### PR TITLE
Fix InvalidOperationException when clicking Last Output cell

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/OutputSheet.cs
@@ -4,7 +4,7 @@ using Ivy.Widgets.AgentOutputView;
 
 namespace Ivy.Tendril.Apps.Jobs;
 
-public partial class OutputSheet(string jobId, IJobService jobService) : ViewBase
+public class OutputSheet(string jobId, IJobService jobService) : ViewBase
 {
     public override object Build()
     {
@@ -37,20 +37,4 @@ public partial class OutputSheet(string jobId, IJobService jobService) : ViewBas
             .Stream(outputStream)
             .Height(Size.Full());
     }
-
-    public string GetSheetTitle()
-    {
-        var job = jobService.GetJob(jobId);
-        return job is not null ? $"{job.Type} {ExtractPlanId(job.PlanFile)}" : "Job Output";
-    }
-
-    private static string ExtractPlanId(string planFile)
-    {
-        if (string.IsNullOrEmpty(planFile)) return "";
-        var match = ExtractPlanIdRegex().Match(planFile);
-        return match.Success ? match.Groups[1].Value : "";
-    }
-
-    [System.Text.RegularExpressions.GeneratedRegex(@"^(\d{5})-")]
-    private static partial System.Text.RegularExpressions.Regex ExtractPlanIdRegex();
 }

--- a/src/Ivy.Tendril/Apps/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Data.cs
@@ -35,7 +35,7 @@ public partial class JobsApp
                 Timer = FormatTimer(j),
                 Cost = j.Cost.HasValue ? $"${j.Cost.Value:F2}" : "",
                 Tokens = j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : "",
-                LastOutput = FormatLastOutput(j),
+                AgentOutput = FormatAgentOutput(j),
                 LastOutputTimestamp = j.LastOutputAt,
                 StatusMessage = GetStatusMessage(j),
                 ErrorContext = j.Status is JobStatus.Failed or JobStatus.Timeout
@@ -86,7 +86,7 @@ public partial class JobsApp
                 new DataTableCellUpdate(j.Id, "Timer", FormatTimer(j)),
                 new DataTableCellUpdate(j.Id, "Cost", j.Cost.HasValue ? $"${j.Cost.Value:F2}" : ""),
                 new DataTableCellUpdate(j.Id, "Tokens", j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : ""),
-                new DataTableCellUpdate(j.Id, "LastOutput", FormatLastOutput(j)),
+                new DataTableCellUpdate(j.Id, "AgentOutput", FormatAgentOutput(j)),
                 new DataTableCellUpdate(j.Id, "Status", FormatStatusBadge(j.Status)),
                 new DataTableCellUpdate(j.Id, "StatusMessage", GetStatusMessage(j))
             });

--- a/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.DataTable.cs
@@ -37,8 +37,8 @@ public partial class JobsApp
             .Header(t => t.Timer, "Timer")
             .Header(t => t.Cost, "Cost")
             .Header(t => t.Tokens, "Tokens")
-            .Header(t => t.LastOutput, "Last Output")
-            .Renderer(t => t.LastOutput, new AnimatedStatusLabelDisplayRenderer
+            .Header(t => t.AgentOutput, "Agent Output")
+            .Renderer(t => t.AgentOutput, new AnimatedStatusLabelDisplayRenderer
             {
                 Mode = AnimatedStatusMode.SpinnerTimer
             })
@@ -49,7 +49,7 @@ public partial class JobsApp
             .Width(t => t.Plan, Size.Px(250))
             .Width(t => t.Project, Size.Px(100))
             .Width(t => t.Timer, Size.Px(100))
-            .Width(t => t.LastOutput, Size.Px(100))
+            .Width(t => t.AgentOutput, Size.Px(100))
             .Width(t => t.Cost, Size.Px(100))
             .Width(t => t.Tokens, Size.Px(100))
             .Width(t => t.StatusMessage, Size.Auto())
@@ -102,7 +102,7 @@ public partial class JobsApp
                 }
                 return ValueTask.CompletedTask;
             })
-            .OnCellAction(t => t.LastOutput, e =>
+            .OnCellAction(t => t.AgentOutput, e =>
             {
                 var id = e.Value.RowId?.ToString();
                 if (!string.IsNullOrEmpty(id))

--- a/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
@@ -36,7 +36,7 @@ public partial class JobsApp
         return match.Success ? match.Groups[1].Value : "";
     }
 
-    private static string FormatLastOutput(JobItem job)
+    private static string FormatAgentOutput(JobItem job)
     {
         if (job.Status == JobStatus.Running)
         {

--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -34,10 +34,12 @@ public partial class JobsApp : ViewBase
         {
             if (!isOpen.Value) return null;
             var outputSheetView = new OutputSheet(jobId, jobService);
+            var job = jobService.GetJob(jobId);
+            var title = job is not null ? $"{job.Type} {ExtractPlanId(job.PlanFile)}" : "Job Output";
             return new Sheet(
                 () => isOpen.Set(false),
                 outputSheetView.Build(),
-                outputSheetView.GetSheetTitle()
+                title
             ).Width(Size.Half()).Resizable();
         });
 

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -292,28 +292,16 @@ public class ContentView(
         INavigator nav,
         ReviewAppArgs? args)
     {
-        return Layout.Horizontal().AlignContent(Align.Left).Gap(1)
-                | new Button("Reset to Draft").Icon(Icons.RotateCcw).Outline().ShortcutKey("r").OnClick(() =>
-                {
-                    showResetToDraftDialog();
-                })
-                | new Button("Suggest Changes").Icon(Icons.MessageSquare).Outline().OnClick(() =>
-                {
-                    showSuggestChangesDialog();
-                }).ShortcutKey("d")
-                | new Button("Discard").Icon(Icons.Trash).Outline().ShortcutKey("Backspace").OnClick(() =>
-                {
-                    showDiscardDialog();
-                })
+        return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
+                | new Button("Reset to Draft").Icon(Icons.RotateCcw).Outline().ShortcutKey("r").OnClick(showResetToDraftDialog)
+                | new Button("Suggest Changes").Icon(Icons.MessageSquare).Outline().OnClick(showSuggestChangesDialog).ShortcutKey("d")
+                | new Button("Discard").Icon(Icons.Trash).Outline().ShortcutKey("Backspace").OnClick(showDiscardDialog)
                 | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(() => GoToPrevious(nav, args))
                     .ShortcutKey("p")
                 | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(() => GoToNext(nav, args))
                     .ShortcutKey("n")
                 | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
-                    new MenuItem("Custom PR", Icon: Icons.GitPullRequest, Tag: "CustomPR").OnSelect(() =>
-                    {
-                        showCustomPrDialog();
-                    }),
+                    new MenuItem("Custom PR", Icon: Icons.GitPullRequest, Tag: "CustomPR").OnSelect(showCustomPrDialog),
                     new MenuItem("Set Completed", Icon: Icons.CircleCheck, Tag: "SetCompleted").OnSelect(() =>
                     {
                         planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -166,7 +166,7 @@ public record JobItemRow
     public string Type { get; init; } = "";
     public string Project { get; init; } = "";
     public string Timer { get; init; } = "";
-    public string LastOutput { get; init; } = "";
+    public string AgentOutput { get; init; } = "";
     public DateTime? LastOutputTimestamp { get; init; }
     public string Cost { get; init; } = "";
     public string Tokens { get; init; } = "";


### PR DESCRIPTION
## Summary
- Fix `InvalidOperationException: Access to Context is only allowed in the Build method` when clicking the Last Output cell in Jobs view
- Move title computation from `OutputSheet.GetSheetTitle()` into the `UseTrigger` callback where `jobService` is accessible within Build context
- Rename `LastOutput` → `AgentOutput` across model, data table, and helpers
- Simplify ContentView button handlers to use method groups

## Test plan
- [x] Build succeeds with 0 errors/warnings
- [x] All 1431 tests pass
- [x] No stale references to old `LastOutput` property name