### PR TITLE
Replace magic strings with nameof() in DataTableCellUpdate calls

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Data.cs
@@ -83,12 +83,12 @@ public partial class JobsApp
                          && DateTime.UtcNow - j.CompletedAt.Value < TimeSpan.FromMinutes(1)))
             .SelectMany(j => new[]
             {
-                new DataTableCellUpdate(j.Id, "Timer", FormatTimer(j)),
-                new DataTableCellUpdate(j.Id, "Cost", j.Cost.HasValue ? $"${j.Cost.Value:F2}" : ""),
-                new DataTableCellUpdate(j.Id, "Tokens", j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : ""),
-                new DataTableCellUpdate(j.Id, "AgentOutput", FormatAgentOutput(j)),
-                new DataTableCellUpdate(j.Id, "Status", FormatStatusBadge(j.Status)),
-                new DataTableCellUpdate(j.Id, "StatusMessage", GetStatusMessage(j))
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Timer), FormatTimer(j)),
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Cost), j.Cost.HasValue ? $"${j.Cost.Value:F2}" : ""),
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Tokens), j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : ""),
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.AgentOutput), FormatAgentOutput(j)),
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.Status), FormatStatusBadge(j.Status)),
+                new DataTableCellUpdate(j.Id, nameof(JobItemRow.StatusMessage), GetStatusMessage(j))
             });
     }
 }


### PR DESCRIPTION
## Summary
- Replace 6 hardcoded column name strings with `nameof(JobItemRow.X)` in `BuildDataTableUpdates`
- Compiler will now catch column name mismatches on renames

## Test plan
- [x] Build succeeds
- [x] All 1431 tests pass
- [x] CodeScene score: 10.0 (Optimal)