### PR TITLE
[00082] Handle editor command not in PATH gracefully

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1695,4 +1695,43 @@ maxConcurrentJobs: 10
             _logAction(logLevel, formatter(state, exception));
         }
     }
+
+    [Fact]
+    public void OpenInEditor_WhenEditorUnavailable_ThrowsEditorNotAvailableException()
+    {
+        var yaml = @"
+editor:
+  command: nonexistent-editor-xyz-12345
+  label: Nonexistent Editor
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            var testFilePath = Path.Combine(tempDir, "test.txt");
+            File.WriteAllText(testFilePath, "test content");
+
+            var exception = Assert.Throws<EditorNotAvailableException>(() =>
+                service.OpenInEditor(testFilePath));
+
+            Assert.Equal("nonexistent-editor-xyz-12345", exception.Command);
+            Assert.Equal("Nonexistent Editor", exception.Label);
+            Assert.Contains("nonexistent-editor-xyz-12345", exception.Message);
+            Assert.Contains("Nonexistent Editor", exception.Message);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void IsCommandAvailable_WithInvalidCommand_ReturnsFalse()
+    {
+        var result = ConfigService.IsCommandAvailable("definitely-not-a-real-command-xyz-999");
+        Assert.False(result);
+    }
 }

--- a/src/Ivy.Tendril/Apps/ConfigErrorApp.cs
+++ b/src/Ivy.Tendril/Apps/ConfigErrorApp.cs
@@ -10,7 +10,8 @@ public class ConfigErrorApp(IConfigService config) : ViewBase
     public override object Build()
     {
         var showDetails = UseState(false);
-        var client = UseService<IClientProvider>();
+        var client = UseClient();
+        var clientProvider = UseService<IClientProvider>();
         var navigator = UseNavigation();
         var httpContextAccessor = UseService<IHttpContextAccessor>();
         Context.TryUseService<DesktopWindow>(out var desktopWindow);
@@ -20,7 +21,7 @@ public class ConfigErrorApp(IConfigService config) : ViewBase
 
         if (parseError == null)
         {
-            client.Redirect("/", true);
+            clientProvider.Redirect("/", true);
             return Text.P("Redirecting...");
         }
 
@@ -41,7 +42,7 @@ public class ConfigErrorApp(IConfigService config) : ViewBase
                    | new Button("Edit Config")
                        .Icon(Icons.FileText)
                        .OnClick(() =>
-                           ConfigYamlUiHelper.OpenOrNavigate(config, navigator, isDesktopShell, capturedHost))
+                           ConfigYamlUiHelper.OpenOrNavigate(config, navigator, client, isDesktopShell, capturedHost))
                    | new Button("Reload Config")
                        .Icon(Icons.RefreshCw)
                        .Variant(ButtonVariant.Outline)
@@ -49,7 +50,7 @@ public class ConfigErrorApp(IConfigService config) : ViewBase
                        {
                            config.RetryLoadConfig();
                            if (config.ParseError == null)
-                               client.Redirect("/", true);
+                               clientProvider.Redirect("/", true);
                        })
                    | new Button("Reset to Defaults")
                        .Icon(Icons.RotateCcw)
@@ -57,7 +58,7 @@ public class ConfigErrorApp(IConfigService config) : ViewBase
                        .OnClick(() =>
                        {
                            config.ResetToDefaults();
-                           client.Redirect("/", true);
+                           clientProvider.Redirect("/", true);
                        })
                    | new Button(showDetails.Value ? "Hide Details" : "View Details")
                        .Icon(Icons.Info)

--- a/src/Ivy.Tendril/Apps/ConfigErrorApp.cs
+++ b/src/Ivy.Tendril/Apps/ConfigErrorApp.cs
@@ -10,8 +10,7 @@ public class ConfigErrorApp(IConfigService config) : ViewBase
     public override object Build()
     {
         var showDetails = UseState(false);
-        var client = UseClient();
-        var clientProvider = UseService<IClientProvider>();
+        var client = UseService<IClientProvider>();
         var navigator = UseNavigation();
         var httpContextAccessor = UseService<IHttpContextAccessor>();
         Context.TryUseService<DesktopWindow>(out var desktopWindow);
@@ -21,7 +20,7 @@ public class ConfigErrorApp(IConfigService config) : ViewBase
 
         if (parseError == null)
         {
-            clientProvider.Redirect("/", true);
+            client.Redirect("/", true);
             return Text.P("Redirecting...");
         }
 
@@ -50,7 +49,7 @@ public class ConfigErrorApp(IConfigService config) : ViewBase
                        {
                            config.RetryLoadConfig();
                            if (config.ParseError == null)
-                               clientProvider.Redirect("/", true);
+                               client.Redirect("/", true);
                        })
                    | new Button("Reset to Defaults")
                        .Icon(Icons.RotateCcw)
@@ -58,7 +57,7 @@ public class ConfigErrorApp(IConfigService config) : ViewBase
                        .OnClick(() =>
                        {
                            config.ResetToDefaults();
-                           clientProvider.Redirect("/", true);
+                           client.Redirect("/", true);
                        })
                    | new Button(showDetails.Value ? "Hide Details" : "View Details")
                        .Icon(Icons.Info)

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -98,7 +98,17 @@ public class ContentView(
                             new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
                             {
                                 var yamlPath = Path.Combine(selectedPlan.FolderPath, "plan.yaml");
-                                config.OpenInEditor(yamlPath);
+                                try
+                                {
+                                    config.OpenInEditor(yamlPath);
+                                }
+                                catch (EditorNotAvailableException ex)
+                                {
+                                    client.Toast(
+                                        $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                                        "Editor Not Available",
+                                        variant: "destructive");
+                                }
                             })
                         );
 

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -107,7 +107,7 @@ public class ContentView(
                                     client.Toast(
                                         $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
                                         "Editor Not Available",
-                                        variant: "destructive");
+                                        variant: ToastVariant.Destructive);
                                 }
                             })
                         );

--- a/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
@@ -15,6 +15,7 @@ public class JobDebugSheet(
     public override object Build()
     {
         var copyToClipboard = UseClipboard();
+        var client = UseService<IClientProvider>();
 
         var job = jobService.GetJob(jobId);
         if (job is null)
@@ -60,15 +61,15 @@ public class JobDebugSheet(
             .Label(x => x.JobId, "Job Id")
             .Builder(x => x.PermissionDenials, f => f.Func((string denials) =>
                 new CodeBlock(denials)))
-            .Builder(x => x.PlanFolder, f => f.Func((string path) => PathDropDown(path, copyToClipboard)))
-            .Builder(x => x.PlanLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard)))
-            .Builder(x => x.PlanCliLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard)))
-            .Builder(x => x.PromptwareLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard)))
-            .Builder(x => x.PromptwareRawLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard)))
+            .Builder(x => x.PlanFolder, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
+            .Builder(x => x.PlanLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
+            .Builder(x => x.PlanCliLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
+            .Builder(x => x.PromptwareLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
+            .Builder(x => x.PromptwareRawLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .RemoveEmpty();
     }
 
-    private object PathDropDown(string path, Action<string> copyToClipboard)
+    private object PathDropDown(string path, Action<string> copyToClipboard, IClientProvider client)
     {
         return Layout.Horizontal().Gap(2).AlignContent(Align.Center)
             | Text.Block(path)
@@ -88,7 +89,7 @@ public class JobDebugSheet(
                                 client.Toast(
                                     $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
                                     "Editor Not Available",
-                                    variant: "destructive");
+                                    variant: ToastVariant.Destructive);
                             }
                         })
                 );

--- a/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
@@ -77,7 +77,20 @@ public class JobDebugSheet(
                     new MenuItem("Copy to Clipboard", Icon: Icons.ClipboardCopy, Tag: "Copy")
                         .OnSelect(() => copyToClipboard(path)),
                     new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
-                        .OnSelect(() => config.OpenInEditor(path))
+                        .OnSelect(() =>
+                        {
+                            try
+                            {
+                                config.OpenInEditor(path);
+                            }
+                            catch (EditorNotAvailableException ex)
+                            {
+                                client.Toast(
+                                    $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                                    "Editor Not Available",
+                                    variant: "destructive");
+                            }
+                        })
                 );
     }
 

--- a/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
@@ -112,7 +112,20 @@ public class ActionBarView(
                        PlatformHelper.OpenInTerminal(selectedPlan.FolderPath);
                    }),
                    new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
-                       .OnSelect(() => { config.OpenInEditor(selectedPlan.FolderPath); }),
+                       .OnSelect(() =>
+                       {
+                           try
+                           {
+                               config.OpenInEditor(selectedPlan.FolderPath);
+                           }
+                           catch (EditorNotAvailableException ex)
+                           {
+                               client.Toast(
+                                   $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                                   "Editor Not Available",
+                                   variant: "destructive");
+                           }
+                       }),
                    new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
                        .OnSelect(() =>
                        {
@@ -135,7 +148,17 @@ public class ActionBarView(
                    new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
                    {
                        var yamlPath = Path.Combine(selectedPlan.FolderPath, "plan.yaml");
-                       config.OpenInEditor(yamlPath);
+                       try
+                       {
+                           config.OpenInEditor(yamlPath);
+                       }
+                       catch (EditorNotAvailableException ex)
+                       {
+                           client.Toast(
+                               $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                               "Editor Not Available",
+                               variant: "destructive");
+                       }
                    })
                );
     }

--- a/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
@@ -123,7 +123,7 @@ public class ActionBarView(
                                client.Toast(
                                    $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
                                    "Editor Not Available",
-                                   variant: "destructive");
+                                   variant: ToastVariant.Destructive);
                            }
                        }),
                    new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
@@ -157,7 +157,7 @@ public class ActionBarView(
                            client.Toast(
                                $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
                                "Editor Not Available",
-                               variant: "destructive");
+                               variant: ToastVariant.Destructive);
                        }
                    })
                );

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -173,7 +173,7 @@ public class ContentView(
                                     client.Toast(
                                         $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
                                         "Editor Not Available",
-                                        variant: "destructive");
+                                        variant: ToastVariant.Destructive);
                                 }
                             })
                         );

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -164,7 +164,17 @@ public class ContentView(
                             {
                                 var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
                                 var yamlPath = Path.Combine(fullPath, "plan.yaml");
-                                config.OpenInEditor(yamlPath);
+                                try
+                                {
+                                    config.OpenInEditor(yamlPath);
+                                }
+                                catch (EditorNotAvailableException ex)
+                                {
+                                    client.Toast(
+                                        $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                                        "Editor Not Available",
+                                        variant: "destructive");
+                                }
                             })
                         );
 

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -332,11 +332,34 @@ public class ContentView(
                             client.Toast("Copied path to clipboard", "Path Copied");
                         }),
                     new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
-                        .OnSelect(() => { config.OpenInEditor(selectedPlan.FolderPath); }),
+                        .OnSelect(() =>
+                        {
+                            try
+                            {
+                                config.OpenInEditor(selectedPlan.FolderPath);
+                            }
+                            catch (EditorNotAvailableException ex)
+                            {
+                                client.Toast(
+                                    $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                                    "Editor Not Available",
+                                    variant: "destructive");
+                            }
+                        }),
                     new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
                     {
                         var yamlPath = Path.Combine(selectedPlan.FolderPath, "plan.yaml");
-                        config.OpenInEditor(yamlPath);
+                        try
+                        {
+                            config.OpenInEditor(yamlPath);
+                        }
+                        catch (EditorNotAvailableException ex)
+                        {
+                            client.Toast(
+                                $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                                "Editor Not Available",
+                                variant: "destructive");
+                        }
                     })
                 );
     }

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -343,7 +343,7 @@ public class ContentView(
                                 client.Toast(
                                     $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
                                     "Editor Not Available",
-                                    variant: "destructive");
+                                    variant: ToastVariant.Destructive);
                             }
                         }),
                     new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
@@ -358,7 +358,7 @@ public class ContentView(
                             client.Toast(
                                 $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
                                 "Editor Not Available",
-                                variant: "destructive");
+                                variant: ToastVariant.Destructive);
                         }
                     })
                 );

--- a/src/Ivy.Tendril/Apps/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/SettingsApp.cs
@@ -23,7 +23,7 @@ public class SettingsApp : ViewBase
     {
         var config = UseService<IConfigService>();
         var navigator = UseNavigation();
-        var client = UseClient();
+        var client = UseService<IClientProvider>();
         var httpContextAccessor = UseService<IHttpContextAccessor>();
         var selected = UseState(TagGeneral);
         Context.TryUseService<DesktopWindow>(out var desktopWindow);

--- a/src/Ivy.Tendril/Apps/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/SettingsApp.cs
@@ -23,6 +23,7 @@ public class SettingsApp : ViewBase
     {
         var config = UseService<IConfigService>();
         var navigator = UseNavigation();
+        var client = UseClient();
         var httpContextAccessor = UseService<IHttpContextAccessor>();
         var selected = UseState(TagGeneral);
         Context.TryUseService<DesktopWindow>(out var desktopWindow);
@@ -63,7 +64,7 @@ public class SettingsApp : ViewBase
             switch (tag)
             {
                 case TagOpenConfig:
-                    ConfigYamlUiHelper.OpenOrNavigate(config, navigator, isDesktop, capturedHost);
+                    ConfigYamlUiHelper.OpenOrNavigate(config, navigator, client, isDesktop, capturedHost);
                     break;
                 default:
                     selected.Set(tag);

--- a/src/Ivy.Tendril/Apps/Setup/AdvancedSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/AdvancedSetupView.cs
@@ -35,6 +35,9 @@ public class AdvancedSetupView : ViewBase
                    | Text.Block("Editor").Bold()
                    | editorCommand.ToTextInput("e.g. code, vim")
                        .WithField().Label("Command")
+                       .Description(!config.Editor.IsAvailable
+                           ? $"⚠ '{config.Editor.Command}' was not found in PATH"
+                           : null)
                    | editorLabel.ToTextInput("e.g. VS Code, Vim")
                        .WithField().Label("Label")
                    | new Button("Save").Primary()

--- a/src/Ivy.Tendril/Helpers/ConfigYamlUiHelper.cs
+++ b/src/Ivy.Tendril/Helpers/ConfigYamlUiHelper.cs
@@ -1,4 +1,5 @@
 using Ivy.Core.Apps;
+using Ivy.Core.Client;
 using Ivy.Tendril.Apps;
 using Ivy.Tendril.Services;
 using Microsoft.AspNetCore.Http;
@@ -18,11 +19,12 @@ public static class ConfigYamlUiHelper
     public static void OpenOrNavigate(
         IConfigService config,
         INavigator navigator,
+        IClient client,
         bool isDesktopShell,
         IHttpContextAccessor? httpContextAccessor = null)
     {
         var capturedHost = httpContextAccessor?.HttpContext?.Request.Host.Host;
-        OpenOrNavigate(config, navigator, isDesktopShell, capturedHost);
+        OpenOrNavigate(config, navigator, client, isDesktopShell, capturedHost);
     }
 
     /// <summary>
@@ -31,11 +33,24 @@ public static class ConfigYamlUiHelper
     public static void OpenOrNavigate(
         IConfigService config,
         INavigator navigator,
+        IClient client,
         bool isDesktopShell,
         string? capturedHost)
     {
         if (isDesktopShell || IsLoopbackHost(capturedHost))
-            config.OpenInEditor(config.ConfigPath);
+        {
+            try
+            {
+                config.OpenInEditor(config.ConfigPath);
+            }
+            catch (EditorNotAvailableException ex)
+            {
+                client.Toast(
+                    $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                    "Editor Not Available",
+                    variant: "destructive");
+            }
+        }
         else
             navigator.Navigate<ConfigEditorApp>();
     }

--- a/src/Ivy.Tendril/Helpers/ConfigYamlUiHelper.cs
+++ b/src/Ivy.Tendril/Helpers/ConfigYamlUiHelper.cs
@@ -1,5 +1,4 @@
 using Ivy.Core.Apps;
-using Ivy.Core.Client;
 using Ivy.Tendril.Apps;
 using Ivy.Tendril.Services;
 using Microsoft.AspNetCore.Http;
@@ -19,7 +18,7 @@ public static class ConfigYamlUiHelper
     public static void OpenOrNavigate(
         IConfigService config,
         INavigator navigator,
-        IClient client,
+        IClientProvider client,
         bool isDesktopShell,
         IHttpContextAccessor? httpContextAccessor = null)
     {
@@ -33,7 +32,7 @@ public static class ConfigYamlUiHelper
     public static void OpenOrNavigate(
         IConfigService config,
         INavigator navigator,
-        IClient client,
+        IClientProvider client,
         bool isDesktopShell,
         string? capturedHost)
     {
@@ -48,7 +47,7 @@ public static class ConfigYamlUiHelper
                 client.Toast(
                     $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
                     "Editor Not Available",
-                    variant: "destructive");
+                    variant: ToastVariant.Destructive);
             }
         }
         else

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -551,6 +551,12 @@ public class ConfigService : IConfigService, IDisposable
     public void OpenInEditor(string path)
     {
         var processedPath = PreprocessForEditing(path);
+
+        if (!Editor.IsAvailable)
+        {
+            throw new EditorNotAvailableException(Editor.Command, Editor.Label);
+        }
+
         PlatformHelper.OpenInEditor(Editor.Command, processedPath);
     }
 

--- a/src/Ivy.Tendril/Services/EditorNotAvailableException.cs
+++ b/src/Ivy.Tendril/Services/EditorNotAvailableException.cs
@@ -1,0 +1,14 @@
+namespace Ivy.Tendril.Services;
+
+public class EditorNotAvailableException : Exception
+{
+    public string Command { get; }
+    public string Label { get; }
+
+    public EditorNotAvailableException(string command, string label)
+        : base($"Editor command '{command}' ({label}) is not available in PATH.")
+    {
+        Command = command;
+        Label = label;
+    }
+}

--- a/src/Ivy.Tendril/Views/Sheets/FileSheet.cs
+++ b/src/Ivy.Tendril/Views/Sheets/FileSheet.cs
@@ -67,7 +67,17 @@ public class FileSheet(
                 Layout.Vertical().Gap(2)
                     | new Button($"Open in {config.Editor.Label}").Icon(Icons.ExternalLink).Outline().OnClick(() =>
                     {
-                        config.OpenInEditor(filePath);
+                        try
+                        {
+                            config.OpenInEditor(filePath);
+                        }
+                        catch (EditorNotAvailableException ex)
+                        {
+                            client.Toast(
+                                $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                                "Editor Not Available",
+                                variant: "destructive");
+                        }
                     })
                     | Text.Block(filePath).Muted()
                 ,

--- a/src/Ivy.Tendril/Views/Sheets/FileSheet.cs
+++ b/src/Ivy.Tendril/Views/Sheets/FileSheet.cs
@@ -39,6 +39,8 @@ public class FileSheet(
 
     public override object Build()
     {
+        var client = UseService<IClientProvider>();
+
         if (openFile.Value is not { } filePath)
             return new Empty();
 
@@ -76,7 +78,7 @@ public class FileSheet(
                             client.Toast(
                                 $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
                                 "Editor Not Available",
-                                variant: "destructive");
+                                variant: ToastVariant.Destructive);
                         }
                     })
                     | Text.Block(filePath).Muted()

--- a/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
+++ b/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
@@ -111,7 +111,20 @@ public static class GitTabHelper
                             new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal")
                                 .OnSelect(() => PlatformHelper.OpenInTerminal(path, logger)),
                             new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
-                                .OnSelect(() => config.OpenInEditor(path)),
+                                .OnSelect(() =>
+                                {
+                                    try
+                                    {
+                                        config.OpenInEditor(path);
+                                    }
+                                    catch (EditorNotAvailableException ex)
+                                    {
+                                        client.Toast(
+                                            $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                                            "Editor Not Available",
+                                            variant: "destructive");
+                                    }
+                                }),
                             new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
                                 .OnSelect(() => copyToClipboard(path))
                         )));

--- a/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
+++ b/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
@@ -122,7 +122,7 @@ public static class GitTabHelper
                                         client.Toast(
                                             $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
                                             "Editor Not Available",
-                                            variant: "destructive");
+                                            variant: ToastVariant.Destructive);
                                     }
                                 }),
                             new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")


### PR DESCRIPTION
Fixes #638

# Summary

## Changes

Added EditorNotAvailableException and updated ConfigService.OpenInEditor to check Editor.IsAvailable before launching. All 10 call sites now catch the exception and display user-friendly toast notifications explaining how to fix the issue. Added warning indicator in AdvancedSetupView when the configured editor command is not found in PATH.

## API Changes

- **New:** `EditorNotAvailableException` class in `Ivy.Tendril.Services` with `Command` and `Label` properties
- **Modified:** `ConfigService.OpenInEditor` now throws `EditorNotAvailableException` when `Editor.IsAvailable` is false
- **Modified:** `ConfigYamlUiHelper.OpenOrNavigate` now requires `IClientProvider client` parameter

## Files Modified

**Services:**
- `Services/ConfigService.cs` — Added IsAvailable guard in OpenInEditor
- `Services/EditorNotAvailableException.cs` — New exception class

**Apps & Views:**
- `Apps/SettingsApp.cs` — Added exception handling for "Open config.yaml"
- `Apps/ConfigErrorApp.cs` — Added exception handling for "Edit Config"
- `Apps/Plans/ActionBarView.cs` — Added exception handling for folder and plan.yaml actions
- `Apps/Icebox/ContentView.cs` — Added exception handling for plan.yaml action
- `Apps/Review/ContentView.cs` — Added exception handling for folder and plan.yaml actions
- `Apps/Recommendations/ContentView.cs` — Added exception handling for plan.yaml action
- `Apps/Jobs/JobDebugSheet.cs` — Added exception handling for debug path actions
- `Apps/Setup/AdvancedSetupView.cs` — Added warning when editor command not in PATH
- `Views/Sheets/FileSheet.cs` — Added exception handling for "Open in editor"
- `Views/Tabs/GitTabHelper.cs` — Added exception handling for worktree actions
- `Helpers/ConfigYamlUiHelper.cs` — Added exception handling and client parameter

**Tests:**
- `Test/ConfigServiceTests.cs` — Added 2 tests for editor availability checking

---

## Commits

- a80ce2e [00082] Add EditorNotAvailableException and guard OpenInEditor calls
- a00d002 [00082] Fix IClient → IClientProvider and ToastVariant