### PR TITLE
[00075] Move job notifications to AppShell for always-on delivery

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -7,6 +7,7 @@ using Ivy.Tendril.AppShell.Dialogs;
 using Ivy.Tendril.Apps;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Views;
 using Ivy.Widgets.Internal;
 using Microsoft.Extensions.Logging;
@@ -131,6 +132,22 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
         UseEffect(() => { menuItems.Set(BuildMenuItems(appRepository, counts.Value)); },
             appRepository.Reloaded.ToTrigger(), counts);
+
+        var jobService = UseService<IJobService>();
+
+        UseEffect(() =>
+        {
+            void OnNotification(JobNotification notification)
+            {
+                if (notification.IsSuccess)
+                    client.Toast(notification.Message, notification.Title);
+                else
+                    client.Toast(notification.Message, notification.Title).Destructive();
+            }
+
+            jobService.NotificationReady += OnNotification;
+            return Disposable.Create(() => jobService.NotificationReady -= OnNotification);
+        });
 
         UseEffect(async () =>
         {

--- a/src/Ivy.Tendril/Apps/JobsApp.Hooks.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Hooks.cs
@@ -6,20 +6,6 @@ namespace Ivy.Tendril.Apps;
 
 public partial class JobsApp
 {
-    private static IDisposable NotificationHookDisposable(IJobService jobService, IClientProvider client)
-    {
-        void OnNotification(JobNotification notification)
-        {
-            if (notification.IsSuccess)
-                client.Toast(notification.Message, notification.Title);
-            else
-                client.Toast(notification.Message, notification.Title).Destructive();
-        }
-
-        jobService.NotificationReady += OnNotification;
-        return Disposable.Create(() => jobService.NotificationReady -= OnNotification);
-    }
-
     private static IDisposable JobChangeHookDisposable(IJobService jobService, RefreshToken refreshToken)
     {
         void OnJobsChanged()

--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -66,7 +66,6 @@ public partial class JobsApp : ViewBase
         });
 #endif
 
-        UseEffect(() => NotificationHookDisposable(jobService, client));
         UseEffect(() => JobChangeHookDisposable(jobService, refreshToken));
         UseInterval(() => AutoRefreshCheck(jobService, refreshToken), TimeSpan.FromSeconds(5));
 


### PR DESCRIPTION
# Summary

## Changes

Moved job notification subscriptions from `JobsApp` to `TendrilAppShell`, ensuring notifications fire regardless of which app is currently open. The notification logic remains unchanged — only the subscription location was moved to the shell level.

## API Changes

None.

## Files Modified

**AppShell:**
- `TendrilAppShell.cs` — Added `IJobService` subscription and `UseEffect` hook for notifications at shell level

**Apps:**
- `JobsApp.cs` — Removed `NotificationHookDisposable` call from `UseEffect`
- `JobsApp.Hooks.cs` — Deleted `NotificationHookDisposable` method (no longer referenced)

---

## Commits

- 97b7fd1 [00075] Move job notifications to AppShell for always-on delivery