### PR TITLE
[00278] Add UI option to apply config changes without restart

### DIFF
--- a/src/Ivy.Tendril/Apps/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/SettingsApp.cs
@@ -17,6 +17,7 @@ public class SettingsApp : ViewBase
     private const string TagProjects = "projects";
     private const string TagAdvanced = "advanced";
     private const string TagOpenConfig = "open-config";
+    private const string TagApplyConfig = "apply-config";
     private const string TagAccount = "account";
 
     public override object Build()
@@ -48,7 +49,8 @@ public class SettingsApp : ViewBase
                 .Icon(Icons.Wrench)
                 .Expanded()
                 .Children(
-                    MenuItem.Default("Open config.yaml", TagOpenConfig).Icon(Icons.FileText)
+                    MenuItem.Default("Open config.yaml", TagOpenConfig).Icon(Icons.FileText),
+                    MenuItem.Default("Apply config.yaml", TagApplyConfig).Icon(Icons.RefreshCw)
                 ),
             MenuItem.Default("Account")
                 .Icon(Icons.User)
@@ -65,6 +67,17 @@ public class SettingsApp : ViewBase
             {
                 case TagOpenConfig:
                     ConfigYamlUiHelper.OpenOrNavigate(config, navigator, client, isDesktop, capturedHost);
+                    break;
+                case TagApplyConfig:
+                    try
+                    {
+                        config.ReloadSettings();
+                        client.Toast("config.yaml has been applied successfully.", "Config reloaded");
+                    }
+                    catch (Exception ex)
+                    {
+                        client.Toast(ex.Message, "Reload failed", variant: ToastVariant.Destructive);
+                    }
                     break;
                 default:
                     selected.Set(tag);


### PR DESCRIPTION
Fixes #447

## Summary

Added an "Apply config.yaml" menu item in Settings → Tools that triggers `ConfigService.ReloadSettings()` to hot-reload configuration without restarting Tendril. Includes error handling with a destructive toast on YAML parse failures.

## Files Modified

- **src/Ivy.Tendril/Apps/SettingsApp.cs** — Added `TagApplyConfig` constant, menu item with RefreshCw icon, and OnSelect handler with try/catch error handling

---

## Commits

- ae78ebc [00278] Add Apply config.yaml menu item to Settings/Tools