### PR TITLE
[00003] Only show confetti on Create PR when prRule is yolo

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -277,10 +277,9 @@ public class ContentView(
             }
         }).ShortcutKey("m");
 
-        if (allYolo)
-            createPrBtn = createPrBtn.WithConfetti(AnimationTrigger.Click);
-
-        header |= createPrBtn;
+        header |= allYolo
+            ? createPrBtn.WithConfetti(AnimationTrigger.Click)
+            : createPrBtn;
 
         return header;
     }

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -258,13 +258,13 @@ public class ContentView(
                          .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
                          .Muted("plans", word: true);
 
-        header |= new Button("Create PR").Icon(Icons.GitPullRequest).Primary().OnClick(() =>
-        {
-            var repoPaths = selectedPlan.GetEffectiveRepoPaths(config);
-            var project = config.GetProject(selectedPlan.Project);
-            var allYolo = repoPaths.All(rp =>
-                project?.GetRepoRef(rp)?.PrRule == "yolo");
+        var repoPaths = selectedPlan.GetEffectiveRepoPaths(config);
+        var project = config.GetProject(selectedPlan.Project);
+        var allYolo = repoPaths.All(rp =>
+            project?.GetRepoRef(rp)?.PrRule == "yolo");
 
+        var createPrBtn = new Button("Create PR").Icon(Icons.GitPullRequest).Primary().OnClick(() =>
+        {
             if (allYolo)
             {
                 jobService.StartJob(new CreatePrArgs(selectedPlan.FolderPath));
@@ -275,7 +275,12 @@ public class ContentView(
             {
                 showCustomPrDialog();
             }
-        }).ShortcutKey("m").WithConfetti(AnimationTrigger.Click);
+        }).ShortcutKey("m");
+
+        if (allYolo)
+            createPrBtn = createPrBtn.WithConfetti(AnimationTrigger.Click);
+
+        header |= createPrBtn;
 
         return header;
     }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -80,29 +80,29 @@ public class CustomPrDialog(
                 }),
                 new Button("Create PR").Primary().Disabled(isCreating.Value).ShortcutKey("Ctrl+Enter").OnClick(() =>
                 {
-                    if (!isCreating.Value)
-                    {
-                        isCreating.Set(true);
-                        _jobService.StartJob(new CreatePrArgs(
-                            _selectedPlan.FolderPath,
-                            Merge: customPrMerge.Value,
-                            DeleteBranch: customPrDeleteBranch.Value && customPrMerge.Value,
-                            IncludeArtifacts: customPrIncludeArtifacts.Value,
-                            Assignee: customPrAssignee.Value,
-                            Comment: string.IsNullOrEmpty(customPrComment.Value) ? null : customPrComment.Value,
-                            Draft: customPrDraft.Value));
-                        _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
-                        _refreshPlans();
-                        isCreating.Set(false);
-                        customPrMerge.Set(true);
-                        customPrDeleteBranch.Set(true);
-                        customPrIncludeArtifacts.Set(true);
-                        customPrAssignee.Set(null);
-                        customPrComment.Set("");
-                        customPrDraft.Set(false);
-                        _dialogOpen.Set(false);
-                    }
-                }).WithConfetti(AnimationTrigger.Click)
+                if (!isCreating.Value)
+                {
+                    isCreating.Set(true);
+                    _jobService.StartJob(new CreatePrArgs(
+                        _selectedPlan.FolderPath,
+                        Merge: customPrMerge.Value,
+                        DeleteBranch: customPrDeleteBranch.Value && customPrMerge.Value,
+                        IncludeArtifacts: customPrIncludeArtifacts.Value,
+                        Assignee: customPrAssignee.Value,
+                        Comment: string.IsNullOrEmpty(customPrComment.Value) ? null : customPrComment.Value,
+                        Draft: customPrDraft.Value));
+                    _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
+                    _refreshPlans();
+                    isCreating.Set(false);
+                    customPrMerge.Set(true);
+                    customPrDeleteBranch.Set(true);
+                    customPrIncludeArtifacts.Set(true);
+                    customPrAssignee.Set(null);
+                    customPrComment.Set("");
+                    customPrDraft.Set(false);
+                    _dialogOpen.Set(false);
+                }
+                )
             )
         ).Width(Size.Rem(30));
     }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -102,7 +102,7 @@ public class CustomPrDialog(
                     customPrDraft.Set(false);
                     _dialogOpen.Set(false);
                 }
-                )
+                })
             )
         ).Width(Size.Rem(30));
     }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -80,28 +80,28 @@ public class CustomPrDialog(
                 }),
                 new Button("Create PR").Primary().Disabled(isCreating.Value).ShortcutKey("Ctrl+Enter").OnClick(() =>
                 {
-                if (!isCreating.Value)
-                {
-                    isCreating.Set(true);
-                    _jobService.StartJob(new CreatePrArgs(
-                        _selectedPlan.FolderPath,
-                        Merge: customPrMerge.Value,
-                        DeleteBranch: customPrDeleteBranch.Value && customPrMerge.Value,
-                        IncludeArtifacts: customPrIncludeArtifacts.Value,
-                        Assignee: customPrAssignee.Value,
-                        Comment: string.IsNullOrEmpty(customPrComment.Value) ? null : customPrComment.Value,
-                        Draft: customPrDraft.Value));
-                    _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
-                    _refreshPlans();
-                    isCreating.Set(false);
-                    customPrMerge.Set(true);
-                    customPrDeleteBranch.Set(true);
-                    customPrIncludeArtifacts.Set(true);
-                    customPrAssignee.Set(null);
-                    customPrComment.Set("");
-                    customPrDraft.Set(false);
-                    _dialogOpen.Set(false);
-                }
+                    if (!isCreating.Value)
+                    {
+                        isCreating.Set(true);
+                        _jobService.StartJob(new CreatePrArgs(
+                            _selectedPlan.FolderPath,
+                            Merge: customPrMerge.Value,
+                            DeleteBranch: customPrDeleteBranch.Value && customPrMerge.Value,
+                            IncludeArtifacts: customPrIncludeArtifacts.Value,
+                            Assignee: customPrAssignee.Value,
+                            Comment: string.IsNullOrEmpty(customPrComment.Value) ? null : customPrComment.Value,
+                            Draft: customPrDraft.Value));
+                        _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
+                        _refreshPlans();
+                        isCreating.Set(false);
+                        customPrMerge.Set(true);
+                        customPrDeleteBranch.Set(true);
+                        customPrIncludeArtifacts.Set(true);
+                        customPrAssignee.Set(null);
+                        customPrComment.Set("");
+                        customPrDraft.Set(false);
+                        _dialogOpen.Set(false);
+                    }
                 })
             )
         ).Width(Size.Rem(30));


### PR DESCRIPTION
# Summary

## Changes

Modified the "Create PR" button in the Review app to conditionally show confetti only when all affected repos have `prRule: yolo` configured. Removed confetti from the Custom PR dialog entirely.

## API Changes

None.

## Files Modified

- **ContentView.cs** — Moved `allYolo` check before button creation; conditionally apply `.WithConfetti()` based on yolo status
- **CustomPrDialog.cs** — Removed `.WithConfetti()` from submit button

---

## Commits

- 90df8e2 [00003] Only show confetti on Create PR when prRule is yolo
- 47ad9c5 [00003] Fix syntax error in CustomPrDialog
- d0809ec [00003] Fix type conversion issue with WithConfetti
- fd9ea1e [00003] Fix indentation in CustomPrDialog