### PR TITLE
[00281] Unify delete button shortcuts across recommendations, drafts, and reviews

### DIFF
--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -87,7 +87,7 @@ public class ContentView(
                      | Text.Rich()
                          .Bold($"{(currentIndex == -1 ? "?" : (currentIndex + 1).ToString())}/{allRecommendations.Count}", word: true)
                          .Muted("recommendations", word: true)
-                     | new Button("Decline").Icon(Icons.X).Outline().ShortcutKey("x").OnClick(() =>
+                     | new Button("Decline").Icon(Icons.X).Outline().ShortcutKey("Backspace").OnClick(() =>
                      {
                          showDeclineDialog();
                      })


### PR DESCRIPTION
## Changes

Changed the Recommendations "Decline" button keyboard shortcut from `"x"` to `"Backspace"` to match the identical shortcut used in Drafts (Delete) and Reviews (Discard). All three views now use `Backspace` for their primary remove/delete action.

## Files Modified

- **src/Ivy.Tendril/Apps/Recommendations/ContentView.cs** — Changed `.ShortcutKey("x")` to `.ShortcutKey("Backspace")` on the Decline button

---

**Commits:**
- 2356557 [00281] Unify Decline button shortcut to Backspace