### PR TITLE
Remove TendrilConfigPath from UpdateProject promptware

### DIFF
--- a/src/Ivy.Tendril/Promptwares/UpdateProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdateProject/Program.md
@@ -9,7 +9,7 @@ The firmware header contains:
 - **Instructions** — what to do (e.g. "Setup verifications and review actions for this project.")
 - **CurrentTime** — current UTC timestamp
 
-Project and verification configuration is available via `tendril project list`, `tendril verification list`, and by reading the config file at the `TendrilConfigPath` from the firmware header (use `Read` tool).
+Project and verification configuration is available via `tendril project list` and `tendril verification list`.
 
 ## Rules
 

--- a/src/Ivy.Tendril/Services/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/FirmwareCompiler.cs
@@ -152,7 +152,7 @@ public static class FirmwareCompiler
 
     private static readonly HashSet<string> PathKeys = new(StringComparer.OrdinalIgnoreCase)
     {
-        "TendrilConfigPath", "TendrilHome", "TendrilPlanFolder",
+        "TendrilHome", "TendrilPlanFolder",
         "TendrilPlansFolder", "SourceUrl", "SourcePath"
     };
 

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -307,8 +307,6 @@ internal class JobLauncher
             ["TendrilHome"] = _configService.TendrilHome ?? ""
         };
 
-        if (job.Type == Constants.JobTypes.UpdateProject)
-            values["TendrilConfigPath"] = _configService!.ConfigPath;
 
         if (job.TypedArgs is CreatePlanArgs)
         {


### PR DESCRIPTION
## Summary
- Removed `TendrilConfigPath` injection from `JobLauncher.cs` for UpdateProject jobs
- Removed config file read reference from `UpdateProject/Program.md` — agent uses CLI commands instead
- Removed `TendrilConfigPath` from `FirmwareCompiler.cs` PathKeys set

Closes #531