### PR TITLE
Enforce summary.md existence in ExecutePlan Final Clean Check

### DIFF
--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -532,7 +532,9 @@ After all verifications pass:
 
 3. Run `git status` in every worktree. If there are any uncommitted files (from verification fixes, generated files, etc.), commit or discard them. The worktrees must be completely clean before finishing.
 
-4. Verify `<TendrilPlanFolder>/artifacts/recommendations.md` exists. If missing, the plan **must fail** — go back to Step 7.5.
+4. Verify `<TendrilPlanFolder>/artifacts/recommendations.md` exists. If missing, go back to Step 7.5.
+
+5. Verify `<TendrilPlanFolder>/artifacts/summary.md` exists. If missing, go back to Step 5.5.
 
 ### 8.5. Worktree Lifecycle
 


### PR DESCRIPTION
## Summary
- Step 8 (Final Clean Check) now verifies `artifacts/summary.md` exists, failing back to Step 5.5 if missing
- Matches existing enforcement pattern for `recommendations.md`
- Ensures plans always produce a summary for downstream use (CreatePr body, UI display, resume logic)