### PR TITLE
Remove auth credentials from committed team config

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -237,9 +237,6 @@ llm:
   endpoint: DotnetUserSecrets:OpenAi:Endpoint
   apiKey: DotnetUserSecrets:OpenAi:ApiKey
   model: gpt-4o-mini
-auth:
-  password: $argon2i$v=19$m=65536,t=3,p=1$0qa4b1GvtDy9kwYpqQRsqg$4GvhXeSXVkTBFJWNQv5VFEEeK756ECGGW51jmH52++E
-  hashSecret: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 promptwares:
   CreatePlan:
     profile: deep


### PR DESCRIPTION
Remove hardcoded auth block (password hash + zero-byte hashSecret) from TeamIvyConfig. Auth should come from environment variables instead.