### PR TITLE
[00287] Add Backspace shortcut to IceboxApp delete button

### DIFF
--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -67,7 +67,7 @@ public class ContentView(
                                     }));
 
         var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(1)
-                        | new Button("Delete").Icon(Icons.Trash).Outline().OnClick(() => showDeleteDialog())
+                        | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace").OnClick(() => showDeleteDialog())
                         | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(() => GoToPrevious())
                             .ShortcutKey("p")
                         | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(() => GoToNext())


### PR DESCRIPTION
# Summary

## Changes

Added `.ShortcutKey("Backspace")` to the Delete button in IceboxApp's `ContentView.cs`, making it consistent with the PlansApp which already uses Backspace for its delete action.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Icebox/ContentView.cs` — Added Backspace shortcut key to Delete button

---

### Commits
- 25b3873 [00287] Add Backspace shortcut to IceboxApp delete button