### PR TITLE
Keep worktrees alive for Failed plans

### DIFF
--- a/src/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -15,7 +15,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
 {
     private static readonly Regex SafeTitleRegex = new(@"^\d{5}-(.+)", RegexOptions.Compiled);
     private static readonly HashSet<string> TerminalStates = new(StringComparer.OrdinalIgnoreCase)
-        { "Completed", "Failed", "Skipped", "Icebox" };
+        { "Completed", "Skipped", "Icebox" };
 
     private static readonly TimeSpan GracePeriod = TimeSpan.FromMinutes(10);
     private static readonly TimeSpan TimerInterval = TimeSpan.FromMinutes(30);


### PR DESCRIPTION
## Summary

- Remove `Failed` from `WorktreeCleanupService.TerminalStates` so worktrees are not auto-cleaned for failed plans
- Failed plans stay alive for RetryPlan to reuse; only Completed, Skipped, and Icebox trigger cleanup

## Test plan

- [x] All 6 `ExecutePlanWorktreeCleanupTests` pass
- Verified no other code references `TerminalStates` with a `Failed` dependency