### PR TITLE
Restructure Git tab to group commits under worktree sections

### DIFF
--- a/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
+++ b/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
@@ -428,5 +428,15 @@ public class PlanContentHelpersTests
             var summaries = commitHashes.ToDictionary(h => h, _ => (commitTitle, commitFiles?.Count ?? 0));
             return GitResult<Dictionary<string, (string Title, int FileCount)>>.Success(summaries);
         }
+
+        public GitResult<bool> HasUncommittedChanges(string repoPath)
+        {
+            return GitResult<bool>.Success(false);
+        }
+
+        public GitResult<List<string>> GetReachableCommits(string repoPath, IEnumerable<string> candidateHashes)
+        {
+            return GitResult<List<string>>.Success(candidateHashes.ToList());
+        }
     }
 }

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reactive.Disposables;
 using Ivy.Core;
 using Ivy.Tendril.Apps.Plans;
@@ -30,6 +31,7 @@ public class ContentView(
         var openArtifact = UseState<string?>(null);
         var openFile = UseState<string?>(null);
         var openCommit = UseState<string?>(null);
+        var syncingWorktrees = UseState(new HashSet<string>());
         var args = UseArgs<ReviewAppArgs>();
         var nav = UseNavigation();
 
@@ -222,7 +224,7 @@ public class ContentView(
         var content = BuildContent(
             selectedPlanState.Value, planData, planContentQuery, selectedTabIndex, tabNames, openVerification,
             openCommit, openFile, openArtifact, artifactContentQuery, assigneesQuery,
-            assigneesError,
+            assigneesError, syncingWorktrees,
             client, copyToClipboard, logger, nav, args);
 
         var mainLayout = new HeaderLayout(
@@ -369,6 +371,7 @@ public class ContentView(
         QueryResult<string> artifactContentQuery,
         QueryResult<string[]> assigneesQuery,
         IState<string?> assigneesError,
+        IState<HashSet<string>> syncingWorktrees,
         IClientProvider client,
         Action<string> copyToClipboard,
         ILogger<ContentView> logger,
@@ -426,6 +429,8 @@ public class ContentView(
                     client.Toast("Copied path to clipboard", "Path Copied");
                     return null!;
                 },
+                syncingWorktrees.Value,
+                worktreePath => SynchronizeWorktreeAsync(worktreePath, syncingWorktrees, planContentQuery, client, logger),
                 logger
             );
 
@@ -507,7 +512,7 @@ public class ContentView(
                 new Tab("Verifications", Cap(new VerificationsTabView(
                     selectedPlan.Verifications, planData.VerificationReports,
                     v => openVerification.Set(v)))).Badge(selectedPlan.Verifications.Count.ToString()),
-                new Tab("Git", Cap(gitLayout)).Badge((gitData.WorktreeRows.Count + selectedPlan.Commits.Count + selectedPlan.Prs.Count).ToString()),
+                new Tab("Git", Cap(gitLayout)).Badge((gitData.WorktreeSections.Count + selectedPlan.Commits.Count + selectedPlan.Prs.Count).ToString()),
                 new Tab("Changes", Layout.Vertical().Width(Size.Full()).Height(Size.Full()) | changesTabView).Badge(changesTabView.FileCount > 0 ? changesTabView.FileCount.ToString() : ""),
                 new Tab("Artifacts", Cap(new ArtifactsTabView(planData.Artifacts))).Badge(totalArtifacts.ToString()),
                 new Tab("Recommendations", Cap(recommendationsLayout)).Badge(planData.Recommendations.Count.ToString())
@@ -576,6 +581,60 @@ public class ContentView(
         var currentIndex = allPlans.FindIndex(p => p.FolderName == selectedPlanState.Value?.FolderName);
         var prevIndex = (currentIndex - 1 + allPlans.Count) % allPlans.Count;
         selectedPlanState.Set(allPlans[prevIndex]);
+    }
+
+    private static async void SynchronizeWorktreeAsync(
+        string worktreePath,
+        IState<HashSet<string>> syncingState,
+        QueryResult<PlanContentData> query,
+        IClientProvider client,
+        ILogger? logger)
+    {
+        var paths = new HashSet<string>(syncingState.Value) { worktreePath };
+        syncingState.Set(paths);
+
+        try
+        {
+            var (exitCode, error) = await Task.Run(() =>
+            {
+                var psi = new ProcessStartInfo("git", "fetch origin")
+                {
+                    WorkingDirectory = worktreePath,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                using var process = Process.Start(psi);
+                if (process == null)
+                    return (1, "Failed to start git process");
+
+                var stderr = process.StandardError.ReadToEnd();
+                process.WaitForExit(60000);
+                return (process.ExitCode, stderr);
+            });
+
+            if (exitCode == 0)
+            {
+                client.Toast("Worktree synchronized successfully", "Synchronized");
+            }
+            else
+            {
+                client.Toast($"git fetch failed: {error}", "Synchronize Failed", variant: ToastVariant.Destructive);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Failed to synchronize worktree at {Path}", worktreePath);
+            client.Toast($"Failed to synchronize: {ex.Message}", "Synchronize Failed", variant: ToastVariant.Destructive);
+        }
+        finally
+        {
+            var updated = new HashSet<string>(syncingState.Value);
+            updated.Remove(worktreePath);
+            syncingState.Set(updated);
+            query.Mutator.Revalidate();
+        }
     }
 
     private record PlanContentData(

--- a/src/Ivy.Tendril/Services/GitService.cs
+++ b/src/Ivy.Tendril/Services/GitService.cs
@@ -586,4 +586,99 @@ public class GitService : IGitService
             return GitResult<List<WorktreeInfo>>.Failure(GitError.UnknownError, ex.Message);
         }
     }
+
+    public GitResult<bool> HasUncommittedChanges(string repoPath)
+    {
+        try
+        {
+            if (!Directory.Exists(repoPath))
+                return GitResult<bool>.Failure(GitError.InvalidRepoPath, $"Repository path does not exist: {repoPath}");
+
+            var psi = new ProcessStartInfo("git", "status --porcelain")
+            {
+                WorkingDirectory = repoPath,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                StandardOutputEncoding = Encoding.UTF8
+            };
+            using var process = Process.Start(psi);
+            if (process == null)
+                return GitResult<bool>.Failure(GitError.GitNotFound, "Failed to start git process");
+
+            var output = process.StandardOutput.ReadToEnd();
+            var timedOut = !process.WaitForExit(_timeoutMs);
+
+            if (timedOut)
+            {
+                try { process.Kill(); } catch { }
+                return GitResult<bool>.Failure(GitError.Timeout, $"Git command timed out after {_timeoutMs}ms");
+            }
+
+            if (process.ExitCode != 0)
+                return GitResult<bool>.Failure(GitError.CommandFailed, $"Git command failed with exit code {process.ExitCode}");
+
+            return GitResult<bool>.Success(!string.IsNullOrWhiteSpace(output));
+        }
+        catch (FileNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "Git executable not found");
+            return GitResult<bool>.Failure(GitError.GitNotFound, "Git executable not found");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unknown error executing git command");
+            return GitResult<bool>.Failure(GitError.UnknownError, ex.Message);
+        }
+    }
+
+    public GitResult<List<string>> GetReachableCommits(string repoPath, IEnumerable<string> candidateHashes)
+    {
+        try
+        {
+            if (!Directory.Exists(repoPath))
+                return GitResult<List<string>>.Failure(GitError.InvalidRepoPath, $"Repository path does not exist: {repoPath}");
+
+            var hashes = candidateHashes.ToList();
+            if (hashes.Count == 0)
+                return GitResult<List<string>>.Success(new List<string>());
+
+            var reachable = new List<string>();
+            foreach (var hash in hashes)
+            {
+                var psi = new ProcessStartInfo("git", $"merge-base --is-ancestor {hash} HEAD")
+                {
+                    WorkingDirectory = repoPath,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                using var process = Process.Start(psi);
+                if (process == null) continue;
+
+                var timedOut = !process.WaitForExit(_timeoutMs);
+                if (timedOut)
+                {
+                    try { process.Kill(); } catch { }
+                    continue;
+                }
+
+                if (process.ExitCode == 0)
+                    reachable.Add(hash);
+            }
+
+            return GitResult<List<string>>.Success(reachable);
+        }
+        catch (FileNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "Git executable not found");
+            return GitResult<List<string>>.Failure(GitError.GitNotFound, "Git executable not found");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unknown error executing git command");
+            return GitResult<List<string>>.Failure(GitError.UnknownError, ex.Message);
+        }
+    }
 }

--- a/src/Ivy.Tendril/Services/IGitService.cs
+++ b/src/Ivy.Tendril/Services/IGitService.cs
@@ -10,6 +10,8 @@ public interface IGitService
     GitResult<List<(string Status, string FilePath)>> GetCombinedChangedFiles(string repoPath, string firstCommit, string lastCommit);
     GitResult<List<WorktreeInfo>> GetWorktrees(string repoPath);
     GitResult<Dictionary<string, (string Title, int FileCount)>> GetCommitSummaries(string repoPath, IEnumerable<string> commitHashes);
+    GitResult<bool> HasUncommittedChanges(string repoPath);
+    GitResult<List<string>> GetReachableCommits(string repoPath, IEnumerable<string> candidateHashes);
 }
 
 public record WorktreeInfo(string Path, string Branch, string CommitHash);

--- a/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
+++ b/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
@@ -10,15 +10,17 @@ namespace Ivy.Tendril.Views.Tabs;
 public static class GitTabHelper
 {
     public record GitTabData(
-        List<PlanContentHelpers.CommitRow> CommitRows,
-        List<WorktreeRow> WorktreeRows
+        List<WorktreeSection> WorktreeSections,
+        List<PlanContentHelpers.CommitRow> UnassociatedCommitRows
     );
 
-    public record WorktreeRow(
+    public record WorktreeSection(
         string Name,
         string Path,
         string Branch,
-        string ShortHash
+        string ShortHash,
+        bool HasUncommittedChanges,
+        List<PlanContentHelpers.CommitRow> CommitRows
     );
 
     public static GitTabData BuildGitTabData(
@@ -27,9 +29,7 @@ public static class GitTabHelper
         IGitService gitService)
     {
         var commitRows = PlanContentHelpers.BuildCommitRows(plan, config, gitService);
-        var worktreeRows = BuildWorktreeRows(plan, config, gitService);
-
-        return new GitTabData(commitRows, worktreeRows);
+        return BuildGitTabDataInternal(plan, config, gitService, commitRows);
     }
 
     public static GitTabData BuildGitTabData(
@@ -38,45 +38,87 @@ public static class GitTabHelper
         IConfigService config,
         IGitService gitService)
     {
-        var worktreeRows = BuildWorktreeRows(plan, config, gitService);
-        return new GitTabData(precomputedCommitRows, worktreeRows);
+        return BuildGitTabDataInternal(plan, config, gitService, precomputedCommitRows);
     }
 
-    private static List<WorktreeRow> BuildWorktreeRows(
+    private static GitTabData BuildGitTabDataInternal(
         PlanFile plan,
         IConfigService config,
-        IGitService gitService)
+        IGitService gitService,
+        List<PlanContentHelpers.CommitRow> allCommitRows)
     {
-        var rows = new List<WorktreeRow>();
+        var sections = new List<WorktreeSection>();
+        var assignedCommitHashes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var worktreesDir = Path.Combine(plan.FolderPath, "worktrees");
 
-        if (!Directory.Exists(worktreesDir)) return rows;
-
-        var repoDirs = Directory.GetDirectories(worktreesDir);
-        foreach (var repoDir in repoDirs)
+        if (Directory.Exists(worktreesDir))
         {
-            var worktreesResult = gitService.GetWorktrees(repoDir);
-            if (!worktreesResult.IsSuccess || worktreesResult.Value == null) continue;
-
-            // Find the worktree that matches this directory (not the main repo)
-            var worktree = worktreesResult.Value.FirstOrDefault(w =>
-                Path.GetFullPath(w.Path).Equals(Path.GetFullPath(repoDir), StringComparison.OrdinalIgnoreCase));
-
-            if (worktree == null) continue;
-
-            var shortHash = worktree.CommitHash.Length > 7
-                ? worktree.CommitHash.Substring(0, 7)
-                : worktree.CommitHash;
-
-            rows.Add(new WorktreeRow(
-                Path.GetFileName(repoDir),
-                repoDir,
-                worktree.Branch,
-                shortHash
-            ));
+            foreach (var repoDir in Directory.GetDirectories(worktreesDir))
+            {
+                var section = BuildSectionForWorktree(repoDir, allCommitRows, assignedCommitHashes, gitService);
+                if (section != null)
+                    sections.Add(section);
+            }
         }
 
-        return rows;
+        var unassigned = allCommitRows
+            .Where(r => !assignedCommitHashes.Contains(r.Hash))
+            .ToList();
+
+        return new GitTabData(sections, unassigned);
+    }
+
+    private static WorktreeSection? BuildSectionForWorktree(
+        string repoDir,
+        List<PlanContentHelpers.CommitRow> allCommitRows,
+        HashSet<string> assignedCommitHashes,
+        IGitService gitService)
+    {
+        var worktreesResult = gitService.GetWorktrees(repoDir);
+        if (!worktreesResult.IsSuccess || worktreesResult.Value == null) return null;
+
+        var worktree = worktreesResult.Value.FirstOrDefault(w =>
+            Path.GetFullPath(w.Path).Equals(Path.GetFullPath(repoDir), StringComparison.OrdinalIgnoreCase));
+
+        if (worktree == null) return null;
+
+        var shortHash = worktree.CommitHash.Length > 7
+            ? worktree.CommitHash[..7]
+            : worktree.CommitHash;
+
+        var hasUncommitted = false;
+        var statusResult = gitService.HasUncommittedChanges(repoDir);
+        if (statusResult.IsSuccess)
+            hasUncommitted = statusResult.Value;
+
+        var worktreeCommits = new List<PlanContentHelpers.CommitRow>();
+        if (allCommitRows.Count > 0)
+        {
+            var candidateHashes = allCommitRows
+                .Where(r => !assignedCommitHashes.Contains(r.Hash))
+                .Select(r => r.Hash)
+                .ToList();
+
+            var reachableResult = gitService.GetReachableCommits(repoDir, candidateHashes);
+            if (reachableResult.IsSuccess && reachableResult.Value != null)
+            {
+                var reachableSet = new HashSet<string>(reachableResult.Value, StringComparer.OrdinalIgnoreCase);
+                worktreeCommits = allCommitRows
+                    .Where(r => reachableSet.Contains(r.Hash))
+                    .ToList();
+                foreach (var c in worktreeCommits)
+                    assignedCommitHashes.Add(c.Hash);
+            }
+        }
+
+        return new WorktreeSection(
+            Path.GetFileName(repoDir),
+            repoDir,
+            worktree.Branch,
+            shortHash,
+            hasUncommitted,
+            worktreeCommits
+        );
     }
 
     public static object RenderGitTab(
@@ -86,95 +128,33 @@ public static class GitTabHelper
         IConfigService config,
         Action<string?> setOpenCommit,
         Func<string, object> copyToClipboard,
+        HashSet<string>? syncingPaths = null,
+        Action<string>? onSynchronize = null,
         ILogger? logger = null)
     {
         var gitLayout = Layout.Vertical().Gap(4);
 
-        // Worktrees section
-        if (gitData.WorktreeRows.Count > 0)
+        foreach (var section in gitData.WorktreeSections)
         {
-            gitLayout |= Text.Block("Worktrees").Bold();
-
-            var worktreeTableRows = gitData.WorktreeRows.Select(row => new WorktreeTableRow(
-                row.Name,
-                $"{row.Branch}:{row.ShortHash}",
-                row.Path
-            )).ToList();
-
-            gitLayout |= new TableBuilder<WorktreeTableRow>(worktreeTableRows)
-                .Header(t => t.BranchCommit, "Branch:Commit")
-                .Builder(t => t.Actions, f => f.Func<WorktreeTableRow, string>(path =>
-                    new Button().Icon(Icons.EllipsisVertical).Ghost().Small()
-                        .WithDropDown(
-                            new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
-                                .OnSelect(() => PlatformHelper.OpenInFileManager(path, logger)),
-                            new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal")
-                                .OnSelect(() => PlatformHelper.OpenInTerminal(path, logger)),
-                            new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
-                                .OnSelect(() =>
-                                {
-                                    try
-                                    {
-                                        config.OpenInEditor(path);
-                                    }
-                                    catch (EditorNotAvailableException ex)
-                                    {
-                                        client.Toast(
-                                            $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
-                                            "Editor Not Available",
-                                            variant: ToastVariant.Destructive);
-                                    }
-                                }),
-                            new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
-                                .OnSelect(() => copyToClipboard(path))
-                        )));
+            var isSyncing = syncingPaths?.Contains(section.Path) == true;
+            gitLayout |= RenderWorktreeSection(section, isSyncing, client, config, setOpenCommit, copyToClipboard, onSynchronize, logger);
         }
 
-        // Problematic commits warning
-        var problematicCommits = gitData.CommitRows
-            .Where(r => string.IsNullOrEmpty(r.Title) || r.FileCount == 0)
-            .ToList();
-
-        if (problematicCommits.Count > 0)
+        // Unassociated commits (commits not in any worktree)
+        if (gitData.UnassociatedCommitRows.Count > 0)
         {
-            var warnings = problematicCommits.Select(r =>
-            {
-                if (string.IsNullOrEmpty(r.Title))
-                    return $"`{r.ShortHash}` — commit not found or has no message";
-                return $"`{r.ShortHash}` — commit has no file changes";
-            });
-            gitLayout |= Callout.Warning(
-                string.Join("\n", warnings),
-                "Potentially corrupted commits");
-        }
+            var commitWarning = PlanContentHelpers.BuildCommitWarningCallout(gitData.UnassociatedCommitRows);
+            if (commitWarning != null)
+                gitLayout |= commitWarning;
 
-        // Commits section
-        if (plan.Commits.Count > 0)
-        {
             gitLayout |= Text.Block("Commits").Bold();
-
-            var commitTableRows = gitData.CommitRows.Select(row => new CommitTableRow(
-                row.ShortHash,
-                row.Hash,
-                row.Title,
-                row.FileCount?.ToString() ?? "–"
-            )).ToList();
-
-            gitLayout |= new TableBuilder<CommitTableRow>(commitTableRows)
-                .Order(t => t.Commit, t => t.Message, t => t.Files)
-                .Builder(t => t.Commit, f => f.Func<CommitTableRow, string>(shortHash =>
-                    new Button(shortHash).Inline().OnClick(() =>
-                    {
-                        var row = commitTableRows.First(r => r.Commit == shortHash);
-                        setOpenCommit(row.Hash);
-                    })))
-                .Remove(t => t.Hash);
+            gitLayout |= RenderCommitTable(gitData.UnassociatedCommitRows, setOpenCommit);
         }
 
         // Pull requests section
         if (plan.Prs.Count > 0)
         {
-            if (plan.Commits.Count > 0)
+            if (gitData.WorktreeSections.Count > 0 || gitData.UnassociatedCommitRows.Count > 0)
                 gitLayout |= new Separator();
 
             gitLayout |= Text.Block("Pull Requests").Bold();
@@ -190,7 +170,7 @@ public static class GitTabHelper
         }
 
         // Empty state
-        if (plan.Commits.Count == 0 && plan.Prs.Count == 0 && gitData.WorktreeRows.Count == 0)
+        if (gitData.WorktreeSections.Count == 0 && gitData.UnassociatedCommitRows.Count == 0 && plan.Prs.Count == 0)
         {
             gitLayout |= Text.Muted("No worktrees, commits, or pull requests yet.");
         }
@@ -198,7 +178,112 @@ public static class GitTabHelper
         return gitLayout;
     }
 
-    private record WorktreeTableRow(string Name, string BranchCommit, string Actions);
+    private static object RenderWorktreeSection(
+        WorktreeSection section,
+        bool isSyncing,
+        IClientProvider client,
+        IConfigService config,
+        Action<string?> setOpenCommit,
+        Func<string, object> copyToClipboard,
+        Action<string>? onSynchronize,
+        ILogger? logger)
+    {
+        var sectionLayout = Layout.Vertical().Gap(2);
+
+        // Header row: name + ... menu
+        var syncMenuItem = new MenuItem("Synchronize", Icon: Icons.RefreshCw, Tag: "Synchronize");
+        if (onSynchronize != null && !isSyncing)
+            syncMenuItem = syncMenuItem.OnSelect(() => onSynchronize(section.Path));
+
+        var headerRow = Layout.Horizontal().Gap(2).AlignContent(Align.SpaceBetween)
+            | (Layout.Horizontal().Gap(2).AlignContent(Align.Left)
+                | Text.Block(section.Name).Bold())
+            | new Button().Icon(Icons.EllipsisVertical).Ghost().Small()
+                .WithDropDown(
+                    syncMenuItem,
+                    new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
+                        .OnSelect(() => PlatformHelper.OpenInFileManager(section.Path, logger)),
+                    new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal")
+                        .OnSelect(() => PlatformHelper.OpenInTerminal(section.Path, logger)),
+                    new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
+                        .OnSelect(() =>
+                        {
+                            try
+                            {
+                                config.OpenInEditor(section.Path);
+                            }
+                            catch (EditorNotAvailableException ex)
+                            {
+                                client.Toast(
+                                    $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                                    "Editor Not Available",
+                                    variant: ToastVariant.Destructive);
+                            }
+                        }),
+                    new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
+                        .OnSelect(() => copyToClipboard(section.Path))
+                );
+
+        sectionLayout |= headerRow;
+
+        // "Based on" line
+        sectionLayout |= Layout.Horizontal().Gap(1).AlignContent(Align.Left)
+            | Text.Muted("Based on:")
+            | new Badge($"{section.Branch}@{section.ShortHash}").Variant(BadgeVariant.Outline).Small();
+
+        // Syncing state
+        if (isSyncing)
+        {
+            sectionLayout |= Text.Muted("Synchronizing...");
+            return sectionLayout;
+        }
+
+        // Warning callout for uncommitted changes
+        if (section.HasUncommittedChanges)
+        {
+            sectionLayout |= Callout.Warning("This worktree has uncommitted changes");
+        }
+
+        // Commit warning callout
+        var commitWarning = PlanContentHelpers.BuildCommitWarningCallout(section.CommitRows);
+        if (commitWarning != null)
+            sectionLayout |= commitWarning;
+
+        // Commits table or empty state
+        if (section.CommitRows.Count > 0)
+        {
+            sectionLayout |= RenderCommitTable(section.CommitRows, setOpenCommit);
+        }
+        else
+        {
+            sectionLayout |= Text.Muted("(no commits)");
+        }
+
+        return sectionLayout;
+    }
+
+    private static object RenderCommitTable(
+        List<PlanContentHelpers.CommitRow> commitRows,
+        Action<string?> setOpenCommit)
+    {
+        var tableRows = commitRows.Select(row => new CommitTableRow(
+            row.ShortHash,
+            row.Hash,
+            row.Title,
+            row.FileCount?.ToString() ?? "–"
+        )).ToList();
+
+        return new TableBuilder<CommitTableRow>(tableRows)
+            .Order(t => t.Commit, t => t.Message, t => t.Files)
+            .Builder(t => t.Commit, f => f.Func<CommitTableRow, string>(shortHash =>
+                new Button(shortHash).Inline().OnClick(() =>
+                {
+                    var row = tableRows.First(r => r.Commit == shortHash);
+                    setOpenCommit(row.Hash);
+                })))
+            .Remove(t => t.Hash);
+    }
+
     private record CommitTableRow(string Commit, string Hash, string Message, string Files);
     private record PrTableRow(string Repository, string Pr);
 }


### PR DESCRIPTION
## Summary
- Restructures the Git tab to display worktrees as top-level sections, each with its own commit table, "Based on" badge, and warning callouts
- Adds Synchronize menu option with inline loading state per worktree (git fetch + data refresh)
- New `IGitService` methods: `HasUncommittedChanges`, `GetReachableCommits`
- Extracts `BuildSectionForWorktree` to reduce nesting complexity

## Test plan
- [x] Build succeeds
- [x] 1431 tests pass (2 pre-existing failures unrelated)
- [x] CodeScene score 8.21 (yellow, improved nesting)