### PR TITLE
Enable GeoIP in PostHog telemetry

### DIFF
--- a/src/Ivy.Tendril/Services/TelemetryService.cs
+++ b/src/Ivy.Tendril/Services/TelemetryService.cs
@@ -27,13 +27,15 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
         {
             // Public key — safe to expose (like a website tracking snippet)
             var sessionId = Guid.NewGuid().ToString();
+            // GeoIP enabled so we can see which countries have active users
             _client = new PostHogClient(new PostHogOptions
             {
                 ProjectApiKey = "phc_uHeJHFURzThFPnizzGMzLEimLWnRAuqy8DunK8N3oYcd",
                 HostUrl = new Uri("https://eu.i.posthog.com"),
                 SuperProperties = new Dictionary<string, object>
                 {
-                    ["$session_id"] = sessionId
+                    ["$session_id"] = sessionId,
+                    ["$geoip_disable"] = false
                 }
             });
             _distinctId = GetOrCreateAnonymousId();


### PR DESCRIPTION
Server-side SDKs disable GeoIP by default (assumes server IP ≠ user IP).
Since Tendril is a desktop app, the request IP is the user's real IP.
Setting $geoip_disable=false lets PostHog resolve country-level location
so we can see which countries have active users.
