### PR TITLE
Add .Article() styling to all Markdown components

### DIFF
--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -53,6 +53,7 @@ public class ContentView(
         var scrollableContent = Layout.Vertical().Width(Size.Full().Max(Size.Units(200)))
                                 |
                                 new Markdown(MarkdownHelper.AnnotateAllBrokenLinks(selectedPlan.LatestRevisionContent, planService.PlansDirectory))
+                                    .Article()
                                     .DangerouslyAllowLocalFiles()
                                     .OnLinkClick(FileSheet.CreateLinkClickHandler(openFile, planId =>
                                     {

--- a/src/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -34,6 +34,7 @@ public class PullRequestApp : ViewBase
                 ? Text.P("Plan not found or empty.")
                 : (object)new Markdown(MarkdownHelper.AnnotateAllBrokenLinks(content, planService.PlansDirectory))
                     .DangerouslyAllowLocalFiles()
+                    .Article()
                     .OnLinkClick(FileSheet.CreateLinkClickHandler(openFile));
 
             var sheet = new Sheet(

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -33,6 +33,7 @@ public class ContentView(
                 ? Text.P("Plan not found or empty.")
                 : (object)new Markdown(MarkdownHelper.AnnotateAllBrokenLinks(content, planService.PlansDirectory))
                     .DangerouslyAllowLocalFiles()
+                    .Article()
                     .OnLinkClick(FileSheet.CreateLinkClickHandler(openFile));
 
             var sheet = new Sheet(

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -389,6 +389,7 @@ public class ContentView(
         var planTabContent = Layout.Vertical().Height(Size.Full())
             | new Markdown(reviewAnnotated)
                 .DangerouslyAllowLocalFiles()
+                .Article()
                 .OnLinkClick(FileSheet.CreateLinkClickHandler(openFile, planId =>
                 {
                     var planFolder = Directory.GetDirectories(planService.PlansDirectory, $"{planId:D5}-*")
@@ -498,7 +499,7 @@ public class ContentView(
 
                     var card = Layout.Vertical().Gap(1)
                                | titleRow
-                               | new Markdown(rec.Description).DangerouslyAllowLocalFiles();
+                               | new Markdown(rec.Description).DangerouslyAllowLocalFiles().Article();
                     recommendationsLayout |= card;
                     recommendationsLayout |= new Separator();
                 }

--- a/src/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/Ivy.Tendril/Apps/TrashApp.cs
@@ -103,6 +103,7 @@ public class TrashApp : ViewBase
             var scrollableContent = Layout.Vertical().Width(Size.Full().Max(Size.Units(200)))
                                     | new Markdown(annotatedContent)
                                         .DangerouslyAllowLocalFiles()
+                                        .Article()
                                         .OnLinkClick(FileSheet.CreateLinkClickHandler(openFile));
 
             var scrollWrapper = Layout.Vertical().Scroll(Scroll.Auto).Width(Size.Full())

--- a/src/Ivy.Tendril/Views/Sheets/VerificationReportSheet.cs
+++ b/src/Ivy.Tendril/Views/Sheets/VerificationReportSheet.cs
@@ -34,7 +34,7 @@ public class VerificationReportSheet(
                 ? Text.Muted("Loading...")
                 : verificationReportQuery.Error is { } err
                     ? Text.Muted($"Failed to load verification report: {err.Message}")
-                    : new Markdown(verificationReportQuery.Value).DangerouslyAllowLocalFiles(),
+                    : new Markdown(verificationReportQuery.Value).DangerouslyAllowLocalFiles().Article(),
             verName
         ).Width(Size.Half()).Resizable();
     }

--- a/src/Ivy.Tendril/Views/Tabs/SummaryTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/SummaryTabView.cs
@@ -7,7 +7,7 @@ public class SummaryTabView(string? summaryMarkdown) : ViewBase
         if (summaryMarkdown is { } md)
         {
             var layout = Layout.Vertical().Gap(2);
-            layout |= new Markdown(md).DangerouslyAllowLocalFiles();
+            layout |= new Markdown(md).DangerouslyAllowLocalFiles().Article();
             return layout;
         }
 


### PR DESCRIPTION
Adds .Article() modifier to all Markdown component instances for consistent article-style typography.