### PR TITLE
Add OS version, app version, and agent to PostHog telemetry

### DIFF
--- a/src/Ivy.Tendril/Services/ITelemetryService.cs
+++ b/src/Ivy.Tendril/Services/ITelemetryService.cs
@@ -8,7 +8,7 @@ public interface ITelemetryService
     void TrackAppStarted(AppStartContext context);
     void TrackPlanCreated(PlanCreatedContext context);
     void TrackPrCreated(PrCreatedContext context);
-    void TrackJobCompleted(string jobType, JobStatus status, int? durationSeconds);
+    void TrackJobCompleted(string jobType, JobStatus status, int? durationSeconds, string? agent = null);
     void TrackPlanStateTransition(string fromState, string toState);
     Task IdentifyAsync(string appVersion);
     Task FlushAsync();
@@ -21,7 +21,9 @@ public record AppStartContext(
 
 public record PlanCreatedContext(
     string Level,
-    int? DurationSeconds);
+    int? DurationSeconds,
+    string? Agent = null);
 
 public record PrCreatedContext(
-    int? DurationSeconds);
+    int? DurationSeconds,
+    string? Agent = null);

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -160,7 +160,7 @@ internal class JobCompletionHandler
         if (isSuccess)
             TrackSuccessTelemetry(job);
 
-        _telemetryService?.TrackJobCompleted(job.Type, job.Status, job.DurationSeconds);
+        _telemetryService?.TrackJobCompleted(job.Type, job.Status, job.DurationSeconds, job.Provider);
         FlushTelemetryAsync();
     }
 
@@ -175,11 +175,11 @@ internal class JobCompletionHandler
                 var plan = PlanYamlHelper.ReadPlanYaml(planFolder);
                 if (plan != null) level = plan.Level;
             }
-            _telemetryService?.TrackPlanCreated(new PlanCreatedContext(level, job.DurationSeconds));
+            _telemetryService?.TrackPlanCreated(new PlanCreatedContext(level, job.DurationSeconds, job.Provider));
         }
         else if (job.TypedArgs is CreatePrArgs)
         {
-            _telemetryService?.TrackPrCreated(new PrCreatedContext(job.DurationSeconds));
+            _telemetryService?.TrackPrCreated(new PrCreatedContext(job.DurationSeconds, job.Provider));
         }
     }
 

--- a/src/Ivy.Tendril/Services/TelemetryService.cs
+++ b/src/Ivy.Tendril/Services/TelemetryService.cs
@@ -28,6 +28,7 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
             // Public key — safe to expose (like a website tracking snippet)
             var sessionId = Guid.NewGuid().ToString();
             // GeoIP enabled so we can see which countries have active users
+            var appVersion = typeof(TelemetryService).Assembly.GetName().Version?.ToString(3) ?? "unknown";
             _client = new PostHogClient(new PostHogOptions
             {
                 ProjectApiKey = "phc_uHeJHFURzThFPnizzGMzLEimLWnRAuqy8DunK8N3oYcd",
@@ -35,7 +36,10 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
                 SuperProperties = new Dictionary<string, object>
                 {
                     ["$session_id"] = sessionId,
-                    ["$geoip_disable"] = false
+                    ["$geoip_disable"] = false,
+                    ["app_version"] = appVersion,
+                    ["os"] = Environment.OSVersion.Platform.ToString(),
+                    ["os_version"] = Environment.OSVersion.VersionString
                 }
             });
             _distinctId = GetOrCreateAnonymousId();
@@ -74,7 +78,8 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
                 personPropertiesToSet: new Dictionary<string, object>
                 {
                     ["app_version"] = appVersion,
-                    ["os"] = Environment.OSVersion.Platform.ToString()
+                    ["os"] = Environment.OSVersion.Platform.ToString(),
+                    ["os_version"] = Environment.OSVersion.VersionString
                 },
                 personPropertiesToSetOnce: new Dictionary<string, object>
                 {
@@ -111,11 +116,13 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
     {
         try
         {
-            _client?.Capture(_distinctId, "plan_created", new Dictionary<string, object>
+            var properties = new Dictionary<string, object>
             {
                 ["level"] = context.Level,
                 ["duration_seconds"] = context.DurationSeconds ?? 0
-            });
+            };
+            if (context.Agent != null) properties["agent"] = context.Agent;
+            _client?.Capture(_distinctId, "plan_created", properties);
             _logger?.LogDebug("Tracked plan_created event");
         }
         catch (Exception ex)
@@ -128,10 +135,12 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
     {
         try
         {
-            _client?.Capture(_distinctId, "pr_created", new Dictionary<string, object>
+            var properties = new Dictionary<string, object>
             {
                 ["duration_seconds"] = context.DurationSeconds ?? 0
-            });
+            };
+            if (context.Agent != null) properties["agent"] = context.Agent;
+            _client?.Capture(_distinctId, "pr_created", properties);
             _logger?.LogDebug("Tracked pr_created event");
         }
         catch (Exception ex)
@@ -140,16 +149,18 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
         }
     }
 
-    public void TrackJobCompleted(string jobType, JobStatus status, int? durationSeconds)
+    public void TrackJobCompleted(string jobType, JobStatus status, int? durationSeconds, string? agent = null)
     {
         try
         {
-            _client?.Capture(_distinctId, "job_completed", new Dictionary<string, object>
+            var properties = new Dictionary<string, object>
             {
                 ["job_type"] = jobType,
                 ["status"] = status.ToString(),
                 ["duration_seconds"] = durationSeconds ?? 0
-            });
+            };
+            if (agent != null) properties["agent"] = agent;
+            _client?.Capture(_distinctId, "job_completed", properties);
             _logger?.LogDebug("Tracked job_completed event: {JobType} - {Status}", jobType, status);
         }
         catch (Exception ex)

--- a/src/Ivy.Tendril/TELEMETRY.md
+++ b/src/Ivy.Tendril/TELEMETRY.md
@@ -13,7 +13,8 @@ This document defines what data Tendril may and may not send to third-party tele
 - **Durations**: Time taken to complete operations (in seconds)
 - **States/Types**: Enum values, state names, job types (e.g., "CreatePlan", "ExecutePlan")
 - **Levels**: Plan levels (e.g., "Bug", "Critical", "NiceToHave")
-- **Versions**: Application version strings
+- **Versions**: Application version strings, OS version strings
+- **Agent providers**: Coding agent name (e.g., "claude", "codex", "gemini")
 - **Booleans**: Feature flags, configuration states (e.g., llm_configured: true)
 - **Status codes**: Success/failure indicators, verification results
 
@@ -55,15 +56,15 @@ When adding new telemetry events, ask:
 
 ## Current Events Audit
 
-All events comply with this policy as of Plan 02085:
+All events comply with this policy:
 
 | Event | Status | Notes |
 |-------|--------|-------|
 | app_started | Compliant | Aggregate counts only |
-| plan_created | Compliant | Project name removed |
-| pr_created | Compliant | Project name removed |
-| job_completed | Compliant | Job types + status enums |
-| plan_state_transition | Compliant | Plan ID removed |
+| plan_created | Compliant | Level, duration, agent provider |
+| pr_created | Compliant | Duration, agent provider |
+| job_completed | Compliant | Job types, status enums, agent provider |
+| plan_state_transition | Compliant | State names only |
 
 ## Implementation
 
@@ -71,5 +72,6 @@ See [ITelemetryService.cs](Services/ITelemetryService.cs) for typed context obje
 
 ## History
 
+- 2026-05-17: Added OS version, app_version as super properties; added agent provider to job/plan/pr events
 - 2026-04-06: Plan 02069 removed repo_url from pr_created event
 - 2026-04-06: Plan 02085 established this policy document and removed project names and plan IDs


### PR DESCRIPTION
Adds three new dimensions to PostHog analytics:

- **OS version** — `os_version` as both person property and super property (e.g. "Microsoft Windows NT 10.0.26100.0")
- **App version** — `app_version` as super property on every event (was only on identify + app_started)
- **Agent provider** — `agent` property on `job_completed`, `plan_created`, and `pr_created` events (e.g. "claude", "codex", "gemini")

All additions comply with the telemetry data classification policy (non-identifying, aggregate-useful values).