### PR TITLE
Instruct CreatePlan to preserve remote images from GitHub issues

### DIFF
--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -32,6 +32,8 @@ The `TaskDescription` header value contains the user's task description. If it r
 
 **Format screenshot paths**: If the task description contains file paths to images (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`), include them in the plan revision as markdown images using `file:///` URLs. Convert backslashes to forward slashes. Example: a path like `D:\Screenshots\2026-05-07_17-16.png` in the description becomes `![screenshot](file:///D:/Screenshots/2026-05-07_17-16.png)` in the revision.
 
+**Preserve remote images**: If the task description contains markdown image references with remote URLs (`![...](https://...)`), include relevant ones in the plan revision as-is. Images showing bugs, UI mockups, error messages, or expected behavior are relevant. Decorative or unrelated images may be omitted.
+
 ### 1.1. Select Project
 
 The **Projects** section of your firmware lists all available projects with their repos, verifications, and context.


### PR DESCRIPTION
When a GitHub issue contains images (bug screenshots, UI mockups, etc.), the agent now knows to include them in the plan revision as-is. The Markdown widget already renders remote https:// images — this just tells the agent to carry them through.