### PR TITLE
Rename plan subfolders to Title Case for consistency

### DIFF
--- a/src/Ivy.Tendril.Test/ContentViewTests.cs
+++ b/src/Ivy.Tendril.Test/ContentViewTests.cs
@@ -21,7 +21,7 @@ public class ContentViewTests
         try
         {
             var planDir = Path.Combine(tempDir, "00001-TestPlan");
-            var logsDir = Path.Combine(planDir, "logs");
+            var logsDir = Path.Combine(planDir, "Logs");
             Directory.CreateDirectory(logsDir);
 
             File.WriteAllText(Path.Combine(logsDir, "001-ExecutePlan.md"),
@@ -48,7 +48,7 @@ public class ContentViewTests
         try
         {
             var planDir = Path.Combine(tempDir, "00001-TestPlan");
-            var logsDir = Path.Combine(planDir, "logs");
+            var logsDir = Path.Combine(planDir, "Logs");
             Directory.CreateDirectory(logsDir);
 
             File.WriteAllText(Path.Combine(logsDir, "001-ExecutePlan.md"),
@@ -97,7 +97,7 @@ public class ContentViewTests
         try
         {
             var planDir = Path.Combine(tempDir, "00001-TestPlan");
-            var logsDir = Path.Combine(planDir, "logs");
+            var logsDir = Path.Combine(planDir, "Logs");
             Directory.CreateDirectory(logsDir);
 
             File.WriteAllText(Path.Combine(logsDir, "001-ExecutePlan.md"),

--- a/src/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
+++ b/src/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
@@ -88,7 +88,7 @@ public class DoctorCommandPlansTests : IDisposable
     public void DoctorPlans_WithWorktrees_CountsCorrectly()
     {
         var planDir = CreatePlan("00004-WithWorktrees", ValidYaml);
-        var wtDir = Path.Combine(planDir, "worktrees");
+        var wtDir = Path.Combine(planDir, "Worktrees");
         Directory.CreateDirectory(Path.Combine(wtDir, "RepoA"));
         Directory.CreateDirectory(Path.Combine(wtDir, "RepoB"));
 
@@ -118,7 +118,7 @@ public class DoctorCommandPlansTests : IDisposable
     public void HasStaleWorktrees_WithStaleDir_ReturnsTrue()
     {
         var planDir = CreatePlan("00022-Stale", ValidYaml);
-        var wtDir = Path.Combine(planDir, "worktrees", "StaleRepo");
+        var wtDir = Path.Combine(planDir, "Worktrees", "StaleRepo");
         Directory.CreateDirectory(wtDir);
 
         var result = DoctorCommand.HasStaleWorktrees(planDir);
@@ -130,7 +130,7 @@ public class DoctorCommandPlansTests : IDisposable
     public void HasStaleWorktrees_WithValidGit_ReturnsFalse()
     {
         var planDir = CreatePlan("00023-Valid", ValidYaml);
-        var wtDir = Path.Combine(planDir, "worktrees", "ValidRepo");
+        var wtDir = Path.Combine(planDir, "Worktrees", "ValidRepo");
         Directory.CreateDirectory(wtDir);
         File.WriteAllText(Path.Combine(wtDir, ".git"), "gitdir: /some/path");
 
@@ -143,7 +143,7 @@ public class DoctorCommandPlansTests : IDisposable
     public void RepairPlan_StaleWorktree_RemovesDirectory()
     {
         var planDir = CreatePlan("00024-RepairStale", ValidYaml);
-        var wtDir = Path.Combine(planDir, "worktrees", "StaleRepo");
+        var wtDir = Path.Combine(planDir, "Worktrees", "StaleRepo");
         Directory.CreateDirectory(wtDir);
         File.WriteAllText(Path.Combine(wtDir, "dummy.txt"), "test");
 
@@ -341,7 +341,7 @@ public class DoctorCommandPlansTests : IDisposable
                                                        commits: []
                                                        prs: []
                                                        """);
-        var revisionsDir = Path.Combine(planDir, "revisions");
+        var revisionsDir = Path.Combine(planDir, "Revisions");
         Directory.CreateDirectory(revisionsDir);
         File.WriteAllText(Path.Combine(revisionsDir, "v1.md"), "# Plan v1");
 

--- a/src/Ivy.Tendril.Test/ExecutePlanWorktreeCleanupTests.cs
+++ b/src/Ivy.Tendril.Test/ExecutePlanWorktreeCleanupTests.cs
@@ -30,7 +30,7 @@ public class ExecutePlanWorktreeCleanupTests : IDisposable
 
     private string CreateWorktreeDir(string planDir, string repoName, bool withGitFile = false)
     {
-        var wtDir = Path.Combine(planDir, "worktrees", repoName);
+        var wtDir = Path.Combine(planDir, "Worktrees", repoName);
         Directory.CreateDirectory(wtDir);
         File.WriteAllText(Path.Combine(wtDir, "dummy.cs"), "// test");
 
@@ -97,9 +97,9 @@ public class ExecutePlanWorktreeCleanupTests : IDisposable
 
         WorktreeCleanupService.RemoveWorktrees(planDir);
 
-        Assert.False(Directory.Exists(Path.Combine(planDir, "worktrees", "RepoA")));
-        Assert.False(Directory.Exists(Path.Combine(planDir, "worktrees", "RepoB")));
-        Assert.False(Directory.Exists(Path.Combine(planDir, "worktrees", "RepoC")));
+        Assert.False(Directory.Exists(Path.Combine(planDir, "Worktrees", "RepoA")));
+        Assert.False(Directory.Exists(Path.Combine(planDir, "Worktrees", "RepoB")));
+        Assert.False(Directory.Exists(Path.Combine(planDir, "Worktrees", "RepoC")));
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/JobServiceLogTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceLogTests.cs
@@ -35,7 +35,7 @@ public class JobServiceLogTests : IDisposable
 
         jobService.WriteJobLog(job);
 
-        var logsDir = Path.Combine(_tempDir.Path, "Plans", "00001-TestPlan", "logs");
+        var logsDir = Path.Combine(_tempDir.Path, "Plans", "00001-TestPlan", "Logs");
         var logFiles = Directory.GetFiles(logsDir, "*.md");
         Assert.Single(logFiles);
 
@@ -66,7 +66,7 @@ public class JobServiceLogTests : IDisposable
 
         jobService.WriteJobLog(job);
 
-        var logsDir = Path.Combine(_tempDir.Path, "Plans", "00002-TestPlan", "logs");
+        var logsDir = Path.Combine(_tempDir.Path, "Plans", "00002-TestPlan", "Logs");
         var logFiles = Directory.GetFiles(logsDir, "*.md");
         Assert.Single(logFiles);
 

--- a/src/Ivy.Tendril.Test/MarkdownLinkPolisherTests.cs
+++ b/src/Ivy.Tendril.Test/MarkdownLinkPolisherTests.cs
@@ -66,7 +66,7 @@ public class MarkdownLinkPolisherTests : IDisposable
     [Fact]
     public void PolishLinks_FixesScreenshotPathToArtifactsFolder()
     {
-        var artifactsDir = Path.Combine(_planFolder, "artifacts");
+        var artifactsDir = Path.Combine(_planFolder, "Artifacts");
         Directory.CreateDirectory(artifactsDir);
         File.WriteAllText(Path.Combine(artifactsDir, "screenshot.png"), "img");
 

--- a/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
@@ -309,7 +309,7 @@ public class PlanToolsTests : IDisposable
         var result = _planTools.AddLog("00001", "ExecutePlan", "Test summary");
         Assert.Contains("Log written", result);
 
-        var logsDir = Path.Combine(planFolder, "logs");
+        var logsDir = Path.Combine(planFolder, "Logs");
         Assert.True(Directory.Exists(logsDir));
         var logFiles = Directory.GetFiles(logsDir, "*.md");
         Assert.Single(logFiles);

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -77,9 +77,9 @@ public class PlanCliCommandTests : IDisposable
             """;
 
         var folder = Path.Combine(_plansDir, $"{planId}-TestPlan");
-        Directory.CreateDirectory(Path.Combine(folder, "revisions"));
+        Directory.CreateDirectory(Path.Combine(folder, "Revisions"));
         File.WriteAllText(Path.Combine(folder, "plan.yaml"), yaml);
-        File.WriteAllText(Path.Combine(folder, "revisions", "001.md"), "# Test Plan");
+        File.WriteAllText(Path.Combine(folder, "Revisions", "001.md"), "# Test Plan");
         return folder;
     }
 
@@ -917,7 +917,7 @@ public class PlanCliCommandTests : IDisposable
     public void PlanList_FilterHasWorktree()
     {
         CreatePlanFolder("20170", "WithWt");
-        var wtDir = Path.Combine(_plansDir, "20170-WithWt", "worktrees", "SomeRepo");
+        var wtDir = Path.Combine(_plansDir, "20170-WithWt", "Worktrees", "SomeRepo");
         Directory.CreateDirectory(wtDir);
 
         CreatePlanFolder("20171", "NoWt");
@@ -1067,7 +1067,7 @@ public class PlanCliCommandTests : IDisposable
 
         _ = PlanAddLogCommand.WriteLog(planDir, "CreatePlan");
 
-        var logsDir = Path.Combine(planDir, "logs");
+        var logsDir = Path.Combine(planDir, "Logs");
         Assert.True(Directory.Exists(logsDir));
         var logFiles = Directory.GetFiles(logsDir, "*.md");
         Assert.Single(logFiles);
@@ -1083,7 +1083,7 @@ public class PlanCliCommandTests : IDisposable
     {
         CreatePlanFolder("30002", "TestLogIncr");
         var planDir = Path.Combine(_plansDir, "30002-TestLogIncr");
-        var logsDir = Path.Combine(planDir, "logs");
+        var logsDir = Path.Combine(planDir, "Logs");
         Directory.CreateDirectory(logsDir);
         File.WriteAllText(Path.Combine(logsDir, "001-ExpandPlan.md"), "first");
         File.WriteAllText(Path.Combine(logsDir, "002-ExecutePlan.md"), "second");
@@ -1101,7 +1101,7 @@ public class PlanCliCommandTests : IDisposable
 
         PlanAddLogCommand.WriteLog(planDir, "ExecutePlan", "Completed all verifications successfully");
 
-        var logsDir = Path.Combine(planDir, "logs");
+        var logsDir = Path.Combine(planDir, "Logs");
         var logFile = Directory.GetFiles(logsDir, "*.md").Single();
         var content = File.ReadAllText(logFile);
         Assert.Contains("Completed all verifications successfully", content);

--- a/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
+++ b/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
@@ -14,7 +14,7 @@ public class PlanContentHelpersTests
         try
         {
             var planDir = Path.Combine(tempDir, "00001-TestPlan");
-            var screenshotsDir = Path.Combine(planDir, "artifacts", "screenshots");
+            var screenshotsDir = Path.Combine(planDir, "Artifacts", "screenshots");
             Directory.CreateDirectory(screenshotsDir);
             File.WriteAllText(Path.Combine(screenshotsDir, "shot1.png"), "fake");
             File.WriteAllText(Path.Combine(screenshotsDir, "shot2.png"), "fake");

--- a/src/Ivy.Tendril.Test/PlanControllerTests.cs
+++ b/src/Ivy.Tendril.Test/PlanControllerTests.cs
@@ -433,7 +433,7 @@ public class PlanControllerTests : IDisposable
         var result = controller.AddLog("00001", new AddLogRequest("ExecutePlan", "Test summary"));
 
         Assert.IsType<OkObjectResult>(result);
-        var logsDir = Path.Combine(planFolder, "logs");
+        var logsDir = Path.Combine(planFolder, "Logs");
         Assert.True(Directory.Exists(logsDir));
         var logFiles = Directory.GetFiles(logsDir, "*.md");
         Assert.Single(logFiles);

--- a/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -37,7 +37,7 @@ public class PlanCountsServiceTests : IDisposable
         File.WriteAllText(Path.Combine(dir, "plan.yaml"),
             $"state: {state}\nproject: Tendril\ntitle: Test\nrepos: []\ncommits: []\nprs: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n");
 
-        var revisionsDir = Path.Combine(dir, "revisions");
+        var revisionsDir = Path.Combine(dir, "Revisions");
         Directory.CreateDirectory(revisionsDir);
         File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "# Test");
     }

--- a/src/Ivy.Tendril.Test/PlanDatabaseSyncServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseSyncServiceTests.cs
@@ -44,7 +44,7 @@ public class PlanDatabaseSyncServiceTests : IDisposable
 
         if (revisionContent != null)
         {
-            var revisionsDir = Path.Combine(dir, "revisions");
+            var revisionsDir = Path.Combine(dir, "Revisions");
             Directory.CreateDirectory(revisionsDir);
             File.WriteAllText(Path.Combine(revisionsDir, "001.md"), revisionContent);
         }
@@ -89,7 +89,7 @@ public class PlanDatabaseSyncServiceTests : IDisposable
         var dir = Path.Combine(_planReader.PlansDirectory, "01500-CostPlan");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "plan.yaml"), yaml);
-        var revisionsDir = Path.Combine(dir, "revisions");
+        var revisionsDir = Path.Combine(dir, "Revisions");
         Directory.CreateDirectory(revisionsDir);
         File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "# Cost Plan");
         File.WriteAllText(Path.Combine(dir, "costs.csv"),
@@ -109,7 +109,7 @@ public class PlanDatabaseSyncServiceTests : IDisposable
         var dir = Path.Combine(_planReader.PlansDirectory, "01500-RecPlan");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "plan.yaml"), yaml);
-        var revisionsDir = Path.Combine(dir, "revisions");
+        var revisionsDir = Path.Combine(dir, "Revisions");
         Directory.CreateDirectory(revisionsDir);
         File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "# Rec Plan");
 
@@ -128,7 +128,7 @@ public class PlanDatabaseSyncServiceTests : IDisposable
         var dir = Path.Combine(_planReader.PlansDirectory, "01502-BadRecsPlan");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "plan.yaml"), yaml);
-        var revisionsDir = Path.Combine(dir, "revisions");
+        var revisionsDir = Path.Combine(dir, "Revisions");
         Directory.CreateDirectory(revisionsDir);
         File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "# Bad Recs Plan");
 

--- a/src/Ivy.Tendril.Test/PlanDownloadHelperTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDownloadHelperTests.cs
@@ -20,15 +20,15 @@ public class PlanDownloadHelperTests
         // Create test plan folder structures
         var planFolder = Path.Combine(tempDir, "00001-TestPlan");
         Directory.CreateDirectory(planFolder);
-        Directory.CreateDirectory(Path.Combine(planFolder, "revisions"));
-        File.WriteAllText(Path.Combine(planFolder, "revisions", "001.md"), "# Test Plan\n\nTest content");
+        Directory.CreateDirectory(Path.Combine(planFolder, "Revisions"));
+        File.WriteAllText(Path.Combine(planFolder, "Revisions", "001.md"), "# Test Plan\n\nTest content");
         File.WriteAllText(Path.Combine(planFolder, "plan.yaml"),
             "state: Draft\nproject: Test\nlevel: Test\ntitle: Test Plan\nrepos: []\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\ninitialPrompt: test\nprs: []\ncommits: []\n");
 
         var planFolder2 = Path.Combine(tempDir, "00002-OtherPlan");
         Directory.CreateDirectory(planFolder2);
-        Directory.CreateDirectory(Path.Combine(planFolder2, "revisions"));
-        File.WriteAllText(Path.Combine(planFolder2, "revisions", "001.md"), "# Other Plan\n\nOther content");
+        Directory.CreateDirectory(Path.Combine(planFolder2, "Revisions"));
+        File.WriteAllText(Path.Combine(planFolder2, "Revisions", "001.md"), "# Other Plan\n\nOther content");
         File.WriteAllText(Path.Combine(planFolder2, "plan.yaml"),
             "state: Draft\nproject: Test\nlevel: Test\ntitle: Other Plan\nrepos: []\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\ninitialPrompt: test\nprs: []\ncommits: []\n");
 

--- a/src/Ivy.Tendril.Test/PlanReaderServiceComputePlanCountsTests.cs
+++ b/src/Ivy.Tendril.Test/PlanReaderServiceComputePlanCountsTests.cs
@@ -34,7 +34,7 @@ public class PlanReaderServiceComputePlanCountsTests : IDisposable
         File.WriteAllText(Path.Combine(dir, "plan.yaml"),
             $"state: {state}\nproject: Tendril\ntitle: Test\nrepos: []\ncommits: []\nprs: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n");
 
-        var revisionsDir = Path.Combine(dir, "revisions");
+        var revisionsDir = Path.Combine(dir, "Revisions");
         Directory.CreateDirectory(revisionsDir);
         File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "# Test");
     }

--- a/src/Ivy.Tendril.Test/PlanReaderServiceGetPlanTests.cs
+++ b/src/Ivy.Tendril.Test/PlanReaderServiceGetPlanTests.cs
@@ -32,7 +32,7 @@ public class PlanReaderServiceGetPlanTests : IDisposable
 
         if (revisionContent != null)
         {
-            var revisionsDir = Path.Combine(dir, "revisions");
+            var revisionsDir = Path.Combine(dir, "Revisions");
             Directory.CreateDirectory(revisionsDir);
             File.WriteAllText(Path.Combine(revisionsDir, "001.md"), revisionContent);
         }

--- a/src/Ivy.Tendril.Test/PlanYamlCorruptionTests.cs
+++ b/src/Ivy.Tendril.Test/PlanYamlCorruptionTests.cs
@@ -21,7 +21,7 @@ public class PlanYamlCorruptionTests : IClassFixture<ConfigServiceFixture>
         var safeTitle = PlanYamlHelper.ToSafeTitle(title);
         var planFolder = Path.Combine(_testPlansDir, $"{planId}-{safeTitle}");
         Directory.CreateDirectory(planFolder);
-        Directory.CreateDirectory(Path.Combine(planFolder, "revisions"));
+        Directory.CreateDirectory(Path.Combine(planFolder, "Revisions"));
 
         var repoDir = Path.Combine(planFolder, "repo");
         Directory.CreateDirectory(repoDir);
@@ -46,7 +46,7 @@ public class PlanYamlCorruptionTests : IClassFixture<ConfigServiceFixture>
         PlanCommandHelpers.WritePlan(planFolder, plan, watcher: null);
 
         // Create initial revision
-        var revisionPath = Path.Combine(planFolder, "revisions", "001.md");
+        var revisionPath = Path.Combine(planFolder, "Revisions", "001.md");
         File.WriteAllText(revisionPath, "# Test Plan\n\n## Problem\n\nTest problem");
 
         return planFolder;

--- a/src/Ivy.Tendril.Test/RecommendationServiceTests.cs
+++ b/src/Ivy.Tendril.Test/RecommendationServiceTests.cs
@@ -41,7 +41,7 @@ public class RecommendationServiceTests : IDisposable
             $"state: {state}\nproject: {project}\ntitle: Test Plan\nrepos: []\ncommits: []\nprs: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\nrecommendations:\n{indented}\n";
         File.WriteAllText(Path.Combine(dir, "plan.yaml"), planYaml);
 
-        var revisionsDir = Path.Combine(dir, "revisions");
+        var revisionsDir = Path.Combine(dir, "Revisions");
         Directory.CreateDirectory(revisionsDir);
         File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "# Test");
 

--- a/src/Ivy.Tendril.Test/RerunDialogTests.cs
+++ b/src/Ivy.Tendril.Test/RerunDialogTests.cs
@@ -11,8 +11,8 @@ public class ResetToDraftDialogTests
         try
         {
             var planDir = Path.Combine(tempDir, "00001-TestPlan");
-            var artifactsDir = Path.Combine(planDir, "artifacts");
-            var logsDir = Path.Combine(planDir, "logs");
+            var artifactsDir = Path.Combine(planDir, "Artifacts");
+            var logsDir = Path.Combine(planDir, "Logs");
             Directory.CreateDirectory(artifactsDir);
             Directory.CreateDirectory(logsDir);
             File.WriteAllText(Path.Combine(artifactsDir, "summary.md"), "test");
@@ -56,10 +56,10 @@ public class ResetToDraftDialogTests
         try
         {
             var planDir = Path.Combine(tempDir, "00001-TestPlan");
-            var artifactsDir = Path.Combine(planDir, "artifacts");
-            var logsDir = Path.Combine(planDir, "logs");
-            var verificationDir = Path.Combine(planDir, "verification");
-            var revisionsDir = Path.Combine(planDir, "revisions");
+            var artifactsDir = Path.Combine(planDir, "Artifacts");
+            var logsDir = Path.Combine(planDir, "Logs");
+            var verificationDir = Path.Combine(planDir, "Verification");
+            var revisionsDir = Path.Combine(planDir, "Revisions");
             Directory.CreateDirectory(artifactsDir);
             Directory.CreateDirectory(logsDir);
             Directory.CreateDirectory(verificationDir);
@@ -86,8 +86,8 @@ public class ResetToDraftDialogTests
         try
         {
             var planDir = Path.Combine(tempDir, "00001-TestPlan");
-            var screenshotsDir = Path.Combine(planDir, "artifacts", "screenshots");
-            var sampleDir = Path.Combine(planDir, "artifacts", "sample", "bin");
+            var screenshotsDir = Path.Combine(planDir, "Artifacts", "screenshots");
+            var sampleDir = Path.Combine(planDir, "Artifacts", "sample", "bin");
             Directory.CreateDirectory(screenshotsDir);
             Directory.CreateDirectory(sampleDir);
             File.WriteAllText(Path.Combine(screenshotsDir, "img.png"), "test");
@@ -95,7 +95,7 @@ public class ResetToDraftDialogTests
 
             ResetToDraftDialog.CleanPlanState(planDir);
 
-            Assert.False(Directory.Exists(Path.Combine(planDir, "artifacts")));
+            Assert.False(Directory.Exists(Path.Combine(planDir, "Artifacts")));
         }
         finally
         {
@@ -111,7 +111,7 @@ public class ResetToDraftDialogTests
         try
         {
             var planDir = Path.Combine(tempDir, "00001-TestPlan");
-            var worktreesDir = Path.Combine(planDir, "worktrees");
+            var worktreesDir = Path.Combine(planDir, "Worktrees");
             var repoDir = Path.Combine(worktreesDir, "Ivy-Framework");
             Directory.CreateDirectory(repoDir);
             File.WriteAllText(Path.Combine(repoDir, "dummy.txt"), "test");

--- a/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -37,7 +37,7 @@ public class WorktreeCleanupServiceTests : IDisposable
 
     private void CreateWorktreeDir(string planDir, string repoName, bool withContent = true)
     {
-        var worktreeDir = Path.Combine(planDir, "worktrees", repoName);
+        var worktreeDir = Path.Combine(planDir, "Worktrees", repoName);
         Directory.CreateDirectory(worktreeDir);
         if (withContent)
             File.WriteAllText(Path.Combine(worktreeDir, "dummy.txt"), "test");
@@ -45,7 +45,7 @@ public class WorktreeCleanupServiceTests : IDisposable
 
     private static void CreateEmptyWorktreesDir(string planDir)
     {
-        Directory.CreateDirectory(Path.Combine(planDir, "worktrees"));
+        Directory.CreateDirectory(Path.Combine(planDir, "Worktrees"));
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public class WorktreeCleanupServiceTests : IDisposable
         foreach (var state in activeStates)
         {
             var worktreesDir = Path.Combine(_plansDir, $"01{Array.IndexOf(activeStates, state):D3}-{state}Plan",
-                "worktrees");
+                "Worktrees");
             Assert.True(Directory.Exists(worktreesDir), $"Worktrees for {state} plan should not be removed");
         }
     }
@@ -85,7 +85,7 @@ public class WorktreeCleanupServiceTests : IDisposable
         foreach (var state in terminalStates)
         {
             var worktreesDir = Path.Combine(_plansDir, $"02{Array.IndexOf(terminalStates, state):D3}-{state}Plan",
-                "worktrees");
+                "Worktrees");
             Assert.False(Directory.Exists(worktreesDir), $"Empty worktrees dir for {state} plan should be removed");
         }
     }
@@ -99,7 +99,7 @@ public class WorktreeCleanupServiceTests : IDisposable
 
         _service.RunCleanup();
 
-        var worktreesDir = Path.Combine(dir, "worktrees");
+        var worktreesDir = Path.Combine(dir, "Worktrees");
         Assert.True(Directory.Exists(worktreesDir), "Recently failed plan should keep worktrees during grace period");
     }
 
@@ -117,7 +117,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     {
         var dir = Path.Combine(_plansDir, "05000-NoPlanYaml");
         Directory.CreateDirectory(dir);
-        var worktreeDir = Path.Combine(dir, "worktrees", "Repo");
+        var worktreeDir = Path.Combine(dir, "Worktrees", "Repo");
         Directory.CreateDirectory(worktreeDir);
 
         // Should not throw
@@ -134,7 +134,7 @@ public class WorktreeCleanupServiceTests : IDisposable
 
         WorktreeCleanupService.CleanupPlanWorktrees(dir);
 
-        var worktreesDir = Path.Combine(dir, "worktrees");
+        var worktreesDir = Path.Combine(dir, "Worktrees");
         Assert.False(Directory.Exists(worktreesDir));
     }
 
@@ -146,7 +146,7 @@ public class WorktreeCleanupServiceTests : IDisposable
 
         WorktreeCleanupService.CleanupPlanWorktrees(dir);
 
-        var worktreesDir = Path.Combine(dir, "worktrees");
+        var worktreesDir = Path.Combine(dir, "Worktrees");
         Assert.True(Directory.Exists(worktreesDir));
     }
 
@@ -154,7 +154,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     public void RemoveWorktrees_ForceDeletes_Directory_Without_GitFile()
     {
         var dir = CreatePlan("08000-ExtractTest", "Failed", DateTime.UtcNow.AddHours(-2));
-        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
         Directory.CreateDirectory(worktreeDir);
         File.WriteAllText(Path.Combine(worktreeDir, "file.txt"), "test");
 
@@ -169,14 +169,14 @@ public class WorktreeCleanupServiceTests : IDisposable
         // Worktree directory with no .git file — RemoveWorktrees skips it,
         // but the force-delete fallback should clean it up
         var dir = CreatePlan("09000-OrphanNoGit", "Completed", DateTime.UtcNow.AddHours(-2));
-        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
         Directory.CreateDirectory(worktreeDir);
         File.WriteAllText(Path.Combine(worktreeDir, "file.txt"), "orphaned content");
 
         WorktreeCleanupService.CleanupPlanWorktrees(dir);
 
         Assert.False(Directory.Exists(worktreeDir), "Orphan directory without .git should be force-deleted");
-        Assert.False(Directory.Exists(Path.Combine(dir, "worktrees")), "Worktrees directory should be removed");
+        Assert.False(Directory.Exists(Path.Combine(dir, "Worktrees")), "Worktrees directory should be removed");
     }
 
     [Fact]
@@ -185,7 +185,7 @@ public class WorktreeCleanupServiceTests : IDisposable
         // Worktree directory with a .git file pointing to a non-existent repo entry —
         // git worktree remove will fail, but force-delete fallback should clean it up
         var dir = CreatePlan("09001-OrphanStaleGit", "Failed", DateTime.UtcNow.AddHours(-2));
-        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
         Directory.CreateDirectory(worktreeDir);
         File.WriteAllText(Path.Combine(worktreeDir, ".git"),
             "gitdir: /nonexistent/path/.git/worktrees/TestRepo");
@@ -194,7 +194,7 @@ public class WorktreeCleanupServiceTests : IDisposable
         WorktreeCleanupService.CleanupPlanWorktrees(dir);
 
         Assert.False(Directory.Exists(worktreeDir), "Orphan directory with stale .git should be force-deleted");
-        Assert.False(Directory.Exists(Path.Combine(dir, "worktrees")), "Worktrees directory should be removed");
+        Assert.False(Directory.Exists(Path.Combine(dir, "Worktrees")), "Worktrees directory should be removed");
     }
 
     [Fact]
@@ -203,7 +203,7 @@ public class WorktreeCleanupServiceTests : IDisposable
         // Worktree directory with read-only files (common in git objects) —
         // ClearReadOnlyAttributes should make them deletable
         var dir = CreatePlan("09002-ReadOnlyFiles", "Completed", DateTime.UtcNow.AddHours(-2));
-        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
         var subDir = Path.Combine(worktreeDir, "objects");
         Directory.CreateDirectory(subDir);
 
@@ -217,7 +217,7 @@ public class WorktreeCleanupServiceTests : IDisposable
         WorktreeCleanupService.CleanupPlanWorktrees(dir);
 
         Assert.False(Directory.Exists(worktreeDir), "Directory with read-only files should be force-deleted");
-        Assert.False(Directory.Exists(Path.Combine(dir, "worktrees")), "Worktrees directory should be removed");
+        Assert.False(Directory.Exists(Path.Combine(dir, "Worktrees")), "Worktrees directory should be removed");
     }
 
     [Fact]
@@ -276,7 +276,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     public void RemoveWorktrees_Logs_Info_And_ForceDeletes_When_GitFile_Missing()
     {
         var dir = CreatePlan("10000-LogWarningTest", "Failed", DateTime.UtcNow.AddHours(-2));
-        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
         Directory.CreateDirectory(worktreeDir);
         File.WriteAllText(Path.Combine(worktreeDir, "file.txt"), "test");
 
@@ -294,7 +294,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     public void CleanupPlanWorktrees_FallbackRemoves_DirectoryMissedByRemoveWorktrees()
     {
         var dir = CreatePlan("10003-TestFallback", "Completed", DateTime.UtcNow.AddHours(-2));
-        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
         Directory.CreateDirectory(worktreeDir);
         File.WriteAllText(Path.Combine(worktreeDir, ".git"),
             "gitdir: /nonexistent/repo/.git/worktrees/TestRepo");
@@ -315,7 +315,7 @@ public class WorktreeCleanupServiceTests : IDisposable
         // Simulates the real-world failure: cleanup must succeed over a deeply nested
         // node_modules tree like the one that crashed on 'helper-string-parser'.
         var dir = CreatePlan("11000-DeepNodeModules", "Completed", DateTime.UtcNow.AddHours(-2));
-        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
 
         var deep = Path.Combine(
             worktreeDir,
@@ -335,7 +335,7 @@ public class WorktreeCleanupServiceTests : IDisposable
 
         Assert.False(Directory.Exists(worktreeDir),
             "Deeply nested node_modules worktree should be force-deleted");
-        Assert.False(Directory.Exists(Path.Combine(dir, "worktrees")),
+        Assert.False(Directory.Exists(Path.Combine(dir, "Worktrees")),
             "Worktrees directory should be removed");
     }
 
@@ -406,7 +406,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     public void CleanupPlanWorktrees_LogsMissingGitFileAge()
     {
         var dir = CreatePlan("12000-MissingGitAge", "Completed", DateTime.UtcNow.AddHours(-2));
-        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
         Directory.CreateDirectory(worktreeDir);
         File.WriteAllText(Path.Combine(worktreeDir, "file.txt"), "content");
 
@@ -423,7 +423,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     public void CleanupPlanWorktrees_HandlesVeryRecentOrphanedDirectory()
     {
         var dir = CreatePlan("12001-RecentOrphan", "Completed", DateTime.UtcNow.AddHours(-2));
-        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
         Directory.CreateDirectory(worktreeDir);
         File.WriteAllText(Path.Combine(worktreeDir, "file.txt"), "content");
 
@@ -462,7 +462,7 @@ public class WorktreeCleanupServiceTests : IDisposable
         foreach (var (folderName, _) in testCases)
         {
             var dir = CreatePlan(folderName, "Failed", DateTime.UtcNow.AddHours(-2));
-            var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+            var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
             Directory.CreateDirectory(worktreeDir);
 
             var logEntries = new List<string>();
@@ -481,7 +481,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     public void RemoveWorktrees_LogsBranchDeletionAttempt()
     {
         var dir = CreatePlan("14001-TestBranchDeletion", "Failed", DateTime.UtcNow.AddHours(-2));
-        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
         Directory.CreateDirectory(worktreeDir);
 
         var logEntries = new List<string>();
@@ -502,7 +502,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     {
         // Verify that if branch deletion fails, the method still completes successfully
         var dir = CreatePlan("14002-BranchDeletionFailure", "Completed", DateTime.UtcNow.AddHours(-2));
-        var worktreeDir = Path.Combine(dir, "worktrees", "TestRepo");
+        var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
         Directory.CreateDirectory(worktreeDir);
 
         var logEntries = new List<string>();

--- a/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
@@ -143,7 +143,7 @@ public class JobDebugSheet(
         var folder = GetPlanFolderPath(job);
         if (string.IsNullOrEmpty(folder)) return null;
 
-        var logsDir = Path.Combine(folder, "logs");
+        var logsDir = Path.Combine(folder, "Logs");
         if (!Directory.Exists(logsDir)) return null;
 
         var files = Directory.GetFiles(logsDir, pattern);

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -65,7 +65,7 @@ public class ContentView(
                             new Dictionary<string, List<string>>(), [],
                             new Dictionary<string, bool>(), null);
 
-                    var summaryPath = Path.Combine(folderPath, "artifacts", "summary.md");
+                    var summaryPath = Path.Combine(folderPath, "Artifacts", "summary.md");
                     var summaryMd = File.Exists(summaryPath) ? FileHelper.ReadAllText(summaryPath) : null;
 
                     var artifacts = PlanContentHelpers.GetArtifacts(folderPath);
@@ -76,7 +76,7 @@ public class ContentView(
 
                     var verReports = selectedPlan.Verifications.ToDictionary(
                         v => v.Name,
-                        v => File.Exists(Path.Combine(folderPath, "verification", $"{v.Name}.md")));
+                        v => File.Exists(Path.Combine(folderPath, "Verification", $"{v.Name}.md")));
 
                     return new PlanContentData(summaryMd, artifacts, commitRows, verReports, allChanges);
                 }, ct);
@@ -254,7 +254,7 @@ public class ContentView(
 
     internal static object BuildFailureCallout(PlanFile plan)
     {
-        var verificationDir = Path.Combine(plan.FolderPath, "verification");
+        var verificationDir = Path.Combine(plan.FolderPath, "Verification");
         var failedVerifications = plan.Verifications
             .Where(v => v.Status is "Fail" or "Pending")
             .ToList();
@@ -295,7 +295,7 @@ public class ContentView(
         }
 
         // Fall back to last execution log
-        var logsDir = Path.Combine(plan.FolderPath, "logs");
+        var logsDir = Path.Combine(plan.FolderPath, "Logs");
         if (!Directory.Exists(logsDir))
             return Callout.Destructive("No details available. Check the logs folder.", "Execution Failed");
         var lastLog = Directory.GetFiles(logsDir, "*.md")

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -99,7 +99,7 @@ public class ContentView(
             {
                 if (string.IsNullOrEmpty(filePath)) return "";
                 if (selectedPlanState.Value is null) return "";
-                var artifactsDir = Path.GetFullPath(Path.Combine(selectedPlanState.Value.FolderPath, "artifacts"));
+                var artifactsDir = Path.GetFullPath(Path.Combine(selectedPlanState.Value.FolderPath, "Artifacts"));
                 var resolvedPath = Path.GetFullPath(filePath);
                 if (!resolvedPath.StartsWith(artifactsDir, StringComparison.OrdinalIgnoreCase))
                     return "Access denied: file is outside the artifacts folder.";
@@ -143,7 +143,7 @@ public class ContentView(
                     }
 
                     // Summary
-                    var summPath = Path.Combine(folderPath, "artifacts", "summary.md");
+                    var summPath = Path.Combine(folderPath, "Artifacts", "summary.md");
                     var summaryMd = File.Exists(summPath) ? FileHelper.ReadAllText(summPath) : null;
 
                     // Artifacts
@@ -158,7 +158,7 @@ public class ContentView(
                     // Verification report existence
                     var verReports = selectedPlanState.Value.Verifications.ToDictionary(
                         v => v.Name,
-                        v => File.Exists(Path.Combine(folderPath, "verification", $"{v.Name}.md")));
+                        v => File.Exists(Path.Combine(folderPath, "Verification", $"{v.Name}.md")));
 
                     // Review action conditions
                     var projectConfig = config.GetProject(selectedPlanState.Value.Project);
@@ -201,7 +201,7 @@ public class ContentView(
             return Disposable.Empty;
         }, [localRefresh]);
 
-        var tabNames = new[] { "summary", "plan", "details", "verifications", "git", "changes", "artifacts", "recommendations" };
+        var tabNames = new[] { "summary", "plan", "details", "verifications", "git", "changes", "Artifacts", "recommendations" };
         var selectedTabIndex = Array.IndexOf(tabNames, args?.Tab ?? "summary");
         if (selectedTabIndex < 0) selectedTabIndex = 0;
 
@@ -556,14 +556,14 @@ public class ContentView(
 
     internal static bool ValidateArtifactPath(string filePath, string planFolderPath)
     {
-        var artifactsDir = Path.GetFullPath(Path.Combine(planFolderPath, "artifacts"));
+        var artifactsDir = Path.GetFullPath(Path.Combine(planFolderPath, "Artifacts"));
         var resolvedPath = Path.GetFullPath(filePath);
         return resolvedPath.StartsWith(artifactsDir, StringComparison.OrdinalIgnoreCase);
     }
 
     internal static bool ValidateVerificationPath(string name, string planFolderPath)
     {
-        var verificationDir = Path.GetFullPath(Path.Combine(planFolderPath, "verification"));
+        var verificationDir = Path.GetFullPath(Path.Combine(planFolderPath, "Verification"));
         var resolvedPath = Path.GetFullPath(Path.Combine(verificationDir, $"{name}.md"));
         return resolvedPath.StartsWith(verificationDir, StringComparison.OrdinalIgnoreCase);
     }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
@@ -59,21 +59,21 @@ public class ResetToDraftDialog(
 
     internal static void CleanPlanState(string planFolderPath, ILogger? logger = null)
     {
-        var artifactsDir = Path.Combine(planFolderPath, "artifacts");
+        var artifactsDir = Path.Combine(planFolderPath, "Artifacts");
         if (Directory.Exists(artifactsDir))
         {
             logger?.LogInformation("Cleaning artifacts directory: {Path}", artifactsDir);
             WorktreeCleanupService.ForceDeleteDirectory(artifactsDir, logger);
         }
 
-        var logsDir = Path.Combine(planFolderPath, "logs");
+        var logsDir = Path.Combine(planFolderPath, "Logs");
         if (Directory.Exists(logsDir))
         {
             logger?.LogInformation("Cleaning logs directory: {Path}", logsDir);
             WorktreeCleanupService.ForceDeleteDirectory(logsDir, logger);
         }
 
-        var verificationDir = Path.Combine(planFolderPath, "verification");
+        var verificationDir = Path.Combine(planFolderPath, "Verification");
         if (Directory.Exists(verificationDir))
         {
             logger?.LogInformation("Cleaning verification directory: {Path}", verificationDir);
@@ -82,7 +82,7 @@ public class ResetToDraftDialog(
 
         WorktreeCleanupService.RemoveWorktrees(planFolderPath, logger);
 
-        var worktreesDir = Path.Combine(planFolderPath, "worktrees");
+        var worktreesDir = Path.Combine(planFolderPath, "Worktrees");
         if (Directory.Exists(worktreesDir))
         {
             logger?.LogInformation("Cleaning worktrees directory: {Path}", worktreesDir);

--- a/src/Ivy.Tendril/Assets/Plans.md
+++ b/src/Ivy.Tendril/Assets/Plans.md
@@ -9,23 +9,23 @@ Plans live under `planFolder` from `config.yaml`.
 ├── .counter                          # Next plan ID (integer, auto-incremented)
 ├── 01098-MakeAnEmptyAppCalledReview/
 │   ├── plan.yaml                     # Plan metadata
-│   ├── revisions/                    # Plan content versions
+│   ├── Revisions/                    # Plan content versions
 │   │   ├── 001.md                    # Initial revision (created by CreatePlan)
 │   │   ├── 002.md                    # After ExpandPlan/UpdatePlan/SplitPlan
 │   │   └── ...
-│   ├── logs/                         # Execution logs per promptware run
+│   ├── Logs/                         # Execution logs per promptware run
 │   │   ├── 001-CreatePlan.md
 │   │   ├── 002-ExpandPlan.md
 │   │   └── ...
-│   ├── artifacts/                    # Output artifacts from execution
+│   ├── Artifacts/                    # Output artifacts from execution
 │   │   ├── tests/                    # Test scripts and data
 │   │   ├── screenshots/              # UI screenshots
 │   │   └── sample/                   # Sample apps exercising new functionality
-│   ├── verification/                 # Verification reports
+│   ├── Verification/                 # Verification reports
 │   │   ├── DotnetBuild.md
 │   │   ├── DotnetTest.md
 │   │   └── ...
-│   ├── worktrees/                    # Git worktrees used during execution
+│   ├── Worktrees/                    # Git worktrees used during execution
 └── ...
 ```
 

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -378,7 +378,7 @@ public static class DoctorCommand
 
     internal static int CountWorktrees(string planPath)
     {
-        var worktreesPath = Path.Combine(planPath, "worktrees");
+        var worktreesPath = Path.Combine(planPath, "Worktrees");
         if (!Directory.Exists(worktreesPath))
             return 0;
 
@@ -387,7 +387,7 @@ public static class DoctorCommand
 
     internal static bool HasStaleWorktrees(string planPath)
     {
-        var worktreesPath = Path.Combine(planPath, "worktrees");
+        var worktreesPath = Path.Combine(planPath, "Worktrees");
         if (!Directory.Exists(worktreesPath))
             return false;
 
@@ -503,7 +503,7 @@ public static class DoctorCommand
 
             if (healthResult.Health.Contains("StaleWorktree"))
             {
-                var worktreesPath = Path.Combine(planPath, "worktrees");
+                var worktreesPath = Path.Combine(planPath, "Worktrees");
                 if (Directory.Exists(worktreesPath))
                 {
                     foreach (var wtDir in Directory.GetDirectories(worktreesPath))
@@ -618,7 +618,7 @@ public static class DoctorCommand
             hasCommits = HasYamlListItems(content, "commits");
         }
 
-        var revisionsDir = Path.Combine(planPath, "revisions");
+        var revisionsDir = Path.Combine(planPath, "Revisions");
         if (Directory.Exists(revisionsDir))
             hasRevisions = Directory.GetFiles(revisionsDir, "*.md").Length > 0;
 

--- a/src/Ivy.Tendril/Commands/PlanAddLogCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddLogCommand.cs
@@ -46,7 +46,7 @@ public class PlanAddLogCommand : Command<PlanAddLogSettings>
 
     internal static string WriteLog(string planFolder, string action, string? summary = null)
     {
-        var logsDir = Path.Combine(planFolder, "logs");
+        var logsDir = Path.Combine(planFolder, "Logs");
         Directory.CreateDirectory(logsDir);
 
         var maxNumber = 0;

--- a/src/Ivy.Tendril/Commands/PlanCleanupCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCleanupCommand.cs
@@ -41,7 +41,7 @@ public class PlanCleanupCommand : Command<PlanCleanupSettings>
                 return 1;
             }
 
-            var worktreesDir = Path.Combine(planFolder, "worktrees");
+            var worktreesDir = Path.Combine(planFolder, "Worktrees");
             if (!Directory.Exists(worktreesDir) || Directory.GetDirectories(worktreesDir).Length == 0)
             {
                 AnsiConsole.MarkupLine("[green]No worktrees to clean up.[/]");
@@ -57,7 +57,7 @@ public class PlanCleanupCommand : Command<PlanCleanupSettings>
             }
             else
             {
-                AnsiConsole.MarkupLine($"[yellow]{remaining} {(remaining == 1 ? "worktree" : "worktrees")} could not be removed.[/]");
+                AnsiConsole.MarkupLine($"[yellow]{remaining} {(remaining == 1 ? "worktree" : "Worktrees")} could not be removed.[/]");
                 return 1;
             }
 

--- a/src/Ivy.Tendril/Commands/PlanListCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanListCommand.cs
@@ -172,7 +172,7 @@ public class PlanListCommand : Command<PlanListSettings>
 
             if (settings.HasWorktree)
             {
-                var wtDir = Path.Combine(dir, "worktrees");
+                var wtDir = Path.Combine(dir, "Worktrees");
                 if (!Directory.Exists(wtDir) || Directory.GetDirectories(wtDir).Length == 0)
                     continue;
             }

--- a/src/Ivy.Tendril/Commands/PlanRemoveWorktreeCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveWorktreeCommand.cs
@@ -35,7 +35,7 @@ public class PlanRemoveWorktreeCommand : Command<PlanRemoveWorktreeSettings>
         try
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var worktreePath = Path.Combine(planFolder, "worktrees", settings.RepoName);
+            var worktreePath = Path.Combine(planFolder, "Worktrees", settings.RepoName);
 
             if (!Directory.Exists(worktreePath))
             {

--- a/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
@@ -27,7 +27,7 @@ public class PlanWriteRevisionCommand : Command<PlanWriteRevisionSettings>
         try
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var revisionsDir = Path.Combine(planFolder, "revisions");
+            var revisionsDir = Path.Combine(planFolder, "Revisions");
             Directory.CreateDirectory(revisionsDir);
 
             var number = ResolveRevisionNumber(revisionsDir);

--- a/src/Ivy.Tendril/Helpers/JobStatusFile.cs
+++ b/src/Ivy.Tendril/Helpers/JobStatusFile.cs
@@ -81,7 +81,7 @@ public static class JobStatusFile
             var logPath = GetJobLogPath(statusFilePath);
             if (!File.Exists(logPath)) return;
 
-            var logsDir = Path.Combine(planFolder, "logs");
+            var logsDir = Path.Combine(planFolder, "Logs");
             FileHelper.EnsureDirectory(logsDir);
 
             var filename = !string.IsNullOrEmpty(jobId)

--- a/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
@@ -55,7 +55,7 @@ public static class PlanContentHelpers
 
     public static Dictionary<string, List<string>> GetArtifacts(string folderPath)
     {
-        var artifactsDir = Path.Combine(folderPath, "artifacts");
+        var artifactsDir = Path.Combine(folderPath, "Artifacts");
         var result = new Dictionary<string, List<string>>();
         if (!Directory.Exists(artifactsDir)) return result;
 

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -517,7 +517,7 @@ public sealed class PlanTools : AuthenticatedToolBase
             sb.AppendLine(plan.InitialPrompt);
         }
 
-        var revisionsDir = Path.Combine(planFolder, "revisions");
+        var revisionsDir = Path.Combine(planFolder, "Revisions");
         if (Directory.Exists(revisionsDir))
         {
             var revFiles = Directory.GetFiles(revisionsDir, "*.md").OrderByDescending(f => f).ToArray();

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -197,7 +197,7 @@ tendril plan write-revision <PlanId> <<'EOF'
 EOF
 ```
 
-This reads from STDIN and auto-creates `revisions/001.md` (or the next sequential number) in the plan folder. Do NOT use the Write or Edit tools to create revision files directly in `revisions/`.
+This reads from STDIN and auto-creates `Revisions/001.md` (or the next sequential number) in the plan folder. Do NOT use the Write or Edit tools to create revision files directly in `Revisions/`.
 
 After creating the plan, report the plan ID and title to the Jobs UI so it can display progress:
 

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -44,9 +44,9 @@ Before processing, read `plan.yaml` and check the `state` field. After reading, 
 
 ### 2. For Each Worktree
 
-Check `<TendrilPlanFolder>/worktrees/` for each repo worktree.
+Check `<TendrilPlanFolder>/Worktrees/` for each repo worktree.
 
-> **Worktree already removed:** If the worktrees/ directory is empty (worktree was already cleaned up), fall back to `plan.yaml` to get the repo path and branch name (format: `tendril/<planId>-<SafeTitle>`, where SafeTitle is extracted from the plan folder name: e.g. `03158-ChangeBranchNaming` → `ChangeBranchNaming`). The commit objects may still exist in the original repo's object store. Use `git cat-file -t <sha>` to verify, then create or force-update the local branch: `git branch -f <branch-name> <sha>` (use `-f` because the branch may already exist from a WIP auto-commit) and push from the original repo path.
+> **Worktree already removed:** If the Worktrees/ directory is empty (worktree was already cleaned up), fall back to `plan.yaml` to get the repo path and branch name (format: `tendril/<planId>-<SafeTitle>`, where SafeTitle is extracted from the plan folder name: e.g. `03158-ChangeBranchNaming` → `ChangeBranchNaming`). The commit objects may still exist in the original repo's object store. Use `git cat-file -t <sha>` to verify, then create or force-update the local branch: `git branch -f <branch-name> <sha>` (use `-f` because the branch may already exist from a WIP auto-commit) and push from the original repo path.
 >
 > **Commit lost (object GC'd):** If `git cat-file -t <sha>` fails, the commit was garbage-collected after worktree removal. In this case: (1) check if the change is already on main, (2) if not, recreate the change from the plan revision — create a new branch from main, apply the changes as described in the revision, commit with the standard `[<planId>] <title>` message, and push. Update commits via CLI: `tendril plan add-commit <plan-id> <new-sha>`.
 
@@ -65,7 +65,7 @@ For each worktree:
 
 **If custom options exist and `includeArtifacts` is `false`, skip this step entirely** (set artifact markdown to empty).
 
-Otherwise, if an artifact upload tool is available in `Tools/`, run it to upload screenshots and videos from `<TendrilPlanFolder>/artifacts/` to persistent storage.
+Otherwise, if an artifact upload tool is available in `Tools/`, run it to upload screenshots and videos from `<TendrilPlanFolder>/Artifacts/` to persistent storage.
 
 Capture the returned markdown. If non-empty, it will be appended to the PR body under an `## Artifacts` heading in the next step. If no upload tool is available, skip this step.
 
@@ -88,7 +88,7 @@ EOF
 - **Title:** `[<planId>] <plan title>`
 - **Body:** 
   1. **If SourceUrl is present in firmware header** and it's a GitHub issue URL (format: `https://github.com/owner/repo/issues/NUMBER`), prepend `Fixes #NUMBER\n\n` to the body
-  2. If `<TendrilPlanFolder>/artifacts/summary.md` exists, use its content as the PR body (after the issue link)
+  2. If `<TendrilPlanFolder>/Artifacts/summary.md` exists, use its content as the PR body (after the issue link)
   3. Otherwise, fall back to summary from Problem + Solution sections
   4. Append commit list
   5. If `$artifactMarkdown` from step 2.5 is non-empty, append it under an `## Artifacts` heading
@@ -150,7 +150,7 @@ done
 
 When the PR status is `CONFLICTING`, resolve the conflict locally before retrying:
 
-1. **Locate the worktree** for this repo. If the worktree still exists in `<TendrilPlanFolder>/worktrees/<repo-folder-name>`, use it. If the worktree was already removed, use the original repo path — create or force-update the local branch first: `git branch -f <branch-name> <sha>` and `git checkout <branch-name>`.
+1. **Locate the worktree** for this repo. If the worktree still exists in `<TendrilPlanFolder>/Worktrees/<repo-folder-name>`, use it. If the worktree was already removed, use the original repo path — create or force-update the local branch first: `git branch -f <branch-name> <sha>` and `git checkout <branch-name>`.
 
 2. **Read the plan revision** to understand the intent of the plan's changes (what matters, what can be safely adapted).
 

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -19,7 +19,7 @@ The launcher sets the working directory to the project's primary repo.
 
 **Note:** Plans are often executed multiple times. For example, a reviewer may not be satisfied with the first execution and sends the plan back to Draft with comments (via UpdatePlan). When re-executing, the worktree branch from the previous run may already exist — handle this gracefully (delete old worktree first, or create with a new branch suffix). Check for existing artifacts and verification reports from prior runs.
 
-**Resume-vs-redo on re-execution:** Before deleting anything, run an integrity check on the prior run. If `plan.yaml` has commits populated and all verifications `Pass`, every `Pass` verification has a report, `artifacts/summary.md` exists, the worktree is clean with HEAD matching the last recorded commit, and the expected code changes are present in the files — then **resume** (log it and exit successfully) rather than redoing work. Redoing creates new commit hashes and breaks downstream CreatePr references. Only fall back to the full re-execution flow if any of those checks fail.
+**Resume-vs-redo on re-execution:** Before deleting anything, run an integrity check on the prior run. If `plan.yaml` has commits populated and all verifications `Pass`, every `Pass` verification has a report, `Artifacts/summary.md` exists, the worktree is clean with HEAD matching the last recorded commit, and the expected code changes are present in the files — then **resume** (log it and exit successfully) rather than redoing work. Redoing creates new commit hashes and breaks downstream CreatePr references. Only fall back to the full re-execution flow if any of those checks fail.
 
 ## Time Budget Awareness
 
@@ -38,7 +38,7 @@ Focus on making progress, not achieving perfect understanding. A working impleme
 ### 1. Read Plan
 
 - Read `plan.yaml` from the plan folder (project, repos, title)
-- Read the latest revision from `revisions/` (highest numbered .md file)
+- Read the latest revision from `Revisions/` (highest numbered .md file)
 - Extract the plan ID from the folder name (e.g. `01105` from `01105-TestPlan`)
 - Report plan context to Jobs UI: `tendril job status TendrilJobId --message "Reading plan..." --plan-id <plan-id> --plan-title "<title>"`
 
@@ -119,7 +119,7 @@ After reading the plan revision, scan it for code validation markers to detect s
    - **If all validation blocks pass** → Proceed to worktree creation
    - **If any validation fails** → Fail the plan immediately with a detailed report
 
-4. **Write validation report** — Create `<TendrilPlanFolder>/verification/PreExecution.md`:
+4. **Write validation report** — Create `<TendrilPlanFolder>/Verification/PreExecution.md`:
 
 ```markdown
 # PreExecution
@@ -148,7 +148,7 @@ After reading the plan revision, scan it for code validation markers to detect s
    - A `<details><summary>Still relevant?</summary>` block whose body starts with `No.`
    - Phrases like *"Already applied"*, *"This plan is redundant"*, *"This plan is superseded"*, or *"previously attempted … was merged to main via PR #NNNN"* in the `## Problem` or `## Solution` sections.
 
-   If any marker is found, verify the claim: run `gh pr view <cited PR> --json state,mergeCommit` (must be `MERGED`), confirm the cited commit is in `git log origin/<default-branch>`, and byte-compare the plan's proposed code against the current file contents. If all three checks pass, write `verification/PreExecution.md` with `Result: Fail`, write `artifacts/summary.md` documenting the no-op, set every verification to `Skipped` via `tendril plan set-verification <plan-id> <name> Skipped`, and fail the plan **without creating a worktree** — running verifications on unchanged code wastes the time budget and produces a 0-commit PR that CreatePr cannot process.
+   If any marker is found, verify the claim: run `gh pr view <cited PR> --json state,mergeCommit` (must be `MERGED`), confirm the cited commit is in `git log origin/<default-branch>`, and byte-compare the plan's proposed code against the current file contents. If all three checks pass, write `Verification/PreExecution.md` with `Result: Fail`, write `Artifacts/summary.md` documenting the no-op, set every verification to `Skipped` via `tendril plan set-verification <plan-id> <name> Skipped`, and fail the plan **without creating a worktree** — running verifications on unchanged code wastes the time budget and produces a 0-commit PR that CreatePr cannot process.
 
 ### 1.8. Auto-Commit Uncommitted Changes
 
@@ -243,7 +243,7 @@ PLAN_FOLDER_NAME=$(basename "<TendrilPlanFolder>")
 PLAN_ID=$(echo "$PLAN_FOLDER_NAME" | grep -oP '^\d+')
 SAFE_TITLE=$(echo "$PLAN_FOLDER_NAME" | sed 's/^[0-9]\+-//')
 BRANCH_NAME="tendril/$PLAN_ID-$SAFE_TITLE"
-git worktree add "<TendrilPlanFolder>/worktrees/<repo-folder-name>" -b "$BRANCH_NAME" "origin/<resolved-base-branch>"
+git worktree add "<TendrilPlanFolder>/Worktrees/<repo-folder-name>" -b "$BRANCH_NAME" "origin/<resolved-base-branch>"
 ```
 
 Example:
@@ -251,7 +251,7 @@ Example:
 ```bash
 cd <RepoPath>
 git fetch origin
-git worktree add "<TendrilPlanFolder>/worktrees/<RepoName>" -b "tendril/<TendrilPlanId>-<SafeTitle>" origin/<resolved-base-branch>
+git worktree add "<TendrilPlanFolder>/Worktrees/<RepoName>" -b "tendril/<TendrilPlanId>-<SafeTitle>" origin/<resolved-base-branch>
 ```
 
 **Important:** Always branch from `origin/<resolved-base-branch>`, not local HEAD. This ensures the PR only contains the plan's commits, not any unpushed local work. The `<resolved-base-branch>` comes from either the `RepoConfigs` firmware header (if `baseBranch` is configured) or auto-detection.
@@ -276,12 +276,12 @@ If `baseBranch` is present for a repo, use it instead of auto-detecting. If abse
 4. After creating the worktree, **verify the `.git` file exists** and fail fast if it's missing:
 
 ```bash
-if [ ! -f "<TendrilPlanFolder>/worktrees/<repo-folder-name>/.git" ]; then
-    echo "ERROR: Worktree creation failed - .git file missing at <TendrilPlanFolder>/worktrees/<repo-folder-name>/.git"
+if [ ! -f "<TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git" ]; then
+    echo "ERROR: Worktree creation failed - .git file missing at <TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git"
     echo "This indicates git worktree add did not fully initialize the worktree."
     exit 1
 fi
-cat "<TendrilPlanFolder>/worktrees/<repo-folder-name>/.git"
+cat "<TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git"
 ```
 
 This ensures ExecutePlan fails immediately if worktree creation is incomplete, rather than leaving orphaned directories that trigger warnings during cleanup.
@@ -291,7 +291,7 @@ This ensures ExecutePlan fails immediately if worktree creation is incomplete, r
    ```bash
    SYNC_STRATEGY="<from RepoConfigs or 'fetch' if not specified>"
    BASE_BRANCH="<resolved-base-branch>"
-   WORKTREE_PATH="<TendrilPlanFolder>/worktrees/<repo-folder-name>"
+   WORKTREE_PATH="<TendrilPlanFolder>/Worktrees/<repo-folder-name>"
 
    tendril plan sync-worktree "$WORKTREE_PATH" --strategy "$SYNC_STRATEGY" --base-branch "$BASE_BRANCH"
    ```
@@ -395,7 +395,7 @@ If there are uncommitted changes, either commit them or discard them with a clea
 
 ### 5.5. Generate Summary
 
-After all implementation commits are made, create `<TendrilPlanFolder>/artifacts/summary.md` summarizing what was done.
+After all implementation commits are made, create `<TendrilPlanFolder>/Artifacts/summary.md` summarizing what was done.
 
 The summary should follow this structure:
 
@@ -443,7 +443,7 @@ If the plan references other plans (e.g. split-from, follow-up), add them via CL
 
 ### 7. Run Verifications
 
-Create a `verification/` directory in the plan folder if it doesn't exist.
+Create a `Verification/` directory in the plan folder if it doesn't exist.
 
 Check the `## Verification` section in the plan revision for checked items (`- [x]`). Skip unchecked items (`- [ ]`).
 
@@ -463,7 +463,7 @@ For each checked verification:
 
 **CRITICAL:** You MUST call `tendril plan set-verification` after EACH verification. The verification report file alone is NOT sufficient — plan.yaml must also be updated via the CLI. Failing to call this command will result in the plan being marked as Failed.
 
-**!IMPORTANT: Every verification MUST produce a report** at `<TendrilPlanFolder>/verification/<VerificationName>.md` using YAML frontmatter:
+**!IMPORTANT: Every verification MUST produce a report** at `<TendrilPlanFolder>/Verification/<VerificationName>.md` using YAML frontmatter:
 
 ```markdown
 ---
@@ -507,7 +507,7 @@ tendril plan rec add <plan-id> "Short descriptive title" -d "Markdown descriptio
 
 Do NOT include items that are part of the current plan's scope. Do NOT include recommendations about code formatting, linting, or style issues — those are handled by verifications.
 
-**After registering any recommendations via the CLI**, create `<TendrilPlanFolder>/artifacts/recommendations.md`. Having zero recommendations is fine — but the file must still be created:
+**After registering any recommendations via the CLI**, create `<TendrilPlanFolder>/Artifacts/recommendations.md`. Having zero recommendations is fine — but the file must still be created:
 
 ~~~markdown
 # Recommendations
@@ -532,9 +532,9 @@ After all verifications pass:
 
 3. Run `git status` in every worktree. If there are any uncommitted files (from verification fixes, generated files, etc.), commit or discard them. The worktrees must be completely clean before finishing.
 
-4. Verify `<TendrilPlanFolder>/artifacts/recommendations.md` exists. If missing, go back to Step 7.5.
+4. Verify `<TendrilPlanFolder>/Artifacts/recommendations.md` exists. If missing, go back to Step 7.5.
 
-5. Verify `<TendrilPlanFolder>/artifacts/summary.md` exists. If missing, go back to Step 5.5.
+5. Verify `<TendrilPlanFolder>/Artifacts/summary.md` exists. If missing, go back to Step 5.5.
 
 ### 8.5. Worktree Lifecycle
 
@@ -546,7 +546,7 @@ Worktrees are **not** cleaned up by ExecutePlan. They remain on disk so that Cre
 
 **Git branches are preserved** until CreatePr consumes them — only the worktree filesystem directories are removed.
 
-**Manual inspection:** If you need to inspect worktrees after failure, check the plan folder's `worktrees/` directory before CreatePr runs. After PR creation, worktrees are cleaned up automatically. You can also temporarily pause WorktreeCleanupService if needed for extended debugging.
+**Manual inspection:** If you need to inspect worktrees after failure, check the plan folder's `Worktrees/` directory before CreatePr runs. After PR creation, worktrees are cleaned up automatically. You can also temporarily pause WorktreeCleanupService if needed for extended debugging.
 
 ### 9. Plan State
 
@@ -566,6 +566,6 @@ You are running in non-interactive mode and CANNOT ask questions. If you are uns
 - Do NOT skip tests or pre-commit formatting
 - Commit messages must reference the plan ID
 - Convert `file:///` paths in plans to local filesystem paths appropriate for your OS
-- Do NOT commit artifact files (screenshots, images) to the repo. Test artifacts belong in `<TendrilPlanFolder>/artifacts/` only — CreatePr handles uploading them to persistent storage.
+- Do NOT commit artifact files (screenshots, images) to the repo. Test artifacts belong in `<TendrilPlanFolder>/Artifacts/` only — CreatePr handles uploading them to persistent storage.
 - If the project uses private package registries, ensure authentication is configured before running dependency installation in worktrees. Credentials should come from environment variables or project-level configuration.
 - Do NOT create filesystem aliases or shortcuts (e.g. symlinks, drive mappings) to worktree paths. The plans directory path is managed by Tendril — additional indirection causes cleanup issues.

--- a/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
@@ -16,7 +16,7 @@ Project configuration is available from the firmware header.
 ### 1. Read the Plan
 
 - Read `plan.yaml` from the plan folder
-- Read the latest revision from `revisions/` (highest numbered .md file)
+- Read the latest revision from `Revisions/` (highest numbered .md file)
 - Identify sections with investigative/exploratory language ("Investigate...", "Check if...", "Research...", "Explore...")
 - Report plan context to Jobs UI: `tendril job status TendrilJobId --message "Expanding plan..." --plan-id <plan-id> --plan-title "<title>"`
 
@@ -53,7 +53,7 @@ Example:
   EOF
   ```
 
-  The command reads from STDIN and auto-creates the next numbered revision file. Do NOT use the Write or Edit tools to create revision files directly in `revisions/`.
+  The command reads from STDIN and auto-creates the next numbered revision file. Do NOT use the Write or Edit tools to create revision files directly in `Revisions/`.
 - Replace all investigative/exploratory language with specific actions
 - Include exact file paths for changes
 - Specify concrete code modifications or additions

--- a/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
@@ -44,7 +44,7 @@ Focus on making progress, not achieving perfect understanding. A working impleme
 ### 1. Read Plan
 
 - Read `plan.yaml` from the plan folder (project, repos, title)
-- Read the latest revision from `revisions/` (highest numbered .md file)
+- Read the latest revision from `Revisions/` (highest numbered .md file)
 - Extract the plan ID from the folder name (e.g. `01105` from `01105-TestPlan`)
 - Report plan context to Jobs UI: `tendril job status TendrilJobId --message "Retrying plan..." --plan-id <plan-id> --plan-title "<title>"`
 
@@ -125,7 +125,7 @@ After reading the plan revision, scan it for code validation markers to detect s
    - **If all validation blocks pass** → Proceed to worktree creation
    - **If any validation fails** → Fail the plan immediately with a detailed report
 
-4. **Write validation report** — Create `<TendrilPlanFolder>/verification/PreExecution.md`:
+4. **Write validation report** — Create `<TendrilPlanFolder>/Verification/PreExecution.md`:
 
 ```markdown
 # PreExecution
@@ -154,7 +154,7 @@ After reading the plan revision, scan it for code validation markers to detect s
    - A `<details><summary>Still relevant?</summary>` block whose body starts with `No.`
    - Phrases like *"Already applied"*, *"This plan is redundant"*, *"This plan is superseded"*, or *"previously attempted … was merged to main via PR #NNNN"* in the `## Problem` or `## Solution` sections.
 
-   If any marker is found, verify the claim: run `gh pr view <cited PR> --json state,mergeCommit` (must be `MERGED`), confirm the cited commit is in `git log origin/<default-branch>`, and byte-compare the plan's proposed code against the current file contents. If all three checks pass, write `verification/PreExecution.md` with `Result: Fail`, write `artifacts/summary.md` documenting the no-op, set every verification to `Skipped` via `tendril plan set-verification <plan-id> <name> Skipped`, and fail the plan **without creating a worktree** — running verifications on unchanged code wastes the time budget and produces a 0-commit PR that CreatePr cannot process.
+   If any marker is found, verify the claim: run `gh pr view <cited PR> --json state,mergeCommit` (must be `MERGED`), confirm the cited commit is in `git log origin/<default-branch>`, and byte-compare the plan's proposed code against the current file contents. If all three checks pass, write `Verification/PreExecution.md` with `Result: Fail`, write `Artifacts/summary.md` documenting the no-op, set every verification to `Skipped` via `tendril plan set-verification <plan-id> <name> Skipped`, and fail the plan **without creating a worktree** — running verifications on unchanged code wastes the time budget and produces a 0-commit PR that CreatePr cannot process.
 
 ### 1.8. Auto-Commit Uncommitted Changes
 
@@ -249,7 +249,7 @@ PLAN_FOLDER_NAME=$(basename "<TendrilPlanFolder>")
 PLAN_ID=$(echo "$PLAN_FOLDER_NAME" | grep -oP '^\d+')
 SAFE_TITLE=$(echo "$PLAN_FOLDER_NAME" | sed 's/^[0-9]\+-//')
 BRANCH_NAME="tendril/$PLAN_ID-$SAFE_TITLE"
-git worktree add "<TendrilPlanFolder>/worktrees/<repo-folder-name>" -b "$BRANCH_NAME" "origin/<resolved-base-branch>"
+git worktree add "<TendrilPlanFolder>/Worktrees/<repo-folder-name>" -b "$BRANCH_NAME" "origin/<resolved-base-branch>"
 ```
 
 Example:
@@ -257,7 +257,7 @@ Example:
 ```bash
 cd <RepoPath>
 git fetch origin
-git worktree add "<TendrilPlanFolder>/worktrees/<RepoName>" -b "tendril/<TendrilPlanId>-<SafeTitle>" origin/<resolved-base-branch>
+git worktree add "<TendrilPlanFolder>/Worktrees/<RepoName>" -b "tendril/<TendrilPlanId>-<SafeTitle>" origin/<resolved-base-branch>
 ```
 
 **Important:** Always branch from `origin/<resolved-base-branch>`, not local HEAD. This ensures the PR only contains the plan's commits, not any unpushed local work. The `<resolved-base-branch>` comes from either the `RepoConfigs` firmware header (if `baseBranch` is configured) or auto-detection.
@@ -282,12 +282,12 @@ If `baseBranch` is present for a repo, use it instead of auto-detecting. If abse
 4. After creating the worktree, **verify the `.git` file exists** and fail fast if it's missing:
 
 ```bash
-if [ ! -f "<TendrilPlanFolder>/worktrees/<repo-folder-name>/.git" ]; then
-    echo "ERROR: Worktree creation failed - .git file missing at <TendrilPlanFolder>/worktrees/<repo-folder-name>/.git"
+if [ ! -f "<TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git" ]; then
+    echo "ERROR: Worktree creation failed - .git file missing at <TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git"
     echo "This indicates git worktree add did not fully initialize the worktree."
     exit 1
 fi
-cat "<TendrilPlanFolder>/worktrees/<repo-folder-name>/.git"
+cat "<TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git"
 ```
 
 This ensures RetryPlan fails immediately if worktree creation is incomplete, rather than leaving orphaned directories that trigger warnings during cleanup.
@@ -297,7 +297,7 @@ This ensures RetryPlan fails immediately if worktree creation is incomplete, rat
    ```bash
    SYNC_STRATEGY="<from RepoConfigs or 'fetch' if not specified>"
    BASE_BRANCH="<resolved-base-branch>"
-   WORKTREE_PATH="<TendrilPlanFolder>/worktrees/<repo-folder-name>"
+   WORKTREE_PATH="<TendrilPlanFolder>/Worktrees/<repo-folder-name>"
 
    tendril plan sync-worktree "$WORKTREE_PATH" --strategy "$SYNC_STRATEGY" --base-branch "$BASE_BRANCH"
    ```
@@ -402,7 +402,7 @@ If there are uncommitted changes, either commit them or discard them with a clea
 
 ### 5.5. Generate Summary
 
-After all implementation commits are made, create `<TendrilPlanFolder>/artifacts/summary.md` summarizing what was done.
+After all implementation commits are made, create `<TendrilPlanFolder>/Artifacts/summary.md` summarizing what was done.
 
 The summary should follow this structure:
 
@@ -454,7 +454,7 @@ If the plan references other plans (e.g. split-from, follow-up), add them via CL
 
 ### 7. Run Verifications
 
-Create a `verification/` directory in the plan folder if it doesn't exist.
+Create a `Verification/` directory in the plan folder if it doesn't exist.
 
 Check the `## Verification` section in the plan revision for checked items (`- [x]`). Skip unchecked items (`- [ ]`).
 
@@ -474,7 +474,7 @@ For each checked verification:
 
 **CRITICAL:** You MUST call `tendril plan set-verification` after EACH verification. The verification report file alone is NOT sufficient — plan.yaml must also be updated via the CLI. Failing to call this command will result in the plan being marked as Failed.
 
-**!IMPORTANT: Every verification MUST produce a report** at `<TendrilPlanFolder>/verification/<VerificationName>.md` using YAML frontmatter:
+**!IMPORTANT: Every verification MUST produce a report** at `<TendrilPlanFolder>/Verification/<VerificationName>.md` using YAML frontmatter:
 
 ```markdown
 ---
@@ -518,7 +518,7 @@ tendril plan rec add <plan-id> "Short descriptive title" -d "Markdown descriptio
 
 Do NOT include items that are part of the current plan's scope. Do NOT include recommendations about code formatting, linting, or style issues — those are handled by verifications.
 
-**After registering any recommendations via the CLI**, create `<TendrilPlanFolder>/artifacts/recommendations.md`. Having zero recommendations is fine — but the file must still be created:
+**After registering any recommendations via the CLI**, create `<TendrilPlanFolder>/Artifacts/recommendations.md`. Having zero recommendations is fine — but the file must still be created:
 
 ~~~markdown
 # Recommendations
@@ -543,7 +543,7 @@ After all verifications pass:
 
 3. Run `git status` in every worktree. If there are any uncommitted files (from verification fixes, generated files, etc.), commit or discard them. The worktrees must be completely clean before finishing.
 
-4. Verify `<TendrilPlanFolder>/artifacts/recommendations.md` exists. If missing, the plan **must fail** — go back to Step 7.5.
+4. Verify `<TendrilPlanFolder>/Artifacts/recommendations.md` exists. If missing, the plan **must fail** — go back to Step 7.5.
 
 ### 8.5. Worktree Lifecycle
 
@@ -555,7 +555,7 @@ Worktrees are **not** cleaned up by RetryPlan. They remain on disk so that Creat
 
 **Git branches are preserved** until CreatePr consumes them — only the worktree filesystem directories are removed.
 
-**Manual inspection:** If you need to inspect worktrees after failure, check the plan folder's `worktrees/` directory before CreatePr runs. After PR creation, worktrees are cleaned up automatically. You can also temporarily pause WorktreeCleanupService if needed for extended debugging.
+**Manual inspection:** If you need to inspect worktrees after failure, check the plan folder's `Worktrees/` directory before CreatePr runs. After PR creation, worktrees are cleaned up automatically. You can also temporarily pause WorktreeCleanupService if needed for extended debugging.
 
 ### 9. Plan State
 
@@ -575,6 +575,6 @@ You are running in non-interactive mode and CANNOT ask questions. If you are uns
 - Do NOT skip tests or pre-commit formatting
 - Commit messages must reference the plan ID
 - Convert `file:///` paths in plans to local filesystem paths appropriate for your OS
-- Do NOT commit artifact files (screenshots, images) to the repo. Test artifacts belong in `<TendrilPlanFolder>/artifacts/` only — CreatePr handles uploading them to persistent storage.
+- Do NOT commit artifact files (screenshots, images) to the repo. Test artifacts belong in `<TendrilPlanFolder>/Artifacts/` only — CreatePr handles uploading them to persistent storage.
 - If the project uses private package registries, ensure authentication is configured before running dependency installation in worktrees. Credentials should come from environment variables or project-level configuration.
 - Do NOT create filesystem aliases or shortcuts (e.g. symlinks, drive mappings) to worktree paths. The plans directory path is managed by Tendril — additional indirection causes cleanup issues.

--- a/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -18,7 +18,7 @@ The plans directory path can be derived from the plan folder's parent directory.
 ### 1. Read the Plan
 
 - Read `plan.yaml` via `tendril plan get <plan-id>` from the plan folder
-- Read the latest revision from `revisions/` (highest numbered .md file)
+- Read the latest revision from `Revisions/` (highest numbered .md file)
 - Identify distinct issues/tasks that should be separate plans
 - Report plan context to Jobs UI: `tendril job status TendrilJobId --message "Splitting plan..." --plan-id <plan-id> --plan-title "<title>"`
 
@@ -60,7 +60,7 @@ tendril plan write-revision <PlanId> <<'EOF'
 EOF
 ```
 
-The command reads from STDIN and auto-creates the next numbered revision file. Fill in Problem, Solution, Remaining Design Questions, Tests sections. Each plan must be fully self-contained. Do NOT use the Write or Edit tools to create revision files directly in `revisions/`.
+The command reads from STDIN and auto-creates the next numbered revision file. Fill in Problem, Solution, Remaining Design Questions, Tests sections. Each plan must be fully self-contained. Do NOT use the Write or Edit tools to create revision files directly in `Revisions/`.
 
 #### Project Assignment
 

--- a/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
@@ -16,7 +16,7 @@ Project configuration is available from the firmware header.
 
 ### 1. Read the Plan
 
-- Read the latest revision from `revisions/` (highest numbered .md file)
+- Read the latest revision from `Revisions/` (highest numbered .md file)
 - Get the plan title: `tendril plan get <TendrilPlanId> title`
 - Report plan context to Jobs UI: `tendril job status TendrilJobId --message "Updating plan..." --plan-id <plan-id> --plan-title "<title>"`
 
@@ -53,7 +53,7 @@ If all questions are resolved and no new questions arose, omit the `## Questions
   EOF
   ```
 
-  The command reads from STDIN and auto-creates the next numbered revision file. Do NOT use the Write or Edit tools to create revision files directly in `revisions/`.
+  The command reads from STDIN and auto-creates the next numbered revision file. Do NOT use the Write or Edit tools to create revision files directly in `Revisions/`.
 - Incorporate the intent of each instruction into the updated plan
 - Maintain the `## Questions` section (placed after the title, before `## Problem`) using `<details>` tags: (1) Existing questions answered by the user's instructions or research should be collapsed into `<details>` blocks with the answer. (2) New questions become new `<details>` blocks with answers. (3) Unanswered questions from prior revisions remain as open items (not in `<details>`). (4) If all questions are resolved and no new ones arose, omit the section entirely. Format:
   ```html

--- a/src/Ivy.Tendril/Promptwares/UpdateProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdateProject/Program.md
@@ -93,20 +93,20 @@ tendril project add-verification <project-name> CheckResult --required
 Review actions make it easy to start the application from a worktree during code review.
 
 Inspect each repo to determine how to run the application:
-- .NET project with a runnable entry point: `dotnet run --project worktrees/<RepoName>/<path-to-project> --browse --find-available-port`
-- Node.js app: `cd worktrees/<RepoName> && npm run dev`
-- Python app: `cd worktrees/<RepoName> && python -m <module>` or `flask run`
-- Static docs: `start worktrees/<RepoName>/docs/index.html`
+- .NET project with a runnable entry point: `dotnet run --project Worktrees/<RepoName>/<path-to-project> --browse --find-available-port`
+- Node.js app: `cd Worktrees/<RepoName> && npm run dev`
+- Python app: `cd Worktrees/<RepoName> && python -m <module>` or `flask run`
+- Static docs: `start Worktrees/<RepoName>/docs/index.html`
 
 For each review action:
 - **name**: Short descriptive name (e.g. "App", "Docs", "Frontend", "API")
-- **condition**: A `Test-Path` expression that checks if the worktree path exists (e.g. `Test-Path "worktrees/<RepoName>/src/<Project>"`)
+- **condition**: A `Test-Path` expression that checks if the worktree path exists (e.g. `Test-Path "Worktrees/<RepoName>/src/<Project>"`)
 - **command**: The command to launch the application
 
 ```bash
 tendril project add-review-action <project-name> "<name>" \
   --command "<launch command>" \
-  --condition "Test-Path \"worktrees/<RepoName>/<path>\""
+  --condition "Test-Path \"Worktrees/<RepoName>/<path>\""
 ```
 
 ### 4. Summary

--- a/src/Ivy.Tendril/Services/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/JobCompletionHandler.cs
@@ -545,7 +545,7 @@ internal class JobCompletionHandler
         var planFolder = job.TypedArgs?.PlanFolder ?? "";
         if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder)) return;
 
-        var worktreesDir = Path.Combine(planFolder, "worktrees");
+        var worktreesDir = Path.Combine(planFolder, "Worktrees");
         if (!Directory.Exists(worktreesDir)) return;
 
         ScheduleWorktreeRemoval(planFolder, worktreesDir);
@@ -684,7 +684,7 @@ internal class JobCompletionHandler
             planFolder = logRoot;
         }
 
-        var logsDir = Path.Combine(planFolder, "logs");
+        var logsDir = Path.Combine(planFolder, "Logs");
         FileHelper.EnsureDirectory(logsDir);
         var outputFile = Path.Combine(logsDir, $"{job.Type}-{job.Id}.output.log");
         File.WriteAllLines(outputFile, job.OutputLines);

--- a/src/Ivy.Tendril/Services/PlanArtifactSyncer.cs
+++ b/src/Ivy.Tendril/Services/PlanArtifactSyncer.cs
@@ -50,7 +50,7 @@ internal class PlanArtifactSyncer
 
     private bool SyncVerificationsFromReports(string planFolder, PlanYaml plan)
     {
-        var verificationDir = Path.Combine(planFolder, "verification");
+        var verificationDir = Path.Combine(planFolder, "Verification");
         if (!Directory.Exists(verificationDir)) return false;
         if (plan.Verifications == null || plan.Verifications.Count == 0) return false;
 
@@ -88,7 +88,7 @@ internal class PlanArtifactSyncer
     {
         if (plan.Commits.Count > 0) return false;
 
-        var worktreesDir = Path.Combine(planFolder, "worktrees");
+        var worktreesDir = Path.Combine(planFolder, "Worktrees");
         if (!Directory.Exists(worktreesDir)) return false;
 
         var planId = PlanYamlHelper.ExtractPlanIdFromFolder(planFolder);

--- a/src/Ivy.Tendril/Services/PlanDatabaseSyncService.cs
+++ b/src/Ivy.Tendril/Services/PlanDatabaseSyncService.cs
@@ -152,7 +152,7 @@ public class PlanDatabaseSyncService : IDisposable
         try
         {
             var lines = FileHelper.ReadAllLines(costsPath);
-            var logsDir = Path.Combine(plan.FolderPath, "logs");
+            var logsDir = Path.Combine(plan.FolderPath, "Logs");
 
             // Build log file map for timestamp correlation
             var logsByPromptware =

--- a/src/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/PlanReaderService.cs
@@ -49,6 +49,41 @@ public class PlanReaderService(
     public event Action? CountsInvalidated;
 
     /// <summary>
+    ///     On startup, rename plan subfolders from lowercase to Title Case for consistency
+    ///     with TENDRIL_HOME folder naming (Inbox, Trash, Plans, etc.).
+    /// </summary>
+    public void MigratePlanSubfolderCasing()
+    {
+        if (!Directory.Exists(PlansDirectory)) return;
+
+        var renames = new[] { "revisions", "logs", "artifacts", "verification", "worktrees" };
+        var titleCase = new[] { "Revisions", "Logs", "Artifacts", "Verification", "Worktrees" };
+
+        foreach (var dir in Directory.GetDirectories(PlansDirectory))
+        {
+            for (var i = 0; i < renames.Length; i++)
+            {
+                var oldPath = Path.Combine(dir, renames[i]);
+                var newPath = Path.Combine(dir, titleCase[i]);
+                if (!Directory.Exists(oldPath) || Directory.Exists(newPath)) continue;
+
+                try
+                {
+                    // Two-step rename for case-insensitive filesystems (Windows)
+                    var tmpPath = oldPath + "_tmp";
+                    Directory.Move(oldPath, tmpPath);
+                    Directory.Move(tmpPath, newPath);
+                    _logger.LogDebug("Renamed {Old} → {New}", oldPath, newPath);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to rename {Old} to {New}", oldPath, newPath);
+                }
+            }
+        }
+    }
+
+    /// <summary>
     ///     On startup, reset any plans stuck in transient states (Building, Executing, Updating)
     ///     back to Failed. These are leftovers from a previous Tendril shutdown.
     /// </summary>
@@ -300,7 +335,7 @@ public class PlanReaderService(
         // Write to disk in background for durability.
         WriteFileInBackground(() =>
         {
-            var revisionsDir = Path.Combine(PlansDirectory, folderName, "revisions");
+            var revisionsDir = Path.Combine(PlansDirectory, folderName, "Revisions");
             FileHelper.EnsureDirectory(revisionsDir);
 
             var nextNumber = GetNextRevisionNumber(revisionsDir);
@@ -347,7 +382,7 @@ public class PlanReaderService(
     /// <returns>List of tuples containing revision number, content, and last-modified timestamp (UTC).</returns>
     public List<(int Number, string Content, DateTime Modified)> GetRevisions(string folderName)
     {
-        var revisionsDir = Path.Combine(PlansDirectory, folderName, "revisions");
+        var revisionsDir = Path.Combine(PlansDirectory, folderName, "Revisions");
         if (!Directory.Exists(revisionsDir)) return new List<(int, string, DateTime)>();
 
         return Directory.GetFiles(revisionsDir, "*.md")
@@ -371,7 +406,7 @@ public class PlanReaderService(
     /// <param name="content">Markdown content of the log entry.</param>
     public void AddLog(string folderName, string action, string content, string? jobId = null)
     {
-        var logsDir = Path.Combine(PlansDirectory, folderName, "logs");
+        var logsDir = Path.Combine(PlansDirectory, folderName, "Logs");
         FileHelper.EnsureDirectory(logsDir);
 
         var logPath = !string.IsNullOrEmpty(jobId)
@@ -450,7 +485,7 @@ public class PlanReaderService(
         // Write to disk in background for durability.
         WriteFileInBackground(() =>
         {
-            var revisionsDir = Path.Combine(PlansDirectory, folderName, "revisions");
+            var revisionsDir = Path.Combine(PlansDirectory, folderName, "Revisions");
             if (!Directory.Exists(revisionsDir)) return;
 
             var latestFile = Directory.GetFiles(revisionsDir, "*.md")
@@ -691,7 +726,7 @@ public class PlanReaderService(
                 continue;
 
             // Ensure at least one revision file exists before yielding the plan
-            var revisionsDir = Path.Combine(dir, "revisions");
+            var revisionsDir = Path.Combine(dir, "Revisions");
             if (!Directory.Exists(revisionsDir))
                 continue;
 
@@ -744,7 +779,7 @@ public class PlanReaderService(
     /// </summary>
     private string ReadLatestRevisionFromFileSystem(string folderName)
     {
-        var revisionsDir = Path.Combine(PlansDirectory, folderName, "revisions");
+        var revisionsDir = Path.Combine(PlansDirectory, folderName, "Revisions");
         if (!Directory.Exists(revisionsDir)) return string.Empty;
 
         var latestFile = Directory.GetFiles(revisionsDir, "*.md")
@@ -845,7 +880,7 @@ public class PlanReaderService(
 
     private static int GetLatestRevisionNumber(string folderPath)
     {
-        var revisionsDir = Path.Combine(folderPath, "revisions");
+        var revisionsDir = Path.Combine(folderPath, "Revisions");
         var revisionCount = Directory.Exists(revisionsDir)
             ? Directory.GetFiles(revisionsDir, "*.md").Length
             : 1;

--- a/src/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -69,7 +69,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
 
     internal static void CleanupPlanWorktrees(string planFolderPath, ILogger? logger = null, IWorktreeLifecycleLogger? lifecycleLogger = null)
     {
-        var worktreesDir = Path.Combine(planFolderPath, "worktrees");
+        var worktreesDir = Path.Combine(planFolderPath, "Worktrees");
         if (!Directory.Exists(worktreesDir)) return;
 
         var planYamlPath = Path.Combine(planFolderPath, "plan.yaml");
@@ -287,7 +287,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
 
     internal static void RemoveWorktrees(string planFolderPath, ILogger? logger = null, IWorktreeLifecycleLogger? lifecycleLogger = null)
     {
-        var worktreesDir = Path.Combine(planFolderPath, "worktrees");
+        var worktreesDir = Path.Combine(planFolderPath, "Worktrees");
         if (!Directory.Exists(worktreesDir)) return;
 
         var planId = WorktreeLifecycleLogger.ExtractPlanId(planFolderPath);

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -91,6 +91,7 @@ public static class TendrilServer
                 sp.GetRequiredService<ILogger<PlanReaderService>>(),
                 sp.GetRequiredService<ITelemetryService>(),
                 sp.GetRequiredService<IWorktreeLifecycleLogger>());
+            planService.MigratePlanSubfolderCasing();
             planService.RepairPlans();
             planService.RecoverStuckPlans();
             return planService;

--- a/src/Ivy.Tendril/Views/Sheets/VerificationReportSheet.cs
+++ b/src/Ivy.Tendril/Views/Sheets/VerificationReportSheet.cs
@@ -15,7 +15,7 @@ public class VerificationReportSheet(
             async (name, ct) =>
             {
                 if (string.IsNullOrEmpty(name) || selectedPlan is null) return "";
-                var verificationDir = Path.GetFullPath(Path.Combine(selectedPlan.FolderPath, "verification"));
+                var verificationDir = Path.GetFullPath(Path.Combine(selectedPlan.FolderPath, "Verification"));
                 var resolvedPath = Path.GetFullPath(Path.Combine(verificationDir, $"{name}.md"));
                 if (!resolvedPath.StartsWith(verificationDir, StringComparison.OrdinalIgnoreCase))
                     return "Access denied: file is outside the verification folder.";

--- a/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
+++ b/src/Ivy.Tendril/Views/Tabs/GitTabHelper.cs
@@ -53,7 +53,7 @@ public static class GitTabHelper
     {
         var sections = new List<WorktreeSection>();
         var assignedCommitHashes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var worktreesDir = Path.Combine(plan.FolderPath, "worktrees");
+        var worktreesDir = Path.Combine(plan.FolderPath, "Worktrees");
 
         if (Directory.Exists(worktreesDir))
         {


### PR DESCRIPTION
## Summary

- Renames plan subfolders from lowercase to Title Case: `revisions/` → `Revisions/`, `logs/` → `Logs/`, `artifacts/` → `Artifacts/`, `verification/` → `Verification/`, `worktrees/` → `Worktrees/`
- Adds startup migration (`MigratePlanSubfolderCasing`) that renames existing folders on disk using a two-step move for Windows case-insensitive filesystem compatibility
- Updates all C# code, test files, reference docs, and promptware instructions

## Test plan

- [x] Build passes
- [x] All tests pass (same 2 pre-existing failures in WorktreeCleanupServiceTests)
- [ ] Manual: start Tendril, verify plans load correctly after folder rename