### PR TITLE
Fix subfolder casing migration and broken cleanup tests

### DIFF
--- a/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -71,7 +71,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     [Fact]
     public void RunCleanup_Cleans_Terminal_State_Plans_Past_Grace_Period()
     {
-        var terminalStates = new[] { "Completed", "Failed", "Skipped", "Icebox" };
+        var terminalStates = new[] { "Completed", "Skipped", "Icebox" };
         foreach (var state in terminalStates)
         {
             var dir = CreatePlan($"02{Array.IndexOf(terminalStates, state):D3}-{state}Plan", state,
@@ -184,7 +184,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     {
         // Worktree directory with a .git file pointing to a non-existent repo entry —
         // git worktree remove will fail, but force-delete fallback should clean it up
-        var dir = CreatePlan("09001-OrphanStaleGit", "Failed", DateTime.UtcNow.AddHours(-2));
+        var dir = CreatePlan("09001-OrphanStaleGit", "Completed", DateTime.UtcNow.AddHours(-2));
         var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
         Directory.CreateDirectory(worktreeDir);
         File.WriteAllText(Path.Combine(worktreeDir, ".git"),

--- a/src/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/PlanReaderService.cs
@@ -56,28 +56,33 @@ public class PlanReaderService(
     {
         if (!Directory.Exists(PlansDirectory)) return;
 
-        var renames = new[] { "revisions", "logs", "artifacts", "verification", "worktrees" };
-        var titleCase = new[] { "Revisions", "Logs", "Artifacts", "Verification", "Worktrees" };
+        var titleCase = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["revisions"] = "Revisions",
+            ["logs"] = "Logs",
+            ["artifacts"] = "Artifacts",
+            ["verification"] = "Verification",
+            ["worktrees"] = "Worktrees"
+        };
 
         foreach (var dir in Directory.GetDirectories(PlansDirectory))
         {
-            for (var i = 0; i < renames.Length; i++)
+            foreach (var subDir in Directory.GetDirectories(dir))
             {
-                var oldPath = Path.Combine(dir, renames[i]);
-                var newPath = Path.Combine(dir, titleCase[i]);
-                if (!Directory.Exists(oldPath) || Directory.Exists(newPath)) continue;
+                var actualName = Path.GetFileName(subDir);
+                if (!titleCase.TryGetValue(actualName, out var desired)) continue;
+                if (actualName == desired) continue;
 
                 try
                 {
-                    // Two-step rename for case-insensitive filesystems (Windows)
-                    var tmpPath = oldPath + "_tmp";
-                    Directory.Move(oldPath, tmpPath);
-                    Directory.Move(tmpPath, newPath);
-                    _logger.LogDebug("Renamed {Old} → {New}", oldPath, newPath);
+                    var tmpPath = subDir + "_tmp";
+                    Directory.Move(subDir, tmpPath);
+                    Directory.Move(tmpPath, Path.Combine(dir, desired));
+                    _logger.LogDebug("Renamed {Old} → {New}", actualName, desired);
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(ex, "Failed to rename {Old} to {New}", oldPath, newPath);
+                    _logger.LogWarning(ex, "Failed to rename {Old} to {New}", subDir, desired);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fix `MigratePlanSubfolderCasing` which was a no-op on Windows due to `Directory.Exists()` being case-insensitive on NTFS. Now enumerates actual subdirectories to get real on-disk names.
- Fix 2 `WorktreeCleanupServiceTests` broken by PR #697 (removed "Failed" from terminal states but tests still expected it).

## Test plan
- [x] All 1433 tests pass
- [x] Verified migration runs correctly on real plans (D:\Plans)