### PR TITLE
Fix error notification when canceling dialogs with ESC (#700)

### DIFF
--- a/src/Ivy.Tendril/Apps/Icebox/Dialogs/DeletePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/Dialogs/DeletePlanDialog.cs
@@ -22,7 +22,7 @@ public class DeletePlanDialog(
                 Text.P($"Are you sure you want to permanently delete plan #{selectedPlan.Id}?")
             ),
             new DialogFooter(
-                new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() => dialogOpen.Set(false)),
+                new Button("Cancel").Outline().OnClick(() => dialogOpen.Set(false)),
                 new Button("Delete").Destructive().ShortcutKey("Enter").AutoFocus().OnClick(() =>
                 {
                     planService.DeletePlan(selectedPlan.FolderName);

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/DeletePlanDialog.cs
@@ -29,7 +29,7 @@ public class DeletePlanDialog(
             ),
             new DialogFooter(
                 Layout.Horizontal().Gap(2).Right()
-                | new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() => _dialogOpen.Set(false))
+                | new Button("Cancel").Outline().OnClick(() => _dialogOpen.Set(false))
                 | new Button("Move to Skipped").Outline().ShortcutKey("s").OnClick(() =>
                 {
                     // Optimistically update UI state before disk I/O

--- a/src/Ivy.Tendril/Apps/Recommendations/Dialogs/AcceptWithNotesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/Dialogs/AcceptWithNotesDialog.cs
@@ -32,7 +32,7 @@ public class AcceptWithNotesDialog(
                 | notesText.ToTextareaInput("Enter your notes...").Rows(6).AutoFocus()
             ),
             new DialogFooter(
-                new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() =>
+                new Button("Cancel").Outline().OnClick(() =>
                 {
                     notesText.Set("");
                     _dialogOpen.Set(false);

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -67,7 +67,7 @@ public class CustomPrDialog(
                 | customPrComment.ToTextareaInput("Comment").Rows(3)
             ),
             new DialogFooter(
-                new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() =>
+                new Button("Cancel").Outline().OnClick(() =>
                 {
                     isCreating.Set(false);
                     customPrMerge.Set(true);

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
@@ -27,7 +27,7 @@ public class DiscardPlanDialog(
                 Text.P($"Are you sure you want to discard plan #{_selectedPlan.Id}?")
             ),
             new DialogFooter(
-                new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() => _dialogOpen.Set(false)),
+                new Button("Cancel").Outline().OnClick(() => _dialogOpen.Set(false)),
                 new Button("Discard").Destructive().ShortcutKey("Enter").AutoFocus().OnClick(() =>
                 {
                     _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Skipped);

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
@@ -36,7 +36,7 @@ public class ResetToDraftDialog(
                 Text.P("Are you sure you want to reset this plan? Will remove all worktrees and artifacts.")
             ),
             new DialogFooter(
-                new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() => _dialogOpen.Set(false)),
+                new Button("Cancel").Outline().OnClick(() => _dialogOpen.Set(false)),
                 new Button("Reset to Draft").Warning().Disabled(isResetting.Value).ShortcutKey("Enter").AutoFocus().OnClick(() =>
                 {
                     if (!isResetting.Value)

--- a/src/Ivy.Tendril/Apps/Trash/Dialogs/DeleteTrashFileDialog.cs
+++ b/src/Ivy.Tendril/Apps/Trash/Dialogs/DeleteTrashFileDialog.cs
@@ -24,7 +24,7 @@ public class DeleteTrashFileDialog(
                 Text.P($"Permanently delete {_selected.FileName}?")
             ),
             new DialogFooter(
-                new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() => _confirmDelete.Set(false)),
+                new Button("Cancel").Outline().OnClick(() => _confirmDelete.Set(false)),
                 new Button("Delete").Destructive().ShortcutKey("Enter").AutoFocus().OnClick(() =>
                 {
                     if (File.Exists(deletePath))


### PR DESCRIPTION
## Summary
- Remove `ShortcutKey("Escape")` from Cancel buttons inside Dialog widgets
- ESC was firing both Radix's native dialog dismiss and the button shortcut, causing a race where the second event targets an already-removed widget node (`NotSupportedException: Node not found`)
- Dialog's native ESC handling via `onOpenChange` → `OnClose` already provides identical behavior

## Test plan
- [x] `dotnet build` passes
- [x] 1433 unit tests pass
- [ ] Open any dialog (e.g. Create PR, Discard, Reset to Draft) → press ESC → no error toast
- [ ] X button on dialogs still works correctly
- [ ] Cancel button click still works correctly