### PR TITLE
Recommendations: filter by Completed plans, add Accept/Decline in Review

### DIFF
--- a/src/Ivy.Tendril.Docs/Run.ps1
+++ b/src/Ivy.Tendril.Docs/Run.ps1
@@ -1,0 +1,1 @@
+dotnet watch --browse --find-available-port

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -79,10 +79,10 @@ projects:
   reviewActions:
   - name: Tendril
     condition: Test-Path "worktrees\Ivy-Tendril\src\Ivy.Tendril"
-    command: dotnet run --browse --find-available-port --project worktrees\Ivy-Tendril\src\Ivy.Tendril
+    command: pwsh -NoProfile -File worktrees\Ivy-Tendril\src\Ivy.Tendril\Run.ps1
   - name: Docs
     condition: Test-Path "worktrees\Ivy-Tendril\src\Ivy.Tendril.Docs"
-    command: dotnet run --browse --find-available-port --project worktrees\Ivy-Tendril\src\Ivy.Tendril.Docs
+    command: pwsh -NoProfile -File worktrees\Ivy-Tendril\src\Ivy.Tendril.Docs\Run.ps1
   hooks:
   - name: SlackNotify
     when: after

--- a/src/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Apps.Recommendations;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
 
@@ -23,7 +24,9 @@ public class RecommendationsApp : ViewBase
 
         var recommendations = planService.GetRecommendations();
 
-        var allPending = recommendations.Where(r => r.State == "Pending").ToList();
+        var allPending = recommendations
+            .Where(r => r.State == "Pending" && r.SourcePlanStatus == PlanStatus.Completed)
+            .ToList();
 
         var filtered = allPending
             .Where(r => projectFilter.Value == null || r.Project == projectFilter.Value)

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -472,11 +472,12 @@ public class ContentView(
                 content |= actionsBar;
             }
 
+            var pendingRecs = planData.Recommendations.Where(r => r.State == "Pending").ToList();
             var recommendationsLayout = Layout.Vertical().Gap(4).Padding(2);
-            if (planData.Recommendations.Count == 0)
+            if (pendingRecs.Count == 0)
                 recommendationsLayout |= Text.Muted("No recommendations.");
             else
-                foreach (var rec in planData.Recommendations)
+                foreach (var rec in pendingRecs)
                 {
                     var titleRow = Layout.Horizontal().Gap(2).AlignContent(Align.Left)
                                    | Text.Block(rec.Title).Bold();
@@ -500,7 +501,25 @@ public class ContentView(
                     var card = Layout.Vertical().Gap(1)
                                | titleRow
                                | new Markdown(rec.Description).DangerouslyAllowLocalFiles().Article();
+
+                    var recTitle = rec.Title;
+                    var buttonRow = Layout.Horizontal().Gap(1)
+                                    | new Button("Accept").Icon(Icons.Check).Primary().OnClick(() =>
+                                    {
+                                        planService.ResetVerificationsForRetry(selectedPlan.FolderName);
+                                        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Executing);
+                                        planService.UpdateRecommendationState(selectedPlan.FolderName, recTitle, "Accepted");
+                                        jobService.StartJob(new RetryPlanArgs(selectedPlan.FolderPath, rec.Description));
+                                        refreshPlans();
+                                    })
+                                    | new Button("Decline").Icon(Icons.X).Outline().OnClick(() =>
+                                    {
+                                        planService.UpdateRecommendationState(selectedPlan.FolderName, recTitle, "Declined");
+                                        refreshPlans();
+                                    });
+
                     recommendationsLayout |= card;
+                    recommendationsLayout |= buttonRow;
                     recommendationsLayout |= new Separator();
                 }
 
@@ -516,7 +535,7 @@ public class ContentView(
                 new Tab("Git", Cap(gitLayout)).Badge((gitData.WorktreeSections.Count + selectedPlan.Commits.Count + selectedPlan.Prs.Count).ToString()),
                 new Tab("Changes", Layout.Vertical().Width(Size.Full()).Height(Size.Full()) | changesTabView).Badge(changesTabView.FileCount > 0 ? changesTabView.FileCount.ToString() : ""),
                 new Tab("Artifacts", Cap(new ArtifactsTabView(planData.Artifacts))).Badge(totalArtifacts.ToString()),
-                new Tab("Recommendations", Cap(recommendationsLayout)).Badge(planData.Recommendations.Count.ToString())
+                new Tab("Recommendations", Cap(recommendationsLayout)).Badge(pendingRecs.Count > 0 ? pendingRecs.Count.ToString() : "")
             ).OnSelect(v =>
             {
                 if (v >= 0 && v < tabNames.Length && selectedPlanState.Value != null)

--- a/src/Ivy.Tendril/Run.ps1
+++ b/src/Ivy.Tendril/Run.ps1
@@ -1,0 +1,1 @@
+dotnet watch --browse --find-available-port


### PR DESCRIPTION
- RecommendationsApp now only shows recommendations from plans with
  SourcePlanStatus == Completed
- Review tab's Recommendations section filters to Pending only and adds
  inline Accept (triggers RetryPlan) and Decline buttons per card
- Add Run.ps1 scripts for Tendril and Docs projects (dotnet watch)
- Update config.yaml reviewActions to use the new Run.ps1 scripts
