### PR TITLE
Review: revalidate recommendations tab after Accept/Decline

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -511,11 +511,13 @@ public class ContentView(
                                         planService.UpdateRecommendationState(selectedPlan.FolderName, recTitle, "Accepted");
                                         jobService.StartJob(new RetryPlanArgs(selectedPlan.FolderPath, rec.Description));
                                         refreshPlans();
+                                        planContentQuery.Mutator.Revalidate();
                                     })
                                     | new Button("Decline").Icon(Icons.X).Outline().OnClick(() =>
                                     {
                                         planService.UpdateRecommendationState(selectedPlan.FolderName, recTitle, "Declined");
                                         refreshPlans();
+                                        planContentQuery.Mutator.Revalidate();
                                     });
 
                     recommendationsLayout |= card;


### PR DESCRIPTION
## Summary
- Added `planContentQuery.Mutator.Revalidate()` after Accept and Decline in the Review Recommendations tab
- Without this, the tab wouldn't refresh and accepted/declined items would remain visible

## Test plan
- [x] 1434 unit tests pass
- [x] Build succeeds