### PR TITLE
Fix: preserve commits across RetryPlan executions (#730)

### DIFF
--- a/src/Ivy.Tendril.Docs/Run.ps1
+++ b/src/Ivy.Tendril.Docs/Run.ps1
@@ -1,1 +1,1 @@
-dotnet watch --browse --find-available-port
+dotnet watch --project "$PSScriptRoot" --browse --find-available-port

--- a/src/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
@@ -86,7 +86,7 @@ public class PlanReaderServiceTests
     }
 
     [Fact]
-    public async Task ResetVerificationsForRetry_ResetsNonSkippedToPending_PreservesSkipped_ClearsCommits()
+    public async Task ResetVerificationsForRetry_ResetsNonSkippedToPending_PreservesSkipped_PreservesCommits()
     {
         // Arrange
         var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-test-{Guid.NewGuid()}");
@@ -119,8 +119,8 @@ public class PlanReaderServiceTests
             Assert.Contains("status: Skipped", result);
             Assert.DoesNotContain("status: Pass", result);
             Assert.DoesNotContain("status: Fail", result);
-            Assert.DoesNotContain("abc1234", result);
-            Assert.DoesNotContain("def5678", result);
+            Assert.Contains("abc1234", result);
+            Assert.Contains("def5678", result);
             Assert.Contains(folderName, testWatcher.NotifiedFolders);
         }
         finally

--- a/src/Ivy.Tendril/Run.ps1
+++ b/src/Ivy.Tendril/Run.ps1
@@ -1,1 +1,1 @@
-dotnet watch --browse --find-available-port
+dotnet watch --project "$PSScriptRoot" --browse --find-available-port

--- a/src/Ivy.Tendril/Services/PlanArtifactSyncer.cs
+++ b/src/Ivy.Tendril/Services/PlanArtifactSyncer.cs
@@ -86,8 +86,6 @@ internal class PlanArtifactSyncer
 
     private bool SyncCommitsFromWorktrees(string planFolder, PlanYaml plan)
     {
-        if (plan.Commits.Count > 0) return false;
-
         var worktreesDir = Path.Combine(planFolder, "Worktrees");
         if (!Directory.Exists(worktreesDir)) return false;
 

--- a/src/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/PlanReaderService.cs
@@ -305,7 +305,6 @@ public class PlanReaderService(
             var yaml = FileHelper.ReadAllText(planYamlPath);
             var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
             planYaml.Updated = DateTime.UtcNow;
-            planYaml.Commits = new List<string>();
             foreach (var v in planYaml.Verifications)
             {
                 if (!v.Status.Equals("Skipped", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## Summary
- `ResetVerificationsForRetry` no longer clears `plan.yaml` commits — they accumulate across retries
- `PlanArtifactSyncer` always reconciles worktree git history into plan.yaml (removed early bail when commits > 0)
- Updated test to assert commits are preserved

## Test plan
- [x] Unit tests pass (1432 passing)
- [x] Build succeeds
- [x] "Reset to Draft" still clears commits (separate method, unchanged)