### PR TITLE
Fix: store full commit hashes in syncer and refresh UI after sync

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -431,7 +431,7 @@ public class ContentView(
                     return null!;
                 },
                 syncingWorktrees.Value,
-                worktreePath => SynchronizeWorktreeAsync(worktreePath, syncingWorktrees, planContentQuery, client, planService, logger),
+                worktreePath => SynchronizeWorktreeAsync(worktreePath, syncingWorktrees, planContentQuery, client, planService, selectedPlanState, logger),
                 logger
             );
 
@@ -611,6 +611,7 @@ public class ContentView(
         QueryResult<PlanContentData> query,
         IClientProvider client,
         IPlanReaderService planService,
+        IState<PlanFile?> selectedPlanState,
         ILogger? logger)
     {
         var paths = new HashSet<string>(syncingState.Value) { worktreePath };
@@ -641,6 +642,9 @@ public class ContentView(
             {
                 var planFolder = Path.GetFullPath(Path.Combine(worktreePath, "..", ".."));
                 planService.SyncPlanArtifacts(planFolder);
+                var refreshed = planService.GetPlanByFolder(planFolder);
+                if (refreshed != null)
+                    selectedPlanState.Set(refreshed);
                 client.Toast("Worktree synchronized successfully", "Synchronized");
             }
             else

--- a/src/Ivy.Tendril/Services/PlanArtifactSyncer.cs
+++ b/src/Ivy.Tendril/Services/PlanArtifactSyncer.cs
@@ -143,7 +143,7 @@ internal class PlanArtifactSyncer
             {
                 var hash = line.Trim();
                 if (hash.Length >= 7)
-                    commits.Add(hash.Length > 9 ? hash[..9] : hash);
+                    commits.Add(hash);
             }
         }
         catch (Exception ex)
@@ -190,7 +190,11 @@ internal class PlanArtifactSyncer
         var changed = false;
         foreach (var commit in commits)
         {
-            if (!plan.Commits.Contains(commit))
+            var alreadyPresent = plan.Commits.Any(existing =>
+                existing.StartsWith(commit, StringComparison.OrdinalIgnoreCase) ||
+                commit.StartsWith(existing, StringComparison.OrdinalIgnoreCase));
+
+            if (!alreadyPresent)
             {
                 plan.Commits.Add(commit);
                 changed = true;


### PR DESCRIPTION
## Summary
- `PlanArtifactSyncer.ExtractCommitsFromWorktree` now stores full 40-char SHAs instead of truncating to 9
- `AddCommitsToPlan` uses prefix matching for dedup (handles mixed full/abbreviated hashes)
- `SynchronizeWorktreeAsync` refreshes `selectedPlanState` after artifact sync so the Git tab re-renders with updated commits

## Test plan
- [x] All 1434 tests pass
- [x] Build succeeds
- [x] Plan 21 yaml manually corrected to full hashes