### PR TITLE
Fix review action commands to work with RunPowerShellAction

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -79,10 +79,10 @@ projects:
   reviewActions:
   - name: Tendril
     condition: Test-Path "worktrees\Ivy-Tendril\src\Ivy.Tendril"
-    command: pwsh -NoProfile -File worktrees\Ivy-Tendril\src\Ivy.Tendril\Run.ps1
+    command: '& worktrees\Ivy-Tendril\src\Ivy.Tendril\Run.ps1'
   - name: Docs
     condition: Test-Path "worktrees\Ivy-Tendril\src\Ivy.Tendril.Docs"
-    command: pwsh -NoProfile -File worktrees\Ivy-Tendril\src\Ivy.Tendril.Docs\Run.ps1
+    command: '& worktrees\Ivy-Tendril\src\Ivy.Tendril.Docs\Run.ps1'
   hooks:
   - name: SlackNotify
     when: after

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -141,7 +141,7 @@ promptwares:
 #     reviewActions:
 #       - name: RunSample
 #         condition: Test-Path "artifacts/sample"
-#         action: <command to run your sample app>
+#         command: <command to run your sample app>
 #     hooks:
 #       - name: SlackNotify
 #         when: after


### PR DESCRIPTION
The commands are passed via pwsh -Command, so they should be PowerShell
expressions (& script.ps1), not full pwsh invocations. Also fix example
config to use 'command' instead of 'action' to match the C# model.
