### PR TITLE
Fix review action command paths to use quoted PowerShell syntax

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -79,10 +79,10 @@ projects:
   reviewActions:
   - name: Tendril
     condition: Test-Path "worktrees\Ivy-Tendril\src\Ivy.Tendril"
-    command: '& worktrees\Ivy-Tendril\src\Ivy.Tendril\Run.ps1'
+    command: "& '.\\worktrees\\Ivy-Tendril\\src\\Ivy.Tendril\\Run.ps1'"
   - name: Docs
     condition: Test-Path "worktrees\Ivy-Tendril\src\Ivy.Tendril.Docs"
-    command: '& worktrees\Ivy-Tendril\src\Ivy.Tendril.Docs\Run.ps1'
+    command: "& '.\\worktrees\\Ivy-Tendril\\src\\Ivy.Tendril.Docs\\Run.ps1'"
   hooks:
   - name: SlackNotify
     when: after


### PR DESCRIPTION
The & call operator needs the path quoted with single quotes and
prefixed with .\ so PowerShell treats it as a file path rather than
trying to load it as a module.
