### PR TITLE
Remove PlanEvaluator hooks that open Tendril.ps1 in VS Code

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -84,12 +84,6 @@ projects:
     - CreatePr
     condition: ''
     action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
-  - name: PlanEvaluator
-    when: after
-    promptwares:
-    - CreatePr
-    condition: ''
-    action: Start-Process -FilePath 'tendril' -ArgumentList 'promptware','PlanEvaluator',$PWD -WindowStyle Hidden
   buildDependencies:
   - D:\Repos\_Ivy\Ivy-Framework
 - name: Rustino
@@ -125,12 +119,6 @@ projects:
     - CreatePr
     condition: ''
     action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
-  - name: PlanEvaluator
-    when: after
-    promptwares:
-    - CreatePr
-    condition: ''
-    action: Start-Process -FilePath 'tendril' -ArgumentList 'promptware','PlanEvaluator',$PWD -WindowStyle Hidden
   buildDependencies: []
 verifications:
 - name: FrameworkDotnetBuild


### PR DESCRIPTION
Start-Process -FilePath 'tendril' resolves to Tendril.ps1 in PATH, which Windows opens with its default handler (VS Code) instead of executing it. Removed from all three projects.