### PR TITLE
[00025] Remove planId prefix from commit messages

### DIFF
--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -139,7 +139,7 @@ For each assertion found:
 3. If validation fails, investigate:
    - Check `git log --oneline -10 --all -- <file>` for recent changes
    - Check `git blame <file>` to find who/when the code changed
-   - Look for plan IDs in commit messages (e.g., `[01234]`)
+   - Look for plan IDs in commit messages (legacy pattern: `[01234]`)
 
 **Decision:**
 - **All validations pass** → Proceed to Step 4, include validated code blocks in plan with `**Current implementation**` headers

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -48,7 +48,7 @@ Check `<TendrilPlanFolder>/Worktrees/` for each repo worktree.
 
 > **Worktree already removed:** If the Worktrees/ directory is empty (worktree was already cleaned up), fall back to `plan.yaml` to get the repo path and branch name (format: `tendril/<planId>-<SafeTitle>`, where SafeTitle is extracted from the plan folder name: e.g. `03158-ChangeBranchNaming` → `ChangeBranchNaming`). The commit objects may still exist in the original repo's object store. Use `git cat-file -t <sha>` to verify, then create or force-update the local branch: `git branch -f <branch-name> <sha>` (use `-f` because the branch may already exist from a WIP auto-commit) and push from the original repo path.
 >
-> **Commit lost (object GC'd):** If `git cat-file -t <sha>` fails, the commit was garbage-collected after worktree removal. In this case: (1) check if the change is already on main, (2) if not, recreate the change from the plan revision — create a new branch from main, apply the changes as described in the revision, commit with the standard `[<planId>] <title>` message, and push. Update commits via CLI: `tendril plan add-commit <plan-id> <new-sha>`.
+> **Commit lost (object GC'd):** If `git cat-file -t <sha>` fails, the commit was garbage-collected after worktree removal. In this case: (1) check if the change is already on main, (2) if not, recreate the change from the plan revision — create a new branch from main, apply the changes as described in the revision, commit with a descriptive message matching the plan title, and push. Update commits via CLI: `tendril plan add-commit <plan-id> <new-sha>`.
 
 For each worktree:
 

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -379,10 +379,10 @@ CHANGED_FILES=$(git diff --name-only --diff-filter=ACM HEAD~1)
 
 If your formatter requires a workspace/solution file that isn't in the current directory, pass it as an explicit argument. Check `Memory/` for repo-specific workspace paths.
 
-Commit messages should reference the plan ID:
+Commit messages should be clear and descriptive:
 
 ```
-[01105] Add settings app with config display
+Add settings app with config display
 ```
 
 After all commits, verify no uncommitted files remain:
@@ -457,7 +457,7 @@ For each checked verification:
 2. Fetch its full prompt: `tendril verification get <Name>`
 3. **Check if delegated:** The **Projects** section indicates which verifications are delegated — follow the prompt's instructions to invoke it as an external process. If the external process cannot be invoked (CLI broken, file lock, etc.), set the verification to `Fail` immediately. Do NOT attempt to do the verification inline or write the report yourself.
 4. Execute the prompt in the worktree directory
-5. If it fails: diagnose, fix the issue, **commit the fix** (e.g. `[01105] Fix lint errors from Build`), and re-run. Repeat until it passes (fail the plan after 3+ failed attempts).
+5. If it fails: diagnose, fix the issue, **commit the fix** (e.g. `Fix lint errors from Build`), and re-run. Repeat until it passes (fail the plan after 3+ failed attempts).
 6. Document all fix commits via CLI: `tendril plan add-commit <plan-id> <sha>`
 7. Update the verification status via CLI: `tendril plan set-verification <plan-id> <Name> Pass` (or `Fail`)
 

--- a/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
@@ -89,10 +89,10 @@ Make logically grouped commits in the worktree(s). Each commit should be a coher
 
 Before each commit, run formatting/linting as defined by the project's verifications. Fetch the full prompt for a verification with `tendril verification get <name>`.
 
-Commit messages should reference the plan ID:
+Write clear commit messages describing the change:
 
 ```
-[00012] Improve error handling per review feedback
+Improve error handling per review feedback
 ```
 
 After all commits, verify no uncommitted files remain:


### PR DESCRIPTION
# Summary

## Changes

Removed the `[planId]` prefix instruction from commit message examples and guidance across ExecutePlan, RetryPlan, CreatePr, and CreatePlan promptware documentation. Commit messages now use plain descriptive titles without plan ID prefixes.

## API Changes

None.

## Files Modified

**Promptware Documentation:**
- `src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md` — Updated commit message format from `[01105] Add settings app` to `Add settings app` in two locations
- `src/Ivy.Tendril/Promptwares/RetryPlan/Program.md` — Changed commit instruction from "reference the plan ID" to "Write clear commit messages describing the change"
- `src/Ivy.Tendril/Promptwares/CreatePr/Program.md` — Removed `[<planId>]` prefix from lost-commit recovery instructions
- `src/Ivy.Tendril/Promptwares/CreatePlan/Program.md` — Marked plan ID in commit messages as legacy pattern

---

**Commits:**
- ee92429 Remove plan ID prefix from commit message instructions