### PR TITLE
[00024] Hide empty Artifacts and Recommendations tabs in Review

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -201,7 +201,8 @@ public class ContentView(
             return Disposable.Empty;
         }, [localRefresh]);
 
-        var tabNames = new[] { "summary", "plan", "details", "verifications", "git", "changes", "Artifacts", "recommendations" };
+        var tabNamesList = new List<string> { "summary", "plan", "details", "verifications", "git", "changes" };
+        var tabNames = tabNamesList.ToArray();
         var selectedTabIndex = Array.IndexOf(tabNames, args?.Tab ?? "summary");
         if (selectedTabIndex < 0) selectedTabIndex = 0;
 
@@ -527,7 +528,8 @@ public class ContentView(
 
             var changesTabView = new ChangesTabView(planData.AllChanges, planContentQuery.Loading, planContentQuery.Error);
 
-            var tabs = Layout.Tabs(
+            var tabList = new List<Tab>
+            {
                 new Tab("Summary", Cap(new SummaryTabView(planData.SummaryMarkdown))),
                 new Tab("Plan", Cap(planTabContent)),
                 new Tab("Details", Cap(new DetailsTabView(selectedPlan))),
@@ -535,10 +537,26 @@ public class ContentView(
                     selectedPlan.Verifications, planData.VerificationReports,
                     v => openVerification.Set(v)))).Badge(selectedPlan.Verifications.Count.ToString()),
                 new Tab("Git", Cap(gitLayout)).Badge((gitData.WorktreeSections.Count + selectedPlan.Commits.Count + selectedPlan.Prs.Count).ToString()),
-                new Tab("Changes", Layout.Vertical().Width(Size.Full()).Height(Size.Full()) | changesTabView).Badge(changesTabView.FileCount > 0 ? changesTabView.FileCount.ToString() : ""),
-                new Tab("Artifacts", Cap(new ArtifactsTabView(planData.Artifacts))).Badge(totalArtifacts.ToString()),
-                new Tab("Recommendations", Cap(recommendationsLayout)).Badge(pendingRecs.Count > 0 ? pendingRecs.Count.ToString() : "")
-            ).OnSelect(v =>
+                new Tab("Changes", Layout.Vertical().Width(Size.Full()).Height(Size.Full()) | changesTabView).Badge(changesTabView.FileCount > 0 ? changesTabView.FileCount.ToString() : "")
+            };
+
+            if (totalArtifacts > 0)
+            {
+                tabList.Add(new Tab("Artifacts", Cap(new ArtifactsTabView(planData.Artifacts))).Badge(totalArtifacts.ToString()));
+                tabNamesList.Add("Artifacts");
+            }
+
+            if (pendingRecs.Count > 0)
+            {
+                tabList.Add(new Tab("Recommendations", Cap(recommendationsLayout)).Badge(pendingRecs.Count.ToString()));
+                tabNamesList.Add("recommendations");
+            }
+
+            tabNames = tabNamesList.ToArray();
+            selectedTabIndex = Array.IndexOf(tabNames, args?.Tab ?? "summary");
+            if (selectedTabIndex < 0) selectedTabIndex = 0;
+
+            var tabs = Layout.Tabs(tabList.ToArray()).OnSelect(v =>
             {
                 if (v >= 0 && v < tabNames.Length && selectedPlanState.Value != null)
                     nav.Navigate<ReviewApp>(new ReviewAppArgs(selectedPlanState.Value.FolderName, tabNames[v]));

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -201,8 +201,7 @@ public class ContentView(
             return Disposable.Empty;
         }, [localRefresh]);
 
-        var tabNamesList = new List<string> { "summary", "plan", "details", "verifications", "git", "changes" };
-        var tabNames = tabNamesList.ToArray();
+        var tabNames = new[] { "summary", "plan", "details", "verifications", "git", "changes", "Artifacts", "recommendations" };
         var selectedTabIndex = Array.IndexOf(tabNames, args?.Tab ?? "summary");
         if (selectedTabIndex < 0) selectedTabIndex = 0;
 
@@ -528,6 +527,7 @@ public class ContentView(
 
             var changesTabView = new ChangesTabView(planData.AllChanges, planContentQuery.Loading, planContentQuery.Error);
 
+            var tabNamesList = new List<string> { "summary", "plan", "details", "verifications", "git", "changes" };
             var tabList = new List<Tab>
             {
                 new Tab("Summary", Cap(new SummaryTabView(planData.SummaryMarkdown))),
@@ -552,15 +552,15 @@ public class ContentView(
                 tabNamesList.Add("recommendations");
             }
 
-            tabNames = tabNamesList.ToArray();
-            selectedTabIndex = Array.IndexOf(tabNames, args?.Tab ?? "summary");
-            if (selectedTabIndex < 0) selectedTabIndex = 0;
+            var actualTabNames = tabNamesList.ToArray();
+            var actualSelectedTabIndex = Array.IndexOf(actualTabNames, args?.Tab ?? "summary");
+            if (actualSelectedTabIndex < 0) actualSelectedTabIndex = 0;
 
             var tabs = Layout.Tabs(tabList.ToArray()).OnSelect(v =>
             {
-                if (v >= 0 && v < tabNames.Length && selectedPlanState.Value != null)
-                    nav.Navigate<ReviewApp>(new ReviewAppArgs(selectedPlanState.Value.FolderName, tabNames[v]));
-            }).SelectedIndex(selectedTabIndex).Variant(TabsVariant.Content);
+                if (v >= 0 && v < actualTabNames.Length && selectedPlanState.Value != null)
+                    nav.Navigate<ReviewApp>(new ReviewAppArgs(selectedPlanState.Value.FolderName, actualTabNames[v]));
+            }).SelectedIndex(actualSelectedTabIndex).Variant(TabsVariant.Content);
 
             content |= (Layout.Vertical().Padding(2, 0).Height(Size.Full()) | tabs);
         }


### PR DESCRIPTION
# Summary

## Changes

Modified the Review app's ContentView to conditionally render Artifacts and Recommendations tabs only when they contain data. Tabs now appear only when `totalArtifacts > 0` or `pendingRecs.Count > 0`, respectively.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Review/ContentView.cs** — Tab list construction logic

---

## Commits

- 34ce185 [00024] Fix tab name scoping issue
- 9fc193a [00024] Hide empty Artifacts and Recommendations tabs in Review