### PR TITLE
Fix "No summary available" flash when opening a plan in Review

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -530,7 +530,7 @@ public class ContentView(
             var tabNamesList = new List<string> { "summary", "plan", "details", "verifications", "git", "changes" };
             var tabList = new List<Tab>
             {
-                new Tab("Summary", Cap(new SummaryTabView(planData.SummaryMarkdown))),
+                new Tab("Summary", Cap(new SummaryTabView(planData.SummaryMarkdown, planContentQuery.Loading))),
                 new Tab("Plan", Cap(planTabContent)),
                 new Tab("Details", Cap(new DetailsTabView(selectedPlan))),
                 new Tab("Verifications", Cap(new VerificationsTabView(

--- a/src/Ivy.Tendril/Views/Tabs/SummaryTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/SummaryTabView.cs
@@ -1,6 +1,6 @@
 namespace Ivy.Tendril.Views.Tabs;
 
-public class SummaryTabView(string? summaryMarkdown) : ViewBase
+public class SummaryTabView(string? summaryMarkdown, bool loading = false) : ViewBase
 {
     public override object Build()
     {
@@ -10,6 +10,9 @@ public class SummaryTabView(string? summaryMarkdown) : ViewBase
             layout |= new Markdown(md).DangerouslyAllowLocalFiles().Article();
             return layout;
         }
+
+        if (loading)
+            return null!;
 
         return Text.Muted("No summary available.");
     }


### PR DESCRIPTION
## Summary
- Pass query loading state to `SummaryTabView` so it renders nothing while data is loading
- Eliminates the brief flash of "No summary available" before the actual summary appears

## Test plan
- [x] Build succeeds with 0 warnings
- [x] All 1445 tests pass
- [ ] Manual: open a plan in Review, confirm no flash of empty-state text