### PR TITLE
Fix Changes tab blinking every 30s during background revalidation

### DIFF
--- a/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Views/Tabs/ChangesTabView.cs
@@ -14,7 +14,7 @@ public class ChangesTabView(
     {
         var client = UseService<IClientProvider>();
 
-        if (loading)
+        if (loading && changesData is null)
             return Text.Muted("Loading...");
 
         if (changesData is null)


### PR DESCRIPTION
## Summary
- Only show "Loading..." in ChangesTabView when there is no existing data (`changesData is null`)
- Prevents the 30-second poll timer from replacing rendered diffs with loading text during background revalidation