### PR TITLE
Stop showing framework exceptions as user-facing notifications

### DIFF
--- a/src/Ivy.Tendril/Services/LoggingExceptionHandler.cs
+++ b/src/Ivy.Tendril/Services/LoggingExceptionHandler.cs
@@ -1,0 +1,13 @@
+using Ivy.Core.Exceptions;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services;
+
+public class LoggingExceptionHandler(ILogger<LoggingExceptionHandler> logger) : IExceptionHandler
+{
+    public bool HandleException(Exception exception)
+    {
+        logger.LogWarning(exception, "Unhandled exception in event handler");
+        return true;
+    }
+}

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -1,4 +1,5 @@
 using System.ClientModel;
+using Ivy.Core.Exceptions;
 using Ivy.Helpers;
 using Ivy.Tendril.AppShell;
 using Ivy.Tendril.Controllers;
@@ -27,6 +28,8 @@ public static class TendrilServer
         server.SetMetaTitle("Ivy Tendril");
 
         server.Services.AddHttpClient();
+        server.Services.AddSingleton<IExceptionHandler>(sp =>
+            new LoggingExceptionHandler(sp.GetRequiredService<ILogger<LoggingExceptionHandler>>()));
 
         // Register VerbosityService before other services
         server.Services.AddSingleton<IVerbosityService, VerbosityService>();


### PR DESCRIPTION
## Summary
- Add `LoggingExceptionHandler` that logs via ILogger instead of sending to the client
- Register it in `TendrilServer.cs`, which prevents the framework's default `ClientExceptionHandler` from being added
- Fixes #663

## Test plan
- [x] Build succeeds with 0 warnings
- [x] All 1445 tests pass
- [ ] Manual: trigger a framework error, confirm no notification shown to user