### PR TITLE
Fix test parallelism contaminating TeamIvyConfig config.yaml

### DIFF
--- a/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
@@ -4,6 +4,7 @@ using Ivy.Tendril.Services.Agents;
 
 namespace Ivy.Tendril.Test.Commands;
 
+[Collection("TendrilHome")]
 public class PromptwareRunCommandTests : IDisposable
 {
     private readonly string _tempDir;

--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Test;
 
+[Collection("TendrilHome")]
 public class ConfigServiceTests : IDisposable
 {
     private readonly TempDirectoryFixture _tempDir = new("ivy-config-test");

--- a/src/Ivy.Tendril.Test/DoctorChecksTests.cs
+++ b/src/Ivy.Tendril.Test/DoctorChecksTests.cs
@@ -4,6 +4,7 @@ using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
 
+[Collection("TendrilHome")]
 public class DoctorChecksTests : IDisposable
 {
     private readonly TempDirectoryFixture _tempDir = new("ivy-doctor-test");


### PR DESCRIPTION
## Summary
- Add `[Collection("TendrilHome")]` to `ConfigServiceTests`, `DoctorChecksTests`, and `PromptwareRunCommandTests`
- These tests manipulate `TENDRIL_HOME`/`TENDRIL_AUTH_*` env vars and were racing with parallel tests that construct `ConfigService`, causing auth blocks to be written to the real config.yaml

## Test plan
- [x] All 1445 tests pass
- [x] config.yaml remains unmodified after full test run