### PR TITLE
Update promptware tool permissions

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -228,6 +228,10 @@ promptwares:
     profile: deep
     allowedTools:
     - Bash(ivy *)
+  RetryPlan:
+    profile: deep
+    allowedTools:
+    - Bash(ivy *)
   ExpandPlan:
     profile: balanced
     allowedTools:
@@ -255,8 +259,6 @@ promptwares:
   IvyFrameworkVerification:
     profile: balanced
     allowedTools:
-    - Write(%PLAN_DIR%\**)
-    - Edit(%PLAN_DIR%\**)
     - Bash(ivy *)
 codingAgents:
 - name: claude


### PR DESCRIPTION
## Summary
- Remove Write/Edit from IvyFrameworkVerification — it's read-only, shouldn't have write access
- Add RetryPlan config entry with Bash(ivy *) permission