### PR TITLE
[Desktop]: display active job count in taskbar badge

### DIFF
--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -137,7 +137,20 @@ public class Program
                 .Title("Ivy Tendril")
                 .Size(1400, 900)
                 .UseDpiScaling(false)
-                .Icon(typeof(Program), iconResource);
+                .Icon(typeof(Program), iconResource)
+                .OnReady(w =>
+                {
+                    if (server.ServiceProvider is { } sp)
+                    {
+                        var countsService = sp.GetService<IPlanCountsService>();
+                        if (countsService != null)
+                        {
+                            UpdateBadge(w, countsService.Current.ActiveJobs);
+                            countsService.CountsChanged += () =>
+                                UpdateBadge(w, countsService.Current.ActiveJobs);
+                        }
+                    }
+                });
 
             return window.Run();
         }
@@ -484,5 +497,13 @@ public class Program
         {
             return "Memory stats unavailable";
         }
+    }
+
+    private static void UpdateBadge(DesktopWindow window, int activeJobs)
+    {
+        if (activeJobs > 0)
+            window.SetBadgeCount(activeJobs);
+        else
+            window.ClearBadge();
     }
 }


### PR DESCRIPTION
## Problem

When Ivy.Tendril runs in desktop mode, there is no way to see the current job status without opening the application window. The `Ivy.Desktop` API already supports taskbar badges (`SetBadgeCount` / `ClearBadge`) via the Rustino native layer, but Tendril never calls these methods — the taskbar icon always remains blank.

Users have to switch to the Tendril window to check if any jobs are still running, which interrupts their workflow.

## Solution

Subscribe to `PlanCountsService.CountsChanged` in the desktop startup path (`Program.cs`) and update the Windows taskbar badge with the number of active jobs (Running, Queued, Blocked).

### What was done

- Added an `OnReady` callback to `DesktopWindow` in `Program.cs` that:
  - Resolves `IPlanCountsService` from the server's DI container
  - Sets the initial badge count on startup
  - Subscribes to `CountsChanged` to reactively update the badge whenever jobs start or finish
- Added a helper method `UpdateBadge` that calls `SetBadgeCount(n)` when there are active jobs and `ClearBadge()` when there are none
- No changes to Ivy.Framework or Rustino were needed — the existing API was sufficient

### How it works

```
PlanCountsService.CountsChanged → UpdateBadge() → DesktopWindow.SetBadgeCount() → Rustino → Windows Taskbar API
```

## Changed files

- `src/Ivy.Tendril/Program.cs` — added `OnReady` callback and `UpdateBadge` helper

## Testing

| Scenario | Expected |
|----------|----------|
| No active jobs | Badge is empty (no number on icon) |
| 1 running job | Badge shows `1` |
| Multiple running jobs | Badge shows the count |
| All jobs complete | Badge clears |

Verified manually by running `tendril --desktop` and observing the taskbar badge during job execution.

<img width="76" height="79" alt="image" src="https://github.com/user-attachments/assets/c851e536-0f16-4ed5-afca-e347e2e3ca78" />
