### PR TITLE
Add Ivy-Framework as a repo to Tendril project config

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -61,6 +61,10 @@ projects:
     prRule: yolo
     baseBranch: development
     syncStrategy: fetch
+  - path: D:\Repos\_Ivy\Ivy-Framework
+    prRule: yolo
+    baseBranch: development
+    syncStrategy: fetch
   verifications:
   - &o2
     name: DotnetBuild
@@ -84,8 +88,7 @@ projects:
     - CreatePr
     condition: ''
     action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
-  buildDependencies:
-  - D:\Repos\_Ivy\Ivy-Framework
+  buildDependencies: []
 - name: Rustino
   color: Orange
   meta:


### PR DESCRIPTION
## Summary
- Move Ivy-Framework from `buildDependencies` (read-only) to `repos` list (read-write)
- Allows plans to modify both Ivy-Tendril and Ivy-Framework together

## Test plan
- [x] Config-only change, no code affected