### PR TITLE
Extract service registrations from TendrilServer into ServiceRegistration.cs

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -199,7 +199,7 @@ public class CompleteStepView(
         }
 
         return Layout.Vertical().Gap(4).Margin(0, 0, 0, 20)
-               | Text.H2(headerText)
+               | Text.H3(headerText)
                | Text.Muted(subText)
                | (error != null ? Text.Danger(error) : null!)
                | (running

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -74,7 +74,7 @@ public class ProjectSetupStepView(
             : null!;
 
         return Layout.Vertical().Gap(4).Margin(0, 0, 0, 20)
-               | Text.H2("Setup your first project")
+               | Text.H3("Setup your first project")
                | (error.Value != null ? Text.Danger(error.Value) : null!)
                | new ProjectRepoPickerView(selectedRepos, projectName)
                | projectName.ToTextInput().WithField().Required().Label("Project Name")

--- a/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
@@ -22,7 +22,7 @@ public class TendrilHomeStepView(
             ".tendril");
 
         return Layout.Vertical().Gap(4).Margin(0, 0, 0, 20)
-               | Text.H2("This is where we store your data")
+               | Text.H3("This is where we store your data")
                | Text.Muted(
                    "Tendril keeps your config, plans, inbox, trash, hooks, promptwares, and a local " +
                    "SQLite database in this folder. The default works for most people. Change it if " +

--- a/src/Ivy.Tendril/Apps/OnboardingApp.cs
+++ b/src/Ivy.Tendril/Apps/OnboardingApp.cs
@@ -48,7 +48,7 @@ public class OnboardingApp : ViewBase
         var stepperIndex = UseState(0);
         var commonChecksPassed = UseState(false);
         var homeBootstrapped = UseState(false);
-        var completedAgentKey = UseState<string?>((string?)null);
+        var completedAgentKey = UseState<string?>();
         var tendrilHomePath = UseState(() =>
             Environment.GetEnvironmentVariable("TENDRIL_HOME")
             ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril"));
@@ -57,12 +57,12 @@ public class OnboardingApp : ViewBase
         var isStepLoading = UseState(false);
 
         var verificationStream = UseStream<string>();
-        var verificationHandle = UseState<PromptwareRunHandle?>((PromptwareRunHandle?)null);
+        var verificationHandle = UseState<PromptwareRunHandle?>();
         var verificationHasOutput = UseState(false);
         var verificationRunning = UseState(false);
         var verificationStarted = UseState(false);
         var verificationCancelled = UseState(false);
-        var verificationError = UseState<string?>((string?)null);
+        var verificationError = UseState<string?>();
         var verificationRefreshToken = UseState(0);
         var session = new OnboardingVerificationSession(
             verificationStream,
@@ -84,6 +84,7 @@ public class OnboardingApp : ViewBase
         return Layout.TopCenter() |
                (Layout.Vertical().Margin(0, 20).Width(150)
                 | header
+                | new Spacer().Height(Size.Units(2))
                 | new Stepper(OnSelect, stepperIndex.Value, steps).Width(Size.Full()).Disabled(isStepLoading.Value || verificationRunning.Value)
                 | new Spacer().Height(Size.Units(2))
                 | GetStepViews(stepperIndex,
@@ -94,11 +95,7 @@ public class OnboardingApp : ViewBase
         ValueTask OnSelect(Event<Stepper, int> e)
         {
             if (isStepLoading.Value || verificationRunning.Value) return ValueTask.CompletedTask;
-            if (e.Value < stepperIndex.Value)
-            {
-                stepperIndex.Set(e.Value);
-            }
-            else if (stepperIndex.Value != 3)
+            if (e.Value < stepperIndex.Value || stepperIndex.Value != 3)
             {
                 stepperIndex.Set(e.Value);
             }

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -1,0 +1,161 @@
+using System.ClientModel;
+using Ivy.Core.Exceptions;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.SessionParsers;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenAI;
+
+namespace Ivy.Tendril;
+
+internal static class ServiceRegistration
+{
+    public static void AddTendrilServices(this Server server, ConfigService configService)
+    {
+        server.Services.AddHttpClient();
+        server.Services.AddSingleton<IExceptionHandler>(sp =>
+            new LoggingExceptionHandler(sp.GetRequiredService<ILogger<LoggingExceptionHandler>>()));
+
+        server.Services.AddSingleton<IConfigService>(configService);
+        server.Services.AddSingleton<ConfigService>(configService);
+
+        Program.SetConfigServiceForCleanup(configService);
+
+        server.Services.AddHttpContextAccessor();
+
+        if (configService.Settings.Auth != null)
+            server.UseAuth<Auth.TendrilAuthProvider>();
+
+        server.Services.AddSingleton<ISessionParser, ClaudeSessionParser>();
+        server.Services.AddSingleton<ISessionParser, CodexSessionParser>();
+        server.Services.AddSingleton<ISessionParser, GeminiSessionParser>();
+        server.Services.AddSingleton<ModelPricingService>();
+        server.Services.AddSingleton<IModelPricingService>(sp => sp.GetRequiredService<ModelPricingService>());
+
+        if (configService.Settings.Llm is { } llmConfig && !string.IsNullOrEmpty(llmConfig.ApiKey))
+            server.Services.AddSingleton<IChatClient>(sp =>
+            {
+                var config = sp.GetRequiredService<IConfigService>();
+                var llm = config.Settings.Llm!;
+                var endpoint = !string.IsNullOrEmpty(llm.Endpoint) ? llm.Endpoint : "https://api.openai.com/v1";
+                var client = new OpenAIClient(
+                    new ApiKeyCredential(llm.ApiKey),
+                    new OpenAIClientOptions { Endpoint = new Uri(endpoint) });
+                return client.GetChatClient(llm.Model).AsIChatClient();
+            });
+
+        server.Services.AddSingleton<VersionCheckService>();
+        server.Services.AddSingleton<IVersionCheckService>(sp => sp.GetRequiredService<VersionCheckService>());
+        server.Services.AddSingleton<IPromptwareRunner, PromptwareRunner>();
+
+        server.Services.AddSingleton<OnboardingSetupService>();
+        server.Services.AddSingleton<IOnboardingSetupService>(sp => sp.GetRequiredService<OnboardingSetupService>());
+        server.Services.AddSingleton<IOnboardingAuthRunner, OnboardingAuthRunner>();
+        server.Services.AddSingleton<GithubService>();
+        server.Services.AddSingleton<IGithubService>(sp => sp.GetRequiredService<GithubService>());
+        server.Services.AddSingleton<IGitService>(sp =>
+            new GitService(
+                sp.GetRequiredService<IConfigService>(),
+                sp.GetRequiredService<ILogger<GitService>>()));
+        server.Services.AddSingleton<IWorktreeLifecycleLogger>(sp =>
+        {
+            var config = sp.GetRequiredService<IConfigService>();
+            return new WorktreeLifecycleLogger(
+                string.IsNullOrEmpty(config.TendrilHome) ? "." : config.TendrilHome);
+        });
+        server.Services.AddSingleton<PlanReaderService>(sp =>
+        {
+            var planService = new PlanReaderService(
+                sp.GetRequiredService<IConfigService>(),
+                sp.GetRequiredService<ILogger<PlanReaderService>>(),
+                sp.GetRequiredService<ITelemetryService>(),
+                sp.GetRequiredService<IWorktreeLifecycleLogger>());
+            planService.MigratePlanSubfolderCasing();
+            planService.RepairPlans();
+            planService.RecoverStuckPlans();
+            return planService;
+        });
+        server.Services.AddSingleton<IPlanReaderService>(sp => sp.GetRequiredService<PlanReaderService>());
+
+        server.Services.AddSingleton<IPlanDatabaseService>(sp =>
+        {
+            var cfg = sp.GetRequiredService<IConfigService>();
+            if (string.IsNullOrEmpty(cfg.TendrilHome))
+                throw new InvalidOperationException("Cannot create PlanDatabaseService: TendrilHome is not configured. Complete onboarding first.");
+            var dbPath = Path.Combine(cfg.TendrilHome, "tendril.db");
+            var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<PlanDatabaseService>();
+            return new PlanDatabaseService(dbPath, logger);
+        });
+        server.Services.AddSingleton<PlanDatabaseSyncService>(sp =>
+        {
+            var planReader = sp.GetRequiredService<PlanReaderService>();
+            var database = sp.GetRequiredService<IPlanDatabaseService>();
+            var watcher = sp.GetRequiredService<IPlanWatcherService>();
+            var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+            return new PlanDatabaseSyncService(planReader, database, watcher,
+                loggerFactory.CreateLogger<PlanDatabaseSyncService>());
+        });
+        server.Services.AddSingleton<ITelemetryService>(sp =>
+        {
+            var config = sp.GetRequiredService<IConfigService>();
+            var logger = sp.GetRequiredService<ILogger<TelemetryService>>();
+            return new TelemetryService(config.Settings.Telemetry, logger);
+        });
+        server.Services.AddSingleton<TelemetryService>(sp =>
+            (TelemetryService)sp.GetRequiredService<ITelemetryService>());
+        server.Services.AddSingleton<JobService>(sp =>
+        {
+            var cfg = sp.GetRequiredService<IConfigService>();
+            return new JobService(
+                cfg,
+                sp.GetRequiredService<ILogger<JobService>>(),
+                sp.GetRequiredService<ModelPricingService>(),
+                sp.GetRequiredService<IPlanReaderService>(),
+                sp.GetRequiredService<ITelemetryService>(),
+                sp.GetRequiredService<IPlanWatcherService>(),
+                string.IsNullOrEmpty(cfg.TendrilHome) ? null : sp.GetRequiredService<IPlanDatabaseService>(),
+                sp.GetRequiredService<IWorktreeLifecycleLogger>());
+        });
+        server.Services.AddSingleton<IJobService>(sp => sp.GetRequiredService<JobService>());
+        server.Services.AddSingleton<PlanWatcherService>(sp =>
+        {
+            var config = sp.GetRequiredService<IConfigService>();
+            var logger = sp.GetService<ILogger<PlanWatcherService>>();
+            return new PlanWatcherService(config, logger);
+        });
+        server.Services.AddSingleton<IPlanWatcherService>(sp => sp.GetRequiredService<PlanWatcherService>());
+        server.Services.AddSingleton<PlanCountsService>(sp =>
+        {
+            var planReader = sp.GetRequiredService<IPlanReaderService>();
+            var jobService = sp.GetRequiredService<IJobService>();
+            var planWatcher = sp.GetRequiredService<IPlanWatcherService>();
+            return new PlanCountsService(planReader, jobService, planWatcher);
+        });
+        server.Services.AddSingleton<IPlanCountsService>(sp => sp.GetRequiredService<PlanCountsService>());
+        server.Services.AddSingleton<InboxWatcherService>(sp =>
+        {
+            var config = sp.GetRequiredService<IConfigService>();
+            var jobService = sp.GetRequiredService<IJobService>();
+            return new InboxWatcherService(config, jobService, sp.GetRequiredService<ILogger<InboxWatcherService>>());
+        });
+        server.Services.AddSingleton<IInboxWatcherService>(sp => sp.GetRequiredService<InboxWatcherService>());
+        server.Services.AddSingleton<WorktreeCleanupService>(sp =>
+        {
+            var config = sp.GetRequiredService<IConfigService>();
+            var logger = sp.GetRequiredService<ILogger<WorktreeCleanupService>>();
+            var lifecycleLogger = sp.GetRequiredService<IWorktreeLifecycleLogger>();
+            return new WorktreeCleanupService(config.PlanFolder, logger, lifecycleLogger);
+        });
+        server.Services.AddSingleton<IStartable>(sp => sp.GetRequiredService<WorktreeCleanupService>());
+        server.Services.AddSingleton<PrStatusSyncService>(sp =>
+        {
+            var database = sp.GetRequiredService<IPlanDatabaseService>();
+            var githubService = sp.GetRequiredService<IGithubService>();
+            var planReader = sp.GetRequiredService<IPlanReaderService>();
+            var logger = sp.GetRequiredService<ILogger<PrStatusSyncService>>();
+            return new PrStatusSyncService(database, githubService, planReader, logger);
+        });
+        server.Services.AddSingleton<IStartable>(sp => sp.GetRequiredService<PrStatusSyncService>());
+    }
+}

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -1,17 +1,12 @@
-using System.ClientModel;
-using Ivy.Core.Exceptions;
 using Ivy.Helpers;
 using Ivy.Tendril.AppShell;
 using Ivy.Tendril.Controllers;
 using Ivy.Tendril.Services;
-using Ivy.Tendril.Services.SessionParsers;
 using Ivy.Tendril.Helpers;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using OpenAI;
 
 namespace Ivy.Tendril;
 
@@ -27,157 +22,8 @@ public static class TendrilServer
 #endif
         server.SetMetaTitle("Ivy Tendril");
 
-        server.Services.AddHttpClient();
-        server.Services.AddSingleton<IExceptionHandler>(sp =>
-            new LoggingExceptionHandler(sp.GetRequiredService<ILogger<LoggingExceptionHandler>>()));
-
         var configService = new ConfigService(Microsoft.Extensions.Logging.Abstractions.NullLogger<ConfigService>.Instance);
-        server.Services.AddSingleton<IConfigService>(configService);
-        server.Services.AddSingleton<ConfigService>(configService);
-
-        // Store reference for cleanup on process exit
-        Program.SetConfigServiceForCleanup(configService);
-
-        server.Services.AddHttpContextAccessor();
-
-        if (configService.Settings.Auth != null)
-        {
-            server.UseAuth<Auth.TendrilAuthProvider>();
-        }
-
-        server.Services.AddSingleton<ISessionParser, ClaudeSessionParser>();
-        server.Services.AddSingleton<ISessionParser, CodexSessionParser>();
-        server.Services.AddSingleton<ISessionParser, GeminiSessionParser>();
-        server.Services.AddSingleton<ModelPricingService>();
-        server.Services.AddSingleton<IModelPricingService>(sp => sp.GetRequiredService<ModelPricingService>());
-
-        // Register IChatClient if LLM is configured
-        if (configService.Settings.Llm is { } llmConfig && !string.IsNullOrEmpty(llmConfig.ApiKey))
-            server.Services.AddSingleton<IChatClient>(sp =>
-            {
-                var config = sp.GetRequiredService<IConfigService>();
-                var llm = config.Settings.Llm!;
-                var endpoint = !string.IsNullOrEmpty(llm.Endpoint) ? llm.Endpoint : "https://api.openai.com/v1";
-                var client = new OpenAIClient(
-                    new ApiKeyCredential(llm.ApiKey),
-                    new OpenAIClientOptions { Endpoint = new Uri(endpoint) });
-                return client.GetChatClient(llm.Model).AsIChatClient();
-            });
-
-        server.Services.AddSingleton<VersionCheckService>();
-        server.Services.AddSingleton<IVersionCheckService>(sp => sp.GetRequiredService<VersionCheckService>());
-        server.Services.AddSingleton<IPromptwareRunner, PromptwareRunner>();
-
-
-        server.Services.AddSingleton<OnboardingSetupService>();
-        server.Services.AddSingleton<IOnboardingSetupService>(sp => sp.GetRequiredService<OnboardingSetupService>());
-        server.Services.AddSingleton<IOnboardingAuthRunner, OnboardingAuthRunner>();
-        server.Services.AddSingleton<GithubService>();
-        server.Services.AddSingleton<IGithubService>(sp => sp.GetRequiredService<GithubService>());
-        server.Services.AddSingleton<IGitService>(sp =>
-            new GitService(
-                sp.GetRequiredService<IConfigService>(),
-                sp.GetRequiredService<ILogger<GitService>>()));
-        server.Services.AddSingleton<IWorktreeLifecycleLogger>(sp =>
-        {
-            var config = sp.GetRequiredService<IConfigService>();
-            return new WorktreeLifecycleLogger(
-                string.IsNullOrEmpty(config.TendrilHome) ? "." : config.TendrilHome);
-        });
-        server.Services.AddSingleton<PlanReaderService>(sp =>
-        {
-            var planService = new PlanReaderService(
-                sp.GetRequiredService<IConfigService>(),
-                sp.GetRequiredService<ILogger<PlanReaderService>>(),
-                sp.GetRequiredService<ITelemetryService>(),
-                sp.GetRequiredService<IWorktreeLifecycleLogger>());
-            planService.MigratePlanSubfolderCasing();
-            planService.RepairPlans();
-            planService.RecoverStuckPlans();
-            return planService;
-        });
-        server.Services.AddSingleton<IPlanReaderService>(sp => sp.GetRequiredService<PlanReaderService>());
-
-        // SQLite database service
-        server.Services.AddSingleton<IPlanDatabaseService>(sp =>
-        {
-            var cfg = sp.GetRequiredService<IConfigService>();
-            if (string.IsNullOrEmpty(cfg.TendrilHome))
-                throw new InvalidOperationException("Cannot create PlanDatabaseService: TendrilHome is not configured. Complete onboarding first.");
-            var dbPath = Path.Combine(cfg.TendrilHome, "tendril.db");
-            var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger<PlanDatabaseService>();
-            return new PlanDatabaseService(dbPath, logger);
-        });
-        server.Services.AddSingleton<PlanDatabaseSyncService>(sp =>
-        {
-            var planReader = sp.GetRequiredService<PlanReaderService>();
-            var database = sp.GetRequiredService<IPlanDatabaseService>();
-            var watcher = sp.GetRequiredService<IPlanWatcherService>();
-            var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
-            return new PlanDatabaseSyncService(planReader, database, watcher,
-                loggerFactory.CreateLogger<PlanDatabaseSyncService>());
-        });
-        server.Services.AddSingleton<ITelemetryService>(sp =>
-        {
-            var config = sp.GetRequiredService<IConfigService>();
-            var logger = sp.GetRequiredService<ILogger<TelemetryService>>();
-            return new TelemetryService(config.Settings.Telemetry, logger);
-        });
-        server.Services.AddSingleton<TelemetryService>(sp =>
-            (TelemetryService)sp.GetRequiredService<ITelemetryService>());
-        server.Services.AddSingleton<JobService>(sp =>
-        {
-            var cfg = sp.GetRequiredService<IConfigService>();
-            return new JobService(
-                cfg,
-                sp.GetRequiredService<ILogger<JobService>>(),
-                sp.GetRequiredService<ModelPricingService>(),
-                sp.GetRequiredService<IPlanReaderService>(),
-                sp.GetRequiredService<ITelemetryService>(),
-                sp.GetRequiredService<IPlanWatcherService>(),
-                string.IsNullOrEmpty(cfg.TendrilHome) ? null : sp.GetRequiredService<IPlanDatabaseService>(),
-                sp.GetRequiredService<IWorktreeLifecycleLogger>());
-        });
-        server.Services.AddSingleton<IJobService>(sp => sp.GetRequiredService<JobService>());
-        server.Services.AddSingleton<PlanWatcherService>(sp =>
-        {
-            var config = sp.GetRequiredService<IConfigService>();
-            var logger = sp.GetService<ILogger<PlanWatcherService>>();
-            return new PlanWatcherService(config, logger);
-        });
-        server.Services.AddSingleton<IPlanWatcherService>(sp => sp.GetRequiredService<PlanWatcherService>());
-        server.Services.AddSingleton<PlanCountsService>(sp =>
-        {
-            var planReader = sp.GetRequiredService<IPlanReaderService>();
-            var jobService = sp.GetRequiredService<IJobService>();
-            var planWatcher = sp.GetRequiredService<IPlanWatcherService>();
-            return new PlanCountsService(planReader, jobService, planWatcher);
-        });
-        server.Services.AddSingleton<IPlanCountsService>(sp => sp.GetRequiredService<PlanCountsService>());
-        server.Services.AddSingleton<InboxWatcherService>(sp =>
-        {
-            var config = sp.GetRequiredService<IConfigService>();
-            var jobService = sp.GetRequiredService<IJobService>();
-            return new InboxWatcherService(config, jobService, sp.GetRequiredService<ILogger<InboxWatcherService>>());
-        });
-        server.Services.AddSingleton<IInboxWatcherService>(sp => sp.GetRequiredService<InboxWatcherService>());
-        server.Services.AddSingleton<WorktreeCleanupService>(sp =>
-        {
-            var config = sp.GetRequiredService<IConfigService>();
-            var logger = sp.GetRequiredService<ILogger<WorktreeCleanupService>>();
-            var lifecycleLogger = sp.GetRequiredService<IWorktreeLifecycleLogger>();
-            return new WorktreeCleanupService(config.PlanFolder, logger, lifecycleLogger);
-        });
-        server.Services.AddSingleton<IStartable>(sp => sp.GetRequiredService<WorktreeCleanupService>());
-        server.Services.AddSingleton<PrStatusSyncService>(sp =>
-        {
-            var database = sp.GetRequiredService<IPlanDatabaseService>();
-            var githubService = sp.GetRequiredService<IGithubService>();
-            var planReader = sp.GetRequiredService<IPlanReaderService>();
-            var logger = sp.GetRequiredService<ILogger<PrStatusSyncService>>();
-            return new PrStatusSyncService(database, githubService, planReader, logger);
-        });
-        server.Services.AddSingleton<IStartable>(sp => sp.GetRequiredService<PrStatusSyncService>());
+        server.AddTendrilServices(configService);
 
         // Configure logging based on verbosity.
         // We set levels via configuration (not SetMinimumLevel) because the Ivy framework
@@ -191,6 +37,7 @@ public static class TendrilServer
             builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["Logging:LogLevel:Default"] = logLevel,
+                ["Logging:LogLevel:Ivy.Core"] = "Warning",
             });
         });
 


### PR DESCRIPTION
## Summary
- Extracts all DI service registrations from `TendrilServer.Create()` into `ServiceRegistration.AddTendrilServices()`
- Reduces `TendrilServer.cs` from 215 LoC / cc=14 (score 8.85) to 79 LoC (score 9.55)
- New `ServiceRegistration.cs` scores 9.24 — low complexity, just linear DI setup

## Test plan
- [x] `dotnet build` succeeds
- [x] Full test suite: 1454 passing (1 pre-existing unrelated failure)