### PR TITLE
Fix onboarding steps stuck after progress completes

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -190,7 +190,7 @@ public class CodingAgentStepView(
                 await progressCts.CancelAsync();
                 progressValue.Set(100);
                 progressMessage.Set("Done");
-                await Task.Delay(250, progressCts.Token);
+                await Task.Delay(250); // no token — progressCts is already cancelled
 
                 progressValue.Set(null);
                 progressMessage.Set(null);

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -195,7 +195,7 @@ public class ProjectSetupStepView(
 
             await StartVerificationSessionAsync(config, setupService, runner, name);
 
-            await Task.Delay(250, progressCts.Token);
+            await Task.Delay(250); // no token — progressCts is already cancelled
 
             progressValue.Set(null);
             progressMessage.Set(null);


### PR DESCRIPTION
## Summary
- `Task.Delay(250, progressCts.Token)` was called after `progressCts.CancelAsync()`, immediately throwing `OperationCanceledException`
- The fire-and-forget async swallowed the exception, leaving the UI permanently stuck at "Setting Up Claude" / project setup
- Removed the token from the cosmetic delay in both `CodingAgentStepView` and `ProjectSetupStepView`

## Test plan
- [x] Manual: onboarding flow advances past step 1 after agent checks complete
- [x] Build succeeds