### PR TITLE
[Notifications]: implement native OS toast notifications, add tab to settings and fix YamlHelper

### DIFF
--- a/src/Ivy.Tendril/Apps/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/SettingsApp.cs
@@ -10,6 +10,7 @@ namespace Ivy.Tendril.Apps;
 public class SettingsApp : ViewBase
 {
     private const string TagGeneral = "general";
+    private const string TagNotifications = "notifications";
     private const string TagSecurity = "security";
     private const string TagLevels = "levels";
     private const string TagVerifications = "verifications";
@@ -36,6 +37,7 @@ public class SettingsApp : ViewBase
                 .Expanded()
                 .Children(
                     MenuItem.Default("General", TagGeneral).Icon(Icons.Settings),
+                    MenuItem.Default("Notifications", TagNotifications).Icon(Icons.Bell),
                     MenuItem.Default("Security", TagSecurity).Icon(Icons.Lock),
                     MenuItem.Default("Levels", TagLevels).Icon(Icons.ListOrdered),
                     MenuItem.Default("Verifications", TagVerifications).Icon(Icons.CircleCheck),
@@ -65,6 +67,7 @@ public class SettingsApp : ViewBase
         object content = selected.Value switch
         {
             TagGeneral => new GeneralSetupView(),
+            TagNotifications => new NotificationsSetupView(),
             TagSecurity => new SecuritySetupView(),
             TagLevels => new LevelsSetupView(),
             TagVerifications => new VerificationsSetupView(),

--- a/src/Ivy.Tendril/Apps/Setup/NotificationsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/NotificationsSetupView.cs
@@ -1,0 +1,35 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Setup;
+
+public class NotificationsSetupView : ViewBase
+{
+    public override object Build()
+    {
+        var config = UseService<IConfigService>();
+        var client = UseService<IClientProvider>();
+
+        var desktopNotifications = UseState(config.Settings.DesktopNotifications);
+        var forceRender = UseState(0);
+
+        var hasChanges = desktopNotifications.Value != config.Settings.DesktopNotifications;
+
+        var form = Layout.Vertical().Gap(4).Padding(4).Width(Size.Auto().Max(Size.Units(120)))
+                   | Text.Block("Notification Settings").Bold()
+                   | Text.Block("Configure how Tendril notifies you about job completions, failures, and other events.").Muted().Small()
+
+                   | desktopNotifications.ToSwitchInput()
+                       .WithField().Label("Enable Desktop Notifications")
+                   | new Button("Save").Primary()
+                       .Disabled(!hasChanges)
+                       .OnClick(() =>
+                       {
+                           config.Settings.DesktopNotifications = desktopNotifications.Value;
+                           config.SaveSettings();
+                           client.Toast("Notification settings saved", "Saved");
+                           forceRender.Value++;
+                       });
+
+        return form;
+    }
+}

--- a/src/Ivy.Tendril/Helpers/YamlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/YamlHelper.cs
@@ -32,6 +32,6 @@ public static class YamlHelper
     /// </summary>
     public static readonly ISerializer SerializerCompact = new SerializerBuilder()
         .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
+        .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
         .Build();
 }

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -136,6 +136,7 @@ public class Program
 
             var window = new DesktopWindow(server)
                 .Title("Ivy Tendril")
+                .AppId("Ivy Tendril")
                 .Size(1400, 900)
                 .UseDpiScaling(false)
                 .Icon(typeof(Program), iconResource)
@@ -149,6 +150,22 @@ public class Program
                             UpdateBadge(w, countsService.Current.ActiveJobs);
                             countsService.CountsChanged += () =>
                                 UpdateBadge(w, countsService.Current.ActiveJobs);
+                        }
+
+                        var jobService = sp.GetService<IJobService>();
+                        var configService = sp.GetService<IConfigService>();
+                        if (jobService != null)
+                        {
+                            jobService.NotificationReady += notification =>
+                            {
+                                if (configService?.Settings.DesktopNotifications != false)
+                                {
+                                    DesktopWindow.ShowNotification(
+                                        notification.Title,
+                                        notification.Message,
+                                        appId: "Ivy Tendril");
+                                }
+                            };
                         }
                     }
                 });

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -173,6 +173,7 @@ public class TendrilSettings
     public Dictionary<string, PromptwareConfig> Promptwares { get; set; } = new();
     public List<AgentConfig> CodingAgents { get; set; } = new();
     public bool Telemetry { get; set; } = true;
+    public bool DesktopNotifications { get; set; } = true;
 
     public List<LevelConfig> Levels { get; set; } = new()
     {


### PR DESCRIPTION
## Overview
This PR implements native OS desktop notifications for the Ivy Tendril application and introduces a dedicated UI in the Settings to manage them. It also resolves a critical global bug with YAML configuration serialization and fixes reactive UI state updates in the settings screen.

## What was the issue?
Users had no way of knowing when background jobs completed, failed, or timed out if the application was minimized. We needed to integrate native desktop notifications (e.g., Windows Toasts) using the existing `Rustino` library API and provide a user toggle to enable/disable them.

## What was done
1. **Application Logic**: Subscribed to `IJobService.NotificationReady` in `Program.cs` to trigger `DesktopWindow.ShowNotification` whenever a job event occurs.
2. **Configuration**: Added a new `DesktopNotifications` boolean property (default `true`) to `TendrilSettings`.
3. **UI Implementation**: Created `NotificationsSetupView.cs` to add a new "Notifications" tab in the Settings app, allowing users to toggle desktop notifications.

## Bugs Encountered & Resolved

During implementation, we encountered and resolved several deeply hidden bugs:

### 1. Windows AUMID (AppUserModelID) Registration
**The Bug:** Native notifications were returning a success status from the Rust library but were silently swallowed by Windows, never appearing on the screen.
**The Investigation:** We discovered that Windows 10/11 strictly requires WinRT notifications to be tied to an `AppUserModelID` that is physically registered in the system via a Start Menu `.lnk` shortcut. We proved this by temporarily injecting the built-in PowerShell AUMID, which successfully forced the notifications to appear. 
**The Resolution:** We reverted the PowerShell hack to keep the codebase clean. The final resolution for the missing Start Menu shortcut will be addressed either via an installer or a dedicated C# COM helper upon application startup in a follow-up task.

### 2. YAML Serialization `OmitDefaults` Bug
**The Bug:** When the user turned the notification toggle off (`false`) and saved, the backend immediately reverted the setting to `true`.
**The Cause:** In `YamlHelper.cs`, the `SerializerCompact` was configured with `DefaultValuesHandling.OmitDefaults`. Since `false` is the C# default value for the `bool` type, YamlDotNet silently omitted the field from `config.yaml`. Upon reloading, the `TendrilSettings` class initialized it back to its class default (`= true`).
**The Resolution:** Changed the serialization configuration from `OmitDefaults` to `OmitNull`. This ensures that `false` values are correctly serialized and persisted across application restarts. This fix also prevents the same bug from affecting other boolean settings like `Telemetry`.

### 3. Reactive UI State Bug in Settings
**The Bug:** After clicking "Save" in the Settings UI, the save button remained active instead of becoming disabled, even though the setting was successfully saved.
**The Cause:** The Ivy frontend is a reactive framework that re-renders only when a `State<T>` changes. Clicking "Save" mutated the global `config.Settings` but didn't modify any local UI state, leaving the framework unaware that a re-render was needed to recalculate the `hasChanges` variable.
**The Resolution:** Introduced a `forceRender` dummy state variable that increments on save. This forces the UI to re-render, correctly evaluating the new config state and disabling the save button.



https://github.com/user-attachments/assets/03143e79-2559-4273-bf80-9096baa1eb1b


