### PR TITLE
Fix onboarding to always start with a fresh project setup

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -9,17 +9,18 @@ projects:
   meta:
     slackEmoji: ':hammer_and_wrench:'
   repos:
-  - path: D:\Repos\_Ivy\Ivy-Framework
+  - &o0
+    path: D:\Repos\_Ivy\Ivy-Framework
     prRule: yolo
     baseBranch: development
     syncStrategy: fetch
   verifications:
   - name: FrameworkDotnetBuild
     required: true
-  - &o0
+  - &o1
     name: DotnetFormat
     required: true
-  - &o3
+  - &o4
     name: DotnetTest
     required: true
   - name: FrameworkFrontendLint
@@ -29,7 +30,7 @@ projects:
   - name: NewWidgetChecklist
   - name: VitePlusCheck
     required: true
-  - &o1
+  - &o2
     name: CheckResult
     required: true
   context: >
@@ -61,17 +62,14 @@ projects:
     prRule: yolo
     baseBranch: development
     syncStrategy: fetch
-  - path: D:\Repos\_Ivy\Ivy-Framework
-    prRule: yolo
-    baseBranch: development
-    syncStrategy: fetch
+  - *o0
   verifications:
-  - &o2
+  - &o3
     name: DotnetBuild
     required: true
-  - *o0
-  - name: DotnetTest
   - *o1
+  - name: DotnetTest
+  - *o2
   context: >
     Plan management TUI. Key folders: - src\Ivy.Tendril\Services\ — ConfigService, PlanReaderService, JobService - src\Ivy.Tendril\Apps\ — PlansApp, JobsApp UI - src\Ivy.Tendril\Promptwares\ — CreatePlan, UpdatePlan, SplitPlan, ExpandPlan This project uses the Ivy Framework - there's CLI helper methods you can use:  ivy docs AGENTS.md  ivy question "How do I make a button in Ivy?"
   reviewActions:
@@ -99,16 +97,16 @@ projects:
     baseBranch: development
     syncStrategy: fetch
   verifications:
-  - *o2
-  - *o0
   - *o3
+  - *o1
+  - *o4
   - name: RustBuild
     required: true
   - name: RustTest
     required: true
   - name: RustClippy
     required: true
-  - *o1
+  - *o2
   context: >
     Rustino — cross-platform native desktop windows with embedded web views (Rust + .NET). Key folders: - src\Rustino.Native\ — Rust cdylib (wry + tao for webview\window) - src\Rustino.NET\ — C# P\Invoke wrapper - src\Rustino.NET.Reactive\ — IObservable extensions - src\Rustino.Samples\ — demo applications Build: `cd src\Rustino.Native && cargo build --release`, then `dotnet build`
   reviewActions:
@@ -122,6 +120,18 @@ projects:
     - CreatePr
     condition: ''
     action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
+  buildDependencies: []
+- name: Ivy-Examples
+  color: Green
+  meta: {}
+  repos:
+  - path: D:\Tendril\Repos\Ivy-Examples
+    prRule: default
+    syncStrategy: fetch
+  verifications: []
+  context: ''
+  reviewActions: []
+  hooks: []
   buildDependencies: []
 verifications:
 - name: FrameworkDotnetBuild

--- a/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -160,7 +160,7 @@ public class CompleteStepView(
         var error = session.Error.Value;
 
         var headerText = running
-            ? "Setting up verifications…"
+            ? "Setting up verifications"
             : "Ready to Go!";
 
         var subText = running

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectSetupStepView.cs
@@ -30,16 +30,6 @@ public class ProjectSetupStepView(
 
         UseEffect(() =>
         {
-            if (selectedRepos.Value.Count == 0 && config.Settings.Projects.Count > 0)
-            {
-                var lastProject = config.Settings.Projects.Last();
-                projectName.Set(lastProject.Name);
-                selectedRepos.Set(lastProject.Repos.ToList());
-            }
-        }, [EffectTrigger.OnMount()]);
-
-        UseEffect(() =>
-        {
             var raw = projectName.Value ?? "";
             var sanitized = InputSanitizer.SanitizeProjectName(raw);
             if (sanitized != raw) projectName.Set(sanitized);
@@ -69,12 +59,13 @@ public class ProjectSetupStepView(
             ? (object)(Layout.Vertical().Gap(2)
                 | Text.Bold("Generate Verifications")
                 | Text.Muted("Automatically detect your project's tech stack and configure verification steps (build, test, lint, etc.) that run after each plan execution.")
-                | new Button("Generate Verifications").Primary().Large().Icon(Icons.Sparkles)
+                | new Button("Generate Verifications").Primary().Icon(Icons.Sparkles)
                     .OnClick(() => _ = GenerateVerificationsAsync(config, setupService, runner, reviewActions, error, isCloning, progressMessage, progressValue)))
             : null!;
 
         return Layout.Vertical().Gap(4).Margin(0, 0, 0, 20)
                | Text.H3("Setup your first project")
+               | Text.Muted("A project groups one or more repositories together so Tendril can plan and verify changes across them.")
                | (error.Value != null ? Text.Danger(error.Value) : null!)
                | new ProjectRepoPickerView(selectedRepos, projectName)
                | projectName.ToTextInput().WithField().Required().Label("Project Name")

--- a/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
@@ -22,21 +22,20 @@ public class TendrilHomeStepView(
             ".tendril");
 
         return Layout.Vertical().Gap(4).Margin(0, 0, 0, 20)
-               | Text.H3("This is where we store your data")
+               | Text.H3("Where should we store your data?")
                | Text.Muted(
-                   "Tendril keeps your config, plans, inbox, trash, hooks, promptwares, and a local " +
-                   "SQLite database in this folder. The default works for most people. Change it if " +
-                   "you want this data on a different drive, synced via Dropbox/iCloud, or shared " +
-                   "between machines.")
+                   """
+                   Tendril keeps your config and work in this folder.
+                   """)
                | (error.Value != null ? Text.Danger(error.Value) : null!)
                | tendrilHomePath.ToTextInput(defaultHome)
                    .WithField().Label("Tendril Home")
                | (Layout.Horizontal().Width(Size.Full())
-                  | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
+                  | new Button("Back").Outline().Icon(Icons.ArrowLeft)
                       .Disabled(isBootstrapping.Value)
                       .OnClick(() => stepperIndex.Set(stepperIndex.Value - 1))
                   | new Spacer()
-                  | new Button("Next").Primary().Large().Icon(Icons.ArrowRight, Align.Right)
+                  | new Button("Next").Primary().Icon(Icons.ArrowRight, Align.Right)
                       .Disabled(isBootstrapping.Value || string.IsNullOrWhiteSpace(tendrilHomePath.Value))
                       .Loading(isBootstrapping.Value)
                       .OnClick(async () =>

--- a/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Views/ProjectRepoPickerView.cs
@@ -75,21 +75,21 @@ public class ProjectRepoPickerView(
         if (isDesktop)
         {
             pickerControls = Layout.Horizontal().Gap(2).Width(Size.Full())
-                             | inputValue.ToTextInput("Repository URL or local path")
+                             | inputValue.ToTextInput("Repository URL or Local Path")
                                  .Width(Size.Grow())
                                  .OnSubmit(() => { _ = AddAsync(); })
                              | new Button("Browse").Icon(Icons.FolderOpen).Outline()
                                  .OnClick(() =>
                                  {
                                      var picked = desktop!.ShowSelectFolderDialog("Select repository folder");
-                                     if (picked != null && picked.Length > 0 && !string.IsNullOrEmpty(picked[0]))
+                                     if (picked is { Length: > 0 } && !string.IsNullOrEmpty(picked[0]))
                                          inputValue.Set(picked[0]);
                                  });
         }
         else
         {
             pickerControls = Layout.Horizontal().Gap(2).Width(Size.Full())
-                             | inputValue.ToTextInput("Repository URL or local path")
+                             | inputValue.ToTextInput("Repository URL or Local Path")
                                  .Width(Size.Grow())
                                  .OnSubmit(() => { _ = AddAsync(); });
         }


### PR DESCRIPTION
- Remove UseEffect that pre-filled project name/repos from last existing project
- Add muted explainer text under "Setup your first project" heading
- Normalize button sizes across all onboarding steps (remove .Large())
