### PR TITLE
[SearchInput]: Use default button size for Drafts filter chevron

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/SidebarView.cs
@@ -32,7 +32,6 @@ public class SidebarView(
                 new Button()
                     .Icon(filtersOpen.Value ? Icons.ChevronUp : Icons.ChevronDown)
                     .Ghost()
-                    .Small()
                     .OnClick(() => filtersOpen.Set(!filtersOpen.Value))
             );
 


### PR DESCRIPTION
## Summary

Remove `.Small()` from the ghost chevron button in the **Drafts** sidebar search field suffix. The filter toggle now uses the default button size so the icon and affix padding align better with nearby controls (e.g. select/dropdown triggers).

## Why

With `.Small()`, the chevron in `ToSearchInput().Suffix(...)` looked too small and the suffix cell padding felt off. Default sizing gives a more balanced appearance in the search bar.

## Changes

- `src/Ivy.Tendril/Apps/Plans/SidebarView.cs` — drop `.Small()` on the filter open/close `Button` (`ChevronUp` / `ChevronDown`).

## Before

<img width="313" height="255" alt="Знімок екрана 2026-05-19 о 20 29 22" src="https://github.com/user-attachments/assets/9beece37-41bd-4d8e-bb0b-4a6de52a08c0" />

## After 
<img width="545" height="348" alt="Знімок екрана 2026-05-19 о 20 25 52" src="https://github.com/user-attachments/assets/eae43007-6fa5-4681-b700-bddcf1ab1591" />
<img width="342" height="309" alt="Знімок екрана 2026-05-19 о 20 26 05" src="https://github.com/user-attachments/assets/f62ff3e6-6f25-458d-9a69-7018584a72fe" />
