### PR TITLE
Fix desktop window being too small on launch

### DIFF
--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -137,7 +137,7 @@ public class Program
             var window = new DesktopWindow(server)
                 .Title("Ivy Tendril")
                 .AppId("Ivy Tendril")
-                .Size(1400, 900)
+                .Size(1800, 1200)
                 .UseDpiScaling(false)
                 .Icon(typeof(Program), iconResource)
                 .OnReady(w =>


### PR DESCRIPTION
The default desktop window size (1400x900) was too small, making the UI feel cramped on modern displays. Increased to 1800x1200.


## Before
<img width="1728" height="1117" alt="Знімок екрана 2026-05-19 о 21 21 04" src="https://github.com/user-attachments/assets/e5f8dc3c-62e1-4d19-8ef4-0a3c2273d77e" />

## After
<img width="1728" height="1117" alt="Знімок екрана 2026-05-19 о 21 19 48" src="https://github.com/user-attachments/assets/34afd728-7170-453c-8298-3b2e6a825551" />
