### PR TITLE
polish the import issues for GitHub feature

### DIFF
--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -21,6 +21,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         var selectedAssignee = UseState<string?>(null);
         var selectedLabels = UseState(Array.Empty<string>());
         var fetchedIssues = UseState<List<GitHubIssue>?>(null);
+        var selectedIssueNumbers = UseState<HashSet<int>>([]);
         var errorMessage = UseState<string?>(null);
         var isFetching = UseState(false);
         var isImporting = UseState(false);
@@ -33,7 +34,6 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             $"assignees:{selectedRepo.Value ?? ""}",
             async (key, _) =>
             {
-                // Strip the "assignees:" prefix to get the actual repo name
                 var repoName = key.StartsWith("assignees:") ? key.Substring("assignees:".Length) : key;
 
                 if (string.IsNullOrEmpty(repoName))
@@ -60,7 +60,6 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             $"labels:{selectedRepo.Value ?? ""}",
             async (key, _) =>
             {
-                // Strip the "labels:" prefix to get the actual repo name
                 var repoName = key.StartsWith("labels:") ? key.Substring("labels:".Length) : key;
 
                 if (string.IsNullOrEmpty(repoName))
@@ -86,6 +85,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         UseEffect(() =>
         {
             fetchedIssues.Set(null);
+            selectedIssueNumbers.Set([]);
             errorMessage.Set(null);
             selectedAssignee.Set(null);
             selectedLabels.Set(Array.Empty<string>());
@@ -129,11 +129,11 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 _ => _dialogOpen.Set(false),
                 new DialogHeader("Import Issues from GitHub"),
                 new DialogBody(
-                    Layout.Vertical().Gap(3)
+                    Layout.Vertical().Gap(3).AlignContent(Align.Center)
                     | Text.Muted("Loading repositories...")
                     | new Loading()
                 )
-            ).Width(Size.Rem(36));
+            ).Width(Size.Rem(42));
         }
 
         if (reposError.Value is { } repoErr)
@@ -146,11 +146,40 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 },
                 new DialogHeader("Import Issues from GitHub"),
                 new DialogBody(Text.Danger(repoErr))
-            ).Width(Size.Rem(36));
+            ).Width(Size.Rem(42));
         }
 
         var repos = reposState.Value!;
         var repositoryOptions = repos.Select(r => r.DisplayName).ToArray();
+        var hasRepo = !string.IsNullOrEmpty(selectedRepo.Value);
+        var filtersLoading = hasRepo && (assigneesQuery.Loading || labelsQuery.Loading);
+
+        void ResetDialogState()
+        {
+            fetchedIssues.Set(null);
+            selectedIssueNumbers.Set([]);
+            errorMessage.Set(null);
+            searchQuery.Set("");
+            selectedAssignee.Set(null);
+            selectedLabels.Set(Array.Empty<string>());
+            selectedRepo.Set(null);
+        }
+
+        void SelectAllIssues()
+        {
+            if (fetchedIssues.Value is not { } issues) return;
+            selectedIssueNumbers.Set(issues.Select(i => i.Number).ToHashSet());
+        }
+
+        void SelectNoIssues() => selectedIssueNumbers.Set([]);
+
+        void ToggleIssueSelection(int issueNumber)
+        {
+            var next = new HashSet<int>(selectedIssueNumbers.Value);
+            if (!next.Remove(issueNumber))
+                next.Add(issueNumber);
+            selectedIssueNumbers.Set(next);
+        }
 
         async Task FetchIssues()
         {
@@ -160,6 +189,8 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
 
             isFetching.Set(true);
             errorMessage.Set(null);
+            fetchedIssues.Set(null);
+            selectedIssueNumbers.Set([]);
             try
             {
                 var labels = selectedLabels.Value.Length > 0 ? selectedLabels.Value : null;
@@ -177,6 +208,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 else
                 {
                     fetchedIssues.Set(issues);
+                    selectedIssueNumbers.Set(issues.Select(i => i.Number).ToHashSet());
                 }
             }
             catch (Exception ex)
@@ -190,12 +222,16 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             }
         }
 
-        async Task ImportAll()
+        async Task ImportSelected()
         {
             if (fetchedIssues.Value is not { Count: > 0 } issues) return;
+            if (selectedIssueNumbers.Value.Count == 0) return;
             if (selectedRepo.Value is not { } repoName) return;
             var repo = repos.FirstOrDefault(r => r.DisplayName == repoName);
             if (repo is null) return;
+
+            var issuesToImport = issues.Where(i => selectedIssueNumbers.Value.Contains(i.Number)).ToList();
+            if (issuesToImport.Count == 0) return;
 
             isImporting.Set(true);
             try
@@ -206,7 +242,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 var projectName = GetProjectForRepo(githubService, repo.Owner, repo.Name);
                 var importedCount = 0;
 
-                foreach (var issue in issues)
+                foreach (var issue in issuesToImport)
                 {
                     var safeName = SanitizeFileName(issue.Title);
                     var fileName = $"{issue.Number}-{safeName}.md";
@@ -228,6 +264,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 }
 
                 client.Toast($"Imported {importedCount} issue{(importedCount == 1 ? "" : "s")} to Inbox", "Import Complete");
+                ResetDialogState();
                 _dialogOpen.Set(false);
             }
             catch (Exception ex)
@@ -241,56 +278,64 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             }
         }
 
-        object? issuesList = null;
+        object? issuesPanel;
         if (isFetching.Value)
         {
-            issuesList = Text.Muted("Fetching issues...");
+            issuesPanel = Layout.Vertical().Gap(2).AlignContent(Align.Center)
+                .Height(Size.Rem(16)).Width(Size.Full())
+                | new Loading()
+                | Text.Muted("Fetching issues from GitHub...");
         }
         else if (fetchedIssues.Value is { } issues)
         {
             if (issues.Count == 0)
             {
-                issuesList = Text.Muted("No issues found matching the filters.");
+                issuesPanel = Layout.Vertical().AlignContent(Align.Center)
+                    .Height(Size.Rem(10)).Width(Size.Full())
+                    | Text.Muted("No issues found matching the filters.");
             }
             else
             {
                 var repo = repos.FirstOrDefault(r => r.DisplayName == selectedRepo.Value);
-                var issueRows = issues.Select(i => new
+                var selectedCount = selectedIssueNumbers.Value.Count;
+                var issueRows = issues.Select(issue =>
                 {
-                    Title = repo != null
-                        ? $"[#{i.Number} - {i.Title}](https://github.com/{repo.Owner}/{repo.Name}/issues/{i.Number})"
-                        : $"#{i.Number} - {i.Title}",
-                    Labels = string.Join(", ", i.Labels),
-                    Assignees = string.Join(", ", i.Assignees)
-                }).ToList();
+                    var issueUrl = repo != null
+                        ? $"https://github.com/{repo.Owner}/{repo.Name}/issues/{issue.Number}"
+                        : null;
+                    return new ImportIssueRowView(
+                        issue,
+                        selectedIssueNumbers,
+                        issueUrl,
+                        ToggleIssueSelection,
+                        () => { if (issueUrl != null) client.OpenUrl(issueUrl); });
+                }).Cast<object>().ToArray();
 
-                issuesList = Layout.Vertical().Gap(1)
-                    | Text.Label($"Found {issues.Count} issue{(issues.Count == 1 ? "" : "s")}")
-                    | issueRows.AsQueryable()
-                        .ToDataTable(i => i.Title)
-                        .Width(Size.Full())
-                        .Height(Size.Rem(20))
-                        .Header(i => i.Title, "Issue")
-                        .Header(i => i.Labels, "Labels")
-                        .Header(i => i.Assignees, "Assignees")
-                        .Width(i => i.Title, Size.Auto())
-                        .Width(i => i.Labels, Size.Px(200))
-                        .Width(i => i.Assignees, Size.Px(150))
-                        .Renderer(i => i.Title, new LinkDisplayRenderer())
-                        .Renderer(i => i.Labels, new TextDisplayRenderer())
-                        .Renderer(i => i.Assignees, new TextDisplayRenderer());
+                issuesPanel = Layout.Vertical().Gap(2)
+                    | Layout.Horizontal().Gap(2).AlignContent(Align.SpaceBetween).Width(Size.Full())
+                        | Text.Label($"Found {issues.Count} issue{(issues.Count == 1 ? "" : "s")} · {selectedCount} selected")
+                        | (Layout.Horizontal().Gap(1)
+                            | new Button("All").Ghost().Small().Disabled(selectedCount == issues.Count)
+                                .OnClick(SelectAllIssues)
+                            | new Button("None").Ghost().Small().Disabled(selectedCount == 0)
+                                .OnClick(SelectNoIssues))
+                    | (Layout.Vertical().Gap(2).Scroll(Scroll.Auto).Height(Size.Rem(22)).Width(Size.Full())
+                        | issueRows);
             }
         }
+        else
+        {
+            issuesPanel = Layout.Vertical().AlignContent(Align.Center)
+                .Height(Size.Rem(10)).Width(Size.Full())
+                | Text.Muted("Choose a repository, set filters, and click Fetch Issues.");
+        }
+
+        var selectedForImport = selectedIssueNumbers.Value.Count;
 
         return new Dialog(
             _ =>
             {
-                fetchedIssues.Set(null);
-                errorMessage.Set(null);
-                searchQuery.Set("");
-                selectedAssignee.Set(null);
-                selectedLabels.Set(Array.Empty<string>());
-                selectedRepo.Set(null);
+                ResetDialogState();
                 _dialogOpen.Set(false);
             },
             new DialogHeader("Import Issues from GitHub"),
@@ -298,11 +343,16 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 Layout.Vertical().Gap(3)
                 | selectedRepo.ToSelectInput(repositoryOptions.ToOptions())
                     .WithField().Label("Repository").Required()
-                | searchQuery.ToTextInput().Placeholder("Search").WithField().Label("Search")
+                | searchQuery.ToTextInput().Placeholder("Search titles and descriptions").WithField().Label("Search")
                 | selectedAssignee.ToSelectInput(assigneesQuery.Value.ToOptions())
-                    .Nullable().WithField().Label("Assignee")
+                    .Nullable()
+                    .Disabled(!hasRepo || filtersLoading)
+                    .Placeholder(filtersLoading ? "Loading assignees..." : "Any assignee")
+                    .WithField().Label("Assignee")
                 | selectedLabels.ToSelectInput(labelsQuery.Value.ToOptions())
-                    .Placeholder("Select labels...").WithField().Label("Labels")
+                    .Disabled(!hasRepo || filtersLoading)
+                    .Placeholder(filtersLoading ? "Loading labels..." : "Select labels...")
+                    .WithField().Label("Labels")
                 | (assigneesError.Value is { } assigneeErr
                     ? Text.Danger(assigneeErr).Small()
                     : null)
@@ -310,29 +360,28 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                     ? Text.Danger(labelErr).Small()
                     : null)
                 | new Button("Fetch Issues").Outline().Loading(isFetching.Value)
+                    .Disabled(!hasRepo || isFetching.Value)
                     .OnClick(async () => await FetchIssues())
                 | (errorMessage.Value is { } error
                     ? Text.Danger(error).Small()
                     : null)
-                | issuesList
+                | issuesPanel
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() =>
                 {
-                    fetchedIssues.Set(null);
-                    errorMessage.Set(null);
-                    searchQuery.Set("");
-                    selectedAssignee.Set(null);
-                    selectedLabels.Set(Array.Empty<string>());
-                    selectedRepo.Set(null);
+                    ResetDialogState();
                     _dialogOpen.Set(false);
                 }),
-                new Button("Import All").Primary()
+                new Button(selectedForImport > 0
+                        ? $"Import Selected ({selectedForImport})"
+                        : "Import Selected")
+                    .Primary()
                     .Loading(isImporting.Value)
-                    .Disabled(fetchedIssues.Value is not { Count: > 0 })
-                    .OnClick(async () => await ImportAll())
+                    .Disabled(selectedForImport == 0 || fetchedIssues.Value is not { Count: > 0 })
+                    .OnClick(async () => await ImportSelected())
             )
-        ).Width(Size.Rem(36));
+        ).Width(Size.Rem(42));
     }
 
     private string GetProjectForRepo(IGithubService githubService, string owner, string repo)
@@ -353,5 +402,56 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         sanitized = Regex.Replace(sanitized, @"\s+", "-");
         sanitized = sanitized.Trim('-').ToLowerInvariant();
         return sanitized.Length > 60 ? sanitized[..60].TrimEnd('-') : sanitized;
+    }
+
+    private static string TruncateBody(string? body, int maxLength = 500)
+    {
+        if (string.IsNullOrWhiteSpace(body)) return "";
+        var trimmed = body.Trim();
+        return trimmed.Length <= maxLength ? trimmed : trimmed[..maxLength] + "…";
+    }
+
+    private sealed class ImportIssueRowView(
+        GitHubIssue issue,
+        IState<HashSet<int>> selectedNumbers,
+        string? issueUrl,
+        Action<int> onToggle,
+        Action onOpenUrl) : ViewBase
+    {
+        public override object? Build()
+        {
+            var isSelected = selectedNumbers.Value.Contains(issue.Number);
+
+            object? labelsRow = null;
+            if (issue.Labels.Length > 0)
+            {
+                labelsRow = Layout.Horizontal().Gap(1).Wrap()
+                    | issue.Labels.Select(label => new Badge(label).Variant(BadgeVariant.Outline).Small())
+                        .Cast<object>().ToArray();
+            }
+
+            var metaParts = new List<string>();
+            if (issue.Assignees.Length > 0)
+                metaParts.Add(string.Join(", ", issue.Assignees));
+
+            var bodyContent = string.IsNullOrWhiteSpace(issue.Body)
+                ? Text.Muted("No description provided.")
+                : Text.Block(TruncateBody(issue.Body));
+
+            return Layout.Vertical().Gap(1).Width(Size.Full())
+                | Layout.Horizontal().Gap(2).AlignContent(Align.Center).Width(Size.Full())
+                    | new Button()
+                        .Icon(isSelected ? Icons.Check : Icons.Square)
+                        .Ghost().Small()
+                        .OnClick(() => onToggle(issue.Number))
+                    | Layout.Vertical().Gap(1).Grow()
+                        | new Expandable($"#{issue.Number} — {issue.Title}", bodyContent)
+                        | (metaParts.Count > 0 ? Text.Muted(string.Join(" · ", metaParts)).Small() : null)
+                        | labelsRow
+                    | (issueUrl != null
+                        ? new Button().Icon(Icons.ExternalLink).Ghost().Small().Tooltip("Open on GitHub")
+                            .OnClick(onOpenUrl)
+                        : null);
+        }
     }
 }

--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -306,6 +306,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                     return (object)new ImportIssueRowView(
                         issue,
                         selectedIssueNumbers,
+                        selectedAssignee.Value,
                         issueUrl,
                         ToggleIssueSelection,
                         () => { if (issueUrl != null) client.OpenUrl(issueUrl); });
@@ -411,9 +412,23 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         return trimmed.Length <= maxLength ? trimmed : trimmed[..maxLength] + "…";
     }
 
+    private static string[] GetIssueAssignees(GitHubIssue issue) =>
+        issue.Assignees.Where(a => !string.IsNullOrWhiteSpace(a)).ToArray();
+
+    private static bool ShouldShowAssignees(GitHubIssue issue, string? assigneeFilter)
+    {
+        var assignees = GetIssueAssignees(issue);
+        if (assignees.Length == 0) return false;
+        if (string.IsNullOrWhiteSpace(assigneeFilter)) return true;
+
+        return assignees.Length > 1
+            || !assignees[0].Equals(assigneeFilter, StringComparison.OrdinalIgnoreCase);
+    }
+
     private sealed class ImportIssueRowView(
         GitHubIssue issue,
         IState<HashSet<int>> selectedNumbers,
+        string? assigneeFilter,
         string? issueUrl,
         Action<int> onToggle,
         Action onOpenUrl) : ViewBase
@@ -422,19 +437,26 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         {
             var isSelected = selectedNumbers.Value.Contains(issue.Number);
 
-            object? labelsRow = null;
+            var bodyContent = Layout.Vertical().Gap(2);
+
+            bodyContent |= string.IsNullOrWhiteSpace(issue.Body)
+                ? Text.Muted("No description provided.")
+                : Text.Block(TruncateBody(issue.Body));
+
             if (issue.Labels.Length > 0)
             {
-                labelsRow = Layout.Horizontal().Gap(1).Wrap()
+                bodyContent |= Layout.Horizontal().Gap(2).AlignContent(Align.TopLeft).Wrap()
+                    | Text.Muted("Labels:")
                     | issue.Labels.Select(label => new Badge(label).Variant(BadgeVariant.Outline).Small())
                         .Cast<object>().ToArray();
             }
 
-            var bodyContent = Layout.Vertical().Gap(2)
-                | (string.IsNullOrWhiteSpace(issue.Body)
-                    ? Text.Muted("No description provided.")
-                    : Text.Block(TruncateBody(issue.Body)))
-                | labelsRow;
+            if (ShouldShowAssignees(issue, assigneeFilter))
+            {
+                bodyContent |= Layout.Horizontal().Gap(2).AlignContent(Align.TopLeft).Wrap()
+                    | Text.Muted("Assigned to:")
+                    | Text.Block(string.Join(", ", GetIssueAssignees(issue)));
+            }
 
             return Layout.Horizontal().Gap(2).AlignContent(Align.Center).Width(Size.Full())
                 | new Button()

--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -298,20 +298,20 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             {
                 var repo = repos.FirstOrDefault(r => r.DisplayName == selectedRepo.Value);
                 var selectedCount = selectedIssueNumbers.Value.Count;
-                var listItems = issues.Select(issue =>
+                var issueRows = issues.Select(issue =>
                 {
                     var issueUrl = repo != null
                         ? $"https://github.com/{repo.Owner}/{repo.Name}/issues/{issue.Number}"
                         : null;
-                    return new ListItem().Content(new ImportIssueRowView(
+                    return (object)new ImportIssueRowView(
                         issue,
                         selectedIssueNumbers,
                         issueUrl,
                         ToggleIssueSelection,
-                        () => { if (issueUrl != null) client.OpenUrl(issueUrl); }));
-                });
+                        () => { if (issueUrl != null) client.OpenUrl(issueUrl); });
+                }).ToArray();
 
-                issuesPanel = Layout.Vertical().Gap(2)
+                issuesPanel = Layout.Vertical().Gap(2).Width(Size.Full())
                     | Layout.Horizontal().Gap(2).AlignContent(Align.SpaceBetween).Width(Size.Full())
                         | Text.Label($"Found {issues.Count} issue{(issues.Count == 1 ? "" : "s")} · {selectedCount} selected")
                         | (Layout.Horizontal().Gap(1)
@@ -320,7 +320,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                             | new Button("None").Ghost().Small().Disabled(selectedCount == 0)
                                 .OnClick(SelectNoIssues))
                     | (Layout.Vertical().Scroll(Scroll.Auto).Height(Size.Rem(22)).Width(Size.Full())
-                        | new List(listItems));
+                        | new List(issueRows).Width(Size.Full()));
             }
         }
         else
@@ -440,11 +440,14 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 | new Button()
                     .Icon(isSelected ? Icons.Check : Icons.Square)
                     .Ghost().Small()
+                    .Width(Size.Shrink())
                     .OnClick(() => onToggle(issue.Number))
-                | Layout.Vertical().Width(Size.Grow().Min(Size.Px(0)))
-                    | new Expandable($"#{issue.Number} — {issue.Title}", bodyContent)
+                | new Expandable($"#{issue.Number} — {issue.Title}", bodyContent)
+                    .Width(Size.Grow().Min(Size.Px(0)))
                 | (issueUrl != null
-                    ? new Button().Icon(Icons.ExternalLink).Ghost().Small().Tooltip("Open on GitHub")
+                    ? new Button().Icon(Icons.ExternalLink).Ghost().Small()
+                        .Width(Size.Shrink())
+                        .Tooltip("Open on GitHub")
                         .OnClick(onOpenUrl)
                     : null);
         }

--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -7,6 +7,8 @@ namespace Ivy.Tendril.AppShell.Dialogs;
 
 public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) : ViewBase
 {
+    private sealed record FetchedIssueGroup(string? Assignee, IReadOnlyList<GitHubIssue> Issues);
+
     private readonly IConfigService _config = config;
     private readonly IState<bool> _dialogOpen = dialogOpen;
 
@@ -18,9 +20,9 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
 
         var selectedRepo = UseState<string?>(null);
         var searchQuery = UseState("");
-        var selectedAssignee = UseState<string?>(null);
+        var selectedAssignees = UseState(Array.Empty<string>());
         var selectedLabels = UseState(Array.Empty<string>());
-        var fetchedIssues = UseState<List<GitHubIssue>?>(null);
+        var fetchedIssueGroups = UseState<IReadOnlyList<FetchedIssueGroup>?>(null);
         var selectedIssueNumbers = UseState<HashSet<int>>([]);
         var errorMessage = UseState<string?>(null);
         var isFetching = UseState(false);
@@ -84,10 +86,10 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
 
         UseEffect(() =>
         {
-            fetchedIssues.Set(null);
+            fetchedIssueGroups.Set(null);
             selectedIssueNumbers.Set([]);
             errorMessage.Set(null);
-            selectedAssignee.Set(null);
+            selectedAssignees.Set(Array.Empty<string>());
             selectedLabels.Set(Array.Empty<string>());
             assigneesError.Set(null);
             labelsError.Set(null);
@@ -156,22 +158,30 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
 
         void ResetDialogState()
         {
-            fetchedIssues.Set(null);
+            fetchedIssueGroups.Set(null);
             selectedIssueNumbers.Set([]);
             errorMessage.Set(null);
             searchQuery.Set("");
-            selectedAssignee.Set(null);
+            selectedAssignees.Set(Array.Empty<string>());
             selectedLabels.Set(Array.Empty<string>());
             selectedRepo.Set(null);
         }
 
-        void SelectAllIssues()
+        void SelectAllInGroup(IReadOnlyList<GitHubIssue> issues)
         {
-            if (fetchedIssues.Value is not { } issues) return;
-            selectedIssueNumbers.Set(issues.Select(i => i.Number).ToHashSet());
+            var next = new HashSet<int>(selectedIssueNumbers.Value);
+            foreach (var issue in issues)
+                next.Add(issue.Number);
+            selectedIssueNumbers.Set(next);
         }
 
-        void SelectNoIssues() => selectedIssueNumbers.Set([]);
+        void SelectNoneInGroup(IReadOnlyList<GitHubIssue> issues)
+        {
+            var next = new HashSet<int>(selectedIssueNumbers.Value);
+            foreach (var issue in issues)
+                next.Remove(issue.Number);
+            selectedIssueNumbers.Set(next);
+        }
 
         void ToggleIssueSelection(int issueNumber)
         {
@@ -189,32 +199,56 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
 
             isFetching.Set(true);
             errorMessage.Set(null);
-            fetchedIssues.Set(null);
+            fetchedIssueGroups.Set(null);
             selectedIssueNumbers.Set([]);
             try
             {
                 var labels = selectedLabels.Value.Length > 0 ? selectedLabels.Value : null;
-                var (issues, error) = await githubService.SearchIssuesAsync(new IssueSearchRequest(
-                    repo.Owner, repo.Name,
-                    string.IsNullOrWhiteSpace(searchQuery.Value) ? null : searchQuery.Value,
-                    selectedAssignee.Value,
-                    labels));
+                var query = string.IsNullOrWhiteSpace(searchQuery.Value) ? null : searchQuery.Value;
+                var assigneeFilters = selectedAssignees.Value
+                    .Where(a => !string.IsNullOrWhiteSpace(a))
+                    .ToArray();
 
-                if (error is not null)
+                var groups = new List<FetchedIssueGroup>();
+                if (assigneeFilters.Length == 0)
                 {
-                    errorMessage.Set(error);
-                    fetchedIssues.Set(null);
+                    var (issues, error) = await githubService.SearchIssuesAsync(new IssueSearchRequest(
+                        repo.Owner, repo.Name, query, null, labels));
+                    if (error is not null)
+                    {
+                        errorMessage.Set(error);
+                        return;
+                    }
+
+                    groups.Add(new FetchedIssueGroup(null, issues));
                 }
                 else
                 {
-                    fetchedIssues.Set(issues);
-                    selectedIssueNumbers.Set(issues.Select(i => i.Number).ToHashSet());
+                    foreach (var assignee in assigneeFilters)
+                    {
+                        var (issues, error) = await githubService.SearchIssuesAsync(new IssueSearchRequest(
+                            repo.Owner, repo.Name, query, assignee, labels));
+                        if (error is not null)
+                        {
+                            errorMessage.Set(error);
+                            return;
+                        }
+
+                        groups.Add(new FetchedIssueGroup(assignee, issues));
+                    }
                 }
+
+                fetchedIssueGroups.Set(groups);
+                var allIssueNumbers = groups
+                    .SelectMany(g => g.Issues)
+                    .Select(i => i.Number)
+                    .ToHashSet();
+                selectedIssueNumbers.Set(allIssueNumbers);
             }
             catch (Exception ex)
             {
                 errorMessage.Set($"Failed to fetch issues: {ex.Message}");
-                fetchedIssues.Set(null);
+                fetchedIssueGroups.Set(null);
             }
             finally
             {
@@ -224,13 +258,18 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
 
         async Task ImportSelected()
         {
-            if (fetchedIssues.Value is not { Count: > 0 } issues) return;
+            if (fetchedIssueGroups.Value is not { Count: > 0 } groups) return;
+            var allIssues = groups.SelectMany(g => g.Issues).ToList();
+            if (allIssues.Count == 0) return;
             if (selectedIssueNumbers.Value.Count == 0) return;
             if (selectedRepo.Value is not { } repoName) return;
             var repo = repos.FirstOrDefault(r => r.DisplayName == repoName);
             if (repo is null) return;
 
-            var issuesToImport = issues.Where(i => selectedIssueNumbers.Value.Contains(i.Number)).ToList();
+            var issuesToImport = allIssues
+                .Where(i => selectedIssueNumbers.Value.Contains(i.Number))
+                .DistinctBy(i => i.Number)
+                .ToList();
             if (issuesToImport.Count == 0) return;
 
             isImporting.Set(true);
@@ -286,9 +325,9 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 | new Loading()
                 | Text.Muted("Fetching issues from GitHub...");
         }
-        else if (fetchedIssues.Value is { } issues)
+        else if (fetchedIssueGroups.Value is { } groups)
         {
-            if (issues.Count == 0)
+            if (groups.All(g => g.Issues.Count == 0))
             {
                 issuesPanel = Layout.Vertical().AlignContent(Align.Center)
                     .Height(Size.Rem(10)).Width(Size.Full())
@@ -297,31 +336,43 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             else
             {
                 var repo = repos.FirstOrDefault(r => r.DisplayName == selectedRepo.Value);
-                var selectedCount = selectedIssueNumbers.Value.Count;
-                var issueRows = issues.Select(issue =>
-                {
-                    var issueUrl = repo != null
-                        ? $"https://github.com/{repo.Owner}/{repo.Name}/issues/{issue.Number}"
-                        : null;
-                    return (object)new ImportIssueRowView(
-                        issue,
-                        selectedIssueNumbers,
-                        selectedAssignee.Value,
-                        issueUrl,
-                        ToggleIssueSelection,
-                        () => { if (issueUrl != null) client.OpenUrl(issueUrl); });
-                }).ToArray();
+                var scrollContent = Layout.Vertical().Gap(4).Width(Size.Full());
 
-                issuesPanel = Layout.Vertical().Gap(2).Width(Size.Full())
-                    | Layout.Horizontal().Gap(2).AlignContent(Align.SpaceBetween).Width(Size.Full())
-                        | Text.Label($"Found {issues.Count} issue{(issues.Count == 1 ? "" : "s")} · {selectedCount} selected")
-                        | (Layout.Horizontal().Gap(1)
-                            | new Button("All").Ghost().Small().Disabled(selectedCount == issues.Count)
-                                .OnClick(SelectAllIssues)
-                            | new Button("None").Ghost().Small().Disabled(selectedCount == 0)
-                                .OnClick(SelectNoIssues))
-                    | (Layout.Vertical().Scroll(Scroll.Auto).Height(Size.Rem(22)).Width(Size.Full())
-                        | new List(issueRows).Width(Size.Full()));
+                foreach (var group in groups)
+                {
+                    var groupIssues = group.Issues;
+                    var groupSelectedCount = groupIssues.Count(i => selectedIssueNumbers.Value.Contains(i.Number));
+                    var issueRows = groupIssues.Select(issue =>
+                    {
+                        var issueUrl = repo != null
+                            ? $"https://github.com/{repo.Owner}/{repo.Name}/issues/{issue.Number}"
+                            : null;
+                        return (object)new ImportIssueRowView(
+                            issue,
+                            selectedIssueNumbers,
+                            group.Assignee,
+                            issueUrl,
+                            ToggleIssueSelection,
+                            () => { if (issueUrl != null) client.OpenUrl(issueUrl); });
+                    }).ToArray();
+
+                    scrollContent |= Layout.Vertical().Gap(2).Width(Size.Full())
+                        | Layout.Horizontal().Gap(2).AlignContent(Align.SpaceBetween).Width(Size.Full())
+                            | Text.Label(FormatGroupHeader(group, groupSelectedCount))
+                            | (Layout.Horizontal().Gap(1)
+                                | new Button("All").Ghost().Small()
+                                    .Disabled(groupSelectedCount == groupIssues.Count || groupIssues.Count == 0)
+                                    .OnClick(() => SelectAllInGroup(groupIssues))
+                                | new Button("None").Ghost().Small()
+                                    .Disabled(groupSelectedCount == 0)
+                                    .OnClick(() => SelectNoneInGroup(groupIssues)))
+                        | (groupIssues.Count > 0
+                            ? new List(issueRows).Width(Size.Full())
+                            : Text.Muted("No issues for this assignee."));
+                }
+
+                issuesPanel = Layout.Vertical().Scroll(Scroll.Auto).Height(Size.Rem(22)).Width(Size.Full())
+                    | scrollContent;
             }
         }
         else
@@ -345,11 +396,10 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 | selectedRepo.ToSelectInput(repositoryOptions.ToOptions())
                     .WithField().Label("Repository").Required()
                 | searchQuery.ToTextInput().Placeholder("Search titles and descriptions").WithField().Label("Search")
-                | selectedAssignee.ToSelectInput(assigneesQuery.Value.ToOptions())
-                    .Nullable()
+                | selectedAssignees.ToSelectInput(assigneesQuery.Value.ToOptions())
                     .Disabled(!hasRepo || filtersLoading)
-                    .Placeholder(filtersLoading ? "Loading assignees..." : "Any assignee")
-                    .WithField().Label("Assignee")
+                    .Placeholder(filtersLoading ? "Loading assignees..." : "Select assignees...")
+                    .WithField().Label("Assignees")
                 | selectedLabels.ToSelectInput(labelsQuery.Value.ToOptions())
                     .Disabled(!hasRepo || filtersLoading)
                     .Placeholder(filtersLoading ? "Loading labels..." : "Select labels...")
@@ -379,7 +429,9 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                         : "Import Selected")
                     .Primary()
                     .Loading(isImporting.Value)
-                    .Disabled(selectedForImport == 0 || fetchedIssues.Value is not { Count: > 0 })
+                    .Disabled(selectedForImport == 0
+                        || fetchedIssueGroups.Value is null
+                        || !fetchedIssueGroups.Value.SelectMany(g => g.Issues).Any())
                     .OnClick(async () => await ImportSelected())
             )
         ).Width(Size.Rem(42));
@@ -410,6 +462,16 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         if (string.IsNullOrWhiteSpace(body)) return "";
         var trimmed = body.Trim();
         return trimmed.Length <= maxLength ? trimmed : trimmed[..maxLength] + "…";
+    }
+
+    private static string FormatGroupHeader(FetchedIssueGroup group, int selectedCount)
+    {
+        var count = group.Issues.Count;
+        var issueLabel = count == 1 ? "issue" : "issues";
+        if (group.Assignee is { } assignee)
+            return $"Found {count} {issueLabel} for {assignee} · {selectedCount} selected";
+
+        return $"Found {count} {issueLabel} · {selectedCount} selected";
     }
 
     private static string[] GetIssueAssignees(GitHubIssue issue) =>

--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -298,18 +298,18 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             {
                 var repo = repos.FirstOrDefault(r => r.DisplayName == selectedRepo.Value);
                 var selectedCount = selectedIssueNumbers.Value.Count;
-                var issueRows = issues.Select(issue =>
+                var listItems = issues.Select(issue =>
                 {
                     var issueUrl = repo != null
                         ? $"https://github.com/{repo.Owner}/{repo.Name}/issues/{issue.Number}"
                         : null;
-                    return new ImportIssueRowView(
+                    return new ListItem().Content(new ImportIssueRowView(
                         issue,
                         selectedIssueNumbers,
                         issueUrl,
                         ToggleIssueSelection,
-                        () => { if (issueUrl != null) client.OpenUrl(issueUrl); });
-                }).Cast<object>().ToArray();
+                        () => { if (issueUrl != null) client.OpenUrl(issueUrl); }));
+                });
 
                 issuesPanel = Layout.Vertical().Gap(2)
                     | Layout.Horizontal().Gap(2).AlignContent(Align.SpaceBetween).Width(Size.Full())
@@ -319,8 +319,8 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                                 .OnClick(SelectAllIssues)
                             | new Button("None").Ghost().Small().Disabled(selectedCount == 0)
                                 .OnClick(SelectNoIssues))
-                    | (Layout.Vertical().Gap(2).Scroll(Scroll.Auto).Height(Size.Rem(22)).Width(Size.Full())
-                        | issueRows);
+                    | (Layout.Vertical().Scroll(Scroll.Auto).Height(Size.Rem(22)).Width(Size.Full())
+                        | new List(listItems));
             }
         }
         else
@@ -430,28 +430,23 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                         .Cast<object>().ToArray();
             }
 
-            var metaParts = new List<string>();
-            if (issue.Assignees.Length > 0)
-                metaParts.Add(string.Join(", ", issue.Assignees));
+            var bodyContent = Layout.Vertical().Gap(2)
+                | (string.IsNullOrWhiteSpace(issue.Body)
+                    ? Text.Muted("No description provided.")
+                    : Text.Block(TruncateBody(issue.Body)))
+                | labelsRow;
 
-            var bodyContent = string.IsNullOrWhiteSpace(issue.Body)
-                ? Text.Muted("No description provided.")
-                : Text.Block(TruncateBody(issue.Body));
-
-            return Layout.Vertical().Gap(1).Width(Size.Full())
-                | Layout.Horizontal().Gap(2).AlignContent(Align.Center).Width(Size.Full())
-                    | new Button()
-                        .Icon(isSelected ? Icons.Check : Icons.Square)
-                        .Ghost().Small()
-                        .OnClick(() => onToggle(issue.Number))
-                    | Layout.Vertical().Gap(1).Grow()
-                        | new Expandable($"#{issue.Number} — {issue.Title}", bodyContent)
-                        | (metaParts.Count > 0 ? Text.Muted(string.Join(" · ", metaParts)).Small() : null)
-                        | labelsRow
-                    | (issueUrl != null
-                        ? new Button().Icon(Icons.ExternalLink).Ghost().Small().Tooltip("Open on GitHub")
-                            .OnClick(onOpenUrl)
-                        : null);
+            return Layout.Horizontal().Gap(2).AlignContent(Align.Center).Width(Size.Full())
+                | new Button()
+                    .Icon(isSelected ? Icons.Check : Icons.Square)
+                    .Ghost().Small()
+                    .OnClick(() => onToggle(issue.Number))
+                | Layout.Vertical().Width(Size.Grow().Min(Size.Px(0)))
+                    | new Expandable($"#{issue.Number} — {issue.Title}", bodyContent)
+                | (issueUrl != null
+                    ? new Button().Icon(Icons.ExternalLink).Ghost().Small().Tooltip("Open on GitHub")
+                        .OnClick(onOpenUrl)
+                    : null);
         }
     }
 }


### PR DESCRIPTION
1) used boolean checkbox input to make available not to import some of issues (imports all by default)
2) presented issue names with list with expandable
3) expandable contains issue description, labels and assigned to
4) labels are shown only if presented
5) assigned to line is shown only if assigned to someone else (if searched issues was mine, this line will be shown only if issue was assigned to me and someone else)
6) small link button at the right side so user could be addressed to source issue on git
7) made assignees select multiple, so it's now possible to search issues for many users. Lists are devided by string in structure (found * issues for * selected * issues, list with issues, found * issues for * selected * issues ....)

https://github.com/user-attachments/assets/57d61a3f-28e8-487a-b3fe-df9434c42ffb
