### PR TITLE
feat(settings): Align Add Project wizard in settings with onboarding

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -7,11 +7,14 @@ using Ivy.Widgets.AgentOutputView;
 namespace Ivy.Tendril.Apps.Onboarding;
 
 public class ProjectAgentStepView(
-    IState<int> projectSubStep,
     IState<List<RepoRef>> selectedRepos,
     IState<string> projectName,
     IState<bool> isStepLoading,
-    OnboardingVerificationSession session) : ViewBase
+    OnboardingVerificationSession session,
+    Action onBack,
+    Action onNext,
+    Action? onSkip = null,
+    bool skipAgent = false) : ViewBase
 {
     public override object Build()
     {
@@ -86,6 +89,13 @@ public class ProjectAgentStepView(
                 progressValue.Set(null);
                 progressMessage.Set(null);
 
+                if (skipAgent)
+                {
+                    isStepLoading.Set(false);
+                    onNext();
+                    return;
+                }
+
                 var notifyingStream = new NotifyingStream<string>(
                     session.Stream,
                     () => session.HasOutput.Set(true));
@@ -140,22 +150,16 @@ public class ProjectAgentStepView(
             }
         }, [EffectTrigger.OnMount()]);
 
-        void OnBack()
-        {
-            session.Reset();
-            isStepLoading.Set(false);
-            projectSubStep.Set(0);
-        }
-
         var running = session.Running.Value || isCloning.Value;
 
         var buttonArea = Layout.Horizontal().Width(Size.Full())
             | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
-                .OnClick(OnBack)
+                .OnClick(() => onBack())
             | new Spacer()
+            | (onSkip != null ? (object)new Button("Skip").Ghost().Large().OnClick(() => onSkip()) : new Spacer())
             | new Button("Next").Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
                 .Disabled(running)
-                .OnClick(() => projectSubStep.Set(2));
+                .OnClick(() => onNext());
 
         var awaitingOutput = !isCloning.Value && session.Running.Value && !session.HasOutput.Value;
 
@@ -176,17 +180,17 @@ public class ProjectAgentStepView(
                    : null!)
                | (session.HasOutput.Value
                    ? (object)new Box(
-                       new AgentOutputView()
-                           .Provider("claude")
-                           .Stream(session.Stream)
-                           .AutoScroll(true)
-                           .ShowStatusLabel(true)
-                           .Width(Size.Full())
-                           .Height(Size.Full())
-                     )
-                       .Width(Size.Full())
-                       .Height(Size.Units(100).Max(Size.Fraction(0.6f)))
-                       .Padding(4)
+                        new AgentOutputView()
+                            .Provider("claude")
+                            .Stream(session.Stream)
+                            .AutoScroll(true)
+                            .ShowStatusLabel(true)
+                            .Width(Size.Full())
+                            .Height(Size.Full())
+                      )
+                        .Width(Size.Full())
+                        .Height(Size.Units(100).Max(Size.Fraction(0.6f)))
+                        .Padding(4)
                    : null!)
                | buttonArea;
     }

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
@@ -5,11 +5,12 @@ using Ivy.Tendril.Services;
 namespace Ivy.Tendril.Apps.Onboarding;
 
 public class ProjectCrudStepView(
-    IState<int> stepperIndex,
-    IState<int> projectSubStep,
     IState<string> projectName,
     IState<bool> isStepLoading,
-    OnboardingVerificationSession session) : ViewBase
+    OnboardingVerificationSession session,
+    Action onBack,
+    Action onNext,
+    string nextButtonText = "Next") : ViewBase
 {
     public override object Build()
     {
@@ -85,10 +86,10 @@ public class ProjectCrudStepView(
 
         var buttonArea = Layout.Horizontal().Width(Size.Full())
             | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
-                .OnClick(() => projectSubStep.Set(0))
+                .OnClick(() => onBack())
             | new Spacer()
-            | new Button("Next").Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
-                .OnClick(() => stepperIndex.Set(3));
+            | new Button(nextButtonText).Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
+                .OnClick(() => onNext());
 
         return Layout.Vertical().Gap(4).Margin(0, 0, 0, 20)
                | Text.H3("Review Configuration")

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -5,14 +5,18 @@ using Ivy.Tendril.Views;
 namespace Ivy.Tendril.Apps.Onboarding;
 
 public class ProjectInputStepView(
-    IState<int> stepperIndex,
-    IState<int> projectSubStep,
     IState<List<RepoRef>> selectedRepos,
     IState<string> projectName,
-    IState<bool> isStepLoading) : ViewBase
+    IState<bool> isStepLoading,
+    Action onBack,
+    Action onNext,
+    Action? onSkip = null,
+    string skipButtonText = "Skip") : ViewBase
 {
     public override object Build()
     {
+        var config = UseService<IConfigService>();
+
         UseEffect(() =>
         {
             var raw = projectName.Value ?? "";
@@ -20,24 +24,28 @@ public class ProjectInputStepView(
             if (sanitized != raw) projectName.Set(sanitized);
         }, projectName);
 
+        var nameExists = !string.IsNullOrWhiteSpace(projectName.Value) &&
+                         config.Settings.Projects.Any(p => p.Name.Equals(projectName.Value.Trim(), StringComparison.OrdinalIgnoreCase));
+
         var canContinue = selectedRepos.Value.Count > 0
-                          && !string.IsNullOrWhiteSpace(projectName.Value);
+                          && !string.IsNullOrWhiteSpace(projectName.Value)
+                          && !nameExists;
 
         var buttonArea = Layout.Horizontal().Width(Size.Full())
             | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
-                .OnClick(() => stepperIndex.Set(stepperIndex.Value - 1))
+                .OnClick(() => onBack())
             | new Spacer()
-            | new Button("Skip").Ghost().Large()
-                .OnClick(() => stepperIndex.Set(3))
+            | (onSkip != null ? (object)new Button(skipButtonText).Ghost().Large().OnClick(() => onSkip()) : new Spacer())
             | new Button("Create Project").Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
                 .Disabled(!canContinue)
-                .OnClick(() => projectSubStep.Set(1));
+                .OnClick(() => onNext());
 
         return Layout.Vertical().Gap(4).Margin(0, 0, 0, 20)
                | Text.H3("Setup your first project")
                | Text.Muted("A project groups one or more repositories together so Tendril can plan and verify changes across them.")
                | new ProjectRepoPickerView(selectedRepos, projectName)
                | projectName.ToTextInput().WithField().Required().Label("Project Name")
+               | (nameExists ? Text.Danger("A project with this name already exists.") : null!)
                | new Spacer()
                | buttonArea;
     }

--- a/src/Ivy.Tendril/Apps/OnboardingApp.cs
+++ b/src/Ivy.Tendril/Apps/OnboardingApp.cs
@@ -40,9 +40,31 @@ public class OnboardingApp : ViewBase
             1 => new TendrilHomeStepView(stepperIndex, tendrilHomePath, homeBootstrapped, isStepLoading),
             2 => projectSubStep.Value switch
             {
-                0 => new ProjectInputStepView(stepperIndex, projectSubStep, selectedRepos, projectName, isStepLoading),
-                1 => new ProjectAgentStepView(projectSubStep, selectedRepos, projectName, isStepLoading, session),
-                2 => new ProjectCrudStepView(stepperIndex, projectSubStep, projectName, isStepLoading, session),
+                0 => new ProjectInputStepView(
+                    selectedRepos,
+                    projectName,
+                    isStepLoading,
+                    onBack: () => stepperIndex.Set(stepperIndex.Value - 1),
+                    onNext: () => projectSubStep.Set(1),
+                    onSkip: () => stepperIndex.Set(3)),
+                1 => new ProjectAgentStepView(
+                    selectedRepos,
+                    projectName,
+                    isStepLoading,
+                    session,
+                    onBack: () =>
+                    {
+                        session.Reset();
+                        isStepLoading.Set(false);
+                        projectSubStep.Set(0);
+                    },
+                    onNext: () => projectSubStep.Set(2)),
+                2 => new ProjectCrudStepView(
+                    projectName,
+                    isStepLoading,
+                    session,
+                    onBack: () => projectSubStep.Set(0),
+                    onNext: () => stepperIndex.Set(3)),
                 _ => throw new ArgumentOutOfRangeException()
             },
             3 => new CompleteStepView(stepperIndex, projectSubStep, isStepLoading),

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
@@ -1,0 +1,146 @@
+using Ivy.Core.Hooks;
+using Ivy.Tendril.Apps.Onboarding;
+using Ivy.Tendril.Apps.Onboarding.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Views;
+
+namespace Ivy.Tendril.Apps.Setup.Dialogs;
+
+public class AddProjectDialog(
+    IState<bool> isOpen,
+    IConfigService config,
+    IClientProvider client,
+    RefreshToken refreshToken) : ViewBase
+{
+    public override object? Build()
+    {
+        var step = UseState(0);
+        var editName = UseState("");
+        var editRepos = UseState(new List<RepoRef>());
+        var isStepLoading = UseState(false);
+
+        // State for step 2 (agent run)
+        var verificationStream = UseStream<string>();
+        var verificationHandle = UseState<PromptwareRunHandle?>();
+        var verificationHasOutput = UseState(false);
+        var verificationRunning = UseState(false);
+        var verificationStarted = UseState(false);
+        var verificationCancelled = UseState(false);
+        var verificationError = UseState<string?>();
+        var verificationRefreshToken = UseState(0);
+        var hasCreated = UseState(false);
+        var skipAgent = UseState(false);
+
+        var session = new OnboardingVerificationSession(
+            verificationStream,
+            verificationHandle,
+            verificationHasOutput,
+            verificationRunning,
+            verificationStarted,
+            verificationCancelled,
+            verificationError,
+            verificationRefreshToken);
+
+        UseEffect(() =>
+        {
+            if (step.Value >= 1)
+            {
+                hasCreated.Set(true);
+            }
+        }, step);
+
+        if (!isOpen.Value) return null;
+
+        void CancelAndClose()
+        {
+            session.Reset();
+
+            if (hasCreated.Value && !string.IsNullOrWhiteSpace(editName.Value))
+            {
+                var project = config.Settings.Projects.FirstOrDefault(p => p.Name.Equals(editName.Value, StringComparison.OrdinalIgnoreCase));
+                if (project != null)
+                {
+                    config.Settings.Projects.Remove(project);
+                    try
+                    {
+                        config.SaveSettings();
+                    }
+                    catch { }
+                }
+            }
+
+            isOpen.Set(false);
+            refreshToken.Refresh();
+        }
+
+        // Stepper steps
+        var steps = new StepperItem[]
+        {
+            new("1", step.Value > 0 ? Icons.Check : null, "Details"),
+            new("2", step.Value > 1 ? Icons.Check : null, "Analyze"),
+            new("3", step.Value > 2 ? Icons.Check : null, "Configure")
+        };
+
+        var stepper = new Stepper((_) => ValueTask.CompletedTask, step.Value, steps).Width(Size.Full()).Disabled(true);
+
+        object activeView = step.Value switch
+        {
+            0 => new ProjectInputStepView(
+                editRepos,
+                editName,
+                isStepLoading,
+                onBack: CancelAndClose,
+                onNext: () => {
+                    skipAgent.Set(false);
+                    step.Set(1);
+                },
+                onSkip: () => {
+                    skipAgent.Set(true);
+                    step.Set(1);
+                },
+                skipButtonText: "Skip AI Setup"),
+            1 => new ProjectAgentStepView(
+                editRepos,
+                editName,
+                isStepLoading,
+                session,
+                onBack: () => {
+                    session.Reset();
+                    isStepLoading.Set(false);
+                    step.Set(0);
+                },
+                onNext: () => {
+                    step.Set(2);
+                },
+                onSkip: null,
+                skipAgent: skipAgent.Value),
+            2 => new ProjectCrudStepView(
+                editName,
+                isStepLoading,
+                session,
+                onBack: () => {
+                    step.Set(0);
+                    session.Reset();
+                },
+                onNext: () => {
+                    hasCreated.Set(false); // Clear so we don't delete on close
+                    isOpen.Set(false);
+                    refreshToken.Refresh();
+                    client.Toast($"Project '{editName.Value}' added successfully", "Success");
+                },
+                nextButtonText: "Finish"),
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        var dialogBody = Layout.Vertical().Gap(4)
+            | stepper
+            | new Separator()
+            | activeView;
+
+        return new Dialog(
+            _ => CancelAndClose(),
+            new DialogHeader("Add Project"),
+            new DialogBody(dialogBody)
+        ).Width(Size.Rem(40));
+    }
+}

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -72,7 +72,7 @@ public class EditProjectDialog(
             }
         }, _editIndex);
 
-        if (_editIndex.Value == -1) return null;
+        if (_editIndex.Value == null || _editIndex.Value == -1) return null;
 
         var isNew = _editIndex.Value == null;
 

--- a/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
@@ -12,6 +12,7 @@ public class ProjectsSetupView : ViewBase
         var client = UseService<IClientProvider>();
         var refreshToken = UseRefreshToken();
         var editIndex = UseState<int?>(-1);
+        var isAddOpen = UseState(false);
         var (alertView, showAlert) = UseAlert();
 
         var projects = config.Settings.Projects;
@@ -74,9 +75,10 @@ public class ProjectsSetupView : ViewBase
                | table
                | new Button("Add Project").Icon(Icons.Plus).Outline().OnClick(() =>
                {
-                   editIndex.Set(null);
+                   isAddOpen.Set(true);
                })
                | new EditProjectDialog(editIndex, projects, allVerifications, config, client, refreshToken)
+               | new AddProjectDialog(isAddOpen, config, client, refreshToken)
                | alertView;
     }
 


### PR DESCRIPTION
Refactored the onboarding step views to be reusable components and implemented a new wizard-style 'Add Project' modal in Settings. Added support for skipping the AI stack detection agent step directly from Screen 1.