### PR TITLE
feat(project): add move-verification CLI command and ordering instructions

### DIFF
--- a/src/Ivy.Tendril.Test/ProjectCommandTests.cs
+++ b/src/Ivy.Tendril.Test/ProjectCommandTests.cs
@@ -221,6 +221,154 @@ verifications: []
         Assert.Equal("Keep", reloaded.Settings.Projects[0].Verifications[0].Name);
     }
 
+    // --- Move Verification ---
+
+    [Fact]
+    public void MoveVerification_After_InsertsCorrectly()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Test",
+            Verifications = [
+                new ProjectVerificationRef { Name = "Lint" },
+                new ProjectVerificationRef { Name = "Build" },
+                new ProjectVerificationRef { Name = "Test" },
+                new ProjectVerificationRef { Name = "CheckResult" }
+            ]
+        });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        var project = config2.Settings.Projects[0];
+        var item = project.Verifications.First(v => v.Name == "CheckResult");
+        project.Verifications.Remove(item);
+        var afterIndex = project.Verifications.FindIndex(v => v.Name == "Lint");
+        project.Verifications.Insert(afterIndex + 1, item);
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal("Lint", reloaded.Settings.Projects[0].Verifications[0].Name);
+        Assert.Equal("CheckResult", reloaded.Settings.Projects[0].Verifications[1].Name);
+        Assert.Equal("Build", reloaded.Settings.Projects[0].Verifications[2].Name);
+        Assert.Equal("Test", reloaded.Settings.Projects[0].Verifications[3].Name);
+    }
+
+    [Fact]
+    public void MoveVerification_Before_InsertsCorrectly()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Test",
+            Verifications = [
+                new ProjectVerificationRef { Name = "Lint" },
+                new ProjectVerificationRef { Name = "Build" },
+                new ProjectVerificationRef { Name = "Test" },
+                new ProjectVerificationRef { Name = "CheckResult" }
+            ]
+        });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        var project = config2.Settings.Projects[0];
+        var item = project.Verifications.First(v => v.Name == "CheckResult");
+        project.Verifications.Remove(item);
+        var beforeIndex = project.Verifications.FindIndex(v => v.Name == "Build");
+        project.Verifications.Insert(beforeIndex, item);
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal("Lint", reloaded.Settings.Projects[0].Verifications[0].Name);
+        Assert.Equal("CheckResult", reloaded.Settings.Projects[0].Verifications[1].Name);
+        Assert.Equal("Build", reloaded.Settings.Projects[0].Verifications[2].Name);
+        Assert.Equal("Test", reloaded.Settings.Projects[0].Verifications[3].Name);
+    }
+
+    [Fact]
+    public void MoveVerification_Position_InsertsCorrectly()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Test",
+            Verifications = [
+                new ProjectVerificationRef { Name = "A" },
+                new ProjectVerificationRef { Name = "B" },
+                new ProjectVerificationRef { Name = "C" }
+            ]
+        });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        var project = config2.Settings.Projects[0];
+        var item = project.Verifications.First(v => v.Name == "C");
+        project.Verifications.Remove(item);
+        project.Verifications.Insert(0, item);
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal("C", reloaded.Settings.Projects[0].Verifications[0].Name);
+        Assert.Equal("A", reloaded.Settings.Projects[0].Verifications[1].Name);
+        Assert.Equal("B", reloaded.Settings.Projects[0].Verifications[2].Name);
+    }
+
+    [Fact]
+    public void MoveVerification_PositionClamped_ClampsToEnd()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Test",
+            Verifications = [
+                new ProjectVerificationRef { Name = "A" },
+                new ProjectVerificationRef { Name = "B" },
+                new ProjectVerificationRef { Name = "C" }
+            ]
+        });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        var project = config2.Settings.Projects[0];
+        var item = project.Verifications.First(v => v.Name == "A");
+        project.Verifications.Remove(item);
+        var clampedPos = Math.Clamp(999, 0, project.Verifications.Count);
+        project.Verifications.Insert(clampedPos, item);
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal("B", reloaded.Settings.Projects[0].Verifications[0].Name);
+        Assert.Equal("C", reloaded.Settings.Projects[0].Verifications[1].Name);
+        Assert.Equal("A", reloaded.Settings.Projects[0].Verifications[2].Name);
+    }
+
+    [Fact]
+    public void AddVerification_WithAfter_InsertsAtCorrectPosition()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Test",
+            Verifications = [
+                new ProjectVerificationRef { Name = "Lint" },
+                new ProjectVerificationRef { Name = "CheckResult" }
+            ]
+        });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        var project = config2.Settings.Projects[0];
+        var afterIndex = project.Verifications.FindIndex(v => v.Name == "Lint");
+        project.Verifications.Insert(afterIndex + 1, new ProjectVerificationRef { Name = "Build", Required = true });
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal(3, reloaded.Settings.Projects[0].Verifications.Count);
+        Assert.Equal("Lint", reloaded.Settings.Projects[0].Verifications[0].Name);
+        Assert.Equal("Build", reloaded.Settings.Projects[0].Verifications[1].Name);
+        Assert.Equal("CheckResult", reloaded.Settings.Projects[0].Verifications[2].Name);
+    }
+
     // --- Add/Remove Build Dependency ---
 
     [Fact]

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -154,12 +154,12 @@ public class ProjectAgentStepView(
 
         var buttonArea = Layout.Horizontal().Width(Size.Full())
             | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
-                .OnClick(() => onBack())
+                .OnClick(onBack)
             | new Spacer()
-            | (onSkip != null ? (object)new Button("Skip").Ghost().Large().OnClick(() => onSkip()) : new Spacer())
+            | (onSkip != null ? (object)new Button("Skip").Ghost().Large().OnClick(onSkip) : new Spacer())
             | new Button("Next").Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
                 .Disabled(running)
-                .OnClick(() => onNext());
+                .OnClick(onNext);
 
         var awaitingOutput = !isCloning.Value && session.Running.Value && !session.HasOutput.Value;
 

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -11,7 +11,7 @@ public class ProjectInputStepView(
     Action onBack,
     Action onNext,
     Action? onSkip = null,
-    string skipButtonText = "Skip") : ViewBase
+    string skipButtonText = "Skip Setup") : ViewBase
 {
     public override object Build()
     {
@@ -33,12 +33,12 @@ public class ProjectInputStepView(
 
         var buttonArea = Layout.Horizontal().Width(Size.Full())
             | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
-                .OnClick(() => onBack())
+                .OnClick(onBack)
             | new Spacer()
             | (onSkip != null ? (object)new Button(skipButtonText).Ghost().Large().OnClick(() => onSkip()) : new Spacer())
             | new Button("Create Project").Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
                 .Disabled(!canContinue)
-                .OnClick(() => onNext());
+                .OnClick(onNext);
 
         return Layout.Vertical().Gap(4).Margin(0, 0, 0, 20)
                | Text.H3("Setup your first project")

--- a/src/Ivy.Tendril/Commands/ProjectCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectCommand.cs
@@ -101,6 +101,10 @@ public class ProjectAddVerificationSettings : CommandSettings
     [CommandOption("--required")]
     [Description("Whether the verification is required")]
     public bool Required { get; set; }
+
+    [CommandOption("--after")]
+    [Description("Place after this verification (default: append to end)")]
+    public string? After { get; set; }
 }
 
 public class ProjectRemoveVerificationSettings : CommandSettings
@@ -112,6 +116,29 @@ public class ProjectRemoveVerificationSettings : CommandSettings
     [Description("Verification name")]
     [CommandArgument(1, "<verification-name>")]
     public string VerificationName { get; set; } = "";
+}
+
+public class ProjectMoveVerificationSettings : CommandSettings
+{
+    [Description("Project name")]
+    [CommandArgument(0, "<project-name>")]
+    public string ProjectName { get; set; } = "";
+
+    [Description("Verification name to move")]
+    [CommandArgument(1, "<verification-name>")]
+    public string VerificationName { get; set; } = "";
+
+    [CommandOption("--before")]
+    [Description("Place before this verification")]
+    public string? Before { get; set; }
+
+    [CommandOption("--after")]
+    [Description("Place after this verification")]
+    public string? After { get; set; }
+
+    [CommandOption("--position")]
+    [Description("Place at this zero-based index position")]
+    public int? Position { get; set; }
 }
 
 public class ProjectAddBuildDepSettings : CommandSettings
@@ -527,11 +554,27 @@ public class ProjectAddVerificationCommand : Command<ProjectAddVerificationSetti
                 return 1;
             }
 
-            project.Verifications.Add(new ProjectVerificationRef
+            var newRef = new ProjectVerificationRef
             {
                 Name = settings.VerificationName,
                 Required = settings.Required
-            });
+            };
+
+            if (!string.IsNullOrEmpty(settings.After))
+            {
+                var afterIndex = project.Verifications
+                    .FindIndex(v => v.Name.Equals(settings.After, StringComparison.OrdinalIgnoreCase));
+                if (afterIndex < 0)
+                {
+                    _logger.LogError("Verification not found for --after: {Name}", settings.After);
+                    return 1;
+                }
+                project.Verifications.Insert(afterIndex + 1, newRef);
+            }
+            else
+            {
+                project.Verifications.Add(newRef);
+            }
 
             config.SaveSettings();
             _logger.LogInformation("Added verification: {Name}", settings.VerificationName);
@@ -582,6 +625,87 @@ public class ProjectRemoveVerificationCommand : Command<ProjectRemoveVerificatio
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to remove verification from project");
+            return 1;
+        }
+    }
+}
+
+public class ProjectMoveVerificationCommand : Command<ProjectMoveVerificationSettings>
+{
+    private readonly ILogger<ProjectMoveVerificationCommand> _logger;
+
+    public ProjectMoveVerificationCommand(ILogger<ProjectMoveVerificationCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, ProjectMoveVerificationSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var optionCount = (settings.Before != null ? 1 : 0) + (settings.After != null ? 1 : 0) + (settings.Position != null ? 1 : 0);
+            if (optionCount != 1)
+            {
+                _logger.LogError("Specify exactly one of --before, --after, or --position");
+                return 1;
+            }
+
+            var config = new ConfigService();
+            var project = config.Settings.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+            {
+                _logger.LogError("Project not found: {Name}", settings.ProjectName);
+                return 1;
+            }
+
+            var item = project.Verifications
+                .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
+
+            if (item == null)
+            {
+                _logger.LogError("Verification not found in project: {Name}", settings.VerificationName);
+                return 1;
+            }
+
+            project.Verifications.Remove(item);
+
+            int insertIndex;
+            if (settings.Before != null)
+            {
+                var targetIndex = project.Verifications
+                    .FindIndex(v => v.Name.Equals(settings.Before, StringComparison.OrdinalIgnoreCase));
+                if (targetIndex < 0)
+                {
+                    project.Verifications.Add(item);
+                    _logger.LogError("Target verification not found for --before: {Name}", settings.Before);
+                    return 1;
+                }
+                insertIndex = targetIndex;
+            }
+            else if (settings.After != null)
+            {
+                var targetIndex = project.Verifications
+                    .FindIndex(v => v.Name.Equals(settings.After, StringComparison.OrdinalIgnoreCase));
+                if (targetIndex < 0)
+                {
+                    project.Verifications.Add(item);
+                    _logger.LogError("Target verification not found for --after: {Name}", settings.After);
+                    return 1;
+                }
+                insertIndex = targetIndex + 1;
+            }
+            else
+            {
+                insertIndex = Math.Clamp(settings.Position!.Value, 0, project.Verifications.Count);
+            }
+
+            project.Verifications.Insert(insertIndex, item);
+            config.SaveSettings();
+            _logger.LogInformation("Moved verification '{Name}' to position {Position}", settings.VerificationName, insertIndex);
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to move verification in project");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -432,6 +432,8 @@ public class Program
                     .WithDescription("Add a verification to a project");
                 project.AddCommand<ProjectRemoveVerificationCommand>("remove-verification")
                     .WithDescription("Remove a verification from a project");
+                project.AddCommand<ProjectMoveVerificationCommand>("move-verification")
+                    .WithDescription("Move a verification to a different position in the list");
                 project.AddCommand<ProjectAddBuildDepCommand>("add-build-dep")
                     .WithDescription("Add a build dependency to a project");
                 project.AddCommand<ProjectRemoveBuildDepCommand>("remove-build-dep")

--- a/src/Ivy.Tendril/Promptwares/UpdateProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdateProject/Program.md
@@ -30,8 +30,11 @@ tendril verification set <name> <field> <value>
 
 ### Project verifications (references)
 ```bash
-tendril project add-verification <project-name> <verification-name> --required
+tendril project add-verification <project-name> <verification-name> --required [--after <other>]
 tendril project remove-verification <project-name> <verification-name>
+tendril project move-verification <project-name> <verification-name> --after <other>
+tendril project move-verification <project-name> <verification-name> --before <other>
+tendril project move-verification <project-name> <verification-name> --position <n>
 ```
 
 ### Review actions
@@ -86,6 +89,27 @@ For each verification:
 Always add `CheckResult` as a verification (it exists in the default config):
 ```bash
 tendril project add-verification <project-name> CheckResult --required
+```
+
+### 2.5. Ensure Correct Verification Order
+
+Verifications run top-to-bottom during plan execution. The correct order is:
+
+1. **Linting/Formatting** — e.g. `DotnetFormat`, `NpmLint`, `RustClippy`, `GoFmt`, `FrameworkFrontendLint`, `VitePlusCheck`
+2. **Build** — e.g. `DotnetBuild`, `FrameworkDotnetBuild`, `NpmBuild`, `RustBuild`, `GoBuild`
+3. **Tests** — e.g. `DotnetTest`, `NpmTest`, `RustTest`, `GoTest`
+4. **CheckResult** — always last
+
+After adding all verifications, verify ordering with `tendril project get <project-name>` and fix with:
+```bash
+tendril project move-verification <project-name> <name> --after <other>
+```
+
+Use `--after` when adding verifications to place them correctly from the start:
+```bash
+tendril project add-verification <project-name> DotnetBuild --required --after DotnetFormat
+tendril project add-verification <project-name> DotnetTest --required --after DotnetBuild
+tendril project add-verification <project-name> CheckResult --required --after DotnetTest
 ```
 
 ### 3. Setup Review Actions


### PR DESCRIPTION
## Summary

- Add `tendril project move-verification` CLI command with `--before`, `--after`, and `--position` options
- Enhance `tendril project add-verification` with `--after` option for ordered insertion
- Add section 2.5 to UpdateProject promptware documenting correct verification order: linting → build → tests → CheckResult
- UI polish: method group conversions in onboarding views, skip button text update

## Test plan

- [x] `dotnet build --warnaserror` passes
- [x] `dotnet test --filter ProjectCommandTests` — all 17 tests pass (5 new)
- [x] Full test suite: 1459 pass, 1 pre-existing unrelated failure