### PR TITLE
[action-bar]: responsive action bar for Drafts, Review, and Recommendations

### DIFF
--- a/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
@@ -32,7 +32,7 @@ public class ActionBarView(
 
         if (isEditingState.Value)
         {
-            return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Scroll(Scroll.Horizontal)
+            return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                 | ActionBarResponsive.WideAndDesktopCompact(new Button("Save Revision").Icon(Icons.Save).Primary().ShortcutKey("S").OnClick(() =>
                 {
                     if (editContentState.Value != originalContentState.Value)
@@ -51,7 +51,7 @@ public class ActionBarView(
                 }));
         }
 
-        return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Scroll(Scroll.Horizontal)
+        return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                | ActionBarResponsive.WideAndDesktopCompact(new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
                    .OnClick(() => isEditingState.Set(true)))
                | ActionBarResponsive.AtWide(new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")

--- a/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
@@ -1,4 +1,3 @@
-using Ivy;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
@@ -27,42 +26,14 @@ public class ActionBarView(
     Action goToPrevious,
     string downloadUrl) : ViewBase
 {
-    // >= 1024 (Wide): all buttons. 768–1023 (Desktop): Edit, Delete, Prev, Next + …. < 768: Prev, Next + …
-    // Ivy renders <kbd> only when Title is set; nbsp hides the label on the Desktop tier.
-    private const string HiddenTitle = "\u00A0";
-
-    private static readonly Responsive<bool?> VisibleAtWide = new() { Default = false, Desktop = false, Wide = true };
-    private static readonly Responsive<bool?> DesktopOnly = new() { Default = false, Desktop = true, Wide = false };
-    private static readonly Responsive<bool?> BelowTablet = new() { Default = true, Desktop = false };
-
-    private static Fragment AtWide(Button template) =>
-        new(template with { ResponsiveVisible = VisibleAtWide });
-
-    private static Fragment WideAndDesktopCompact(Button template)
-    {
-        var label = template.Title;
-        return new Fragment(
-            template with { Title = label, ResponsiveVisible = VisibleAtWide },
-            template with { Title = HiddenTitle, ResponsiveVisible = DesktopOnly });
-    }
-
-    private static Fragment WideDesktopAndMobileNav(Button template)
-    {
-        var label = template.Title;
-        return new Fragment(
-            template with { Title = label, ResponsiveVisible = VisibleAtWide },
-            template with { Title = HiddenTitle, ResponsiveVisible = DesktopOnly },
-            template with { Title = HiddenTitle, ResponsiveVisible = BelowTablet });
-    }
-
     public override object Build()
     {
         var client = UseService<IClientProvider>();
 
         if (isEditingState.Value)
         {
-            return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
-                | WideAndDesktopCompact(new Button("Save Revision").Icon(Icons.Save).Primary().ShortcutKey("S").OnClick(() =>
+            return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Scroll(Scroll.Horizontal)
+                | ActionBarResponsive.WideAndDesktopCompact(new Button("Save Revision").Icon(Icons.Save).Primary().ShortcutKey("S").OnClick(() =>
                 {
                     if (editContentState.Value != originalContentState.Value)
                     {
@@ -73,35 +44,36 @@ public class ActionBarView(
                     }
                     isEditingState.Set(false);
                 }))
-                | WideAndDesktopCompact(new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() =>
+                | ActionBarResponsive.WideAndDesktopCompact(new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() =>
                 {
                     editContentState.Set(originalContentState.Value);
                     isEditingState.Set(false);
                 }));
         }
-        return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
-               | WideAndDesktopCompact(new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
+
+        return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Scroll(Scroll.Horizontal)
+               | ActionBarResponsive.WideAndDesktopCompact(new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
                    .OnClick(() => isEditingState.Set(true)))
-               | AtWide(new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")
+               | ActionBarResponsive.AtWide(new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")
                    .OnClick(showUpdateDialog))
-               | AtWide(new Button("Split").Icon(Icons.Scissors).Outline().ShortcutKey("s")
+               | ActionBarResponsive.AtWide(new Button("Split").Icon(Icons.Scissors).Outline().ShortcutKey("s")
                    .Disabled(hasActiveSplitJob)
                    .OnClick(SplitPlan))
-               | AtWide(new Button("Expand").Icon(Icons.UnfoldVertical).Outline().ShortcutKey("x")
+               | ActionBarResponsive.AtWide(new Button("Expand").Icon(Icons.UnfoldVertical).Outline().ShortcutKey("x")
                    .Disabled(hasActiveExpandJob)
                    .OnClick(ExpandPlan))
-               | WideAndDesktopCompact(new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
+               | ActionBarResponsive.WideAndDesktopCompact(new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
                    .OnClick(showDeleteDialog))
-               | WideDesktopAndMobileNav(new Button("Previous").Icon(Icons.ChevronLeft).Outline()
+               | ActionBarResponsive.WideDesktopAndMobileNav(new Button("Previous").Icon(Icons.ChevronLeft).Outline()
                    .ShortcutKey("p").OnClick(goToPrevious))
-               | WideDesktopAndMobileNav(new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline()
+               | ActionBarResponsive.WideDesktopAndMobileNav(new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline()
                    .ShortcutKey("n").OnClick(goToNext))
-               | (new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(BuildMobileMenu(client))
-                   with { ResponsiveVisible = BelowTablet })
-               | (new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(BuildDesktopCompactMenu(client))
-                   with { ResponsiveVisible = DesktopOnly })
-               | (new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(BuildOverflowMenu(client))
-                   with { ResponsiveVisible = VisibleAtWide });
+               | ActionBarResponsive.BelowTabletMenu(
+                   new Button().Icon(Icons.EllipsisVertical).Ghost(), BuildMobileMenu(client))
+               | ActionBarResponsive.DesktopOnlyMenu(
+                   new Button().Icon(Icons.EllipsisVertical).Ghost(), BuildDesktopCompactMenu(client))
+               | ActionBarResponsive.WideOnlyMenu(
+                   new Button().Icon(Icons.EllipsisVertical).Ghost(), BuildOverflowMenu(client));
     }
 
     private void SplitPlan()

--- a/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
@@ -33,7 +33,7 @@ public class ActionBarView(
         if (isEditingState.Value)
         {
             // Edit mode: show only Save and Cancel buttons
-            return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
+            return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Scroll(Scroll.Horizontal)
                 | new Button("Save Revision").Icon(Icons.Save).Primary().ShortcutKey("S").OnClick(() =>
                 {
                     if (editContentState.Value != originalContentState.Value)
@@ -53,7 +53,7 @@ public class ActionBarView(
         }
 
         // Normal mode: show all action buttons (Edit first)
-        return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
+        return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Scroll(Scroll.Horizontal)
                | new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
                    .OnClick(() => isEditingState.Set(true))
                | new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")

--- a/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
@@ -1,3 +1,4 @@
+using Ivy;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
@@ -26,15 +27,42 @@ public class ActionBarView(
     Action goToPrevious,
     string downloadUrl) : ViewBase
 {
+    // >= 1024 (Wide): all buttons. 768–1023 (Desktop): Edit, Delete, Prev, Next + …. < 768: Prev, Next + …
+    // Ivy renders <kbd> only when Title is set; nbsp hides the label on the Desktop tier.
+    private const string HiddenTitle = "\u00A0";
+
+    private static readonly Responsive<bool?> VisibleAtWide = new() { Default = false, Desktop = false, Wide = true };
+    private static readonly Responsive<bool?> DesktopOnly = new() { Default = false, Desktop = true, Wide = false };
+    private static readonly Responsive<bool?> BelowTablet = new() { Default = true, Desktop = false };
+
+    private static Fragment AtWide(Button template) =>
+        new(template with { ResponsiveVisible = VisibleAtWide });
+
+    private static Fragment WideAndDesktopCompact(Button template)
+    {
+        var label = template.Title;
+        return new Fragment(
+            template with { Title = label, ResponsiveVisible = VisibleAtWide },
+            template with { Title = HiddenTitle, ResponsiveVisible = DesktopOnly });
+    }
+
+    private static Fragment WideDesktopAndMobileNav(Button template)
+    {
+        var label = template.Title;
+        return new Fragment(
+            template with { Title = label, ResponsiveVisible = VisibleAtWide },
+            template with { Title = HiddenTitle, ResponsiveVisible = DesktopOnly },
+            template with { Title = HiddenTitle, ResponsiveVisible = BelowTablet });
+    }
+
     public override object Build()
     {
         var client = UseService<IClientProvider>();
 
         if (isEditingState.Value)
         {
-            // Edit mode: show only Save and Cancel buttons
-            return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Scroll(Scroll.Horizontal)
-                | new Button("Save Revision").Icon(Icons.Save).Primary().ShortcutKey("S").OnClick(() =>
+            return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
+                | WideAndDesktopCompact(new Button("Save Revision").Icon(Icons.Save).Primary().ShortcutKey("S").OnClick(() =>
                 {
                     if (editContentState.Value != originalContentState.Value)
                     {
@@ -44,122 +72,143 @@ public class ActionBarView(
                         refreshPlans();
                     }
                     isEditingState.Set(false);
-                })
-                | new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() =>
+                }))
+                | WideAndDesktopCompact(new Button("Cancel").Outline().ShortcutKey("Escape").OnClick(() =>
                 {
                     editContentState.Set(originalContentState.Value);
                     isEditingState.Set(false);
-                });
+                }));
         }
-
-        // Normal mode: show all action buttons (Edit first)
-        return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Scroll(Scroll.Horizontal)
-               | new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
-                   .OnClick(() => isEditingState.Set(true))
-               | new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")
-                   .OnClick(showUpdateDialog)
-               | new Button("Split").Icon(Icons.Scissors).Outline().ShortcutKey("s")
+        return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
+               | WideAndDesktopCompact(new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
+                   .OnClick(() => isEditingState.Set(true)))
+               | AtWide(new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")
+                   .OnClick(showUpdateDialog))
+               | AtWide(new Button("Split").Icon(Icons.Scissors).Outline().ShortcutKey("s")
                    .Disabled(hasActiveSplitJob)
-                   .OnClick(() =>
-                   {
-                       if (hasActiveSplitJob) return;
-
-                       // Optimistically update UI state before disk I/O
-                       var optimisticPlan = selectedPlan with
-                       {
-                           Metadata = selectedPlan.Metadata with { State = PlanStatus.Updating }
-                       };
-                       selectedPlanState.Set(optimisticPlan);
-
-                       planService.TransitionState(selectedPlan.FolderName, PlanStatus.Updating);
-                       jobService.StartJob(new SplitPlanArgs(selectedPlan.FolderPath));
-                       refreshPlans();
-                   })
-               | new Button("Expand").Icon(Icons.UnfoldVertical).Outline().ShortcutKey("x")
+                   .OnClick(SplitPlan))
+               | AtWide(new Button("Expand").Icon(Icons.UnfoldVertical).Outline().ShortcutKey("x")
                    .Disabled(hasActiveExpandJob)
-                   .OnClick(() =>
-                   {
-                       if (hasActiveExpandJob) return;
-
-                       // Optimistically update UI state before disk I/O
-                       var optimisticPlan = selectedPlan with
-                       {
-                           Metadata = selectedPlan.Metadata with { State = PlanStatus.Building }
-                       };
-                       selectedPlanState.Set(optimisticPlan);
-
-                       planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
-                       var planPath = selectedPlan.FolderPath;
-                       jobService.StartJob(new ExpandPlanArgs(planPath));
-                       refreshPlans();
-                   })
-               | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
-                   .OnClick(showDeleteDialog)
-               | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(goToPrevious)
-                   .ShortcutKey("p")
-               | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(goToNext)
-                   .ShortcutKey("n")
-               | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
-                   new MenuItem("Create Issue", Icon: Icons.Github, Tag: "CreateIssue").OnSelect(showCreateIssueDialog),
-                   new MenuItem("Download", Icon: Icons.Download, Tag: "Download").OnSelect(() =>
-                   {
-                       if (!string.IsNullOrEmpty(downloadUrl)) client.OpenUrl(downloadUrl);
-                   }),
-                   new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
-                       .OnSelect(() => { PlatformHelper.OpenInFileManager(selectedPlan.FolderPath); }),
-                   new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal").OnSelect(() =>
-                   {
-                       PlatformHelper.OpenInTerminal(selectedPlan.FolderPath);
-                   }),
-                   new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
-                       .OnSelect(() =>
-                       {
-                           try
-                           {
-                               config.OpenInEditor(selectedPlan.FolderPath);
-                           }
-                           catch (EditorNotAvailableException ex)
-                           {
-                               client.Toast(
-                                   $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
-                                   "Editor Not Available",
-                                   variant: ToastVariant.Destructive);
-                           }
-                       }),
-                   new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
-                       .OnSelect(() =>
-                       {
-                           copyToClipboard(selectedPlan.FolderPath);
-                           client.Toast("Copied path to clipboard", "Path Copied");
-                       }),
-                   new MenuItem("Copy Plan to Clipboard", Icon: Icons.Share, Tag: "CopyPlan")
-                       .OnSelect(() =>
-                       {
-                           var exported = PlanExportHelper.ExportToClipboard(selectedPlan);
-                           copyToClipboard(exported);
-                           client.Toast("Plan copied to clipboard", "Plan Exported");
-                       }),
-                   new MenuItem("Mark as Completed", Icon: Icons.CircleCheck, Tag: "MarkCompleted")
-                       .OnSelect(() =>
-                       {
-                           planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
-                           refreshPlans();
-                       }),
-                   new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
-                   {
-                       var yamlPath = Path.Combine(selectedPlan.FolderPath, "plan.yaml");
-                       try
-                       {
-                           config.OpenInEditor(yamlPath);
-                       }
-                       catch (EditorNotAvailableException ex)
-                       {
-                           client.Toast(
-                               $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
-                               "Editor Not Available",
-                               variant: ToastVariant.Destructive);
-                       }
-                   })
-               );
+                   .OnClick(ExpandPlan))
+               | WideAndDesktopCompact(new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
+                   .OnClick(showDeleteDialog))
+               | WideDesktopAndMobileNav(new Button("Previous").Icon(Icons.ChevronLeft).Outline()
+                   .ShortcutKey("p").OnClick(goToPrevious))
+               | WideDesktopAndMobileNav(new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline()
+                   .ShortcutKey("n").OnClick(goToNext))
+               | (new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(BuildMobileMenu(client))
+                   with { ResponsiveVisible = BelowTablet })
+               | (new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(BuildDesktopCompactMenu(client))
+                   with { ResponsiveVisible = DesktopOnly })
+               | (new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(BuildOverflowMenu(client))
+                   with { ResponsiveVisible = VisibleAtWide });
     }
+
+    private void SplitPlan()
+    {
+        if (hasActiveSplitJob) return;
+
+        var optimisticPlan = selectedPlan with
+        {
+            Metadata = selectedPlan.Metadata with { State = PlanStatus.Updating }
+        };
+        selectedPlanState.Set(optimisticPlan);
+
+        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Updating);
+        jobService.StartJob(new SplitPlanArgs(selectedPlan.FolderPath));
+        refreshPlans();
+    }
+
+    private void ExpandPlan()
+    {
+        if (hasActiveExpandJob) return;
+
+        var optimisticPlan = selectedPlan with
+        {
+            Metadata = selectedPlan.Metadata with { State = PlanStatus.Building }
+        };
+        selectedPlanState.Set(optimisticPlan);
+
+        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+        jobService.StartJob(new ExpandPlanArgs(selectedPlan.FolderPath));
+        refreshPlans();
+    }
+
+    private MenuItem[] BuildMobileMenu(IClientProvider client) =>
+    [
+        new MenuItem("Edit", Icon: Icons.Pencil).OnSelect(() => isEditingState.Set(true)),
+        new MenuItem("Update", Icon: Icons.WandSparkles).OnSelect(showUpdateDialog),
+        new MenuItem("Split", Icon: Icons.Scissors).OnSelect(SplitPlan),
+        new MenuItem("Expand", Icon: Icons.UnfoldVertical).OnSelect(ExpandPlan),
+        new MenuItem("Delete", Icon: Icons.Trash).OnSelect(showDeleteDialog),
+        ..BuildOverflowMenu(client),
+    ];
+
+    private MenuItem[] BuildDesktopCompactMenu(IClientProvider client) =>
+    [
+        new MenuItem("Update", Icon: Icons.WandSparkles).OnSelect(showUpdateDialog),
+        new MenuItem("Split", Icon: Icons.Scissors).OnSelect(SplitPlan),
+        new MenuItem("Expand", Icon: Icons.UnfoldVertical).OnSelect(ExpandPlan),
+        ..BuildOverflowMenu(client),
+    ];
+
+    private MenuItem[] BuildOverflowMenu(IClientProvider client) =>
+    [
+        new MenuItem("Create Issue", Icon: Icons.Github, Tag: "CreateIssue").OnSelect(showCreateIssueDialog),
+        new MenuItem("Download", Icon: Icons.Download, Tag: "Download").OnSelect(() =>
+        {
+            if (!string.IsNullOrEmpty(downloadUrl)) client.OpenUrl(downloadUrl);
+        }),
+        new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
+            .OnSelect(() => PlatformHelper.OpenInFileManager(selectedPlan.FolderPath)),
+        new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal").OnSelect(() =>
+        {
+            PlatformHelper.OpenInTerminal(selectedPlan.FolderPath);
+        }),
+        new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor").OnSelect(() =>
+        {
+            try
+            {
+                config.OpenInEditor(selectedPlan.FolderPath);
+            }
+            catch (EditorNotAvailableException ex)
+            {
+                client.Toast(
+                    $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                    "Editor Not Available",
+                    variant: ToastVariant.Destructive);
+            }
+        }),
+        new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath").OnSelect(() =>
+        {
+            copyToClipboard(selectedPlan.FolderPath);
+            client.Toast("Copied path to clipboard", "Path Copied");
+        }),
+        new MenuItem("Copy Plan to Clipboard", Icon: Icons.Share, Tag: "CopyPlan").OnSelect(() =>
+        {
+            var exported = PlanExportHelper.ExportToClipboard(selectedPlan);
+            copyToClipboard(exported);
+            client.Toast("Plan copied to clipboard", "Plan Exported");
+        }),
+        new MenuItem("Mark as Completed", Icon: Icons.CircleCheck, Tag: "MarkCompleted").OnSelect(() =>
+        {
+            planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+            refreshPlans();
+        }),
+        new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
+        {
+            var yamlPath = Path.Combine(selectedPlan.FolderPath, "plan.yaml");
+            try
+            {
+                config.OpenInEditor(yamlPath);
+            }
+            catch (EditorNotAvailableException ex)
+            {
+                client.Toast(
+                    $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                    "Editor Not Available",
+                    variant: ToastVariant.Destructive);
+            }
+        }),
+    ];
 }

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -129,7 +129,7 @@ public class ContentView(
         scrollableContent |= new Markdown(selectedRecommendation.Description);
 
         // Action bar (secondary actions)
-        var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(1)
+        var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(1).Scroll(Scroll.Horizontal)
                         | new Button("Accept with Notes").Icon(Icons.CircleCheck).Outline().ShortcutKey("w")
                             .OnClick(() => showNotesDialog())
                         | new Button("View Plan").Icon(Icons.ExternalLink).Outline().ShortcutKey("d").OnClick(() =>

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -159,7 +159,7 @@ public class ContentView(
         var planFolderPath = Path.Combine(planService.PlansDirectory, recommendation.PlanFolderName);
         var overflow = BuildOverflowMenu(client, config, planFolderPath, copyToClipboard);
 
-        return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Scroll(Scroll.Horizontal)
+        return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                | ActionBarResponsive.WideAndDesktopCompact(new Button("Accept with Notes").Icon(Icons.CircleCheck).Outline()
                    .ShortcutKey("w").OnClick(showNotesDialog))
                | ActionBarResponsive.AtWide(new Button("View Plan").Icon(Icons.ExternalLink).Outline().ShortcutKey("d")

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -1,3 +1,4 @@
+using Ivy.Core;
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Apps.Recommendations.Dialogs;
 using Ivy.Tendril.Models;
@@ -128,52 +129,13 @@ public class ContentView(
         scrollableContent |= new Separator();
         scrollableContent |= new Markdown(selectedRecommendation.Description);
 
-        // Action bar (secondary actions)
-        var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(1).Scroll(Scroll.Horizontal)
-                        | new Button("Accept with Notes").Icon(Icons.CircleCheck).Outline().ShortcutKey("w")
-                            .OnClick(() => showNotesDialog())
-                        | new Button("View Plan").Icon(Icons.ExternalLink).Outline().ShortcutKey("d").OnClick(() =>
-                        {
-                            var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
-                            if (Directory.Exists(fullPath))
-                                showPlan(fullPath);
-                        })
-                        | new Button("Previous").Icon(Icons.ChevronLeft).Outline().ShortcutKey("p")
-                            .OnClick(() => GoToPrevious())
-                        | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().ShortcutKey("n")
-                            .OnClick(() => GoToNext())
-                        | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
-                            new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
-                                .OnSelect(() =>
-                                {
-                                    var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
-                                    if (Directory.Exists(fullPath))
-                                        PlatformHelper.OpenInFileManager(fullPath);
-                                }),
-                            new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
-                                .OnSelect(() =>
-                                {
-                                    var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
-                                    copyToClipboard(fullPath);
-                                    client.Toast("Copied path to clipboard", "Path Copied");
-                                }),
-                            new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
-                            {
-                                var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
-                                var yamlPath = Path.Combine(fullPath, "plan.yaml");
-                                try
-                                {
-                                    config.OpenInEditor(yamlPath);
-                                }
-                                catch (EditorNotAvailableException ex)
-                                {
-                                    client.Toast(
-                                        $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
-                                        "Editor Not Available",
-                                        variant: ToastVariant.Destructive);
-                                }
-                            })
-                        );
+        var actionBar = BuildActionBar(
+            selectedRecommendation,
+            () => showNotesDialog(),
+            showPlan,
+            copyToClipboard,
+            client,
+            config);
 
         var mainLayout = new HeaderLayout(
             header,
@@ -185,6 +147,103 @@ public class ContentView(
 
         return new Fragment(mainLayout, planSheet, notesDialog);
     }
+
+    private object BuildActionBar(
+        Recommendation recommendation,
+        Action showNotesDialog,
+        Action<string> showPlan,
+        Action<string> copyToClipboard,
+        IClientProvider client,
+        IConfigService config)
+    {
+        var planFolderPath = Path.Combine(planService.PlansDirectory, recommendation.PlanFolderName);
+        var overflow = BuildOverflowMenu(client, config, planFolderPath, copyToClipboard);
+
+        return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Scroll(Scroll.Horizontal)
+               | ActionBarResponsive.WideAndDesktopCompact(new Button("Accept with Notes").Icon(Icons.CircleCheck).Outline()
+                   .ShortcutKey("w").OnClick(showNotesDialog))
+               | ActionBarResponsive.AtWide(new Button("View Plan").Icon(Icons.ExternalLink).Outline().ShortcutKey("d")
+                   .OnClick(() =>
+                   {
+                       if (Directory.Exists(planFolderPath))
+                           showPlan(planFolderPath);
+                   }))
+               | ActionBarResponsive.WideDesktopAndMobileNav(new Button("Previous").Icon(Icons.ChevronLeft).Outline()
+                   .ShortcutKey("p").OnClick(GoToPrevious))
+               | ActionBarResponsive.WideDesktopAndMobileNav(new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline()
+                   .ShortcutKey("n").OnClick(GoToNext))
+               | ActionBarResponsive.BelowTabletMenu(
+                   new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                   BuildMobileMenu(showNotesDialog, showPlan, planFolderPath, overflow))
+               | ActionBarResponsive.DesktopOnlyMenu(
+                   new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                   BuildDesktopCompactMenu(showPlan, planFolderPath, overflow))
+               | ActionBarResponsive.WideOnlyMenu(
+                   new Button().Icon(Icons.EllipsisVertical).Ghost(), overflow);
+    }
+
+    private static MenuItem[] BuildMobileMenu(
+        Action showNotesDialog,
+        Action<string> showPlan,
+        string planFolderPath,
+        MenuItem[] overflow) =>
+    [
+        new MenuItem("Accept with Notes", Icon: Icons.CircleCheck).OnSelect(showNotesDialog),
+        new MenuItem("View Plan", Icon: Icons.ExternalLink).OnSelect(() =>
+        {
+            if (Directory.Exists(planFolderPath))
+                showPlan(planFolderPath);
+        }),
+        ..overflow,
+    ];
+
+    private static MenuItem[] BuildDesktopCompactMenu(
+        Action<string> showPlan,
+        string planFolderPath,
+        MenuItem[] overflow) =>
+    [
+        new MenuItem("View Plan", Icon: Icons.ExternalLink).OnSelect(() =>
+        {
+            if (Directory.Exists(planFolderPath))
+                showPlan(planFolderPath);
+        }),
+        ..overflow,
+    ];
+
+    private static MenuItem[] BuildOverflowMenu(
+        IClientProvider client,
+        IConfigService config,
+        string planFolderPath,
+        Action<string> copyToClipboard) =>
+    [
+        new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
+            .OnSelect(() =>
+            {
+                if (Directory.Exists(planFolderPath))
+                    PlatformHelper.OpenInFileManager(planFolderPath);
+            }),
+        new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
+            .OnSelect(() =>
+            {
+                copyToClipboard(planFolderPath);
+                client.Toast("Copied path to clipboard", "Path Copied");
+            }),
+        new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
+        {
+            var yamlPath = Path.Combine(planFolderPath, "plan.yaml");
+            try
+            {
+                config.OpenInEditor(yamlPath);
+            }
+            catch (EditorNotAvailableException ex)
+            {
+                client.Toast(
+                    $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                    "Editor Not Available",
+                    variant: ToastVariant.Destructive);
+            }
+        }),
+    ];
 
     private void GoToNext()
     {

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -298,7 +298,7 @@ public class ContentView(
         INavigator nav,
         ReviewAppArgs? args)
     {
-        return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
+        return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Scroll(Scroll.Horizontal)
                 | new Button("Reset to Draft").Icon(Icons.RotateCcw).Outline().ShortcutKey("r").OnClick(showResetToDraftDialog)
                 | new Button("Suggest Changes").Icon(Icons.MessageSquare).Outline().OnClick(showSuggestChangesDialog).ShortcutKey("d")
                 | new Button("Discard").Icon(Icons.Trash).Outline().ShortcutKey("Backspace").OnClick(showDiscardDialog)

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -300,7 +300,7 @@ public class ContentView(
     {
         var overflow = BuildReviewOverflowMenu(selectedPlan, showCustomPrDialog, copyToClipboard, client, logger);
 
-        return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Scroll(Scroll.Horizontal)
+        return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                | ActionBarResponsive.WideAndDesktopCompact(new Button("Reset to Draft").Icon(Icons.RotateCcw).Outline()
                    .ShortcutKey("r").OnClick(showResetToDraftDialog))
                | ActionBarResponsive.AtWide(new Button("Suggest Changes").Icon(Icons.MessageSquare).Outline()

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -298,65 +298,103 @@ public class ContentView(
         INavigator nav,
         ReviewAppArgs? args)
     {
+        var overflow = BuildReviewOverflowMenu(selectedPlan, showCustomPrDialog, copyToClipboard, client, logger);
+
         return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Scroll(Scroll.Horizontal)
-                | new Button("Reset to Draft").Icon(Icons.RotateCcw).Outline().ShortcutKey("r").OnClick(showResetToDraftDialog)
-                | new Button("Suggest Changes").Icon(Icons.MessageSquare).Outline().OnClick(showSuggestChangesDialog).ShortcutKey("d")
-                | new Button("Discard").Icon(Icons.Trash).Outline().ShortcutKey("Backspace").OnClick(showDiscardDialog)
-                | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(() => GoToPrevious(nav, args))
-                    .ShortcutKey("p")
-                | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(() => GoToNext(nav, args))
-                    .ShortcutKey("n")
-                | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
-                    new MenuItem("Custom PR", Icon: Icons.GitPullRequest, Tag: "CustomPR").OnSelect(showCustomPrDialog),
-                    new MenuItem("Set Completed", Icon: Icons.CircleCheck, Tag: "SetCompleted").OnSelect(() =>
-                    {
-                        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
-                        refreshPlans();
-                    }),
-                    new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
-                        .OnSelect(() => { PlatformHelper.OpenInFileManager(selectedPlan.FolderPath, logger); }),
-                    new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal").OnSelect(() =>
-                    {
-                        PlatformHelper.OpenInTerminal(selectedPlan.FolderPath, logger);
-                    }),
-                    new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
-                        .OnSelect(() =>
-                        {
-                            copyToClipboard(selectedPlan.FolderPath);
-                            client.Toast("Copied path to clipboard", "Path Copied");
-                        }),
-                    new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
-                        .OnSelect(() =>
-                        {
-                            try
-                            {
-                                config.OpenInEditor(selectedPlan.FolderPath);
-                            }
-                            catch (EditorNotAvailableException ex)
-                            {
-                                client.Toast(
-                                    $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
-                                    "Editor Not Available",
-                                    variant: ToastVariant.Destructive);
-                            }
-                        }),
-                    new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
-                    {
-                        var yamlPath = Path.Combine(selectedPlan.FolderPath, "plan.yaml");
-                        try
-                        {
-                            config.OpenInEditor(yamlPath);
-                        }
-                        catch (EditorNotAvailableException ex)
-                        {
-                            client.Toast(
-                                $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
-                                "Editor Not Available",
-                                variant: ToastVariant.Destructive);
-                        }
-                    })
-                );
+               | ActionBarResponsive.WideAndDesktopCompact(new Button("Reset to Draft").Icon(Icons.RotateCcw).Outline()
+                   .ShortcutKey("r").OnClick(showResetToDraftDialog))
+               | ActionBarResponsive.AtWide(new Button("Suggest Changes").Icon(Icons.MessageSquare).Outline()
+                   .ShortcutKey("d").OnClick(showSuggestChangesDialog))
+               | ActionBarResponsive.WideAndDesktopCompact(new Button("Discard").Icon(Icons.Trash).Outline()
+                   .ShortcutKey("Backspace").OnClick(showDiscardDialog))
+               | ActionBarResponsive.WideDesktopAndMobileNav(new Button("Previous").Icon(Icons.ChevronLeft).Outline()
+                   .ShortcutKey("p").OnClick(() => GoToPrevious(nav, args)))
+               | ActionBarResponsive.WideDesktopAndMobileNav(new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline()
+                   .ShortcutKey("n").OnClick(() => GoToNext(nav, args)))
+               | ActionBarResponsive.BelowTabletMenu(
+                   new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                   BuildReviewMobileMenu(showResetToDraftDialog, showSuggestChangesDialog, showDiscardDialog, overflow))
+               | ActionBarResponsive.DesktopOnlyMenu(
+                   new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                   BuildReviewDesktopCompactMenu(showSuggestChangesDialog, overflow))
+               | ActionBarResponsive.WideOnlyMenu(
+                   new Button().Icon(Icons.EllipsisVertical).Ghost(), overflow);
     }
+
+    private MenuItem[] BuildReviewMobileMenu(
+        Action showResetToDraftDialog,
+        Action showSuggestChangesDialog,
+        Action showDiscardDialog,
+        MenuItem[] overflow) =>
+    [
+        new MenuItem("Reset to Draft", Icon: Icons.RotateCcw).OnSelect(showResetToDraftDialog),
+        new MenuItem("Suggest Changes", Icon: Icons.MessageSquare).OnSelect(showSuggestChangesDialog),
+        new MenuItem("Discard", Icon: Icons.Trash).OnSelect(showDiscardDialog),
+        ..overflow,
+    ];
+
+    private MenuItem[] BuildReviewDesktopCompactMenu(Action showSuggestChangesDialog, MenuItem[] overflow) =>
+    [
+        new MenuItem("Suggest Changes", Icon: Icons.MessageSquare).OnSelect(showSuggestChangesDialog),
+        ..overflow,
+    ];
+
+    private MenuItem[] BuildReviewOverflowMenu(
+        PlanFile selectedPlan,
+        Action showCustomPrDialog,
+        Action<string> copyToClipboard,
+        IClientProvider client,
+        ILogger<ContentView> logger) =>
+    [
+        new MenuItem("Custom PR", Icon: Icons.GitPullRequest, Tag: "CustomPR").OnSelect(showCustomPrDialog),
+        new MenuItem("Set Completed", Icon: Icons.CircleCheck, Tag: "SetCompleted").OnSelect(() =>
+        {
+            planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+            refreshPlans();
+        }),
+        new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
+            .OnSelect(() => PlatformHelper.OpenInFileManager(selectedPlan.FolderPath, logger)),
+        new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal").OnSelect(() =>
+        {
+            PlatformHelper.OpenInTerminal(selectedPlan.FolderPath, logger);
+        }),
+        new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
+            .OnSelect(() =>
+            {
+                copyToClipboard(selectedPlan.FolderPath);
+                client.Toast("Copied path to clipboard", "Path Copied");
+            }),
+        new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
+            .OnSelect(() =>
+            {
+                try
+                {
+                    config.OpenInEditor(selectedPlan.FolderPath);
+                }
+                catch (EditorNotAvailableException ex)
+                {
+                    client.Toast(
+                        $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                        "Editor Not Available",
+                        variant: ToastVariant.Destructive);
+                }
+            }),
+        new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
+        {
+            var yamlPath = Path.Combine(selectedPlan.FolderPath, "plan.yaml");
+            try
+            {
+                config.OpenInEditor(yamlPath);
+            }
+            catch (EditorNotAvailableException ex)
+            {
+                client.Toast(
+                    $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                    "Editor Not Available",
+                    variant: ToastVariant.Destructive);
+            }
+        }),
+    ];
 
     private object BuildContent(
         PlanFile selectedPlan,

--- a/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
+++ b/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
@@ -1,0 +1,46 @@
+using Ivy;
+
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+/// Responsive breakpoints for plan/review action bars.
+/// >= 1024 (Wide): all buttons. 768–1023 (Desktop): four icon + kbd + …. &lt; 768: prev/next + ….
+/// </summary>
+public static class ActionBarResponsive
+{
+    // Ivy renders <kbd> only when Title is set; nbsp hides the label on compact tiers.
+    private const string HiddenTitle = "\u00A0";
+
+    private static readonly Responsive<bool?> VisibleAtWide = new() { Default = false, Desktop = false, Wide = true };
+    private static readonly Responsive<bool?> DesktopOnly = new() { Default = false, Desktop = true, Wide = false };
+    private static readonly Responsive<bool?> BelowTablet = new() { Default = true, Desktop = false };
+
+    public static Fragment AtWide(Button template) =>
+        new(template with { ResponsiveVisible = VisibleAtWide });
+
+    public static Fragment WideAndDesktopCompact(Button template)
+    {
+        var label = template.Title;
+        return new Fragment(
+            template with { Title = label, ResponsiveVisible = VisibleAtWide },
+            template with { Title = HiddenTitle, ResponsiveVisible = DesktopOnly });
+    }
+
+    public static Fragment WideDesktopAndMobileNav(Button template)
+    {
+        var label = template.Title;
+        return new Fragment(
+            template with { Title = label, ResponsiveVisible = VisibleAtWide },
+            template with { Title = HiddenTitle, ResponsiveVisible = DesktopOnly },
+            template with { Title = HiddenTitle, ResponsiveVisible = BelowTablet });
+    }
+
+    public static DropDownMenu BelowTabletMenu(Button trigger, params MenuItem[] items) =>
+        trigger.WithDropDown(items) with { ResponsiveVisible = BelowTablet };
+
+    public static DropDownMenu DesktopOnlyMenu(Button trigger, params MenuItem[] items) =>
+        trigger.WithDropDown(items) with { ResponsiveVisible = DesktopOnly };
+
+    public static DropDownMenu WideOnlyMenu(Button trigger, params MenuItem[] items) =>
+        trigger.WithDropDown(items) with { ResponsiveVisible = VisibleAtWide };
+}


### PR DESCRIPTION
## Summary

Fixes #724

Action bar buttons in the **Drafts**, **Review**, and **Recommendations** views were
clipped when the window was too narrow. This PR adds horizontal scrolling so all
buttons remain accessible.

## Changes

- `Apps/Plans/ActionBarView.cs` — `.Scroll(Scroll.Horizontal)` on both normal and edit mode bars
- `Apps/Review/ContentView.cs` — `.Scroll(Scroll.Horizontal)` on the review action bar
- `Apps/Recommendations/ContentView.cs` — `.Scroll(Scroll.Horizontal)` on the recommendations action bar

## Dependency

Requires [Ivy-Interactive/Ivy-Framework#4462](https://github.com/Ivy-Interactive/Ivy-Framework/pull/4462) — adds frontend support for `Scroll.Horizontal` in `StackLayoutWidget`. Without that PR the `.Scroll(Scroll.Horizontal)` call has no visual effect.

https://github.com/user-attachments/assets/0b202190-eb10-44f5-b0df-4a568ca31389

