### PR TITLE
fix: reset to draft now updates UI immediately after confirmation

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
@@ -42,14 +42,22 @@ public class ResetToDraftDialog(
                     if (!isResetting.Value)
                     {
                         isResetting.Set(true);
+
+                        _planService.ResetToDraft(_selectedPlan.FolderName);
+                        _refreshPlans();
                         _dialogOpen.Set(false);
 
                         var folderPath = _selectedPlan.FolderPath;
                         Task.Run(() =>
                         {
-                            CleanPlanState(folderPath, _logger);
-                            _planService.ResetToDraft(_selectedPlan.FolderName);
-                            _refreshPlans();
+                            try
+                            {
+                                CleanPlanState(folderPath, _logger);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogWarning(ex, "Failed to clean plan state for {FolderPath}", folderPath);
+                            }
                         });
                     }
                 })


### PR DESCRIPTION
Moves the state transition and refresh calls out of Task.Run so the plan disappears from the review list immediately after confirming the dialog. Filesystem cleanup remains in a background task with error handling.