### PR TITLE
fix: refactor import issues dialog to use UseTrigger

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -102,7 +102,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var serverArgs = UseService<ServerArgs>();
         var navigate = Context.UseSignal<NavigateSignal, NavigateArgs, Unit>();
         var navigator = UseNavigation();
-        var importIssuesDialogOpen = UseState(false);
+        var (importIssuesDialogView, showImportIssuesDialog) = UseTrigger(isOpen =>
+            new ImportIssuesDialog(isOpen, config));
         var newsArticles = UseState(Array.Empty<SidebarNewsArticle>());
 
         UseEffect(async () =>
@@ -427,7 +428,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             MenuItem.Default("Import Issues from GitHub")
                 .Tag("$import-issues")
                 .Icon(Icons.Download)
-                .OnSelect(() => importIssuesDialogOpen.Set(true)),
+                .OnSelect(() => showImportIssuesDialog()),
             MenuItem.Default("Theme")
                 .Tag("$theme")
                 .Icon(Icons.SunMoon)
@@ -476,7 +477,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 ),
                 settings.Width
             ).Open(sidebarOpen.Value).MainAppSidebar(),
-            new ImportIssuesDialog(importIssuesDialogOpen, config)
+            importIssuesDialogView
         );
     }
 

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -163,7 +163,7 @@ public class ProjectAgentStepView(
 
         var awaitingOutput = !isCloning.Value && session.Running.Value && !session.HasOutput.Value;
 
-        return Layout.Vertical().Margin(0, 0, 0, 20)
+        return Layout.Vertical()
                | Text.H3("Setting up your project")
                | Text.Muted(isCloning.Value
                    ? (progressMessage.Value ?? "Setting up your project...")

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
@@ -90,7 +90,7 @@ public class ProjectCrudStepView(
             | new Button(nextButtonText).Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
                 .OnClick(onNext);
 
-        return Layout.Vertical().Margin(0, 0, 0, 20)
+        return Layout.Vertical()
                | Text.H3("Review Harness")
                | Text.Muted("Review and edit the configuration generated for your project.")
                | (Layout.Vertical()

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -40,7 +40,7 @@ public class ProjectInputStepView(
                 .Disabled(!canContinue)
                 .OnClick(onNext);
 
-        return Layout.Vertical().Margin(0, 0, 0, 20)
+        return Layout.Vertical()
                | Text.H3("Setup your first project")
                | Text.Muted("A project groups one or more repositories together so Tendril can plan and verify changes across them.")
                | new ProjectRepoPickerView(selectedRepos, projectName)

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
@@ -49,6 +49,20 @@ public class AddProjectDialog(
             }
         }, step);
 
+        UseEffect(() =>
+        {
+            if (isOpen.Value)
+            {
+                step.Set(0);
+                editName.Set("");
+                editRepos.Set(new List<RepoRef>());
+                isStepLoading.Set(false);
+                hasCreated.Set(false);
+                skipAgent.Set(false);
+                session.Reset();
+            }
+        }, isOpen);
+
         if (!isOpen.Value) return null;
 
         void CancelAndClose()
@@ -73,15 +87,7 @@ public class AddProjectDialog(
             refreshToken.Refresh();
         }
 
-        // Stepper steps
-        var steps = new StepperItem[]
-        {
-            new("1", step.Value > 0 ? Icons.Check : null, "Details"),
-            new("2", step.Value > 1 ? Icons.Check : null, "Analyze"),
-            new("3", step.Value > 2 ? Icons.Check : null, "Configure")
-        };
 
-        var stepper = new Stepper((_) => ValueTask.CompletedTask, step.Value, steps).Width(Size.Full()).Disabled(true);
 
         object activeView = step.Value switch
         {
@@ -133,8 +139,6 @@ public class AddProjectDialog(
         };
 
         var dialogBody = Layout.Vertical()
-            | stepper
-            | new Separator()
             | activeView;
 
         return new Dialog(


### PR DESCRIPTION
Refactor the GitHub issue import dialog to use UseTrigger instead of local state to prevent unwanted re-opening, and clean up project creation dialogue layout.