### PR TITLE
fix(backend): fix github issues import load hang and setup/onboarding table layout clipping

### DIFF
--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -121,7 +121,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 reposError.Set($"Failed to load repositories: {ex.Message}");
                 logger.LogWarning(ex, "Exception loading repos");
             }
-        }, _dialogOpen);
+        }, _dialogOpen, EffectTrigger.OnMount());
 
         if (!_dialogOpen.Value) return null;
 

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
@@ -81,7 +81,9 @@ public class ProjectCrudStepView(
                     }, "Delete Verification", AlertButtonSet.OkCancel);
                 })
             ))
-            .Width(Size.Fit());
+            .ColumnWidth(t => t.Index, Size.Units(8))
+            .ColumnWidth(t => t.Name, Size.Units(50))
+            .Width(Size.Full());
 
         var buttonArea = Layout.Horizontal().Width(Size.Full())
             | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -248,7 +248,9 @@ internal class ReviewActionsTableView(
                     }, "Delete Review Action");
                 })
             ))
-            .Width(Size.Fit());
+            .ColumnWidth(t => t.Index, Size.Units(8))
+            .ColumnWidth(t => t.Name, Size.Units(50))
+            .Width(Size.Full());
     }
 
     private record ReviewActionRow(string Name, int Index);

--- a/src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/LevelsSetupView.cs
@@ -57,7 +57,10 @@ public class LevelsSetupView : ViewBase
                     }, "Delete Level");
                 })
             ))
-            .Width(Size.Fit());
+            .ColumnWidth(t => t.Index, Size.Units(8))
+            .ColumnWidth(t => t.Name, Size.Units(50))
+            .ColumnWidth(t => t.Badge, Size.Units(20))
+            .Width(Size.Full());
 
         return Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Priority Levels").Bold()

--- a/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/ProjectsSetupView.cs
@@ -67,7 +67,10 @@ public class ProjectsSetupView : ViewBase
                     }, "Delete Project", AlertButtonSet.OkCancel);
                 })
             ))
-            .Width(Size.Fit());
+            .ColumnWidth(t => t.Index, Size.Units(8))
+            .ColumnWidth(t => t.Name, Size.Units(50))
+            .ColumnWidth(t => t.Repos, Size.Grow())
+            .Width(Size.Full());
 
         return Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Projects").Bold()

--- a/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/PromptwaresSetupView.cs
@@ -61,7 +61,10 @@ public class PromptwaresSetupView : ViewBase
                                }, "Delete Promptware");
                            }));
             }))
-            .Width(Size.Fit());
+            .ColumnWidth(t => t.Index, Size.Units(8))
+            .ColumnWidth(t => t.Name, Size.Units(50))
+            .ColumnWidth(t => t.Profile, Size.Units(20))
+            .Width(Size.Full());
 
         return Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Promptware Configuration").Bold()

--- a/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/VerificationsSetupView.cs
@@ -51,7 +51,9 @@ public class VerificationsSetupView : ViewBase
                     }, "Delete Verification", AlertButtonSet.OkCancel);
                 })
             ))
-            .Width(Size.Fit());
+            .ColumnWidth(t => t.Index, Size.Units(8))
+            .ColumnWidth(t => t.Name, Size.Units(50))
+            .Width(Size.Full());
 
         return Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(400)))
                | Text.Block("Verification Definitions").Bold()


### PR DESCRIPTION
Fixes two issues: 1) The GitHub issues import dialog was stuck in the loading state, resolved by updating UseEffect dependencies. 2) Settings and onboarding tables had layout clipping and horizontal scrollbars, resolved by replacing rigid Size.Fit() with Size.Full() and explicit/flexible column widths.