### PR TITLE
chore: remove SlayZone project and simplify email template

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -123,18 +123,6 @@ projects:
     condition: ''
     action: pwsh -NoProfile -File D:\Tendril\Hooks\NotifySlack.ps1
   buildDependencies: []
-- name: SlayZone
-  color: Green
-  meta: {}
-  repos:
-  - path: D:\Tendril\Repos\SlayZone
-    prRule: default
-    syncStrategy: fetch
-  verifications: []
-  context: ''
-  reviewActions: []
-  hooks: []
-  buildDependencies: []
 verifications:
 - name: FrameworkDotnetBuild
   prompt: >

--- a/src/resend/template.html
+++ b/src/resend/template.html
@@ -119,11 +119,6 @@
                 <p class="body-text" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #5A6361; font-size: 16px; line-height: 1.65; margin: 0 0 16px; padding: 0;">{{{SECTION_1_BODY}}}</p>
 
 
-                <!-- Section 2 -->
-                <h2 class="section-title" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #0D4A2F; font-size: 20px; font-weight: 600; line-height: 1.3; margin: 0 0 12px; padding: 0;">{{{SECTION_2_TITLE}}}</h2>
-
-                <p class="body-text" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #5A6361; font-size: 16px; line-height: 1.65; margin: 0 0 16px; padding: 0;">{{{SECTION_2_BODY}}}</p>
-
                 <!-- CTA Button -->
                 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin: 32px 0;">
                   <tr>
@@ -140,20 +135,11 @@
                   </tr>
                 </table>
 
-                <!-- Divider -->
-                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
-                  <tr><td class="divider" style="padding: 16px 0; border-top: 1px solid #D8DCDB; font-size: 1px; line-height: 1px;">&nbsp;</td></tr>
-                </table>
-
-                <p class="signoff" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #202221; font-size: 14px; font-weight: 500; line-height: 1.6; margin: 0; padding: 0;">— Niels & the Tendril team</p>
-
-                <!-- Divider -->
-                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
-                  <tr><td class="divider" style="padding: 16px 0; border-top: 1px solid #D8DCDB; font-size: 1px; line-height: 1px;">&nbsp;</td></tr>
-                </table>
 
                 <!-- Update Tendril Section -->
-                <h2 class="section-title" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #0D4A2F; font-size: 20px; font-weight: 600; line-height: 1.3; margin: 0 0 12px; padding: 0;">Update Tendril</h2>
+                <h2 class="section-title" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #0D4A2F; font-size: 20px; font-weight: 600; line-height: 1.3; margin: 0 0 8px; padding: 0;">Update Tendril</h2>
+
+                <p class="body-text" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #5A6361; font-size: 16px; line-height: 1.65; margin: 0 0 12px; padding: 0;">Type this in your terminal to update Tendril to the latest version:</p>
 
                 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin: 0 0 12px;">
                   <tr>
@@ -163,14 +149,16 @@
                   </tr>
                 </table>
 
-                <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #9CA3A1; font-size: 13px; line-height: 1.5; margin: 0 0 24px; padding: 0;">If you experience issues after updating try &quot;tendril reset&quot; to get a clean installation.</p>
+                <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #9CA3A1; font-size: 13px; line-height: 1.5; margin: 0 0 24px; padding: 0;">If you experience issues after updating try <span style="font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 12px; color: #202221;">tendril reset</span> to get a clean installation.</p>
 
                 <!-- Feature Requests Section -->
                 <h2 class="section-title" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #0D4A2F; font-size: 20px; font-weight: 600; line-height: 1.3; margin: 0 0 12px; padding: 0;">Feature Requests?</h2>
 
                 <p class="body-text" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #5A6361; font-size: 16px; line-height: 1.65; margin: 0 0 12px; padding: 0;">Email us on <a href="mailto:tendril@ivy.app" style="color: #0ccb91; text-decoration: underline;">tendril@ivy.app</a> or submit a ticket on <a href="https://github.com/Ivy-Interactive/Ivy-Tendril/issues" style="color: #0ccb91; text-decoration: underline;">GitHub Issues</a>. Our goal is to make you and your colleagues as productive as possible when coding with AI.</p>
 
-                <p class="body-text" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #5A6361; font-size: 16px; line-height: 1.65; margin: 0; padding: 0;">Please consider giving us a <a href="https://github.com/Ivy-Interactive/" style="color: #0ccb91; text-decoration: underline;">star on GitHub</a> and PRs are welcome!</p>
+                <p class="body-text" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #5A6361; font-size: 16px; line-height: 1.65; margin: 0 0 24px; padding: 0;">Please consider giving us a &#11088; on <a href="https://github.com/Ivy-Interactive/" style="color: #0ccb91; text-decoration: underline;">GitHub</a>!</p>
+
+                <p class="signoff" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif; color: #202221; font-size: 14px; font-weight: 500; line-height: 1.6; margin: 0; padding: 0;">— Niels & the Tendril team</p>
 
               </td>
             </tr>


### PR DESCRIPTION
Remove SlayZone project from config and simplify email template layout (remove section 2, reorder signoff, add update instructions text).