### PR TITLE
fix: update Add Project dialog header to say 'Add a project'

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -11,7 +11,8 @@ public class ProjectInputStepView(
     Action onBack,
     Action onNext,
     Action? onSkip = null,
-    string skipButtonText = "Skip Setup") : ViewBase
+    string skipButtonText = "Skip Setup",
+    string title = "Setup your first project") : ViewBase
 {
     public override object Build()
     {
@@ -41,7 +42,7 @@ public class ProjectInputStepView(
                 .OnClick(onNext);
 
         return Layout.Vertical()
-               | Text.H3("Setup your first project")
+               | Text.H3(title)
                | Text.Muted("A project groups one or more repositories together so Tendril can plan and verify changes across them.")
                | new ProjectRepoPickerView(selectedRepos, projectName)
                | new Spacer()

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
@@ -104,7 +104,8 @@ public class AddProjectDialog(
                     skipAgent.Set(true);
                     step.Set(1);
                 },
-                skipButtonText: "Skip AI Setup"),
+                skipButtonText: "Skip AI Setup",
+                title: "Add a project"),
             1 => new ProjectAgentStepView(
                 editRepos,
                 editName,


### PR DESCRIPTION
Updates the header in the 'Add Project' settings dialog from 'Setup your first project' to 'Add a project'.