### PR TITLE
fix: revert dialog trigger to UseState to fix infinite load / re-triggering

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -102,8 +102,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var serverArgs = UseService<ServerArgs>();
         var navigate = Context.UseSignal<NavigateSignal, NavigateArgs, Unit>();
         var navigator = UseNavigation();
-        var (importIssuesDialogView, showImportIssuesDialog) = UseTrigger(isOpen =>
-            new ImportIssuesDialog(isOpen, config));
+        var importIssuesDialogOpen = UseState(false);
         var newsArticles = UseState(Array.Empty<SidebarNewsArticle>());
 
         UseEffect(async () =>
@@ -428,7 +427,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             MenuItem.Default("Import Issues from GitHub")
                 .Tag("$import-issues")
                 .Icon(Icons.Download)
-                .OnSelect(() => showImportIssuesDialog()),
+                .OnSelect(() => importIssuesDialogOpen.Set(true)),
             MenuItem.Default("Theme")
                 .Tag("$theme")
                 .Icon(Icons.SunMoon)
@@ -477,7 +476,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 ),
                 settings.Width
             ).Open(sidebarOpen.Value).MainAppSidebar(),
-            importIssuesDialogView
+            new ImportIssuesDialog(importIssuesDialogOpen, config)
         );
     }
 


### PR DESCRIPTION
Reverts the GitHub issue import dialog to use UseState instead of UseTrigger to fix the infinite load / re-triggering issues when a repository is selected for the first time.