### PR TITLE
fix: rename project setup buttons to Manual Setup and AI Setup

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -11,8 +11,10 @@ public class ProjectInputStepView(
     Action onBack,
     Action onNext,
     Action? onSkip = null,
-    string skipButtonText = "Skip Setup",
-    string title = "Setup your first project") : ViewBase
+    string skipButtonText = "Skip",
+    string nextButtonText = "AI Setup",
+    string title = "Setup your first project",
+    bool disableSkipWhenCannotContinue = false) : ViewBase
 {
     public override object Build()
     {
@@ -36,8 +38,8 @@ public class ProjectInputStepView(
             | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
                 .OnClick(onBack)
             | new Spacer()
-            | (onSkip != null ? (object)new Button(skipButtonText).Ghost().Large().OnClick(() => onSkip()) : new Spacer())
-            | new Button("Create Project").Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
+            | (onSkip != null ? (object)new Button(skipButtonText).Ghost().Large().Disabled(disableSkipWhenCannotContinue && !canContinue).OnClick(() => onSkip()) : new Spacer())
+            | new Button(nextButtonText).Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
                 .Disabled(!canContinue)
                 .OnClick(onNext);
 

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
@@ -104,8 +104,10 @@ public class AddProjectDialog(
                     skipAgent.Set(true);
                     step.Set(1);
                 },
-                skipButtonText: "Skip AI Setup",
-                title: "Add a project"),
+                skipButtonText: "Manual Setup",
+                nextButtonText: "AI Setup",
+                title: "Add a project",
+                disableSkipWhenCannotContinue: true),
             1 => new ProjectAgentStepView(
                 editRepos,
                 editName,


### PR DESCRIPTION
Renames 'Skip AI Setup' to 'Manual Setup' and 'Create Project' to 'AI Setup' in the Add Project dialog, disabling 'Manual Setup' if no repo is selected. For onboarding, it keeps 'Skip' enabled by default.