### PR TITLE
feat: add `tendril update` command with Photino GUI updater

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -78,6 +78,37 @@ jobs:
       - name: Restore
         run: dotnet restore src/Ivy.Tendril/Ivy.Tendril.csproj
 
+      - name: Restore Updater
+        run: dotnet restore src/Ivy.Tendril.Updater/Ivy.Tendril.Updater.csproj
+
+      - name: Build Updater (all platforms)
+        run: |
+          dotnet publish src/Ivy.Tendril.Updater/Ivy.Tendril.Updater.csproj -c Release -r win-x64 --self-contained false -o ./PublishedBinaries/Ivy.Tendril.Updater/win-x64
+          dotnet publish src/Ivy.Tendril.Updater/Ivy.Tendril.Updater.csproj -c Release -r win-arm64 --self-contained false -o ./PublishedBinaries/Ivy.Tendril.Updater/win-arm64
+          dotnet publish src/Ivy.Tendril.Updater/Ivy.Tendril.Updater.csproj -c Release -r osx-x64 --self-contained false -o ./PublishedBinaries/Ivy.Tendril.Updater/osx-x64
+          dotnet publish src/Ivy.Tendril.Updater/Ivy.Tendril.Updater.csproj -c Release -r osx-arm64 --self-contained false -o ./PublishedBinaries/Ivy.Tendril.Updater/osx-arm64
+
+      - name: Clean Updater binaries
+        run: |
+          for dir in win-x64 win-arm64 osx-x64 osx-arm64; do
+            find ./PublishedBinaries/Ivy.Tendril.Updater/$dir -type f ! \( -name "*.exe" -o -name "*.dll" -o -name "*.dylib" -o -name "Ivy.Tendril.Updater" \) -delete
+          done
+
+      - name: Zip Updater binaries
+        run: |
+          cd PublishedBinaries/Ivy.Tendril.Updater/win-x64 && zip -r ../../../Ivy.Tendril.Updater.win-x64.zip . && cd ../../..
+          cd PublishedBinaries/Ivy.Tendril.Updater/win-arm64 && zip -r ../../../Ivy.Tendril.Updater.win-arm64.zip . && cd ../../..
+          cd PublishedBinaries/Ivy.Tendril.Updater/osx-x64 && zip -r ../../../Ivy.Tendril.Updater.osx-x64.zip . && cd ../../..
+          cd PublishedBinaries/Ivy.Tendril.Updater/osx-arm64 && zip -r ../../../Ivy.Tendril.Updater.osx-arm64.zip . && cd ../../..
+
+      - name: Embed Updater binaries in Ivy.Tendril
+        run: |
+          mkdir -p src/Ivy.Tendril/PublishedBinaries
+          cp Ivy.Tendril.Updater.win-x64.zip src/Ivy.Tendril/PublishedBinaries/
+          cp Ivy.Tendril.Updater.win-arm64.zip src/Ivy.Tendril/PublishedBinaries/
+          cp Ivy.Tendril.Updater.osx-x64.zip src/Ivy.Tendril/PublishedBinaries/
+          cp Ivy.Tendril.Updater.osx-arm64.zip src/Ivy.Tendril/PublishedBinaries/
+
       - name: Pack NuGet
         run: |
           dotnet pack src/Ivy.Tendril/Ivy.Tendril.csproj \

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ x86/
 **/tmp_out/
 msbuild.binlog
 
+## Updater binaries (CI-generated, embedded as resources)
+**/PublishedBinaries/
+
 ## Config backups
 *.yaml.backup
 

--- a/src/Ivy.Tendril.Updater/Apps/LoadingApp.cs
+++ b/src/Ivy.Tendril.Updater/Apps/LoadingApp.cs
@@ -1,0 +1,139 @@
+using System.Diagnostics;
+using Ivy;
+
+namespace Ivy.Tendril.Updater.Apps;
+
+[App()]
+public class LoadingApp : ViewBase
+{
+    public override object? Build()
+    {
+        var loading = UseState(true);
+        var failed = UseState(false);
+
+        UseEffect(async () =>
+        {
+            var updateResult = await Update();
+            if (!updateResult)
+            {
+                failed.Set(true);
+                loading.Set(false);
+                return;
+            }
+
+            var unpackResult = await Unpack();
+            if (!unpackResult)
+            {
+                failed.Set(true);
+                loading.Set(false);
+                return;
+            }
+
+            loading.Set(false);
+        }, [EffectTrigger.OnMount()]);
+
+        if (failed.Value)
+            return Layout.Center() | new FailedView();
+        return Layout.Center() | (loading.Value ? new LoadingView() : new FinishedView());
+    }
+
+    private async Task<bool> Update()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = "tool update -g Ivy.Tendril",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using var process = new Process();
+        process.StartInfo = startInfo;
+        process.OutputDataReceived += (_, _) => { };
+        process.ErrorDataReceived += (_, _) => { };
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        await process.WaitForExitAsync();
+        return process.ExitCode == 0;
+    }
+
+    private async Task<bool> Unpack()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "tendril",
+            Arguments = "version",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        using var process = new Process();
+        process.StartInfo = startInfo;
+        process.OutputDataReceived += (_, _) => { };
+        process.ErrorDataReceived += (_, _) => { };
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        await process.WaitForExitAsync();
+        return process.ExitCode == 0;
+    }
+}
+
+public class LoadingView : ViewBase
+{
+    public override object? Build()
+    {
+        var progress = UseState(0);
+
+        this.UseEffect(() =>
+        {
+            var progressObservable = ProgressObservable.Create(70, EasingFunctions.DualLinearEasing);
+            return progressObservable.Subscribe(
+                onNext: p => progress.Set(p)
+            );
+        });
+
+        void OnLinkClick(Event<Markdown, string> @event)
+        {
+            ProcessHelper.OpenBrowser(@event.Value);
+        }
+
+        return new Animation(AnimationType.FadeIn).Repeat(0)
+               | (Layout.Vertical().Width(100)
+                  | new Loading()
+                  | Text.H2("Updating Ivy.Tendril...")
+                  | new Progress(progress)
+                  | new Markdown(
+                      "While you wait, please star us on [GitHub](https://github.com/Ivy-Interactive/Ivy-Tendril).",
+                      OnLinkClick)
+               );
+    }
+}
+
+public class FinishedView : ViewBase
+{
+    public override object? Build()
+    {
+        return new Animation(AnimationType.FadeIn).Repeat(0)
+               | (Layout.Vertical().Width(100)
+                  | new Confetti(Text.H2("Ivy.Tendril has been updated")).Trigger(AnimationTrigger.Auto)
+                  | Text.Muted("You can now close this window."));
+    }
+}
+
+public class FailedView : ViewBase
+{
+    public override object? Build()
+    {
+        return new Animation(AnimationType.FadeIn).Repeat(0)
+               | (Layout.Vertical().Width(100)
+                  | Text.H2("Update Failed")
+                  | Text.Markdown("Please run `dotnet tool update -g Ivy.Tendril` to repair your installation.")
+                  | Text.Muted("You can now close this window."));
+    }
+}

--- a/src/Ivy.Tendril.Updater/DpiDetector.cs
+++ b/src/Ivy.Tendril.Updater/DpiDetector.cs
@@ -1,0 +1,136 @@
+using System.Runtime.InteropServices;
+
+namespace Ivy.Tendril.Updater;
+
+public static class DpiDetector
+{
+    public static double GetSystemScalingFactor()
+    {
+        try
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return GetWindowsScalingFactor();
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return GetMacOSScalingFactor();
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return GetLinuxScalingFactor();
+        }
+        catch
+        {
+        }
+
+        return 1.0;
+    }
+
+    #region Windows DPI Detection
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetDC(IntPtr hWnd);
+
+    [DllImport("gdi32.dll")]
+    private static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
+
+    [DllImport("user32.dll")]
+    private static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
+
+    private const int LOGPIXELSX = 88;
+
+    private static double GetWindowsScalingFactor()
+    {
+        IntPtr hdc = GetDC(IntPtr.Zero);
+        int dpiX = GetDeviceCaps(hdc, LOGPIXELSX);
+        ReleaseDC(IntPtr.Zero, hdc);
+        return dpiX / 96.0;
+    }
+
+    #endregion
+
+    #region macOS Retina Detection
+
+    [DllImport("libobjc.dylib")]
+    private static extern IntPtr objc_getClass(string className);
+
+    [DllImport("libobjc.dylib")]
+    private static extern IntPtr objc_msgSend(IntPtr receiver, IntPtr selector);
+
+    [DllImport("libobjc.dylib")]
+    private static extern IntPtr sel_registerName(string selectorName);
+
+    [DllImport("libobjc.dylib")]
+    private static extern double objc_msgSend_fpret(IntPtr receiver, IntPtr selector);
+
+    private static double GetMacOSScalingFactor()
+    {
+        var nsScreenClass = objc_getClass("NSScreen");
+        var mainScreenSelector = sel_registerName("mainScreen");
+        var backingScaleFactorSelector = sel_registerName("backingScaleFactor");
+
+        var mainScreen = objc_msgSend(nsScreenClass, mainScreenSelector);
+        if (mainScreen == IntPtr.Zero)
+            return 1.0;
+
+        var scaleFactor = objc_msgSend_fpret(mainScreen, backingScaleFactorSelector);
+
+        return scaleFactor > 0 ? scaleFactor : 1.0;
+    }
+
+    #endregion
+
+    #region Linux DPI Detection
+
+    [DllImport("libX11", EntryPoint = "XOpenDisplay")]
+    private static extern IntPtr XOpenDisplay(string? display_name);
+
+    [DllImport("libX11", EntryPoint = "XDisplayWidth")]
+    private static extern int XDisplayWidth(IntPtr display, int screen_number);
+
+    [DllImport("libX11", EntryPoint = "XDisplayWidthMM")]
+    private static extern int XDisplayWidthMM(IntPtr display, int screen_number);
+
+    [DllImport("libX11", EntryPoint = "XCloseDisplay")]
+    private static extern int XCloseDisplay(IntPtr display);
+
+    private static double GetLinuxScalingFactor()
+    {
+        var envScale = GetLinuxScalingFromEnvironment();
+        if (envScale > 1.0)
+            return envScale;
+
+        try
+        {
+            var display = XOpenDisplay(null);
+            if (display == IntPtr.Zero)
+                return 1.0;
+
+            int widthPixels = XDisplayWidth(display, 0);
+            int widthMM = XDisplayWidthMM(display, 0);
+            XCloseDisplay(display);
+
+            if (widthMM <= 0)
+                return 1.0;
+
+            double dpi = (widthPixels * 25.4) / widthMM;
+            return dpi / 96.0;
+        }
+        catch
+        {
+            return 1.0;
+        }
+    }
+
+    private static double GetLinuxScalingFromEnvironment()
+    {
+        var scalingVars = new[] { "GDK_SCALE", "GDK_DPI_SCALE", "QT_SCALE_FACTOR" };
+
+        foreach (var variable in scalingVars)
+        {
+            var value = Environment.GetEnvironmentVariable(variable);
+            if (!string.IsNullOrEmpty(value) && double.TryParse(value, out var scale) && scale > 0)
+                return scale;
+        }
+
+        return 1.0;
+    }
+
+    #endregion
+}

--- a/src/Ivy.Tendril.Updater/Ivy.Tendril.Updater.csproj
+++ b/src/Ivy.Tendril.Updater/Ivy.Tendril.Updater.csproj
@@ -1,0 +1,64 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>CS8618;CS8603</NoWarn>
+    <RootNamespace>Ivy.Tendril.Updater</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <CI Condition="'$(GITHUB_ACTIONS)' == 'true'">true</CI>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CI)' == 'true'">
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>false</SelfContained>
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PublishDir)' != ''">
+    <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IvySource)' == 'true'">
+    <ProjectReference Include="..\..\..\Ivy-Framework\src\Ivy\Ivy.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IvySource)' != 'true'">
+    <PackageReference Include="Ivy" Version="1.2.58" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IvySource)' == 'true'">
+    <ProjectReference Include="..\..\..\Ivy-Framework\src\Ivy.Analyser\Ivy.Analyser.csproj">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Analyzer</OutputItemType>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(IvySource)' != 'true'">
+    <PackageReference Include="Ivy.Analyser" Version="1.2.58">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Photino.NET" Version="4.0.16" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="../Ivy.Tendril/Assets/icon.ico" Link="icon.ico" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="../Ivy.Tendril/Assets/icon.icns" Link="icon.icns" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="../Ivy.Tendril/Assets/icon.png" Link="icon.png" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="build/Ivy.Tendril.Updater.targets" Pack="true" PackagePath="build/Ivy.Tendril.Updater.targets" />
+    <None Include="build/Ivy.Tendril.Updater.targets" Pack="true" PackagePath="buildTransitive/Ivy.Tendril.Updater.targets" />
+  </ItemGroup>
+
+  <Import Project="build/Ivy.Tendril.Updater.targets" />
+
+</Project>

--- a/src/Ivy.Tendril.Updater/Program.cs
+++ b/src/Ivy.Tendril.Updater/Program.cs
@@ -1,0 +1,111 @@
+using System.Globalization;
+using System.Net.NetworkInformation;
+using System.Runtime.InteropServices;
+using Photino.NET;
+
+namespace Ivy.Tendril.Updater;
+
+internal static class Program
+{
+    [STAThread]
+    public static int Main()
+    {
+        return Updater().GetAwaiter().GetResult();
+    }
+
+    private static async Task<int> Updater()
+    {
+        CultureInfo.DefaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
+
+        var port = 5010;
+        var url = $"https://localhost:{port}";
+        var server = new Server(new ServerArgs()
+        {
+            Port = port,
+            Silent = true,
+            DefaultAppId = "loading"
+        });
+
+        server.AddAppsFromAssembly();
+        server.UseHotReload();
+
+        CancellationTokenSource cts = new CancellationTokenSource();
+
+        var serverTask = server.RunAsync(cts);
+
+        if (!await CheckIfPortIsListening(port))
+        {
+            Console.WriteLine($@"Error: Unable to connect to {url}. Something went wrong.");
+            return 1;
+        }
+
+        var window = new PhotinoWindow() { LogVerbosity = 0 };
+
+        var scalingFactor = DpiDetector.GetSystemScalingFactor();
+        var baseWidth = 800;
+        var baseHeight = 600;
+        var windowWidth = (int)(baseWidth * scalingFactor);
+        var windowHeight = (int)(baseHeight * scalingFactor);
+
+        var iconPath = GetIconPath();
+
+        window
+            .SetUseOsDefaultSize(false)
+            .SetSize(windowWidth, windowHeight)
+            .SetTitle("Ivy Tendril Updater")
+            .SetIconFile(iconPath)
+            .SetResizable(false)
+            .SetTopMost(true)
+            .SetJavascriptClipboardAccessEnabled(false)
+            .SetDevToolsEnabled(false)
+            .SetIgnoreCertificateErrorsEnabled(true)
+            .SetWebSecurityEnabled(false)
+            .Center()
+            .Load(new Uri(url));
+
+        window.WaitForClose();
+
+        await cts.CancelAsync();
+        await serverTask;
+
+        return 0;
+    }
+
+    private static string GetIconPath()
+    {
+        var baseDir = Path.GetDirectoryName(typeof(Program).Assembly.Location) ?? ".";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return Path.Combine(baseDir, "icon.ico");
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return Path.Combine(baseDir, "icon.icns");
+        return Path.Combine(baseDir, "icon.png");
+    }
+
+    private static async Task<bool> CheckIfPortIsListening(int port, int maxAttempts = 10)
+    {
+        var delayMs = 1000;
+
+        for (var i = 0; i < maxAttempts; i++)
+        {
+            try
+            {
+                bool isListening = IPGlobalProperties
+                    .GetIPGlobalProperties()
+                    .GetActiveTcpListeners()
+                    .Any(endpoint => endpoint.Port == port);
+                if (isListening)
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                //ignore
+            }
+            if (i == maxAttempts - 1) return false;
+            await Task.Delay(delayMs);
+        }
+
+        return false;
+    }
+}

--- a/src/Ivy.Tendril.Updater/ProgressObservable.cs
+++ b/src/Ivy.Tendril.Updater/ProgressObservable.cs
@@ -1,0 +1,45 @@
+using System.Reactive.Linq;
+
+namespace Ivy.Tendril.Updater;
+
+public static class ProgressObservable
+{
+    public delegate double EasingFunction(double t);
+
+    private static double LinearEasing(double t) => t;
+
+    public static IObservable<int> Create(double duration = 10, EasingFunction? easingFunction = null)
+    {
+        var easing = easingFunction ?? LinearEasing;
+        double updateInterval = (duration * 1000.0) / 100;
+
+        return Observable.Interval(TimeSpan.FromMilliseconds(updateInterval))
+            .Take(101)
+            .Select(tick =>
+            {
+                double t = tick / 100.0;
+                double progress = easing(t) * 100.0;
+                return (int)progress;
+            });
+    }
+}
+
+public static class EasingFunctions
+{
+    public static double DualLinearEasing(double t)
+    {
+        const double transitionPoint = 0.25;
+        if (t <= transitionPoint)
+        {
+            return (t / transitionPoint) * 0.75;
+        }
+        else
+        {
+            double startVal = 0.75;
+            double endVal = 1.0;
+            double phaseDuration = 1.0 - transitionPoint;
+            double phaseProgress = (t - transitionPoint) / phaseDuration;
+            return startVal + (endVal - startVal) * phaseProgress;
+        }
+    }
+}

--- a/src/Ivy.Tendril/Commands/UpdateCliCommand.cs
+++ b/src/Ivy.Tendril/Commands/UpdateCliCommand.cs
@@ -1,0 +1,158 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+[Description("Update Tendril to the latest version")]
+public class UpdateCliCommand : AsyncCommand<UpdateCliCommand.Settings>
+{
+    public class Settings : CommandSettings
+    {
+    }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        var currentVersion = GetCurrentVersion();
+        var latestVersion = await GetLatestVersionAsync();
+        var isUpToDate = currentVersion != null && latestVersion != null && currentVersion == latestVersion;
+
+        if (isUpToDate)
+        {
+            AnsiConsole.MarkupLine("[green]You are already on the latest version of Ivy.Tendril.[/]");
+            return 0;
+        }
+
+        AnsiConsole.MarkupLine("[grey]Please wait...[/]");
+
+        var executablePath = await Extract();
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = executablePath,
+            UseShellExecute = false,
+        };
+        Process.Start(psi);
+
+        return 0;
+    }
+
+    private static Version? GetCurrentVersion()
+    {
+        try
+        {
+            var assembly = typeof(Program).Assembly;
+            return NormalizeVersion(assembly.GetName().Version?.ToString());
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static async Task<Version?> GetLatestVersionAsync()
+    {
+        try
+        {
+            using var httpClient = new HttpClient();
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "Ivy.Tendril");
+
+            var response = await httpClient.GetStringAsync("https://api.nuget.org/v3-flatcontainer/ivy.tendril/index.json");
+            var json = JsonDocument.Parse(response);
+
+            if (json.RootElement.TryGetProperty("versions", out var versions))
+            {
+                var versionArray = versions.EnumerateArray().ToArray();
+                return NormalizeVersion(versionArray.LastOrDefault().GetString());
+            }
+        }
+        catch
+        {
+        }
+
+        return null;
+    }
+
+    private static Version? NormalizeVersion(string? versionString)
+    {
+        if (string.IsNullOrEmpty(versionString))
+            return null;
+
+        var parts = versionString.Split('.');
+        var major = parts.Length > 0 ? int.Parse(parts[0]) : 0;
+        var minor = parts.Length > 1 ? int.Parse(parts[1]) : 0;
+        var build = parts.Length > 2 ? int.Parse(parts[2]) : 0;
+        var revision = parts.Length > 3 ? int.Parse(parts[3]) : 0;
+
+        return new Version(major, minor, build, revision);
+    }
+
+    private static (string resourcePath, string executableFileName) GetPlatformResource()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var arch = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "win-arm64" : "win-x64";
+            return ($"Ivy.Tendril.PublishedBinaries.Ivy.Tendril.Updater.{arch}.zip", "Ivy.Tendril.Updater.exe");
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            var arch = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "osx-arm64" : "osx-x64";
+            return ($"Ivy.Tendril.PublishedBinaries.Ivy.Tendril.Updater.{arch}.zip", "Ivy.Tendril.Updater");
+        }
+
+        throw new PlatformNotSupportedException(RuntimeInformation.OSDescription);
+    }
+
+    private static async Task<string> Extract()
+    {
+        var (resourcePath, executableFileName) = GetPlatformResource();
+
+        string tempDir = Path.Combine(Path.GetTempPath(), "Ivy.Tendril.Updater");
+
+        if (Directory.Exists(tempDir))
+            Directory.Delete(tempDir, true);
+
+        Directory.CreateDirectory(tempDir);
+
+        string zipPath = Path.Combine(tempDir, "Ivy.Tendril.Updater.zip");
+
+        var assembly = Assembly.GetExecutingAssembly();
+
+        await using (var stream = assembly.GetManifestResourceStream(resourcePath)
+                                  ?? throw new InvalidOperationException($"Resource '{resourcePath}' not found."))
+        {
+            await using var resourceStream = new FileStream(zipPath, FileMode.Create, FileAccess.Write);
+            await stream.CopyToAsync(resourceStream);
+        }
+
+        using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Read))
+        {
+            foreach (var entry in archive.Entries)
+            {
+                var filePath = Path.Combine(tempDir, entry.Name);
+                await using var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write);
+                await entry.Open().CopyToAsync(fileStream);
+            }
+        }
+
+        var exePath = Path.Combine(tempDir, executableFileName);
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var chmod = new ProcessStartInfo("chmod", $"+x \"{exePath}\"")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            Process.Start(chmod)?.WaitForExit();
+        }
+
+        return exePath;
+    }
+}

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -30,6 +30,9 @@
     <EmbeddedResource Include="Assets/**/*" />
     <EmbeddedResource Include="../Tendril.svg" Link="Assets/Tendril.svg" />
   </ItemGroup>
+  <ItemGroup Condition="Exists('PublishedBinaries')">
+    <EmbeddedResource Include="PublishedBinaries/**/*.zip" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />

--- a/src/Ivy.Tendril/Ivy.Tendril.slnx
+++ b/src/Ivy.Tendril/Ivy.Tendril.slnx
@@ -5,6 +5,7 @@
     <Platform Name="x86" />
   </Configurations>
   <Project Path="Ivy.Tendril.csproj" />
+  <Project Path="../Ivy.Tendril.Updater/Ivy.Tendril.Updater.csproj" />
   <Project Path="../Ivy.Tendril.Test/Ivy.Tendril.Test.csproj" />
   <Project Path="../Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj" />
   <Project Path="../Ivy.Tendril.Test.End2End/Ivy.Tendril.Test.End2End.csproj" />

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -209,7 +209,7 @@ public class Program
             "doctor", "db-version", "db-migrate", "db-reset",
             "update-promptwares", "job", "plan", "promptware",
             "trash", "verification", "project",
-            "version", "--version", "report-bug", "reset"
+            "version", "--version", "report-bug", "reset", "update"
         };
         return cliCommands.Contains(firstArg);
     }
@@ -309,6 +309,8 @@ public class Program
             });
             config.AddCommand<VersionCommand>("version")
                 .WithDescription("Show version information");
+            config.AddCommand<UpdateCliCommand>("update")
+                .WithDescription("Update Tendril to the latest version");
             config.AddCommand<ReportBugCommand>("report-bug")
                 .WithDescription("Report a bug with plan/job context");
 


### PR DESCRIPTION
## Summary
- New `Ivy.Tendril.Updater` project — Photino GUI window showing progress while running `dotnet tool update -g Ivy.Tendril`
- `tendril update` CLI command checks NuGet for latest version, extracts embedded platform-specific updater binary, and launches it
- CI workflow updated to build updater for 4 platforms (win-x64, win-arm64, osx-x64, osx-arm64) and embed as resources in the NuGet package
- Added `.gitignore` entry for `PublishedBinaries/`

## Test plan
- [x] `Ivy.Tendril.Updater` project builds successfully
- [x] `Ivy.Tendril` project builds successfully with new command
- [x] Unit tests pass (1459/1460, 1 pre-existing unrelated failure)
- [x] Updater GUI launches and displays correctly
- [ ] Verify CI workflow builds and embeds updater binaries on next release