### PR TITLE
fix: make process view targets import conditional with nuget fallback

### DIFF
--- a/src/Ivy.Widget.TendrilProcessView/Ivy.Widget.TendrilProcessView.csproj
+++ b/src/Ivy.Widget.TendrilProcessView/Ivy.Widget.TendrilProcessView.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy" Version="1.2.58" />
+    <PackageReference Include="Ivy" Version="1.2.58" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>
@@ -50,6 +50,10 @@
     <None Include=".samples\**\*" CopyToOutputDirectory="Never" />
   </ItemGroup>
 
-  <Import Project="../../../Ivy-Framework/src/Ivy/Build/Ivy.ExternalWidget.targets" />
+  <!-- Import framework targets from sibling Ivy-Framework repo if present (local dev) -->
+  <Import Project="../../../Ivy-Framework/src/Ivy/Build/Ivy.ExternalWidget.targets" Condition="Exists('../../../Ivy-Framework/src/Ivy/Build/Ivy.ExternalWidget.targets')" />
+
+  <!-- Fallback to the targets in the Ivy NuGet package if local sibling is not present (CI / standalone) -->
+  <Import Project="$(PkgIvy)\build\Ivy.ExternalWidget.targets" Condition="!Exists('../../../Ivy-Framework/src/Ivy/Build/Ivy.ExternalWidget.targets') And '$(PkgIvy)' != '' And Exists('$(PkgIvy)\build\Ivy.ExternalWidget.targets')" />
 
 </Project>


### PR DESCRIPTION
Resolves the MSB4019 targets import error when packing Tendril in CI where the sibling framework repository is not cloned. Uses sibling framework targets if present, falling back to NuGet package targets.