### PR TITLE
(full job prompt view): use codeblock instead of markdown

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/PromptSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/PromptSheet.cs
@@ -4,6 +4,6 @@ public class PromptSheet(string promptText) : ViewBase
 {
     public override object Build()
     {
-        return new Markdown($"```\n{promptText}\n```");
+        return new CodeBlock(promptText, Languages.Text);
     }
 }


### PR DESCRIPTION
Had a problem with UI when view full prompt
Steps to reproduce: jobs -  click prompt/title cell. 
Markdown was showing wrong borders. 
<img width="810" height="207" alt="Screenshot 2026-05-21 at 00 42 28" src="https://github.com/user-attachments/assets/e1668afd-6fe7-45c5-a238-eb4279cde7ce" />

Used CodeBlock instead of it. 

Fixed:
<img width="769" height="159" alt="Screenshot 2026-05-21 at 00 45 24" src="https://github.com/user-attachments/assets/d981c7aa-567a-4fcf-8ef7-3dd4ce8e0072" />

