### PR TITLE
refactor: use CodeBlock widget and early returns in agent resolution

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/AGENTS.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/AGENTS.md
@@ -11,3 +11,7 @@ Shipped promptwares are used by all Tendril customers across different teams, te
 - **Tool references.** Refer to shipped tools by name without file extension: `Tools/Apply-SyncStrategy`, not `Tools/Apply-SyncStrategy.ps1`. The runtime resolves the correct script format.
 - **Config over convention.** Anything that varies between customers belongs in config.yaml or the firmware header, not in Program.md. If you find yourself writing "if using X, do Y" for a customer-specific X, it should be a config option instead.
 - **Keep it concise.** The limiting factor is a human reading the plan. Every sentence must earn its place.
+
+## Reference
+
+For detailed intel on CLI coding agents (capabilities, quirks, configuration tips), see the companion repository at `D:\Repos\_Ivy\Coding-Agent-Experiments`.

--- a/src/Ivy.Tendril/Apps/Jobs/PromptSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/PromptSheet.cs
@@ -4,6 +4,6 @@ public class PromptSheet(string promptText) : ViewBase
 {
     public override object Build()
     {
-        return new Markdown($"```\n{promptText}\n```");
+        return new CodeBlock(promptText, Languages.Text);
     }
 }

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -574,7 +574,7 @@ public class ContentView(
                     ? Text.Muted("Loading...")
                     : artifactContentQuery.Error is { } err
                         ? Text.Muted($"Failed to load artifact: {err.Message}")
-                        : new Markdown($"```{language.ToString().ToLowerInvariant()}\n{artifactContentQuery.Value}\n```"),
+                        : new CodeBlock($"{language.ToString().ToLowerInvariant()}\n{artifactContentQuery.Value}\n", Languages.Text),
                 Path.GetFileName(artifactPath)
             ).Width(Size.Half()).Resizable();
         }

--- a/src/Ivy.Tendril/Apps/Views/Sheets/FileSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/FileSheet.cs
@@ -57,11 +57,11 @@ public class FileSheet(
         {
             var fileContent = FileHelper.ReadAllText(filePath);
             var language = FileHelper.GetLanguage(ext);
-            sheetContent = new Markdown($"```{language.ToString().ToLowerInvariant()}\n{fileContent}\n```");
+            sheetContent =  new CodeBlock($"{language.ToString().ToLowerInvariant()}\n{fileContent}", Languages.Text);
         }
         else
         {
-            sheetContent = new Markdown("File not found.");
+            sheetContent = Text.Block("File not found.");
         }
 
         var finalContent = fileExists

--- a/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
+++ b/src/Ivy.Tendril/Services/Agents/AgentProviderFactory.cs
@@ -103,25 +103,20 @@ public class AgentProviderFactory
             (a.Name.Equals("Copilot", StringComparison.OrdinalIgnoreCase) && codingAgent == "copilot") ||
             (a.Name.Equals("OpenCode", StringComparison.OrdinalIgnoreCase) && codingAgent == "opencode"));
 
-        if (agentConfig != null)
-        {
-            if (!string.IsNullOrWhiteSpace(agentConfig.Arguments))
-                extraArgs.AddRange(SplitArgs(agentConfig.Arguments));
+        if (agentConfig == null) return new AgentResolution(provider, model, effort, allowedTools, extraArgs);
+        if (!string.IsNullOrWhiteSpace(agentConfig.Arguments))
+            extraArgs.AddRange(SplitArgs(agentConfig.Arguments));
 
-            if (!string.IsNullOrEmpty(profileName))
-            {
-                var profile = agentConfig.Profiles.FirstOrDefault(p =>
-                    p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+        if (string.IsNullOrEmpty(profileName))
+            return new AgentResolution(provider, model, effort, allowedTools, extraArgs);
+        var profile = agentConfig.Profiles.FirstOrDefault(p =>
+            p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
 
-                if (profile != null)
-                {
-                    if (!string.IsNullOrEmpty(profile.Model)) model = profile.Model;
-                    if (!string.IsNullOrEmpty(profile.Effort)) effort = profile.Effort;
-                    if (!string.IsNullOrWhiteSpace(profile.Arguments))
-                        extraArgs.AddRange(SplitArgs(profile.Arguments));
-                }
-            }
-        }
+        if (profile == null) return new AgentResolution(provider, model, effort, allowedTools, extraArgs);
+        if (!string.IsNullOrEmpty(profile.Model)) model = profile.Model;
+        if (!string.IsNullOrEmpty(profile.Effort)) effort = profile.Effort;
+        if (!string.IsNullOrWhiteSpace(profile.Arguments))
+            extraArgs.AddRange(SplitArgs(profile.Arguments));
 
         return new AgentResolution(provider, model, effort, allowedTools, extraArgs);
     }


### PR DESCRIPTION
Replace Markdown code-fence rendering with CodeBlock widget in PromptSheet, ContentView, and FileSheet. Flatten nested conditionals in AgentProviderFactory using early returns. Add coding-agent reference to AGENTS.md.