### PR TITLE
[AppShell]: Remove StayOpen from settings menu to fix dismissal bug

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -451,7 +451,6 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 DropDownMenu.DefaultSelectHandler(),
                 settingsTrigger)
             .Top()
-            .StayOpen()
             .Items(settings.FooterMenuItemsTransformer(settingsMenuItems, navigator));
 
         object? footer = settingsMenu;


### PR DESCRIPTION
## Problem Description
In the Tendril application (on both `plugins` and `development` branches), a bug was found where the Settings dropdown menu in the sidebar failed to dismiss automatically after a user selected an item (such as "Configuration", "Trash", or "Import Issues from GitHub").

## Analysis & Root Cause
In `TendrilAppShell.cs` (line 454), the `DropDownMenu` used for the settings menu was initialized with a `.StayOpen()` method call.
This property was passed down to the frontend component (`DropDownMenuWidget.tsx`), where it added an `e.preventDefault()` call to the `onSelect` event for **all** menu items. This completely blocked the default Radix UI behavior, preventing the dropdown from closing.

For comparison, the base `DefaultSidebarAppShell.cs` from `Ivy-Framework` did not use this method, which is why other dropdown menus dismissed correctly.

## Proposed Solutions

During the investigation, the following options were considered:

1. **Remove `.StayOpen()` globally (Chosen Solution)**
   * **Approach:** Simply remove the `.StayOpen()` call when creating the settings menu.
   * **Pros:** Solves the issue with a single-line change. Makes the behavior consistent with the rest of the framework.
   * **Cons:** When switching the theme via the "Theme" -> "Light/Dark/System" submenu, the menu will close. However, this is a standard and expected behavior for most UI dropdown components.

2. **Control `StayOpen` on a per-item basis**
   * **Approach:** Remove the global `.StayOpen()` call from the menu component but introduce logic to keep the menu open *only* when interacting with the "Theme" submenu.
   * **Pros:** Ideal UX for theme switching.
   * **Cons:** Requires changes in `Ivy-Framework` at the C# `MenuItem` abstraction level and corresponding frontend support, which is architectural over-engineering for this specific bug.

3. **Manual menu dismissal via `OnSelect` handlers**
   * **Approach:** Add explicit menu dismiss events to the frontend inside the `OnSelect` handlers for items like "Configuration" and "Trash".
   * **Cons:** Unnecessary logic complication, mixing UI state (open/closed) with business logic (routing).

## Implementation
**Option 1** was chosen as the most elegant and simple solution.
* Removed the `.StayOpen()` call for `settingsMenu` in `src/Ivy.Tendril/AppShell/TendrilAppShell.cs`.

## How to Test
1. Build and run the application: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj /p:IvySource=false -- --desktop`
2. Open the `Settings` menu in the bottom-left corner of the sidebar.
3. Click on the `Configuration` or `Trash` item.
4. Verify that navigation occurs successfully and the dropdown menu dismisses immediately.
