### PR TITLE
fix: parse tool results from Claude Code user messages

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudeEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudeEventParserTests.cs
@@ -371,6 +371,50 @@ public class ClaudeEventParserTests
     }
 
     [Fact]
+    public void ParseLine_UserMessageToolResult_ParsesResult()
+    {
+        var json = """{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_01","type":"tool_result","content":"file contents here"}]}}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Single(events);
+        var resultEvt = Assert.IsType<ToolResultEvent>(events[0]);
+        Assert.Equal("toolu_01", resultEvt.ToolUseId);
+        Assert.Equal("file contents here", resultEvt.Output);
+        Assert.False(resultEvt.IsError);
+    }
+
+    [Fact]
+    public void ParseLine_UserMessageToolResult_WithArrayContent_ParsesResult()
+    {
+        var json = """{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_02","type":"tool_result","content":[{"type":"text","text":"line 1"},{"type":"text","text":"line 2"}]}]}}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Single(events);
+        var resultEvt = Assert.IsType<ToolResultEvent>(events[0]);
+        Assert.Equal("toolu_02", resultEvt.ToolUseId);
+        Assert.Equal("line 1\nline 2", resultEvt.Output);
+    }
+
+    [Fact]
+    public void ParseLine_UserMessageToolResult_WithError_ParsesIsError()
+    {
+        var json = """{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_03","type":"tool_result","content":"Permission denied","is_error":true}]}}""";
+        var events = _parser.ParseLine(json);
+
+        var resultEvt = Assert.IsType<ToolResultEvent>(events[0]);
+        Assert.True(resultEvt.IsError);
+        Assert.Equal("Permission denied", resultEvt.Output);
+    }
+
+    [Fact]
+    public void ParseLine_UserMessageWithoutToolResult_ReturnsEmpty()
+    {
+        var json = """{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}""";
+        var events = _parser.ParseLine(json);
+        Assert.Empty(events);
+    }
+
+    [Fact]
     public void ParseLine_PartialJsonTruncated_ReturnsUnknown()
     {
         var json = """{"type":"assistant","message":{"id":"msg_01","content":[{"type":"te""";

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeEventParser.cs
@@ -45,6 +45,7 @@ public sealed class ClaudeEventParser : IEventParser
             {
                 "system" => ParseSystem(root, rawLine),
                 "assistant" => ParseAssistant(root, rawLine),
+                "user" => ParseUser(root, rawLine),
                 "result" => ParseResult(root, rawLine),
                 _ => Empty
             };
@@ -218,6 +219,36 @@ public sealed class ClaudeEventParser : IEventParser
                     });
                     break;
             }
+        }
+
+        return events.Count > 0 ? events : Empty;
+    }
+
+    private static IReadOnlyList<AgentEvent> ParseUser(JsonElement root, string rawLine)
+    {
+        if (!root.TryGetProperty("message", out var message)) return Empty;
+        if (!message.TryGetProperty("content", out var content)) return Empty;
+        if (content.ValueKind != JsonValueKind.Array) return Empty;
+
+        var events = new List<AgentEvent>();
+
+        foreach (var block in content.EnumerateArray())
+        {
+            if (!block.TryGetProperty("type", out var blockType)) continue;
+            if (blockType.GetString() != "tool_result") continue;
+
+            var toolUseId = block.TryGetProperty("tool_use_id", out var tidProp) ? tidProp.GetString() ?? "" : "";
+            var output = block.TryGetProperty("content", out var outProp) ? ContentExtractor.ExtractText(outProp) : null;
+            var isError = block.TryGetProperty("is_error", out var errProp) && errProp.GetBoolean();
+
+            events.Add(new ToolResultEvent
+            {
+                Kind = AgentEventKind.ToolResult,
+                ToolUseId = toolUseId,
+                Output = output,
+                IsError = isError,
+                RawLine = rawLine,
+            });
         }
 
         return events.Count > 0 ? events : Empty;

--- a/src/Ivy.Widgets.AgentOutputView/.samples/Program.cs
+++ b/src/Ivy.Widgets.AgentOutputView/.samples/Program.cs
@@ -47,13 +47,11 @@ class LiveStreamDemo : ViewBase
     {
         var stream = UseStream<string>();
         var running = UseState(false);
-        var resetToken = UseState(0);
 
         var button = running.Value
             ? new Button("Running...").Disabled()
             : new Button("Start").Primary().OnClick(async () =>
             {
-                resetToken.Set(resetToken.Value + 1);
                 running.Set(true);
                 foreach (var evt in SampleData.Events)
                 {
@@ -67,7 +65,6 @@ class LiveStreamDemo : ViewBase
                | button
                | new AgentOutputView()
                    .Stream(stream)
-                   .ResetToken(resetToken.Value)
                    .ShowStatusLabel(true)
                    .Height(Size.Full());
     }

--- a/src/Ivy.Widgets.AgentOutputView/AgentOutputView.cs
+++ b/src/Ivy.Widgets.AgentOutputView/AgentOutputView.cs
@@ -26,9 +26,6 @@ public record AgentOutputView : WidgetBase<AgentOutputView>
     /// <summary>Override the auto-derived status label text. Null = derive from latest event.</summary>
     [Prop] public string? StatusLabelOverride { get; init; }
 
-    /// <summary>Changing this value clears all accumulated stream output.</summary>
-    [Prop] public int ResetToken { get; init; } = 0;
-
     [Event] public Func<Event<AgentOutputView, string>, ValueTask>? OnComplete { get; init; }
 }
 
@@ -54,9 +51,6 @@ public static class AgentOutputViewExtensions
 
     public static AgentOutputView StatusLabel(this AgentOutputView w, string? statusLabel) =>
         w with { StatusLabelOverride = statusLabel };
-
-    public static AgentOutputView ResetToken(this AgentOutputView w, int resetToken) =>
-        w with { ResetToken = resetToken };
 
     public static AgentOutputView OnComplete(
         this AgentOutputView w,

--- a/src/Ivy.Widgets.AgentOutputView/frontend/src/AgentOutputView.tsx
+++ b/src/Ivy.Widgets.AgentOutputView/frontend/src/AgentOutputView.tsx
@@ -44,7 +44,6 @@ interface AgentOutputViewProps {
   showSystemEvents?: boolean;
   showStatusLabel?: boolean;
   statusLabelOverride?: string;
-  resetToken?: number;
 }
 
 export const AgentOutputView: React.FC<AgentOutputViewProps> = ({
@@ -61,13 +60,12 @@ export const AgentOutputView: React.FC<AgentOutputViewProps> = ({
   showSystemEvents = false,
   showStatusLabel = true,
   statusLabelOverride,
-  resetToken = 0,
 }) => {
   const [streamedLines, setStreamedLines] = useState<string[]>([]);
 
   useEffect(() => {
     setStreamedLines([]);
-  }, [resetToken, jsonStream]);
+  }, [jsonStream]);
 
   useEffect(() => {
     if (!stream?.id || !subscribeToStream) return;


### PR DESCRIPTION
## Summary
- Claude Code sends tool_result events in `{"type":"user"}` messages, not inside assistant messages. The ClaudeEventParser only handled system/assistant/result top-level types, so tool outputs never reached the frontend (OUT sections empty).
- Adds `ParseUser` method to extract tool_result content blocks from user messages.
- Removes unused `ResetToken` prop from AgentOutputView.

## Test plan
- [x] 4 new unit tests for user-message tool result parsing (string, array, error, non-result)
- [x] All 44 ClaudeEventParser tests pass
- [x] Full agent test suite passes
- [x] Build clean (0 warnings)