### PR TITLE
[ProjectInputStepView]: show "Cancel" instead of "Back" on first dialog step

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -8,12 +8,11 @@ public class ProjectInputStepView(
     IState<List<RepoRef>> selectedRepos,
     IState<string> projectName,
     IState<bool> isStepLoading,
-    Action onBack,
     Action onNext,
+    Action? onBack = null,
     Action? onSkip = null,
     string skipButtonText = "Skip",
     string nextButtonText = "AI Setup",
-    string backButtonText = "Back",
     string title = "Setup your first project",
     bool disableSkipWhenCannotContinue = false) : ViewBase
 {
@@ -35,11 +34,8 @@ public class ProjectInputStepView(
                           && !string.IsNullOrWhiteSpace(projectName.Value)
                           && !nameExists;
 
-        var backButton = new Button(backButtonText).Outline().Large().OnClick(onBack);
-        if (backButtonText == "Back") backButton.Icon(Icons.ArrowLeft);
-
         var buttonArea = Layout.Horizontal().Width(Size.Full())
-            | backButton
+            | (onBack != null ? (object)new Button("Back").Outline().Large().Icon(Icons.ArrowLeft).OnClick(onBack) : new Spacer())
             | new Spacer()
             | (onSkip != null ? (object)new Button(skipButtonText).Ghost().Large().Disabled(disableSkipWhenCannotContinue && !canContinue).OnClick(() => onSkip()) : new Spacer())
             | new Button(nextButtonText).Secondary().Large().Icon(Icons.ArrowRight, Align.Right)

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -13,6 +13,7 @@ public class ProjectInputStepView(
     Action? onSkip = null,
     string skipButtonText = "Skip",
     string nextButtonText = "AI Setup",
+    string backButtonText = "Back",
     string title = "Setup your first project",
     bool disableSkipWhenCannotContinue = false) : ViewBase
 {
@@ -34,9 +35,11 @@ public class ProjectInputStepView(
                           && !string.IsNullOrWhiteSpace(projectName.Value)
                           && !nameExists;
 
+        var backButton = new Button(backButtonText).Outline().Large().OnClick(onBack);
+        if (backButtonText == "Back") backButton.Icon(Icons.ArrowLeft);
+
         var buttonArea = Layout.Horizontal().Width(Size.Full())
-            | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
-                .OnClick(onBack)
+            | backButton
             | new Spacer()
             | (onSkip != null ? (object)new Button(skipButtonText).Ghost().Large().Disabled(disableSkipWhenCannotContinue && !canContinue).OnClick(() => onSkip()) : new Spacer())
             | new Button(nextButtonText).Secondary().Large().Icon(Icons.ArrowRight, Align.Right)

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
@@ -95,7 +95,6 @@ public class AddProjectDialog(
                 editRepos,
                 editName,
                 isStepLoading,
-                onBack: CancelAndClose,
                 onNext: () => {
                     skipAgent.Set(false);
                     step.Set(1);
@@ -106,7 +105,6 @@ public class AddProjectDialog(
                 },
                 skipButtonText: "Manual Setup",
                 nextButtonText: "AI Setup",
-                backButtonText: "Cancel",
                 title: "Add a project",
                 disableSkipWhenCannotContinue: true),
             1 => new ProjectAgentStepView(

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
@@ -106,6 +106,7 @@ public class AddProjectDialog(
                 },
                 skipButtonText: "Manual Setup",
                 nextButtonText: "AI Setup",
+                backButtonText: "Cancel",
                 title: "Add a project",
                 disableSkipWhenCannotContinue: true),
             1 => new ProjectAgentStepView(


### PR DESCRIPTION
## Problem

The `ProjectInputStepView` component is used in two different contexts:

| Context | File | Step Position | Back Action |
|---------|------|---------------|-------------|
| **OnboardingApp** | `OnboardingApp.cs` | 3rd step of 4 | Navigates to previous step |
| **AddProjectDialog** | `AddProjectDialog.cs` | **1st step of 3** | Closes the dialog (`CancelAndClose()`) |

In `AddProjectDialog`, the view is the **first step** in the flow — there is no previous step to navigate back to. However, the button was hardcoded as **"← Back"**, which is misleading. The `onBack` action actually calls `CancelAndClose()`, so the button should reflect that.

## What needed to be done

The button label and icon needed to adapt to the context:
- When used as a **middle/later step** (e.g. in Onboarding) → show **"← Back"** with an arrow icon
- When used as the **first step** (e.g. in AddProjectDialog) → show **"Cancel"** without an arrow icon

## What was changed

### `ProjectInputStepView.cs`

- Added a new optional constructor parameter `backButtonText` (default: `"Back"`) — following the existing pattern already used for `skipButtonText` and `nextButtonText`
- The button now uses `backButtonText` instead of the hardcoded `"Back"` string
- The arrow icon (`Icons.ArrowLeft`) is now **conditionally rendered** — it only appears when the button text is `"Back"`, and is hidden for `"Cancel"` since a left arrow doesn't make sense for a cancel action

### `AddProjectDialog.cs`

- Passed `backButtonText: "Cancel"` when constructing `ProjectInputStepView` at step 0

### No changes to `OnboardingApp.cs`

The default value `"Back"` preserves the existing behavior — no modifications needed.

## Result

| Context | Before | After |
|---------|--------|-------|
| AddProjectDialog (step 0) | ← Back | Cancel |
| OnboardingApp (step 2) | ← Back | ← Back (unchanged) |

<img width="816" height="575" alt="image" src="https://github.com/user-attachments/assets/c5a68f3f-295c-40cd-b3bd-60eaf3abfa74" />
<img width="818" height="694" alt="image" src="https://github.com/user-attachments/assets/7c963afc-0a3d-4630-bbc2-bad1308d3d63" />
