### PR TITLE
[CLI]: handle --help flag without starting the server

### DIFF
--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -221,7 +221,8 @@ public class Program
             "doctor", "db-version", "db-migrate", "db-reset",
             "update-promptwares", "job", "plan", "promptware",
             "trash", "verification", "project",
-            "version", "--version", "report-bug", "reset", "update"
+            "version", "--version", "report-bug", "reset", "update",
+            "--help", "-h"
         };
         return cliCommands.Contains(firstArg);
     }


### PR DESCRIPTION
## Issue

When running `tendril --help`, the application starts the full server on `localhost:5010` and displays warnings about missing script resources instead of showing usage information and exiting.

**Actual behavior:**
```
PS D:\Repos\_Ivy> tendril --help
[ExternalWidgetRegistry] Warning: Script resource 'Ivy_Widget_TendrilProcessView.frontend.dist.Ivy_Widget_TendrilProcess
View.js' not found for Ivy.Widget.TendrilProcessView.TendrilProcessView
[ExternalWidgetRegistry] Available resources in Ivy.Widget.TendrilProcessView:
Ivy is running on http://localhost:5010 [6716]. Press Ctrl+C to stop.
```

**Expected behavior:**
Running `tendril --help` should display the help/usage information and exit without launching the application.

## Root Cause

In `Program.cs`, the `ShouldHandleAsCliCommand()` method determines which arguments are routed to the Spectre.Console.Cli command handler. The `--help` and `-h` flags were not included in the list of recognized CLI arguments, causing execution to fall through past all CLI handling and into the server startup code (`TendrilServer.Create()`).

A similar issue was previously addressed for the `--version` flag, which is explicitly converted to the `"version"` command before CLI routing. However, no equivalent handling existed for `--help`.

## Changes

**`src/Ivy.Tendril/Program.cs`**

Added `"--help"` and `"-h"` to the `cliCommands` array in `ShouldHandleAsCliCommand()`. This routes help flags to Spectre.Console.Cli, which automatically generates and displays help text listing all registered commands, then exits cleanly without starting the server.

```diff
 private static bool ShouldHandleAsCliCommand(string firstArg)
 {
     string[] cliCommands = new[]
     {
         "doctor", "db-version", "db-migrate", "db-reset",
         "update-promptwares", "job", "plan", "promptware",
         "trash", "verification", "project",
-        "version", "--version", "report-bug", "reset", "update"
+        "version", "--version", "report-bug", "reset", "update",
+        "--help", "-h"
     };
     return cliCommands.Contains(firstArg);
 }
```

## Testing

- `tendril --help` — displays help text and exits with code 0
- `tendril -h` — same behavior
- `tendril` — starts the server as before (no regression)
- `tendril --version` — shows version as before (no regression)

<img width="1003" height="639" alt="image" src="https://github.com/user-attachments/assets/24781173-d319-449d-9e9c-8977656f1870" />
