### PR TITLE
[Projects]: prevent adding invalid local repositories to projects

### DIFF
--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/EditProjectDialog.cs
@@ -135,6 +135,9 @@ public class EditProjectDialog(
                                        : new Spacer());
         }
 
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        var hasInvalidRepos = RepoPathValidator.HasInvalidLocalRepos(editRepos.Value, tendrilHome);
+
         var mainDialog = new Dialog(
             _ => _editIndex.Set(-1),
             new DialogHeader(isNew ? "Add Project" : $"Edit Project: {editName.Value}"),
@@ -168,7 +171,9 @@ public class EditProjectDialog(
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() => _editIndex.Set(-1)),
-                new Button(isNew ? "Add" : "Save").Primary().OnClick(() =>
+                new Button(isNew ? "Add" : "Save").Primary()
+                    .Disabled(hasInvalidRepos)
+                    .OnClick(() =>
                 {
                     if (string.IsNullOrWhiteSpace(editName.Value)) return;
                     var project = isNew ? new ProjectConfig() : _projects[_editIndex.Value!.Value];
@@ -208,7 +213,8 @@ public class EditProjectDialog(
                         _refreshToken.Refresh();
                         _client.Toast($"Failed to save project: {ex.Message}", "Error");
                     }
-                })
+                    })
+                    .WithTooltip(hasInvalidRepos ? "Fix or remove invalid repositories before saving" : null)
             )
         ).Width(Size.Rem(40));
 

--- a/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
@@ -33,6 +33,13 @@ public class ProjectRepoPickerView(
                 return;
             }
 
+            var localRepoError = RepoPathValidator.ValidateLocalRepo(path, tendrilHome);
+            if (localRepoError != null)
+            {
+                addingError.Set(localRepoError);
+                return;
+            }
+
             if (repos.Value.Any(r => string.Equals(r.Path, path, StringComparison.OrdinalIgnoreCase)))
             {
                 inputValue.Set("");

--- a/src/Ivy.Tendril/Helpers/RepoPathValidator.cs
+++ b/src/Ivy.Tendril/Helpers/RepoPathValidator.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Helpers;
 
@@ -51,6 +52,31 @@ public static class RepoPathValidator
         if (trimmed.Length >= 2 && char.IsLetter(trimmed[0]) && trimmed[1] == ':') return true;
 
         return false;
+    }
+
+    public static string? ValidateLocalRepo(string path, string? tendrilHome = null)
+    {
+        var kind = Classify(path);
+        if (kind != RepoPathKind.LocalPath)
+            return null; 
+
+        var expanded = tendrilHome != null
+            ? VariableExpansion.ExpandVariables(path, tendrilHome)
+            : path;
+
+        if (!Directory.Exists(expanded))
+            return $"Path does not exist: {expanded}";
+
+        var gitPath = Path.Combine(expanded, ".git");
+        if (!Path.Exists(gitPath))
+            return $"Not a git repository: {expanded}";
+
+        return null;
+    }
+
+    public static bool HasInvalidLocalRepos(IEnumerable<RepoRef> repos, string? tendrilHome = null)
+    {
+        return repos.Any(r => ValidateLocalRepo(r.Path, tendrilHome) != null);
     }
 
     public static string? ExtractRepoName(string input)


### PR DESCRIPTION
## What was the issue?
Users were able to create and save projects with local repository paths that either did not exist or were not valid git repositories. While the UI visually flagged these invalid paths with a warning icon and red text, it did not block the user from adding them to the project or saving the configuration. This allowed invalid state to be persisted to `config.yaml`, leading to downstream errors (such as exceptions thrown by `PlanValidationService` when attempting to create a plan for that project).

## What needed to be done?
Validation for local repository paths needed to be enforced at the UI level *before* they are added to a project's repository list, and the UI needed to prevent saving any project that contains invalid repository paths.

## What I did
1. **Centralized Validation:** Added `ValidateLocalRepo` and `HasInvalidLocalRepos` methods to `RepoPathValidator.cs`. This encapsulates the logic for checking if a directory exists and contains a `.git` folder, replacing the scattered, UI-only checks.
2. **Blocked Addition of Invalid Paths:** Updated `ProjectRepoPickerView.AddAsync()`. Now, if a user attempts to add an invalid local repository path, the UI immediately shows an error message and prevents the path from being added to the list.
3. **Disabled Saving with Invalid State:** Updated `EditProjectDialog.cs` to disable the "Save" (or "Add") button if the project currently contains any invalid local repositories. A tooltip was added to explain why the button is disabled.

## Why?
- Rejecting invalid paths at the input stage (`ProjectRepoPickerView`) is the most robust way to prevent bad data entry.
- Disabling the "Save" button in `EditProjectDialog` acts as a crucial safety net for users who might open an *already existing* project configuration that contains invalid paths from before this fix was applied.
- By keeping the validation purely at the UI level (rather than strictly blocking it deep in `ConfigService.SaveSettings()`), we avoid the risk of breaking existing installations or causing false positives during background operations, maintaining a minimal and safe diff.

<img width="953" height="663" alt="image" src="https://github.com/user-attachments/assets/b2e54db9-b31f-4b91-ac91-86d106c93841" />
