### PR TITLE
fix(opencode): suppress intermediate step_finish events in output view

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeEventParserTests.cs
@@ -158,7 +158,7 @@ public class OpenCodeEventParserTests
     }
 
     [Fact]
-    public void ParseLine_StepFinish_WithReasonNotStop_ReturnsFailureResult()
+    public void ParseLine_StepFinish_WithReasonError_ReturnsFailureResult()
     {
         var json = """{"type":"step_finish","part":{"reason":"error"}}""";
         var events = _parser.ParseLine(json);
@@ -166,6 +166,15 @@ public class OpenCodeEventParserTests
         Assert.Single(events);
         var result = Assert.IsType<ResultEvent>(events[0]);
         Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public void ParseLine_StepFinish_WithReasonToolCalls_SuppressedAsEmpty()
+    {
+        var json = """{"type":"step_finish","part":{"reason":"tool-calls","cost":0.012,"tokens":{"input":14000,"output":134}}}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Empty(events);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeEventParser.cs
@@ -185,6 +185,12 @@ public sealed class OpenCodeEventParser : IEventParser
         if (!root.TryGetProperty("part", out var part)) return Empty;
 
         var reason = part.TryGetProperty("reason", out var rProp) ? rProp.GetString() : null;
+
+        // Intermediate steps (reason == "tool-calls") are not terminal — suppress them
+        // to avoid the UI rendering each step as an error.
+        if (reason is not ("stop" or "error"))
+            return Empty;
+
         var cost = part.TryGetProperty("cost", out var cProp) ? cProp.GetDecimal() : (decimal?)null;
 
         int inputTokens = 0;


### PR DESCRIPTION
OpenCode emits step_finish after every LLM turn with reason "tool-calls".
These were being emitted as ResultEvents with is_success=false, causing
the AgentOutputView to render "X Error" blocks between each tool call.

Now only terminal step_finish events (reason "stop" or "error") produce
a ResultEvent. Intermediate steps are suppressed.
