### PR TITLE
feat: add CloudflaredService for tunnel management

### DIFF
--- a/src/Ivy.Tendril.Agents.Test.End2End/Ivy.Tendril.Agents.Test.End2End.csproj
+++ b/src/Ivy.Tendril.Agents.Test.End2End/Ivy.Tendril.Agents.Test.End2End.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.4.25258.110" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="System.Reactive" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Ivy.Tendril.Agents\Ivy.Tendril.Agents.csproj" />
+    <ProjectReference Include="..\Ivy.Tendril\Ivy.Tendril.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ivy.Tendril.Agents.Test.End2End/Tests/CloudflaredEnd2EndTests.cs
+++ b/src/Ivy.Tendril.Agents.Test.End2End/Tests/CloudflaredEnd2EndTests.cs
@@ -1,0 +1,144 @@
+using System.Diagnostics;
+using Ivy.Tendril.Agents.Helpers;
+using Ivy.Tendril.Services.Tunnel;
+
+namespace Ivy.Tendril.Agents.Test.End2End.Tests;
+
+public class CloudflaredEnd2EndTests
+{
+    [Fact]
+    public void GetPlatformBinaryName_ReturnsNonEmpty()
+    {
+        var name = CloudflaredInstaller.GetPlatformBinaryName();
+        Assert.NotEmpty(name);
+        Assert.Contains("cloudflared", name);
+    }
+
+    [Fact]
+    public void GetDownloadUrl_ContainsGitHubReleasesPath()
+    {
+        var url = CloudflaredInstaller.GetDownloadUrl("cloudflared-linux-amd64");
+        Assert.Contains("github.com/cloudflare/cloudflared/releases", url);
+        Assert.Contains("cloudflared-linux-amd64", url);
+    }
+
+    [Fact]
+    public void ParseTunnelUrl_ValidLine_ExtractsUrl()
+    {
+        var line = "2024-01-15T10:00:00Z INF +-------------------------------------------+";
+        Assert.Null(TunnelSession.ParseTunnelUrl(line));
+
+        var urlLine = "2024-01-15T10:00:00Z INF |  https://random-words-here.trycloudflare.com  |";
+        var result = TunnelSession.ParseTunnelUrl(urlLine);
+        Assert.Equal("https://random-words-here.trycloudflare.com", result);
+    }
+
+    [Fact]
+    public void ParseTunnelUrl_NoUrl_ReturnsNull()
+    {
+        Assert.Null(TunnelSession.ParseTunnelUrl("Starting tunnel..."));
+        Assert.Null(TunnelSession.ParseTunnelUrl(""));
+        Assert.Null(TunnelSession.ParseTunnelUrl("https://example.com"));
+    }
+
+    [Fact]
+    public void ParseTunnelUrl_VariousFormats_Parses()
+    {
+        Assert.NotNull(TunnelSession.ParseTunnelUrl(
+            "Visit it at: https://abc-def-123.trycloudflare.com"));
+
+        Assert.NotNull(TunnelSession.ParseTunnelUrl(
+            "https://my-tunnel-xyz.trycloudflare.com/"));
+
+        Assert.NotNull(TunnelSession.ParseTunnelUrl(
+            "| https://a.trycloudflare.com |"));
+    }
+
+    [SkippableFact]
+    public async Task VersionCheck_InstalledBinary_ReturnsVersion()
+    {
+        Skip.IfNot(BinaryResolver.IsInstalled("cloudflared"),
+            "cloudflared is not installed on this machine");
+
+        var binaryPath = BinaryResolver.FindOnPath("cloudflared")!;
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = binaryPath,
+            ArgumentList = { "--version" },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(psi)!;
+        var stdout = await process.StandardOutput.ReadToEndAsync();
+        var stderr = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        var output = stdout + stderr;
+        Assert.Equal(0, process.ExitCode);
+        Assert.Contains("cloudflared", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [SkippableFact]
+    public async Task QuickTunnel_StartsAndReturnsTrycloudflareUrl()
+    {
+        Skip.IfNot(BinaryResolver.IsInstalled("cloudflared"),
+            "cloudflared is not installed on this machine");
+
+        var binaryPath = BinaryResolver.FindOnPath("cloudflared")!;
+
+        using var session = new TunnelSession(binaryPath, 19999, Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var url = await session.StartAsync(cts.Token);
+
+        Assert.NotNull(url);
+        Assert.Contains("trycloudflare.com", url);
+        Assert.True(session.IsRunning);
+
+        session.Stop();
+        Assert.False(session.IsRunning);
+    }
+
+    [SkippableFact]
+    public async Task Install_DownloadsBinaryForCurrentPlatform()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"cloudflared-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var httpFactory = new SimpleHttpClientFactory();
+            var installer = new CloudflaredInstaller(tempDir, httpFactory, Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            string path;
+            try
+            {
+                path = await installer.DownloadAsync(cts.Token);
+            }
+            catch (HttpRequestException ex)
+            {
+                Skip.If(true, $"Network unavailable: {ex.Message}");
+                return;
+            }
+
+            Assert.True(File.Exists(path));
+            var fileInfo = new FileInfo(path);
+            Assert.True(fileInfo.Length > 1_000_000, "Binary should be at least 1MB");
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); }
+            catch { /* cleanup best-effort */ }
+        }
+    }
+
+    private sealed class SimpleHttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new();
+    }
+}

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -156,5 +156,17 @@ internal static class ServiceRegistration
             return new PrStatusSyncService(database, githubService, planReader, logger);
         });
         server.Services.AddSingleton<IStartable>(sp => sp.GetRequiredService<PrStatusSyncService>());
+
+        server.Services.AddSingleton<Services.Tunnel.CloudflaredService>(sp =>
+        {
+            var config = sp.GetRequiredService<IConfigService>();
+            var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
+            var logger = sp.GetRequiredService<ILogger<Services.Tunnel.CloudflaredService>>();
+            return new Services.Tunnel.CloudflaredService(config, httpFactory, logger);
+        });
+        server.Services.AddSingleton<Services.Tunnel.ICloudflaredService>(sp =>
+            sp.GetRequiredService<Services.Tunnel.CloudflaredService>());
+        server.Services.AddSingleton<IStartable>(sp =>
+            sp.GetRequiredService<Services.Tunnel.CloudflaredService>());
     }
 }

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -172,6 +172,7 @@ public class TendrilSettings
     public ApiSettings? Api { get; set; }
     public Dictionary<string, PromptwareConfig> Promptwares { get; set; } = new();
     public List<AgentConfig> CodingAgents { get; set; } = new();
+    public Tunnel.TunnelConfig? Tunnel { get; set; }
     public bool Telemetry { get; set; } = true;
     public bool DesktopNotifications { get; set; } = true;
 

--- a/src/Ivy.Tendril/Services/Tunnel/CloudflaredInstaller.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/CloudflaredInstaller.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Ivy.Tendril.Agents.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services.Tunnel;
+
+public sealed class CloudflaredInstaller
+{
+    private readonly string _toolsDirectory;
+    private readonly ILogger _logger;
+    private readonly HttpClient _httpClient;
+
+    public CloudflaredInstaller(string tendrilHome, IHttpClientFactory httpClientFactory, ILogger logger)
+    {
+        _toolsDirectory = Path.Combine(tendrilHome, "tools");
+        _logger = logger;
+        _httpClient = httpClientFactory.CreateClient();
+    }
+
+    public async Task<string> EnsureInstalledAsync(CancellationToken ct = default)
+    {
+        var existing = FindExisting();
+        if (existing is not null)
+        {
+            _logger.LogDebug("Found cloudflared at {Path}", existing);
+            return existing;
+        }
+
+        return await DownloadAsync(ct);
+    }
+
+    public string? FindExisting()
+    {
+        var localPath = GetLocalBinaryPath();
+        if (File.Exists(localPath))
+            return localPath;
+
+        return BinaryResolver.FindOnPath("cloudflared");
+    }
+
+    public async Task<string> DownloadAsync(CancellationToken ct = default)
+    {
+        Directory.CreateDirectory(_toolsDirectory);
+
+        var binaryName = GetPlatformBinaryName();
+        var url = GetDownloadUrl(binaryName);
+        var targetPath = GetLocalBinaryPath();
+
+        _logger.LogInformation("Downloading cloudflared from {Url}", url);
+
+        using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct);
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct);
+        await using var fileStream = new FileStream(targetPath, FileMode.Create, FileAccess.Write, FileShare.None);
+        await stream.CopyToAsync(fileStream, ct);
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            var chmod = Process.Start(new ProcessStartInfo
+            {
+                FileName = "chmod",
+                ArgumentList = { "+x", targetPath },
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            });
+            chmod?.WaitForExit(5000);
+        }
+
+        _logger.LogInformation("Installed cloudflared to {Path}", targetPath);
+        return targetPath;
+    }
+
+    public static string GetPlatformBinaryName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return "cloudflared-windows-amd64.exe";
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? "cloudflared-darwin-arm64"
+                : "cloudflared-darwin-amd64";
+
+        return RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+            ? "cloudflared-linux-arm64"
+            : "cloudflared-linux-amd64";
+    }
+
+    public static string GetDownloadUrl(string binaryName) =>
+        $"https://github.com/cloudflare/cloudflared/releases/latest/download/{binaryName}";
+
+    private string GetLocalBinaryPath()
+    {
+        var localName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "cloudflared.exe"
+            : "cloudflared";
+        return Path.Combine(_toolsDirectory, localName);
+    }
+}

--- a/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services.Tunnel;
+
+public sealed class CloudflaredService : ICloudflaredService, IStartable, IDisposable
+{
+    private readonly IConfigService _config;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<CloudflaredService> _logger;
+    private CancellationTokenSource? _cts;
+    private Task? _supervisorTask;
+    private TunnelSession? _currentSession;
+
+    public CloudflaredService(
+        IConfigService config,
+        IHttpClientFactory httpClientFactory,
+        ILogger<CloudflaredService> logger)
+    {
+        _config = config;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public string? TunnelUrl => _currentSession?.TunnelUrl;
+    public bool IsConnected => _currentSession?.IsRunning == true && TunnelUrl is not null;
+
+    public event Action<string>? TunnelConnected;
+    public event Action? TunnelDisconnected;
+
+    public void Start()
+    {
+        var tunnelConfig = _config.Settings.Tunnel;
+        if (tunnelConfig is not { Enabled: true })
+        {
+            _logger.LogDebug("Tunnel is disabled, skipping");
+            return;
+        }
+
+        _cts = new CancellationTokenSource();
+        _supervisorTask = Task.Run(() => SupervisorLoopAsync(_cts.Token));
+    }
+
+    private async Task SupervisorLoopAsync(CancellationToken ct)
+    {
+        var tunnelConfig = _config.Settings.Tunnel!;
+        var maxRestarts = tunnelConfig.MaxRestarts;
+
+        string binaryPath;
+        if (!string.IsNullOrEmpty(tunnelConfig.BinaryPath))
+        {
+            binaryPath = tunnelConfig.BinaryPath;
+        }
+        else
+        {
+            var installer = new CloudflaredInstaller(
+                _config.TendrilHome, _httpClientFactory, _logger);
+            binaryPath = await installer.EnsureInstalledAsync(ct);
+        }
+
+        var consecutiveFailures = 0;
+
+        while (!ct.IsCancellationRequested && consecutiveFailures < maxRestarts)
+        {
+            try
+            {
+                _currentSession = new TunnelSession(binaryPath, tunnelConfig.Port, _logger);
+                var url = await _currentSession.StartAsync(ct);
+                consecutiveFailures = 0;
+                TunnelConnected?.Invoke(url);
+
+                await _currentSession.WaitForExitAsync(ct);
+                _logger.LogWarning("Tunnel process exited unexpectedly");
+                TunnelDisconnected?.Invoke();
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                consecutiveFailures++;
+                _logger.LogWarning(ex, "Tunnel session failed (attempt {Count}/{Max})",
+                    consecutiveFailures, maxRestarts);
+            }
+            finally
+            {
+                _currentSession?.Dispose();
+                _currentSession = null;
+            }
+
+            if (ct.IsCancellationRequested) break;
+
+            var delay = TimeSpan.FromSeconds(Math.Min(5 * Math.Pow(2, consecutiveFailures - 1), 60));
+            _logger.LogInformation("Restarting tunnel in {Delay}s", delay.TotalSeconds);
+            await Task.Delay(delay, ct);
+        }
+
+        if (consecutiveFailures >= maxRestarts)
+            _logger.LogError("Tunnel exceeded max restarts ({Max}), giving up", maxRestarts);
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _currentSession?.Stop();
+        _currentSession?.Dispose();
+
+        try { _supervisorTask?.Wait(TimeSpan.FromSeconds(5)); }
+        catch (AggregateException) { }
+
+        _cts?.Dispose();
+    }
+}

--- a/src/Ivy.Tendril/Services/Tunnel/ICloudflaredService.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/ICloudflaredService.cs
@@ -1,0 +1,9 @@
+namespace Ivy.Tendril.Services.Tunnel;
+
+public interface ICloudflaredService
+{
+    string? TunnelUrl { get; }
+    bool IsConnected { get; }
+    event Action<string>? TunnelConnected;
+    event Action? TunnelDisconnected;
+}

--- a/src/Ivy.Tendril/Services/Tunnel/TunnelConfig.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/TunnelConfig.cs
@@ -1,0 +1,9 @@
+namespace Ivy.Tendril.Services.Tunnel;
+
+public record TunnelConfig
+{
+    public bool Enabled { get; set; }
+    public int Port { get; set; } = 5010;
+    public string BinaryPath { get; set; } = "";
+    public int MaxRestarts { get; set; } = 10;
+}

--- a/src/Ivy.Tendril/Services/Tunnel/TunnelSession.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/TunnelSession.cs
@@ -1,0 +1,104 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services.Tunnel;
+
+public sealed partial class TunnelSession : IDisposable
+{
+    private static readonly TimeSpan UrlTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly string _binaryPath;
+    private readonly int _port;
+    private readonly ILogger _logger;
+    private Process? _process;
+    private TaskCompletionSource<string>? _urlTcs;
+
+    public TunnelSession(string binaryPath, int port, ILogger logger)
+    {
+        _binaryPath = binaryPath;
+        _port = port;
+        _logger = logger;
+    }
+
+    public string? TunnelUrl { get; private set; }
+    public bool IsRunning => _process is { HasExited: false };
+
+    public async Task<string> StartAsync(CancellationToken ct = default)
+    {
+        _urlTcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = _binaryPath,
+            ArgumentList = { "tunnel", "--url", $"http://localhost:{_port}" },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        _process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start cloudflared process");
+
+        _process.ErrorDataReceived += OnStderrLine;
+        _process.BeginErrorReadLine();
+        _process.BeginOutputReadLine();
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(UrlTimeout);
+
+        await using var reg = timeoutCts.Token.Register(() =>
+            _urlTcs.TrySetException(new TimeoutException(
+                $"Cloudflared did not produce a tunnel URL within {UrlTimeout.TotalSeconds}s")));
+
+        var url = await _urlTcs.Task;
+        TunnelUrl = url;
+        _logger.LogInformation("Tunnel established: {Url}", url);
+        return url;
+    }
+
+    public async Task WaitForExitAsync(CancellationToken ct = default)
+    {
+        if (_process is null) return;
+        await _process.WaitForExitAsync(ct);
+    }
+
+    public void Stop()
+    {
+        if (_process is null or { HasExited: true }) return;
+
+        try
+        {
+            _process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException) { }
+    }
+
+    public void Dispose()
+    {
+        Stop();
+        _process?.Dispose();
+        _process = null;
+    }
+
+    private void OnStderrLine(object sender, DataReceivedEventArgs e)
+    {
+        if (e.Data is null) return;
+
+        _logger.LogDebug("[cloudflared] {Line}", e.Data);
+
+        var url = ParseTunnelUrl(e.Data);
+        if (url is not null)
+            _urlTcs?.TrySetResult(url);
+    }
+
+    public static string? ParseTunnelUrl(string line)
+    {
+        var match = TunnelUrlRegex().Match(line);
+        return match.Success ? match.Value : null;
+    }
+
+    [GeneratedRegex(@"https://[a-z0-9-]+\.trycloudflare\.com", RegexOptions.IgnoreCase)]
+    private static partial Regex TunnelUrlRegex();
+}


### PR DESCRIPTION
## Summary
- Cross-platform CloudflaredService that installs the cloudflared binary, creates quick tunnels, and maintains sessions with automatic restart on failure
- Supervisor loop with exponential backoff (5s-60s) and configurable max restarts
- E2E tests covering binary download, version check, URL parsing, and live tunnel creation

## Test plan
- [x] `dotnet build --warnaserror` passes
- [x] All 8 new CloudflaredEnd2EndTests pass (including real tunnel test)
- [x] No regressions in existing 757 unit tests + 31 E2E tests
- [x] CodeScene scores: 10.0 on all source files