### PR TITLE
fix: rename "AI Setup" button to "Create Project"

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -12,7 +12,7 @@ public class ProjectInputStepView(
     Action? onBack = null,
     Action? onSkip = null,
     string skipButtonText = "Skip",
-    string nextButtonText = "AI Setup",
+    string nextButtonText = "Create Project",
     string title = "Setup your first project",
     bool disableSkipWhenCannotContinue = false) : ViewBase
 {

--- a/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Setup/Dialogs/AddProjectDialog.cs
@@ -104,7 +104,7 @@ public class AddProjectDialog(
                     step.Set(1);
                 },
                 skipButtonText: "Manual Setup",
-                nextButtonText: "AI Setup",
+                nextButtonText: "Create Project",
                 title: "Add a project",
                 disableSkipWhenCannotContinue: true),
             1 => new ProjectAgentStepView(


### PR DESCRIPTION
Renames the next button from "AI Setup" to "Create Project" in both the onboarding project input step and the add project dialog.