### PR TITLE
feat: inject plan template into firmware and track actual model per job

### DIFF
--- a/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
@@ -236,4 +236,49 @@ public class FirmwareCompilerTests : IDisposable
         var referenceIdx = result.IndexOf("## Reference Documents");
         Assert.True(projectsIdx < referenceIdx);
     }
+
+    // --- Plan Template Section ---
+
+    [Fact]
+    public void Compile_RendersPlanTemplateSection()
+    {
+        var template = "# {title}\n\n## Problem\n\n## Solution\n";
+        var context = new FirmwareContext("/programs/Test", new Dictionary<string, string>(), PlanTemplate: template);
+        var result = FirmwareCompiler.Compile(context);
+
+        Assert.Contains("## Plan Template", result);
+        Assert.Contains("```markdown", result);
+        Assert.Contains("# {title}", result);
+        Assert.Contains("## Problem", result);
+    }
+
+    [Fact]
+    public void Compile_OmitsPlanTemplateSection_WhenNull()
+    {
+        var context = new FirmwareContext("/programs/Test", new Dictionary<string, string>());
+        var result = FirmwareCompiler.Compile(context);
+
+        Assert.DoesNotContain("## Plan Template", result);
+    }
+
+    [Fact]
+    public void Compile_OmitsPlanTemplateSection_WhenEmpty()
+    {
+        var context = new FirmwareContext("/programs/Test", new Dictionary<string, string>(), PlanTemplate: "");
+        var result = FirmwareCompiler.Compile(context);
+
+        Assert.DoesNotContain("## Plan Template", result);
+    }
+
+    [Fact]
+    public void Compile_PlanTemplateAppearsAfterReferenceDocuments()
+    {
+        var template = "# {title}\n\n## Problem\n";
+        var context = new FirmwareContext("/programs/Test", new Dictionary<string, string>(), PlanTemplate: template);
+        var result = FirmwareCompiler.Compile(context);
+
+        var referenceIdx = result.IndexOf("## Reference Documents");
+        var templateIdx = result.IndexOf("## Plan Template");
+        Assert.True(referenceIdx < templateIdx);
+    }
 }

--- a/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
@@ -30,6 +30,7 @@ public class JobDebugSheet(
             job.Type,
             job.Project,
             job.Provider,
+            Model = job.Model ?? "",
             SessionId = job.SessionId ?? "",
             Started = job.StartedAt?.ToString("u") ?? "",
             Completed = job.CompletedAt?.ToString("u") ?? "",

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -53,6 +53,7 @@ public record JobItem
     public bool CancellationRequested { get; set; }
     public string? SessionId { get; set; }
     public string Provider { get; init; } = "claude";
+    public string? Model { get; set; }
     public int Priority { get; init; }
     public decimal? Cost { get; set; }
     public int? Tokens { get; set; }
@@ -111,6 +112,9 @@ public record JobItem
         _eventSerializer ??= new JsonEventSerializer();
         foreach (var evt in EventParser.ParseLine(line))
         {
+            if (evt is SessionInitEvent { Model: not null } initEvt)
+                Model = initEvt.Model;
+
             var serialized = _eventSerializer.Serialize(evt);
             OutputLines.Enqueue(serialized);
             while (OutputLines.Count > MaxOutputLines)

--- a/src/Ivy.Tendril/Services/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/FirmwareCompiler.cs
@@ -106,6 +106,13 @@ public static class FirmwareCompiler
             firmware += $"\n### Plans\n\n{plansContent}\n";
         }
 
+        if (!string.IsNullOrWhiteSpace(context.PlanTemplate))
+        {
+            firmware += "\n\n## Plan Template\n\n";
+            firmware += "Use this template structure when writing plan revisions:\n\n";
+            firmware += "```markdown\n" + context.PlanTemplate + "\n```\n";
+        }
+
         if (!string.IsNullOrWhiteSpace(context.CustomInstructions))
         {
             firmware += "\n\n## Custom Instructions\n\n";
@@ -192,7 +199,8 @@ public record FirmwareContext(
     string ProgramFolder,
     Dictionary<string, string> Values,
     string? CustomInstructions = null,
-    ProjectInfo[]? Projects = null);
+    ProjectInfo[]? Projects = null,
+    string? PlanTemplate = null);
 
 public record ProjectInfo(
     string Name,

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -27,6 +27,11 @@ internal record RepoConfigEntry(
 
 internal class JobLauncher
 {
+    private static readonly HashSet<string> PlanWritingTypes = new(StringComparer.Ordinal)
+    {
+        "CreatePlan", "SplitPlan", "UpdatePlan", "ExpandPlan"
+    };
+
     private readonly IConfigService? _configService;
     private readonly IAgentRunner? _agentRunner;
     private readonly ILogger _logger;
@@ -238,7 +243,10 @@ internal class JobLauncher
 
         var customInstructions = ResolveCustomInstructions(job.Type);
         var projects = BuildProjectInfos(job);
-        var prompt = FirmwareCompiler.Compile(new FirmwareContext(programFolder, values, customInstructions, projects));
+        var planTemplate = PlanWritingTypes.Contains(job.Type)
+            ? _configService.Settings.PlanTemplate
+            : null;
+        var prompt = FirmwareCompiler.Compile(new FirmwareContext(programFolder, values, customInstructions, projects, planTemplate));
         job.CompiledPrompt = prompt;
 
         var promptFilePath = WritePromptFileIfNeeded(resolution, prompt, job.Id, values);
@@ -255,6 +263,8 @@ internal class JobLauncher
             ExtraArguments = resolution.ExtraArgs,
             PromptFilePath = promptFilePath,
         };
+
+        job.Model = launchConfig.Model;
 
         var spec = resolution.Cli.BuildProcessSpec(launchConfig);
         var psi = AgentProcessHelper.ToPsi(spec);


### PR DESCRIPTION
- Pass planTemplate from config to FirmwareCompiler for plan-writing
  promptwares (CreatePlan, SplitPlan, UpdatePlan, ExpandPlan)
- Add Model property to JobItem, set from configured profile at launch
  and overridden by stream-extracted model (Claude/Copilot)
- Display Model in JobDebugSheet
- Add FirmwareCompiler tests for PlanTemplate section rendering
