### PR TITLE
fix: prepend .NET 10 to PATH in install.sh

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -43,7 +43,7 @@ else
     
     # Export for current session
     export DOTNET_ROOT="$HOME/.dotnet"
-    export PATH="$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools"
+    export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$PATH"
     printf "%b\\n" "${GREEN}✓ .NET 10 SDK installed successfully.${NC}"
 fi
 
@@ -146,9 +146,9 @@ if [[ -n "$SHELL_PROFILE" ]]; then
     if ! grep -q -E "(\.dotnet/tools|DOTNET_ROOT/tools)" "$SHELL_PROFILE"; then
         printf "%b\\n" "Adding .NET environment variables to $SHELL_PROFILE"
         if [[ -f "$HOME/.dotnet/dotnet" ]]; then
-            printf "%b\\n" "\n# .NET SDK & Tools\nexport DOTNET_ROOT=\"\$HOME/.dotnet\"\nexport PATH=\"\$PATH:\$DOTNET_ROOT:\$HOME/.dotnet/tools\"" >> "$SHELL_PROFILE"
+            printf "%b\n" "\n# .NET SDK & Tools\nexport DOTNET_ROOT=\"\$HOME/.dotnet\"\nexport PATH=\"\$DOTNET_ROOT:\$HOME/.dotnet/tools:\$PATH\"" >> "$SHELL_PROFILE"
         else
-            printf "%b\\n" "\n# .NET Tools\nexport PATH=\"\$PATH:\$HOME/.dotnet/tools\"" >> "$SHELL_PROFILE"
+            printf "%b\n" "\n# .NET Tools\nexport PATH=\"\$HOME/.dotnet/tools:\$PATH\"" >> "$SHELL_PROFILE"
         fi
         printf "%b\\n" "${GREEN}✓ PATH updated. Please restart your terminal or run: source $SHELL_PROFILE${NC}"
     else


### PR DESCRIPTION
This PR fixes a bug in the macOS/Linux installer script where .NET 10 is appended instead of prepended to PATH. Prepending it ensures the correct .NET 10 SDK is used during the installer's execution instead of any older pre-existing .NET SDK versions.