### PR TITLE
fix: set environment to production for upload-install-scripts job

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -364,6 +364,7 @@ jobs:
 
   upload-install-scripts:
     runs-on: ubuntu-latest
+    environment: production
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This PR adds environment: production to the upload-install-scripts job in publish-tendril.yml to resolve the Entra ID workload identity federation login failure (which requires environment production credentials).