### PR TITLE
feat: extract shared NewsletterView with better error reporting

### DIFF
--- a/src/Ivy.Tendril/Apps/HelpApp.cs
+++ b/src/Ivy.Tendril/Apps/HelpApp.cs
@@ -1,5 +1,4 @@
-using System.Net.Http.Json;
-using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps;
@@ -10,12 +9,6 @@ public class HelpApp : ViewBase
     public override object Build()
     {
         var client = UseService<IClientProvider>();
-        var httpClientFactory = UseService<IHttpClientFactory>();
-        var telemetry = UseService<ITelemetryService>();
-        var email = UseState("");
-        var subscribed = UseState(false);
-        var error = UseState<string?>(null);
-        var isLoading = UseState(false);
 
         return Layout.TopCenter()
                | (Layout.Vertical().Margin(0, 20).Width(150)
@@ -40,50 +33,7 @@ public class HelpApp : ViewBase
                   | new Separator()
                   | Text.H2("Newsletter")
                   | Text.Muted("Be the first to know when we have a new release!")
-                  | (subscribed.Value
-                      ? Text.Success("Subscribed!")
-                      : (Layout.Horizontal()
-                         | email.ToTextInput("you@example.com")
-                         | new Button("Subscribe")
-                             .Primary()
-                             .Disabled(!InputSanitizer.IsValidEmail(email.Value))
-                             .Loading(isLoading.Value)
-                             .OnClick(Subscribe)))
-                  | (error.Value != null ? Text.Danger(error.Value) : null)
+                  | new NewsletterView()
                );
-
-        async ValueTask Subscribe(Event<Button> e)
-        {
-            if (!InputSanitizer.IsValidEmail(email.Value))
-            {
-                error.Value = "Please enter a valid email address.";
-                return;
-            }
-
-            isLoading.Value = true;
-            try
-            {
-                using var http = httpClientFactory.CreateClient();
-                var response = await http.PostAsJsonAsync("https://tendril-api.ivy.app/subscribers", new
-                {
-                    email = email.Value,
-                    anonymousId = telemetry.AnonymousId
-                });
-                response.EnsureSuccessStatusCode();
-                subscribed.Value = true;
-                error.Value = null;
-            }
-            catch (Exception ex)
-            {
-                error.Value = ex.Message;
-            }
-            finally
-            {
-                isLoading.Value = false;
-            }
-        }
-
     }
 }
-
-

--- a/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -1,5 +1,4 @@
-using System.Net.Http.Json;
-using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps.Onboarding;
@@ -13,15 +12,9 @@ public class CompleteStepView(
     {
         var setupService = UseService<IOnboardingSetupService>();
         var client = UseService<IClientProvider>();
-        var httpClientFactory = UseService<IHttpClientFactory>();
-        var telemetry = UseService<ITelemetryService>();
 
         var isFinishing = UseState(false);
         var error = UseState<string?>(null);
-        var newsletterEmail = UseState("");
-        var newsletterSubscribed = UseState(false);
-        var newsletterError = UseState<string?>(null);
-        var newsletterLoading = UseState(false);
 
         async Task OnFinish()
         {
@@ -42,37 +35,6 @@ public class CompleteStepView(
             }
         }
 
-        async ValueTask Subscribe(Event<Button> e)
-        {
-            if (!InputSanitizer.IsValidEmail(newsletterEmail.Value))
-            {
-                newsletterError.Set("Please enter a valid email address.");
-                return;
-            }
-
-            newsletterLoading.Set(true);
-            try
-            {
-                using var http = httpClientFactory.CreateClient();
-                var response = await http.PostAsJsonAsync("https://tendril-api.ivy.app/subscribers", new
-                {
-                    email = newsletterEmail.Value,
-                    anonymousId = telemetry.AnonymousId
-                });
-                response.EnsureSuccessStatusCode();
-                newsletterSubscribed.Set(true);
-                newsletterError.Set(null);
-            }
-            catch
-            {
-                newsletterError.Set("Subscription failed. Please try again.");
-            }
-            finally
-            {
-                newsletterLoading.Set(false);
-            }
-        }
-
         void OnBack()
         {
             projectSubStep.Set(0);
@@ -82,16 +44,7 @@ public class CompleteStepView(
         var newsletter = new Box().Padding(4) | (Layout.Vertical().Gap(2)
                           | Text.H3("Newsletter")
                           | Text.Muted("Be the first to know when we have a new release!")
-                          | (newsletterSubscribed.Value
-                              ? Text.Success("Subscribed!")
-                              : (Layout.Horizontal().Gap(2)
-                                 | newsletterEmail.ToTextInput("you@example.com")
-                                 | new Button("Subscribe")
-                                     .Primary()
-                                     .Disabled(!InputSanitizer.IsValidEmail(newsletterEmail.Value))
-                                     .Loading(newsletterLoading.Value)
-                                     .OnClick(Subscribe)))
-                          | (newsletterError.Value != null ? Text.Danger(newsletterError.Value) : null!));
+                          | new NewsletterView());
 
         return Layout.Vertical().Margin(0, 0, 0, 20)
                | Text.H3("Ready to Go!")

--- a/src/Ivy.Tendril/Apps/Views/NewsletterView.cs
+++ b/src/Ivy.Tendril/Apps/Views/NewsletterView.cs
@@ -1,0 +1,74 @@
+using System.Net.Http.Json;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Views;
+
+public class NewsletterView : ViewBase
+{
+    public override object Build()
+    {
+        var httpClientFactory = UseService<IHttpClientFactory>();
+        var telemetry = UseService<ITelemetryService>();
+
+        var email = UseState("");
+        var subscribed = UseState(false);
+        var error = UseState<string?>(null);
+        var isLoading = UseState(false);
+
+        async ValueTask Subscribe(Event<Button> e)
+        {
+            if (!InputSanitizer.IsValidEmail(email.Value))
+            {
+                error.Value = "Please enter a valid email address.";
+                return;
+            }
+
+            isLoading.Value = true;
+            try
+            {
+                using var http = httpClientFactory.CreateClient();
+                var response = await http.PostAsJsonAsync("https://tendril-api.ivy.app/subscribers", new
+                {
+                    email = email.Value,
+                    anonymousId = telemetry.AnonymousId,
+                    source = "tendril"
+                });
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    error.Value = response.StatusCode switch
+                    {
+                        System.Net.HttpStatusCode.TooManyRequests => "Too many attempts. Please try again later.",
+                        System.Net.HttpStatusCode.Conflict => "This email is already subscribed.",
+                        _ => "Something went wrong. Please try again later."
+                    };
+                    return;
+                }
+
+                subscribed.Value = true;
+                error.Value = null;
+            }
+            catch
+            {
+                error.Value = "Could not connect. Please check your internet connection.";
+            }
+            finally
+            {
+                isLoading.Value = false;
+            }
+        }
+
+        return Layout.Vertical()
+               | (subscribed.Value
+                   ? Text.Success("Subscribed!")
+                   : (Layout.Horizontal()
+                      | email.ToTextInput("you@example.com")
+                      | new Button("Subscribe")
+                          .Primary()
+                          .Disabled(!InputSanitizer.IsValidEmail(email.Value))
+                          .Loading(isLoading.Value)
+                          .OnClick(Subscribe)))
+               | (error.Value != null ? Text.Danger(error.Value) : null);
+    }
+}


### PR DESCRIPTION
## Summary
- Extract newsletter signup into reusable `NewsletterView` component shared by `HelpApp` and `CompleteStepView`
- Add friendly error messages for known HTTP status codes (429, 409) and network failures
- Add `source: "tendril"` field to subscriber API requests

## Test plan
- [x] Build passes with no errors
- [x] All 1295 tests pass
- [x] CodeScene code health: 10.0 on all changed files