### PR TITLE
refactor: rename PlansApp to DraftsApp, fix agent setup reactivity, surface provider errors

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/04_Apps/03_Drafts.md
+++ b/src/Ivy.Tendril.Docs/Docs/04_Apps/03_Drafts.md
@@ -11,7 +11,7 @@ icon: Feather
 # Drafts
 
 <Ingress>
-Plans in **Draft** (or **Blocked**): shape the work before execution (`PlansApp`).
+Plans in **Draft** (or **Blocked**): shape the work before execution (`DraftsApp`).
 </Ingress>
 
 ## Role

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -73,7 +73,7 @@ projects:
   - name: CheckResult
     required: true
   context: >
-    Plan management TUI. Key folders: - src\Ivy.Tendril\Services\ — ConfigService, PlanReaderService, JobService - src\Ivy.Tendril\Apps\ — PlansApp, JobsApp UI - src\Ivy.Tendril\Promptwares\ — CreatePlan, UpdatePlan, SplitPlan, ExpandPlan This project uses the Ivy Framework - there's CLI helper methods you can use:  ivy docs AGENTS.md  ivy question "How do I make a button in Ivy?"
+    Plan management TUI. Key folders: - src\Ivy.Tendril\Services\ — ConfigService, PlanReaderService, JobService - src\Ivy.Tendril\Apps\ — DraftsApp, JobsApp UI - src\Ivy.Tendril\Promptwares\ — CreatePlan, UpdatePlan, SplitPlan, ExpandPlan This project uses the Ivy Framework - there's CLI helper methods you can use:  ivy docs AGENTS.md  ivy question "How do I make a button in Ivy?"
   reviewActions:
   - name: Tendril
     condition: Test-Path "worktrees\Ivy-Tendril\src\Ivy.Tendril"

--- a/src/Ivy.Tendril.Test/ContentViewTests.cs
+++ b/src/Ivy.Tendril.Test/ContentViewTests.cs
@@ -1,4 +1,4 @@
-using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Apps.Drafts;
 using Ivy.Tendril.Models;
 using ReviewContentView = Ivy.Tendril.Apps.Review.ContentView;
 

--- a/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
@@ -180,4 +180,37 @@ public class JobServiceFailureReasonTests : IDisposable
         Assert.Equal(JobStatus.Failed, job.Status);
         Assert.Equal("Execution failed (exit code: 1)", job.StatusMessage);
     }
+
+    [Fact]
+    public void CompleteJob_ZeroExitCode_WithErrorEvent_MarksAsFailed()
+    {
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var id = service.CreateTestJob(new ExecutePlanArgs(Path.GetTempPath()));
+        var job = service.GetJob(id)!;
+        job.OutputLines.Enqueue(
+            """{"kind":"error","timestamp":"2026-05-26T12:18:29Z","message":"Access to Meta Llama models is not allowed from unsupported regions","is_retryable":false,"is_auth_error":false}""");
+
+        service.CompleteJob(id, 0);
+
+        job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.Contains("Access to Meta Llama models", job.StatusMessage);
+    }
+
+    [Fact]
+    public void CompleteJob_ZeroExitCode_WithoutErrorEvent_RemainsCompleted()
+    {
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var planFolder = CreateValidPlanFolder();
+        var id = service.StartJob(new ExecutePlanArgs(planFolder));
+        var job = service.GetJob(id)!;
+        job.OutputLines.Enqueue(
+            """{"kind":"text","timestamp":"2026-05-26T12:18:29Z","text":"All done"}""");
+
+        service.CompleteJob(id, 0);
+
+        job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Completed, job.Status);
+        Assert.Null(job.StatusMessage);
+    }
 }

--- a/src/Ivy.Tendril.Test/JobServicePriorityTests.cs
+++ b/src/Ivy.Tendril.Test/JobServicePriorityTests.cs
@@ -1,4 +1,4 @@
-using Ivy.Tendril.Apps.Plans.Dialogs;
+using Ivy.Tendril.Apps.Drafts.Dialogs;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 

--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -1,9 +1,8 @@
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
-using Ivy.Tendril.Helpers;
-using Ivy.Core;
 
-namespace Ivy.Tendril.Apps.Plans;
+namespace Ivy.Tendril.Apps.Drafts;
 
 public class ActionBarView(
     PlanFile selectedPlan,

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -1,14 +1,14 @@
-using Ivy.Tendril.Models;
 using System.Text.RegularExpressions;
 using Ivy.Core;
-using Ivy.Tendril.Apps.Plans.Dialogs;
+using Ivy.Tendril.Apps.Drafts.Dialogs;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Apps.Views.Tabs;
-using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Plans;
+namespace Ivy.Tendril.Apps.Drafts;
 
 public class ContentView(
     PlanFile? selectedPlan,

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreateIssueDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreateIssueDialog.cs
@@ -1,8 +1,7 @@
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
-using Ivy.Tendril.Helpers;
 
-namespace Ivy.Tendril.Apps.Plans.Dialogs;
+namespace Ivy.Tendril.Apps.Drafts.Dialogs;
 
 public class CreateIssueDialog(
     IState<bool> dialogOpen,

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -1,6 +1,6 @@
 using Ivy.Core.Hooks;
 
-namespace Ivy.Tendril.Apps.Plans.Dialogs;
+namespace Ivy.Tendril.Apps.Drafts.Dialogs;
 
 public class CreatePlanDialog(
     List<string> projectNames,

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/DeletePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/DeletePlanDialog.cs
@@ -1,8 +1,7 @@
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
-using Ivy.Tendril.Helpers;
 
-namespace Ivy.Tendril.Apps.Plans.Dialogs;
+namespace Ivy.Tendril.Apps.Drafts.Dialogs;
 
 public class DeletePlanDialog(
     IState<bool> dialogOpen,

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/NoProjectsDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/NoProjectsDialog.cs
@@ -1,4 +1,4 @@
-namespace Ivy.Tendril.Apps.Plans.Dialogs;
+namespace Ivy.Tendril.Apps.Drafts.Dialogs;
 
 public class NoProjectsDialog(Action onClose, Action onGoToProjects) : ViewBase
 {

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/UpdatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/UpdatePlanDialog.cs
@@ -1,9 +1,7 @@
-using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
-using Ivy.Tendril.Helpers;
 
-namespace Ivy.Tendril.Apps.Plans.Dialogs;
+namespace Ivy.Tendril.Apps.Drafts.Dialogs;
 
 public class UpdatePlanDialog(
     IState<bool> dialogOpen,

--- a/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
@@ -1,10 +1,9 @@
+using Ivy.Tendril.Apps.Views.Sheets;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
-using Ivy.Tendril.Helpers;
-using Ivy.Core;
-using Ivy.Tendril.Apps.Views.Sheets;
 
-namespace Ivy.Tendril.Apps.Plans;
+namespace Ivy.Tendril.Apps.Drafts;
 
 public class PlanTabView(
     PlanFile selectedPlan,

--- a/src/Ivy.Tendril/Apps/Drafts/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/SidebarView.cs
@@ -1,9 +1,9 @@
-using Ivy.Tendril.Models;
-using Ivy.Tendril.Helpers;
-using Ivy.Tendril.Services;
 using Ivy.Tendril.Apps.Views;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Plans;
+namespace Ivy.Tendril.Apps.Drafts;
 
 public class SidebarView(
     List<PlanFile> plans,

--- a/src/Ivy.Tendril/Apps/DraftsApp.cs
+++ b/src/Ivy.Tendril/Apps/DraftsApp.cs
@@ -1,5 +1,5 @@
 using System.Reactive.Disposables;
-using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Apps.Drafts;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
@@ -7,7 +7,7 @@ using Ivy.Tendril.Helpers;
 namespace Ivy.Tendril.Apps;
 
 [App(title: "Drafts", icon: Icons.Feather, group: ["Apps"], order: Constants.Drafts)]
-public class PlansApp : ViewBase
+public class DraftsApp : ViewBase
 {
     public override object Build()
     {

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -1,6 +1,5 @@
 using Ivy.Core;
 using Ivy.Tendril.Apps.Icebox.Dialogs;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Models;

--- a/src/Ivy.Tendril/Apps/Icebox/Dialogs/DeletePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/Dialogs/DeletePlanDialog.cs
@@ -1,4 +1,3 @@
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
@@ -1,4 +1,3 @@
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Apps/IceboxApp.cs
+++ b/src/Ivy.Tendril/Apps/IceboxApp.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Disposables;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
@@ -70,7 +70,7 @@ public class JobDebugSheet(
             .RemoveEmpty();
 
         return new HeaderLayout(
-            new Button("Copy all Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>
+            new Button("Copy Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>
             {
                 var lines = new List<(string Label, string Value)>
                 {
@@ -102,6 +102,7 @@ public class JobDebugSheet(
                     .Select(l => $"{l.Label}: {l.Value}"));
 
                 copyToClipboard(formatted);
+                client.Toast("Job details copied to clipboard", "Copied");
             }),
             detailsView
         );

--- a/src/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
+++ b/src/Ivy.Tendril/Apps/PullRequest/Dialogs/FollowUpDialog.cs
@@ -1,4 +1,4 @@
-using Ivy.Tendril.Apps.Plans.Dialogs;
+using Ivy.Tendril.Apps.Drafts.Dialogs;
 
 namespace Ivy.Tendril.Apps.PullRequest.Dialogs;
 

--- a/src/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -1,7 +1,5 @@
 using System.Text.RegularExpressions;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
-using Ivy.Tendril.Apps.Plans.Dialogs;
 using Ivy.Tendril.Apps.PullRequest;
 using Ivy.Tendril.Apps.PullRequest.Dialogs;
 using Ivy.Tendril.Apps.Views.Sheets;

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -1,4 +1,3 @@
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Apps.Recommendations.Dialogs;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Apps.Views.Sheets;

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Reactive.Disposables;
 using Ivy.Core;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Apps.Review.Dialogs;
 using Ivy.Tendril.Apps.Views;

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -1,4 +1,3 @@
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
@@ -1,4 +1,3 @@
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
@@ -1,4 +1,3 @@
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
@@ -1,4 +1,3 @@
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Apps/Review/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/SidebarView.cs
@@ -1,4 +1,3 @@
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Apps/ReviewApp.cs
+++ b/src/Ivy.Tendril/Apps/ReviewApp.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Disposables;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Apps/Setup/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Setup/CodingAgentSetupView.cs
@@ -20,9 +20,10 @@ public class CodingAgentSetupView : ViewBase
         var config = UseService<IConfigService>();
         var client = UseService<IClientProvider>();
 
-        var currentAgent = string.IsNullOrWhiteSpace(config.Settings.CodingAgent)
-            ? "claude"
-            : config.Settings.CodingAgent;
+        var selectedAgent = UseState(
+            string.IsNullOrWhiteSpace(config.Settings.CodingAgent)
+                ? "claude"
+                : config.Settings.CodingAgent);
 
         var grid = Layout.Grid().Columns(3).Gap(2);
 
@@ -31,11 +32,12 @@ public class CodingAgentSetupView : ViewBase
                 Layout.Horizontal().Gap(2).AlignContent(Align.Center).Padding(0)
                 | a.Logo.ToIcon().Width(Size.Px(32)).Height(Size.Px(32))
                 | Text.Block(a.Label)
-                | (a.Key == currentAgent ? Icons.Check.ToIcon() : null)
-            ).OnClick(() =>
+                | (a.Key == selectedAgent.Value ? Icons.Check.ToIcon() : null)
+            ).Width(Size.Px(150)).OnClick(() =>
             {
                 config.Settings.CodingAgent = a.Key;
                 config.SaveSettings();
+                selectedAgent.Set(a.Key);
                 client.Toast($"Coding agent set to {a.Label}", "Saved");
             }));
 

--- a/src/Ivy.Tendril/Apps/Views/CreatePlanDialogLauncher.cs
+++ b/src/Ivy.Tendril/Apps/Views/CreatePlanDialogLauncher.cs
@@ -1,4 +1,4 @@
-using Ivy.Tendril.Apps.Plans.Dialogs;
+using Ivy.Tendril.Apps.Drafts.Dialogs;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 

--- a/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Commands/PlanListCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanListCommand.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Commands/PlanRecCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRecCommand.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Commands/PlanUpdateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanUpdateCommand.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;

--- a/src/Ivy.Tendril/Controllers/PlanController.cs
+++ b/src/Ivy.Tendril/Controllers/PlanController.cs
@@ -1,4 +1,3 @@
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Commands;
 using Ivy.Tendril.Services;

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Commands;
 using Ivy.Tendril.Services;

--- a/src/Ivy.Tendril/Services/IPlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/IPlanDatabaseService.cs
@@ -1,5 +1,4 @@
 using Ivy.Tendril.Apps.Jobs;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Services;

--- a/src/Ivy.Tendril/Services/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/IPlanReaderService.cs
@@ -1,4 +1,3 @@
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Services;

--- a/src/Ivy.Tendril/Services/JobFailureAnalyzer.cs
+++ b/src/Ivy.Tendril/Services/JobFailureAnalyzer.cs
@@ -1,4 +1,6 @@
 using System.Text.RegularExpressions;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Runtime;
 using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Services;
@@ -134,6 +136,17 @@ internal static class JobFailureAnalyzer
         catch { }
 
         return "Claude API error (see output for details)";
+    }
+
+    internal static string? TryExtractErrorEvent(IEnumerable<string> outputLines)
+    {
+        var serializer = new JsonEventSerializer();
+        foreach (var line in outputLines.Reverse())
+        {
+            if (serializer.Deserialize(line) is ErrorEvent { Message.Length: > 0 } e)
+                return SanitizeForDisplay(e.Message);
+        }
+        return null;
     }
 
     internal static string? TryReadFailureArtifact(List<string> outputLines)

--- a/src/Ivy.Tendril/Services/JobService.cs
+++ b/src/Ivy.Tendril/Services/JobService.cs
@@ -152,10 +152,23 @@ public class JobService : IJobService
         else
         {
             var success = exitCode == 0;
-            if (!success)
-                job.StatusMessage ??= ExtractFailureReason(job.OutputLines.ToList(), job.Type);
+            if (success)
+            {
+                var errorMessage = JobFailureAnalyzer.TryExtractErrorEvent(job.OutputLines);
+                if (errorMessage != null)
+                {
+                    success = false;
+                    job.StatusMessage = errorMessage;
+                }
+                else
+                {
+                    job.StatusMessage = null;
+                }
+            }
             else
-                job.StatusMessage = null;
+            {
+                job.StatusMessage ??= ExtractFailureReason(job.OutputLines.ToList(), job.Type);
+            }
             job.Status = success ? JobStatus.Completed : JobStatus.Failed;
         }
 

--- a/src/Ivy.Tendril/Services/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/PlanDatabaseService.cs
@@ -2,7 +2,6 @@ using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Apps.Jobs;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Database;
 using Ivy.Tendril.Repositories;

--- a/src/Ivy.Tendril/Services/PlanDatabaseSyncService.cs
+++ b/src/Ivy.Tendril/Services/PlanDatabaseSyncService.cs
@@ -1,7 +1,6 @@
 using Ivy.Tendril.Helpers;
 using System.Diagnostics;
 using System.Globalization;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Microsoft.Extensions.Logging;
 

--- a/src/Ivy.Tendril/Services/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/PlanReaderService.cs
@@ -2,7 +2,6 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using Ivy.Helpers;
 using Ivy.Tendril.Helpers;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 using Microsoft.Extensions.Logging;
 

--- a/src/Ivy.Tendril/Services/PlanValidationService.cs
+++ b/src/Ivy.Tendril/Services/PlanValidationService.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Services;

--- a/src/Ivy.Tendril/Services/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/WorktreeCleanupService.cs
@@ -2,7 +2,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Ivy.Helpers;
-using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
## Summary

- Rename `Apps/Plans/` to `Apps/Drafts/` and `PlansApp` to `DraftsApp`
- CodingAgentSetupView: use state for reactive checkmark update + wider card buttons (150px)
- JobDebugSheet: add toast on "Copy Details" click
- JobService: detect error events on exit-code-0 providers (e.g. OpenCode) and mark job as Failed with actual error message
- Update stale `PlansApp` references in config.yaml and docs
- Add tests for exit-0-with-error-event scenario