### PR TITLE
fix: remove em-dashes from UI strings, add TendrilProcessView to solution, improve job debug sheet

### DIFF
--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -526,7 +526,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                     .Ghost().Small()
                     .Width(Size.Shrink())
                     .OnClick(() => onToggle(issue.Number))
-                | new Expandable($"#{issue.Number} — {issue.Title}", bodyContent)
+                | new Expandable($"#{issue.Number} {issue.Title}", bodyContent)
                     .Width(Size.Grow().Min(Size.Px(0)))
                 | (issueUrl != null
                     ? new Button().Icon(Icons.ExternalLink).Ghost().Small()

--- a/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
@@ -26,7 +26,7 @@ public class JobDebugSheet(
             JobId = job.Id,
             PlanId = GetPlanId(job),
             PromptTitle = JobsApp.GetFullPrompt(job, planService) ?? "",
-            Status = $"{job.Status}{(job.StatusMessage != null ? $" — {job.StatusMessage}" : "")}",
+            Status = $"{job.Status}{(job.StatusMessage != null ? $": {job.StatusMessage}" : "")}",
             job.Type,
             job.Project,
             job.Provider,
@@ -49,6 +49,7 @@ public class JobDebugSheet(
         var detailsView = data.ToDetails()
             .Multiline(x => x.PromptTitle)
             .Multiline(x => x.PermissionDenials)
+            .Multiline(x => x.Status)
             .Label(x => x.PromptTitle, "Prompt/Title")
             .Label(x => x.PlanId, "Plan Id")
             .Label(x => x.SessionId, "Session Id")

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -32,7 +32,7 @@ public class PromptwareRunSettings : CommandSettings
     public string[]? Values { get; init; }
 
     [CommandOption("--plan")]
-    [Description("Plan ID or folder path — populates TendrilPlanFolder, TendrilPlansFolder, TendrilPlanId")]
+    [Description("Plan ID or folder path")]
     public string? Plan { get; init; }
 
     [CommandOption("--promptware-path")]
@@ -48,7 +48,7 @@ public class PromptwareRunSettings : CommandSettings
     public string? Agent { get; init; }
 
     [CommandOption("--cli-log")]
-    [Description("Path to write CLI invocation log (JSONL) — tracks tendril calls made by the agent")]
+    [Description("Path to write CLI invocation log (JSONL)")]
     public string? CliLog { get; init; }
 
     [CommandOption("--dry-run")]

--- a/src/Ivy.Tendril/Ivy.Tendril.slnx
+++ b/src/Ivy.Tendril/Ivy.Tendril.slnx
@@ -4,6 +4,7 @@
     <Platform Name="x64" />
     <Platform Name="x86" />
   </Configurations>
+  <Project Path="../Ivy.Widgets.TendrilProcessView/Ivy.Widgets.TendrilProcessView.csproj" />
   <Project Path="Ivy.Tendril.csproj" />
   <Project Path="../Ivy.Tendril.Updater/Ivy.Tendril.Updater.csproj" />
   <Project Path="../Ivy.Tendril.Test/Ivy.Tendril.Test.csproj" />

--- a/src/Ivy.Tendril/Services/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/JobLauncher.cs
@@ -113,7 +113,7 @@ internal class JobLauncher
             var programFolder = Path.Combine(_promptsRoot, type);
             _logger.LogError("Job {JobId}: No agent program found for '{Type}' in {Folder}", id, type, programFolder);
             job.Status = JobStatus.Failed;
-            job.StatusMessage = $"No agent program found for '{type}' — ensure {programFolder}/Program.md exists and config is loaded";
+            job.StatusMessage = $"No agent program found for '{type}'. Ensure {programFolder}/Program.md exists and config is loaded";
             job.CompletedAt = DateTime.UtcNow;
             ctx.JobSlotSemaphore.Release();
             ctx.RaiseStructureChanged();

--- a/src/Ivy.Tendril/Services/PlanPdfService.cs
+++ b/src/Ivy.Tendril/Services/PlanPdfService.cs
@@ -56,7 +56,7 @@ public class PlanPdfService(ILogger<PlanPdfService> logger)
         {
             FileName = "pandoc",
             Arguments =
-                $"\"{inputPath}\" -o \"{outputPath}\" --pdf-engine=xelatex -V geometry:margin=2.5cm -V fontsize=11pt -V header-includes=\"\\usepackage{{fancyhdr}}\\pagestyle{{fancy}}\\fancyhead[L]{{Ivy Tendril — Plan \\#{planId}}}\"",
+                $"\"{inputPath}\" -o \"{outputPath}\" --pdf-engine=xelatex -V geometry:margin=2.5cm -V fontsize=11pt -V header-includes=\"\\usepackage{{fancyhdr}}\\pagestyle{{fancy}}\\fancyhead[L]{{Ivy Tendril Plan \\#{planId}}}\"",
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,


### PR DESCRIPTION
## Summary
- Replace em-dash (—) separators with simpler alternatives across UI strings and error messages
- Add Ivy.Widgets.TendrilProcessView project to the solution file
- Make job status multiline in JobDebugSheet for better readability
- Simplify command option descriptions in PromptwareRunCommand