### PR TITLE
feat: add model-per-profile selection to Coding Agent settings

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps.Settings;
@@ -19,14 +20,54 @@ public class CodingAgentSetupView : ViewBase
     {
         var config = UseService<IConfigService>();
         var client = UseService<IClientProvider>();
+        var runner = UseService<IAgentRunner>();
 
         var selectedAgent = UseState(
             string.IsNullOrWhiteSpace(config.Settings.CodingAgent)
                 ? "claude"
                 : config.Settings.CodingAgent);
 
-        var grid = Layout.Grid().Columns(3).Gap(2);
+        var deepModel = UseState(GetProfileModel(config, selectedAgent.Value, "deep"));
+        var balancedModel = UseState(GetProfileModel(config, selectedAgent.Value, "balanced"));
+        var quickModel = UseState(GetProfileModel(config, selectedAgent.Value, "quick"));
+        var lastAgent = UseState(selectedAgent.Value);
 
+        var modelsQuery = UseQuery<ModelInfo[], string>(
+            selectedAgent.Value,
+            async (agentId, ct) =>
+            {
+                var catalog = runner.GetModelCatalog(agentId);
+                if (catalog is null) return [];
+                var result = await catalog.GetModelsAsync(ct);
+                return result.Models.ToArray();
+            },
+            initialValue: []
+        );
+
+        if (lastAgent.Value != selectedAgent.Value)
+        {
+            deepModel.Set(GetProfileModel(config, selectedAgent.Value, "deep"));
+            balancedModel.Set(GetProfileModel(config, selectedAgent.Value, "balanced"));
+            quickModel.Set(GetProfileModel(config, selectedAgent.Value, "quick"));
+            lastAgent.Set(selectedAgent.Value);
+        }
+
+        var modelOptions = new[] { new Option<string>("Default", "") }
+            .Concat(modelsQuery.Value.Select(m =>
+            {
+                var label = !string.IsNullOrEmpty(m.Alias) ? $"{m.DisplayName} ({m.Alias})" : m.DisplayName;
+                return new Option<string>(label, m.Id);
+            }))
+            .ToArray<IAnyOption>();
+
+        var hasProfileChanges =
+            deepModel.Value != GetProfileModel(config, selectedAgent.Value, "deep") ||
+            balancedModel.Value != GetProfileModel(config, selectedAgent.Value, "balanced") ||
+            quickModel.Value != GetProfileModel(config, selectedAgent.Value, "quick");
+
+        var hasChanges = selectedAgent.Value != config.Settings.CodingAgent || hasProfileChanges;
+
+        var grid = Layout.Grid().Columns(3).Gap(2);
         grid = Agents.Aggregate(grid, (current, a) =>
             current | new Card(
                 Layout.Horizontal().Gap(2).AlignContent(Align.Center).Padding(0)
@@ -35,15 +76,64 @@ public class CodingAgentSetupView : ViewBase
                 | (a.Key == selectedAgent.Value ? Icons.Check.ToIcon() : null)
             ).Width(Size.Px(200)).OnClick(() =>
             {
-                config.Settings.CodingAgent = a.Key;
-                config.SaveSettings();
                 selectedAgent.Set(a.Key);
-                client.Toast($"Coding agent set to {a.Label}", "Saved");
             }));
 
         return Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(120)))
                | Text.Block("Coding Agent").Bold()
                | Text.Muted("Pick the coding agent Tendril orchestrates:")
-               | grid;
+               | grid
+               | Text.Block("Model Per Profile").Bold()
+               | Text.Muted("Override the model used for each profile tier:")
+               | deepModel.ToSelectInput(modelOptions).WithField().Label("Deep")
+               | balancedModel.ToSelectInput(modelOptions).WithField().Label("Balanced")
+               | quickModel.ToSelectInput(modelOptions).WithField().Label("Quick")
+               | new Button("Save").Primary()
+                   .Disabled(!hasChanges)
+                   .OnClick(() =>
+                   {
+                       config.Settings.CodingAgent = selectedAgent.Value;
+                       SaveProfiles(config, selectedAgent.Value, deepModel.Value, balancedModel.Value, quickModel.Value);
+                       config.SaveSettings();
+                       client.Toast("Coding agent settings saved", "Saved");
+                   });
+    }
+
+    private static string GetProfileModel(IConfigService config, string agentId, string profileName)
+    {
+        var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
+        var profile = ac?.Profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+        return profile?.Model ?? "";
+    }
+
+    private static void SaveProfiles(IConfigService config, string agentId, string deep, string balanced, string quick)
+    {
+        var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
+
+        if (ac == null)
+        {
+            ac = new AgentConfig { Name = agentId };
+            config.Settings.CodingAgents.Add(ac);
+        }
+
+        SetProfileModel(ac, "deep", deep);
+        SetProfileModel(ac, "balanced", balanced);
+        SetProfileModel(ac, "quick", quick);
+    }
+
+    private static void SetProfileModel(AgentConfig ac, string profileName, string model)
+    {
+        var profile = ac.Profiles.FirstOrDefault(p =>
+            p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+
+        if (profile == null)
+        {
+            profile = new AgentProfileConfig { Name = profileName };
+            ac.Profiles.Add(profile);
+        }
+
+        profile.Model = model;
     }
 }


### PR DESCRIPTION
Adds three dropdowns (Deep, Balanced, Quick) to the Coding Agent
settings page, allowing users to override the model used for each
profile tier. Models are fetched from the agent's model catalog.
"Default" uses the agent's built-in choice. Agent selection and
profile models now save together via a single Save button.
