### PR TITLE
feat: open CreatePlanDialog from wallpaper New Plan button

### DIFF
--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -34,17 +34,19 @@ public class WallpaperApp : ViewBase
 
         var status = processStatus.Value;
 
-        var processView = new TendrilProcessView()
-            .DraftCount(status.DraftCount)
-            .ReviewCount(status.ReviewCount)
-            .CreatingPlansCount(status.CreatingPlansCount)
-            .UpdatingPlansCount(status.UpdatingPlansCount)
-            .ExecutingPlansCount(status.ExecutingPlansCount)
-            .RetryingPlansCount(status.RetryingPlansCount)
-            .OnCreate(() => navigator.Navigate<DraftsApp>())
-            .OnDrafts(() => navigator.Navigate<DraftsApp>())
-            .OnReview(() => navigator.Navigate<ReviewApp>())
-            .OnJobs(() => navigator.Navigate<JobsApp>());
+        var processView = new CreatePlanDialogLauncher(open =>
+            new TendrilProcessView()
+                .DraftCount(status.DraftCount)
+                .ReviewCount(status.ReviewCount)
+                .CreatingPlansCount(status.CreatingPlansCount)
+                .UpdatingPlansCount(status.UpdatingPlansCount)
+                .ExecutingPlansCount(status.ExecutingPlansCount)
+                .RetryingPlansCount(status.RetryingPlansCount)
+                .OnCreate(open)
+                .OnDrafts(() => navigator.Navigate<DraftsApp>())
+                .OnReview(() => navigator.Navigate<ReviewApp>())
+                .OnJobs(() => navigator.Navigate<JobsApp>())
+        );
 
         var elements = new List<object>
         {


### PR DESCRIPTION
Previously the OnCreate handler just navigated to DraftsApp.
Now it uses CreatePlanDialogLauncher so users can immediately
start creating a plan from the home screen.
