### PR TITLE
fix: wait for server ready before launching cloudflared tunnel

### DIFF
--- a/src/Ivy.Tendril.Agents.Test.End2End/Tests/CloudflaredEnd2EndTests.cs
+++ b/src/Ivy.Tendril.Agents.Test.End2End/Tests/CloudflaredEnd2EndTests.cs
@@ -90,7 +90,7 @@ public class CloudflaredEnd2EndTests
 
         var binaryPath = BinaryResolver.FindOnPath("cloudflared")!;
 
-        using var session = new TunnelSession(binaryPath, 19999, Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+        using var session = new TunnelSession(binaryPath, "http://localhost:19999", Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         var url = await session.StartAsync(cts.Token);

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -163,8 +163,9 @@ internal static class ServiceRegistration
         {
             var config = sp.GetRequiredService<IConfigService>();
             var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
+            var appLifetime = sp.GetRequiredService<Microsoft.Extensions.Hosting.IHostApplicationLifetime>();
             var logger = sp.GetRequiredService<ILogger<Services.Tunnel.CloudflaredService>>();
-            return new Services.Tunnel.CloudflaredService(config, httpFactory, logger);
+            return new Services.Tunnel.CloudflaredService(config, httpFactory, appLifetime, logger);
         });
         server.Services.AddSingleton<Services.Tunnel.ICloudflaredService>(sp =>
             sp.GetRequiredService<Services.Tunnel.CloudflaredService>());

--- a/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Services.Tunnel;
@@ -6,6 +7,7 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
 {
     private readonly IConfigService _config;
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IHostApplicationLifetime _appLifetime;
     private readonly ILogger<CloudflaredService> _logger;
     private CancellationTokenSource? _cts;
     private Task? _supervisorTask;
@@ -15,10 +17,12 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
     public CloudflaredService(
         IConfigService config,
         IHttpClientFactory httpClientFactory,
+        IHostApplicationLifetime appLifetime,
         ILogger<CloudflaredService> logger)
     {
         _config = config;
         _httpClientFactory = httpClientFactory;
+        _appLifetime = appLifetime;
         _logger = logger;
     }
 
@@ -115,13 +119,24 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
             binaryPath = await installer.EnsureInstalledAsync(ct);
         }
 
+        if (!_appLifetime.ApplicationStarted.IsCancellationRequested)
+        {
+            _logger.LogInformation("Waiting for server before launching tunnel");
+            await Task.Delay(Timeout.Infinite, _appLifetime.ApplicationStarted)
+                .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            if (ct.IsCancellationRequested) return;
+        }
+
+        var originUrl = Environment.GetEnvironmentVariable("TENDRIL_URL")
+            ?? $"http://localhost:{tunnelConfig.Port}";
+
         var consecutiveFailures = 0;
 
         while (!ct.IsCancellationRequested && consecutiveFailures < maxRestarts)
         {
             try
             {
-                _currentSession = new TunnelSession(binaryPath, tunnelConfig.Port, _logger);
+                _currentSession = new TunnelSession(binaryPath, originUrl, _logger);
                 var url = await _currentSession.StartAsync(ct);
                 consecutiveFailures = 0;
                 TunnelConnected?.Invoke(url);

--- a/src/Ivy.Tendril/Services/Tunnel/TunnelSession.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/TunnelSession.cs
@@ -9,15 +9,15 @@ public sealed partial class TunnelSession : IDisposable
     private static readonly TimeSpan UrlTimeout = TimeSpan.FromSeconds(30);
 
     private readonly string _binaryPath;
-    private readonly int _port;
+    private readonly string _originUrl;
     private readonly ILogger _logger;
     private Process? _process;
     private TaskCompletionSource<string>? _urlTcs;
 
-    public TunnelSession(string binaryPath, int port, ILogger logger)
+    public TunnelSession(string binaryPath, string originUrl, ILogger logger)
     {
         _binaryPath = binaryPath;
-        _port = port;
+        _originUrl = originUrl;
         _logger = logger;
     }
 
@@ -31,12 +31,16 @@ public sealed partial class TunnelSession : IDisposable
         var psi = new ProcessStartInfo
         {
             FileName = _binaryPath,
-            ArgumentList = { "tunnel", "--url", $"http://localhost:{_port}" },
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true,
         };
+        psi.ArgumentList.Add("tunnel");
+        psi.ArgumentList.Add("--url");
+        psi.ArgumentList.Add(_originUrl);
+        if (_originUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            psi.ArgumentList.Add("--no-tls-verify");
 
         _process = Process.Start(psi)
             ?? throw new InvalidOperationException("Failed to start cloudflared process");


### PR DESCRIPTION
## Summary

- Await `IHostApplicationLifetime.ApplicationStarted` before launching cloudflared, fixing 502 Bad Gateway race condition
- Use `TENDRIL_URL` env var for origin URL to handle HTTP/HTTPS correctly
- Add `--no-tls-verify` when tunneling to HTTPS localhost (dev cert)

## Test plan

- [x] `dotnet build --warnaserror` passes (0 warnings, 0 errors)
- [x] `dotnet test` passes (1299 passed, 0 failed)
- [ ] Manual: activate tunnel from Settings UI, confirm no 502 on first request