### PR TITLE
fix: resolve Windows PTY command to .cmd extension before spawning

### DIFF
--- a/src/Ivy.Tendril.Agents/Helpers/AgentPtySpecExtensions.cs
+++ b/src/Ivy.Tendril.Agents/Helpers/AgentPtySpecExtensions.cs
@@ -1,0 +1,27 @@
+using System.Runtime.InteropServices;
+using Ivy.Tendril.Agents.Abstractions;
+
+namespace Ivy.Tendril.Agents.Helpers;
+
+public static class AgentPtySpecExtensions
+{
+    public static AgentPtySpec ResolveCommand(this AgentPtySpec spec)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return spec;
+        if (spec.CommandLine.Count == 0)
+            return spec;
+
+        var command = spec.CommandLine[0];
+        if (Path.HasExtension(command) || Path.IsPathRooted(command))
+            return spec;
+
+        var resolved = BinaryResolver.FindOnPath(command);
+        if (resolved is null)
+            return spec;
+
+        var newCommandLine = spec.CommandLine.ToList();
+        newCommandLine[0] = resolved;
+        return spec with { CommandLine = newCommandLine };
+    }
+}

--- a/src/Ivy.Tendril/Apps/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/AgentApp.cs
@@ -1,5 +1,6 @@
 using Ivy.Hooks.Pty;
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Helpers;
 using Ivy.Tendril.Services;
 using Ivy.Widgets.Xterm;
 using Xterm = Ivy.Widgets.Xterm;
@@ -42,7 +43,7 @@ public class AgentApp : ViewBase
             WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             PermissionMode = PermissionMode.Default,
         });
-        return spec?.CommandLine.ToArray() ?? [cli.Id];
+        return spec?.ResolveCommand().CommandLine.ToArray() ?? [cli.Id];
     }
 
     private static string GetWorkDir(IConfigService config, IAgentRunner runner)


### PR DESCRIPTION
## Summary
- On Windows, npm-installed CLIs (opencode, codex) have both a Unix shell script and a `.cmd` wrapper. The PTY was spawning the shell script, causing "not a valid Win32 application" errors.
- Added `AgentPtySpecExtensions.ResolveCommand()` that uses `BinaryResolver.FindOnPath()` to resolve bare command names to their `.cmd`/`.exe`/`.bat` path on Windows before passing to the PTY provider.
- Called from `AgentApp.GetCommandLine()` so all agents benefit automatically.

## Test plan
- [x] Build passes (0 errors)
- [x] 757 unit tests pass
- [ ] Manual: set `codingAgent: opencode` and verify Agent tab launches OpenCode
- [ ] Manual: set `codingAgent: codex` and verify Agent tab launches Codex