### PR TITLE
fix: wait for tunnel to become routable before declaring connected

### DIFF
--- a/src/Ivy.Tendril.Agents.Test.End2End/Tests/CloudflaredEnd2EndTests.cs
+++ b/src/Ivy.Tendril.Agents.Test.End2End/Tests/CloudflaredEnd2EndTests.cs
@@ -1,4 +1,7 @@
 using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
 using Ivy.Tendril.Agents.Helpers;
 using Ivy.Tendril.Services.Tunnel;
 
@@ -134,6 +137,175 @@ public class CloudflaredEnd2EndTests
         {
             try { Directory.Delete(tempDir, true); }
             catch { /* cleanup best-effort */ }
+        }
+    }
+
+    [SkippableFact]
+    public async Task QuickTunnel_ProxiesTrafficToOrigin()
+    {
+        Skip.IfNot(BinaryResolver.IsInstalled("cloudflared"),
+            "cloudflared is not installed on this machine");
+
+        var port = GetAvailablePort();
+        const string expectedBody = "TENDRIL_TUNNEL_OK";
+        var listener = StartTcpOrigin(port, expectedBody);
+
+        try
+        {
+            var binaryPath = BinaryResolver.FindOnPath("cloudflared")!;
+            using var session = new TunnelSession(binaryPath, $"http://localhost:{port}",
+                Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+            using var startCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var tunnelUrl = await session.StartAsync(startCts.Token);
+
+            Assert.Contains("trycloudflare.com", tunnelUrl);
+            await AssertTunnelProxiesContent(tunnelUrl, expectedBody);
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [SkippableFact]
+    public async Task QuickTunnel_Returns502WhenOriginNotListening()
+    {
+        Skip.IfNot(BinaryResolver.IsInstalled("cloudflared"),
+            "cloudflared is not installed on this machine");
+
+        var port = GetAvailablePort();
+        var binaryPath = BinaryResolver.FindOnPath("cloudflared")!;
+
+        using var session = new TunnelSession(binaryPath, $"http://localhost:{port}",
+            Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var tunnelUrl = await session.StartAsync(cts.Token);
+
+        using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        await Task.Delay(3000);
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await httpClient.GetAsync(tunnelUrl);
+        }
+        catch (HttpRequestException) { }
+
+        if (response != null)
+            Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+
+        session.Stop();
+    }
+
+    [SkippableFact]
+    public async Task QuickTunnel_EventuallyProxiesWhenOriginStartsLate()
+    {
+        Skip.IfNot(BinaryResolver.IsInstalled("cloudflared"),
+            "cloudflared is not installed on this machine");
+
+        var port = GetAvailablePort();
+        var binaryPath = BinaryResolver.FindOnPath("cloudflared")!;
+
+        using var session = new TunnelSession(binaryPath, $"http://localhost:{port}",
+            Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+
+        using var startCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var tunnelUrl = await session.StartAsync(startCts.Token);
+
+        await Task.Delay(3000);
+
+        const string expectedBody = "LATE_START_OK";
+        var listener = StartTcpOrigin(port, expectedBody);
+
+        try
+        {
+            await AssertTunnelProxiesContent(tunnelUrl, expectedBody);
+        }
+        finally
+        {
+            listener.Stop();
+            session.Stop();
+        }
+    }
+
+    private static async Task AssertTunnelProxiesContent(string tunnelUrl, string expectedBody)
+    {
+        using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(60);
+        HttpResponseMessage? response = null;
+        string? body = null;
+        string? lastError = null;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                response = await httpClient.GetAsync(tunnelUrl);
+                body = await response.Content.ReadAsStringAsync();
+                if (response.IsSuccessStatusCode && body.Contains(expectedBody))
+                    break;
+                lastError = $"HTTP {(int)response.StatusCode}: {body?[..Math.Min(body?.Length ?? 0, 100)]}";
+                response = null;
+            }
+            catch (Exception ex)
+            {
+                lastError = ex.Message;
+            }
+
+            await Task.Delay(2000);
+        }
+
+        Assert.NotNull(response ?? throw new Exception(
+            $"Tunnel never proxied successfully within 60s. Last error: {lastError}"));
+        Assert.True(response!.IsSuccessStatusCode,
+            $"Expected 2xx but got {(int)response.StatusCode}. Body: {body?[..Math.Min(body?.Length ?? 0, 200)]}");
+        Assert.Contains(expectedBody, body!);
+    }
+
+    private static int GetAvailablePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static TcpListener StartTcpOrigin(int port, string responseBody)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, port);
+        listener.Start();
+        _ = AcceptLoop(listener, responseBody);
+        return listener;
+    }
+
+    private static async Task AcceptLoop(TcpListener listener, string responseBody)
+    {
+        var bodyBytes = Encoding.UTF8.GetBytes(responseBody);
+        var httpResponse = $"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {bodyBytes.Length}\r\nConnection: close\r\n\r\n";
+        var responseBytes = Encoding.UTF8.GetBytes(httpResponse).Concat(bodyBytes).ToArray();
+
+        while (true)
+        {
+            TcpClient client;
+            try { client = await listener.AcceptTcpClientAsync(); }
+            catch (ObjectDisposedException) { break; }
+            catch (SocketException) { break; }
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await using var stream = client.GetStream();
+                    var buffer = new byte[4096];
+                    _ = await stream.ReadAsync(buffer);
+                    await stream.WriteAsync(responseBytes);
+                    await stream.FlushAsync();
+                }
+                finally { client.Dispose(); }
+            });
         }
     }
 

--- a/src/Ivy.Tendril/Apps/Settings/TunnelSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/TunnelSetupView.cs
@@ -11,6 +11,7 @@ public class TunnelSetupView : ViewBase
     {
         var client = UseService<IClientProvider>();
         var tunnelService = UseService<ICloudflaredService>();
+        var copyToClipboard = UseClipboard();
 
         var isLoading = UseState(false);
         var error = UseState<string?>(null);
@@ -55,11 +56,22 @@ public class TunnelSetupView : ViewBase
             form |= Callout.Error(error.Value, "Error");
         }
 
-        if (isConnected.Value && tunnelUrl.Value is not null)
+        if (isLoading.Value)
+        {
+            form |= Callout.Info("Starting tunnel and waiting for it to become routable. This typically takes 15-30 seconds.", "Tunnel Starting...");
+            form |= new Loading();
+        }
+        else if (isConnected.Value && tunnelUrl.Value is not null)
         {
             form |= Callout.Success("Your tunnel is running and accessible at the URL below.", "Tunnel Active");
             form |= Text.Block("Tunnel URL").Bold().Small();
             form |= Text.Monospaced(tunnelUrl.Value);
+            form |= new Button("Copy URL").Icon(Icons.ClipboardCopy).Outline()
+                .OnClick(() =>
+                {
+                    copyToClipboard(tunnelUrl.Value!);
+                    client.Toast("Tunnel URL copied to clipboard", "URL Copied");
+                });
             form |= Text.Block("Scan QR Code").Bold().Small();
             form |= new QRCode { Value = tunnelUrl.Value, PixelSize = 200, ErrorCorrectionLevel = QrErrorCorrectionLevel.Medium };
             form |= new Button("Deactivate").Secondary()

--- a/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
@@ -102,6 +102,40 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
         _supervisorTask = Task.Run(() => SupervisorLoopAsync(_cts.Token));
     }
 
+    private async Task WaitForTunnelHealthyAsync(string tunnelUrl, CancellationToken ct)
+    {
+        using var http = _httpClientFactory.CreateClient("TunnelHealthCheck");
+        http.Timeout = TimeSpan.FromSeconds(10);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(60);
+        _logger.LogInformation("Waiting for tunnel to become routable: {Url}", tunnelUrl);
+
+        while (DateTime.UtcNow < deadline && !ct.IsCancellationRequested)
+        {
+            try
+            {
+                var response = await http.GetAsync(tunnelUrl, ct);
+                if (response.StatusCode != System.Net.HttpStatusCode.BadGateway)
+                {
+                    _logger.LogInformation("Tunnel is routable (HTTP {Status})", (int)response.StatusCode);
+                    return;
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug("Tunnel health check attempt failed: {Error}", ex.Message);
+            }
+
+            await Task.Delay(2000, ct);
+        }
+
+        _logger.LogWarning("Tunnel health check timed out after 60s, proceeding anyway");
+    }
+
     private async Task SupervisorLoopAsync(CancellationToken ct)
     {
         var tunnelConfig = _config.Settings.Tunnel!;
@@ -138,6 +172,7 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
             {
                 _currentSession = new TunnelSession(binaryPath, originUrl, _logger);
                 var url = await _currentSession.StartAsync(ct);
+                await WaitForTunnelHealthyAsync(url, ct);
                 consecutiveFailures = 0;
                 TunnelConnected?.Invoke(url);
 


### PR DESCRIPTION
The TunnelConnected event fired as soon as cloudflared printed the URL,
but Cloudflare's edge network needs 15-30s to route traffic. This caused
502 Bad Gateway errors despite the UI showing "Tunnel Active".

- Add health-check polling in CloudflaredService that waits for non-502
  response before firing TunnelConnected
- Add loading UI state with spinner while tunnel is starting
- Add "Copy URL" button for easy clipboard access
- Add E2E tests verifying actual traffic proxying through the tunnel
