### PR TITLE
fix: use "default" sentinel value so model dropdown shows Default option (#882)

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -53,7 +53,7 @@ public class CodingAgentSetupView : ViewBase
         }
 
         var models = modelsQuery.Value ?? [];
-        var modelOptions = new[] { new Option<string>("Default", "") }
+        var modelOptions = new[] { new Option<string>("Default", "default") }
             .Concat(models.Select(m => new Option<string>(m.DisplayName, m.Id)))
             .ToArray<IAnyOption>();
 
@@ -101,7 +101,8 @@ public class CodingAgentSetupView : ViewBase
         var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
             AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
         var profile = ac?.Profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
-        return profile?.Model ?? "";
+        var value = profile?.Model;
+        return string.IsNullOrEmpty(value) ? "default" : value;
     }
 
     private static void SaveProfiles(IConfigService config, string agentId, string deep, string balanced, string quick)


### PR DESCRIPTION
## Summary
- The Ivy Framework's `SelectInput` filters out options with empty string values, making the "Default" option invisible in Model Per Profile dropdowns
- Changed the option value from `""` to `"default"` which `AgentProviderFactory` already treats as no-override
- Updated `GetProfileModel` to return `"default"` instead of `""` for unconfigured profiles so the dropdown shows the correct selection

## Test plan
- [x] All 1299 tests pass
- [x] Build succeeds with no warnings