### PR TITLE
fix: pass writable directories to Codex sandbox for plan-writing jobs

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexCliTests.cs
@@ -157,7 +157,8 @@ public class CodexCliTests
 
         Assert.Equal("codex", spec.FileName);
         Assert.Contains("exec", spec.Arguments);
-        Assert.Contains("--full-auto", spec.Arguments);
+        Assert.Contains("--sandbox", spec.Arguments);
+        Assert.Contains("workspace-write", spec.Arguments);
         Assert.Contains("--json", spec.Arguments);
         Assert.Contains("--skip-git-repo-check", spec.Arguments);
         Assert.Contains("-", spec.Arguments);

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexCli.cs
@@ -64,7 +64,7 @@ public sealed class CodexCli : IAgentCli
         var args = new List<string>
         {
             "exec",
-            "--full-auto",
+            "--sandbox", "workspace-write",
             "--json",
             "--skip-git-repo-check",
         };

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -260,6 +260,7 @@ internal class JobLauncher
             SessionId = job.SessionId,
             PermissionMode = PermissionMode.FullAuto,
             AllowedTools = resolution.AllowedTools,
+            WritableDirectories = ResolveWritableDirectories(job.Type),
             ExtraArguments = resolution.ExtraArgs,
             PromptFilePath = promptFilePath,
         };
@@ -450,6 +451,21 @@ internal class JobLauncher
             }
         }
         return workDir;
+    }
+
+    private IReadOnlyList<string> ResolveWritableDirectories(string promptwareType)
+    {
+        if (_configService == null) return [];
+
+        var dirs = new List<string>();
+
+        if (PlanWritingTypes.Contains(promptwareType))
+        {
+            dirs.Add(_configService.PlanFolder);
+            dirs.Add(Path.Combine(_configService.TendrilHome, "Trash"));
+        }
+
+        return dirs;
     }
 
     private void SetTendrilEnvironment(ProcessStartInfo psi, JobItem job)

--- a/src/Ivy.Tendril/Services/Promptware/PromptwareRunner.cs
+++ b/src/Ivy.Tendril/Services/Promptware/PromptwareRunner.cs
@@ -55,6 +55,11 @@ public interface IPromptwareRunner
 
 public class PromptwareRunner : IPromptwareRunner
 {
+    private static readonly HashSet<string> PlanWritingTypes = new(StringComparer.Ordinal)
+    {
+        "CreatePlan", "SplitPlan", "UpdatePlan", "ExpandPlan"
+    };
+
     private readonly IConfigService _configService;
     private readonly IAgentRunner _agentRunner;
     private readonly ILogger<PromptwareRunner> _logger;
@@ -107,6 +112,7 @@ public class PromptwareRunner : IPromptwareRunner
             Effort = AgentProviderFactory.ParseEffort(resolution.Effort),
             PermissionMode = PermissionMode.FullAuto,
             AllowedTools = resolution.AllowedTools,
+            WritableDirectories = ResolveWritableDirectories(options.Promptware),
             ExtraArguments = resolution.ExtraArgs,
             PromptFilePath = promptFilePath,
         };
@@ -156,6 +162,19 @@ public class PromptwareRunner : IPromptwareRunner
         };
 
         return handle;
+    }
+
+    private IReadOnlyList<string> ResolveWritableDirectories(string promptwareType)
+    {
+        var dirs = new List<string>();
+
+        if (PlanWritingTypes.Contains(promptwareType))
+        {
+            dirs.Add(_configService.PlanFolder);
+            dirs.Add(Path.Combine(_configService.TendrilHome, "Trash"));
+        }
+
+        return dirs;
     }
 
     private static async Task PipeOutputAndLog(Process process, IWriteStream<string> stream, PromptwareRunHandle handle, CancellationToken ct)


### PR DESCRIPTION
## Summary

- Populate `WritableDirectories` on `AgentLaunchConfig` with the plans folder and trash folder for plan-writing promptwares (CreatePlan, SplitPlan, UpdatePlan, ExpandPlan)
- Applied to both `JobLauncher` (job queue path) and `PromptwareRunner` (manual CLI path)
- Replace deprecated `--full-auto` flag with `--sandbox workspace-write` in CodexCli

## Test plan

- [x] All 2,056 tests pass (757 agents + 1,299 Tendril)
- [x] Build succeeds with zero warnings
- [x] CodexCliTests updated to assert new sandbox flag