### PR TITLE
feat: inject Tendril system prompt into AgentApp

### DIFF
--- a/src/Ivy.Tendril/Apps/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/AgentApp.cs
@@ -40,8 +40,10 @@ public class AgentApp : ViewBase
         var pty = runner.GetPty(agentId);
         var spec = pty?.BuildPtySpec(new AgentPtyConfig
         {
-            WorkingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            WorkingDirectory = GetDefaultWorkDir(config),
             PermissionMode = PermissionMode.Default,
+            SystemPrompt = AgentPromptCompiler.Compile(config),
+            AppendSystemPrompt = true,
         });
         return spec?.ResolveCommand().CommandLine.ToArray() ?? [cli.Id];
     }
@@ -50,7 +52,7 @@ public class AgentApp : ViewBase
     {
         var agentId = config.Settings.CodingAgent;
         var pty = runner.GetPty(agentId);
-        var defaultDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var defaultDir = GetDefaultWorkDir(config);
         var spec = pty?.BuildPtySpec(new AgentPtyConfig
         {
             WorkingDirectory = defaultDir,
@@ -58,4 +60,9 @@ public class AgentApp : ViewBase
         });
         return spec?.WorkingDirectory ?? defaultDir;
     }
+
+    private static string GetDefaultWorkDir(IConfigService config) =>
+        !string.IsNullOrEmpty(config.TendrilHome)
+            ? config.TendrilHome
+            : Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 }

--- a/src/Ivy.Tendril/Assets/AgentPrompt.md
+++ b/src/Ivy.Tendril/Assets/AgentPrompt.md
@@ -1,0 +1,144 @@
+# Tendril Environment
+
+You are running inside Tendril, a plan management and agentic orchestration system.
+
+- **TENDRIL_HOME**: `{TENDRIL_HOME}`
+- **Plans folder**: `{PLAN_FOLDER}`
+- **Config**: `{TENDRIL_HOME}/config.yaml`
+- **Database**: `{TENDRIL_HOME}/tendril.db`
+
+## Directory Structure
+
+```
+{TENDRIL_HOME}/
+  config.yaml          # Main configuration
+  tendril.db           # SQLite database
+  Plans/               # Plan folders ({ID}-{Title}/)
+  Promptwares/         # Promptware programs
+  Inbox/               # Incoming plan requests
+  Trash/               # Discarded plans
+  Hooks/               # Event hooks
+  Logs/Jobs/           # Failed job output
+```
+
+## Tendril CLI Reference
+
+The `tendril` CLI manages plans, projects, verifications, and system state.
+
+Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare number (e.g., `15`).
+
+### Root Commands
+
+| Command | Description |
+|---------|-------------|
+| `tendril doctor` | Check system health |
+| `tendril db-version` | Show database version |
+| `tendril db-migrate` | Run database migrations |
+| `tendril db-reset` | Reset database |
+| `tendril reset` | Reset Tendril state |
+| `tendril update-promptwares` | Update promptware programs |
+| `tendril version` | Show version |
+| `tendril update` | Update Tendril CLI |
+| `tendril report-bug` | Report a bug |
+| `tendril models` | List available models and pricing |
+
+### Job Commands
+
+| Command | Description |
+|---------|-------------|
+| `tendril job status <job-id> --message "..."` | Report job status |
+
+### Plan Commands
+
+| Command | Description |
+|---------|-------------|
+| `tendril plan list` | List plans (supports filters) |
+| `tendril plan create` | Create a new plan |
+| `tendril plan update <plan-id>` | Update plan from stdin |
+| `tendril plan set <plan-id> <field> <value>` | Set a plan field |
+| `tendril plan get <plan-id> [field]` | Get plan data |
+| `tendril plan validate <plan-id>` | Validate plan health |
+| `tendril plan doctor` | Check all plans health |
+| `tendril plan add-repo <plan-id> <path>` | Add repo to plan |
+| `tendril plan remove-repo <plan-id> <path>` | Remove repo from plan |
+| `tendril plan add-pr <plan-id> <url>` | Add PR to plan |
+| `tendril plan add-commit <plan-id> <sha>` | Add commit to plan |
+| `tendril plan add-related-plan <plan-id> <folder>` | Add related plan |
+| `tendril plan remove-related-plan <plan-id> <folder>` | Remove related plan |
+| `tendril plan add-depends-on <plan-id> <folder>` | Add dependency |
+| `tendril plan remove-depends-on <plan-id> <folder>` | Remove dependency |
+| `tendril plan add-log <plan-id> <action>` | Add execution log entry |
+| `tendril plan write-revision <plan-id>` | Write revision from stdin |
+| `tendril plan cleanup <plan-id>` | Remove worktrees |
+| `tendril plan remove-worktree <plan-id>` | Remove a single worktree |
+| `tendril plan sync-worktree <plan-id>` | Apply sync strategy |
+| `tendril plan set-verification <plan-id> <name> <status>` | Set verification status |
+
+### Plan Recommendation Commands
+
+| Command | Description |
+|---------|-------------|
+| `tendril plan rec list <plan-id>` | List recommendations |
+| `tendril plan rec add <plan-id> <title>` | Add recommendation |
+| `tendril plan rec remove <plan-id> <title>` | Remove recommendation |
+| `tendril plan rec set <plan-id> <title> <field> <value>` | Update recommendation field |
+| `tendril plan rec accept <plan-id> <title>` | Accept recommendation |
+| `tendril plan rec decline <plan-id> <title>` | Decline recommendation |
+
+### Plan Verification Commands
+
+| Command | Description |
+|---------|-------------|
+| `tendril plan verification list <plan-id>` | List plan verifications |
+| `tendril plan verification add <plan-id> <name>` | Add verification to plan |
+| `tendril plan verification remove <plan-id> <name>` | Remove verification from plan |
+
+### Verification Definition Commands
+
+| Command | Description |
+|---------|-------------|
+| `tendril verification list` | List verification definitions |
+| `tendril verification get <name>` | Get verification details |
+| `tendril verification add <name>` | Add verification definition |
+| `tendril verification remove <name>` | Remove verification definition |
+| `tendril verification set <name> <field> <value>` | Set verification field |
+
+### Promptware Commands
+
+| Command | Description |
+|---------|-------------|
+| `tendril promptware run <name>` | Run a promptware |
+| `tendril promptware read-memory <name> <file>` | Read promptware memory |
+| `tendril promptware write-memory <name> <file>` | Write promptware memory (stdin) |
+| `tendril promptware write-tool <name> <file>` | Write promptware tool (stdin) |
+
+### Trash Commands
+
+| Command | Description |
+|---------|-------------|
+| `tendril trash write` | Write to trash from stdin |
+
+### Project Commands
+
+| Command | Description |
+|---------|-------------|
+| `tendril project list` | List projects |
+| `tendril project get <name>` | Get project details |
+| `tendril project add <name>` | Add project |
+| `tendril project remove <name>` | Remove project |
+| `tendril project set <name> <field> <value>` | Set project field |
+| `tendril project add-repo <name> <path>` | Add repo to project |
+| `tendril project remove-repo <name> <path>` | Remove repo from project |
+| `tendril project add-verification <name> <ver>` | Add verification to project |
+| `tendril project remove-verification <name> <ver>` | Remove verification from project |
+| `tendril project move-verification <name> <ver> <pos>` | Move verification position |
+| `tendril project add-build-dep <name> <dep>` | Add build dependency |
+| `tendril project remove-build-dep <name> <dep>` | Remove build dependency |
+| `tendril project add-review-action <name>` | Add review action |
+| `tendril project remove-review-action <name> <action>` | Remove review action |
+
+## Important Notes
+
+- **Never read or write `plan.yaml` directly** — always use `tendril plan` CLI commands.
+- Verification statuses: `Pending`, `Pass`, `Fail`, `Skipped`.
+- Plan states: `Draft`, `Building`, `Updating`, `Executing`, `ReadyForReview`, `Failed`, `Completed`, `Skipped`, `Blocked`, `Icebox`.

--- a/src/Ivy.Tendril/Services/AgentPromptCompiler.cs
+++ b/src/Ivy.Tendril/Services/AgentPromptCompiler.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+
+namespace Ivy.Tendril.Services;
+
+public static class AgentPromptCompiler
+{
+    private static readonly Lazy<string?> Template = new(() =>
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        using var stream = asm.GetManifestResourceStream("Ivy.Tendril.Assets.AgentPrompt.md");
+        if (stream == null) return null;
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    });
+
+    public static string? Compile(IConfigService config)
+    {
+        var template = Template.Value;
+        if (template == null) return null;
+
+        var tendrilHome = config.TendrilHome.Replace('\\', '/');
+        var planFolder = config.PlanFolder.Replace('\\', '/');
+
+        return template
+            .Replace("{TENDRIL_HOME}", tendrilHome)
+            .Replace("{PLAN_FOLDER}", planFolder);
+    }
+}


### PR DESCRIPTION
## Summary

- Append a system prompt to the interactive AgentApp with Tendril environment info and full CLI command reference
- Default working directory changed from user profile to TENDRIL_HOME
- New `AgentPromptCompiler` static class (follows `FirmwareCompiler` pattern) loads an embedded markdown template and substitutes paths

## Test plan

- [x] Build passes (`dotnet build src/Ivy.Tendril --no-dependencies`)
- [x] All 757 agent tests pass
- [x] CodeScene code health: 10.0 on both new/modified files