### PR TITLE
fix: resolve cloudflared 502 by reading actual server address from IServer

### DIFF
--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -164,8 +164,9 @@ internal static class ServiceRegistration
             var config = sp.GetRequiredService<IConfigService>();
             var httpFactory = sp.GetRequiredService<IHttpClientFactory>();
             var appLifetime = sp.GetRequiredService<Microsoft.Extensions.Hosting.IHostApplicationLifetime>();
+            var svr = sp.GetRequiredService<Microsoft.AspNetCore.Hosting.Server.IServer>();
             var logger = sp.GetRequiredService<ILogger<Services.Tunnel.CloudflaredService>>();
-            return new Services.Tunnel.CloudflaredService(config, httpFactory, appLifetime, logger);
+            return new Services.Tunnel.CloudflaredService(config, httpFactory, appLifetime, svr, logger);
         });
         server.Services.AddSingleton<Services.Tunnel.ICloudflaredService>(sp =>
             sp.GetRequiredService<Services.Tunnel.CloudflaredService>());

--- a/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -8,6 +10,7 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
     private readonly IConfigService _config;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IHostApplicationLifetime _appLifetime;
+    private readonly IServer _server;
     private readonly ILogger<CloudflaredService> _logger;
     private CancellationTokenSource? _cts;
     private Task? _supervisorTask;
@@ -18,11 +21,13 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
         IConfigService config,
         IHttpClientFactory httpClientFactory,
         IHostApplicationLifetime appLifetime,
+        IServer server,
         ILogger<CloudflaredService> logger)
     {
         _config = config;
         _httpClientFactory = httpClientFactory;
         _appLifetime = appLifetime;
+        _server = server;
         _logger = logger;
     }
 
@@ -161,8 +166,11 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
             if (ct.IsCancellationRequested) return;
         }
 
-        var originUrl = Environment.GetEnvironmentVariable("TENDRIL_URL")
+        var addresses = _server.Features.Get<IServerAddressesFeature>()?.Addresses;
+        var originUrl = addresses?.FirstOrDefault()
             ?? $"http://localhost:{tunnelConfig.Port}";
+        originUrl = originUrl.Replace("://localhost:", "://127.0.0.1:");
+        _logger.LogInformation("Tunnel origin URL: {OriginUrl}", originUrl);
 
         var consecutiveFailures = 0;
 

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -45,11 +45,6 @@ public static class TendrilServer
         {
             app.UseMiddleware<ApiKeyAuthMiddleware>();
 
-            // Publish the actual bound URL so child processes can reach this server
-            var serverUrl = app.Urls.FirstOrDefault();
-            if (serverUrl != null)
-                Environment.SetEnvironmentVariable("TENDRIL_URL", serverUrl);
-
             if (!configService.NeedsOnboarding)
             {
                 // Auto-update promptwares if the running version is newer than what's deployed

--- a/src/Ivy.Widgets.TendrilProcessView/frontend/src/TendrilProcessView.css
+++ b/src/Ivy.Widgets.TendrilProcessView/frontend/src/TendrilProcessView.css
@@ -34,7 +34,7 @@
 .tpv-curve-svg {
   width: 100%;
   height: 30px;
-  color: var(--color-muted-foreground, #6b7280);
+  color: var(--muted-foreground, #6b7280);
   display: block;
   overflow: visible;
 }
@@ -65,12 +65,12 @@
 
 .tpv-box:hover {
   opacity: 0.85;
-  box-shadow: 0 2px 8px color-mix(in srgb, var(--color-foreground, #0f172a) 8%, transparent);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--foreground, #0f172a) 8%, transparent);
 }
 
 .tpv-box-create {
-  background: var(--color-primary, #4db6a0);
-  color: var(--color-primary-foreground, #ffffff);
+  background: var(--primary, #4db6a0);
+  color: var(--primary-foreground, #ffffff);
   border-radius: 0.5rem;
   padding: 0.5rem 1rem;
   font-weight: 600;
@@ -84,9 +84,9 @@
 }
 
 .tpv-box-stage {
-  background: var(--color-card, #ffffff);
-  color: var(--color-card-foreground, #0f172a);
-  border-color: var(--color-border, #e2e8f0);
+  background: var(--card, #ffffff);
+  color: var(--card-foreground, #0f172a);
+  border-color: var(--border, #e2e8f0);
 }
 
 .tpv-box-stage-icon {
@@ -95,7 +95,7 @@
 
 .tpv-box-count {
   margin-left: 0.25rem;
-  color: var(--color-muted-foreground, #6b7280);
+  color: var(--muted-foreground, #6b7280);
 }
 
 /* Arrow segments between boxes */
@@ -117,7 +117,7 @@
 .tpv-arrow-svg {
   width: 80px;
   height: 12px;
-  color: var(--color-muted-foreground, #6b7280);
+  color: var(--muted-foreground, #6b7280);
 }
 
 /* Arrow label (count + spinner) */
@@ -129,7 +129,7 @@
   border: none;
   background: transparent;
   cursor: pointer;
-  color: var(--color-muted-foreground, #6b7280);
+  color: var(--muted-foreground, #6b7280);
   font-size: 0.8125rem;
   font-weight: 500;
   border-radius: 0.25rem;
@@ -137,8 +137,8 @@
 }
 
 .tpv-arrow-label:hover {
-  color: var(--color-foreground, #0f172a);
-  background: var(--color-muted, #f1f5f9);
+  color: var(--foreground, #0f172a);
+  background: var(--muted, #f1f5f9);
 }
 
 .tpv-arrow-count {
@@ -152,10 +152,10 @@
 
 @keyframes tpv-pulse {
   0%, 100% {
-    box-shadow: 0 1px 2px color-mix(in srgb, var(--color-foreground, #0f172a) 5%, transparent);
+    box-shadow: 0 1px 2px color-mix(in srgb, var(--foreground, #0f172a) 5%, transparent);
   }
   50% {
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-muted-foreground, #6b7280) 50%, transparent);
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--muted-foreground, #6b7280) 50%, transparent);
   }
 }
 


### PR DESCRIPTION
## Summary

- Cloudflared tunnel was always getting 502 because the origin URL defaulted to `http://localhost:5010` while the Ivy framework binds to `https://localhost:5010`
- Root cause: `app.Urls.FirstOrDefault()` was called during build time (before server started), so `TENDRIL_URL` was never set
- Fix: inject `IServer` into `CloudflaredService` and read `IServerAddressesFeature` after `ApplicationStarted` fires
- Also normalizes `localhost` → `127.0.0.1` to avoid IPv4/IPv6 ambiguity on Windows

## Test plan

- [x] Build succeeds (0 errors, 0 warnings)
- [x] 2056 unit tests pass
- [ ] Verify tunnel connects successfully with `TENDRIL_VERBOSE=1` and confirm log shows `https://127.0.0.1:5010` as origin URL