### PR TITLE
fix: switch copilot provider to stdin prompt to avoid Win32 command-line length limit

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Copilot/CopilotCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Copilot/CopilotCliTests.cs
@@ -20,9 +20,9 @@ public class CopilotCliTests
     }
 
     [Fact]
-    public void Capabilities_IncludesArgumentPrompt()
+    public void Capabilities_DoesNotIncludeArgumentPrompt()
     {
-        Assert.True(_cli.Capabilities.HasFlag(AgentCapabilities.ArgumentPrompt));
+        Assert.False(_cli.Capabilities.HasFlag(AgentCapabilities.ArgumentPrompt));
     }
 
     [Fact]
@@ -68,9 +68,9 @@ public class CopilotCliTests
     }
 
     [Fact]
-    public void PromptTransport_IsArgument()
+    public void PromptTransport_IsStdin()
     {
-        Assert.Equal(PromptTransport.Argument, _cli.PromptTransport);
+        Assert.Equal(PromptTransport.Stdin, _cli.PromptTransport);
     }
 
     [Fact]
@@ -202,15 +202,15 @@ public class CopilotCliTests
 
         Assert.True(spec.FileName == "copilot" || spec.FileName == "gh",
             $"Expected 'copilot' or 'gh', got '{spec.FileName}'");
-        Assert.Contains("-p", spec.Arguments);
-        Assert.Contains("Hello world", spec.Arguments);
+        Assert.DoesNotContain("-p", spec.Arguments);
+        Assert.DoesNotContain("Hello world", spec.Arguments);
         Assert.Contains("--allow-all-paths", spec.Arguments);
         Assert.Contains("--allow-all-urls", spec.Arguments);
         Assert.Contains("--output-format", spec.Arguments);
         Assert.Contains("json", spec.Arguments);
         Assert.Contains("-s", spec.Arguments);
-        Assert.Null(spec.StdinContent);
-        Assert.False(spec.RedirectStdin);
+        Assert.Equal("Hello world", spec.StdinContent);
+        Assert.True(spec.RedirectStdin);
         Assert.Equal("/tmp", spec.WorkingDirectory);
     }
 

--- a/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotCli.cs
@@ -12,7 +12,6 @@ public sealed class CopilotCli : IAgentCli
     public string DisplayName => "GitHub Copilot";
 
     public AgentCapabilities Capabilities =>
-        AgentCapabilities.ArgumentPrompt |
         AgentCapabilities.StreamJsonOutput |
         AgentCapabilities.ModelSelection |
         AgentCapabilities.EffortControl |
@@ -21,7 +20,7 @@ public sealed class CopilotCli : IAgentCli
         AgentCapabilities.ExtraArgPassthrough;
 
     public TransportKind SupportedTransports => TransportKind.CliSpawn;
-    public PromptTransport PromptTransport => PromptTransport.Argument;
+    public PromptTransport PromptTransport => PromptTransport.Stdin;
     public OutputFormat PreferredOutputFormat => OutputFormat.StreamJson;
 
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles { get; } =
@@ -82,7 +81,6 @@ public sealed class CopilotCli : IAgentCli
     {
         var args = new List<string>
         {
-            "-p", config.Prompt,
             "--allow-all-paths",
             "--allow-all-urls",
             "--output-format", "json",
@@ -150,8 +148,8 @@ public sealed class CopilotCli : IAgentCli
             Arguments = [..prefixArgs, ..args],
             WorkingDirectory = config.WorkingDirectory,
             Environment = env,
-            StdinContent = null,
-            RedirectStdin = false,
+            StdinContent = config.Prompt,
+            RedirectStdin = true,
         };
     }
 

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -144,7 +144,12 @@ internal class JobLauncher
         {
             _logger.LogError(ex, "Job {JobId}: Failed to start process '{FileName}'", id, psi.FileName);
             job.Status = JobStatus.Failed;
-            job.StatusMessage = $"Agent binary not found: {psi.FileName}";
+            job.StatusMessage = ex.NativeErrorCode switch
+            {
+                2 => $"Agent binary not found: {psi.FileName}",
+                206 => $"Command line too long when launching '{psi.FileName}'",
+                _ => $"Failed to start '{psi.FileName}': {ex.Message}"
+            };
             job.CompletedAt = DateTime.UtcNow;
             ctx.JobSlotSemaphore.Release();
             ctx.RaiseStructureChanged();

--- a/src/Ivy.Widgets.TendrilProcessView/frontend/src/TendrilProcessView.css
+++ b/src/Ivy.Widgets.TendrilProcessView/frontend/src/TendrilProcessView.css
@@ -86,7 +86,7 @@
 .tpv-box-stage {
   background: var(--card, #ffffff);
   color: var(--card-foreground, #0f172a);
-  border-color: var(--border, #e2e8f0);
+  border-color: color-mix(in srgb, var(--foreground, #0f172a) 20%, transparent);
 }
 
 .tpv-box-stage-icon {


### PR DESCRIPTION
## Summary
- Switch CopilotCli from passing prompt as `-p` argument to piping via stdin, avoiding Windows' ~32K command-line length limit (Win32 error 206)
- Improve Win32Exception error messages in JobLauncher to differentiate "binary not found" (code 2) from "command line too long" (code 206)
- Update tests to reflect new stdin transport behavior

## Test plan
- [x] All CopilotCli tests pass (45/45)
- [ ] Run a copilot job and verify it launches without error 206