### PR TITLE
feat: add --beta flag to gate AgentApp and Tunnel settings

### DIFF
--- a/src/Ivy.Tendril/Apps/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/SettingsApp.cs
@@ -25,6 +25,7 @@ public class SettingsApp : ViewBase
     public override object Build()
     {
         var config = UseService<IConfigService>();
+        var tendrilArgs = UseService<TendrilArgs>();
         var navigator = UseNavigation();
         var client = UseService<IClientProvider>();
         var httpContextAccessor = UseService<IHttpContextAccessor>();
@@ -33,25 +34,31 @@ public class SettingsApp : ViewBase
         var isDesktop = desktopWindow != null;
         var capturedHost = ConfigYamlUiHelper.CaptureHost(httpContextAccessor);
 
+        var children = new List<MenuItem>
+        {
+            MenuItem.Default("Coding Agent", TagCodingAgent).Icon(Icons.Bot),
+            MenuItem.Default("Plans", TagPlans).Icon(Icons.FileText),
+            MenuItem.Default("Appearance", TagAppearance).Icon(Icons.Palette),
+            MenuItem.Default("Projects", TagProjects).Icon(Icons.Folder),
+            MenuItem.Default("Verifications", TagVerifications).Icon(Icons.CircleCheck),
+            MenuItem.Default("Promptwares", TagPromptwares).Icon(Icons.Wand),
+            MenuItem.Default("Levels", TagLevels).Icon(Icons.ListOrdered),
+            MenuItem.Default("Notifications", TagNotifications).Icon(Icons.Bell),
+            MenuItem.Default("Security", TagSecurity).Icon(Icons.Lock),
+        };
+
+        if (tendrilArgs.Beta)
+            children.Add(MenuItem.Default("Tunnel", TagTunnel).Icon(Icons.Globe));
+
+        children.Add(MenuItem.Default("Advanced", TagAdvanced).Icon(Icons.Cog));
+        children.Add(MenuItem.Default("Open config.yaml", TagOpenConfig).Icon(Icons.FileText));
+
         var menuItems = new[]
         {
             MenuItem.Default("Configuration")
                 .Icon(Icons.Settings2)
                 .Expanded()
-                .Children(
-                    MenuItem.Default("Coding Agent", TagCodingAgent).Icon(Icons.Bot),
-                    MenuItem.Default("Plans", TagPlans).Icon(Icons.FileText),
-                    MenuItem.Default("Appearance", TagAppearance).Icon(Icons.Palette),
-                    MenuItem.Default("Projects", TagProjects).Icon(Icons.Folder),
-                    MenuItem.Default("Verifications", TagVerifications).Icon(Icons.CircleCheck),
-                    MenuItem.Default("Promptwares", TagPromptwares).Icon(Icons.Wand),
-                    MenuItem.Default("Levels", TagLevels).Icon(Icons.ListOrdered),
-                    MenuItem.Default("Notifications", TagNotifications).Icon(Icons.Bell),
-                    MenuItem.Default("Security", TagSecurity).Icon(Icons.Lock),
-                    MenuItem.Default("Tunnel", TagTunnel).Icon(Icons.Globe),
-                    MenuItem.Default("Advanced", TagAdvanced).Icon(Icons.Cog),
-                    MenuItem.Default("Open config.yaml", TagOpenConfig).Icon(Icons.FileText)
-                )
+                .Children(children.ToArray())
         };
 
         void OnSelect(Event<SidebarMenu, object> @event)

--- a/src/Ivy.Tendril/Commands/RunCommand.cs
+++ b/src/Ivy.Tendril/Commands/RunCommand.cs
@@ -65,7 +65,7 @@ public class RunCommand : AsyncCommand<RunCommand.Settings>
 
         AnsiConsole.MarkupLine("[green]Starting Ivy Tendril server on localhost:5010...[/]");
 
-        var server = TendrilServer.Create([]);
+        var server = TendrilServer.Create([], new Services.TendrilArgs());
         if (settings.Port.HasValue)
         {
             server.Args.Port = settings.Port.Value;

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -53,7 +53,7 @@ public class Program
 
         VelopackApp.Build().Run();
 
-        var (verbose, quiet, forceDesktop, forceWeb, filteredArgs) = ParseGlobalFlags(args);
+        var (verbose, quiet, forceDesktop, forceWeb, beta, filteredArgs) = ParseGlobalFlags(args);
 
         bool isTool = IsTendrilToolInvocation();
         bool useDesktop = (isTool || forceDesktop) && !forceWeb;
@@ -140,7 +140,8 @@ public class Program
         if (useDesktop && string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IVY_TLS")))
             Environment.SetEnvironmentVariable("IVY_TLS", "0");
 
-        var server = TendrilServer.Create(filteredArgs);
+        var tendrilArgs = new Services.TendrilArgs { Beta = beta, Verbose = verbose, Quiet = quiet };
+        var server = TendrilServer.Create(filteredArgs, tendrilArgs);
 
         if (useDesktop)
         {
@@ -192,13 +193,14 @@ public class Program
         }
     }
 
-    private static (bool verbose, bool quiet, bool forceDesktop, bool forceWeb, string[] filtered)
+    private static (bool verbose, bool quiet, bool forceDesktop, bool forceWeb, bool beta, string[] filtered)
         ParseGlobalFlags(string[] args)
     {
         bool verbose = args.Contains("--verbose") || args.Contains("-v");
         bool quiet = args.Contains("--quiet") || args.Contains("-q");
         bool forceDesktop = args.Contains("--desktop");
         bool forceWeb = args.Contains("--web");
+        bool beta = args.Contains("--beta");
 
         if (verbose)
             Environment.SetEnvironmentVariable("TENDRIL_VERBOSE", "1");
@@ -209,10 +211,11 @@ public class Program
             a != "--desktop" && a != "--web" &&
             a != "--verbose" && a != "-v" &&
             a != "--quiet" && a != "-q" &&
+            a != "--beta" &&
             a != DetachedLaunchMarker
         ).ToArray();
 
-        return (verbose, quiet, forceDesktop, forceWeb, filtered);
+        return (verbose, quiet, forceDesktop, forceWeb, beta, filtered);
     }
 
     private static bool ShouldHandleAsCliCommand(string firstArg)

--- a/src/Ivy.Tendril/Services/TendrilArgs.cs
+++ b/src/Ivy.Tendril/Services/TendrilArgs.cs
@@ -1,0 +1,8 @@
+namespace Ivy.Tendril.Services;
+
+public class TendrilArgs
+{
+    public bool Beta { get; init; }
+    public bool Verbose { get; init; }
+    public bool Quiet { get; init; }
+}

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -1,4 +1,6 @@
+using Ivy.Core.Apps;
 using Ivy.Helpers;
+using Ivy.Tendril.Apps;
 using Ivy.Tendril.AppShell;
 using Ivy.Tendril.Controllers;
 using Ivy.Tendril.Services;
@@ -12,7 +14,7 @@ namespace Ivy.Tendril;
 
 public static class TendrilServer
 {
-    public static Server Create(string[] args)
+    public static Server Create(string[] args, TendrilArgs tendrilArgs)
     {
         var server = new Server();
         server.DangerouslyAllowLocalFiles();
@@ -23,14 +25,11 @@ public static class TendrilServer
         server.SetMetaTitle("Ivy Tendril");
 
         var configService = new ConfigService(Microsoft.Extensions.Logging.Abstractions.NullLogger<ConfigService>.Instance);
+        server.Services.AddSingleton(tendrilArgs);
         server.AddTendrilServices(configService);
 
-        // Configure logging based on verbosity.
-        // We set levels via configuration (not SetMinimumLevel) because the Ivy framework
-        // calls SetMinimumLevel after UseWebApplicationBuilder mods, which would override ours.
-        // Configuration-based rules take precedence over SetMinimumLevel.
-        var logLevel = Environment.GetEnvironmentVariable("TENDRIL_VERBOSE") == "1" ? "Debug"
-            : Environment.GetEnvironmentVariable("TENDRIL_QUIET") == "1" ? "Warning"
+        var logLevel = tendrilArgs.Verbose ? "Debug"
+            : tendrilArgs.Quiet ? "Warning"
             : "Error";
         server.UseWebApplicationBuilder(builder =>
         {
@@ -81,7 +80,10 @@ public static class TendrilServer
             app.UseAssets(server.Args, app.Services.GetRequiredService<ILogger<Server>>(), "Assets", "tendril/assets");
         });
 
-        server.AddAppsFromAssembly(typeof(TendrilServer).Assembly);
+        var assembly = typeof(TendrilServer).Assembly;
+        server.AppRepository.AddFactory(() => AppHelpers.GetApps(assembly)
+            .Where(a => tendrilArgs.Beta || a.Type != typeof(AgentApp))
+            .ToArray());
         server.AddConnectionsFromAssembly(typeof(TendrilServer).Assembly);
 
         var version = typeof(TendrilAppShell).Assembly.GetName().Version!;


### PR DESCRIPTION
## Summary
- Adds `--beta` CLI flag parsed in `Program.cs`
- Introduces `TendrilArgs` DI service (replaces env var reads for verbose/quiet in TendrilServer)
- AgentApp excluded from app repository when `--beta` is not passed
- Tunnel menu item hidden from Settings when `--beta` is not passed

## Test plan
- [x] Build succeeds
- [x] Unit tests pass (1299/1299)
- [ ] Run `tendril --beta` → AgentApp visible, Tunnel in Settings
- [ ] Run `tendril` → AgentApp hidden, Tunnel hidden