### PR TITLE
feat: simplify model catalog, extract agent test dialog, resolve default models

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudeHealthCheckTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudeHealthCheckTests.cs
@@ -53,12 +53,12 @@ public class ClaudeHealthCheckTests
     [Fact]
     public async Task ValidateModel_ValidModel_ReturnsOkOrKnownStatus()
     {
-        var result = await _healthCheck.ValidateModelAsync("claude-sonnet-4-6");
+        var result = await _healthCheck.ValidateModelAsync("sonnet");
 
         // Model validation may succeed or fail depending on plan/quota,
         // but should never return InvalidModel for a real model name
         Assert.NotEqual(ModelValidationStatus.InvalidModel, result.Status);
-        Assert.Equal("claude-sonnet-4-6", result.Model);
+        Assert.Equal("sonnet", result.Model);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs
@@ -10,18 +10,18 @@ public class ModelPricingProviderTests
     [Fact]
     public void GetPricing_KnownModel_ReturnsPricing()
     {
-        var pricing = _provider.GetPricing("claude-opus-4");
+        var pricing = _provider.GetPricing("opus");
 
         Assert.NotNull(pricing);
-        Assert.Equal("claude-opus-4", pricing.Model);
-        Assert.Equal(15m, pricing.InputPerMillion);
-        Assert.Equal(75m, pricing.OutputPerMillion);
+        Assert.Equal("opus", pricing.Model);
+        Assert.Equal(10m, pricing.InputPerMillion);
+        Assert.Equal(50m, pricing.OutputPerMillion);
     }
 
     [Fact]
     public void GetPricing_Sonnet_ReturnsPricing()
     {
-        var pricing = _provider.GetPricing("claude-sonnet-4-5");
+        var pricing = _provider.GetPricing("sonnet");
 
         Assert.NotNull(pricing);
         Assert.Equal(3m, pricing.InputPerMillion);
@@ -29,7 +29,7 @@ public class ModelPricingProviderTests
     }
 
     [Fact]
-    public void GetPricing_Sonnet4_ReturnsPricing()
+    public void GetPricing_Sonnet4_SubstringMatch_ReturnsPricing()
     {
         var pricing = _provider.GetPricing("claude-sonnet-4");
 
@@ -41,11 +41,11 @@ public class ModelPricingProviderTests
     [Fact]
     public void GetPricing_Haiku_ReturnsPricing()
     {
-        var pricing = _provider.GetPricing("claude-haiku-4");
+        var pricing = _provider.GetPricing("haiku");
 
         Assert.NotNull(pricing);
-        Assert.Equal(0.80m, pricing.InputPerMillion);
-        Assert.Equal(4m, pricing.OutputPerMillion);
+        Assert.Equal(1m, pricing.InputPerMillion);
+        Assert.Equal(5m, pricing.OutputPerMillion);
     }
 
     [Fact]
@@ -68,7 +68,7 @@ public class ModelPricingProviderTests
     [Fact]
     public void GetPricing_CaseInsensitive()
     {
-        var pricing = _provider.GetPricing("Claude-Opus-4");
+        var pricing = _provider.GetPricing("Opus");
 
         Assert.NotNull(pricing);
     }
@@ -77,24 +77,24 @@ public class ModelPricingProviderTests
     public void CalculateCost_KnownModel_ReturnsCorrectCost()
     {
         var cost = _provider.CalculateCost(
-            "claude-opus-4",
+            "opus",
             inputTokens: 1_000_000,
             outputTokens: 1_000_000);
 
-        Assert.Equal(15m + 75m, cost);
+        Assert.Equal(10m + 50m, cost);
     }
 
     [Fact]
     public void CalculateCost_WithCache_IncludesCacheCost()
     {
         var cost = _provider.CalculateCost(
-            "claude-opus-4",
+            "opus",
             inputTokens: 0,
             outputTokens: 0,
             cacheReadTokens: 1_000_000,
             cacheWriteTokens: 1_000_000);
 
-        Assert.Equal(1.50m + 18.75m, cost);
+        Assert.Equal(1.00m + 12.50m, cost);
     }
 
     [Fact]
@@ -109,7 +109,7 @@ public class ModelPricingProviderTests
     public void CalculateCost_SmallUsage_ReturnsProportionalCost()
     {
         var cost = _provider.CalculateCost(
-            "claude-sonnet-4-5",
+            "sonnet",
             inputTokens: 1000,
             outputTokens: 500);
 
@@ -139,13 +139,13 @@ public class ModelPricingProviderTests
     {
         var override_ = new ModelPricing
         {
-            Model = "claude-opus-4",
+            Model = "opus",
             InputPerMillion = 99m,
             OutputPerMillion = 99m,
         };
 
         var provider = new ModelPricingProvider([override_]);
-        var pricing = provider.GetPricing("claude-opus-4");
+        var pricing = provider.GetPricing("opus");
 
         Assert.NotNull(pricing);
         Assert.Equal(99m, pricing.InputPerMillion);
@@ -154,18 +154,26 @@ public class ModelPricingProviderTests
     [Fact]
     public void Constructor_Default_IncludesAllKnownModels()
     {
-        Assert.NotNull(_provider.GetPricing("claude-opus-4"));
-        Assert.NotNull(_provider.GetPricing("claude-sonnet-4-5"));
-        Assert.NotNull(_provider.GetPricing("claude-sonnet-4"));
-        Assert.NotNull(_provider.GetPricing("claude-haiku-4"));
+        Assert.NotNull(_provider.GetPricing("opus"));
+        Assert.NotNull(_provider.GetPricing("sonnet"));
+        Assert.NotNull(_provider.GetPricing("haiku"));
     }
 
     [Fact]
     public void GetPricing_IncludesCacheRates()
     {
-        var pricing = _provider.GetPricing("claude-opus-4")!;
+        var pricing = _provider.GetPricing("opus")!;
 
-        Assert.Equal(18.75m, pricing.CacheWritePerMillion);
-        Assert.Equal(1.50m, pricing.CacheReadPerMillion);
+        Assert.Equal(12.50m, pricing.CacheWritePerMillion);
+        Assert.Equal(1.00m, pricing.CacheReadPerMillion);
+    }
+
+    [Fact]
+    public void GetPricing_SubstringMatch_FullModelIdFromOutput()
+    {
+        var pricing = _provider.GetPricing("claude-opus-4-7-20250219");
+
+        Assert.NotNull(pricing);
+        Assert.Contains("opus", pricing.Model);
     }
 }

--- a/src/Ivy.Tendril.Agents/Abstractions/ModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/ModelCatalog.cs
@@ -4,7 +4,6 @@ public sealed record ModelInfo
 {
     public required string Id { get; init; }
     public required string DisplayName { get; init; }
-    public string? Alias { get; init; }
     public ModelCapabilities Capabilities { get; init; }
     public int? ContextWindow { get; init; }
     public int? MaxOutputTokens { get; init; }

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeHealthCheck.cs
@@ -25,8 +25,10 @@ public sealed class ClaudeHealthCheck : IAgentHealthCheck
             TimeSpan.FromSeconds(30),
             ct);
 
+        var provider = DetectProvider();
+
         if (exitCode == 0)
-            return new AgentAuthResult { Status = AuthStatus.Authenticated };
+            return new AgentAuthResult { Status = AuthStatus.Authenticated, Provider = provider };
 
         if (stderr.Contains("auth", StringComparison.OrdinalIgnoreCase) ||
             stderr.Contains("login", StringComparison.OrdinalIgnoreCase) ||
@@ -34,11 +36,28 @@ public sealed class ClaudeHealthCheck : IAgentHealthCheck
             return new AgentAuthResult
             {
                 Status = AuthStatus.NotAuthenticated,
+                Provider = provider,
                 Error = stderr,
                 SignInHint = "Run 'claude login' to authenticate",
             };
 
-        return new AgentAuthResult { Status = AuthStatus.CheckFailed, Error = stderr };
+        return new AgentAuthResult { Status = AuthStatus.CheckFailed, Provider = provider, Error = stderr };
+    }
+
+    private static string? DetectProvider()
+    {
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CLAUDE_CODE_USE_BEDROCK")) ||
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AWS_BEARER_TOKEN_BEDROCK")))
+            return "bedrock";
+
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CLAUDE_CODE_USE_VERTEX")) ||
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CLOUD_ML_REGION")))
+            return "vertex";
+
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY")))
+            return "anthropic-api";
+
+        return null;
     }
 
     public async Task<string?> GetVersionAsync(CancellationToken ct = default)
@@ -52,7 +71,7 @@ public sealed class ClaudeHealthCheck : IAgentHealthCheck
 
     public async Task<ModelValidationResult> ValidateModelAsync(string model, CancellationToken ct = default)
     {
-        var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
+        var (exitCode, stdout, stderr) = await HealthCheckRunner.RunAsync(
             "claude",
             ["-p", "ping", "--model", model, "--max-turns", "1"],
             TimeSpan.FromSeconds(30),
@@ -61,29 +80,37 @@ public sealed class ClaudeHealthCheck : IAgentHealthCheck
         if (exitCode == 0)
             return new ModelValidationResult { Status = ModelValidationStatus.Ok, Model = model };
 
-        if (stderr.Contains("model", StringComparison.OrdinalIgnoreCase) &&
-            (stderr.Contains("invalid", StringComparison.OrdinalIgnoreCase) ||
-             stderr.Contains("not found", StringComparison.OrdinalIgnoreCase)))
+        var combined = string.IsNullOrEmpty(stderr) ? stdout : stderr;
+
+        if (combined.Contains("model", StringComparison.OrdinalIgnoreCase) &&
+            (combined.Contains("invalid", StringComparison.OrdinalIgnoreCase) ||
+             combined.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
+             combined.Contains("does not exist", StringComparison.OrdinalIgnoreCase) ||
+             combined.Contains("not supported", StringComparison.OrdinalIgnoreCase) ||
+             combined.Contains("not available", StringComparison.OrdinalIgnoreCase)))
             return new ModelValidationResult
             {
                 Status = ModelValidationStatus.InvalidModel,
                 Model = model,
-                ErrorMessage = stderr,
+                ErrorMessage = combined,
             };
 
-        if (stderr.Contains("auth", StringComparison.OrdinalIgnoreCase))
+        if (combined.Contains("auth", StringComparison.OrdinalIgnoreCase) ||
+            combined.Contains("permission", StringComparison.OrdinalIgnoreCase) ||
+            combined.Contains("unauthorized", StringComparison.OrdinalIgnoreCase))
             return new ModelValidationResult
             {
                 Status = ModelValidationStatus.AuthError,
                 Model = model,
-                ErrorMessage = stderr,
+                ErrorMessage = combined,
             };
 
+        var fullOutput = $"exit={exitCode}\nstdout: {stdout}\nstderr: {stderr}";
         return new ModelValidationResult
         {
             Status = ModelValidationStatus.Unknown,
             Model = model,
-            ErrorMessage = stderr,
+            ErrorMessage = fullOutput,
         };
     }
 

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
@@ -31,7 +31,7 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
     [
         new()
         {
-            Id = "claude-opus-4-7", DisplayName = "Claude Opus 4.7", Alias = "opus",
+            Id = "opus", DisplayName = "Claude Opus",
             Capabilities = FullCaps,
             ContextWindow = 200_000, MaxOutputTokens = 32_000,
             Provider = "anthropic", IsDefault = true,
@@ -40,25 +40,7 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         },
         new()
         {
-            Id = "claude-opus-4-6", DisplayName = "Claude Opus 4.6",
-            Capabilities = FullCaps,
-            ContextWindow = 200_000, MaxOutputTokens = 32_000,
-            Provider = "anthropic",
-            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
-            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
-        },
-        new()
-        {
-            Id = "claude-opus-4-5", DisplayName = "Claude Opus 4.5", Alias = null,
-            Capabilities = FullCaps,
-            ContextWindow = 200_000, MaxOutputTokens = 32_000,
-            Provider = "anthropic",
-            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
-            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
-        },
-        new()
-        {
-            Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6", Alias = "sonnet",
+            Id = "sonnet", DisplayName = "Claude Sonnet",
             Capabilities = MidCaps,
             ContextWindow = 200_000, MaxOutputTokens = 16_000,
             Provider = "anthropic",
@@ -67,57 +49,12 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         },
         new()
         {
-            Id = "claude-sonnet-4-5", DisplayName = "Claude Sonnet 4.5", Alias = null,
-            Capabilities = MidCaps,
-            ContextWindow = 200_000, MaxOutputTokens = 16_000,
-            Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
-        },
-        new()
-        {
-            Id = "claude-haiku-4-5", DisplayName = "Claude Haiku 4.5", Alias = "haiku",
+            Id = "haiku", DisplayName = "Claude Haiku",
             Capabilities = LiteCaps,
             ContextWindow = 200_000, MaxOutputTokens = 8_192,
             Provider = "anthropic",
             InputPerMillion = 1.00m, OutputPerMillion = 5.00m,
             CacheWritePerMillion = 1.25m, CacheReadPerMillion = 0.10m,
-        },
-        new()
-        {
-            Id = "claude-opus-4-1", DisplayName = "Claude Opus 4.1",
-            Capabilities = FullCaps,
-            ContextWindow = 200_000, MaxOutputTokens = 32_000,
-            Provider = "anthropic",
-            InputPerMillion = 15.00m, OutputPerMillion = 75.00m,
-            CacheWritePerMillion = 18.75m, CacheReadPerMillion = 1.50m,
-        },
-        new()
-        {
-            Id = "claude-opus-4", DisplayName = "Claude Opus 4",
-            Capabilities = FullCaps,
-            ContextWindow = 200_000, MaxOutputTokens = 32_000,
-            Provider = "anthropic",
-            InputPerMillion = 15.00m, OutputPerMillion = 75.00m,
-            CacheWritePerMillion = 18.75m, CacheReadPerMillion = 1.50m,
-        },
-        new()
-        {
-            Id = "claude-sonnet-4", DisplayName = "Claude Sonnet 4",
-            Capabilities = MidCaps,
-            ContextWindow = 200_000, MaxOutputTokens = 16_000,
-            Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
-        },
-        new()
-        {
-            Id = "claude-haiku-4", DisplayName = "Claude Haiku 4",
-            Capabilities = LiteCaps,
-            ContextWindow = 200_000, MaxOutputTokens = 8_192,
-            Provider = "anthropic",
-            InputPerMillion = 0.80m, OutputPerMillion = 4.00m,
-            CacheWritePerMillion = 1.00m, CacheReadPerMillion = 0.08m,
         },
     ];
 }

--- a/src/Ivy.Tendril.Agents/Runtime/ModelPricingProvider.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/ModelPricingProvider.cs
@@ -45,8 +45,6 @@ public sealed class ModelPricingProvider : IModelPricingProvider
                 else
                     _pricing.TryAdd(model.Id, pricing);
 
-                if (model.Alias is not null)
-                    _pricing.TryAdd(model.Alias, pricing);
             }
         }
 

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -1,4 +1,4 @@
-codingAgent: codex
+codingAgent: claude
 jobTimeout: 30
 staleOutputTimeout: 10
 gitTimeout: 10
@@ -278,15 +278,15 @@ codingAgents:
   arguments: ''
   profiles:
   - name: deep
-    model: claude-opus-4-7
+    model: opus
     effort: max
     arguments: ''
   - name: balanced
-    model: claude-sonnet-4-6
+    model: sonnet
     effort: high
     arguments: ''
   - name: quick
-    model: claude-haiku-4-5
+    model: haiku
     effort: low
     arguments: ''
 - name: codex

--- a/src/Ivy.Tendril/Apps/Settings/AgentTestResult.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AgentTestResult.cs
@@ -1,0 +1,5 @@
+namespace Ivy.Tendril.Apps.Settings;
+
+public enum TestStatus { Pending, Running, Passed, Failed, Warning }
+
+public record AgentTestResult(string Label, TestStatus Status, string? Message = null, string? RawOutput = null);

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Apps.Settings.Dialogs;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps.Settings;
@@ -6,9 +7,6 @@ namespace Ivy.Tendril.Apps.Settings;
 public class CodingAgentSetupView : ViewBase
 {
     private record AgentInfo(string Key, string Label, Icons Logo);
-
-    private enum TestStatus { Running, Passed, Failed, Warning }
-    private record AgentTestResult(string Label, TestStatus Status, string? Message = null);
 
     private static readonly AgentInfo[] Agents =
     [
@@ -36,6 +34,8 @@ public class CodingAgentSetupView : ViewBase
         var lastAgent = UseState(selectedAgent.Value);
         var isTesting = UseState(false);
         var testResults = UseState<List<AgentTestResult>?>(null);
+        var showTestDialog = UseState(false);
+        var testCts = UseState<CancellationTokenSource?>(null);
 
         var modelsQuery = UseQuery<ModelInfo[], string>(
             selectedAgent.Value,
@@ -77,89 +77,130 @@ public class CodingAgentSetupView : ViewBase
                 | a.Logo.ToIcon().Width(Size.Px(32)).Height(Size.Px(32))
                 | Text.Block(a.Label)
                 | (a.Key == selectedAgent.Value ? Icons.Check.ToIcon() : null)
-            ).Width(Size.Px(200)).OnClick(() =>
+            ).Width(Size.Px(210)).OnClick(() =>
             {
                 selectedAgent.Set(a.Key);
             }));
 
         async Task RunTestsAsync()
         {
+            var cts = new CancellationTokenSource();
+            testCts.Set(cts);
             isTesting.Set(true);
-            var results = new List<AgentTestResult>();
-            testResults.Set(results);
+            showTestDialog.Set(true);
+
+            var descriptor = runner.GetDescriptor(selectedAgent.Value);
+            var profileModels = new[] { deepModel.Value, balancedModel.Value, quickModel.Value };
+            var profileTiers = new[] { "deep", "balanced", "quick" };
+            var modelValues = profileModels
+                .Select((m, i) => string.IsNullOrEmpty(m) || m.Equals("default", StringComparison.OrdinalIgnoreCase)
+                    ? descriptor.DefaultProfiles
+                        .FirstOrDefault(p => p.Name.Equals(profileTiers[i], StringComparison.OrdinalIgnoreCase))?.Model
+                    : m)
+                .Where(m => !string.IsNullOrEmpty(m))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var results = new List<AgentTestResult>
+            {
+                new("Installation", TestStatus.Pending),
+                new("Authentication", TestStatus.Pending),
+            };
+            results.AddRange(modelValues.Select(m => new AgentTestResult($"Model: {m}", TestStatus.Pending)));
+            testResults.Set([..results]);
 
             try
             {
+                var ct = cts.Token;
                 var healthCheck = runner.GetHealthCheck(selectedAgent.Value);
 
-                results.Add(new AgentTestResult("Installation", TestStatus.Running));
+                results[0] = results[0] with { Status = TestStatus.Running };
                 testResults.Set([..results]);
 
-                var installStatus = await healthCheck.CheckInstallAsync();
-                results[^1] = installStatus.IsInstalled
-                    ? new AgentTestResult("Installation", TestStatus.Passed, installStatus.Version != null ? $"v{installStatus.Version}" : "Installed")
-                    : new AgentTestResult("Installation", TestStatus.Failed, installStatus.Error ?? "Not installed");
+                var installStatus = await healthCheck.CheckInstallAsync(ct);
+                results[0] = installStatus.IsInstalled
+                    ? new AgentTestResult("Installation", TestStatus.Passed,
+                        installStatus.Version != null ? $"v{installStatus.Version}" : "Installed")
+                    : new AgentTestResult("Installation", TestStatus.Failed,
+                        installStatus.Error ?? "Not installed", installStatus.Error);
                 testResults.Set([..results]);
 
                 if (!installStatus.IsInstalled)
                 {
                     isTesting.Set(false);
+                    testCts.Set(null);
                     return;
                 }
 
-                results.Add(new AgentTestResult("Authentication", TestStatus.Running));
+                ct.ThrowIfCancellationRequested();
+
+                results[1] = results[1] with { Status = TestStatus.Running };
                 testResults.Set([..results]);
 
-                var authResult = await healthCheck.CheckAuthAsync();
-                results[^1] = authResult.Status switch
+                var authResult = await healthCheck.CheckAuthAsync(ct);
+                var providerLabel = authResult.Provider != null ? $" ({authResult.Provider})" : "";
+                results[1] = authResult.Status switch
                 {
-                    AuthStatus.Authenticated => new AgentTestResult("Authentication", TestStatus.Passed, "Authenticated"),
-                    AuthStatus.NotAuthenticated => new AgentTestResult("Authentication", TestStatus.Failed, "Not authenticated"),
-                    _ => new AgentTestResult("Authentication", TestStatus.Warning, authResult.Error ?? "Check inconclusive")
+                    AuthStatus.Authenticated => new AgentTestResult("Authentication", TestStatus.Passed,
+                        $"Authenticated{providerLabel}"),
+                    AuthStatus.NotAuthenticated => new AgentTestResult("Authentication", TestStatus.Failed,
+                        "Not authenticated", authResult.Error),
+                    _ => new AgentTestResult("Authentication", TestStatus.Warning,
+                        authResult.Error ?? "Check inconclusive", authResult.Error)
                 };
                 testResults.Set([..results]);
 
-                var modelValues = new[] { deepModel.Value, balancedModel.Value, quickModel.Value }
-                    .Where(m => !string.IsNullOrEmpty(m) && !m.Equals("default", StringComparison.OrdinalIgnoreCase))
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .ToList();
-
-                foreach (var model in modelValues)
+                for (var i = 0; i < modelValues.Count; i++)
                 {
-                    results.Add(new AgentTestResult($"Model: {model}", TestStatus.Running));
+                    ct.ThrowIfCancellationRequested();
+                    var idx = 2 + i;
+                    var model = modelValues[i];
+
+                    results[idx] = results[idx] with { Status = TestStatus.Running };
                     testResults.Set([..results]);
 
-                    var modelResult = await healthCheck.ValidateModelAsync(model);
-                    results[^1] = modelResult.Status switch
+                    var modelResult = await healthCheck.ValidateModelAsync(model, ct);
+                    results[idx] = modelResult.Status switch
                     {
                         ModelValidationStatus.Ok => new AgentTestResult($"Model: {model}", TestStatus.Passed),
-                        ModelValidationStatus.InvalidModel => new AgentTestResult($"Model: {model}", TestStatus.Failed, modelResult.ErrorMessage ?? "Invalid model"),
-                        ModelValidationStatus.AuthError => new AgentTestResult($"Model: {model}", TestStatus.Failed, modelResult.ErrorMessage ?? "Auth error"),
-                        ModelValidationStatus.Timeout => new AgentTestResult($"Model: {model}", TestStatus.Warning, "Timed out"),
-                        _ => new AgentTestResult($"Model: {model}", TestStatus.Warning, modelResult.ErrorMessage ?? "Unknown")
+                        ModelValidationStatus.InvalidModel => new AgentTestResult($"Model: {model}", TestStatus.Failed,
+                            modelResult.ErrorMessage ?? "Invalid model", modelResult.ErrorMessage),
+                        ModelValidationStatus.AuthError => new AgentTestResult($"Model: {model}", TestStatus.Failed,
+                            modelResult.ErrorMessage ?? "Auth error", modelResult.ErrorMessage),
+                        ModelValidationStatus.Timeout => new AgentTestResult($"Model: {model}", TestStatus.Warning,
+                            "Timed out", modelResult.ErrorMessage),
+                        _ => new AgentTestResult($"Model: {model}", TestStatus.Warning,
+                            modelResult.ErrorMessage ?? "Unknown", modelResult.ErrorMessage)
                     };
                     testResults.Set([..results]);
                 }
             }
-            catch
+            catch (OperationCanceledException)
             {
-                results.Add(new AgentTestResult("Unexpected error", TestStatus.Failed, "Test run failed"));
+                for (var i = 0; i < results.Count; i++)
+                    if (results[i].Status is TestStatus.Running or TestStatus.Pending)
+                        results[i] = results[i] with { Status = TestStatus.Warning, Message = "Cancelled" };
+                testResults.Set([..results]);
+            }
+            catch (Exception ex)
+            {
+                results.Add(new AgentTestResult("Unexpected error", TestStatus.Failed, "Test run failed", ex.ToString()));
                 testResults.Set([..results]);
             }
 
             isTesting.Set(false);
+            testCts.Set(null);
         }
 
         return Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(120)))
                | Text.Block("Coding Agent").Bold()
-               | Text.Muted("Pick the coding agent Tendril orchestrates:")
                | grid
                | Text.Block("Model Per Profile").Bold()
-               | Text.Muted("Override the model used for each profile tier:")
+               | Text.Muted("Promptwares are configured to use different profiles depending on the complexity of the task. You can specify what model to use for each profile.").Small()
                | deepModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Deep")
                | balancedModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Balanced")
                | quickModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Quick")
-               | new Separator()
+               | new Spacer().Height(Size.Units(4))
                | (Layout.Horizontal().Gap(2)
                    | new Button("Test Agent").Outline()
                        .Loading(isTesting.Value)
@@ -174,7 +215,7 @@ public class CodingAgentSetupView : ViewBase
                            config.SaveSettings();
                            client.Toast("Coding agent settings saved", "Saved");
                        }))
-               | BuildTestResults(testResults.Value);
+               | new AgentTestDialog(showTestDialog, testResults, isTesting, testCts);
     }
 
     private static string GetProfileModel(IConfigService config, string agentId, string profileName)
@@ -216,27 +257,4 @@ public class CodingAgentSetupView : ViewBase
         profile.Model = model;
     }
 
-    private static object? BuildTestResults(List<AgentTestResult>? results)
-    {
-        if (results is not { Count: > 0 }) return null;
-
-        var layout = Layout.Vertical().Gap(1);
-        foreach (var r in results)
-        {
-            var (icon, color) = r.Status switch
-            {
-                TestStatus.Passed => (Icons.CircleCheck, Colors.Success),
-                TestStatus.Failed => (Icons.CircleX, Colors.Destructive),
-                TestStatus.Warning => (Icons.Info, Colors.Warning),
-                _ => (Icons.RotateCw, Colors.Muted)
-            };
-
-            layout |= Layout.Horizontal().Gap(2).AlignContent(Align.Center)
-                      | icon.ToIcon().Color(color)
-                      | Text.Block(r.Label)
-                      | (r.Message != null ? Text.Muted(r.Message) : null);
-        }
-
-        return layout;
-    }
 }

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/AgentTestDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/AgentTestDialog.cs
@@ -1,0 +1,78 @@
+namespace Ivy.Tendril.Apps.Settings.Dialogs;
+
+public class AgentTestDialog(
+    IState<bool> isOpen,
+    IState<List<AgentTestResult>?> testResults,
+    IState<bool> isTesting,
+    IState<CancellationTokenSource?> testCts) : ViewBase
+{
+    public override object? Build()
+    {
+        var debugOutput = UseState<string?>(null);
+        var results = testResults.Value;
+
+        if (!isOpen.Value) return null;
+
+        var body = Layout.Vertical().Gap(2);
+
+        if (results is { Count: > 0 })
+        {
+            var table = new Table();
+
+            foreach (var r in results)
+            {
+                object statusIcon = r.Status switch
+                {
+                    TestStatus.Passed => Icons.CircleCheck.ToIcon().Color(Colors.Success),
+                    TestStatus.Failed => Icons.CircleX.ToIcon().Color(Colors.Destructive),
+                    TestStatus.Warning => Icons.Info.ToIcon().Color(Colors.Warning),
+                    TestStatus.Running => new Loading(),
+                    _ => Icons.CircleDashed.ToIcon().Color(Colors.Muted)
+                };
+
+                object? messageCell = r.Message != null ? Text.Muted(r.Message) : null;
+
+                object? debugCell = r.RawOutput != null
+                    ? new Button().Icon(Icons.Bug).Outline().Small()
+                        .Tooltip("Show raw output")
+                        .OnClick(() => debugOutput.Set(
+                            debugOutput.Value == r.RawOutput ? null : r.RawOutput))
+                    : null;
+
+                table |= new TableRow(
+                    new TableCell(statusIcon),
+                    new TableCell(Text.Block(r.Label)),
+                    new TableCell(messageCell),
+                    new TableCell(debugCell)
+                );
+            }
+
+            body |= table;
+        }
+
+        if (debugOutput.Value != null)
+        {
+            body |= new Separator();
+            body |= Text.Block("Raw Output").Bold().Small();
+            body |= Text.Code(debugOutput.Value).Small();
+        }
+
+        void CloseDialog()
+        {
+            testCts.Value?.Cancel();
+            isOpen.Set(false);
+            debugOutput.Set(null);
+        }
+
+        return new Dialog(
+            _ => CloseDialog(),
+            new DialogHeader("Agent Test Results"),
+            new DialogBody(body),
+            new DialogFooter(
+                isTesting.Value
+                    ? new Button("Cancel").Outline().OnClick(() => testCts.Value?.Cancel())
+                    : new Button("Close").Outline().OnClick(CloseDialog)
+            )
+        ).Width(Size.Rem(40));
+    }
+}

--- a/src/Ivy.Tendril/Apps/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/SettingsApp.cs
@@ -37,8 +37,8 @@ public class SettingsApp : ViewBase
         var children = new List<MenuItem>
         {
             MenuItem.Default("Coding Agent", TagCodingAgent).Icon(Icons.Bot),
-            MenuItem.Default("Plans", TagPlans).Icon(Icons.FileText),
-            MenuItem.Default("Appearance", TagAppearance).Icon(Icons.Palette),
+            MenuItem.Default("Plans", TagPlans).Icon(Icons.Feather),
+            MenuItem.Default("Appearance", TagAppearance).Icon(Icons.Sun),
             MenuItem.Default("Projects", TagProjects).Icon(Icons.Folder),
             MenuItem.Default("Verifications", TagVerifications).Icon(Icons.CircleCheck),
             MenuItem.Default("Promptwares", TagPromptwares).Icon(Icons.Wand),

--- a/src/Ivy.Tendril/Commands/ModelsCommand.cs
+++ b/src/Ivy.Tendril/Commands/ModelsCommand.cs
@@ -85,7 +85,7 @@ public sealed class ModelsCommand(IAgentRunner runner) : AsyncCommand<ModelsComm
         table.Border(TableBorder.Rounded);
 
         table.AddColumn("Model");
-        table.AddColumn("Alias");
+        table.AddColumn("Display Name");
         table.AddColumn(new TableColumn("Input $/M").RightAligned());
         table.AddColumn(new TableColumn("Output $/M").RightAligned());
         table.AddColumn(new TableColumn("Cache R $/M").RightAligned());
@@ -112,7 +112,7 @@ public sealed class ModelsCommand(IAgentRunner runner) : AsyncCommand<ModelsComm
 
             table.AddRow(
                 model.Id.EscapeMarkup(),
-                model.Alias?.EscapeMarkup() ?? "",
+                model.DisplayName.EscapeMarkup(),
                 FormatPrice(model.InputPerMillion),
                 FormatPrice(model.OutputPerMillion),
                 FormatPrice(model.CacheReadPerMillion),


### PR DESCRIPTION
- Simplify Claude model catalog to alias-based IDs (opus, sonnet, haiku) for Bedrock compatibility
- Extract test dialog into AgentTestDialog ViewBase class following project dialog patterns
- Resolve default models from agent descriptor when profiles are set to "Default"
- Add Bedrock/Vertex provider detection in health check auth
- Remove unused Alias/Hidden properties from ModelInfo
- Fix Cancel button reactivity by passing IState<bool> instead of captured bool
