### PR TITLE
feat: refactor agent test dialog with auto-run, display names, and codex fix

### DIFF
--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeHealthCheck.cs
@@ -71,11 +71,12 @@ public sealed class ClaudeHealthCheck : IAgentHealthCheck
 
     public async Task<ModelValidationResult> ValidateModelAsync(string model, CancellationToken ct = default)
     {
+        var args = string.IsNullOrEmpty(model)
+            ? (IReadOnlyList<string>)["-p", "ping", "--max-turns", "1"]
+            : ["-p", "ping", "--model", model, "--max-turns", "1"];
+
         var (exitCode, stdout, stderr) = await HealthCheckRunner.RunAsync(
-            "claude",
-            ["-p", "ping", "--model", model, "--max-turns", "1"],
-            TimeSpan.FromSeconds(30),
-            ct);
+            "claude", args, TimeSpan.FromSeconds(30), ct);
 
         if (exitCode == 0)
             return new ModelValidationResult { Status = ModelValidationStatus.Ok, Model = model };

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexHealthCheck.cs
@@ -53,13 +53,19 @@ public sealed class CodexHealthCheck : IAgentHealthCheck
 
     public async Task<ModelValidationResult> ValidateModelAsync(string model, CancellationToken ct = default)
     {
-        // Codex reads from stdin when '-' is specified, but HealthCheckRunner does not support stdin.
-        // We rely on Codex validating the model flag at startup before waiting for input.
+        // Codex exec reads from stdin ('-'), so it hangs waiting for input.
+        // Use a short timeout: if the model is invalid, Codex errors immediately.
+        // If it doesn't error within 5s, the model is accepted (process is killed).
+        var args = string.IsNullOrEmpty(model)
+            ? (IReadOnlyList<string>)["exec", "--full-auto", "--json", "--skip-git-repo-check", "-"]
+            : ["exec", "--full-auto", "--json", "--skip-git-repo-check", "--model", model, "-"];
+
         var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
-            "codex",
-            ["exec", "--full-auto", "--json", "--skip-git-repo-check", "--model", model, "-"],
-            TimeSpan.FromSeconds(30),
-            ct);
+            "codex", args, TimeSpan.FromSeconds(5), ct);
+
+        // Timeout means the process started successfully (model was accepted)
+        if (exitCode == -1 && stderr == "Timed out")
+            return new ModelValidationResult { Status = ModelValidationStatus.Ok, Model = model };
 
         if (exitCode == 0)
             return new ModelValidationResult { Status = ModelValidationStatus.Ok, Model = model };

--- a/src/Ivy.Tendril/Apps/Settings/AgentTestResult.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AgentTestResult.cs
@@ -1,5 +1,0 @@
-namespace Ivy.Tendril.Apps.Settings;
-
-public enum TestStatus { Pending, Running, Passed, Failed, Warning }
-
-public record AgentTestResult(string Label, TestStatus Status, string? Message = null, string? RawOutput = null);

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -32,10 +32,7 @@ public class CodingAgentSetupView : ViewBase
         var balancedModel = UseState(GetProfileModel(config, selectedAgent.Value, "balanced"));
         var quickModel = UseState(GetProfileModel(config, selectedAgent.Value, "quick"));
         var lastAgent = UseState(selectedAgent.Value);
-        var isTesting = UseState(false);
-        var testResults = UseState<List<AgentTestResult>?>(null);
         var showTestDialog = UseState(false);
-        var testCts = UseState<CancellationTokenSource?>(null);
 
         var modelsQuery = UseQuery<ModelInfo[], string>(
             selectedAgent.Value,
@@ -54,7 +51,6 @@ public class CodingAgentSetupView : ViewBase
             deepModel.Set(GetProfileModel(config, selectedAgent.Value, "deep"));
             balancedModel.Set(GetProfileModel(config, selectedAgent.Value, "balanced"));
             quickModel.Set(GetProfileModel(config, selectedAgent.Value, "quick"));
-            testResults.Set(null);
             lastAgent.Set(selectedAgent.Value);
         }
 
@@ -77,120 +73,10 @@ public class CodingAgentSetupView : ViewBase
                 | a.Logo.ToIcon().Width(Size.Px(32)).Height(Size.Px(32))
                 | Text.Block(a.Label)
                 | (a.Key == selectedAgent.Value ? Icons.Check.ToIcon() : null)
-            ).Width(Size.Px(210)).OnClick(() =>
+            ).Width(Size.Px(200)).OnClick(() =>
             {
                 selectedAgent.Set(a.Key);
             }));
-
-        async Task RunTestsAsync()
-        {
-            var cts = new CancellationTokenSource();
-            testCts.Set(cts);
-            isTesting.Set(true);
-            showTestDialog.Set(true);
-
-            var descriptor = runner.GetDescriptor(selectedAgent.Value);
-            var profileModels = new[] { deepModel.Value, balancedModel.Value, quickModel.Value };
-            var profileTiers = new[] { "deep", "balanced", "quick" };
-            var modelValues = profileModels
-                .Select((m, i) => string.IsNullOrEmpty(m) || m.Equals("default", StringComparison.OrdinalIgnoreCase)
-                    ? descriptor.DefaultProfiles
-                        .FirstOrDefault(p => p.Name.Equals(profileTiers[i], StringComparison.OrdinalIgnoreCase))?.Model
-                    : m)
-                .Where(m => !string.IsNullOrEmpty(m))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-
-            var results = new List<AgentTestResult>
-            {
-                new("Installation", TestStatus.Pending),
-                new("Authentication", TestStatus.Pending),
-            };
-            results.AddRange(modelValues.Select(m => new AgentTestResult($"Model: {m}", TestStatus.Pending)));
-            testResults.Set([..results]);
-
-            try
-            {
-                var ct = cts.Token;
-                var healthCheck = runner.GetHealthCheck(selectedAgent.Value);
-
-                results[0] = results[0] with { Status = TestStatus.Running };
-                testResults.Set([..results]);
-
-                var installStatus = await healthCheck.CheckInstallAsync(ct);
-                results[0] = installStatus.IsInstalled
-                    ? new AgentTestResult("Installation", TestStatus.Passed,
-                        installStatus.Version != null ? $"v{installStatus.Version}" : "Installed")
-                    : new AgentTestResult("Installation", TestStatus.Failed,
-                        installStatus.Error ?? "Not installed", installStatus.Error);
-                testResults.Set([..results]);
-
-                if (!installStatus.IsInstalled)
-                {
-                    isTesting.Set(false);
-                    testCts.Set(null);
-                    return;
-                }
-
-                ct.ThrowIfCancellationRequested();
-
-                results[1] = results[1] with { Status = TestStatus.Running };
-                testResults.Set([..results]);
-
-                var authResult = await healthCheck.CheckAuthAsync(ct);
-                var providerLabel = authResult.Provider != null ? $" ({authResult.Provider})" : "";
-                results[1] = authResult.Status switch
-                {
-                    AuthStatus.Authenticated => new AgentTestResult("Authentication", TestStatus.Passed,
-                        $"Authenticated{providerLabel}"),
-                    AuthStatus.NotAuthenticated => new AgentTestResult("Authentication", TestStatus.Failed,
-                        "Not authenticated", authResult.Error),
-                    _ => new AgentTestResult("Authentication", TestStatus.Warning,
-                        authResult.Error ?? "Check inconclusive", authResult.Error)
-                };
-                testResults.Set([..results]);
-
-                for (var i = 0; i < modelValues.Count; i++)
-                {
-                    ct.ThrowIfCancellationRequested();
-                    var idx = 2 + i;
-                    var model = modelValues[i];
-
-                    results[idx] = results[idx] with { Status = TestStatus.Running };
-                    testResults.Set([..results]);
-
-                    var modelResult = await healthCheck.ValidateModelAsync(model, ct);
-                    results[idx] = modelResult.Status switch
-                    {
-                        ModelValidationStatus.Ok => new AgentTestResult($"Model: {model}", TestStatus.Passed),
-                        ModelValidationStatus.InvalidModel => new AgentTestResult($"Model: {model}", TestStatus.Failed,
-                            modelResult.ErrorMessage ?? "Invalid model", modelResult.ErrorMessage),
-                        ModelValidationStatus.AuthError => new AgentTestResult($"Model: {model}", TestStatus.Failed,
-                            modelResult.ErrorMessage ?? "Auth error", modelResult.ErrorMessage),
-                        ModelValidationStatus.Timeout => new AgentTestResult($"Model: {model}", TestStatus.Warning,
-                            "Timed out", modelResult.ErrorMessage),
-                        _ => new AgentTestResult($"Model: {model}", TestStatus.Warning,
-                            modelResult.ErrorMessage ?? "Unknown", modelResult.ErrorMessage)
-                    };
-                    testResults.Set([..results]);
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                for (var i = 0; i < results.Count; i++)
-                    if (results[i].Status is TestStatus.Running or TestStatus.Pending)
-                        results[i] = results[i] with { Status = TestStatus.Warning, Message = "Cancelled" };
-                testResults.Set([..results]);
-            }
-            catch (Exception ex)
-            {
-                results.Add(new AgentTestResult("Unexpected error", TestStatus.Failed, "Test run failed", ex.ToString()));
-                testResults.Set([..results]);
-            }
-
-            isTesting.Set(false);
-            testCts.Set(null);
-        }
 
         return Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(120)))
                | Text.Block("Coding Agent").Bold()
@@ -203,9 +89,8 @@ public class CodingAgentSetupView : ViewBase
                | new Spacer().Height(Size.Units(4))
                | (Layout.Horizontal().Gap(2)
                    | new Button("Test Agent").Outline()
-                       .Loading(isTesting.Value)
-                       .Disabled(isTesting.Value || modelsQuery.Loading)
-                       .OnClick(async () => await RunTestsAsync())
+                       .Disabled(modelsQuery.Loading)
+                       .OnClick(() => showTestDialog.Set(true))
                    | new Button("Save").Primary()
                        .Disabled(!hasChanges)
                        .OnClick(() =>
@@ -215,7 +100,35 @@ public class CodingAgentSetupView : ViewBase
                            config.SaveSettings();
                            client.Toast("Coding agent settings saved", "Saved");
                        }))
-               | new AgentTestDialog(showTestDialog, testResults, isTesting, testCts);
+               | new AgentTestDialog(
+                   showTestDialog,
+                   selectedAgent,
+                   () =>
+                   {
+                       var currentModels = new[] { deepModel.Value, balancedModel.Value, quickModel.Value };
+                       var entries = new List<TestModelEntry>();
+                       var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                       foreach (var m in currentModels)
+                       {
+                           if (string.IsNullOrEmpty(m) || m.Equals("default", StringComparison.OrdinalIgnoreCase))
+                           {
+                               if (seen.Add("default"))
+                                   entries.Add(new TestModelEntry(null, "Default"));
+                           }
+                           else
+                           {
+                               if (seen.Add(m))
+                               {
+                                   var displayName = models.FirstOrDefault(x => x.Id.Equals(m, StringComparison.OrdinalIgnoreCase))?.DisplayName ?? m;
+                                   entries.Add(new TestModelEntry(m, displayName));
+                               }
+                           }
+                       }
+
+                       return entries;
+                   },
+                   runner);
     }
 
     private static string GetProfileModel(IConfigService config, string agentId, string profileName)

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/AgentTestDebugDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/AgentTestDebugDialog.cs
@@ -1,0 +1,16 @@
+namespace Ivy.Tendril.Apps.Settings.Dialogs;
+
+public class AgentTestDebugDialog(IState<string?> content) : ViewBase
+{
+    public override object? Build()
+    {
+        if (content.Value is null) return null;
+
+        return new Dialog(
+            _ => content.Set(null),
+            new DialogHeader("Raw Output"),
+            new DialogBody(Text.Code(content.Value)),
+            new DialogFooter(new Button("Close").Outline().OnClick(() => content.Set(null)))
+        ).Width(Size.Rem(50));
+    }
+}

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/AgentTestDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/AgentTestDialog.cs
@@ -1,78 +1,203 @@
+using Ivy.Tendril.Agents.Abstractions;
+
 namespace Ivy.Tendril.Apps.Settings.Dialogs;
+
+public enum TestStatus { Pending, Running, Passed, Failed, Warning }
+
+public record AgentTestResult(string Label, TestStatus Status, string? Message = null, string? RawOutput = null);
+
+public record TestModelEntry(string? Id, string DisplayName);
+
+internal record AgentTestRow(object Icon, string Test, object? Result);
 
 public class AgentTestDialog(
     IState<bool> isOpen,
-    IState<List<AgentTestResult>?> testResults,
-    IState<bool> isTesting,
-    IState<CancellationTokenSource?> testCts) : ViewBase
+    IState<string> selectedAgent,
+    Func<List<TestModelEntry>> getModels,
+    IAgentRunner runner) : ViewBase
 {
     public override object? Build()
     {
+        var isTesting = UseState(false);
+        var testResults = UseState<List<AgentTestResult>?>(null);
+        var testCts = UseState<CancellationTokenSource?>(null);
         var debugOutput = UseState<string?>(null);
+        var wasOpen = UseState(false);
+        var lastAgentId = UseState(selectedAgent.Value);
+
+        if (lastAgentId.Value != selectedAgent.Value)
+        {
+            testResults.Set(null);
+            lastAgentId.Set(selectedAgent.Value);
+        }
+
+        if (!isOpen.Value)
+        {
+            if (wasOpen.Value)
+                wasOpen.Set(false);
+            return null;
+        }
+
+        if (!wasOpen.Value)
+        {
+            wasOpen.Set(true);
+            testResults.Set(null);
+            debugOutput.Set(null);
+            _ = RunTestsAsync();
+        }
+
+        async Task RunTestsAsync()
+        {
+            var cts = new CancellationTokenSource();
+            testCts.Set(cts);
+            isTesting.Set(true);
+            debugOutput.Set(null);
+
+            var agentId = selectedAgent.Value;
+            var models = getModels();
+
+            var results = new List<AgentTestResult>
+            {
+                new("Installation", TestStatus.Pending),
+                new("Authentication", TestStatus.Pending),
+            };
+            results.AddRange(models.Select(m => new AgentTestResult($"Model: {m.DisplayName}", TestStatus.Pending)));
+            testResults.Set([..results]);
+
+            try
+            {
+                var ct = cts.Token;
+                var healthCheck = runner.GetHealthCheck(agentId);
+
+                results[0] = results[0] with { Status = TestStatus.Running };
+                testResults.Set([..results]);
+
+                var installStatus = await healthCheck.CheckInstallAsync(ct);
+                results[0] = installStatus.IsInstalled
+                    ? new AgentTestResult("Installation", TestStatus.Passed,
+                        installStatus.Version != null ? $"v{installStatus.Version}" : "Installed")
+                    : new AgentTestResult("Installation", TestStatus.Failed,
+                        installStatus.Error ?? "Not installed", installStatus.Error);
+                testResults.Set([..results]);
+
+                if (!installStatus.IsInstalled)
+                {
+                    isTesting.Set(false);
+                    testCts.Set(null);
+                    return;
+                }
+
+                ct.ThrowIfCancellationRequested();
+
+                results[1] = results[1] with { Status = TestStatus.Running };
+                testResults.Set([..results]);
+
+                var authResult = await healthCheck.CheckAuthAsync(ct);
+                var providerLabel = authResult.Provider != null ? $" ({authResult.Provider})" : "";
+                results[1] = authResult.Status switch
+                {
+                    AuthStatus.Authenticated => new AgentTestResult("Authentication", TestStatus.Passed,
+                        $"Authenticated{providerLabel}"),
+                    AuthStatus.NotAuthenticated => new AgentTestResult("Authentication", TestStatus.Failed,
+                        "Not authenticated", authResult.Error),
+                    _ => new AgentTestResult("Authentication", TestStatus.Warning,
+                        authResult.Error ?? "Check inconclusive", authResult.Error)
+                };
+                testResults.Set([..results]);
+
+                for (var i = 0; i < models.Count; i++)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    var idx = 2 + i;
+                    var entry = models[i];
+
+                    results[idx] = results[idx] with { Status = TestStatus.Running };
+                    testResults.Set([..results]);
+
+                    var modelResult = await healthCheck.ValidateModelAsync(entry.Id ?? "", ct);
+                    results[idx] = modelResult.Status switch
+                    {
+                        ModelValidationStatus.Ok => new AgentTestResult($"Model: {entry.DisplayName}", TestStatus.Passed),
+                        ModelValidationStatus.InvalidModel => new AgentTestResult($"Model: {entry.DisplayName}", TestStatus.Failed,
+                            modelResult.ErrorMessage ?? "Invalid model", modelResult.ErrorMessage),
+                        ModelValidationStatus.AuthError => new AgentTestResult($"Model: {entry.DisplayName}", TestStatus.Failed,
+                            modelResult.ErrorMessage ?? "Auth error", modelResult.ErrorMessage),
+                        ModelValidationStatus.Timeout => new AgentTestResult($"Model: {entry.DisplayName}", TestStatus.Warning,
+                            "Timed out", modelResult.ErrorMessage),
+                        _ => new AgentTestResult($"Model: {entry.DisplayName}", TestStatus.Warning,
+                            modelResult.ErrorMessage ?? "Unknown", modelResult.ErrorMessage)
+                    };
+                    testResults.Set([..results]);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                for (var i = 0; i < results.Count; i++)
+                    if (results[i].Status is TestStatus.Running or TestStatus.Pending)
+                        results[i] = results[i] with { Status = TestStatus.Warning, Message = "Cancelled" };
+                testResults.Set([..results]);
+            }
+            catch (Exception ex)
+            {
+                results.Add(new AgentTestResult("Unexpected error", TestStatus.Failed, "Test run failed", ex.ToString()));
+                testResults.Set([..results]);
+            }
+
+            isTesting.Set(false);
+            testCts.Set(null);
+        }
+
         var results = testResults.Value;
-
-        if (!isOpen.Value) return null;
-
         var body = Layout.Vertical().Gap(2);
 
         if (results is { Count: > 0 })
         {
-            var table = new Table();
+            var tableRows = results.Select(r => new AgentTestRow(
+                Layout.Horizontal().Gap(1)
+                    | (r.Status switch
+                    {
+                        TestStatus.Passed => Icons.CircleCheck.ToIcon().Color(Colors.Success),
+                        TestStatus.Failed => Icons.CircleX.ToIcon().Color(Colors.Destructive),
+                        TestStatus.Warning => Icons.Info.ToIcon().Color(Colors.Warning),
+                        TestStatus.Running => Icons.LoaderCircle.ToIcon().Color(Colors.Muted).WithAnimation(AnimationType.Rotate),
+                        _ => (object)Icons.CircleDashed.ToIcon().Color(Colors.Muted)
+                    })
+                    | (r.RawOutput != null
+                        ? new Button().Icon(Icons.Bug).Outline().Small()
+                            .Tooltip("Show raw output")
+                            .OnClick(() => debugOutput.Set(
+                                debugOutput.Value == r.RawOutput ? null : r.RawOutput))
+                        : null),
+                r.Label,
+                r.Message != null ? Text.Muted(r.Message) : null
+            )).ToList();
 
-            foreach (var r in results)
-            {
-                object statusIcon = r.Status switch
-                {
-                    TestStatus.Passed => Icons.CircleCheck.ToIcon().Color(Colors.Success),
-                    TestStatus.Failed => Icons.CircleX.ToIcon().Color(Colors.Destructive),
-                    TestStatus.Warning => Icons.Info.ToIcon().Color(Colors.Warning),
-                    TestStatus.Running => new Loading(),
-                    _ => Icons.CircleDashed.ToIcon().Color(Colors.Muted)
-                };
-
-                object? messageCell = r.Message != null ? Text.Muted(r.Message) : null;
-
-                object? debugCell = r.RawOutput != null
-                    ? new Button().Icon(Icons.Bug).Outline().Small()
-                        .Tooltip("Show raw output")
-                        .OnClick(() => debugOutput.Set(
-                            debugOutput.Value == r.RawOutput ? null : r.RawOutput))
-                    : null;
-
-                table |= new TableRow(
-                    new TableCell(statusIcon),
-                    new TableCell(Text.Block(r.Label)),
-                    new TableCell(messageCell),
-                    new TableCell(debugCell)
-                );
-            }
+            var table = new TableBuilder<AgentTestRow>(tableRows)
+                .Header(r => r.Icon, "")
+                .Header(r => r.Test, "Test")
+                .Header(r => r.Result, "Result")
+                .ColumnWidth(r => r.Result, Size.Percent(60));
 
             body |= table;
-        }
-
-        if (debugOutput.Value != null)
-        {
-            body |= new Separator();
-            body |= Text.Block("Raw Output").Bold().Small();
-            body |= Text.Code(debugOutput.Value).Small();
         }
 
         void CloseDialog()
         {
             testCts.Value?.Cancel();
-            isOpen.Set(false);
+            testResults.Set(null);
             debugOutput.Set(null);
+            isOpen.Set(false);
         }
 
-        return new Dialog(
-            _ => CloseDialog(),
-            new DialogHeader("Agent Test Results"),
-            new DialogBody(body),
-            new DialogFooter(
-                isTesting.Value
-                    ? new Button("Cancel").Outline().OnClick(() => testCts.Value?.Cancel())
-                    : new Button("Close").Outline().OnClick(CloseDialog)
-            )
-        ).Width(Size.Rem(40));
+        var footer = new Button(isTesting.Value ? "Cancel" : "Close").Outline().OnClick(CloseDialog);
+
+        return Layout.Vertical()
+            | new Dialog(
+                _ => CloseDialog(),
+                new DialogHeader("Coding Agent Test"),
+                new DialogBody(body),
+                new DialogFooter(footer)
+            ).Width(Size.Rem(40))
+            | new AgentTestDebugDialog(debugOutput);
     }
 }


### PR DESCRIPTION
- Move all test logic into AgentTestDialog (self-contained ViewBase)
- Pass model entries with ID + display name for proper labels
- Auto-start tests on dialog open, reset on each re-open
- Fix Codex model validation timeout (treat 5s timeout as success)
- Support testing "Default" model (no --model flag)
- Extract raw output into separate RawOutputDialog
- Use spinning LoaderCircle icon instead of Loading widget
- Delete standalone AgentTestResult.cs (types now in dialog file)
