### PR TITLE
fix: clean up doctor output — version parsing, model validation, formatting

### DIFF
--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityHealthCheck.cs
@@ -50,14 +50,29 @@ public sealed class AntigravityHealthCheck : IAgentHealthCheck
         return stdout.Trim();
     }
 
-    public Task<ModelValidationResult> ValidateModelAsync(string model, CancellationToken ct = default)
+    public async Task<ModelValidationResult> ValidateModelAsync(string model, CancellationToken ct = default)
     {
-        return Task.FromResult(new ModelValidationResult
+        if (!string.IsNullOrEmpty(model) && !string.Equals(model, "default", StringComparison.OrdinalIgnoreCase))
+            return new ModelValidationResult
+            {
+                Status = ModelValidationStatus.Unknown,
+                Model = model,
+                ErrorMessage = "Model validation not supported via Antigravity CLI",
+            };
+
+        var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
+            "agy", ["--print", "ping", "--dangerously-skip-permissions"],
+            TimeSpan.FromSeconds(30), ct);
+
+        if (exitCode == 0)
+            return new ModelValidationResult { Status = ModelValidationStatus.Ok, Model = model };
+
+        return new ModelValidationResult
         {
             Status = ModelValidationStatus.Unknown,
             Model = model,
-            ErrorMessage = "Model validation not supported via Antigravity CLI",
-        });
+            ErrorMessage = stderr,
+        };
     }
 
     public Task<bool> RunAuthFlowAsync(AuthFlowCallbacks callbacks, CancellationToken ct = default)

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeHealthCheck.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Helpers;
 
@@ -66,12 +67,14 @@ public sealed class ClaudeHealthCheck : IAgentHealthCheck
             "claude", ["--version"], TimeSpan.FromSeconds(10), ct);
 
         if (exitCode != 0) return null;
-        return stdout.Trim();
+        var match = Regex.Match(stdout, @"\d+\.\d+\.\d+");
+        return match.Success ? match.Value : stdout.Trim();
     }
 
     public async Task<ModelValidationResult> ValidateModelAsync(string model, CancellationToken ct = default)
     {
-        var args = string.IsNullOrEmpty(model)
+        var useDefault = string.IsNullOrEmpty(model) || string.Equals(model, "default", StringComparison.OrdinalIgnoreCase);
+        var args = useDefault
             ? (IReadOnlyList<string>)["-p", "ping", "--max-turns", "1"]
             : ["-p", "ping", "--model", model, "--max-turns", "1"];
 

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexHealthCheck.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Helpers;
 
@@ -48,7 +49,8 @@ public sealed class CodexHealthCheck : IAgentHealthCheck
             "codex", ["--version"], TimeSpan.FromSeconds(10), ct);
 
         if (exitCode != 0) return null;
-        return stdout.Trim();
+        var match = Regex.Match(stdout, @"\d+\.\d+\.\d+");
+        return match.Success ? match.Value : stdout.Trim();
     }
 
     public async Task<ModelValidationResult> ValidateModelAsync(string model, CancellationToken ct = default)
@@ -56,7 +58,8 @@ public sealed class CodexHealthCheck : IAgentHealthCheck
         // Codex exec reads from stdin ('-'), so it hangs waiting for input.
         // Use a short timeout: if the model is invalid, Codex errors immediately.
         // If it doesn't error within 5s, the model is accepted (process is killed).
-        var args = string.IsNullOrEmpty(model)
+        var useDefault = string.IsNullOrEmpty(model) || string.Equals(model, "default", StringComparison.OrdinalIgnoreCase);
+        var args = useDefault
             ? (IReadOnlyList<string>)["exec", "--full-auto", "--json", "--skip-git-repo-check", "-"]
             : ["exec", "--full-auto", "--json", "--skip-git-repo-check", "--model", model, "-"];
 

--- a/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotHealthCheck.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Helpers;
 
@@ -50,17 +51,25 @@ public sealed class CopilotHealthCheck : IAgentHealthCheck
             fileName, [..prefixArgs, "--version"], TimeSpan.FromSeconds(10), ct);
 
         if (exitCode != 0) return null;
-        return stdout.Trim();
+        var match = Regex.Match(stdout, @"\d+\.\d+\.\d+");
+        return match.Success ? match.Value : stdout.Trim();
     }
 
     public async Task<ModelValidationResult> ValidateModelAsync(string model, CancellationToken ct = default)
     {
         var (fileName, prefixArgs) = CopilotBinaryResolver.Resolve();
+
+        var useDefault = string.IsNullOrEmpty(model) || string.Equals(model, "default", StringComparison.OrdinalIgnoreCase);
+        var args = new List<string>(prefixArgs) { "-p", "ping" };
+        if (!useDefault)
+        {
+            args.Add("--model");
+            args.Add(model);
+        }
+        args.AddRange(["--allow-all-paths", "--allow-all-urls", "--allow-all-tools", "-s"]);
+
         var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
-            fileName,
-            [..prefixArgs, "-p", "ping", "--model", model, "--allow-all-paths", "--allow-all-urls", "--allow-all-tools", "-s"],
-            TimeSpan.FromSeconds(30),
-            ct);
+            fileName, args, TimeSpan.FromSeconds(30), ct);
 
         if (exitCode == 0)
             return new ModelValidationResult { Status = ModelValidationStatus.Ok, Model = model };

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeHealthCheck.cs
@@ -48,14 +48,29 @@ public sealed class OpenCodeHealthCheck : IAgentHealthCheck
         return stdout.Trim();
     }
 
-    public Task<ModelValidationResult> ValidateModelAsync(string model, CancellationToken ct = default)
+    public async Task<ModelValidationResult> ValidateModelAsync(string model, CancellationToken ct = default)
     {
-        return Task.FromResult(new ModelValidationResult
+        if (!string.IsNullOrEmpty(model) && !string.Equals(model, "default", StringComparison.OrdinalIgnoreCase))
+            return new ModelValidationResult
+            {
+                Status = ModelValidationStatus.Unknown,
+                Model = model,
+                ErrorMessage = "OpenCode does not support model validation for non-default models",
+            };
+
+        var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
+            "opencode", ["run", "ping"],
+            TimeSpan.FromSeconds(30), ct);
+
+        if (exitCode == 0)
+            return new ModelValidationResult { Status = ModelValidationStatus.Ok, Model = model };
+
+        return new ModelValidationResult
         {
             Status = ModelValidationStatus.Unknown,
             Model = model,
-            ErrorMessage = "OpenCode does not provide a model validation command",
-        });
+            ErrorMessage = stderr,
+        };
     }
 
     public Task<bool> RunAuthFlowAsync(AuthFlowCallbacks callbacks, CancellationToken ct = default)

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -316,21 +316,6 @@ codingAgents:
     model: default
     effort: low
     arguments: ''
-- name: gemini
-  arguments: ''
-  profiles:
-  - name: deep
-    model: gemini-3-flash-preview
-    effort: ''
-    arguments: ''
-  - name: balanced
-    model: gemini-2.5-flash
-    effort: ''
-    arguments: ''
-  - name: quick
-    model: gemini-2.5-flash-lite
-    effort: ''
-    arguments: ''
 - name: opencode
   arguments: ''
   profiles:

--- a/src/Ivy.Tendril/Apps/Views/NoContentView.cs
+++ b/src/Ivy.Tendril/Apps/Views/NoContentView.cs
@@ -10,8 +10,8 @@ public class NoContentView(string title, string description, object? cta = null)
 
         if (cta is not null)
         {
-            layout |= new Spacer().Height(Size.Units(4));
-            layout |= cta;
+            //layout |= new Spacer().Height(Size.Units(4));
+            layout |= cta; //.WithMargin(0,4,0,0);
         }
 
         return layout;

--- a/src/Ivy.Tendril/Commands/DoctorChecks/AgentModelsCheck.cs
+++ b/src/Ivy.Tendril/Commands/DoctorChecks/AgentModelsCheck.cs
@@ -47,18 +47,25 @@ internal class AgentModelsCheck(ConfigService? configService = null, IAgentRunne
                 continue;
             }
 
-            statuses.Add(new CheckStatus($"  {label}", "", StatusKind.Ok));
+            statuses.Add(new CheckStatus(label, "", StatusKind.Ok));
+
+            var validatedModels = new Dictionary<string, ModelValidationResult>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var profile in agent.Profiles)
             {
                 if (string.IsNullOrEmpty(profile.Model))
                 {
-                    statuses.Add(new CheckStatus($"    {profile.Name}", "No model specified", StatusKind.Warn));
+                    statuses.Add(new CheckStatus($"  {profile.Name}", "No model specified", StatusKind.Warn));
                     continue;
                 }
 
-                var result = await healthCheck.ValidateModelAsync(profile.Model);
-                var profileLabel = $"    {profile.Name}: {profile.Model}";
+                if (!validatedModels.TryGetValue(profile.Model, out var result))
+                {
+                    result = await healthCheck.ValidateModelAsync(profile.Model);
+                    validatedModels[profile.Model] = result;
+                }
+
+                var profileLabel = $"  {profile.Name}: {profile.Model}";
 
                 switch (result.Status)
                 {

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -92,7 +92,7 @@ public static class DoctorCommand
             DoctorChecks.StatusKind.Error => ("✗", "red"),
             _ => (" ", "grey")
         };
-        AnsiConsole.MarkupLine($"[{color}]  {symbol} {label.PadRight(40)}{value}[/]");
+        AnsiConsole.MarkupLine($"[{color}]{symbol} {label.PadRight(40)}{value}[/]");
     }
 
     // --- doctor plans subcommand ---


### PR DESCRIPTION
- Extract semver from verbose --version output (Claude, Codex, Copilot)
- Treat "default" model as no-model and still run a ping to validate
- Add live validation for Antigravity and OpenCode default models
- Cache model validation results to avoid redundant checks per agent
- Remove leading whitespace from doctor status lines
- Remove unregistered gemini agent from config
