### PR TITLE
[00006] Add --search option to plan list CLI command

### DIFF
--- a/src/Ivy.Tendril/Commands/PlanListCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanListCommand.cs
@@ -30,6 +30,10 @@ public class PlanListSettings : CommandSettings
     [Description("Only plans with worktrees")]
     public bool HasWorktree { get; init; }
 
+    [CommandOption("--search")]
+    [Description("Filter by title or ID text")]
+    public string? Search { get; init; }
+
     [CommandOption("--format")]
     [Description("Output format: table (default), ids, folders, json")]
     public string? Format { get; init; }
@@ -173,6 +177,14 @@ public class PlanListCommand : Command<PlanListSettings>
             {
                 var wtDir = Path.Combine(dir, "Worktrees");
                 if (!Directory.Exists(wtDir) || Directory.GetDirectories(wtDir).Length == 0)
+                    continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.Search))
+            {
+                var search = settings.Search.Trim().TrimStart('#').ToLowerInvariant();
+                if (!title.ToLowerInvariant().Contains(search) &&
+                    !folderName[..dashIndex].Contains(search))
                     continue;
             }
 


### PR DESCRIPTION
Fixes https://linear.app/ivy-interactive/issue/ENG-2/add-very-small-feature-to-tendril

# Summary

## Changes

Added a `--search` option to the `tendril plan list` CLI command that filters plans by title and ID, matching the text search functionality already available in the UI applications (DraftsApp, IceboxApp, ReviewApp).

## API Changes

**CLI:**
- `tendril plan list --search <text>` - New command option that filters plans by title or ID (case-insensitive, supports `#` prefix)

**C# API:**
- `PlanListSettings.Search` - New property for search text filter

## Files Modified

- **src/Ivy.Tendril/Commands/PlanListCommand.cs** - Added `Search` property to settings class and search filtering logic in `ScanPlans` method

---

## Commits

- d01d8c7 Add --search option to plan list CLI command