### PR TITLE
fix: resolve release workflow and build warnings

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -4,6 +4,9 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   release:
     types: [published]
@@ -362,23 +365,3 @@ jobs:
               --slot preproduction \
               --target-slot production
 
-  upload-install-scripts:
-    runs-on: ubuntu-latest
-    environment: production
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: 'Az login with OIDC'
-        uses: azure/login@v2
-        with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-
-      - name: 'Upload install scripts to CDN'
-        continue-on-error: true
-        run: |
-          az storage blob upload --account-name ivycdn --container-name public --name install-tendril.sh --file src/install.sh --content-type "text/x-shellscript" --auth-mode login
-          az storage blob upload --account-name ivycdn --container-name public --name install-tendril.ps1 --file src/install.ps1 --content-type "text/plain" --auth-mode login

--- a/src/Ivy.Tendril.Updater/Program.cs
+++ b/src/Ivy.Tendril.Updater/Program.cs
@@ -73,7 +73,7 @@ internal static class Program
 
     private static string GetIconPath()
     {
-        var baseDir = Path.GetDirectoryName(typeof(Program).Assembly.Location) ?? ".";
+        var baseDir = System.AppContext.BaseDirectory;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             return Path.Combine(baseDir, "icon.ico");
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))


### PR DESCRIPTION
This PR removes the upload-install-scripts job, configures actions to run with Node 24, and fixes the Assembly.Location single-file compiler warning.