### PR TITLE
fix: use clean console formatter for CLI output

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -1,4 +1,4 @@
-codingAgent: claude
+codingAgent: copilot
 jobTimeout: 30
 staleOutputTimeout: 10
 gitTimeout: 10
@@ -146,7 +146,7 @@ projects:
   context: ''
   reviewActions:
   - name: App
-    condition: Test-Path "Worktrees/lots-of-dev-tools/package.json"
+    condition: Test-Path Worktrees/lots-of-dev-tools/package.json
     command: cd Worktrees/lots-of-dev-tools && npm run dev
   hooks: []
   buildDependencies: []

--- a/src/Ivy.Tendril/Infrastructure/CleanConsoleFormatter.cs
+++ b/src/Ivy.Tendril/Infrastructure/CleanConsoleFormatter.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Console;
+
+namespace Ivy.Tendril.Infrastructure;
+
+public sealed class CleanConsoleFormatter : ConsoleFormatter
+{
+    public CleanConsoleFormatter() : base("clean") { }
+
+    public override void Write<TState>(in LogEntry<TState> logEntry, IExternalScopeProvider? scopeProvider, TextWriter textWriter)
+    {
+        var message = logEntry.Formatter?.Invoke(logEntry.State, logEntry.Exception);
+        if (message is null) return;
+        textWriter.WriteLine(message);
+    }
+}

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -10,6 +10,7 @@ using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using Velopack;
@@ -74,7 +75,10 @@ public class Program
         {
             var cliServices = new ServiceCollection();
             var cliLogLevel = verbose ? LogLevel.Debug : quiet ? LogLevel.Warning : LogLevel.Information;
-            cliServices.AddLogging(builder => builder.AddConsole().SetMinimumLevel(cliLogLevel));
+            cliServices.AddLogging(builder => builder
+                .SetMinimumLevel(cliLogLevel)
+                .AddConsole(options => options.FormatterName = "clean")
+                .AddConsoleFormatter<CleanConsoleFormatter, ConsoleFormatterOptions>());
             cliServices.AddSingleton<IPlanWatcherService, NullPlanWatcherService>();
             cliServices.AddAgentInfrastructure();
 

--- a/src/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx
+++ b/src/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx
@@ -68,9 +68,7 @@ export const ToolUseCard: React.FC<ToolUseCardProps> = ({ tool }) => {
   if (tool.result != null && tool.result.length > 0) {
     const firstLine = tool.result.split("\n")[0].slice(0, 80);
     const hasWeirdChars = /[┌┐└┘├┤┬┴┼─│═║╔╗╚╝╠╣╦╩╬]/.test(firstLine);
-    if (tool.isError) {
-      headerPreview += ` → ${firstLine}`;
-    } else if (!hasWeirdChars) {
+    if (firstLine.trim() && (tool.isError || !hasWeirdChars)) {
       headerPreview += ` → ${firstLine}`;
     }
   }


### PR DESCRIPTION
Replaces the default .NET console logger (which outputs verbose structured logging with category names and event IDs) with a custom CleanConsoleFormatter that only prints the message.