### PR TITLE
fix: verify git executes successfully in install.sh

### DIFF
--- a/src/install.sh
+++ b/src/install.sh
@@ -57,7 +57,7 @@ else
 fi
 
 printf "%b\\n" "\n${BLUE}Step 3: Checking for Git...${NC}"
-if command -v git &> /dev/null; then
+if command -v git &> /dev/null && git --version &> /dev/null; then
     printf "%b\\n" "${GREEN}✓ Git is already installed.${NC}"
 else
     if [[ "$OS_TYPE" == "macos" ]]; then


### PR DESCRIPTION
Ensures that git not only exists on PATH but can run successfully, catching cases where Xcode command line tools are missing on macOS.