### PR TITLE
fix: add missing ResolveCommandShim call in PromptwareRunner

### DIFF
--- a/src/Ivy.Tendril/Services/Promptware/PromptwareRunner.cs
+++ b/src/Ivy.Tendril/Services/Promptware/PromptwareRunner.cs
@@ -127,6 +127,7 @@ public class PromptwareRunner : IPromptwareRunner
         psi.Environment["TENDRIL_PLANS"] = _configService.PlanFolder;
 
         AgentProcessHelper.EnsureTendrilOnPath(psi);
+        AgentProcessHelper.ResolveCommandShim(psi);
 
         _logger.LogInformation("PromptwareRunner: launching {Promptware} via {Provider} (model={Model}, effort={Effort})",
             options.Promptware, resolution.AgentId, resolution.Model, resolution.Effort);


### PR DESCRIPTION
## Summary
- Adds the missing `AgentProcessHelper.ResolveCommandShim(psi)` call in `PromptwareRunner.Run()` before `Process.Start()`
- Fixes "system cannot find the file specified" error when launching codex (or other npm-installed CLIs) on Windows during onboarding
- Both `PromptwareRunCommand` and `JobLauncher` already had this call — this makes `PromptwareRunner` consistent

## Test plan
- [x] `dotnet build` passes
- [x] Unit tests pass (1299 + 760)
- [ ] Manual: re-run onboarding "Setting up your project" with codex provider