### PR TITLE
fix: add 5s STDIN timeout to prevent copilot process hangs

### DIFF
--- a/src/Ivy.Tendril/Commands/PlanUpdateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanUpdateCommand.cs
@@ -32,7 +32,7 @@ public class PlanUpdateCommand : Command<PlanUpdateSettings>
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
 
             // Read YAML from STDIN
-            var yaml = Console.In.ReadToEnd();
+            var yaml = ConsoleHelper.ReadStdinWithTimeout();
             if (string.IsNullOrWhiteSpace(yaml))
                 throw new ArgumentException("No YAML content provided on STDIN");
 

--- a/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
@@ -36,7 +36,7 @@ public class PlanWriteRevisionCommand : Command<PlanWriteRevisionSettings>
 
             var content = !string.IsNullOrEmpty(settings.FilePath)
                 ? File.ReadAllText(settings.FilePath)
-                : Console.In.ReadToEnd();
+                : ConsoleHelper.ReadStdinWithTimeout();
             if (string.IsNullOrWhiteSpace(content))
                 throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
 

--- a/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
@@ -35,7 +35,7 @@ public class PromptwareWriteMemoryCommand : Command<PromptwareWriteMemorySetting
             var filename = Path.GetFileName(settings.Filename);
             var filePath = Path.Combine(memoryDir, filename);
 
-            var content = Console.In.ReadToEnd();
+            var content = ConsoleHelper.ReadStdinWithTimeout();
             if (string.IsNullOrWhiteSpace(content))
                 throw new ArgumentException("No content provided (pipe to STDIN)");
 

--- a/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
@@ -35,7 +35,7 @@ public class PromptwareWriteToolCommand : Command<PromptwareWriteToolSettings>
             var filename = Path.GetFileName(settings.Filename);
             var filePath = Path.Combine(toolsDir, filename);
 
-            var content = Console.In.ReadToEnd();
+            var content = ConsoleHelper.ReadStdinWithTimeout();
             if (string.IsNullOrWhiteSpace(content))
                 throw new ArgumentException("No content provided (pipe to STDIN)");
 

--- a/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
+++ b/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Ivy.Tendril.Helpers;
 using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
@@ -31,7 +32,7 @@ public class TrashWriteCommand : Command<TrashWriteSettings>
             var filename = Path.GetFileName(settings.Filename);
             var filePath = Path.Combine(trashDir, filename);
 
-            var content = Console.In.ReadToEnd();
+            var content = ConsoleHelper.ReadStdinWithTimeout();
             if (string.IsNullOrWhiteSpace(content))
                 throw new ArgumentException("No content provided (pipe to STDIN)");
 

--- a/src/Ivy.Tendril/Helpers/ConsoleHelper.cs
+++ b/src/Ivy.Tendril/Helpers/ConsoleHelper.cs
@@ -1,0 +1,17 @@
+namespace Ivy.Tendril.Helpers;
+
+public static class ConsoleHelper
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+
+    public static string ReadStdinWithTimeout(TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? DefaultTimeout;
+        var readTask = Task.Run(() => Console.In.ReadToEnd());
+        if (!readTask.Wait(effectiveTimeout))
+            throw new InvalidOperationException(
+                $"No content received on STDIN within {effectiveTimeout.TotalSeconds}s. " +
+                "Pipe content to this command or use a file-based alternative.");
+        return readTask.Result;
+    }
+}

--- a/src/Ivy.Tendril/Services/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/FirmwareCompiler.cs
@@ -52,10 +52,18 @@ public static class FirmwareCompiler
 
         Every execution needs to end with a reflection step. This is your opportunity to improve over time. What did we learn during this session? Save reflections using the CLI:
 
+        **Bash:**
         ```bash
         tendril promptware write-memory {PROMPTWARE_NAME} <filename>.md <<'EOF'
         <reflection content>
         EOF
+        ```
+
+        **PowerShell:**
+        ```powershell
+        @'
+        <reflection content>
+        '@ | tendril promptware write-memory {PROMPTWARE_NAME} <filename>.md
         ```
 
         - Note that learnings might be falsified over time. Pruning memory is just as important as storing new memory.


### PR DESCRIPTION
## Summary

- Commands using `Console.In.ReadToEnd()` blocked indefinitely when copilot's PowerShell tool couldn't pipe bash heredoc content
- Orphaned child processes prevented copilot from exiting, causing jobs to appear stuck at "Verifying: CheckResult"
- Added `ConsoleHelper.ReadStdinWithTimeout()` (5s default) applied to all 5 unconditional STDIN readers
- Documented both bash and PowerShell pipe syntax in the firmware template

## Test plan

- [x] `dotnet build` passes
- [x] All 1299 tests pass
- [x] Verified `PlanRecCommand` and `VerificationCommand` already guard with `Console.IsInputRedirected` (unchanged)