### PR TITLE
fix(onboarding): fix path resolution for empty tendrilHome parameter

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.38</Version>
+    <Version>1.0.39</Version>
     <!-- Use local Ivy source by default for development, but use NuGet packages in CI or for release builds -->
     <IvySource Condition="'$(IvySource)' == ''">true</IvySource>
     <IvySource Condition="'$(GITHUB_ACTIONS)' == 'true' or '$(Publishing)' == 'true'">false</IvySource>

--- a/src/Ivy.Tendril.Test/PromptwareHelperTests.cs
+++ b/src/Ivy.Tendril.Test/PromptwareHelperTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using Ivy.Tendril.Helpers;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class PromptwareHelperTests : IDisposable
+{
+    private readonly string? _originalTendrilHome;
+
+    public PromptwareHelperTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+    }
+
+    [Fact]
+    public void ResolvePromptsRoot_WithEmptyTendrilHome_FallsBackToEnvironmentVariable()
+    {
+        // Arrange
+        var tempHome = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var tempPromptwares = Path.Combine(tempHome, "Promptwares");
+        Directory.CreateDirectory(tempPromptwares);
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", tempHome);
+
+        try
+        {
+            // Act
+            var result = PromptwareHelper.ResolvePromptsRoot("");
+
+            // Assert
+            Assert.Equal(tempPromptwares, result);
+        }
+        finally
+        {
+            if (Directory.Exists(tempHome))
+            {
+                try { Directory.Delete(tempHome, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void ResolvePromptwareFolder_WithEmptyTendrilHome_FallsBackToEnvironmentVariable()
+    {
+        // Arrange
+        var tempHome = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var tempPromptwares = Path.Combine(tempHome, "Promptwares");
+        var tempUpdateProject = Path.Combine(tempPromptwares, "UpdateProject");
+        Directory.CreateDirectory(tempUpdateProject);
+        var programFile = Path.Combine(tempUpdateProject, "Program.md");
+        File.WriteAllText(programFile, "# Program");
+
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", tempHome);
+
+        try
+        {
+            // Act
+            var result = PromptwareHelper.ResolvePromptwareFolder("UpdateProject", "");
+
+            // Assert
+            Assert.Equal(tempUpdateProject, result);
+        }
+        finally
+        {
+            if (Directory.Exists(tempHome))
+            {
+                try { Directory.Delete(tempHome, true); } catch { }
+            }
+        }
+    }
+}

--- a/src/Ivy.Tendril/Helpers/PromptwareHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PromptwareHelper.cs
@@ -17,7 +17,8 @@ public static class PromptwareHelper
         if (File.Exists(Path.Combine(sourceFolder, "Program.md")))
             return sourceFolder;
 
-        tendrilHome ??= Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        if (string.IsNullOrEmpty(tendrilHome))
+            tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
         if (!string.IsNullOrEmpty(tendrilHome))
         {
             var deployedRoot = Path.Combine(tendrilHome, "Promptwares");
@@ -43,7 +44,8 @@ public static class PromptwareHelper
         }
 
         // 2. Production mode: use TENDRIL_HOME/Promptwares
-        tendrilHome ??= Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        if (string.IsNullOrEmpty(tendrilHome))
+            tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
         if (!string.IsNullOrEmpty(tendrilHome))
         {
             var deployedRoot = Path.Combine(tendrilHome, "Promptwares");


### PR DESCRIPTION
Resolves the onboarding crash in Step 3 by correctly resolving empty strings passed for tendrilHome using the environment variable TENDRIL_HOME. Includes unit tests.