### PR TITLE
feat: add description field to ToolCallWire for human-readable tool titles

### DIFF
--- a/src/Ivy.Tendril.Agents/Abstractions/AgentEvent.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/AgentEvent.cs
@@ -93,6 +93,7 @@ public sealed record ToolCallEvent : AgentEvent
     public required string ToolUseId { get; init; }
     public required string ToolName { get; init; }
     public string? InputJson { get; init; }
+    public string? Description { get; init; }
 }
 
 public sealed record ToolResultEvent : AgentEvent

--- a/src/Ivy.Tendril.Agents/Abstractions/AgentEventSchema.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/AgentEventSchema.cs
@@ -40,6 +40,7 @@ public sealed record ToolCallWire : EventWire
     public override string Kind => "tool_call";
     public required string ToolUseId { get; init; }
     public required string ToolName { get; init; }
+    public string? Description { get; init; }
     public JsonElement? Input { get; init; }
 }
 

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeEventParser.cs
@@ -194,12 +194,19 @@ public sealed class ClaudeEventParser : IEventParser
                         ? inputProp.GetRawText()
                         : null;
 
+                    string? toolDescription = null;
+                    if (inputProp.ValueKind == JsonValueKind.Object &&
+                        inputProp.TryGetProperty("description", out var tdProp) &&
+                        tdProp.ValueKind == JsonValueKind.String)
+                        toolDescription = tdProp.GetString();
+
                     events.Add(new ToolCallEvent
                     {
                         Kind = AgentEventKind.ToolCall,
                         ToolUseId = toolId,
                         ToolName = toolName,
                         InputJson = inputJson,
+                        Description = toolDescription,
                         RawLine = rawLine,
                     });
                     break;

--- a/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotEventParser.cs
@@ -182,12 +182,22 @@ public sealed class CopilotEventParser : IEventParser
                 if (string.Equals(toolName, "report_intent", StringComparison.OrdinalIgnoreCase))
                     continue;
 
+                string? description = null;
+                if (parameters is not null)
+                {
+                    using var paramDoc = JsonDocument.Parse(parameters);
+                    if (paramDoc.RootElement.TryGetProperty("description", out var descProp) &&
+                        descProp.ValueKind == JsonValueKind.String)
+                        description = descProp.GetString();
+                }
+
                 events.Add(new ToolCallEvent
                 {
                     Kind = AgentEventKind.ToolCall,
                     ToolUseId = toolCallId,
                     ToolName = toolName,
                     InputJson = parameters,
+                    Description = description,
                     RawLine = rawLine,
                 });
             }

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeEventParser.cs
@@ -143,9 +143,13 @@ public sealed class OpenCodeEventParser : IEventParser
         var callId = part.TryGetProperty("callID", out var cidProp) ? cidProp.GetString() ?? "" : "";
 
         string? inputJson = null;
+        string? description = null;
         if (part.TryGetProperty("state", out var state) && state.TryGetProperty("input", out var input))
         {
             inputJson = input.GetRawText();
+            if (input.TryGetProperty("description", out var descProp) &&
+                descProp.ValueKind == JsonValueKind.String)
+                description = descProp.GetString();
         }
 
         var events = new List<AgentEvent>
@@ -156,6 +160,7 @@ public sealed class OpenCodeEventParser : IEventParser
                 ToolUseId = callId,
                 ToolName = toolName,
                 InputJson = inputJson,
+                Description = description,
                 RawLine = rawLine,
             }
         };

--- a/src/Ivy.Tendril.Agents/Runtime/JsonEventSerializer.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/JsonEventSerializer.cs
@@ -98,6 +98,7 @@ public sealed class JsonEventSerializer : IEventSerializer
                 Timestamp = ts,
                 ToolUseId = e.ToolUseId,
                 ToolName = e.ToolName,
+                Description = e.Description,
                 Input = e.InputJson is not null ? JsonDocument.Parse(e.InputJson).RootElement : null,
             },
             ToolResultEvent e => new ToolResultWire
@@ -235,6 +236,7 @@ public sealed class JsonEventSerializer : IEventSerializer
         Timestamp = DateTimeOffset.Parse(timestamp),
         ToolUseId = root.TryGetProperty("tool_use_id", out var id) ? id.GetString()! : "",
         ToolName = root.TryGetProperty("tool_name", out var name) ? name.GetString()! : "",
+        Description = root.TryGetProperty("description", out var desc) ? desc.GetString() : null,
         InputJson = root.TryGetProperty("input", out var input) ? input.GetRawText() : null,
     };
 

--- a/src/Ivy.Widgets.AgentOutputView/frontend/src/parse-events.ts
+++ b/src/Ivy.Widgets.AgentOutputView/frontend/src/parse-events.ts
@@ -54,6 +54,7 @@ export function parseEventWireStream(jsonStream: string): PresentationEvent[] {
         const tool: ToolUsePresentation = {
           toolUseId: evt.tool_use_id,
           name: evt.tool_name,
+          description: evt.description,
           input: evt.input ?? {},
         };
         toolMap.set(evt.tool_use_id, tool);

--- a/src/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx
+++ b/src/Ivy.Widgets.AgentOutputView/frontend/src/tool-use-card.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 
 interface ToolCall {
   name: string;
+  description?: string;
   input: Record<string, unknown>;
   result?: string;
   isError?: boolean;
@@ -24,8 +25,11 @@ function displayInput(name: string, input: Record<string, unknown>): string {
   return JSON.stringify(input, null, 2);
 }
 
-function inputSummary(name: string, input: Record<string, unknown>): string {
-  if (name === "Bash" && typeof input.command === "string") return input.command;
+function inputSummary(tool: ToolCall): string {
+  if (tool.description) return tool.description;
+  const { input } = tool;
+  if (typeof input.description === "string") return input.description;
+  if (typeof input.command === "string") return input.command;
   if (typeof input.file_path === "string") return input.file_path;
   if (typeof input.path === "string") return input.path;
   if (typeof input.pattern === "string") return input.pattern;
@@ -63,7 +67,7 @@ export const ToolUseCard: React.FC<ToolUseCardProps> = ({ tool }) => {
 
   const handleToggle = () => setOpen((o) => !o);
 
-  const summary = inputSummary(tool.name, tool.input);
+  const summary = inputSummary(tool);
   let headerPreview = summary || "";
   if (tool.result != null && tool.result.length > 0) {
     const firstLine = tool.result.split("\n")[0].slice(0, 80);

--- a/src/Ivy.Widgets.AgentOutputView/frontend/src/types.ts
+++ b/src/Ivy.Widgets.AgentOutputView/frontend/src/types.ts
@@ -28,6 +28,7 @@ export interface ToolCallWire {
   timestamp: string;
   tool_use_id: string;
   tool_name: string;
+  description?: string;
   input?: Record<string, unknown>;
 }
 
@@ -130,6 +131,7 @@ export type EventWire =
 export interface ToolUsePresentation {
   toolUseId: string;
   name: string;
+  description?: string;
   input: Record<string, unknown>;
   result?: string;
   isError?: boolean;


### PR DESCRIPTION
Extract the description field from tool inputs (when available) and surface
it as a top-level field on the tool_call EventWire event. The frontend now
prefers this description for the tool call title, falling back to command,
file_path, path, or pattern. Implemented for Claude, Copilot, and OpenCode
parsers.
