### PR TITLE
Gate antigravity provider behind --beta flag

### DIFF
--- a/src/Ivy.Tendril.Agents/AgentServiceCollectionExtensions.cs
+++ b/src/Ivy.Tendril.Agents/AgentServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public sealed class AgentInfrastructureOptions
     public IInteractionHandler? DefaultInteractionHandler { get; set; }
     public IEnumerable<ModelPricing> AdditionalPricing { get; set; } = [];
     public ConcurrencyOptions? Concurrency { get; set; }
+    public bool IncludeBetaProviders { get; set; }
 }
 
 public static class AgentServiceCollectionExtensions
@@ -41,14 +42,17 @@ public static class AgentServiceCollectionExtensions
         {
             var logger = sp.GetService<ILogger<AgentRunner>>() ?? NullLogger<AgentRunner>.Instance;
             var runner = new AgentRunner(logger, options.Concurrency);
-            runner.Register(
-                new AntigravityCli(),
-                new AntigravityEventParser(),
-                new AntigravityHealthCheck(),
-                new AntigravityFailureAnalyzer(),
-                new AntigravitySessionCostParser(),
-                new AntigravityPty(),
-                new AntigravityModelCatalog());
+            if (options.IncludeBetaProviders)
+            {
+                runner.Register(
+                    new AntigravityCli(),
+                    new AntigravityEventParser(),
+                    new AntigravityHealthCheck(),
+                    new AntigravityFailureAnalyzer(),
+                    new AntigravitySessionCostParser(),
+                    new AntigravityPty(),
+                    new AntigravityModelCatalog());
+            }
             runner.Register(
                 new ClaudeCli(),
                 new ClaudeEventParser(),

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -66,8 +66,11 @@ public class CodingAgentSetupView : ViewBase
 
         var hasChanges = selectedAgent.Value != config.Settings.CodingAgent || hasProfileChanges;
 
+        var registeredAgents = runner.RegisteredAgents;
+        var visibleAgents = Agents.Where(a => registeredAgents.Contains(a.Key)).ToArray();
+
         var grid = Layout.Grid().Columns(3).Gap(2);
-        grid = Agents.Aggregate(grid, (current, a) =>
+        grid = visibleAgents.Aggregate(grid, (current, a) =>
             current | new Card(
                 Layout.Horizontal().Gap(2).Padding(0)
                 | a.Logo.ToIcon().Width(Size.Px(32)).Height(Size.Px(32))

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -80,7 +80,7 @@ public class Program
                 .AddConsole(options => options.FormatterName = "clean")
                 .AddConsoleFormatter<CleanConsoleFormatter, ConsoleFormatterOptions>());
             cliServices.AddSingleton<IPlanWatcherService, NullPlanWatcherService>();
-            cliServices.AddAgentInfrastructure();
+            cliServices.AddAgentInfrastructure(opts => opts.IncludeBetaProviders = beta);
 
             var app = ConfigureCliCommands(cliServices);
             var firstArg = filteredArgs[0];

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -12,7 +12,7 @@ namespace Ivy.Tendril;
 
 internal static class ServiceRegistration
 {
-    public static void AddTendrilServices(this Server server, ConfigService configService)
+    public static void AddTendrilServices(this Server server, ConfigService configService, TendrilArgs? tendrilArgs = null)
     {
         server.Services.AddHttpClient();
         server.Services.AddSingleton<IExceptionHandler>(sp =>
@@ -28,7 +28,10 @@ internal static class ServiceRegistration
         if (configService.Settings.Auth != null)
             server.UseAuth<Auth.TendrilAuthProvider>();
 
-        server.Services.AddAgentInfrastructure();
+        server.Services.AddAgentInfrastructure(opts =>
+        {
+            opts.IncludeBetaProviders = tendrilArgs?.Beta ?? false;
+        });
 
         server.Services.AddSingleton<ModelPricingService>();
 

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -26,7 +26,7 @@ public static class TendrilServer
 
         var configService = new ConfigService(Microsoft.Extensions.Logging.Abstractions.NullLogger<ConfigService>.Instance);
         server.Services.AddSingleton(tendrilArgs);
-        server.AddTendrilServices(configService);
+        server.AddTendrilServices(configService, tendrilArgs);
 
         var logLevel = tendrilArgs.Verbose ? "Debug"
             : tendrilArgs.Quiet ? "Warning"


### PR DESCRIPTION
## Summary

- Gate the antigravity agent provider behind `--beta` flag — its `--print` mode is broken in agy v1.0.3 (contacts Gemini API but never writes to stdout, causing jobs to hang at "Starting...")
- Add `IncludeBetaProviders` option to `AgentInfrastructureOptions`
- Filter the Settings UI agent picker by `runner.RegisteredAgents`
- Doctor command keeps unconditional registration for diagnostic visibility

## Test plan

- [x] `dotnet build` passes (0 errors)
- [x] All 1302 tests pass
- [ ] Launch without `--beta` → Antigravity not shown in Settings
- [ ] Launch with `--beta` → Antigravity shown in Settings