### PR TITLE
feat: add Report Bug button to Job Debug sheet

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
@@ -16,6 +16,7 @@ public class JobDebugSheet(
     {
         var copyToClipboard = UseClipboard();
         var client = UseService<IClientProvider>();
+        var showReportDialog = UseState(false);
 
         var job = jobService.GetJob(jobId);
         if (job is null)
@@ -70,8 +71,8 @@ public class JobDebugSheet(
             .Builder(x => x.PromptwareRawLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .RemoveEmpty();
 
-        return new HeaderLayout(
-            new Button("Copy Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>
+        var header = Layout.Horizontal().Gap(2)
+            | new Button("Copy Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>
             {
                 var lines = new List<(string Label, string Value)>
                 {
@@ -104,9 +105,12 @@ public class JobDebugSheet(
 
                 copyToClipboard(formatted);
                 client.Toast("Job details copied to clipboard", "Copied");
-            }),
-            detailsView
-        );
+            })
+            | new Button("Report Bug").Icon(Icons.Bug).Destructive().OnClick(() => showReportDialog.Set(true));
+
+        return Layout.Vertical()
+            | new HeaderLayout(header, detailsView)
+            | (showReportDialog.Value ? new ReportBugDialog(showReportDialog, jobId) : null);
     }
 
     private object PathDropDown(string path, Action<string> copyToClipboard, IClientProvider client)

--- a/src/Ivy.Tendril/Apps/Jobs/ReportBugDialog.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/ReportBugDialog.cs
@@ -1,0 +1,62 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Jobs;
+
+public class ReportBugDialog(IState<bool> isOpen, string jobId) : ViewBase
+{
+    public override object Build()
+    {
+        var client = UseService<IClientProvider>();
+        var config = UseService<IConfigService>();
+        var description = UseState("");
+        var isSubmitting = UseState(false);
+
+        async Task Submit()
+        {
+            if (string.IsNullOrWhiteSpace(description.Value)) return;
+
+            isSubmitting.Set(true);
+            try
+            {
+                var service = new BugReportService(config);
+                var files = service.CollectFilesForJob(jobId);
+                var result = await service.SubmitReportAsync(description.Value, files);
+
+                if (result != null)
+                {
+                    client.OpenUrl(result.IssueUrl);
+                    isOpen.Set(false);
+                }
+                else
+                {
+                    client.Toast("Failed to submit bug report", "Error", variant: ToastVariant.Destructive);
+                }
+            }
+            catch (Exception ex)
+            {
+                client.Toast(ex.Message, "Error", variant: ToastVariant.Destructive);
+            }
+            finally
+            {
+                isSubmitting.Set(false);
+            }
+        }
+
+        return new Dialog(
+            _ => isOpen.Set(false),
+            new DialogHeader("Report Bug"),
+            new DialogBody(
+                Layout.Vertical().Gap(2)
+                | Text.Muted("Describe the issue. Job logs will be attached to a public GitHub issue.")
+                | description.ToTextInput()
+                    .Placeholder("What went wrong?")
+                    .Rows(4)
+                    .Disabled(isSubmitting.Value)),
+            new DialogFooter(
+                new Button("Cancel").Ghost().OnClick(() => isOpen.Set(false)).Disabled(isSubmitting.Value),
+                new Button("Send Report").Primary().OnClick(async () => await Submit())
+                    .Disabled(isSubmitting.Value || string.IsNullOrWhiteSpace(description.Value))
+                    .Loading(isSubmitting.Value))
+        ).Width(Size.Rem(32));
+    }
+}

--- a/src/Ivy.Tendril/Commands/ReportBugCommand.cs
+++ b/src/Ivy.Tendril/Commands/ReportBugCommand.cs
@@ -1,8 +1,4 @@
 using System.ComponentModel;
-using System.IO.Compression;
-using System.Net.Http.Headers;
-using System.Text.Json;
-using System.Text.RegularExpressions;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 using Microsoft.Extensions.Logging;
@@ -36,9 +32,6 @@ public class ReportBugSettings : CommandSettings
 
 public class ReportBugCommand : Command<ReportBugSettings>
 {
-    private static readonly Regex JobIdFromLogRegex = new(@"^(\d{5})-", RegexOptions.Compiled);
-    private const string BugReportApiUrl = "https://tendril-api.ivy.app/report-bug";
-
     private readonly ILogger<ReportBugCommand> _logger;
 
     public ReportBugCommand(ILogger<ReportBugCommand> logger) => _logger = logger;
@@ -66,11 +59,13 @@ public class ReportBugCommand : Command<ReportBugSettings>
     private int Run(ReportBugSettings settings, CancellationToken cancellationToken)
     {
         var configService = new ConfigService();
+        var service = new BugReportService(configService);
+
         var description = settings.Description;
         if (string.IsNullOrEmpty(description))
             description = AnsiConsole.Ask<string>("Describe the bug:");
 
-        var files = CollectFiles(settings, configService);
+        var files = CollectFiles(settings, service);
         if (files.Count == 0)
         {
             AnsiConsole.MarkupLine("[yellow]No files found to include in the report.[/]");
@@ -96,111 +91,38 @@ public class ReportBugCommand : Command<ReportBugSettings>
             return 0;
         }
 
-        var zipPath = CreateZip(files);
-        try
-        {
-            var version = typeof(ReportBugCommand).Assembly.GetName().Version?.ToString(3) ?? "unknown";
-            var osVersion = Environment.OSVersion.VersionString;
-            var agent = configService.Settings.CodingAgent;
+        AnsiConsole.MarkupLine("[dim]Uploading bug report...[/]");
+        var result = service.SubmitReportAsync(description, files, cancellationToken).GetAwaiter().GetResult();
 
-            var result = UploadReport(zipPath, description, osVersion, version, agent, cancellationToken);
-            if (result == null) return 1;
-
-            AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine($"[green]Bug report submitted successfully![/]");
-            AnsiConsole.MarkupLine($"[link]{result.IssueUrl}[/]");
-            return 0;
-        }
-        finally
+        if (result == null)
         {
-            File.Delete(zipPath);
+            AnsiConsole.MarkupLine("[red]Upload failed.[/]");
+            return 1;
         }
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[green]Bug report submitted successfully![/]");
+        AnsiConsole.MarkupLine($"[link]{result.IssueUrl}[/]");
+        return 0;
     }
 
-    private List<BugReportFile> CollectFiles(ReportBugSettings settings, ConfigService configService)
+    private static List<BugReportService.BugReportFile> CollectFiles(ReportBugSettings settings, BugReportService service)
     {
-        var files = new List<BugReportFile>();
-        var jobIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var files = new List<BugReportService.BugReportFile>();
 
         if (!string.IsNullOrEmpty(settings.PlanId))
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            CollectPlanFiles(planFolder, files);
-            ExtractJobIdsFromPlanLogs(planFolder, jobIds);
+            files.AddRange(service.CollectFilesForPlan(planFolder));
         }
 
         if (!string.IsNullOrEmpty(settings.JobId))
-        {
-            var normalized = NormalizeJobId(settings.JobId);
-            jobIds.Add(normalized);
-        }
-
-        if (jobIds.Count > 0)
-            CollectPromptwareLogFiles(jobIds, configService, files);
+            files.AddRange(service.CollectFilesForJob(settings.JobId));
 
         return files;
     }
 
-    private static void CollectPlanFiles(string planFolder, List<BugReportFile> files)
-    {
-        foreach (var file in Directory.EnumerateFiles(planFolder, "*", SearchOption.AllDirectories))
-        {
-            var relativePath = Path.GetRelativePath(planFolder, file);
-            if (relativePath.StartsWith("Worktrees", StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            files.Add(new BugReportFile(file, relativePath));
-        }
-    }
-
-    private static void ExtractJobIdsFromPlanLogs(string planFolder, HashSet<string> jobIds)
-    {
-        var logsDir = Path.Combine(planFolder, "Logs");
-        if (!Directory.Exists(logsDir)) return;
-
-        foreach (var logFile in Directory.GetFiles(logsDir, "*.md"))
-        {
-            var fileName = Path.GetFileNameWithoutExtension(logFile);
-            var match = JobIdFromLogRegex.Match(fileName);
-            if (match.Success)
-                jobIds.Add(match.Groups[1].Value);
-        }
-    }
-
-    private static void CollectPromptwareLogFiles(HashSet<string> jobIds, ConfigService configService, List<BugReportFile> files)
-    {
-        var promptsRoot = PromptwareHelper.ResolvePromptsRoot(configService.TendrilHome);
-        if (!Directory.Exists(promptsRoot)) return;
-
-        foreach (var pwDir in Directory.GetDirectories(promptsRoot))
-        {
-            var logsDir = Path.Combine(pwDir, "Logs");
-            if (!Directory.Exists(logsDir)) continue;
-
-            var pwName = Path.GetFileName(pwDir);
-
-            foreach (var jobId in jobIds)
-            {
-                var mdFile = Path.Combine(logsDir, $"{jobId}.md");
-                if (File.Exists(mdFile))
-                    files.Add(new BugReportFile(mdFile, Path.Combine("Jobs", pwName, $"{jobId}.md")));
-
-                var jsonlFile = Path.Combine(logsDir, $"{jobId}.raw.jsonl");
-                if (File.Exists(jsonlFile))
-                    files.Add(new BugReportFile(jsonlFile, Path.Combine("Jobs", pwName, $"{jobId}.raw.jsonl")));
-            }
-        }
-    }
-
-    private static string NormalizeJobId(string input)
-    {
-        input = input.Trim();
-        if (int.TryParse(input, out var num))
-            return num.ToString("D5");
-        return input;
-    }
-
-    private static void DisplayFileList(List<BugReportFile> files)
+    private static void DisplayFileList(List<BugReportService.BugReportFile> files)
     {
         var table = new Spectre.Console.Table();
         table.AddColumn("File");
@@ -231,52 +153,4 @@ public class ReportBugCommand : Command<ReportBugSettings>
             _ => $"{bytes / (1024.0 * 1024.0):F1} MB"
         };
     }
-
-    private static string CreateZip(List<BugReportFile> files)
-    {
-        var zipPath = Path.Combine(Path.GetTempPath(), $"tendril-bug-report-{Guid.NewGuid():N}.zip");
-        using var zip = ZipFile.Open(zipPath, ZipArchiveMode.Create);
-
-        foreach (var file in files)
-        {
-            zip.CreateEntryFromFile(file.AbsolutePath, file.ZipEntryPath.Replace('\\', '/'));
-        }
-
-        return zipPath;
-    }
-
-    private BugReportResult? UploadReport(string zipPath, string description, string osVersion, string tendrilVersion, string agent, CancellationToken cancellationToken)
-    {
-        using var httpClient = new HttpClient();
-        httpClient.Timeout = TimeSpan.FromMinutes(5);
-
-        using var form = new MultipartFormDataContent();
-        form.Add(new StringContent(description), "description");
-        form.Add(new StringContent(osVersion), "osVersion");
-        form.Add(new StringContent(tendrilVersion), "tendrilVersion");
-        form.Add(new StringContent(agent), "agent");
-
-        var fileStream = File.OpenRead(zipPath);
-        var fileContent = new StreamContent(fileStream);
-        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
-        form.Add(fileContent, "file", "bug-report.zip");
-
-        AnsiConsole.MarkupLine("[dim]Uploading bug report...[/]");
-
-        var response = httpClient.PostAsync(BugReportApiUrl, form, cancellationToken).GetAwaiter().GetResult();
-
-        if (!response.IsSuccessStatusCode)
-        {
-            var body = response.Content.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult();
-            AnsiConsole.MarkupLine($"[red]Upload failed ({(int)response.StatusCode}):[/] {body.EscapeMarkup()}");
-            return null;
-        }
-
-        var json = response.Content.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult();
-        return JsonSerializer.Deserialize<BugReportResult>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-    }
-
-    private record BugReportFile(string AbsolutePath, string ZipEntryPath);
-
-    private record BugReportResult(string ReportId, string IssueUrl);
 }

--- a/src/Ivy.Tendril/Services/BugReportService.cs
+++ b/src/Ivy.Tendril/Services/BugReportService.cs
@@ -1,0 +1,152 @@
+using System.IO.Compression;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Services;
+
+public sealed class BugReportService
+{
+    private static readonly Regex JobIdFromLogRegex = new(@"^(\d{5})-", RegexOptions.Compiled);
+    private const string BugReportApiUrl = "https://tendril-api.ivy.app/report-bug";
+
+    private readonly IConfigService _config;
+
+    public BugReportService(IConfigService config) => _config = config;
+
+    public record BugReportFile(string AbsolutePath, string ZipEntryPath);
+    public record BugReportResult(string ReportId, string IssueUrl);
+
+    public static string NormalizeJobId(string input)
+    {
+        input = input.Trim();
+        if (int.TryParse(input, out var num))
+            return num.ToString("D5");
+        return input;
+    }
+
+    public List<BugReportFile> CollectFilesForJob(string jobId)
+    {
+        var files = new List<BugReportFile>();
+        var normalized = NormalizeJobId(jobId);
+        CollectPromptwareLogFiles([normalized], files);
+        return files;
+    }
+
+    public List<BugReportFile> CollectFilesForPlan(string planFolder)
+    {
+        var files = new List<BugReportFile>();
+        var jobIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        CollectPlanFiles(planFolder, files);
+        ExtractJobIdsFromPlanLogs(planFolder, jobIds);
+
+        if (jobIds.Count > 0)
+            CollectPromptwareLogFiles(jobIds, files);
+
+        return files;
+    }
+
+    public async Task<BugReportResult?> SubmitReportAsync(string description, IReadOnlyList<BugReportFile> files, CancellationToken ct = default)
+    {
+        var zipPath = CreateZip(files);
+        try
+        {
+            var version = typeof(BugReportService).Assembly.GetName().Version?.ToString(3) ?? "unknown";
+            var osVersion = Environment.OSVersion.VersionString;
+            var agent = _config.Settings.CodingAgent;
+
+            return await UploadAsync(zipPath, description, osVersion, version, agent, ct);
+        }
+        finally
+        {
+            File.Delete(zipPath);
+        }
+    }
+
+    private void CollectPromptwareLogFiles(IReadOnlyCollection<string> jobIds, List<BugReportFile> files)
+    {
+        var promptsRoot = PromptwareHelper.ResolvePromptsRoot(_config.TendrilHome);
+        if (!Directory.Exists(promptsRoot)) return;
+
+        foreach (var pwDir in Directory.GetDirectories(promptsRoot))
+        {
+            var logsDir = Path.Combine(pwDir, "Logs");
+            if (!Directory.Exists(logsDir)) continue;
+
+            var pwName = Path.GetFileName(pwDir);
+
+            foreach (var jobId in jobIds)
+            {
+                var mdFile = Path.Combine(logsDir, $"{jobId}.md");
+                if (File.Exists(mdFile))
+                    files.Add(new BugReportFile(mdFile, Path.Combine("Jobs", pwName, $"{jobId}.md")));
+
+                var jsonlFile = Path.Combine(logsDir, $"{jobId}.raw.jsonl");
+                if (File.Exists(jsonlFile))
+                    files.Add(new BugReportFile(jsonlFile, Path.Combine("Jobs", pwName, $"{jobId}.raw.jsonl")));
+            }
+        }
+    }
+
+    private static void CollectPlanFiles(string planFolder, List<BugReportFile> files)
+    {
+        foreach (var file in Directory.EnumerateFiles(planFolder, "*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(planFolder, file);
+            if (relativePath.StartsWith("Worktrees", StringComparison.OrdinalIgnoreCase))
+                continue;
+            files.Add(new BugReportFile(file, relativePath));
+        }
+    }
+
+    private static void ExtractJobIdsFromPlanLogs(string planFolder, HashSet<string> jobIds)
+    {
+        var logsDir = Path.Combine(planFolder, "Logs");
+        if (!Directory.Exists(logsDir)) return;
+
+        foreach (var logFile in Directory.GetFiles(logsDir, "*.md"))
+        {
+            var fileName = Path.GetFileNameWithoutExtension(logFile);
+            var match = JobIdFromLogRegex.Match(fileName);
+            if (match.Success)
+                jobIds.Add(match.Groups[1].Value);
+        }
+    }
+
+    private static string CreateZip(IReadOnlyList<BugReportFile> files)
+    {
+        var zipPath = Path.Combine(Path.GetTempPath(), $"tendril-bug-report-{Guid.NewGuid():N}.zip");
+        using var zip = ZipFile.Open(zipPath, ZipArchiveMode.Create);
+
+        foreach (var file in files)
+            zip.CreateEntryFromFile(file.AbsolutePath, file.ZipEntryPath.Replace('\\', '/'));
+
+        return zipPath;
+    }
+
+    private static async Task<BugReportResult?> UploadAsync(string zipPath, string description, string osVersion, string tendrilVersion, string agent, CancellationToken ct)
+    {
+        using var httpClient = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
+        using var form = new MultipartFormDataContent();
+
+        form.Add(new StringContent(description), "description");
+        form.Add(new StringContent(osVersion), "osVersion");
+        form.Add(new StringContent(tendrilVersion), "tendrilVersion");
+        form.Add(new StringContent(agent), "agent");
+
+        var fileStream = File.OpenRead(zipPath);
+        var fileContent = new StreamContent(fileStream);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
+        form.Add(fileContent, "file", "bug-report.zip");
+
+        var response = await httpClient.PostAsync(BugReportApiUrl, form, ct);
+
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        var json = await response.Content.ReadAsStringAsync(ct);
+        return JsonSerializer.Deserialize<BugReportResult>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+    }
+}


### PR DESCRIPTION
## Summary

- Extract bug report logic from `ReportBugCommand` into reusable `BugReportService`
- Add `ReportBugDialog` with description field in Job Debug sheet
- On submit, opens the resulting GitHub issue URL in the browser
- CLI `tendril report-bug` refactored to use the shared service

## Test plan

- [x] Build passes
- [ ] Manual: Open Job Debug → click Report Bug → enter description → verify issue opens in browser