### PR TITLE
feat: add Jobs DataTable to plan Details tab

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using Ivy.Core;
 using Ivy.Tendril.Apps.Drafts.Dialogs;
+using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Apps.Views.Tabs;
@@ -43,6 +44,16 @@ public class ContentView(
             if (!isOpen.Value) return null;
             return new CreateIssueDialog(isOpen, selectedRepoState, issueAssigneeState, issueLabelsState,
                 issueCommentState, selectedPlan!, jobService);
+        });
+
+        var (debugSheet, showDebugJob) = UseTrigger<string>((isOpen, jobId) =>
+        {
+            if (!isOpen.Value) return null;
+            return new Sheet(
+                () => isOpen.Set(false),
+                new JobDebugSheet(jobId, jobService, planService, config),
+                "Job Debug"
+            ).Width(Size.Half()).Resizable();
         });
 
         var isEditing = UseState(false);
@@ -189,7 +200,9 @@ public class ContentView(
         {
             var tabs = Layout.Tabs(
                 new Tab("Plan", Cap(planTabContent)),
-                new Tab("Details", Cap(new DetailsTabView(selectedPlan!)))
+                new Tab("Details", Cap(new DetailsTabView(selectedPlan!,
+                    jobService.GetJobs().Where(j => j.PlanFile == selectedPlan!.FolderName).ToList(),
+                    showDebugJob)))
             ).OnSelect(v => selectedTab.Set(v)).SelectedIndex(selectedTab.Value).Variant(TabsVariant.Content).Padding(4, 0, 0, 0).RemoveParentPadding();
 
             content |= (Layout.Vertical().Padding(2).Height(Size.Full()) | tabs);
@@ -244,7 +257,8 @@ public class ContentView(
             mainLayout,
             updateDialog,
             deleteDialog,
-            createIssueDialog
+            createIssueDialog,
+            debugSheet
         };
 
         elements.Add(new FileSheet(openFile, config));

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Reactive.Disposables;
 using Ivy.Core;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Review.Dialogs;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Apps.Views.Sheets;
@@ -93,6 +94,16 @@ public class ContentView(
             if (!isOpen.Value) return null;
             return new ResetToDraftDialog(isOpen, selectedPlanState.Value!, planService, refreshPlans,
                 resetToDraftLogger);
+        });
+
+        var (debugSheet, showDebugJob) = UseTrigger<string>((isOpen, jobId) =>
+        {
+            if (!isOpen.Value) return null;
+            return new Sheet(
+                () => isOpen.Set(false),
+                new JobDebugSheet(jobId, jobService, planService, config),
+                "Job Debug"
+            ).Width(Size.Half()).Resizable();
         });
 
         var artifactContentQuery = UseQuery<string, string>(
@@ -227,7 +238,7 @@ public class ContentView(
             selectedPlanState.Value, planData, planContentQuery, selectedTabIndex, tabNames, openVerification,
             openCommit, openFile, openArtifact, artifactContentQuery, assigneesQuery,
             assigneesError, syncingWorktrees,
-            client, copyToClipboard, logger, nav, args);
+            client, copyToClipboard, logger, nav, args, showDebugJob);
 
         var mainLayout = new HeaderLayout(
             header,
@@ -237,7 +248,7 @@ public class ContentView(
             ).Scroll(Scroll.None).Size(Size.Full())
         ).Scroll(Scroll.None).Size(Size.Full()).Key(selectedPlanState.Value.Id);
 
-        return new Fragment(mainLayout, discardDialog, suggestChangesDialog, customPrDialog, resetToDraftDialog);
+        return new Fragment(mainLayout, discardDialog, suggestChangesDialog, customPrDialog, resetToDraftDialog, debugSheet);
     }
 
     private object BuildHeader(
@@ -378,7 +389,8 @@ public class ContentView(
         Action<string> copyToClipboard,
         ILogger<ContentView> logger,
         INavigator nav,
-        ReviewAppArgs? args)
+        ReviewAppArgs? args,
+        Action<string> showDebugJob)
     {
         var content = Layout.Vertical().Height(Size.Full()).Gap(0);
 
@@ -531,7 +543,9 @@ public class ContentView(
             {
                 new Tab("Summary", Cap(new SummaryTabView(planData.SummaryMarkdown, planContentQuery.Loading))),
                 new Tab("Plan", Cap(planTabContent)),
-                new Tab("Details", Cap(new DetailsTabView(selectedPlan))),
+                new Tab("Details", Cap(new DetailsTabView(selectedPlan,
+                    jobService.GetJobs().Where(j => j.PlanFile == selectedPlan.FolderName).ToList(),
+                    showDebugJob))),
                 new Tab("Verifications", Cap(new VerificationsTabView(
                     selectedPlan.Verifications, planData.VerificationReports,
                     v => openVerification.Set(v)))).Badge(selectedPlan.Verifications.Count.ToString()),

--- a/src/Ivy.Tendril/Apps/Views/PlanJobsDataTableView.cs
+++ b/src/Ivy.Tendril/Apps/Views/PlanJobsDataTableView.cs
@@ -1,0 +1,89 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Apps.Views;
+
+public class PlanJobsDataTableView(List<JobItem> jobs, Action<string> showDebug) : ViewBase
+{
+    public override object Build()
+    {
+        if (jobs.Count == 0)
+            return Text.Muted("No jobs for this plan.");
+
+        var rows = jobs
+            .OrderByDescending(j => j.StartedAt ?? DateTime.MinValue)
+            .Select(j => new PlanJobRow
+            {
+                Id = j.Id,
+                Status = j.Status == JobStatus.Running
+                    ? AnimatedStatusValue.Running(j.Status.ToString())
+                    : AnimatedStatusValue.Idle(j.Status.ToString()),
+                Type = j.Type,
+                Cost = j.Cost.HasValue ? $"${j.Cost.Value:F2}" : "",
+                Tokens = j.Tokens.HasValue ? FormatHelper.FormatTokens(j.Tokens.Value) : "",
+                StatusMessage = j.StatusMessage ?? ""
+            })
+            .ToList();
+
+        return rows.AsQueryable()
+            .ToDataTable(t => t.Id)
+            .Width(Size.Full())
+            .Header(t => t.Status, "Status")
+            .Header(t => t.Type, "Type")
+            .Header(t => t.Cost, "Cost")
+            .Header(t => t.Tokens, "Tokens")
+            .Header(t => t.StatusMessage, "Status")
+            .Width(t => t.Status, Size.Px(110))
+            .Width(t => t.Type, Size.Px(110))
+            .Width(t => t.Cost, Size.Px(80))
+            .Width(t => t.Tokens, Size.Px(80))
+            .Width(t => t.StatusMessage, Size.Auto())
+            .Renderer(t => t.Status, new AnimatedStatusLabelDisplayRenderer
+            {
+                Mode = AnimatedStatusMode.Badge,
+                BadgeColorMapping = Constants.JobStatusColors.ToDictionary(
+                    kvp => kvp.Key.ToString(),
+                    kvp => kvp.Value.ToString()
+                )
+            })
+            .Renderer(t => t.Type, new LabelsDisplayRenderer
+            {
+                BadgeColorMapping = Constants.JobTypeColors.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => kvp.Value.ToString()
+                )
+            })
+            .Renderer(t => t.StatusMessage, new TextDisplayRenderer())
+            .Hidden(t => t.Id)
+            .Config(c =>
+            {
+                c.AllowSorting = false;
+                c.AllowFiltering = false;
+                c.ShowSearch = false;
+                c.SelectionMode = SelectionModes.None;
+                c.ShowIndexColumn = false;
+            })
+            .RowActions(_ => new[]
+            {
+                new MenuItem("Debug", Icon: Icons.Bug, Tag: "debug-job")
+                    .Tooltip("Show debug details for this job")
+            })
+            .OnRowAction(e =>
+            {
+                var id = e.Value.Id?.ToString();
+                if (!string.IsNullOrEmpty(id))
+                    showDebug(id);
+                return ValueTask.CompletedTask;
+            });
+    }
+
+    private record PlanJobRow
+    {
+        public string Id { get; init; } = "";
+        public string Status { get; init; } = "";
+        public string Type { get; init; } = "";
+        public string Cost { get; init; } = "";
+        public string Tokens { get; init; } = "";
+        public string StatusMessage { get; init; } = "";
+    }
+}

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -3,7 +3,7 @@ using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Apps.Views.Tabs;
 
-public class DetailsTabView(PlanFile plan) : ViewBase
+public class DetailsTabView(PlanFile plan, List<JobItem> jobs, Action<string> showDebug) : ViewBase
 {
     public override object Build()
     {
@@ -22,10 +22,18 @@ public class DetailsTabView(PlanFile plan) : ViewBase
             State = plan.Status.ToString()
         };
 
-        return detailsData.ToDetails()
+        var details = detailsData.ToDetails()
             .Multiline(x => x.InitialPrompt)
             .Builder(x => x.Issue, f => f.Link())
             .RemoveEmpty();
+
+        return Layout.Vertical().Gap(4)
+               | details
+               | (jobs.Count > 0
+                   ? (Layout.Vertical().Gap(2)
+                      | Text.H4("Jobs")
+                      | new PlanJobsDataTableView(jobs, showDebug))
+                   : null);
     }
 
     private static string FormatPlanLinks(List<string> planFolders)


### PR DESCRIPTION
## Summary
- Add a Jobs DataTable to the Details tab in both Review and Drafts apps
- Shows Status, Type, Cost, Tokens, and StatusMessage columns for jobs belonging to the selected plan
- Includes a Debug row action that opens the JobDebugSheet

## Test plan
- [ ] Open a plan in the Review app, click Details tab — verify jobs table appears
- [ ] Confirm only jobs for that plan are shown
- [ ] Click Debug row action — verify JobDebugSheet opens
- [ ] Check Drafts app Details tab shows the same behavior