### PR TITLE
fix: promptware memory/tools written to deployed copy instead of source

### DIFF
--- a/src/Ivy.Tendril/Helpers/PromptwareHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PromptwareHelper.cs
@@ -35,15 +35,9 @@ public static class PromptwareHelper
         var sourceRoot = Path.GetFullPath(
             Path.Combine(System.AppContext.BaseDirectory, "..", "..", "..", "Promptwares"));
 
-        // 1. Debug/source mode: check if Promptwares exists relative to BaseDirectory
-        // Only if embedded resource is NOT available (indicating we are in development/source mode)
-        if (!Services.Promptware.PromptwareDeployer.IsEmbeddedAvailable())
-        {
-            if (Directory.Exists(sourceRoot))
-                return sourceRoot;
-        }
+        if (Directory.Exists(sourceRoot))
+            return sourceRoot;
 
-        // 2. Production mode: use TENDRIL_HOME/Promptwares
         if (string.IsNullOrEmpty(tendrilHome))
             tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
         if (!string.IsNullOrEmpty(tendrilHome))
@@ -53,7 +47,6 @@ public static class PromptwareHelper
                 return deployedRoot;
         }
 
-        // 3. Fallback (will fail at runtime, but gives a clear error location)
         if (!string.IsNullOrEmpty(tendrilHome))
             return Path.Combine(tendrilHome, "Promptwares");
 


### PR DESCRIPTION
## Summary

- Removes the `IsEmbeddedAvailable()` guard in `ResolvePromptsRoot`
- Source Promptwares folder is now always preferred when it exists on disk
- Fixes memory/tool writes landing in `TeamIvyConfig/Promptwares/` instead of `src/Ivy.Tendril/Promptwares/`

## Test plan

- [x] Build succeeds
- [x] 1302 unit tests pass
- [ ] Run a job that writes memory, verify it goes to `src/Ivy.Tendril/Promptwares/<type>/Memory/`