### PR TITLE
docs: reorganize installation instructions using tabs

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
+++ b/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
@@ -22,15 +22,12 @@ public class InstallationTabs : ViewBase
     {
         return Layout.Tabs(
             new Tab("macOS / Linux", Layout.Vertical().Padding(8, 0)
-                | Text.P("One-liner: installs Tendril and required backend tools.")
                 | new CodeBlock("curl -sSf https://cdn.ivy.app/install-tendril.sh | sh", Languages.Bash)
             ),
             new Tab("Windows", Layout.Vertical().Padding(8, 0)
-                | Text.P("One-liner: installs Tendril and required backend tools.")
                 | new CodeBlock("irm https://cdn.ivy.app/install-tendril.ps1 | iex", Languages.Powershell)
             ),
             new Tab(".NET Tool", Layout.Vertical().Padding(8, 0)
-                | Text.P("Global install from NuGet:")
                 | new CodeBlock("dotnet tool install -g Ivy.Tendril", Languages.Bash)
                 | new Callout("Powershell 7, Git and gh CLI need to be present on your machine if you install using `dotnet tool` command", icon: Icons.Info)
                 | new Callout("On macOS/Linux, if you've never used .NET tools before, you may need to add the global tool directory to your PATH. Add `export PATH=\"$PATH:$HOME/.dotnet/tools\"` to your `~/.zshrc` or `~/.bashrc` to run `tendril` directly from your terminal. This is done automatically with the quick install commands above.", icon: Icons.Info)
@@ -55,3 +52,13 @@ You can update Ivy Tendril at anytime after the initial install using the dotnet
 ```bash
 dotnet tool update -g Ivy.Tendril
 ```
+
+<style>
+  article h2 {
+    border-bottom: none !important;
+    padding-bottom: 0 !important;
+  }
+  footer {
+    border-top: none !important;
+  }
+</style>

--- a/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
+++ b/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
@@ -15,37 +15,30 @@ icon: Download
 Install Tendril on macOS, Linux, or Windows using one of the methods below.
 </Ingress>
 
-## Quick Install
-
-One-liner: installs Tendril and required backend tools.
-
-### macOS / Linux
-
-```bash
-curl -sSf https://cdn.ivy.app/install-tendril.sh | sh
+```csharp demo
+public class InstallationTabs : ViewBase
+{
+    public override object? Build()
+    {
+        return Layout.Tabs(
+            new Tab("macOS / Linux", Layout.Vertical().Padding(8, 0)
+                | Text.P("One-liner: installs Tendril and required backend tools.")
+                | new CodeBlock("curl -sSf https://cdn.ivy.app/install-tendril.sh | sh", Languages.Bash)
+            ),
+            new Tab("Windows", Layout.Vertical().Padding(8, 0)
+                | Text.P("One-liner: installs Tendril and required backend tools.")
+                | new CodeBlock("irm https://cdn.ivy.app/install-tendril.ps1 | iex", Languages.Powershell)
+            ),
+            new Tab(".NET Tool", Layout.Vertical().Padding(8, 0)
+                | Text.P("Global install from NuGet:")
+                | new CodeBlock("dotnet tool install -g Ivy.Tendril", Languages.Bash)
+                | new Callout("Powershell 7, Git and gh CLI need to be present on your machine if you install using `dotnet tool` command", icon: Icons.Info)
+                | new Callout("On macOS/Linux, if you've never used .NET tools before, you may need to add the global tool directory to your PATH. Add `export PATH=\"$PATH:$HOME/.dotnet/tools\"` to your `~/.zshrc` or `~/.bashrc` to run `tendril` directly from your terminal. This is done automatically with the quick install commands above.", icon: Icons.Info)
+            )
+        ).Variant(TabsVariant.Content);
+    }
+}
 ```
-
-### Windows
-
-```powershell
-irm https://cdn.ivy.app/install-tendril.ps1 | iex
-```
-
-## .NET Tool
-
-Global install from NuGet:
-
-```bash
-dotnet tool install -g Ivy.Tendril
-```
-
-<Callout type="Tip">
-Powershell 7, Git and gh CLI need to be present on your machine if you install using `dotnet tool` command
-</Callout>
-
-<Callout type="Info">
-On macOS/Linux, if you've never used .NET tools before, you may need to add the global tool directory to your PATH. Add `export PATH="$PATH:$HOME/.dotnet/tools"` to your `~/.zshrc` or `~/.bashrc` to run `tendril` directly from your terminal. This is done automatically with the quick install commands above.
-</Callout>
 
 ## Run
 


### PR DESCRIPTION
Reorganizes the platform installation instructions on the Installation doc page to use a tabbed widget (via C# demo block) resolving issue #927.