### PR TITLE
fix: deliver system prompt to non-Claude agents via AGENTS.md and temp files

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs
@@ -262,7 +262,7 @@ public class ClaudeCliTests
     }
 
     [Fact]
-    public void BuildProcessSpec_WithSystemPrompt_IncludesFlag()
+    public void BuildProcessSpec_WithSystemPrompt_WritesFileAndIncludesFlag()
     {
         var config = new AgentLaunchConfig
         {
@@ -273,9 +273,12 @@ public class ClaudeCliTests
 
         var spec = _cli.BuildProcessSpec(config);
 
-        var idx = spec.Arguments.ToList().IndexOf("--system-prompt");
+        var idx = spec.Arguments.ToList().IndexOf("--system-prompt-file");
         Assert.True(idx >= 0);
-        Assert.Equal("You are a helpful assistant", spec.Arguments[idx + 1]);
+        var filePath = spec.Arguments[idx + 1];
+        Assert.True(File.Exists(filePath));
+        Assert.Equal("You are a helpful assistant", File.ReadAllText(filePath));
+        File.Delete(filePath);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudePtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudePtyTests.cs
@@ -251,7 +251,7 @@ public class ClaudePtyTests
     }
 
     [Fact]
-    public void BuildPtySpec_WithSystemPrompt_IncludesFlag()
+    public void BuildPtySpec_WithSystemPrompt_WritesFileAndIncludesFlag()
     {
         var config = new AgentPtyConfig
         {
@@ -261,13 +261,16 @@ public class ClaudePtyTests
 
         var spec = _pty.BuildPtySpec(config);
 
-        var idx = IndexOf(spec.CommandLine,"--system-prompt");
+        var idx = IndexOf(spec.CommandLine, "--system-prompt-file");
         Assert.NotEqual(-1, idx);
-        Assert.Equal("Be helpful", spec.CommandLine[idx + 1]);
+        var filePath = spec.CommandLine[idx + 1];
+        Assert.True(File.Exists(filePath));
+        Assert.Equal("Be helpful", File.ReadAllText(filePath));
+        File.Delete(filePath);
     }
 
     [Fact]
-    public void BuildPtySpec_WithAppendSystemPrompt_UsesAppendFlag()
+    public void BuildPtySpec_WithAppendSystemPrompt_UsesAppendFileFlag()
     {
         var config = new AgentPtyConfig
         {
@@ -278,8 +281,13 @@ public class ClaudePtyTests
 
         var spec = _pty.BuildPtySpec(config);
 
-        Assert.Contains("--append-system-prompt", spec.CommandLine);
-        Assert.DoesNotContain("--system-prompt", spec.CommandLine);
+        Assert.Contains("--append-system-prompt-file", spec.CommandLine);
+        Assert.DoesNotContain("--system-prompt-file", spec.CommandLine);
+        var idx = IndexOf(spec.CommandLine, "--append-system-prompt-file");
+        var filePath = spec.CommandLine[idx + 1];
+        Assert.True(File.Exists(filePath));
+        Assert.Equal("Extra instructions", File.ReadAllText(filePath));
+        File.Delete(filePath);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeCli.cs
@@ -113,8 +113,10 @@ public sealed class ClaudeCli : IAgentCli
 
         if (!string.IsNullOrEmpty(config.SystemPrompt))
         {
-            args.Add("--system-prompt");
-            args.Add(config.SystemPrompt);
+            var tempFile = Path.Combine(Path.GetTempPath(), $"tendril-sysprompt-{Guid.NewGuid():N}.md");
+            File.WriteAllText(tempFile, config.SystemPrompt);
+            args.Add("--system-prompt-file");
+            args.Add(tempFile);
         }
 
         foreach (var mcp in config.McpServers)

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudePty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudePty.cs
@@ -81,8 +81,10 @@ public sealed class ClaudePty : IAgentPty
 
         if (!string.IsNullOrEmpty(config.SystemPrompt))
         {
-            args.Add(config.AppendSystemPrompt ? "--append-system-prompt" : "--system-prompt");
-            args.Add(config.SystemPrompt);
+            var tempFile = Path.Combine(Path.GetTempPath(), $"tendril-sysprompt-{Guid.NewGuid():N}.md");
+            File.WriteAllText(tempFile, config.SystemPrompt);
+            args.Add(config.AppendSystemPrompt ? "--append-system-prompt-file" : "--system-prompt-file");
+            args.Add(tempFile);
         }
 
         foreach (var mcp in config.McpServers)

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeCli.cs
@@ -95,13 +95,17 @@ public sealed class OpenCodeCli : IAgentCli
                 env[key] = value;
         }
 
+        var stdinContent = config.Prompt;
+        if (!string.IsNullOrEmpty(config.SystemPrompt))
+            stdinContent = config.SystemPrompt + "\n\n---\n\n" + stdinContent;
+
         return new AgentProcessSpec
         {
             FileName = "opencode",
             Arguments = args,
             WorkingDirectory = config.WorkingDirectory,
             Environment = env,
-            StdinContent = config.Prompt,
+            StdinContent = stdinContent,
             RedirectStdin = true,
         };
     }

--- a/src/Ivy.Tendril/Apps/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/AgentApp.cs
@@ -38,14 +38,33 @@ public class AgentApp : ViewBase
         var agentId = config.Settings.CodingAgent;
         var cli = runner.GetCli(agentId);
         var pty = runner.GetPty(agentId);
+        var workDir = GetDefaultWorkDir(config);
+        var systemPrompt = AgentPromptCompiler.Compile(config);
+
+        WriteAgentInstructionsIfNeeded(workDir, systemPrompt, pty);
+
         var spec = pty?.BuildPtySpec(new AgentPtyConfig
         {
-            WorkingDirectory = GetDefaultWorkDir(config),
+            WorkingDirectory = workDir,
             PermissionMode = PermissionMode.Default,
-            SystemPrompt = AgentPromptCompiler.Compile(config),
+            SystemPrompt = systemPrompt,
             AppendSystemPrompt = true,
         });
         return spec?.ResolveCommand().CommandLine.ToArray() ?? [cli.Id];
+    }
+
+    private static void WriteAgentInstructionsIfNeeded(string workDir, string? systemPrompt, IAgentPty? pty)
+    {
+        if (string.IsNullOrEmpty(systemPrompt) || string.IsNullOrEmpty(workDir))
+            return;
+
+        // Claude handles system prompt via --system-prompt / --append-system-prompt flags.
+        // All other agents (OpenCode, Gemini, Codex, Copilot, Antigravity) read AGENTS.md from cwd.
+        if (pty?.Id != AgentId.Claude)
+        {
+            var path = Path.Combine(workDir, "AGENTS.md");
+            File.WriteAllText(path, systemPrompt);
+        }
     }
 
     private static string GetWorkDir(IConfigService config, IAgentRunner runner)


### PR DESCRIPTION
## Summary

- **AgentApp**: writes `AGENTS.md` to the working directory for non-Claude agents (OpenCode, Gemini, Codex, Copilot, Antigravity) so they pick up the Tendril CLI reference automatically
- **ClaudePty/ClaudeCli**: switched from inline `--system-prompt` to `--system-prompt-file` / `--append-system-prompt-file` to handle large prompts safely
- **OpenCodeCli**: prepends SystemPrompt to stdin content when set (for promptware execution path)

Fixes the issue where OpenCode launched from the Agent tab had no knowledge of Tendril CLI commands.

## Test plan

- [x] All 855 Agents tests pass
- [ ] Launch Agent tab with `codingAgent: opencode`, ask "what tendril commands are available?"
- [ ] Launch Agent tab with `codingAgent: claude`, verify system prompt still works via file