### PR TITLE
[App]: fix taskbar icon missing

### DIFF
--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <ApplicationIcon>Assets\icon.ico</ApplicationIcon>
+    <ApplicationIcon>Assets/icon.ico</ApplicationIcon>
     <NoWarn>CS8618;CS8603;CS8602;CS8604;CS9113</NoWarn>
     <RootNamespace>Ivy.Tendril</RootNamespace>
     <UserSecretsId>a8f3c2e1-4b7d-4e9f-a1c3-8d6e2f5b9a7c</UserSecretsId>

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <ApplicationIcon>Assets\icon.ico</ApplicationIcon>
     <NoWarn>CS8618;CS8603;CS8602;CS8604;CS9113</NoWarn>
     <RootNamespace>Ivy.Tendril</RootNamespace>
     <UserSecretsId>a8f3c2e1-4b7d-4e9f-a1c3-8d6e2f5b9a7c</UserSecretsId>


### PR DESCRIPTION
## Problem

The Ivy Tendril application was missing its icon in the Windows taskbar. Users reported that the application window appeared without a recognizable icon (issue #962). The issue was specific to Windows — macOS was fixed separately in Rustino `f58f9c6`.

## Root Cause

The compiled `.exe` had the wrong icon embedded in its PE header. The `Ivy.Desktop` NuGet package includes an MSBuild targets file (`Ivy.Desktop.targets`) that automatically sets `ApplicationIcon` to a generic Ivy framework icon (`ivy.ico`, 358 KB) as a fallback when no explicit icon is specified by the consuming project.

`Ivy.Tendril.csproj` did not override this property, so the built executable contained the generic Ivy icon instead of the Tendril-specific icon (`Assets/icon.ico`, 13 KB). While the runtime window icon was set correctly via `DesktopWindow.Icon()`, Windows uses the PE-embedded icon for certain taskbar scenarios (pinned apps, Alt+Tab, shortcuts).

## Fix

Added an explicit `<ApplicationIcon>` property to the project file to override the Ivy.Desktop default:

```xml
<ApplicationIcon>Assets/icon.ico</ApplicationIcon>
```

This ensures the Tendril icon is embedded directly into the `.exe` PE header, so Windows displays the correct icon in all contexts — taskbar, Alt+Tab, Task Manager, and file explorer.

## Note

The companion fix in **Ivy-Framework** (branch `962-fix`) is also required — it wires up `DesktopWindow.AppId()` to actually call `RustinoWindow.SetApplicationId()`, which was previously a no-op.

## Related

- Closes #962
- Depends on Ivy-Framework PR: `[Desktop]: fix taskbar icon missing`
