### PR TITLE
[Docs]: remove hardcoded paddings from installation tabs

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
+++ b/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
@@ -21,13 +21,13 @@ public class InstallationTabs : ViewBase
     public override object? Build()
     {
         return Layout.Tabs(
-            new Tab("macOS / Linux", Layout.Vertical().Padding(8, 0)
+            new Tab("macOS / Linux", Layout.Vertical()
                 | new CodeBlock("curl -sSf https://cdn.ivy.app/install-tendril.sh | sh", Languages.Bash)
             ),
-            new Tab("Windows", Layout.Vertical().Padding(8, 0)
+            new Tab("Windows", Layout.Vertical()
                 | new CodeBlock("irm https://cdn.ivy.app/install-tendril.ps1 | iex", Languages.Powershell)
             ),
-            new Tab(".NET Tool", Layout.Vertical().Padding(8, 0)
+            new Tab(".NET Tool", Layout.Vertical()
                 | new CodeBlock("dotnet tool install -g Ivy.Tendril", Languages.Bash)
                 | new Callout("Powershell 7, Git and gh CLI need to be present on your machine if you install using `dotnet tool` command", icon: Icons.Info)
                 | new Callout("On macOS/Linux, if you've never used .NET tools before, you may need to add the global tool directory to your PATH. Add `export PATH=\"$PATH:$HOME/.dotnet/tools\"` to your `~/.zshrc` or `~/.bashrc` to run `tendril` directly from your terminal. This is done automatically with the quick install commands above.", icon: Icons.Info)


### PR DESCRIPTION
## Description

This PR refines the visual appearance of the tabbed installation instructions on the Getting Started page. 

Following the recent migration to the `Layout.Tabs` component (Issue #927), the UI suffered from a cluttered "double-box" effect and awkward spacing. This was caused by hardcoded `.Padding(8, 0)` being applied to the inner `Layout.Vertical()` wrappers of each tab.

By removing the explicit padding, we allow the nested `CodeBlock` and `Callout` components to handle their own margins naturally. This results in a much cleaner, tighter layout without unnecessary whitespace.

## Changes
- Removed `.Padding(8, 0)` from `Layout.Vertical()` containers inside `InstallationTabs` (`02_Installation.md`).

## Related Issues
- Refines the implementation of #927 (Use tabs for installation instructions to reduce user confusion).

## Screenshots
<img width="1048" height="379" alt="image" src="https://github.com/user-attachments/assets/e6e9db22-e2f5-4468-98c4-9a3156f0ce8b" />
<img width="1038" height="363" alt="image" src="https://github.com/user-attachments/assets/f97c657c-a408-4507-b5b7-d01be8a7b9e6" />
<img width="1086" height="693" alt="image" src="https://github.com/user-attachments/assets/80a80b6f-dc28-45fb-bfe5-9c372bd2cb58" />

