### PR TITLE
[ProjectAgentStepView]: add bottom spacer to fix missing padding

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -189,7 +189,7 @@ public class ProjectAgentStepView(
                       )
                         .Width(Size.Full())
                         .Height(Size.Units(100).Max(Size.Fraction(0.6f)))
-                        .Padding(4)
+                        .Padding(4, 4, 0, 4)
                    : null!)
                | buttonArea
                | new Spacer().Height(Size.Units(4));

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -191,6 +191,7 @@ public class ProjectAgentStepView(
                         .Height(Size.Units(100).Max(Size.Fraction(0.6f)))
                         .Padding(4)
                    : null!)
-               | buttonArea;
+               | buttonArea
+               | new Spacer().Height(Size.Units(4));
     }
 }


### PR DESCRIPTION
##  The Issue
On the third step of onboarding ("Setting up your project", located in `ProjectAgentStepView`), the terminal output container expands to occupy up to 60% of the screen height. 
When the user resizes the application window to a smaller height, a scrollbar appears, and the content at the bottom of the screen (the "Back" and "Next" buttons) ends up flush against the bottom edge of the application window. There was no padding below the buttons, which made the UI look cramped and cut-off.

##  What needed to be done
We needed to ensure that there is always a safe empty space (padding/margin) at the absolute bottom of the scrollable view, directly after the navigation buttons. This guarantees that the buttons will never touch the window boundaries, regardless of the window height or the presence of a scrollbar.

##  The Solution
Added a `Spacer()` with a height of `4` units directly *after* the `buttonArea` inside the root `Layout.Vertical()` container. 

```csharp
    | buttonArea
    | new Spacer().Height(Size.Units(4));
```

This acts as a flexible bottom margin, preserving the required empty space beneath the buttons while keeping the declarative layout simple and easy to read.

<img width="1605" height="604" alt="image" src="https://github.com/user-attachments/assets/a21f3e03-d3db-41cf-a726-0d062517ab07" />
