### PR TITLE
[ContentView]: add bottom padding to prevent abrupt scroll end

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -266,7 +266,7 @@ public class ContentView(
         return new Fragment(elements.ToArray());
 
         object Cap(object inner) => Layout.Vertical().Scroll().Width(Size.Full()).Height(Size.Full())
-            | (Layout.Vertical().Width(Size.Full().Max(Size.Units(200))) | inner);
+            | (Layout.Vertical().Padding(0, 0, 0, 4).Width(Size.Full().Max(Size.Units(200))) | inner);
     }
 
     internal static object BuildFailureCallout(PlanFile plan)

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -602,7 +602,7 @@ public class ContentView(
         object Cap(object inner)
         {
             return Layout.Vertical().Scroll(Scroll.Auto).Width(Size.Full()).Height(Size.Full())
-                | (Layout.Vertical().Width(Size.Full().Max(Size.Units(200))) | inner);
+                | (Layout.Vertical().Padding(0, 0, 0, 4).Width(Size.Full().Max(Size.Units(200))) | inner);
         }
     }
 


### PR DESCRIPTION
## Issue Description
When scrolling down to the very end of a plan document (e.g., in the Drafts or Review tabs), the content ended abruptly without any extra space at the bottom. This caused the last line of text or UI element to touch the bottom edge of the scroll view directly above the sticky action bar, resulting in a poor user experience.

## Goal
The goal was to add some additional padding/spacing at the bottom of the document so that when a user scrolls to the end, there is sufficient "breathing room" and the content doesn't terminate directly at the viewport edge.

## Solution & Rationale
**Solution:** 
Added a bottom padding of `4` to the inner `Layout.Vertical()` container inside the `Cap()` wrapper method. This change was applied to both:
- `src/Ivy.Tendril/Apps/Drafts/ContentView.cs`
- `src/Ivy.Tendril/Apps/Review/ContentView.cs`

**Why:**
The `Cap()` method is responsible for wrapping the content of the tabs (Plan, Details, Summary, etc.) inside a `Scroll()` layout. By applying the padding to the `Layout.Vertical()` container that wraps the `inner` content within `Cap()`, we ensure that the breathing room is consistently applied across *all* tabs that use this wrapper. This approach is much more robust and DRY (Don't Repeat Yourself) compared to manually adding spacers or padding inside each individual tab view (like `PlanTabView` or `DetailsTabView`).

<img width="1821" height="1254" alt="image" src="https://github.com/user-attachments/assets/4ca56b0a-c80a-4ba4-b001-d734db5faa39" />