### PR TITLE
[Docs]: add agent authorization warning to onboarding guide

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
+++ b/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/02_Installation.md
@@ -43,6 +43,10 @@ public class InstallationTabs : ViewBase
 tendril
 ```
 
+<Callout type="warning">
+Before starting the onboarding wizard, please make sure your preferred coding agent is installed and fully authorized on your machine.
+</Callout>
+
 The first time you run Tendril, you'll be guided through an onboarding wizard. During setup, Tendril will create a configuration file at `$TENDRIL_HOME/config.yaml` (default: `~/.tendril/config.yaml`).
 
 ## Update


### PR DESCRIPTION
## The Issue
Issue #932 reported that during the onboarding flow, when a user selected an agent (like Claude), they were presented with a static "Setting up" screen with no progress indication. It was later identified that this occurred because the selected agent was not installed or authorized on the user's machine, causing a silent failure without a proper error message or fallback. 

## What Needed to be Done
1. Provide UI feedback (progress bars, status updates) during the agent setup phase.
2. Prevent the application from hanging indefinitely by displaying clear error messages and a "go back" mechanism if the agent is not present or authorized.
3. Update the documentation to explicitly state that the chosen agent must be installed and authorized *before* starting the Tendril onboarding process.

## What Was Done
* **UI & Logic Improvements (Previously completed):** 
  * Added a progress bar and dynamic status texts (`Checking Claude Code...`, `Verifying Claude Code Authentication...`) during the onboarding agent setup.
  * Added a clear warning directly on the agent selection screen (`Please make sure your agent is present and you are authorized.`).
  * Ensured the user is returned to the selection screen in case of a failure, effectively providing a "go back" option.
  
<img width="1873" height="860" alt="image" src="https://github.com/user-attachments/assets/1fe144eb-4217-406b-9874-46b337e43ed8" />
<img width="1557" height="703" alt="image" src="https://github.com/user-attachments/assets/e01c05a5-cf64-44f0-976a-ab003c03d8f7" />
<img width="1304" height="939" alt="image" src="https://github.com/user-attachments/assets/b3be2271-11b4-4df3-9712-66200e3024b1" />


* **Documentation Update (This commit):**
  * Added a warning `Callout` to the `02_Installation.md` documentation page explicitly advising users to verify their agent is installed and fully authorized before initiating the onboarding wizard.

<img width="1252" height="668" alt="image" src="https://github.com/user-attachments/assets/1ffad250-9b11-45f4-829f-4030f40b2b4f" />

