### PR TITLE
[TendrilProcessView]: shorten arrows, shrink arrowheads, and add logical margins

### DIFF
--- a/src/Ivy.Tendril.Widgets/Widgets/frontend/src/TendrilProcessView.css
+++ b/src/Ivy.Tendril.Widgets/Widgets/frontend/src/TendrilProcessView.css
@@ -103,7 +103,7 @@
   position: relative;
   display: flex;
   align-items: center;
-  margin: 0 -1px;
+  margin: 0 8px;
 }
 
 .tpv-arrow-segment .tpv-arrow-label {
@@ -115,7 +115,7 @@
 }
 
 .tpv-arrow-svg {
-  width: 80px;
+  width: 60px;
   height: 12px;
   color: var(--muted-foreground, #6b7280);
 }

--- a/src/Ivy.Tendril.Widgets/Widgets/frontend/src/TendrilProcessView.tsx
+++ b/src/Ivy.Tendril.Widgets/Widgets/frontend/src/TendrilProcessView.tsx
@@ -18,13 +18,13 @@ const Arrow: React.FC<ArrowProps> = ({ count, spinning, onClick }) => (
         {spinning && <LoaderCircle className="tpv-spinner" size={13} />}
       </button>
     )}
-    <svg className="tpv-arrow-svg" viewBox="0 0 80 12" preserveAspectRatio="none">
+    <svg className="tpv-arrow-svg" viewBox="0 0 60 12" preserveAspectRatio="none">
       <defs>
-        <marker id="arrowhead" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
-          <polygon points="0,0 6,3 0,6" fill="currentColor" />
+        <marker id="arrowhead" markerWidth="4" markerHeight="4" refX="3" refY="2" orient="auto">
+          <polygon points="0,0 4,2 0,4" fill="currentColor" />
         </marker>
       </defs>
-      <line x1="0" y1="6" x2="78" y2="6" stroke="currentColor" strokeWidth="1.5" markerEnd="url(#arrowhead)" />
+      <line x1="0" y1="6" x2="58" y2="6" stroke="currentColor" strokeWidth="1.5" markerEnd="url(#arrowhead)" />
     </svg>
   </div>
 );
@@ -42,8 +42,8 @@ const LoopArrow: React.FC<LoopArrowProps> = ({ count, onClick }) => (
     </button>
     <svg className="tpv-curve-svg" viewBox="0 0 100 30" fill="none">
       <defs>
-        <marker id="arrowhead-curve" markerWidth="6" markerHeight="6" refX="3" refY="3" orient="auto">
-          <polygon points="0,0 6,3 0,6" fill="currentColor" />
+        <marker id="arrowhead-curve" markerWidth="4" markerHeight="4" refX="2" refY="2" orient="auto">
+          <polygon points="0,0 4,2 0,4" fill="currentColor" />
         </marker>
       </defs>
       <path


### PR DESCRIPTION
## Description
This Pull Request improves the visual appearance of the `TendrilProcessView` workflow diagram arrows. 

### The Issue
Previously, the directional arrows connecting the process blocks (e.g., "New Plan", "Drafts", "Review") were overly long (80px) and their arrowheads were a bit too bulky (6x6). Furthermore, the arrows lacked proper logical spacing and appeared to "collide" or cut directly into the adjacent block edges due to a negative horizontal margin (`margin: 0 -1px`).

### What was done
- **Shortened Arrow Length**: Decreased the SVG arrow length from `80px` to `60px` for a more compact and balanced look.
- **Resized Arrowheads**: Shrunk the arrowhead SVG markers from `6x6` to `4x4` across both straight arrows and curved loop arrows to keep visual consistency.
- **Added Logical Margins**: Replaced the `-1px` horizontal margin with an `8px` margin (`margin: 0 8px`) on `.tpv-arrow-segment`. This adds proper "breathing room" between the ends of the arrows and the UI blocks.

### Why
These adjustments create a much cleaner, more refined diagram. The arrows now feel proportional to the blocks, and the added spacing ensures UI elements don't overlap or feel cramped, significantly enhancing the overall visual aesthetic.

Before:
<img width="984" height="543" alt="image" src="https://github.com/user-attachments/assets/7011b8b6-489b-4c18-8880-a0c48e43bf29" />


After:
<img width="868" height="538" alt="image" src="https://github.com/user-attachments/assets/1ce96a07-e0b0-451e-84a5-539630010324" />
