### PR TITLE
feat: integrate Velopack auto-updates and fix installer name collisions

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -253,7 +253,24 @@ jobs:
             --icon "$ICON_PATH" \
             $( [[ "${{ matrix.os }}" != "ubuntu-latest" ]] && echo "--noPortable" ) \
             --delta None \
-            $( [[ "${{ matrix.rid }}" == osx-* ]] && echo "--bundleId com.ivy.tendril" )
+            $( [[ "${{ matrix.rid }}" == osx-* ]] && echo "--bundleId com.ivy.tendril" ) \
+            --channel ${{ matrix.rid }}
+
+      - name: Rename Installer Setup Packages
+        run: |
+          cd releases
+          if [[ "${{ matrix.os }}" == windows-* ]]; then
+            mv IvyTendril-${{ matrix.rid }}-Setup.exe IvyTendril-${{ needs.version.outputs.version }}-${{ matrix.rid }}.exe
+          elif [[ "${{ matrix.os }}" == macos-* ]]; then
+            mv IvyTendril-${{ matrix.rid }}-Setup.pkg IvyTendril-${{ needs.version.outputs.version }}-${{ matrix.rid }}.pkg
+          elif [[ "${{ matrix.os }}" == ubuntu-* ]]; then
+            if [ -f IvyTendril-${{ matrix.rid }}.AppImage ]; then
+              mv IvyTendril-${{ matrix.rid }}.AppImage IvyTendril-${{ needs.version.outputs.version }}-${{ matrix.rid }}.AppImage
+            elif [ -f IvyTendril.AppImage ]; then
+              mv IvyTendril.AppImage IvyTendril-${{ needs.version.outputs.version }}-${{ matrix.rid }}.AppImage
+            fi
+          fi
+          cd ..
 
       - name: Prepare Windows installer for signing
         if: startsWith(matrix.rid, 'win-')
@@ -289,6 +306,7 @@ jobs:
             releases/*.AppImage
             releases/*.nupkg
             releases/RELEASES
+            releases/releases.*.json
 
   upload-release-assets:
     needs: [version, publish-nuget, publish-desktop]

--- a/src/Ivy.Tendril/Commands/UpdateCliCommand.cs
+++ b/src/Ivy.Tendril/Commands/UpdateCliCommand.cs
@@ -6,6 +6,9 @@ using System.Runtime.InteropServices;
 using System.Text.Json;
 using Spectre.Console;
 using Spectre.Console.Cli;
+using Velopack;
+using Velopack.Sources;
+using Velopack.Locators;
 
 namespace Ivy.Tendril.Commands;
 
@@ -18,6 +21,64 @@ public class UpdateCliCommand : AsyncCommand<UpdateCliCommand.Settings>
 
     protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
+        var includeBeta = Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1";
+        var source = new GithubSource("https://github.com/Ivy-Interactive/Ivy-Tendril", null, includeBeta);
+        var mgr = new UpdateManager(source);
+
+        if (mgr.IsInstalled)
+        {
+            var currentChannel = VelopackLocator.Current?.Channel ?? "win";
+            var targetChannel = currentChannel;
+
+            if (includeBeta && !currentChannel.EndsWith("-beta"))
+            {
+                targetChannel = $"{currentChannel}-beta";
+            }
+            else if (!includeBeta && currentChannel.EndsWith("-beta"))
+            {
+                targetChannel = currentChannel.Substring(0, currentChannel.Length - "-beta".Length);
+            }
+
+            if (targetChannel != currentChannel)
+            {
+                var options = new UpdateOptions
+                {
+                    ExplicitChannel = targetChannel,
+                    AllowVersionDowngrade = true
+                };
+                mgr = new UpdateManager(source, options);
+            }
+
+            AnsiConsole.MarkupLine("[grey]Checking for updates via Velopack...[/]");
+            UpdateInfo? updateInfo = null;
+
+            await AnsiConsole.Status()
+                .StartAsync("Connecting to release server...", async ctx =>
+                {
+                    updateInfo = await mgr.CheckForUpdatesAsync();
+                });
+
+            if (updateInfo == null)
+            {
+                AnsiConsole.MarkupLine("[green]You are already on the latest version of Ivy.Tendril.[/]");
+                return 0;
+            }
+
+            AnsiConsole.MarkupLine($"[green]New version {updateInfo.TargetFullRelease.Version} is available![/]");
+
+            await AnsiConsole.Progress()
+                .StartAsync(async ctx =>
+                {
+                    var task = ctx.AddTask("[green]Downloading update...[/]", autoStart: true, maxValue: 100);
+
+                    await mgr.DownloadUpdatesAsync(updateInfo, progress => task.Value = progress);
+                });
+
+            AnsiConsole.MarkupLine("[green]Update downloaded successfully. Restarting application to apply...[/]");
+            mgr.ApplyUpdatesAndRestart(updateInfo);
+            return 0;
+        }
+
         var currentVersion = GetCurrentVersion();
         var latestVersion = await GetLatestVersionAsync();
         var isUpToDate = currentVersion != null && latestVersion != null && currentVersion == latestVersion;


### PR DESCRIPTION
This PR integrates the native Velopack UpdateManager into the `tendril update` CLI command, configures architecture-specific update channels via `vpk pack --channel`, and renames the generated setup files to have clear version-and-architecture-specific filenames (e.g. `IvyTendril-1.0.47-osx-arm64.pkg`).