### PR TITLE
ci: build and sign installers in test-mode

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -168,7 +168,6 @@ jobs:
   publish-desktop:
     needs: version
     runs-on: ${{ matrix.os }}
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && !inputs.test-mode)
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR removes the `test-mode` skip condition from the `publish-desktop` job. This allows testing the compilation, packaging, and signing of the installers during manual `test-mode` workflow runs, uploading them as action artifacts without publishing them to GitHub Releases or NuGet.org.