### PR TITLE
ci: update test-mode description

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       test-mode:
-        description: 'Test mode (do not publish to NuGet, do not build installers, do not create release)'
+        description: 'Test mode (do not publish to NuGet, do not create release)'
         required: false
         type: boolean
         default: false


### PR DESCRIPTION
This PR updates the description of the manual trigger `test-mode` parameter in `publish-tendril.yml` to remove the outdated `do not build installers` text, since installers are now built and signed in test-mode.