### PR TITLE
ci: add linux-arm64 target and update osx-x64 runner

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -178,8 +178,10 @@ jobs:
             os: windows-latest
           - rid: linux-x64
             os: ubuntu-latest
+          - rid: linux-arm64
+            os: ubuntu-24.04-arm
           - rid: osx-x64
-            os: macos-latest
+            os: macos-13
           - rid: osx-arm64
             os: macos-latest
     defaults:


### PR DESCRIPTION
This PR adds the `linux-arm64` target to the build matrix in `publish-tendril.yml`, configured to run on the native `ubuntu-24.04-arm` runner. It also updates the `osx-x64` target to run on `macos-13` (which is Intel-based) to ensure it compiles a true x64 macOS app package.