### PR TITLE
ci: fix Linux ARM64 pack command and add version to upload-artifact name

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -220,15 +220,15 @@ jobs:
       - name: Install vpk tool and dependencies
         run: |
           dotnet tool install -g vpk
-          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+          if [[ "${{ matrix.rid }}" == linux-* ]]; then
             sudo apt-get update && sudo apt-get install -y libfuse2
           fi
 
       - name: Set Icon Path
         run: |
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+          if [[ "${{ matrix.rid }}" == win-* ]]; then
             echo "ICON_PATH=src/Ivy.Tendril/Assets/icon.ico" >> $GITHUB_ENV
-          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+          elif [[ "${{ matrix.rid }}" == osx-* ]]; then
             echo "ICON_PATH=src/Ivy.Tendril/Assets/icon.icns" >> $GITHUB_ENV
           else
             echo "ICON_PATH=src/Ivy.Tendril/Assets/icon.png" >> $GITHUB_ENV
@@ -249,7 +249,7 @@ jobs:
         run: |
           export PATH="$PATH:$HOME/.dotnet/tools"
           EXE_NAME="Ivy.Tendril"
-          if [[ "${{ matrix.os }}" == windows-* ]]; then
+          if [[ "${{ matrix.rid }}" == win-* ]]; then
             EXE_NAME="Ivy.Tendril.exe"
           fi
 
@@ -260,7 +260,7 @@ jobs:
             --mainExe $EXE_NAME \
             --outputDir ./releases \
             --icon "$ICON_PATH" \
-            $( [[ "${{ matrix.os }}" != "ubuntu-latest" ]] && echo "--noPortable" ) \
+            $( [[ "${{ matrix.rid }}" != linux-* ]] && echo "--noPortable" ) \
             --delta None \
             $( [[ "${{ matrix.rid }}" == osx-* ]] && echo "--bundleId com.ivy.tendril" ) \
             --channel ${{ matrix.rid }}
@@ -268,11 +268,11 @@ jobs:
       - name: Rename Installer Setup Packages
         run: |
           cd releases
-          if [[ "${{ matrix.os }}" == windows-* ]]; then
+          if [[ "${{ matrix.rid }}" == win-* ]]; then
             mv IvyTendril-${{ matrix.rid }}-Setup.exe IvyTendril-${{ needs.version.outputs.version }}-${{ matrix.rid }}.exe
-          elif [[ "${{ matrix.os }}" == macos-* ]]; then
+          elif [[ "${{ matrix.rid }}" == osx-* ]]; then
             mv IvyTendril-${{ matrix.rid }}-Setup.pkg IvyTendril-${{ needs.version.outputs.version }}-${{ matrix.rid }}.pkg
-          elif [[ "${{ matrix.os }}" == ubuntu-* ]]; then
+          elif [[ "${{ matrix.rid }}" == linux-* ]]; then
             if [ -f IvyTendril-${{ matrix.rid }}.AppImage ]; then
               mv IvyTendril-${{ matrix.rid }}.AppImage IvyTendril-${{ needs.version.outputs.version }}-${{ matrix.rid }}.AppImage
             elif [ -f IvyTendril.AppImage ]; then
@@ -308,7 +308,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: tendril-installer-${{ matrix.rid }}
+          name: tendril-installer-${{ needs.version.outputs.version }}-${{ matrix.rid }}
           path: |
             releases/*.exe
             releases/*.pkg


### PR DESCRIPTION
This PR fixes the `--noPortable` error on Linux ARM64 (by checking `matrix.rid` instead of `matrix.os`), uses robust RID-based checks for other packing/signing steps, and adds the resolved version to the upload-artifact name to ensure artifacts contain the version in their filenames when downloaded.