### PR TITLE
ci: change osx-x64 runner to macos-latest

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -181,7 +181,7 @@ jobs:
           - rid: linux-arm64
             os: ubuntu-24.04-arm
           - rid: osx-x64
-            os: macos-13
+            os: macos-latest
           - rid: osx-arm64
             os: macos-latest
     defaults:


### PR DESCRIPTION
This PR updates the osx-x64 target runner from the retired macos-13 to macos-latest.