### PR TITLE
ci: add 3 minute timeout to publish-desktop

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -168,6 +168,7 @@ jobs:
   publish-desktop:
     needs: version
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 3
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR adds a 3-minute timeout to the publish-desktop job to prevent it from hanging if a runner is unavailable.