### PR TITLE
ci: configure target-specific timeouts

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -168,23 +168,29 @@ jobs:
   publish-desktop:
     needs: version
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 3
+    timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - rid: win-x64
             os: windows-latest
+            timeout: 5
           - rid: win-arm64
             os: windows-latest
+            timeout: 5
           - rid: linux-x64
             os: ubuntu-latest
+            timeout: 3
           - rid: linux-arm64
             os: ubuntu-24.04-arm
+            timeout: 3
           - rid: osx-x64
             os: macos-latest
+            timeout: 3
           - rid: osx-arm64
             os: macos-latest
+            timeout: 3
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
This PR sets target-specific timeouts (5 minutes for Windows, 3 minutes for macOS/Linux) to accommodate Windows signing latency.