### PR TITLE
ci: set publish-desktop timeout to 30 minutes

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -168,29 +168,23 @@ jobs:
   publish-desktop:
     needs: version
     runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.timeout }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
           - rid: win-x64
             os: windows-latest
-            timeout: 5
           - rid: win-arm64
             os: windows-latest
-            timeout: 5
           - rid: linux-x64
             os: ubuntu-latest
-            timeout: 3
           - rid: linux-arm64
             os: ubuntu-24.04-arm
-            timeout: 3
           - rid: osx-x64
             os: macos-latest
-            timeout: 3
           - rid: osx-arm64
             os: macos-latest
-            timeout: 3
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
This PR updates the publish-desktop job timeout-minutes to 30 to allow all target builds to run to completion once they start.