### PR TITLE
[00079] Fix EventWire serialization of SystemEvent and UnknownEvent

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Runtime/JsonEventSerializerTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Runtime/JsonEventSerializerTests.cs
@@ -380,4 +380,39 @@ public class JsonEventSerializerTests
         Assert.DoesNotContain("\"output\"", json);
         Assert.DoesNotContain("\"tool_name\"", json);
     }
+
+    [Fact]
+    public void Serialize_SystemEvent_ProducesEmptyTextWire()
+    {
+        var evt = new SystemEvent
+        {
+            Kind = AgentEventKind.System,
+            Subtype = "init",
+            Message = "System initialized",
+        };
+
+        var json = _serializer.Serialize(evt);
+
+        Assert.Contains("\"kind\":\"text\"", json);
+        Assert.Contains("\"text\":\"\"", json);
+        Assert.DoesNotContain("SystemEvent", json);
+        Assert.DoesNotContain("Subtype", json);
+    }
+
+    [Fact]
+    public void Serialize_UnknownEvent_ProducesEmptyTextWire()
+    {
+        var evt = new UnknownEvent
+        {
+            Kind = AgentEventKind.Unknown,
+            Content = "{\"type\":\"future_event\"}",
+        };
+
+        var json = _serializer.Serialize(evt);
+
+        Assert.Contains("\"kind\":\"text\"", json);
+        Assert.Contains("\"text\":\"\"", json);
+        Assert.DoesNotContain("UnknownEvent", json);
+        Assert.DoesNotContain("Content", json);
+    }
 }

--- a/src/Ivy.Tendril.Agents/Runtime/JsonEventSerializer.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/JsonEventSerializer.cs
@@ -178,7 +178,7 @@ public sealed class JsonEventSerializer : IEventSerializer
             _ => new TextWire
             {
                 Timestamp = ts,
-                Text = evt.ToString() ?? "",
+                Text = "",
             },
         };
     }

--- a/src/Ivy.Tendril/Services/Promptware/PromptwareRunner.cs
+++ b/src/Ivy.Tendril/Services/Promptware/PromptwareRunner.cs
@@ -196,6 +196,8 @@ private readonly IConfigService _configService;
                 {
                     foreach (var evt in parser.ParseLine(e.Data))
                     {
+                        if (evt is SystemEvent or UnknownEvent or StderrEvent)
+                            continue;
                         var serialized = serializer.Serialize(evt);
                         stream.Write(serialized);
                     }

--- a/src/Ivy.Tendril/Services/Promptware/PromptwareRunner.cs
+++ b/src/Ivy.Tendril/Services/Promptware/PromptwareRunner.cs
@@ -55,7 +55,7 @@ public interface IPromptwareRunner
 
 public class PromptwareRunner : IPromptwareRunner
 {
-private readonly IConfigService _configService;
+    private readonly IConfigService _configService;
     private readonly IAgentRunner _agentRunner;
     private readonly ILogger<PromptwareRunner> _logger;
 


### PR DESCRIPTION
# Summary

## Changes

Fixed EventWire serialization to prevent internal agent lifecycle events (SystemEvent, UnknownEvent, StderrEvent) from appearing as garbled record metadata in the UI. Added filtering in PromptwareRunner to skip these event types, and changed JsonEventSerializer's default fallback to return empty text instead of calling ToString().

## API Changes

- `PromptwareRunner.PipeOutputAndLog` now filters `SystemEvent`, `UnknownEvent`, and `StderrEvent` before serialization
- `JsonEventSerializer.ToWire()` default case now returns empty `TextWire` instead of `evt.ToString()`

## Files Modified

**Core Implementation:**
- `src/Ivy.Tendril/Services/Promptware/PromptwareRunner.cs` — Added filtering for internal event types
- `src/Ivy.Tendril.Agents/Runtime/JsonEventSerializer.cs` — Changed default fallback to empty text

**Tests:**
- `src/Ivy.Tendril.Agents.Test/Runtime/JsonEventSerializerTests.cs` — Added tests for SystemEvent and UnknownEvent serialization

---

## Commits

- Fix indentation from dotnet format (a7ea6e3)
- Fix EventWire serialization of SystemEvent and UnknownEvent (08c77c9)