### PR TITLE
[00082] MoveRevisionFromHeaderToDetailsTab

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -145,7 +145,6 @@ public class ContentView(
 
         var header = Layout.Horizontal().Width(Size.Full()).Height(Size.Px(40)).Gap(2)
                      | Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis);
-        header |= Text.Muted($"rev:{selectedPlan.RevisionCount}");
 
         if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
             header |= new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -12,6 +12,7 @@ public class DetailsTabView(PlanFile plan, List<JobItem> jobs, Action<string> sh
         var detailsData = new
         {
             plan.InitialPrompt,
+            Revision = plan.RevisionCount.ToString(),
             Profile = planYaml?.ExecutionProfile ?? "",
             RelatedPlans = FormatPlanLinks(plan.RelatedPlans),
             DependsOn = FormatPlanLinks(plan.DependsOn),


### PR DESCRIPTION
# Summary

## Changes

Moved the revision count display from the header bar to the Details tab. The revision now appears as a dedicated "Revision" field below "Initial Prompt" in the plan details panel, improving the visual hierarchy and grouping related metadata together.

## API Changes

None.

## Files Modified

- **Apps/Views/Tabs/DetailsTabView.cs** — Added `Revision` property to details data object
- **Apps/Drafts/ContentView.cs** — Removed `rev:{count}` display from header

---

## Commits

- 628cfbf Move revision count from header to Details tab