### PR TITLE
feat: show all jobs in plan details tab, including cleared ones

### DIFF
--- a/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
+++ b/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
@@ -133,6 +133,11 @@ public class UseStartJobTests
             return new List<JobItem>();
         }
 
+        public List<JobItem> GetJobsForPlan(string planFile)
+        {
+            return new List<JobItem>();
+        }
+
         public bool IsInboxFileTracked(string filePath)
         {
             return false;

--- a/src/Ivy.Tendril.Test/InboxControllerTests.cs
+++ b/src/Ivy.Tendril.Test/InboxControllerTests.cs
@@ -114,6 +114,11 @@ public class InboxControllerTests
             return new List<JobItem>();
         }
 
+        public List<JobItem> GetJobsForPlan(string planFile)
+        {
+            return new List<JobItem>();
+        }
+
         public JobItem? GetJob(string id)
         {
             return null;

--- a/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
@@ -231,6 +231,7 @@ public class InboxWatcherServiceTests : IDisposable
         public void ClearFailedJobs() { }
         public void ClearAllJobs() { }
         public List<JobItem> GetJobs() => new();
+        public List<JobItem> GetJobsForPlan(string planFile) => new();
         public JobItem? GetJob(string id) => null;
         public void Dispose() { }
 
@@ -377,6 +378,7 @@ public class InboxWatcherServiceTests : IDisposable
         public void ClearFailedJobs() { }
         public void ClearAllJobs() { }
         public List<JobItem> GetJobs() => new();
+        public List<JobItem> GetJobsForPlan(string planFile) => new();
         public JobItem? GetJob(string id) => null;
         public void Dispose() { }
 
@@ -409,6 +411,7 @@ public class InboxWatcherServiceTests : IDisposable
         public void ClearFailedJobs() { }
         public void ClearAllJobs() { }
         public List<JobItem> GetJobs() => new();
+        public List<JobItem> GetJobsForPlan(string planFile) => new();
         public JobItem? GetJob(string id) => null;
         public void Dispose() { }
 

--- a/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
@@ -48,7 +48,7 @@ public class JobServiceDeletionTests
     }
 
     [Fact]
-    public void ClearCompletedJobs_DeletesFromMemoryAndDatabase()
+    public void ClearCompletedJobs_RemovesFromMemoryButNotDatabase()
     {
         var db = new FakeDatabaseService();
         var service = CreateService(db);
@@ -61,13 +61,11 @@ public class JobServiceDeletionTests
         Assert.Null(service.GetJob("completed-1"));
         Assert.Null(service.GetJob("completed-2"));
         Assert.NotNull(service.GetJob("running-1"));
-        Assert.Contains("completed-1", db.DeletedJobIds);
-        Assert.Contains("completed-2", db.DeletedJobIds);
-        Assert.DoesNotContain("running-1", db.DeletedJobIds);
+        Assert.Empty(db.DeletedJobIds);
     }
 
     [Fact]
-    public void ClearFailedJobs_DeletesFromMemoryAndDatabase()
+    public void ClearFailedJobs_RemovesFromMemoryButNotDatabase()
     {
         var db = new FakeDatabaseService();
         var service = CreateService(db);
@@ -82,10 +80,7 @@ public class JobServiceDeletionTests
         Assert.Null(service.GetJob("timeout-1"));
         Assert.NotNull(service.GetJob("blocked-1"));
         Assert.NotNull(service.GetJob("completed-1"));
-        Assert.Contains("failed-1", db.DeletedJobIds);
-        Assert.Contains("timeout-1", db.DeletedJobIds);
-        Assert.DoesNotContain("blocked-1", db.DeletedJobIds);
-        Assert.DoesNotContain("completed-1", db.DeletedJobIds);
+        Assert.Empty(db.DeletedJobIds);
     }
 
     [Fact]
@@ -218,6 +213,11 @@ public class JobServiceDeletionTests
         }
 
         public List<JobItem> GetRecentJobs(int limit = 100)
+        {
+            return new List<JobItem>();
+        }
+
+        public List<JobItem> GetJobsForPlan(string planFile)
         {
             return new List<JobItem>();
         }

--- a/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
@@ -81,6 +81,11 @@ public class JobServiceStartupTests
             return Jobs;
         }
 
+        public List<JobItem> GetJobsForPlan(string planFile)
+        {
+            return Jobs.Where(j => j.PlanFile == planFile).ToList();
+        }
+
         public void DeleteJob(string id)
         {
         }

--- a/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -199,6 +199,11 @@ public class TendrilProcessStatusServiceTests : IDisposable
             return _jobs;
         }
 
+        public List<JobItem> GetJobsForPlan(string planFile)
+        {
+            return _jobs.Where(j => j.PlanFile == planFile).ToList();
+        }
+
         public JobItem? GetJob(string id)
         {
             return _jobs.FirstOrDefault(j => j.Id == id);

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -199,7 +199,7 @@ public class ContentView(
             var tabs = Layout.Tabs(
                 new Tab("Plan", Cap(planTabContent)),
                 new Tab("Details", Cap(new DetailsTabView(selectedPlan!,
-                    jobService.GetJobs().Where(j => j.PlanFile == selectedPlan!.FolderName).ToList(),
+                    jobService.GetJobsForPlan(selectedPlan!.FolderName),
                     showDebugJob)))
             ).OnSelect(v => selectedTab.Set(v)).SelectedIndex(selectedTab.Value).Variant(TabsVariant.Content).RemoveParentPadding();
 

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -544,7 +544,7 @@ public class ContentView(
                 new Tab("Summary", Cap(new SummaryTabView(planData.SummaryMarkdown, planContentQuery.Loading))),
                 new Tab("Plan", Cap(planTabContent)),
                 new Tab("Details", Cap(new DetailsTabView(selectedPlan,
-                    jobService.GetJobs().Where(j => j.PlanFile == selectedPlan.FolderName).ToList(),
+                    jobService.GetJobsForPlan(selectedPlan.FolderName),
                     showDebugJob))),
                 new Tab("Verifications", Cap(new VerificationsTabView(
                     selectedPlan.Verifications, planData.VerificationReports,

--- a/src/Ivy.Tendril/Database/Migrations/Migration_012_JobsPlanFileIndex.cs
+++ b/src/Ivy.Tendril/Database/Migrations/Migration_012_JobsPlanFileIndex.cs
@@ -1,0 +1,20 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Database.Migrations;
+
+public class Migration_012_JobsPlanFileIndex : IMigration
+{
+    public int Version => 12;
+    public string Description => "Add index on Jobs.PlanFile for plan-specific queries";
+
+    public void Apply(SqliteConnection connection, ILogger? logger = null)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            CREATE INDEX IF NOT EXISTS idx_jobs_planfile ON Jobs(PlanFile);
+            PRAGMA user_version = 12;
+            """;
+        cmd.ExecuteNonQuery();
+    }
+}

--- a/src/Ivy.Tendril/Services/Jobs/IJobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/IJobService.cs
@@ -18,6 +18,7 @@ public interface IJobService : IDisposable
     void ClearFailedJobs();
     void ClearAllJobs();
     List<JobItem> GetJobs();
+    List<JobItem> GetJobsForPlan(string planFile);
     JobItem? GetJob(string id);
     bool IsInboxFileTracked(string filePath);
 }

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -278,7 +278,6 @@ public class JobService : IJobService
         {
             if (_jobs.TryRemove(id, out var removed))
                 removed.DisposeResources(_logger);
-            try { _database?.DeleteJob(id); } catch { /* Best-effort */ }
         }
         if (ids.Count > 0)
             RaiseJobsStructureChanged();
@@ -292,6 +291,22 @@ public class JobService : IJobService
     public JobItem? GetJob(string id)
     {
         return _jobs.GetValueOrDefault(id);
+    }
+
+    public List<JobItem> GetJobsForPlan(string planFile)
+    {
+        var activeJobs = _jobs.Values
+            .Where(j => j.PlanFile == planFile)
+            .ToDictionary(j => j.Id);
+
+        var dbJobs = _database?.GetJobsForPlan(planFile) ?? [];
+
+        foreach (var dbJob in dbJobs)
+            activeJobs.TryAdd(dbJob.Id, dbJob);
+
+        return activeJobs.Values
+            .OrderByDescending(j => j.StartedAt ?? DateTime.MinValue)
+            .ToList();
     }
 
     /// <summary>

--- a/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
@@ -46,6 +46,7 @@ public interface IPlanDatabaseService : IDisposable
     // Jobs
     void UpsertJob(JobItem job);
     List<JobItem> GetRecentJobs(int limit = 100);
+    List<JobItem> GetJobsForPlan(string planFile);
     void PurgeOldJobs(int keepCount = 500);
     void DeleteJob(string id);
 

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -673,41 +673,56 @@ public class PlanDatabaseService : IPlanDatabaseService
         using (new ReadLockHandle(_lock))
         {
             return ReadList("SELECT * FROM Jobs ORDER BY CompletedAt DESC LIMIT @limit",
-                reader => new JobItem
-                {
-                    Id = reader.GetString(reader.GetOrdinal("Id")),
-                    Type = reader.GetString(reader.GetOrdinal("Type")),
-                    PlanFile = reader.GetString(reader.GetOrdinal("PlanFile")),
-                    Project = reader.GetString(reader.GetOrdinal("Project")),
-                    Status = Enum.Parse<JobStatus>(reader.GetString(reader.GetOrdinal("Status"))),
-                    Provider = reader.GetString(reader.GetOrdinal("Provider")),
-                    SessionId = reader.IsDBNull(reader.GetOrdinal("SessionId"))
-                        ? null
-                        : reader.GetString(reader.GetOrdinal("SessionId")),
-                    StartedAt = reader.IsDBNull(reader.GetOrdinal("StartedAt"))
-                        ? null
-                        : DateTime.Parse(reader.GetString(reader.GetOrdinal("StartedAt")), CultureInfo.InvariantCulture,
-                            DateTimeStyles.RoundtripKind),
-                    CompletedAt = reader.IsDBNull(reader.GetOrdinal("CompletedAt"))
-                        ? null
-                        : DateTime.Parse(reader.GetString(reader.GetOrdinal("CompletedAt")),
-                            CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
-                    DurationSeconds = reader.IsDBNull(reader.GetOrdinal("DurationSeconds"))
-                        ? null
-                        : reader.GetInt32(reader.GetOrdinal("DurationSeconds")),
-                    Cost = reader.IsDBNull(reader.GetOrdinal("Cost"))
-                        ? null
-                        : (decimal)reader.GetDouble(reader.GetOrdinal("Cost")),
-                    Tokens = reader.IsDBNull(reader.GetOrdinal("Tokens"))
-                        ? null
-                        : reader.GetInt32(reader.GetOrdinal("Tokens")),
-                    StatusMessage = reader.IsDBNull(reader.GetOrdinal("StatusMessage"))
-                        ? null
-                        : reader.GetString(reader.GetOrdinal("StatusMessage")),
-                    TypedArgs = ReadTypedArgs(reader)
-                },
+                MapJobRow,
                 new SqliteParameter("@limit", limit));
         }
+    }
+
+    public List<JobItem> GetJobsForPlan(string planFile)
+    {
+        using (new ReadLockHandle(_lock))
+        {
+            return ReadList("SELECT * FROM Jobs WHERE PlanFile = @planFile ORDER BY CompletedAt DESC",
+                MapJobRow,
+                new SqliteParameter("@planFile", planFile));
+        }
+    }
+
+    private JobItem MapJobRow(SqliteDataReader reader)
+    {
+        return new JobItem
+        {
+            Id = reader.GetString(reader.GetOrdinal("Id")),
+            Type = reader.GetString(reader.GetOrdinal("Type")),
+            PlanFile = reader.GetString(reader.GetOrdinal("PlanFile")),
+            Project = reader.GetString(reader.GetOrdinal("Project")),
+            Status = Enum.Parse<JobStatus>(reader.GetString(reader.GetOrdinal("Status"))),
+            Provider = reader.GetString(reader.GetOrdinal("Provider")),
+            SessionId = reader.IsDBNull(reader.GetOrdinal("SessionId"))
+                ? null
+                : reader.GetString(reader.GetOrdinal("SessionId")),
+            StartedAt = reader.IsDBNull(reader.GetOrdinal("StartedAt"))
+                ? null
+                : DateTime.Parse(reader.GetString(reader.GetOrdinal("StartedAt")), CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind),
+            CompletedAt = reader.IsDBNull(reader.GetOrdinal("CompletedAt"))
+                ? null
+                : DateTime.Parse(reader.GetString(reader.GetOrdinal("CompletedAt")),
+                    CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
+            DurationSeconds = reader.IsDBNull(reader.GetOrdinal("DurationSeconds"))
+                ? null
+                : reader.GetInt32(reader.GetOrdinal("DurationSeconds")),
+            Cost = reader.IsDBNull(reader.GetOrdinal("Cost"))
+                ? null
+                : (decimal)reader.GetDouble(reader.GetOrdinal("Cost")),
+            Tokens = reader.IsDBNull(reader.GetOrdinal("Tokens"))
+                ? null
+                : reader.GetInt32(reader.GetOrdinal("Tokens")),
+            StatusMessage = reader.IsDBNull(reader.GetOrdinal("StatusMessage"))
+                ? null
+                : reader.GetString(reader.GetOrdinal("StatusMessage")),
+            TypedArgs = ReadTypedArgs(reader)
+        };
     }
 
     public void PurgeOldJobs(int keepCount = 500)


### PR DESCRIPTION
## Summary
- Clearing jobs from the Jobs UI now only removes them from in-memory dictionary, preserving the SQLite record
- Added `GetJobsForPlan` method that merges active in-memory jobs with historical DB jobs
- Details tab in both Review and Drafts views now shows full job history for a plan
- Added Migration 012 for `idx_jobs_planfile` index

## Test plan
- [x] All 1294 tests pass (`dotnet test`)
- [x] Clear tests updated to verify DB records are preserved
- [x] Build succeeds with no warnings