### PR TITLE
Fix PowerShell onboarding detection and surface detailed error logs

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -304,6 +304,64 @@ jobs:
           fi
           echo "PowerShell bundled successfully!"
 
+      - name: Bundle .NET 10 SDK
+        shell: bash
+        run: |
+          DOTNET_VERSION="10.0.100"
+          RID="${{ matrix.rid }}"
+          PUBLISH_DIR="./publish/desktop/$RID"
+          TARGET_DIR="$PUBLISH_DIR/dotnet"
+          mkdir -p "$TARGET_DIR"
+          
+          echo "Bundling .NET $DOTNET_VERSION for $RID into $TARGET_DIR..."
+          
+          if [[ "$RID" == win-x64 ]]; then
+            URL="https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_VERSION/dotnet-sdk-$DOTNET_VERSION-win-x64.zip"
+            curl -L -o dotnet.zip "$URL"
+            unzip -q dotnet.zip -d "$TARGET_DIR"
+            rm dotnet.zip
+          elif [[ "$RID" == win-arm64 ]]; then
+            URL="https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_VERSION/dotnet-sdk-$DOTNET_VERSION-win-arm64.zip"
+            curl -L -o dotnet.zip "$URL"
+            unzip -q dotnet.zip -d "$TARGET_DIR"
+            rm dotnet.zip
+          elif [[ "$RID" == osx-x64 ]]; then
+            URL="https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_VERSION/dotnet-sdk-$DOTNET_VERSION-osx-x64.tar.gz"
+            curl -L -o dotnet.tar.gz "$URL"
+            tar -xzf dotnet.tar.gz -C "$TARGET_DIR"
+            rm dotnet.tar.gz
+          elif [[ "$RID" == osx-arm64 ]]; then
+            URL="https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_VERSION/dotnet-sdk-$DOTNET_VERSION-osx-arm64.tar.gz"
+            curl -L -o dotnet.tar.gz "$URL"
+            tar -xzf dotnet.tar.gz -C "$TARGET_DIR"
+            rm dotnet.tar.gz
+          elif [[ "$RID" == linux-x64 ]]; then
+            URL="https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_VERSION/dotnet-sdk-$DOTNET_VERSION-linux-x64.tar.gz"
+            curl -L -o dotnet.tar.gz "$URL"
+            tar -xzf dotnet.tar.gz -C "$TARGET_DIR"
+            rm dotnet.tar.gz
+          elif [[ "$RID" == linux-arm64 ]]; then
+            URL="https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_VERSION/dotnet-sdk-$DOTNET_VERSION-linux-arm64.tar.gz"
+            curl -L -o dotnet.tar.gz "$URL"
+            tar -xzf dotnet.tar.gz -C "$TARGET_DIR"
+            rm dotnet.tar.gz
+          fi
+          
+          # Verify dotnet executable exists and is executable
+          if [[ "$RID" == win-* ]]; then
+            if [[ ! -f "$TARGET_DIR/dotnet.exe" ]]; then
+              echo "Error: dotnet.exe not found after extraction!"
+              exit 1
+            fi
+          else
+            if [[ ! -f "$TARGET_DIR/dotnet" ]]; then
+              echo "Error: dotnet not found after extraction!"
+              exit 1
+            fi
+            chmod +x "$TARGET_DIR/dotnet"
+          fi
+          echo ".NET SDK bundled successfully!"
+
       - name: Pack Installer (Velopack)
         run: |
           export PATH="$PATH:$HOME/.dotnet/tools"

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -260,10 +260,20 @@ public class CodingAgentStepView(
                 return success;
             });
 
+        SoftwareCheck? dotnetCheck = null;
+        dotnetCheck = new SoftwareCheck(".NET 10 SDK", "dotnet", "https://dotnet.microsoft.com/download/dotnet/10.0", true,
+            async () =>
+            {
+                var (success, error) = await ProcessCheckHelper.TryCheckCommand(PathHelper.GetDotnetPath(), "--version");
+                if (dotnetCheck != null) dotnetCheck.LastError = error;
+                return success;
+            });
+
         return
         [
             gitCheck,
             pwshCheck,
+            dotnetCheck,
             BuildAgentCheck(runner, agentKey)
         ];
     }

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -29,6 +29,7 @@ internal class InstallMissingDialog(
             new DialogBody(
                 Text.Markdown(
                     $"Tendril needs **{check.Name}** but it isn't installed.\n\n" +
+                    (string.IsNullOrEmpty(check.LastError) ? "" : $"**Error details:**\n`{check.LastError}`\n\n") +
                     $"Click **Install** to open the install page, then click **OK** once you've installed it.")),
             new DialogFooter(
                 new Button("Cancel")
@@ -239,21 +240,46 @@ public class CodingAgentStepView(
                | grid;
     }
 
-    private static List<SoftwareCheck> BuildChecks(IAgentRunner runner, string agentKey) =>
-    [
-        new("Git", "git", "https://git-scm.com/downloads", true,
-            () => ProcessCheckHelper.CheckCommand("git", "--version")),
-        new("PowerShell", "powershell", "https://github.com/PowerShell/PowerShell", true,
-            ProcessCheckHelper.CheckPowerShell),
-        BuildAgentCheck(runner, agentKey)
-    ];
+    private static List<SoftwareCheck> BuildChecks(IAgentRunner runner, string agentKey)
+    {
+        SoftwareCheck? gitCheck = null;
+        gitCheck = new SoftwareCheck("Git", "git", "https://git-scm.com/downloads", true,
+            async () =>
+            {
+                var (success, error) = await ProcessCheckHelper.TryCheckCommand("git", "--version");
+                if (gitCheck != null) gitCheck.LastError = error;
+                return success;
+            });
+
+        SoftwareCheck? pwshCheck = null;
+        pwshCheck = new SoftwareCheck("PowerShell", "powershell", "https://github.com/PowerShell/PowerShell", true,
+            async () =>
+            {
+                var (success, error) = await ProcessCheckHelper.CheckPowerShellWithDetails();
+                if (pwshCheck != null) pwshCheck.LastError = error;
+                return success;
+            });
+
+        return
+        [
+            gitCheck,
+            pwshCheck,
+            BuildAgentCheck(runner, agentKey)
+        ];
+    }
 
     private static SoftwareCheck BuildAgentCheck(IAgentRunner runner, string agentKey)
     {
         var healthCheck = runner.GetHealthCheck(agentKey);
         var info = healthCheck.GetOnboardingInfo();
-        return new SoftwareCheck(info.DisplayName, agentKey, info.InstallUrl ?? "", true,
-            async () => (await healthCheck.CheckInstallAsync()).IsInstalled,
+        SoftwareCheck? agentCheck = null;
+        agentCheck = new SoftwareCheck(info.DisplayName, agentKey, info.InstallUrl ?? "", true,
+            async () =>
+            {
+                var status = await healthCheck.CheckInstallAsync();
+                if (agentCheck != null) agentCheck.LastError = status.Error;
+                return status.IsInstalled;
+            },
             async () =>
             {
                 var result = await healthCheck.CheckAuthAsync();
@@ -262,6 +288,7 @@ public class CodingAgentStepView(
                     : HealthCheckStatus.NotAuthenticated;
             },
             info.SignInHint);
+        return agentCheck;
     }
 
 }

--- a/src/Ivy.Tendril/Apps/Onboarding/Models/SoftwareCheck.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/Models/SoftwareCheck.cs
@@ -9,4 +9,7 @@ public record SoftwareCheck(
     bool IsRequired,
     Func<Task<bool>> InstallCheck,
     Func<Task<HealthCheckStatus>>? HealthCheck = null,
-    string? HealthHint = null);
+    string? HealthHint = null)
+{
+    public string? LastError { get; set; }
+}

--- a/src/Ivy.Tendril/Commands/DoctorChecks/SoftwareCheck.cs
+++ b/src/Ivy.Tendril/Commands/DoctorChecks/SoftwareCheck.cs
@@ -100,20 +100,19 @@ internal class SoftwareCheck : IDoctorCheck
 
     private static async Task<bool> CheckPowerShell(List<CheckStatus> statuses)
     {
-        var pwshPath = PathHelper.GetPwshPath();
-        var pwshInstalled = await ProcessCheckHelper.CheckCommand(pwshPath, "-Version");
-        if (pwshInstalled)
+        var bundledPath = PathHelper.GetPwshPath();
+        var (success, error) = await ProcessCheckHelper.CheckPowerShellWithDetails();
+        if (success)
         {
-            var isBundled = pwshPath != "pwsh";
+            // Determine if the working PowerShell is the bundled one
+            var isBundled = bundledPath != "pwsh" && await ProcessCheckHelper.CheckCommand(bundledPath, "-Version");
             statuses.Add(new CheckStatus("powershell", isBundled ? "OK (bundled pwsh)" : "OK (pwsh)", StatusKind.Ok));
             return false;
         }
 
-        var legacyInstalled = await ProcessCheckHelper.CheckCommand("powershell", "-Version");
-        statuses.Add(legacyInstalled
-            ? new CheckStatus("powershell", "OK (powershell)", StatusKind.Ok)
-            : new CheckStatus("powershell", "Not found", StatusKind.Error));
-        return !legacyInstalled;
+        var errorMessage = $"Not found or failed to execute. Details: {error}";
+        statuses.Add(new CheckStatus("powershell", errorMessage, StatusKind.Error));
+        return true;
     }
 
     private string[] GetAgentIds()

--- a/src/Ivy.Tendril/Commands/DoctorChecks/SoftwareCheck.cs
+++ b/src/Ivy.Tendril/Commands/DoctorChecks/SoftwareCheck.cs
@@ -27,8 +27,9 @@ internal class SoftwareCheck : IDoctorCheck
         var reqErrors = await CheckRequiredSoftware(statuses);
         var agentErrors = await CheckAgentClis(statuses);
         var pwshErrors = await CheckPowerShell(statuses);
+        var dotnetErrors = await CheckDotNet(statuses);
 
-        return new CheckResult(reqErrors || agentErrors || pwshErrors, statuses);
+        return new CheckResult(reqErrors || agentErrors || pwshErrors || dotnetErrors, statuses);
     }
 
     private static async Task<bool> CheckRequiredSoftware(List<CheckStatus> statuses)
@@ -112,6 +113,34 @@ internal class SoftwareCheck : IDoctorCheck
 
         var errorMessage = $"Not found or failed to execute. Details: {error}";
         statuses.Add(new CheckStatus("powershell", errorMessage, StatusKind.Error));
+        return true;
+    }
+
+    private static async Task<bool> CheckDotNet(List<CheckStatus> statuses)
+    {
+        var bundledPath = PathHelper.GetBundledDotnetPath();
+        
+        // Try bundled first if it exists
+        if (bundledPath != null)
+        {
+            var (success, err) = await ProcessCheckHelper.TryCheckCommand(bundledPath, "--version");
+            if (success)
+            {
+                statuses.Add(new CheckStatus("dotnet", "OK (bundled dotnet)", StatusKind.Ok));
+                return false;
+            }
+        }
+        
+        // Try system dotnet next
+        var (sysSuccess, sysErr) = await ProcessCheckHelper.TryCheckCommand("dotnet", "--version");
+        if (sysSuccess)
+        {
+            statuses.Add(new CheckStatus("dotnet", "OK (dotnet)", StatusKind.Ok));
+            return false;
+        }
+        
+        var details = bundledPath != null ? $"bundled: {bundledPath} failed, system: {sysErr}" : sysErr;
+        statuses.Add(new CheckStatus("dotnet", $"Not found or failed to execute. Details: {details}", StatusKind.Error));
         return true;
     }
 

--- a/src/Ivy.Tendril/Helpers/PathHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PathHelper.cs
@@ -40,9 +40,63 @@ public static class PathHelper
         var bundled = Path.Combine(System.AppContext.BaseDirectory, "PowerShell", OperatingSystem.IsWindows() ? "pwsh.exe" : "pwsh");
         if (File.Exists(bundled))
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                try
+                {
+                    var mode = File.GetUnixFileMode(bundled);
+                    if (!mode.HasFlag(UnixFileMode.UserExecute))
+                    {
+                        File.SetUnixFileMode(bundled, mode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+                    }
+                }
+                catch
+                {
+                    // Best-effort permission repair
+                }
+            }
             return bundled;
         }
         return "pwsh";
+    }
+
+    public static void AugmentPath()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var pathVar = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var separator = ':';
+        var dirs = new HashSet<string>(pathVar.Split(separator, StringSplitOptions.RemoveEmptyEntries));
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var commonDirs = new[]
+        {
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+            "/usr/local/bin",
+            "/usr/local/sbin",
+            Path.Combine(home, ".dotnet", "tools"),
+            Path.Combine(home, ".npm-global", "bin"),
+            Path.Combine(home, ".local", "bin")
+        };
+
+        var added = false;
+        var pathList = new List<string>(dirs);
+
+        foreach (var dir in commonDirs)
+        {
+            if (Directory.Exists(dir) && !dirs.Contains(dir))
+            {
+                pathList.Add(dir);
+                added = true;
+            }
+        }
+
+        if (added)
+        {
+            var newPath = string.Join(separator, pathList);
+            Environment.SetEnvironmentVariable("PATH", newPath);
+        }
     }
 
     public static string ResolvePath(string raw)

--- a/src/Ivy.Tendril/Helpers/PathHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PathHelper.cs
@@ -60,41 +60,102 @@ public static class PathHelper
         return "pwsh";
     }
 
+    public static string? GetBundledDotnetPath()
+    {
+        var dir = Path.Combine(System.AppContext.BaseDirectory, "dotnet");
+        var exe = Path.Combine(dir, OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet");
+        if (File.Exists(exe))
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                try
+                {
+                    var mode = File.GetUnixFileMode(exe);
+                    if (!mode.HasFlag(UnixFileMode.UserExecute))
+                    {
+                        File.SetUnixFileMode(exe, mode | UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+                    }
+                }
+                catch
+                {
+                    // Best-effort permission repair
+                }
+            }
+            return exe;
+        }
+        return null;
+    }
+
+    public static string GetDotnetPath()
+    {
+        return GetBundledDotnetPath() ?? "dotnet";
+    }
+
     public static void AugmentPath()
     {
-        if (OperatingSystem.IsWindows()) return;
-
         var pathVar = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-        var separator = ':';
-        var dirs = new HashSet<string>(pathVar.Split(separator, StringSplitOptions.RemoveEmptyEntries));
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        var dirs = new HashSet<string>(pathVar.Split(separator, StringSplitOptions.RemoveEmptyEntries),
+            OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
 
-        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var commonDirs = new[]
+        var pathList = new List<string>();
+
+        // 1. Prepend bundled tools directories to prioritize them
+        var baseDir = System.AppContext.BaseDirectory;
+        var bundledDotnetDir = Path.Combine(baseDir, "dotnet");
+        if (Directory.Exists(bundledDotnetDir))
         {
-            "/opt/homebrew/bin",
-            "/opt/homebrew/sbin",
-            "/usr/local/bin",
-            "/usr/local/sbin",
-            Path.Combine(home, ".dotnet", "tools"),
-            Path.Combine(home, ".npm-global", "bin"),
-            Path.Combine(home, ".local", "bin")
-        };
-
-        var added = false;
-        var pathList = new List<string>(dirs);
-
-        foreach (var dir in commonDirs)
-        {
-            if (Directory.Exists(dir) && !dirs.Contains(dir))
+            // Verify and auto-repair permissions on Unix
+            _ = GetBundledDotnetPath();
+            
+            if (!dirs.Contains(bundledDotnetDir))
             {
-                pathList.Add(dir);
-                added = true;
+                pathList.Add(bundledDotnetDir);
             }
         }
 
-        if (added)
+        var bundledPwshDir = Path.Combine(baseDir, "PowerShell");
+        if (Directory.Exists(bundledPwshDir))
         {
-            var newPath = string.Join(separator, pathList);
+            // Verify and auto-repair permissions on Unix
+            _ = GetPwshPath();
+            
+            if (!dirs.Contains(bundledPwshDir))
+            {
+                pathList.Add(bundledPwshDir);
+            }
+        }
+
+        // 2. Add existing PATH directories
+        pathList.AddRange(dirs);
+
+        // 3. For macOS/Linux, append common system search paths
+        if (!OperatingSystem.IsWindows())
+        {
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var commonDirs = new[]
+            {
+                "/opt/homebrew/bin",
+                "/opt/homebrew/sbin",
+                "/usr/local/bin",
+                "/usr/local/sbin",
+                Path.Combine(home, ".dotnet", "tools"),
+                Path.Combine(home, ".npm-global", "bin"),
+                Path.Combine(home, ".local", "bin")
+            };
+
+            foreach (var dir in commonDirs)
+            {
+                if (Directory.Exists(dir) && !dirs.Contains(dir) && !pathList.Contains(dir))
+                {
+                    pathList.Add(dir);
+                }
+            }
+        }
+
+        var newPath = string.Join(separator, pathList);
+        if (newPath != pathVar)
+        {
             Environment.SetEnvironmentVariable("PATH", newPath);
         }
     }

--- a/src/Ivy.Tendril/Helpers/ProcessCheckHelper.cs
+++ b/src/Ivy.Tendril/Helpers/ProcessCheckHelper.cs
@@ -59,8 +59,72 @@ public static class ProcessCheckHelper
         }
     }
 
+    public static async Task<(bool Success, string? Error)> TryCheckCommand(string fileName, string arguments, int timeoutMs = 10_000)
+    {
+        try
+        {
+            return await Task.Run(async () =>
+            {
+                var psi = MakeStartInfo(fileName, arguments);
+                var proc = Process.Start(psi);
+                if (proc is null) return (false, "Failed to start process.");
+                var outTask = proc.StandardOutput.ReadToEndAsync();
+                var errTask = proc.StandardError.ReadToEndAsync();
+                
+                var exited = proc.WaitForExitOrKill(timeoutMs);
+                if (!exited)
+                {
+                    return (false, $"Process timed out after {timeoutMs}ms.");
+                }
+                
+                var stdout = await outTask;
+                var stderr = await errTask;
+                
+                if (proc.ExitCode == 0)
+                {
+                    return (true, (string?)null);
+                }
+                
+                var errorMsg = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+                var details = string.IsNullOrWhiteSpace(errorMsg) ? $"Exit code {proc.ExitCode}" : $"Exit code {proc.ExitCode}: {errorMsg.Trim()}";
+                return (false, details);
+            });
+        }
+        catch (Exception ex)
+        {
+            return (false, ex.Message);
+        }
+    }
+
     public static async Task<bool> CheckPowerShell()
-        => await CheckCommand(PathHelper.GetPwshPath(), "-Version") || await CheckCommand("powershell", "-Version");
+    {
+        var (success, _) = await CheckPowerShellWithDetails();
+        return success;
+    }
+
+    public static async Task<(bool Success, string? Error)> CheckPowerShellWithDetails()
+    {
+        var errors = new List<string>();
+
+        var bundledPath = PathHelper.GetPwshPath();
+        var hasBundled = bundledPath != "pwsh";
+        if (hasBundled)
+        {
+            var (success, err) = await TryCheckCommand(bundledPath, "-Version");
+            if (success) return (true, null);
+            errors.Add($"bundled: {err ?? "unknown error"}");
+        }
+
+        var (pwshSuccess, pwshErr) = await TryCheckCommand("pwsh", "-Version");
+        if (pwshSuccess) return (true, null);
+        errors.Add($"system pwsh: {pwshErr ?? "unknown error"}");
+
+        var (legacySuccess, legacyErr) = await TryCheckCommand("powershell", "-Version");
+        if (legacySuccess) return (true, null);
+        errors.Add($"system powershell: {legacyErr ?? "unknown error"}");
+
+        return (false, string.Join("; ", errors));
+    }
 
     public static Task<HealthCheckStatus> CheckFileAuth(string filePath, long minSize = 1)
     {

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -41,6 +41,8 @@ public class Program
     [STAThread]
     public static async Task<int> Main(string[] args)
     {
+        PathHelper.AugmentPath();
+
         if (OperatingSystem.IsWindows())
         {
             try

--- a/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
@@ -226,7 +226,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
         try
         {
             logger?.LogInformation("Shutting down .NET build servers to release file locks");
-            var psi = new ProcessStartInfo("dotnet", "build-server shutdown")
+            var psi = new ProcessStartInfo(PathHelper.GetDotnetPath(), "build-server shutdown")
             {
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,


### PR DESCRIPTION
This PR fixes issues where users get stuck during onboarding on macOS/Linux due to missing PATH directories (such as Homebrew and Node paths), missing execute permissions on the bundled pwsh executable, and incorrect PowerShell Core fallback order. It also captures and displays detailed error logs in the onboarding UI on failure.