### PR TITLE
feat: add HTTP-based IPC with master election for CLI-server communication

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/00_Overview.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/00_Overview.md
@@ -78,6 +78,7 @@ Every command supports `--help` for detailed usage. For example: `tendril plan c
 | `TENDRIL_PLANS` | Override plans directory (defaults to `TENDRIL_HOME/Plans`) |
 | `TENDRIL_VERBOSE` | Enable verbose debug output (set to `1`) |
 | `TENDRIL_QUIET` | Suppress non-essential output (set to `1`) |
+| `TENDRIL_NOT_MASTER` | Run server without claiming master (set to `1`). Used for development/debugging — the instance won't accept CLI IPC or process inbox files. |
 
 ## Common Commands
 

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/05_Other.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/05_Other.md
@@ -52,13 +52,43 @@ Read and write files in a promptware's `Memory/` and `Tools/` directories. Used 
 
 ## job
 
+#### job start
+
+```terminal
+>tendril job start <job-type> <plan-id> [options]
+```
+
+Starts a job on the running Tendril server. Requires Tendril to be running (communicates via HTTP).
+
+| Job Type | Required Options | Optional |
+|----------|-----------------|----------|
+| `ExecutePlan` | `<plan-id>` | `--note` |
+| `UpdatePlan` | `<plan-id>`, `--instructions` | — |
+| `SplitPlan` | `<plan-id>` | — |
+| `ExpandPlan` | `<plan-id>` | — |
+| `CreateIssue` | `<plan-id>`, `--repo` | `--assignee`, `--comment`, `--labels` |
+| `CreatePr` | `<plan-id>` | `--no-merge`, `--no-delete-branch`, `--no-artifacts`, `--assignee`, `--comment`, `--draft` |
+| `RetryPlan` | `<plan-id>`, `--change-request` | — |
+| `CreatePlan` | `--description`, `--project` | `--priority`, `--force`, `--source-path` |
+
+```terminal
+>tendril job start ExecutePlan 00042
+>tendril job start RetryPlan 00042 --change-request "Fix the failing tests"
+>tendril job start CreatePlan --description "Add dark mode" --project MyProject
+```
+
+<Callout type="Info">
+The Tendril server must be running for this command to work. It discovers the server via the `.master` lock file in `TENDRIL_HOME`.
+
+</Callout>
+
 #### job status
 
 ```terminal
 >tendril job status <job-id> --message <text> [--plan-id <id>] [--plan-title <title>]
 ```
 
-Writes a status update file for a running job. Used internally by agents to report progress visible in the Tendril UI.
+Reports a status update to the running Tendril server for a job in progress. Used internally by agents to report progress visible in the Tendril UI.
 
 | Option | Effect |
 |--------|--------|

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/02_REST.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/02_REST.md
@@ -178,13 +178,49 @@ Content-Type: application/json
 
 Starts a `CreatePlan` job and returns the job ID.
 
-## Job Status
+## Jobs
 
-Job status is reported via the CLI (not the REST API). Promptware agents use the `tendril job status` command to update progress:
+### Start Job
 
-```bash
-tendril job status <job-id> --message "Running verifications..."
-tendril job status <job-id> --message "Planning..." --plan-id 01234 --plan-title "My Plan"
+```
+POST /api/jobs
+Content-Type: application/json
+
+{ "$type": "ExecutePlan", "folderPath": "D:\\TendrilHome\\Plans\\00042-fix-login" }
 ```
 
-The `<job-id>` is provided as the `TendrilJobId` firmware header in the agent's prompt.
+Starts a job and returns the job ID. The request body is a polymorphic `JobArgsBase` — the `$type` discriminator selects the job type.
+
+Available types: `CreatePlan`, `ExecutePlan`, `RetryPlan`, `ExpandPlan`, `UpdatePlan`, `SplitPlan`, `CreatePr`, `CreateIssue`.
+
+Response:
+```json
+{ "jobId": "00143", "status": "Started" }
+```
+
+### Get Job
+
+```
+GET /api/jobs/{jobId}
+```
+
+Returns the current status of a job.
+
+### Update Job Status
+
+```
+PUT /api/jobs/{jobId}/status
+Content-Type: application/json
+
+{ "message": "Running verifications...", "planId": "01234", "planTitle": "My Plan" }
+```
+
+Updates progress for a running job. Used by promptware agents via the `tendril job status` CLI command.
+
+### Health Check
+
+```
+GET /api/jobs/health
+```
+
+Returns `{ "status": "ok", "pid": 12345 }`. Used for master election validation.

--- a/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
@@ -146,29 +146,4 @@ projects:
         Assert.False(job.StaleOutputDetected);
     }
 
-    [Fact]
-    public async Task RunStatusFilePoller_ExitsWhenJobCompletes()
-    {
-        var job = new JobItem
-        {
-            Id = "test-1",
-            Type = "CreatePlan",
-            TypedArgs = new CreatePlanArgs("Test", "Auto"),
-            Project = "TestProject",
-            Status = JobStatus.Running,
-            StatusFilePath = Path.Combine(_tempTendrilHome, "status-test-1.json")
-        };
-        var jobs = new ConcurrentDictionary<string, JobItem>();
-        jobs[job.Id] = job;
-
-        var cts = new CancellationTokenSource();
-        var pollerTask = JobMonitor.RunStatusFilePoller(job.Id, cts, jobs);
-
-        job.Status = JobStatus.Completed;
-        await Task.Delay(TimeSpan.FromSeconds(2));
-
-        await pollerTask;
-
-        Assert.Equal(JobStatus.Completed, job.Status);
-    }
 }

--- a/src/Ivy.Tendril/AGENTS.md
+++ b/src/Ivy.Tendril/AGENTS.md
@@ -50,7 +50,7 @@ All paths derive from these sources:
 **What does NOT work in production:**
 - Setting process-specific env vars on the agent process and expecting nested `tendril` calls to read them (e.g., `TENDRIL_CLI_LOG`, `TENDRIL_JOB_ID`, `TENDRIL_SESSION_ID`)
 
-**CLI Logging:** The `--job-id <id>` global flag on `tendril` commands derives the CLI log path from `TENDRIL_HOME` (system-wide) + the job ID. The firmware template instructs agents to append `--job-id TendrilJobId` to all CLI commands. The `tendril job status` command also self-logs (derives the log path from its positional job ID argument). As a fallback for E2E tests, the `TENDRIL_CLI_LOG` env var still works.
+**CLI Logging:** The `--job-id <id>` global flag on `tendril` commands derives the CLI log path from `TENDRIL_HOME` (system-wide) + the job ID. The firmware template instructs agents to append `--job-id TendrilJobId` to all CLI commands. CLI invocations are logged to `TENDRIL_HOME/Jobs/{jobId}.cli.jsonl`. As a fallback for E2E tests, the `TENDRIL_CLI_LOG` env var still works.
 
 **Rule:** To pass information from Tendril to an agent and back through the CLI:
 1. Include it as a firmware header value (agent reads from prompt)
@@ -174,7 +174,7 @@ These are the primary debugging artifacts. The `.md` log tells you what the agen
 
 The Jobs table uses `DataTableCellUpdate` for live updates (Timer, Cost, Tokens, StatusMessage columns). A 1-second `Observable.Interval` emits cell updates via `UseDataTableUpdates` — this is how values change without a full table refresh.
 
-**Status messages flow:** Agent calls `tendril job status <TendrilJobId> --message "..."` → writes `{TENDRIL_HOME}/Jobs/{jobId}.status` → `JobMonitor.RunStatusFilePoller` reads it every 1s → sets `job.StatusMessage` → DataTable cell update picks it up on next tick.
+**Status messages flow:** Agent calls `tendril job status <TendrilJobId> --message "..."` → HTTP PUT to `localhost:{port}/api/jobs/{id}/status` → sets `job.StatusMessage` in memory → DataTable cell update picks it up on next tick.
 
 Do not trigger `RaiseStructureChanged` or full-table refreshes for individual cell value changes — the cell update stream already handles it.
 

--- a/src/Ivy.Tendril/Commands/JobStartCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStartCommand.cs
@@ -1,0 +1,175 @@
+using System.ComponentModel;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Microsoft.Extensions.Logging;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class JobStartSettings : CommandSettings
+{
+    [Description("Job type (ExecutePlan, UpdatePlan, SplitPlan, ExpandPlan, CreateIssue, CreatePr, RetryPlan, CreatePlan)")]
+    [CommandArgument(0, "<job-type>")]
+    public string JobType { get; set; } = "";
+
+    [Description("Plan ID (e.g., 00042). Not required for CreatePlan.")]
+    [CommandArgument(1, "[plan-id]")]
+    public string? PlanId { get; set; }
+
+    [Description("Note for ExecutePlan")]
+    [CommandOption("--note")]
+    public string? Note { get; set; }
+
+    [Description("Instructions for UpdatePlan (required)")]
+    [CommandOption("--instructions")]
+    public string? Instructions { get; set; }
+
+    [Description("Repository path for CreateIssue (required)")]
+    [CommandOption("--repo")]
+    public string? Repo { get; set; }
+
+    [Description("Assignee")]
+    [CommandOption("--assignee")]
+    public string? Assignee { get; set; }
+
+    [Description("Comment")]
+    [CommandOption("--comment")]
+    public string? Comment { get; set; }
+
+    [Description("Labels (comma-separated) for CreateIssue")]
+    [CommandOption("--labels")]
+    public string? Labels { get; set; }
+
+    [Description("Change request for RetryPlan (required)")]
+    [CommandOption("--change-request")]
+    public string? ChangeRequest { get; set; }
+
+    [Description("Description for CreatePlan (required)")]
+    [CommandOption("--description")]
+    public string? Description { get; set; }
+
+    [Description("Project for CreatePlan (required)")]
+    [CommandOption("--project")]
+    public string? Project { get; set; }
+
+    [Description("Priority for CreatePlan")]
+    [CommandOption("--priority")]
+    public int? Priority { get; set; }
+
+    [Description("Force for CreatePlan")]
+    [CommandOption("--force")]
+    public bool Force { get; set; }
+
+    [Description("Source path for CreatePlan")]
+    [CommandOption("--source-path")]
+    public string? SourcePath { get; set; }
+
+    [Description("Skip merge for CreatePr")]
+    [CommandOption("--no-merge")]
+    public bool NoMerge { get; set; }
+
+    [Description("Skip branch deletion for CreatePr")]
+    [CommandOption("--no-delete-branch")]
+    public bool NoDeleteBranch { get; set; }
+
+    [Description("Skip artifacts for CreatePr")]
+    [CommandOption("--no-artifacts")]
+    public bool NoArtifacts { get; set; }
+
+    [Description("Create as draft PR")]
+    [CommandOption("--draft")]
+    public bool Draft { get; set; }
+}
+
+public class JobStartCommand : Command<JobStartSettings>
+{
+    private readonly ILogger<JobStartCommand> _logger;
+
+    public JobStartCommand(ILogger<JobStartCommand> logger) => _logger = logger;
+
+    protected override int Execute(CommandContext context, JobStartSettings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var args = BuildJobArgs(settings);
+            var discovery = MasterClient.Discover();
+            var result = MasterClient.SubmitJob(discovery, args);
+
+            AnsiConsole.MarkupLine($"[green]Job started:[/] {result.JobId}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static JobArgsBase BuildJobArgs(JobStartSettings settings)
+    {
+        var jobType = settings.JobType;
+
+        if (string.Equals(jobType, Constants.JobTypes.CreatePlan, StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrEmpty(settings.Description))
+                throw new ArgumentException("--description is required for CreatePlan");
+            if (string.IsNullOrEmpty(settings.Project))
+                throw new ArgumentException("--project is required for CreatePlan");
+
+            return new CreatePlanArgs(
+                settings.Description,
+                settings.Project,
+                settings.Priority ?? 0,
+                settings.Force,
+                settings.SourcePath);
+        }
+
+        if (string.IsNullOrEmpty(settings.PlanId))
+            throw new ArgumentException($"<plan-id> is required for {jobType}");
+
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+
+        if (string.Equals(jobType, Constants.JobTypes.ExecutePlan, StringComparison.OrdinalIgnoreCase))
+            return new ExecutePlanArgs(planFolder, settings.Note);
+
+        if (string.Equals(jobType, Constants.JobTypes.UpdatePlan, StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrEmpty(settings.Instructions))
+                throw new ArgumentException("--instructions is required for UpdatePlan");
+            return new UpdatePlanArgs(planFolder, settings.Instructions);
+        }
+
+        if (string.Equals(jobType, Constants.JobTypes.SplitPlan, StringComparison.OrdinalIgnoreCase))
+            return new SplitPlanArgs(planFolder);
+
+        if (string.Equals(jobType, Constants.JobTypes.ExpandPlan, StringComparison.OrdinalIgnoreCase))
+            return new ExpandPlanArgs(planFolder);
+
+        if (string.Equals(jobType, Constants.JobTypes.CreateIssue, StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrEmpty(settings.Repo))
+                throw new ArgumentException("--repo is required for CreateIssue");
+            return new CreateIssueArgs(planFolder, settings.Repo, settings.Assignee, settings.Comment, settings.Labels);
+        }
+
+        if (string.Equals(jobType, Constants.JobTypes.CreatePr, StringComparison.OrdinalIgnoreCase))
+            return new CreatePrArgs(
+                planFolder,
+                Merge: !settings.NoMerge,
+                DeleteBranch: !settings.NoDeleteBranch,
+                IncludeArtifacts: !settings.NoArtifacts,
+                Assignee: settings.Assignee,
+                Comment: settings.Comment,
+                Draft: settings.Draft);
+
+        if (string.Equals(jobType, Constants.JobTypes.RetryPlan, StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.IsNullOrEmpty(settings.ChangeRequest))
+                throw new ArgumentException("--change-request is required for RetryPlan");
+            return new RetryPlanArgs(planFolder, settings.ChangeRequest);
+        }
+
+        throw new ArgumentException($"Unknown job type: {jobType}. Valid types: {string.Join(", ", Constants.JobTypes.BuiltIn)}");
+    }
+}

--- a/src/Ivy.Tendril/Commands/JobStatusCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStatusCommand.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel;
+using System.Text;
+using System.Text.Json;
 using Ivy.Tendril.Helpers;
 using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
@@ -26,22 +28,31 @@ public class JobStatusSettings : CommandSettings
 
 public class JobStatusCommand : Command<JobStatusSettings>
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
     private readonly ILogger<JobStatusCommand> _logger;
 
     public JobStatusCommand(ILogger<JobStatusCommand> logger) => _logger = logger;
 
     protected override int Execute(CommandContext context, JobStatusSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var statusFile = JobStatusFile.GetStatusFilePath(settings.JobId);
-            JobStatusFile.Write(statusFile, settings.Message, settings.PlanId, settings.PlanTitle);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to write job status for {JobId}", settings.JobId);
-            return 1;
-        }
+        var discovery = MasterClient.Discover();
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+
+        if (!string.IsNullOrEmpty(discovery.ApiKey))
+            client.DefaultRequestHeaders.Add("X-Api-Key", discovery.ApiKey);
+
+        var payload = new { message = settings.Message, planId = settings.PlanId, planTitle = settings.PlanTitle };
+        var json = JsonSerializer.Serialize(payload, JsonOptions);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = client.PutAsync($"{discovery.BaseUrl}/api/jobs/{settings.JobId}/status", content)
+            .GetAwaiter().GetResult();
+        response.EnsureSuccessStatusCode();
+
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Controllers/JobController.cs
+++ b/src/Ivy.Tendril/Controllers/JobController.cs
@@ -1,0 +1,82 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ivy.Tendril.Controllers;
+
+[ApiController]
+[Route("api/jobs")]
+public class JobController(IJobService jobService, IPlanReaderService planReaderService) : ControllerBase
+{
+    [HttpPost]
+    public IActionResult StartJob([FromBody] JobArgsBase args)
+    {
+        try
+        {
+            TransitionPlanState(args);
+            var jobId = jobService.StartJob(args);
+            return Ok(new { jobId, status = "Started" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpGet("{jobId}")]
+    public IActionResult GetJob(string jobId)
+    {
+        var job = jobService.GetJob(jobId);
+        if (job == null)
+            return NotFound(new { error = "Job not found" });
+
+        return Ok(new { job.Id, status = job.Status.ToString(), message = job.StatusMessage });
+    }
+
+    [HttpPut("{jobId}/status")]
+    public IActionResult UpdateJobStatus(string jobId, [FromBody] UpdateJobStatusRequest request)
+    {
+        var job = jobService.GetJob(jobId);
+        if (job == null)
+            return NotFound(new { error = "Job not found" });
+
+        job.StatusMessage = request.Message;
+        if (!string.IsNullOrEmpty(request.PlanId))
+            job.ReportedPlanId = request.PlanId;
+        if (!string.IsNullOrEmpty(request.PlanTitle))
+            job.ReportedPlanTitle = request.PlanTitle;
+
+        return Ok(new { status = "Updated" });
+    }
+
+    [HttpGet("health")]
+    public IActionResult Health() => Ok(new { status = "ok", pid = Environment.ProcessId });
+
+    private void TransitionPlanState(JobArgsBase args)
+    {
+        if (args.PlanFolder == null) return;
+
+        var folderName = Path.GetFileName(args.PlanFolder);
+
+        var targetState = args switch
+        {
+            ExecutePlanArgs => PlanStatus.Building,
+            ExpandPlanArgs => PlanStatus.Building,
+            CreatePrArgs => PlanStatus.Building,
+            CreateIssueArgs => PlanStatus.Building,
+            RetryPlanArgs => PlanStatus.Executing,
+            UpdatePlanArgs => PlanStatus.Updating,
+            SplitPlanArgs => PlanStatus.Updating,
+            _ => (PlanStatus?)null
+        };
+
+        if (targetState == null) return;
+
+        if (args is RetryPlanArgs)
+            planReaderService.ResetVerificationsForRetry(folderName);
+
+        planReaderService.TransitionState(folderName, targetState.Value);
+    }
+}
+
+public record UpdateJobStatusRequest(string Message, string? PlanId = null, string? PlanTitle = null);

--- a/src/Ivy.Tendril/Helpers/JobStatusFile.cs
+++ b/src/Ivy.Tendril/Helpers/JobStatusFile.cs
@@ -9,56 +9,11 @@ public static class JobStatusFile
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    public static string GetStatusFilePath(string jobId)
+    public static string GetCliLogPath(string jobId)
     {
         var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
-        return Path.Combine(tendrilHome, "Jobs", $"{jobId}.status");
+        return Path.Combine(tendrilHome, "Jobs", $"{jobId}.cli.jsonl");
     }
-
-    public static void Write(string statusFilePath, string message, string? planId = null, string? planTitle = null)
-    {
-        var dir = Path.GetDirectoryName(statusFilePath)!;
-        FileHelper.EnsureDirectory(dir);
-
-        var payload = new StatusPayload(message, planId, planTitle);
-        var json = JsonSerializer.Serialize(payload, JsonOptions);
-        FileHelper.WriteAllText(statusFilePath, json);
-    }
-
-    public static StatusPayload? Read(string statusFilePath)
-    {
-        try
-        {
-            if (!File.Exists(statusFilePath)) return null;
-            var json = File.ReadAllText(statusFilePath);
-            if (string.IsNullOrWhiteSpace(json)) return null;
-            return JsonSerializer.Deserialize<StatusPayload>(json, JsonOptions);
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    public static void Delete(string statusFilePath)
-    {
-        try { if (File.Exists(statusFilePath)) File.Delete(statusFilePath); }
-        catch { /* Best-effort */ }
-    }
-
-    private static string GetJobLogPath(string statusFilePath) => statusFilePath + ".jsonl";
-
-    // public static void AppendCliInvocation(string statusFilePath, string command, int exitCode, double durationMs)
-    // {
-    //     try
-    //     {
-    //         var logPath = GetJobLogPath(statusFilePath);
-    //         var entry = new CliLogEntry(DateTime.UtcNow.ToString("O"), command, exitCode, durationMs);
-    //         var line = JsonSerializer.Serialize(entry, JsonOptions);
-    //         File.AppendAllText(logPath, line + "\n");
-    //     }
-    //     catch { /* Best-effort */ }
-    // }
 
     public static void AppendCliInvocationDirect(string logPath, string command, int exitCode, double durationMs)
     {
@@ -74,11 +29,10 @@ public static class JobStatusFile
         catch { /* Best-effort */ }
     }
 
-    public static void MoveLogToPlanFolder(string statusFilePath, string planFolder, string jobType, string? jobId = null)
+    public static void MoveLogToPlanFolder(string logPath, string planFolder, string jobType, string? jobId = null)
     {
         try
         {
-            var logPath = GetJobLogPath(statusFilePath);
             if (!File.Exists(logPath)) return;
 
             var logsDir = Path.Combine(planFolder, "Logs");
@@ -94,6 +48,5 @@ public static class JobStatusFile
         catch { /* Best-effort */ }
     }
 
-    public record StatusPayload(string Message, string? PlanId = null, string? PlanTitle = null);
     public record CliLogEntry(string Timestamp, string Command, int ExitCode, double DurationMs);
 }

--- a/src/Ivy.Tendril/Helpers/MasterClient.cs
+++ b/src/Ivy.Tendril/Helpers/MasterClient.cs
@@ -1,0 +1,163 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Helpers;
+
+public static class MasterClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+
+    public record DiscoveryResult(string BaseUrl, string? ApiKey);
+    public record JobStartResponse(string JobId, string Status);
+
+    public static DiscoveryResult Discover(string? tendrilHome = null)
+    {
+        tendrilHome ??= Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
+        if (string.IsNullOrEmpty(tendrilHome))
+            throw new InvalidOperationException("TENDRIL_HOME environment variable is not set.");
+
+        var masterFilePath = Path.Combine(tendrilHome, ".master");
+        if (!File.Exists(masterFilePath))
+            throw new InvalidOperationException("No Tendril server is running (no .master file found). Start with 'tendril' or 'tendril run'.");
+
+        MasterElectionService.MasterFileData data;
+        try
+        {
+            var json = File.ReadAllText(masterFilePath);
+            data = JsonSerializer.Deserialize<MasterElectionService.MasterFileData>(json, JsonOptions)!;
+        }
+        catch (Exception ex)
+        {
+            TryDelete(masterFilePath);
+            throw new InvalidOperationException($"Failed to read .master file (deleted): {ex.Message}");
+        }
+
+        if (!IsProcessAlive(data.Pid))
+        {
+            TryDelete(masterFilePath);
+            throw new InvalidOperationException($"Tendril server is not running (stale .master file, PID {data.Pid} is dead). Cleaned up.");
+        }
+
+        if (DateTime.UtcNow - data.Heartbeat > TimeSpan.FromSeconds(90))
+        {
+            TryDelete(masterFilePath);
+            throw new InvalidOperationException("Tendril server appears hung (heartbeat stale). Cleaned up .master file.");
+        }
+
+        var apiKey = ReadApiKeyFromConfig(tendrilHome);
+        return new DiscoveryResult($"http://localhost:{data.Port}", apiKey);
+    }
+
+    public static JobStartResponse SubmitJob(DiscoveryResult discovery, JobArgsBase args)
+    {
+        using var client = new HttpClient { Timeout = DefaultTimeout };
+
+        if (!string.IsNullOrEmpty(discovery.ApiKey))
+            client.DefaultRequestHeaders.Add("X-Api-Key", discovery.ApiKey);
+
+        var json = JsonSerializer.Serialize<JobArgsBase>(args, JsonOptions);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response;
+        try
+        {
+            response = client.PostAsync($"{discovery.BaseUrl}/api/jobs", content).GetAwaiter().GetResult();
+        }
+        catch (TaskCanceledException)
+        {
+            throw new InvalidOperationException("Server did not respond in time (5s timeout).");
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new InvalidOperationException($"Failed to connect to Tendril server: {ex.Message}");
+        }
+
+        var responseJson = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+
+        if (!response.IsSuccessStatusCode)
+        {
+            if ((int)response.StatusCode == 401)
+                throw new InvalidOperationException("Authentication failed. Check Api.ApiKey in config.yaml.");
+
+            try
+            {
+                var errorDoc = JsonDocument.Parse(responseJson);
+                if (errorDoc.RootElement.TryGetProperty("error", out var errorProp))
+                    throw new InvalidOperationException(errorProp.GetString() ?? "Unknown server error");
+            }
+            catch (JsonException) { }
+
+            throw new InvalidOperationException($"Server returned {(int)response.StatusCode}: {responseJson}");
+        }
+
+        var result = JsonSerializer.Deserialize<JobStartResponse>(responseJson, JsonOptions);
+        return result ?? throw new InvalidOperationException("Empty response from server");
+    }
+
+    private static string? ReadApiKeyFromConfig(string tendrilHome)
+    {
+        var configPath = Path.Combine(tendrilHome, "config.yaml");
+        if (!File.Exists(configPath)) return null;
+
+        try
+        {
+            var content = File.ReadAllText(configPath);
+            return ExtractApiKey(content);
+        }
+        catch { return null; }
+    }
+
+    private static string? ExtractApiKey(string yamlContent)
+    {
+        var inApiSection = false;
+
+        foreach (var line in yamlContent.Split('\n'))
+        {
+            var trimmed = line.TrimEnd();
+            var isTopLevel = trimmed.Length > 0 && trimmed[0] != ' ' && trimmed[0] != '\t';
+
+            if (isTopLevel)
+            {
+                inApiSection = trimmed.StartsWith("Api:", StringComparison.OrdinalIgnoreCase);
+                continue;
+            }
+
+            if (!inApiSection) continue;
+
+            var inner = trimmed.Trim();
+            if (!inner.StartsWith("ApiKey:", StringComparison.OrdinalIgnoreCase)) continue;
+
+            var value = inner[(inner.IndexOf(':') + 1)..].Trim().Trim('"', '\'');
+            if (string.IsNullOrEmpty(value) || value.StartsWith('%')) return null;
+            return value;
+        }
+
+        return null;
+    }
+
+    private static bool IsProcessAlive(int pid)
+    {
+        try
+        {
+            var proc = Process.GetProcessById(pid);
+            return !proc.HasExited;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { }
+    }
+}

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -82,12 +82,9 @@ public record JobItem
     // Pre-allocated plan ID for CreatePlan jobs (used for filesystem verification)
     public string? AllocatedPlanId { get; set; }
 
-    // Reported by the agent via the status file during execution
+    // Reported by the agent via HTTP during execution
     public string? ReportedPlanId { get; set; }
     public string? ReportedPlanTitle { get; set; }
-
-    // Path to the status file used for cross-process status updates
-    public string? StatusFilePath { get; set; }
 
     // Automatic logging metadata (transient, not persisted)
     [JsonIgnore] public string? CompiledPrompt { get; set; }
@@ -208,19 +205,6 @@ public record JobItem
         catch (Exception ex)
         {
             logger?.LogWarning(ex, "Job {JobId}: Failed to dispose TimeoutCts", Id);
-        }
-
-        try
-        {
-            if (StatusFilePath != null && File.Exists(StatusFilePath))
-            {
-                File.Delete(StatusFilePath);
-                logger?.LogDebug("Job {JobId}: Status file deleted successfully", Id);
-            }
-        }
-        catch (Exception ex)
-        {
-            logger?.LogWarning(ex, "Job {JobId}: Failed to delete status file at {StatusFilePath}", Id, StatusFilePath);
         }
 
         Process = null;

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -147,7 +147,7 @@ public class Program
                         {
                             var home = Environment.GetEnvironmentVariable("TENDRIL_HOME");
                             if (!string.IsNullOrEmpty(home))
-                                cliLog = JobStatusFile.GetStatusFilePath(resolvedJobId) + ".jsonl";
+                                cliLog = JobStatusFile.GetCliLogPath(resolvedJobId);
                         }
                     }
 
@@ -465,6 +465,8 @@ public class Program
             {
                 job.AddCommand<JobStatusCommand>("status")
                     .WithDescription("Report job status (message, planId, planTitle)");
+                job.AddCommand<JobStartCommand>("start")
+                    .WithDescription("Start a job via the running Tendril server");
             });
 
             // Plan management commands
@@ -618,6 +620,25 @@ public class Program
         AppDomain.CurrentDomain.ProcessExit += (_, _) =>
         {
             CrashLog.Write($"[{DateTime.UtcNow:O}] ProcessExit event fired (PID {Environment.ProcessId}) | {GetMemoryStats()}");
+
+            // Clean up .master file if we own it
+            try
+            {
+                var home = Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
+                if (!string.IsNullOrEmpty(home))
+                {
+                    var masterFile = Path.Combine(home, ".master");
+                    if (File.Exists(masterFile))
+                    {
+                        var masterJson = File.ReadAllText(masterFile);
+                        var masterData = System.Text.Json.JsonSerializer.Deserialize<Services.MasterElectionService.MasterFileData>(
+                            masterJson, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase });
+                        if (masterData?.Pid == Environment.ProcessId)
+                            File.Delete(masterFile);
+                    }
+                }
+            }
+            catch { }
 
             // Clean up tracked temp files
             try

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -164,6 +164,17 @@ internal static class ServiceRegistration
         });
         server.Services.AddSingleton<IStartable>(sp => sp.GetRequiredService<PrStatusSyncService>());
 
+        server.Services.AddSingleton<MasterElectionService>(sp =>
+        {
+            var config = sp.GetRequiredService<IConfigService>();
+            var appLifetime = sp.GetRequiredService<Microsoft.Extensions.Hosting.IHostApplicationLifetime>();
+            var svr = sp.GetRequiredService<Microsoft.AspNetCore.Hosting.Server.IServer>();
+            var logger = sp.GetRequiredService<ILogger<MasterElectionService>>();
+            return new MasterElectionService(config, appLifetime, svr, logger);
+        });
+        server.Services.AddSingleton<IMasterElectionService>(sp => sp.GetRequiredService<MasterElectionService>());
+        server.Services.AddSingleton<IStartable>(sp => sp.GetRequiredService<MasterElectionService>());
+
         server.Services.AddSingleton<Services.Tunnel.CloudflaredService>(sp =>
         {
             var config = sp.GetRequiredService<IConfigService>();

--- a/src/Ivy.Tendril/Services/BackgroundServiceActivator.cs
+++ b/src/Ivy.Tendril/Services/BackgroundServiceActivator.cs
@@ -37,9 +37,16 @@ public static class BackgroundServiceActivator
         logger?.LogInformation("PlanWatcherService initialized ({ElapsedMs}ms)", sw.ElapsedMilliseconds);
 
         sw.Restart();
-        logger?.LogInformation("Resolving InboxWatcherService...");
-        services.GetRequiredService<IInboxWatcherService>();
-        logger?.LogInformation("InboxWatcherService initialized ({ElapsedMs}ms)", sw.ElapsedMilliseconds);
+        if (Environment.GetEnvironmentVariable("TENDRIL_NOT_MASTER") != "1")
+        {
+            logger?.LogInformation("Resolving InboxWatcherService...");
+            services.GetRequiredService<IInboxWatcherService>();
+            logger?.LogInformation("InboxWatcherService initialized ({ElapsedMs}ms)", sw.ElapsedMilliseconds);
+        }
+        else
+        {
+            logger?.LogInformation("Skipping InboxWatcherService (TENDRIL_NOT_MASTER=1)");
+        }
 
         sw.Restart();
         logger?.LogInformation("Starting IStartable services...");

--- a/src/Ivy.Tendril/Services/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/FirmwareCompiler.cs
@@ -96,8 +96,9 @@ public static class FirmwareCompiler
         if (headerValues.TryGetValue("TendrilJobId", out var tendrilJobId) && !string.IsNullOrEmpty(tendrilJobId))
         {
             firmware += $"\n\n**CLI Logging:** Append `--job-id {tendrilJobId}` to every `tendril` CLI command you run " +
-                        $"(e.g., `tendril plan add-commit ... --job-id {tendrilJobId}`). This enables execution logging. " +
-                        "Exception: `tendril job status` already receives the job ID as its first argument — skip `--job-id` there.\n";
+                        $"(e.g., `tendril plan add-commit ... --job-id {tendrilJobId}`). This enables execution logging.\n" +
+                        $"\n**Status Reporting:** Use `tendril job status {tendrilJobId} --message \"your status\"` to report progress. " +
+                        "You can also pass `--plan-id` and `--plan-title` to associate the job with a plan.\n";
         }
 
         // Include Program.md inline

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -617,13 +617,19 @@ internal class JobCompletionHandler
         {
             PromptwareLogWriter.WriteLog(job);
         }
-        catch { }
+        catch
+        {
+            // ignored
+        }
 
         try
         {
-            MoveStatusFileIfNeeded(job);
+            MoveCliLogIfNeeded(job);
         }
-        catch { }
+        catch
+        {
+            // ignored
+        }
 
         if (_planReaderService == null || string.IsNullOrEmpty(job.PlanFile))
             return;
@@ -639,16 +645,18 @@ internal class JobCompletionHandler
         }
         catch
         {
+            // ignored
         }
     }
 
-    private void MoveStatusFileIfNeeded(JobItem job)
+    private void MoveCliLogIfNeeded(JobItem job)
     {
-        if (string.IsNullOrEmpty(job.StatusFilePath)) return;
+        var logPath = JobStatusFile.GetCliLogPath(job.Id);
+        if (!File.Exists(logPath)) return;
 
         var planFolder = ResolvePlanFolder(job);
         if (!string.IsNullOrEmpty(planFolder) && Directory.Exists(planFolder))
-            JobStatusFile.MoveLogToPlanFolder(job.StatusFilePath, planFolder, job.Type, job.Id);
+            JobStatusFile.MoveLogToPlanFolder(logPath, planFolder, job.Type, job.Id);
     }
 
     private string BuildJobLogContent(JobItem job)

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -551,7 +551,6 @@ internal class JobLauncher
             psi.Environment["TENDRIL_HOME"] = tendrilHome;
         psi.Environment["TENDRIL_PLANS"] = _configService.PlanFolder;
 
-        job.StatusFilePath = JobStatusFile.GetStatusFilePath(job.Id);
         EnsureTendrilOnPath(psi);
     }
 

--- a/src/Ivy.Tendril/Services/Jobs/JobMonitor.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobMonitor.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Ivy.Helpers;
-using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Microsoft.Extensions.Logging;
 
@@ -38,8 +37,8 @@ internal class JobMonitor
         if (_ctx.StaleOutputTimeout > TimeSpan.Zero)
             _ = RunStaleOutputWatchdog(_id, _timeoutCts, _ctx.Jobs, _ctx.StaleOutputTimeout);
 
-        if (job != null && !string.IsNullOrEmpty(job.StatusFilePath))
-            _ = RunStatusFilePoller(_id, _timeoutCts, _ctx.Jobs);
+        // Status updates now arrive via HTTP (PUT /api/jobs/{id}/status)
+        // — no file polling needed.
     }
 
     private async Task MonitorProcessAsync()
@@ -144,35 +143,6 @@ internal class JobMonitor
         catch (ObjectDisposedException) { }
     }
 
-    internal static async Task RunStatusFilePoller(
-        string id,
-        CancellationTokenSource timeoutCts,
-        ConcurrentDictionary<string, JobItem> jobs)
-    {
-        try
-        {
-            while (!timeoutCts.Token.IsCancellationRequested)
-            {
-                await Task.Delay(TimeSpan.FromSeconds(1), timeoutCts.Token);
-                if (!jobs.TryGetValue(id, out var job) || job.Status != JobStatus.Running)
-                    return;
-                if (string.IsNullOrEmpty(job.StatusFilePath))
-                    return;
-
-                var payload = JobStatusFile.Read(job.StatusFilePath);
-                if (payload == null)
-                    continue;
-
-                job.StatusMessage = payload.Message;
-                if (IsValidPlanId(payload.PlanId))
-                    job.ReportedPlanId = payload.PlanId;
-                if (!string.IsNullOrEmpty(payload.PlanTitle))
-                    job.ReportedPlanTitle = payload.PlanTitle;
-            }
-        }
-        catch (OperationCanceledException) { }
-        catch (ObjectDisposedException) { }
-    }
 
     private static bool IsValidPlanId(string? planId)
     {

--- a/src/Ivy.Tendril/Services/MasterElectionService.cs
+++ b/src/Ivy.Tendril/Services/MasterElectionService.cs
@@ -1,0 +1,222 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Ivy.Tendril.Helpers;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services;
+
+public interface IMasterElectionService : IDisposable
+{
+    bool IsMaster { get; }
+}
+
+public class MasterElectionService(
+    IConfigService configService,
+    IHostApplicationLifetime appLifetime,
+    IServer server,
+    ILogger<MasterElectionService> logger)
+    : IMasterElectionService, IStartable
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    private Timer? _heartbeatTimer;
+    private string? _masterFilePath;
+
+    public bool IsMaster { get; private set; }
+
+    public void Start()
+    {
+        if (Environment.GetEnvironmentVariable("TENDRIL_NOT_MASTER") == "1")
+        {
+            logger.LogInformation("Running in non-master mode (TENDRIL_NOT_MASTER=1)");
+            return;
+        }
+
+        if (string.IsNullOrEmpty(configService.TendrilHome))
+            return;
+
+        _masterFilePath = Path.Combine(configService.TendrilHome, ".master");
+
+        if (!TryClaim())
+        {
+            logger.LogWarning("Another Tendril master is running. This instance will not accept CLI commands.");
+            return;
+        }
+
+        IsMaster = true;
+
+        appLifetime.ApplicationStarted.Register(OnApplicationStarted);
+        appLifetime.ApplicationStopping.Register(OnApplicationStopping);
+    }
+
+    private void OnApplicationStarted()
+    {
+        var port = GetBoundPort();
+        if (port == null)
+        {
+            logger.LogWarning("Could not determine bound port — .master file not written");
+            IsMaster = false;
+            return;
+        }
+
+        WriteMasterFile(port.Value);
+        _heartbeatTimer = new Timer(UpdateHeartbeat, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+        logger.LogInformation("Master election won — listening on port {Port}", port.Value);
+    }
+
+    private void OnApplicationStopping()
+    {
+        Cleanup();
+    }
+
+    private bool TryClaim()
+    {
+        if (_masterFilePath == null) return false;
+
+        if (!File.Exists(_masterFilePath))
+            return true;
+
+        try
+        {
+            var json = File.ReadAllText(_masterFilePath);
+            var existing = JsonSerializer.Deserialize<MasterFileData>(json, JsonOptions);
+            if (existing == null)
+            {
+                File.Delete(_masterFilePath);
+                return true;
+            }
+
+            if (!IsProcessAlive(existing.Pid))
+            {
+                logger.LogInformation("Stale .master file (PID {Pid} is dead) — claiming master", existing.Pid);
+                File.Delete(_masterFilePath);
+                return true;
+            }
+
+            if (DateTime.UtcNow - existing.Heartbeat > TimeSpan.FromSeconds(90))
+            {
+                logger.LogInformation("Stale .master file (heartbeat expired) — claiming master");
+                File.Delete(_masterFilePath);
+                return true;
+            }
+
+            return false;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read .master file — deleting and claiming");
+            try { File.Delete(_masterFilePath); } catch { }
+            return true;
+        }
+    }
+
+    private void WriteMasterFile(int port)
+    {
+        if (_masterFilePath == null) return;
+
+        var data = new MasterFileData
+        {
+            Pid = Environment.ProcessId,
+            Port = port,
+            StartedAt = DateTime.UtcNow,
+            Heartbeat = DateTime.UtcNow
+        };
+
+        var json = JsonSerializer.Serialize(data, JsonOptions);
+        FileHelper.WriteAllText(_masterFilePath, json);
+    }
+
+    private void UpdateHeartbeat(object? state)
+    {
+        if (_masterFilePath == null || !IsMaster) return;
+
+        try
+        {
+            if (!File.Exists(_masterFilePath)) return;
+
+            var json = File.ReadAllText(_masterFilePath);
+            var data = JsonSerializer.Deserialize<MasterFileData>(json, JsonOptions);
+            if (data == null || data.Pid != Environment.ProcessId) return;
+
+            data.Heartbeat = DateTime.UtcNow;
+            json = JsonSerializer.Serialize(data, JsonOptions);
+            FileHelper.WriteAllText(_masterFilePath, json);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to update heartbeat");
+        }
+    }
+
+    private int? GetBoundPort()
+    {
+        var addresses = server.Features.Get<IServerAddressesFeature>()?.Addresses;
+        if (addresses == null || addresses.Count == 0) return null;
+
+        var address = addresses.First();
+        if (Uri.TryCreate(address, UriKind.Absolute, out var uri))
+            return uri.Port;
+
+        var lastColon = address.LastIndexOf(':');
+        if (lastColon >= 0 && int.TryParse(address[(lastColon + 1)..], out var port))
+            return port;
+
+        return null;
+    }
+
+    private void Cleanup()
+    {
+        _heartbeatTimer?.Dispose();
+        _heartbeatTimer = null;
+
+        if (_masterFilePath != null && IsMaster)
+        {
+            try
+            {
+                if (File.Exists(_masterFilePath))
+                {
+                    var json = File.ReadAllText(_masterFilePath);
+                    var data = JsonSerializer.Deserialize<MasterFileData>(json, JsonOptions);
+                    if (data?.Pid == Environment.ProcessId)
+                        File.Delete(_masterFilePath);
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+
+        IsMaster = false;
+    }
+
+    public void Dispose() => Cleanup();
+
+    private static bool IsProcessAlive(int pid)
+    {
+        try
+        {
+            var proc = Process.GetProcessById(pid);
+            return !proc.HasExited;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public record MasterFileData
+    {
+        public int Pid { get; set; }
+        public int Port { get; set; }
+        public DateTime StartedAt { get; set; }
+        public DateTime Heartbeat { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds master election via `.master` lock file (PID + port + heartbeat)
- New `POST /api/jobs` endpoint to start any job type from CLI
- New `PUT /api/jobs/{id}/status` endpoint replacing file-based status polling
- `tendril job start <Type> <id>` CLI command for all 8 job types
- `TENDRIL_NOT_MASTER=1` env var for debug/worktree isolation
- Removes `JobMonitor.RunStatusFilePoller` and `StatusFilePath` (file-based status IPC)

## Test plan
- [x] Unit tests pass (1294 passed, 0 failed)
- [x] `.master` created on start, deleted on shutdown
- [x] Force-kill → stale PID detected and cleaned by CLI
- [x] `job start ExecutePlan` creates job, plan transitions to Building
- [x] `job status` message appears in Jobs UI via HTTP
- [x] Health endpoint responds correctly
- [x] Validation errors for missing required args