### PR TITLE
docs: add job commands and promptware usage note to AgentPrompt.md

### DIFF
--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -168,11 +168,40 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 | `tendril verification remove <name>` | Remove verification definition |
 | `tendril verification set <name> <field> <value>` | Set verification field |
 
-### Promptware Commands
+### Job Commands
 
 | Command | Description |
 |---------|-------------|
-| `tendril promptware run <name>` | Run a promptware |
+| `tendril job start <Type> <plan-id> [options]` | Start a job on the running Tendril server |
+| `tendril job status <job-id> -m <message>` | Report job status to the server |
+
+**Job types and options for `tendril job start`:**
+
+| Type | Required | Optional |
+|------|----------|----------|
+| `ExecutePlan` | `<plan-id>` | `--note` |
+| `UpdatePlan` | `<plan-id>`, `--instructions` | — |
+| `SplitPlan` | `<plan-id>` | — |
+| `ExpandPlan` | `<plan-id>` | — |
+| `CreateIssue` | `<plan-id>`, `--repo` | `--assignee`, `--comment`, `--labels` |
+| `CreatePr` | `<plan-id>` | `--no-merge`, `--no-delete-branch`, `--no-artifacts`, `--assignee`, `--comment`, `--draft` |
+| `RetryPlan` | `<plan-id>`, `--change-request` | — |
+| `CreatePlan` | `--description`, `--project` | `--priority`, `--force`, `--source-path` |
+
+Examples:
+```bash
+tendril job start ExecutePlan 00042
+tendril job start RetryPlan 00042 --change-request "Fix the failing tests"
+tendril job start CreatePlan --description "Add dark mode" --project MyProject
+```
+
+### Promptware Commands
+
+These commands are for internal use by other promptwares (e.g., a verification step that invokes a custom promptware). Do not use these to start jobs — use `tendril job start` instead.
+
+| Command | Description |
+|---------|-------------|
+| `tendril promptware run <name>` | Run a promptware directly (bypasses job service) |
 | `tendril promptware read-memory <name> <file>` | Read promptware memory |
 | `tendril promptware write-memory <name> <file>` | Write promptware memory (stdin) |
 | `tendril promptware write-tool <name> <file>` | Write promptware tool (stdin) |
@@ -196,6 +225,7 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 ## Important Notes
 
 - **Never read or write `plan.yaml` directly** -- always use `tendril plan` CLI commands.
+- **`tendril job start` and `tendril job status` require the Tendril server to be running.** They communicate via HTTP to the master instance (discovered via `TENDRIL_HOME/.master`).
 - Verification statuses: `Pending`, `Pass`, `Fail`, `Skipped`.
 - Plan states: `Draft`, `Building`, `Updating`, `Executing`, `ReadyForReview`, `Failed`, `Completed`, `Skipped`, `Blocked`, `Icebox`.
 - To create a plan interactively: use `tendril plan create "<title>"` then `tendril plan write-revision <id> <<'EOF' ... EOF` to add content.


### PR DESCRIPTION
Adds job start/status CLI reference and clarifies promptware commands are internal-only.