### PR TITLE
feat: add job-level WaitForJobs blocking with cascade failure

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -351,26 +351,19 @@ public class JobServiceRetryBlockedTests : IDisposable
     }
 
     [Fact]
-    public void RetryBlockedJobs_WhenNewJobStartsBeforeRetry_DoesNotRetryBlockedJob()
+    public void RetryBlockedJobs_WhenSamePlanFolderJobRunning_DoesNotRetryBlockedJob()
     {
         SynchronizationContext.SetSynchronizationContext(null);
 
-        // Create three plan folders that will compete for the same repo
-        var planA = Path.Combine(_tempDir.Path, "plan-A-new");
-        var planB = Path.Combine(_tempDir.Path, "plan-B-new");
-        var planC = Path.Combine(_tempDir.Path, "plan-C-new");
+        // Same plan folder — this should still block (worktree conflict)
+        var planA = Path.Combine(_tempDir.Path, "plan-A-same");
         Directory.CreateDirectory(planA);
-        Directory.CreateDirectory(planB);
-        Directory.CreateDirectory(planC);
 
-        // All plans target the same repo
-        var repo = Path.Combine(_tempDir.Path, "shared-repo-new");
+        var repo = Path.Combine(planA, "repo");
         Directory.CreateDirectory(repo);
 
         var planYaml = $"state: Draft\nproject: TestProject\nlevel: NiceToHave\ntitle: Test\nupdated: 2026-01-01T00:00:00Z\nrepos:\n- {repo}\ndependsOn: []\nprs: []\ncommits: []\nverifications: []\nrelatedPlans: []\n";
         File.WriteAllText(Path.Combine(planA, "plan.yaml"), planYaml);
-        File.WriteAllText(Path.Combine(planB, "plan.yaml"), planYaml);
-        File.WriteAllText(Path.Combine(planC, "plan.yaml"), planYaml);
 
         var planReader = new FakePlanReaderService(_tempDir.Path);
         var service = new JobService(
@@ -378,32 +371,28 @@ public class JobServiceRetryBlockedTests : IDisposable
             TimeSpan.FromMinutes(10),
             planReaderService: planReader);
 
-        // Start job A (this will hold the repo lock)
-        var jobAId = service.CreateTestJob(new ExecutePlanArgs(planA));
-        Assert.Equal(JobStatus.Running, service.GetJob(jobAId)!.Status);
+        // Start job on planA
+        var jobRunningId = service.CreateTestJob(new ExecutePlanArgs(planA));
+        Assert.Equal(JobStatus.Running, service.GetJob(jobRunningId)!.Status);
 
-        // Attempt to start job B (should get blocked due to repo concurrency)
-        var jobBId = service.CreateTestJob(new ExecutePlanArgs(planB));
-        var blockedJob = service.GetJob(jobBId)!;
+        // Manually create a blocked job for same plan folder
+        var blockedId = service.CreateTestJob(new ExecutePlanArgs(planA));
+        var blockedJob = service.GetJob(blockedId)!;
         blockedJob.Status = JobStatus.Blocked;
 
-        // Start job C on the same repo (simulating a new job starting before job A completes)
-        var jobCId = service.CreateTestJob(new ExecutePlanArgs(planC));
-        Assert.Equal(JobStatus.Running, service.GetJob(jobCId)!.Status);
+        // Create a completing CreatePr job to trigger RetryBlockedJobs
+        var completingId = service.CreateTestJob(new CreatePrArgs(Path.GetTempPath()));
 
         var notifications = new List<JobNotification>();
         service.NotificationReady += n => notifications.Add(n);
 
-        // Fail job A — this should trigger RetryBlockedJobs
-        service.CompleteJob(jobAId, 1);
+        service.CompleteJob(completingId, 0);
 
-        // Job B should NOT be retried because job C is still running on the same repo
-        // Job B should still be blocked
-        var stillBlocked = service.GetJob(jobBId);
+        // Job should still be blocked — same plan folder has an active job
+        var stillBlocked = service.GetJob(blockedId);
         Assert.NotNull(stillBlocked);
         Assert.Equal(JobStatus.Blocked, stillBlocked.Status);
 
-        // Should NOT have received an "unblocked" notification for job B
         Assert.DoesNotContain(notifications, n => n.Title == "Job Unblocked");
     }
 

--- a/src/Ivy.Tendril.Test/JobServiceWaitForJobsTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceWaitForJobsTests.cs
@@ -1,0 +1,212 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Jobs;
+
+namespace Ivy.Tendril.Test;
+
+public class JobServiceWaitForJobsTests
+{
+    [Fact]
+    public void StartJob_WithWaitForJobs_BlocksWhenDependencyRunning()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            maxConcurrentJobs: 5);
+
+        var depId = service.CreateTestJob(new CreatePlanArgs("Dep job", "Auto"));
+        Assert.Equal(JobStatus.Running, service.GetJob(depId)!.Status);
+
+        var id = service.StartJob(new CreatePlanArgs("Waiting job", "Auto") { WaitForJobs = [depId] });
+        var job = service.GetJob(id);
+
+        Assert.NotNull(job);
+        Assert.Equal(JobStatus.Blocked, job.Status);
+        Assert.Contains(depId, job.StatusMessage);
+    }
+
+    [Fact]
+    public void StartJob_WithWaitForJobs_DoesNotBlockWhenAllCompleted()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            maxConcurrentJobs: 5);
+
+        var depId = service.CreateTestJob(new CreatePlanArgs("Dep job", "Auto"));
+        service.CompleteJob(depId, 0);
+
+        var id = service.StartJob(new CreatePlanArgs("Waiting job", "Auto") { WaitForJobs = [depId] });
+        var job = service.GetJob(id);
+
+        Assert.NotNull(job);
+        Assert.NotEqual(JobStatus.Blocked, job.Status);
+    }
+
+    [Fact]
+    public void StartJob_WithWaitForJobs_FailsImmediatelyWhenDependencyAlreadyFailed()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            maxConcurrentJobs: 5);
+
+        var depId = service.CreateTestJob(new CreatePlanArgs("Dep job", "Auto"));
+        service.CompleteJob(depId, 1);
+
+        var id = service.StartJob(new CreatePlanArgs("Waiting job", "Auto") { WaitForJobs = [depId] });
+        var job = service.GetJob(id);
+
+        Assert.NotNull(job);
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.Contains(depId, job.StatusMessage);
+    }
+
+    [Fact]
+    public void CompleteJob_Success_UnblocksWaitingJobs()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            maxConcurrentJobs: 5);
+
+        var depId = service.CreateTestJob(new CreatePlanArgs("Dep job", "Auto"));
+
+        var waitingId = service.StartJob(new CreatePlanArgs("Waiting job", "Auto") { WaitForJobs = [depId] });
+        Assert.Equal(JobStatus.Blocked, service.GetJob(waitingId)!.Status);
+
+        var notifications = new List<JobNotification>();
+        service.NotificationReady += n => notifications.Add(n);
+
+        service.CompleteJob(depId, 0);
+
+        // The blocked job should have been removed (restarted as a new job)
+        Assert.Null(service.GetJob(waitingId));
+        Assert.Contains(notifications, n => n.Title == "Job Unblocked");
+    }
+
+    [Fact]
+    public void CompleteJob_Failure_CascadesFailureToWaitingJobs()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            maxConcurrentJobs: 5);
+
+        var depId = service.CreateTestJob(new CreatePlanArgs("Dep job", "Auto"));
+
+        var waitingId = service.StartJob(new CreatePlanArgs("Waiting job", "Auto") { WaitForJobs = [depId] });
+        Assert.Equal(JobStatus.Blocked, service.GetJob(waitingId)!.Status);
+
+        var notifications = new List<JobNotification>();
+        service.NotificationReady += n => notifications.Add(n);
+
+        service.CompleteJob(depId, 1);
+
+        var waitingJob = service.GetJob(waitingId);
+        Assert.NotNull(waitingJob);
+        Assert.Equal(JobStatus.Failed, waitingJob.Status);
+        Assert.Contains(depId, waitingJob.StatusMessage);
+        Assert.Contains(notifications, n => n.Title == "Job Failed");
+    }
+
+    [Fact]
+    public void CompleteJob_Failure_CascadesTransitively()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            maxConcurrentJobs: 5);
+
+        // A -> B -> C chain
+        var jobAId = service.CreateTestJob(new CreatePlanArgs("Job A", "Auto"));
+
+        var jobBId = service.StartJob(new CreatePlanArgs("Job B", "Auto") { WaitForJobs = [jobAId] });
+        Assert.Equal(JobStatus.Blocked, service.GetJob(jobBId)!.Status);
+
+        var jobCId = service.StartJob(new CreatePlanArgs("Job C", "Auto") { WaitForJobs = [jobBId] });
+        Assert.Equal(JobStatus.Blocked, service.GetJob(jobCId)!.Status);
+
+        // Fail A -> should cascade to B -> should cascade to C
+        service.CompleteJob(jobAId, 1);
+
+        var jobB = service.GetJob(jobBId);
+        var jobC = service.GetJob(jobCId);
+
+        Assert.NotNull(jobB);
+        Assert.Equal(JobStatus.Failed, jobB.Status);
+
+        Assert.NotNull(jobC);
+        Assert.Equal(JobStatus.Failed, jobC.Status);
+    }
+
+    [Fact]
+    public void StopJob_CascadesFailureToWaitingJobs()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            maxConcurrentJobs: 5);
+
+        var depId = service.CreateTestJob(new CreatePlanArgs("Dep job", "Auto"));
+
+        var waitingId = service.StartJob(new CreatePlanArgs("Waiting job", "Auto") { WaitForJobs = [depId] });
+        Assert.Equal(JobStatus.Blocked, service.GetJob(waitingId)!.Status);
+
+        service.StopJob(depId);
+
+        var waitingJob = service.GetJob(waitingId);
+        Assert.NotNull(waitingJob);
+        Assert.Equal(JobStatus.Failed, waitingJob.Status);
+        Assert.Contains(depId, waitingJob.StatusMessage);
+    }
+
+    [Fact]
+    public void CompleteJob_MultipleWaitForJobs_UnblocksOnlyWhenAllComplete()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            maxConcurrentJobs: 5);
+
+        var dep1Id = service.CreateTestJob(new CreatePlanArgs("Dep 1", "Auto"));
+        var dep2Id = service.CreateTestJob(new CreatePlanArgs("Dep 2", "Auto"));
+
+        var waitingId = service.StartJob(new CreatePlanArgs("Waiting job", "Auto") { WaitForJobs = [dep1Id, dep2Id] });
+        Assert.Equal(JobStatus.Blocked, service.GetJob(waitingId)!.Status);
+
+        // Complete first dep — should still be blocked
+        service.CompleteJob(dep1Id, 0);
+        var stillBlocked = service.GetJob(waitingId);
+        Assert.NotNull(stillBlocked);
+        Assert.Equal(JobStatus.Blocked, stillBlocked.Status);
+
+        // Complete second dep — should now unblock
+        service.CompleteJob(dep2Id, 0);
+        Assert.Null(service.GetJob(waitingId));
+    }
+
+    [Fact]
+    public void StartJob_WithoutWaitForJobs_NotBlocked()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            maxConcurrentJobs: 5);
+
+        var id = service.StartJob(new CreatePlanArgs("Normal job", "Auto"));
+        var job = service.GetJob(id);
+
+        Assert.NotNull(job);
+        Assert.NotEqual(JobStatus.Blocked, job.Status);
+    }
+}

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -70,6 +70,8 @@ internal class JobCompletionHandler
         if (job.Status is JobStatus.Failed or JobStatus.Timeout)
             ScheduleWorktreeCleanup(job);
 
+        HandleWaitForJobsDependents(job, jobs, raiseNotification, startJobSkipDepCheck, persistJob);
+
         if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or CreatePrArgs)
             _dependencyChecker.RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
 
@@ -513,6 +515,64 @@ internal class JobCompletionHandler
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to reset plan state to Blocked for job {JobId}", job.Id);
+        }
+    }
+
+    internal void HandleWaitForJobsDependents(
+        JobItem completedJob,
+        ConcurrentDictionary<string, JobItem> jobs,
+        Action<JobNotification> raiseNotification,
+        Func<JobArgsBase, string> startJobSkipDepCheck,
+        Action<JobItem>? persistJob = null)
+    {
+        var queue = new Queue<JobItem>();
+        queue.Enqueue(completedJob);
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+
+            var waitingJobs = jobs.Values
+                .Where(j => j.Status == JobStatus.Blocked &&
+                            j.WaitForJobIds is { Count: > 0 } &&
+                            j.WaitForJobIds.Contains(current.Id))
+                .ToList();
+
+            foreach (var waitingJob in waitingJobs)
+            {
+                if (current.Status is JobStatus.Failed or JobStatus.Timeout or JobStatus.Stopped)
+                {
+                    waitingJob.Status = JobStatus.Failed;
+                    waitingJob.StatusMessage = $"Blocked job {current.Id} failed";
+                    waitingJob.CompletedAt = DateTime.UtcNow;
+                    persistJob?.Invoke(waitingJob);
+
+                    raiseNotification(new JobNotification(
+                        "Job Failed",
+                        $"{waitingJob.PlanFile}: blocked job {current.Id} failed",
+                        false));
+
+                    queue.Enqueue(waitingJob);
+                    continue;
+                }
+
+                var stillPending = waitingJob.WaitForJobIds!
+                    .Any(id => jobs.TryGetValue(id, out var dep) &&
+                               dep.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending or JobStatus.Blocked);
+
+                if (stillPending)
+                    continue;
+
+                waitingJob.Status = JobStatus.Pending;
+                waitingJob.StatusMessage = null;
+                startJobSkipDepCheck(waitingJob.TypedArgs!);
+                jobs.TryRemove(waitingJob.Id, out _);
+
+                raiseNotification(new JobNotification(
+                    "Job Unblocked",
+                    $"{waitingJob.PlanFile}: all blocking jobs completed, starting",
+                    true));
+            }
         }
     }
 

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -222,6 +222,8 @@ public class JobService : IJobService
         if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or CreatePrArgs)
             _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck);
 
+        _completionHandler.HandleWaitForJobsDependents(job, _jobs, RaiseNotification, StartJobSkipDepCheck, PersistJob);
+
         RaiseJobsStructureChanged();
 
         // Try to start queued jobs now that a slot is free

--- a/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
+++ b/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
@@ -165,22 +165,13 @@ internal class DependencyChecker
 
     private static bool HasActiveJobForPlan(string planFolder, ConcurrentDictionary<string, JobItem> jobs)
     {
-        var planRepos = PlanYamlHelper.ReadPlanYaml(planFolder)?.Repos;
-
         return jobs.Values.Any(j =>
         {
             if (j.TypedArgs is not (ExecutePlanArgs or RetryPlanArgs)) return false;
             if (j.Status is not (JobStatus.Running or JobStatus.Queued or JobStatus.Pending)) return false;
 
             var otherFolder = j.TypedArgs?.PlanFolder;
-            if (otherFolder == null) return false;
-
-            if (otherFolder.Equals(planFolder, StringComparison.OrdinalIgnoreCase))
-                return true;
-
-            if (planRepos is not { Count: > 0 }) return false;
-            var otherRepos = PlanYamlHelper.ReadPlanYaml(otherFolder)?.Repos;
-            return otherRepos != null && planRepos.Any(r => otherRepos.Contains(r, StringComparer.OrdinalIgnoreCase));
+            return otherFolder != null && otherFolder.Equals(planFolder, StringComparison.OrdinalIgnoreCase);
         });
     }
 }


### PR DESCRIPTION
## Summary
- Add `HandleWaitForJobsDependents` to unblock waiting jobs on success and cascade failure transitively on failure/timeout/stop
- Remove repo-overlap blocking from `HasActiveJobForPlan` (plans use isolated worktrees, only same-plan-folder conflicts matter)
- Wire cascade handling into both `CompleteJob` and `StopJob` paths
- Use iterative BFS instead of recursion for transitive cascade
- Persist cascade-failed jobs to SQLite via `persistJob` delegate

## Test plan
- [x] 9 new tests in `JobServiceWaitForJobsTests` covering basic blocking, unblock on success, cascade failure, transitive cascade, stop cascade, multi-wait
- [x] Updated `JobServiceRetryBlockedTests` to validate same-plan-folder blocking (replacing repo-overlap test)
- [x] Full test suite passes (1320 tests)