### PR TITLE
feat: add preflight dirty-repo check before Execute and Create Plan

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -3,6 +3,7 @@ using Ivy.Core;
 using Ivy.Tendril.Apps.Drafts.Dialogs;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Views;
+using Ivy.Tendril.Apps.Views.Dialogs;
 using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Apps.Views.Tabs;
 using Ivy.Tendril.Helpers;
@@ -31,6 +32,8 @@ public class ContentView(
         var issueAssigneeState = UseState<string?>(null);
         var issueLabelsState = UseState<string[]>([]);
         var issueCommentState = UseState("");
+        var showDirtyDialog = UseState(false);
+        var (runPreflight, isCheckingPreflight, preflightResult) = Context.UsePreflightCheck();
 
         var processView = Context.UseTendrilProcessView();
 
@@ -165,19 +168,16 @@ public class ContentView(
         header |= Text.Rich()
             .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
             .Muted("plans", word: true);
-        header |= new Button("Execute").Icon(Icons.Rocket).Primary().ShortcutKey("e").OnClick(() =>
-        {
-            // Optimistically update UI state before disk I/O
-            var optimisticPlan = selectedPlan with
+        header |= new Button("Execute").Icon(Icons.Rocket).Primary().ShortcutKey("e")
+            .Loading(isCheckingPreflight)
+            .Disabled(isCheckingPreflight)
+            .OnClick(() => runPreflight(selectedPlan.Project, result =>
             {
-                Metadata = selectedPlan.Metadata with { State = PlanStatus.Building }
-            };
-            selectedPlanState.Set(optimisticPlan);
-
-            planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
-            jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath));
-            refreshPlans();
-        });
+                if (result.DirtyRepos.Count > 0)
+                    showDirtyDialog.Set(true);
+                else
+                    LaunchExecute();
+            }));
 
         var content = Layout.Vertical().Height(Size.Full());
 
@@ -249,6 +249,16 @@ public class ContentView(
             ).Scroll(Scroll.None).Size(Size.Full())
         ).Scroll(Scroll.None).Size(Size.Full()).Key(selectedPlan.Id);
 
+        var dirtyRepoDialog = showDirtyDialog.Value && preflightResult is { DirtyRepos.Count: > 0 }
+            ? new DirtyRepoDialog(
+                showDirtyDialog,
+                preflightResult,
+                proceedLabel: "Execute Anyway",
+                contextMessage: "These changes will NOT be included in this plan. The plan will execute against origin/<baseBranch>. If these changes are meant for this plan, commit and push them first.",
+                onSyncRepos: () => LaunchWithSync(preflightResult),
+                onProceed: LaunchExecute)
+            : null;
+
         var elements = new List<object>
         {
             mainLayout,
@@ -257,6 +267,9 @@ public class ContentView(
             createIssueDialog,
             debugSheet
         };
+
+        if (dirtyRepoDialog is not null)
+            elements.Add(dirtyRepoDialog);
 
         elements.Add(new FileSheet(openFile, config));
 
@@ -333,6 +346,43 @@ public class ContentView(
                 "State Mismatch");
         return Callout.Destructive($"Last execution status: {status}", "Execution Failed");
 
+    }
+
+    private void LaunchExecute()
+    {
+        if (selectedPlan is null) return;
+
+        var optimisticPlan = selectedPlan with
+        {
+            Metadata = selectedPlan.Metadata with { State = PlanStatus.Building }
+        };
+        selectedPlanState.Set(optimisticPlan);
+
+        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+        jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath));
+        refreshPlans();
+    }
+
+    private void LaunchWithSync(PreflightResult preflight)
+    {
+        if (selectedPlan is null) return;
+
+        var syncJobIds = new List<string>();
+        foreach (var (repoPath, baseBranch, _) in preflight.DirtyRepos)
+        {
+            var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch));
+            syncJobIds.Add(jobId);
+        }
+
+        var optimisticPlan = selectedPlan with
+        {
+            Metadata = selectedPlan.Metadata with { State = PlanStatus.Building }
+        };
+        selectedPlanState.Set(optimisticPlan);
+
+        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+        jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath) { WaitForJobs = syncJobIds });
+        refreshPlans();
     }
 
     private void GoToNext()

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -1,7 +1,9 @@
 using Ivy.Core;
 using Ivy.Tendril.Apps.Icebox.Dialogs;
 using Ivy.Tendril.Apps.Views;
+using Ivy.Tendril.Apps.Views.Dialogs;
 using Ivy.Tendril.Apps.Views.Sheets;
+using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
@@ -22,6 +24,8 @@ public class ContentView(
         var client = UseService<IClientProvider>();
         var copyToClipboard = UseClipboard();
         var openFile = UseState<string?>(null);
+        var showDirtyDialog = UseState(false);
+        var (runPreflight, isCheckingPreflight, preflightResult) = Context.UsePreflightCheck();
 
         var (deleteDialog, showDeleteDialog) = UseTrigger((isOpen) =>
         {
@@ -76,12 +80,16 @@ public class ContentView(
                             planService.TransitionState(selectedPlan.FolderName, PlanStatus.Draft);
                             refreshPlans();
                         })
-                        | new Button("Execute").Icon(Icons.Rocket).Outline().ShortcutKey("e").OnClick(() =>
-                        {
-                            planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
-                            jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath));
-                            refreshPlans();
-                        })
+                        | new Button("Execute").Icon(Icons.Rocket).Outline().ShortcutKey("e")
+                            .Loading(isCheckingPreflight)
+                            .Disabled(isCheckingPreflight)
+                            .OnClick(() => runPreflight(selectedPlan.Project, result =>
+                            {
+                                if (result.DirtyRepos.Count > 0)
+                                    showDirtyDialog.Set(true);
+                                else
+                                    LaunchExecute();
+                            }))
                         | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
                             new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
                                 .OnSelect(() =>
@@ -117,15 +125,52 @@ public class ContentView(
             ).Size(Size.Full())
         ).Scroll(Scroll.None).Size(Size.Full()).Key(selectedPlan.Id);
 
+        var dirtyRepoDialog = showDirtyDialog.Value && preflightResult is { DirtyRepos.Count: > 0 }
+            ? new DirtyRepoDialog(
+                showDirtyDialog,
+                preflightResult,
+                proceedLabel: "Execute Anyway",
+                contextMessage: "These changes will NOT be included in this plan. The plan will execute against origin/<baseBranch>. If these changes are meant for this plan, commit and push them first.",
+                onSyncRepos: () => LaunchWithSync(preflightResult),
+                onProceed: LaunchExecute)
+            : null;
+
         var elements = new List<object>
         {
             mainLayout,
             deleteDialog
         };
 
+        if (dirtyRepoDialog is not null)
+            elements.Add(dirtyRepoDialog);
+
         elements.Add(new FileSheet(openFile, config));
 
         return new Fragment(elements.ToArray());
+    }
+
+    private void LaunchExecute()
+    {
+        if (selectedPlan is null) return;
+        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+        jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath));
+        refreshPlans();
+    }
+
+    private void LaunchWithSync(PreflightResult preflight)
+    {
+        if (selectedPlan is null) return;
+
+        var syncJobIds = new List<string>();
+        foreach (var (repoPath, baseBranch, _) in preflight.DirtyRepos)
+        {
+            var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch));
+            syncJobIds.Add(jobId);
+        }
+
+        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+        jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath) { WaitForJobs = syncJobIds });
+        refreshPlans();
     }
 
     private void GoToNext()

--- a/src/Ivy.Tendril/Apps/Views/CreatePlanDialogLauncher.cs
+++ b/src/Ivy.Tendril/Apps/Views/CreatePlanDialogLauncher.cs
@@ -1,4 +1,6 @@
 using Ivy.Tendril.Apps.Drafts.Dialogs;
+using Ivy.Tendril.Apps.Views.Dialogs;
+using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
@@ -12,6 +14,10 @@ public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : View
         var configService = UseService<IConfigService>();
         var navigator = UseNavigation();
         var lastSelectedProjects = UseState<string[]>(["Auto"]);
+        var showDirtyDialog = UseState(false);
+        var pendingJobArgs = UseState<CreatePlanArgs?>(null);
+        var (runPreflight, _, preflightResult) = Context.UsePreflightCheck();
+
         var (dialog, showDialog) = UseTrigger((isOpen) =>
         {
             if (!isOpen.Value) return null;
@@ -27,13 +33,55 @@ public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : View
                 {
                     lastSelectedProjects.Set(projects);
                     var project = string.Join(",", projects);
-                    jobService.StartJob(new CreatePlanArgs(description, project, priority, Force: true));
+                    var args = new CreatePlanArgs(description, project, priority, Force: true);
+                    pendingJobArgs.Set(args);
+                    isOpen.Set(false);
+                    runPreflight(project, result =>
+                    {
+                        if (result.DirtyRepos.Count > 0)
+                            showDirtyDialog.Set(true);
+                        else
+                            LaunchCreatePlan(args);
+                    });
                 },
                 () => isOpen.Set(false),
                 lastSelectedProjects.Value
             );
         });
 
-        return new Fragment(renderTrigger(() => showDialog()), dialog);
+        var dirtyRepoDialog = showDirtyDialog.Value && preflightResult is { DirtyRepos.Count: > 0 } && pendingJobArgs.Value is not null
+            ? new DirtyRepoDialog(
+                showDirtyDialog,
+                preflightResult,
+                proceedLabel: "Create Anyway",
+                contextMessage: "The plan will be based on this state, but ExecutePlan will branch from origin/<baseBranch>. Commit and push first if these changes should be included in the plan.",
+                onSyncRepos: () => LaunchWithSync(pendingJobArgs.Value, preflightResult),
+                onProceed: () => LaunchCreatePlan(pendingJobArgs.Value))
+            : null;
+
+        var elements = new List<object> { renderTrigger(() => showDialog()), dialog };
+        if (dirtyRepoDialog is not null)
+            elements.Add(dirtyRepoDialog);
+
+        return new Fragment(elements.ToArray());
+
+        void LaunchCreatePlan(CreatePlanArgs args)
+        {
+            jobService.StartJob(args);
+            pendingJobArgs.Set(null);
+        }
+
+        void LaunchWithSync(CreatePlanArgs args, PreflightResult preflight)
+        {
+            var syncJobIds = new List<string>();
+            foreach (var (repoPath, baseBranch, _) in preflight.DirtyRepos)
+            {
+                var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch));
+                syncJobIds.Add(jobId);
+            }
+
+            jobService.StartJob(args with { WaitForJobs = syncJobIds });
+            pendingJobArgs.Set(null);
+        }
     }
 }

--- a/src/Ivy.Tendril/Apps/Views/Dialogs/DirtyRepoDialog.cs
+++ b/src/Ivy.Tendril/Apps/Views/Dialogs/DirtyRepoDialog.cs
@@ -1,0 +1,68 @@
+using Ivy.Tendril.Hooks;
+using Ivy.Tendril.Services.Git;
+
+namespace Ivy.Tendril.Apps.Views.Dialogs;
+
+public class DirtyRepoDialog(
+    IState<bool> dialogOpen,
+    PreflightResult preflightResult,
+    string proceedLabel,
+    string contextMessage,
+    Action onSyncRepos,
+    Action onProceed) : ViewBase
+{
+    public override object? Build()
+    {
+        if (!dialogOpen.Value) return null;
+
+        var body = Layout.Vertical().Gap(3);
+
+        foreach (var (repoPath, _, dirtyState) in preflightResult.DirtyRepos)
+        {
+            var repoSection = Layout.Vertical().Gap(1);
+            repoSection |= Text.Block(Path.GetFileName(repoPath)).Bold();
+            repoSection |= Text.Muted(repoPath);
+
+            foreach (var reason in dirtyState.Reasons)
+            {
+                repoSection |= Text.Block($"• {FormatReason(reason)}");
+            }
+
+            body |= repoSection;
+        }
+
+        body |= Text.Muted(contextMessage);
+
+        return new Dialog(
+            _ => dialogOpen.Set(false),
+            new DialogHeader("Local Changes Detected"),
+            new DialogBody(body),
+            new DialogFooter(
+                Layout.Horizontal().Gap(2).Right()
+                | new Button("Cancel").Outline().OnClick(() => dialogOpen.Set(false))
+                | new Button(proceedLabel).Outline().OnClick(() =>
+                {
+                    onProceed();
+                    dialogOpen.Set(false);
+                })
+                | new Button("Sync Repos").Primary().Icon(Icons.RefreshCw).OnClick(() =>
+                {
+                    onSyncRepos();
+                    dialogOpen.Set(false);
+                })
+            )
+        ).Width(Size.Rem(40));
+    }
+
+    private static string FormatReason(DirtyReasonDetail detail) => detail.Reason switch
+    {
+        DirtyReason.NotOnExpectedBranch => detail.Message,
+        DirtyReason.AheadOfOrigin => detail.Message,
+        DirtyReason.UncommittedChanges => detail.Message,
+        DirtyReason.UntrackedFiles => detail.Message,
+        DirtyReason.InProgressOperation => detail.Message,
+        DirtyReason.DetachedHead => "Detached HEAD",
+        DirtyReason.NoRemoteConfigured => "No remote configured",
+        _ => detail.Message
+    };
+}

--- a/src/Ivy.Tendril/Hooks/UsePreflightCheck.cs
+++ b/src/Ivy.Tendril/Hooks/UsePreflightCheck.cs
@@ -1,0 +1,60 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
+
+namespace Ivy.Tendril.Hooks;
+
+public record PreflightResult(
+    List<(string RepoPath, string BaseBranch, DirtyRepoResult DirtyState)> DirtyRepos);
+
+public static class UsePreflightCheckExtensions
+{
+    public static (
+        Action<string, Action<PreflightResult>> RunCheck,
+        bool IsChecking,
+        PreflightResult? Result
+    ) UsePreflightCheck(this IViewContext context)
+    {
+        var gitService = context.UseService<IGitService>();
+        var configService = context.UseService<IConfigService>();
+        var isChecking = context.UseState(false);
+        var result = context.UseState((PreflightResult?)null);
+
+        return (RunCheck, isChecking.Value, result.Value);
+
+        void RunCheck(string projectValue, Action<PreflightResult> onComplete)
+        {
+            isChecking.Set(true);
+            result.Set(null);
+
+            Task.Run(() =>
+            {
+                var projectNames = ProjectHelper.ParseProjects(projectValue);
+                var dirtyRepos = new List<(string, string, DirtyRepoResult)>();
+                var checkedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var projectName in projectNames)
+                {
+                    var project = configService.GetProject(projectName);
+                    if (project is null) continue;
+
+                    foreach (var repo in project.Repos)
+                    {
+                        var baseBranch = repo.BaseBranch ?? "main";
+                        var expanded = Environment.ExpandEnvironmentVariables(repo.Path);
+                        if (!checkedPaths.Add(expanded)) continue;
+
+                        var checkResult = gitService.GetRepoDirtyState(expanded, baseBranch);
+                        if (checkResult.IsSuccess && checkResult.Value!.IsDirty)
+                            dirtyRepos.Add((expanded, baseBranch, checkResult.Value));
+                    }
+                }
+
+                var preflightResult = new PreflightResult(dirtyRepos);
+                result.Set(preflightResult);
+                isChecking.Set(false);
+                onComplete(preflightResult);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a preflight check that runs `GetRepoDirtyState` on all project repos before Execute (Drafts + Icebox) and Create Plan flows
- Shows a `DirtyRepoDialog` when repos have uncommitted changes, unpushed commits, or branch mismatches
- Dialog offers three options: Sync Repos (starts SyncRepo jobs + chains the original job via WaitForJobs), Proceed Anyway, or Cancel
- New shared `UsePreflightCheck` hook and `DirtyRepoDialog` component under `Apps/Views/Dialogs/`

## Test plan
- [ ] Execute from Drafts with clean repos → job starts immediately
- [ ] Execute from Drafts with dirty repo → dialog shown with correct details
- [ ] Click "Execute Anyway" → job starts without sync
- [ ] Click "Sync Repos" → SyncRepo jobs created, Execute job waits for them
- [ ] Click "Cancel" → no jobs created
- [ ] Execute from Icebox with dirty repo → same dialog behavior
- [ ] Create Plan with dirty repo → dialog shown after submit with "Create Anyway" label
- [ ] Button shows loading spinner during preflight check