### PR TITLE
[00085] Add agent-instructions CLI command

### DIFF
--- a/src/Ivy.Tendril/Commands/AgentInstructionsCommand.cs
+++ b/src/Ivy.Tendril/Commands/AgentInstructionsCommand.cs
@@ -8,7 +8,7 @@ public sealed class AgentInstructionsCommand(IConfigService config) : Command<Ag
 {
     public class Settings : CommandSettings { }
 
-    public override int Execute(CommandContext context, Settings settings)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         var prompt = AgentPromptCompiler.Compile(config);
         if (prompt == null)

--- a/src/Ivy.Tendril/Commands/AgentInstructionsCommand.cs
+++ b/src/Ivy.Tendril/Commands/AgentInstructionsCommand.cs
@@ -1,0 +1,23 @@
+using Ivy.Tendril.Services;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public sealed class AgentInstructionsCommand(IConfigService config) : Command<AgentInstructionsCommand.Settings>
+{
+    public class Settings : CommandSettings { }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        var prompt = AgentPromptCompiler.Compile(config);
+        if (prompt == null)
+        {
+            AnsiConsole.MarkupLine("[red]Failed to compile agent prompt (embedded resource missing)[/]");
+            return 1;
+        }
+
+        Console.Write(prompt);
+        return 0;
+    }
+}

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -564,6 +564,9 @@ public class Program
             config.AddCommand<ModelsCommand>("models")
                 .WithDescription("List available models and pricing for agent CLIs");
 
+            config.AddCommand<AgentInstructionsCommand>("agent-instructions")
+                .WithDescription("Print the agent system prompt");
+
             config.AddBranch("trash", trash =>
             {
                 trash.AddCommand<TrashWriteCommand>("write")

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -367,7 +367,7 @@ public class Program
     {
         // If the executing assembly is in the .store / .dotnet folder, it's a global tool invocation
         var path = System.AppContext.BaseDirectory;
-        if (path.Contains(".store", StringComparison.OrdinalIgnoreCase) || 
+        if (path.Contains(".store", StringComparison.OrdinalIgnoreCase) ||
             path.Contains(".dotnet", StringComparison.OrdinalIgnoreCase))
         {
             return true;


### PR DESCRIPTION
# Summary

## Changes

Added a new `agent-instructions` CLI command that compiles and prints the same system prompt used by AgentApp.

## API Changes

- **New command**: `tendril agent-instructions` — prints the agent system prompt to stdout

## Files Modified

- **Commands/AgentInstructionsCommand.cs** — new command implementation
- **Program.cs** — registered command

---

## Commits

- 02ad5a3 Add agent-instructions CLI command
- 9b23b3b Fix Execute method signature and access modifier
- 38b9dab Apply dotnet format