### PR TITLE
fix: filter out SystemEvent/UnknownEvent from AgentOutputView

### DIFF
--- a/src/Ivy.Tendril.Widgets/Widgets/frontend/src/parse-events.ts
+++ b/src/Ivy.Tendril.Widgets/Widgets/frontend/src/parse-events.ts
@@ -22,10 +22,10 @@ export function parseEventWireStream(jsonStream: string): PresentationEvent[] {
   let pendingText: string | null = null;
 
   const flushText = () => {
-    if (pendingText !== null) {
+    if (pendingText !== null && pendingText.trim().length > 0) {
       out.push({ kind: "assistant-text", text: pendingText });
-      pendingText = null;
     }
+    pendingText = null;
   };
 
   for (const evt of events) {

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -111,6 +111,8 @@ public record JobItem
         AppendToRawLog(line);
         foreach (var evt in EventParser.ParseLine(line))
         {
+            if (evt is SystemEvent or UnknownEvent) continue;
+
             if (evt is SessionInitEvent { Model: not null } initEvt)
                 Model = initEvt.Model;
 


### PR DESCRIPTION
These noise events (e.g. thinking_tokens) were serialized as empty
TextWire, rendering as blank gaps in the output widget.
