### PR TITLE
[00092] Change Execute Shortcut To X

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -73,7 +73,7 @@ public class ActionBarView(
                        jobService.StartJob(new SplitPlanArgs(selectedPlan.FolderPath));
                        refreshPlans();
                    })
-               | new Button("Expand").Icon(Icons.UnfoldVertical).Outline().ShortcutKey("x")
+               | new Button("Expand").Icon(Icons.UnfoldVertical).Outline().ShortcutKey("e")
                    .Disabled(hasActiveExpandJob)
                    .OnClick(() =>
                    {

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -168,7 +168,7 @@ public class ContentView(
         header |= Text.Rich()
             .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
             .Muted("plans", word: true);
-        header |= new Button("Execute").Icon(Icons.Rocket).Primary().ShortcutKey("e")
+        header |= new Button("Execute").Icon(Icons.Rocket).Primary().ShortcutKey("x")
             .Loading(isCheckingPreflight)
             .Disabled(isCheckingPreflight)
             .OnClick(() => runPreflight(selectedPlan.Project, result =>

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -80,7 +80,7 @@ public class ContentView(
                             planService.TransitionState(selectedPlan.FolderName, PlanStatus.Draft);
                             refreshPlans();
                         })
-                        | new Button("Execute").Icon(Icons.Rocket).Outline().ShortcutKey("e")
+                        | new Button("Execute").Icon(Icons.Rocket).Outline().ShortcutKey("x")
                             .Loading(isCheckingPreflight)
                             .Disabled(isCheckingPreflight)
                             .OnClick(() => runPreflight(selectedPlan.Project, result =>


### PR DESCRIPTION
# Summary

## Changes

Swapped keyboard shortcuts for Execute and Expand buttons to match user preferences. Execute now uses "x" (previously "e"), and Expand now uses "e" (previously "x").

## API Changes

None — internal UI configuration only.

## Files Modified

- **src/Ivy.Tendril/Apps/Drafts/ContentView.cs** — Changed Execute button shortcut from "e" to "x"
- **src/Ivy.Tendril/Apps/Icebox/ContentView.cs** — Changed Execute button shortcut from "e" to "x"
- **src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs** — Changed Expand button shortcut from "x" to "e"

---

## Commits

- ae4df8f793e6849db8b36a530860a05922ad53a4 Swap Execute and Expand keyboard shortcuts