### PR TITLE
[00093] Auto-select first plan when opening Icebox

### DIFF
--- a/src/Ivy.Tendril/Apps/IceboxApp.cs
+++ b/src/Ivy.Tendril/Apps/IceboxApp.cs
@@ -39,6 +39,8 @@ public class IceboxApp : ViewBase
         var filteredPlans = PlanFilters.ApplyFilters(plans, projectFilter.Value, levelFilter.Value, textFilter.Value)
             .ToList();
 
+        if (selectedPlanState.Value == null && filteredPlans.Count > 0) selectedPlanState.Set(filteredPlans[0]);
+
         if (selectedPlanState.Value is { } selected && filteredPlans.All(p => p.FolderName != selected.FolderName))
         {
             var oldIndex = previousPlans.Value.FindIndex(p => p.FolderName == selected.FolderName);


### PR DESCRIPTION
Added auto-selection logic to IceboxApp to automatically select the first plan when the Icebox tab is opened and no plan is currently selected. This matches the existing behavior in DraftsApp.

## API Changes

None.

## Files Modified

- **Apps/IceboxApp.cs** — Added auto-selection of first plan when none is selected

---

**Commits:**
- 50e7e1d Auto-select first plan when opening Icebox