### PR TITLE
[00089] Fix JobDebug 'not found' for evicted jobs

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
@@ -217,6 +217,11 @@ public class JobServiceDeletionTests
             return new List<JobItem>();
         }
 
+        public JobItem? GetJobById(string id)
+        {
+            return null;
+        }
+
         public List<JobItem> GetJobsForPlan(string planFile)
         {
             return new List<JobItem>();

--- a/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
@@ -81,6 +81,11 @@ public class JobServiceStartupTests
             return Jobs;
         }
 
+        public JobItem? GetJobById(string id)
+        {
+            return Jobs.FirstOrDefault(j => j.Id == id);
+        }
+
         public List<JobItem> GetJobsForPlan(string planFile)
         {
             return Jobs.Where(j => j.PlanFile == planFile).ToList();

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -292,7 +292,7 @@ public class JobService : IJobService
 
     public JobItem? GetJob(string id)
     {
-        return _jobs.GetValueOrDefault(id);
+        return _jobs.GetValueOrDefault(id) ?? _database?.GetJobById(id);
     }
 
     public List<JobItem> GetJobsForPlan(string planFile)

--- a/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
@@ -46,6 +46,7 @@ public interface IPlanDatabaseService : IDisposable
     // Jobs
     void UpsertJob(JobItem job);
     List<JobItem> GetRecentJobs(int limit = 100);
+    JobItem? GetJobById(string id);
     List<JobItem> GetJobsForPlan(string planFile);
     void PurgeOldJobs(int keepCount = 500);
     void DeleteJob(string id);

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -678,6 +678,17 @@ public class PlanDatabaseService : IPlanDatabaseService
         }
     }
 
+    public JobItem? GetJobById(string id)
+    {
+        using (new ReadLockHandle(_lock))
+        {
+            return ReadList("SELECT * FROM Jobs WHERE Id = @id LIMIT 1",
+                MapJobRow,
+                new SqliteParameter("@id", id))
+                .FirstOrDefault();
+        }
+    }
+
     public List<JobItem> GetJobsForPlan(string planFile)
     {
         using (new ReadLockHandle(_lock))


### PR DESCRIPTION
# Summary

## Changes

Added database fallback to `JobService.GetJob()` so completed jobs evicted from memory can still be retrieved. The Job Debug dialog now correctly displays information for evicted jobs instead of showing "Job not found."

## API Changes

- **IPlanDatabaseService.GetJobById(string id)** — new method to query a single job by ID from the database
- **PlanDatabaseService.GetJobById(string id)** — implementation that queries the Jobs table
- **JobService.GetJob(string id)** — now falls back to database when job not found in memory cache

## Files Modified

**Database Layer:**
- src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs — added GetJobById method signature
- src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs — implemented GetJobById with SQL query

**Service Layer:**
- src/Ivy.Tendril/Services/Jobs/JobService.cs — updated GetJob to use database fallback

---

### Commits
- dcb991f Fix test mocks for GetJobById
- ad56143 Add database fallback for JobService.GetJob