### PR TITLE
[00088] Add solve merge conflicts option to Create PR dialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -282,7 +282,7 @@ public class ContentView(
         {
             if (allYolo)
             {
-                jobService.StartJob(new CreatePrArgs(selectedPlan.FolderPath));
+                jobService.StartJob(new CreatePrArgs(selectedPlan.FolderPath, SolveMergeConflicts: true));
                 planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
                 refreshPlans();
             }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -24,6 +24,7 @@ public class CustomPrDialog(
     public override object? Build()
     {
         var isCreating = UseState(false);
+        var customPrSolveMergeConflicts = UseState(true);
         var customPrMerge = UseState(false);
         var customPrDeleteBranch = UseState(false);
         var customPrIncludeArtifacts = UseState(false);
@@ -42,6 +43,7 @@ public class CustomPrDialog(
             _ =>
             {
                 isCreating.Set(false);
+                customPrSolveMergeConflicts.Set(true);
                 customPrMerge.Set(true);
                 customPrDeleteBranch.Set(true);
                 customPrIncludeArtifacts.Set(true);
@@ -53,7 +55,8 @@ public class CustomPrDialog(
             new DialogHeader($"Custom PR for #{_selectedPlan.Id}"),
             new DialogBody(
                 Layout.Vertical().Gap(2)
-                | customPrMerge.ToBoolInput("Merge").AutoFocus()
+                | customPrSolveMergeConflicts.ToBoolInput("Solve Merge Conflicts").AutoFocus()
+                | customPrMerge.ToBoolInput("Merge")
                 | customPrDeleteBranch.ToBoolInput("Delete Branch")
                     .Disabled(!customPrMerge.Value)
                 | customPrIncludeArtifacts.ToBoolInput("Include Artifacts")
@@ -69,6 +72,7 @@ public class CustomPrDialog(
                 new Button("Cancel").Outline().OnClick(() =>
                 {
                     isCreating.Set(false);
+                    customPrSolveMergeConflicts.Set(true);
                     customPrMerge.Set(true);
                     customPrDeleteBranch.Set(true);
                     customPrIncludeArtifacts.Set(true);
@@ -84,6 +88,7 @@ public class CustomPrDialog(
                         isCreating.Set(true);
                         _jobService.StartJob(new CreatePrArgs(
                             _selectedPlan.FolderPath,
+                            SolveMergeConflicts: customPrSolveMergeConflicts.Value,
                             Merge: customPrMerge.Value,
                             DeleteBranch: customPrDeleteBranch.Value && customPrMerge.Value,
                             IncludeArtifacts: customPrIncludeArtifacts.Value,
@@ -93,6 +98,7 @@ public class CustomPrDialog(
                         _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
                         _refreshPlans();
                         isCreating.Set(false);
+                        customPrSolveMergeConflicts.Set(true);
                         customPrMerge.Set(true);
                         customPrDeleteBranch.Set(true);
                         customPrIncludeArtifacts.Set(true);

--- a/src/Ivy.Tendril/Models/JobArgs.cs
+++ b/src/Ivy.Tendril/Models/JobArgs.cs
@@ -71,6 +71,7 @@ public record SplitPlanArgs(
 
 public record CreatePrArgs(
     string FolderPath,
+    bool SolveMergeConflicts = true,
     bool Merge = true,
     bool DeleteBranch = true,
     bool IncludeArtifacts = true,

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -35,6 +35,7 @@ Before processing, read `plan.yaml` and check the `state` field. After reading, 
 - Read the latest revision for the plan title and description
 - Find the `prRule` for each repo from the firmware header
 - **Check for custom options:** Read the following firmware header values (if present). These override the default behavior in subsequent steps. If not present, all flags default to the behavior defined by the repo's `prRule`.
+  - `PrSolveMergeConflicts` — `true`/`false` (default: `true`)
   - `PrMerge` — `true`/`false` (default: `true`)
   - `PrDeleteBranch` — `true`/`false` (default: `true`)
   - `PrIncludeArtifacts` — `true`/`false` (default: `true`)
@@ -122,20 +123,13 @@ gh pr comment <pr-number> --repo <owner/repo> --body "<comment>"
 
 If no custom options or `comment` is empty, skip this step.
 
-### 4. Apply PR Rule
+### 3.7. Resolve Merge Conflicts (if enabled)
 
-Report status: `tendril job status TendrilJobId --message "Applying PR rule..."`
+If `PrSolveMergeConflicts` is `true` (default), check each PR for merge conflicts and resolve them proactively:
 
-**!MANDATORY** — look up the `prRule` for this repo in the `RepoConfigs` firmware header.
+Report status: `tendril job status TendrilJobId --message "Checking for merge conflicts..."`
 
-**Custom options override:** If custom options exist, the flags override the yolo behavior:
-- If `merge` is `false`: skip the entire merge step (treat as `default` rule regardless of prRule)
-- If `merge` is `true` but `deleteBranch` is `false`: merge without `--delete-branch` flag
-- If `merge` and `deleteBranch` are both `true`: behave exactly like `yolo`
-
-**Merge conflict handling (applies to ALL merge paths below):**
-
-Before calling `gh pr merge`, check for merge conflicts:
+For each PR created in step 3:
 
 ```bash
 # Poll mergeability (GitHub computes it asynchronously)
@@ -148,13 +142,13 @@ done
 
 | Mergeable status | Action |
 |---|---|
-| `MERGEABLE` | Proceed with merge |
-| `CONFLICTING` | **Resolve conflicts** (see below), then retry |
-| `UNKNOWN` (after 30s timeout) | Fail conservatively |
+| `MERGEABLE` | No action needed, proceed to step 4 |
+| `CONFLICTING` | **Resolve conflicts** (see below), then continue |
+| `UNKNOWN` (after 30s timeout) | Proceed to step 4 (assume clean) |
 
 #### Conflict Resolution
 
-When the PR status is `CONFLICTING`, resolve the conflict locally before retrying:
+When the PR status is `CONFLICTING`, resolve the conflict locally:
 
 1. **Locate the worktree** for this repo. If the worktree still exists in `<TendrilPlanFolder>/Worktrees/<repo-folder-name>`, use it. If the worktree was already removed, use the original repo path — create or force-update the local branch first: `git branch -f <branch-name> <sha>` and `git checkout <branch-name>`.
 
@@ -189,9 +183,26 @@ When the PR status is `CONFLICTING`, resolve the conflict locally before retryin
    git push origin <branch>
    ```
 
-8. **Re-check mergeability** (poll up to 30s again). If now `MERGEABLE`, proceed with the merge. If still `CONFLICTING` after resolution, **fail with a detailed error** explaining which files could not be resolved.
+8. **Re-check mergeability** (poll up to 30s again). If now `MERGEABLE`, proceed to step 4. If still `CONFLICTING` after resolution, **fail with a detailed error** explaining which files could not be resolved.
 
 **Important:** Only attempt conflict resolution **once**. If the second mergeability check still shows CONFLICTING, fail the execution — infinite retry loops waste tokens and time.
+
+This step runs regardless of whether a merge will be performed in step 4. Even if `PrMerge` is `false`, resolving conflicts ensures the PR is ready for manual review or future merging.
+
+If `PrSolveMergeConflicts` is `false`, skip this step entirely — the PR may be left in a conflicting state.
+
+### 4. Apply PR Rule
+
+Report status: `tendril job status TendrilJobId --message "Applying PR rule..."`
+
+**!MANDATORY** — look up the `prRule` for this repo in the `RepoConfigs` firmware header.
+
+**Custom options override:** If custom options exist, the flags override the yolo behavior:
+- If `merge` is `false`: skip the entire merge step (treat as `default` rule regardless of prRule)
+- If `merge` is `true` but `deleteBranch` is `false`: merge without `--delete-branch` flag
+- If `merge` and `deleteBranch` are both `true`: behave exactly like `yolo`
+
+**Note:** Merge conflict resolution is handled in step 3.7 if `PrSolveMergeConflicts` was `true`. By this step, the PR should already be conflict-free (if step 3.7 ran successfully).
 
 **If `yolo` (and no custom options overriding):**
 ```bash

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -423,6 +423,7 @@ internal class JobLauncher
         if (job.TypedArgs is not CreatePrArgs pr)
             return;
 
+        values["PrSolveMergeConflicts"] = pr.SolveMergeConflicts.ToString().ToLowerInvariant();
         values["PrMerge"] = pr.Merge.ToString().ToLowerInvariant();
         values["PrDeleteBranch"] = pr.DeleteBranch.ToString().ToLowerInvariant();
         values["PrIncludeArtifacts"] = pr.IncludeArtifacts.ToString().ToLowerInvariant();


### PR DESCRIPTION
# Summary

## Changes

Added a "Solve Merge Conflicts" toggle to the Create PR dialog that enables conflict resolution independently of the merge decision. The toggle is positioned as the first checkbox in the Custom PR dialog and defaults to enabled. When enabled, CreatePr now proactively resolves merge conflicts after PR creation (step 3.7) but before attempting any merge (step 4), ensuring PRs are conflict-free even when merge is disabled.

## API Changes

- `CreatePrArgs` — Added `bool SolveMergeConflicts = true` parameter (positioned after `FolderPath`, before `Merge`)
- CreatePr firmware — Added `PrSolveMergeConflicts` firmware value (default: `true`)

## Files Modified

**Core changes:**
- `src/Ivy.Tendril/Models/JobArgs.cs` — Added `SolveMergeConflicts` parameter to `CreatePrArgs`
- `src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs` — Added checkbox UI and state management
- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — Updated yolo quick-create path to pass default value
- `src/Ivy.Tendril/Services/Jobs/JobLauncher.cs` — Pass firmware value in `AddCreatePrOptions`

**Promptware documentation:**
- `src/Ivy.Tendril/Promptwares/CreatePr/Program.md` — Added step 3.7 for conflict resolution, updated step 4

---

## Commits
- 11307762b22b891e0a12e9bb5dfc53300870cd44