### PR TITLE
[00087] GlobalLastSelectedProjectInCreatePlanDialog

### DIFF
--- a/src/Ivy.Tendril.Test/CreatePlanPreferencesTests.cs
+++ b/src/Ivy.Tendril.Test/CreatePlanPreferencesTests.cs
@@ -1,0 +1,40 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class CreatePlanPreferencesTests
+{
+    [Fact]
+    public void DefaultValue_IsAuto()
+    {
+        var preferences = new CreatePlanPreferences();
+
+        Assert.Single(preferences.LastSelectedProjects);
+        Assert.Equal("Auto", preferences.LastSelectedProjects[0]);
+    }
+
+    [Fact]
+    public void SharedInstance_PreservesSelection()
+    {
+        var sharedPreferences = new CreatePlanPreferences();
+
+        sharedPreferences.LastSelectedProjects = ["Tendril", "Other"];
+        var retrieved = sharedPreferences.LastSelectedProjects;
+
+        Assert.Equal(2, retrieved.Length);
+        Assert.Equal("Tendril", retrieved[0]);
+        Assert.Equal("Other", retrieved[1]);
+    }
+
+    [Fact]
+    public void MultipleReferences_ShareState()
+    {
+        ICreatePlanPreferences preferences = new CreatePlanPreferences();
+        ICreatePlanPreferences sameReference = preferences;
+
+        preferences.LastSelectedProjects = ["ProjectA"];
+
+        Assert.Single(sameReference.LastSelectedProjects);
+        Assert.Equal("ProjectA", sameReference.LastSelectedProjects[0]);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Views/CreatePlanDialogLauncher.cs
+++ b/src/Ivy.Tendril/Apps/Views/CreatePlanDialogLauncher.cs
@@ -13,7 +13,7 @@ public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : View
         var jobService = UseService<IJobService>();
         var configService = UseService<IConfigService>();
         var navigator = UseNavigation();
-        var lastSelectedProjects = UseState<string[]>(["Auto"]);
+        var preferences = UseService<ICreatePlanPreferences>();
         var showDirtyDialog = UseState(false);
         var pendingJobArgs = UseState<CreatePlanArgs?>(null);
         var (runPreflight, _, preflightResult) = Context.UsePreflightCheck();
@@ -31,7 +31,7 @@ public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : View
                 projectNames,
                 (description, projects, priority) =>
                 {
-                    lastSelectedProjects.Set(projects);
+                    preferences.LastSelectedProjects = projects;
                     var project = string.Join(",", projects);
                     var args = new CreatePlanArgs(description, project, priority, Force: true);
                     pendingJobArgs.Set(args);
@@ -45,7 +45,7 @@ public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : View
                     });
                 },
                 () => isOpen.Set(false),
-                lastSelectedProjects.Value
+                preferences.LastSelectedProjects
             );
         });
 

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -20,6 +20,7 @@ internal static class ServiceRegistration
 
         server.Services.AddSingleton<IConfigService>(configService);
         server.Services.AddSingleton<ConfigService>(configService);
+        server.Services.AddSingleton<ICreatePlanPreferences, CreatePlanPreferences>();
 
         Program.SetConfigServiceForCleanup(configService);
 

--- a/src/Ivy.Tendril/Services/CreatePlanPreferences.cs
+++ b/src/Ivy.Tendril/Services/CreatePlanPreferences.cs
@@ -1,0 +1,6 @@
+namespace Ivy.Tendril.Services;
+
+public class CreatePlanPreferences : ICreatePlanPreferences
+{
+    public string[] LastSelectedProjects { get; set; } = ["Auto"];
+}

--- a/src/Ivy.Tendril/Services/ICreatePlanPreferences.cs
+++ b/src/Ivy.Tendril/Services/ICreatePlanPreferences.cs
@@ -1,0 +1,6 @@
+namespace Ivy.Tendril.Services;
+
+public interface ICreatePlanPreferences
+{
+    string[] LastSelectedProjects { get; set; }
+}


### PR DESCRIPTION
# Summary

## Changes

Replaced component-local state in CreatePlanDialogLauncher with a shared singleton ICreatePlanPreferences service. All "New Plan" buttons across the application (sidebar, dashboard, and review apps) now share the same project selection state.

## API Changes

**New public APIs:**
- `ICreatePlanPreferences` interface with `string[] LastSelectedProjects` property
- `CreatePlanPreferences` class implementing the interface
- Service registered as singleton in DI container

**Modified:**
- `CreatePlanDialogLauncher` now depends on `ICreatePlanPreferences` instead of using local state

## Files Modified

**Services:**
- `src/Ivy.Tendril/Services/ICreatePlanPreferences.cs` (new)
- `src/Ivy.Tendril/Services/CreatePlanPreferences.cs` (new)
- `src/Ivy.Tendril/ServiceRegistration.cs` (registration)

**Components:**
- `src/Ivy.Tendril/Apps/Views/CreatePlanDialogLauncher.cs` (refactored to use service)

**Tests:**
- `src/Ivy.Tendril.Test/CreatePlanPreferencesTests.cs` (new)

---

**Commits:**
- f5c031f6b03949deeb95918f35d0f96e89c64f2c