### PR TITLE
[00091] Add missing Web API and MCP endpoints for CLI parity

### DIFF
--- a/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
@@ -485,4 +485,327 @@ public class PlanToolsTests : IDisposable
         Assert.Contains("Build a widget", content);
         Assert.Contains("project: TestProject", content);
     }
+
+    // --- PlanCreate (direct) ---
+
+    [Fact]
+    public void PlanCreate_ReturnsIdAndFolder()
+    {
+        var plansDir = Path.Combine(_tempDir, "Plans");
+        Directory.CreateDirectory(plansDir);
+
+        var result = _planTools.PlanCreate("Direct Plan Test", repos: _repoDir);
+
+        Assert.Contains("Plan created:", result);
+        Assert.Contains("PlanId:", result);
+        Assert.Contains("Directory:", result);
+    }
+
+    [Fact]
+    public void PlanCreate_WithAllOptions_SetsAllFields()
+    {
+        var plansDir = Path.Combine(_tempDir, "Plans");
+        Directory.CreateDirectory(plansDir);
+
+        var result = _planTools.PlanCreate(
+            "Full Plan",
+            project: "MyProject",
+            level: "Critical",
+            initialPrompt: "Do the thing",
+            executionProfile: "deep",
+            sourceUrl: "https://github.com/org/repo/issues/1",
+            repos: _repoDir,
+            verifications: "DotnetBuild,DotnetTest");
+
+        Assert.Contains("Plan created:", result);
+
+        var planId = result.Split('\n')
+            .First(l => l.StartsWith("PlanId:"))
+            .Replace("PlanId: ", "").Trim();
+
+        var plan = _planTools.GetPlan(planId);
+        Assert.Contains("MyProject", plan);
+        Assert.Contains("Critical", plan);
+        Assert.Contains("Do the thing", plan);
+    }
+
+    // --- WriteRevision ---
+
+    [Fact]
+    public void WriteRevision_CreatesRevisionFile()
+    {
+        var planFolder = CreateTestPlan();
+
+        var result = _planTools.WriteRevision("00001", "# Test Revision\n\nContent here.");
+
+        Assert.Contains("Revision written: 001.md", result);
+        var revFile = Path.Combine(planFolder, "Revisions", "001.md");
+        Assert.True(File.Exists(revFile));
+        Assert.Contains("Test Revision", File.ReadAllText(revFile));
+    }
+
+    [Fact]
+    public void WriteRevision_IncrementsNumber()
+    {
+        var planFolder = CreateTestPlan();
+        var revisionsDir = Path.Combine(planFolder, "Revisions");
+        Directory.CreateDirectory(revisionsDir);
+        File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "First");
+
+        var result = _planTools.WriteRevision("00001", "Second revision");
+
+        Assert.Contains("002.md", result);
+    }
+
+    // --- AddRelated / RemoveRelated ---
+
+    [Fact]
+    public void AddRelated_AddsLink()
+    {
+        CreateTestPlan();
+
+        var result = _planTools.AddRelated("00001", "00010-OtherPlan");
+
+        Assert.Contains("Added related plan", result);
+        var plan = _planTools.GetPlan("00001", "relatedPlans");
+        Assert.Contains("00010-OtherPlan", plan);
+    }
+
+    [Fact]
+    public void AddRelated_Duplicate_IsIdempotent()
+    {
+        CreateTestPlan();
+        _planTools.AddRelated("00001", "00010-OtherPlan");
+
+        var result = _planTools.AddRelated("00001", "00010-OtherPlan");
+
+        Assert.Contains("Added related plan", result);
+    }
+
+    [Fact]
+    public void RemoveRelated_RemovesLink()
+    {
+        CreateTestPlan();
+        _planTools.AddRelated("00001", "00010-OtherPlan");
+
+        var result = _planTools.RemoveRelated("00001", "00010-OtherPlan");
+
+        Assert.Contains("Removed related plan", result);
+        var plan = _planTools.GetPlan("00001", "relatedPlans");
+        Assert.DoesNotContain("00010-OtherPlan", plan);
+    }
+
+    [Fact]
+    public void RemoveRelated_NotFound_ReturnsError()
+    {
+        CreateTestPlan();
+
+        var result = _planTools.RemoveRelated("00001", "NonExistent");
+
+        Assert.Contains("Error:", result);
+    }
+
+    // --- AddDependsOn / RemoveDependsOn ---
+
+    [Fact]
+    public void AddDependsOn_AddsDependency()
+    {
+        CreateTestPlan();
+
+        var result = _planTools.AddDependsOn("00001", "00005-BasePlan");
+
+        Assert.Contains("Added dependency", result);
+        var plan = _planTools.GetPlan("00001", "dependsOn");
+        Assert.Contains("00005-BasePlan", plan);
+    }
+
+    [Fact]
+    public void AddDependsOn_Duplicate_IsIdempotent()
+    {
+        CreateTestPlan();
+        _planTools.AddDependsOn("00001", "00005-BasePlan");
+
+        var result = _planTools.AddDependsOn("00001", "00005-BasePlan");
+
+        Assert.Contains("Added dependency", result);
+    }
+
+    [Fact]
+    public void RemoveDependsOn_RemovesDependency()
+    {
+        CreateTestPlan();
+        _planTools.AddDependsOn("00001", "00005-BasePlan");
+
+        var result = _planTools.RemoveDependsOn("00001", "00005-BasePlan");
+
+        Assert.Contains("Removed dependency", result);
+        var plan = _planTools.GetPlan("00001", "dependsOn");
+        Assert.DoesNotContain("00005-BasePlan", plan);
+    }
+
+    [Fact]
+    public void RemoveDependsOn_NotFound_ReturnsError()
+    {
+        CreateTestPlan();
+
+        var result = _planTools.RemoveDependsOn("00001", "NonExistent");
+
+        Assert.Contains("Error:", result);
+    }
+
+    // --- Validate ---
+
+    [Fact]
+    public void Validate_ValidPlan_ReturnsValid()
+    {
+        CreateTestPlan();
+
+        var result = _planTools.Validate("00001");
+
+        Assert.Contains("Plan is valid", result);
+    }
+
+    [Fact]
+    public void Validate_InvalidPlan_ReturnsFailure()
+    {
+        var plansDir = Path.Combine(_tempDir, "Plans");
+        var planFolder = Path.Combine(plansDir, "00002-BadPlan");
+        Directory.CreateDirectory(planFolder);
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), """
+            state: InvalidState
+            project: TestProject
+            level: NiceToHave
+            title: Bad Plan
+            repos:
+            - /nonexistent/path
+            commits: []
+            prs: []
+            created: 2026-04-01T10:00:00.0000000Z
+            updated: 2026-04-01T10:00:00.0000000Z
+            verifications: []
+            relatedPlans: []
+            dependsOn: []
+            priority: 0
+            """);
+
+        var result = _planTools.Validate("00002");
+
+        Assert.Contains("Validation failed:", result);
+    }
+
+    // --- VerificationList ---
+
+    [Fact]
+    public void VerificationList_ReturnsAll()
+    {
+        CreateTestPlan();
+        _planTools.VerificationAdd("00001", "Build");
+        _planTools.VerificationAdd("00001", "Test", "Pass");
+
+        var result = _planTools.VerificationList("00001");
+
+        Assert.Contains("Build", result);
+        Assert.Contains("Test", result);
+    }
+
+    [Fact]
+    public void VerificationList_FilterByStatus()
+    {
+        CreateTestPlan();
+        _planTools.VerificationAdd("00001", "Build", "Pending");
+        _planTools.VerificationAdd("00001", "Test", "Pass");
+
+        var result = _planTools.VerificationList("00001", "Pass");
+
+        Assert.Contains("Test", result);
+        Assert.DoesNotContain("Build", result);
+    }
+
+    // --- VerificationAdd ---
+
+    [Fact]
+    public void VerificationAdd_AddsNew()
+    {
+        CreateTestPlan();
+
+        var result = _planTools.VerificationAdd("00001", "NewCheck");
+
+        Assert.Contains("Added verification", result);
+        var list = _planTools.VerificationList("00001");
+        Assert.Contains("NewCheck", list);
+        Assert.Contains("Pending", list);
+    }
+
+    [Fact]
+    public void VerificationAdd_Duplicate_ReturnsError()
+    {
+        CreateTestPlan();
+        _planTools.VerificationAdd("00001", "Build");
+
+        var result = _planTools.VerificationAdd("00001", "Build");
+
+        Assert.Contains("Error:", result);
+    }
+
+    // --- VerificationRemove ---
+
+    [Fact]
+    public void VerificationRemove_Removes()
+    {
+        CreateTestPlan();
+        _planTools.VerificationAdd("00001", "Build");
+
+        var result = _planTools.VerificationRemove("00001", "Build");
+
+        Assert.Contains("Removed verification", result);
+        var list = _planTools.VerificationList("00001");
+        Assert.DoesNotContain("Build", list);
+    }
+
+    [Fact]
+    public void VerificationRemove_NotFound_ReturnsError()
+    {
+        CreateTestPlan();
+
+        var result = _planTools.VerificationRemove("00001", "NonExistent");
+
+        Assert.Contains("Error:", result);
+    }
+
+    // --- RecSet ---
+
+    [Fact]
+    public void RecSet_UpdatesDescription()
+    {
+        CreateTestPlan();
+        _planTools.RecAdd("00001", "MyRec", "Original desc");
+
+        var result = _planTools.RecSet("00001", "MyRec", "description", "Updated desc");
+
+        Assert.Contains("Updated recommendation", result);
+        var list = _planTools.RecList("00001");
+        Assert.Contains("MyRec", list);
+    }
+
+    [Fact]
+    public void RecSet_UnknownField_ReturnsError()
+    {
+        CreateTestPlan();
+        _planTools.RecAdd("00001", "MyRec", "desc");
+
+        var result = _planTools.RecSet("00001", "MyRec", "nonexistent", "value");
+
+        Assert.Contains("Error:", result);
+        Assert.Contains("Unknown field", result);
+    }
+
+    [Fact]
+    public void RecSet_NotFound_ReturnsError()
+    {
+        CreateTestPlan();
+
+        var result = _planTools.RecSet("00001", "NonExistent", "description", "value");
+
+        Assert.Contains("Error:", result);
+    }
 }

--- a/src/Ivy.Tendril.Test/PlanControllerTests.cs
+++ b/src/Ivy.Tendril.Test/PlanControllerTests.cs
@@ -581,6 +581,340 @@ public class PlanControllerTests : IDisposable
         Assert.Contains("Rec1", json2);
         Assert.DoesNotContain("Rec2", json2);
     }
+
+    // --- CreatePlanDirect ---
+
+    [Fact]
+    public void CreatePlanDirect_ReturnsIdAndFolder()
+    {
+        var plansDir = Path.Combine(_tempDir.Path, "Plans");
+        Directory.CreateDirectory(plansDir);
+        var controller = CreateController();
+
+        var result = controller.CreatePlanDirect(new CreatePlanDirectRequest("Test Direct Plan", Repos: [_repoDir]));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("\"id\":", json);
+        Assert.Contains("\"folder\":", json);
+        Assert.Contains("Test Direct Plan", json);
+    }
+
+    [Fact]
+    public void CreatePlanDirect_WithAllOptions_SetsAllFields()
+    {
+        var plansDir = Path.Combine(_tempDir.Path, "Plans");
+        Directory.CreateDirectory(plansDir);
+        var controller = CreateController();
+
+        var request = new CreatePlanDirectRequest(
+            "Full Plan",
+            Project: "MyProject",
+            Level: "Critical",
+            InitialPrompt: "Do the thing",
+            ExecutionProfile: "deep",
+            SourceUrl: "https://github.com/org/repo/issues/1",
+            Repos: [_repoDir],
+            Verifications: ["DotnetBuild", "DotnetTest"],
+            RelatedPlans: ["00010-OtherPlan"],
+            DependsOn: ["00005-BasePlan"]);
+
+        var result = controller.CreatePlanDirect(request);
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("\"id\":", json);
+
+        var idStr = JsonDocument.Parse(json).RootElement.GetProperty("id").GetString()!;
+        var getPlanResult = controller.GetPlan(idStr);
+        var getOk = Assert.IsType<OkObjectResult>(getPlanResult);
+        var planJson = JsonSerializer.Serialize(getOk.Value);
+        Assert.Contains("MyProject", planJson);
+        Assert.Contains("Critical", planJson);
+        Assert.Contains("Do the thing", planJson);
+        Assert.Contains("deep", planJson);
+    }
+
+    // --- WriteRevision ---
+
+    [Fact]
+    public void WriteRevision_CreatesRevisionFile()
+    {
+        var planFolder = CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.WriteRevision("00001", new WriteRevisionRequest("# Test Revision\n\nContent here."));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("001.md", json);
+
+        var revFile = Path.Combine(planFolder, "Revisions", "001.md");
+        Assert.True(System.IO.File.Exists(revFile));
+        Assert.Contains("Test Revision", System.IO.File.ReadAllText(revFile));
+    }
+
+    [Fact]
+    public void WriteRevision_IncrementsNumber()
+    {
+        var planFolder = CreateTestPlan();
+        var revisionsDir = Path.Combine(planFolder, "Revisions");
+        Directory.CreateDirectory(revisionsDir);
+        System.IO.File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "First");
+
+        var controller = CreateController();
+        var result = controller.WriteRevision("00001", new WriteRevisionRequest("Second revision"));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("002.md", json);
+    }
+
+    // --- AddRelatedPlan ---
+
+    [Fact]
+    public void AddRelatedPlan_AddsLink()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.AddRelatedPlan("00001", new AddRelatedPlanRequest("00010-OtherPlan"));
+
+        Assert.IsType<OkObjectResult>(result);
+        var getResult = controller.GetPlan("00001");
+        var json = JsonSerializer.Serialize(((OkObjectResult)getResult).Value);
+        Assert.Contains("00010-OtherPlan", json);
+    }
+
+    [Fact]
+    public void AddRelatedPlan_Duplicate_ReturnsOk()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddRelatedPlan("00001", new AddRelatedPlanRequest("00010-OtherPlan"));
+
+        var result = controller.AddRelatedPlan("00001", new AddRelatedPlanRequest("00010-OtherPlan"));
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    // --- RemoveRelatedPlan ---
+
+    [Fact]
+    public void RemoveRelatedPlan_RemovesLink()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddRelatedPlan("00001", new AddRelatedPlanRequest("00010-OtherPlan"));
+
+        var result = controller.RemoveRelatedPlan("00001", new RemoveRelatedPlanRequest("00010-OtherPlan"));
+
+        Assert.IsType<OkObjectResult>(result);
+        var getResult = controller.GetPlan("00001");
+        var json = JsonSerializer.Serialize(((OkObjectResult)getResult).Value);
+        Assert.DoesNotContain("00010-OtherPlan", json);
+    }
+
+    [Fact]
+    public void RemoveRelatedPlan_NotFound_Returns404()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.RemoveRelatedPlan("00001", new RemoveRelatedPlanRequest("NonExistent"));
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    // --- AddDependsOn ---
+
+    [Fact]
+    public void AddDependsOn_AddsDependency()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.AddDependsOn("00001", new AddDependsOnRequest("00005-BasePlan"));
+
+        Assert.IsType<OkObjectResult>(result);
+        var getResult = controller.GetPlan("00001");
+        var json = JsonSerializer.Serialize(((OkObjectResult)getResult).Value);
+        Assert.Contains("00005-BasePlan", json);
+    }
+
+    [Fact]
+    public void AddDependsOn_Duplicate_ReturnsOk()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddDependsOn("00001", new AddDependsOnRequest("00005-BasePlan"));
+
+        var result = controller.AddDependsOn("00001", new AddDependsOnRequest("00005-BasePlan"));
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    // --- RemoveDependsOn ---
+
+    [Fact]
+    public void RemoveDependsOn_RemovesDependency()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddDependsOn("00001", new AddDependsOnRequest("00005-BasePlan"));
+
+        var result = controller.RemoveDependsOn("00001", new RemoveDependsOnRequest("00005-BasePlan"));
+
+        Assert.IsType<OkObjectResult>(result);
+        var getResult = controller.GetPlan("00001");
+        var json = JsonSerializer.Serialize(((OkObjectResult)getResult).Value);
+        Assert.DoesNotContain("00005-BasePlan", json);
+    }
+
+    [Fact]
+    public void RemoveDependsOn_NotFound_Returns404()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.RemoveDependsOn("00001", new RemoveDependsOnRequest("NonExistent"));
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    // --- ValidatePlan ---
+
+    [Fact]
+    public void ValidatePlan_ReturnsValidationResult()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.ValidatePlan("00001");
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("\"valid\":", json);
+    }
+
+    // --- ListVerifications ---
+
+    [Fact]
+    public void ListVerifications_ReturnsAll()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddVerification("00001", new AddVerificationRequest("Build"));
+        controller.AddVerification("00001", new AddVerificationRequest("Test", "Pass"));
+
+        var result = controller.ListVerifications("00001");
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("Build", json);
+        Assert.Contains("Test", json);
+    }
+
+    [Fact]
+    public void ListVerifications_FilterByStatus()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddVerification("00001", new AddVerificationRequest("Build", "Pending"));
+        controller.AddVerification("00001", new AddVerificationRequest("Test", "Pass"));
+
+        var result = controller.ListVerifications("00001", "Pass");
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var json = JsonSerializer.Serialize(ok.Value);
+        Assert.Contains("Test", json);
+        Assert.DoesNotContain("Build", json);
+    }
+
+    // --- AddVerification ---
+
+    [Fact]
+    public void AddVerification_AddsNew()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.AddVerification("00001", new AddVerificationRequest("NewCheck"));
+
+        Assert.IsType<OkObjectResult>(result);
+        var listResult = controller.ListVerifications("00001");
+        var json = JsonSerializer.Serialize(((OkObjectResult)listResult).Value);
+        Assert.Contains("NewCheck", json);
+        Assert.Contains("Pending", json);
+    }
+
+    [Fact]
+    public void AddVerification_Duplicate_ReturnsConflict()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddVerification("00001", new AddVerificationRequest("Build"));
+
+        var result = controller.AddVerification("00001", new AddVerificationRequest("Build"));
+
+        Assert.IsType<ConflictObjectResult>(result);
+    }
+
+    // --- RemoveVerification ---
+
+    [Fact]
+    public void RemoveVerification_Removes()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddVerification("00001", new AddVerificationRequest("Build"));
+
+        var result = controller.RemoveVerification("00001", "Build");
+
+        Assert.IsType<OkObjectResult>(result);
+        var listResult = controller.ListVerifications("00001");
+        var json = JsonSerializer.Serialize(((OkObjectResult)listResult).Value);
+        Assert.DoesNotContain("Build", json);
+    }
+
+    [Fact]
+    public void RemoveVerification_NotFound_Returns404()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+
+        var result = controller.RemoveVerification("00001", "NonExistent");
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    // --- SetRecField ---
+
+    [Fact]
+    public void SetRecField_UpdatesDescription()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddRecommendation("00001", new AddRecRequest("MyRec", "Original desc"));
+
+        var result = controller.SetRecField("00001", "MyRec", new SetRecFieldRequest("description", "Updated desc"));
+
+        Assert.IsType<OkObjectResult>(result);
+        var listResult = controller.ListRecommendations("00001");
+        var json = JsonSerializer.Serialize(((OkObjectResult)listResult).Value);
+        Assert.Contains("Updated desc", json);
+    }
+
+    [Fact]
+    public void SetRecField_UnknownField_ReturnsBadRequest()
+    {
+        CreateTestPlan();
+        var controller = CreateController();
+        controller.AddRecommendation("00001", new AddRecRequest("MyRec"));
+
+        var result = controller.SetRecField("00001", "MyRec", new SetRecFieldRequest("nonexistent", "value"));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
 }
 
 file class NullPlanWatcherService : IPlanWatcherService

--- a/src/Ivy.Tendril/Controllers/PlanController.cs
+++ b/src/Ivy.Tendril/Controllers/PlanController.cs
@@ -1,6 +1,7 @@
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Commands;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
 using Ivy.Tendril.Helpers;
 using Microsoft.AspNetCore.Mvc;
 
@@ -371,6 +372,246 @@ public class PlanController : ControllerBase
             return (true, $"Removed recommendation '{title}'", 200);
         });
 
+    [HttpPut("{planId}/recommendations/{title}")]
+    public IActionResult SetRecField(string planId, string title, [FromBody] SetRecFieldRequest request)
+    {
+        var validFields = new[] { "title", "description", "state", "impact", "risk", "declinereason" };
+        if (!validFields.Contains(request.Field.ToLower()))
+            return BadRequest(new { error = $"Unknown field: {request.Field}. Valid: {string.Join(", ", validFields)}" });
+
+        return ModifyPlanEndpoint(planId, plan =>
+        {
+            var rec = (plan.Recommendations ?? [])
+                .FirstOrDefault(r => r.Title.Equals(title, StringComparison.OrdinalIgnoreCase));
+            if (rec == null)
+                return (false, $"Recommendation '{title}' not found", 404);
+
+            switch (request.Field.ToLower())
+            {
+                case "title": rec.Title = request.Value; break;
+                case "description": rec.Description = request.Value; break;
+                case "state": rec.State = request.Value; break;
+                case "impact": rec.Impact = request.Value; break;
+                case "risk": rec.Risk = request.Value; break;
+                case "declinereason": rec.DeclineReason = request.Value; break;
+            }
+
+            return (true, $"Updated recommendation field '{request.Field}'", 200);
+        });
+    }
+
+    [HttpPost]
+    public IActionResult CreatePlanDirect([FromBody] CreatePlanDirectRequest request)
+    {
+        try
+        {
+            var plansDir = PlanCommandHelpers.GetPlansDirectory();
+            var planId = PlanYamlHelper.AllocatePlanId(plansDir);
+            var safeTitle = PlanYamlHelper.ToSafeTitle(request.Title);
+            var folderName = $"{planId}-{safeTitle}";
+            var planFolder = Path.Combine(plansDir, folderName);
+
+            Directory.CreateDirectory(planFolder);
+            FileHelper.GrantBroadWriteAccess(planFolder);
+
+            var plan = new PlanYaml
+            {
+                State = nameof(PlanStatus.Draft),
+                Project = request.Project ?? "Auto",
+                Level = request.Level ?? "NiceToHave",
+                Title = request.Title,
+                Created = DateTime.UtcNow,
+                Updated = DateTime.UtcNow,
+                InitialPrompt = request.InitialPrompt,
+                SourceUrl = request.SourceUrl,
+                ExecutionProfile = request.ExecutionProfile,
+                Priority = 0
+            };
+
+            if (request.Repos != null)
+                foreach (var repo in request.Repos)
+                    plan.Repos.Add(repo);
+
+            if (request.Verifications != null)
+                foreach (var v in request.Verifications)
+                    plan.Verifications.Add(new PlanVerificationEntry { Name = v, Status = VerificationStatus.Pending });
+
+            if (request.RelatedPlans != null)
+                foreach (var rp in request.RelatedPlans)
+                    plan.RelatedPlans.Add(rp);
+
+            if (request.DependsOn != null)
+                foreach (var dep in request.DependsOn)
+                    plan.DependsOn.Add(dep);
+
+            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+            return Ok(new { id = planId, folder = planFolder, title = plan.Title });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPost("{planId}/revisions")]
+    public IActionResult WriteRevision(string planId, [FromBody] WriteRevisionRequest request)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var revisionsDir = Path.Combine(planFolder, "Revisions");
+            Directory.CreateDirectory(revisionsDir);
+
+            var number = ResolveNextRevisionNumber(revisionsDir);
+            var filename = $"{number:D3}.md";
+            var filePath = Path.Combine(revisionsDir, filename);
+
+            System.IO.File.WriteAllText(filePath, request.Content);
+            return Ok(new { file = filename, path = filePath });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPost("{planId}/related-plans")]
+    public IActionResult AddRelatedPlan(string planId, [FromBody] AddRelatedPlanRequest request) =>
+        ModifyPlanEndpoint(planId, plan =>
+        {
+            if (plan.RelatedPlans.Contains(request.RelatedPlan, StringComparer.OrdinalIgnoreCase))
+                return (true, $"Related plan already present: {request.RelatedPlan}", 200);
+
+            plan.RelatedPlans.Add(request.RelatedPlan);
+            return (true, $"Added related plan: {request.RelatedPlan}", 200);
+        });
+
+    [HttpDelete("{planId}/related-plans")]
+    public IActionResult RemoveRelatedPlan(string planId, [FromBody] RemoveRelatedPlanRequest request) =>
+        ModifyPlanEndpoint(planId, plan =>
+        {
+            var removed = plan.RelatedPlans.RemoveAll(r => r.Equals(request.RelatedPlan, StringComparison.OrdinalIgnoreCase));
+            if (removed == 0)
+                return (false, $"Related plan not found: {request.RelatedPlan}", 404);
+
+            return (true, $"Removed related plan: {request.RelatedPlan}", 200);
+        });
+
+    [HttpPost("{planId}/depends-on")]
+    public IActionResult AddDependsOn(string planId, [FromBody] AddDependsOnRequest request) =>
+        ModifyPlanEndpoint(planId, plan =>
+        {
+            if (plan.DependsOn.Contains(request.DependsOn, StringComparer.OrdinalIgnoreCase))
+                return (true, $"Dependency already present: {request.DependsOn}", 200);
+
+            plan.DependsOn.Add(request.DependsOn);
+            return (true, $"Added dependency: {request.DependsOn}", 200);
+        });
+
+    [HttpDelete("{planId}/depends-on")]
+    public IActionResult RemoveDependsOn(string planId, [FromBody] RemoveDependsOnRequest request) =>
+        ModifyPlanEndpoint(planId, plan =>
+        {
+            var removed = plan.DependsOn.RemoveAll(d => d.Equals(request.DependsOn, StringComparison.OrdinalIgnoreCase));
+            if (removed == 0)
+                return (false, $"Dependency not found: {request.DependsOn}", 404);
+
+            return (true, $"Removed dependency: {request.DependsOn}", 200);
+        });
+
+    [HttpPost("{planId}/validate")]
+    public IActionResult ValidatePlan(string planId)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            PlanValidationService.Validate(plan);
+            return Ok(new { valid = true, message = "Plan is valid" });
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (ArgumentException ex)
+        {
+            return Ok(new { valid = false, message = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpGet("{planId}/verifications")]
+    public IActionResult ListVerifications(string planId, [FromQuery] string? status = null)
+    {
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var verifications = plan.Verifications;
+
+            if (!string.IsNullOrEmpty(status))
+                verifications = verifications.Where(v => v.Status.Equals(status, StringComparison.OrdinalIgnoreCase)).ToList();
+
+            return Ok(verifications.Select(v => new { name = v.Name, status = v.Status }));
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return NotFound(new { error = $"Plan '{planId}' not found" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
+    }
+
+    [HttpPost("{planId}/verifications/add")]
+    public IActionResult AddVerification(string planId, [FromBody] AddVerificationRequest request) =>
+        ModifyPlanEndpoint(planId, plan =>
+        {
+            if (plan.Verifications.Any(v => v.Name.Equals(request.Name, StringComparison.OrdinalIgnoreCase)))
+                return (false, $"Verification '{request.Name}' already exists", 409);
+
+            plan.Verifications.Add(new PlanVerificationEntry
+            {
+                Name = request.Name,
+                Status = request.Status ?? VerificationStatus.Pending
+            });
+
+            return (true, $"Added verification '{request.Name}'", 200);
+        });
+
+    [HttpDelete("{planId}/verifications/{name}")]
+    public IActionResult RemoveVerification(string planId, string name) =>
+        ModifyPlanEndpoint(planId, plan =>
+        {
+            var match = plan.Verifications.FirstOrDefault(v => v.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+            if (match == null)
+                return (false, $"Verification '{name}' not found", 404);
+
+            plan.Verifications.Remove(match);
+            return (true, $"Removed verification '{name}'", 200);
+        });
+
+    private static int ResolveNextRevisionNumber(string revisionsDir)
+    {
+        var max = 0;
+        foreach (var file in Directory.GetFiles(revisionsDir, "*.md"))
+        {
+            var name = Path.GetFileNameWithoutExtension(file);
+            if (int.TryParse(name, out var num) && num > max)
+                max = num;
+        }
+        return max + 1;
+    }
+
     private static bool ExtractPlanId(string folderName, out string id)
     {
         id = "";
@@ -430,3 +671,21 @@ public record AddLogRequest(string Action, string? Summary = null);
 public record AddRecRequest(string Title, string? Description = null, string? Impact = null, string? Risk = null);
 public record AcceptRecRequest(string? Notes = null);
 public record DeclineRecRequest(string? Reason = null);
+public record CreatePlanDirectRequest(
+    string Title,
+    string? Project = null,
+    string? Level = null,
+    string? InitialPrompt = null,
+    string? ExecutionProfile = null,
+    string? SourceUrl = null,
+    List<string>? Repos = null,
+    List<string>? Verifications = null,
+    List<string>? RelatedPlans = null,
+    List<string>? DependsOn = null);
+public record WriteRevisionRequest(string Content);
+public record AddRelatedPlanRequest(string RelatedPlan);
+public record RemoveRelatedPlanRequest(string RelatedPlan);
+public record AddDependsOnRequest(string DependsOn);
+public record RemoveDependsOnRequest(string DependsOn);
+public record AddVerificationRequest(string Name, string? Status = null);
+public record SetRecFieldRequest(string Field, string Value);

--- a/src/Ivy.Tendril/Mcp/Tools/AuthenticatedToolBase.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/AuthenticatedToolBase.cs
@@ -1,9 +1,5 @@
 namespace Ivy.Tendril.Mcp.Tools;
 
-/// <summary>
-/// Base class for MCP tool classes requiring authentication.
-/// Provides centralized authentication checking via ExecuteAuthenticated.
-/// </summary>
 public abstract class AuthenticatedToolBase
 {
     private readonly McpAuthenticationService _authService;
@@ -13,15 +9,18 @@ public abstract class AuthenticatedToolBase
         _authService = authService;
     }
 
-    /// <summary>
-    /// Executes an action after validating authentication.
-    /// Returns an error message if authentication fails.
-    /// </summary>
     protected string ExecuteAuthenticated(Func<string> action)
     {
         if (!_authService.ValidateEnvironmentToken())
             return "Error: Authentication failed. Access denied.";
 
-        return action();
+        try
+        {
+            return action();
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
     }
 }

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Commands;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
 using Ivy.Tendril.Helpers;
 using ModelContextProtocol.Server;
 
@@ -418,6 +419,295 @@ public sealed class PlanTools : AuthenticatedToolBase
         {
             return $"Error: {ex.Message}";
         }
+    }
+
+    [McpServerTool(Name = "tendril_plan_rec_set"), Description("Update a field on a recommendation")]
+    public string RecSet(
+        [Description("Plan ID")] string planId,
+        [Description("Recommendation title")] string title,
+        [Description("Field to update: title, description, state, impact, risk, declineReason")] string field,
+        [Description("New value")] string value)
+    {
+        if (!_authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            var rec = (plan.Recommendations ?? [])
+                .FirstOrDefault(r => r.Title.Equals(title, StringComparison.OrdinalIgnoreCase));
+            if (rec == null)
+                return $"Error: Recommendation '{title}' not found";
+
+            switch (field.ToLower())
+            {
+                case "title": rec.Title = value; break;
+                case "description": rec.Description = value; break;
+                case "state": rec.State = value; break;
+                case "impact": rec.Impact = value; break;
+                case "risk": rec.Risk = value; break;
+                case "declinereason": rec.DeclineReason = value; break;
+                default:
+                    return $"Error: Unknown field '{field}'. Valid: title, description, state, impact, risk, declineReason";
+            }
+
+            plan.Updated = DateTime.UtcNow;
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return $"Updated recommendation '{title}' field '{field}' to '{value}'";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_create"), Description("Create a plan directly (allocates ID, creates folder)")]
+    public string PlanCreate(
+        [Description("Plan title")] string title,
+        [Description("Project name (optional)")] string? project = null,
+        [Description("Priority level: Critical, Important, NiceToHave (optional)")] string? level = null,
+        [Description("Initial prompt/description (optional)")] string? initialPrompt = null,
+        [Description("Execution profile: deep or balanced (optional)")] string? executionProfile = null,
+        [Description("Source URL (optional)")] string? sourceUrl = null,
+        [Description("Comma-separated repository paths (optional)")] string? repos = null,
+        [Description("Comma-separated verification names (optional)")] string? verifications = null,
+        [Description("Comma-separated related plan folder names (optional)")] string? relatedPlans = null,
+        [Description("Comma-separated dependency plan folder names (optional)")] string? dependsOn = null)
+    {
+        if (!_authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var plansDir = PlanCommandHelpers.GetPlansDirectory();
+            var planId = PlanYamlHelper.AllocatePlanId(plansDir);
+            var safeTitle = PlanYamlHelper.ToSafeTitle(title);
+            var folderName = $"{planId}-{safeTitle}";
+            var planFolder = Path.Combine(plansDir, folderName);
+
+            Directory.CreateDirectory(planFolder);
+            FileHelper.GrantBroadWriteAccess(planFolder);
+
+            var plan = new PlanYaml
+            {
+                State = nameof(PlanStatus.Draft),
+                Project = project ?? "Auto",
+                Level = level ?? "NiceToHave",
+                Title = title,
+                Created = DateTime.UtcNow,
+                Updated = DateTime.UtcNow,
+                InitialPrompt = initialPrompt,
+                SourceUrl = sourceUrl,
+                ExecutionProfile = executionProfile,
+                Priority = 0
+            };
+
+            if (!string.IsNullOrEmpty(repos))
+                foreach (var repo in repos.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    plan.Repos.Add(repo);
+
+            if (!string.IsNullOrEmpty(verifications))
+                foreach (var v in verifications.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    plan.Verifications.Add(new PlanVerificationEntry { Name = v, Status = VerificationStatus.Pending });
+
+            if (!string.IsNullOrEmpty(relatedPlans))
+                foreach (var rp in relatedPlans.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    plan.RelatedPlans.Add(rp);
+
+            if (!string.IsNullOrEmpty(dependsOn))
+                foreach (var dep in dependsOn.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    plan.DependsOn.Add(dep);
+
+            PlanCommandHelpers.WritePlan(planFolder, plan);
+            return $"Plan created: {folderName}\nPlanId: {planId}\nDirectory: {planFolder}";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_write_revision"), Description("Write revision content to a plan")]
+    public string WriteRevision(
+        [Description("Plan ID")] string planId,
+        [Description("Revision content (markdown)")] string content)
+    {
+        if (!_authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var revisionsDir = Path.Combine(planFolder, "Revisions");
+            Directory.CreateDirectory(revisionsDir);
+
+            var number = ResolveNextRevisionNumber(revisionsDir);
+            var filename = $"{number:D3}.md";
+            var filePath = Path.Combine(revisionsDir, filename);
+
+            File.WriteAllText(filePath, content);
+            return $"Revision written: {filename}";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_add_related"), Description("Add a related plan link")]
+    public string AddRelated(
+        [Description("Plan ID")] string planId,
+        [Description("Related plan folder name (e.g., 01478-WorktreeIsolation)")] string relatedPlan)
+    {
+        return ModifyPlan(planId, plan =>
+        {
+            if (plan.RelatedPlans.Contains(relatedPlan, StringComparer.OrdinalIgnoreCase))
+                return;
+            plan.RelatedPlans.Add(relatedPlan);
+        }, $"Added related plan: {relatedPlan}");
+    }
+
+    [McpServerTool(Name = "tendril_plan_remove_related"), Description("Remove a related plan link")]
+    public string RemoveRelated(
+        [Description("Plan ID")] string planId,
+        [Description("Related plan folder name")] string relatedPlan)
+    {
+        return ModifyPlan(planId, plan =>
+        {
+            var removed = plan.RelatedPlans.RemoveAll(r => r.Equals(relatedPlan, StringComparison.OrdinalIgnoreCase));
+            if (removed == 0)
+                throw new InvalidOperationException($"Related plan not found: {relatedPlan}");
+        }, $"Removed related plan: {relatedPlan}");
+    }
+
+    [McpServerTool(Name = "tendril_plan_add_depends_on"), Description("Add a dependency to a plan")]
+    public string AddDependsOn(
+        [Description("Plan ID")] string planId,
+        [Description("Dependency plan folder name (e.g., 01478-WorktreeIsolation)")] string dependency)
+    {
+        return ModifyPlan(planId, plan =>
+        {
+            if (plan.DependsOn.Contains(dependency, StringComparer.OrdinalIgnoreCase))
+                return;
+            plan.DependsOn.Add(dependency);
+        }, $"Added dependency: {dependency}");
+    }
+
+    [McpServerTool(Name = "tendril_plan_remove_depends_on"), Description("Remove a dependency from a plan")]
+    public string RemoveDependsOn(
+        [Description("Plan ID")] string planId,
+        [Description("Dependency plan folder name")] string dependency)
+    {
+        return ModifyPlan(planId, plan =>
+        {
+            var removed = plan.DependsOn.RemoveAll(d => d.Equals(dependency, StringComparison.OrdinalIgnoreCase));
+            if (removed == 0)
+                throw new InvalidOperationException($"Dependency not found: {dependency}");
+        }, $"Removed dependency: {dependency}");
+    }
+
+    [McpServerTool(Name = "tendril_plan_validate"), Description("Validate plan health (checks required fields, valid states, repo paths, etc.)")]
+    public string Validate(
+        [Description("Plan ID")] string planId)
+    {
+        if (!_authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            PlanValidationService.Validate(plan);
+            return "Plan is valid.";
+        }
+        catch (ArgumentException ex)
+        {
+            return $"Validation failed: {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_verification_list"), Description("List verifications on a plan")]
+    public string VerificationList(
+        [Description("Plan ID")] string planId,
+        [Description("Filter by status: Pending, Pass, Fail, Skipped (optional)")] string? status = null)
+    {
+        if (!_authService.ValidateEnvironmentToken())
+            return "Error: Authentication failed. Access denied.";
+
+        try
+        {
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var verifications = plan.Verifications;
+
+            if (!string.IsNullOrEmpty(status))
+                verifications = verifications.Where(v => v.Status.Equals(status, StringComparison.OrdinalIgnoreCase)).ToList();
+
+            if (verifications.Count == 0)
+                return "No verifications found.";
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Found {verifications.Count} {(verifications.Count == 1 ? "verification" : "verifications")}:");
+            foreach (var v in verifications)
+                sb.AppendLine($"- {v.Name} = {v.Status}");
+
+            return sb.ToString();
+        }
+        catch (Exception ex)
+        {
+            return $"Error: {ex.Message}";
+        }
+    }
+
+    [McpServerTool(Name = "tendril_plan_verification_add"), Description("Add a verification to a plan")]
+    public string VerificationAdd(
+        [Description("Plan ID")] string planId,
+        [Description("Verification name (e.g., DotnetBuild)")] string name,
+        [Description("Initial status: Pending, Pass, Fail, Skipped (default: Pending)")] string? status = null)
+    {
+        return ModifyPlan(planId, plan =>
+        {
+            if (plan.Verifications.Any(v => v.Name.Equals(name, StringComparison.OrdinalIgnoreCase)))
+                throw new InvalidOperationException($"Verification '{name}' already exists");
+
+            plan.Verifications.Add(new PlanVerificationEntry
+            {
+                Name = name,
+                Status = status ?? VerificationStatus.Pending
+            });
+        }, $"Added verification '{name}'");
+    }
+
+    [McpServerTool(Name = "tendril_plan_verification_remove"), Description("Remove a verification from a plan")]
+    public string VerificationRemove(
+        [Description("Plan ID")] string planId,
+        [Description("Verification name")] string name)
+    {
+        return ModifyPlan(planId, plan =>
+        {
+            var match = plan.Verifications.FirstOrDefault(v => v.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+            if (match == null)
+                throw new InvalidOperationException($"Verification '{name}' not found");
+            plan.Verifications.Remove(match);
+        }, $"Removed verification '{name}'");
+    }
+
+    private static int ResolveNextRevisionNumber(string revisionsDir)
+    {
+        var max = 0;
+        foreach (var file in Directory.GetFiles(revisionsDir, "*.md"))
+        {
+            var name = Path.GetFileNameWithoutExtension(file);
+            if (int.TryParse(name, out var num) && num > max)
+                max = num;
+        }
+        return max + 1;
     }
 
     private string ModifyPlan(string planId, Action<PlanYaml> modifier, string successMessage)

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -13,11 +13,8 @@ namespace Ivy.Tendril.Mcp.Tools;
 [McpServerToolType]
 public sealed class PlanTools : AuthenticatedToolBase
 {
-    private readonly McpAuthenticationService _authService;
-
     public PlanTools(McpAuthenticationService authService) : base(authService)
     {
-        _authService = authService;
     }
 
     private static readonly Regex FolderNameRegex = new(@"^(\d{5})-(.+)$", RegexOptions.Compiled);
@@ -29,20 +26,13 @@ public sealed class PlanTools : AuthenticatedToolBase
     {
         return ExecuteAuthenticated(() =>
         {
-            try
-            {
-                var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
-                var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-                if (!string.IsNullOrEmpty(field))
-                    return GetPlanField(plan, planFolder, field);
+            if (!string.IsNullOrEmpty(field))
+                return GetPlanField(plan, planFolder, field);
 
-                return ReadPlanSummary(plan, planFolder);
-            }
-            catch (Exception ex)
-            {
-                return $"Error: {ex.Message}";
-            }
+            return ReadPlanSummary(plan, planFolder);
         });
     }
 
@@ -54,51 +44,44 @@ public sealed class PlanTools : AuthenticatedToolBase
     {
         return ExecuteAuthenticated(() =>
         {
-            try
+            var plansDir = PlanCommandHelpers.GetPlansDirectory();
+
+            DateTime? sinceDate = null;
+            if (!string.IsNullOrEmpty(since) && DateTime.TryParse(since, out var parsed))
+                sinceDate = parsed;
+
+            var sb = new StringBuilder();
+            var count = 0;
+
+            foreach (var dir in Directory.GetDirectories(plansDir).OrderByDescending(d => Path.GetFileName(d)))
             {
-                var plansDir = PlanCommandHelpers.GetPlansDirectory();
+                var folderName = Path.GetFileName(dir);
+                var match = FolderNameRegex.Match(folderName);
+                if (!match.Success) continue;
 
-                DateTime? sinceDate = null;
-                if (!string.IsNullOrEmpty(since) && DateTime.TryParse(since, out var parsed))
-                    sinceDate = parsed;
+                PlanYaml yaml;
+                try { yaml = PlanCommandHelpers.ReadPlan(dir); }
+                catch { continue; }
 
-                var sb = new StringBuilder();
-                var count = 0;
+                if (!MatchesFilters(yaml, state, project, sinceDate))
+                    continue;
 
-                foreach (var dir in Directory.GetDirectories(plansDir).OrderByDescending(d => Path.GetFileName(d)))
+                var id = match.Groups[1].Value;
+                sb.AppendLine($"- [{id}] {yaml.Title} | State: {yaml.State} | Project: {yaml.Project} | Level: {yaml.Level}");
+                count++;
+
+                if (count >= 50)
                 {
-                    var folderName = Path.GetFileName(dir);
-                    var match = FolderNameRegex.Match(folderName);
-                    if (!match.Success) continue;
-
-                    PlanYaml yaml;
-                    try { yaml = PlanCommandHelpers.ReadPlan(dir); }
-                    catch { continue; }
-
-                    if (!MatchesFilters(yaml, state, project, sinceDate))
-                        continue;
-
-                    var id = match.Groups[1].Value;
-                    sb.AppendLine($"- [{id}] {yaml.Title} | State: {yaml.State} | Project: {yaml.Project} | Level: {yaml.Level}");
-                    count++;
-
-                    if (count >= 50)
-                    {
-                        sb.AppendLine("... (showing first 50 of potentially more results)");
-                        break;
-                    }
+                    sb.AppendLine("... (showing first 50 of potentially more results)");
+                    break;
                 }
-
-                if (count == 0)
-                    return "No plans found matching the specified criteria.";
-
-                sb.Insert(0, $"Found {count} {(count == 1 ? "plan" : "plans")}:\n");
-                return sb.ToString();
             }
-            catch (Exception ex)
-            {
-                return $"Error: {ex.Message}";
-            }
+
+            if (count == 0)
+                return "No plans found matching the specified criteria.";
+
+            sb.Insert(0, $"Found {count} {(count == 1 ? "plan" : "plans")}:\n");
+            return sb.ToString();
         });
     }
 
@@ -109,44 +92,44 @@ public sealed class PlanTools : AuthenticatedToolBase
         [Description("Priority level: Critical, Important, NiceToHave (optional)")] string? level = null,
         [Description("Detailed prompt/description for plan creation (optional)")] string? prompt = null)
     {
-        if (!_authService.ValidateEnvironmentToken())
-            return "Error: Authentication failed. Access denied.";
-
-        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
-        if (string.IsNullOrEmpty(tendrilHome))
-            return "Error: TENDRIL_HOME is not set.";
-
-        var inboxDir = Path.Combine(tendrilHome, "Inbox");
-        if (!Directory.Exists(inboxDir))
-            Directory.CreateDirectory(inboxDir);
-
-        var safeName = Regex.Replace(title, @"[^a-zA-Z0-9\s-]", "").Trim();
-        safeName = Regex.Replace(safeName, @"\s+", "-");
-        if (safeName.Length > 60) safeName = safeName[..60];
-        var fileName = $"{safeName}-{DateTime.UtcNow:yyyyMMddHHmmss}.md";
-
-        var sb = new StringBuilder();
-        if (!string.IsNullOrEmpty(project) || !string.IsNullOrEmpty(level))
+        return ExecuteAuthenticated(() =>
         {
-            sb.AppendLine("---");
-            if (!string.IsNullOrEmpty(project))
-                sb.AppendLine($"project: {project}");
-            if (!string.IsNullOrEmpty(level))
-                sb.AppendLine($"level: {level}");
-            sb.AppendLine("---");
-        }
+            var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
+            if (string.IsNullOrEmpty(tendrilHome))
+                return "Error: TENDRIL_HOME is not set.";
 
-        sb.AppendLine(title);
-        if (!string.IsNullOrEmpty(prompt))
-        {
-            sb.AppendLine();
-            sb.AppendLine(prompt);
-        }
+            var inboxDir = Path.Combine(tendrilHome, "Inbox");
+            if (!Directory.Exists(inboxDir))
+                Directory.CreateDirectory(inboxDir);
 
-        var filePath = Path.Combine(inboxDir, fileName);
-        File.WriteAllText(filePath, sb.ToString());
+            var safeName = Regex.Replace(title, @"[^a-zA-Z0-9\s-]", "").Trim();
+            safeName = Regex.Replace(safeName, @"\s+", "-");
+            if (safeName.Length > 60) safeName = safeName[..60];
+            var fileName = $"{safeName}-{DateTime.UtcNow:yyyyMMddHHmmss}.md";
 
-        return $"Plan submitted to inbox: {fileName}\nThe InboxWatcher will pick it up and create a plan automatically.";
+            var sb = new StringBuilder();
+            if (!string.IsNullOrEmpty(project) || !string.IsNullOrEmpty(level))
+            {
+                sb.AppendLine("---");
+                if (!string.IsNullOrEmpty(project))
+                    sb.AppendLine($"project: {project}");
+                if (!string.IsNullOrEmpty(level))
+                    sb.AppendLine($"level: {level}");
+                sb.AppendLine("---");
+            }
+
+            sb.AppendLine(title);
+            if (!string.IsNullOrEmpty(prompt))
+            {
+                sb.AppendLine();
+                sb.AppendLine(prompt);
+            }
+
+            var filePath = Path.Combine(inboxDir, fileName);
+            File.WriteAllText(filePath, sb.ToString());
+
+            return $"Plan submitted to inbox: {fileName}\nThe InboxWatcher will pick it up and create a plan automatically.";
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_set"), Description("Set a scalar field on a plan")]
@@ -155,10 +138,7 @@ public sealed class PlanTools : AuthenticatedToolBase
         [Description("Field name (state, project, level, title, executionProfile, initialPrompt, sourceUrl, priority)")] string field,
         [Description("New value")] string value)
     {
-        if (!_authService.ValidateEnvironmentToken())
-            return "Error: Authentication failed. Access denied.";
-
-        try
+        return ExecuteAuthenticated(() =>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
@@ -186,11 +166,7 @@ public sealed class PlanTools : AuthenticatedToolBase
 
             PlanCommandHelpers.WritePlan(planFolder, plan);
             return $"Updated {field} to '{value}'";
-        }
-        catch (Exception ex)
-        {
-            return $"Error: {ex.Message}";
-        }
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_add_repo"), Description("Add a repository path to a plan")]
@@ -251,10 +227,7 @@ public sealed class PlanTools : AuthenticatedToolBase
         [Description("Verification name (e.g., DotnetBuild, DotnetTest)")] string name,
         [Description("Status: Pending, Pass, Fail, Skipped")] string status)
     {
-        if (!_authService.ValidateEnvironmentToken())
-            return "Error: Authentication failed. Access denied.";
-
-        try
+        return ExecuteAuthenticated(() =>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
@@ -270,11 +243,7 @@ public sealed class PlanTools : AuthenticatedToolBase
             plan.Updated = DateTime.UtcNow;
             PlanCommandHelpers.WritePlan(planFolder, plan);
             return $"Set verification '{name}' to '{status}'";
-        }
-        catch (Exception ex)
-        {
-            return $"Error: {ex.Message}";
-        }
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_add_log"), Description("Write an execution log entry to a plan")]
@@ -283,19 +252,12 @@ public sealed class PlanTools : AuthenticatedToolBase
         [Description("Action name (e.g., CreatePlan, ExecutePlan)")] string action,
         [Description("Optional summary text")] string? summary = null)
     {
-        if (!_authService.ValidateEnvironmentToken())
-            return "Error: Authentication failed. Access denied.";
-
-        try
+        return ExecuteAuthenticated(() =>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var logPath = PlanAddLogCommand.WriteLog(planFolder, action, summary);
             return $"Log written: {Path.GetFileName(logPath)}";
-        }
-        catch (Exception ex)
-        {
-            return $"Error: {ex.Message}";
-        }
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_rec_add"), Description("Add a recommendation to a plan")]
@@ -306,10 +268,7 @@ public sealed class PlanTools : AuthenticatedToolBase
         [Description("Impact level: Small, Medium, High (optional)")] string? impact = null,
         [Description("Risk level: Small, Medium, High (optional)")] string? risk = null)
     {
-        if (!_authService.ValidateEnvironmentToken())
-            return "Error: Authentication failed. Access denied.";
-
-        try
+        return ExecuteAuthenticated(() =>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
@@ -330,11 +289,7 @@ public sealed class PlanTools : AuthenticatedToolBase
             plan.Updated = DateTime.UtcNow;
             PlanCommandHelpers.WritePlan(planFolder, plan);
             return $"Added recommendation '{title}'";
-        }
-        catch (Exception ex)
-        {
-            return $"Error: {ex.Message}";
-        }
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_rec_accept"), Description("Accept a recommendation")]
@@ -393,10 +348,7 @@ public sealed class PlanTools : AuthenticatedToolBase
         [Description("Plan ID")] string planId,
         [Description("Filter by state: Pending, Accepted, Declined (optional)")] string? state = null)
     {
-        if (!_authService.ValidateEnvironmentToken())
-            return "Error: Authentication failed. Access denied.";
-
-        try
+        return ExecuteAuthenticated(() =>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
@@ -414,11 +366,7 @@ public sealed class PlanTools : AuthenticatedToolBase
                 sb.AppendLine($"- {rec.Title} | State: {rec.State} | Impact: {rec.Impact ?? "-"} | Risk: {rec.Risk ?? "-"}");
 
             return sb.ToString();
-        }
-        catch (Exception ex)
-        {
-            return $"Error: {ex.Message}";
-        }
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_rec_set"), Description("Update a field on a recommendation")]
@@ -428,10 +376,7 @@ public sealed class PlanTools : AuthenticatedToolBase
         [Description("Field to update: title, description, state, impact, risk, declineReason")] string field,
         [Description("New value")] string value)
     {
-        if (!_authService.ValidateEnvironmentToken())
-            return "Error: Authentication failed. Access denied.";
-
-        try
+        return ExecuteAuthenticated(() =>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
@@ -456,11 +401,7 @@ public sealed class PlanTools : AuthenticatedToolBase
             plan.Updated = DateTime.UtcNow;
             PlanCommandHelpers.WritePlan(planFolder, plan);
             return $"Updated recommendation '{title}' field '{field}' to '{value}'";
-        }
-        catch (Exception ex)
-        {
-            return $"Error: {ex.Message}";
-        }
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_create"), Description("Create a plan directly (allocates ID, creates folder)")]
@@ -476,10 +417,7 @@ public sealed class PlanTools : AuthenticatedToolBase
         [Description("Comma-separated related plan folder names (optional)")] string? relatedPlans = null,
         [Description("Comma-separated dependency plan folder names (optional)")] string? dependsOn = null)
     {
-        if (!_authService.ValidateEnvironmentToken())
-            return "Error: Authentication failed. Access denied.";
-
-        try
+        return ExecuteAuthenticated(() =>
         {
             var plansDir = PlanCommandHelpers.GetPlansDirectory();
             var planId = PlanYamlHelper.AllocatePlanId(plansDir);
@@ -522,11 +460,7 @@ public sealed class PlanTools : AuthenticatedToolBase
 
             PlanCommandHelpers.WritePlan(planFolder, plan);
             return $"Plan created: {folderName}\nPlanId: {planId}\nDirectory: {planFolder}";
-        }
-        catch (Exception ex)
-        {
-            return $"Error: {ex.Message}";
-        }
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_write_revision"), Description("Write revision content to a plan")]
@@ -534,10 +468,7 @@ public sealed class PlanTools : AuthenticatedToolBase
         [Description("Plan ID")] string planId,
         [Description("Revision content (markdown)")] string content)
     {
-        if (!_authService.ValidateEnvironmentToken())
-            return "Error: Authentication failed. Access denied.";
-
-        try
+        return ExecuteAuthenticated(() =>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var revisionsDir = Path.Combine(planFolder, "Revisions");
@@ -549,11 +480,7 @@ public sealed class PlanTools : AuthenticatedToolBase
 
             File.WriteAllText(filePath, content);
             return $"Revision written: {filename}";
-        }
-        catch (Exception ex)
-        {
-            return $"Error: {ex.Message}";
-        }
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_add_related"), Description("Add a related plan link")]
@@ -612,24 +539,21 @@ public sealed class PlanTools : AuthenticatedToolBase
     public string Validate(
         [Description("Plan ID")] string planId)
     {
-        if (!_authService.ValidateEnvironmentToken())
-            return "Error: Authentication failed. Access denied.";
-
-        try
+        return ExecuteAuthenticated(() =>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
-            PlanValidationService.Validate(plan);
-            return "Plan is valid.";
-        }
-        catch (ArgumentException ex)
-        {
-            return $"Validation failed: {ex.Message}";
-        }
-        catch (Exception ex)
-        {
-            return $"Error: {ex.Message}";
-        }
+
+            try
+            {
+                PlanValidationService.Validate(plan);
+                return "Plan is valid.";
+            }
+            catch (ArgumentException ex)
+            {
+                return $"Validation failed: {ex.Message}";
+            }
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_verification_list"), Description("List verifications on a plan")]
@@ -637,10 +561,7 @@ public sealed class PlanTools : AuthenticatedToolBase
         [Description("Plan ID")] string planId,
         [Description("Filter by status: Pending, Pass, Fail, Skipped (optional)")] string? status = null)
     {
-        if (!_authService.ValidateEnvironmentToken())
-            return "Error: Authentication failed. Access denied.";
-
-        try
+        return ExecuteAuthenticated(() =>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
@@ -658,11 +579,7 @@ public sealed class PlanTools : AuthenticatedToolBase
                 sb.AppendLine($"- {v.Name} = {v.Status}");
 
             return sb.ToString();
-        }
-        catch (Exception ex)
-        {
-            return $"Error: {ex.Message}";
-        }
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_verification_add"), Description("Add a verification to a plan")]
@@ -712,10 +629,7 @@ public sealed class PlanTools : AuthenticatedToolBase
 
     private string ModifyPlan(string planId, Action<PlanYaml> modifier, string successMessage)
     {
-        if (!_authService.ValidateEnvironmentToken())
-            return "Error: Authentication failed. Access denied.";
-
-        try
+        return ExecuteAuthenticated(() =>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
@@ -725,11 +639,7 @@ public sealed class PlanTools : AuthenticatedToolBase
             plan.Updated = DateTime.UtcNow;
             PlanCommandHelpers.WritePlan(planFolder, plan);
             return successMessage;
-        }
-        catch (Exception ex)
-        {
-            return $"Error: {ex.Message}";
-        }
+        });
     }
 
     private static bool MatchesFilters(PlanYaml plan, string? state, string? project, DateTime? sinceDate)


### PR DESCRIPTION
# Summary

## Changes

Added 11 new Web API endpoints to `PlanController` and 11 new MCP tools to `PlanTools` to achieve parity with CLI commands that were previously only accessible via `tendril plan` CLI. All new functionality includes comprehensive unit tests.

## API Changes

**Web API (PlanController.cs):**
- `POST /api/plans` — create a plan directly with full options
- `POST /api/plans/{id}/revisions` — write revision content
- `POST /api/plans/{id}/related-plans` — add a related plan link
- `DELETE /api/plans/{id}/related-plans` — remove a related plan link
- `POST /api/plans/{id}/depends-on` — add a dependency
- `DELETE /api/plans/{id}/depends-on` — remove a dependency
- `POST /api/plans/{id}/validate` — validate plan health
- `GET /api/plans/{id}/verifications` — list verifications (with optional status filter)
- `POST /api/plans/{id}/verifications/add` — add a verification
- `DELETE /api/plans/{id}/verifications/{name}` — remove a verification
- `PUT /api/plans/{id}/recommendations/{title}` — set a recommendation field

**New Request DTOs:** `CreatePlanDirectRequest`, `WriteRevisionRequest`, `AddRelatedPlanRequest`, `RemoveRelatedPlanRequest`, `AddDependsOnRequest`, `RemoveDependsOnRequest`, `AddVerificationRequest`, `SetRecFieldRequest`

**MCP Tools (PlanTools.cs):**
- `tendril_plan_create` — create a plan directly (allocates ID)
- `tendril_plan_write_revision` — write revision content
- `tendril_plan_add_related` / `tendril_plan_remove_related` — manage related plans
- `tendril_plan_add_depends_on` / `tendril_plan_remove_depends_on` — manage dependencies
- `tendril_plan_validate` — validate plan health
- `tendril_plan_verification_list` / `tendril_plan_verification_add` / `tendril_plan_verification_remove` — manage verifications
- `tendril_plan_rec_set` — update a recommendation field

## Files Modified

- `src/Ivy.Tendril/Controllers/PlanController.cs` — new endpoints and DTOs
- `src/Ivy.Tendril/Mcp/Tools/PlanTools.cs` — new MCP tools
- `src/Ivy.Tendril.Test/PlanControllerTests.cs` — 20 new test methods
- `src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs` — 22 new test methods

## Fix: Consolidate MCP tool authentication pattern

Moved the try/catch error wrapping into `AuthenticatedToolBase.ExecuteAuthenticated`, then converted all PlanTools methods to delegate both authentication and error handling to this single helper. This eliminates the repeated auth check + try/catch boilerplate across 12 tool methods and the `ModifyPlan` helper, reducing the file by ~90 lines while preserving identical behavior.

### Files Modified

- `src/Ivy.Tendril/Mcp/Tools/AuthenticatedToolBase.cs` — added try/catch wrapping to ExecuteAuthenticated
- `src/Ivy.Tendril/Mcp/Tools/PlanTools.cs` — removed inline auth checks and try/catch blocks, removed unused _authService field

---

**Commits:**
- 77aceba Add missing Web API and MCP endpoints for CLI parity
- 6837d8a Add tests for new Web API and MCP endpoints
- 39a3c18 Consolidate MCP tool auth+error pattern into ExecuteAuthenticated