### PR TITLE
[00094] ShowCompletePlanButtonWhenNoCommits

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -9,6 +9,7 @@ using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Apps.Views.Tabs;
 using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
 using Ivy.Tendril.Helpers;
 using Microsoft.Extensions.Logging;
 
@@ -273,28 +274,43 @@ public class ContentView(
                          .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
                          .Muted("plans", word: true);
 
-        var repoPaths = selectedPlan.GetEffectiveRepoPaths(config);
-        var project = config.GetProject(selectedPlan.Project);
-        var allYolo = repoPaths.All(rp =>
-            project?.GetRepoRef(rp)?.PrRule == "yolo");
-
-        var createPrBtn = new Button("Create PR").Icon(Icons.GitPullRequest).Primary().OnClick(() =>
+        if (selectedPlan.Commits.Count > 0)
         {
-            if (allYolo)
-            {
-                jobService.StartJob(new CreatePrArgs(selectedPlan.FolderPath, SolveMergeConflicts: true));
-                planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
-                refreshPlans();
-            }
-            else
-            {
-                showCustomPrDialog();
-            }
-        }).ShortcutKey("m");
+            var repoPaths = selectedPlan.GetEffectiveRepoPaths(config);
+            var project = config.GetProject(selectedPlan.Project);
+            var allYolo = repoPaths.All(rp =>
+                project?.GetRepoRef(rp)?.PrRule == "yolo");
 
-        header |= allYolo
-            ? createPrBtn.WithConfetti(AnimationTrigger.Click)
-            : createPrBtn;
+            var createPrBtn = new Button("Create PR").Icon(Icons.GitPullRequest).Primary().OnClick(() =>
+            {
+                if (allYolo)
+                {
+                    jobService.StartJob(new CreatePrArgs(selectedPlan.FolderPath, SolveMergeConflicts: true));
+                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+                    refreshPlans();
+                }
+                else
+                {
+                    showCustomPrDialog();
+                }
+            }).ShortcutKey("m");
+
+            header |= allYolo
+                ? createPrBtn.WithConfetti(AnimationTrigger.Click)
+                : createPrBtn;
+        }
+        else
+        {
+            header |= new Button("Complete Plan").Icon(Icons.CircleCheck).Primary().OnClick(() =>
+            {
+                // Optimistic UI - update state and refresh immediately
+                planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+                refreshPlans();
+
+                // Fire and forget - clean up worktrees in the background
+                Task.Run(() => WorktreeCleanupService.RemoveWorktrees(selectedPlan.FolderPath));
+            }).ShortcutKey("m");
+        }
 
         return header;
     }


### PR DESCRIPTION
Fixes #48

# Summary

## Changes

Modified the Review app's ContentView to conditionally render either "Create PR" or "Complete Plan" button based on whether the plan has commits. Plans without commits now show a "Complete Plan" button that transitions the plan to Completed state and cleans up worktrees in the background.

## API Changes

- Modified `BuildHeader` method in `ContentView.cs` to check `selectedPlan.Commits.Count` before rendering action button
- Added dependency on `WorktreeCleanupService.RemoveWorktrees` for background cleanup

## Files Modified

**Review App:**
- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — Added conditional button rendering and "Complete Plan" button implementation

---

**Commits:**
- 9c90e82 Add Complete Plan button when no commits exist