### PR TITLE
[00099] Add image capability indicator to models CLI table

### DIFF
--- a/src/Ivy.Tendril/Commands/ModelsCommand.cs
+++ b/src/Ivy.Tendril/Commands/ModelsCommand.cs
@@ -92,6 +92,7 @@ public sealed class ModelsCommand(IAgentRunner runner) : AsyncCommand<ModelsComm
         table.AddColumn(new TableColumn("Cache W $/M").RightAligned());
         table.AddColumn("Source");
         table.AddColumn("Default");
+        table.AddColumn("Vision");
 
         var sourceIndex = new Dictionary<string, int>();
 
@@ -110,6 +111,8 @@ public sealed class ModelsCommand(IAgentRunner runner) : AsyncCommand<ModelsComm
                 sourceRef = $"[dim]{idx}[/]";
             }
 
+            var hasVision = model.Capabilities.HasFlag(ModelCapabilities.ImageInput) ? "[green]✓[/]" : "[dim]-[/]";
+
             table.AddRow(
                 model.Id.EscapeMarkup(),
                 model.DisplayName.EscapeMarkup(),
@@ -118,7 +121,8 @@ public sealed class ModelsCommand(IAgentRunner runner) : AsyncCommand<ModelsComm
                 FormatPrice(model.CacheReadPerMillion),
                 FormatPrice(model.CacheWritePerMillion),
                 sourceRef,
-                isDefault);
+                isDefault,
+                hasVision);
         }
 
         AnsiConsole.Write(table);


### PR DESCRIPTION
# Summary

## Changes

Added a "Vision" column to the `tendril models` CLI command output table. The column displays a green checkmark (✓) for models with image input capability and a dash (-) for models without this capability.

## API Changes

**Modified:**
- `ModelsCommand.RenderTable()` — Added "Vision" column to the models table output

## Files Modified

- `src/Ivy.Tendril/Commands/ModelsCommand.cs` — Added Vision column header and hasVision indicator logic

---

## Commits

- fbc54c0 Add Vision column to models CLI table