### PR TITLE
[00096] Add Manual Testing Section to ExecutePlan and RetryPlan Summaries

### DIFF
--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -338,6 +338,15 @@ The summary should follow this structure:
 ## Files Modified
 
 <Bulleted list of key files changed, grouped by category. Don't list every file — focus on the important ones.>
+
+## Manual Testing
+
+<Step-by-step instructions for a human reviewer to verify this change works correctly. Include:
+- What to launch/open (e.g., "Run the app", "Open the Plans view")
+- What action to perform (e.g., "Click the Execute button on a plan with dependencies")
+- What to observe (e.g., "The plan should show 'Blocked' status instead of executing")
+
+If the change has no observable user-facing behavior (e.g., internal refactor, dependency update, code cleanup), write "N/A — internal change with no user-facing behavior.">
 ~~~
 
 Focus on **what changed** (past tense), not what the plan said to do. Emphasize API surface changes — new classes, renamed methods, added properties, changed signatures — since these affect consumers.

--- a/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
@@ -110,6 +110,8 @@ The prior ExecutePlan run created `<TendrilPlanFolder>/Artifacts/summary.md`. **
 ### Files Modified
 
 <Bulleted list of files changed in this retry.>
+
+**Note:** Update the manual testing section if this fix affects user-facing behavior.
 ~~~
 
 Add one such section per logical fix. If the retry addresses multiple items from the ChangeRequest, add a section for each.


### PR DESCRIPTION
# Summary

## Changes

Updated the summary template in ExecutePlan's Program.md to include a "Manual Testing" section after "Files Modified". Added guidance in RetryPlan's Program.md to update manual testing instructions when fixes affect user-facing behavior.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md` — Added Manual Testing section to summary template
- `src/Ivy.Tendril/Promptwares/RetryPlan/Program.md` — Added note about updating manual testing section

## Manual Testing

N/A — internal change with no user-facing behavior. These changes affect only promptware documentation that guides future ExecutePlan and RetryPlan agent runs.

---

## Commits

- 62e3ecb Add Manual Testing section to ExecutePlan and RetryPlan summaries