### PR TITLE
Fix plan.yaml lost-write race condition on recommendation accept

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -134,25 +134,15 @@ public class ContentView(
                             new Dictionary<string, List<string>>(), new List<PlanContentHelpers.CommitRow>(),
                             new Dictionary<string, bool>(), new List<(string Name, bool ConditionMet)>(), null);
 
-                    // Recommendations from plan.yaml
+                    // Recommendations from database (or plan.yaml fallback)
                     List<RecommendationYaml> recs;
                     try
                     {
-                        var planYamlPath = Path.Combine(folderPath, "plan.yaml");
-                        if (File.Exists(planYamlPath))
-                        {
-                            var yaml = FileHelper.ReadAllText(planYamlPath);
-                            var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml);
-                            recs = planYaml?.Recommendations ?? new List<RecommendationYaml>();
-                        }
-                        else
-                        {
-                            recs = new List<RecommendationYaml>();
-                        }
+                        recs = planService.GetRecommendationsForPlan(selectedPlanState.Value.FolderName);
                     }
                     catch (Exception ex)
                     {
-                        logger.LogWarning(ex, "Failed to parse recommendations from plan.yaml for {FolderPath}", folderPath);
+                        logger.LogWarning(ex, "Failed to get recommendations for {FolderPath}", folderPath);
                         recs = new List<RecommendationYaml>();
                     }
 
@@ -533,9 +523,7 @@ public class ContentView(
                     var buttonRow = Layout.Horizontal().Gap(1)
                                     | new Button("Accept").Icon(Icons.Check).Primary().OnClick(() =>
                                     {
-                                        planService.ResetVerificationsForRetry(selectedPlan.FolderName);
-                                        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Executing);
-                                        planService.UpdateRecommendationState(selectedPlan.FolderName, recTitle, RecommendationStatus.Accepted);
+                                        planService.AcceptRecommendationAndRetry(selectedPlan.FolderName, recTitle);
                                         jobService.StartJob(new RetryPlanArgs(selectedPlan.FolderPath, rec.Description));
                                         refreshPlans();
                                         planContentQuery.Mutator.Revalidate();

--- a/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
@@ -115,6 +115,7 @@ public static class PlanCommandHelpers
     /// <summary>
     ///     Writes a plan.yaml file atomically.
     ///     Validates the plan, writes to temp file, reads back for verification, then atomically moves to target.
+    ///     Uses a lock file to coordinate with in-process background writes from PlanReaderService.
     /// </summary>
     public static void WritePlan(string planFolder, PlanYaml plan, IPlanWatcherService? watcher = null)
     {
@@ -124,6 +125,7 @@ public static class PlanCommandHelpers
         var yamlPath = Path.Combine(planFolder, "plan.yaml");
         var tempPath = Path.Combine(planFolder, $"plan.yaml.tmp.{Guid.NewGuid():N}");
 
+        using var lockFile = PlanFileLock.Acquire(planFolder);
         try
         {
             // Serialize to temp file
@@ -152,4 +154,5 @@ public static class PlanCommandHelpers
             throw;
         }
     }
+
 }

--- a/src/Ivy.Tendril/Helpers/PlanFileLock.cs
+++ b/src/Ivy.Tendril/Helpers/PlanFileLock.cs
@@ -1,0 +1,32 @@
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+///     Cross-process file lock for plan.yaml writes.
+///     Both PlanReaderService (in-process) and PlanCommandHelpers (CLI) use this
+///     to coordinate concurrent read-modify-write operations on the same plan.yaml.
+/// </summary>
+public static class PlanFileLock
+{
+    private const int MaxRetries = 50;
+    private const int DelayMs = 100;
+
+    public static FileStream Acquire(string planFolder)
+    {
+        var lockPath = Path.Combine(planFolder, "plan.yaml.lock");
+
+        for (var i = 0; i < MaxRetries; i++)
+        {
+            try
+            {
+                return new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None,
+                    bufferSize: 1, FileOptions.DeleteOnClose);
+            }
+            catch (IOException) when (i < MaxRetries - 1)
+            {
+                Thread.Sleep(DelayMs);
+            }
+        }
+
+        throw new TimeoutException($"Could not acquire plan lock at {lockPath} after {MaxRetries * DelayMs}ms");
+    }
+}

--- a/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
@@ -179,35 +179,6 @@ attempts: <number>
 <any remaining issues, or "None">
 ```
 
-### 6.5. Generate Recommendations
-
-After all verifications pass, write down anything you noticed that isn't part of this plan's scope:
-
-- Follow-up work, edge cases not covered, or related features
-- Confusing code, inconsistent patterns, or technical debt
-- Unrelated bugs, broken tests, or incorrect behavior
-- Performance improvements or refactoring opportunities
-
-For each item, register it via the CLI:
-
-```bash
-tendril plan rec add <plan-id> "Short descriptive title" -d "Markdown description with context and location." --impact Medium --risk Small --job-id TendrilJobId
-```
-
-**After registering recommendations**, create `<TendrilPlanFolder>/Artifacts/recommendations.md`:
-
-~~~markdown
-# Recommendations
-
-## Items
-
-- **<Title>** — <one-line summary>
-
-*Or: "None — <one sentence explaining why>"*
-~~~
-
-**This file is mandatory.** Step 7 will verify it exists.
-
 ### 7. Final Clean Check
 
 Report status: `tendril job status TendrilJobId --message "Running final checks..."`
@@ -217,8 +188,6 @@ After all verifications pass:
 1. Kill any remaining processes spawned during plan execution (e.g. dev servers) whose working directory is under the plan's worktree or artifacts directory. **See Prohibited Actions below — never kill dotnet.exe or Ivy.Tendril.exe.**
 
 2. Run `git status` in every worktree. If there are uncommitted files, commit or discard them. The worktrees must be completely clean.
-
-3. Verify `<TendrilPlanFolder>/Artifacts/recommendations.md` exists. If missing, go back to Step 6.5.
 
 ### 8. Plan State
 

--- a/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
@@ -34,6 +34,9 @@ public interface IPlanReaderService
     void UpdateRecommendationState(string planFolderName, string recommendationTitle, string newState,
         string? declineReason = null);
 
+    List<RecommendationYaml> GetRecommendationsForPlan(string folderName);
+    void AcceptRecommendationAndRetry(string folderName, string recommendationTitle);
+
     void SyncPlanArtifacts(string planFolder);
     void InvalidateCaches();
     Task FlushPendingWritesAsync();

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -250,7 +250,7 @@ public class PlanReaderService(
             planYaml.State = newState.ToString();
             planYaml.Updated = DateTime.UtcNow;
             FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
-        });
+        }, Path.Combine(PlansDirectory, folderName));
     }
 
     /// <summary>
@@ -283,7 +283,7 @@ public class PlanReaderService(
             foreach (var v in planYaml.Verifications)
                 v.Status = VerificationStatus.Pending;
             FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
-        });
+        }, Path.Combine(PlansDirectory, folderName));
     }
 
     public void ResetVerificationsForRetry(string folderName)
@@ -304,7 +304,7 @@ public class PlanReaderService(
                     v.Status = VerificationStatus.Pending;
             }
             FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
-        });
+        }, Path.Combine(PlansDirectory, folderName));
     }
 
     /// <summary>
@@ -347,7 +347,7 @@ public class PlanReaderService(
                 planYaml.Updated = DateTime.UtcNow;
                 FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
             }
-        });
+        }, Path.Combine(PlansDirectory, folderName));
     }
 
     /// <summary>
@@ -502,7 +502,7 @@ public class PlanReaderService(
                     FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
                 }
             }
-        });
+        }, Path.Combine(PlansDirectory, folderName));
     }
 
     /// <summary>
@@ -680,7 +680,94 @@ public class PlanReaderService(
                 item.DeclineReason = null;
 
             FileHelper.WriteAllText(planYamlPath, YamlHelper.Serializer.Serialize(plan));
-        });
+        }, Path.Combine(PlansDirectory, planFolderName));
+    }
+
+    public List<RecommendationYaml> GetRecommendationsForPlan(string folderName)
+    {
+        if (_useDatabaseForReads && _database != null)
+        {
+            var planId = ExtractPlanId(folderName);
+            if (planId.HasValue)
+            {
+                var allRecs = _database.GetRecommendations();
+                return allRecs
+                    .Where(r => r.PlanFolderName == folderName)
+                    .Select(r => new RecommendationYaml
+                    {
+                        Title = r.Title,
+                        Description = r.Description,
+                        State = r.State,
+                        DeclineReason = r.DeclineReason,
+                        Impact = r.Impact,
+                        Risk = r.Risk
+                    })
+                    .ToList();
+            }
+        }
+
+        var planYamlPath = Path.Combine(PlansDirectory, folderName, "plan.yaml");
+        if (!File.Exists(planYamlPath)) return new List<RecommendationYaml>();
+
+        var yaml = FileHelper.ReadAllText(planYamlPath);
+        var plan = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml);
+        return plan?.Recommendations ?? new List<RecommendationYaml>();
+    }
+
+    public void AcceptRecommendationAndRetry(string folderName, string recommendationTitle)
+    {
+        var planId = ExtractPlanId(folderName);
+
+        // Track state transition in telemetry.
+        if (planId.HasValue)
+        {
+            var currentPlan = GetPlanByFolder(Path.Combine(PlansDirectory, folderName));
+            var oldState = currentPlan?.Status.ToString() ?? "Unknown";
+            telemetryService?.TrackPlanStateTransition(oldState, PlanStatus.Executing.ToString());
+        }
+
+        // Update database atomically for all three mutations.
+        if (planId.HasValue && _database != null)
+        {
+            _database.UpdatePlanState(planId.Value, PlanStatus.Executing);
+            _database.UpdateRecommendationState(planId.Value, recommendationTitle, RecommendationStatus.Accepted, null);
+        }
+
+        _planCountsCache.Invalidate();
+        _recommendationsCache.Invalidate();
+        CountsInvalidated?.Invoke();
+        planWatcherService?.NotifyChanged(folderName);
+
+        // Single background write that performs all three mutations atomically on disk.
+        WriteFileInBackground(() =>
+        {
+            var planYamlPath = Path.Combine(PlansDirectory, folderName, "plan.yaml");
+            if (!File.Exists(planYamlPath)) return;
+
+            var yaml = FileHelper.ReadAllText(planYamlPath);
+            var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
+
+            // Reset verifications
+            foreach (var v in planYaml.Verifications)
+            {
+                if (!v.Status.Equals(VerificationStatus.Skipped, StringComparison.OrdinalIgnoreCase))
+                    v.Status = VerificationStatus.Pending;
+            }
+
+            // Transition state
+            planYaml.State = PlanStatus.Executing.ToString();
+            planYaml.Updated = DateTime.UtcNow;
+
+            // Accept recommendation
+            var rec = planYaml.Recommendations?.FirstOrDefault(r => r.Title == recommendationTitle);
+            if (rec != null)
+            {
+                rec.State = RecommendationStatus.Accepted;
+                rec.DeclineReason = null;
+            }
+
+            FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
+        }, Path.Combine(PlansDirectory, folderName));
     }
 
     public void SyncPlanArtifacts(string planFolder)
@@ -1028,41 +1115,67 @@ public class PlanReaderService(
     /// <summary>
     ///     Runs a file write operation in the background (fire-and-forget).
     ///     The database is the primary data source; file writes are for durability only.
+    ///     All writes are serialized through _writeQueue to prevent lost-update races
+    ///     when multiple mutations fire concurrently (e.g., Accept recommendation click).
     /// </summary>
+    private readonly SemaphoreSlim _writeQueue = new(1, 1);
     private Task _lastWriteTask = Task.CompletedTask;
 
-    private void WriteFileInBackground(Action action)
+    private void ExecuteWithLock(Action action, string? planFolder)
     {
-        _lastWriteTask = Task.Run(() =>
+        if (planFolder != null)
         {
+            using var _ = PlanFileLock.Acquire(planFolder);
+            action();
+        }
+        else
+        {
+            action();
+        }
+    }
+
+    private void WriteFileInBackground(Action action, string? planFolder = null)
+    {
+        _lastWriteTask = Task.Run(async () =>
+        {
+            await _writeQueue.WaitAsync();
             try
             {
-                action();
+                ExecuteWithLock(action, planFolder);
             }
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "Background file write failed");
             }
+            finally
+            {
+                _writeQueue.Release();
+            }
         });
     }
 
-    private void WriteFile(Action action)
+    private void WriteFile(Action action, string? planFolder = null)
     {
         if (_database == null)
         {
+            _writeQueue.Wait();
             try
             {
-                action();
+                ExecuteWithLock(action, planFolder);
             }
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "File write failed");
             }
+            finally
+            {
+                _writeQueue.Release();
+            }
 
             return;
         }
 
-        WriteFileInBackground(action);
+        WriteFileInBackground(action, planFolder);
     }
 
     /// <summary>


### PR DESCRIPTION
The Accept button in Review fired three concurrent background writes
(ResetVerificationsForRetry, TransitionState, UpdateRecommendationState)
that each did independent read-modify-write on plan.yaml. The last
writer won, silently dropping the others' changes — causing accepted/
declined recommendations to revert to Pending.

Fixes:
- Serialize all in-process plan.yaml writes through a SemaphoreSlim
- Add PlanFileLock for cross-process coordination with CLI commands
- Add AcceptRecommendationAndRetry that performs all three mutations
  in a single atomic read-modify-write
- Read recommendations from database (not stale file) in Review UI
- Remove recommendation generation from RetryPlan (not its job)
