### PR TITLE
[00098] Add Revert Revision Button to Plan Details Tab

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -216,6 +216,10 @@ public class JobServiceCompletionGuardTests : IDisposable
         {
         }
 
+        public void RevertRevision(string folderName)
+        {
+        }
+
         public void SaveRevision(string folderName, string content)
         {
         }

--- a/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
@@ -345,6 +345,10 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         {
         }
 
+        public void RevertRevision(string folderName)
+        {
+        }
+
         public void SaveRevision(string folderName, string content)
         {
         }

--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -447,6 +447,10 @@ public class JobServiceRetryBlockedTests : IDisposable
         {
         }
 
+        public void RevertRevision(string folderName)
+        {
+        }
+
         public void SaveRevision(string folderName, string content)
         {
         }

--- a/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
@@ -68,6 +68,7 @@ public class JobServiceSplitPlanCompletionTests
 
         public void ResetToDraft(string folderName) { }
         public void ResetVerificationsForRetry(string folderName) { }
+        public void RevertRevision(string folderName) { }
 
         public void RecoverStuckPlans() { }
         public void RepairPlans() { }

--- a/src/Ivy.Tendril/Apps/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/AgentApp.cs
@@ -7,26 +7,26 @@ using Xterm = Ivy.Widgets.Xterm;
 
 namespace Ivy.Tendril.Apps;
 
-[App(title: "Agent", icon: Icons.Terminal, group: ["Apps"], order: Constants.Agent, isVisible: true, allowDuplicateTabs:true)]
+[App(title: "Agent", icon: Icons.Terminal, group: ["Apps"], order: Constants.Agent, isVisible: true, allowDuplicateTabs: true)]
 public class AgentApp : ViewBase
 {
     public override object Build()
     {
         var configService = UseService<IConfigService>();
         var agentRunner = UseService<IAgentRunner>();
-        
+
         var ptyHandle = Context.UsePty(
             GetCommandLine(configService, agentRunner),
             GetWorkDir(configService, agentRunner)
         );
-        
+
         var terminal = new Xterm.Terminal()
             .Stream(ptyHandle.Stream)
             .OnInput(ptyHandle.HandleInput)
             .OnResize(ptyHandle.HandleResize)
             .Closed(ptyHandle.Closed)
             .AllowClipboard();
-        
+
         return terminal
             .WithLayout()
             .Full()

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -200,7 +200,7 @@ public class ContentView(
                 new Tab("Plan", Cap(planTabContent)),
                 new Tab("Details", Cap(new DetailsTabView(selectedPlan!,
                     jobService.GetJobsForPlan(selectedPlan!.FolderName),
-                    showDebugJob)))
+                    showDebugJob, planService, selectedPlanState, refreshPlans)))
             ).OnSelect(v => selectedTab.Set(v)).SelectedIndex(selectedTab.Value).Variant(TabsVariant.Content).RemoveParentPadding();
 
             content |= (Layout.Vertical().Padding(2).Height(Size.Full()) | tabs);

--- a/src/Ivy.Tendril/Apps/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.cs
@@ -52,7 +52,7 @@ public partial class JobsApp : ViewBase
                 "Full Prompt"
             ).Width(Size.Half()).Resizable();
         });
-        
+
         var (debugSheet, showDebug) = UseTrigger<string>((isOpen, jobId) =>
         {
             if (!isOpen.Value) return null;
@@ -74,7 +74,7 @@ public partial class JobsApp : ViewBase
         var projectColors = BuildProjectColorMapping(config);
         var rows = BuildJobRows(jobs, planService);
         var jobsProgress = BuildStatusProgress(jobs, config);
-        
+
         var dataTable = BuildDataTable(rows, refreshToken, updateStream, config, planService,
             jobService, client, showPlan, showOutput, showPrompt, showDebug, jobs, projectColors, jobsProgress);
 

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -229,7 +229,7 @@ public class CodingAgentStepView(
     private static object BuildPicker(Action<string> onSelect, string? errorMessage)
     {
         var grid = Layout.Grid().Columns(3).Gap(2);
-        
+
         grid = Agents.Aggregate(grid, (current, a) => current | new Card(Layout.Horizontal().Gap(2).AlignContent(Align.Center).Padding(0) | a.Logo.ToIcon().Width(Size.Px(32)).Height(Size.Px(32)) | Text.Block(a.Label)).OnClick(() => onSelect(a.Key)));
 
         return Layout.Vertical().Margin(0, 0, 0, 20)

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -545,7 +545,7 @@ public class ContentView(
                 new Tab("Plan", Cap(planTabContent)),
                 new Tab("Details", Cap(new DetailsTabView(selectedPlan,
                     jobService.GetJobsForPlan(selectedPlan.FolderName),
-                    showDebugJob))),
+                    showDebugJob, planService, selectedPlanState, refreshPlans))),
                 new Tab("Verifications", Cap(new VerificationsTabView(
                     selectedPlan.Verifications, planData.VerificationReports,
                     v => openVerification.Set(v)))).Badge(selectedPlan.Verifications.Count.ToString()),

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/AddProjectDialog.cs
@@ -95,11 +95,13 @@ public class AddProjectDialog(
                 editRepos,
                 editName,
                 isStepLoading,
-                onNext: () => {
+                onNext: () =>
+                {
                     skipAgent.Set(false);
                     step.Set(1);
                 },
-                onSkip: () => {
+                onSkip: () =>
+                {
                     skipAgent.Set(true);
                     step.Set(1);
                 },
@@ -113,12 +115,14 @@ public class AddProjectDialog(
                 editName,
                 isStepLoading,
                 session,
-                onBack: () => {
+                onBack: () =>
+                {
                     session.Reset();
                     isStepLoading.Set(false);
                     step.Set(0);
                 },
-                onNext: () => {
+                onNext: () =>
+                {
                     step.Set(2);
                 },
                 onSkip: null,
@@ -128,11 +132,13 @@ public class AddProjectDialog(
                 editName,
                 isStepLoading,
                 session,
-                onBack: () => {
+                onBack: () =>
+                {
                     step.Set(0);
                     session.Reset();
                 },
-                onNext: () => {
+                onNext: () =>
+                {
                     hasCreated.Set(false); // Clear so we don't delete on close
                     isOpen.Set(false);
                     refreshToken.Refresh();

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/AgentTestDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/AgentTestDialog.cs
@@ -62,7 +62,7 @@ public class AgentTestDialog(
                 new("Authentication", TestStatus.Pending),
             };
             results.AddRange(models.Select(m => new AgentTestResult($"Model: {m.DisplayName}", TestStatus.Pending)));
-            testResults.Set([..results]);
+            testResults.Set([.. results]);
 
             try
             {
@@ -70,7 +70,7 @@ public class AgentTestDialog(
                 var healthCheck = runner.GetHealthCheck(agentId);
 
                 results[0] = results[0] with { Status = TestStatus.Running };
-                testResults.Set([..results]);
+                testResults.Set([.. results]);
 
                 var installStatus = await healthCheck.CheckInstallAsync(ct);
                 results[0] = installStatus.IsInstalled
@@ -78,7 +78,7 @@ public class AgentTestDialog(
                         installStatus.Version != null ? $"v{installStatus.Version}" : "Installed")
                     : new AgentTestResult("Installation", TestStatus.Failed,
                         installStatus.Error ?? "Not installed", installStatus.Error);
-                testResults.Set([..results]);
+                testResults.Set([.. results]);
 
                 if (!installStatus.IsInstalled)
                 {
@@ -90,7 +90,7 @@ public class AgentTestDialog(
                 ct.ThrowIfCancellationRequested();
 
                 results[1] = results[1] with { Status = TestStatus.Running };
-                testResults.Set([..results]);
+                testResults.Set([.. results]);
 
                 var authResult = await healthCheck.CheckAuthAsync(ct);
                 var providerLabel = authResult.Provider != null ? $" ({authResult.Provider})" : "";
@@ -103,7 +103,7 @@ public class AgentTestDialog(
                     _ => new AgentTestResult("Authentication", TestStatus.Warning,
                         authResult.Error ?? "Check inconclusive", authResult.Error)
                 };
-                testResults.Set([..results]);
+                testResults.Set([.. results]);
 
                 for (var i = 0; i < models.Count; i++)
                 {
@@ -112,7 +112,7 @@ public class AgentTestDialog(
                     var entry = models[i];
 
                     results[idx] = results[idx] with { Status = TestStatus.Running };
-                    testResults.Set([..results]);
+                    testResults.Set([.. results]);
 
                     var modelResult = await healthCheck.ValidateModelAsync(entry.Id ?? "", ct);
                     results[idx] = modelResult.Status switch
@@ -127,7 +127,7 @@ public class AgentTestDialog(
                         _ => new AgentTestResult($"Model: {entry.DisplayName}", TestStatus.Warning,
                             modelResult.ErrorMessage ?? "Unknown", modelResult.ErrorMessage)
                     };
-                    testResults.Set([..results]);
+                    testResults.Set([.. results]);
                 }
             }
             catch (OperationCanceledException)
@@ -135,12 +135,12 @@ public class AgentTestDialog(
                 for (var i = 0; i < results.Count; i++)
                     if (results[i].Status is TestStatus.Running or TestStatus.Pending)
                         results[i] = results[i] with { Status = TestStatus.Warning, Message = "Cancelled" };
-                testResults.Set([..results]);
+                testResults.Set([.. results]);
             }
             catch (Exception ex)
             {
                 results.Add(new AgentTestResult("Unexpected error", TestStatus.Failed, "Test run failed", ex.ToString()));
-                testResults.Set([..results]);
+                testResults.Set([.. results]);
             }
 
             isTesting.Set(false);

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs
@@ -234,7 +234,7 @@ public class EditProjectDialog(
                         _refreshToken.Refresh();
                         _client.Toast($"Failed to save project: {ex.Message}", "Error");
                     }
-                    })
+                })
                     .WithTooltip(hasInvalidRepos ? "Fix or remove invalid repositories before saving" : null)
             )
         ).Width(Size.Rem(40));

--- a/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
@@ -150,7 +150,7 @@ public class ProjectRepoPickerView(
         return Layout.Vertical().Width(Size.Full()).Gap(2)
                | Text.Label("Add one or more Git repositories")
                | (addingError.Value != null ? Text.Danger(addingError.Value) : null!)
-               | (Layout.Horizontal() | pickerControls  | addButton)
+               | (Layout.Horizontal() | pickerControls | addButton)
                //| (current.Count > 0 ? new Separator() : null!)
                | (current.Count > 0 ? listLayout : null!);
     }

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -16,23 +16,10 @@ public class DetailsTabView(
     {
         var planYaml = PlanYamlHelper.ParsePlanYaml(plan.PlanYamlRaw);
 
-        var revisionWidget = Layout.Horizontal().Gap(2).AlignContent(Align.Center)
-                             | Text.Block(plan.RevisionCount.ToString())
-                             | new Button().Icon(Icons.Undo).Ghost().Small()
-                                 .Tooltip("Revert to previous revision")
-                                 .Disabled(plan.RevisionCount <= 1)
-                                 .OnClick(() =>
-                                 {
-                                     planService.RevertRevision(plan.FolderName);
-                                     var updated = planService.GetPlanByFolder(plan.FolderPath);
-                                     if (updated != null) selectedPlanState.Set(updated);
-                                     refreshPlans();
-                                 });
-
         var detailsData = new
         {
             plan.InitialPrompt,
-            Revision = revisionWidget,
+            Revision = plan.RevisionCount,
             Profile = planYaml?.ExecutionProfile ?? "",
             RelatedPlans = FormatPlanLinks(plan.RelatedPlans),
             DependsOn = FormatPlanLinks(plan.DependsOn),
@@ -45,6 +32,19 @@ public class DetailsTabView(
 
         var details = detailsData.ToDetails()
             .Multiline(x => x.InitialPrompt)
+            .Builder(x => x.Revision, f => f.Func((int count) =>
+                Layout.Horizontal().Gap(2).AlignItems(Align.Center)
+                | Text.Block(count.ToString())
+                | new Button().Icon(Icons.Undo).Ghost().Small()
+                    .Tooltip("Revert to previous revision")
+                    .Disabled(count <= 1)
+                    .OnClick(() =>
+                    {
+                        planService.RevertRevision(plan.FolderName);
+                        var updated = planService.GetPlanByFolder(plan.FolderPath);
+                        if (updated != null) selectedPlanState.Set(updated);
+                        refreshPlans();
+                    })))
             .Builder(x => x.Issue, f => f.Link())
             .RemoveEmpty();
 

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -1,18 +1,37 @@
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Plans;
 
 namespace Ivy.Tendril.Apps.Views.Tabs;
 
-public class DetailsTabView(PlanFile plan, List<JobItem> jobs, Action<string> showDebug) : ViewBase
+public class DetailsTabView(
+    PlanFile plan,
+    List<JobItem> jobs,
+    Action<string> showDebug,
+    IPlanReaderService planService,
+    IState<PlanFile?> selectedPlanState,
+    Action refreshPlans) : ViewBase
 {
     public override object Build()
     {
         var planYaml = PlanYamlHelper.ParsePlanYaml(plan.PlanYamlRaw);
 
+        var revisionWidget = Layout.Horizontal().Gap(2).AlignItems(Align.Center)
+                             | Text.Block(plan.RevisionCount.ToString())
+                             | new Button().Icon(Icons.Undo).Ghost().Small()
+                                 .Tooltip("Revert to previous revision")
+                                 .Disabled(plan.RevisionCount <= 1)
+                                 .OnClick(() =>
+                                 {
+                                     planService.RevertRevision(plan.FolderName);
+                                     var updated = planService.GetPlanByFolder(plan.FolderPath);
+                                     if (updated != null) selectedPlanState.Set(updated);
+                                     refreshPlans();
+                                 });
+
         var detailsData = new
         {
             plan.InitialPrompt,
-            Revision = plan.RevisionCount.ToString(),
             Profile = planYaml?.ExecutionProfile ?? "",
             RelatedPlans = FormatPlanLinks(plan.RelatedPlans),
             DependsOn = FormatPlanLinks(plan.DependsOn),
@@ -30,11 +49,19 @@ public class DetailsTabView(PlanFile plan, List<JobItem> jobs, Action<string> sh
 
         return Layout.Vertical().Gap(4)
                | details
+               | LabeledRow("Revision", revisionWidget)
                | (jobs.Count > 0
                    ? (Layout.Vertical().Gap(2)
                       | Text.H4("Jobs")
                       | new PlanJobsDataTableView(jobs, showDebug))
                    : null);
+    }
+
+    private static object LabeledRow(string label, object value)
+    {
+        return Layout.Horizontal().Gap(2)
+               | Text.Block(label + ":").Width(15).TextAlign(TextAlign.End)
+               | value;
     }
 
     private static string FormatPlanLinks(List<string> planFolders)

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -16,7 +16,7 @@ public class DetailsTabView(
     {
         var planYaml = PlanYamlHelper.ParsePlanYaml(plan.PlanYamlRaw);
 
-        var revisionWidget = Layout.Horizontal().Gap(2).AlignItems(Align.Center)
+        var revisionWidget = Layout.Horizontal().Gap(2).AlignContent(Align.Center)
                              | Text.Block(plan.RevisionCount.ToString())
                              | new Button().Icon(Icons.Undo).Ghost().Small()
                                  .Tooltip("Revert to previous revision")
@@ -32,6 +32,7 @@ public class DetailsTabView(
         var detailsData = new
         {
             plan.InitialPrompt,
+            Revision = revisionWidget,
             Profile = planYaml?.ExecutionProfile ?? "",
             RelatedPlans = FormatPlanLinks(plan.RelatedPlans),
             DependsOn = FormatPlanLinks(plan.DependsOn),
@@ -49,19 +50,11 @@ public class DetailsTabView(
 
         return Layout.Vertical().Gap(4)
                | details
-               | LabeledRow("Revision", revisionWidget)
                | (jobs.Count > 0
                    ? (Layout.Vertical().Gap(2)
                       | Text.H4("Jobs")
                       | new PlanJobsDataTableView(jobs, showDebug))
                    : null);
-    }
-
-    private static object LabeledRow(string label, object value)
-    {
-        return Layout.Horizontal().Gap(2)
-               | Text.Block(label + ":").Width(15).TextAlign(TextAlign.End)
-               | value;
     }
 
     private static string FormatPlanLinks(List<string> planFolders)

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -35,7 +35,7 @@ public class DetailsTabView(
             .Builder(x => x.Revision, f => f.Func((int count) =>
                 Layout.Horizontal().Gap(2).AlignContent(Align.Center)
                 | Text.Block(count.ToString())
-                | new Button().Icon(Icons.Undo).Ghost().Small()
+                | new Button().Icon(Icons.Undo).Outline().Small()
                     .Tooltip("Revert to previous revision")
                     .Disabled(count <= 1)
                     .OnClick(() =>

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -33,7 +33,7 @@ public class DetailsTabView(
         var details = detailsData.ToDetails()
             .Multiline(x => x.InitialPrompt)
             .Builder(x => x.Revision, f => f.Func((int count) =>
-                Layout.Horizontal().Gap(2).AlignItems(Align.Center)
+                Layout.Horizontal().Gap(2).AlignContent(Align.Center)
                 | Text.Block(count.ToString())
                 | new Button().Icon(Icons.Undo).Ghost().Small()
                     .Tooltip("Revert to previous revision")

--- a/src/Ivy.Tendril/Commands/DoctorChecks/SoftwareCheck.cs
+++ b/src/Ivy.Tendril/Commands/DoctorChecks/SoftwareCheck.cs
@@ -119,7 +119,7 @@ internal class SoftwareCheck : IDoctorCheck
     private static async Task<bool> CheckDotNet(List<CheckStatus> statuses)
     {
         var bundledPath = PathHelper.GetBundledDotnetPath();
-        
+
         // Try bundled first if it exists
         if (bundledPath != null)
         {
@@ -130,7 +130,7 @@ internal class SoftwareCheck : IDoctorCheck
                 return false;
             }
         }
-        
+
         // Try system dotnet next
         var (sysSuccess, sysErr) = await ProcessCheckHelper.TryCheckCommand("dotnet", "--version");
         if (sysSuccess)
@@ -138,7 +138,7 @@ internal class SoftwareCheck : IDoctorCheck
             statuses.Add(new CheckStatus("dotnet", "OK (dotnet)", StatusKind.Ok));
             return false;
         }
-        
+
         var details = bundledPath != null ? $"bundled: {bundledPath} failed, system: {sysErr}" : sysErr;
         statuses.Add(new CheckStatus("dotnet", $"Not found or failed to execute. Details: {details}", StatusKind.Error));
         return true;

--- a/src/Ivy.Tendril/Helpers/GitHelper.cs
+++ b/src/Ivy.Tendril/Helpers/GitHelper.cs
@@ -60,11 +60,11 @@ public static class GitHelper
 
                     using var process = Process.Start(psi);
                     if (process == null) return false;
-                    
+
                     var outTask = process.StandardOutput.ReadToEndAsync();
                     var errTask = process.StandardError.ReadToEndAsync();
                     process.WaitForExit(5000);
-                    
+
                     var output = outTask.GetAwaiter().GetResult();
                     _ = errTask.GetAwaiter().GetResult();
 
@@ -110,11 +110,11 @@ public static class GitHelper
 
                     using var process = Process.Start(psi);
                     if (process == null) return false;
-                    
+
                     var outTask = process.StandardOutput.ReadToEndAsync();
                     var errTask = process.StandardError.ReadToEndAsync();
                     process.WaitForExit(10000);
-                    
+
                     var output = outTask.GetAwaiter().GetResult();
                     _ = errTask.GetAwaiter().GetResult();
 
@@ -153,14 +153,14 @@ public static class GitHelper
 
             using var process = Process.Start(psi);
             if (process == null) return false;
-            
+
             var outTask = process.StandardOutput.ReadToEndAsync();
             var errTask = process.StandardError.ReadToEndAsync();
             process.WaitForExit(5000);
-            
+
             _ = outTask.GetAwaiter().GetResult();
             _ = errTask.GetAwaiter().GetResult();
-            
+
             return process.ExitCode == 0;
         }
         catch

--- a/src/Ivy.Tendril/Helpers/PathHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PathHelper.cs
@@ -110,7 +110,7 @@ public static class PathHelper
         {
             // Verify and auto-repair permissions on Unix
             _ = GetBundledDotnetPath();
-            
+
             if (!dirs.Contains(bundledDotnetDir))
             {
                 pathList.Add(bundledDotnetDir);
@@ -122,7 +122,7 @@ public static class PathHelper
         {
             // Verify and auto-repair permissions on Unix
             _ = GetPwshPath();
-            
+
             if (!dirs.Contains(bundledPwshDir))
             {
                 pathList.Add(bundledPwshDir);
@@ -272,11 +272,11 @@ public static class PathHelper
     private static bool IsSecretKey(string key)
     {
         var normalized = key.ToUpperInvariant();
-        return normalized.Contains("KEY") || 
-               normalized.Contains("SECRET") || 
-               normalized.Contains("TOKEN") || 
-               normalized.Contains("PASSWORD") || 
-               normalized.Contains("AUTH") || 
+        return normalized.Contains("KEY") ||
+               normalized.Contains("SECRET") ||
+               normalized.Contains("TOKEN") ||
+               normalized.Contains("PASSWORD") ||
+               normalized.Contains("AUTH") ||
                normalized.Contains("CREDENTIAL");
     }
 
@@ -331,7 +331,7 @@ public static class PathHelper
 
             Ivy.Helpers.CrashLog.Write($"[PathHelper] RunShellForEnv: starting process with args: {string.Join(" ", process.StartInfo.ArgumentList)}");
             process.Start();
-            
+
             if (process.WaitForExit(TimeSpan.FromSeconds(2)))
             {
                 var output = process.StandardOutput.ReadToEnd();

--- a/src/Ivy.Tendril/Helpers/ProcessCheckHelper.cs
+++ b/src/Ivy.Tendril/Helpers/ProcessCheckHelper.cs
@@ -70,21 +70,21 @@ public static class ProcessCheckHelper
                 if (proc is null) return (false, "Failed to start process.");
                 var outTask = proc.StandardOutput.ReadToEndAsync();
                 var errTask = proc.StandardError.ReadToEndAsync();
-                
+
                 var exited = proc.WaitForExitOrKill(timeoutMs);
                 if (!exited)
                 {
                     return (false, $"Process timed out after {timeoutMs}ms.");
                 }
-                
+
                 var stdout = await outTask;
                 var stderr = await errTask;
-                
+
                 if (proc.ExitCode == 0)
                 {
                     return (true, (string?)null);
                 }
-                
+
                 var errorMsg = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
                 var details = string.IsNullOrWhiteSpace(errorMsg) ? $"Exit code {proc.ExitCode}" : $"Exit code {proc.ExitCode}: {errorMsg.Trim()}";
                 return (false, details);

--- a/src/Ivy.Tendril/Helpers/RepoPathValidator.cs
+++ b/src/Ivy.Tendril/Helpers/RepoPathValidator.cs
@@ -58,7 +58,7 @@ public static class RepoPathValidator
     {
         var kind = Classify(path);
         if (kind != RepoPathKind.LocalPath)
-            return null; 
+            return null;
 
         var expanded = tendrilHome != null
             ? VariableExpansion.ExpandVariables(path, tendrilHome)

--- a/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
@@ -16,6 +16,7 @@ public interface IPlanReaderService
     void ResetToDraft(string folderName);
     void ResetVerificationsForRetry(string folderName);
     void SaveRevision(string folderName, string content);
+    void RevertRevision(string folderName);
     string ReadLatestRevision(string folderName);
     List<(int Number, string Content, DateTime Modified)> GetRevisions(string folderName);
     void AddLog(string folderName, string action, string content, string? jobId = null);

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -350,6 +350,45 @@ public class PlanReaderService(
         });
     }
 
+    public void RevertRevision(string folderName)
+    {
+        var revisionsDir = Path.Combine(PlansDirectory, folderName, "Revisions");
+        if (!Directory.Exists(revisionsDir)) return;
+
+        var files = Directory.GetFiles(revisionsDir, "*.md").OrderBy(f => f).ToArray();
+        if (files.Length <= 1) return; // Can't revert below revision 1
+
+        var latestFile = files.Last();
+        var previousFile = files[^2];
+        var previousContent = FileHelper.ReadAllText(previousFile);
+        var newCount = files.Length - 1;
+
+        // Update database first for instant UI feedback
+        var planId = ExtractPlanId(folderName);
+        if (planId.HasValue && _database != null)
+            _database.UpdatePlanContent(planId.Value, previousContent, newCount);
+
+        _planCountsCache.Invalidate();
+        CountsInvalidated?.Invoke();
+        planWatcherService?.NotifyChanged(folderName);
+
+        // Delete the latest revision file in background
+        WriteFileInBackground(() =>
+        {
+            if (File.Exists(latestFile))
+                File.Delete(latestFile);
+
+            var planYamlPath = Path.Combine(PlansDirectory, folderName, "plan.yaml");
+            if (File.Exists(planYamlPath))
+            {
+                var yaml = FileHelper.ReadAllText(planYamlPath);
+                var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
+                planYaml.Updated = DateTime.UtcNow;
+                FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
+            }
+        });
+    }
+
     /// <summary>
     ///     Reads the content of the most recent revision file for a plan.
     /// </summary>


### PR DESCRIPTION
# Summary

## Changes

Added a revert revision button to the Plan Details tab. Implemented RevertRevision in PlanReaderService to delete the latest revision file and update the database. The undo icon button appears next to the Revision field and is disabled on revision 1.

## API Changes

**IPlanReaderService:**
- Added `void RevertRevision(string folderName)` method

**PlanReaderService:**
- Implemented `RevertRevision(string folderName)` — deletes the latest revision file, updates the database with previous revision content, and invalidates caches

**DetailsTabView:**
- Constructor now accepts `IPlanReaderService planService`, `IState<PlanFile?> selectedPlanState`, and `Action refreshPlans` parameters

## Files Modified

**Services:**
- src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
- src/Ivy.Tendril/Services/Plans/PlanReaderService.cs

**UI:**
- src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
- src/Ivy.Tendril/Apps/Drafts/ContentView.cs
- src/Ivy.Tendril/Apps/Review/ContentView.cs

**Tests:**
- src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
- src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
- src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
- src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs

## Fix: Uninitialized ViewBase Error

The initial implementation attempted to construct a Layout widget outside the `.ToDetails()` builder flow and pass it directly as a property value in the anonymous object. This caused a runtime error: "Trying to access an uninitialized ViewBase Id in a Ivy.LayoutView view."

The fix uses the Ivy Framework's `.Builder()` API with `.Func()` to properly construct the revision widget inline. The pattern uses a simple `int` property value and transforms it into a complex widget through the builder:
- Change `Revision` property from `Layout` to `int` 
- Use `.Builder(x => x.Revision, f => f.Func((int count) => ...))` to construct the widget
- Use `AlignContent` instead of `AlignItems` (correct Ivy API)

### Files Modified

- src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs

**Note:** The manual testing section remains valid - the button functionality is unchanged, only the construction pattern was corrected.

---

## Commits

- 34fa604 Change revert button style to outlined in DetailsTabView
- 93840de Fix Builder API usage - use AlignContent and correct Func syntax
- 2a558b7 Apply dotnet format fixes
- 33b4184 Fix uninitialized ViewBase error in revert button
- de1648f Add RevertRevision to test mocks
- 9d74a4e Add revert revision button to plan Details tab