### PR TITLE
[00101] Fix tendril doctor crash on unescaped Spectre.Console markup

### DIFF
--- a/src/Ivy.Tendril.Test/DoctorChecksTests.cs
+++ b/src/Ivy.Tendril.Test/DoctorChecksTests.cs
@@ -42,4 +42,24 @@ public class DoctorChecksTests : IDisposable
             Environment.SetEnvironmentVariable("TENDRIL_HOME", null);
         }
     }
+
+    [Fact]
+    public void PrintStatus_WithBracketCharacters_DoesNotThrow()
+    {
+        // Arrange
+        var status = new Status(StatusKind.Ok, "Test Label", "[flags] and [error] markup");
+        var testConsole = new Spectre.Console.Testing.TestConsole();
+        AnsiConsole.Console = testConsole;
+
+        // Act & Assert - should not throw on markup characters
+        var exception = Record.Exception(() =>
+            Commands.DoctorCommand.PrintStatus(status));
+
+        Assert.Null(exception);
+
+        // Verify the output contains escaped brackets
+        var output = testConsole.Output;
+        Assert.Contains("[[flags]]", output);
+        Assert.Contains("[[error]]", output);
+    }
 }

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -93,7 +93,7 @@ public static class DoctorCommand
             DoctorChecks.StatusKind.Error => ("✗", "red"),
             _ => (" ", "grey")
         };
-        AnsiConsole.MarkupLine($"[{color}]{symbol} {label.PadRight(40)}{value}[/]");
+        AnsiConsole.MarkupLine($"[{color}]{symbol} {label.EscapeMarkup().PadRight(40)}{value.EscapeMarkup()}[/]");
     }
 
     // --- doctor plans subcommand ---
@@ -435,7 +435,7 @@ public static class DoctorCommand
 
             var healthColor = r.IsHealthy ? "green" : "red";
             var healthText = r.IsHealthy ? "OK" : r.Health;
-            AnsiConsole.MarkupLine($"{r.Id.PadRight(idWidth)}  {truncatedTitle.PadRight(planWidth)}  {r.State.PadRight(stateWidth)}  {r.Worktrees.ToString().PadRight(wtWidth)}  [{healthColor}]{healthText}[/]");
+            AnsiConsole.MarkupLine($"{r.Id.PadRight(idWidth)}  {truncatedTitle.EscapeMarkup().PadRight(planWidth)}  {r.State.PadRight(stateWidth)}  {r.Worktrees.ToString().PadRight(wtWidth)}  [{healthColor}]{healthText.EscapeMarkup()}[/]");
         }
     }
 


### PR DESCRIPTION
# Summary

## Changes

Fixed a crash in `tendril doctor` caused by unescaped Spectre.Console markup. Added `.EscapeMarkup()` calls to prevent markup injection when displaying external values (like `gh copilot` stderr output containing `[flags]`).

## API Changes

**Public method signature change:**
- `DoctorCommand.PrintStatus(Status status)` — now escapes label and value before rendering (internal behavior change, no signature change)

**No breaking API changes** — the fix is internal to how status messages are rendered.

## Files Modified

**Core fix:**
- `src/Ivy.Tendril/Commands/DoctorCommand.cs` — Added `.EscapeMarkup()` to 4 string parameters across 2 methods

**Test coverage:**
- `src/Ivy.Tendril.Test/DoctorChecksTests.cs` — Added `PrintStatus_WithBracketCharacters_DoesNotThrow` test

## Manual Testing

1. Run `tendril doctor` in a workspace where `gh copilot` is installed but not properly configured (so it outputs usage text to stderr containing `[flags]`)
2. **Before fix:** Command crashes with `Could not find color or style flags`
3. **After fix:** Command displays the error message with escaped brackets (`[[flags]]`) and continues without crashing

**Alternative test:**
1. Create a plan with a title containing brackets, e.g., `Fix [critical] bug`
2. Run `tendril doctor plans`
3. **Before fix:** Command crashes when rendering the plan table
4. **After fix:** Plan title is displayed with escaped brackets and no crash occurs

---

## Commits

- f1fb0e0 Escape markup in DoctorCommand to prevent Spectre.Console crash