### PR TITLE
[ProjectAgentStepView]: reduce right padding on project setup agent output

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -189,7 +189,7 @@ public class ProjectAgentStepView(
                       )
                         .Width(Size.Full())
                         .Height(Size.Units(100).Max(Size.Fraction(0.6f)))
-                        .Padding(4, 4, 0, 4)
+                        .Padding(4, 4, 2, 4)
                    : null!)
                | buttonArea
                | new Spacer().Height(Size.Units(4));


### PR DESCRIPTION
## Summary

Adjusts padding on the `AgentOutputView` container in `ProjectAgentStepView` (Add Project / onboarding “Setting up your project” step).

- **Before:** `Padding(4, 4, 0, 4)` — no inset on the right (left/top/bottom: 1rem, right: 0).
- **After:** `Padding(4, 4, 2, 4)` — small right inset (0.5rem) so content does not sit flush against the scroll edge.

Used by both the onboarding flow and **Settings → Configuration → Projects → Add Project**.

## Why

The agent output stream looked cramped against the right side of the dialog and contributed to awkward scrolling/layout in the setup step (#1060).

https://github.com/user-attachments/assets/6198afc3-fc4b-4313-b069-859fddebeb5d

<img width="1502" height="1005" alt="Знімок екрана 2026-06-04 о 18 18 22" src="https://github.com/user-attachments/assets/083e8553-dc43-4953-bf6a-13f89a887f81" />

