### PR TITLE
[00103] Add Ivy Tendril attribution footer to PR body text

### DIFF
--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -108,7 +108,7 @@ EOF
   fi
 
   # Construct body with issue link prepended
-  body="${issueLink}${summaryContent}\n\n---\n${commitsList}${artifactMarkdown}"
+  body="${issueLink}${summaryContent}\n\n---\n${commitsList}${artifactMarkdown}\n\n---\nCreated using [Ivy Tendril](https://ivy.app)."
   ```
 - **Draft (custom options):** If custom options exist and `draft` is `true`, add `--draft` to the `gh pr create` command to create the PR in draft mode. If no custom options or `draft` is `false`, create as ready for review (default behavior).
 - **Assignee (custom options):** If custom options exist and `assignee` is non-empty, add `--assignee <assignee>` to the `gh pr create` command.


### PR DESCRIPTION
# Summary

## Changes

Modified the CreatePr promptware to append an attribution footer to all GitHub PR body text. The footer now includes "Created using [Ivy Tendril](https://ivy.app)." separated by a horizontal rule at the end of every PR body.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Promptwares/CreatePr/Program.md` — Updated PR body construction logic (line 111) to include the attribution footer

## Manual Testing

1. Run Tendril and execute a plan with verifications enabled
2. After ExecutePlan completes, run CreatePr on the plan
3. Open the created GitHub PR in a browser
4. Scroll to the bottom of the PR description
5. Verify the last line reads "Created using [Ivy Tendril](https://ivy.app)." with a horizontal rule above it

---

## Commits

- Add Ivy Tendril attribution footer to PR body text (2c99acc)

---
Created using [Ivy Tendril](https://ivy.app).