### PR TITLE
[00107] Escape dynamic values in all AnsiConsole.MarkupLine calls

### DIFF
--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -136,7 +136,7 @@ public static class DoctorCommand
             : Path.Combine(tendrilHome, "Plans");
         if (!Directory.Exists(plansDir))
         {
-            AnsiConsole.MarkupLine($"[red]Plans directory not found: {plansDir}[/]");
+            AnsiConsole.MarkupLine($"[red]Plans directory not found: {plansDir.EscapeMarkup()}[/]");
             return 1;
         }
 
@@ -181,12 +181,12 @@ public static class DoctorCommand
             var repairResult = RepairPlan(result.FolderPath, result);
             if (repairResult.Success)
             {
-                AnsiConsole.MarkupLine($"[green]  ✓ {result.Id}: {repairResult.Message}[/]");
+                AnsiConsole.MarkupLine($"[green]  ✓ {result.Id}: {repairResult.Message.EscapeMarkup()}[/]");
                 repairedCount++;
             }
             else if (repairResult.Message != null)
             {
-                AnsiConsole.MarkupLine($"[red]  ✗ {result.Id}: {repairResult.Message}[/]");
+                AnsiConsole.MarkupLine($"[red]  ✗ {result.Id}: {repairResult.Message.EscapeMarkup()}[/]");
                 failedCount++;
             }
         }
@@ -207,7 +207,7 @@ public static class DoctorCommand
 
             foreach (var (_, result, reason) in pruneCandidates)
             {
-                AnsiConsole.MarkupLine($"[grey]  {result.Id}-{result.Title}  ({reason})[/]");
+                AnsiConsole.MarkupLine($"[grey]  {result.Id}-{result.Title.EscapeMarkup()}  ({reason.EscapeMarkup()})[/]");
             }
 
             AnsiConsole.WriteLine();
@@ -219,12 +219,12 @@ public static class DoctorCommand
                     try
                     {
                         Directory.Delete(dir, true);
-                        AnsiConsole.MarkupLine($"[green]  ✓ Removed {result.Id}-{result.Title}[/]");
+                        AnsiConsole.MarkupLine($"[green]  ✓ Removed {result.Id}-{result.Title.EscapeMarkup()}[/]");
                         removed++;
                     }
                     catch (Exception ex)
                     {
-                        AnsiConsole.MarkupLine($"[red]  ✗ Failed to remove {result.Id}-{result.Title}: {ex.Message}[/]");
+                        AnsiConsole.MarkupLine($"[red]  ✗ Failed to remove {result.Id}-{result.Title.EscapeMarkup()}: {ex.Message.EscapeMarkup()}[/]");
                     }
                 }
 

--- a/src/Ivy.Tendril/Commands/JobStartCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStartCommand.cs
@@ -109,7 +109,7 @@ public class JobStartCommand : Command<JobStartSettings>
         }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message}");
+            AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message.EscapeMarkup()}");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Commands/ModelsCommand.cs
+++ b/src/Ivy.Tendril/Commands/ModelsCommand.cs
@@ -54,7 +54,7 @@ public sealed class ModelsCommand(IAgentRunner runner) : AsyncCommand<ModelsComm
                 }
                 : "[dim]none[/]";
 
-            AnsiConsole.MarkupLine($"[bold]{agentId}[/]");
+            AnsiConsole.MarkupLine($"[bold]{agentId.EscapeMarkup()}[/]");
             AnsiConsole.MarkupLine(
                 $"  Installed: {(installed ? "[green]YES[/]" : "[red]NO[/]")}  " +
                 $"Authenticated: {(authenticated ? "[green]YES[/]" : "[red]NO[/]")}  " +
@@ -66,7 +66,7 @@ public sealed class ModelsCommand(IAgentRunner runner) : AsyncCommand<ModelsComm
                 foreach (var profile in descriptor.DefaultProfiles)
                 {
                     var model = profile.Model ?? "-";
-                    AnsiConsole.MarkupLine($"    {profile.Name,-10} : {model}");
+                    AnsiConsole.MarkupLine($"    {profile.Name.EscapeMarkup(),-10} : {model.EscapeMarkup()}");
                 }
             }
 

--- a/src/Ivy.Tendril/Commands/ResetCommand.cs
+++ b/src/Ivy.Tendril/Commands/ResetCommand.cs
@@ -97,7 +97,7 @@ public class ResetCommand : Command<ResetSettings>
         AnsiConsole.WriteLine();
         foreach (var target in targets.Where(t => t.Exists))
         {
-            AnsiConsole.MarkupLine($"[yellow]{target.Type}:[/] {target.Description}");
+            AnsiConsole.MarkupLine($"[yellow]{target.Type}:[/] {target.Description.EscapeMarkup()}");
         }
         AnsiConsole.WriteLine();
 
@@ -120,12 +120,12 @@ public class ResetCommand : Command<ResetSettings>
             try
             {
                 Directory.Delete(tendrilHome, recursive: true);
-                AnsiConsole.MarkupLine($"[green]✓[/] Deleted directory: {tendrilHome}");
+                AnsiConsole.MarkupLine($"[green]✓[/] Deleted directory: {tendrilHome.EscapeMarkup()}");
             }
             catch (Exception ex)
             {
                 errors.Add($"Failed to delete {tendrilHome}: {ex.Message}");
-                AnsiConsole.MarkupLine($"[red]✗[/] Failed to delete directory: {tendrilHome}");
+                AnsiConsole.MarkupLine($"[red]✗[/] Failed to delete directory: {tendrilHome.EscapeMarkup()}");
                 _logger.LogError(ex, "Failed to delete TENDRIL_HOME directory");
             }
         }
@@ -136,12 +136,12 @@ public class ResetCommand : Command<ResetSettings>
             try
             {
                 Directory.Delete(tendrilPlans, recursive: true);
-                AnsiConsole.MarkupLine($"[green]✓[/] Deleted directory: {tendrilPlans}");
+                AnsiConsole.MarkupLine($"[green]✓[/] Deleted directory: {tendrilPlans.EscapeMarkup()}");
             }
             catch (Exception ex)
             {
                 errors.Add($"Failed to delete {tendrilPlans}: {ex.Message}");
-                AnsiConsole.MarkupLine($"[red]✗[/] Failed to delete directory: {tendrilPlans}");
+                AnsiConsole.MarkupLine($"[red]✗[/] Failed to delete directory: {tendrilPlans.EscapeMarkup()}");
                 _logger.LogError(ex, "Failed to delete TENDRIL_PLANS directory");
             }
         }
@@ -195,7 +195,7 @@ public class ResetCommand : Command<ResetSettings>
             AnsiConsole.MarkupLine("[yellow]Reset completed with errors.[/]");
             foreach (var error in errors)
             {
-                AnsiConsole.MarkupLine($"[red]- {error}[/]");
+                AnsiConsole.MarkupLine($"[red]- {error.EscapeMarkup()}[/]");
             }
         }
 

--- a/src/Ivy.Tendril/Commands/RunCommand.cs
+++ b/src/Ivy.Tendril/Commands/RunCommand.cs
@@ -59,7 +59,7 @@ public class RunCommand : AsyncCommand<RunCommand.Settings>
         }
         catch (Exception ex)
         {
-            AnsiConsole.MarkupLine($"[red]Database migration failed: {ex.Message}[/]");
+            AnsiConsole.MarkupLine($"[red]Database migration failed: {ex.Message.EscapeMarkup()}[/]");
             return 1;
         }
 

--- a/src/Ivy.Tendril/Services/Promptware/PromptwareCommands.cs
+++ b/src/Ivy.Tendril/Services/Promptware/PromptwareCommands.cs
@@ -41,7 +41,7 @@ public static class PromptwareCommands
             return 0;
         }
 
-        AnsiConsole.MarkupLine($"[bold]Updating promptwares in[/] [blue]{target}[/]...");
+        AnsiConsole.MarkupLine($"[bold]Updating promptwares in[/] [blue]{target.EscapeMarkup()}[/]...");
         PromptwareDeployer.Deploy(target);
         AnsiConsole.MarkupLine("[green]✓[/] Done.");
         return 0;


### PR DESCRIPTION
# Summary

## Changes

Fixed 14 AnsiConsole.MarkupLine call sites across 6 files where unescaped dynamic values could crash Tendril when those values contained Spectre.Console markup characters (`[`, `]`). All vulnerable sites now call `.EscapeMarkup()` on dynamic strings before interpolation.

## API Changes

None — this is an internal bug fix with no public API surface changes.

## Files Modified

- **Commands/DoctorCommand.cs** — escaped 6 sites (plan titles, repair/prune messages, exception messages, directory paths)
- **Commands/ResetCommand.cs** — escaped 6 sites (directory paths, error messages)
- **Commands/RunCommand.cs** — escaped 1 site (exception message)
- **Commands/JobStartCommand.cs** — escaped 1 site (exception message)
- **Commands/ModelsCommand.cs** — escaped 2 sites (agent ID, profile names)
- **Services/Promptware/PromptwareCommands.cs** — escaped 1 site (file path)

## Manual Testing

1. Run `tendril doctor --prune` on a Plans directory containing a plan with brackets in its title (e.g., `00123-Fix[Bug]InParser`)
2. Observe that Tendril displays the plan title correctly without crashing
3. Run `tendril reset` with a TENDRIL_HOME path containing brackets
4. Observe that the reset command displays the path correctly without crashing

Previously these scenarios would crash with Spectre.Console markup parsing errors. Now they handle brackets safely.

---

## Commits

- 3f55213 Escape dynamic values in AnsiConsole.MarkupLine calls

---
Created using [Ivy Tendril](https://ivy.app).