### PR TITLE
[00108] Add Plan Id and Folder with Copy Buttons to Details Tab

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -14,10 +14,13 @@ public class DetailsTabView(
 {
     public override object Build()
     {
+        var copyToClipboard = UseClipboard();
         var planYaml = PlanYamlHelper.ParsePlanYaml(plan.PlanYamlRaw);
 
         var detailsData = new
         {
+            PlanId = plan.Id.ToString("D5"),
+            Folder = plan.FolderName,
             plan.InitialPrompt,
             Revision = plan.RevisionCount,
             Profile = planYaml?.ExecutionProfile ?? "",
@@ -31,6 +34,18 @@ public class DetailsTabView(
         };
 
         var details = detailsData.ToDetails()
+            .Builder(x => x.PlanId, f => f.Func((string id) =>
+                Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                | Text.Block(id)
+                | new Button().Icon(Icons.ClipboardCopy).Ghost().Small()
+                    .Tooltip("Copy plan ID")
+                    .OnClick(() => copyToClipboard(id))))
+            .Builder(x => x.Folder, f => f.Func((string folder) =>
+                Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                | Text.Block(folder)
+                | new Button().Icon(Icons.ClipboardCopy).Ghost().Small()
+                    .Tooltip("Copy folder name")
+                    .OnClick(() => copyToClipboard(folder))))
             .Multiline(x => x.InitialPrompt)
             .Builder(x => x.Revision, f => f.Func((int count) =>
                 Layout.Horizontal().Gap(2).AlignContent(Align.Center)

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -20,7 +20,7 @@ public class DetailsTabView(
         var detailsData = new
         {
             PlanId = plan.Id.ToString("D5"),
-            Folder = plan.FolderName,
+            Folder = plan.FolderPath,
             plan.InitialPrompt,
             Revision = plan.RevisionCount,
             Profile = planYaml?.ExecutionProfile ?? "",
@@ -44,7 +44,7 @@ public class DetailsTabView(
                 Layout.Horizontal().Gap(2).AlignContent(Align.Center)
                 | Text.Block(folder)
                 | new Button().Icon(Icons.ClipboardCopy).Ghost().Small()
-                    .Tooltip("Copy folder name")
+                    .Tooltip("Copy folder path")
                     .OnClick(() => copyToClipboard(folder))))
             .Multiline(x => x.InitialPrompt)
             .Builder(x => x.Revision, f => f.Func((int count) =>


### PR DESCRIPTION
# Summary

## Changes

Added Plan ID and Folder fields with copy-to-clipboard buttons to the Details tab in the plan view. These fields appear at the top of the details table, making it easier to copy plan identifiers for CLI commands and debugging.

## API Changes

None — UI-only change.

## Files Modified

- `src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs` — Added PlanId and Folder fields with copy buttons

## Manual Testing

1. Run the Tendril app: `dotnet run`
2. Open the Plans view and select any plan
3. Navigate to the Details tab
4. Verify that "Plan Id" and "Folder" appear at the top of the details table
5. Click the clipboard icon next to the Plan Id — the 5-digit ID (e.g., "00108") should be copied to clipboard
6. Click the clipboard icon next to the Folder — the full folder path (e.g., "D:/Plans/00108-AddPlanIdAndFolderWithCopyButtonsToDetailsTab") should be copied to clipboard
7. Paste the copied values elsewhere to confirm they copied correctly

## Fix: Show full folder path

Changed the Folder field from displaying just the folder name to displaying the full folder path. This makes it easier to navigate directly to the plan folder in the filesystem or use the path in CLI commands.

### Files Modified

- `src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs` — Changed `plan.FolderName` to `plan.FolderPath` and updated tooltip text

**Note:** Manual testing should now verify that clicking the copy button next to "Folder" copies the full path (e.g., `D:/Plans/00108-...`) instead of just the folder name.

---

## Commits

- fd89238 Add Plan ID and Folder with copy buttons to Details tab
- 0544b5f Show full folder path instead of just folder name in Details tab

---
Created using [Ivy Tendril](https://ivy.app).