### PR TITLE
[00112] Optimistic close for Sync Repos dialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Dialogs/DirtyRepoDialog.cs
+++ b/src/Ivy.Tendril/Apps/Views/Dialogs/DirtyRepoDialog.cs
@@ -41,13 +41,13 @@ public class DirtyRepoDialog(
                 | new Button("Cancel").Outline().OnClick(() => dialogOpen.Set(false))
                 | new Button(proceedLabel).Outline().OnClick(() =>
                 {
-                    onProceed();
                     dialogOpen.Set(false);
+                    onProceed();
                 })
                 | new Button("Sync Repos").Primary().Icon(Icons.RefreshCw).OnClick(() =>
                 {
-                    onSyncRepos();
                     dialogOpen.Set(false);
+                    onSyncRepos();
                 })
             )
         ).Width(Size.Rem(40));


### PR DESCRIPTION
# Summary

## Changes

Implemented optimistic close for the DirtyRepoDialog. Both the "Proceed" and "Sync Repos" buttons now close the dialog immediately before executing their callbacks, preventing the UI from appearing frozen during background operations.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Views/Dialogs/DirtyRepoDialog.cs** — Swapped statement order in both button click handlers

## Manual Testing

1. Launch Tendril and navigate to the Plans view
2. Select a plan and click the Execute button while your repo has uncommitted changes
3. When the DirtyRepoDialog appears, click "Sync Repos"
4. Observe that the dialog closes immediately (optimistic close) instead of staying visible while background sync operations execute
5. Verify the same behavior for the "Proceed" button variant in other contexts (Drafts app, Icebox app, CreatePlanDialogLauncher)

---

## Commits

- d7d2d78 Optimistic close for DirtyRepoDialog buttons

---
Created using [Ivy Tendril](https://ivy.app).