### PR TITLE
[00111] Show repo path as Prompt/Title for SyncRepo jobs

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
@@ -110,6 +110,10 @@ public partial class JobsApp
         if (j.TypedArgs is CreatePlanArgs)
             return TruncatePrompt(GetFullPrompt(j) ?? j.PlanFile);
 
+        // Try SyncRepo path
+        if (j.TypedArgs is SyncRepoArgs syncArgs)
+            return TruncatePrompt(syncArgs.RepoPath);
+
         // Fallback to full prompt (resolves InitialPrompt/Title from plan.yaml) or plan file
         return TruncatePrompt(GetFullPrompt(j, planService) ?? j.PlanFile);
     }


### PR DESCRIPTION
# Summary

## Changes

Added display of repository path in the Jobs table's Prompt/Title column for SyncRepo jobs. Previously this column was empty for SyncRepo operations.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/JobsApp.Helpers.cs` — Added SyncRepoArgs handler to GetPromptDisplay method

## Manual Testing

1. Launch the Tendril application
2. Navigate to the Jobs view
3. Create a SyncRepo job (or view an existing one)
4. Verify that the Prompt/Title column now shows the full repository path (e.g., `D:\Repos\_Ivy\Ivy-Framework`) instead of being empty

---

## Commits

- f745c56 Show repo path in Prompt/Title column for SyncRepo jobs

---
Created using [Ivy Tendril](https://ivy.app).