### PR TITLE
Fix job status UI not updating and add descriptive CLI output

### DIFF
--- a/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
+++ b/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
@@ -138,6 +138,11 @@ public class UseStartJobTests
             return new List<JobItem>();
         }
 
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null)
+        {
+            return false;
+        }
+
         public bool IsInboxFileTracked(string filePath)
         {
             return false;

--- a/src/Ivy.Tendril.Test/InboxControllerTests.cs
+++ b/src/Ivy.Tendril.Test/InboxControllerTests.cs
@@ -124,6 +124,11 @@ public class InboxControllerTests
             return null;
         }
 
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null)
+        {
+            return false;
+        }
+
         public bool IsInboxFileTracked(string filePath)
         {
             return false;

--- a/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
@@ -233,6 +233,7 @@ public class InboxWatcherServiceTests : IDisposable
         public List<JobItem> GetJobs() => new();
         public List<JobItem> GetJobsForPlan(string planFile) => new();
         public JobItem? GetJob(string id) => null;
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => false;
         public void Dispose() { }
 
 #pragma warning disable CS0067
@@ -380,6 +381,7 @@ public class InboxWatcherServiceTests : IDisposable
         public List<JobItem> GetJobs() => new();
         public List<JobItem> GetJobsForPlan(string planFile) => new();
         public JobItem? GetJob(string id) => null;
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => false;
         public void Dispose() { }
 
 #pragma warning disable CS0067
@@ -413,6 +415,7 @@ public class InboxWatcherServiceTests : IDisposable
         public List<JobItem> GetJobs() => new();
         public List<JobItem> GetJobsForPlan(string planFile) => new();
         public JobItem? GetJob(string id) => null;
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => false;
         public void Dispose() { }
 
 #pragma warning disable CS0067

--- a/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -246,6 +246,11 @@ public class TendrilProcessStatusServiceTests : IDisposable
             throw new NotImplementedException();
         }
 
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsInboxFileTracked(string filePath)
         {
             throw new NotImplementedException();

--- a/src/Ivy.Tendril/Commands/JobStatusCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStatusCommand.cs
@@ -54,13 +54,16 @@ public class JobStatusCommand : Command<JobStatusSettings>
             var response = client.PutAsync($"{discovery.BaseUrl}/api/jobs/{settings.JobId}/status", content)
                 .GetAwaiter().GetResult();
             response.EnsureSuccessStatusCode();
-        }
-        catch (HttpRequestException ex)
-        {
-            _logger.LogDebug(ex, "Failed to report job status for {JobId}", settings.JobId);
+
+            _logger.LogInformation("Status updated for job {JobId}: {Message}", settings.JobId, settings.Message);
+            Console.WriteLine($"Status updated: {settings.Message}");
             return 0;
         }
-
-        return 0;
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to report job status for {JobId}", settings.JobId);
+            Console.Error.WriteLine($"Failed to report status: {ex.Message}");
+            return 1;
+        }
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanAddCommitCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddCommitCommand.cs
@@ -41,28 +41,30 @@ public class PlanAddCommitCommand : Command<PlanAddCommitSettings>
             if (!Regex.IsMatch(settings.Sha, @"^[0-9a-fA-F]{7,40}$"))
             {
                 _logger.LogError("Invalid commit hash format: {Sha}", settings.Sha);
+                Console.Error.WriteLine($"Invalid commit hash format: {settings.Sha}");
                 return 1;
             }
 
-            // Check if already present
             if (plan.Commits.Contains(settings.Sha))
             {
                 _logger.LogInformation("Commit already in plan: {Sha}", settings.Sha);
+                Console.WriteLine($"Commit already in plan: {settings.Sha}");
                 return 0;
             }
 
-            // Add commit
             plan.Commits.Add(settings.Sha);
             plan.Updated = DateTime.UtcNow;
 
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
             _logger.LogInformation("Added commit: {Sha}", settings.Sha);
+            Console.WriteLine($"Added commit: {settings.Sha}");
             return 0;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to add commit to plan {PlanId}", settings.PlanId);
+            Console.Error.WriteLine($"Failed to add commit: {ex.Message}");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Commands/PlanAddDependsOnCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddDependsOnCommand.cs
@@ -38,6 +38,7 @@ public class PlanAddDependsOnCommand : Command<PlanAddDependsOnSettings>
             if (plan.DependsOn.Contains(settings.DependsOn, StringComparer.OrdinalIgnoreCase))
             {
                 _logger.LogInformation("Dependency already present: {DependsOn}", settings.DependsOn);
+                Console.WriteLine($"Dependency already present: {settings.DependsOn}");
                 return 0;
             }
 
@@ -47,11 +48,13 @@ public class PlanAddDependsOnCommand : Command<PlanAddDependsOnSettings>
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
             _logger.LogInformation("Added dependency: {DependsOn}", settings.DependsOn);
+            Console.WriteLine($"Added dependency: {settings.DependsOn}");
             return 0;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to add dependency to plan {PlanId}", settings.PlanId);
+            Console.Error.WriteLine($"Failed to add dependency: {ex.Message}");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Commands/PlanAddPrCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddPrCommand.cs
@@ -36,25 +36,26 @@ public class PlanAddPrCommand : Command<PlanAddPrSettings>
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-            // Check if already present
             if (plan.Prs.Contains(settings.PrUrl))
             {
                 _logger.LogInformation("PR already in plan: {PrUrl}", settings.PrUrl);
+                Console.WriteLine($"PR already in plan: {settings.PrUrl}");
                 return 0;
             }
 
-            // Add PR
             plan.Prs.Add(settings.PrUrl);
             plan.Updated = DateTime.UtcNow;
 
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
             _logger.LogInformation("Added PR: {PrUrl}", settings.PrUrl);
+            Console.WriteLine($"Added PR: {settings.PrUrl}");
             return 0;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to add PR to plan {PlanId}", settings.PlanId);
+            Console.Error.WriteLine($"Failed to add PR: {ex.Message}");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Commands/PlanAddRelatedPlanCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddRelatedPlanCommand.cs
@@ -38,6 +38,7 @@ public class PlanAddRelatedPlanCommand : Command<PlanAddRelatedPlanSettings>
             if (plan.RelatedPlans.Contains(settings.RelatedPlan, StringComparer.OrdinalIgnoreCase))
             {
                 _logger.LogInformation("Related plan already present: {RelatedPlan}", settings.RelatedPlan);
+                Console.WriteLine($"Related plan already present: {settings.RelatedPlan}");
                 return 0;
             }
 
@@ -47,11 +48,13 @@ public class PlanAddRelatedPlanCommand : Command<PlanAddRelatedPlanSettings>
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
             _logger.LogInformation("Added related plan: {RelatedPlan}", settings.RelatedPlan);
+            Console.WriteLine($"Added related plan: {settings.RelatedPlan}");
             return 0;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to add related plan to plan {PlanId}", settings.PlanId);
+            Console.Error.WriteLine($"Failed to add related plan: {ex.Message}");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Commands/PlanAddRepoCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddRepoCommand.cs
@@ -36,25 +36,26 @@ public class PlanAddRepoCommand : Command<PlanAddRepoSettings>
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-            // Check if already present
             if (plan.Repos.Contains(settings.RepoPath, StringComparer.OrdinalIgnoreCase))
             {
                 _logger.LogInformation("Repository already in plan: {RepoPath}", settings.RepoPath);
+                Console.WriteLine($"Repository already in plan: {settings.RepoPath}");
                 return 0;
             }
 
-            // Add repo
             plan.Repos.Add(settings.RepoPath);
             plan.Updated = DateTime.UtcNow;
 
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
             _logger.LogInformation("Added repository: {RepoPath}", settings.RepoPath);
+            Console.WriteLine($"Added repository: {settings.RepoPath}");
             return 0;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to add repository to plan {PlanId}", settings.PlanId);
+            Console.Error.WriteLine($"Failed to add repo: {ex.Message}");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Commands/PlanRemoveDependsOnCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveDependsOnCommand.cs
@@ -39,6 +39,7 @@ public class PlanRemoveDependsOnCommand : Command<PlanRemoveDependsOnSettings>
             if (removed == 0)
             {
                 _logger.LogError("Dependency not found: {DependsOn}", settings.DependsOn);
+                Console.Error.WriteLine($"Dependency not found: {settings.DependsOn}");
                 return 1;
             }
 
@@ -47,11 +48,13 @@ public class PlanRemoveDependsOnCommand : Command<PlanRemoveDependsOnSettings>
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
             _logger.LogInformation("Removed dependency: {DependsOn}", settings.DependsOn);
+            Console.WriteLine($"Removed dependency: {settings.DependsOn}");
             return 0;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to remove dependency from plan {PlanId}", settings.PlanId);
+            Console.Error.WriteLine($"Failed to remove dependency: {ex.Message}");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Commands/PlanRemoveRelatedPlanCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveRelatedPlanCommand.cs
@@ -39,6 +39,7 @@ public class PlanRemoveRelatedPlanCommand : Command<PlanRemoveRelatedPlanSetting
             if (removed == 0)
             {
                 _logger.LogError("Related plan not found: {RelatedPlan}", settings.RelatedPlan);
+                Console.Error.WriteLine($"Related plan not found: {settings.RelatedPlan}");
                 return 1;
             }
 
@@ -47,11 +48,13 @@ public class PlanRemoveRelatedPlanCommand : Command<PlanRemoveRelatedPlanSetting
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
             _logger.LogInformation("Removed related plan: {RelatedPlan}", settings.RelatedPlan);
+            Console.WriteLine($"Removed related plan: {settings.RelatedPlan}");
             return 0;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to remove related plan from plan {PlanId}", settings.PlanId);
+            Console.Error.WriteLine($"Failed to remove related plan: {ex.Message}");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Commands/PlanRemoveRepoCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveRepoCommand.cs
@@ -41,6 +41,7 @@ public class PlanRemoveRepoCommand : Command<PlanRemoveRepoSettings>
             if (removed == 0)
             {
                 _logger.LogError("Repository not found in plan: {RepoPath}", settings.RepoPath);
+                Console.Error.WriteLine($"Repository not found in plan: {settings.RepoPath}");
                 return 1;
             }
 
@@ -49,11 +50,13 @@ public class PlanRemoveRepoCommand : Command<PlanRemoveRepoSettings>
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
             _logger.LogInformation("Removed repository: {RepoPath}", settings.RepoPath);
+            Console.WriteLine($"Removed repository: {settings.RepoPath}");
             return 0;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to remove repository from plan {PlanId}", settings.PlanId);
+            Console.Error.WriteLine($"Failed to remove repository: {ex.Message}");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Commands/PlanSetCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetCommand.cs
@@ -85,12 +85,14 @@ public class PlanSetCommand : Command<PlanSetSettings>
 
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Updated {Field} to '{Value}'", settings.Field, settings.Value);
+            _logger.LogInformation("Set {Field} = {Value}", settings.Field, settings.Value);
+            Console.WriteLine($"Set {settings.Field} = {settings.Value}");
             return 0;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to set field on plan {PlanId}", settings.PlanId);
+            Console.Error.WriteLine($"Failed to set {settings.Field}: {ex.Message}");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
@@ -63,12 +63,14 @@ public class PlanSetVerificationCommand : Command<PlanSetVerificationSettings>
 
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Set verification '{Name}' to '{Status}'", settings.Name, settings.Status);
+            _logger.LogInformation("Set verification {Name} = {Status}", settings.Name, settings.Status);
+            Console.WriteLine($"Set verification {settings.Name} = {settings.Status}");
             return 0;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to set verification on plan {PlanId}", settings.PlanId);
+            Console.Error.WriteLine($"Failed to set verification: {ex.Message}");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Controllers/JobController.cs
+++ b/src/Ivy.Tendril/Controllers/JobController.cs
@@ -8,6 +8,9 @@ namespace Ivy.Tendril.Controllers;
 [Route("api/jobs")]
 public class JobController(IJobService jobService, IPlanReaderService planReaderService) : ControllerBase
 {
+    private static string NormalizeJobId(string jobId) =>
+        int.TryParse(jobId, out var num) ? num.ToString("D5") : jobId;
+
     [HttpPost]
     public IActionResult StartJob([FromBody] JobArgsBase args)
     {
@@ -26,7 +29,7 @@ public class JobController(IJobService jobService, IPlanReaderService planReader
     [HttpGet("{jobId}")]
     public IActionResult GetJob(string jobId)
     {
-        var job = jobService.GetJob(jobId);
+        var job = jobService.GetJob(NormalizeJobId(jobId));
         if (job == null)
             return NotFound(new { error = "Job not found" });
 
@@ -36,15 +39,8 @@ public class JobController(IJobService jobService, IPlanReaderService planReader
     [HttpPut("{jobId}/status")]
     public IActionResult UpdateJobStatus(string jobId, [FromBody] UpdateJobStatusRequest request)
     {
-        var job = jobService.GetJob(jobId);
-        if (job == null)
+        if (!jobService.UpdateJobStatus(NormalizeJobId(jobId), request.Message, request.PlanId, request.PlanTitle))
             return NotFound(new { error = "Job not found" });
-
-        job.StatusMessage = request.Message;
-        if (!string.IsNullOrEmpty(request.PlanId))
-            job.ReportedPlanId = request.PlanId;
-        if (!string.IsNullOrEmpty(request.PlanTitle))
-            job.ReportedPlanTitle = request.PlanTitle;
 
         return Ok(new { status = "Updated" });
     }

--- a/src/Ivy.Tendril/Services/Jobs/IJobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/IJobService.cs
@@ -20,5 +20,6 @@ public interface IJobService : IDisposable
     List<JobItem> GetJobs();
     List<JobItem> GetJobsForPlan(string planFile);
     JobItem? GetJob(string id);
+    bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null);
     bool IsInboxFileTracked(string filePath);
 }

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -318,6 +318,21 @@ public class JobService : IJobService
         return _jobs.GetValueOrDefault(id) ?? _database?.GetJobById(id);
     }
 
+    public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null)
+    {
+        if (!_jobs.TryGetValue(id, out var job))
+            return false;
+
+        job.StatusMessage = message;
+        if (!string.IsNullOrEmpty(planId))
+            job.ReportedPlanId = planId;
+        if (!string.IsNullOrEmpty(planTitle))
+            job.ReportedPlanTitle = planTitle;
+
+        RaiseJobsPropertyChanged();
+        return true;
+    }
+
     public List<JobItem> GetJobsForPlan(string planFile)
     {
         var activeJobs = _jobs.Values


### PR DESCRIPTION
## Summary
- Move job status mutation into `JobService.UpdateJobStatus` so `RaiseJobsPropertyChanged` fires and the DataTable UI refreshes in real time
- Add `NormalizeJobId` to `JobController` so bare numeric IDs (e.g. `460`) work alongside zero-padded ones (`00460`)
- All plan/job CLI commands now print descriptive stdout/stderr messages alongside structured logger calls

## Test plan
- [x] All 1369 tests pass
- [x] Zero build warnings