### PR TITLE
[00105] Add Heatmap Widget To Wallpaper App Showing Completed PRs

### DIFF
--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -27,8 +27,8 @@ public class WallpaperApp : ViewBase
             });
         }, []);
 
-        // Query last 30 days of completed PRs
-        var prData = planDbService.GetCompletedPrsByDay(30);
+        // Query last 90 days of completed PRs
+        var prData = planDbService.GetCompletedPrsByDay(90);
         var activities = prData.Select(x => new Activity { Date = x.Date, Count = x.Count }).ToArray();
 
         var elements = new List<object>
@@ -42,7 +42,7 @@ public class WallpaperApp : ViewBase
                        .Data(activities)
                        .ShowMonthLabels(false)
                        .ShowDayLabels(false)
-                       .StartDate(DateOnly.FromDateTime(DateTime.Today.AddDays(-29)))
+                       .StartDate(DateOnly.FromDateTime(DateTime.Today.AddDays(-89)))
                        .EndDate(DateOnly.FromDateTime(DateTime.Today))
                        .ValueLabel("PRs")
                 )

--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -1,6 +1,8 @@
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
+using Ivy.Widgets.ActivityHeatmap;
 
 namespace Ivy.Tendril.Apps;
 
@@ -10,6 +12,7 @@ public class WallpaperApp : ViewBase
     public override object Build()
     {
         var versionService = UseService<IVersionCheckService>();
+        var planDbService = UseService<IPlanDatabaseService>();
         var versionInfo = UseState<VersionInfo?>(null);
         var dismissedVersion = UseState<string?>(null);
 
@@ -24,6 +27,10 @@ public class WallpaperApp : ViewBase
             });
         }, []);
 
+        // Query last 30 days of completed PRs
+        var prData = planDbService.GetCompletedPrsByDay(30);
+        var activities = prData.Select(x => new Activity { Date = x.Date, Count = x.Count }).ToArray();
+
         var elements = new List<object>
         {
             Layout.Center()
@@ -31,6 +38,13 @@ public class WallpaperApp : ViewBase
                    | new Image("/tendril/assets/Tendril.svg").Width(Size.Units(30)).Height(Size.Auto())
                    | Text.H2("What are we making next?")
                    | processView
+                   | new ActivityHeatmap()
+                       .Data(activities)
+                       .ShowMonthLabels(false)
+                       .ShowDayLabels(false)
+                       .StartDate(DateOnly.FromDateTime(DateTime.Today.AddDays(-29)))
+                       .EndDate(DateOnly.FromDateTime(DateTime.Today))
+                       .ValueLabel("PRs")
                 )
         };
 

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -61,6 +61,7 @@
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy/Ivy.csproj" />
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Desktop/Ivy.Desktop.csproj" />
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Hooks.Pty/Ivy.Hooks.Pty.csproj" />
+    <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.ActivityHeatmap/Ivy.Widgets.ActivityHeatmap.csproj" />
     <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.AnimatedStatusLabel/Ivy.Widgets.AnimatedStatusLabel.csproj" />
     <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.DiffView/Ivy.Widgets.DiffView.csproj" />
     <ProjectReference Include="../../../Ivy-Framework/src/widgets/Ivy.Widgets.QRCode/Ivy.Widgets.QRCode.csproj" />
@@ -71,6 +72,7 @@
     <PackageReference Include="Ivy" Version="1.2.66" />
     <PackageReference Include="Ivy.Desktop" Version="1.2.66" />
     <PackageReference Include="Ivy.Hooks.Pty" Version="1.2.66" />
+    <PackageReference Include="Ivy.Widgets.ActivityHeatmap" Version="1.2.66" />
     <PackageReference Include="Ivy.Widgets.AnimatedStatusLabel" Version="1.2.66" />
     <PackageReference Include="Ivy.Widgets.DiffView" Version="1.2.66" />
     <PackageReference Include="Ivy.Widgets.QRCode" Version="1.2.66" />

--- a/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
@@ -13,6 +13,7 @@ public interface IPlanDatabaseService : IDisposable
     // Aggregates
     PlanReaderService.PlanCountSnapshot ComputePlanCounts();
     DashboardModels GetDashboardData(string? projectFilter);
+    List<(DateOnly Date, int Count)> GetCompletedPrsByDay(int days = 30);
 
     // Costs and tokens
     decimal GetPlanTotalCost(int planId);

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -245,6 +245,37 @@ public class PlanDatabaseService : IPlanDatabaseService
     public DashboardModels GetDashboardData(string? projectFilter) =>
         _dashboardRepository.GetDashboardData(projectFilter);
 
+    public List<(DateOnly Date, int Count)> GetCompletedPrsByDay(int days = 30)
+    {
+        using (new ReadLockHandle(_lock))
+        {
+            var cutoff = DateTime.UtcNow.Date.AddDays(-days + 1).ToString("yyyy-MM-dd");
+            var results = new List<(DateOnly Date, int Count)>();
+
+            using var cmd = _connection.CreateCommand();
+            cmd.CommandText = """
+                SELECT DATE(p.Updated) AS d, COUNT(*) AS cnt
+                FROM PullRequests pr
+                JOIN Plans p ON p.Id = pr.PlanId
+                WHERE p.Updated >= @cutoff AND p.State = 'Completed'
+                GROUP BY DATE(p.Updated)
+                ORDER BY DATE(p.Updated)
+                """;
+            cmd.Parameters.AddWithValue("@cutoff", cutoff);
+
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                var dateStr = reader.GetString(0);
+                var count = reader.GetInt32(1);
+                var date = DateOnly.ParseExact(dateStr, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+                results.Add((date, count));
+            }
+
+            return results;
+        }
+    }
+
     public decimal GetPlanTotalCost(int planId)
     {
         using (new ReadLockHandle(_lock))


### PR DESCRIPTION
Fixes #572

# Summary

## Changes

Added an ActivityHeatmap widget to the wallpaper app displaying the count of completed PRs for each day over the last 30 days. The heatmap is rendered without month or day labels and shows the value label "PRs".

## API Changes

- **Added** `IPlanDatabaseService.GetCompletedPrsByDay(int days = 30)` — returns a list of (DateOnly Date, int Count) tuples representing completed PRs per day
- **Added** ActivityHeatmap widget dependency to Ivy.Tendril (both NuGet package and IvySource project reference)

## Files Modified

**Database Layer:**
- `src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs` — added GetCompletedPrsByDay method signature
- `src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs` — implemented query joining PullRequests with Plans table

**UI Layer:**
- `src/Ivy.Tendril/Apps/WallpaperApp.cs` — injected IPlanDatabaseService, queried 30-day data, rendered ActivityHeatmap widget

**Project Configuration:**
- `src/Ivy.Tendril/Ivy.Tendril.csproj` — added Ivy.Widgets.ActivityHeatmap project reference and NuGet package

## Manual Testing

1. Run Tendril: `tendril`
2. The wallpaper screen should display automatically (or switch to it if another app is visible)
3. Observe the ActivityHeatmap widget rendered below the process view
4. The heatmap should show:
   - A 90-day calendar grid (no month/day labels), centered on the screen
   - Boxes that are 16px × 16px (50% larger than the original 11px)
   - Green intensity corresponding to PR completion count per day
   - Tooltip on hover showing date and "N PRs"
   - Days with no completed PRs appear as empty/gray cells
5. Verify the data is accurate by comparing against recent PR merge activity in your Tendril projects

## Fix: Extend to 90 days and enlarge boxes

Changed the heatmap to display 90 days of PR activity instead of 30 days, and increased the box size from 11px to 16px (approximately 50% larger) for better visibility.

### Files Modified

**Ivy-Tendril:**
- `src/Ivy.Tendril/Apps/WallpaperApp.cs` — changed query from 30 to 90 days, updated date range

**Ivy-Framework:**
- `src/widgets/Ivy.Widgets.ActivityHeatmap/frontend/src/ActivityHeatmap.tsx` — parameterized cell size, increased from 11px to 16px, adjusted all related dimensions (labels, tooltips, grid layout)

---

## Commits

- 8f28178 Add ActivityHeatmap widget to wallpaper app showing 30-day completed PRs
- 61fa321 Change heatmap to show 90 days instead of 30