### PR TITLE
[00419] Add left padding to Markdown stack layouts in Drafts and Review apps

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
@@ -63,7 +63,7 @@ public class ChangesTabView(
             .Width(Size.Rem(12).Min(Size.Rem(12))).Scroll(Scroll.Auto).Height(Size.Full().Min(Size.Px(0)))
             | tree;
 
-        return Layout.Horizontal().Height(Size.Full().Min(Size.Px(0)))
+        return Layout.Horizontal().Height(Size.Full().Min(Size.Px(0))).Padding(0, 0, 0, 2)
             | treePanel
             | diffsLayout;
     }


### PR DESCRIPTION
## Summary

Added left padding to the Changes tab layout in the Review app. The Drafts and Review Cap functions already had `.Padding(0, 0, 0, 4)` applied in `origin/development`, so only the Changes tab (which bypasses Cap) needed the padding addition (`.Padding(0, 0, 0, 2)`).

## Files Modified

- `src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs` — Added `.Padding(0, 0, 0, 2)` to the outer horizontal layout

---

### Commits

- `2655362` Add left padding to ChangesTabView in Review app