### PR TITLE
[00129] Add copy to clipboard buttons for Plan Id and Job Id in Job Debug sheet

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
@@ -75,7 +75,9 @@ public class JobDebugSheet(
             .Builder(x => x.PlanCliLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .Builder(x => x.PromptwareLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .Builder(x => x.PromptwareRawLog,
-                f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)));
+                f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
+            .Builder(x => x.JobId, f => f.CopyToClipboard())
+            .Builder(x => x.PlanId, f => f.CopyToClipboard());
 
         var header = Layout.Horizontal().Gap(2)
             | new Button("Copy Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -60,7 +60,12 @@ public class DetailsTabView(
                         if (updated != null) selectedPlanState.Set(updated);
                         refreshPlans();
                     })))
-            .Builder(x => x.Issue, f => f.Link(target:LinkTarget.Blank))
+            .Builder(x => x.Issue, f => f.Func((string url) =>
+                string.IsNullOrEmpty(url)
+                    ? null
+                    : new Button(url, variant: ButtonVariant.Inline)
+                        .Url(url)
+                        .Target(LinkTarget.Blank)))
             .RemoveEmpty();
 
         return Layout.Vertical().Gap(4)


### PR DESCRIPTION
# Summary

## Changes

Added inline copy-to-clipboard buttons for Plan Id and Job Id fields in the Job Debug sheet. These buttons use the framework's `CopyToClipboard` builder to provide one-click copying with toast notification. Also fixed a pre-existing compilation error in DetailsTabView where the Issue field's link builder was using invalid syntax.

## API Changes

None.

## Files Modified

- **JobDebugSheet.cs** — Added two `.Builder()` calls using `f.CopyToClipboard()` for `JobId` and `PlanId` properties
- **DetailsTabView.cs** — Fixed compilation error in Issue field builder (replaced invalid `.Link(target:LinkTarget.Blank)` with custom `.Func()` builder)

## Manual Testing

1. Launch Tendril
2. Navigate to the Jobs app
3. Open any job and click the Debug button to open the Job Debug sheet
4. Observe that Plan Id and Job Id fields now have small clipboard icon buttons next to their values
5. Click the clipboard icon for Plan Id — a toast should appear saying "Copied '<plan-id>' to clipboard"
6. Click the clipboard icon for Job Id — a toast should appear saying "Copied '<job-id>' to clipboard"
7. Verify the values are actually copied by pasting them elsewhere

---

## Commits

- 9903d25dee7a75558ef147b9b94e3e4d0b2fddb1
- 2816ca01614139098c1cf5b4d840ddd21c5d061c

---
Created using [Ivy Tendril](https://ivy.app).