### PR TITLE
[00125] Add Working Directory And Arguments To Job Debug View

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs
@@ -46,7 +46,9 @@ public class JobDebugSheet(
             PromptwareLearnings = GetPromptwareLearnings(job),
             PromptwareLog = GetPromptwareLogPath(job) ?? "",
             PromptwareRawLog = GetPromptwareRawLogPath(job) ?? "",
-            ExitCode = job.ExitCode?.ToString() ?? ""
+            ExitCode = job.ExitCode?.ToString() ?? "",
+            WorkingDirectory = job.WorkingDirectory ?? "",
+            CliCommand = job.CliCommand ?? ""
         };
 
         var detailsView = data.ToDetails()
@@ -65,6 +67,8 @@ public class JobDebugSheet(
             .Label(x => x.PromptwareRawLog, "Promptware Raw Log")
             .Label(x => x.PermissionDenials, "Permission Denials")
             .Label(x => x.ExitCode, "Exit Code")
+            .Label(x => x.WorkingDirectory, "Working Directory")
+            .Label(x => x.CliCommand, "Arguments")
             .Label(x => x.JobId, "Job Id")
             .Builder(x => x.PermissionDenials, f => f.Func((string denials) =>
                 new CodeBlock(denials)))
@@ -75,7 +79,9 @@ public class JobDebugSheet(
             .Builder(x => x.PlanCliLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .Builder(x => x.PromptwareLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .Builder(x => x.PromptwareRawLog,
-                f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)));
+                f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
+            .Builder(x => x.WorkingDirectory, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
+            .Builder(x => x.CliCommand, f => f.Func((string cmd) => new CodeBlock(cmd)));
 
         var header = Layout.Horizontal().Gap(2)
             | new Button("Copy Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>
@@ -97,6 +103,8 @@ public class JobDebugSheet(
                     ("Cost", data.Cost),
                     ("Tokens", data.Tokens),
                     ("Exit Code", data.ExitCode),
+                    ("Working Directory", data.WorkingDirectory),
+                    ("Arguments", data.CliCommand),
                     ("Permission Denials", data.PermissionDenials),
                     ("Plan Folder", data.PlanFolder),
                     ("Plan Log", data.PlanLog),

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -60,7 +60,7 @@ public class DetailsTabView(
                         if (updated != null) selectedPlanState.Set(updated);
                         refreshPlans();
                     })))
-            .Builder(x => x.Issue, f => f.Link(target:LinkTarget.Blank))
+            .Builder(x => x.Issue, f => f.Link())
             .RemoveEmpty();
 
         return Layout.Vertical().Gap(4)

--- a/src/Ivy.Tendril/Database/Migrations/Migration_013_JobsWorkingDirAndCliCommand.cs
+++ b/src/Ivy.Tendril/Database/Migrations/Migration_013_JobsWorkingDirAndCliCommand.cs
@@ -1,0 +1,21 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Database.Migrations;
+
+public class Migration_013_JobsWorkingDirAndCliCommand : IMigration
+{
+    public int Version => 13;
+    public string Description => "Add WorkingDirectory and CliCommand columns to Jobs table";
+
+    public void Apply(SqliteConnection connection, ILogger? logger = null)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            ALTER TABLE Jobs ADD COLUMN WorkingDirectory TEXT;
+            ALTER TABLE Jobs ADD COLUMN CliCommand TEXT;
+            PRAGMA user_version = 13;
+            """;
+        cmd.ExecuteNonQuery();
+    }
+}

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -87,9 +87,12 @@ public record JobItem
     public string? ReportedPlanId { get; set; }
     public string? ReportedPlanTitle { get; set; }
 
+    // Agent launch details (persisted)
+    public string? WorkingDirectory { get; set; }
+    public string? CliCommand { get; set; }
+
     // Automatic logging metadata (transient, not persisted)
     [JsonIgnore] public string? CompiledPrompt { get; set; }
-    [JsonIgnore] public string? CliCommand { get; set; }
     [JsonIgnore] public int? ExitCode { get; set; }
 
     private string? _logFilePath;

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -244,6 +244,7 @@ internal class JobLauncher
         var resolution = AgentProviderFactory.Resolve(_agentRunner, settings, job.Type, profileOverride, jobContext);
         job.EventParser = _agentRunner.GetParser(resolution.AgentId);
         var workDir = ResolveWorkingDirectory(job, programFolder);
+        job.WorkingDirectory = workDir;
 
         var logFile = FirmwareCompiler.GetLogFile(programFolder, job.Id);
         job.LogFilePath = logFile;

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -673,8 +673,8 @@ public class PlanDatabaseService : IPlanDatabaseService
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
-                              INSERT OR REPLACE INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, SessionId, StartedAt, CompletedAt, DurationSeconds, Cost, Tokens, StatusMessage, Args, TypedArgs)
-                              VALUES (@id, @type, @planFile, @project, @status, @provider, @sessionId, @startedAt, @completedAt, @durationSeconds, @cost, @tokens, @statusMessage, @args, @typedArgs)
+                              INSERT OR REPLACE INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, SessionId, StartedAt, CompletedAt, DurationSeconds, Cost, Tokens, StatusMessage, Args, TypedArgs, WorkingDirectory, CliCommand)
+                              VALUES (@id, @type, @planFile, @project, @status, @provider, @sessionId, @startedAt, @completedAt, @durationSeconds, @cost, @tokens, @statusMessage, @args, @typedArgs, @workingDirectory, @cliCommand)
                               """;
             cmd.Parameters.AddWithValue("@id", job.Id);
             cmd.Parameters.AddWithValue("@type", job.Type);
@@ -695,6 +695,8 @@ public class PlanDatabaseService : IPlanDatabaseService
             cmd.Parameters.AddWithValue("@typedArgs", job.TypedArgs != null
                 ? JsonSerializer.Serialize<JobArgsBase>(job.TypedArgs)
                 : DBNull.Value);
+            cmd.Parameters.AddWithValue("@workingDirectory", (object?)job.WorkingDirectory ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@cliCommand", (object?)job.CliCommand ?? DBNull.Value);
             cmd.ExecuteNonQuery();
         }
     }
@@ -763,7 +765,13 @@ public class PlanDatabaseService : IPlanDatabaseService
             StatusMessage = reader.IsDBNull(reader.GetOrdinal("StatusMessage"))
                 ? null
                 : reader.GetString(reader.GetOrdinal("StatusMessage")),
-            TypedArgs = ReadTypedArgs(reader)
+            TypedArgs = ReadTypedArgs(reader),
+            WorkingDirectory = reader.IsDBNull(reader.GetOrdinal("WorkingDirectory"))
+                ? null
+                : reader.GetString(reader.GetOrdinal("WorkingDirectory")),
+            CliCommand = reader.IsDBNull(reader.GetOrdinal("CliCommand"))
+                ? null
+                : reader.GetString(reader.GetOrdinal("CliCommand"))
         };
     }
 


### PR DESCRIPTION
# Summary

## Changes

Added working directory and CLI arguments to the Job Debug view in Tendril. The agent launch details (working directory and full CLI command) are now persisted to the database and displayed in the debug sheet with appropriate UI components.

## API Changes

**JobItem model:**
- Added `public string? WorkingDirectory { get; set; }`
- Changed `CliCommand` from `[JsonIgnore]` to persisted property

**Database schema:**
- Migration_013 adds `WorkingDirectory` and `CliCommand` columns to Jobs table

**PlanDatabaseService:**
- `UpsertJob` now persists WorkingDirectory and CliCommand
- `MapJobRow` reads both columns from database

## Files Modified

**Database:**
- `src/Ivy.Tendril/Database/Migrations/Migration_013_JobsWorkingDirAndCliCommand.cs` (new)

**Models:**
- `src/Ivy.Tendril/Models/JobModels.cs`

**Services:**
- `src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs`
- `src/Ivy.Tendril/Services/Jobs/JobLauncher.cs`

**UI:**
- `src/Ivy.Tendril/Apps/Jobs/JobDebugSheet.cs`

**Build fix (pre-existing issue):**
- `src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs`

## Manual Testing

1. Run Tendril
2. Navigate to Jobs app
3. Select any job (running or completed)
4. Click the Debug icon to open the Job Debug sheet
5. Verify the sheet displays:
   - **Working Directory** — shown with path dropdown (copy/open in editor)
   - **Arguments** — shown in code block format
6. Click "Copy Details" button
7. Verify the clipboard output includes both "Working Directory" and "Arguments" fields

---

## Commits

- 60c5b38 Fix DetailsTabView.cs Link builder call
- a4fdaa6 Add working directory and CLI arguments to job debug view

---
Created using [Ivy Tendril](https://ivy.app).