### PR TITLE
[00131] Change DiffView from Split to Unified mode

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
@@ -54,7 +54,6 @@ public class ChangesTabView(
             diffsLayout |= Text.Block("").Anchor(path);
             diffsLayout |= new DiffView()
                 .Diff(fileDiff.Diff)
-                .Split()
                 .Collapsible()
                 .Width(Size.Full());
         }

--- a/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
@@ -168,7 +168,6 @@ public static class PlanContentHelpers
                 {
                     commitSheetContent |= new DiffView()
                         .Diff(fileDiff.Diff)
-                        .Split()
                         .Collapsible()
                         .DefaultCollapsed();
                 }
@@ -194,7 +193,7 @@ public static class PlanContentHelpers
                 if (!string.IsNullOrWhiteSpace(data.Diff))
                 {
                     commitSheetContent |= Text.Block("Diff").Bold();
-                    commitSheetContent |= new DiffView().Diff(data.Diff).Split();
+                    commitSheetContent |= new DiffView().Diff(data.Diff);
                 }
             }
 


### PR DESCRIPTION
# Summary

## Changes

Changed all DiffView widgets from Split mode to Unified (inline) mode by removing `.Split()` method calls. Since `DiffViewType.Unified` is the default, no explicit `.Unified()` call is needed.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs** — Removed `.Split()` from DiffView in changes tab file loop
- **src/Ivy.Tendril/Helpers/PlanContentHelpers.cs** — Removed `.Split()` from DiffView in commit sheet per-file diff loop (line 171) and fallback diff display (line 197)

## Manual Testing

1. Run the Tendril app
2. Open the Plans view and navigate to a plan with code changes
3. Go to the Changes tab
4. Verify that diffs are displayed in unified (inline) mode, not side-by-side
5. Click on a commit in the plan view to open the commit details sheet
6. Verify that the commit diffs are also displayed in unified mode

---

## Commits

- bb8f4ab Change DiffView from Split to Unified mode

---
Created using [Ivy Tendril](https://ivy.app).