### PR TITLE
[00115] AssignSyncRepoJobToSamePlanAsParentJob

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -370,7 +370,7 @@ public class ContentView(
         var syncJobIds = new List<string>();
         foreach (var (repoPath, baseBranch, _) in preflight.DirtyRepos)
         {
-            var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch));
+            var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch, selectedPlan.FolderPath));
             syncJobIds.Add(jobId);
         }
 

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -164,7 +164,7 @@ public class ContentView(
         var syncJobIds = new List<string>();
         foreach (var (repoPath, baseBranch, _) in preflight.DirtyRepos)
         {
-            var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch));
+            var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch, selectedPlan.FolderPath));
             syncJobIds.Add(jobId);
         }
 

--- a/src/Ivy.Tendril/Models/JobArgs.cs
+++ b/src/Ivy.Tendril/Models/JobArgs.cs
@@ -103,7 +103,9 @@ public record UpdateProjectArgs(
 
 public record SyncRepoArgs(
     string RepoPath,
-    string BaseBranch = "main") : JobArgsBase
+    string BaseBranch = "main",
+    string? PlanFolderPath = null) : JobArgsBase
 {
     public override string Type => Constants.JobTypes.SyncRepo;
+    public override string? PlanFolder => PlanFolderPath;
 }


### PR DESCRIPTION
# Summary

## Changes

Added optional `PlanFolderPath` parameter to `SyncRepoArgs` and updated Drafts and Icebox apps to pass plan folder when creating SyncRepo jobs. This associates SyncRepo jobs with their parent plan for proper display in the Jobs UI.

## API Changes

- `SyncRepoArgs` constructor: Added optional `string? PlanFolderPath = null` parameter
- `SyncRepoArgs.PlanFolder` property override: Returns `PlanFolderPath`

## Files Modified

- **Models/JobArgs.cs** — Added `PlanFolderPath` parameter and `PlanFolder` override to `SyncRepoArgs`
- **Apps/Drafts/ContentView.cs** — Pass `selectedPlan.FolderPath` when creating `SyncRepoArgs`
- **Apps/Icebox/ContentView.cs** — Pass `selectedPlan.FolderPath` when creating `SyncRepoArgs`

## Manual Testing

1. Ensure a plan's repo has uncommitted changes
2. In the Plans app, select the plan and click Execute
3. Observe that dirty repos trigger SyncRepo jobs
4. Switch to the Jobs app
5. Verify that SyncRepo jobs now show the correct Plan ID and Project (matching the parent ExecutePlan job) instead of showing blank Plan ID and "Auto" project

---

**Commits:**
- a00fac8 [00115] AssignSyncRepoJobToSamePlanAsParentJob

---
Created using [Ivy Tendril](https://ivy.app).