### PR TITLE
[00132] Remove 0m prefix from timer display when under one minute

### DIFF
--- a/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/JobsApp.Helpers.cs
@@ -84,6 +84,8 @@ public partial class JobsApp
     {
         if (span.TotalHours >= 1)
             return $"{(int)span.TotalHours}h {span.Minutes:D2}m";
+        if (span.Minutes == 0)
+            return $"{span.Seconds}s";
         return $"{span.Minutes}m {span.Seconds:D2}s";
     }
 


### PR DESCRIPTION
# Summary

## Changes

Modified the `FormatTimeSpan` helper method in `JobsApp.Helpers.cs` to suppress the "0m " prefix when displaying durations under one minute. The Timer column and Agent Output elapsed display now show "35s" instead of "0m 35s" for sub-minute durations.

## API Changes

- **`FormatTimeSpan` (private static method)** — Added conditional logic to omit minutes display when `span.Minutes == 0`

## Files Modified

- **src/Ivy.Tendril/Apps/JobsApp.Helpers.cs** — Updated `FormatTimeSpan` method

## Manual Testing

1. Run the Tendril TUI: `tendril`
2. Navigate to the Jobs view
3. Observe the Timer column for any running job with elapsed time under one minute
4. Expected: Timer displays as "35s" (or similar) without the "0m " prefix
5. For jobs over one minute, verify the display still shows "1m 23s" format correctly

---

**Commits:**
- 1042bbe Remove 0m prefix from timer display when under one minute

---
Created using [Ivy Tendril](https://ivy.app).