### PR TITLE
Normalize plan references in dependsOn/relatedPlans CLI commands

### DIFF
--- a/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
@@ -563,6 +563,7 @@ public class PlanToolsTests : IDisposable
     public void AddRelated_AddsLink()
     {
         CreateTestPlan();
+        CreateTestPlan("00010", "OtherPlan");
 
         var result = _planTools.AddRelated("00001", "00010-OtherPlan");
 
@@ -575,6 +576,7 @@ public class PlanToolsTests : IDisposable
     public void AddRelated_Duplicate_IsIdempotent()
     {
         CreateTestPlan();
+        CreateTestPlan("00010", "OtherPlan");
         _planTools.AddRelated("00001", "00010-OtherPlan");
 
         var result = _planTools.AddRelated("00001", "00010-OtherPlan");
@@ -586,6 +588,7 @@ public class PlanToolsTests : IDisposable
     public void RemoveRelated_RemovesLink()
     {
         CreateTestPlan();
+        CreateTestPlan("00010", "OtherPlan");
         _planTools.AddRelated("00001", "00010-OtherPlan");
 
         var result = _planTools.RemoveRelated("00001", "00010-OtherPlan");
@@ -611,6 +614,7 @@ public class PlanToolsTests : IDisposable
     public void AddDependsOn_AddsDependency()
     {
         CreateTestPlan();
+        CreateTestPlan("00005", "BasePlan");
 
         var result = _planTools.AddDependsOn("00001", "00005-BasePlan");
 
@@ -623,6 +627,7 @@ public class PlanToolsTests : IDisposable
     public void AddDependsOn_Duplicate_IsIdempotent()
     {
         CreateTestPlan();
+        CreateTestPlan("00005", "BasePlan");
         _planTools.AddDependsOn("00001", "00005-BasePlan");
 
         var result = _planTools.AddDependsOn("00001", "00005-BasePlan");
@@ -634,6 +639,7 @@ public class PlanToolsTests : IDisposable
     public void RemoveDependsOn_RemovesDependency()
     {
         CreateTestPlan();
+        CreateTestPlan("00005", "BasePlan");
         _planTools.AddDependsOn("00001", "00005-BasePlan");
 
         var result = _planTools.RemoveDependsOn("00001", "00005-BasePlan");

--- a/src/Ivy.Tendril.Test/PlanControllerTests.cs
+++ b/src/Ivy.Tendril.Test/PlanControllerTests.cs
@@ -605,6 +605,8 @@ public class PlanControllerTests : IDisposable
     {
         var plansDir = Path.Combine(_tempDir.Path, "Plans");
         Directory.CreateDirectory(plansDir);
+        CreateTestPlan("00010", "OtherPlan");
+        CreateTestPlan("00005", "BasePlan");
         var controller = CreateController();
 
         var request = new CreatePlanDirectRequest(
@@ -675,6 +677,7 @@ public class PlanControllerTests : IDisposable
     public void AddRelatedPlan_AddsLink()
     {
         CreateTestPlan();
+        CreateTestPlan("00010", "OtherPlan");
         var controller = CreateController();
 
         var result = controller.AddRelatedPlan("00001", new AddRelatedPlanRequest("00010-OtherPlan"));
@@ -689,6 +692,7 @@ public class PlanControllerTests : IDisposable
     public void AddRelatedPlan_Duplicate_ReturnsOk()
     {
         CreateTestPlan();
+        CreateTestPlan("00010", "OtherPlan");
         var controller = CreateController();
         controller.AddRelatedPlan("00001", new AddRelatedPlanRequest("00010-OtherPlan"));
 
@@ -703,6 +707,7 @@ public class PlanControllerTests : IDisposable
     public void RemoveRelatedPlan_RemovesLink()
     {
         CreateTestPlan();
+        CreateTestPlan("00010", "OtherPlan");
         var controller = CreateController();
         controller.AddRelatedPlan("00001", new AddRelatedPlanRequest("00010-OtherPlan"));
 
@@ -731,6 +736,7 @@ public class PlanControllerTests : IDisposable
     public void AddDependsOn_AddsDependency()
     {
         CreateTestPlan();
+        CreateTestPlan("00005", "BasePlan");
         var controller = CreateController();
 
         var result = controller.AddDependsOn("00001", new AddDependsOnRequest("00005-BasePlan"));
@@ -745,6 +751,7 @@ public class PlanControllerTests : IDisposable
     public void AddDependsOn_Duplicate_ReturnsOk()
     {
         CreateTestPlan();
+        CreateTestPlan("00005", "BasePlan");
         var controller = CreateController();
         controller.AddDependsOn("00001", new AddDependsOnRequest("00005-BasePlan"));
 
@@ -759,6 +766,7 @@ public class PlanControllerTests : IDisposable
     public void RemoveDependsOn_RemovesDependency()
     {
         CreateTestPlan();
+        CreateTestPlan("00005", "BasePlan");
         var controller = CreateController();
         controller.AddDependsOn("00001", new AddDependsOnRequest("00005-BasePlan"));
 

--- a/src/Ivy.Tendril/Commands/PlanAddDependsOnCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddDependsOnCommand.cs
@@ -12,7 +12,7 @@ public class PlanAddDependsOnSettings : CommandSettings
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
 
-    [Description("Dependency plan folder name (e.g., 01478-WorktreeIsolation)")]
+    [Description("Plan reference (ID, folder name, or path)")]
     [CommandArgument(1, "<depends-on>")]
     public string DependsOn { get; set; } = "";
 }
@@ -34,19 +34,20 @@ public class PlanAddDependsOnCommand : Command<PlanAddDependsOnSettings>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var resolvedDep = PlanCommandHelpers.ResolvePlanFolderName(settings.DependsOn);
 
-            if (plan.DependsOn.Contains(settings.DependsOn, StringComparer.OrdinalIgnoreCase))
+            if (plan.DependsOn.Contains(resolvedDep, StringComparer.OrdinalIgnoreCase))
             {
-                _logger.LogInformation("Dependency already present: {DependsOn}", settings.DependsOn);
+                _logger.LogInformation("Dependency already present: {DependsOn}", resolvedDep);
                 return 0;
             }
 
-            plan.DependsOn.Add(settings.DependsOn);
+            plan.DependsOn.Add(resolvedDep);
             plan.Updated = DateTime.UtcNow;
 
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Added dependency: {DependsOn}", settings.DependsOn);
+            _logger.LogInformation("Added dependency: {DependsOn}", resolvedDep);
             return 0;
         }
         catch (Exception ex)

--- a/src/Ivy.Tendril/Commands/PlanAddRelatedPlanCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddRelatedPlanCommand.cs
@@ -12,7 +12,7 @@ public class PlanAddRelatedPlanSettings : CommandSettings
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
 
-    [Description("Related plan folder name (e.g., 01478-WorktreeIsolation)")]
+    [Description("Plan reference (ID, folder name, or path)")]
     [CommandArgument(1, "<related-plan>")]
     public string RelatedPlan { get; set; } = "";
 }
@@ -34,19 +34,20 @@ public class PlanAddRelatedPlanCommand : Command<PlanAddRelatedPlanSettings>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var resolvedRp = PlanCommandHelpers.ResolvePlanFolderName(settings.RelatedPlan);
 
-            if (plan.RelatedPlans.Contains(settings.RelatedPlan, StringComparer.OrdinalIgnoreCase))
+            if (plan.RelatedPlans.Contains(resolvedRp, StringComparer.OrdinalIgnoreCase))
             {
-                _logger.LogInformation("Related plan already present: {RelatedPlan}", settings.RelatedPlan);
+                _logger.LogInformation("Related plan already present: {RelatedPlan}", resolvedRp);
                 return 0;
             }
 
-            plan.RelatedPlans.Add(settings.RelatedPlan);
+            plan.RelatedPlans.Add(resolvedRp);
             plan.Updated = DateTime.UtcNow;
 
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Added related plan: {RelatedPlan}", settings.RelatedPlan);
+            _logger.LogInformation("Added related plan: {RelatedPlan}", resolvedRp);
             return 0;
         }
         catch (Exception ex)

--- a/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
@@ -123,11 +123,11 @@ public class PlanCreateCommand : Command<PlanCreateSettings>
 
             if (settings.RelatedPlans != null)
                 foreach (var rp in settings.RelatedPlans)
-                    plan.RelatedPlans.Add(rp);
+                    plan.RelatedPlans.Add(PlanCommandHelpers.ResolvePlanFolderName(rp));
 
             if (settings.DependsOn != null)
                 foreach (var dep in settings.DependsOn)
-                    plan.DependsOn.Add(dep);
+                    plan.DependsOn.Add(PlanCommandHelpers.ResolvePlanFolderName(dep));
 
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 

--- a/src/Ivy.Tendril/Commands/PlanRemoveDependsOnCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveDependsOnCommand.cs
@@ -12,7 +12,7 @@ public class PlanRemoveDependsOnSettings : CommandSettings
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
 
-    [Description("Dependency plan folder name (e.g., 01478-WorktreeIsolation)")]
+    [Description("Plan reference (ID, folder name, or path)")]
     [CommandArgument(1, "<depends-on>")]
     public string DependsOn { get; set; } = "";
 }
@@ -34,11 +34,12 @@ public class PlanRemoveDependsOnCommand : Command<PlanRemoveDependsOnSettings>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var resolvedDep = PlanCommandHelpers.ResolvePlanFolderName(settings.DependsOn);
 
-            var removed = plan.DependsOn.RemoveAll(d => d.Equals(settings.DependsOn, StringComparison.OrdinalIgnoreCase));
+            var removed = plan.DependsOn.RemoveAll(d => d.Equals(resolvedDep, StringComparison.OrdinalIgnoreCase));
             if (removed == 0)
             {
-                _logger.LogError("Dependency not found: {DependsOn}", settings.DependsOn);
+                _logger.LogError("Dependency not found: {DependsOn}", resolvedDep);
                 return 1;
             }
 
@@ -46,7 +47,7 @@ public class PlanRemoveDependsOnCommand : Command<PlanRemoveDependsOnSettings>
 
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Removed dependency: {DependsOn}", settings.DependsOn);
+            _logger.LogInformation("Removed dependency: {DependsOn}", resolvedDep);
             return 0;
         }
         catch (Exception ex)

--- a/src/Ivy.Tendril/Commands/PlanRemoveRelatedPlanCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveRelatedPlanCommand.cs
@@ -12,7 +12,7 @@ public class PlanRemoveRelatedPlanSettings : CommandSettings
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
 
-    [Description("Related plan folder name (e.g., 01478-WorktreeIsolation)")]
+    [Description("Plan reference (ID, folder name, or path)")]
     [CommandArgument(1, "<related-plan>")]
     public string RelatedPlan { get; set; } = "";
 }
@@ -34,11 +34,12 @@ public class PlanRemoveRelatedPlanCommand : Command<PlanRemoveRelatedPlanSetting
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var resolvedRp = PlanCommandHelpers.ResolvePlanFolderName(settings.RelatedPlan);
 
-            var removed = plan.RelatedPlans.RemoveAll(r => r.Equals(settings.RelatedPlan, StringComparison.OrdinalIgnoreCase));
+            var removed = plan.RelatedPlans.RemoveAll(r => r.Equals(resolvedRp, StringComparison.OrdinalIgnoreCase));
             if (removed == 0)
             {
-                _logger.LogError("Related plan not found: {RelatedPlan}", settings.RelatedPlan);
+                _logger.LogError("Related plan not found: {RelatedPlan}", resolvedRp);
                 return 1;
             }
 
@@ -46,7 +47,7 @@ public class PlanRemoveRelatedPlanCommand : Command<PlanRemoveRelatedPlanSetting
 
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Removed related plan: {RelatedPlan}", settings.RelatedPlan);
+            _logger.LogInformation("Removed related plan: {RelatedPlan}", resolvedRp);
             return 0;
         }
         catch (Exception ex)

--- a/src/Ivy.Tendril/Controllers/PlanController.cs
+++ b/src/Ivy.Tendril/Controllers/PlanController.cs
@@ -438,11 +438,11 @@ public class PlanController : ControllerBase
 
             if (request.RelatedPlans != null)
                 foreach (var rp in request.RelatedPlans)
-                    plan.RelatedPlans.Add(rp);
+                    plan.RelatedPlans.Add(PlanCommandHelpers.ResolvePlanFolderName(rp));
 
             if (request.DependsOn != null)
                 foreach (var dep in request.DependsOn)
-                    plan.DependsOn.Add(dep);
+                    plan.DependsOn.Add(PlanCommandHelpers.ResolvePlanFolderName(dep));
 
             PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
@@ -481,48 +481,72 @@ public class PlanController : ControllerBase
     }
 
     [HttpPost("{planId}/related-plans")]
-    public IActionResult AddRelatedPlan(string planId, [FromBody] AddRelatedPlanRequest request) =>
-        ModifyPlanEndpoint(planId, plan =>
-        {
-            if (plan.RelatedPlans.Contains(request.RelatedPlan, StringComparer.OrdinalIgnoreCase))
-                return (true, $"Related plan already present: {request.RelatedPlan}", 200);
+    public IActionResult AddRelatedPlan(string planId, [FromBody] AddRelatedPlanRequest request)
+    {
+        string resolved;
+        try { resolved = PlanCommandHelpers.ResolvePlanFolderName(request.RelatedPlan); }
+        catch (DirectoryNotFoundException) { return NotFound(new { error = $"Referenced plan '{request.RelatedPlan}' not found" }); }
 
-            plan.RelatedPlans.Add(request.RelatedPlan);
-            return (true, $"Added related plan: {request.RelatedPlan}", 200);
+        return ModifyPlanEndpoint(planId, plan =>
+        {
+            if (plan.RelatedPlans.Contains(resolved, StringComparer.OrdinalIgnoreCase))
+                return (true, $"Related plan already present: {resolved}", 200);
+
+            plan.RelatedPlans.Add(resolved);
+            return (true, $"Added related plan: {resolved}", 200);
         });
+    }
 
     [HttpDelete("{planId}/related-plans")]
-    public IActionResult RemoveRelatedPlan(string planId, [FromBody] RemoveRelatedPlanRequest request) =>
-        ModifyPlanEndpoint(planId, plan =>
-        {
-            var removed = plan.RelatedPlans.RemoveAll(r => r.Equals(request.RelatedPlan, StringComparison.OrdinalIgnoreCase));
-            if (removed == 0)
-                return (false, $"Related plan not found: {request.RelatedPlan}", 404);
+    public IActionResult RemoveRelatedPlan(string planId, [FromBody] RemoveRelatedPlanRequest request)
+    {
+        string resolved;
+        try { resolved = PlanCommandHelpers.ResolvePlanFolderName(request.RelatedPlan); }
+        catch (DirectoryNotFoundException) { return NotFound(new { error = $"Referenced plan '{request.RelatedPlan}' not found" }); }
 
-            return (true, $"Removed related plan: {request.RelatedPlan}", 200);
+        return ModifyPlanEndpoint(planId, plan =>
+        {
+            var removed = plan.RelatedPlans.RemoveAll(r => r.Equals(resolved, StringComparison.OrdinalIgnoreCase));
+            if (removed == 0)
+                return (false, $"Related plan not found: {resolved}", 404);
+
+            return (true, $"Removed related plan: {resolved}", 200);
         });
+    }
 
     [HttpPost("{planId}/depends-on")]
-    public IActionResult AddDependsOn(string planId, [FromBody] AddDependsOnRequest request) =>
-        ModifyPlanEndpoint(planId, plan =>
-        {
-            if (plan.DependsOn.Contains(request.DependsOn, StringComparer.OrdinalIgnoreCase))
-                return (true, $"Dependency already present: {request.DependsOn}", 200);
+    public IActionResult AddDependsOn(string planId, [FromBody] AddDependsOnRequest request)
+    {
+        string resolved;
+        try { resolved = PlanCommandHelpers.ResolvePlanFolderName(request.DependsOn); }
+        catch (DirectoryNotFoundException) { return NotFound(new { error = $"Referenced plan '{request.DependsOn}' not found" }); }
 
-            plan.DependsOn.Add(request.DependsOn);
-            return (true, $"Added dependency: {request.DependsOn}", 200);
+        return ModifyPlanEndpoint(planId, plan =>
+        {
+            if (plan.DependsOn.Contains(resolved, StringComparer.OrdinalIgnoreCase))
+                return (true, $"Dependency already present: {resolved}", 200);
+
+            plan.DependsOn.Add(resolved);
+            return (true, $"Added dependency: {resolved}", 200);
         });
+    }
 
     [HttpDelete("{planId}/depends-on")]
-    public IActionResult RemoveDependsOn(string planId, [FromBody] RemoveDependsOnRequest request) =>
-        ModifyPlanEndpoint(planId, plan =>
-        {
-            var removed = plan.DependsOn.RemoveAll(d => d.Equals(request.DependsOn, StringComparison.OrdinalIgnoreCase));
-            if (removed == 0)
-                return (false, $"Dependency not found: {request.DependsOn}", 404);
+    public IActionResult RemoveDependsOn(string planId, [FromBody] RemoveDependsOnRequest request)
+    {
+        string resolved;
+        try { resolved = PlanCommandHelpers.ResolvePlanFolderName(request.DependsOn); }
+        catch (DirectoryNotFoundException) { return NotFound(new { error = $"Referenced plan '{request.DependsOn}' not found" }); }
 
-            return (true, $"Removed dependency: {request.DependsOn}", 200);
+        return ModifyPlanEndpoint(planId, plan =>
+        {
+            var removed = plan.DependsOn.RemoveAll(d => d.Equals(resolved, StringComparison.OrdinalIgnoreCase));
+            if (removed == 0)
+                return (false, $"Dependency not found: {resolved}", 404);
+
+            return (true, $"Removed dependency: {resolved}", 200);
         });
+    }
 
     [HttpPost("{planId}/validate")]
     public IActionResult ValidatePlan(string planId)

--- a/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
@@ -55,6 +55,16 @@ public static class PlanCommandHelpers
     }
 
     /// <summary>
+    ///     Resolves any plan reference format to the canonical folder name (not the full path).
+    ///     Accepts: full path, folder name (e.g. "00015-Title"), zero-padded ID ("00015"), or bare number ("15").
+    /// </summary>
+    public static string ResolvePlanFolderName(string planRef)
+    {
+        var fullPath = ResolvePlanFolder(planRef);
+        return Path.GetFileName(fullPath);
+    }
+
+    /// <summary>
     ///     Resolves the plans directory from an explicit override, TENDRIL_PLANS, or TENDRIL_HOME/Plans.
     /// </summary>
     public static string GetPlansDirectory(string? explicitPlansDir = null)

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -452,11 +452,11 @@ public sealed class PlanTools : AuthenticatedToolBase
 
             if (!string.IsNullOrEmpty(relatedPlans))
                 foreach (var rp in relatedPlans.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                    plan.RelatedPlans.Add(rp);
+                    plan.RelatedPlans.Add(PlanCommandHelpers.ResolvePlanFolderName(rp));
 
             if (!string.IsNullOrEmpty(dependsOn))
                 foreach (var dep in dependsOn.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                    plan.DependsOn.Add(dep);
+                    plan.DependsOn.Add(PlanCommandHelpers.ResolvePlanFolderName(dep));
 
             PlanCommandHelpers.WritePlan(planFolder, plan);
             return $"Plan created: {folderName}\nPlanId: {planId}\nDirectory: {planFolder}";
@@ -486,53 +486,59 @@ public sealed class PlanTools : AuthenticatedToolBase
     [McpServerTool(Name = "tendril_plan_add_related"), Description("Add a related plan link")]
     public string AddRelated(
         [Description("Plan ID")] string planId,
-        [Description("Related plan folder name (e.g., 01478-WorktreeIsolation)")] string relatedPlan)
+        [Description("Plan reference (ID, folder name, or path)")] string relatedPlan)
     {
         return ModifyPlan(planId, plan =>
         {
-            if (plan.RelatedPlans.Contains(relatedPlan, StringComparer.OrdinalIgnoreCase))
-                return;
-            plan.RelatedPlans.Add(relatedPlan);
-        }, $"Added related plan: {relatedPlan}");
+            var resolved = PlanCommandHelpers.ResolvePlanFolderName(relatedPlan);
+            if (!plan.RelatedPlans.Contains(resolved, StringComparer.OrdinalIgnoreCase))
+                plan.RelatedPlans.Add(resolved);
+            return $"Added related plan: {resolved}";
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_remove_related"), Description("Remove a related plan link")]
     public string RemoveRelated(
         [Description("Plan ID")] string planId,
-        [Description("Related plan folder name")] string relatedPlan)
+        [Description("Plan reference (ID, folder name, or path)")] string relatedPlan)
     {
         return ModifyPlan(planId, plan =>
         {
-            var removed = plan.RelatedPlans.RemoveAll(r => r.Equals(relatedPlan, StringComparison.OrdinalIgnoreCase));
+            var resolved = PlanCommandHelpers.ResolvePlanFolderName(relatedPlan);
+            var removed = plan.RelatedPlans.RemoveAll(r => r.Equals(resolved, StringComparison.OrdinalIgnoreCase));
             if (removed == 0)
-                throw new InvalidOperationException($"Related plan not found: {relatedPlan}");
-        }, $"Removed related plan: {relatedPlan}");
+                throw new InvalidOperationException($"Related plan not found: {resolved}");
+            return $"Removed related plan: {resolved}";
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_add_depends_on"), Description("Add a dependency to a plan")]
     public string AddDependsOn(
         [Description("Plan ID")] string planId,
-        [Description("Dependency plan folder name (e.g., 01478-WorktreeIsolation)")] string dependency)
+        [Description("Plan reference (ID, folder name, or path)")] string dependency)
     {
         return ModifyPlan(planId, plan =>
         {
-            if (plan.DependsOn.Contains(dependency, StringComparer.OrdinalIgnoreCase))
-                return;
-            plan.DependsOn.Add(dependency);
-        }, $"Added dependency: {dependency}");
+            var resolved = PlanCommandHelpers.ResolvePlanFolderName(dependency);
+            if (!plan.DependsOn.Contains(resolved, StringComparer.OrdinalIgnoreCase))
+                plan.DependsOn.Add(resolved);
+            return $"Added dependency: {resolved}";
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_remove_depends_on"), Description("Remove a dependency from a plan")]
     public string RemoveDependsOn(
         [Description("Plan ID")] string planId,
-        [Description("Dependency plan folder name")] string dependency)
+        [Description("Plan reference (ID, folder name, or path)")] string dependency)
     {
         return ModifyPlan(planId, plan =>
         {
-            var removed = plan.DependsOn.RemoveAll(d => d.Equals(dependency, StringComparison.OrdinalIgnoreCase));
+            var resolved = PlanCommandHelpers.ResolvePlanFolderName(dependency);
+            var removed = plan.DependsOn.RemoveAll(d => d.Equals(resolved, StringComparison.OrdinalIgnoreCase));
             if (removed == 0)
-                throw new InvalidOperationException($"Dependency not found: {dependency}");
-        }, $"Removed dependency: {dependency}");
+                throw new InvalidOperationException($"Dependency not found: {resolved}");
+            return $"Removed dependency: {resolved}";
+        });
     }
 
     [McpServerTool(Name = "tendril_plan_validate"), Description("Validate plan health (checks required fields, valid states, repo paths, etc.)")]
@@ -629,16 +635,21 @@ public sealed class PlanTools : AuthenticatedToolBase
 
     private string ModifyPlan(string planId, Action<PlanYaml> modifier, string successMessage)
     {
+        return ModifyPlan(planId, plan => { modifier(plan); return successMessage; });
+    }
+
+    private string ModifyPlan(string planId, Func<PlanYaml, string> modifier)
+    {
         return ExecuteAuthenticated(() =>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-            modifier(plan);
+            var message = modifier(plan);
 
             plan.Updated = DateTime.UtcNow;
             PlanCommandHelpers.WritePlan(planFolder, plan);
-            return successMessage;
+            return message;
         });
     }
 


### PR DESCRIPTION
## Summary
- All plan reference arguments (depends-on, related-plan) now resolve any input format (bare number, zero-padded, folder name, or full path) to the canonical folder name before storing
- Applies consistently across CLI commands, MCP tools, and REST API
- Added `ResolvePlanFolderName` helper to `PlanCommandHelpers`

## Test plan
- [x] All 1369 tests pass
- [x] Verified bare IDs, zero-padded IDs, and folder names all resolve correctly
- [x] Verified non-existent plan references return proper errors