### PR TITLE
Fix Synchronize button not refreshing commits table

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -677,7 +677,7 @@ public class ContentView(
             {
                 var planFolder = Path.GetFullPath(Path.Combine(worktreePath, "..", ".."));
                 planService.SyncPlanArtifacts(planFolder);
-                var refreshed = planService.GetPlanByFolder(planFolder);
+                var refreshed = planService.GetPlanByFolderFromDisk(planFolder);
                 if (refreshed != null)
                     selectedPlanState.Set(refreshed);
                 client.Toast("Worktree synchronized successfully", "Synchronized");

--- a/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
@@ -39,6 +39,7 @@ public interface IPlanReaderService
     void AcceptRecommendationAndRetry(string folderName, string recommendationTitle);
 
     void SyncPlanArtifacts(string planFolder);
+    PlanFile? GetPlanByFolderFromDisk(string folderPath) => GetPlanByFolder(folderPath);
     void InvalidateCaches();
     Task FlushPendingWritesAsync();
 

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -198,6 +198,12 @@ public class PlanReaderService(
         return ParsePlanFolder(folderPath);
     }
 
+    public PlanFile? GetPlanByFolderFromDisk(string folderPath)
+    {
+        if (!Directory.Exists(folderPath)) return null;
+        return ParsePlanFolder(folderPath);
+    }
+
     /// <summary>
     ///     Retrieves all plans that are in the <see cref="PlanStatus.Icebox" /> state.
     /// </summary>


### PR DESCRIPTION
Read plan from disk after SyncPlanArtifacts instead of from the database, which hasn't been synced yet due to the 500ms debounce on PlanWatcherService.

Adds `GetPlanByFolderFromDisk` to `IPlanReaderService` (with default interface implementation) so the Synchronize action reads fresh commit data immediately from the filesystem rather than the stale database cache.