### PR TITLE
Add PlanMarkdownView widget with pinned fixed-content slot

### DIFF
--- a/src/Ivy.Tendril.Widgets/Widgets/PlanMarkdownView.cs
+++ b/src/Ivy.Tendril.Widgets/Widgets/PlanMarkdownView.cs
@@ -1,0 +1,74 @@
+using Ivy;
+using Ivy.Core;
+using Ivy.Core.ExternalWidgets;
+
+namespace Ivy.Widgets.PlanMarkdownView;
+
+/// <summary>
+/// Renders plan markdown in its own internal scroll container, alongside a
+/// <c>FixedContent</c> slot that is pinned in place and unaffected by the
+/// markdown scroll. Use the slot for interactive elements that should stay put
+/// (to the right of the markdown) while the plan content scrolls.
+/// </summary>
+[ExternalWidget(
+    "Widgets/frontend/dist/ivy-tendril-widgets.js",
+    StylePath = "Widgets/frontend/dist/ivy-tendril-widgets.css",
+    ExportName = "PlanMarkdownView",
+    GlobalName = "IvyTendrilWidgets"
+)]
+[Slot("FixedContent")]
+public record PlanMarkdownView : WidgetBase<PlanMarkdownView>
+{
+    public PlanMarkdownView(string content) : base()
+    {
+        Content = content;
+    }
+
+    internal PlanMarkdownView() { }
+
+    /// <summary>The markdown source to render.</summary>
+    [Prop] public string Content { get; init; } = string.Empty;
+
+    /// <summary>Apply article-grade typography (heading spacing, h2 divider, relaxed line-height).</summary>
+    [Prop] public bool Article { get; init; }
+
+    /// <summary>Allow rendering of links to local files (e.g. file:// and relative artifact links).</summary>
+    [Prop] public bool DangerouslyAllowLocalFiles { get; init; }
+
+    /// <summary>Fired when a link inside the markdown is clicked; the payload is the href.</summary>
+    [Event] public EventHandler<Event<PlanMarkdownView, string>>? OnLinkClick { get; init; }
+}
+
+public static class PlanMarkdownViewExtensions
+{
+    public static PlanMarkdownView Article(this PlanMarkdownView w, bool article = true) =>
+        w with { Article = article };
+
+    public static PlanMarkdownView DangerouslyAllowLocalFiles(this PlanMarkdownView w, bool allow = true) =>
+        w with { DangerouslyAllowLocalFiles = allow };
+
+    /// <summary>Sets the pinned (non-scrolling) content rendered to the right of the markdown.</summary>
+    public static PlanMarkdownView FixedContent(this PlanMarkdownView w, object? content)
+    {
+        var others = w.Children.Where(c => c is not Slot s || s.Name != "FixedContent");
+        var children = content != null
+            ? others.Append(new Slot("FixedContent", content)).ToArray()
+            : others.ToArray();
+        return w with { Children = children };
+    }
+
+    public static PlanMarkdownView OnLinkClick(
+        this PlanMarkdownView w,
+        Func<Event<PlanMarkdownView, string>, ValueTask> handler
+    ) => w with { OnLinkClick = new(handler) };
+
+    public static PlanMarkdownView OnLinkClick(this PlanMarkdownView w, Action<string> handler) =>
+        w with
+        {
+            OnLinkClick = new(e =>
+            {
+                handler(e.Value);
+                return ValueTask.CompletedTask;
+            }),
+        };
+}

--- a/src/Ivy.Tendril.Widgets/Widgets/frontend/src/PlanMarkdownView.tsx
+++ b/src/Ivy.Tendril.Widgets/Widgets/frontend/src/PlanMarkdownView.tsx
@@ -1,0 +1,102 @@
+import React, { useCallback } from "react";
+import Markdown from "react-markdown";
+import rehypeHighlight from "rehype-highlight";
+import remarkGfm from "remark-gfm";
+import "./plan-markdown-view.css";
+import { getHeight, getWidth } from "./styles";
+
+type IvyEventHandler = (eventName: string, widgetId: string, args: unknown[]) => void;
+
+interface PlanMarkdownViewProps {
+  id: string;
+  width?: string;
+  height?: string;
+  content?: string;
+  article?: boolean;
+  dangerouslyAllowLocalFiles?: boolean;
+  events?: string[];
+  onIvyEvent?: IvyEventHandler;
+  /** Slot content injected by the backend. `FixedContent` is pinned and does not scroll. */
+  slots?: {
+    FixedContent?: React.ReactNode[];
+  };
+}
+
+const EMPTY_EVENTS: string[] = [];
+
+export const PlanMarkdownView: React.FC<PlanMarkdownViewProps> = ({
+  id,
+  width,
+  height,
+  content = "",
+  article = false,
+  dangerouslyAllowLocalFiles = false,
+  events = EMPTY_EVENTS,
+  onIvyEvent,
+  slots,
+}) => {
+  const handleLinkClick = useCallback(
+    (href: string) => {
+      if (events.includes("OnLinkClick") && onIvyEvent) {
+        onIvyEvent("OnLinkClick", id, [href]);
+      }
+    },
+    [events, onIvyEvent, id],
+  );
+
+  // Intercept link clicks so the backend OnLinkClick handler runs (file sheets,
+  // cross-plan navigation, etc.) instead of a hard browser navigation.
+  const anchor = useCallback(
+    (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
+      const { href, children, ...rest } = props;
+      const isLocalFile =
+        !!href && (href.startsWith("file:") || (!/^[a-z]+:\/\//i.test(href) && !href.startsWith("#")));
+      if (isLocalFile && !dangerouslyAllowLocalFiles) {
+        return <span {...rest}>{children}</span>;
+      }
+      return (
+        <a
+          href={href}
+          {...rest}
+          onClick={(e) => {
+            if (events.includes("OnLinkClick") && href) {
+              e.preventDefault();
+              handleLinkClick(href);
+            }
+          }}
+        >
+          {children}
+        </a>
+      );
+    },
+    [events, dangerouslyAllowLocalFiles, handleLinkClick],
+  );
+
+  const fixed = slots?.FixedContent;
+  const hasFixed = !!fixed && React.Children.count(fixed) > 0;
+
+  const shellStyle: React.CSSProperties = {
+    ...getWidth(width),
+    ...getHeight(height),
+  };
+
+  return (
+    <div className="pmv-shell" style={shellStyle}>
+      {/* Scrollable markdown body — owns the vertical scroll. */}
+      <div className="pmv-body">
+        <div className={article ? "pmv-markdown pmv-article" : "pmv-markdown"}>
+          <Markdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeHighlight]}
+            components={{ a: anchor }}
+          >
+            {content}
+          </Markdown>
+        </div>
+      </div>
+
+      {/* Fixed (pinned) slot — sibling of the scroll body, so it stays in place. */}
+      {hasFixed && <div className="pmv-fixed">{fixed}</div>}
+    </div>
+  );
+};

--- a/src/Ivy.Tendril.Widgets/Widgets/frontend/src/index.ts
+++ b/src/Ivy.Tendril.Widgets/Widgets/frontend/src/index.ts
@@ -1,11 +1,13 @@
 import { TendrilProcessView } from "./TendrilProcessView";
 import { AgentOutputView } from "./AgentOutputView";
+import { PlanMarkdownView } from "./PlanMarkdownView";
 
 if (typeof window !== "undefined") {
   (window as unknown as Record<string, unknown>).IvyTendrilWidgets = {
     TendrilProcessView,
     AgentOutputView,
+    PlanMarkdownView,
   };
 }
 
-export { TendrilProcessView, AgentOutputView };
+export { TendrilProcessView, AgentOutputView, PlanMarkdownView };

--- a/src/Ivy.Tendril.Widgets/Widgets/frontend/src/plan-markdown-view.css
+++ b/src/Ivy.Tendril.Widgets/Widgets/frontend/src/plan-markdown-view.css
@@ -1,0 +1,250 @@
+@tailwind components;
+@tailwind utilities;
+
+/* ─── Layout: scrollable markdown body + pinned fixed slot ──────────────── */
+.pmv-shell {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+.pmv-shell * {
+  box-sizing: border-box;
+}
+
+/* The markdown body is the only scrolling region. */
+.pmv-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+/* The widget owns its own scroll (and the pinned FixedContent slot), so the Plan
+   tab does NOT wrap it in Cap(). The widget therefore reproduces what Cap() would
+   provide: max-width 200 units and a 1.5rem left inset, so the markdown lines up
+   exactly with the Details tab content. */
+.pmv-markdown {
+  width: 100%;
+  max-width: 50rem; /* 200 units * 0.25rem */
+  padding: 0 0 1rem 1.5rem; /* left 1.5rem matches Details' Padding(6,…) */
+}
+
+/* Fixed slot: a flex sibling outside .pmv-body, so the markdown scroll never
+   moves it. It stays pinned to the right of the markdown. */
+.pmv-fixed {
+  flex: 0 0 auto;
+  align-self: flex-start;
+  height: 100%;
+  overflow: visible;
+}
+
+/* ─── Typography ─────────────────────────────────────────────────────────
+   Replicates the Ivy framework Markdown widget's `typography` map (and the
+   `article` variant) using the host design-system CSS variables, since the
+   widget bundle's Tailwind build does not emit utility classes for the
+   markdown content. Keep in sync with Ivy-Framework src/frontend/src/lib/styles.ts. */
+.pmv-markdown {
+  color: var(--foreground);
+  font-size: 1rem;
+  line-height: 1.5;
+  word-break: normal;
+  overflow-wrap: break-word;
+}
+
+/* Headings */
+.pmv-markdown h1 {
+  font-size: 2.25rem;
+  line-height: 2.5rem;
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+}
+.pmv-markdown h2 {
+  font-size: 1.875rem;
+  line-height: 2.25rem;
+  font-weight: 500;
+  margin: 0;
+}
+.pmv-markdown h3 {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-weight: 500;
+  margin: 0;
+  padding-bottom: 0.25rem;
+}
+.pmv-markdown h4 {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  font-weight: 500;
+  margin: 0;
+}
+.pmv-markdown h5 {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  font-weight: 500;
+  margin: 0;
+}
+.pmv-markdown h6 {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 500;
+  margin: 0;
+}
+
+/* Body */
+.pmv-markdown p {
+  font-size: 1rem;
+  margin: 0.5rem 0;
+}
+.pmv-markdown p:first-child {
+  margin-top: 0;
+}
+.pmv-markdown strong {
+  font-weight: 600;
+}
+.pmv-markdown em {
+  font-style: italic;
+}
+
+/* Lists */
+.pmv-markdown ul,
+.pmv-markdown ol {
+  margin: 0.5rem 0;
+  padding-inline-start: 2rem;
+  display: flex;
+  flex-direction: column;
+  row-gap: 0.25rem;
+}
+.pmv-markdown ul {
+  list-style: disc outside;
+}
+.pmv-markdown ol {
+  list-style: decimal outside;
+}
+.pmv-markdown li {
+  display: list-item;
+}
+.pmv-markdown li > p {
+  margin: 0;
+}
+
+/* Links */
+.pmv-markdown a {
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  filter: brightness(0.9);
+}
+.pmv-markdown a:hover {
+  filter: brightness(1);
+}
+
+/* Inline code */
+.pmv-markdown code {
+  position: relative;
+  border-radius: 0.25rem;
+  background: var(--muted);
+  padding: 0.05rem 0.25rem;
+  font-family: "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo,
+    Consolas, monospace;
+  font-weight: 600;
+}
+
+/* Code blocks */
+.pmv-markdown pre {
+  margin: 0.5rem 0;
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  padding: 0.75rem;
+  overflow-x: auto;
+}
+.pmv-markdown pre code {
+  background: none;
+  padding: 0;
+  font-weight: 400;
+  border-radius: 0;
+}
+
+/* Blockquote */
+.pmv-markdown blockquote {
+  border-left: 2px solid var(--border);
+  padding-left: 1.5rem;
+  font-style: italic;
+  margin: 0.5rem 0;
+}
+
+/* Tables */
+.pmv-markdown table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--border);
+  margin: 0.5rem 0;
+}
+.pmv-markdown thead {
+  background: var(--muted);
+}
+.pmv-markdown tr {
+  border: 1px solid var(--border);
+}
+.pmv-markdown th {
+  border: 1px solid var(--border);
+  padding: 0.5rem 1rem;
+  text-align: left;
+  font-weight: 700;
+  font-size: 0.875em;
+}
+.pmv-markdown td {
+  border: 1px solid var(--border);
+  padding: 0.5rem 1rem;
+  font-size: 0.875em;
+}
+
+/* Media + rules */
+.pmv-markdown img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  margin: 1rem 0;
+}
+.pmv-markdown hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 1rem 0;
+}
+
+/* ─── Article variant ───────────────────────────────────────────────────
+   Matches `articleTypography`: heading top-margins, the h2 divider, and
+   relaxed body line-height. */
+.pmv-article h1 {
+  margin-top: 1.5rem;
+}
+.pmv-article h2 {
+  margin-top: 1.25rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+.pmv-article h3 {
+  margin-top: 1rem;
+}
+.pmv-article h4,
+.pmv-article h5,
+.pmv-article h6 {
+  margin-top: 0.75rem;
+}
+.pmv-article p,
+.pmv-article li,
+.pmv-article blockquote {
+  line-height: 1.625;
+}
+.pmv-article ul,
+.pmv-article ol {
+  padding-inline-start: 2.25rem;
+}

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -197,7 +197,10 @@ public class ContentView(
         else
         {
             var tabs = Layout.Tabs(
-                new Tab("Plan", Cap(planTabContent)),
+                // PlanMarkdownView owns its own scroll and the pinned FixedContent slot,
+                // so it is not wrapped in Cap() (whose outer scroll would also scroll the
+                // pinned element). The widget reproduces Cap()'s left inset + max-width.
+                new Tab("Plan", planTabContent),
                 new Tab("Details", Cap(new DetailsTabView(selectedPlan!,
                     jobService.GetJobsForPlan(selectedPlan!.FolderName),
                     showDebugJob, planService, selectedPlanState, refreshPlans)))

--- a/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
@@ -2,6 +2,7 @@ using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Widgets.PlanMarkdownView;
 
 namespace Ivy.Tendril.Apps.Drafts;
 
@@ -17,9 +18,13 @@ public class PlanTabView(
     {
         if (isEditing)
         {
-            return editContentState.ToCodeInput()
-                .Language(Languages.Markdown)
-                .Width(Size.Full());
+            // The Plan tab is no longer wrapped in Cap(), so provide the scroll,
+            // full height, and 1.5rem left inset (Padding(6,…)) here.
+            return Layout.Vertical().Scroll(Scroll.Vertical).Width(Size.Full()).Height(Size.Full())
+                | (Layout.Vertical().Padding(6, 0, 0, 4).Width(Size.Full().Max(Size.Units(200)))
+                    | editContentState.ToCodeInput()
+                        .Language(Languages.Markdown)
+                        .Width(Size.Full()));
         }
         else
         {
@@ -31,20 +36,33 @@ public class PlanTabView(
                 selectedPlan.LatestRevisionContent,
                 planService.PlansDirectory);
 
-            planLayout |= new Markdown(annotatedContent)
+            // Placeholder for the pinned interactive element. It lives in the widget's
+            // FixedContent slot, which renders outside the markdown's scroll region, so
+            // it stays in place while the plan content scrolls.
+            var fixedElement = new Card(
+                Layout.Vertical().Gap(2)
+                | Text.Block("Actions").Bold()
+                | new Button("Placeholder").Outline()
+            ).Width(Size.Px(280));
+
+            Action<string> onLinkClick = FileSheet.CreateLinkClickHandler(openFileState, planId =>
+            {
+                var planFolder = Directory.GetDirectories(planService.PlansDirectory, $"{planId:D5}-*")
+                    .FirstOrDefault();
+                if (planFolder != null)
+                {
+                    var plan = planService.GetPlanByFolder(planFolder);
+                    if (plan != null)
+                        selectedPlanState.Set(plan);
+                }
+            });
+
+            planLayout |= new PlanMarkdownView(annotatedContent)
                 .Article()
                 .DangerouslyAllowLocalFiles()
-                .OnLinkClick(FileSheet.CreateLinkClickHandler(openFileState, planId =>
-                {
-                    var planFolder = Directory.GetDirectories(planService.PlansDirectory, $"{planId:D5}-*")
-                        .FirstOrDefault();
-                    if (planFolder != null)
-                    {
-                        var plan = planService.GetPlanByFolder(planFolder);
-                        if (plan != null)
-                            selectedPlanState.Set(plan);
-                    }
-                }));
+                .Height(Size.Full())
+                .FixedContent(fixedElement)
+                .OnLinkClick(onLinkClick);
 
             return planLayout;
         }


### PR DESCRIPTION
## Summary

Introduces an external **`PlanMarkdownView`** widget in `Ivy.Tendril.Widgets` that renders plan markdown in its own scroll container alongside a **`FixedContent` slot** for interactive elements that should stay pinned in place while the plan content scrolls. Wires it into the Drafts **Plan** tab with a placeholder pinned element.

## What's included

- **`Widgets/PlanMarkdownView.cs`** — external widget with `Content`, `Article`, `DangerouslyAllowLocalFiles`, `OnLinkClick`, and a `[Slot("FixedContent")]` exposed via a `.FixedContent(...)` builder. Follows the `AgentOutputView` / `TendrilProcessView` conventions (uses the framework's `EventHandler<Event<T,V>>?` pattern for the event prop).
- **`frontend/src/PlanMarkdownView.tsx`** + **`plan-markdown-view.css`** — renders markdown via `react-markdown` / `remark-gfm` / `rehype-highlight` inside a scrolling body, with the `FixedContent` slot as a flex sibling **outside** the scroll region so it stays pinned. Registered in `index.ts`.
- **Typography** — replicates the Ivy framework Markdown widget's `typography` map and `article` variant (heading top-margins, h2 divider, relaxed body line-height) as scoped CSS on `.pmv-markdown`, using the host design-system CSS variables. The widget bundle's Tailwind build doesn't emit utility classes for markdown content, so this matches the existing `AgentOutputView` hand-written-CSS convention.
- **Wiring** (`Apps/Drafts/PlanTabView.cs`, `Apps/Drafts/ContentView.cs`) — the Plan tab uses `PlanMarkdownView` with a placeholder fixed `Card`. The Plan tab no longer wraps content in `Cap()` (whose outer scroll would also scroll the pinned element); the widget reproduces `Cap()`'s **1.5rem left inset** + 200-unit max-width so the markdown lines up exactly with the **Details** tab content. The edit-mode branch is made self-contained (own scroll + inset) since `Cap()` is gone.

## Notes

- The fixed-slot element is a **placeholder** (`Actions` card with a button) — intended to be replaced with the real interactive content.
- Like `AgentOutputView`, fenced code gets a styled block (background/border/mono) but not per-token syntax colors; the framework's richer `CodeBlock` was intentionally not ported.

## Testing

- `Ivy.Tendril` and `Ivy.Tendril.Widgets` build clean against local framework source (`-p:IvySource=true`).
- Widget frontend bundle builds clean (tsc + vite); `.pmv-markdown` / `.pmv-article` rules verified present in the compiled CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)