### PR TITLE
Standardize CLI error handling with unified exception propagation (#1035)

### DIFF
--- a/src/Ivy.Tendril/Commands/JobStatusCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStatusCommand.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using System.Text;
 using System.Text.Json;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -33,32 +32,20 @@ public class JobStatusCommand : Command<JobStatusSettings>
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    private readonly ILogger<JobStatusCommand> _logger;
-
-    public JobStatusCommand(ILogger<JobStatusCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, JobStatusSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var discovery = MasterClient.Discover();
-            using var client = MasterClient.CreateHttpClient(discovery);
+        var discovery = MasterClient.Discover();
+        using var client = MasterClient.CreateHttpClient(discovery);
 
-            var payload = new { message = settings.Message, planId = settings.PlanId, planTitle = settings.PlanTitle };
-            var json = JsonSerializer.Serialize(payload, JsonOptions);
-            var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var payload = new { message = settings.Message, planId = settings.PlanId, planTitle = settings.PlanTitle };
+        var json = JsonSerializer.Serialize(payload, JsonOptions);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-            var response = client.PutAsync($"{discovery.BaseUrl}/api/jobs/{settings.JobId}/status", content, cancellationToken)
-                .GetAwaiter().GetResult();
-            response.EnsureSuccessStatusCode();
+        var response = client.PutAsync($"{discovery.BaseUrl}/api/jobs/{settings.JobId}/status", content, cancellationToken)
+            .GetAwaiter().GetResult();
+        response.EnsureSuccessStatusCode();
 
-            _logger.LogInformation("Status updated for job {JobId}: {Message}", settings.JobId, settings.Message);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to report status for job {JobId}: {Message}", settings.JobId, ex.Message);
-            return 1;
-        }
+        Console.WriteLine($"Status updated for job {settings.JobId}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanAddCommitCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddCommitCommand.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -21,47 +20,33 @@ public class PlanAddCommitSettings : CommandSettings
 
 public class PlanAddCommitCommand : Command<PlanAddCommitSettings>
 {
-    private readonly ILogger<PlanAddCommitCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanAddCommitCommand(ILogger<PlanAddCommitCommand> logger, IPlanWatcherService planWatcher)
+    public PlanAddCommitCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanAddCommitSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        if (!Regex.IsMatch(settings.Sha, @"^[0-9a-fA-F]{7,40}$"))
+            throw new ArgumentException($"Invalid commit hash format: {settings.Sha}. Expected 7-40 character hex string.");
+
+        if (plan.Commits.Contains(settings.Sha))
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-
-            // Validate commit hash format
-            if (!Regex.IsMatch(settings.Sha, @"^[0-9a-fA-F]{7,40}$"))
-            {
-                _logger.LogError("Invalid commit hash format: {Sha}", settings.Sha);
-                return 1;
-            }
-
-            if (plan.Commits.Contains(settings.Sha))
-            {
-                _logger.LogInformation("Commit already in plan: {Sha}", settings.Sha);
-                return 0;
-            }
-
-            plan.Commits.Add(settings.Sha);
-            plan.Updated = DateTime.UtcNow;
-
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
-
-            _logger.LogInformation("Added commit: {Sha}", settings.Sha);
+            Console.WriteLine($"Commit already in plan: {settings.Sha}");
             return 0;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to add commit to plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+
+        plan.Commits.Add(settings.Sha);
+        plan.Updated = DateTime.UtcNow;
+
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+        Console.WriteLine($"Added commit: {settings.Sha}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanAddDependsOnCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddDependsOnCommand.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -19,41 +18,31 @@ public class PlanAddDependsOnSettings : CommandSettings
 
 public class PlanAddDependsOnCommand : Command<PlanAddDependsOnSettings>
 {
-    private readonly ILogger<PlanAddDependsOnCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanAddDependsOnCommand(ILogger<PlanAddDependsOnCommand> logger, IPlanWatcherService planWatcher)
+    public PlanAddDependsOnCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanAddDependsOnSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var resolvedDep = PlanCommandHelpers.ResolvePlanFolderName(settings.DependsOn);
+
+        if (plan.DependsOn.Contains(resolvedDep, StringComparer.OrdinalIgnoreCase))
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-            var resolvedDep = PlanCommandHelpers.ResolvePlanFolderName(settings.DependsOn);
-
-            if (plan.DependsOn.Contains(resolvedDep, StringComparer.OrdinalIgnoreCase))
-            {
-                _logger.LogInformation("Dependency already present: {DependsOn}", resolvedDep);
-                return 0;
-            }
-
-            plan.DependsOn.Add(resolvedDep);
-            plan.Updated = DateTime.UtcNow;
-
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
-
-            _logger.LogInformation("Added dependency: {DependsOn}", resolvedDep);
+            Console.WriteLine($"Dependency already present: {resolvedDep}");
             return 0;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to add dependency to plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+
+        plan.DependsOn.Add(resolvedDep);
+        plan.Updated = DateTime.UtcNow;
+
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+        Console.WriteLine($"Added dependency: {resolvedDep}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanAddLogCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddLogCommand.cs
@@ -2,7 +2,6 @@ using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -24,24 +23,12 @@ public class PlanAddLogSettings : CommandSettings
 
 public class PlanAddLogCommand : Command<PlanAddLogSettings>
 {
-    private readonly ILogger<PlanAddLogCommand> _logger;
-
-    public PlanAddLogCommand(ILogger<PlanAddLogCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, PlanAddLogSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var logPath = WriteLog(planFolder, settings.Action, settings.Summary);
-            Console.Write(logPath);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to add log to plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var logPath = WriteLog(planFolder, settings.Action, settings.Summary);
+        Console.Write(logPath);
+        return 0;
     }
 
     internal static string WriteLog(string planFolder, string action, string? summary = null)

--- a/src/Ivy.Tendril/Commands/PlanAddPrCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddPrCommand.cs
@@ -2,7 +2,6 @@ using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -20,40 +19,30 @@ public class PlanAddPrSettings : CommandSettings
 
 public class PlanAddPrCommand : Command<PlanAddPrSettings>
 {
-    private readonly ILogger<PlanAddPrCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanAddPrCommand(ILogger<PlanAddPrCommand> logger, IPlanWatcherService planWatcher)
+    public PlanAddPrCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanAddPrSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        if (plan.Prs.Contains(settings.PrUrl))
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-
-            if (plan.Prs.Contains(settings.PrUrl))
-            {
-                _logger.LogInformation("PR already in plan: {PrUrl}", settings.PrUrl);
-                return 0;
-            }
-
-            plan.Prs.Add(settings.PrUrl);
-            plan.Updated = DateTime.UtcNow;
-
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
-
-            _logger.LogInformation("Added PR: {PrUrl}", settings.PrUrl);
+            Console.WriteLine($"PR already in plan: {settings.PrUrl}");
             return 0;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to add PR to plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+
+        plan.Prs.Add(settings.PrUrl);
+        plan.Updated = DateTime.UtcNow;
+
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+        Console.WriteLine($"Added PR: {settings.PrUrl}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanAddRelatedPlanCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddRelatedPlanCommand.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -19,41 +18,31 @@ public class PlanAddRelatedPlanSettings : CommandSettings
 
 public class PlanAddRelatedPlanCommand : Command<PlanAddRelatedPlanSettings>
 {
-    private readonly ILogger<PlanAddRelatedPlanCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanAddRelatedPlanCommand(ILogger<PlanAddRelatedPlanCommand> logger, IPlanWatcherService planWatcher)
+    public PlanAddRelatedPlanCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanAddRelatedPlanSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var resolvedRp = PlanCommandHelpers.ResolvePlanFolderName(settings.RelatedPlan);
+
+        if (plan.RelatedPlans.Contains(resolvedRp, StringComparer.OrdinalIgnoreCase))
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-            var resolvedRp = PlanCommandHelpers.ResolvePlanFolderName(settings.RelatedPlan);
-
-            if (plan.RelatedPlans.Contains(resolvedRp, StringComparer.OrdinalIgnoreCase))
-            {
-                _logger.LogInformation("Related plan already present: {RelatedPlan}", resolvedRp);
-                return 0;
-            }
-
-            plan.RelatedPlans.Add(resolvedRp);
-            plan.Updated = DateTime.UtcNow;
-
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
-
-            _logger.LogInformation("Added related plan: {RelatedPlan}", resolvedRp);
+            Console.WriteLine($"Related plan already present: {resolvedRp}");
             return 0;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to add related plan to plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+
+        plan.RelatedPlans.Add(resolvedRp);
+        plan.Updated = DateTime.UtcNow;
+
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+        Console.WriteLine($"Added related plan: {resolvedRp}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanAddRepoCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddRepoCommand.cs
@@ -2,7 +2,6 @@ using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -20,40 +19,30 @@ public class PlanAddRepoSettings : CommandSettings
 
 public class PlanAddRepoCommand : Command<PlanAddRepoSettings>
 {
-    private readonly ILogger<PlanAddRepoCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanAddRepoCommand(ILogger<PlanAddRepoCommand> logger, IPlanWatcherService planWatcher)
+    public PlanAddRepoCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanAddRepoSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        if (plan.Repos.Contains(settings.RepoPath, StringComparer.OrdinalIgnoreCase))
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-
-            if (plan.Repos.Contains(settings.RepoPath, StringComparer.OrdinalIgnoreCase))
-            {
-                _logger.LogInformation("Repository already in plan: {RepoPath}", settings.RepoPath);
-                return 0;
-            }
-
-            plan.Repos.Add(settings.RepoPath);
-            plan.Updated = DateTime.UtcNow;
-
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
-
-            _logger.LogInformation("Added repository: {RepoPath}", settings.RepoPath);
+            Console.WriteLine($"Repository already in plan: {settings.RepoPath}");
             return 0;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to add repository to plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+
+        plan.Repos.Add(settings.RepoPath);
+        plan.Updated = DateTime.UtcNow;
+
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+        Console.WriteLine($"Added repository: {settings.RepoPath}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanCleanupCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCleanupCommand.cs
@@ -2,7 +2,6 @@ using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -21,52 +20,36 @@ public class PlanCleanupSettings : CommandSettings
 
 public class PlanCleanupCommand : Command<PlanCleanupSettings>
 {
-    private readonly ILogger<PlanCleanupCommand> _logger;
-
-    public PlanCleanupCommand(ILogger<PlanCleanupCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, PlanCleanupSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        var terminalStates = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            { nameof(PlanStatus.Completed), nameof(PlanStatus.Failed), nameof(PlanStatus.Skipped), nameof(PlanStatus.Icebox) };
+
+        if (!settings.Force && !terminalStates.Contains(plan.State))
+            throw new InvalidOperationException($"Plan is not in a terminal state (current: {plan.State}). Use --force to override.");
+
+        var worktreesDir = Path.Combine(planFolder, "Worktrees");
+        if (!Directory.Exists(worktreesDir) || Directory.GetDirectories(worktreesDir).Length == 0)
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-
-            var terminalStates = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-                { nameof(PlanStatus.Completed), nameof(PlanStatus.Failed), nameof(PlanStatus.Skipped), nameof(PlanStatus.Icebox) };
-
-            if (!settings.Force && !terminalStates.Contains(plan.State))
-            {
-                AnsiConsole.MarkupLine($"[yellow]Plan is not in a terminal state (current: {plan.State.EscapeMarkup()}). Use --force to override.[/]");
-                return 1;
-            }
-
-            var worktreesDir = Path.Combine(planFolder, "Worktrees");
-            if (!Directory.Exists(worktreesDir) || Directory.GetDirectories(worktreesDir).Length == 0)
-            {
-                AnsiConsole.MarkupLine("[green]No worktrees to clean up.[/]");
-                return 0;
-            }
-
-            WorktreeCleanupService.RemoveWorktrees(planFolder);
-
-            var remaining = Directory.Exists(worktreesDir) ? Directory.GetDirectories(worktreesDir).Length : 0;
-            if (remaining == 0)
-            {
-                AnsiConsole.MarkupLine("[green]Worktrees cleaned up successfully.[/]");
-            }
-            else
-            {
-                AnsiConsole.MarkupLine($"[yellow]{remaining} {(remaining == 1 ? "worktree" : "Worktrees")} could not be removed.[/]");
-                return 1;
-            }
-
+            AnsiConsole.MarkupLine("[green]No worktrees to clean up.[/]");
             return 0;
         }
-        catch (Exception ex)
+
+        WorktreeCleanupService.RemoveWorktrees(planFolder);
+
+        var remaining = Directory.Exists(worktreesDir) ? Directory.GetDirectories(worktreesDir).Length : 0;
+        if (remaining == 0)
         {
-            _logger.LogError("Failed to clean up plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
+            AnsiConsole.MarkupLine("[green]Worktrees cleaned up successfully.[/]");
         }
+        else
+        {
+            throw new InvalidOperationException($"{remaining} {(remaining == 1 ? "worktree" : "worktrees")} could not be removed.");
+        }
+
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -61,85 +60,83 @@ public class PlanCreateSettings : CommandSettings
 
 public class PlanCreateCommand : Command<PlanCreateSettings>
 {
-    private readonly ILogger<PlanCreateCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanCreateCommand(ILogger<PlanCreateCommand> logger, IPlanWatcherService planWatcher)
+    public PlanCreateCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanCreateSettings settings, CancellationToken cancellationToken)
     {
-        try
+        if (settings.Repos == null || settings.Repos.Length == 0)
+            throw new ArgumentException("At least one --repo is required.");
+
+        var plansDir = PlanCommandHelpers.GetPlansDirectory(settings.PlansDir);
+
+        var planId = PlanYamlHelper.AllocatePlanId(plansDir);
+        var safeTitle = PlanYamlHelper.ToSafeTitle(settings.Title);
+        var folderName = $"{planId}-{safeTitle}";
+        var planFolder = Path.Combine(plansDir, folderName);
+
+        if (Directory.Exists(planFolder))
+            throw new InvalidOperationException($"Plan folder already exists: {planFolder}");
+
+        var plan = new PlanYaml
         {
-            var plansDir = PlanCommandHelpers.GetPlansDirectory(settings.PlansDir);
+            State = nameof(PlanStatus.Draft),
+            Project = settings.Project ?? "Auto",
+            Level = settings.Level ?? "NiceToHave",
+            Title = settings.Title,
+            Created = DateTime.UtcNow,
+            Updated = DateTime.UtcNow,
+            InitialPrompt = settings.InitialPrompt,
+            SourceUrl = settings.SourceUrl,
+            ExecutionProfile = settings.ExecutionProfile,
+            Priority = settings.Priority ?? 0
+        };
 
-            var planId = PlanYamlHelper.AllocatePlanId(plansDir);
-            var safeTitle = PlanYamlHelper.ToSafeTitle(settings.Title);
-            var folderName = $"{planId}-{safeTitle}";
-            var planFolder = Path.Combine(plansDir, folderName);
+        if (settings.Repos != null)
+            foreach (var repo in settings.Repos)
+                plan.Repos.Add(repo);
 
-            if (Directory.Exists(planFolder))
+        if (settings.Verifications != null)
+            foreach (var v in settings.Verifications)
             {
-                _logger.LogError("Plan folder already exists: {PlanFolder}", planFolder);
-                return 1;
+                var eqIdx = v.IndexOf('=');
+                if (eqIdx < 0)
+                    throw new ArgumentException($"Invalid verification format '{v}'. Expected Name=Status.");
+                plan.Verifications.Add(new PlanVerificationEntry
+                {
+                    Name = v[..eqIdx],
+                    Status = v[(eqIdx + 1)..]
+                });
             }
 
-            Directory.CreateDirectory(planFolder);
-            FileHelper.GrantBroadWriteAccess(planFolder);
+        if (settings.RelatedPlans != null)
+            foreach (var rp in settings.RelatedPlans)
+                plan.RelatedPlans.Add(PlanCommandHelpers.ResolvePlanFolderName(rp));
 
-            var plan = new PlanYaml
-            {
-                State = nameof(PlanStatus.Draft),
-                Project = settings.Project ?? "Auto",
-                Level = settings.Level ?? "NiceToHave",
-                Title = settings.Title,
-                Created = DateTime.UtcNow,
-                Updated = DateTime.UtcNow,
-                InitialPrompt = settings.InitialPrompt,
-                SourceUrl = settings.SourceUrl,
-                ExecutionProfile = settings.ExecutionProfile,
-                Priority = settings.Priority ?? 0
-            };
+        if (settings.DependsOn != null)
+            foreach (var dep in settings.DependsOn)
+                plan.DependsOn.Add(PlanCommandHelpers.ResolvePlanFolderName(dep));
 
-            if (settings.Repos != null)
-                foreach (var repo in settings.Repos)
-                    plan.Repos.Add(repo);
+        Directory.CreateDirectory(planFolder);
+        FileHelper.GrantBroadWriteAccess(planFolder);
 
-            if (settings.Verifications != null)
-                foreach (var v in settings.Verifications)
-                {
-                    var eqIdx = v.IndexOf('=');
-                    if (eqIdx < 0)
-                        throw new ArgumentException($"Invalid verification format '{v}'. Expected Name=Status.");
-                    plan.Verifications.Add(new PlanVerificationEntry
-                    {
-                        Name = v[..eqIdx],
-                        Status = v[(eqIdx + 1)..]
-                    });
-                }
-
-            if (settings.RelatedPlans != null)
-                foreach (var rp in settings.RelatedPlans)
-                    plan.RelatedPlans.Add(PlanCommandHelpers.ResolvePlanFolderName(rp));
-
-            if (settings.DependsOn != null)
-                foreach (var dep in settings.DependsOn)
-                    plan.DependsOn.Add(PlanCommandHelpers.ResolvePlanFolderName(dep));
-
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
-
-            Console.WriteLine($"PlanId: {planId}");
-            Console.WriteLine($"Directory: {planFolder}");
-            Console.WriteLine($"Plan created: {folderName}");
-            return 0;
-        }
-        catch (Exception ex)
+        try
         {
-            _logger.LogError("Failed to create plan: {Message}", ex.Message);
-            return 1;
+            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
         }
+        catch
+        {
+            try { Directory.Delete(planFolder, true); } catch { }
+            throw;
+        }
+
+        Console.WriteLine($"PlanId: {planId}");
+        Console.WriteLine($"Directory: {planFolder}");
+        Console.WriteLine($"Plan created: {folderName}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanGetCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanGetCommand.cs
@@ -2,7 +2,6 @@ using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -20,82 +19,64 @@ public class PlanGetSettings : CommandSettings
 
 public class PlanGetCommand : Command<PlanGetSettings>
 {
-    private readonly ILogger<PlanGetCommand> _logger;
-
-    public PlanGetCommand(ILogger<PlanGetCommand> logger)
-    {
-        _logger = logger;
-    }
-
     protected override int Execute(CommandContext context, PlanGetSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        if (string.IsNullOrWhiteSpace(settings.Field))
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            var yaml = YamlHelper.Serializer.Serialize(plan);
+            Console.Write(yaml);
+        }
+        else
+        {
+            var field = settings.Field.ToLower();
 
-            if (string.IsNullOrWhiteSpace(settings.Field))
+            switch (field)
             {
-                // Output full YAML
-                var yaml = YamlHelper.Serializer.Serialize(plan);
-                Console.Write(yaml);
-            }
-            else
-            {
-                var field = settings.Field.ToLower();
-
-                // List fields — output one item per line
-                switch (field)
-                {
-                    case "repos":
-                        foreach (var r in plan.Repos) Console.WriteLine(r);
-                        return 0;
-                    case "prs":
-                        foreach (var pr in plan.Prs) Console.WriteLine(pr);
-                        return 0;
-                    case "commits":
-                        foreach (var c in plan.Commits) Console.WriteLine(c);
-                        return 0;
-                    case "verifications":
-                        foreach (var v in plan.Verifications) Console.WriteLine($"{v.Name}={v.Status}");
-                        return 0;
-                    case "dependson":
-                        foreach (var d in plan.DependsOn) Console.WriteLine(d);
-                        return 0;
-                    case "relatedplans":
-                        foreach (var rp in plan.RelatedPlans) Console.WriteLine(rp);
-                        return 0;
-                    case "recommendations":
-                        foreach (var rec in plan.Recommendations ?? [])
-                            Console.WriteLine($"{rec.Title}={rec.State}");
-                        return 0;
-                }
-
-                // Scalar fields
-                var value = field switch
-                {
-                    "state" => plan.State,
-                    "project" => plan.Project,
-                    "level" => plan.Level,
-                    "title" => plan.Title,
-                    "created" => plan.Created.ToString("O"),
-                    "updated" => plan.Updated.ToString("O"),
-                    "executionprofile" => plan.ExecutionProfile ?? "",
-                    "initialprompt" => plan.InitialPrompt ?? "",
-                    "sourceurl" => plan.SourceUrl ?? "",
-                    "priority" => plan.Priority.ToString(),
-                    _ => throw new ArgumentException($"Unknown field: {settings.Field}")
-                };
-
-                Console.WriteLine(value);
+                case "repos":
+                    foreach (var r in plan.Repos) Console.WriteLine(r);
+                    return 0;
+                case "prs":
+                    foreach (var pr in plan.Prs) Console.WriteLine(pr);
+                    return 0;
+                case "commits":
+                    foreach (var c in plan.Commits) Console.WriteLine(c);
+                    return 0;
+                case "verifications":
+                    foreach (var v in plan.Verifications) Console.WriteLine($"{v.Name}={v.Status}");
+                    return 0;
+                case "dependson":
+                    foreach (var d in plan.DependsOn) Console.WriteLine(d);
+                    return 0;
+                case "relatedplans":
+                    foreach (var rp in plan.RelatedPlans) Console.WriteLine(rp);
+                    return 0;
+                case "recommendations":
+                    foreach (var rec in plan.Recommendations ?? [])
+                        Console.WriteLine($"{rec.Title}={rec.State}");
+                    return 0;
             }
 
-            return 0;
+            var value = field switch
+            {
+                "state" => plan.State,
+                "project" => plan.Project,
+                "level" => plan.Level,
+                "title" => plan.Title,
+                "created" => plan.Created.ToString("O"),
+                "updated" => plan.Updated.ToString("O"),
+                "executionprofile" => plan.ExecutionProfile ?? "",
+                "initialprompt" => plan.InitialPrompt ?? "",
+                "sourceurl" => plan.SourceUrl ?? "",
+                "priority" => plan.Priority.ToString(),
+                _ => throw new ArgumentException($"Unknown field: {settings.Field}")
+            };
+
+            Console.WriteLine(value);
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to get plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanListCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanListCommand.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -45,86 +44,68 @@ public class PlanListSettings : CommandSettings
 
 public class PlanListCommand : Command<PlanListSettings>
 {
-    private readonly ILogger<PlanListCommand> _logger;
-
-    public PlanListCommand(ILogger<PlanListCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, PlanListSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var plansDirectory = Environment.GetEnvironmentVariable("TENDRIL_PLANS")?.Trim();
+        if (string.IsNullOrEmpty(plansDirectory))
         {
-            var plansDirectory = Environment.GetEnvironmentVariable("TENDRIL_PLANS")?.Trim();
-            if (string.IsNullOrEmpty(plansDirectory))
-            {
-                var home = Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
-                if (string.IsNullOrEmpty(home))
+            var home = Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
+            if (string.IsNullOrEmpty(home))
+                throw new InvalidOperationException("TENDRIL_HOME environment variable is not set");
+            plansDirectory = Path.Combine(home, "Plans");
+        }
+
+        if (!Directory.Exists(plansDirectory))
+            throw new InvalidOperationException($"Plans directory not found: {plansDirectory}");
+
+        var results = ScanPlans(plansDirectory, settings);
+
+        if (settings.Limit.HasValue && settings.Limit.Value > 0)
+            results = results.Take(settings.Limit.Value).ToList();
+
+        var format = (settings.Format ?? "table").ToLower();
+        switch (format)
+        {
+            case "ids":
+                foreach (var r in results) Console.WriteLine(r.Id);
+                break;
+            case "folders":
+                foreach (var r in results) Console.WriteLine(r.FolderName);
+                break;
+            case "json":
+                Console.WriteLine("[");
+                for (var i = 0; i < results.Count; i++)
                 {
-                    _logger.LogError("TENDRIL_HOME environment variable is not set");
-                    return 1;
+                    var r = results[i];
+                    var comma = i < results.Count - 1 ? "," : "";
+                    Console.WriteLine($"  {{\"id\":\"{Escape(r.Id)}\",\"title\":\"{Escape(r.Title)}\",\"state\":\"{Escape(r.State)}\",\"project\":\"{Escape(r.Project)}\",\"level\":\"{Escape(r.Level)}\"}}{comma}");
                 }
-                plansDirectory = Path.Combine(home, "Plans");
-            }
-
-            if (!Directory.Exists(plansDirectory))
-            {
-                _logger.LogError("Plans directory not found: {PlansDirectory}", plansDirectory);
-                return 1;
-            }
-
-            var results = ScanPlans(plansDirectory, settings);
-
-            if (settings.Limit.HasValue && settings.Limit.Value > 0)
-                results = results.Take(settings.Limit.Value).ToList();
-
-            var format = (settings.Format ?? "table").ToLower();
-            switch (format)
-            {
-                case "ids":
-                    foreach (var r in results) Console.WriteLine(r.Id);
-                    break;
-                case "folders":
-                    foreach (var r in results) Console.WriteLine(r.FolderName);
-                    break;
-                case "json":
-                    Console.WriteLine("[");
-                    for (var i = 0; i < results.Count; i++)
-                    {
-                        var r = results[i];
-                        var comma = i < results.Count - 1 ? "," : "";
-                        Console.WriteLine($"  {{\"id\":\"{Escape(r.Id)}\",\"title\":\"{Escape(r.Title)}\",\"state\":\"{Escape(r.State)}\",\"project\":\"{Escape(r.Project)}\",\"level\":\"{Escape(r.Level)}\"}}{comma}");
-                    }
-                    Console.WriteLine("]");
-                    break;
-                default:
-                    if (results.Count == 0)
-                    {
-                        AnsiConsole.MarkupLine("[dim]No plans found.[/]");
-                        return 0;
-                    }
-                    var table = new Spectre.Console.Table();
-                    table.AddColumn("Id");
-                    table.AddColumn("Title");
-                    table.AddColumn("State");
-                    table.AddColumn("Project");
-                    table.AddColumn("Level");
-                    foreach (var r in results)
-                        table.AddRow(
-                            r.Id.EscapeMarkup(),
-                            Truncate(r.Title, 40).EscapeMarkup(),
-                            r.State.EscapeMarkup(),
-                            r.Project.EscapeMarkup(),
-                            r.Level.EscapeMarkup());
-                    AnsiConsole.Write(table);
-                    break;
-            }
-
-            return 0;
+                Console.WriteLine("]");
+                break;
+            default:
+                if (results.Count == 0)
+                {
+                    AnsiConsole.MarkupLine("[dim]No plans found.[/]");
+                    return 0;
+                }
+                var table = new Spectre.Console.Table();
+                table.AddColumn("Id");
+                table.AddColumn("Title");
+                table.AddColumn("State");
+                table.AddColumn("Project");
+                table.AddColumn("Level");
+                foreach (var r in results)
+                    table.AddRow(
+                        r.Id.EscapeMarkup(),
+                        Truncate(r.Title, 40).EscapeMarkup(),
+                        r.State.EscapeMarkup(),
+                        r.Project.EscapeMarkup(),
+                        r.Level.EscapeMarkup());
+                AnsiConsole.Write(table);
+                break;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to list plans: {Message}", ex.Message);
-            return 1;
-        }
+
+        return 0;
     }
 
     internal static List<PlanListEntry> ScanPlans(string plansDirectory, PlanListSettings settings)

--- a/src/Ivy.Tendril/Commands/PlanRecCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRecCommand.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -104,302 +103,222 @@ public class PlanRecSetSettings : CommandSettings
 
 public class PlanRecListCommand : Command<PlanRecListSettings>
 {
-    private readonly ILogger<PlanRecListCommand> _logger;
-
-    public PlanRecListCommand(ILogger<PlanRecListCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, PlanRecListSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var recs = plan.Recommendations ?? [];
+
+        if (!string.IsNullOrEmpty(settings.State))
+            recs = recs.Where(r => r.State.Equals(settings.State, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        if (recs.Count == 0)
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-            var recs = plan.Recommendations ?? [];
-
-            if (!string.IsNullOrEmpty(settings.State))
-                recs = recs.Where(r => r.State.Equals(settings.State, StringComparison.OrdinalIgnoreCase)).ToList();
-
-            if (recs.Count == 0)
-            {
-                AnsiConsole.MarkupLine("[dim]No recommendations found.[/]");
-                return 0;
-            }
-
-            var table = new Spectre.Console.Table();
-            table.AddColumn("Title");
-            table.AddColumn("State");
-            table.AddColumn("Impact");
-            table.AddColumn("Risk");
-
-            foreach (var rec in recs)
-                table.AddRow(
-                    rec.Title.EscapeMarkup(),
-                    rec.State.EscapeMarkup(),
-                    (rec.Impact ?? "-").EscapeMarkup(),
-                    (rec.Risk ?? "-").EscapeMarkup());
-
-            AnsiConsole.Write(table);
+            AnsiConsole.MarkupLine("[dim]No recommendations found.[/]");
             return 0;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to list recommendations for plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+
+        var table = new Spectre.Console.Table();
+        table.AddColumn("Title");
+        table.AddColumn("State");
+        table.AddColumn("Impact");
+        table.AddColumn("Risk");
+
+        foreach (var rec in recs)
+            table.AddRow(
+                rec.Title.EscapeMarkup(),
+                rec.State.EscapeMarkup(),
+                (rec.Impact ?? "-").EscapeMarkup(),
+                (rec.Risk ?? "-").EscapeMarkup());
+
+        AnsiConsole.Write(table);
+        return 0;
     }
 }
 
 public class PlanRecAddCommand : Command<PlanRecAddSettings>
 {
-    private readonly ILogger<PlanRecAddCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanRecAddCommand(ILogger<PlanRecAddCommand> logger, IPlanWatcherService planWatcher)
+    public PlanRecAddCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanRecAddSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        plan.Recommendations ??= [];
+
+        if (plan.Recommendations.Any(r => r.Title.Equals(settings.Title, StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException($"Recommendation already exists: {settings.Title}");
+
+        var description = settings.Description;
+        if (string.IsNullOrEmpty(description))
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-
-            plan.Recommendations ??= [];
-
-            if (plan.Recommendations.Any(r => r.Title.Equals(settings.Title, StringComparison.OrdinalIgnoreCase)))
-            {
-                _logger.LogError("Recommendation already exists: {Title}", settings.Title);
-                return 1;
-            }
-
-            var description = settings.Description;
-            if (string.IsNullOrEmpty(description))
-            {
-                if (!Console.IsInputRedirected)
-                {
-                    _logger.LogError("Provide --description or pipe content via stdin");
-                    return 1;
-                }
-                description = Console.In.ReadToEnd().Trim();
-            }
-
-            plan.Recommendations.Add(new RecommendationYaml
-            {
-                Title = settings.Title,
-                Description = description,
-                State = RecommendationStatus.Pending,
-                Impact = settings.Impact,
-                Risk = settings.Risk
-            });
-
-            plan.Updated = DateTime.UtcNow;
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
-
-            _logger.LogInformation("Added recommendation: {Title}", settings.Title);
-            return 0;
+            if (!Console.IsInputRedirected)
+                throw new ArgumentException("Provide --description or pipe content via stdin");
+            description = Console.In.ReadToEnd().Trim();
         }
-        catch (Exception ex)
+
+        plan.Recommendations.Add(new RecommendationYaml
         {
-            _logger.LogError("Failed to add recommendation to plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+            Title = settings.Title,
+            Description = description,
+            State = RecommendationStatus.Pending,
+            Impact = settings.Impact,
+            Risk = settings.Risk
+        });
+
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+        Console.WriteLine($"Added recommendation: {settings.Title}");
+        return 0;
     }
 }
 
 public class PlanRecRemoveCommand : Command<PlanRecRemoveSettings>
 {
-    private readonly ILogger<PlanRecRemoveCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanRecRemoveCommand(ILogger<PlanRecRemoveCommand> logger, IPlanWatcherService planWatcher)
+    public PlanRecRemoveCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanRecRemoveSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-            var recs = plan.Recommendations ?? [];
-            var match = recs.FirstOrDefault(r => r.Title.Equals(settings.Title, StringComparison.OrdinalIgnoreCase));
+        var recs = plan.Recommendations ?? [];
+        var match = recs.FirstOrDefault(r => r.Title.Equals(settings.Title, StringComparison.OrdinalIgnoreCase));
 
-            if (match == null)
-            {
-                _logger.LogError("Recommendation not found: {Title}", settings.Title);
-                return 1;
-            }
+        if (match == null)
+            throw new InvalidOperationException($"Recommendation not found: {settings.Title}");
 
-            recs.Remove(match);
-            plan.Updated = DateTime.UtcNow;
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+        recs.Remove(match);
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Removed recommendation: {Title}", settings.Title);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to remove recommendation from plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+        Console.WriteLine($"Removed recommendation: {settings.Title}");
+        return 0;
     }
 }
 
 public class PlanRecAcceptCommand : Command<PlanRecAcceptSettings>
 {
-    private readonly ILogger<PlanRecAcceptCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanRecAcceptCommand(ILogger<PlanRecAcceptCommand> logger, IPlanWatcherService planWatcher)
+    public PlanRecAcceptCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanRecAcceptSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-            var rec = (plan.Recommendations ?? [])
-                .FirstOrDefault(r => r.Title.Equals(settings.Title, StringComparison.OrdinalIgnoreCase));
+        var rec = (plan.Recommendations ?? [])
+            .FirstOrDefault(r => r.Title.Equals(settings.Title, StringComparison.OrdinalIgnoreCase));
 
-            if (rec == null)
-            {
-                _logger.LogError("Recommendation not found: {Title}", settings.Title);
-                return 1;
-            }
+        if (rec == null)
+            throw new InvalidOperationException($"Recommendation not found: {settings.Title}");
 
-            rec.State = string.IsNullOrEmpty(settings.Notes) ? RecommendationStatus.Accepted : RecommendationStatus.AcceptedWithNotes;
-            rec.DeclineReason = null;
+        rec.State = string.IsNullOrEmpty(settings.Notes) ? RecommendationStatus.Accepted : RecommendationStatus.AcceptedWithNotes;
+        rec.DeclineReason = null;
 
-            plan.Updated = DateTime.UtcNow;
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Accepted recommendation: {Title}", settings.Title);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to accept recommendation for plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+        Console.WriteLine($"Accepted recommendation: {settings.Title}");
+        return 0;
     }
 }
 
 public class PlanRecDeclineCommand : Command<PlanRecDeclineSettings>
 {
-    private readonly ILogger<PlanRecDeclineCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanRecDeclineCommand(ILogger<PlanRecDeclineCommand> logger, IPlanWatcherService planWatcher)
+    public PlanRecDeclineCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanRecDeclineSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-            var rec = (plan.Recommendations ?? [])
-                .FirstOrDefault(r => r.Title.Equals(settings.Title, StringComparison.OrdinalIgnoreCase));
+        var rec = (plan.Recommendations ?? [])
+            .FirstOrDefault(r => r.Title.Equals(settings.Title, StringComparison.OrdinalIgnoreCase));
 
-            if (rec == null)
-            {
-                _logger.LogError("Recommendation not found: {Title}", settings.Title);
-                return 1;
-            }
+        if (rec == null)
+            throw new InvalidOperationException($"Recommendation not found: {settings.Title}");
 
-            rec.State = RecommendationStatus.Declined;
-            rec.DeclineReason = settings.Reason;
+        rec.State = RecommendationStatus.Declined;
+        rec.DeclineReason = settings.Reason;
 
-            plan.Updated = DateTime.UtcNow;
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Declined recommendation: {Title}", settings.Title);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to decline recommendation for plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+        Console.WriteLine($"Declined recommendation: {settings.Title}");
+        return 0;
     }
 }
 
 public class PlanRecSetCommand : Command<PlanRecSetSettings>
 {
-    private readonly ILogger<PlanRecSetCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanRecSetCommand(ILogger<PlanRecSetCommand> logger, IPlanWatcherService planWatcher)
+    public PlanRecSetCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanRecSetSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        var rec = (plan.Recommendations ?? [])
+            .FirstOrDefault(r => r.Title.Equals(settings.Title, StringComparison.OrdinalIgnoreCase));
+
+        if (rec == null)
+            throw new InvalidOperationException($"Recommendation not found: {settings.Title}");
+
+        switch (settings.Field.ToLower())
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-
-            var rec = (plan.Recommendations ?? [])
-                .FirstOrDefault(r => r.Title.Equals(settings.Title, StringComparison.OrdinalIgnoreCase));
-
-            if (rec == null)
-            {
-                _logger.LogError("Recommendation not found: {Title}", settings.Title);
-                return 1;
-            }
-
-            switch (settings.Field.ToLower())
-            {
-                case "title":
-                    rec.Title = settings.Value;
-                    break;
-                case "description":
-                    rec.Description = settings.Value;
-                    break;
-                case "state":
-                    rec.State = settings.Value;
-                    break;
-                case "impact":
-                    rec.Impact = settings.Value;
-                    break;
-                case "risk":
-                    rec.Risk = settings.Value;
-                    break;
-                case "declinereason":
-                    rec.DeclineReason = settings.Value;
-                    break;
-                default:
-                    throw new ArgumentException($"Unknown field: {settings.Field}");
-            }
-
-            plan.Updated = DateTime.UtcNow;
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
-
-            _logger.LogInformation("Updated recommendation {Field} to '{Value}'", settings.Field, settings.Value);
-            return 0;
+            case "title":
+                rec.Title = settings.Value;
+                break;
+            case "description":
+                rec.Description = settings.Value;
+                break;
+            case "state":
+                rec.State = settings.Value;
+                break;
+            case "impact":
+                rec.Impact = settings.Value;
+                break;
+            case "risk":
+                rec.Risk = settings.Value;
+                break;
+            case "declinereason":
+                rec.DeclineReason = settings.Value;
+                break;
+            default:
+                throw new ArgumentException($"Unknown field: {settings.Field}");
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to set recommendation field for plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+        Console.WriteLine($"Updated recommendation {settings.Field} to '{settings.Value}'");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanRemoveDependsOnCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveDependsOnCommand.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -19,41 +18,28 @@ public class PlanRemoveDependsOnSettings : CommandSettings
 
 public class PlanRemoveDependsOnCommand : Command<PlanRemoveDependsOnSettings>
 {
-    private readonly ILogger<PlanRemoveDependsOnCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanRemoveDependsOnCommand(ILogger<PlanRemoveDependsOnCommand> logger, IPlanWatcherService planWatcher)
+    public PlanRemoveDependsOnCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanRemoveDependsOnSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-            var resolvedDep = PlanCommandHelpers.ResolvePlanFolderName(settings.DependsOn);
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var resolvedDep = PlanCommandHelpers.ResolvePlanFolderName(settings.DependsOn);
 
-            var removed = plan.DependsOn.RemoveAll(d => d.Equals(resolvedDep, StringComparison.OrdinalIgnoreCase));
-            if (removed == 0)
-            {
-                _logger.LogError("Dependency not found: {DependsOn}", resolvedDep);
-                return 1;
-            }
+        var removed = plan.DependsOn.RemoveAll(d => d.Equals(resolvedDep, StringComparison.OrdinalIgnoreCase));
+        if (removed == 0)
+            throw new InvalidOperationException($"Dependency not found: {resolvedDep}");
 
-            plan.Updated = DateTime.UtcNow;
+        plan.Updated = DateTime.UtcNow;
 
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Removed dependency: {DependsOn}", resolvedDep);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to remove dependency from plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+        Console.WriteLine($"Removed dependency: {resolvedDep}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanRemoveRelatedPlanCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveRelatedPlanCommand.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -19,41 +18,28 @@ public class PlanRemoveRelatedPlanSettings : CommandSettings
 
 public class PlanRemoveRelatedPlanCommand : Command<PlanRemoveRelatedPlanSettings>
 {
-    private readonly ILogger<PlanRemoveRelatedPlanCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanRemoveRelatedPlanCommand(ILogger<PlanRemoveRelatedPlanCommand> logger, IPlanWatcherService planWatcher)
+    public PlanRemoveRelatedPlanCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanRemoveRelatedPlanSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-            var resolvedRp = PlanCommandHelpers.ResolvePlanFolderName(settings.RelatedPlan);
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var resolvedRp = PlanCommandHelpers.ResolvePlanFolderName(settings.RelatedPlan);
 
-            var removed = plan.RelatedPlans.RemoveAll(r => r.Equals(resolvedRp, StringComparison.OrdinalIgnoreCase));
-            if (removed == 0)
-            {
-                _logger.LogError("Related plan not found: {RelatedPlan}", resolvedRp);
-                return 1;
-            }
+        var removed = plan.RelatedPlans.RemoveAll(r => r.Equals(resolvedRp, StringComparison.OrdinalIgnoreCase));
+        if (removed == 0)
+            throw new InvalidOperationException($"Related plan not found: {resolvedRp}");
 
-            plan.Updated = DateTime.UtcNow;
+        plan.Updated = DateTime.UtcNow;
 
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Removed related plan: {RelatedPlan}", resolvedRp);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to remove related plan from plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+        Console.WriteLine($"Removed related plan: {resolvedRp}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanRemoveRepoCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveRepoCommand.cs
@@ -2,7 +2,6 @@ using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -20,41 +19,27 @@ public class PlanRemoveRepoSettings : CommandSettings
 
 public class PlanRemoveRepoCommand : Command<PlanRemoveRepoSettings>
 {
-    private readonly ILogger<PlanRemoveRepoCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanRemoveRepoCommand(ILogger<PlanRemoveRepoCommand> logger, IPlanWatcherService planWatcher)
+    public PlanRemoveRepoCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanRemoveRepoSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-            // Remove repo (case-insensitive)
-            var removed = plan.Repos.RemoveAll(r => r.Equals(settings.RepoPath, StringComparison.OrdinalIgnoreCase));
-            if (removed == 0)
-            {
-                _logger.LogError("Repository not found in plan: {RepoPath}", settings.RepoPath);
-                return 1;
-            }
+        var removed = plan.Repos.RemoveAll(r => r.Equals(settings.RepoPath, StringComparison.OrdinalIgnoreCase));
+        if (removed == 0)
+            throw new InvalidOperationException($"Repository not found in plan: {settings.RepoPath}");
 
-            plan.Updated = DateTime.UtcNow;
+        plan.Updated = DateTime.UtcNow;
 
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Removed repository: {RepoPath}", settings.RepoPath);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to remove repository from plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+        Console.WriteLine($"Removed repository: {settings.RepoPath}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanRemoveWorktreeCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveWorktreeCommand.cs
@@ -32,59 +32,50 @@ public class PlanRemoveWorktreeCommand : Command<PlanRemoveWorktreeSettings>
 
     protected override int Execute(CommandContext context, PlanRemoveWorktreeSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var worktreePath = Path.Combine(planFolder, "Worktrees", settings.RepoName);
+
+        if (!Directory.Exists(worktreePath))
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var worktreePath = Path.Combine(planFolder, "Worktrees", settings.RepoName);
+            AnsiConsole.MarkupLine($"[yellow]Worktree directory not found: {worktreePath.EscapeMarkup()}[/]");
+            return 0;
+        }
+
+        var branchName = settings.Branch ?? DeriveBranchName(planFolder);
+        var repoRoot = ResolveRepoRoot(worktreePath);
+
+        if (repoRoot != null)
+        {
+            var psi = new ProcessStartInfo("git", $"worktree remove --force \"{worktreePath}\"")
+            {
+                WorkingDirectory = repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            using var process = Process.Start(psi);
+            process?.WaitForExit(30000);
 
             if (!Directory.Exists(worktreePath))
             {
-                AnsiConsole.MarkupLine($"[yellow]Worktree directory not found: {worktreePath.EscapeMarkup()}[/]");
+                DeleteBranch(repoRoot, branchName);
+                AnsiConsole.MarkupLine("[green]Worktree removed successfully.[/]");
                 return 0;
             }
+        }
 
-            var branchName = settings.Branch ?? DeriveBranchName(planFolder);
-            var repoRoot = ResolveRepoRoot(worktreePath);
+        WorktreeCleanupService.ForceDeleteDirectory(worktreePath, _logger);
 
+        if (!Directory.Exists(worktreePath))
+        {
             if (repoRoot != null)
-            {
-                var psi = new ProcessStartInfo("git", $"worktree remove --force \"{worktreePath}\"")
-                {
-                    WorkingDirectory = repoRoot,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-                using var process = Process.Start(psi);
-                process?.WaitForExit(30000);
-
-                if (!Directory.Exists(worktreePath))
-                {
-                    DeleteBranch(repoRoot, branchName);
-                    AnsiConsole.MarkupLine("[green]Worktree removed successfully.[/]");
-                    return 0;
-                }
-            }
-
-            WorktreeCleanupService.ForceDeleteDirectory(worktreePath, _logger);
-
-            if (!Directory.Exists(worktreePath))
-            {
-                if (repoRoot != null)
-                    DeleteBranch(repoRoot, branchName);
-                AnsiConsole.MarkupLine("[green]Worktree removed (force delete).[/]");
-                return 0;
-            }
-
-            AnsiConsole.MarkupLine("[red]Failed to remove worktree.[/]");
-            return 1;
+                DeleteBranch(repoRoot, branchName);
+            AnsiConsole.MarkupLine("[green]Worktree removed (force delete).[/]");
+            return 0;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to remove worktree for plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+
+        throw new InvalidOperationException("Failed to remove worktree.");
     }
 
     private static string? ResolveRepoRoot(string worktreePath)

--- a/src/Ivy.Tendril/Commands/PlanSetCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetCommand.cs
@@ -2,7 +2,6 @@ using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -24,74 +23,62 @@ public class PlanSetSettings : CommandSettings
 
 public class PlanSetCommand : Command<PlanSetSettings>
 {
-    private readonly ILogger<PlanSetCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanSetCommand(ILogger<PlanSetCommand> logger, IPlanWatcherService planWatcher)
+    public PlanSetCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanSetSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        switch (settings.Field.ToLower())
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-
-            // Update the field
-            switch (settings.Field.ToLower())
-            {
-                case "state":
-                    plan.State = settings.Value;
-                    break;
-                case "project":
-                    plan.Project = settings.Value;
-                    break;
-                case "level":
-                    plan.Level = settings.Value;
-                    break;
-                case "title":
-                    plan.Title = settings.Value;
-                    break;
-                case "created":
-                    plan.Created = PlanValidationService.ParseDate(settings.Value, "created");
-                    break;
-                case "updated":
-                    plan.Updated = PlanValidationService.ParseDate(settings.Value, "updated");
-                    break;
-                case "executionprofile":
-                    plan.ExecutionProfile = settings.Value;
-                    break;
-                case "initialprompt":
-                    plan.InitialPrompt = settings.Value;
-                    break;
-                case "sourceurl":
-                    plan.SourceUrl = settings.Value;
-                    break;
-                case "priority":
-                    if (!int.TryParse(settings.Value, out var priority))
-                        throw new ArgumentException($"Invalid priority value: {settings.Value}. Must be an integer.");
-                    plan.Priority = priority;
-                    break;
-                default:
-                    throw new ArgumentException($"Unknown field: {settings.Field}");
-            }
-
-            // Always update the 'updated' timestamp when any field changes
-            if (settings.Field.ToLower() != "updated")
-                plan.Updated = DateTime.UtcNow;
-
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
-
-            _logger.LogInformation("Set {Field} = {Value}", settings.Field, settings.Value);
-            return 0;
+            case "state":
+                plan.State = settings.Value;
+                break;
+            case "project":
+                plan.Project = settings.Value;
+                break;
+            case "level":
+                plan.Level = settings.Value;
+                break;
+            case "title":
+                plan.Title = settings.Value;
+                break;
+            case "created":
+                plan.Created = PlanValidationService.ParseDate(settings.Value, "created");
+                break;
+            case "updated":
+                plan.Updated = PlanValidationService.ParseDate(settings.Value, "updated");
+                break;
+            case "executionprofile":
+                plan.ExecutionProfile = settings.Value;
+                break;
+            case "initialprompt":
+                plan.InitialPrompt = settings.Value;
+                break;
+            case "sourceurl":
+                plan.SourceUrl = settings.Value;
+                break;
+            case "priority":
+                if (!int.TryParse(settings.Value, out var priority))
+                    throw new ArgumentException($"Invalid priority value: {settings.Value}. Must be an integer.");
+                plan.Priority = priority;
+                break;
+            default:
+                throw new ArgumentException($"Unknown field: {settings.Field}");
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to set {Field} on plan {PlanId}: {Message}", settings.Field, settings.PlanId, ex.Message);
-            return 1;
-        }
+
+        if (settings.Field.ToLower() != "updated")
+            plan.Updated = DateTime.UtcNow;
+
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+        Console.WriteLine($"Set {settings.Field} = {settings.Value}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -24,52 +23,39 @@ public class PlanSetVerificationSettings : CommandSettings
 
 public class PlanSetVerificationCommand : Command<PlanSetVerificationSettings>
 {
-    private readonly ILogger<PlanSetVerificationCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanSetVerificationCommand(ILogger<PlanSetVerificationCommand> logger, IPlanWatcherService planWatcher)
+    public PlanSetVerificationCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanSetVerificationSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        var verification = plan.Verifications.FirstOrDefault(v =>
+            v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+
+        if (verification != null)
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-
-            // Find existing verification
-            var verification = plan.Verifications.FirstOrDefault(v =>
-                v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
-
-            if (verification != null)
-            {
-                // Update existing
-                verification.Status = settings.Status;
-            }
-            else
-            {
-                // Add new
-                plan.Verifications.Add(new PlanVerificationEntry
-                {
-                    Name = settings.Name,
-                    Status = settings.Status
-                });
-            }
-
-            plan.Updated = DateTime.UtcNow;
-
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
-
-            _logger.LogInformation("Set verification {Name} = {Status}", settings.Name, settings.Status);
-            return 0;
+            verification.Status = settings.Status;
         }
-        catch (Exception ex)
+        else
         {
-            _logger.LogError("Failed to set verification on plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
+            plan.Verifications.Add(new PlanVerificationEntry
+            {
+                Name = settings.Name,
+                Status = settings.Status
+            });
         }
+
+        plan.Updated = DateTime.UtcNow;
+
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+
+        Console.WriteLine($"Set verification {settings.Name} = {settings.Status}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanUpdateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanUpdateCommand.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -16,41 +15,28 @@ public class PlanUpdateSettings : CommandSettings
 
 public class PlanUpdateCommand : Command<PlanUpdateSettings>
 {
-    private readonly ILogger<PlanUpdateCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanUpdateCommand(ILogger<PlanUpdateCommand> logger, IPlanWatcherService planWatcher)
+    public PlanUpdateCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanUpdateSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
 
-            // Read YAML from STDIN
-            var yaml = ConsoleHelper.ReadStdinWithTimeout();
-            if (string.IsNullOrWhiteSpace(yaml))
-                throw new ArgumentException("No YAML content provided on STDIN");
+        var yaml = ConsoleHelper.ReadStdinWithTimeout();
+        if (string.IsNullOrWhiteSpace(yaml))
+            throw new ArgumentException("No YAML content provided on STDIN");
 
-            // Deserialize
-            var plan = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml);
-            if (plan == null)
-                throw new InvalidOperationException("Failed to deserialize YAML from STDIN");
+        var plan = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml);
+        if (plan == null)
+            throw new InvalidOperationException("Failed to deserialize YAML from STDIN");
 
-            // Write with validation
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Updated plan {PlanId}", settings.PlanId);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to update plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+        Console.WriteLine($"Updated plan {settings.PlanId}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanValidateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanValidateCommand.cs
@@ -2,7 +2,6 @@ using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -16,27 +15,14 @@ public class PlanValidateSettings : CommandSettings
 
 public class PlanValidateCommand : Command<PlanValidateSettings>
 {
-    private readonly ILogger<PlanValidateCommand> _logger;
-
-    public PlanValidateCommand(ILogger<PlanValidateCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, PlanValidateSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-            // Validate the plan
-            PlanValidationService.Validate(plan);
+        PlanValidationService.Validate(plan);
 
-            _logger.LogInformation("Plan {PlanId} is valid", settings.PlanId);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Validation failed for plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+        Console.WriteLine($"Plan {settings.PlanId} is valid");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanVerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanVerificationCommand.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
-using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -47,127 +46,89 @@ public class PlanVerificationRemoveSettings : CommandSettings
 
 public class PlanVerificationListCommand : Command<PlanVerificationListSettings>
 {
-    private readonly ILogger<PlanVerificationListCommand> _logger;
-
-    public PlanVerificationListCommand(ILogger<PlanVerificationListCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, PlanVerificationListSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var verifications = plan.Verifications;
+
+        if (!string.IsNullOrEmpty(settings.Status))
+            verifications = verifications.Where(v => v.Status.Equals(settings.Status, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        if (verifications.Count == 0)
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
-            var verifications = plan.Verifications;
-
-            if (!string.IsNullOrEmpty(settings.Status))
-                verifications = verifications.Where(v => v.Status.Equals(settings.Status, StringComparison.OrdinalIgnoreCase)).ToList();
-
-            if (verifications.Count == 0)
-            {
-                AnsiConsole.MarkupLine("[dim]No verifications found.[/]");
-                return 0;
-            }
-
-            var table = new Spectre.Console.Table();
-            table.AddColumn("Name");
-            table.AddColumn("Status");
-
-            foreach (var v in verifications)
-                table.AddRow(v.Name.EscapeMarkup(), v.Status.EscapeMarkup());
-
-            AnsiConsole.Write(table);
+            AnsiConsole.MarkupLine("[dim]No verifications found.[/]");
             return 0;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to list verifications for plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+
+        var table = new Spectre.Console.Table();
+        table.AddColumn("Name");
+        table.AddColumn("Status");
+
+        foreach (var v in verifications)
+            table.AddRow(v.Name.EscapeMarkup(), v.Status.EscapeMarkup());
+
+        AnsiConsole.Write(table);
+        return 0;
     }
 }
 
 public class PlanVerificationAddCommand : Command<PlanVerificationAddSettings>
 {
-    private readonly ILogger<PlanVerificationAddCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanVerificationAddCommand(ILogger<PlanVerificationAddCommand> logger, IPlanWatcherService planWatcher)
+    public PlanVerificationAddCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanVerificationAddSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        if (plan.Verifications.Any(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException($"Verification already exists: {settings.Name}");
+
+        plan.Verifications.Add(new PlanVerificationEntry
         {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            Name = settings.Name,
+            Status = settings.Status ?? VerificationStatus.Pending
+        });
 
-            if (plan.Verifications.Any(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
-            {
-                _logger.LogError("Verification already exists: {Name}", settings.Name);
-                return 1;
-            }
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            plan.Verifications.Add(new PlanVerificationEntry
-            {
-                Name = settings.Name,
-                Status = settings.Status ?? VerificationStatus.Pending
-            });
-
-            plan.Updated = DateTime.UtcNow;
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
-
-            _logger.LogInformation("Added verification: {Name}", settings.Name);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to add verification to plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+        Console.WriteLine($"Added verification: {settings.Name}");
+        return 0;
     }
 }
 
 public class PlanVerificationRemoveCommand : Command<PlanVerificationRemoveSettings>
 {
-    private readonly ILogger<PlanVerificationRemoveCommand> _logger;
     private readonly IPlanWatcherService _planWatcher;
 
-    public PlanVerificationRemoveCommand(ILogger<PlanVerificationRemoveCommand> logger, IPlanWatcherService planWatcher)
+    public PlanVerificationRemoveCommand(IPlanWatcherService planWatcher)
     {
-        _logger = logger;
         _planWatcher = planWatcher;
     }
 
     protected override int Execute(CommandContext context, PlanVerificationRemoveSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-            var match = plan.Verifications
-                .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+        var match = plan.Verifications
+            .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-            if (match == null)
-            {
-                _logger.LogError("Verification not found: {Name}", settings.Name);
-                return 1;
-            }
+        if (match == null)
+            throw new InvalidOperationException($"Verification not found: {settings.Name}");
 
-            plan.Verifications.Remove(match);
-            plan.Updated = DateTime.UtcNow;
-            PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
+        plan.Verifications.Remove(match);
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcher);
 
-            _logger.LogInformation("Removed verification: {Name}", settings.Name);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to remove verification from plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+        Console.WriteLine($"Removed verification: {settings.Name}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -18,37 +17,25 @@ public class PlanWriteRevisionSettings : CommandSettings
 
 public class PlanWriteRevisionCommand : Command<PlanWriteRevisionSettings>
 {
-    private readonly ILogger<PlanWriteRevisionCommand> _logger;
-
-    public PlanWriteRevisionCommand(ILogger<PlanWriteRevisionCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, PlanWriteRevisionSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-            var revisionsDir = Path.Combine(planFolder, "Revisions");
-            Directory.CreateDirectory(revisionsDir);
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var revisionsDir = Path.Combine(planFolder, "Revisions");
+        Directory.CreateDirectory(revisionsDir);
 
-            var number = ResolveRevisionNumber(revisionsDir);
-            var filename = $"{number:D3}.md";
-            var filePath = Path.Combine(revisionsDir, filename);
+        var number = ResolveRevisionNumber(revisionsDir);
+        var filename = $"{number:D3}.md";
+        var filePath = Path.Combine(revisionsDir, filename);
 
-            var content = !string.IsNullOrEmpty(settings.FilePath)
-                ? File.ReadAllText(settings.FilePath)
-                : ConsoleHelper.ReadStdinWithTimeout();
-            if (string.IsNullOrWhiteSpace(content))
-                throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
+        var content = !string.IsNullOrEmpty(settings.FilePath)
+            ? File.ReadAllText(settings.FilePath)
+            : ConsoleHelper.ReadStdinWithTimeout();
+        if (string.IsNullOrWhiteSpace(content))
+            throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
 
-            File.WriteAllText(filePath, content);
-            Console.Write(filePath);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to write revision for plan {PlanId}: {Message}", settings.PlanId, ex.Message);
-            return 1;
-        }
+        File.WriteAllText(filePath, content);
+        Console.Write(filePath);
+        return 0;
     }
 
     private static int ResolveRevisionNumber(string revisionsDir)

--- a/src/Ivy.Tendril/Commands/ProjectCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectCommand.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using Ivy.Tendril.Services;
-using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -193,676 +192,430 @@ public class ProjectRemoveReviewActionSettings : CommandSettings
 
 public class ProjectListCommand : Command<ProjectListSettings>
 {
-    private readonly ILogger<ProjectListCommand> _logger;
-
-    public ProjectListCommand(ILogger<ProjectListCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectListSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var config = new ConfigService();
+        var projects = config.Settings.Projects;
+
+        if (projects.Count == 0)
         {
-            var config = new ConfigService();
-            var projects = config.Settings.Projects;
-
-            if (projects.Count == 0)
-            {
-                AnsiConsole.MarkupLine("[dim]No projects found.[/]");
-                return 0;
-            }
-
-            foreach (var p in projects)
-                AnsiConsole.MarkupLine(p.Name.EscapeMarkup());
+            AnsiConsole.MarkupLine("[dim]No projects found.[/]");
             return 0;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to list projects: {Message}", ex.Message);
-            return 1;
-        }
+
+        foreach (var p in projects)
+            AnsiConsole.MarkupLine(p.Name.EscapeMarkup());
+        return 0;
     }
 }
 
 public class ProjectGetCommand : Command<ProjectGetSettings>
 {
-    private readonly ILogger<ProjectGetCommand> _logger;
-
-    public ProjectGetCommand(ILogger<ProjectGetCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectGetSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var config = new ConfigService();
+        var project = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+
+        if (project == null)
+            throw new InvalidOperationException($"Project not found: {settings.Name}");
+
+        AnsiConsole.MarkupLine($"[bold]{project.Name.EscapeMarkup()}[/]");
+        if (!string.IsNullOrEmpty(project.Color))
+            AnsiConsole.MarkupLine($"  Color: {project.Color.EscapeMarkup()}");
+        if (!string.IsNullOrEmpty(project.Context))
+            AnsiConsole.MarkupLine($"  Context: {project.Context.EscapeMarkup()}");
+
+        if (project.Repos.Count > 0)
         {
-            var config = new ConfigService();
-            var project = config.Settings.Projects
-                .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
-
-            if (project == null)
-            {
-                _logger.LogError("Project not found: {Name}", settings.Name);
-                return 1;
-            }
-
-            AnsiConsole.MarkupLine($"[bold]{project.Name.EscapeMarkup()}[/]");
-            if (!string.IsNullOrEmpty(project.Color))
-                AnsiConsole.MarkupLine($"  Color: {project.Color.EscapeMarkup()}");
-            if (!string.IsNullOrEmpty(project.Context))
-                AnsiConsole.MarkupLine($"  Context: {project.Context.EscapeMarkup()}");
-
-            if (project.Repos.Count > 0)
-            {
-                AnsiConsole.MarkupLine("\n[bold]Repositories[/]");
-                var repoTable = new Spectre.Console.Table();
-                repoTable.AddColumn("Path");
-                repoTable.AddColumn("PR Rule");
-                repoTable.AddColumn("Base Branch");
-                foreach (var r in project.Repos)
-                    repoTable.AddRow(
-                        r.Path.EscapeMarkup(),
-                        r.PrRule.EscapeMarkup(),
-                        (r.BaseBranch ?? "-").EscapeMarkup());
-                AnsiConsole.Write(repoTable);
-            }
-
-            if (project.Verifications.Count > 0)
-            {
-                AnsiConsole.MarkupLine("\n[bold]Verifications[/]");
-                var verTable = new Spectre.Console.Table();
-                verTable.AddColumn("Name");
-                verTable.AddColumn("Required");
-                foreach (var v in project.Verifications)
-                    verTable.AddRow(v.Name.EscapeMarkup(), v.Required ? "Yes" : "No");
-                AnsiConsole.Write(verTable);
-            }
-
-            if (project.ReviewActions.Count > 0)
-            {
-                AnsiConsole.MarkupLine("\n[bold]Review Actions[/]");
-                var raTable = new Spectre.Console.Table();
-                raTable.AddColumn("Name");
-                raTable.AddColumn("Command");
-                raTable.AddColumn("Condition");
-                foreach (var ra in project.ReviewActions)
-                    raTable.AddRow(
-                        ra.Name.EscapeMarkup(),
-                        ra.Command.EscapeMarkup(),
-                        ra.Condition.EscapeMarkup());
-                AnsiConsole.Write(raTable);
-            }
-
-            if (project.BuildDependencies.Count > 0)
-            {
-                AnsiConsole.MarkupLine("\n[bold]Build Dependencies[/]");
-                foreach (var dep in project.BuildDependencies)
-                    AnsiConsole.MarkupLine($"  - {dep.EscapeMarkup()}");
-            }
-
-            return 0;
+            AnsiConsole.MarkupLine("\n[bold]Repositories[/]");
+            var repoTable = new Spectre.Console.Table();
+            repoTable.AddColumn("Path");
+            repoTable.AddColumn("PR Rule");
+            repoTable.AddColumn("Base Branch");
+            foreach (var r in project.Repos)
+                repoTable.AddRow(
+                    r.Path.EscapeMarkup(),
+                    r.PrRule.EscapeMarkup(),
+                    (r.BaseBranch ?? "-").EscapeMarkup());
+            AnsiConsole.Write(repoTable);
         }
-        catch (Exception ex)
+
+        if (project.Verifications.Count > 0)
         {
-            _logger.LogError("Failed to get project: {Message}", ex.Message);
-            return 1;
+            AnsiConsole.MarkupLine("\n[bold]Verifications[/]");
+            var verTable = new Spectre.Console.Table();
+            verTable.AddColumn("Name");
+            verTable.AddColumn("Required");
+            foreach (var v in project.Verifications)
+                verTable.AddRow(v.Name.EscapeMarkup(), v.Required ? "Yes" : "No");
+            AnsiConsole.Write(verTable);
         }
+
+        if (project.ReviewActions.Count > 0)
+        {
+            AnsiConsole.MarkupLine("\n[bold]Review Actions[/]");
+            var raTable = new Spectre.Console.Table();
+            raTable.AddColumn("Name");
+            raTable.AddColumn("Command");
+            raTable.AddColumn("Condition");
+            foreach (var ra in project.ReviewActions)
+                raTable.AddRow(
+                    ra.Name.EscapeMarkup(),
+                    ra.Command.EscapeMarkup(),
+                    ra.Condition.EscapeMarkup());
+            AnsiConsole.Write(raTable);
+        }
+
+        if (project.BuildDependencies.Count > 0)
+        {
+            AnsiConsole.MarkupLine("\n[bold]Build Dependencies[/]");
+            foreach (var dep in project.BuildDependencies)
+                AnsiConsole.MarkupLine($"  - {dep.EscapeMarkup()}");
+        }
+
+        return 0;
     }
 }
 
 public class ProjectAddCommand : Command<ProjectAddSettings>
 {
-    private readonly ILogger<ProjectAddCommand> _logger;
-
-    public ProjectAddCommand(ILogger<ProjectAddCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectAddSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var config = new ConfigService();
+
+        if (config.Settings.Projects.Any(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException($"Project already exists: {settings.Name}");
+
+        config.Settings.Projects.Add(new ProjectConfig
         {
-            var config = new ConfigService();
+            Name = settings.Name,
+            Color = settings.Color ?? "",
+            Context = settings.Context ?? ""
+        });
 
-            if (config.Settings.Projects.Any(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
-            {
-                _logger.LogError("Project already exists: {Name}", settings.Name);
-                return 1;
-            }
-
-            config.Settings.Projects.Add(new ProjectConfig
-            {
-                Name = settings.Name,
-                Color = settings.Color ?? "",
-                Context = settings.Context ?? ""
-            });
-
-            config.SaveSettings();
-            _logger.LogInformation("Added project: {Name}", settings.Name);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to add project: {Message}", ex.Message);
-            return 1;
-        }
+        config.SaveSettings();
+        Console.WriteLine($"Added project: {settings.Name}");
+        return 0;
     }
 }
 
 public class ProjectRemoveCommand : Command<ProjectRemoveSettings>
 {
-    private readonly ILogger<ProjectRemoveCommand> _logger;
-
-    public ProjectRemoveCommand(ILogger<ProjectRemoveCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectRemoveSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var config = new ConfigService();
-            var match = config.Settings.Projects
-                .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+        var config = new ConfigService();
+        var match = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-            if (match == null)
-            {
-                _logger.LogError("Project not found: {Name}", settings.Name);
-                return 1;
-            }
+        if (match == null)
+            throw new InvalidOperationException($"Project not found: {settings.Name}");
 
-            config.Settings.Projects.Remove(match);
-            config.SaveSettings();
-            _logger.LogInformation("Removed project: {Name}", settings.Name);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to remove project: {Message}", ex.Message);
-            return 1;
-        }
+        config.Settings.Projects.Remove(match);
+        config.SaveSettings();
+        Console.WriteLine($"Removed project: {settings.Name}");
+        return 0;
     }
 }
 
 public class ProjectSetCommand : Command<ProjectSetSettings>
 {
-    private readonly ILogger<ProjectSetCommand> _logger;
-
-    public ProjectSetCommand(ILogger<ProjectSetCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectSetSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var config = new ConfigService();
+        var match = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+
+        if (match == null)
+            throw new InvalidOperationException($"Project not found: {settings.Name}");
+
+        switch (settings.Field.ToLower())
         {
-            var config = new ConfigService();
-            var match = config.Settings.Projects
-                .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
-
-            if (match == null)
-            {
-                _logger.LogError("Project not found: {Name}", settings.Name);
-                return 1;
-            }
-
-            switch (settings.Field.ToLower())
-            {
-                case "name":
-                    match.Name = settings.Value;
-                    break;
-                case "color":
-                    match.Color = settings.Value;
-                    break;
-                case "context":
-                    match.Context = settings.Value;
-                    break;
-                default:
-                    _logger.LogError("Unknown field: {Field}. Valid fields: name, color, context", settings.Field);
-                    return 1;
-            }
-
-            config.SaveSettings();
-            _logger.LogInformation("Updated project {Field} to '{Value}'", settings.Field, settings.Value);
-            return 0;
+            case "name":
+                match.Name = settings.Value;
+                break;
+            case "color":
+                match.Color = settings.Value;
+                break;
+            case "context":
+                match.Context = settings.Value;
+                break;
+            default:
+                throw new ArgumentException($"Unknown field: {settings.Field}. Valid fields: name, color, context");
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to update project: {Message}", ex.Message);
-            return 1;
-        }
+
+        config.SaveSettings();
+        Console.WriteLine($"Updated project {settings.Field} to '{settings.Value}'");
+        return 0;
     }
 }
 
 public class ProjectAddRepoCommand : Command<ProjectAddRepoSettings>
 {
-    private readonly ILogger<ProjectAddRepoCommand> _logger;
-
-    public ProjectAddRepoCommand(ILogger<ProjectAddRepoCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectAddRepoSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var config = new ConfigService();
+        var project = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+        if (project == null)
+            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
+
+        if (project.GetRepoRef(settings.RepoPath) != null)
+            throw new InvalidOperationException($"Repository already exists in project: {settings.RepoPath}");
+
+        if (!string.IsNullOrWhiteSpace(settings.BaseBranch))
         {
-            var config = new ConfigService();
-            var project = config.Settings.Projects
-                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
-
-            if (project == null)
-            {
-                _logger.LogError("Project not found: {Name}", settings.ProjectName);
-                return 1;
-            }
-
-            if (project.GetRepoRef(settings.RepoPath) != null)
-            {
-                _logger.LogError("Repository already exists in project: {Path}", settings.RepoPath);
-                return 1;
-            }
-
-            if (!string.IsNullOrWhiteSpace(settings.BaseBranch))
-            {
-                var isValid = Ivy.Tendril.Helpers.GitHelper.IsValidBranchAsync(settings.RepoPath, settings.BaseBranch, config.TendrilHome).GetAwaiter().GetResult();
-                if (!isValid)
-                {
-                    _logger.LogError("Branch '{Branch}' does not exist in repository: {Path}", settings.BaseBranch, settings.RepoPath);
-                    return 1;
-                }
-            }
-
-            project.Repos.Add(new RepoRef
-            {
-                Path = settings.RepoPath,
-                PrRule = settings.PrRule ?? "default",
-                BaseBranch = settings.BaseBranch
-            });
-
-            config.SaveSettings();
-            _logger.LogInformation("Added repository: {Path}", settings.RepoPath);
-            return 0;
+            var isValid = Ivy.Tendril.Helpers.GitHelper.IsValidBranchAsync(settings.RepoPath, settings.BaseBranch, config.TendrilHome).GetAwaiter().GetResult();
+            if (!isValid)
+                throw new InvalidOperationException($"Branch '{settings.BaseBranch}' does not exist in repository: {settings.RepoPath}");
         }
-        catch (Exception ex)
+
+        project.Repos.Add(new RepoRef
         {
-            _logger.LogError("Failed to add repository to project: {Message}", ex.Message);
-            return 1;
-        }
+            Path = settings.RepoPath,
+            PrRule = settings.PrRule ?? "default",
+            BaseBranch = settings.BaseBranch
+        });
+
+        config.SaveSettings();
+        Console.WriteLine($"Added repository: {settings.RepoPath}");
+        return 0;
     }
 }
 
 public class ProjectRemoveRepoCommand : Command<ProjectRemoveRepoSettings>
 {
-    private readonly ILogger<ProjectRemoveRepoCommand> _logger;
-
-    public ProjectRemoveRepoCommand(ILogger<ProjectRemoveRepoCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectRemoveRepoSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var config = new ConfigService();
-            var project = config.Settings.Projects
-                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+        var config = new ConfigService();
+        var project = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-            if (project == null)
-            {
-                _logger.LogError("Project not found: {Name}", settings.ProjectName);
-                return 1;
-            }
+        if (project == null)
+            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
 
-            var match = project.GetRepoRef(settings.RepoPath);
-            if (match == null)
-            {
-                _logger.LogError("Repository not found in project: {Path}", settings.RepoPath);
-                return 1;
-            }
+        var match = project.GetRepoRef(settings.RepoPath);
+        if (match == null)
+            throw new InvalidOperationException($"Repository not found in project: {settings.RepoPath}");
 
-            project.Repos.Remove(match);
-            config.SaveSettings();
-            _logger.LogInformation("Removed repository: {Path}", settings.RepoPath);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to remove repository from project: {Message}", ex.Message);
-            return 1;
-        }
+        project.Repos.Remove(match);
+        config.SaveSettings();
+        Console.WriteLine($"Removed repository: {settings.RepoPath}");
+        return 0;
     }
 }
 
 public class ProjectAddVerificationCommand : Command<ProjectAddVerificationSettings>
 {
-    private readonly ILogger<ProjectAddVerificationCommand> _logger;
-
-    public ProjectAddVerificationCommand(ILogger<ProjectAddVerificationCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectAddVerificationSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var config = new ConfigService();
+        var project = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+        if (project == null)
+            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
+
+        if (project.Verifications.Any(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException($"Verification already exists in project: {settings.VerificationName}");
+
+        var newRef = new ProjectVerificationRef
         {
-            var config = new ConfigService();
-            var project = config.Settings.Projects
-                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+            Name = settings.VerificationName,
+            Required = settings.Required
+        };
 
-            if (project == null)
-            {
-                _logger.LogError("Project not found: {Name}", settings.ProjectName);
-                return 1;
-            }
-
-            if (project.Verifications.Any(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase)))
-            {
-                _logger.LogError("Verification already exists in project: {Name}", settings.VerificationName);
-                return 1;
-            }
-
-            var newRef = new ProjectVerificationRef
-            {
-                Name = settings.VerificationName,
-                Required = settings.Required
-            };
-
-            if (!string.IsNullOrEmpty(settings.After))
-            {
-                var afterIndex = project.Verifications
-                    .FindIndex(v => v.Name.Equals(settings.After, StringComparison.OrdinalIgnoreCase));
-                if (afterIndex < 0)
-                {
-                    _logger.LogError("Verification not found for --after: {Name}", settings.After);
-                    return 1;
-                }
-                project.Verifications.Insert(afterIndex + 1, newRef);
-            }
-            else
-            {
-                project.Verifications.Add(newRef);
-            }
-
-            config.SaveSettings();
-            _logger.LogInformation("Added verification: {Name}", settings.VerificationName);
-            return 0;
-        }
-        catch (Exception ex)
+        if (!string.IsNullOrEmpty(settings.After))
         {
-            _logger.LogError("Failed to add verification to project: {Message}", ex.Message);
-            return 1;
+            var afterIndex = project.Verifications
+                .FindIndex(v => v.Name.Equals(settings.After, StringComparison.OrdinalIgnoreCase));
+            if (afterIndex < 0)
+                throw new InvalidOperationException($"Verification not found for --after: {settings.After}");
+            project.Verifications.Insert(afterIndex + 1, newRef);
         }
+        else
+        {
+            project.Verifications.Add(newRef);
+        }
+
+        config.SaveSettings();
+        Console.WriteLine($"Added verification: {settings.VerificationName}");
+        return 0;
     }
 }
 
 public class ProjectRemoveVerificationCommand : Command<ProjectRemoveVerificationSettings>
 {
-    private readonly ILogger<ProjectRemoveVerificationCommand> _logger;
-
-    public ProjectRemoveVerificationCommand(ILogger<ProjectRemoveVerificationCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectRemoveVerificationSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var config = new ConfigService();
-            var project = config.Settings.Projects
-                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+        var config = new ConfigService();
+        var project = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-            if (project == null)
-            {
-                _logger.LogError("Project not found: {Name}", settings.ProjectName);
-                return 1;
-            }
+        if (project == null)
+            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
 
-            var match = project.Verifications
-                .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
+        var match = project.Verifications
+            .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
 
-            if (match == null)
-            {
-                _logger.LogError("Verification not found in project: {Name}", settings.VerificationName);
-                return 1;
-            }
+        if (match == null)
+            throw new InvalidOperationException($"Verification not found in project: {settings.VerificationName}");
 
-            project.Verifications.Remove(match);
-            config.SaveSettings();
-            _logger.LogInformation("Removed verification: {Name}", settings.VerificationName);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to remove verification from project: {Message}", ex.Message);
-            return 1;
-        }
+        project.Verifications.Remove(match);
+        config.SaveSettings();
+        Console.WriteLine($"Removed verification: {settings.VerificationName}");
+        return 0;
     }
 }
 
 public class ProjectMoveVerificationCommand : Command<ProjectMoveVerificationSettings>
 {
-    private readonly ILogger<ProjectMoveVerificationCommand> _logger;
-
-    public ProjectMoveVerificationCommand(ILogger<ProjectMoveVerificationCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectMoveVerificationSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var optionCount = (settings.Before != null ? 1 : 0) + (settings.After != null ? 1 : 0) + (settings.Position != null ? 1 : 0);
+        if (optionCount != 1)
+            throw new ArgumentException("Specify exactly one of --before, --after, or --position");
+
+        var config = new ConfigService();
+        var project = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+        if (project == null)
+            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
+
+        var item = project.Verifications
+            .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
+
+        if (item == null)
+            throw new InvalidOperationException($"Verification not found in project: {settings.VerificationName}");
+
+        project.Verifications.Remove(item);
+
+        int insertIndex;
+        if (settings.Before != null)
         {
-            var optionCount = (settings.Before != null ? 1 : 0) + (settings.After != null ? 1 : 0) + (settings.Position != null ? 1 : 0);
-            if (optionCount != 1)
+            var targetIndex = project.Verifications
+                .FindIndex(v => v.Name.Equals(settings.Before, StringComparison.OrdinalIgnoreCase));
+            if (targetIndex < 0)
             {
-                _logger.LogError("Specify exactly one of --before, --after, or --position");
-                return 1;
+                project.Verifications.Add(item);
+                throw new InvalidOperationException($"Target verification not found for --before: {settings.Before}");
             }
-
-            var config = new ConfigService();
-            var project = config.Settings.Projects
-                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
-
-            if (project == null)
-            {
-                _logger.LogError("Project not found: {Name}", settings.ProjectName);
-                return 1;
-            }
-
-            var item = project.Verifications
-                .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
-
-            if (item == null)
-            {
-                _logger.LogError("Verification not found in project: {Name}", settings.VerificationName);
-                return 1;
-            }
-
-            project.Verifications.Remove(item);
-
-            int insertIndex;
-            if (settings.Before != null)
-            {
-                var targetIndex = project.Verifications
-                    .FindIndex(v => v.Name.Equals(settings.Before, StringComparison.OrdinalIgnoreCase));
-                if (targetIndex < 0)
-                {
-                    project.Verifications.Add(item);
-                    _logger.LogError("Target verification not found for --before: {Name}", settings.Before);
-                    return 1;
-                }
-                insertIndex = targetIndex;
-            }
-            else if (settings.After != null)
-            {
-                var targetIndex = project.Verifications
-                    .FindIndex(v => v.Name.Equals(settings.After, StringComparison.OrdinalIgnoreCase));
-                if (targetIndex < 0)
-                {
-                    project.Verifications.Add(item);
-                    _logger.LogError("Target verification not found for --after: {Name}", settings.After);
-                    return 1;
-                }
-                insertIndex = targetIndex + 1;
-            }
-            else
-            {
-                insertIndex = Math.Clamp(settings.Position!.Value, 0, project.Verifications.Count);
-            }
-
-            project.Verifications.Insert(insertIndex, item);
-            config.SaveSettings();
-            _logger.LogInformation("Moved verification '{Name}' to position {Position}", settings.VerificationName, insertIndex);
-            return 0;
+            insertIndex = targetIndex;
         }
-        catch (Exception ex)
+        else if (settings.After != null)
         {
-            _logger.LogError("Failed to move verification in project: {Message}", ex.Message);
-            return 1;
+            var targetIndex = project.Verifications
+                .FindIndex(v => v.Name.Equals(settings.After, StringComparison.OrdinalIgnoreCase));
+            if (targetIndex < 0)
+            {
+                project.Verifications.Add(item);
+                throw new InvalidOperationException($"Target verification not found for --after: {settings.After}");
+            }
+            insertIndex = targetIndex + 1;
         }
+        else
+        {
+            insertIndex = Math.Clamp(settings.Position!.Value, 0, project.Verifications.Count);
+        }
+
+        project.Verifications.Insert(insertIndex, item);
+        config.SaveSettings();
+        Console.WriteLine($"Moved verification '{settings.VerificationName}' to position {insertIndex}");
+        return 0;
     }
 }
 
 public class ProjectAddBuildDepCommand : Command<ProjectAddBuildDepSettings>
 {
-    private readonly ILogger<ProjectAddBuildDepCommand> _logger;
-
-    public ProjectAddBuildDepCommand(ILogger<ProjectAddBuildDepCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectAddBuildDepSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var config = new ConfigService();
-            var project = config.Settings.Projects
-                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+        var config = new ConfigService();
+        var project = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-            if (project == null)
-            {
-                _logger.LogError("Project not found: {Name}", settings.ProjectName);
-                return 1;
-            }
+        if (project == null)
+            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
 
-            if (project.BuildDependencies.Contains(settings.Dependency, StringComparer.OrdinalIgnoreCase))
-            {
-                _logger.LogError("Build dependency already exists: {Dependency}", settings.Dependency);
-                return 1;
-            }
+        if (project.BuildDependencies.Contains(settings.Dependency, StringComparer.OrdinalIgnoreCase))
+            throw new InvalidOperationException($"Build dependency already exists: {settings.Dependency}");
 
-            project.BuildDependencies.Add(settings.Dependency);
-            config.SaveSettings();
-            _logger.LogInformation("Added build dependency: {Dependency}", settings.Dependency);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to add build dependency to project: {Message}", ex.Message);
-            return 1;
-        }
+        project.BuildDependencies.Add(settings.Dependency);
+        config.SaveSettings();
+        Console.WriteLine($"Added build dependency: {settings.Dependency}");
+        return 0;
     }
 }
 
 public class ProjectRemoveBuildDepCommand : Command<ProjectRemoveBuildDepSettings>
 {
-    private readonly ILogger<ProjectRemoveBuildDepCommand> _logger;
-
-    public ProjectRemoveBuildDepCommand(ILogger<ProjectRemoveBuildDepCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectRemoveBuildDepSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var config = new ConfigService();
-            var project = config.Settings.Projects
-                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+        var config = new ConfigService();
+        var project = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-            if (project == null)
-            {
-                _logger.LogError("Project not found: {Name}", settings.ProjectName);
-                return 1;
-            }
+        if (project == null)
+            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
 
-            var removed = project.BuildDependencies.RemoveAll(d => d.Equals(settings.Dependency, StringComparison.OrdinalIgnoreCase));
-            if (removed == 0)
-            {
-                _logger.LogError("Build dependency not found: {Dependency}", settings.Dependency);
-                return 1;
-            }
+        var removed = project.BuildDependencies.RemoveAll(d => d.Equals(settings.Dependency, StringComparison.OrdinalIgnoreCase));
+        if (removed == 0)
+            throw new InvalidOperationException($"Build dependency not found: {settings.Dependency}");
 
-            config.SaveSettings();
-            _logger.LogInformation("Removed build dependency: {Dependency}", settings.Dependency);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to remove build dependency from project: {Message}", ex.Message);
-            return 1;
-        }
+        config.SaveSettings();
+        Console.WriteLine($"Removed build dependency: {settings.Dependency}");
+        return 0;
     }
 }
 
 public class ProjectAddReviewActionCommand : Command<ProjectAddReviewActionSettings>
 {
-    private readonly ILogger<ProjectAddReviewActionCommand> _logger;
-
-    public ProjectAddReviewActionCommand(ILogger<ProjectAddReviewActionCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectAddReviewActionSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var config = new ConfigService();
+        var project = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+        if (project == null)
+            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
+
+        if (project.ReviewActions.Any(r => r.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException($"Review action already exists: {settings.Name}");
+
+        project.ReviewActions.Add(new ReviewActionConfig
         {
-            var config = new ConfigService();
-            var project = config.Settings.Projects
-                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+            Name = settings.Name,
+            Command = settings.Command ?? "",
+            Condition = settings.Condition ?? ""
+        });
 
-            if (project == null)
-            {
-                _logger.LogError("Project not found: {Name}", settings.ProjectName);
-                return 1;
-            }
-
-            if (project.ReviewActions.Any(r => r.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
-            {
-                _logger.LogError("Review action already exists: {Name}", settings.Name);
-                return 1;
-            }
-
-            project.ReviewActions.Add(new ReviewActionConfig
-            {
-                Name = settings.Name,
-                Command = settings.Command ?? "",
-                Condition = settings.Condition ?? ""
-            });
-
-            config.SaveSettings();
-            _logger.LogInformation("Added review action: {Name}", settings.Name);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to add review action to project: {Message}", ex.Message);
-            return 1;
-        }
+        config.SaveSettings();
+        Console.WriteLine($"Added review action: {settings.Name}");
+        return 0;
     }
 }
 
 public class ProjectRemoveReviewActionCommand : Command<ProjectRemoveReviewActionSettings>
 {
-    private readonly ILogger<ProjectRemoveReviewActionCommand> _logger;
-
-    public ProjectRemoveReviewActionCommand(ILogger<ProjectRemoveReviewActionCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ProjectRemoveReviewActionSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var config = new ConfigService();
-            var project = config.Settings.Projects
-                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+        var config = new ConfigService();
+        var project = config.Settings.Projects
+            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-            if (project == null)
-            {
-                _logger.LogError("Project not found: {Name}", settings.ProjectName);
-                return 1;
-            }
+        if (project == null)
+            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
 
-            var match = project.ReviewActions
-                .FirstOrDefault(r => r.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+        var match = project.ReviewActions
+            .FirstOrDefault(r => r.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-            if (match == null)
-            {
-                _logger.LogError("Review action not found: {Name}", settings.Name);
-                return 1;
-            }
+        if (match == null)
+            throw new InvalidOperationException($"Review action not found: {settings.Name}");
 
-            project.ReviewActions.Remove(match);
-            config.SaveSettings();
-            _logger.LogInformation("Removed review action: {Name}", settings.Name);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to remove review action from project: {Message}", ex.Message);
-            return 1;
-        }
+        project.ReviewActions.Remove(match);
+        config.SaveSettings();
+        Console.WriteLine($"Removed review action: {settings.Name}");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PromptwareReadMemoryCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareReadMemoryCommand.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -18,34 +17,19 @@ public class PromptwareReadMemorySettings : CommandSettings
 
 public class PromptwareReadMemoryCommand : Command<PromptwareReadMemorySettings>
 {
-    private readonly ILogger<PromptwareReadMemoryCommand> _logger;
-
-    public PromptwareReadMemoryCommand(ILogger<PromptwareReadMemoryCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, PromptwareReadMemorySettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
-            var programFolder = PromptwareHelper.ResolvePromptwareFolder(settings.Name, tendrilHome);
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        var programFolder = PromptwareHelper.ResolvePromptwareFolder(settings.Name, tendrilHome);
 
-            var memoryDir = Path.Combine(programFolder, "Memory");
-            var filename = Path.GetFileName(settings.Filename);
-            var filePath = Path.Combine(memoryDir, filename);
+        var memoryDir = Path.Combine(programFolder, "Memory");
+        var filename = Path.GetFileName(settings.Filename);
+        var filePath = Path.Combine(memoryDir, filename);
 
-            if (!File.Exists(filePath))
-            {
-                _logger.LogError("Memory file not found: {Filename}", filename);
-                return 1;
-            }
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException($"Memory file not found: {filename}", filePath);
 
-            Console.Write(File.ReadAllText(filePath));
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to read memory file {Filename} for {Name}: {Message}", settings.Filename, settings.Name, ex.Message);
-            return 1;
-        }
+        Console.Write(File.ReadAllText(filePath));
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -69,15 +69,7 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
 
     protected override int Execute(CommandContext context, PromptwareRunSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            return Run(settings, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to run promptware {Promptware}: {Message}", settings.Promptware, ex.Message);
-            return 1;
-        }
+        return Run(settings, cancellationToken);
     }
 
 
@@ -93,10 +85,7 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
         var programMd = Path.Combine(programFolder, "Program.md");
 
         if (!File.Exists(programMd))
-        {
-            _logger.LogError("Program.md not found at {ProgramMdPath}", programMd);
-            return 1;
-        }
+            throw new FileNotFoundException($"Program.md not found at {programMd}", programMd);
 
         var values = BuildFirmwareValues(settings, configService);
 
@@ -201,10 +190,7 @@ public class PromptwareRunCommand : Command<PromptwareRunSettings>
 
         using var process = Process.Start(psi);
         if (process == null)
-        {
-            _logger.LogError("Failed to start agent process");
-            return 1;
-        }
+            throw new InvalidOperationException("Failed to start agent process");
 
         if (resolution.UsesStdinPrompt && psi.RedirectStandardInput)
         {

--- a/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -18,35 +17,23 @@ public class PromptwareWriteMemorySettings : CommandSettings
 
 public class PromptwareWriteMemoryCommand : Command<PromptwareWriteMemorySettings>
 {
-    private readonly ILogger<PromptwareWriteMemoryCommand> _logger;
-
-    public PromptwareWriteMemoryCommand(ILogger<PromptwareWriteMemoryCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, PromptwareWriteMemorySettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
-            var programFolder = PromptwareHelper.ResolvePromptwareFolder(settings.Name, tendrilHome);
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        var programFolder = PromptwareHelper.ResolvePromptwareFolder(settings.Name, tendrilHome);
 
-            var memoryDir = Path.Combine(programFolder, "Memory");
-            Directory.CreateDirectory(memoryDir);
+        var memoryDir = Path.Combine(programFolder, "Memory");
+        Directory.CreateDirectory(memoryDir);
 
-            var filename = Path.GetFileName(settings.Filename);
-            var filePath = Path.Combine(memoryDir, filename);
+        var filename = Path.GetFileName(settings.Filename);
+        var filePath = Path.Combine(memoryDir, filename);
 
-            var content = ConsoleHelper.ReadStdinWithTimeout();
-            if (string.IsNullOrWhiteSpace(content))
-                throw new ArgumentException("No content provided (pipe to STDIN)");
+        var content = ConsoleHelper.ReadStdinWithTimeout();
+        if (string.IsNullOrWhiteSpace(content))
+            throw new ArgumentException("No content provided (pipe to STDIN)");
 
-            File.WriteAllText(filePath, content);
-            Console.Write(filePath);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to write memory file {Filename} for {Name}: {Message}", settings.Filename, settings.Name, ex.Message);
-            return 1;
-        }
+        File.WriteAllText(filePath, content);
+        Console.Write(filePath);
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -18,35 +17,23 @@ public class PromptwareWriteToolSettings : CommandSettings
 
 public class PromptwareWriteToolCommand : Command<PromptwareWriteToolSettings>
 {
-    private readonly ILogger<PromptwareWriteToolCommand> _logger;
-
-    public PromptwareWriteToolCommand(ILogger<PromptwareWriteToolCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, PromptwareWriteToolSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
-            var programFolder = PromptwareHelper.ResolvePromptwareFolder(settings.Name, tendrilHome);
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        var programFolder = PromptwareHelper.ResolvePromptwareFolder(settings.Name, tendrilHome);
 
-            var toolsDir = Path.Combine(programFolder, "Tools");
-            Directory.CreateDirectory(toolsDir);
+        var toolsDir = Path.Combine(programFolder, "Tools");
+        Directory.CreateDirectory(toolsDir);
 
-            var filename = Path.GetFileName(settings.Filename);
-            var filePath = Path.Combine(toolsDir, filename);
+        var filename = Path.GetFileName(settings.Filename);
+        var filePath = Path.Combine(toolsDir, filename);
 
-            var content = ConsoleHelper.ReadStdinWithTimeout();
-            if (string.IsNullOrWhiteSpace(content))
-                throw new ArgumentException("No content provided (pipe to STDIN)");
+        var content = ConsoleHelper.ReadStdinWithTimeout();
+        if (string.IsNullOrWhiteSpace(content))
+            throw new ArgumentException("No content provided (pipe to STDIN)");
 
-            File.WriteAllText(filePath, content);
-            Console.Write(filePath);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to write tool file {Filename} for {Name}: {Message}", settings.Filename, settings.Name, ex.Message);
-            return 1;
-        }
+        File.WriteAllText(filePath, content);
+        Console.Write(filePath);
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/ReportBugCommand.cs
+++ b/src/Ivy.Tendril/Commands/ReportBugCommand.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
-using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -32,31 +31,11 @@ public class ReportBugSettings : CommandSettings
 
 public class ReportBugCommand : Command<ReportBugSettings>
 {
-    private readonly ILogger<ReportBugCommand> _logger;
-
-    public ReportBugCommand(ILogger<ReportBugCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, ReportBugSettings settings, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(settings.PlanId) && string.IsNullOrEmpty(settings.JobId))
-        {
-            AnsiConsole.MarkupLine("[red]Error:[/] Either --plan or --job must be specified.");
-            return 1;
-        }
+            throw new ArgumentException("Either --plan or --job must be specified.");
 
-        try
-        {
-            return Run(settings, cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to report bug: {Message}", ex.Message);
-            return 1;
-        }
-    }
-
-    private int Run(ReportBugSettings settings, CancellationToken cancellationToken)
-    {
         var configService = new ConfigService();
         var service = new BugReportService(configService);
 
@@ -94,10 +73,7 @@ public class ReportBugCommand : Command<ReportBugSettings>
         var result = service.SubmitReportAsync(description, files, cancellationToken).GetAwaiter().GetResult();
 
         if (result == null)
-        {
-            AnsiConsole.MarkupLine("[red]Upload failed.[/]");
-            return 1;
-        }
+            throw new InvalidOperationException("Upload failed.");
 
         AnsiConsole.WriteLine();
         AnsiConsole.MarkupLine("[green]Bug report submitted successfully![/]");

--- a/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
+++ b/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using Ivy.Tendril.Helpers;
-using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -14,36 +13,24 @@ public class TrashWriteSettings : CommandSettings
 
 public class TrashWriteCommand : Command<TrashWriteSettings>
 {
-    private readonly ILogger<TrashWriteCommand> _logger;
-
-    public TrashWriteCommand(ILogger<TrashWriteCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, TrashWriteSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
-            if (string.IsNullOrEmpty(tendrilHome))
-                throw new InvalidOperationException("TENDRIL_HOME not set");
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        if (string.IsNullOrEmpty(tendrilHome))
+            throw new InvalidOperationException("TENDRIL_HOME not set");
 
-            var trashDir = Path.Combine(tendrilHome, "Trash");
-            Directory.CreateDirectory(trashDir);
+        var trashDir = Path.Combine(tendrilHome, "Trash");
+        Directory.CreateDirectory(trashDir);
 
-            var filename = Path.GetFileName(settings.Filename);
-            var filePath = Path.Combine(trashDir, filename);
+        var filename = Path.GetFileName(settings.Filename);
+        var filePath = Path.Combine(trashDir, filename);
 
-            var content = ConsoleHelper.ReadStdinWithTimeout();
-            if (string.IsNullOrWhiteSpace(content))
-                throw new ArgumentException("No content provided (pipe to STDIN)");
+        var content = ConsoleHelper.ReadStdinWithTimeout();
+        if (string.IsNullOrWhiteSpace(content))
+            throw new ArgumentException("No content provided (pipe to STDIN)");
 
-            File.WriteAllText(filePath, content);
-            Console.Write(filePath);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to write trash file {Filename}: {Message}", settings.Filename, ex.Message);
-            return 1;
-        }
+        File.WriteAllText(filePath, content);
+        Console.Write(filePath);
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/VerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/VerificationCommand.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using Ivy.Tendril.Services;
-using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -50,196 +49,120 @@ public class VerificationSetSettings : CommandSettings
 
 public class VerificationListCommand : Command<VerificationListSettings>
 {
-    private readonly ILogger<VerificationListCommand> _logger;
-
-    public VerificationListCommand(ILogger<VerificationListCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, VerificationListSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var config = new ConfigService();
+        var verifications = config.Settings.Verifications;
+
+        if (verifications.Count == 0)
         {
-            var config = new ConfigService();
-            var verifications = config.Settings.Verifications;
-
-            if (verifications.Count == 0)
-            {
-                AnsiConsole.MarkupLine("[dim]No verification definitions found.[/]");
-                return 0;
-            }
-
-            var table = new Spectre.Console.Table();
-            table.AddColumn("Name");
-            table.AddColumn("Prompt");
-
-            foreach (var v in verifications)
-            {
-                var prompt = v.Prompt.Length > 60 ? v.Prompt[..60] + "..." : v.Prompt;
-                table.AddRow(v.Name.EscapeMarkup(), prompt.EscapeMarkup());
-            }
-
-            AnsiConsole.Write(table);
+            AnsiConsole.MarkupLine("[dim]No verification definitions found.[/]");
             return 0;
         }
-        catch (Exception ex)
+
+        var table = new Spectre.Console.Table();
+        table.AddColumn("Name");
+        table.AddColumn("Prompt");
+
+        foreach (var v in verifications)
         {
-            _logger.LogError("Failed to list verification definitions: {Message}", ex.Message);
-            return 1;
+            var prompt = v.Prompt.Length > 60 ? v.Prompt[..60] + "..." : v.Prompt;
+            table.AddRow(v.Name.EscapeMarkup(), prompt.EscapeMarkup());
         }
+
+        AnsiConsole.Write(table);
+        return 0;
     }
 }
 
 public class VerificationGetCommand : Command<VerificationGetSettings>
 {
-    private readonly ILogger<VerificationGetCommand> _logger;
-
-    public VerificationGetCommand(ILogger<VerificationGetCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, VerificationGetSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var config = new ConfigService();
-            var match = config.Settings.Verifications
-                .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+        var config = new ConfigService();
+        var match = config.Settings.Verifications
+            .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-            if (match == null)
-            {
-                _logger.LogError("Verification not found: {Name}", settings.Name);
-                return 1;
-            }
+        if (match == null)
+            throw new InvalidOperationException($"Verification not found: {settings.Name}");
 
-            Console.Write(match.Prompt);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to get verification definition: {Message}", ex.Message);
-            return 1;
-        }
+        Console.Write(match.Prompt);
+        return 0;
     }
 }
 
 public class VerificationAddCommand : Command<VerificationAddSettings>
 {
-    private readonly ILogger<VerificationAddCommand> _logger;
-
-    public VerificationAddCommand(ILogger<VerificationAddCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, VerificationAddSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var config = new ConfigService();
+
+        if (config.Settings.Verifications.Any(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
+            throw new InvalidOperationException($"Verification already exists: {settings.Name}");
+
+        var prompt = settings.Prompt;
+        if (string.IsNullOrEmpty(prompt))
         {
-            var config = new ConfigService();
-
-            if (config.Settings.Verifications.Any(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
-            {
-                _logger.LogError("Verification already exists: {Name}", settings.Name);
-                return 1;
-            }
-
-            var prompt = settings.Prompt;
-            if (string.IsNullOrEmpty(prompt))
-            {
-                if (!Console.IsInputRedirected)
-                {
-                    _logger.LogError("Provide --prompt or pipe content via stdin");
-                    return 1;
-                }
-                prompt = Console.In.ReadToEnd().Trim();
-            }
-
-            config.Settings.Verifications.Add(new VerificationConfig
-            {
-                Name = settings.Name,
-                Prompt = prompt
-            });
-
-            config.SaveSettings();
-            _logger.LogInformation("Added verification definition: {Name}", settings.Name);
-            return 0;
+            if (!Console.IsInputRedirected)
+                throw new ArgumentException("Provide --prompt or pipe content via stdin");
+            prompt = Console.In.ReadToEnd().Trim();
         }
-        catch (Exception ex)
+
+        config.Settings.Verifications.Add(new VerificationConfig
         {
-            _logger.LogError("Failed to add verification definition: {Message}", ex.Message);
-            return 1;
-        }
+            Name = settings.Name,
+            Prompt = prompt
+        });
+
+        config.SaveSettings();
+        Console.WriteLine($"Added verification definition: {settings.Name}");
+        return 0;
     }
 }
 
 public class VerificationRemoveCommand : Command<VerificationRemoveSettings>
 {
-    private readonly ILogger<VerificationRemoveCommand> _logger;
-
-    public VerificationRemoveCommand(ILogger<VerificationRemoveCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, VerificationRemoveSettings settings, CancellationToken cancellationToken)
     {
-        try
-        {
-            var config = new ConfigService();
-            var match = config.Settings.Verifications
-                .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+        var config = new ConfigService();
+        var match = config.Settings.Verifications
+            .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-            if (match == null)
-            {
-                _logger.LogError("Verification not found: {Name}", settings.Name);
-                return 1;
-            }
+        if (match == null)
+            throw new InvalidOperationException($"Verification not found: {settings.Name}");
 
-            config.Settings.Verifications.Remove(match);
-            config.SaveSettings();
-            _logger.LogInformation("Removed verification definition: {Name}", settings.Name);
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to remove verification definition: {Message}", ex.Message);
-            return 1;
-        }
+        config.Settings.Verifications.Remove(match);
+        config.SaveSettings();
+        Console.WriteLine($"Removed verification definition: {settings.Name}");
+        return 0;
     }
 }
 
 public class VerificationSetCommand : Command<VerificationSetSettings>
 {
-    private readonly ILogger<VerificationSetCommand> _logger;
-
-    public VerificationSetCommand(ILogger<VerificationSetCommand> logger) => _logger = logger;
-
     protected override int Execute(CommandContext context, VerificationSetSettings settings, CancellationToken cancellationToken)
     {
-        try
+        var config = new ConfigService();
+        var match = config.Settings.Verifications
+            .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+
+        if (match == null)
+            throw new InvalidOperationException($"Verification not found: {settings.Name}");
+
+        switch (settings.Field.ToLower())
         {
-            var config = new ConfigService();
-            var match = config.Settings.Verifications
-                .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
-
-            if (match == null)
-            {
-                _logger.LogError("Verification not found: {Name}", settings.Name);
-                return 1;
-            }
-
-            switch (settings.Field.ToLower())
-            {
-                case "name":
-                    match.Name = settings.Value;
-                    break;
-                case "prompt":
-                    match.Prompt = settings.Value;
-                    break;
-                default:
-                    _logger.LogError("Unknown field: {Field}. Valid fields: name, prompt", settings.Field);
-                    return 1;
-            }
-
-            config.SaveSettings();
-            _logger.LogInformation("Updated verification {Field} to '{Value}'", settings.Field, settings.Value);
-            return 0;
+            case "name":
+                match.Name = settings.Value;
+                break;
+            case "prompt":
+                match.Prompt = settings.Value;
+                break;
+            default:
+                throw new ArgumentException($"Unknown field: {settings.Field}. Valid fields: name, prompt");
         }
-        catch (Exception ex)
-        {
-            _logger.LogError("Failed to update verification definition: {Message}", ex.Message);
-            return 1;
-        }
+
+        config.SaveSettings();
+        Console.WriteLine($"Updated verification {settings.Field} to '{settings.Value}'");
+        return 0;
     }
 }

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -175,6 +175,13 @@ public class Program
                     AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message.EscapeMarkup()}");
                     return 1;
                 }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Error: {ex.Message}");
+                    if (verbose)
+                        Console.Error.WriteLine(ex.ToString());
+                    return 1;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Remove per-command try/catch blocks from ~30 CLI commands, letting exceptions propagate to a single catch in Program.cs
- Errors now print to stderr as plain text (`Error: <message>`) with optional `--verbose` stack trace
- Add early `--repo` validation to `PlanCreateCommand` and fix orphaned folder creation on validation failure
- Remove unused `ILogger<T>` dependencies from all refactored commands

## Test plan
- [ ] Run `tendril plan create "test"` with no `--repo` → verify `Error: At least one --repo is required.`
- [ ] Run `tendril plan get 99999` → verify `Error: Plan not found: 99999`
- [ ] Run with `--verbose` on a failing command → verify full stack trace appears
- [ ] Run happy-path commands (`plan list`, `project list`) → verify normal output unchanged
- [ ] Confirm no orphaned folders created on validation failure