### PR TITLE
Deduplicate SyncRepo jobs for the same repository

### DIFF
--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -442,6 +442,13 @@ public class JobService : IJobService
 
     private string StartJobInternal(JobArgsBase args, string? inboxFilePath, bool skipDependencyCheck = false)
     {
+        if (args is SyncRepoArgs syncRepoArgs)
+        {
+            var existingId = TryFindExistingSyncRepoJob(syncRepoArgs);
+            if (existingId != null)
+                return existingId;
+        }
+
         var id = _configService != null
             ? JobIdAllocator.AllocateJobId(_configService.TendrilHome)
             : Guid.NewGuid().ToString("N")[..5];
@@ -565,6 +572,18 @@ public class JobService : IJobService
             false));
         RaiseJobsStructureChanged();
         return true;
+    }
+
+    private string? TryFindExistingSyncRepoJob(SyncRepoArgs args)
+    {
+        var normalizedPath = Path.GetFullPath(args.RepoPath);
+
+        var existingJob = _jobs.Values.FirstOrDefault(j =>
+            j.TypedArgs is SyncRepoArgs existingArgs &&
+            j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending or JobStatus.Blocked &&
+            Path.GetFullPath(existingArgs.RepoPath).Equals(normalizedPath, StringComparison.OrdinalIgnoreCase));
+
+        return existingJob?.Id;
     }
 
     private bool TryBlockForDependencies(JobItem job, bool skipDependencyCheck)


### PR DESCRIPTION
## Summary
- Detect when a SyncRepo is already active (Running/Queued/Pending/Blocked) for the same RepoPath
- Return the existing job ID instead of spawning a duplicate
- Callers that use the ID for WaitForJobs work seamlessly with the shared job

## Test plan
- [x] Build succeeds
- [x] All 1369 tests pass