### PR TITLE
Make project required on plan create and add CLI input validation

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/03_Tutorial.md
+++ b/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/03_Tutorial.md
@@ -99,8 +99,7 @@ From the dashboard, click **New Plan** and describe what you want to build or fi
 You can also create a plan from the CLI:
 
 ```bash
-tendril plan create my-first-plan "Add a health-check endpoint"
-tendril plan add-repo my-first-plan "D:\Repos\MyProject"
+tendril plan create "Add a health-check endpoint" MyProject
 ```
 
 Either way, the plan starts in **Draft** state. Open it in the dashboard to review the drafted revision — this is your chance to refine the scope before execution.

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/00_Overview.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/00_Overview.md
@@ -43,7 +43,7 @@ Tendril CLI gives you complete control over your workflow without touching the U
 **3. Create a new plan**
 
 ```terminal
->tendril plan create "Fix login bug" --project MyProject
+>tendril plan create "Fix login bug" MyProject
 ```
 
 **4. List active plans**

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
@@ -32,20 +32,18 @@ Create, read, update, and validate plans from the terminal. All subcommands reso
 #### plan create
 
 ```terminal
->tendril plan create <title> [options]
+>tendril plan create <title> <project> [options]
 ```
 
-Creates a new plan folder and `plan.yaml` scaffold with state `Draft`. The plan ID is auto-allocated from the `.counter` file.
+Creates a new plan folder and `plan.yaml` scaffold with state `Draft`. The plan ID is auto-allocated from the `.counter` file. Repos are derived from the project configuration.
 
 | Option | Description |
 |--------|-------------|
-| `--project <name>` | Project name (default: Auto) |
 | `--level <level>` | Priority level (default: NiceToHave) |
 | `--initial-prompt <text>` | Initial prompt text |
 | `--source-url <url>` | Source URL (GitHub issue or PR) |
 | `--execution-profile <profile>` | Execution profile (`deep` or `balanced`) |
 | `--priority <number>` | Priority number (default: 0) |
-| `--repo <path>` | Repository path (repeatable) |
 | `--verification <Name=Status>` | Verification entry (repeatable) |
 | `--related-plan <folder>` | Related plan folder name (repeatable) |
 | `--depends-on <folder>` | Dependency plan folder name (repeatable) |

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
@@ -44,7 +44,7 @@ The **Projects** section of your firmware lists all available projects with thei
 **If `TendrilProject: Auto`**:
 - Analyze the task description to infer the correct project from the **Projects** section
 - Match based on keywords, repo paths, or component names in the description
-- If no project matches, set `project: Auto` in plan.yaml and leave `repos: []` empty
+- **If no project matches**: Write trash file via `tendril trash write <SafeTitle>.md <<'EOF'...EOF` explaining that the project could not be determined from the task description, list the available project names, then exit without creating a plan
 - Use the matched project's context to scope your research
 
 ### 2. Plan ID
@@ -163,19 +163,16 @@ Create the plan using CLI commands according to the plan structure in the **Refe
 Use `tendril plan create` to allocate a plan ID, create the folder, and write `plan.yaml` in a single command:
 
 ```bash
-tendril plan create "<Title>" \
+tendril plan create "<Title>" "<TendrilProject>" \
   --plans-dir "<TendrilPlansFolder>" \
-  --project "<TendrilProject>" \
   --level "NiceToHave" \
   --initial-prompt "<cleaned task description>" \
   --execution-profile "balanced" \
-  --repo "<repo-path-1>" \
-  --repo "<repo-path-2>" \
   --verification "Build=Pending" \
   --verification "Test=Pending"
 ```
 
-**IMPORTANT:** Always pass `--plans-dir` with the `TendrilPlansFolder` firmware value. This ensures the plan is created in the correct directory regardless of environment variable inheritance.
+**IMPORTANT:** Always pass `--plans-dir` with the `TendrilPlansFolder` firmware value. This ensures the plan is created in the correct directory regardless of environment variable inheritance. The project name must be the exact name from the **Projects** section — repos are derived automatically from the project configuration.
 
 The command outputs:
 ```

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SplitPlan/Program.md
@@ -27,19 +27,17 @@ The plans directory path can be derived from the plan folder's parent directory.
 For each distinct issue, use `tendril plan create` to allocate an ID, create the folder, and write `plan.yaml`:
 
 ```bash
-tendril plan create "<Title>" \
+tendril plan create "<Title>" "<TendrilProject>" \
   --plans-dir "<TendrilPlansFolder>" \
-  --project "<TendrilProject>" \
   --level "<Level>" \
   --initial-prompt "<original plan's initialPrompt>" \
   --execution-profile "balanced" \
-  --repo "<repo-path>" \
   --verification "Build=Pending" \
   --verification "Test=Pending" \
   --related-plan "<original-plan-folder-name>"
 ```
 
-**IMPORTANT:** Always pass `--plans-dir` with the plans directory (derive from the plan folder's parent). This ensures child plans are created in the correct directory regardless of environment variable inheritance.
+**IMPORTANT:** Always pass `--plans-dir` with the plans directory (derive from the plan folder's parent). This ensures child plans are created in the correct directory regardless of environment variable inheritance. Repos are derived automatically from the project configuration.
 
 The command outputs `PlanId`, `Directory`, and `Plan created` lines. Parse the `Directory` to write the revision file.
 

--- a/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Mcp;
 using Ivy.Tendril.Mcp.Tools;
+using Ivy.Tendril.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ivy.Tendril.Test.Mcp;
@@ -13,6 +14,7 @@ public class PlanToolsTests : IDisposable
     private readonly PlanTools _planTools;
     private readonly string _repoDir;
     private readonly string _tempDir;
+    private readonly IConfigService _configService;
 
     public PlanToolsTests()
     {
@@ -26,7 +28,8 @@ public class PlanToolsTests : IDisposable
         Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir);
         Environment.SetEnvironmentVariable("TENDRIL_PLANS", null);
         Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", null);
-        _planTools = new PlanTools(new McpAuthenticationService(NullLogger<McpAuthenticationService>.Instance));
+        _configService = new TestPlanConfigService(_repoDir);
+        _planTools = new PlanTools(new McpAuthenticationService(NullLogger<McpAuthenticationService>.Instance), _configService);
     }
 
     public void Dispose()
@@ -425,7 +428,7 @@ public class PlanToolsTests : IDisposable
         var authedService = new McpAuthenticationService(NullLogger<McpAuthenticationService>.Instance);
         Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", null);
 
-        var authedTools = new PlanTools(authedService);
+        var authedTools = new PlanTools(authedService, _configService);
         var result = authedTools.GetPlan("00001");
         Assert.Contains("Error: Authentication failed", result);
     }
@@ -438,7 +441,7 @@ public class PlanToolsTests : IDisposable
         Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", "secret-token");
         var authedService = new McpAuthenticationService(NullLogger<McpAuthenticationService>.Instance);
         Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", null);
-        var authedTools = new PlanTools(authedService);
+        var authedTools = new PlanTools(authedService, _configService);
 
         // Act & Assert - verify all 15 tool methods return auth error
         Assert.Contains("Error: Authentication failed", authedTools.GetPlan("00001"));
@@ -494,7 +497,7 @@ public class PlanToolsTests : IDisposable
         var plansDir = Path.Combine(_tempDir, "Plans");
         Directory.CreateDirectory(plansDir);
 
-        var result = _planTools.PlanCreate("Direct Plan Test", repos: _repoDir);
+        var result = _planTools.PlanCreate("Direct Plan Test", project: "TestProject");
 
         Assert.Contains("Plan created:", result);
         Assert.Contains("PlanId:", result);
@@ -509,12 +512,11 @@ public class PlanToolsTests : IDisposable
 
         var result = _planTools.PlanCreate(
             "Full Plan",
-            project: "MyProject",
+            project: "TestProject",
             level: "Critical",
             initialPrompt: "Do the thing",
             executionProfile: "deep",
             sourceUrl: "https://github.com/org/repo/issues/1",
-            repos: _repoDir,
             verifications: "DotnetBuild,DotnetTest");
 
         Assert.Contains("Plan created:", result);
@@ -524,7 +526,7 @@ public class PlanToolsTests : IDisposable
             .Replace("PlanId: ", "").Trim();
 
         var plan = _planTools.GetPlan(planId);
-        Assert.Contains("MyProject", plan);
+        Assert.Contains("TestProject", plan);
         Assert.Contains("Critical", plan);
         Assert.Contains("Do the thing", plan);
     }

--- a/src/Ivy.Tendril.Test/PlanControllerTests.cs
+++ b/src/Ivy.Tendril.Test/PlanControllerTests.cs
@@ -59,9 +59,9 @@ public class PlanControllerTests : IDisposable
         return planFolder;
     }
 
-    private static PlanController CreateController()
+    private PlanController CreateController()
     {
-        var controller = new PlanController(new NullPlanWatcherService());
+        var controller = new PlanController(new NullPlanWatcherService(), new TestPlanConfigService(_repoDir));
         controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext()
@@ -591,7 +591,7 @@ public class PlanControllerTests : IDisposable
         Directory.CreateDirectory(plansDir);
         var controller = CreateController();
 
-        var result = controller.CreatePlanDirect(new CreatePlanDirectRequest("Test Direct Plan", Repos: [_repoDir]));
+        var result = controller.CreatePlanDirect(new CreatePlanDirectRequest("Test Direct Plan", "TestProject"));
 
         var ok = Assert.IsType<OkObjectResult>(result);
         var json = JsonSerializer.Serialize(ok.Value);
@@ -611,12 +611,11 @@ public class PlanControllerTests : IDisposable
 
         var request = new CreatePlanDirectRequest(
             "Full Plan",
-            Project: "MyProject",
+            Project: "TestProject",
             Level: "Critical",
             InitialPrompt: "Do the thing",
             ExecutionProfile: "deep",
             SourceUrl: "https://github.com/org/repo/issues/1",
-            Repos: [_repoDir],
             Verifications: ["DotnetBuild", "DotnetTest"],
             RelatedPlans: ["00010-OtherPlan"],
             DependsOn: ["00005-BasePlan"]);
@@ -630,7 +629,7 @@ public class PlanControllerTests : IDisposable
         var getPlanResult = controller.GetPlan(idStr);
         var getOk = Assert.IsType<OkObjectResult>(getPlanResult);
         var planJson = JsonSerializer.Serialize(getOk.Value);
-        Assert.Contains("MyProject", planJson);
+        Assert.Contains("TestProject", planJson);
         Assert.Contains("Critical", planJson);
         Assert.Contains("Do the thing", planJson);
         Assert.Contains("deep", planJson);

--- a/src/Ivy.Tendril.Test/TestPlanConfigService.cs
+++ b/src/Ivy.Tendril.Test/TestPlanConfigService.cs
@@ -1,0 +1,56 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+internal class TestPlanConfigService : IConfigService
+{
+    private readonly List<ProjectConfig> _projects;
+
+    public TestPlanConfigService(string repoDir)
+    {
+        _projects =
+        [
+            new ProjectConfig
+            {
+                Name = "TestProject",
+                Repos = [new RepoRef { Path = repoDir }]
+            }
+        ];
+    }
+
+    public TendrilSettings Settings => new() { Projects = _projects };
+    public string TendrilHome => "";
+    public string ConfigPath => "";
+    public string PlanFolder => "";
+    public List<ProjectConfig> Projects => _projects;
+    public List<LevelConfig> Levels => [];
+    public string[] LevelNames => [];
+    public EditorConfig Editor => new();
+    public bool NeedsOnboarding => false;
+    public ConfigParseError? ParseError => null;
+#pragma warning disable CS0067
+    public event EventHandler? SettingsReloaded;
+#pragma warning restore CS0067
+
+    public ProjectConfig? GetProject(string name) =>
+        _projects.FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+    public bool TryAutoHeal() => false;
+    public void ResetToDefaults() { }
+    public void RetryLoadConfig() { }
+    public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Info;
+    public Colors? GetProjectColor(string projectName) => null;
+    public void SaveSettings() { }
+    public void ReloadSettings() { }
+    public void SetPendingTendrilHome(string path) { }
+    public string? GetPendingTendrilHome() => null;
+    public void SetPendingProject(ProjectConfig project) { }
+    public ProjectConfig? GetPendingProject() => null;
+    public void SetPendingCodingAgent(string name) { }
+    public string? GetPendingCodingAgent() => null;
+    public void SetPendingVerificationDefinitions(List<VerificationConfig> definitions) { }
+    public List<VerificationConfig>? GetPendingVerificationDefinitions() => null;
+    public void CompleteOnboarding(string tendrilHome) { }
+    public void OpenInEditor(string path) { }
+    public string PreprocessForEditing(string path) => path;
+}

--- a/src/Ivy.Tendril/Commands/DoctorCliCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCliCommand.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -22,12 +23,17 @@ public class PlanDoctorSettings : CommandSettings
     public bool Prune { get; init; }
 
     [CommandOption("--state")]
-    [Description("Filter plans by state")]
+    [Description("Filter plans by state (Draft, Building, Updating, Executing, ReadyForReview, Failed, Completed, Skipped, Blocked, Icebox)")]
     public string? State { get; init; }
 
     [CommandOption("--worktrees")]
     [Description("Check worktrees only")]
     public bool WorktreesOnly { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.ValidateOneOf(State, "--state", CliValidation.ValidStates);
+    }
 }
 
 public class DoctorCliCommand : AsyncCommand<DoctorSettings>

--- a/src/Ivy.Tendril/Commands/JobStartCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStartCommand.cs
@@ -88,6 +88,18 @@ public class JobStartSettings : CommandSettings
     [Description("Create as draft PR")]
     [CommandOption("--draft")]
     public bool Draft { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        var result = CliValidation.RequireNonEmpty(JobType, "job-type");
+        if (!result.Successful) return result;
+
+        if (!Constants.JobTypes.BuiltIn.Contains(JobType, StringComparer.OrdinalIgnoreCase))
+            return Spectre.Console.ValidationResult.Error(
+                $"Unknown job type '{JobType}'. Valid types: {string.Join(", ", Constants.JobTypes.BuiltIn)}");
+
+        return Spectre.Console.ValidationResult.Success();
+    }
 }
 
 public class JobStartCommand : Command<JobStartSettings>

--- a/src/Ivy.Tendril/Commands/JobStatusCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStatusCommand.cs
@@ -23,6 +23,11 @@ public class JobStatusSettings : CommandSettings
     [Description("Plan title to report")]
     [CommandOption("--plan-title")]
     public string? PlanTitle { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(JobId, "job-id");
+    }
 }
 
 public class JobStatusCommand : Command<JobStatusSettings>

--- a/src/Ivy.Tendril/Commands/PlanAddCommitCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddCommitCommand.cs
@@ -1,6 +1,5 @@
 using Ivy.Tendril.Models;
 using System.ComponentModel;
-using System.Text.RegularExpressions;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
@@ -13,9 +12,23 @@ public class PlanAddCommitSettings : CommandSettings
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
 
-    [Description("Commit SHA")]
+    [Description("Commit SHA (7-40 hex characters)")]
     [CommandArgument(1, "<sha>")]
     public string Sha { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        var result = CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(Sha, "sha"));
+        if (!result.Successful) return result;
+
+        if (!System.Text.RegularExpressions.Regex.IsMatch(Sha, @"^[0-9a-fA-F]{7,40}$"))
+            return Spectre.Console.ValidationResult.Error(
+                $"Invalid commit SHA '{Sha}'. Expected 7-40 character hex string (e.g., abc1234 or full 40-char hash).");
+
+        return Spectre.Console.ValidationResult.Success();
+    }
 }
 
 public class PlanAddCommitCommand : Command<PlanAddCommitSettings>
@@ -31,9 +44,6 @@ public class PlanAddCommitCommand : Command<PlanAddCommitSettings>
     {
         var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
         var plan = PlanCommandHelpers.ReadPlan(planFolder);
-
-        if (!Regex.IsMatch(settings.Sha, @"^[0-9a-fA-F]{7,40}$"))
-            throw new ArgumentException($"Invalid commit hash format: {settings.Sha}. Expected 7-40 character hex string.");
 
         if (plan.Commits.Contains(settings.Sha))
         {

--- a/src/Ivy.Tendril/Commands/PlanAddDependsOnCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddDependsOnCommand.cs
@@ -14,6 +14,13 @@ public class PlanAddDependsOnSettings : CommandSettings
     [Description("Plan reference (ID, folder name, or path)")]
     [CommandArgument(1, "<depends-on>")]
     public string DependsOn { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(DependsOn, "depends-on"));
+    }
 }
 
 public class PlanAddDependsOnCommand : Command<PlanAddDependsOnSettings>

--- a/src/Ivy.Tendril/Commands/PlanAddLogCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddLogCommand.cs
@@ -19,6 +19,13 @@ public class PlanAddLogSettings : CommandSettings
     [CommandOption("--summary")]
     [Description("Optional summary text")]
     public string? Summary { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(Action, "action"));
+    }
 }
 
 public class PlanAddLogCommand : Command<PlanAddLogSettings>

--- a/src/Ivy.Tendril/Commands/PlanAddPrCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddPrCommand.cs
@@ -12,9 +12,16 @@ public class PlanAddPrSettings : CommandSettings
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
 
-    [Description("PR URL")]
+    [Description("PR URL (e.g., https://github.com/org/repo/pull/123)")]
     [CommandArgument(1, "<pr-url>")]
     public string PrUrl { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(PrUrl, "pr-url"));
+    }
 }
 
 public class PlanAddPrCommand : Command<PlanAddPrSettings>

--- a/src/Ivy.Tendril/Commands/PlanAddRelatedPlanCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddRelatedPlanCommand.cs
@@ -14,6 +14,13 @@ public class PlanAddRelatedPlanSettings : CommandSettings
     [Description("Plan reference (ID, folder name, or path)")]
     [CommandArgument(1, "<related-plan>")]
     public string RelatedPlan { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(RelatedPlan, "related-plan"));
+    }
 }
 
 public class PlanAddRelatedPlanCommand : Command<PlanAddRelatedPlanSettings>

--- a/src/Ivy.Tendril/Commands/PlanAddRepoCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddRepoCommand.cs
@@ -15,6 +15,13 @@ public class PlanAddRepoSettings : CommandSettings
     [Description("Repository path")]
     [CommandArgument(1, "<repo-path>")]
     public string RepoPath { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(RepoPath, "repo-path"));
+    }
 }
 
 public class PlanAddRepoCommand : Command<PlanAddRepoSettings>

--- a/src/Ivy.Tendril/Commands/PlanCleanupCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCleanupCommand.cs
@@ -16,6 +16,11 @@ public class PlanCleanupSettings : CommandSettings
     [CommandOption("--force")]
     [Description("Skip terminal-state and grace-period checks")]
     public bool Force { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(PlanId, "plan-id");
+    }
 }
 
 public class PlanCleanupCommand : Command<PlanCleanupSettings>

--- a/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
+using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -12,12 +13,11 @@ public class PlanCreateSettings : CommandSettings
     [CommandArgument(0, "<title>")]
     public string Title { get; set; } = "";
 
+    [Description("Project name")]
+    [CommandArgument(1, "<project>")]
+    public string Project { get; set; } = "";
 
-    [Description("Project name (default: Auto)")]
-    [CommandOption("--project")]
-    public string? Project { get; set; }
-
-    [Description("Priority level (default: NiceToHave)")]
+    [Description("Priority level: Critical, Bug, NiceToHave, Backlog, Icebox (default: NiceToHave)")]
     [CommandOption("--level")]
     public string? Level { get; set; }
 
@@ -29,17 +29,13 @@ public class PlanCreateSettings : CommandSettings
     [CommandOption("--source-url")]
     public string? SourceUrl { get; set; }
 
-    [Description("Execution profile (deep or balanced)")]
+    [Description("Execution profile: deep, balanced")]
     [CommandOption("--execution-profile")]
     public string? ExecutionProfile { get; set; }
 
     [Description("Priority number (default: 0)")]
     [CommandOption("--priority")]
     public int? Priority { get; set; }
-
-    [Description("Repository paths (repeatable)")]
-    [CommandOption("--repo")]
-    public string[]? Repos { get; set; }
 
     [Description("Verifications in Name=Status format (repeatable)")]
     [CommandOption("--verification")]
@@ -56,21 +52,41 @@ public class PlanCreateSettings : CommandSettings
     [Description("Explicit plans directory (overrides TENDRIL_PLANS / TENDRIL_HOME)")]
     [CommandOption("--plans-dir")]
     public string? PlansDir { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(Title, "title"),
+            CliValidation.RequireNonEmpty(Project, "project"),
+            CliValidation.ValidateOneOf(Level, "--level", CliValidation.ValidLevels),
+            CliValidation.ValidateOneOf(ExecutionProfile, "--execution-profile", CliValidation.ValidExecutionProfiles)
+        );
+    }
 }
 
 public class PlanCreateCommand : Command<PlanCreateSettings>
 {
     private readonly IPlanWatcherService _planWatcher;
+    private readonly IConfigService _configService;
 
-    public PlanCreateCommand(IPlanWatcherService planWatcher)
+    public PlanCreateCommand(IPlanWatcherService planWatcher, IConfigService configService)
     {
         _planWatcher = planWatcher;
+        _configService = configService;
     }
 
     protected override int Execute(CommandContext context, PlanCreateSettings settings, CancellationToken cancellationToken)
     {
-        if (settings.Repos == null || settings.Repos.Length == 0)
-            throw new ArgumentException("At least one --repo is required.");
+        ProjectConfig resolvedProject;
+        try
+        {
+            resolvedProject = PlanProjectResolver.ResolveProject(settings.Project, _configService.Projects);
+        }
+        catch (ArgumentException ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message.EscapeMarkup()}");
+            return 1;
+        }
 
         var plansDir = PlanCommandHelpers.GetPlansDirectory(settings.PlansDir);
 
@@ -85,7 +101,7 @@ public class PlanCreateCommand : Command<PlanCreateSettings>
         var plan = new PlanYaml
         {
             State = nameof(PlanStatus.Draft),
-            Project = settings.Project ?? "Auto",
+            Project = resolvedProject.Name,
             Level = settings.Level ?? "NiceToHave",
             Title = settings.Title,
             Created = DateTime.UtcNow,
@@ -96,9 +112,8 @@ public class PlanCreateCommand : Command<PlanCreateSettings>
             Priority = settings.Priority ?? 0
         };
 
-        if (settings.Repos != null)
-            foreach (var repo in settings.Repos)
-                plan.Repos.Add(repo);
+        foreach (var repoPath in resolvedProject.RepoPaths)
+            plan.Repos.Add(repoPath);
 
         if (settings.Verifications != null)
             foreach (var v in settings.Verifications)

--- a/src/Ivy.Tendril/Commands/PlanGetCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanGetCommand.cs
@@ -8,13 +8,32 @@ namespace Ivy.Tendril.Commands;
 
 public class PlanGetSettings : CommandSettings
 {
+    internal static readonly string[] ValidFields =
+        ["state", "project", "level", "title", "created", "updated", "executionprofile", "initialprompt", "sourceurl", "priority",
+         "repos", "prs", "commits", "verifications", "dependson", "relatedplans", "recommendations"];
+
     [Description("Plan ID (e.g., 03430)")]
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
 
-    [Description("Optional field name to read")]
+    [Description("Optional field name to read (state, project, level, title, created, updated, executionProfile, initialPrompt, sourceUrl, priority, repos, prs, commits, verifications, dependsOn, relatedPlans, recommendations)")]
     [CommandArgument(1, "[field]")]
     public string? Field { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        var result = CliValidation.RequireNonEmpty(PlanId, "plan-id");
+        if (!result.Successful) return result;
+
+        if (!string.IsNullOrWhiteSpace(Field))
+        {
+            if (!ValidFields.Contains(Field.ToLower(), StringComparer.OrdinalIgnoreCase))
+                return Spectre.Console.ValidationResult.Error(
+                    $"Unknown field '{Field}'. Valid fields: state, project, level, title, created, updated, executionProfile, initialPrompt, sourceUrl, priority, repos, prs, commits, verifications, dependsOn, relatedPlans, recommendations");
+        }
+
+        return Spectre.Console.ValidationResult.Success();
+    }
 }
 
 public class PlanGetCommand : Command<PlanGetSettings>
@@ -71,7 +90,7 @@ public class PlanGetCommand : Command<PlanGetSettings>
                 "initialprompt" => plan.InitialPrompt ?? "",
                 "sourceurl" => plan.SourceUrl ?? "",
                 "priority" => plan.Priority.ToString(),
-                _ => throw new ArgumentException($"Unknown field: {settings.Field}")
+                _ => throw new ArgumentException($"Unknown field '{settings.Field}'. Valid fields: state, project, level, title, created, updated, executionProfile, initialPrompt, sourceUrl, priority, repos, prs, commits, verifications, dependsOn, relatedPlans, recommendations")
             };
 
             Console.WriteLine(value);

--- a/src/Ivy.Tendril/Commands/PlanListCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanListCommand.cs
@@ -10,7 +10,7 @@ namespace Ivy.Tendril.Commands;
 public class PlanListSettings : CommandSettings
 {
     [CommandOption("--state")]
-    [Description("Filter by state (Draft, Executing, Failed, Completed, etc.)")]
+    [Description("Filter by state (Draft, Building, Updating, Executing, ReadyForReview, Failed, Completed, Skipped, Blocked, Icebox)")]
     public string? State { get; init; }
 
     [CommandOption("--project")]
@@ -40,6 +40,18 @@ public class PlanListSettings : CommandSettings
     [CommandOption("--limit")]
     [Description("Maximum number of results")]
     public int? Limit { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.ValidateOneOf(State, "--state", CliValidation.ValidStates),
+            CliValidation.ValidateOneOf(Level, "--level", CliValidation.ValidLevels),
+            CliValidation.ValidateOneOf(Format, "--format", CliValidation.ValidFormats),
+            Limit.HasValue && Limit.Value <= 0
+                ? Spectre.Console.ValidationResult.Error("--limit must be a positive integer.")
+                : Spectre.Console.ValidationResult.Success()
+        );
+    }
 }
 
 public class PlanListCommand : Command<PlanListSettings>

--- a/src/Ivy.Tendril/Commands/PlanRecCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRecCommand.cs
@@ -14,8 +14,16 @@ public class PlanRecListSettings : CommandSettings
     public string PlanId { get; set; } = "";
 
     [CommandOption("--state")]
-    [Description("Filter by state (Pending, Accepted, Declined)")]
+    [Description("Filter by state (Pending, Accepted, AcceptedWithNotes, Declined)")]
     public string? State { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.ValidateOneOf(State, "--state", CliValidation.ValidRecommendationStates)
+        );
+    }
 }
 
 public class PlanRecAddSettings : CommandSettings
@@ -39,6 +47,16 @@ public class PlanRecAddSettings : CommandSettings
     [CommandOption("--risk")]
     [Description("Risk level (Small, Medium, High)")]
     public string? Risk { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(Title, "title"),
+            CliValidation.ValidateOneOf(Impact, "--impact", CliValidation.ValidImpactLevels),
+            CliValidation.ValidateOneOf(Risk, "--risk", CliValidation.ValidImpactLevels)
+        );
+    }
 }
 
 public class PlanRecRemoveSettings : CommandSettings
@@ -50,6 +68,14 @@ public class PlanRecRemoveSettings : CommandSettings
     [Description("Recommendation title")]
     [CommandArgument(1, "<title>")]
     public string Title { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(Title, "title")
+        );
+    }
 }
 
 public class PlanRecAcceptSettings : CommandSettings
@@ -65,6 +91,14 @@ public class PlanRecAcceptSettings : CommandSettings
     [CommandOption("--notes")]
     [Description("Optional notes to include")]
     public string? Notes { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(Title, "title")
+        );
+    }
 }
 
 public class PlanRecDeclineSettings : CommandSettings
@@ -80,10 +114,20 @@ public class PlanRecDeclineSettings : CommandSettings
     [CommandOption("--reason")]
     [Description("Decline reason")]
     public string? Reason { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(Title, "title")
+        );
+    }
 }
 
 public class PlanRecSetSettings : CommandSettings
 {
+    private static readonly string[] ValidFields = ["title", "description", "state", "impact", "risk", "declinereason"];
+
     [Description("Plan ID (e.g., 03430)")]
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
@@ -99,6 +143,24 @@ public class PlanRecSetSettings : CommandSettings
     [Description("Field value")]
     [CommandArgument(3, "<value>")]
     public string Value { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        var required = CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(Title, "title"),
+            CliValidation.ValidateField(Field, ValidFields));
+        if (!required.Successful)
+            return required;
+
+        var field = Field.ToLower();
+        if (field == "state")
+            return CliValidation.ValidateOneOf(Value, "<value> for field 'state'", CliValidation.ValidRecommendationStates);
+        if (field == "impact" || field == "risk")
+            return CliValidation.ValidateOneOf(Value, $"<value> for field '{field}'", CliValidation.ValidImpactLevels);
+
+        return Spectre.Console.ValidationResult.Success();
+    }
 }
 
 public class PlanRecListCommand : Command<PlanRecListSettings>
@@ -312,7 +374,7 @@ public class PlanRecSetCommand : Command<PlanRecSetSettings>
                 rec.DeclineReason = settings.Value;
                 break;
             default:
-                throw new ArgumentException($"Unknown field: {settings.Field}");
+                throw new ArgumentException($"Unknown field '{settings.Field}'. Valid fields: title, description, state, impact, risk, declineReason");
         }
 
         plan.Updated = DateTime.UtcNow;

--- a/src/Ivy.Tendril/Commands/PlanRemoveDependsOnCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveDependsOnCommand.cs
@@ -14,6 +14,13 @@ public class PlanRemoveDependsOnSettings : CommandSettings
     [Description("Plan reference (ID, folder name, or path)")]
     [CommandArgument(1, "<depends-on>")]
     public string DependsOn { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(DependsOn, "depends-on"));
+    }
 }
 
 public class PlanRemoveDependsOnCommand : Command<PlanRemoveDependsOnSettings>

--- a/src/Ivy.Tendril/Commands/PlanRemoveRelatedPlanCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveRelatedPlanCommand.cs
@@ -14,6 +14,13 @@ public class PlanRemoveRelatedPlanSettings : CommandSettings
     [Description("Plan reference (ID, folder name, or path)")]
     [CommandArgument(1, "<related-plan>")]
     public string RelatedPlan { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(RelatedPlan, "related-plan"));
+    }
 }
 
 public class PlanRemoveRelatedPlanCommand : Command<PlanRemoveRelatedPlanSettings>

--- a/src/Ivy.Tendril/Commands/PlanRemoveRepoCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveRepoCommand.cs
@@ -15,6 +15,13 @@ public class PlanRemoveRepoSettings : CommandSettings
     [Description("Repository path")]
     [CommandArgument(1, "<repo-path>")]
     public string RepoPath { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(RepoPath, "repo-path"));
+    }
 }
 
 public class PlanRemoveRepoCommand : Command<PlanRemoveRepoSettings>

--- a/src/Ivy.Tendril/Commands/PlanRemoveWorktreeCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveWorktreeCommand.cs
@@ -22,6 +22,13 @@ public class PlanRemoveWorktreeSettings : CommandSettings
     [CommandOption("--branch")]
     [Description("Branch name to delete (auto-derived from plan if not specified)")]
     public string? Branch { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(RepoName, "repo-name"));
+    }
 }
 
 public class PlanRemoveWorktreeCommand : Command<PlanRemoveWorktreeSettings>

--- a/src/Ivy.Tendril/Commands/PlanSetCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetCommand.cs
@@ -8,6 +8,9 @@ namespace Ivy.Tendril.Commands;
 
 public class PlanSetSettings : CommandSettings
 {
+    private static readonly string[] ValidFields =
+        ["state", "project", "level", "title", "created", "updated", "executionprofile", "initialprompt", "sourceurl", "priority"];
+
     [Description("Plan ID (e.g., 03430)")]
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
@@ -19,6 +22,25 @@ public class PlanSetSettings : CommandSettings
     [Description("Field value")]
     [CommandArgument(2, "<value>")]
     public string Value { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        var required = CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.ValidateField(Field, ValidFields));
+        if (!required.Successful)
+            return required;
+
+        var field = Field.ToLower();
+        if (field == "state")
+            return CliValidation.ValidateOneOf(Value, "<value> for field 'state'", CliValidation.ValidStates);
+        if (field == "level")
+            return CliValidation.ValidateOneOf(Value, "<value> for field 'level'", CliValidation.ValidLevels);
+        if (field == "executionprofile")
+            return CliValidation.ValidateOneOf(Value, "<value> for field 'executionProfile'", CliValidation.ValidExecutionProfiles);
+
+        return Spectre.Console.ValidationResult.Success();
+    }
 }
 
 public class PlanSetCommand : Command<PlanSetSettings>
@@ -70,7 +92,7 @@ public class PlanSetCommand : Command<PlanSetSettings>
                 plan.Priority = priority;
                 break;
             default:
-                throw new ArgumentException($"Unknown field: {settings.Field}");
+                throw new ArgumentException($"Unknown field '{settings.Field}'. Valid fields: state, project, level, title, created, updated, executionProfile, initialPrompt, sourceUrl, priority");
         }
 
         if (settings.Field.ToLower() != "updated")

--- a/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
-using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -19,6 +19,16 @@ public class PlanSetVerificationSettings : CommandSettings
     [Description("Verification status (Pending, Pass, Fail, Skipped)")]
     [CommandArgument(2, "<status>")]
     public string Status { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(Name, "name"),
+            CliValidation.RequireNonEmpty(Status, "status"),
+            CliValidation.ValidateOneOf(Status, "<status>", CliValidation.ValidVerificationStatuses)
+        );
+    }
 }
 
 public class PlanSetVerificationCommand : Command<PlanSetVerificationSettings>

--- a/src/Ivy.Tendril/Commands/PlanUpdateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanUpdateCommand.cs
@@ -11,6 +11,11 @@ public class PlanUpdateSettings : CommandSettings
     [Description("Plan ID (e.g., 03430)")]
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(PlanId, "plan-id");
+    }
 }
 
 public class PlanUpdateCommand : Command<PlanUpdateSettings>

--- a/src/Ivy.Tendril/Commands/PlanValidateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanValidateCommand.cs
@@ -11,6 +11,11 @@ public class PlanValidateSettings : CommandSettings
     [Description("Plan ID (e.g., 03430)")]
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(PlanId, "plan-id");
+    }
 }
 
 public class PlanValidateCommand : Command<PlanValidateSettings>

--- a/src/Ivy.Tendril/Commands/PlanVerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanVerificationCommand.cs
@@ -16,6 +16,14 @@ public class PlanVerificationListSettings : CommandSettings
     [CommandOption("--status")]
     [Description("Filter by status (Pending, Pass, Fail, Skipped)")]
     public string? Status { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.ValidateOneOf(Status, "--status", CliValidation.ValidVerificationStatuses)
+        );
+    }
 }
 
 public class PlanVerificationAddSettings : CommandSettings
@@ -29,8 +37,17 @@ public class PlanVerificationAddSettings : CommandSettings
     public string Name { get; set; } = "";
 
     [CommandOption("--status")]
-    [Description("Initial status (default: Pending)")]
+    [Description("Initial status (default: Pending). Valid values: Pending, Pass, Fail, Skipped")]
     public string? Status { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(Name, "name"),
+            CliValidation.ValidateOneOf(Status, "--status", CliValidation.ValidVerificationStatuses)
+        );
+    }
 }
 
 public class PlanVerificationRemoveSettings : CommandSettings
@@ -42,6 +59,14 @@ public class PlanVerificationRemoveSettings : CommandSettings
     [Description("Verification name")]
     [CommandArgument(1, "<name>")]
     public string Name { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(Name, "name")
+        );
+    }
 }
 
 public class PlanVerificationListCommand : Command<PlanVerificationListSettings>

--- a/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
@@ -13,6 +13,11 @@ public class PlanWriteRevisionSettings : CommandSettings
     [Description("Read content from file instead of STDIN")]
     [CommandOption("--file|-f")]
     public string? FilePath { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(PlanId, "plan-id");
+    }
 }
 
 public class PlanWriteRevisionCommand : Command<PlanWriteRevisionSettings>

--- a/src/Ivy.Tendril/Commands/ProjectCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectCommand.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -22,6 +23,11 @@ public class ProjectAddSettings : CommandSettings
     [CommandOption("--context")]
     [Description("Project context/prompt")]
     public string? Context { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(Name, "name");
+    }
 }
 
 public class ProjectGetSettings : CommandSettings
@@ -29,6 +35,11 @@ public class ProjectGetSettings : CommandSettings
     [Description("Project name")]
     [CommandArgument(0, "<name>")]
     public string Name { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(Name, "name");
+    }
 }
 
 public class ProjectRemoveSettings : CommandSettings
@@ -36,10 +47,17 @@ public class ProjectRemoveSettings : CommandSettings
     [Description("Project name")]
     [CommandArgument(0, "<name>")]
     public string Name { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(Name, "name");
+    }
 }
 
 public class ProjectSetSettings : CommandSettings
 {
+    private static readonly string[] ValidFields = ["name", "color", "context"];
+
     [Description("Project name")]
     [CommandArgument(0, "<name>")]
     public string Name { get; set; } = "";
@@ -51,6 +69,14 @@ public class ProjectSetSettings : CommandSettings
     [Description("Field value")]
     [CommandArgument(2, "<value>")]
     public string Value { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(Name, "name"),
+            CliValidation.ValidateField(Field, ValidFields)
+        );
+    }
 }
 
 public class ProjectAddRepoSettings : CommandSettings
@@ -64,12 +90,21 @@ public class ProjectAddRepoSettings : CommandSettings
     public string RepoPath { get; set; } = "";
 
     [CommandOption("--pr-rule")]
-    [Description("PR rule (default, yolo)")]
+    [Description("PR rule: default, yolo")]
     public string? PrRule { get; set; }
 
     [CommandOption("--base-branch")]
     [Description("Base branch name")]
     public string? BaseBranch { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(ProjectName, "project-name"),
+            CliValidation.RequireNonEmpty(RepoPath, "repo-path"),
+            CliValidation.ValidateOneOf(PrRule, "--pr-rule", CliValidation.ValidPrRules)
+        );
+    }
 }
 
 public class ProjectRemoveRepoSettings : CommandSettings
@@ -81,6 +116,13 @@ public class ProjectRemoveRepoSettings : CommandSettings
     [Description("Repository path")]
     [CommandArgument(1, "<repo-path>")]
     public string RepoPath { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(ProjectName, "project-name"),
+            CliValidation.RequireNonEmpty(RepoPath, "repo-path"));
+    }
 }
 
 public class ProjectAddVerificationSettings : CommandSettings
@@ -100,6 +142,13 @@ public class ProjectAddVerificationSettings : CommandSettings
     [CommandOption("--after")]
     [Description("Place after this verification (default: append to end)")]
     public string? After { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(ProjectName, "project-name"),
+            CliValidation.RequireNonEmpty(VerificationName, "verification-name"));
+    }
 }
 
 public class ProjectRemoveVerificationSettings : CommandSettings
@@ -111,6 +160,13 @@ public class ProjectRemoveVerificationSettings : CommandSettings
     [Description("Verification name")]
     [CommandArgument(1, "<verification-name>")]
     public string VerificationName { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(ProjectName, "project-name"),
+            CliValidation.RequireNonEmpty(VerificationName, "verification-name"));
+    }
 }
 
 public class ProjectMoveVerificationSettings : CommandSettings
@@ -134,6 +190,13 @@ public class ProjectMoveVerificationSettings : CommandSettings
     [CommandOption("--position")]
     [Description("Place at this zero-based index position")]
     public int? Position { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(ProjectName, "project-name"),
+            CliValidation.RequireNonEmpty(VerificationName, "verification-name"));
+    }
 }
 
 public class ProjectAddBuildDepSettings : CommandSettings
@@ -145,6 +208,13 @@ public class ProjectAddBuildDepSettings : CommandSettings
     [Description("Build dependency")]
     [CommandArgument(1, "<dependency>")]
     public string Dependency { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(ProjectName, "project-name"),
+            CliValidation.RequireNonEmpty(Dependency, "dependency"));
+    }
 }
 
 public class ProjectRemoveBuildDepSettings : CommandSettings
@@ -156,6 +226,13 @@ public class ProjectRemoveBuildDepSettings : CommandSettings
     [Description("Build dependency")]
     [CommandArgument(1, "<dependency>")]
     public string Dependency { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(ProjectName, "project-name"),
+            CliValidation.RequireNonEmpty(Dependency, "dependency"));
+    }
 }
 
 public class ProjectAddReviewActionSettings : CommandSettings
@@ -175,6 +252,13 @@ public class ProjectAddReviewActionSettings : CommandSettings
     [CommandOption("--condition")]
     [Description("Condition expression (e.g. Test-Path \"...\")")]
     public string? Condition { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(ProjectName, "project-name"),
+            CliValidation.RequireNonEmpty(Name, "name"));
+    }
 }
 
 public class ProjectRemoveReviewActionSettings : CommandSettings
@@ -186,6 +270,13 @@ public class ProjectRemoveReviewActionSettings : CommandSettings
     [Description("Review action name")]
     [CommandArgument(1, "<name>")]
     public string Name { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(ProjectName, "project-name"),
+            CliValidation.RequireNonEmpty(Name, "name"));
+    }
 }
 
 // --- Commands ---

--- a/src/Ivy.Tendril/Commands/PromptwareReadMemoryCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareReadMemoryCommand.cs
@@ -13,6 +13,14 @@ public class PromptwareReadMemorySettings : CommandSettings
     [Description("Filename to read (e.g., cli-quirks.md)")]
     [CommandArgument(1, "<filename>")]
     public string Filename { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(Name, "name"),
+            CliValidation.RequireNonEmpty(Filename, "filename")
+        );
+    }
 }
 
 public class PromptwareReadMemoryCommand : Command<PromptwareReadMemorySettings>

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -28,7 +28,7 @@ public class PromptwareRunSettings : CommandSettings
     public string? WorkingDir { get; init; }
 
     [CommandOption("--value")]
-    [Description("Additional firmware header values (key=value, repeatable)")]
+    [Description("Additional firmware header values (key=value format, repeatable). Example: --value MyKey=MyValue")]
     public string[]? Values { get; init; }
 
     [CommandOption("--plan")]
@@ -54,6 +54,24 @@ public class PromptwareRunSettings : CommandSettings
     [CommandOption("--dry-run")]
     [Description("Print the compiled firmware and exit without launching the agent")]
     public bool DryRun { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        var result = CliValidation.RequireNonEmpty(Promptware, "promptware");
+        if (!result.Successful) return result;
+
+        if (Values != null)
+        {
+            foreach (var kv in Values)
+            {
+                if (kv.IndexOf('=') <= 0)
+                    return Spectre.Console.ValidationResult.Error(
+                        $"Invalid --value format '{kv}'. Expected key=value (e.g., --value MyKey=MyValue).");
+            }
+        }
+
+        return Spectre.Console.ValidationResult.Success();
+    }
 }
 
 public class PromptwareRunCommand : Command<PromptwareRunSettings>

--- a/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
@@ -13,6 +13,14 @@ public class PromptwareWriteMemorySettings : CommandSettings
     [Description("Filename to write (e.g., pattern-name.md)")]
     [CommandArgument(1, "<filename>")]
     public string Filename { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(Name, "name"),
+            CliValidation.RequireNonEmpty(Filename, "filename")
+        );
+    }
 }
 
 public class PromptwareWriteMemoryCommand : Command<PromptwareWriteMemorySettings>

--- a/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
@@ -13,6 +13,14 @@ public class PromptwareWriteToolSettings : CommandSettings
     [Description("Filename to write (e.g., tool-name.md)")]
     [CommandArgument(1, "<filename>")]
     public string Filename { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(Name, "name"),
+            CliValidation.RequireNonEmpty(Filename, "filename")
+        );
+    }
 }
 
 public class PromptwareWriteToolCommand : Command<PromptwareWriteToolSettings>

--- a/src/Ivy.Tendril/Commands/ReportBugCommand.cs
+++ b/src/Ivy.Tendril/Commands/ReportBugCommand.cs
@@ -27,15 +27,20 @@ public class ReportBugSettings : CommandSettings
     [CommandOption("--dry-run")]
     [Description("Show what would be sent without uploading")]
     public bool DryRun { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        if (string.IsNullOrEmpty(PlanId) && string.IsNullOrEmpty(JobId))
+            return Spectre.Console.ValidationResult.Error(
+                "Either --plan or --job must be specified.");
+        return Spectre.Console.ValidationResult.Success();
+    }
 }
 
 public class ReportBugCommand : Command<ReportBugSettings>
 {
     protected override int Execute(CommandContext context, ReportBugSettings settings, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrEmpty(settings.PlanId) && string.IsNullOrEmpty(settings.JobId))
-            throw new ArgumentException("Either --plan or --job must be specified.");
-
         var configService = new ConfigService();
         var service = new BugReportService(configService);
 

--- a/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
+++ b/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
@@ -9,6 +9,11 @@ public class TrashWriteSettings : CommandSettings
     [Description("Filename to write (e.g., DuplicateTitle.md)")]
     [CommandArgument(0, "<filename>")]
     public string Filename { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(Filename, "filename");
+    }
 }
 
 public class TrashWriteCommand : Command<TrashWriteSettings>

--- a/src/Ivy.Tendril/Commands/VerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/VerificationCommand.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -16,6 +17,11 @@ public class VerificationAddSettings : CommandSettings
     [CommandOption("-p|--prompt")]
     [Description("Verification prompt (reads from stdin if omitted)")]
     public string? Prompt { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(Name, "name");
+    }
 }
 
 public class VerificationRemoveSettings : CommandSettings
@@ -23,6 +29,11 @@ public class VerificationRemoveSettings : CommandSettings
     [Description("Verification name")]
     [CommandArgument(0, "<name>")]
     public string Name { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(Name, "name");
+    }
 }
 
 public class VerificationGetSettings : CommandSettings
@@ -30,10 +41,17 @@ public class VerificationGetSettings : CommandSettings
     [Description("Verification name")]
     [CommandArgument(0, "<name>")]
     public string Name { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(Name, "name");
+    }
 }
 
 public class VerificationSetSettings : CommandSettings
 {
+    private static readonly string[] ValidFields = ["name", "prompt"];
+
     [Description("Verification name")]
     [CommandArgument(0, "<name>")]
     public string Name { get; set; } = "";
@@ -45,6 +63,15 @@ public class VerificationSetSettings : CommandSettings
     [Description("Field value")]
     [CommandArgument(2, "<value>")]
     public string Value { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(Name, "name"),
+            CliValidation.ValidateField(Field, ValidFields),
+            CliValidation.RequireNonEmpty(Value, "value")
+        );
+    }
 }
 
 public class VerificationListCommand : Command<VerificationListSettings>

--- a/src/Ivy.Tendril/Controllers/PlanController.cs
+++ b/src/Ivy.Tendril/Controllers/PlanController.cs
@@ -67,10 +67,12 @@ internal static class PlanFieldAccessors
 public class PlanController : ControllerBase
 {
     private readonly IPlanWatcherService _planWatcher;
+    private readonly IConfigService _configService;
 
-    public PlanController(IPlanWatcherService planWatcher)
+    public PlanController(IPlanWatcherService planWatcher, IConfigService configService)
     {
         _planWatcher = planWatcher;
+        _configService = configService;
     }
 
     private IActionResult ModifyPlanEndpoint(
@@ -405,6 +407,8 @@ public class PlanController : ControllerBase
     {
         try
         {
+            var resolvedProject = PlanProjectResolver.ResolveProject(request.Project, _configService.Projects);
+
             var plansDir = PlanCommandHelpers.GetPlansDirectory();
             var planId = PlanYamlHelper.AllocatePlanId(plansDir);
             var safeTitle = PlanYamlHelper.ToSafeTitle(request.Title);
@@ -417,7 +421,7 @@ public class PlanController : ControllerBase
             var plan = new PlanYaml
             {
                 State = nameof(PlanStatus.Draft),
-                Project = request.Project ?? "Auto",
+                Project = resolvedProject.Name,
                 Level = request.Level ?? "NiceToHave",
                 Title = request.Title,
                 Created = DateTime.UtcNow,
@@ -428,9 +432,8 @@ public class PlanController : ControllerBase
                 Priority = 0
             };
 
-            if (request.Repos != null)
-                foreach (var repo in request.Repos)
-                    plan.Repos.Add(repo);
+            foreach (var repoPath in resolvedProject.RepoPaths)
+                plan.Repos.Add(repoPath);
 
             if (request.Verifications != null)
                 foreach (var v in request.Verifications)
@@ -697,12 +700,11 @@ public record AcceptRecRequest(string? Notes = null);
 public record DeclineRecRequest(string? Reason = null);
 public record CreatePlanDirectRequest(
     string Title,
-    string? Project = null,
+    string Project,
     string? Level = null,
     string? InitialPrompt = null,
     string? ExecutionProfile = null,
     string? SourceUrl = null,
-    List<string>? Repos = null,
     List<string>? Verifications = null,
     List<string>? RelatedPlans = null,
     List<string>? DependsOn = null);

--- a/src/Ivy.Tendril/Helpers/CliValidation.cs
+++ b/src/Ivy.Tendril/Helpers/CliValidation.cs
@@ -1,0 +1,79 @@
+using Ivy.Tendril.Models;
+using SpectreValidation = Spectre.Console.ValidationResult;
+
+namespace Ivy.Tendril.Helpers;
+
+public static class CliValidation
+{
+    public static readonly string[] ValidStates =
+    [
+        nameof(PlanStatus.Draft), nameof(PlanStatus.Building), nameof(PlanStatus.Updating),
+        nameof(PlanStatus.Executing), nameof(PlanStatus.ReadyForReview), nameof(PlanStatus.Failed),
+        nameof(PlanStatus.Completed), nameof(PlanStatus.Skipped), nameof(PlanStatus.Blocked),
+        nameof(PlanStatus.Icebox)
+    ];
+
+    public static readonly string[] ValidLevels =
+    [
+        "Critical", "Bug", "NiceToHave", "Backlog", "Icebox"
+    ];
+
+    public static readonly string[] ValidVerificationStatuses =
+    [
+        VerificationStatus.Pending, VerificationStatus.Pass, VerificationStatus.Fail, VerificationStatus.Skipped
+    ];
+
+    public static readonly string[] ValidRecommendationStates =
+    [
+        RecommendationStatus.Pending, RecommendationStatus.Accepted,
+        RecommendationStatus.AcceptedWithNotes, RecommendationStatus.Declined
+    ];
+
+    public static readonly string[] ValidFormats = ["table", "ids", "folders", "json"];
+
+    public static readonly string[] ValidExecutionProfiles = ["deep", "balanced"];
+
+    public static readonly string[] ValidImpactLevels = ["Small", "Medium", "High"];
+
+    public static readonly string[] ValidPrRules = ["default", "yolo"];
+
+    public static SpectreValidation RequireNonEmpty(string? value, string argumentName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return SpectreValidation.Error($"<{argumentName}> is required and cannot be empty.");
+        return SpectreValidation.Success();
+    }
+
+    public static SpectreValidation ValidateOneOf(string? value, string optionName, string[] allowed)
+    {
+        if (string.IsNullOrEmpty(value))
+            return SpectreValidation.Success();
+
+        if (!allowed.Contains(value, StringComparer.OrdinalIgnoreCase))
+            return SpectreValidation.Error(
+                $"Invalid value '{value}' for {optionName}. Valid values: {string.Join(", ", allowed)}");
+
+        return SpectreValidation.Success();
+    }
+
+    public static SpectreValidation ValidateField(string? value, string[] validFields)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return SpectreValidation.Error(
+                $"<field> is required and cannot be empty. Valid fields: {string.Join(", ", validFields)}");
+
+        if (!validFields.Contains(value, StringComparer.OrdinalIgnoreCase))
+            return SpectreValidation.Error(
+                $"Unknown field '{value}'. Valid fields: {string.Join(", ", validFields)}");
+
+        return SpectreValidation.Success();
+    }
+
+    public static SpectreValidation Combine(params SpectreValidation[] results)
+    {
+        foreach (var r in results)
+            if (!r.Successful)
+                return r;
+        return SpectreValidation.Success();
+    }
+}

--- a/src/Ivy.Tendril/Helpers/PlanProjectResolver.cs
+++ b/src/Ivy.Tendril/Helpers/PlanProjectResolver.cs
@@ -1,0 +1,29 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Helpers;
+
+public static class PlanProjectResolver
+{
+    public static ProjectConfig ResolveProject(string? projectName, List<ProjectConfig> available)
+    {
+        var names = available.Select(p => p.Name).ToList();
+        var namesList = string.Join(", ", names);
+
+        if (string.IsNullOrWhiteSpace(projectName) ||
+            projectName.Equals("Auto", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException($"Project is required. Available: {namesList}");
+        }
+
+        var project = available.FirstOrDefault(p =>
+            p.Name.Equals(projectName, StringComparison.OrdinalIgnoreCase));
+
+        if (project == null)
+            throw new ArgumentException($"Project '{projectName}' not found. Available: {namesList}");
+
+        if (project.Repos.Count == 0)
+            throw new ArgumentException($"Project '{project.Name}' has no repos configured.");
+
+        return project;
+    }
+}

--- a/src/Ivy.Tendril/Mcp/TendrilMcpServer.cs
+++ b/src/Ivy.Tendril/Mcp/TendrilMcpServer.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -16,6 +17,7 @@ public class TendrilMcpServer
 
             // Register authentication service
             builder.Services.AddSingleton<McpAuthenticationService>();
+            builder.Services.AddSingleton<IConfigService>(new ConfigService());
 
             builder.Services
                 .AddMcpServer(options =>
@@ -46,7 +48,7 @@ public class TendrilMcpServer
         catch (Exception ex)
         {
             // Logger unavailable when host build fails; use stderr fallback
-            Console.Error.WriteLine($"MCP server error: {ex}");
+            await Console.Error.WriteLineAsync($"MCP server error: {ex}");
             return 1;
         }
     }

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -13,8 +13,11 @@ namespace Ivy.Tendril.Mcp.Tools;
 [McpServerToolType]
 public sealed class PlanTools : AuthenticatedToolBase
 {
-    public PlanTools(McpAuthenticationService authService) : base(authService)
+    private readonly IConfigService _configService;
+
+    public PlanTools(McpAuthenticationService authService, IConfigService configService) : base(authService)
     {
+        _configService = configService;
     }
 
     private static readonly Regex FolderNameRegex = new(@"^(\d{5})-(.+)$", RegexOptions.Compiled);
@@ -407,18 +410,19 @@ public sealed class PlanTools : AuthenticatedToolBase
     [McpServerTool(Name = "tendril_plan_create"), Description("Create a plan directly (allocates ID, creates folder)")]
     public string PlanCreate(
         [Description("Plan title")] string title,
-        [Description("Project name (optional)")] string? project = null,
+        [Description("Project name (must match a configured project)")] string project,
         [Description("Priority level: Critical, Important, NiceToHave (optional)")] string? level = null,
         [Description("Initial prompt/description (optional)")] string? initialPrompt = null,
         [Description("Execution profile: deep or balanced (optional)")] string? executionProfile = null,
         [Description("Source URL (optional)")] string? sourceUrl = null,
-        [Description("Comma-separated repository paths (optional)")] string? repos = null,
         [Description("Comma-separated verification names (optional)")] string? verifications = null,
         [Description("Comma-separated related plan folder names (optional)")] string? relatedPlans = null,
         [Description("Comma-separated dependency plan folder names (optional)")] string? dependsOn = null)
     {
         return ExecuteAuthenticated(() =>
         {
+            var resolvedProject = PlanProjectResolver.ResolveProject(project, _configService.Projects);
+
             var plansDir = PlanCommandHelpers.GetPlansDirectory();
             var planId = PlanYamlHelper.AllocatePlanId(plansDir);
             var safeTitle = PlanYamlHelper.ToSafeTitle(title);
@@ -431,7 +435,7 @@ public sealed class PlanTools : AuthenticatedToolBase
             var plan = new PlanYaml
             {
                 State = nameof(PlanStatus.Draft),
-                Project = project ?? "Auto",
+                Project = resolvedProject.Name,
                 Level = level ?? "NiceToHave",
                 Title = title,
                 Created = DateTime.UtcNow,
@@ -442,9 +446,8 @@ public sealed class PlanTools : AuthenticatedToolBase
                 Priority = 0
             };
 
-            if (!string.IsNullOrEmpty(repos))
-                foreach (var repo in repos.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                    plan.Repos.Add(repo);
+            foreach (var repoPath in resolvedProject.RepoPaths)
+                plan.Repos.Add(repoPath);
 
             if (!string.IsNullOrEmpty(verifications))
                 foreach (var v in verifications.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -118,10 +118,12 @@ tendril plan validate <plan-id>
 ### Creating a plan
 
 ```bash
-tendril plan create <title> [options]
+tendril plan create <title> <project> [options]
 ```
 
-Auto-allocates a plan ID, creates the folder, and writes `plan.yaml`. Outputs:
+Auto-allocates a plan ID, creates the folder, and writes `plan.yaml`. Repos are derived from the project configuration.
+
+Outputs:
 ```
 PlanId: <ID>
 Directory: <TendrilPlansFolder>/<ID>-<SafeTitle>
@@ -129,13 +131,11 @@ Plan created: <ID>-<SafeTitle>
 ```
 
 Options:
-- `--project <name>` — Project name (default: Auto)
 - `--level <level>` — Priority level (default: NiceToHave)
 - `--initial-prompt <text>` — Original user description
 - `--source-url <url>` — GitHub issue or PR URL
 - `--execution-profile <profile>` — deep or balanced
 - `--priority <number>` — Priority (default: 0)
-- `--repo <path>` — Repository path (repeatable)
 - `--verification <Name=Status>` — Verification entry (repeatable)
 - `--related-plan <folder>` — Related plan folder name (repeatable)
 - `--depends-on <folder>` — Dependency plan folder name (repeatable)

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -46,7 +46,7 @@ The **Projects** section of your firmware lists all available projects with thei
 **If `TendrilProject: Auto`**:
 - Analyze the task description to infer the correct project from the **Projects** section
 - Match based on keywords, repo paths, or component names in the description
-- If no project matches, set `project: Auto` in plan.yaml and leave `repos: []` empty
+- **If no project matches**: Write trash file via `tendril trash write <SafeTitle>.md <<'EOF'...EOF` explaining that the project could not be determined from the task description, list the available project names, then exit without creating a plan
 - Use the matched project's context to scope your research
 
 ### 2. Plan ID
@@ -174,20 +174,17 @@ Create the plan using CLI commands according to the plan structure in the **Refe
 Use `tendril plan create` to allocate a plan ID, create the folder, and write `plan.yaml` in a single command:
 
 ```bash
-tendril plan create "<Title>" \
+tendril plan create "<Title>" "<Project>" \
   --plans-dir "<TendrilPlansFolder>" \
-  --project "<TendrilProject>" \
   --level "NiceToHave" \
   --initial-prompt "<cleaned task description>" \
   --execution-profile "balanced" \
-  --repo "<repo-path-1>" \
-  --repo "<repo-path-2>" \
   --verification "Build=Pending" \
   --verification "Test=Pending" \
   --job-id TendrilJobId
 ```
 
-**IMPORTANT:** Always pass `--plans-dir` with the `TendrilPlansFolder` firmware value. This ensures the plan is created in the correct directory regardless of environment variable inheritance.
+**IMPORTANT:** Always pass `--plans-dir` with the `TendrilPlansFolder` firmware value. This ensures the plan is created in the correct directory regardless of environment variable inheritance. The `<Project>` must be the exact project name from the **Projects** section — repos are derived automatically from the project configuration.
 
 The command outputs:
 ```

--- a/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -29,20 +29,18 @@ Report status: `tendril job status TendrilJobId --message "Creating split plans.
 For each distinct issue, use `tendril plan create` to allocate an ID, create the folder, and write `plan.yaml`:
 
 ```bash
-tendril plan create "<Title>" \
+tendril plan create "<Title>" "<TendrilProject>" \
   --plans-dir "<TendrilPlansFolder>" \
-  --project "<TendrilProject>" \
   --level "<Level>" \
   --initial-prompt "<original plan's initialPrompt>" \
   --execution-profile "balanced" \
-  --repo "<repo-path>" \
   --verification "Build=Pending" \
   --verification "Test=Pending" \
   --related-plan "<original-plan-folder-name>" \
   --job-id TendrilJobId
 ```
 
-**IMPORTANT:** Always pass `--plans-dir` with the plans directory (derive from the plan folder's parent). This ensures child plans are created in the correct directory regardless of environment variable inheritance.
+**IMPORTANT:** Always pass `--plans-dir` with the plans directory (derive from the plan folder's parent). This ensures child plans are created in the correct directory regardless of environment variable inheritance. Repos are derived automatically from the project configuration.
 
 The command outputs `PlanId`, `Directory`, and `Plan created` lines. Parse the `Directory` to write the revision file.
 


### PR DESCRIPTION
## Summary
- Make `project` a required positional argument on `plan create` (CLI, MCP, API) — removes `--repo` option, repos derived from project config
- Add `PlanProjectResolver` shared validation helper that rejects "Auto" and lists available projects on invalid input
- Add `CliValidation` helper with `Validate()` overrides on all CLI commands for early input validation with helpful error messages

## Test plan
- [x] `dotnet build` passes
- [x] All 1369 tests pass
- [x] Manual: `plan create "X"` errors with missing project arg
- [x] Manual: `plan create "X" InvalidProject` shows available projects
- [x] Manual: `plan create "X" Auto` rejected