### PR TITLE
Replace BadgeVariant with Colors for plan levels

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
@@ -39,7 +39,7 @@ Creates a new plan folder and `plan.yaml` scaffold with state `Draft`. The plan 
 
 | Option | Description |
 |--------|-------------|
-| `--level <level>` | Priority level (default: NiceToHave) |
+| `--level <level>` | Priority level (default: Feature) |
 | `--initial-prompt <text>` | Initial prompt text |
 | `--source-url <url>` | Source URL (GitHub issue or PR) |
 | `--execution-profile <profile>` | Execution profile (`deep` or `balanced`) |
@@ -60,7 +60,7 @@ Lists plans with optional filters.
 |--------|--------|
 | `--state <state>` | Filter by state (e.g. `Draft`, `Executing`, `Failed`) |
 | `--project <name>` | Filter by project name |
-| `--level <level>` | Filter by level (e.g. `Bug`, `Critical`, `NiceToHave`) |
+| `--level <level>` | Filter by level (e.g. `Bug`, `Feature`, `Epic`) |
 | `--has-pr` | Only plans that have associated PRs |
 | `--has-worktree` | Only plans that have worktrees |
 | `--limit <n>` | Maximum number of results |

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
@@ -165,7 +165,7 @@ Use `tendril plan create` to allocate a plan ID, create the folder, and write `p
 ```bash
 tendril plan create "<Title>" "<TendrilProject>" \
   --plans-dir "<TendrilPlansFolder>" \
-  --level "NiceToHave" \
+  --level "Feature" \
   --initial-prompt "<cleaned task description>" \
   --execution-profile "balanced" \
   --verification "Build=Pending" \

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -475,10 +475,12 @@ telemetry: true
 desktopNotifications: true
 levels:
 - name: Bug
-  badge: Destructive
-- name: Critical
-  badge: Warning
-- name: NiceToHave
-  badge: Outline
+  color: Red
+- name: Feature
+  color: Blue
 - name: Epic
-  badge: Info
+  color: Purple
+- name: Chore
+  color: Slate
+- name: Nitpick
+  color: Gray

--- a/src/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
+++ b/src/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
@@ -261,9 +261,9 @@ public class BackgroundServiceActivatorTests : IAsyncLifetime
             return null;
         }
 
-        public BadgeVariant GetBadgeVariant(string level)
+        public Colors? GetLevelColor(string level)
         {
-            return BadgeVariant.Outline;
+            return null;
         }
 
         public Colors? GetProjectColor(string projectName)

--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -351,6 +351,115 @@ projects:
         }
     }
 
+    [Theory]
+    [InlineData("Destructive", "Red")]
+    [InlineData("Warning", "Orange")]
+    [InlineData("Info", "Blue")]
+    [InlineData("Success", "Green")]
+    [InlineData("Secondary", "Slate")]
+    [InlineData("Outline", "Gray")]
+    [InlineData("Blue", "Blue")]
+    [InlineData("Purple", "Purple")]
+    [InlineData("", "Gray")]
+    [InlineData(null, "Gray")]
+    [InlineData("garbage", "Gray")]
+    public void MigrateLevelBadgeToColor_HandlesVariousInputs(string? input, string expected)
+    {
+        var result = ConfigService.MigrateLevelBadgeToColor(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void LoadSettings_MigratesLevelBadgeToColor()
+    {
+        var tempDir = CreateTempConfigFile(@"
+levels:
+  - name: Bug
+    badge: Destructive
+  - name: Critical
+    badge: Warning
+  - name: NiceToHave
+    badge: Outline
+");
+
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            Assert.Equal("Red", service.Settings.Levels[0].Color);
+            Assert.Equal("Orange", service.Settings.Levels[1].Color);
+            Assert.Equal("Gray", service.Settings.Levels[2].Color);
+
+            Assert.Null(service.Settings.Levels[0].Badge);
+            Assert.Null(service.Settings.Levels[1].Badge);
+            Assert.Null(service.Settings.Levels[2].Badge);
+
+            var savedYaml = File.ReadAllText(Path.Combine(tempDir, "config.yaml"));
+            Assert.Contains("color: Red", savedYaml);
+            Assert.DoesNotContain("badge: Destructive", savedYaml);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void LoadSettings_PreservesAlreadyMigratedLevelColors()
+    {
+        var tempDir = CreateTempConfigFile(@"
+levels:
+  - name: Bug
+    color: Red
+  - name: Feature
+    color: Blue
+");
+
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            Assert.Equal("Red", service.Settings.Levels[0].Color);
+            Assert.Equal("Blue", service.Settings.Levels[1].Color);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void LoadSettings_MigratesLevelBadge_PreservesNames()
+    {
+        var tempDir = CreateTempConfigFile(@"
+levels:
+  - name: MyCustomLevel
+    badge: Info
+  - name: AnotherLevel
+    badge: Success
+");
+
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            Assert.Equal("MyCustomLevel", service.Settings.Levels[0].Name);
+            Assert.Equal("Blue", service.Settings.Levels[0].Color);
+            Assert.Equal("AnotherLevel", service.Settings.Levels[1].Name);
+            Assert.Equal("Green", service.Settings.Levels[1].Color);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
     [Fact]
     public void ExpandVariables_NormalizesMixedPathSeparators()
     {

--- a/src/Ivy.Tendril.Test/GitServiceTests.cs
+++ b/src/Ivy.Tendril.Test/GitServiceTests.cs
@@ -40,7 +40,7 @@ public class GitServiceTests
         public bool TryAutoHeal() => false;
         public void ResetToDefaults() { }
         public void RetryLoadConfig() { }
-        public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Info;
+        public Colors? GetLevelColor(string level) => null;
         public Colors? GetProjectColor(string projectName) => null;
         public void SaveSettings() { }
         public void ReloadSettings() { }

--- a/src/Ivy.Tendril.Test/IConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/IConfigServiceTests.cs
@@ -41,7 +41,7 @@ public class IConfigServiceTests
 
         Assert.Equal("TestProject", config.GetProject("TestProject")?.Name);
         Assert.Null(config.GetProject("NonExistent"));
-        Assert.Equal(BadgeVariant.Outline, config.GetBadgeVariant("UnknownLevel"));
+        Assert.Null(config.GetLevelColor("UnknownLevel"));
         Assert.Null(config.GetProjectColor("NonExistent"));
         Assert.Equal(Colors.Blue, config.GetProjectColor("TestProject"));
     }

--- a/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
@@ -207,7 +207,7 @@ public class JobServiceConcurrencyTests
         public bool TryAutoHeal() => false;
         public void ResetToDefaults() { }
         public void RetryLoadConfig() { }
-        public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Info;
+        public Colors? GetLevelColor(string level) => null;
         public Colors? GetProjectColor(string projectName) => null;
         public void SaveSettings() { }
         public void ReloadSettings() { }

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -255,7 +255,7 @@ public class PlanCliCommandTests : IDisposable
 
         Assert.Equal("Draft", plan.State);
         Assert.Equal("TestProject", plan.Project);
-        Assert.Equal("NiceToHave", plan.Level);
+        Assert.Equal("Feature", plan.Level);
         Assert.Equal("GetFieldTest", plan.Title);
         Assert.Equal(0, plan.Priority);
     }
@@ -359,8 +359,9 @@ public class PlanCliCommandTests : IDisposable
         var plan = PlanCommandHelpers.ReadPlan(folder);
         plan.Level = "BogusLevel";
 
-        Assert.Throws<ArgumentException>(() =>
-            PlanCommandHelpers.WritePlan(folder, plan));
+        // Level validation is no longer enforced by WritePlan (levels are user-configurable)
+        var exception = Record.Exception(() => PlanCommandHelpers.WritePlan(folder, plan));
+        Assert.Null(exception);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/PlanReaderServiceGetPlanTests.cs
+++ b/src/Ivy.Tendril.Test/PlanReaderServiceGetPlanTests.cs
@@ -82,7 +82,7 @@ public class PlanReaderServiceGetPlanTests : IDisposable
         Assert.NotNull(result.DependsOn);
         Assert.Equal("", result.Project);
         Assert.Equal("", result.Title);
-        Assert.Equal("NiceToHave", result.Level);
+        Assert.Equal("Feature", result.Level);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Services/PlanValidationServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PlanValidationServiceTests.cs
@@ -118,27 +118,39 @@ public class PlanValidationServiceTests : IDisposable
     }
 
     [Fact]
-    public void Validate_ThrowsForInvalidLevel()
+    public void Validate_ThrowsForInvalidLevel_WhenConfiguredLevelsProvided()
     {
         var plan = CreateValidPlan();
         plan.Level = "InvalidLevel";
+        var configuredLevels = new[] { "Bug", "Feature", "Epic", "Chore", "Nitpick" };
 
-        var ex = Assert.Throws<ArgumentException>(() => PlanValidationService.Validate(plan));
+        var ex = Assert.Throws<ArgumentException>(() => PlanValidationService.Validate(plan, configuredLevels));
 
         Assert.Contains("Invalid level value", ex.Message);
     }
 
     [Fact]
-    public void Validate_AcceptsAllValidLevels()
+    public void Validate_AcceptsAnyLevel_WhenNoConfiguredLevelsProvided()
     {
-        var validLevels = new[] { "Critical", "Bug", "NiceToHave", "Backlog", "Icebox" };
+        var plan = CreateValidPlan();
+        plan.Level = "AnythingGoes";
 
-        foreach (var level in validLevels)
+        var exception = Record.Exception(() => PlanValidationService.Validate(plan));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Validate_AcceptsAllConfiguredLevels()
+    {
+        var configuredLevels = new[] { "Bug", "Feature", "Epic", "Chore", "Nitpick" };
+
+        foreach (var level in configuredLevels)
         {
             var plan = CreateValidPlan();
             plan.Level = level;
 
-            var exception = Record.Exception(() => PlanValidationService.Validate(plan));
+            var exception = Record.Exception(() => PlanValidationService.Validate(plan, configuredLevels));
 
             Assert.Null(exception);
         }

--- a/src/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs
+++ b/src/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs
@@ -20,9 +20,9 @@ public class StubConfigService : IConfigService
         return null;
     }
 
-    public BadgeVariant GetBadgeVariant(string level)
+    public Colors? GetLevelColor(string level)
     {
-        return BadgeVariant.Outline;
+        return null;
     }
 
     public Colors? GetProjectColor(string projectName)

--- a/src/Ivy.Tendril.Test/TestPlanConfigService.cs
+++ b/src/Ivy.Tendril.Test/TestPlanConfigService.cs
@@ -38,7 +38,7 @@ internal class TestPlanConfigService : IConfigService
     public bool TryAutoHeal() => false;
     public void ResetToDefaults() { }
     public void RetryLoadConfig() { }
-    public BadgeVariant GetBadgeVariant(string level) => BadgeVariant.Info;
+    public Colors? GetLevelColor(string level) => null;
     public Colors? GetProjectColor(string projectName) => null;
     public void SaveSettings() { }
     public void ReloadSettings() { }

--- a/src/Ivy.Tendril/Apps/Drafts/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/SidebarView.cs
@@ -76,7 +76,7 @@ public class SidebarView(
                 badges |= new Badge(proj).Variant(BadgeVariant.Outline).Small()
                     .WithProjectColor(config, proj);
             }
-            badges |= new Badge(plan.Level).Variant(config.GetBadgeVariant(plan.Level)).Small();
+            badges |= new Badge(plan.Level).Color(config.GetLevelColor(plan.Level) ?? Colors.Gray).Small();
 
             return new ListItem($"#{plan.Id} {plan.Title}")
                 .Content(badges)

--- a/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
@@ -69,7 +69,7 @@ public class SidebarView(
                 .Content(Layout.Horizontal().Gap(1)
                          | new Badge(plan.Project).Variant(BadgeVariant.Outline).Small()
                              .WithProjectColor(config, plan.Project)
-                         | new Badge(plan.Level).Variant(config.GetBadgeVariant(plan.Level)).Small())
+                         | new Badge(plan.Level).Color(config.GetLevelColor(plan.Level) ?? Colors.Gray).Small())
                 .OnClick(() => selectedPlanState.Set(clickablePlan));
         }));
 

--- a/src/Ivy.Tendril/Apps/Settings/LevelsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/LevelsSetupView.cs
@@ -17,12 +17,12 @@ public class LevelsSetupView : ViewBase
         // Use levels in config.yaml order (not alphabetically sorted).
         var levels = config.Settings.Levels;
 
-        var rows = levels.Select((level, i) => new LevelRow(level.Name, level.Badge, i)).ToList();
+        var rows = levels.Select((level, i) => new LevelRow(level.Name, level.Color, i)).ToList();
 
         var table = new TableBuilder<LevelRow>(rows)
-            .Builder(t => t.Badge, f => f.Func<LevelRow, string>(badge =>
-                new Badge(badge).Variant(
-                    Enum.TryParse<BadgeVariant>(badge, out var v) ? v : BadgeVariant.Outline
+            .Builder(t => t.Color, f => f.Func<LevelRow, string>(color =>
+                new Badge(color).Color(
+                    Enum.TryParse<Colors>(color, out var c) ? c : Colors.Gray
                 )
             ))
             .Header(t => t.Index, "")
@@ -71,7 +71,7 @@ public class LevelsSetupView : ViewBase
                | alertView;
     }
 
-    private record LevelRow(string Name, string Badge, int Index);
+    private record LevelRow(string Name, string Color, int Index);
 }
 
 file class EditLevelDialogContent(
@@ -84,19 +84,19 @@ file class EditLevelDialogContent(
     public override object? Build()
     {
         var editName = UseState("");
-        var editBadge = UseState("Outline");
+        var editColor = UseState("Gray");
         UseEffect(() =>
         {
             var levels = config.Settings.Levels;
             if (existingIndex != null && existingIndex >= 0 && existingIndex < levels.Count)
             {
                 editName.Set(levels[existingIndex.Value].Name);
-                editBadge.Set(levels[existingIndex.Value].Badge);
+                editColor.Set(levels[existingIndex.Value].Color);
             }
         }, EffectTrigger.OnMount());
 
         var levels = config.Settings.Levels;
-        var badgeOptions = Enum.GetNames<BadgeVariant>().ToList();
+        var colorOptions = Enum.GetNames<Colors>().ToList();
         var isNew = existingIndex == null;
 
         return new Dialog(
@@ -105,7 +105,7 @@ file class EditLevelDialogContent(
             new DialogBody(
                 Layout.Vertical()
                 | editName.ToTextInput("Level name...").WithField().Label("Name")
-                | editBadge.ToSelectInput(badgeOptions).WithField().Label("Badge Variant")
+                | editColor.ToSelectInput(colorOptions).WithField().Label("Color")
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() => isOpen.Set(false)),
@@ -113,16 +113,16 @@ file class EditLevelDialogContent(
                 {
                     if (string.IsNullOrWhiteSpace(editName.Value)) return;
                     var oldLevelName = isNew ? null : levels[existingIndex!.Value].Name;
-                    var oldBadge = isNew ? null : levels[existingIndex!.Value].Badge;
+                    var oldColor = isNew ? null : levels[existingIndex!.Value].Color;
                     if (isNew)
                     {
-                        levels.Add(new LevelConfig { Name = editName.Value, Badge = editBadge.Value });
+                        levels.Add(new LevelConfig { Name = editName.Value, Color = editColor.Value });
                     }
                     else
                     {
                         var level = levels[existingIndex!.Value];
                         level.Name = editName.Value;
-                        level.Badge = editBadge.Value;
+                        level.Color = editColor.Value;
                     }
 
                     try
@@ -140,7 +140,7 @@ file class EditLevelDialogContent(
                         {
                             var level = levels[existingIndex!.Value];
                             level.Name = oldLevelName!;
-                            level.Badge = oldBadge!;
+                            level.Color = oldColor!;
                         }
                         refreshToken.Refresh();
                         client.Toast($"Failed to save level: {ex.Message}", "Error");

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -464,7 +464,7 @@ public static class DoctorCommand
                 if (!File.Exists(yamlPath))
                 {
                     var folderTitle = TitleFromFolderName(Path.GetFileName(planPath));
-                    var scaffold = $"state: Draft\nproject: Auto\ntitle: {EscapeYamlString(folderTitle)}\nlevel: NiceToHave\nrepos: []\ncommits: []\nprs: []\ncreated: {DateTime.UtcNow:O}\nupdated: {DateTime.UtcNow:O}\nverifications: []\nrelatedPlans: []\ndependsOn: []\n";
+                    var scaffold = $"state: Draft\nproject: Auto\ntitle: {EscapeYamlString(folderTitle)}\nlevel: Feature\nrepos: []\ncommits: []\nprs: []\ncreated: {DateTime.UtcNow:O}\nupdated: {DateTime.UtcNow:O}\nverifications: []\nrelatedPlans: []\ndependsOn: []\n";
                     File.WriteAllText(yamlPath, scaffold);
                     repairs.Add("created missing plan.yaml");
                 }

--- a/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
@@ -17,7 +17,7 @@ public class PlanCreateSettings : CommandSettings
     [CommandArgument(1, "<project>")]
     public string Project { get; set; } = "";
 
-    [Description("Priority level: Critical, Bug, NiceToHave, Backlog, Icebox (default: NiceToHave)")]
+    [Description("Priority level: Bug, Feature, Epic, Chore, Nitpick (default: Feature)")]
     [CommandOption("--level")]
     public string? Level { get; set; }
 
@@ -102,7 +102,7 @@ public class PlanCreateCommand : Command<PlanCreateSettings>
         {
             State = nameof(PlanStatus.Draft),
             Project = resolvedProject.Name,
-            Level = settings.Level ?? "NiceToHave",
+            Level = settings.Level ?? "Feature",
             Title = settings.Title,
             Created = DateTime.UtcNow,
             Updated = DateTime.UtcNow,

--- a/src/Ivy.Tendril/Commands/PlanListCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanListCommand.cs
@@ -18,7 +18,7 @@ public class PlanListSettings : CommandSettings
     public string? Project { get; init; }
 
     [CommandOption("--level")]
-    [Description("Filter by level (Critical, Bug, NiceToHave, Backlog, Icebox)")]
+    [Description("Filter by level (Bug, Feature, Epic, Chore, Nitpick)")]
     public string? Level { get; init; }
 
     [CommandOption("--has-pr")]

--- a/src/Ivy.Tendril/Controllers/PlanController.cs
+++ b/src/Ivy.Tendril/Controllers/PlanController.cs
@@ -422,7 +422,7 @@ public class PlanController : ControllerBase
             {
                 State = nameof(PlanStatus.Draft),
                 Project = resolvedProject.Name,
-                Level = request.Level ?? "NiceToHave",
+                Level = request.Level ?? "Feature",
                 Title = request.Title,
                 Created = DateTime.UtcNow,
                 Updated = DateTime.UtcNow,

--- a/src/Ivy.Tendril/Helpers/CliValidation.cs
+++ b/src/Ivy.Tendril/Helpers/CliValidation.cs
@@ -15,7 +15,7 @@ public static class CliValidation
 
     public static readonly string[] ValidLevels =
     [
-        "Critical", "Bug", "NiceToHave", "Backlog", "Icebox"
+        "Bug", "Feature", "Epic", "Chore", "Nitpick"
     ];
 
     public static readonly string[] ValidVerificationStatuses =

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -92,7 +92,7 @@ public sealed class PlanTools : AuthenticatedToolBase
     public string CreatePlan(
         [Description("Plan title/description")] string title,
         [Description("Project name (optional)")] string? project = null,
-        [Description("Priority level: Critical, Important, NiceToHave (optional)")] string? level = null,
+        [Description("Priority level: Bug, Feature, Epic, Chore, Nitpick (optional)")] string? level = null,
         [Description("Detailed prompt/description for plan creation (optional)")] string? prompt = null)
     {
         return ExecuteAuthenticated(() =>
@@ -411,7 +411,7 @@ public sealed class PlanTools : AuthenticatedToolBase
     public string PlanCreate(
         [Description("Plan title")] string title,
         [Description("Project name (must match a configured project)")] string project,
-        [Description("Priority level: Critical, Important, NiceToHave (optional)")] string? level = null,
+        [Description("Priority level: Bug, Feature, Epic, Chore, Nitpick (optional)")] string? level = null,
         [Description("Initial prompt/description (optional)")] string? initialPrompt = null,
         [Description("Execution profile: deep or balanced (optional)")] string? executionProfile = null,
         [Description("Source URL (optional)")] string? sourceUrl = null,
@@ -436,7 +436,7 @@ public sealed class PlanTools : AuthenticatedToolBase
             {
                 State = nameof(PlanStatus.Draft),
                 Project = resolvedProject.Name,
-                Level = level ?? "NiceToHave",
+                Level = level ?? "Feature",
                 Title = title,
                 Created = DateTime.UtcNow,
                 Updated = DateTime.UtcNow,

--- a/src/Ivy.Tendril/Models/PlanModels.cs
+++ b/src/Ivy.Tendril/Models/PlanModels.cs
@@ -128,7 +128,7 @@ public class PlanYaml
 {
     public string State { get; set; } = nameof(PlanStatus.Draft);
     public string Project { get; set; } = "Auto";
-    public string Level { get; set; } = "NiceToHave";
+    public string Level { get; set; } = "Feature";
     public string Title { get; set; } = "";
     public List<string> Repos { get; set; } = new();
     public DateTime Created { get; set; } = DateTime.UtcNow;

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -131,7 +131,7 @@ Plan created: <ID>-<SafeTitle>
 ```
 
 Options:
-- `--level <level>` — Priority level (default: NiceToHave)
+- `--level <level>` — Priority level (default: Feature)
 - `--initial-prompt <text>` — Original user description
 - `--source-url <url>` — GitHub issue or PR URL
 - `--execution-profile <profile>` — deep or balanced
@@ -167,7 +167,7 @@ tendril plan cleanup <plan-id> [--force]
 ```yaml
 state: Draft
 project: Tendril
-level: NiceToHave
+level: Feature
 title: "Make an empty app called Review"
 sessionId: "a1b2c3d4-e5f6-..."
 repos: []

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -176,7 +176,7 @@ Use `tendril plan create` to allocate a plan ID, create the folder, and write `p
 ```bash
 tendril plan create "<Title>" "<Project>" \
   --plans-dir "<TendrilPlansFolder>" \
-  --level "NiceToHave" \
+  --level "Feature" \
   --initial-prompt "<cleaned task description>" \
   --execution-profile "balanced" \
   --verification "Build=Pending" \

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -75,7 +75,8 @@ public record ProjectConfig
 public record LevelConfig
 {
     public string Name { get; set; } = "";
-    public string Badge { get; set; } = "Outline";
+    public string Color { get; set; } = "";
+    public string? Badge { get; set; }
 }
 
 public record VerificationConfig
@@ -177,10 +178,11 @@ public class TendrilSettings
 
     public List<LevelConfig> Levels { get; set; } = new()
     {
-        new LevelConfig { Name = "Bug", Badge = "Destructive" },
-        new LevelConfig { Name = "Critical", Badge = "Warning" },
-        new LevelConfig { Name = "NiceToHave", Badge = "Outline" },
-        new LevelConfig { Name = "Epic", Badge = "Info" }
+        new LevelConfig { Name = "Bug", Color = "Red" },
+        new LevelConfig { Name = "Feature", Color = "Blue" },
+        new LevelConfig { Name = "Epic", Color = "Purple" },
+        new LevelConfig { Name = "Chore", Color = "Slate" },
+        new LevelConfig { Name = "Nitpick", Color = "Gray" }
     };
 }
 
@@ -247,6 +249,7 @@ public class ConfigService : IConfigService, IDisposable
                            ?? new TendrilSettings();
 
             MigrateProjectColors();
+            MigrateLevelColors();
             CreateConfigBackup();
 
             return (true, settings);
@@ -404,12 +407,10 @@ public class ConfigService : IConfigService, IDisposable
         return Settings.Projects.FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
     }
 
-    public BadgeVariant GetBadgeVariant(string level)
+    public Colors? GetLevelColor(string level)
     {
-        return Enum.TryParse<BadgeVariant>(Settings.Levels.FirstOrDefault(l => l.Name == level)?.Badge ?? "Outline",
-            out var v)
-            ? v
-            : BadgeVariant.Outline;
+        var colorStr = Settings.Levels.FirstOrDefault(l => l.Name == level)?.Color;
+        return !string.IsNullOrEmpty(colorStr) && Enum.TryParse<Colors>(colorStr, out var c) ? c : null;
     }
 
     public Colors? GetProjectColor(string projectName)
@@ -461,6 +462,7 @@ public class ConfigService : IConfigService, IDisposable
 
             ValidateSettings();
             MigrateProjectColors();
+            MigrateLevelColors();
             _levelNamesCache = null;
             VariableExpansion.InitializeUserSecrets(_logger);
             ExpandSettingsVariables();
@@ -636,6 +638,7 @@ public class ConfigService : IConfigService, IDisposable
                     FileHelper.WriteAllText(ConfigPath, backupYaml);
                     Settings = restored;
                     MigrateProjectColors();
+                    MigrateLevelColors();
                     VariableExpansion.InitializeUserSecrets(_logger);
                     ExpandSettingsVariables();
                     ExpandRepoPaths();
@@ -678,6 +681,7 @@ public class ConfigService : IConfigService, IDisposable
             yaml = Regex.Replace(yaml, @"(?m)^(\s*-\s+)(%\w+%.*)$", "$1'$2'");
             Settings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml) ?? new TendrilSettings();
             MigrateProjectColors();
+            MigrateLevelColors();
             CreateConfigBackup();
             ParseError = null;
             NeedsOnboarding = false;
@@ -735,10 +739,11 @@ public class ConfigService : IConfigService, IDisposable
             Verifications = new List<VerificationConfig>(),
             Levels = new List<LevelConfig>
             {
-                new() { Name = "Bug", Badge = "Destructive" },
-                new() { Name = "Critical", Badge = "Warning" },
-                new() { Name = "NiceToHave", Badge = "Outline" },
-                new() { Name = "Epic", Badge = "Info" }
+                new() { Name = "Bug", Color = "Red" },
+                new() { Name = "Feature", Color = "Blue" },
+                new() { Name = "Epic", Color = "Purple" },
+                new() { Name = "Chore", Color = "Slate" },
+                new() { Name = "Nitpick", Color = "Gray" }
             }
         };
     }
@@ -791,6 +796,52 @@ public class ConfigService : IConfigService, IDisposable
         }
     }
 
+    internal static string MigrateLevelBadgeToColor(string? badgeValue)
+    {
+        if (string.IsNullOrEmpty(badgeValue))
+            return "Gray";
+
+        return badgeValue switch
+        {
+            "Destructive" => "Red",
+            "Warning" => "Orange",
+            "Info" => "Blue",
+            "Success" => "Green",
+            "Secondary" => "Slate",
+            "Outline" => "Gray",
+            "Muted" => "Gray",
+            "Primary" => "Blue",
+            _ => Enum.TryParse<Colors>(badgeValue, out _) ? badgeValue : "Gray"
+        };
+    }
+
+    private void MigrateLevelColors()
+    {
+        if (Settings?.Levels == null) return;
+
+        var needsSave = false;
+        foreach (var level in Settings.Levels)
+        {
+            if (!string.IsNullOrEmpty(level.Badge) && string.IsNullOrEmpty(level.Color))
+            {
+                level.Color = MigrateLevelBadgeToColor(level.Badge);
+                level.Badge = null;
+                needsSave = true;
+            }
+            else if (!string.IsNullOrEmpty(level.Badge))
+            {
+                level.Badge = null;
+                needsSave = true;
+            }
+        }
+
+        if (needsSave && File.Exists(ConfigPath))
+        {
+            var yaml = YamlHelper.SerializerCompact.Serialize(Settings);
+            FileHelper.WriteAllText(ConfigPath, yaml);
+        }
+    }
+
     internal void SetTendrilHome(string tendrilHome)
     {
         TendrilHome = tendrilHome;
@@ -820,6 +871,7 @@ public class ConfigService : IConfigService, IDisposable
 
         ValidateSettings();
         MigrateProjectColors();
+        MigrateLevelColors();
         _levelNamesCache = null;
         VariableExpansion.InitializeUserSecrets(_logger);
         ExpandSettingsVariables();

--- a/src/Ivy.Tendril/Services/IConfigService.cs
+++ b/src/Ivy.Tendril/Services/IConfigService.cs
@@ -17,7 +17,7 @@ public interface IConfigService
     bool TryAutoHeal();
     void ResetToDefaults();
     void RetryLoadConfig();
-    BadgeVariant GetBadgeVariant(string level);
+    Colors? GetLevelColor(string level);
     Colors? GetProjectColor(string projectName);
     void SaveSettings();
     void ReloadSettings();

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -184,7 +184,7 @@ internal class JobCompletionHandler
         if (job.TypedArgs is CreatePlanArgs)
         {
             var planFolder = job.TypedArgs?.PlanFolder ?? "";
-            var level = "NiceToHave";
+            var level = "Feature";
             if (Directory.Exists(planFolder))
             {
                 var plan = PlanYamlHelper.ReadPlanYaml(planFolder);

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -962,7 +962,7 @@ public class PlanReaderService(
             var metadata = new PlanMetadata(
                 id,
                 string.IsNullOrWhiteSpace(planYaml.Project) ? "" : planYaml.Project,
-                string.IsNullOrWhiteSpace(planYaml.Level) ? "NiceToHave" : planYaml.Level,
+                string.IsNullOrWhiteSpace(planYaml.Level) ? "Feature" : planYaml.Level,
                 string.IsNullOrWhiteSpace(planYaml.Title) ? "" : planYaml.Title,
                 status,
                 planYaml.Repos ?? [],

--- a/src/Ivy.Tendril/Services/Plans/PlanValidationService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanValidationService.cs
@@ -15,15 +15,10 @@ public static class PlanValidationService
         nameof(PlanStatus.Failed), nameof(PlanStatus.Completed), nameof(PlanStatus.Skipped), nameof(PlanStatus.Blocked), nameof(PlanStatus.Icebox)
     ];
 
-    private static readonly string[] ValidLevels =
-    [
-        "Critical", "Bug", "NiceToHave", "Backlog", "Icebox"
-    ];
-
     /// <summary>
     ///     Validates a PlanYaml object. Throws ArgumentException with detailed error message on failure.
     /// </summary>
-    public static void Validate(PlanYaml plan)
+    public static void Validate(PlanYaml plan, string[]? configuredLevels = null)
     {
         // Required fields
         if (string.IsNullOrWhiteSpace(plan.State))
@@ -40,10 +35,11 @@ public static class PlanValidationService
             throw new ArgumentException(
                 $"Invalid state value '{plan.State}'. Valid states: {string.Join(", ", ValidStates)}");
 
-        // Validate level enum
-        if (!ValidLevels.Contains(plan.Level, StringComparer.OrdinalIgnoreCase))
+        // Validate level against configured levels (if provided)
+        if (configuredLevels is { Length: > 0 } &&
+            !configuredLevels.Contains(plan.Level, StringComparer.OrdinalIgnoreCase))
             throw new ArgumentException(
-                $"Invalid level value '{plan.Level}'. Valid levels: {string.Join(", ", ValidLevels)}");
+                $"Invalid level value '{plan.Level}'. Valid levels: {string.Join(", ", configuredLevels)}");
 
         // Validate dates
         ValidateDate(plan.Created, "created");

--- a/src/Ivy.Tendril/TELEMETRY.md
+++ b/src/Ivy.Tendril/TELEMETRY.md
@@ -12,7 +12,7 @@ This document defines what data Tendril may and may not send to third-party tele
 - **Counts**: Number of projects, plans, jobs (aggregate totals only)
 - **Durations**: Time taken to complete operations (in seconds)
 - **States/Types**: Enum values, state names, job types (e.g., "CreatePlan", "ExecutePlan")
-- **Levels**: Plan levels (e.g., "Bug", "Critical", "NiceToHave")
+- **Levels**: Plan levels (e.g., "Bug", "Feature", "Epic")
 - **Versions**: Application version strings, OS version strings
 - **Agent providers**: Coding agent name (e.g., "claude", "codex", "copilot", "gemini")
 - **Booleans**: Feature flags, configuration states (e.g., llm_configured: true)

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -223,13 +223,15 @@ verifications:
 
 levels:
   - name: Bug
-    badge: Destructive
-  - name: Critical
-    badge: Warning
-  - name: NiceToHave
-    badge: Outline
+    color: Red
+  - name: Feature
+    color: Blue
   - name: Epic
-    badge: Info
+    color: Purple
+  - name: Chore
+    color: Slate
+  - name: Nitpick
+    color: Gray
 
 # Editor configuration for opening files and folders.
 # The 'command' must be available on your system's PATH.


### PR DESCRIPTION
## Summary
- Replace default levels (Bug, Critical, NiceToHave, Epic) with (Bug, Feature, Epic, Chore, Nitpick)
- Switch level styling from BadgeVariant to real Colors (Red, Blue, Purple, Slate, Gray)
- Add automatic migration for existing configs (badge → color)
- Make level validation config-driven; default new plans to "Feature"

## Test plan
- [x] All 1408 tests pass
- [x] Migration unit tests cover all badge-to-color mappings
- [x] Integration tests verify config file round-trip
- [x] Build succeeds with no warnings