### PR TITLE
Preserve agent status message when CreatePlan fails to produce a plan

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
@@ -44,7 +44,7 @@ The **Projects** section of your firmware lists all available projects with thei
 **If `TendrilProject: Auto`**:
 - Analyze the task description to infer the correct project from the **Projects** section
 - Match based on keywords, repo paths, or component names in the description
-- **If no project matches**: Write trash file via `tendril trash write <SafeTitle>.md <<'EOF'...EOF` explaining that the project could not be determined from the task description, list the available project names, then exit without creating a plan
+- **If no project matches**: Report final status via `tendril job status TendrilJobId --message "Could not determine project from task description. Available projects: <list>"`, write trash file via `tendril trash write <SafeTitle>.md <<'EOF'...EOF` explaining that the project could not be determined, list the available project names, then exit without creating a plan
 - Use the matched project's context to scope your research
 
 ### 2. Plan ID
@@ -91,7 +91,13 @@ Do NOT read or modify `.counter` directly. Plan IDs are allocated by the `tendri
 
   #### Step 5: Write trash file (when trashing)
 
-  Write a trash file using the CLI (where `<SafeTitle>` is the title with spaces replaced by hyphens and special characters removed), then exit without creating a plan folder:
+  First, report a final status describing why no plan is being created:
+
+  ```bash
+  tendril job status TendrilJobId --message "Duplicate of <existing plan folder name> (<state>): <brief reason>"
+  ```
+
+  Then write a trash file using the CLI (where `<SafeTitle>` is the title with spaces replaced by hyphens and special characters removed), then exit without creating a plan folder:
 
   ```bash
   tendril trash write <SafeTitle>.md <<'EOF'
@@ -150,7 +156,7 @@ For each assertion found:
 
 **Decision:**
 - **All validations pass** → Proceed to Step 4, include validated code blocks in plan with `**Current implementation**` headers
-- **Any validation fails** → Write trash file via `tendril trash write <SafeTitle>.md <<'EOF'...EOF` explaining the validation failure, then exit without creating a plan
+- **Any validation fails** → Report final status via `tendril job status TendrilJobId --message "Code state validation failed: <brief description of what changed>"`, write trash file via `tendril trash write <SafeTitle>.md <<'EOF'...EOF` explaining the validation failure, then exit without creating a plan
 
 This catches stale plans before they enter the review queue, reducing wasted review time.
 

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -46,7 +46,7 @@ The **Projects** section of your firmware lists all available projects with thei
 **If `TendrilProject: Auto`**:
 - Analyze the task description to infer the correct project from the **Projects** section
 - Match based on keywords, repo paths, or component names in the description
-- **If no project matches**: Write trash file via `tendril trash write <SafeTitle>.md <<'EOF'...EOF` explaining that the project could not be determined from the task description, list the available project names, then exit without creating a plan
+- **If no project matches**: Report final status via `tendril job status TendrilJobId --message "Could not determine project from task description. Available projects: <list>"`, write trash file via `tendril trash write <SafeTitle>.md <<'EOF'...EOF` explaining that the project could not be determined, list the available project names, then exit without creating a plan
 - Use the matched project's context to scope your research
 
 ### 2. Plan ID
@@ -95,7 +95,13 @@ Report status: `tendril job status TendrilJobId --message "Researching codebase.
 
   #### Step 5: Write trash file (when trashing)
 
-  Write a trash file using the CLI (where `<SafeTitle>` is the title with spaces replaced by hyphens and special characters removed), then exit without creating a plan folder:
+  First, report a final status describing why no plan is being created:
+
+  ```bash
+  tendril job status TendrilJobId --message "Duplicate of <existing plan folder name> (<state>): <brief reason>"
+  ```
+
+  Then write a trash file using the CLI (where `<SafeTitle>` is the title with spaces replaced by hyphens and special characters removed), then exit without creating a plan folder:
 
   ```bash
   tendril trash write <SafeTitle>.md <<'EOF'
@@ -159,7 +165,7 @@ For each assertion found:
 
 **Decision:**
 - **All validations pass** → Proceed to Step 4, include validated code blocks in plan with `**Current implementation**` headers
-- **Any validation fails** → Write trash file via `tendril trash write <SafeTitle>.md <<'EOF'...EOF` explaining the validation failure, then exit without creating a plan
+- **Any validation fails** → Report final status via `tendril job status TendrilJobId --message "Code state validation failed: <brief description of what changed>"`, write trash file via `tendril trash write <SafeTitle>.md <<'EOF'...EOF` explaining the validation failure, then exit without creating a plan
 
 This catches stale plans before they enter the review queue, reducing wasted review time.
 

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -471,7 +471,9 @@ internal class JobCompletionHandler
         job.EnqueueSystemOutput(
             "[Tendril] WARNING: CreatePlan completed but no plan folder or trash entry was found.");
         job.Status = JobStatus.Failed;
-        job.StatusMessage = JobFailureAnalyzer.TryReadFailureArtifact(job.OutputLines.ToList()) ?? "No plan created";
+        job.StatusMessage = JobFailureAnalyzer.TryReadFailureArtifact(job.OutputLines.ToList())
+            ?? job.StatusMessage
+            ?? "No plan created";
     }
 
     private static bool TryVerifyByReportedId(JobItem job, string plansDir)

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -136,6 +136,9 @@ public class JobService : IJobService
         _completionHandler.HandleCompletion(
             job, _jobs, PersistJob, RaiseNotification, RaiseJobsPropertyChanged, StartJobSkipDepCheck);
 
+        if (job.Status == JobStatus.Completed)
+            job.StatusMessage = null;
+
         job.DisposeResources(_logger);
         PersistJob(job);
         EvictStaleJobs();
@@ -162,10 +165,6 @@ public class JobService : IJobService
                 {
                     success = false;
                     job.StatusMessage = errorMessage;
-                }
-                else
-                {
-                    job.StatusMessage = null;
                 }
             }
             else


### PR DESCRIPTION
## Summary

- Move StatusMessage clearing to after HandleCompletion, only for jobs that stay Completed
- In MarkCreatePlanFailed, fall back to agent's last status message before "No plan created"
- Update CreatePlan promptware to always send a descriptive final status before exiting without a plan

Fixes the issue where CreatePlan jobs that legitimately decide not to create a plan (duplicate, already implemented, validation failure) show generic "No plan created" instead of the agent's explanation.