### PR TITLE
[00494] Improve Add Project Dialog Layout

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -47,9 +47,9 @@ public class ProjectInputStepView(
                           && !nameExists;
 
         var buttonArea = Layout.Horizontal().Width(Size.Full())
-            | (onBack != null ? (object)new Button("Back").Outline().Large().Icon(Icons.ArrowLeft).OnClick(onBack) : new Spacer())
-            | new Spacer()
             | (onSkip != null ? (object)new Button(skipButtonText).Ghost().Large().Disabled(disableSkipWhenCannotContinue && !canContinue).OnClick(() => onSkip()) : new Spacer())
+            | new Spacer()
+            | (onBack != null ? (object)new Button("Back").Outline().Large().Icon(Icons.ArrowLeft).OnClick(onBack) : null!)
             | new Button(nextButtonText).Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
                 .Disabled(!canContinue)
                 .OnClick(onNext);

--- a/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
@@ -147,12 +147,15 @@ public class ProjectRepoPickerView(
             listLayout |= new Box(row).BorderStyle(BorderStyle.None).Background(Colors.Muted).Padding(4, 2, 2, 2).Width(Size.Full());
         }
 
+        var scrollableContent = Layout.Vertical().Gap(2).Scroll(Scroll.Auto).Height(Size.Rem(20))
+               | pickerControls
+               | (current.Count > 0 ? listLayout : null!)
+               | addButton;
+
         return Layout.Vertical().Width(Size.Full()).Gap(2)
                | Text.Label("Add one or more Git repositories")
                | (addingError.Value != null ? Text.Danger(addingError.Value) : null!)
-               | (Layout.Horizontal() | pickerControls | addButton)
-               //| (current.Count > 0 ? new Separator() : null!)
-               | (current.Count > 0 ? listLayout : null!);
+               | scrollableContent;
     }
 
     private static object BuildBaseBranchSelector(IState<List<RepoRef>> repos, int idx)


### PR DESCRIPTION
Fixes #1155

# Summary

## Changes

Improved the "Add a project" dialog layout by moving the "Add Repository" button below the repository list, wrapping the input/list/button in a scrollable container so they scroll together when the list is long, and repositioning the "Manual Setup" button to the leftmost footer position.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs** — Replaced horizontal input+button layout with vertical scrollable container; moved add button below repo list
- **src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs** — Reordered footer buttons to place skip/Manual Setup leftmost

---

Commits:
- b9a9a5b