### PR TITLE
[00485] Make TendrilProcessView mobile responsive

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css
@@ -199,3 +199,70 @@
     transform: rotate(360deg);
   }
 }
+
+/* Mobile responsive layout */
+@media (max-width: 540px) {
+  .tpv-container {
+    padding: 2rem 1rem 1rem;
+  }
+
+  .tpv-flow {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .tpv-box {
+    min-width: unset;
+    width: 100%;
+    max-width: 12rem;
+  }
+
+  .tpv-arrow-segment {
+    margin: 0;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .tpv-arrow-segment .tpv-arrow-label {
+    position: static;
+    transform: none;
+    margin-bottom: 0.125rem;
+  }
+
+  .tpv-arrow-svg {
+    width: 12px;
+    height: 50px;
+    transform: rotate(90deg);
+  }
+
+  .tpv-stage-wrapper {
+    width: 100%;
+    max-width: 12rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .tpv-stage-wrapper .tpv-box {
+    width: 100%;
+  }
+
+  .tpv-loop-arrow {
+    position: static;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.25rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .tpv-curve-svg {
+    width: 30px;
+    height: 20px;
+  }
+
+  .tpv-sub-label {
+    position: static;
+    transform: none;
+    margin-top: 0.25rem;
+  }
+}


### PR DESCRIPTION
Fixes #1148

## Changes

Added responsive CSS media query to `TendrilProcessViewer` that activates at `max-width: 540px`. The horizontal flow layout switches to vertical, boxes expand to full width, arrows rotate to point downward, and loop arrows/sub-labels use static positioning instead of absolute.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css` — added `@media (max-width: 540px)` responsive rules

---

### Commits
- df4c4e9