### PR TITLE
[00498] Left-align loading indicator in project agent step view

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -175,7 +175,7 @@ public class ProjectAgentStepView(
                    ? (object)new Progress(progressValue.Value.Value)
                    : null!)
                | (awaitingOutput
-                   ? (object)(Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                   ? (object)(Layout.Horizontal().Gap(2).AlignContent(Align.Left)
                        | new Loading())
                    : null!)
                | (session.HasOutput.Value


### PR DESCRIPTION
Fixes #1160

## Summary

Changed the loading indicator alignment in `ProjectAgentStepView.cs` from `Align.Center` to `Align.Left` so it matches the left-aligned `AgentOutputView` that replaces it when agent output begins streaming.

## Files Modified

- `src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs` — Changed `AlignContent(Align.Center)` to `AlignContent(Align.Left)` on the loading indicator layout

---

**Commits:**
- ad96172