### PR TITLE
[00495] Fix duplicate project error when navigating back in Add Project dialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/AddProjectDialog.cs
@@ -119,6 +119,19 @@ public class AddProjectDialog(
                 {
                     session.Reset();
                     isStepLoading.Set(false);
+
+                    if (hasCreated.Value && !string.IsNullOrWhiteSpace(editName.Value))
+                    {
+                        var project = config.Settings.Projects.FirstOrDefault(
+                            p => p.Name.Equals(editName.Value, StringComparison.OrdinalIgnoreCase));
+                        if (project != null)
+                        {
+                            config.Settings.Projects.Remove(project);
+                            try { config.SaveSettings(); } catch { }
+                        }
+                        hasCreated.Set(false);
+                    }
+
                     step.Set(0);
                 },
                 onNext: () =>
@@ -134,6 +147,18 @@ public class AddProjectDialog(
                 session,
                 onBack: () =>
                 {
+                    if (hasCreated.Value && !string.IsNullOrWhiteSpace(editName.Value))
+                    {
+                        var project = config.Settings.Projects.FirstOrDefault(
+                            p => p.Name.Equals(editName.Value, StringComparison.OrdinalIgnoreCase));
+                        if (project != null)
+                        {
+                            config.Settings.Projects.Remove(project);
+                            try { config.SaveSettings(); } catch { }
+                        }
+                        hasCreated.Set(false);
+                    }
+
                     step.Set(0);
                     session.Reset();
                 },


### PR DESCRIPTION
Fixes #1161

## Summary

Added project removal logic to the `onBack` handlers in `AddProjectDialog.cs` for both step 1 (agent setup) and step 2 (review harness). When navigating back to step 0, the committed project is removed from `config.Settings.Projects` and saved to disk, preventing `ProjectInputStepView` from detecting it as a duplicate.

## Files Modified

- **src/Ivy.Tendril/Apps/Settings/Dialogs/AddProjectDialog.cs** — Added cleanup logic in step 1 and step 2 `onBack` handlers to remove the project from settings before navigating back to step 0.

---

## Commits

- 635e66e Fix duplicate project error when navigating back in Add Project dialog