### PR TITLE
[00497] Remove Scrollbar From Plan Content Area

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -225,13 +225,17 @@ public class ContentView(
         var annotationsDialog = BuildAnnotationsGuardDialog(
             annotations, showAnnotationsDialog, preflightResult, pendingWaitJobIds, showDirtyDialog);
 
+        var hideScrollbar = new Html("<style>[role=tabpanel]>.overflow-hidden>[data-orientation]{display:none!important}</style>")
+            .DangerouslyAllowScripts().Width(Size.Px(0)).Height(Size.Px(0));
+
         var elements = new List<object>
         {
             mainLayout,
             updateDialog,
             deleteDialog,
             createIssueDialog,
-            debugSheet
+            debugSheet,
+            hideScrollbar
         };
 
         if (dirtyRepoDialog is not null)

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -239,7 +239,10 @@ public class ContentView(
             ).Scroll(Scroll.None).Size(Size.Full())
         ).Scroll(Scroll.None).Size(Size.Full()).Key(selectedPlanState.Value.Id);
 
-        return new Fragment(mainLayout, discardDialog, suggestChangesDialog, customPrDialog, resetToDraftDialog, debugSheet);
+        var hideScrollbar = new Html("<style>[role=tabpanel]>.overflow-hidden>[data-orientation]{display:none!important}</style>")
+            .DangerouslyAllowScripts().Width(Size.Px(0)).Height(Size.Px(0));
+
+        return new Fragment(mainLayout, discardDialog, suggestChangesDialog, customPrDialog, resetToDraftDialog, debugSheet, hideScrollbar);
     }
 
     private object BuildHeader(


### PR DESCRIPTION
Fixes #1009

## Summary

Hid the Radix scrollbar indicator in the plan content tab panels of both the Drafts and Review apps. The scrolling functionality is preserved (Radix viewport still handles scroll via trackpad/mouse wheel), only the visual scrollbar indicator is hidden via CSS injection targeting `[data-orientation]` elements inside tab panel scroll areas.

## Files Modified

- **src/Ivy.Tendril/Apps/Drafts/ContentView.cs** — Added CSS injection via Html widget to hide scrollbar in tab panels
- **src/Ivy.Tendril/Apps/Review/ContentView.cs** — Same CSS injection for the Review app

---

**Commits:**
- 2fb1d5a