### PR TITLE
[00486] Add spacing between elements in all Edit Project dialog tabs

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs
@@ -96,7 +96,7 @@ public class EditProjectDialog(
             return draft with { Path = destPath };
         };
 
-        var verificationsLayout = Layout.Vertical().Gap(1);
+        var verificationsLayout = Layout.Vertical().Gap(2);
         var allVerificationsList = _config.Settings.Verifications.Select(v => v.Name).ToList();
         foreach (var vName in allVerificationsList)
         {
@@ -147,19 +147,21 @@ public class EditProjectDialog(
             new DialogBody(
                 Layout.Tabs(
                     new Tab("Basic",
-                        Layout.Vertical()
+                        Layout.Vertical().Gap(4)
+                        | Text.Block("Configure the project's name, color, and AI context.").Muted()
                         | editName.ToTextInput("Project name...").WithField().Label("Name")
                         | editColor.ToColorInput().Variant(ColorInputVariant.SwatchPicker).Nullable().WithField().Label("Color")
                         | editContext.ToTextareaInput("Project context or prompt for AI agents (optional)...").Rows(4)
                             .WithField().Label("Context / Prompt (Optional)")
                     ),
                     new Tab("Repositories",
-                        Layout.Vertical().Gap(2)
+                        Layout.Vertical().Gap(4)
+                        | Text.Block("Manage source code repositories for this project.").Muted()
                         | new ProjectRepoPickerView(editRepos, onAdd: cloneRemoteOnAdd, showBaseBranchPicker: true)
                     ),
                     new Tab("Review Actions",
-                        Layout.Vertical().Gap(2)
-                        | Text.Block("Commands that run during plan review (e.g., tests, linting).").Muted().Small()
+                        Layout.Vertical().Gap(4)
+                        | Text.Block("Commands that run during plan review (e.g., tests, linting).").Muted()
                         | new ReviewActionsTableView(editReviewActions, showReviewActionTrigger, showReviewActionAlert)
                         | new Button("Add Review Action").Icon(Icons.Plus).Outline()
                             .OnClick(() => showReviewActionTrigger(null))
@@ -167,7 +169,8 @@ public class EditProjectDialog(
                         | reviewActionAlertView
                     ),
                     new Tab("Verifications",
-                        Layout.Vertical().Gap(2)
+                        Layout.Vertical().Gap(4)
+                        | Text.Block("Quality checks required before plans are marked complete.").Muted()
                         | verificationsLayout
                     )
                 ).Variant(TabsVariant.Content).Width(Size.Full())

--- a/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
@@ -104,7 +104,7 @@ public class ProjectRepoPickerView(
             .Loading(isAdding.Value)
             .OnClick(() => { _ = AddAsync(); });
 
-        var listLayout = Layout.Vertical().Gap(2);
+        var listLayout = Layout.Vertical().Gap(3);
         var current = repos.Value;
         for (var i = 0; i < current.Count; i++)
         {
@@ -147,7 +147,7 @@ public class ProjectRepoPickerView(
             listLayout |= new Box(row).BorderStyle(BorderStyle.None).Background(Colors.Muted).Padding(4, 2, 2, 2).Width(Size.Full());
         }
 
-        return Layout.Vertical().Width(Size.Full()).Gap(2)
+        return Layout.Vertical().Width(Size.Full()).Gap(4)
                | Text.Label("Add one or more Git repositories")
                | (addingError.Value != null ? Text.Danger(addingError.Value) : null!)
                | (Layout.Horizontal() | pickerControls | addButton)


### PR DESCRIPTION
Fixes #1162

## Changes

Increased spacing between elements across all four tabs of the Edit Project dialog (Basic, Repositories, Review Actions, Verifications) by changing gap values from 2 to 4. Added consistent `.Muted()` subtitle descriptions as the first element in each tab for visual alignment. Also increased spacing in ProjectRepoPickerView between repo cards (Gap 2→3) and between the label/input/list sections (Gap 2→4).

## Files Modified

- **src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs** — Updated gap values on all tab layouts, added subtitle Text.Block elements, removed `.Small()` from Review Actions description
- **src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs** — Increased gap values for repo list and outer layout

---

**Commits:**
- 2b49f23