### PR TITLE
[00499] Increase touch target size for TendrilProcessViewer buttons on mobile

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css
@@ -215,6 +215,7 @@
     min-width: unset;
     width: 100%;
     max-width: 12rem;
+    min-height: 44px;
   }
 
   .tpv-arrow-segment {
@@ -227,6 +228,7 @@
     position: static;
     transform: none;
     margin-bottom: 0.125rem;
+    min-height: 44px;
   }
 
   .tpv-arrow-svg {
@@ -264,5 +266,6 @@
     position: static;
     transform: none;
     margin-top: 0.25rem;
+    min-height: 44px;
   }
 }


### PR DESCRIPTION
# Summary

## Changes

Added `min-height: 44px` to `.tpv-box`, `.tpv-arrow-label`, and `.tpv-sub-label` within the existing mobile media query (`@media max-width: 540px`) in `tendril-process.css`. This ensures all interactive buttons in the TendrilProcessViewer meet the WCAG 2.5.5 / Apple HIG recommended minimum touch target size on mobile devices.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css` — added min-height rules in mobile media query

---

## Commits

- 29ee453 Increase mobile touch target size to 44px for process viewer buttons