### PR TITLE
[00500] Extract RemoveCommittedProject Helper In AddProjectDialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/AddProjectDialog.cs
@@ -65,24 +65,25 @@ public class AddProjectDialog(
 
         if (!isOpen.Value) return null;
 
+        void RemoveCommittedProject()
+        {
+            if (!hasCreated.Value || string.IsNullOrWhiteSpace(editName.Value)) return;
+
+            var project = config.Settings.Projects.FirstOrDefault(
+                p => p.Name.Equals(editName.Value, StringComparison.OrdinalIgnoreCase));
+            if (project != null)
+            {
+                config.Settings.Projects.Remove(project);
+                try { config.SaveSettings(); } catch { }
+            }
+
+            hasCreated.Set(false);
+        }
+
         void CancelAndClose()
         {
             session.Reset();
-
-            if (hasCreated.Value && !string.IsNullOrWhiteSpace(editName.Value))
-            {
-                var project = config.Settings.Projects.FirstOrDefault(p => p.Name.Equals(editName.Value, StringComparison.OrdinalIgnoreCase));
-                if (project != null)
-                {
-                    config.Settings.Projects.Remove(project);
-                    try
-                    {
-                        config.SaveSettings();
-                    }
-                    catch { }
-                }
-            }
-
+            RemoveCommittedProject();
             isOpen.Set(false);
             refreshToken.Refresh();
         }
@@ -119,19 +120,7 @@ public class AddProjectDialog(
                 {
                     session.Reset();
                     isStepLoading.Set(false);
-
-                    if (hasCreated.Value && !string.IsNullOrWhiteSpace(editName.Value))
-                    {
-                        var project = config.Settings.Projects.FirstOrDefault(
-                            p => p.Name.Equals(editName.Value, StringComparison.OrdinalIgnoreCase));
-                        if (project != null)
-                        {
-                            config.Settings.Projects.Remove(project);
-                            try { config.SaveSettings(); } catch { }
-                        }
-                        hasCreated.Set(false);
-                    }
-
+                    RemoveCommittedProject();
                     step.Set(0);
                 },
                 onNext: () =>
@@ -147,18 +136,7 @@ public class AddProjectDialog(
                 session,
                 onBack: () =>
                 {
-                    if (hasCreated.Value && !string.IsNullOrWhiteSpace(editName.Value))
-                    {
-                        var project = config.Settings.Projects.FirstOrDefault(
-                            p => p.Name.Equals(editName.Value, StringComparison.OrdinalIgnoreCase));
-                        if (project != null)
-                        {
-                            config.Settings.Projects.Remove(project);
-                            try { config.SaveSettings(); } catch { }
-                        }
-                        hasCreated.Set(false);
-                    }
-
+                    RemoveCommittedProject();
                     step.Set(0);
                     session.Reset();
                 },


### PR DESCRIPTION
## Summary

Extracted a `RemoveCommittedProject()` local function in `AddProjectDialog.Build()` that encapsulates the duplicated project-removal logic (find by name, remove from config, save settings, reset `hasCreated`). Replaced three duplicate sites (`CancelAndClose()`, step 1 `onBack`, step 2 `onBack`) with calls to this helper.

## Files Modified

- `src/Ivy.Tendril/Apps/Settings/Dialogs/AddProjectDialog.cs` — extracted helper, replaced 3 duplicate blocks

---

## Commits

- f58d0d3 Extract RemoveCommittedProject helper in AddProjectDialog