### PR TITLE
[00502] Remove 'No Verifications Configured' Text From Review Harness

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
@@ -97,7 +97,7 @@ public class ProjectCrudStepView(
                | (Layout.Vertical()
                   | Text.H4("Verifications")
                   | Text.Muted("The steps run after each plan execution to validate changes.")
-                  | (verificationRows.Count > 0 ? (object)verificationTable : Text.Muted("No verifications configured."))
+                  | (verificationRows.Count > 0 ? (object)verificationTable : null!)
                   | new Button("Add Verification").Icon(Icons.Plus).Outline()
                       .OnClick(() => showVerificationTrigger(null)))
                | (Layout.Vertical()


### PR DESCRIPTION
Fixes #1157

## Changes

Removed the "No verifications configured." muted text placeholder from the Review Harness step in the Add Project dialog. When no verifications exist, the space is now empty rather than showing a placeholder message.

## Files Modified

- `src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs` — Changed ternary fallback from `Text.Muted("No verifications configured.")` to `null!`

---

## Commits

- 18633b4 Remove 'No verifications configured.' placeholder text from Review Harness