### PR TITLE
[00504] Add separator below each section in Review Harness

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
@@ -100,12 +100,14 @@ public class ProjectCrudStepView(
                   | (verificationRows.Count > 0 ? (object)verificationTable : Text.Muted("No verifications configured."))
                   | new Button("Add Verification").Icon(Icons.Plus).Outline()
                       .OnClick(() => showVerificationTrigger(null)))
+               | new Separator()
                | (Layout.Vertical()
                   | Text.H4("Review Actions")
                   | Text.Muted("Commands that makes it easy to start you project for manual testing.")
                   | new ReviewActionsTableView(reviewActions, showReviewActionTrigger, showReviewActionAlert)
                   | new Button("Add Review Action").Icon(Icons.Plus).Outline()
                       .OnClick(() => showReviewActionTrigger(null)))
+               | new Separator()
                | verificationTriggerView
                | verificationAlertView
                | reviewActionTriggerView


### PR DESCRIPTION
Fixes #1156

## Changes

Added visual separators between the "Verifications" and "Review Actions" sections in the Review Harness dialog (ProjectCrudStepView). Two `new Separator()` elements were inserted to improve readability and visual hierarchy.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs** — Added `new Separator()` after each section's layout block

---

### Commits

- ffa8a36 — Add separator below each section in Review Harness