### PR TITLE
[00507] Replace CSS Scrollbar Hack With HideScrollbar API

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -225,17 +225,13 @@ public class ContentView(
         var annotationsDialog = BuildAnnotationsGuardDialog(
             annotations, showAnnotationsDialog, preflightResult, pendingWaitJobIds, showDirtyDialog);
 
-        var hideScrollbar = new Html("<style>[role=tabpanel]>.overflow-hidden>[data-orientation]{display:none!important}</style>")
-            .DangerouslyAllowScripts().Width(Size.Px(0)).Height(Size.Px(0));
-
         var elements = new List<object>
         {
             mainLayout,
             updateDialog,
             deleteDialog,
             createIssueDialog,
-            debugSheet,
-            hideScrollbar
+            debugSheet
         };
 
         if (dirtyRepoDialog is not null)
@@ -248,7 +244,7 @@ public class ContentView(
 
         return new Fragment(elements.ToArray());
 
-        object Cap(object inner) => Layout.Vertical().Scroll().Width(Size.Full()).Height(Size.Full())
+        object Cap(object inner) => Layout.Vertical().Scroll().HideScrollbar().Width(Size.Full()).Height(Size.Full())
             | (Layout.Vertical().Padding(6, 0, 0, 4).Width(Size.Full().Max(Size.Units(200))) | inner);
     }
 

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -239,10 +239,7 @@ public class ContentView(
             ).Scroll(Scroll.None).Size(Size.Full())
         ).Scroll(Scroll.None).Size(Size.Full()).Key(selectedPlanState.Value.Id);
 
-        var hideScrollbar = new Html("<style>[role=tabpanel]>.overflow-hidden>[data-orientation]{display:none!important}</style>")
-            .DangerouslyAllowScripts().Width(Size.Px(0)).Height(Size.Px(0));
-
-        return new Fragment(mainLayout, discardDialog, suggestChangesDialog, customPrDialog, resetToDraftDialog, debugSheet, hideScrollbar);
+        return new Fragment(mainLayout, discardDialog, suggestChangesDialog, customPrDialog, resetToDraftDialog, debugSheet);
     }
 
     private object BuildHeader(
@@ -608,7 +605,7 @@ public class ContentView(
 
         object Cap(object inner)
         {
-            return Layout.Vertical().Scroll(Scroll.Auto).Width(Size.Full()).Height(Size.Full())
+            return Layout.Vertical().Scroll(Scroll.Auto).HideScrollbar().Width(Size.Full()).Height(Size.Full())
                 | (Layout.Vertical().Padding(6, 0, 0, 4).Width(Size.Full().Max(Size.Units(200))) | inner);
         }
     }


### PR DESCRIPTION
## Summary

Replaced the fragile CSS injection workaround (`Html` widget with `<style>` tag targeting Radix ScrollArea internals) with the first-class `HideScrollbar()` API in both the Drafts and Review content views. The `hideScrollbar` variable and its usage were removed entirely.

## Files Modified

- `src/Ivy.Tendril/Apps/Drafts/ContentView.cs` — Removed `hideScrollbar` Html widget, added `.HideScrollbar()` to `Cap()` method's scroll layout
- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — Removed `hideScrollbar` Html widget, added `.HideScrollbar()` to `Cap()` method's scroll layout

## Commits

- baf8295 Replace CSS scrollbar hack with HideScrollbar() API