### PR TITLE
feat: pass prompt as CLI arg and grant FullAuto permissions in AgentApp

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudePtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudePtyTests.cs
@@ -155,6 +155,35 @@ public class ClaudePtyTests
     }
 
     [Fact]
+    public void BuildPtySpec_WithInitialPrompt_AddsAsPositionalArgAfterClaude()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            InitialPrompt = "fix the failing test",
+        };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.Equal("claude", spec.CommandLine[0]);
+        Assert.Equal("fix the failing test", spec.CommandLine[1]);
+    }
+
+    [Fact]
+    public void BuildPtySpec_NoInitialPrompt_SecondArgIsAFlag()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+        };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.Equal("claude", spec.CommandLine[0]);
+        Assert.StartsWith("--", spec.CommandLine[1]);
+    }
+
+    [Fact]
     public void BuildPtySpec_WithModel_IncludesModelFlag()
     {
         var config = new AgentPtyConfig

--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexPtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexPtyTests.cs
@@ -1,0 +1,37 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Codex;
+
+namespace Ivy.Tendril.Agents.Test.Codex;
+
+public class CodexPtyTests
+{
+    private readonly CodexPty _pty = new();
+
+    [Fact]
+    public void BuildPtySpec_FullAuto_IncludesFullAutoFlag()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            PermissionMode = PermissionMode.FullAuto,
+        };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.Contains("--full-auto", spec.CommandLine);
+    }
+
+    [Fact]
+    public void BuildPtySpec_DefaultPermission_OmitsFullAutoFlag()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            PermissionMode = PermissionMode.Default,
+        };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.DoesNotContain("--full-auto", spec.CommandLine);
+    }
+}

--- a/src/Ivy.Tendril.Agents.Test/Copilot/CopilotPtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Copilot/CopilotPtyTests.cs
@@ -1,0 +1,41 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Copilot;
+
+namespace Ivy.Tendril.Agents.Test.Copilot;
+
+public class CopilotPtyTests
+{
+    private readonly CopilotPty _pty = new();
+
+    [Fact]
+    public void BuildPtySpec_FullAuto_GrantsAllToolsPathsAndUrls()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            PermissionMode = PermissionMode.FullAuto,
+        };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.Contains("--allow-all-tools", spec.CommandLine);
+        Assert.Contains("--allow-all-paths", spec.CommandLine);
+        Assert.Contains("--allow-all-urls", spec.CommandLine);
+    }
+
+    [Fact]
+    public void BuildPtySpec_DefaultPermission_OmitsAllowAllFlags()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            PermissionMode = PermissionMode.Default,
+        };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.DoesNotContain("--allow-all-tools", spec.CommandLine);
+        Assert.DoesNotContain("--allow-all-paths", spec.CommandLine);
+        Assert.DoesNotContain("--allow-all-urls", spec.CommandLine);
+    }
+}

--- a/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodePtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodePtyTests.cs
@@ -1,0 +1,37 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.OpenCode;
+
+namespace Ivy.Tendril.Agents.Test.OpenCode;
+
+public class OpenCodePtyTests
+{
+    private readonly OpenCodePty _pty = new();
+
+    [Fact]
+    public void BuildPtySpec_FullAuto_SkipsPermissions()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            PermissionMode = PermissionMode.FullAuto,
+        };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.Contains("--dangerously-skip-permissions", spec.CommandLine);
+    }
+
+    [Fact]
+    public void BuildPtySpec_DefaultPermission_OmitsSkipPermissions()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            PermissionMode = PermissionMode.Default,
+        };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.DoesNotContain("--dangerously-skip-permissions", spec.CommandLine);
+    }
+}

--- a/src/Ivy.Tendril.Agents/Abstractions/IAgentPty.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/IAgentPty.cs
@@ -12,6 +12,11 @@ public sealed record AgentPtyConfig
     public string? Model { get; init; }
     public string? SystemPrompt { get; init; }
     public bool AppendSystemPrompt { get; init; }
+    /// <summary>
+    /// Initial user prompt to pass on the command line as a positional argument
+    /// (for agents that accept one), instead of typing it into the PTY after launch.
+    /// </summary>
+    public string? InitialPrompt { get; init; }
     public PermissionMode PermissionMode { get; init; } = PermissionMode.FullAuto;
     public string? SessionId { get; init; }
     public IReadOnlyDictionary<string, string> EnvironmentVariables { get; init; } = new Dictionary<string, string>();

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudePty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudePty.cs
@@ -58,6 +58,11 @@ public sealed class ClaudePty : IAgentPty
     {
         var args = new List<string> { "claude" };
 
+        // Pass the initial prompt as a positional argument (claude "<prompt>" ...)
+        // so it is submitted on launch rather than typed into the PTY afterwards.
+        if (!string.IsNullOrEmpty(config.InitialPrompt))
+            args.Add(config.InitialPrompt);
+
         if (!string.IsNullOrEmpty(config.Model))
         {
             args.Add("--model");

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexPty.cs
@@ -46,6 +46,10 @@ public sealed class CodexPty : IAgentPty
     {
         var args = new List<string> { "codex" };
 
+        // FullAuto → run without approval prompts (workspace-write sandbox).
+        if (config.PermissionMode == PermissionMode.FullAuto)
+            args.Add("--full-auto");
+
         if (!string.IsNullOrEmpty(config.Model))
         {
             args.Add("--model");

--- a/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotPty.cs
@@ -62,6 +62,14 @@ public sealed class CopilotPty : IAgentPty
         var args = new List<string> { fileName };
         args.AddRange(prefixArgs);
 
+        // FullAuto → grant all tools, paths, and URLs without prompting.
+        if (config.PermissionMode == PermissionMode.FullAuto)
+        {
+            args.Add("--allow-all-paths");
+            args.Add("--allow-all-urls");
+            args.Add("--allow-all-tools");
+        }
+
         if (!string.IsNullOrEmpty(config.Model))
         {
             args.Add("--model");

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodePty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodePty.cs
@@ -55,6 +55,10 @@ public sealed class OpenCodePty : IAgentPty
     {
         var args = new List<string> { "opencode" };
 
+        // FullAuto → run without permission prompts.
+        if (config.PermissionMode == PermissionMode.FullAuto)
+            args.Add("--dangerously-skip-permissions");
+
         if (!string.IsNullOrEmpty(config.Model))
         {
             args.Add("--model");

--- a/src/Ivy.Tendril/Apps/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/AgentApp.cs
@@ -16,20 +16,25 @@ public class AgentApp : ViewBase
     {
         var configService = UseService<IConfigService>();
         var agentRunner = UseService<IAgentRunner>();
+        var args = UseArgs<AgentAppArgs>();
+
+        // Agents that accept the prompt as a positional CLI argument get it embedded
+        // in the command line; the rest fall back to typing it into the PTY on launch.
+        var promptInArgs = PromptPassedAsArg(configService, agentRunner);
+        var initialPrompt = promptInArgs ? args?.Prompt : null;
 
         var ptyHandle = Context.UsePty(
-            GetCommandLine(configService, agentRunner),
+            GetCommandLine(configService, agentRunner, initialPrompt),
             GetWorkDir(configService, agentRunner),
             new PtyOptions { Environment = GetEnvironment(configService) }
         );
 
-        var args = UseArgs<AgentAppArgs>();
         var promptSent = UseRef(false);
 
-        // Auto-send prompt if provided
+        // Auto-send prompt if provided and not already passed on the command line.
         Context.UseEffect(async () =>
         {
-            if (string.IsNullOrEmpty(args?.Prompt) || promptSent.Value)
+            if (promptInArgs || string.IsNullOrEmpty(args?.Prompt) || promptSent.Value)
                 return (IDisposable?)null;
 
             // Wait for agent to be ready (simple delay approach)
@@ -57,7 +62,7 @@ public class AgentApp : ViewBase
             .RemoveParentPadding();
     }
 
-    private static string[] GetCommandLine(IConfigService config, IAgentRunner runner)
+    private static string[] GetCommandLine(IConfigService config, IAgentRunner runner, string? initialPrompt)
     {
         var agentId = config.Settings.CodingAgent;
         var cli = runner.GetCli(agentId);
@@ -67,14 +72,27 @@ public class AgentApp : ViewBase
 
         WriteAgentInstructionsIfNeeded(workDir, systemPrompt, pty);
 
+        // Claude takes "--model default" to explicitly select its configured default model.
+        var model = pty?.Id == AgentId.Claude ? "default" : null;
+
         var spec = pty?.BuildPtySpec(new AgentPtyConfig
         {
             WorkingDirectory = workDir,
-            PermissionMode = PermissionMode.Default,
+            PermissionMode = PermissionMode.FullAuto,
             SystemPrompt = systemPrompt,
             AppendSystemPrompt = true,
+            InitialPrompt = initialPrompt,
+            Model = model,
         });
         return spec?.ResolveCommand().CommandLine.ToArray() ?? [cli.Id];
+    }
+
+    // Claude accepts the initial prompt as a positional CLI argument; other agents
+    // (OpenCode, Gemini, Codex, Copilot, Antigravity) receive it typed into the PTY.
+    private static bool PromptPassedAsArg(IConfigService config, IAgentRunner runner)
+    {
+        var agentId = config.Settings.CodingAgent;
+        return runner.GetPty(agentId)?.Id == AgentId.Claude;
     }
 
     private static void WriteAgentInstructionsIfNeeded(string workDir, string? systemPrompt, IAgentPty? pty)

--- a/src/Ivy.Tendril/Apps/DraftsApp.cs
+++ b/src/Ivy.Tendril/Apps/DraftsApp.cs
@@ -108,9 +108,13 @@ public class DraftsApp : ViewBase
 
         var sidebar = new SidebarView(plans, selectedPlanState, projectFilter, levelFilter, textFilter, filtersOpen, configService);
 
+        var content = new ContentView(selectedPlanState.Value, filteredPlans, selectedPlanState, planService, jobService,
+            RefreshPlans, configService, gitService);
+        if (plans.Count == 0)
+            return content;
+
         return new SidebarLayout(
-            new ContentView(selectedPlanState.Value, filteredPlans, selectedPlanState, planService, jobService,
-                RefreshPlans, configService, gitService),
+            content,
             sidebar
         ).SidebarContentScroll(Scroll.None);
 

--- a/src/Ivy.Tendril/Apps/IceboxApp.cs
+++ b/src/Ivy.Tendril/Apps/IceboxApp.cs
@@ -59,9 +59,13 @@ public class IceboxApp : ViewBase
 
         var sidebar = new SidebarView(plans, selectedPlanState, projectFilter, levelFilter, textFilter, filtersOpen, configService);
 
+        var content = new ContentView(selectedPlanState.Value, filteredPlans, selectedPlanState, planService, jobService,
+            RefreshPlans, configService);
+        if (plans.Count == 0)
+            return content;
+
         return new SidebarLayout(
-            new ContentView(selectedPlanState.Value, filteredPlans, selectedPlanState, planService, jobService,
-                RefreshPlans, configService),
+            content,
             sidebar
         ).SidebarContentScroll(Scroll.None);
 

--- a/src/Ivy.Tendril/Apps/RecommendationsApp.cs
+++ b/src/Ivy.Tendril/Apps/RecommendationsApp.cs
@@ -72,8 +72,12 @@ public class RecommendationsApp : ViewBase
             filtersOpen
         );
 
+        var content = new ContentView(selectedState.Value, filtered, selectedState, planService, jobService, Refresh);
+        if (allPending.Count == 0)
+            return content;
+
         return new SidebarLayout(
-            new ContentView(selectedState.Value, filtered, selectedState, planService, jobService, Refresh),
+            content,
             sidebar
         ).SidebarContentScroll(Scroll.None);
     }

--- a/src/Ivy.Tendril/Apps/ReviewApp.cs
+++ b/src/Ivy.Tendril/Apps/ReviewApp.cs
@@ -104,9 +104,13 @@ public class ReviewApp : ViewBase
 
         var sidebar = new SidebarView(plans, selectedPlanState, projectFilter, levelFilter, textFilter, filtersOpen, showCompleted, configService);
 
+        var content = new ContentView(selectedPlanState, filteredPlans, planService, jobService,
+            RefreshPlans, configService, gitService);
+        if (plans.Count == 0)
+            return content;
+
         return new SidebarLayout(
-            new ContentView(selectedPlanState, filteredPlans, planService, jobService,
-                RefreshPlans, configService, gitService),
+            content,
             sidebar
         ).SidebarContentScroll(Scroll.None);
 

--- a/src/Ivy.Tendril/Apps/TrashApp.cs
+++ b/src/Ivy.Tendril/Apps/TrashApp.cs
@@ -126,13 +126,14 @@ public class TrashApp : ViewBase
             ).Scroll(Scroll.None).Size(Size.Full());
         }
 
-        var elements = new List<object>
-        {
-            new SidebarLayout(
+        object body = files.Count == 0
+            ? mainContent
+            : new SidebarLayout(
                 mainContent,
                 sidebar
-            ).SidebarContentScroll(Scroll.None)
-        };
+            ).SidebarContentScroll(Scroll.None);
+
+        var elements = new List<object> { body };
 
         elements.Add(new FileSheet(openFile, configService));
 


### PR DESCRIPTION
- AgentApp passes the initial prompt as a positional CLI argument for Claude (instead of typing into the PTY) and sets --model default.
- Launch PTY agents with PermissionMode.FullAuto to match the CreatePlan promptware posture; add FullAuto handling to the Codex (--full-auto), Copilot (--allow-all-*), and OpenCode (--dangerously-skip-permissions) PTY builders so it works for all coding agents.
- Add InitialPrompt to AgentPtyConfig and PTY tests for the new flags.
