### PR TITLE
fix: type AgentApp prompt with Enter, full-bypass permissions, job-based plan creation

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudePtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudePtyTests.cs
@@ -155,35 +155,6 @@ public class ClaudePtyTests
     }
 
     [Fact]
-    public void BuildPtySpec_WithInitialPrompt_AddsAsPositionalArgAfterClaude()
-    {
-        var config = new AgentPtyConfig
-        {
-            WorkingDirectory = "/tmp/test",
-            InitialPrompt = "fix the failing test",
-        };
-
-        var spec = _pty.BuildPtySpec(config);
-
-        Assert.Equal("claude", spec.CommandLine[0]);
-        Assert.Equal("fix the failing test", spec.CommandLine[1]);
-    }
-
-    [Fact]
-    public void BuildPtySpec_NoInitialPrompt_SecondArgIsAFlag()
-    {
-        var config = new AgentPtyConfig
-        {
-            WorkingDirectory = "/tmp/test",
-        };
-
-        var spec = _pty.BuildPtySpec(config);
-
-        Assert.Equal("claude", spec.CommandLine[0]);
-        Assert.StartsWith("--", spec.CommandLine[1]);
-    }
-
-    [Fact]
     public void BuildPtySpec_WithModel_IncludesModelFlag()
     {
         var config = new AgentPtyConfig
@@ -200,7 +171,7 @@ public class ClaudePtyTests
     }
 
     [Fact]
-    public void BuildPtySpec_FullAutoPermission_MapsToDontAsk()
+    public void BuildPtySpec_FullAutoPermission_SkipsPermissions()
     {
         var config = new AgentPtyConfig
         {
@@ -210,9 +181,8 @@ public class ClaudePtyTests
 
         var spec = _pty.BuildPtySpec(config);
 
-        var idx = IndexOf(spec.CommandLine,"--permission-mode");
-        Assert.NotEqual(-1, idx);
-        Assert.Equal("dontAsk", spec.CommandLine[idx + 1]);
+        Assert.Contains("--dangerously-skip-permissions", spec.CommandLine);
+        Assert.DoesNotContain("--permission-mode", spec.CommandLine);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents/Abstractions/IAgentPty.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/IAgentPty.cs
@@ -12,11 +12,6 @@ public sealed record AgentPtyConfig
     public string? Model { get; init; }
     public string? SystemPrompt { get; init; }
     public bool AppendSystemPrompt { get; init; }
-    /// <summary>
-    /// Initial user prompt to pass on the command line as a positional argument
-    /// (for agents that accept one), instead of typing it into the PTY after launch.
-    /// </summary>
-    public string? InitialPrompt { get; init; }
     public PermissionMode PermissionMode { get; init; } = PermissionMode.FullAuto;
     public string? SessionId { get; init; }
     public IReadOnlyDictionary<string, string> EnvironmentVariables { get; init; } = new Dictionary<string, string>();

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudePty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudePty.cs
@@ -58,25 +58,29 @@ public sealed class ClaudePty : IAgentPty
     {
         var args = new List<string> { "claude" };
 
-        // Pass the initial prompt as a positional argument (claude "<prompt>" ...)
-        // so it is submitted on launch rather than typed into the PTY afterwards.
-        if (!string.IsNullOrEmpty(config.InitialPrompt))
-            args.Add(config.InitialPrompt);
-
         if (!string.IsNullOrEmpty(config.Model))
         {
             args.Add("--model");
             args.Add(config.Model);
         }
 
-        args.Add("--permission-mode");
-        args.Add(config.PermissionMode switch
+        if (config.PermissionMode == PermissionMode.FullAuto)
         {
-            PermissionMode.FullAuto => "dontAsk",
-            PermissionMode.AcceptEdits => "acceptEdits",
-            PermissionMode.Plan => "plan",
-            _ => "default"
-        });
+            // Full bypass for an interactive session — auto-approves every tool and
+            // command. --permission-mode dontAsk does NOT bypass command execution,
+            // so the agent would still prompt before running e.g. `tendril plan create`.
+            args.Add("--dangerously-skip-permissions");
+        }
+        else
+        {
+            args.Add("--permission-mode");
+            args.Add(config.PermissionMode switch
+            {
+                PermissionMode.AcceptEdits => "acceptEdits",
+                PermissionMode.Plan => "plan",
+                _ => "default"
+            });
+        }
 
         if (!string.IsNullOrEmpty(config.SessionId))
         {

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/AnnotationPopover.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/AnnotationPopover.tsx
@@ -168,10 +168,18 @@ interface SelectionToolbarProps {
   onAddComment: () => void;
 }
 
+const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
+const ADD_COMMENT_SHORTCUT = isMac ? "⌘⌥M" : "Ctrl+Alt+M";
+
 export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({ position, onAddComment }) => {
   return createPortal(
     <div className="pmv-selection-toolbar" style={{ top: position.top, left: position.left }}>
-      <button type="button" className="pmv-selection-toolbar-btn" onClick={onAddComment}>
+      <button
+        type="button"
+        className="pmv-selection-toolbar-btn"
+        onClick={onAddComment}
+        title={`Add Comment (${ADD_COMMENT_SHORTCUT})`}
+      >
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="12"
@@ -187,6 +195,7 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({ position, on
           <path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4" />
         </svg>
         Add Comment
+        <kbd className="pmv-selection-toolbar-kbd">{ADD_COMMENT_SHORTCUT}</kbd>
       </button>
     </div>,
     document.body,

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
@@ -156,6 +156,24 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
     window.getSelection()?.removeAllRanges();
   }, [selectionToolbar]);
 
+  // Keyboard shortcuts while a selection toolbar is showing:
+  // Cmd/Ctrl+Alt+M opens the comment dialog, Escape dismisses the toolbar.
+  useEffect(() => {
+    if (!selectionToolbar) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Match the physical key (e.code) so Windows AltGr (Ctrl+Alt) and non-US
+      // layouts, which can remap e.key, still trigger the shortcut.
+      if (e.code === "KeyM" && (e.metaKey || e.ctrlKey) && e.altKey) {
+        e.preventDefault();
+        handleAddComment();
+      } else if (e.key === "Escape") {
+        setSelectionToolbar(null);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [selectionToolbar, handleAddComment]);
+
   const handleAddAnnotation = useCallback(
     (comment: string) => {
       if (!addPopover) return;

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -492,6 +492,19 @@
   background: var(--muted);
 }
 
+.pmv-selection-toolbar-kbd {
+  margin-left: 0.25rem;
+  padding: 0.0625rem 0.25rem;
+  border-radius: 0.1875rem;
+  border: 1px solid var(--border);
+  background: var(--muted);
+  color: var(--muted-foreground);
+  font-family: inherit;
+  font-size: 0.6875rem;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
 /* ─── Diagram renderers (Mermaid + Graphviz) ─────────────────────────── */
 .pmv-diagram-container {
   border-radius: 0.375rem;

--- a/src/Ivy.Tendril/Apps/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/AgentApp.cs
@@ -18,23 +18,21 @@ public class AgentApp : ViewBase
         var agentRunner = UseService<IAgentRunner>();
         var args = UseArgs<AgentAppArgs>();
 
-        // Agents that accept the prompt as a positional CLI argument get it embedded
-        // in the command line; the rest fall back to typing it into the PTY on launch.
-        var promptInArgs = PromptPassedAsArg(configService, agentRunner);
-        var initialPrompt = promptInArgs ? args?.Prompt : null;
-
         var ptyHandle = Context.UsePty(
-            GetCommandLine(configService, agentRunner, initialPrompt),
+            GetCommandLine(configService, agentRunner),
             GetWorkDir(configService, agentRunner),
             new PtyOptions { Environment = GetEnvironment(configService) }
         );
 
         var promptSent = UseRef(false);
 
-        // Auto-send prompt if provided and not already passed on the command line.
+        // Auto-send the prompt by typing it into the PTY once the agent is ready.
+        // Typing (rather than passing it as a CLI argument) keeps arbitrary content
+        // intact — quotes, '#', newlines, pasted-image references. A separate Enter
+        // keystroke is sent afterwards so the agent actually submits the prompt.
         Context.UseEffect(async () =>
         {
-            if (promptInArgs || string.IsNullOrEmpty(args?.Prompt) || promptSent.Value)
+            if (string.IsNullOrEmpty(args?.Prompt) || promptSent.Value)
                 return (IDisposable?)null;
 
             // Wait for agent to be ready (simple delay approach)
@@ -43,7 +41,16 @@ public class AgentApp : ViewBase
             if (!promptSent.Value)
             {
                 promptSent.Value = true;
-                ptyHandle.HandleInput(args.Prompt + "\n");
+                ptyHandle.HandleInput(args.Prompt);
+
+                // Submit with Enter. The text arrives as one chunk, so the agent's
+                // paste handling can absorb an Enter that follows too quickly — give it
+                // time to settle, then press Enter. A second Enter guards against the
+                // first being swallowed; an extra Enter on an empty buffer is a no-op.
+                await Task.Delay(700);
+                ptyHandle.HandleInput("\r");
+                await Task.Delay(300);
+                ptyHandle.HandleInput("\r");
             }
 
             return (IDisposable?)null;
@@ -62,7 +69,7 @@ public class AgentApp : ViewBase
             .RemoveParentPadding();
     }
 
-    private static string[] GetCommandLine(IConfigService config, IAgentRunner runner, string? initialPrompt)
+    private static string[] GetCommandLine(IConfigService config, IAgentRunner runner)
     {
         var agentId = config.Settings.CodingAgent;
         var cli = runner.GetCli(agentId);
@@ -81,18 +88,9 @@ public class AgentApp : ViewBase
             PermissionMode = PermissionMode.FullAuto,
             SystemPrompt = systemPrompt,
             AppendSystemPrompt = true,
-            InitialPrompt = initialPrompt,
             Model = model,
         });
         return spec?.ResolveCommand().CommandLine.ToArray() ?? [cli.Id];
-    }
-
-    // Claude accepts the initial prompt as a positional CLI argument; other agents
-    // (OpenCode, Gemini, Codex, Copilot, Antigravity) receive it typed into the PTY.
-    private static bool PromptPassedAsArg(IConfigService config, IAgentRunner runner)
-    {
-        var agentId = config.Settings.CodingAgent;
-        return runner.GetPty(agentId)?.Id == AgentId.Claude;
     }
 
     private static void WriteAgentInstructionsIfNeeded(string workDir, string? systemPrompt, IAgentPty? pty)

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -70,7 +70,7 @@ public class CreatePlanDialog(
                         ? selectedProjects.Value
                         : projectNames.Count == 1 ? [projectNames[0]] : ["Auto"];
                     var projectNamesStr = string.Join(", ", projects);
-                    var prompt = $"User wants to chat about creating a Tendril plan for project {projectNamesStr} with the description \"{createPlanText.Value}\"";
+                    var prompt = $"I want to discuss creating a Tendril plan for the project {projectNamesStr} from this description: \"{createPlanText.Value}\"";
                     nav.Navigate<AgentApp>(new AgentAppArgs(prompt));
                     onClose();
                 }),

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -222,10 +222,22 @@ These commands are for internal use by other promptwares (e.g., a verification s
 | `tendril project add-review-action <name>` | Add review action |
 | `tendril project remove-review-action <name> <action>` | Remove review action |
 
+## Creating Plans Interactively
+
+When the user asks you to create a plan:
+
+1. **Do the work the description implies, first.** If the description asks you to *suggest*, *research*, *investigate*, *compare*, or *decide* something, actually do that work before creating the plan. Explore the project's repos, read the relevant code, and produce concrete, specific proposals. For example, "Suggest a few dev tools we can add" means you go look at the project and come back with named tools and why — it does **not** mean creating a plan titled "Suggest dev tools to add".
+2. **Confirm scope when it's open-ended.** Briefly share what you found and what you propose, so the user can steer before you commit it to a plan.
+3. **Create the plan by starting a CreatePlan job** — do **not** run `tendril plan create` / `write-revision` yourself. Once the scope is concrete, start the job:
+   ```bash
+   tendril job start CreatePlan --description "<concrete, refined description>" --project "<project>"
+   ```
+   The CreatePlan promptware then researches, detects duplicates, and writes the full plan. Pass the specific description you developed (the concrete tools/steps you proposed), **not** the user's original vague request. Add `--priority <n>` or `--force` if appropriate. Report the job back to the user.
+
 ## Important Notes
 
 - **Never read or write `plan.yaml` directly** -- always use `tendril plan` CLI commands.
 - **`tendril job start` and `tendril job status` require the Tendril server to be running.** They communicate via HTTP to the master instance (discovered via `TENDRIL_HOME/.master`).
 - Verification statuses: `Pending`, `Pass`, `Fail`, `Skipped`.
 - Plan states: `Draft`, `Building`, `Updating`, `Executing`, `ReadyForReview`, `Failed`, `Completed`, `Skipped`, `Blocked`, `Icebox`.
-- To create a plan interactively: use `tendril plan create "<title>"` then `tendril plan write-revision <id> <<'EOF' ... EOF` to add content.
+- To create a new plan, start a CreatePlan job: `tendril job start CreatePlan --description "<description>" --project "<project>"` (see "Creating Plans Interactively"). Use the lower-level `tendril plan create` / `write-revision` commands only to edit an existing plan's content, never to create a new plan from a chat request.


### PR DESCRIPTION
- Revert Claude prompt to being typed into the PTY (not a positional CLI arg) so arbitrary content survives; send a separate Enter after a delay so it submits.
- ClaudePty FullAuto now emits --dangerously-skip-permissions instead of --permission-mode dontAsk, which did not bypass command execution.
- AgentPrompt.md + CreatePlanDialog: interactive agent does the suggest/research work first, then creates plans by starting a CreatePlan job (tendril job start CreatePlan) rather than running tendril plan create directly.
- Remove now-unused InitialPrompt plumbing.
- Includes DraftMarkdown annotation popover frontend tweaks.
