### PR TITLE
fix: CreatePlan prompt phrasing/trim and Agent prompt submission

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -379,7 +379,7 @@ codingAgents:
 - name: claude
   arguments: ''
   environmentVariables:
-    CLAUDE_CODE_USE_BEDROCK: "1"
+    CLAUDE_CODE_USE_BEDROCK: 1
   profiles:
   - name: deep
     model: opus
@@ -395,6 +395,7 @@ codingAgents:
     arguments: ''
 - name: codex
   arguments: ''
+  environmentVariables: {}
   profiles:
   - name: deep
     model: default
@@ -410,6 +411,7 @@ codingAgents:
     arguments: ''
 - name: opencode
   arguments: ''
+  environmentVariables: {}
   profiles:
   - name: deep
     model: default
@@ -425,6 +427,7 @@ codingAgents:
     arguments: ''
 - name: antigravity
   arguments: ''
+  environmentVariables: {}
   profiles:
   - name: deep
     model: default
@@ -440,6 +443,7 @@ codingAgents:
     arguments: ''
 - name: copilot
   arguments: ''
+  environmentVariables: {}
   profiles:
   - name: deep
     model: default
@@ -455,6 +459,7 @@ codingAgents:
     arguments: ''
 - name: gemini
   arguments: ''
+  environmentVariables: {}
   profiles:
   - name: deep
     model: default

--- a/src/Ivy.Tendril.Test/CreatePlanDialogTests.cs
+++ b/src/Ivy.Tendril.Test/CreatePlanDialogTests.cs
@@ -1,0 +1,45 @@
+using Ivy.Tendril.Apps.Drafts.Dialogs;
+
+namespace Ivy.Tendril.Test;
+
+public class CreatePlanDialogTests
+{
+    [Fact]
+    public void BuildAgentPrompt_SingleProject_UsesSingularProject()
+    {
+        var prompt = CreatePlanDialog.BuildAgentPrompt(["Tendril-Services"], "Make a md5 tool");
+
+        Assert.Equal(
+            "I want to discuss creating a Tendril plan for the project Tendril-Services from this description: \"Make a md5 tool\"",
+            prompt);
+    }
+
+    [Fact]
+    public void BuildAgentPrompt_MultipleProjects_UsesPluralAndOr()
+    {
+        var prompt = CreatePlanDialog.BuildAgentPrompt(["Tendril-Services", "lots-of-dev-tools"], "Make a md5 tool");
+
+        Assert.Equal(
+            "I want to discuss creating a Tendril plan for the projects Tendril-Services or lots-of-dev-tools from this description: \"Make a md5 tool\"",
+            prompt);
+    }
+
+    [Fact]
+    public void BuildAgentPrompt_Auto_LetsAgentPickProject()
+    {
+        var prompt = CreatePlanDialog.BuildAgentPrompt(["Auto"], "Make a md5 tool");
+
+        Assert.Equal(
+            "I want to discuss creating a Tendril plan from this description: \"Make a md5 tool\". Determine the most appropriate project for it yourself.",
+            prompt);
+    }
+
+    [Fact]
+    public void BuildAgentPrompt_TrimsDescriptionWhitespace()
+    {
+        var prompt = CreatePlanDialog.BuildAgentPrompt(["Tendril-Services"], "  Make a md5 tool  ");
+
+        Assert.Contains("description: \"Make a md5 tool\"", prompt);
+        Assert.DoesNotContain("md5 tool \"", prompt);
+    }
+}

--- a/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
@@ -62,6 +62,12 @@ public class JobServiceDeletionTests
         Assert.Null(service.GetJob("completed-2"));
         Assert.NotNull(service.GetJob("running-1"));
         Assert.Empty(db.DeletedJobIds);
+
+        // Cleared jobs are soft-deleted: persisted with Cleared=true so they
+        // stay out of the Jobs app after restart but remain in plan history
+        Assert.Contains(db.UpsertedJobs, j => j.Id == "completed-1" && j.Cleared);
+        Assert.Contains(db.UpsertedJobs, j => j.Id == "completed-2" && j.Cleared);
+        Assert.DoesNotContain(db.UpsertedJobs, j => j.Id == "running-1");
     }
 
     [Fact]
@@ -81,6 +87,8 @@ public class JobServiceDeletionTests
         Assert.NotNull(service.GetJob("blocked-1"));
         Assert.NotNull(service.GetJob("completed-1"));
         Assert.Empty(db.DeletedJobIds);
+        Assert.Contains(db.UpsertedJobs, j => j.Id == "failed-1" && j.Cleared);
+        Assert.Contains(db.UpsertedJobs, j => j.Id == "timeout-1" && j.Cleared);
     }
 
     [Fact]
@@ -98,6 +106,7 @@ public class JobServiceDeletionTests
     private class FakeDatabaseService : IPlanDatabaseService
     {
         public List<string> DeletedJobIds { get; } = new();
+        public List<JobItem> UpsertedJobs { get; } = new();
         public bool ThrowOnDelete { get; init; }
 
         public void DeleteJob(string id)
@@ -215,6 +224,7 @@ public class JobServiceDeletionTests
 
         public void UpsertJob(JobItem job)
         {
+            UpsertedJobs.Add(job);
         }
 
         public List<JobItem> GetRecentJobs(int limit = 100)

--- a/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -888,6 +888,35 @@ public class PlanDatabaseServiceTests : IDisposable
     }
 
     [Fact]
+    public void ClearedJob_ExcludedFromRecentJobs_ButKeptInPlanHistory()
+    {
+        var job = new JobItem
+        {
+            Id = "job-001",
+            Type = "ExecutePlan",
+            PlanFile = "01500-TestPlan",
+            Project = "Tendril",
+            Status = JobStatus.Completed,
+            Provider = "claude",
+            CompletedAt = new DateTime(2026, 4, 7, 10, 0, 0, DateTimeKind.Utc)
+        };
+        _db.UpsertJob(job);
+        Assert.Single(_db.GetRecentJobs());
+
+        job.Cleared = true;
+        _db.UpsertJob(job);
+
+        // Hidden from the Jobs app (loaded via GetRecentJobs on startup)
+        Assert.Empty(_db.GetRecentJobs());
+
+        // Still visible in plan Details history and direct lookups
+        var planJobs = _db.GetJobsForPlan("01500-TestPlan");
+        Assert.Single(planJobs);
+        Assert.True(planJobs[0].Cleared);
+        Assert.NotNull(_db.GetJobById("job-001"));
+    }
+
+    [Fact]
     public void PurgeOldJobs_RemovesExcessJobs()
     {
         // Insert 600 jobs with distinct CompletedAt times

--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -41,10 +41,14 @@ public class AgentApp : ViewBase
             {
                 promptSent.Value = true;
                 ptyHandle.HandleInput("\u001b[200~" + args.Prompt + "\u001b[201~");
-                await Task.Delay(300);
-                ptyHandle.HandleInput("\r");
-                await Task.Delay(300);
-                ptyHandle.HandleInput("\r");
+                // The paste takes a moment to settle before the agent accepts an Enter
+                // as "submit" (an Enter sent too early is absorbed). Retry over a longer
+                // window; once submitted, further Enters hit an empty buffer and no-op.
+                for (var i = 0; i < 3; i++)
+                {
+                    await Task.Delay(800);
+                    ptyHandle.HandleInput("\r");
+                }
             }
 
             return (IDisposable?)null;
@@ -55,7 +59,8 @@ public class AgentApp : ViewBase
             .OnInput(ptyHandle.HandleInput)
             .OnResize(ptyHandle.HandleResize)
             .Closed(ptyHandle.Closed)
-            .AllowClipboard();
+            .AllowClipboard()
+            .Loading($"Starting {agentRunner.GetCli(configService.Settings.CodingAgent).DisplayName}...");
 
         return terminal
             .WithLayout()

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -23,6 +23,22 @@ public class CreatePlanDialog(
         _ => 0
     };
 
+    // Builds the seed prompt for the "Continue with Agent" flow. The description is
+    // trimmed, a single project reads "the project X", multiple read "the projects X or Y",
+    // and "Auto" lets the agent pick the project itself.
+    internal static string BuildAgentPrompt(string[] projects, string description)
+    {
+        var trimmed = description.Trim();
+        var realProjects = projects.Where(p => p != "Auto").ToArray();
+
+        if (realProjects.Length == 0)
+            return $"I want to discuss creating a Tendril plan from this description: \"{trimmed}\". Determine the most appropriate project for it yourself.";
+
+        var projectWord = realProjects.Length == 1 ? "project" : "projects";
+        var projectList = string.Join(" or ", realProjects);
+        return $"I want to discuss creating a Tendril plan for the {projectWord} {projectList} from this description: \"{trimmed}\"";
+    }
+
     public override object Build()
     {
         var nav = UseNavigation();
@@ -69,8 +85,7 @@ public class CreatePlanDialog(
                     var projects = selectedProjects.Value.Any()
                         ? selectedProjects.Value
                         : projectNames.Count == 1 ? [projectNames[0]] : ["Auto"];
-                    var projectNamesStr = string.Join(", ", projects);
-                    var prompt = $"I want to discuss creating a Tendril plan for the project {projectNamesStr} from this description: \"{createPlanText.Value}\"";
+                    var prompt = BuildAgentPrompt(projects, createPlanText.Value);
                     nav.Navigate<AgentApp>(new AgentAppArgs(prompt));
                     onClose();
                 }),
@@ -82,7 +97,7 @@ public class CreatePlanDialog(
                         var projects = selectedProjects.Value.Any()
                             ? selectedProjects.Value
                             : projectNames.Count == 1 ? [projectNames[0]] : ["Auto"];
-                        onCreatePlan(createPlanText.Value, projects, ParsePriority(selectedPriority.Value));
+                        onCreatePlan(createPlanText.Value.Trim(), projects, ParsePriority(selectedPriority.Value));
                         onClose();
                     }
                 })

--- a/src/Ivy.Tendril/Database/Migrations/Migration_014_JobsCleared.cs
+++ b/src/Ivy.Tendril/Database/Migrations/Migration_014_JobsCleared.cs
@@ -1,0 +1,20 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Database.Migrations;
+
+public class Migration_014_JobsCleared : IMigration
+{
+    public int Version => 14;
+    public string Description => "Add Cleared column to Jobs table for soft-clearing jobs from the Jobs app";
+
+    public void Apply(SqliteConnection connection, ILogger? logger = null)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            ALTER TABLE Jobs ADD COLUMN Cleared INTEGER NOT NULL DEFAULT 0;
+            PRAGMA user_version = 14;
+            """;
+        cmd.ExecuteNonQuery();
+    }
+}

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -59,6 +59,9 @@ public record JobItem
     public decimal? Cost { get; set; }
     public int? Tokens { get; set; }
 
+    // Soft-cleared from the Jobs app; still shown in plan Details history
+    public bool Cleared { get; set; }
+
     [JsonIgnore]
     public IEventParser? EventParser { get; set; }
     private IEventSerializer? _eventSerializer;

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -301,7 +301,13 @@ public class JobService : IJobService
         foreach (var id in ids)
         {
             if (_jobs.TryRemove(id, out var removed))
+            {
+                // Soft-clear: hide from the Jobs app across restarts while keeping
+                // the row in SQLite so plan Details history stays complete.
+                removed.Cleared = true;
+                PersistJob(removed);
                 removed.DisposeResources(_logger);
+            }
         }
         if (ids.Count > 0)
             RaiseJobsStructureChanged();

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -673,8 +673,8 @@ public class PlanDatabaseService : IPlanDatabaseService
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
-                              INSERT OR REPLACE INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, SessionId, StartedAt, CompletedAt, DurationSeconds, Cost, Tokens, StatusMessage, Args, TypedArgs, WorkingDirectory, CliCommand)
-                              VALUES (@id, @type, @planFile, @project, @status, @provider, @sessionId, @startedAt, @completedAt, @durationSeconds, @cost, @tokens, @statusMessage, @args, @typedArgs, @workingDirectory, @cliCommand)
+                              INSERT OR REPLACE INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, SessionId, StartedAt, CompletedAt, DurationSeconds, Cost, Tokens, StatusMessage, Args, TypedArgs, WorkingDirectory, CliCommand, Cleared)
+                              VALUES (@id, @type, @planFile, @project, @status, @provider, @sessionId, @startedAt, @completedAt, @durationSeconds, @cost, @tokens, @statusMessage, @args, @typedArgs, @workingDirectory, @cliCommand, @cleared)
                               """;
             cmd.Parameters.AddWithValue("@id", job.Id);
             cmd.Parameters.AddWithValue("@type", job.Type);
@@ -697,6 +697,7 @@ public class PlanDatabaseService : IPlanDatabaseService
                 : DBNull.Value);
             cmd.Parameters.AddWithValue("@workingDirectory", (object?)job.WorkingDirectory ?? DBNull.Value);
             cmd.Parameters.AddWithValue("@cliCommand", (object?)job.CliCommand ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@cleared", job.Cleared ? 1 : 0);
             cmd.ExecuteNonQuery();
         }
     }
@@ -705,7 +706,7 @@ public class PlanDatabaseService : IPlanDatabaseService
     {
         using (new ReadLockHandle(_lock))
         {
-            return ReadList("SELECT * FROM Jobs ORDER BY CompletedAt DESC LIMIT @limit",
+            return ReadList("SELECT * FROM Jobs WHERE Cleared = 0 ORDER BY CompletedAt DESC LIMIT @limit",
                 MapJobRow,
                 new SqliteParameter("@limit", limit));
         }
@@ -771,7 +772,8 @@ public class PlanDatabaseService : IPlanDatabaseService
                 : reader.GetString(reader.GetOrdinal("WorkingDirectory")),
             CliCommand = reader.IsDBNull(reader.GetOrdinal("CliCommand"))
                 ? null
-                : reader.GetString(reader.GetOrdinal("CliCommand"))
+                : reader.GetString(reader.GetOrdinal("CliCommand")),
+            Cleared = reader.GetInt32(reader.GetOrdinal("Cleared")) != 0
         };
     }
 


### PR DESCRIPTION
- CreatePlanDialog: BuildAgentPrompt trims the description and phrases projects correctly — 'the project X', 'the projects X or Y', and an Auto case that lets the agent pick the project. Trim the description on the direct Create path too. Tests added.
- AgentApp: retry Enter a few times after the bracketed paste so the prompt actually submits (the byte matches a real user Enter; the issue was timing).
- Includes unrelated jobs-cleared migration (Migration_014) and related JobService/PlanDatabaseService changes.
