### PR TITLE
[00514] Hide empty progress bar in Jobs data table

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -22,7 +22,7 @@ public partial class JobsApp
         Action<string>? showDebug,
         List<JobItem> jobs,
         Dictionary<string, string> projectColors,
-        StackedProgress jobsProgress)
+        StackedProgress? jobsProgress)
     {
         return rows.AsQueryable()
             .ToDataTable(t => t.Id)
@@ -263,7 +263,7 @@ public partial class JobsApp
                 return ValueTask.CompletedTask;
             })
             .HeaderRight(_ => Layout.Horizontal()
-                              | jobsProgress
+                              | (jobsProgress != null ? jobsProgress : null!)
                               | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
                                   new MenuItem("Clear Completed", Icon: Icons.Trash, Tag: "ClearCompleted")
                                       .OnSelect(() =>

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
@@ -73,7 +73,7 @@ public partial class JobsApp : ViewBase
         var jobs = jobService.GetJobs();
         var projectColors = BuildProjectColorMapping(config);
         var rows = BuildJobRows(jobs, planService);
-        var jobsProgress = BuildStatusProgress(jobs, config);
+        var jobsProgress = jobs.Count > 0 ? BuildStatusProgress(jobs, config) : null;
 
         var dataTable = JobsApp.BuildDataTable(nav, rows, refreshToken, updateStream, config, planService,
             jobService, client, showPlan, showOutput, showPrompt, showDebug, jobs, projectColors, jobsProgress);


### PR DESCRIPTION
# Summary

## Changes

Modified the Jobs app to hide the empty progress bar when there are no jobs in the data table. The `StackedProgress` component is now conditionally created only when jobs exist, and the header layout conditionally includes it using the `(condition ? element : null!)` pattern.

## API Changes

- `JobsApp.BuildDataTable()` — parameter `jobsProgress` changed from `StackedProgress` to `StackedProgress?`

## Files Modified

- **src/Ivy.Tendril/Apps/Jobs/JobsApp.cs** — conditional creation of jobsProgress (only when jobs.Count > 0)
- **src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs** — nullable parameter type and conditional rendering in HeaderRight

---

## Commits

- 97212fa Apply dotnet format