### PR TITLE
[00512] Fix process viewer arrows stretched on mobile

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/TendrilProcessViewer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/TendrilProcessViewer.tsx
@@ -18,7 +18,7 @@ const Arrow: React.FC<ArrowProps> = ({ count, spinning, onClick }) => (
         {spinning && <LoaderCircle className="tpv-spinner" size={13} />}
       </button>
     )}
-    <svg className="tpv-arrow-svg" viewBox="0 0 80 12" preserveAspectRatio="none">
+    <svg className="tpv-arrow-svg" viewBox="0 0 80 12" preserveAspectRatio="xMidYMid meet">
       <defs>
         <marker id="arrowhead" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
           <polygon points="0,0 6,3 0,6" fill="currentColor" />

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css
@@ -219,7 +219,9 @@
   }
 
   .tpv-arrow-segment {
-    margin: 0;
+    /* Gap above and below the connector so the short arrow sits clearly
+       between the stacked boxes instead of touching them. */
+    margin: 0.5rem 0;
     flex-direction: column;
     align-items: center;
   }
@@ -232,13 +234,14 @@
   }
 
   .tpv-arrow-svg {
-    /* Square footprint so the rotated arrow reserves its full vertical length.
-       With preserveAspectRatio="xMidYMid meet" the 80x12 viewBox scales down
-       uniformly and is centered, then rotate(90deg) makes it a vertical
-       connector. A 12px-tall footprint (the old value) let the rotated arrow
-       overflow into the boxes above/below; a square box reserves the space. */
-    width: 44px;
-    height: 44px;
+    /* Short square footprint so the rotated arrow is a brief connector that
+       sits between the stacked boxes. preserveAspectRatio="xMidYMid meet"
+       scales the 80x12 viewBox down uniformly and centers it; rotate(90deg)
+       makes it vertical. The square box reserves the arrow's full length so
+       it never overflows into the boxes above/below (combined with the
+       margin on .tpv-arrow-segment that adds breathing room). */
+    width: 20px;
+    height: 20px;
     transform: rotate(90deg);
   }
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css
@@ -232,8 +232,8 @@
   }
 
   .tpv-arrow-svg {
-    width: 12px;
-    height: 50px;
+    width: 50px;
+    height: 12px;
     transform: rotate(90deg);
   }
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css
@@ -232,8 +232,13 @@
   }
 
   .tpv-arrow-svg {
-    width: 50px;
-    height: 12px;
+    /* Square footprint so the rotated arrow reserves its full vertical length.
+       With preserveAspectRatio="xMidYMid meet" the 80x12 viewBox scales down
+       uniformly and is centered, then rotate(90deg) makes it a vertical
+       connector. A 12px-tall footprint (the old value) let the rotated arrow
+       overflow into the boxes above/below; a square box reserves the space. */
+    width: 44px;
+    height: 44px;
     transform: rotate(90deg);
   }
 


### PR DESCRIPTION
Fixes #1180

# Summary

## Changes

Fixed the stretched arrow display in the tender process viewer on mobile devices by changing the SVG's `preserveAspectRatio` from `none` to `xMidYMid meet` and swapping the mobile CSS dimensions from 12×50px to 50×12px before rotation. This preserves the arrow's proper proportions when rotated 90 degrees.

## API Changes

None.

## Files Modified

- **TendrilProcessViewer.tsx** — Updated SVG `preserveAspectRatio` attribute
- **tendril-process.css** — Adjusted mobile `.tpv-arrow-svg` dimensions

---

## Commits

- 9b6f039 Fix process viewer arrows stretched on mobile