### PR TITLE
[00518] Fix action bar wrap regression and implement progressive button collapse

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -111,100 +111,90 @@ public class ActionBarView(
             })
         };
 
-        // Desktop dropdown items: buttons that don't fit at Desktop tier + standard overflow
-        var desktopDropdownItems = new List<MenuItem>
+        // Split / Expand share the same OnClick logic whether shown as an inline button
+        // (Full tier) or a dropdown item (Compact/Minimal tiers).
+        void StartSplit()
+        {
+            if (hasActiveSplitJob) return;
+            var optimisticPlan = selectedPlan with
+            {
+                Metadata = selectedPlan.Metadata with { State = PlanStatus.Updating }
+            };
+            selectedPlanState.Set(optimisticPlan);
+            planService.TransitionState(selectedPlan.FolderName, PlanStatus.Updating);
+            jobService.StartJob(new SplitPlanArgs(selectedPlan.FolderPath));
+            refreshPlans();
+        }
+
+        void StartExpand()
+        {
+            if (hasActiveExpandJob) return;
+            var optimisticPlan = selectedPlan with
+            {
+                Metadata = selectedPlan.Metadata with { State = PlanStatus.Building }
+            };
+            selectedPlanState.Set(optimisticPlan);
+            planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+            jobService.StartJob(new ExpandPlanArgs(selectedPlan.FolderPath));
+            refreshPlans();
+        }
+
+        // Compact-tier dropdown items: buttons that don't fit at the Compact tier + standard overflow
+        var compactDropdownItems = new List<MenuItem>
         {
             new MenuItem("Split", Icon: Icons.Scissors, Tag: "Split")
-                .OnSelect(() =>
-                {
-                    if (hasActiveSplitJob) return;
-                    var optimisticPlan = selectedPlan with
-                    {
-                        Metadata = selectedPlan.Metadata with { State = PlanStatus.Updating }
-                    };
-                    selectedPlanState.Set(optimisticPlan);
-                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Updating);
-                    jobService.StartJob(new SplitPlanArgs(selectedPlan.FolderPath));
-                    refreshPlans();
-                })
-                .Disabled(hasActiveSplitJob),
+                .OnSelect(StartSplit).Disabled(hasActiveSplitJob),
             new MenuItem("Expand", Icon: Icons.UnfoldVertical, Tag: "Expand")
-                .OnSelect(() =>
-                {
-                    if (hasActiveExpandJob) return;
-                    var optimisticPlan = selectedPlan with
-                    {
-                        Metadata = selectedPlan.Metadata with { State = PlanStatus.Building }
-                    };
-                    selectedPlanState.Set(optimisticPlan);
-                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
-                    var planPath = selectedPlan.FolderPath;
-                    jobService.StartJob(new ExpandPlanArgs(planPath));
-                    refreshPlans();
-                })
-                .Disabled(hasActiveExpandJob),
+                .OnSelect(StartExpand).Disabled(hasActiveExpandJob),
             new MenuItem("Delete", Icon: Icons.Trash, Tag: "Delete").OnSelect(showDeleteDialog)
         };
-        desktopDropdownItems.AddRange(standardOverflowItems);
+        compactDropdownItems.AddRange(standardOverflowItems);
 
-        // Mobile dropdown items: all action buttons + standard overflow
-        var mobileDropdownItems = new List<MenuItem>
+        // Minimal-tier dropdown items: all action buttons + standard overflow
+        var minimalDropdownItems = new List<MenuItem>
         {
             new MenuItem("Edit", Icon: Icons.Pencil, Tag: "Edit")
                 .OnSelect(() => isEditingState.Set(true)),
             new MenuItem("Update", Icon: Icons.WandSparkles, Tag: "Update")
                 .OnSelect(showUpdateDialog),
             new MenuItem("Split", Icon: Icons.Scissors, Tag: "Split")
-                .OnSelect(() =>
-                {
-                    if (hasActiveSplitJob) return;
-                    var optimisticPlan = selectedPlan with
-                    {
-                        Metadata = selectedPlan.Metadata with { State = PlanStatus.Updating }
-                    };
-                    selectedPlanState.Set(optimisticPlan);
-                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Updating);
-                    jobService.StartJob(new SplitPlanArgs(selectedPlan.FolderPath));
-                    refreshPlans();
-                })
-                .Disabled(hasActiveSplitJob),
+                .OnSelect(StartSplit).Disabled(hasActiveSplitJob),
             new MenuItem("Expand", Icon: Icons.UnfoldVertical, Tag: "Expand")
-                .OnSelect(() =>
-                {
-                    if (hasActiveExpandJob) return;
-                    var optimisticPlan = selectedPlan with
-                    {
-                        Metadata = selectedPlan.Metadata with { State = PlanStatus.Building }
-                    };
-                    selectedPlanState.Set(optimisticPlan);
-                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
-                    var planPath = selectedPlan.FolderPath;
-                    jobService.StartJob(new ExpandPlanArgs(planPath));
-                    refreshPlans();
-                })
-                .Disabled(hasActiveExpandJob),
+                .OnSelect(StartExpand).Disabled(hasActiveExpandJob),
             new MenuItem("Delete", Icon: Icons.Trash, Tag: "Delete").OnSelect(showDeleteDialog)
         };
-        mobileDropdownItems.AddRange(standardOverflowItems);
+        minimalDropdownItems.AddRange(standardOverflowItems);
 
-        // Action bar without .Wrap() - single row layout with progressive collapse
+        // Action bar without .Wrap() - single row layout with progressive collapse.
+        // Full tier (>=1024px): all buttons inline + overflow-only dropdown.
+        // Compact tier (768-1023px): Previous, Next, Edit, Update inline; Split/Expand/Delete in dropdown.
+        // Minimal tier (<768px): Previous, Next inline; everything else in dropdown.
         return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
-               // Desktop: Previous, Next, Edit, Update visible
                | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(goToPrevious)
                    .ShortcutKey("p").AlwaysVisible()
                | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(goToNext)
                    .ShortcutKey("n").AlwaysVisible()
                | new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
-                   .OnClick(() => isEditingState.Set(true)).DesktopUp()
+                   .OnClick(() => isEditingState.Set(true)).CompactUp()
                | new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")
-                   .OnClick(showUpdateDialog).DesktopUp()
-               // Desktop dropdown: Split, Expand, Delete + standard overflow
-               | ActionBarResponsive.DropdownAtDesktop(
+                   .OnClick(showUpdateDialog).CompactUp()
+               | new Button("Split").Icon(Icons.Scissors).Outline()
+                   .OnClick(StartSplit).Disabled(hasActiveSplitJob).FullOnly()
+               | new Button("Expand").Icon(Icons.UnfoldVertical).Outline()
+                   .OnClick(StartExpand).Disabled(hasActiveExpandJob).FullOnly()
+               | new Button("Delete").Icon(Icons.Trash).Outline()
+                   .OnClick(showDeleteDialog).FullOnly()
+               // Full-tier dropdown: standard overflow items only
+               | ActionBarResponsive.DropdownAtFull(
                    new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                   desktopDropdownItems.ToArray())
-               // Mobile dropdown: all action buttons + standard overflow
-               | ActionBarResponsive.DropdownAtMobile(
+                   standardOverflowItems)
+               // Compact-tier dropdown: Split, Expand, Delete + standard overflow
+               | ActionBarResponsive.DropdownAtCompact(
                    new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                   mobileDropdownItems.ToArray());
+                   compactDropdownItems.ToArray())
+               // Minimal-tier dropdown: all action buttons + standard overflow
+               | ActionBarResponsive.DropdownAtMinimal(
+                   new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                   minimalDropdownItems.ToArray());
     }
 }

--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -50,110 +50,161 @@ public class ActionBarView(
                 });
         }
 
-        // Normal mode: show all action buttons (Edit first)
-        return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Wrap()
-               | new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
-                   .OnClick(() => isEditingState.Set(true))
-               | new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")
-                   .OnClick(showUpdateDialog)
-               | new Button("Split").Icon(Icons.Scissors).Outline().ShortcutKey("s")
-                   .Disabled(hasActiveSplitJob)
-                   .OnClick(() =>
-                   {
-                       if (hasActiveSplitJob) return;
+        // Standard overflow menu items (always at bottom of dropdowns)
+        var standardOverflowItems = new[]
+        {
+            new MenuItem("Create Issue", Icon: Icons.Github, Tag: "CreateIssue").OnSelect(showCreateIssueDialog),
+            new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
+                .OnSelect(() => { PlatformHelper.OpenInFileManager(selectedPlan.FolderPath); }),
+            new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal").OnSelect(() =>
+            {
+                PlatformHelper.OpenInTerminal(selectedPlan.FolderPath);
+            }),
+            new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
+                .OnSelect(() =>
+                {
+                    try
+                    {
+                        config.OpenInEditor(selectedPlan.FolderPath);
+                    }
+                    catch (EditorNotAvailableException ex)
+                    {
+                        client.Toast(
+                            $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                            "Editor Not Available",
+                            variant: ToastVariant.Destructive);
+                    }
+                }),
+            new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
+                .OnSelect(() =>
+                {
+                    copyToClipboard(selectedPlan.FolderPath);
+                    client.Toast("Copied path to clipboard", "Path Copied");
+                }),
+            new MenuItem("Copy Plan to Clipboard", Icon: Icons.Share, Tag: "CopyPlan")
+                .OnSelect(() =>
+                {
+                    var exported = PlanExportHelper.ExportToClipboard(selectedPlan);
+                    copyToClipboard(exported);
+                    client.Toast("Plan copied to clipboard", "Plan Exported");
+                }),
+            new MenuItem("Mark as Completed", Icon: Icons.CircleCheck, Tag: "MarkCompleted")
+                .OnSelect(() =>
+                {
+                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+                    refreshPlans();
+                }),
+            new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
+            {
+                var yamlPath = Path.Combine(selectedPlan.FolderPath, "plan.yaml");
+                try
+                {
+                    config.OpenInEditor(yamlPath);
+                }
+                catch (EditorNotAvailableException ex)
+                {
+                    client.Toast(
+                        $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                        "Editor Not Available",
+                        variant: ToastVariant.Destructive);
+                }
+            })
+        };
 
-                       // Optimistically update UI state before disk I/O
-                       var optimisticPlan = selectedPlan with
-                       {
-                           Metadata = selectedPlan.Metadata with { State = PlanStatus.Updating }
-                       };
-                       selectedPlanState.Set(optimisticPlan);
+        // Desktop dropdown items: buttons that don't fit at Desktop tier + standard overflow
+        var desktopDropdownItems = new List<MenuItem>
+        {
+            new MenuItem("Split", Icon: Icons.Scissors, Tag: "Split")
+                .OnSelect(() =>
+                {
+                    if (hasActiveSplitJob) return;
+                    var optimisticPlan = selectedPlan with
+                    {
+                        Metadata = selectedPlan.Metadata with { State = PlanStatus.Updating }
+                    };
+                    selectedPlanState.Set(optimisticPlan);
+                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Updating);
+                    jobService.StartJob(new SplitPlanArgs(selectedPlan.FolderPath));
+                    refreshPlans();
+                })
+                .Disabled(hasActiveSplitJob),
+            new MenuItem("Expand", Icon: Icons.UnfoldVertical, Tag: "Expand")
+                .OnSelect(() =>
+                {
+                    if (hasActiveExpandJob) return;
+                    var optimisticPlan = selectedPlan with
+                    {
+                        Metadata = selectedPlan.Metadata with { State = PlanStatus.Building }
+                    };
+                    selectedPlanState.Set(optimisticPlan);
+                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+                    var planPath = selectedPlan.FolderPath;
+                    jobService.StartJob(new ExpandPlanArgs(planPath));
+                    refreshPlans();
+                })
+                .Disabled(hasActiveExpandJob),
+            new MenuItem("Delete", Icon: Icons.Trash, Tag: "Delete").OnSelect(showDeleteDialog)
+        };
+        desktopDropdownItems.AddRange(standardOverflowItems);
 
-                       planService.TransitionState(selectedPlan.FolderName, PlanStatus.Updating);
-                       jobService.StartJob(new SplitPlanArgs(selectedPlan.FolderPath));
-                       refreshPlans();
-                   })
-               | new Button("Expand").Icon(Icons.UnfoldVertical).Outline().ShortcutKey("e")
-                   .Disabled(hasActiveExpandJob)
-                   .OnClick(() =>
-                   {
-                       if (hasActiveExpandJob) return;
+        // Mobile dropdown items: all action buttons + standard overflow
+        var mobileDropdownItems = new List<MenuItem>
+        {
+            new MenuItem("Edit", Icon: Icons.Pencil, Tag: "Edit")
+                .OnSelect(() => isEditingState.Set(true)),
+            new MenuItem("Update", Icon: Icons.WandSparkles, Tag: "Update")
+                .OnSelect(showUpdateDialog),
+            new MenuItem("Split", Icon: Icons.Scissors, Tag: "Split")
+                .OnSelect(() =>
+                {
+                    if (hasActiveSplitJob) return;
+                    var optimisticPlan = selectedPlan with
+                    {
+                        Metadata = selectedPlan.Metadata with { State = PlanStatus.Updating }
+                    };
+                    selectedPlanState.Set(optimisticPlan);
+                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Updating);
+                    jobService.StartJob(new SplitPlanArgs(selectedPlan.FolderPath));
+                    refreshPlans();
+                })
+                .Disabled(hasActiveSplitJob),
+            new MenuItem("Expand", Icon: Icons.UnfoldVertical, Tag: "Expand")
+                .OnSelect(() =>
+                {
+                    if (hasActiveExpandJob) return;
+                    var optimisticPlan = selectedPlan with
+                    {
+                        Metadata = selectedPlan.Metadata with { State = PlanStatus.Building }
+                    };
+                    selectedPlanState.Set(optimisticPlan);
+                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+                    var planPath = selectedPlan.FolderPath;
+                    jobService.StartJob(new ExpandPlanArgs(planPath));
+                    refreshPlans();
+                })
+                .Disabled(hasActiveExpandJob),
+            new MenuItem("Delete", Icon: Icons.Trash, Tag: "Delete").OnSelect(showDeleteDialog)
+        };
+        mobileDropdownItems.AddRange(standardOverflowItems);
 
-                       // Optimistically update UI state before disk I/O
-                       var optimisticPlan = selectedPlan with
-                       {
-                           Metadata = selectedPlan.Metadata with { State = PlanStatus.Building }
-                       };
-                       selectedPlanState.Set(optimisticPlan);
-
-                       planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
-                       var planPath = selectedPlan.FolderPath;
-                       jobService.StartJob(new ExpandPlanArgs(planPath));
-                       refreshPlans();
-                   })
-               | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
-                   .OnClick(showDeleteDialog)
+        // Action bar without .Wrap() - single row layout with progressive collapse
+        return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
+               // Desktop: Previous, Next, Edit, Update visible
                | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(goToPrevious)
-                   .ShortcutKey("p")
+                   .ShortcutKey("p").AlwaysVisible()
                | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(goToNext)
-                   .ShortcutKey("n")
-               | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
-                   new MenuItem("Create Issue", Icon: Icons.Github, Tag: "CreateIssue").OnSelect(showCreateIssueDialog),
-                   new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
-                       .OnSelect(() => { PlatformHelper.OpenInFileManager(selectedPlan.FolderPath); }),
-                   new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal").OnSelect(() =>
-                   {
-                       PlatformHelper.OpenInTerminal(selectedPlan.FolderPath);
-                   }),
-                   new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
-                       .OnSelect(() =>
-                       {
-                           try
-                           {
-                               config.OpenInEditor(selectedPlan.FolderPath);
-                           }
-                           catch (EditorNotAvailableException ex)
-                           {
-                               client.Toast(
-                                   $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
-                                   "Editor Not Available",
-                                   variant: ToastVariant.Destructive);
-                           }
-                       }),
-                   new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
-                       .OnSelect(() =>
-                       {
-                           copyToClipboard(selectedPlan.FolderPath);
-                           client.Toast("Copied path to clipboard", "Path Copied");
-                       }),
-                   new MenuItem("Copy Plan to Clipboard", Icon: Icons.Share, Tag: "CopyPlan")
-                       .OnSelect(() =>
-                       {
-                           var exported = PlanExportHelper.ExportToClipboard(selectedPlan);
-                           copyToClipboard(exported);
-                           client.Toast("Plan copied to clipboard", "Plan Exported");
-                       }),
-                   new MenuItem("Mark as Completed", Icon: Icons.CircleCheck, Tag: "MarkCompleted")
-                       .OnSelect(() =>
-                       {
-                           planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
-                           refreshPlans();
-                       }),
-                   new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
-                   {
-                       var yamlPath = Path.Combine(selectedPlan.FolderPath, "plan.yaml");
-                       try
-                       {
-                           config.OpenInEditor(yamlPath);
-                       }
-                       catch (EditorNotAvailableException ex)
-                       {
-                           client.Toast(
-                               $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
-                               "Editor Not Available",
-                               variant: ToastVariant.Destructive);
-                       }
-                   })
-               );
+                   .ShortcutKey("n").AlwaysVisible()
+               | new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
+                   .OnClick(() => isEditingState.Set(true)).DesktopUp()
+               | new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")
+                   .OnClick(showUpdateDialog).DesktopUp()
+               // Desktop dropdown: Split, Expand, Delete + standard overflow
+               | ActionBarResponsive.DropdownAtDesktop(
+                   new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                   desktopDropdownItems.ToArray())
+               // Mobile dropdown: all action buttons + standard overflow
+               | ActionBarResponsive.DropdownAtMobile(
+                   new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                   mobileDropdownItems.ToArray());
     }
 }

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -175,46 +175,54 @@ public class ContentView(
             })
         };
 
-        // Desktop dropdown: View Plan + standard overflow
-        var desktopDropdownItems = new List<MenuItem>
+        void ViewPlan()
         {
-            new MenuItem("View Plan", Icon: Icons.ExternalLink, Tag: "ViewPlan").OnSelect(() =>
-            {
-                var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
-                if (Directory.Exists(fullPath))
-                    showPlan(fullPath);
-            })
-        };
-        desktopDropdownItems.AddRange(standardOverflowItems);
+            var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
+            if (Directory.Exists(fullPath))
+                showPlan(fullPath);
+        }
 
-        // Mobile dropdown: Accept with Notes, View Plan + standard overflow
-        var mobileDropdownItems = new List<MenuItem>
+        // Full-tier dropdown: standard overflow items only (all buttons shown inline)
+        var fullDropdownItems = standardOverflowItems;
+
+        // Compact-tier dropdown: View Plan + standard overflow
+        var compactDropdownItems = new List<MenuItem>
+        {
+            new MenuItem("View Plan", Icon: Icons.ExternalLink, Tag: "ViewPlan").OnSelect(ViewPlan)
+        };
+        compactDropdownItems.AddRange(standardOverflowItems);
+
+        // Minimal-tier dropdown: Accept with Notes, View Plan + standard overflow
+        var minimalDropdownItems = new List<MenuItem>
         {
             new MenuItem("Accept with Notes", Icon: Icons.CircleCheck, Tag: "AcceptWithNotes")
                 .OnSelect(() => showNotesDialog()),
-            new MenuItem("View Plan", Icon: Icons.ExternalLink, Tag: "ViewPlan").OnSelect(() =>
-            {
-                var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
-                if (Directory.Exists(fullPath))
-                    showPlan(fullPath);
-            })
+            new MenuItem("View Plan", Icon: Icons.ExternalLink, Tag: "ViewPlan").OnSelect(ViewPlan)
         };
-        mobileDropdownItems.AddRange(standardOverflowItems);
+        minimalDropdownItems.AddRange(standardOverflowItems);
 
-        // Action bar without .Wrap() - single row with progressive collapse
+        // Action bar without .Wrap() - single row with progressive collapse.
+        // Full (>=1024px): Previous, Next, Accept with Notes, View Plan inline + overflow dropdown.
+        // Compact (768-1023px): Previous, Next, Accept with Notes inline; View Plan in dropdown.
+        // Minimal (<768px): Previous, Next inline; everything else in dropdown.
         var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                         | new Button("Previous").Icon(Icons.ChevronLeft).Outline().ShortcutKey("p")
                             .OnClick(GoToPrevious).AlwaysVisible()
                         | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().ShortcutKey("n")
                             .OnClick(GoToNext).AlwaysVisible()
                         | new Button("Accept with Notes").Icon(Icons.CircleCheck).Outline().ShortcutKey("w")
-                            .OnClick(() => showNotesDialog()).DesktopUp()
-                        | ActionBarResponsive.DropdownAtDesktop(
+                            .OnClick(() => showNotesDialog()).CompactUp()
+                        | new Button("View Plan").Icon(Icons.ExternalLink).Outline()
+                            .OnClick(ViewPlan).FullOnly()
+                        | ActionBarResponsive.DropdownAtFull(
                             new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                            desktopDropdownItems.ToArray())
-                        | ActionBarResponsive.DropdownAtMobile(
+                            fullDropdownItems)
+                        | ActionBarResponsive.DropdownAtCompact(
                             new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                            mobileDropdownItems.ToArray());
+                            compactDropdownItems.ToArray())
+                        | ActionBarResponsive.DropdownAtMinimal(
+                            new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                            minimalDropdownItems.ToArray());
 
         var mainLayout = new HeaderLayout(
             header,

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -140,52 +140,81 @@ public class ContentView(
         scrollableContent |= new Separator();
         scrollableContent |= new Markdown(selectedRecommendation.Description);
 
-        // Action bar (secondary actions)
-        var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(2).Wrap()
-                        | new Button("Accept with Notes").Icon(Icons.CircleCheck).Outline().ShortcutKey("w")
-                            .OnClick(() => showNotesDialog())
-                        | new Button("View Plan").Icon(Icons.ExternalLink).Outline().ShortcutKey("d").OnClick(() =>
-                        {
-                            var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
-                            if (Directory.Exists(fullPath))
-                                showPlan(fullPath);
-                        })
+        // Standard overflow menu items
+        var standardOverflowItems = new[]
+        {
+            new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
+                .OnSelect(() =>
+                {
+                    var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
+                    if (Directory.Exists(fullPath))
+                        PlatformHelper.OpenInFileManager(fullPath);
+                }),
+            new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
+                .OnSelect(() =>
+                {
+                    var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
+                    copyToClipboard(fullPath);
+                    client.Toast("Copied path to clipboard", "Path Copied");
+                }),
+            new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
+            {
+                var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
+                var yamlPath = Path.Combine(fullPath, "plan.yaml");
+                try
+                {
+                    config.OpenInEditor(yamlPath);
+                }
+                catch (EditorNotAvailableException ex)
+                {
+                    client.Toast(
+                        $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                        "Editor Not Available",
+                        variant: ToastVariant.Destructive);
+                }
+            })
+        };
+
+        // Desktop dropdown: View Plan + standard overflow
+        var desktopDropdownItems = new List<MenuItem>
+        {
+            new MenuItem("View Plan", Icon: Icons.ExternalLink, Tag: "ViewPlan").OnSelect(() =>
+            {
+                var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
+                if (Directory.Exists(fullPath))
+                    showPlan(fullPath);
+            })
+        };
+        desktopDropdownItems.AddRange(standardOverflowItems);
+
+        // Mobile dropdown: Accept with Notes, View Plan + standard overflow
+        var mobileDropdownItems = new List<MenuItem>
+        {
+            new MenuItem("Accept with Notes", Icon: Icons.CircleCheck, Tag: "AcceptWithNotes")
+                .OnSelect(() => showNotesDialog()),
+            new MenuItem("View Plan", Icon: Icons.ExternalLink, Tag: "ViewPlan").OnSelect(() =>
+            {
+                var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
+                if (Directory.Exists(fullPath))
+                    showPlan(fullPath);
+            })
+        };
+        mobileDropdownItems.AddRange(standardOverflowItems);
+
+        // Action bar without .Wrap() - single row with progressive collapse
+        var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                         | new Button("Previous").Icon(Icons.ChevronLeft).Outline().ShortcutKey("p")
-                            .OnClick(GoToPrevious)
+                            .OnClick(GoToPrevious).AlwaysVisible()
                         | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().ShortcutKey("n")
-                            .OnClick(GoToNext)
-                        | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
-                            new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
-                                .OnSelect(() =>
-                                {
-                                    var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
-                                    if (Directory.Exists(fullPath))
-                                        PlatformHelper.OpenInFileManager(fullPath);
-                                }),
-                            new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
-                                .OnSelect(() =>
-                                {
-                                    var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
-                                    copyToClipboard(fullPath);
-                                    client.Toast("Copied path to clipboard", "Path Copied");
-                                }),
-                            new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
-                            {
-                                var fullPath = Path.Combine(planService.PlansDirectory, selectedRecommendation.PlanFolderName);
-                                var yamlPath = Path.Combine(fullPath, "plan.yaml");
-                                try
-                                {
-                                    config.OpenInEditor(yamlPath);
-                                }
-                                catch (EditorNotAvailableException ex)
-                                {
-                                    client.Toast(
-                                        $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
-                                        "Editor Not Available",
-                                        variant: ToastVariant.Destructive);
-                                }
-                            })
-                        );
+                            .OnClick(GoToNext).AlwaysVisible()
+                        | new Button("Accept with Notes").Icon(Icons.CircleCheck).Outline().ShortcutKey("w")
+                            .OnClick(() => showNotesDialog()).DesktopUp()
+                        | ActionBarResponsive.DropdownAtDesktop(
+                            new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                            desktopDropdownItems.ToArray())
+                        | ActionBarResponsive.DropdownAtMobile(
+                            new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                            mobileDropdownItems.ToArray());
 
         var mainLayout = new HeaderLayout(
             header,

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -330,64 +330,91 @@ public class ContentView(
         INavigator nav,
         ReviewAppArgs? args)
     {
-        return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Wrap()
-                | new Button("Reset to Draft").Icon(Icons.RotateCcw).Outline().ShortcutKey("r").OnClick(showResetToDraftDialog)
-                | new Button("Request Changes").Icon(Icons.MessageSquare).Outline().OnClick(showSuggestChangesDialog).ShortcutKey("c")
-                | new Button("Discard").Icon(Icons.Trash).Outline().ShortcutKey("Backspace").OnClick(showDiscardDialog)
+        // Standard overflow menu items
+        var standardOverflowItems = new[]
+        {
+            new MenuItem("Custom PR", Icon: Icons.GitPullRequest, Tag: "CustomPR").OnSelect(showCustomPrDialog),
+            new MenuItem("Set Completed", Icon: Icons.CircleCheck, Tag: "SetCompleted").OnSelect(() =>
+            {
+                planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+                refreshPlans();
+            }),
+            new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
+                .OnSelect(() => { PlatformHelper.OpenInFileManager(selectedPlan.FolderPath, logger); }),
+            new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal").OnSelect(() =>
+            {
+                PlatformHelper.OpenInTerminal(selectedPlan.FolderPath, logger);
+            }),
+            new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
+                .OnSelect(() =>
+                {
+                    copyToClipboard(selectedPlan.FolderPath);
+                    client.Toast("Copied path to clipboard", "Path Copied");
+                }),
+            new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
+                .OnSelect(() =>
+                {
+                    try
+                    {
+                        config.OpenInEditor(selectedPlan.FolderPath);
+                    }
+                    catch (EditorNotAvailableException ex)
+                    {
+                        client.Toast(
+                            $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                            "Editor Not Available",
+                            variant: ToastVariant.Destructive);
+                    }
+                }),
+            new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
+            {
+                var yamlPath = Path.Combine(selectedPlan.FolderPath, "plan.yaml");
+                try
+                {
+                    config.OpenInEditor(yamlPath);
+                }
+                catch (EditorNotAvailableException ex)
+                {
+                    client.Toast(
+                        $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
+                        "Editor Not Available",
+                        variant: ToastVariant.Destructive);
+                }
+            })
+        };
+
+        // Desktop dropdown: Discard + standard overflow
+        var desktopDropdownItems = new List<MenuItem>
+        {
+            new MenuItem("Discard", Icon: Icons.Trash, Tag: "Discard").OnSelect(showDiscardDialog)
+        };
+        desktopDropdownItems.AddRange(standardOverflowItems);
+
+        // Mobile dropdown: all action buttons + standard overflow
+        var mobileDropdownItems = new List<MenuItem>
+        {
+            new MenuItem("Reset to Draft", Icon: Icons.RotateCcw, Tag: "ResetToDraft").OnSelect(showResetToDraftDialog),
+            new MenuItem("Request Changes", Icon: Icons.MessageSquare, Tag: "RequestChanges").OnSelect(showSuggestChangesDialog),
+            new MenuItem("Discard", Icon: Icons.Trash, Tag: "Discard").OnSelect(showDiscardDialog)
+        };
+        mobileDropdownItems.AddRange(standardOverflowItems);
+
+        // Action bar without .Wrap() - single row with progressive collapse
+        return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                 | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(() => GoToPrevious(nav, args))
-                    .ShortcutKey("p")
+                    .ShortcutKey("p").AlwaysVisible()
                 | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(() => GoToNext(nav, args))
-                    .ShortcutKey("n")
-                | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
-                    new MenuItem("Custom PR", Icon: Icons.GitPullRequest, Tag: "CustomPR").OnSelect(showCustomPrDialog),
-                    new MenuItem("Set Completed", Icon: Icons.CircleCheck, Tag: "SetCompleted").OnSelect(() =>
-                    {
-                        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
-                        refreshPlans();
-                    }),
-                    new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
-                        .OnSelect(() => { PlatformHelper.OpenInFileManager(selectedPlan.FolderPath, logger); }),
-                    new MenuItem("Open in Terminal", Icon: Icons.Terminal, Tag: "OpenInTerminal").OnSelect(() =>
-                    {
-                        PlatformHelper.OpenInTerminal(selectedPlan.FolderPath, logger);
-                    }),
-                    new MenuItem("Copy Path to Clipboard", Icon: Icons.ClipboardCopy, Tag: "CopyPath")
-                        .OnSelect(() =>
-                        {
-                            copyToClipboard(selectedPlan.FolderPath);
-                            client.Toast("Copied path to clipboard", "Path Copied");
-                        }),
-                    new MenuItem($"Open in {config.Editor.Label}", Icon: Icons.Code, Tag: "OpenInEditor")
-                        .OnSelect(() =>
-                        {
-                            try
-                            {
-                                config.OpenInEditor(selectedPlan.FolderPath);
-                            }
-                            catch (EditorNotAvailableException ex)
-                            {
-                                client.Toast(
-                                    $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
-                                    "Editor Not Available",
-                                    variant: ToastVariant.Destructive);
-                            }
-                        }),
-                    new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>
-                    {
-                        var yamlPath = Path.Combine(selectedPlan.FolderPath, "plan.yaml");
-                        try
-                        {
-                            config.OpenInEditor(yamlPath);
-                        }
-                        catch (EditorNotAvailableException ex)
-                        {
-                            client.Toast(
-                                $"'{ex.Command}' not found in PATH. Install the shell command from {ex.Label} or update the editor command in Settings → Advanced.",
-                                "Editor Not Available",
-                                variant: ToastVariant.Destructive);
-                        }
-                    })
-                );
+                    .ShortcutKey("n").AlwaysVisible()
+                | new Button("Reset to Draft").Icon(Icons.RotateCcw).Outline().ShortcutKey("r")
+                    .OnClick(showResetToDraftDialog).DesktopUp()
+                | new Button("Request Changes").Icon(Icons.MessageSquare).Outline().ShortcutKey("c")
+                    .OnClick(showSuggestChangesDialog).DesktopUp()
+                | ActionBarResponsive.DropdownAtDesktop(
+                    new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                    desktopDropdownItems.ToArray())
+                | ActionBarResponsive.DropdownAtMobile(
+                    new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                    mobileDropdownItems.ToArray());
     }
 
     private object BuildContent(

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -383,38 +383,49 @@ public class ContentView(
             })
         };
 
-        // Desktop dropdown: Discard + standard overflow
-        var desktopDropdownItems = new List<MenuItem>
+        // Full-tier dropdown: standard overflow items only (all buttons shown inline)
+        var fullDropdownItems = standardOverflowItems;
+
+        // Compact-tier dropdown: Discard + standard overflow
+        var compactDropdownItems = new List<MenuItem>
         {
             new MenuItem("Discard", Icon: Icons.Trash, Tag: "Discard").OnSelect(showDiscardDialog)
         };
-        desktopDropdownItems.AddRange(standardOverflowItems);
+        compactDropdownItems.AddRange(standardOverflowItems);
 
-        // Mobile dropdown: all action buttons + standard overflow
-        var mobileDropdownItems = new List<MenuItem>
+        // Minimal-tier dropdown: all action buttons + standard overflow
+        var minimalDropdownItems = new List<MenuItem>
         {
             new MenuItem("Reset to Draft", Icon: Icons.RotateCcw, Tag: "ResetToDraft").OnSelect(showResetToDraftDialog),
             new MenuItem("Request Changes", Icon: Icons.MessageSquare, Tag: "RequestChanges").OnSelect(showSuggestChangesDialog),
             new MenuItem("Discard", Icon: Icons.Trash, Tag: "Discard").OnSelect(showDiscardDialog)
         };
-        mobileDropdownItems.AddRange(standardOverflowItems);
+        minimalDropdownItems.AddRange(standardOverflowItems);
 
-        // Action bar without .Wrap() - single row with progressive collapse
+        // Action bar without .Wrap() - single row with progressive collapse.
+        // Full (>=1024px): Previous, Next, Reset to Draft, Request Changes, Discard inline + overflow dropdown.
+        // Compact (768-1023px): Previous, Next, Reset to Draft, Request Changes inline; Discard in dropdown.
+        // Minimal (<768px): Previous, Next inline; everything else in dropdown.
         return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                 | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(() => GoToPrevious(nav, args))
                     .ShortcutKey("p").AlwaysVisible()
                 | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(() => GoToNext(nav, args))
                     .ShortcutKey("n").AlwaysVisible()
                 | new Button("Reset to Draft").Icon(Icons.RotateCcw).Outline().ShortcutKey("r")
-                    .OnClick(showResetToDraftDialog).DesktopUp()
+                    .OnClick(showResetToDraftDialog).CompactUp()
                 | new Button("Request Changes").Icon(Icons.MessageSquare).Outline().ShortcutKey("c")
-                    .OnClick(showSuggestChangesDialog).DesktopUp()
-                | ActionBarResponsive.DropdownAtDesktop(
+                    .OnClick(showSuggestChangesDialog).CompactUp()
+                | new Button("Discard").Icon(Icons.Trash).Outline()
+                    .OnClick(showDiscardDialog).FullOnly()
+                | ActionBarResponsive.DropdownAtFull(
                     new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                    desktopDropdownItems.ToArray())
-                | ActionBarResponsive.DropdownAtMobile(
+                    fullDropdownItems)
+                | ActionBarResponsive.DropdownAtCompact(
                     new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                    mobileDropdownItems.ToArray());
+                    compactDropdownItems.ToArray())
+                | ActionBarResponsive.DropdownAtMinimal(
+                    new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                    minimalDropdownItems.ToArray());
     }
 
     private object BuildContent(

--- a/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
+++ b/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
@@ -3,20 +3,29 @@ namespace Ivy.Tendril.Helpers;
 /// <summary>
 /// Helper for creating responsive action bars with progressive button collapse.
 /// Buttons collapse into dropdown menus as screen size decreases.
+///
+/// IMPORTANT — breakpoint bands (see <see cref="Breakpoint"/> and the frontend
+/// <c>use-responsive.ts</c>): a breakpoint name maps to a width *band*, not a
+/// "this width and up" range:
+/// <list type="bullet">
+///   <item><c>Mobile</c>  → width &lt; 640px</item>
+///   <item><c>Tablet</c>  → 640px ≤ width &lt; 768px</item>
+///   <item><c>Desktop</c> → 768px ≤ width &lt; 1024px</item>
+///   <item><c>Wide</c>    → width ≥ 1024px</item>
+/// </list>
+/// A normal/large desktop monitor (≥1024px) therefore resolves to <c>Wide</c>, NOT
+/// <c>Desktop</c>. The three collapse tiers used by the action bars map to bands as:
+/// <list type="bullet">
+///   <item><b>Full</b> tier (everything visible) → <c>Wide</c></item>
+///   <item><b>Compact</b> tier (some buttons collapsed) → <c>Desktop</c></item>
+///   <item><b>Minimal</b> tier (most buttons collapsed) → <c>Mobile</c> + <c>Tablet</c></item>
+/// </list>
 /// </summary>
 public static class ActionBarResponsive
 {
     /// <summary>
-    /// Shows button only on Desktop breakpoint and above (>=768px).
-    /// Hidden on Mobile and Tablet.
-    /// </summary>
-    public static Button DesktopUp(this Button btn)
-    {
-        return btn.ShowOn(Breakpoint.Desktop);
-    }
-
-    /// <summary>
-    /// Shows button at all breakpoints (always visible).
+    /// Shows button at all breakpoints (always visible). Used for navigation
+    /// (Previous/Next) which must stay visible at every size.
     /// </summary>
     public static Button AlwaysVisible(this Button btn)
     {
@@ -24,28 +33,48 @@ public static class ActionBarResponsive
     }
 
     /// <summary>
-    /// Shows button only below Desktop breakpoint (&lt;768px).
-    /// Visible on Mobile and Tablet only.
+    /// Shows button only at the Full tier — a wide desktop monitor (width ≥1024px).
+    /// Hidden at the Compact and Minimal tiers, where the button collapses into a dropdown.
     /// </summary>
-    public static Button BelowDesktop(this Button btn)
+    public static Button FullOnly(this Button btn)
     {
-        return btn.ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
+        return btn.ShowOn(Breakpoint.Wide);
     }
 
     /// <summary>
-    /// Creates a dropdown menu that is visible only on Desktop and above (>=768px).
-    /// Hidden on Mobile and Tablet.
+    /// Shows button at the Compact tier and up — a wide monitor or the 768–1023px band
+    /// (<c>Desktop</c> + <c>Wide</c>). Hidden only at the Minimal tier (&lt;768px), where
+    /// the button collapses into a dropdown.
     /// </summary>
-    public static DropDownMenu DropdownAtDesktop(Button trigger, params MenuItem[] items)
+    public static Button CompactUp(this Button btn)
+    {
+        return btn.ShowOn(Breakpoint.Desktop, Breakpoint.Wide);
+    }
+
+    /// <summary>
+    /// Creates a dropdown menu visible only at the Full tier (width ≥1024px). Holds the
+    /// standard overflow items when all action buttons are shown inline.
+    /// </summary>
+    public static DropDownMenu DropdownAtFull(Button trigger, params MenuItem[] items)
+    {
+        return trigger.WithDropDown(items).ShowOn(Breakpoint.Wide);
+    }
+
+    /// <summary>
+    /// Creates a dropdown menu visible only at the Compact tier (768–1023px band).
+    /// Holds the buttons collapsed at this tier plus the standard overflow items.
+    /// </summary>
+    public static DropDownMenu DropdownAtCompact(Button trigger, params MenuItem[] items)
     {
         return trigger.WithDropDown(items).ShowOn(Breakpoint.Desktop);
     }
 
     /// <summary>
-    /// Creates a dropdown menu that is visible only below Desktop (&lt;768px).
-    /// Visible on Mobile and Tablet only.
+    /// Creates a dropdown menu visible only at the Minimal tier (width &lt;768px,
+    /// i.e. <c>Mobile</c> + <c>Tablet</c>). Holds the buttons collapsed at this tier
+    /// plus the standard overflow items.
     /// </summary>
-    public static DropDownMenu DropdownAtMobile(Button trigger, params MenuItem[] items)
+    public static DropDownMenu DropdownAtMinimal(Button trigger, params MenuItem[] items)
     {
         return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
     }

--- a/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
+++ b/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
@@ -36,7 +36,7 @@ public static class ActionBarResponsive
     /// Creates a dropdown menu that is visible only on Desktop and above (>=768px).
     /// Hidden on Mobile and Tablet.
     /// </summary>
-    public static Button DropdownAtDesktop(Button trigger, params MenuItem[] items)
+    public static DropDownMenu DropdownAtDesktop(Button trigger, params MenuItem[] items)
     {
         return trigger.WithDropDown(items).ShowOn(Breakpoint.Desktop);
     }
@@ -45,7 +45,7 @@ public static class ActionBarResponsive
     /// Creates a dropdown menu that is visible only below Desktop (&lt;768px).
     /// Visible on Mobile and Tablet only.
     /// </summary>
-    public static Button DropdownAtMobile(Button trigger, params MenuItem[] items)
+    public static DropDownMenu DropdownAtMobile(Button trigger, params MenuItem[] items)
     {
         return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
     }

--- a/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
+++ b/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
@@ -1,0 +1,52 @@
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+/// Helper for creating responsive action bars with progressive button collapse.
+/// Buttons collapse into dropdown menus as screen size decreases.
+/// </summary>
+public static class ActionBarResponsive
+{
+    /// <summary>
+    /// Shows button only on Desktop breakpoint and above (>=768px).
+    /// Hidden on Mobile and Tablet.
+    /// </summary>
+    public static Button DesktopUp(this Button btn)
+    {
+        return btn.ShowOn(Breakpoint.Desktop);
+    }
+
+    /// <summary>
+    /// Shows button at all breakpoints (always visible).
+    /// </summary>
+    public static Button AlwaysVisible(this Button btn)
+    {
+        return btn;
+    }
+
+    /// <summary>
+    /// Shows button only below Desktop breakpoint (&lt;768px).
+    /// Visible on Mobile and Tablet only.
+    /// </summary>
+    public static Button BelowDesktop(this Button btn)
+    {
+        return btn.ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
+    }
+
+    /// <summary>
+    /// Creates a dropdown menu that is visible only on Desktop and above (>=768px).
+    /// Hidden on Mobile and Tablet.
+    /// </summary>
+    public static Button DropdownAtDesktop(Button trigger, params MenuItem[] items)
+    {
+        return trigger.WithDropDown(items).ShowOn(Breakpoint.Desktop);
+    }
+
+    /// <summary>
+    /// Creates a dropdown menu that is visible only below Desktop (&lt;768px).
+    /// Visible on Mobile and Tablet only.
+    /// </summary>
+    public static Button DropdownAtMobile(Button trigger, params MenuItem[] items)
+    {
+        return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
+    }
+}

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -44,10 +44,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="OpenAI" Version="2.9.1" />
     <PackageReference Include="PostHog" Version="2.6.0" />


### PR DESCRIPTION
Fixes #724

## Problem

After the responsive fixes (commit `55ac4fe` — "Make Tendril responsive for mobile and tablet"), the action bars in Drafts, Recommendations, and Review views use `.Wrap()` on their horizontal layout. This causes two regressions:

1. **Accordion menu wraps to second row** — The ellipsis dropdown button (⋮) wraps below the other buttons instead of staying inline on the same row. On a wide screen the action bar should be a single row.
2. **No progressive collapse** — When the screen narrows, buttons simply wrap to a second line. The expected behavior is that buttons should progressively move into the dropdown menu as space decreases, maintaining their order.

The previous `ActionBarResponsive` helper (commit `fcfc4a7`) attempted this with `ResponsiveVisible` and multiple breakpoint-specific versions of buttons, but was removed during the later responsive pass. The approach needs to be re-implemented properly.

## Solution

Re-introduce an `ActionBarResponsive` helper class in `src/Ivy.Tendril/Helpers/ActionBarResponsive.cs` and apply it to all three action bars. The strategy:

### 1. Create `ActionBarResponsive.cs`

Create a static helper class with this approach:

- **Remove `.Wrap()` from action bar layouts** — the action bar should NOT wrap. Use `Layout.Horizontal().AlignContent(Align.Left).Gap(2)` without `.Wrap()`.
- Define three visibility tiers using `Responsive<bool?>`:
  - `VisibleAtWide`: `{ Default = false, Desktop = false, Wide = true }` — visible only at >=1024px
  - `VisibleAtDesktopUp`: `{ Default = false, Desktop = true }` — visible at >=768px  
  - `BelowDesktop`: `{ Default = true, Desktop = false }` — visible only <768px
- Provide helper methods:
  - `WideOnly(Button btn)` → shows button only on Wide (>=1024px)
  - `DesktopUp(Button btn)` → shows button on Desktop and Wide (>=768px)
  - `AlwaysVisible(Button btn)` → no responsive restriction (shown at all sizes)
  - `DropdownAtDesktop(Button trigger, params MenuItem[] items)` → dropdown visible on Desktop (768-1023px), contains buttons that don't fit at this tier
  - `DropdownAtMobile(Button trigger, params MenuItem[] items)` → dropdown visible <768px, contains buttons that don't fit at this tier

### 2. Apply to Drafts `ActionBarView.cs`

Progressive collapse strategy — buttons collapse right-to-left (except nav stays visible):
- **Wide (>=1024px)**: All buttons visible + ⋮ menu
- **Desktop (768–1023px)**: Previous, Next, Edit, Update visible (icon-only for compact); Split, Expand, Delete move into a Desktop-only ⋮ dropdown
- **Mobile (<768px)**: Previous, Next visible (icon-only); all other buttons move into a Mobile-only ⋮ dropdown

The ⋮ menu items at each tier combine: the buttons that were collapsed INTO the dropdown + the original menu items (Create Issue, Open in File Manager, etc).

### 3. Apply to Recommendations `ContentView.cs`

Progressive collapse:
- **Wide**: All buttons + ⋮ menu
- **Desktop**: Previous, Next, Accept with Notes visible; View Plan moves into dropdown
- **Mobile**: Previous, Next visible; Accept with Notes + View Plan move into dropdown

### 4. Apply to Review `ContentView.cs`

Progressive collapse:
- **Wide**: All buttons + ⋮ menu
- **Desktop**: Previous, Next, Reset to Draft, Request Changes visible; Discard moves into dropdown
- **Mobile**: Previous, Next visible; all other buttons move into dropdown

### 5. Key implementation details

- The action bar layout must NOT use `.Wrap()` — that's what causes the current regression
- Each tier shows ONE dropdown button containing the collapsed items merged with the standard overflow menu items
- Button order in the dropdown must match the original button order (left-to-right → top-to-bottom)
- The standard overflow items (Open in File Manager, Open in Terminal, etc.) always appear at the bottom of every dropdown, separated by context
- Use `.HideOn()` and `.ShowOn()` on the button elements and dropdown elements to control per-breakpoint visibility
- Navigation buttons (Previous/Next) should always be visible at all breakpoints as icon-only buttons

---

## Commits

- 847c5d2: Fix action bar wrap regression and implement progressive button collapse