### PR TITLE
[00001] HideHeatmapWhenNoPrs

### DIFF
--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -31,21 +31,27 @@ public class WallpaperApp : ViewBase
         var prData = planDbService.GetCompletedPrsByDay(90);
         var activities = prData.Select(x => new Activity { Date = x.Date, Count = x.Count }).ToArray();
 
+        // Build vertical layout conditionally including heatmap only if there are PRs
+        var verticalLayout = Layout.Vertical().Gap(2).AlignContent(Align.Center)
+            | new Image("/tendril/assets/Tendril.svg").Width(Size.Units(30)).Height(Size.Auto())
+            | Text.H2("What are we making next?")
+            | processView;
+
+        if (activities.Length > 0)
+        {
+            verticalLayout = verticalLayout
+                | new ActivityHeatmap()
+                    .Data(activities)
+                    .ShowMonthLabels(false)
+                    .ShowDayLabels(false)
+                    .StartDate(DateOnly.FromDateTime(DateTime.Today.AddDays(-89)))
+                    .EndDate(DateOnly.FromDateTime(DateTime.Today))
+                    .ValueLabel("PRs");
+        }
+
         var elements = new List<object>
         {
-            Layout.Center()
-                | (Layout.Vertical().Gap(2).AlignContent(Align.Center)
-                   | new Image("/tendril/assets/Tendril.svg").Width(Size.Units(30)).Height(Size.Auto())
-                   | Text.H2("What are we making next?")
-                   | processView
-                   | new ActivityHeatmap()
-                       .Data(activities)
-                       .ShowMonthLabels(false)
-                       .ShowDayLabels(false)
-                       .StartDate(DateOnly.FromDateTime(DateTime.Today.AddDays(-89)))
-                       .EndDate(DateOnly.FromDateTime(DateTime.Today))
-                       .ValueLabel("PRs")
-                )
+            Layout.Center() | verticalLayout
         };
 
         if (versionInfo.Value?.HasUpdate == true && versionInfo.Value.LatestVersion != dismissedVersion.Value)


### PR DESCRIPTION
# Summary

## Changes

Modified `WallpaperApp.cs` to conditionally render the ActivityHeatmap widget only when there are completed PRs in the last 90 days. This prevents an empty, unhelpful heatmap grid from appearing on the wallpaper screen when the user has no recent PR activity.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/WallpaperApp.cs** — Added conditional check to only include ActivityHeatmap in layout when `activities.Length > 0`

## Manual Testing

1. Run Tendril: `dotnet run --project src/Ivy.Tendril`
2. Navigate to the wallpaper/home screen
3. **If you have PRs in the last 90 days**: The heatmap should display as before
4. **If you have zero PRs in the last 90 days**: The heatmap should be hidden, showing only the Tendril logo, heading, and process view

To test the zero-PR scenario without waiting 90 days, you can temporarily modify the `GetCompletedPrsByDay` call to return an empty array or adjust the date range to a period with no activity.

---

## Commits

- Hide heatmap when no PRs in last 90 days (4d9ca48)

---
Created using [Ivy Tendril](https://ivy.app).