### PR TITLE
[00520] Fix Git tab header row to use full width for accordion positioning

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Tabs/GitTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/GitTabView.cs
@@ -77,7 +77,7 @@ public class GitTabView(
         if (onSynchronize != null && !isSyncing)
             syncMenuItem = syncMenuItem.OnSelect(() => onSynchronize(section.Path));
 
-        var headerRow = Layout.Horizontal().AlignContent(Align.SpaceBetween)
+        var headerRow = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.SpaceBetween)
             | (Layout.Horizontal().Gap(2).AlignContent(Align.Left)
                 | Icons.GitBranchPlus.ToIcon().Color(Colors.Muted)
                 | Text.H3(section.Name))


### PR DESCRIPTION
Fixes #1214

# Summary

## Changes

Added `.Width(Size.Full())` to the Git tab header row layout in `GitTabView.cs` to ensure the dropdown menu button positions at the far right edge of the container instead of immediately after the title text.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Views/Tabs/GitTabView.cs** — Added Width(Size.Full()) to headerRow layout

---

## Commits

- a65737d6 Add Width(Size.Full()) to Git tab header row for proper accordion positioning