### PR TITLE
[00522] Add confirmation dialog for delete job action

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -22,9 +22,11 @@ public partial class JobsApp
         Action<string>? showDebug,
         List<JobItem> jobs,
         Dictionary<string, string> projectColors,
-        StackedProgress? jobsProgress)
+        StackedProgress? jobsProgress,
+        IState<bool> confirmDeleteOpen,
+        IState<string?> deleteJobId)
     {
-        return rows.AsQueryable()
+        var dataTable = rows.AsQueryable()
             .ToDataTable(t => t.Id)
             .Density(new Responsive<Density?> { Default = Density.Large, Desktop = Density.Medium })
             .RefreshToken(refreshToken)
@@ -250,13 +252,8 @@ public partial class JobsApp
                     }
                     else if (tag == "delete-job")
                     {
-                        if (job.Status is JobStatus.Running or JobStatus.Queued)
-                        {
-                            jobService.StopJob(job.Id);
-                        }
-
-                        jobService.DeleteJob(job.Id);
-                        refreshToken.Refresh();
+                        deleteJobId.Set(job.Id);
+                        confirmDeleteOpen.Set(true);
                     }
                 }
 
@@ -282,5 +279,30 @@ public partial class JobsApp
                                       refreshToken.Refresh();
                                   })
                               ));
+
+        var confirmDialog = confirmDeleteOpen.Value ? new Dialog(
+            _ => confirmDeleteOpen.Set(false),
+            new DialogHeader("Delete Job"),
+            new DialogBody(Text.P("Are you sure you want to delete this job? This cannot be undone.")),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(() => confirmDeleteOpen.Set(false)),
+                new Button("Delete").Destructive().ShortcutKey("Enter").AutoFocus().OnClick(() =>
+                {
+                    var id = deleteJobId.Value;
+                    if (id != null)
+                    {
+                        var jobToDelete = jobs.FirstOrDefault(j => j.Id == id);
+                        if (jobToDelete?.Status is JobStatus.Running or JobStatus.Queued)
+                            jobService.StopJob(id);
+                        jobService.DeleteJob(id);
+                    }
+                    confirmDeleteOpen.Set(false);
+                    deleteJobId.Set(null);
+                    refreshToken.Refresh();
+                })
+            )
+        ).Width(Size.Rem(40)) : null;
+
+        return new Fragment(dataTable, confirmDialog);
     }
 }

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
@@ -17,6 +17,8 @@ public partial class JobsApp : ViewBase
         var nav = UseNavigation();
         var refreshToken = UseRefreshToken();
         var openFile = UseState<string?>(null);
+        var confirmDeleteOpen = UseState(false);
+        var deleteJobId = UseState<string?>(null);
 
         var (planSheet, showPlan) = UseTrigger<string>((isOpen, planPath) =>
         {
@@ -76,7 +78,8 @@ public partial class JobsApp : ViewBase
         var jobsProgress = jobs.Count > 0 ? BuildStatusProgress(jobs, config) : null;
 
         var dataTable = JobsApp.BuildDataTable(nav, rows, refreshToken, updateStream, config, planService,
-            jobService, client, showPlan, showOutput, showPrompt, showDebug, jobs, projectColors, jobsProgress);
+            jobService, client, showPlan, showOutput, showPrompt, showDebug, jobs, projectColors, jobsProgress,
+            confirmDeleteOpen, deleteJobId);
 
         var layout = Layout.Vertical().Height(Size.Full());
 


### PR DESCRIPTION
Fixes #1203

# Summary

## Changes

Added a confirmation dialog to the delete job action in the Jobs app. When a user clicks the "Delete" button on a job row, a modal dialog now appears asking for confirmation before proceeding. The dialog follows the same state-based pattern as `DeleteTrashFileDialog`.

## API Changes

None. This is a UI-only change that wraps the existing `IJobService.DeleteJob()` method with a confirmation step.

## Files Modified

- **src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs** — Added state parameters for dialog management, modified delete-job handler to open confirmation dialog instead of deleting immediately, added Dialog component with Cancel/Delete buttons
- **src/Ivy.Tendril/Apps/Jobs/JobsApp.cs** — Added `confirmDeleteOpen` and `deleteJobId` state variables, passed them to `BuildDataTable`

---

## Commits

- fa6fbc96: [00522] Add confirmation dialog for delete job action