### PR TITLE
[00523] Fix issue link button wrapping to new line on desktop

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -135,27 +135,13 @@ public class ContentView(
 
         var currentIndex = allPlans.FindIndex(p => p.FolderName == selectedPlan.FolderName);
 
-        var titleArea = Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow())
-                        | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
-                            .BorderThickness(0).Padding(0).Width(Size.Full())
-                            .HideOn(Breakpoint.Mobile, Breakpoint.Tablet)
-                        | MobileItemPicker.Build(
-                                $"#{selectedPlan.Id} {selectedPlan.Title}",
-                                allPlans,
-                                p => $"#{p.Id} {p.Title}",
-                                p => p.FolderName == selectedPlan.FolderName,
-                                p => selectedPlanState.Set(p))
-                            .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
-
-        var titleBadges = Layout.Horizontal().Wrap().Gap(2).AlignContent(Align.Left);
-        var hasTitleBadges = false;
+        var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
+            | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
+                .BorderThickness(0).Padding(0).Width(Size.Grow());
 
         if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
-        {
-            titleBadges |= new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
+            desktopTitleLayout |= new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
                 .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
-            hasTitleBadges = true;
-        }
 
         if (selectedPlan.DependsOn.Count > 0)
         {
@@ -165,12 +151,21 @@ public class ContentView(
                 var dashIdx = name.IndexOf('-');
                 return dashIdx > 0 ? name[..dashIdx] : name;
             }));
-            titleBadges |= new Badge($"Depends on: {depIds}").Variant(BadgeVariant.Secondary);
-            hasTitleBadges = true;
+            desktopTitleLayout |= new Badge($"Depends on: {depIds}").Variant(BadgeVariant.Secondary);
         }
 
-        if (hasTitleBadges)
-            titleArea |= titleBadges;
+        var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
+            .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
+
+        var titleArea = Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow())
+                        | desktopTitle
+                        | MobileItemPicker.Build(
+                                $"#{selectedPlan.Id} {selectedPlan.Title}",
+                                allPlans,
+                                p => $"#{p.Id} {p.Title}",
+                                p => p.FolderName == selectedPlan.FolderName,
+                                p => selectedPlanState.Set(p))
+                            .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
 
         var controls = Layout.Horizontal().Gap(2).AlignContent(Align.Right)
                        | Text.Rich()

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -71,20 +71,24 @@ public class ContentView(
         }
         var currentIndex = allRecommendations.FindIndex(r => r.PlanId == selectedRecommendation.PlanId && r.Title == selectedRecommendation.Title);
 
+        var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
+            | new Box(Text.Block($"#{selectedRecommendation.PlanId} {selectedRecommendation.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
+                .BorderThickness(0).Padding(0).Width(Size.Grow())
+            | new Badge(selectedRecommendation.Project).Variant(BadgeVariant.Outline)
+                .WithProjectColor(config, selectedRecommendation.Project);
+
+        var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
+            .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
+
         var titleArea = Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow())
-                        | new Box(Text.Block($"#{selectedRecommendation.PlanId} {selectedRecommendation.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
-                            .BorderThickness(0).Padding(0).Width(Size.Full())
-                            .HideOn(Breakpoint.Mobile, Breakpoint.Tablet)
+                        | desktopTitle
                         | MobileItemPicker.Build(
                                 $"#{selectedRecommendation.PlanId} {selectedRecommendation.Title}",
                                 allRecommendations,
                                 r => $"#{r.PlanId} {r.Title}",
                                 r => r.PlanId == selectedRecommendation.PlanId && r.Title == selectedRecommendation.Title,
                                 r => selectedState.Set(r))
-                            .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet)
-                        | (Layout.Horizontal().Wrap().Gap(2).AlignContent(Align.Left)
-                            | new Badge(selectedRecommendation.Project).Variant(BadgeVariant.Outline)
-                                .WithProjectColor(config, selectedRecommendation.Project));
+                            .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
 
         var controls = Layout.Horizontal().Gap(2).AlignContent(Align.Right)
                        | Text.Rich()

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -251,10 +251,19 @@ public class ContentView(
         INavigator nav,
         ReviewAppArgs? args)
     {
+        var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
+            | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
+                .BorderThickness(0).Padding(0).Width(Size.Grow());
+
+        if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
+            desktopTitleLayout |= new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
+                .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
+
+        var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
+            .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
+
         var titleArea = Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow())
-                        | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
-                            .BorderThickness(0).Padding(0).Width(Size.Full())
-                            .HideOn(Breakpoint.Mobile, Breakpoint.Tablet)
+                        | desktopTitle
                         | MobileItemPicker.Build(
                                 $"#{selectedPlan.Id} {selectedPlan.Title}",
                                 allPlans,
@@ -262,11 +271,6 @@ public class ContentView(
                                 p => p.FolderName == selectedPlan.FolderName,
                                 p => selectedPlanState.Set(p))
                             .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
-
-        if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
-            titleArea |= (Layout.Horizontal().Wrap().Gap(2).AlignContent(Align.Left)
-                | new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
-                    .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl)));
 
         var controls = Layout.Horizontal().Gap(2).AlignContent(Align.Right)
                        | Text.Rich()


### PR DESCRIPTION
Fixes #1212

# Summary

## Changes

Restructured desktop title rows in three apps to prevent issue/PR link buttons and badges from wrapping to new lines. The title text and inline badges/buttons now sit side-by-side in a horizontal layout on desktop, while mobile displays continue to show them vertically.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Review/ContentView.cs** — Issue/PR button now inline with title on desktop
- **src/Ivy.Tendril/Apps/Drafts/ContentView.cs** — Issue button and dependency badges now inline with title on desktop
- **src/Ivy.Tendril/Apps/Recommendations/ContentView.cs** — Project badge now inline with title on desktop

---

## Commits

- 9dd20559 Fix issue link button wrapping to new line on desktop