### PR TITLE
Reapply process-viewer arrow fix (reverted after #1207)

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/TendrilProcessViewer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/TendrilProcessViewer.tsx
@@ -18,7 +18,7 @@ const Arrow: React.FC<ArrowProps> = ({ count, spinning, onClick }) => (
         {spinning && <LoaderCircle className="tpv-spinner" size={13} />}
       </button>
     )}
-    <svg className="tpv-arrow-svg" viewBox="0 0 80 12" preserveAspectRatio="none">
+    <svg className="tpv-arrow-svg" viewBox="0 0 80 12" preserveAspectRatio="xMidYMid meet">
       <defs>
         <marker id="arrowhead" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
           <polygon points="0,0 6,3 0,6" fill="currentColor" />

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/tendril-process.css
@@ -219,7 +219,9 @@
   }
 
   .tpv-arrow-segment {
-    margin: 0;
+    /* Gap above and below the connector so the short arrow sits clearly
+       between the stacked boxes instead of touching them. */
+    margin: 0.5rem 0;
     flex-direction: column;
     align-items: center;
   }
@@ -232,8 +234,14 @@
   }
 
   .tpv-arrow-svg {
-    width: 12px;
-    height: 50px;
+    /* Short square footprint so the rotated arrow is a brief connector that
+       sits between the stacked boxes. preserveAspectRatio="xMidYMid meet"
+       scales the 80x12 viewBox down uniformly and centers it; rotate(90deg)
+       makes it vertical. The square box reserves the arrow's full length so
+       it never overflows into the boxes above/below (combined with the
+       margin on .tpv-arrow-segment that adds breathing room). */
+    width: 20px;
+    height: 20px;
     transform: rotate(90deg);
   }
 


### PR DESCRIPTION
Re-fixes #1180

## Background

PR #1207 fixed the stretched mobile process-viewer arrows, was merged (`8da4c44`), then **reverted 9 minutes later** by `ca8144c` with no recorded reason (no PR/issue comments). That revert has since flowed into `development`, so the arrows are stretched horizontally again and #1180 is closed-but-broken.

## Changes

Restores PR #1207's fix exactly (the two files now byte-match its tip `14524ee`):

- **TendrilProcessViewer.tsx** — arrow SVG `preserveAspectRatio` `none` → `xMidYMid meet`, so the 80×12 viewBox scales uniformly instead of stretching to fill its box.
- **tendril-process.css** — mobile `.tpv-arrow-svg` back to a `20px × 20px` square footprint and `.tpv-arrow-segment` margin restored, with explanatory comments. The square box reserves the rotated arrow's full length so it never overflows into the stacked boxes.

The other mobile-arrow commits (`7ad6c35`, `14524ee`) are untouched.

## Why this won't get reverted again

The original revert left no rationale. If you recall what prompted it (a collision with the just-merged `7ad6c35`/`14524ee`, or a different regression), worth noting here before merge. As reapplied, the diff is identical to what #1207 shipped, reconciled cleanly on top of the now-present arrow commits.

## Verification

- Frontend build passes: `npm run build` (tsc typecheck + Vite production build, no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)