### PR TITLE
[00524] Plan widget fixed slot not mobile responsive

### DIFF
--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/sticky-content.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/sticky-content.spec.ts
@@ -21,4 +21,23 @@ test.describe("DraftMarkdown Sticky Content", () => {
     await expect(body).toContainText("Section One");
     await stepScreenshot("markdown-body-rendered");
   });
+
+  test("sticky content positions at top on mobile", async ({ page, stepScreenshot }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    const shell = page.locator(".pmv-shell");
+    const sticky = shell.locator(".pmv-sticky");
+    const body = shell.locator(".pmv-body");
+
+    await expect(sticky).toBeVisible({ timeout: 10_000 });
+    await stepScreenshot("mobile-layout");
+
+    const stickyBox = await sticky.boundingBox();
+    const bodyBox = await body.boundingBox();
+    expect(stickyBox).not.toBeNull();
+    expect(bodyBox).not.toBeNull();
+    expect(stickyBox!.y + stickyBox!.height).toBeLessThanOrEqual(bodyBox!.y);
+
+    const position = await sticky.evaluate((el) => window.getComputedStyle(el).position);
+    expect(position).toBe("static");
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -45,6 +45,23 @@
   padding: 0 1.5rem;
 }
 
+@media (max-width: 768px) {
+  .pmv-shell {
+    flex-direction: column;
+  }
+
+  .pmv-sticky {
+    position: static;
+    order: -1;
+    padding: 0.75rem 1rem;
+    width: 100%;
+  }
+
+  .pmv-markdown {
+    padding-left: 1rem;
+  }
+}
+
 /* ─── Typography ─────────────────────────────────────────────────────────
    Replicates the Ivy framework Markdown widget's `typography` map (and the
    `article` variant) using the host design-system CSS variables, since the


### PR DESCRIPTION
Fixes #1226

# Summary

## Changes

Added mobile responsive breakpoint to the DraftMarkdown widget's sticky content slot. On viewports 768px and narrower, the layout switches from side-by-side to stacked, with the sticky slot positioned at the top of the plan.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css** — Added `@media (max-width: 768px)` breakpoint to reflow layout
- **src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/sticky-content.spec.ts** — Added mobile viewport test

---

## Commits

- a2a45e3f Add mobile responsive breakpoint to DraftMarkdown sticky content
- b2ff7585 Merge pull request #1225 from Ivy-Interactive/tendril/reapply-1207-process-viewer-arrows-stretched
- a717c227 Reapply process-viewer arrow fix reverted after PR #1207
- fce41315 Merge pull request #1224 from Ivy-Interactive/tendril/00523-FixIssueLinkButtonWrappingToNewLineOnDesktop
- 9dd20559 Fix issue link button wrapping to new line on desktop