### PR TITLE
[00007] HideVerifiedBadgeInReviewSidebar

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/SidebarView.cs
@@ -73,9 +73,9 @@ public class SidebarView(
                 .Content(Layout.Horizontal().Gap(1)
                          | new Badge(plan.Project).Variant(BadgeVariant.Outline).Small()
                              .WithProjectColor(config, plan.Project)
-                         | (verificationsPassed
-                             ? new Badge("Verified").Variant(BadgeVariant.Success).Small()
-                             : new Badge("Unverified").Variant(BadgeVariant.Warning).Small())
+                         | (!verificationsPassed
+                             ? new Badge("Unverified").Variant(BadgeVariant.Warning).Small()
+                             : null)
                 )
                 .OnClick(() => selectedPlanState.Set(clickablePlan));
         }));


### PR DESCRIPTION
# Summary

## Changes

Modified the Review sidebar to only show the "Unverified" badge for plans that haven't passed all verifications. Removed the "Verified" badge entirely, as verified is the expected/normal state and doesn't need visual highlighting.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Review/SidebarView.cs` — Changed badge rendering logic in the plan list item

## Manual Testing

1. Run the Tendril app: `tendril`
2. Navigate to the Review view (press 'r' from the main menu)
3. Observe the sidebar plan list:
   - Plans with all verifications passed should show NO badge (only project badge)
   - Plans with failing/pending verifications should show an orange "Unverified" badge
4. Compare with before: verified plans previously showed a green "Verified" badge, now they show nothing

---

**Commits:**
- ecbaae4c Hide Verified badge in Review sidebar

---
Created using [Ivy Tendril](https://ivy.app).