### PR TITLE
[00008] LinkListViewAndPlanNavigation

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -215,7 +215,8 @@ public class ContentView(
                 new Tab("Plan", planTabContent),
                 new Tab("Details", Cap(new DetailsTabView(selectedPlan!,
                     jobService.GetJobsForPlan(selectedPlan!.FolderName),
-                    showDebugJob, planService, selectedPlanState, refreshPlans)))
+                    showDebugJob, planService, selectedPlanState, refreshPlans,
+                    folderPath => selectedPlanState.Set(planService.GetPlanByFolder(folderPath)))))
             ).OnSelect(v => selectedTab.Set(v)).SelectedIndex(selectedTab.Value).Variant(TabsVariant.Content).RemoveParentPadding();
 
             content |= (Layout.Vertical().Padding(2).Height(Size.Full()) | tabs);

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -566,7 +566,8 @@ public class ContentView(
                 new Tab("Plan", Cap(planTabContent)),
                 new Tab("Details", Cap(new DetailsTabView(selectedPlan,
                     jobService.GetJobsForPlan(selectedPlan.FolderName),
-                    showDebugJob, planService, selectedPlanState, refreshPlans))),
+                    showDebugJob, planService, selectedPlanState, refreshPlans,
+                    folderPath => selectedPlanState.Set(planService.GetPlanByFolder(folderPath))))),
                 new Tab("Verifications", Cap(new VerificationsTabView(
                     selectedPlan.Verifications, planData.VerificationReports,
                     v => openVerification.Set(v)))).Badge(selectedPlan.Verifications.Count.ToString()),

--- a/src/Ivy.Tendril/Apps/Views/LinkListView.cs
+++ b/src/Ivy.Tendril/Apps/Views/LinkListView.cs
@@ -1,0 +1,32 @@
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Apps.Views;
+
+public class LinkListView(List<Link> links, Action<string> onLinkClick) : ViewBase
+{
+    public override object Build()
+    {
+        if (links.Count == 0)
+            return Text.Block("");
+
+        var elements = new List<object>();
+
+        for (var i = 0; i < links.Count; i++)
+        {
+            var link = links[i];
+            elements.Add(
+                new Button()
+                    .Ghost()
+                    .Small()
+                    .Text($"[{link.Title}]")
+                    .OnClick(() => onLinkClick(link.Href))
+            );
+
+            if (i < links.Count - 1)
+                elements.Add(Text.Block(", "));
+        }
+
+        return Layout.Horizontal().Gap(1).AlignContent(Align.Center)
+               | elements;
+    }
+}

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services.Plans;
 
@@ -10,12 +11,14 @@ public class DetailsTabView(
     Action<string> showDebug,
     IPlanReaderService planService,
     IState<PlanFile?> selectedPlanState,
-    Action refreshPlans) : ViewBase
+    Action refreshPlans,
+    Action<string> showPlanSheet) : ViewBase
 {
     public override object Build()
     {
         var copyToClipboard = UseClipboard();
         var planYaml = PlanYamlHelper.ParsePlanYaml(plan.PlanYamlRaw);
+        var navigateToPlan = this.UsePlanNavigation(planService, showPlanSheet);
 
         var detailsData = new
         {
@@ -24,8 +27,8 @@ public class DetailsTabView(
             plan.InitialPrompt,
             Revision = plan.RevisionCount,
             Profile = planYaml?.ExecutionProfile ?? "",
-            RelatedPlans = FormatPlanLinks(plan.RelatedPlans),
-            DependsOn = FormatPlanLinks(plan.DependsOn),
+            RelatedPlans = ParsePlanLinks(plan.RelatedPlans),
+            DependsOn = ParsePlanLinks(plan.DependsOn),
             Issue = plan.SourceUrl ?? "",
             Created = plan.Created.ToString("yyyy-MM-dd"),
             plan.Level,
@@ -60,6 +63,26 @@ public class DetailsTabView(
                         if (updated != null) selectedPlanState.Set(updated);
                         refreshPlans();
                     })))
+            .Builder(x => x.RelatedPlans, f => f.Func((List<Link> links) =>
+                new LinkListView(links, href =>
+                {
+                    if (href.StartsWith("plan://"))
+                    {
+                        var planIdStr = href.Replace("plan://", "").TrimStart('0');
+                        if (int.TryParse(planIdStr, out var planId))
+                            navigateToPlan(planId);
+                    }
+                })))
+            .Builder(x => x.DependsOn, f => f.Func((List<Link> links) =>
+                new LinkListView(links, href =>
+                {
+                    if (href.StartsWith("plan://"))
+                    {
+                        var planIdStr = href.Replace("plan://", "").TrimStart('0');
+                        if (int.TryParse(planIdStr, out var planId))
+                            navigateToPlan(planId);
+                    }
+                })))
             .Builder(x => x.Issue, f => f.Link(target: LinkTarget.Blank))
             .RemoveEmpty();
 
@@ -72,19 +95,18 @@ public class DetailsTabView(
                    : null);
     }
 
-    private static string FormatPlanLinks(List<string> planFolders)
+    private static List<Link> ParsePlanLinks(List<string> planFolders)
     {
-        if (planFolders.Count == 0)
-            return "";
-
-        var links = planFolders.Select(folder =>
+        return planFolders.Select(folder =>
         {
             var fileName = Path.GetFileName(folder);
             var dashIdx = fileName.IndexOf('-');
-            var planId = dashIdx > 0 ? fileName[..dashIdx] : fileName;
-            return $"[{planId}](plan://{planId})";
-        });
+            var planIdStr = dashIdx > 0 ? fileName[..dashIdx] : fileName;
 
-        return string.Join(", ", links);
+            if (int.TryParse(planIdStr, out var planId))
+                return new Link($"#{planId}", $"plan://{planIdStr}");
+
+            return new Link(planIdStr, $"plan://{planIdStr}");
+        }).ToList();
     }
 }

--- a/src/Ivy.Tendril/Hooks/UsePlanNavigation.cs
+++ b/src/Ivy.Tendril/Hooks/UsePlanNavigation.cs
@@ -1,0 +1,38 @@
+using Ivy.Tendril.Apps.Drafts;
+using Ivy.Tendril.Apps.Review;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Plans;
+
+namespace Ivy.Tendril.Hooks;
+
+public static class UsePlanNavigationExtensions
+{
+    public static Action<int> UsePlanNavigation(
+        this IViewContext context,
+        IPlanReaderService planService,
+        Action<string> showPlanSheet)
+    {
+        var nav = context.UseNavigation();
+
+        return planId =>
+        {
+            var planFolder = Directory.GetDirectories(planService.PlansDirectory, $"{planId:D5}-*")
+                .FirstOrDefault();
+            if (planFolder == null) return;
+
+            var plan = planService.GetPlanByFolder(planFolder);
+            if (plan == null)
+            {
+                showPlanSheet(planFolder);
+                return;
+            }
+
+            if (plan.Status is PlanStatus.Draft or PlanStatus.Blocked)
+                nav.Navigate<DraftsApp>(new DraftsAppArgs(plan.FolderName));
+            else if (plan.Status is PlanStatus.ReadyForReview or PlanStatus.Failed)
+                nav.Navigate<ReviewApp>(new ReviewAppArgs(plan.FolderName));
+            else
+                showPlanSheet(planFolder);
+        };
+    }
+}

--- a/src/Ivy.Tendril/Models/PlanModels.cs
+++ b/src/Ivy.Tendril/Models/PlanModels.cs
@@ -3,6 +3,8 @@ using YamlDotNet.Serialization;
 
 namespace Ivy.Tendril.Models;
 
+public record Link(string Title, string Href);
+
 public enum PlanStatus
 {
     Draft,


### PR DESCRIPTION
# Summary

## Changes

Created reusable components for rendering and navigating plan references in the Tendril UI. Plan links in the Details tab (Related Plans, Depends On) are now clickable buttons that navigate to the appropriate app based on plan state, replacing the previous raw markdown text display.

## API Changes

- **New:** `Link` record in `PlanModels.cs` — represents a clickable link with title and href
- **New:** `LinkListView` component — renders a list of links as small ghost buttons with comma separators
- **New:** `UsePlanNavigationExtensions.UsePlanNavigation()` hook — returns an `Action<int>` that navigates to the correct app (Drafts, Review, or sheet) based on plan state
- **Changed:** `DetailsTabView` constructor — added `Action<string> showPlanSheet` parameter
- **Changed:** `DetailsTabView.Build()` — RelatedPlans and Depends On now render as interactive `LinkListView` instead of plain text

## Files Modified

**New files:**
- `src/Ivy.Tendril/Apps/Views/LinkListView.cs` — Link list rendering component
- `src/Ivy.Tendril/Hooks/UsePlanNavigation.cs` — Plan navigation hook

**Modified files:**
- `src/Ivy.Tendril/Models/PlanModels.cs` — Added Link record
- `src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs` — Replaced string-based plan links with LinkListView, added showPlanSheet parameter, changed ParsePlanLinks to return List<Link>
- `src/Ivy.Tendril/Apps/Drafts/ContentView.cs` — Pass showPlanSheet callback to DetailsTabView
- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — Pass showPlanSheet callback to DetailsTabView

## Manual Testing

1. Launch Tendril
2. Open the **Drafts** or **Review** app
3. Select a plan that has Related Plans or Depends On entries (e.g., a plan created via SplitPlan)
4. Click the **Details** tab
5. Observe the Related Plans and/or Depends On fields:
   - Should display as clickable buttons with shortened format: `[#6]`, `[#7]` instead of raw markdown text
   - Buttons should be small, ghost-styled, and separated by commas
6. Click a plan link button:
   - If the target plan is in Draft/Blocked state → should navigate to Drafts app with that plan selected
   - If the target plan is in ReadyForReview/Failed state → should navigate to Review app with that plan selected
   - Otherwise → should open the plan in a sheet overlay

---

## Commits

- a6223173 Add LinkListView and UsePlanNavigation hook for plan references

---
Created using [Ivy Tendril](https://ivy.app).