### PR TITLE
[00009] FixReviewActionsDescriptionCopy

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs
@@ -161,7 +161,7 @@ public class EditProjectDialog(
                     ),
                     new Tab("Review Actions",
                         Layout.Vertical().Gap(4)
-                        | Text.Block("Commands that run during plan review (e.g., tests, linting).").Muted()
+                        | Text.Block("Quick-launch buttons shown during review to preview or run the app.").Muted()
                         | new ReviewActionsTableView(editReviewActions, showReviewActionTrigger, showReviewActionAlert)
                         | new Button("Add Review Action").Icon(Icons.Plus).Outline()
                             .OnClick(() => showReviewActionTrigger(null))


### PR DESCRIPTION
# Summary

## Changes

Fixed the description text for the "Review Actions" tab in the Edit Project dialog. The description now correctly explains that review actions are quick-launch buttons for human reviewers to preview or run the app, rather than automated tests/linting commands (which are handled by verifications).

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs` — Updated description text on line 164

## Manual Testing

1. Run the Tendril app
2. Navigate to Settings > Projects
3. Edit any project (or create a new one)
4. Click on the "Review Actions" tab
5. Verify the description text below the tab header reads: "Quick-launch buttons shown during review to preview or run the app."

---

## Commits

- 9f48dee3 Fix review actions description copy

---
Created using [Ivy Tendril](https://ivy.app).