### PR TITLE
[00011] FormatDependsOnBadgeIdWithHashPrefix

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -149,7 +149,8 @@ public class ContentView(
             {
                 var name = Path.GetFileName(d);
                 var dashIdx = name.IndexOf('-');
-                return dashIdx > 0 ? name[..dashIdx] : name;
+                var idStr = dashIdx > 0 ? name[..dashIdx] : name;
+                return int.TryParse(idStr, out var id) ? $"#{id}" : idStr;
             }));
             desktopTitleLayout |= new Badge($"Depends on: {depIds}").Variant(BadgeVariant.Secondary);
         }


### PR DESCRIPTION
# Summary

## Changes

Changed the "Depends on" badge in the Drafts app to display plan IDs using the standard `#N` format (e.g., "#1") instead of showing the zero-padded folder prefix (e.g., "00001"). This makes the dependency badge consistent with plan ID display throughout the rest of the UI.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Drafts/ContentView.cs** — Updated DependsOn badge formatting logic

## Manual Testing

1. Run Tendril and navigate to the Drafts view
2. Select a plan that has dependencies (i.e., a plan with a populated `dependsOn` list in its plan.yaml)
3. Observe the "Depends on" badge in the plan header
4. **Expected:** The badge should display "#1" (or whatever the numeric plan ID is) instead of "00001"

---

## Commits

- e1d0fd76 Format DependsOn badge ID with # prefix

---
Created using [Ivy Tendril](https://ivy.app).