### PR TITLE
[00010] ShowFileDetailsInDirtyRepoDialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Dialogs/DirtyRepoDialog.cs
+++ b/src/Ivy.Tendril/Apps/Views/Dialogs/DirtyRepoDialog.cs
@@ -26,6 +26,25 @@ public class DirtyRepoDialog(
             foreach (var reason in dirtyState.Reasons)
             {
                 repoSection |= Text.Block($"• {FormatReason(reason)}");
+
+                // Show file/commit details
+                var items = reason.Reason == DirtyReason.AheadOfOrigin
+                    ? reason.Commits
+                    : reason.Files;
+
+                var displayCount = Math.Min(3, items.Count);
+                for (var i = 0; i < displayCount; i++)
+                {
+                    var item = items[i];
+                    // Strip leading status characters from uncommitted changes
+                    if (reason.Reason == DirtyReason.UncommittedChanges && item.Length > 3)
+                        item = item.Substring(3);
+
+                    repoSection |= Text.Muted($"  {item}");
+                }
+
+                if (items.Count > 3)
+                    repoSection |= Text.Muted($"  + {items.Count - 3} more");
             }
 
             repoSection |= Text.Markdown(contextMessage.Replace("origin/<baseBranch>", $"`origin/{baseBranch}`")).Muted();

--- a/src/Ivy.Tendril/Services/Git/GitResult.cs
+++ b/src/Ivy.Tendril/Services/Git/GitResult.cs
@@ -25,6 +25,7 @@ public record DirtyReasonDetail
     public DirtyReason Reason { get; init; }
     public string Message { get; init; } = "";
     public List<string> Files { get; init; } = new();
+    public List<string> Commits { get; init; } = new();
 }
 
 public record DirtyRepoResult

--- a/src/Ivy.Tendril/Services/Git/GitService.cs
+++ b/src/Ivy.Tendril/Services/Git/GitService.cs
@@ -163,7 +163,7 @@ public class GitService : IGitService
                 {
                     Reason = DirtyReason.AheadOfOrigin,
                     Message = $"{commits.Count} commit(s) ahead of origin/{expectedBaseBranch}",
-                    Files = commits
+                    Commits = commits
                 });
             }
         }


### PR DESCRIPTION
# Summary

## Changes

Enhanced the "Local Changes Detected" dialog to display detailed file and commit information. The dialog now shows up to 3 files or commit messages for each dirty reason, with a "+ N more" indicator when there are additional items.

## API Changes

**DirtyReasonDetail (GitResult.cs)**
- Added: `public List<string> Commits { get; init; } = new();` — stores commit oneline summaries for AheadOfOrigin reasons

## Files Modified

- **src/Ivy.Tendril/Services/Git/GitResult.cs** — Added Commits property to DirtyReasonDetail
- **src/Ivy.Tendril/Services/Git/GitService.cs** — Updated CheckAheadOfOrigin to populate Commits instead of Files
- **src/Ivy.Tendril/Apps/Views/Dialogs/DirtyRepoDialog.cs** — Added file/commit detail rendering logic

## Manual Testing

1. Create uncommitted changes in a Tendril worktree (modify 2-3 files)
2. Make a few commits ahead of origin/development
3. Trigger any operation that shows the dirty repo dialog (e.g., Execute Plan on a different plan)
4. Observe the dialog now shows:
   - Individual file names under "Uncommitted changes" (without status prefixes)
   - Commit messages under "X commit(s) ahead of origin/development"
   - "+ N more" line if there are more than 3 items

---

**Commits:**
- 9a0d1f8b Show file and commit details in dirty repo dialog

---
Created using [Ivy Tendril](https://ivy.app).