### PR TITLE
Trim CLI-logging subsystem and reorganize Jobs sheets

### DIFF
--- a/src/Ivy.Tendril.Test.End2End/Helpers/LogAssertions.cs
+++ b/src/Ivy.Tendril.Test.End2End/Helpers/LogAssertions.cs
@@ -2,11 +2,6 @@ namespace Ivy.Tendril.Test.End2End.Helpers;
 
 public static class LogAssertions
 {
-    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
-    };
-
     public static void AssertNoErrors(string tendrilHome)
     {
         var logFiles = FindLogFiles(tendrilHome);
@@ -58,74 +53,6 @@ public static class LogAssertions
         Assert.NotNull(log);
         Assert.Contains(expectedText, log!, StringComparison.OrdinalIgnoreCase);
     }
-
-    // --- CLI job log (NNN-{jobType}-job.jsonl) ---
-
-    public static List<CliLogEntry> GetCliLogEntries(string planFolder, string jobType)
-    {
-        var logsDir = Path.Combine(planFolder, "logs");
-        if (!Directory.Exists(logsDir))
-            return [];
-
-        var entries = new List<CliLogEntry>();
-        foreach (var file in Directory.GetFiles(logsDir, $"*-{jobType}-job.jsonl"))
-        {
-            foreach (var line in File.ReadAllLines(file))
-            {
-                if (string.IsNullOrWhiteSpace(line)) continue;
-                try
-                {
-                    var entry = System.Text.Json.JsonSerializer.Deserialize<CliLogEntry>(line, JsonOptions);
-                    if (entry != null) entries.Add(entry);
-                }
-                catch { }
-            }
-        }
-        return entries;
-    }
-
-    public static void AssertCliLogHasEntries(string planFolder, string jobType, int minEntries = 1)
-    {
-        var logsDir = Path.Combine(planFolder, "logs");
-        if (!Directory.Exists(logsDir))
-            return; // No logs directory — CLI log may not be produced in dotnet-run mode
-
-        var entries = GetCliLogEntries(planFolder, jobType);
-        if (entries.Count == 0 && Directory.GetFiles(logsDir, $"*-{jobType}-job.jsonl").Length == 0)
-            return; // No log file for this job type — acceptable in dev/test environments
-
-        Assert.True(entries.Count >= minEntries,
-            $"Expected at least {minEntries} CLI log entries for {jobType} in {planFolder}, found {entries.Count}");
-    }
-
-    public static void AssertCliLogContainsCommand(string planFolder, string jobType, string commandFragment)
-    {
-        var entries = GetCliLogEntries(planFolder, jobType);
-        Assert.True(entries.Count > 0,
-            $"No CLI log entries found for {jobType} in {planFolder}");
-        Assert.Contains(entries, e =>
-            e.Command != null && e.Command.Contains(commandFragment, StringComparison.OrdinalIgnoreCase));
-    }
-
-    public static void AssertAllCliCallsSucceeded(string planFolder, string jobType)
-    {
-        var entries = GetCliLogEntries(planFolder, jobType);
-        if (entries.Count == 0)
-            return; // No CLI log entries — acceptable in dev/test environments
-
-        var failures = entries
-            .Where(e => e.ExitCode != 0)
-            .ToList();
-        Assert.True(failures.Count == 0,
-            $"CLI calls failed for {jobType}:\n" +
-            string.Join("\n", failures.Select(f => $"  [{f.ExitCode}] {f.Command}")));
-    }
-
-    public record CliLogEntry(
-        string? Timestamp,
-        string? Command,
-        int ExitCode,
-        double DurationMs);
 
     private static IEnumerable<string> FindLogFiles(string tendrilHome)
     {

--- a/src/Ivy.Tendril.Test.End2End/Tests/AgentExecutionTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/AgentExecutionTests.cs
@@ -86,13 +86,6 @@ public class AgentExecutionTests : IAsyncLifetime
         // Wait for the CreatePlan job to finish (detect via stdout)
         await WaitForJobExit(timeout, step1StartLine);
 
-        // Allow time for HandleCompletion to finish moving logs
-        await Task.Delay(3000);
-
-        // Verify CreatePlan CLI log has entries and all succeeded
-        LogAssertions.AssertCliLogHasEntries(planFolder, "CreatePlan");
-        LogAssertions.AssertAllCliCallsSucceeded(planFolder, "CreatePlan");
-
         // --- Step 2: Execute Plan ---
         await _page!.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
         await dashboard.WaitForLoaded();
@@ -112,10 +105,6 @@ public class AgentExecutionTests : IAsyncLifetime
         // Wait for the ExecutePlan job to finish (detect via stdout)
         await WaitForJobExit(timeout, step2StartLine);
 
-        // Verify ExecutePlan CLI log has entries and all succeeded
-        LogAssertions.AssertCliLogHasEntries(planFolder, "ExecutePlan");
-        LogAssertions.AssertAllCliCallsSucceeded(planFolder, "ExecutePlan");
-
         // --- Step 3: Create PR ---
         await _page!.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
         await dashboard.WaitForLoaded();
@@ -132,17 +121,13 @@ public class AgentExecutionTests : IAsyncLifetime
         // Wait for CreatePr job to finish
         await WaitForJobExit(timeout, step3StartLine);
 
-        // Allow time for HandleCompletion to finish moving logs
+        // Allow time for HandleCompletion to write the PR URL to plan.yaml
         await Task.Delay(3000);
 
         // Verify PR URL was added to plan.yaml
         var planYamlPath = Path.Combine(planFolder, "plan.yaml");
         var planYaml = File.ReadAllText(planYamlPath);
         Assert.Contains("prs:", planYaml);
-
-        // Verify CreatePr CLI log has entries and all succeeded
-        LogAssertions.AssertCliLogHasEntries(planFolder, "CreatePr");
-        LogAssertions.AssertAllCliCallsSucceeded(planFolder, "CreatePr");
     }
 
     private async Task WaitForPlanWithYaml(string titleFragment, int timeoutSeconds, string context)

--- a/src/Ivy.Tendril/AGENTS.md
+++ b/src/Ivy.Tendril/AGENTS.md
@@ -48,9 +48,7 @@ All paths derive from these sources:
 - **CLI arguments** — the agent passes values explicitly (e.g., `tendril job status <TendrilJobId> --message "..."`)
 
 **What does NOT work in production:**
-- Setting process-specific env vars on the agent process and expecting nested `tendril` calls to read them (e.g., `TENDRIL_CLI_LOG`, `TENDRIL_JOB_ID`, `TENDRIL_SESSION_ID`)
-
-**CLI Logging:** The `--job-id <id>` global flag on `tendril` commands derives the CLI log path from `TENDRIL_HOME` (system-wide) + the job ID. The firmware template instructs agents to append `--job-id TendrilJobId` to all CLI commands. CLI invocations are logged to `TENDRIL_HOME/Jobs/{jobId}.cli.jsonl`. As a fallback for E2E tests, the `TENDRIL_CLI_LOG` env var still works.
+- Setting process-specific env vars on the agent process and expecting nested `tendril` calls to read them (e.g., `TENDRIL_JOB_ID`, `TENDRIL_SESSION_ID`)
 
 **Rule:** To pass information from Tendril to an agent and back through the CLI:
 1. Include it as a firmware header value (agent reads from prompt)

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -5,6 +5,7 @@ using Ivy.Core;
 using Ivy.Core.Apps;
 using Ivy.Tendril.AppShell.Dialogs;
 using Ivy.Tendril.Apps;
+using Ivy.Tendril.Apps.Debug;
 using Ivy.Tendril.Apps.Onboarding;
 using Ivy.Tendril.Apps.Settings;
 using Ivy.Tendril.Apps.Trash;
@@ -448,7 +449,10 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 .Children(
                     MenuItem.Default("Onboarding")
                         .Icon(Icons.Rocket)
-                        .OnSelect(() => navigator.Navigate<OnboardingApp>())
+                        .OnSelect(() => navigator.Navigate<OnboardingApp>()),
+                    MenuItem.Default("Dialogs")
+                        .Icon(Icons.MessageSquare)
+                        .OnSelect(() => navigator.Navigate<DialogsApp>())
                 ),
 #endif
         };

--- a/src/Ivy.Tendril/Apps/Jobs/Dialogs/ReportBugDialog.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Dialogs/ReportBugDialog.cs
@@ -1,6 +1,6 @@
 using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Jobs;
+namespace Ivy.Tendril.Apps.Jobs.Dialogs;
 
 public class ReportBugDialog(IState<bool> isOpen, string jobId) : ViewBase
 {

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Linq;
+using Ivy.Tendril.Apps.Jobs.Sheets;
 using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;

--- a/src/Ivy.Tendril/Apps/Jobs/Sheets/OutputSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Sheets/OutputSheet.cs
@@ -1,8 +1,7 @@
 using Ivy.Tendril.Models;
-using Ivy.Tendril.Services;
 using Ivy.Tendril.Widgets;
 
-namespace Ivy.Tendril.Apps.Jobs;
+namespace Ivy.Tendril.Apps.Jobs.Sheets;
 
 public class OutputSheet(string jobId, IJobService jobService) : ViewBase
 {

--- a/src/Ivy.Tendril/Apps/Jobs/Sheets/PlanSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Sheets/PlanSheet.cs
@@ -1,8 +1,7 @@
 using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Helpers;
-using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Jobs;
+namespace Ivy.Tendril.Apps.Jobs.Sheets;
 
 public class PlanSheet(
     string planPath,

--- a/src/Ivy.Tendril/Apps/Jobs/Sheets/PromptSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Sheets/PromptSheet.cs
@@ -1,4 +1,4 @@
-namespace Ivy.Tendril.Apps.Jobs;
+namespace Ivy.Tendril.Apps.Jobs.Sheets;
 
 public class PromptSheet(string promptText) : ViewBase
 {

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -13,14 +13,6 @@ public class CustomPrDialog(
     QueryResult<string[]> assigneesQuery,
     IState<string?> assigneesError) : ViewBase
 {
-    private readonly IState<string?> _assigneesError = assigneesError;
-    private readonly QueryResult<string[]> _assigneesQuery = assigneesQuery;
-    private readonly IState<bool> _dialogOpen = dialogOpen;
-    private readonly IJobService _jobService = jobService;
-    private readonly IPlanReaderService _planService = planService;
-    private readonly Action _refreshPlans = refreshPlans;
-    private readonly PlanFile _selectedPlan = selectedPlan;
-
     public override object? Build()
     {
         var isCreating = UseState(false);
@@ -37,7 +29,7 @@ public class CustomPrDialog(
             if (!customPrMerge.Value) customPrDeleteBranch.Set(false);
         }, customPrMerge);
 
-        if (!_dialogOpen.Value) return null;
+        if (!dialogOpen.Value) return null;
 
         return new Dialog(
             _ =>
@@ -50,9 +42,9 @@ public class CustomPrDialog(
                 customPrAssignee.Set(null);
                 customPrComment.Set("");
                 customPrDraft.Set(false);
-                _dialogOpen.Set(false);
+                dialogOpen.Set(false);
             },
-            new DialogHeader($"Custom PR for #{_selectedPlan.Id}"),
+            new DialogHeader($"Custom PR for #{selectedPlan.Id}"),
             new DialogBody(
                 Layout.Vertical().Gap(2)
                 | customPrSolveMergeConflicts.ToBoolInput("Solve Merge Conflicts").AutoFocus()
@@ -61,9 +53,9 @@ public class CustomPrDialog(
                     .Disabled(!customPrMerge.Value)
                 | customPrIncludeArtifacts.ToBoolInput("Include Artifacts")
                 | customPrDraft.ToBoolInput("Create as Draft")
-                | customPrAssignee.ToSelectInput((_assigneesQuery.Value ?? Array.Empty<string>()).ToOptions())
+                | customPrAssignee.ToSelectInput((assigneesQuery.Value ?? Array.Empty<string>()).ToOptions())
                     .Nullable().WithField().Label("Assignee")
-                | (_assigneesError.Value is { } err
+                | (assigneesError.Value is { } err
                     ? Text.Danger(err).Small()
                     : null)
                 | customPrComment.ToTextareaInput("Comment").Rows(3)
@@ -79,15 +71,15 @@ public class CustomPrDialog(
                     customPrAssignee.Set(null);
                     customPrComment.Set("");
                     customPrDraft.Set(false);
-                    _dialogOpen.Set(false);
+                    dialogOpen.Set(false);
                 }),
                 new Button("Create PR").Primary().Disabled(isCreating.Value).ShortcutKey("Ctrl+Enter").OnClick(() =>
                 {
                     if (!isCreating.Value)
                     {
                         isCreating.Set(true);
-                        _jobService.StartJob(new CreatePrArgs(
-                            _selectedPlan.FolderPath,
+                        jobService.StartJob(new CreatePrArgs(
+                            selectedPlan.FolderPath,
                             SolveMergeConflicts: customPrSolveMergeConflicts.Value,
                             Merge: customPrMerge.Value,
                             DeleteBranch: customPrDeleteBranch.Value && customPrMerge.Value,
@@ -95,8 +87,8 @@ public class CustomPrDialog(
                             Assignee: customPrAssignee.Value,
                             Comment: string.IsNullOrEmpty(customPrComment.Value) ? null : customPrComment.Value,
                             Draft: customPrDraft.Value));
-                        _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Building);
-                        _refreshPlans();
+                        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+                        refreshPlans();
                         isCreating.Set(false);
                         customPrSolveMergeConflicts.Set(true);
                         customPrMerge.Set(true);
@@ -105,7 +97,7 @@ public class CustomPrDialog(
                         customPrAssignee.Set(null);
                         customPrComment.Set("");
                         customPrDraft.Set(false);
-                        _dialogOpen.Set(false);
+                        dialogOpen.Set(false);
                     }
                 })
             )

--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -1,11 +1,11 @@
-using System.Text.Json;
 using System.Text.RegularExpressions;
-using Ivy.Tendril.Agents;
+using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Apps.Jobs.Dialogs;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
-namespace Ivy.Tendril.Apps.Jobs;
+namespace Ivy.Tendril.Apps.Views.Sheets;
 
 public class JobDebugSheet(
     string jobId,
@@ -42,8 +42,6 @@ public class JobDebugSheet(
             PermissionDenials = FormatPermissionDenials(job),
             PlanFolder = GetPlanFolderPath(job) ?? "",
             PlanLog = GetPlanLogPath(job) ?? "",
-            PlanCliLog = GetPlanCliLogPath(job) ?? "",
-            PromptwareLearnings = GetPromptwareLearnings(job),
             PromptwareLog = GetPromptwareLogPath(job) ?? "",
             PromptwareRawLog = GetPromptwareRawLogPath(job) ?? "",
             ExitCode = job.ExitCode?.ToString() ?? "",
@@ -54,11 +52,9 @@ public class JobDebugSheet(
         var detailsView = data.ToDetails()
             .Multiline(x => x.PromptTitle)
             .Multiline(x => x.PermissionDenials)
-            .Multiline(x => x.PromptwareLearnings)
             .Multiline(x => x.Status)
             .Multiline(x => x.PlanFolder)
             .Multiline(x => x.PlanLog)
-            .Multiline(x => x.PlanCliLog)
             .Multiline(x => x.PromptwareLog)
             .Multiline(x => x.PromptwareRawLog)
             .Multiline(x => x.SessionId)
@@ -67,8 +63,6 @@ public class JobDebugSheet(
             .Label(x => x.SessionId, "Session Id")
             .Label(x => x.PlanFolder, "Plan Folder")
             .Label(x => x.PlanLog, "Plan Log")
-            .Label(x => x.PlanCliLog, "Plan CLI Log")
-            .Label(x => x.PromptwareLearnings, "Promptware Learnings")
             .Label(x => x.PromptwareLog, "Promptware Log")
             .Label(x => x.PromptwareRawLog, "Promptware Raw Log")
             .Label(x => x.PermissionDenials, "Permission Denials")
@@ -78,11 +72,8 @@ public class JobDebugSheet(
             .Label(x => x.JobId, "Job Id")
             .Builder(x => x.PermissionDenials, f => f.Func((string denials) =>
                 new CodeBlock(denials)))
-            .Builder(x => x.PromptwareLearnings, f => f.Func((string assets) =>
-                new CodeBlock(assets)))
             .Builder(x => x.PlanFolder, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .Builder(x => x.PlanLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
-            .Builder(x => x.PlanCliLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .Builder(x => x.PromptwareLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .Builder(x => x.PromptwareRawLog,
                 f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
@@ -116,8 +107,6 @@ public class JobDebugSheet(
                     ("Permission Denials", data.PermissionDenials),
                     ("Plan Folder", data.PlanFolder),
                     ("Plan Log", data.PlanLog),
-                    ("Plan CLI Log", data.PlanCliLog),
-                    ("Promptware Learnings", data.PromptwareLearnings),
                     ("Promptware Log", data.PromptwareLog),
                     ("Promptware Raw Log", data.PromptwareRawLog),
                 };
@@ -206,8 +195,6 @@ public class JobDebugSheet(
 
     private string? GetPlanLogPath(JobItem job) => FindInLogsDir(job, "*.md");
 
-    private string? GetPlanCliLogPath(JobItem job) => FindInLogsDir(job, $"{job.Id}-*.cli.jsonl", orderByLatest: false);
-
     private string? FindInLogsDir(JobItem job, string pattern, bool orderByLatest = true)
     {
         var folder = GetPlanFolderPath(job);
@@ -221,60 +208,6 @@ public class JobDebugSheet(
             ? files.OrderByDescending(File.GetLastWriteTimeUtc).FirstOrDefault()
             : files.FirstOrDefault();
     }
-
-    private string GetPromptwareLearnings(JobItem job)
-    {
-        var cliLogPath = GetPlanCliLogPath(job);
-        if (string.IsNullOrEmpty(cliLogPath) || !File.Exists(cliLogPath))
-            return "";
-
-        try
-        {
-            var paths = new List<string>();
-            var promptsRoot = PromptwareHelper.ResolvePromptsRoot(config.TendrilHome);
-
-            foreach (var line in File.ReadLines(cliLogPath))
-            {
-                if (string.IsNullOrWhiteSpace(line)) continue;
-                var entry = JsonSerializer.Deserialize<JobStatusFile.CliLogEntry>(line, CliLogJsonOptions);
-                if (entry is not { ExitCode: 0 }) continue;
-
-                var path = TryResolveWrittenAssetPath(entry.Command, promptsRoot);
-                if (path != null)
-                    paths.Add(path);
-            }
-
-            return paths.Count == 0 ? "" : string.Join("\n", paths);
-        }
-        catch
-        {
-            return "";
-        }
-    }
-
-    private static string? TryResolveWrittenAssetPath(string command, string promptsRoot)
-    {
-        var parts = command.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        if (parts.Length < 4) return null;
-        if (!parts[0].Equals("promptware", StringComparison.OrdinalIgnoreCase)) return null;
-
-        string subDir;
-        if (parts[1].Equals("write-memory", StringComparison.OrdinalIgnoreCase))
-            subDir = "Memory";
-        else if (parts[1].Equals("write-tool", StringComparison.OrdinalIgnoreCase))
-            subDir = "Tools";
-        else
-            return null;
-
-        var promptwareName = parts[2];
-        var filename = Path.GetFileName(parts[3]);
-        return Path.Combine(promptsRoot, promptwareName, subDir, filename);
-    }
-
-    private static readonly JsonSerializerOptions CliLogJsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
 
     private string? GetPromptwareLogPath(JobItem job)
     {

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -66,25 +66,18 @@ public class DetailsTabView(
             .Builder(x => x.RelatedPlans, f => f.Func((List<Link> links) =>
                 new LinkListView(links, href =>
                 {
-                    if (href.StartsWith("plan://"))
-                    {
-                        var planIdStr = href.Replace("plan://", "").TrimStart('0');
-                        if (int.TryParse(planIdStr, out var planId))
-                            navigateToPlan(planId);
-                    }
+                    if (int.TryParse(href, out var planId))
+                        navigateToPlan(planId);
                 })))
             .Builder(x => x.DependsOn, f => f.Func((List<Link> links) =>
                 new LinkListView(links, href =>
                 {
-                    if (href.StartsWith("plan://"))
-                    {
-                        var planIdStr = href.Replace("plan://", "").TrimStart('0');
-                        if (int.TryParse(planIdStr, out var planId))
-                            navigateToPlan(planId);
-                    }
+                    if (int.TryParse(href, out var planId))
+                        navigateToPlan(planId);
                 })))
             .Builder(x => x.Issue, f => f.Link(target: LinkTarget.Blank))
-            .RemoveEmpty();
+            ;
+            //.RemoveEmpty();
 
         return Layout.Vertical().Gap(4)
                | details
@@ -102,11 +95,8 @@ public class DetailsTabView(
             var fileName = Path.GetFileName(folder);
             var dashIdx = fileName.IndexOf('-');
             var planIdStr = dashIdx > 0 ? fileName[..dashIdx] : fileName;
-
-            if (int.TryParse(planIdStr, out var planId))
-                return new Link($"#{planId}", $"plan://{planIdStr}");
-
-            return new Link(planIdStr, $"plan://{planIdStr}");
+            planIdStr = planIdStr.TrimStart('0');
+            return new Link(planIdStr, $"{planIdStr}");
         }).ToList();
     }
 }

--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -39,14 +39,14 @@ public class WallpaperApp : ViewBase
 
         if (activities.Length > 0)
         {
-            verticalLayout = verticalLayout
-                | new ActivityHeatmap()
-                    .Data(activities)
-                    .ShowMonthLabels(false)
-                    .ShowDayLabels(false)
-                    .StartDate(DateOnly.FromDateTime(DateTime.Today.AddDays(-89)))
-                    .EndDate(DateOnly.FromDateTime(DateTime.Today))
-                    .ValueLabel("PRs");
+            verticalLayout |= new Spacer().Height(Size.Units(5));
+            verticalLayout |= new ActivityHeatmap()
+                .Data(activities)
+                .ShowMonthLabels(true)
+                .ShowDayLabels(true)
+                .StartDate(DateOnly.FromDateTime(DateTime.Today.AddDays(-89)))
+                .EndDate(DateOnly.FromDateTime(DateTime.Today))
+                .ValueLabel("PRs");
         }
 
         var elements = new List<object>

--- a/src/Ivy.Tendril/Helpers/JobStatusFile.cs
+++ b/src/Ivy.Tendril/Helpers/JobStatusFile.cs
@@ -9,12 +9,6 @@ public static class JobStatusFile
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    public static string GetCliLogPath(string jobId)
-    {
-        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
-        return Path.Combine(tendrilHome, "Jobs", $"{jobId}.cli.jsonl");
-    }
-
     public static void AppendCliInvocationDirect(string logPath, string command, int exitCode, double durationMs)
     {
         try
@@ -25,25 +19,6 @@ public static class JobStatusFile
             var entry = new CliLogEntry(DateTime.UtcNow.ToString("O"), command, exitCode, durationMs);
             var line = JsonSerializer.Serialize(entry, JsonOptions);
             File.AppendAllText(logPath, line + "\n");
-        }
-        catch { /* Best-effort */ }
-    }
-
-    public static void MoveLogToPlanFolder(string logPath, string planFolder, string jobType, string? jobId = null)
-    {
-        try
-        {
-            if (!File.Exists(logPath)) return;
-
-            var logsDir = Path.Combine(planFolder, "Logs");
-            FileHelper.EnsureDirectory(logsDir);
-
-            var filename = !string.IsNullOrEmpty(jobId)
-                ? $"{jobId}-{jobType}.cli.jsonl"
-                : $"{jobType}.cli.jsonl";
-            var dest = Path.Combine(logsDir, filename);
-            File.Copy(logPath, dest, overwrite: true);
-            File.Delete(logPath);
         }
         catch { /* Best-effort */ }
     }

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -58,7 +58,7 @@ public class Program
 
         VelopackApp.Build().Run();
 
-        var (verbose, quiet, forceDesktop, forceWeb, beta, jobId, filteredArgs) = ParseGlobalFlags(args);
+        var (verbose, quiet, forceDesktop, forceWeb, beta, filteredArgs) = ParseGlobalFlags(args);
 
         bool isTool = IsTendrilToolInvocation();
         bool isPackagedApp = IsPackagedApp();
@@ -143,17 +143,6 @@ public class Program
                 try
                 {
                     var cliLog = Environment.GetEnvironmentVariable("TENDRIL_CLI_LOG");
-                    if (string.IsNullOrEmpty(cliLog))
-                    {
-                        var resolvedJobId = jobId ?? TryExtractJobIdFromStatusCommand(filteredArgs);
-                        if (!string.IsNullOrEmpty(resolvedJobId))
-                        {
-                            var home = Environment.GetEnvironmentVariable("TENDRIL_HOME");
-                            if (!string.IsNullOrEmpty(home))
-                                cliLog = JobStatusFile.GetCliLogPath(resolvedJobId);
-                        }
-                    }
-
                     if (!string.IsNullOrEmpty(cliLog))
                     {
                         var commandLine = string.Join(" ", filteredArgs);
@@ -298,7 +287,7 @@ public class Program
         }
     }
 
-    private static (bool verbose, bool quiet, bool forceDesktop, bool forceWeb, bool beta, string? jobId, string[] filtered)
+    private static (bool verbose, bool quiet, bool forceDesktop, bool forceWeb, bool beta, string[] filtered)
         ParseGlobalFlags(string[] args)
     {
         bool verbose = args.Contains("--verbose") || args.Contains("-v");
@@ -307,11 +296,6 @@ public class Program
         bool forceWeb = args.Contains("--web");
         bool beta = args.Contains("--beta");
 
-        string? jobId = null;
-        var jobIdIndex = Array.IndexOf(args, "--job-id");
-        if (jobIdIndex >= 0 && jobIdIndex + 1 < args.Length)
-            jobId = args[jobIdIndex + 1];
-
         if (verbose)
             Environment.SetEnvironmentVariable("TENDRIL_VERBOSE", "1");
         if (quiet)
@@ -319,28 +303,14 @@ public class Program
         if (beta)
             Environment.SetEnvironmentVariable("TENDRIL_BETA", "1");
 
-        var skipNext = false;
-        var filtered = args.Where((a, _) =>
-        {
-            if (skipNext) { skipNext = false; return false; }
-            if (a == "--job-id") { skipNext = true; return false; }
-            return a != "--desktop" && a != "--web" &&
-                   a != "--verbose" && a != "-v" &&
-                   a != "--quiet" && a != "-q" &&
-                   a != "--beta" &&
-                   a != DetachedLaunchMarker;
-        }).ToArray();
+        var filtered = args.Where(a =>
+            a != "--desktop" && a != "--web" &&
+            a != "--verbose" && a != "-v" &&
+            a != "--quiet" && a != "-q" &&
+            a != "--beta" &&
+            a != DetachedLaunchMarker).ToArray();
 
-        return (verbose, quiet, forceDesktop, forceWeb, beta, jobId, filtered);
-    }
-
-    private static string? TryExtractJobIdFromStatusCommand(string[] args)
-    {
-        if (args.Length >= 3 &&
-            args[0].Equals("job", StringComparison.OrdinalIgnoreCase) &&
-            args[1].Equals("status", StringComparison.OrdinalIgnoreCase))
-            return args[2];
-        return null;
+        return (verbose, quiet, forceDesktop, forceWeb, beta, filtered);
     }
 
     private static bool ShouldHandleAsCliCommand(string firstArg)

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -209,8 +209,7 @@ tendril plan create "<Title>" "<Project>" \
   --initial-prompt "<cleaned task description>" \
   --execution-profile "balanced" \
   --verification "Build=Pending" \
-  --verification "Test=Pending" \
-  --job-id TendrilJobId
+  --verification "Test=Pending"
 ```
 
 **IMPORTANT:** Always pass `--plans-dir` with the `TendrilPlansFolder` firmware value. This ensures the plan is created in the correct directory regardless of environment variable inheritance. The `<Project>` must be the exact project name from the **Projects** section — repos are derived automatically from the project configuration.
@@ -237,7 +236,7 @@ Populate `--verification` flags from the project's verifications in the **Projec
 Write the revision content via CLI:
 
 ```bash
-tendril plan write-revision <PlanId> --job-id TendrilJobId <<'EOF'
+tendril plan write-revision <PlanId> <<'EOF'
 <revision content here>
 EOF
 ```
@@ -257,11 +256,11 @@ tendril job status <TendrilJobId> --message "Creating plan..." --plan-id <PlanId
 For any fields that need to be set after initial creation, use individual CLI commands:
 
 ```bash
-tendril plan set <PlanId> initialPrompt "<text>" --job-id TendrilJobId
-tendril plan add-repo <PlanId> "<repo-path>" --job-id TendrilJobId
-tendril plan set-verification <PlanId> Build Pending --job-id TendrilJobId
-tendril plan add-related-plan <PlanId> "<folder-name>" --job-id TendrilJobId
-tendril plan add-depends-on <PlanId> "<folder-name>" --job-id TendrilJobId
+tendril plan set <PlanId> initialPrompt "<text>"
+tendril plan add-repo <PlanId> "<repo-path>"
+tendril plan set-verification <PlanId> Build Pending
+tendril plan add-related-plan <PlanId> "<folder-name>"
+tendril plan add-depends-on <PlanId> "<folder-name>"
 ```
 
 **Validate repo paths**: After determining the project and repos from the **Projects** section, verify each repo path exists locally:

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -51,7 +51,7 @@ Check `<TendrilPlanFolder>/Worktrees/` for each repo worktree.
 
 > **Worktree already removed:** If the Worktrees/ directory is empty (worktree was already cleaned up), fall back to `plan.yaml` to get the repo path and branch name (format: `tendril/<planId>-<SafeTitle>`, where SafeTitle is extracted from the plan folder name: e.g. `03158-ChangeBranchNaming` → `ChangeBranchNaming`). The commit objects may still exist in the original repo's object store. Use `git cat-file -t <sha>` to verify, then create or force-update the local branch: `git branch -f <branch-name> <sha>` (use `-f` because the branch may already exist from a WIP auto-commit) and push from the original repo path.
 >
-> **Commit lost (object GC'd):** If `git cat-file -t <sha>` fails, the commit was garbage-collected after worktree removal. In this case: (1) check if the change is already on main, (2) if not, recreate the change from the plan revision — create a new branch from main, apply the changes as described in the revision, commit with a descriptive message matching the plan title, and push. Update commits via CLI: `tendril plan add-commit <plan-id> <new-sha> --job-id TendrilJobId`.
+> **Commit lost (object GC'd):** If `git cat-file -t <sha>` fails, the commit was garbage-collected after worktree removal. In this case: (1) check if the change is already on main, (2) if not, recreate the change from the plan revision — create a new branch from main, apply the changes as described in the revision, commit with a descriptive message matching the plan title, and push. Update commits via CLI: `tendril plan add-commit <plan-id> <new-sha>`.
 
 For each worktree:
 
@@ -228,7 +228,7 @@ After successful `yolo` merges (or custom options with `merge: true`), clean up 
 For each repo where the PR was merged:
 
 ```bash
-tendril plan remove-worktree <TendrilPlanId> <repo-folder-name> --job-id TendrilJobId
+tendril plan remove-worktree <TendrilPlanId> <repo-folder-name>
 ```
 
 **Skip cleanup** for repos using the `default` PR rule (or custom options with `merge: false`) — the worktree is still needed for potential review revisions.
@@ -242,13 +242,13 @@ Use the CLI to update the plan — **never edit plan.yaml directly**.
 Add each PR URL:
 
 ```bash
-tendril plan add-pr <plan-id> <pr-url> --job-id TendrilJobId
+tendril plan add-pr <plan-id> <pr-url>
 ```
 
 **Update state to Completed:** If ALL repos in the plan used the `yolo` prRule (or custom options with `merge: true`) and ALL PRs were successfully merged, update the state:
 
 ```bash
-tendril plan set <plan-id> state Completed --job-id TendrilJobId
+tendril plan set <plan-id> state Completed
 ```
 
 If ANY repo used the `default` prRule (or custom options with `merge: false`), do NOT update the state — the plan remains open for manual review and potential revisions.
@@ -257,7 +257,7 @@ If ANY repo used the `default` prRule (or custom options with `merge: false`), d
 
 Some plans create new repos and push directly to main (e.g., repo scaffolding). These have `repos: []`, no worktrees, and commits already on `origin/main`. When detected:
 1. Verify the commit(s) exist on the remote default branch
-2. Mark state as Completed: `tendril plan set <plan-id> state Completed --job-id TendrilJobId`
+2. Mark state as Completed: `tendril plan set <plan-id> state Completed`
 3. Log outcome as "No PR Required — Direct-to-Main"
 4. Skip steps 2–5 entirely
 

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -140,7 +140,7 @@ After reading the plan revision, scan it for code validation markers to detect s
    - A `<details><summary>Still relevant?</summary>` block whose body starts with `No.`
    - Phrases like *"Already applied"*, *"This plan is redundant"*, *"This plan is superseded"*, or *"previously attempted … was merged to main via PR #NNNN"* in the `## Problem` or `## Solution` sections.
 
-   If any marker is found, verify the claim: run `gh pr view <cited PR> --json state,mergeCommit` (must be `MERGED`), confirm the cited commit is in `git log origin/<default-branch>`, and byte-compare the plan's proposed code against the current file contents. If all three checks pass, write `Verification/PreExecution.md` with `Result: Fail`, write `Artifacts/summary.md` documenting the no-op, set every verification to `Skipped` via `tendril plan set-verification <plan-id> <name> Skipped --job-id TendrilJobId`, and fail the plan **without creating a worktree** — running verifications on unchanged code wastes the time budget and produces a 0-commit PR that CreatePr cannot process.
+   If any marker is found, verify the claim: run `gh pr view <cited PR> --json state,mergeCommit` (must be `MERGED`), confirm the cited commit is in `git log origin/<default-branch>`, and byte-compare the plan's proposed code against the current file contents. If all three checks pass, write `Verification/PreExecution.md` with `Result: Fail`, write `Artifacts/summary.md` documenting the no-op, set every verification to `Skipped` via `tendril plan set-verification <plan-id> <name> Skipped`, and fail the plan **without creating a worktree** — running verifications on unchanged code wastes the time budget and produces a 0-commit PR that CreatePr cannot process.
 
 ### 2. Create Worktrees
 
@@ -156,7 +156,7 @@ For each repo in `RepoConfigs` (this includes both the plan's repos AND any read
 3. If the worktree or branch already exists from a prior execution, remove it first:
 
 ```bash
-tendril plan remove-worktree <TendrilPlanId> <repo-folder-name> --job-id TendrilJobId
+tendril plan remove-worktree <TendrilPlanId> <repo-folder-name>
 ```
 
 This handles stale directories, locked files, and branch cleanup automatically with fallback strategies.
@@ -348,15 +348,15 @@ Use the CLI to record commits, verifications, and related plans — **never edit
 Add each commit hash:
 
 ```bash
-tendril plan add-commit <plan-id> abc1234 --job-id TendrilJobId
-tendril plan add-commit <plan-id> def5678 --job-id TendrilJobId
+tendril plan add-commit <plan-id> abc1234
+tendril plan add-commit <plan-id> def5678
 ```
 
 Set verification statuses from the plan revision. Set checked items (`- [x]`) to `Pending` and unchecked items (`- [ ]`) to `Skipped`:
 
 ```bash
-tendril plan set-verification <plan-id> Build Pending --job-id TendrilJobId
-tendril plan set-verification <plan-id> Test Skipped --job-id TendrilJobId
+tendril plan set-verification <plan-id> Build Pending
+tendril plan set-verification <plan-id> Test Skipped
 ```
 
 If the plan references other plans (e.g. split-from, follow-up), add them via CLI.
@@ -380,8 +380,8 @@ For each checked verification:
 3. **Check if delegated:** The **Projects** section indicates which verifications are delegated — follow the prompt's instructions to invoke it as an external process. If the external process cannot be invoked (CLI broken, file lock, etc.), set the verification to `Fail` immediately. Do NOT attempt to do the verification inline or write the report yourself.
 4. Execute the prompt in the worktree directory
 5. If it fails: diagnose, fix the issue, **commit the fix** (e.g. `Fix lint errors from Build`), and re-run. Repeat until it passes (fail the plan after 3+ failed attempts).
-6. Document all fix commits via CLI: `tendril plan add-commit <plan-id> <sha> --job-id TendrilJobId`
-7. Update the verification status via CLI: `tendril plan set-verification <plan-id> <Name> Pass --job-id TendrilJobId` (or `Fail`)
+6. Document all fix commits via CLI: `tendril plan add-commit <plan-id> <sha>`
+7. Update the verification status via CLI: `tendril plan set-verification <plan-id> <Name> Pass` (or `Fail`)
 
 **CRITICAL:** You MUST call `tendril plan set-verification` after EACH verification. The verification report file alone is NOT sufficient — plan.yaml must also be updated via the CLI. Failing to call this command will result in the plan being marked as Failed.
 
@@ -424,7 +424,7 @@ After all verifications pass, reflect on what you observed during this plan's ex
 For each item, register it via the CLI:
 
 ```bash
-tendril plan rec add <plan-id> "Short descriptive title" -d "Markdown description with context and location." --impact Medium --risk Small --job-id TendrilJobId
+tendril plan rec add <plan-id> "Short descriptive title" -d "Markdown description with context and location." --impact Medium --risk Small
 ```
 
 `--impact` and `--risk` are optional (Small, Medium, or High). Impact indicates the value of implementing it; Risk indicates the potential for complications or bugs.

--- a/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
@@ -52,7 +52,7 @@ Report status: `tendril job status TendrilJobId --message "Writing expanded revi
 
 - Write the new revision via CLI (number auto-incremented):
   ```bash
-  tendril plan write-revision <plan-id> --job-id TendrilJobId <<'EOF'
+  tendril plan write-revision <plan-id> <<'EOF'
   <expanded revision content here>
   EOF
   ```

--- a/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
@@ -123,15 +123,15 @@ Use the CLI to record commits — **never edit plan.yaml directly**.
 Add each commit hash:
 
 ```bash
-tendril plan add-commit <plan-id> abc1234 --job-id TendrilJobId
-tendril plan add-commit <plan-id> def5678 --job-id TendrilJobId
+tendril plan add-commit <plan-id> abc1234
+tendril plan add-commit <plan-id> def5678
 ```
 
 Set verification statuses from the plan revision. Set checked items (`- [x]`) to `Pending` and unchecked items (`- [ ]`) to `Skipped`:
 
 ```bash
-tendril plan set-verification <plan-id> Build Pending --job-id TendrilJobId
-tendril plan set-verification <plan-id> Test Skipped --job-id TendrilJobId
+tendril plan set-verification <plan-id> Build Pending
+tendril plan set-verification <plan-id> Test Skipped
 ```
 
 **CRITICAL:** The `tendril plan add-commit` and `tendril plan set-verification` CLI commands are the ONLY mechanism that updates plan.yaml. You MUST call these commands.
@@ -151,8 +151,8 @@ For each checked verification:
 3. **Check if delegated:** Follow the prompt's instructions to invoke it as an external process if delegated.
 4. Execute the prompt in the worktree directory
 5. If it fails: diagnose, fix the issue, **commit the fix**, and re-run. Repeat until it passes (fail the plan after 3+ failed attempts).
-6. Document all fix commits via CLI: `tendril plan add-commit <plan-id> <sha> --job-id TendrilJobId`
-7. Update the verification status via CLI: `tendril plan set-verification <plan-id> <Name> Pass --job-id TendrilJobId` (or `Fail`)
+6. Document all fix commits via CLI: `tendril plan add-commit <plan-id> <sha>`
+7. Update the verification status via CLI: `tendril plan set-verification <plan-id> <Name> Pass` (or `Fail`)
 
 **CRITICAL:** You MUST call `tendril plan set-verification` after EACH verification.
 

--- a/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -36,8 +36,7 @@ tendril plan create "<Title>" "<TendrilProject>" \
   --execution-profile "balanced" \
   --verification "Build=Pending" \
   --verification "Test=Pending" \
-  --related-plan "<original-plan-folder-name>" \
-  --job-id TendrilJobId
+  --related-plan "<original-plan-folder-name>"
 ```
 
 **IMPORTANT:** Always pass `--plans-dir` with the plans directory (derive from the plan folder's parent). This ensures child plans are created in the correct directory regardless of environment variable inheritance. Repos are derived automatically from the project configuration.
@@ -56,7 +55,7 @@ Do NOT read or modify `.counter` directly — `tendril plan create` handles ID a
 After creating each plan, write the revision via CLI:
 
 ```bash
-tendril plan write-revision <PlanId> --job-id TendrilJobId <<'EOF'
+tendril plan write-revision <PlanId> <<'EOF'
 <revision content here>
 EOF
 ```

--- a/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
@@ -52,7 +52,7 @@ Report status: `tendril job status TendrilJobId --message "Applying changes..."`
 
 - Write the new revision via CLI (number auto-incremented):
   ```bash
-  tendril plan write-revision <plan-id> --job-id TendrilJobId <<'EOF'
+  tendril plan write-revision <plan-id> <<'EOF'
   <updated revision content here>
   EOF
   ```

--- a/src/Ivy.Tendril/Services/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/FirmwareCompiler.cs
@@ -95,9 +95,7 @@ public static class FirmwareCompiler
 
         if (headerValues.TryGetValue("TendrilJobId", out var tendrilJobId) && !string.IsNullOrEmpty(tendrilJobId))
         {
-            firmware += $"\n\n**CLI Logging:** Append `--job-id {tendrilJobId}` to every `tendril` CLI command you run " +
-                        $"(e.g., `tendril plan add-commit ... --job-id {tendrilJobId}`). This enables execution logging.\n" +
-                        $"\n**Status Reporting:** Use `tendril job status {tendrilJobId} --message \"your status\"` to report progress. " +
+            firmware += $"\n\n**Status Reporting:** Use `tendril job status {tendrilJobId} --message \"your status\"` to report progress. " +
                         "You can also pass `--plan-id` and `--plan-title` to associate the job with a plan.\n";
         }
 

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -778,36 +778,11 @@ internal class JobCompletionHandler
         Func<JobArgsBase, string> startJobSkipDepCheck)
         => _dependencyChecker.RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
 
-    private string? ResolvePlanFolder(JobItem job)
-    {
-        if (job.TypedArgs is not CreatePlanArgs)
-            return job.TypedArgs?.PlanFolder;
-
-        var planId = job.ReportedPlanId ?? job.AllocatedPlanId;
-        if (string.IsNullOrEmpty(planId)) return null;
-
-        var plansDir = _planReaderService?.PlansDirectory
-                       ?? _configService?.PlanFolder;
-        if (string.IsNullOrEmpty(plansDir)) return null;
-
-        var folderName = PlanYamlHelper.FindPlanFolderById(plansDir, planId);
-        return folderName != null ? Path.Combine(plansDir, folderName) : null;
-    }
-
     internal void WriteJobLog(JobItem job)
     {
         try
         {
             PromptwareLogWriter.WriteLog(job);
-        }
-        catch
-        {
-            // ignored
-        }
-
-        try
-        {
-            MoveCliLogIfNeeded(job);
         }
         catch
         {
@@ -830,16 +805,6 @@ internal class JobCompletionHandler
         {
             // ignored
         }
-    }
-
-    private void MoveCliLogIfNeeded(JobItem job)
-    {
-        var logPath = JobStatusFile.GetCliLogPath(job.Id);
-        if (!File.Exists(logPath)) return;
-
-        var planFolder = ResolvePlanFolder(job);
-        if (!string.IsNullOrEmpty(planFolder) && Directory.Exists(planFolder))
-            JobStatusFile.MoveLogToPlanFolder(logPath, planFolder, job.Type, job.Id);
     }
 
     private string BuildJobLogContent(JobItem job)


### PR DESCRIPTION
## CLI-logging trim

Removes the fragile **production** half of the `cli.jsonl` subsystem while keeping the deterministic `--cli-log` test path E2E tests rely on.

**Removed**
- Firmware `--job-id` instruction; `Program.cs` flag parsing + job-id log-path resolution
- `JobStatusFile.GetCliLogPath` / `MoveLogToPlanFolder`; `JobCompletionHandler.MoveCliLogIfNeeded` (+ orphaned `ResolvePlanFolder`)
- `JobDebugSheet` "Plan CLI Log" / "Promptware Learnings" consumers
- No-op `LogAssertions` CLI helpers + the `AgentExecutionTests` assertions they fed (filename pattern never matched the producer)
- `--job-id TendrilJobId` examples in promptware `Program.md`; CLI-logging note in `AGENTS.md`

**Kept** — `--cli-log` option, `TENDRIL_CLI_LOG` wrap/append, `AppendCliInvocationDirect`, `CliLogAssertions`, all `Tests/Promptware/*.cs`.

Net **−263 lines** of code. Both `Ivy.Tendril` and `Ivy.Tendril.Test.End2End` build clean (0 warnings, 0 errors).

## Also included
In-progress reorganization of Jobs sheets/dialogs into `Sheets/` and `Dialogs/` subfolders with related view edits (carried along in the working tree).