### PR TITLE
Pluralize count-based status messages in GitService and JobService

### DIFF
--- a/src/Ivy.Tendril/Services/Git/GitService.cs
+++ b/src/Ivy.Tendril/Services/Git/GitService.cs
@@ -162,7 +162,7 @@ public class GitService : IGitService
                 reasons.Add(new DirtyReasonDetail
                 {
                     Reason = DirtyReason.AheadOfOrigin,
-                    Message = $"{commits.Count} commit(s) ahead of origin/{expectedBaseBranch}",
+                    Message = $"{commits.Count} {(commits.Count == 1 ? "commit" : "commits")} ahead of origin/{expectedBaseBranch}",
                     Commits = commits
                 });
             }
@@ -194,7 +194,7 @@ public class GitService : IGitService
             reasons.Add(new DirtyReasonDetail
             {
                 Reason = DirtyReason.UncommittedChanges,
-                Message = $"{tracked.Count} file(s) with uncommitted changes",
+                Message = $"{tracked.Count} {(tracked.Count == 1 ? "file" : "files")} with uncommitted changes",
                 Files = tracked
             });
         }
@@ -216,7 +216,7 @@ public class GitService : IGitService
             reasons.Add(new DirtyReasonDetail
             {
                 Reason = DirtyReason.UntrackedFiles,
-                Message = $"{files.Count} untracked file(s)",
+                Message = $"{files.Count} untracked {(files.Count == 1 ? "file" : "files")}",
                 Files = files
             });
         }

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -643,7 +643,7 @@ public class JobService : IJobService
         }
 
         job.Status = JobStatus.Blocked;
-        job.StatusMessage = $"Waiting for job(s): {string.Join(", ", pendingIds)}";
+        job.StatusMessage = $"Waiting for {(pendingIds.Count == 1 ? "job" : "jobs")}: {string.Join(", ", pendingIds)}";
         RaiseNotification(new JobNotification("Job Blocked", $"{job.PlanFile}: waiting for {string.Join(", ", pendingIds)}", false));
         RaiseJobsStructureChanged();
         return true;


### PR DESCRIPTION
Replaces hardcoded `(s)` placeholders with proper singular/plural wording based on the actual count.

**GitService**
- `N commit(s) ahead` → `commit` / `commits`
- `N file(s) with uncommitted changes` → `file` / `files`
- `N untracked file(s)` → `file` / `files`

**JobService**
- `Waiting for job(s):` → `Waiting for job:` / `Waiting for jobs:`

Each uses an inline `count == 1 ? singular : plural` ternary against the collection already in scope. Build clean (0 warnings, 0 errors).