### PR TITLE
[00526] Fix content header height in Icebox and Recommendations apps

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -5,7 +5,6 @@ using Ivy.Core;
 using Ivy.Core.Apps;
 using Ivy.Tendril.AppShell.Dialogs;
 using Ivy.Tendril.Apps;
-using Ivy.Tendril.Apps.Debug;
 using Ivy.Tendril.Apps.Onboarding;
 using Ivy.Tendril.Apps.Settings;
 using Ivy.Tendril.Apps.Trash;

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -61,7 +61,7 @@ public class ContentView(
                            .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
                            .Muted("plans", word: true);
 
-        var header = Layout.Horizontal().Width(Size.Full()).Gap(2).AlignContent(Align.Left)
+        var header = Layout.Horizontal().Height(Size.Px(40)).Width(Size.Full()).Gap(2).AlignContent(Align.Left)
                      | titleArea
                      | controls;
 

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -109,7 +109,7 @@ public class ContentView(
                            GoToNext();
                        });
 
-        var header = Layout.Horizontal().Width(Size.Full()).Gap(2).AlignContent(Align.Left)
+        var header = Layout.Horizontal().Height(Size.Px(40)).Width(Size.Full()).Gap(2).AlignContent(Align.Left)
                      | titleArea
                      | controls;
 


### PR DESCRIPTION
Fixes #1236

# Summary

## Changes

Added a fixed height of 40px to the content header in both the Icebox and Recommendations apps. This aligns them with the Drafts and Review apps and fixes the misalignment with the sidebar search widget. Also fixed a pre-existing build error by removing an unused namespace import.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Icebox/ContentView.cs** — Added `.Height(Size.Px(40))` to header layout
- **src/Ivy.Tendril/Apps/Recommendations/ContentView.cs** — Added `.Height(Size.Px(40))` to header layout
- **src/Ivy.Tendril/AppShell/TendrilAppShell.cs** — Removed unused `using Ivy.Tendril.Apps.Debug;` to fix Debug build errors

---

## Commits

- fc62f88d Fix build: remove unused Debug namespace import
- fb20c255 Fix content header height in Icebox and Recommendations apps