### PR TITLE
[00530] Remove non-existent DialogsApp reference from Debug menu

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -448,10 +448,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 .Children(
                     MenuItem.Default("Onboarding")
                         .Icon(Icons.Rocket)
-                        .OnSelect(() => navigator.Navigate<OnboardingApp>()),
-                    MenuItem.Default("Dialogs")
-                        .Icon(Icons.MessageSquare)
-                        .OnSelect(() => navigator.Navigate<DialogsApp>())
+                        .OnSelect(() => navigator.Navigate<OnboardingApp>())
                 ),
 #endif
         };


### PR DESCRIPTION
# Summary

## Changes

Removed the non-existent "Dialogs" menu item from the Debug menu in TendrilAppShell.cs. The menu item referenced `DialogsApp`, a class that does not exist, causing CS0246 compiler errors in Debug configuration builds.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/AppShell/TendrilAppShell.cs** — Removed Dialogs menu item from DEBUG menu block

---

**Commits:**

- Remove non-existent DialogsApp reference from Debug menu (70484e0b)