### PR TITLE
[00531] Add mobile right padding to Review and Drafts content areas

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -59,6 +59,7 @@
 
   .pmv-markdown {
     padding-left: 1rem;
+    padding-right: 1rem;
   }
 }
 

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -298,7 +298,9 @@ public class ContentView(
         return new Fragment(elements.ToArray());
 
         object Cap(object inner) => Layout.Vertical().Scroll().HideScrollbar().Width(Size.Full()).Height(Size.Full())
-            | (Layout.Vertical().Padding(6, 0, 0, 4).Width(Size.Full().Max(Size.Units(200))) | inner);
+            | (Layout.Vertical()
+                .Padding(new Responsive<Thickness?> { Default = new Thickness(6, 0, 0, 4), Mobile = new Thickness(6, 4, 0, 4) })
+                .Width(Size.Full().Max(Size.Units(200))) | inner);
     }
 
     private object BuildNoSelectionView(object processView)

--- a/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
@@ -23,7 +23,9 @@ public class PlanTabView(
             // The Plan tab is no longer wrapped in Cap(), so provide the scroll,
             // full height, and 1.5rem left inset (Padding(6,…)) here.
             return Layout.Vertical().Scroll(Scroll.Vertical).Width(Size.Full()).Height(Size.Full())
-                | (Layout.Vertical().Padding(6, 0, 0, 4).Width(Size.Full().Max(Size.Units(200)))
+                | (Layout.Vertical()
+                    .Padding(new Responsive<Thickness?> { Default = new Thickness(6, 0, 0, 4), Mobile = new Thickness(6, 4, 0, 4) })
+                    .Width(Size.Full().Max(Size.Units(200)))
                     | editContentState.ToCodeInput()
                         .Language(Languages.Markdown)
                         .Width(Size.Full()));

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -662,7 +662,9 @@ public class ContentView(
         object Cap(object inner)
         {
             return Layout.Vertical().Scroll(Scroll.Auto).HideScrollbar().Width(Size.Full()).Height(Size.Full())
-                | (Layout.Vertical().Padding(6, 0, 0, 4).Width(Size.Full().Max(Size.Units(200))) | inner);
+                | (Layout.Vertical()
+                    .Padding(new Responsive<Thickness?> { Default = new Thickness(6, 0, 0, 4), Mobile = new Thickness(6, 4, 0, 4) })
+                    .Width(Size.Full().Max(Size.Units(200))) | inner);
         }
     }
 


### PR DESCRIPTION
# Summary

## Changes

Added responsive right padding (1rem on mobile) to content areas in Review and Drafts apps to prevent markdown and tab content from extending to the screen edge on mobile devices. Applied the responsive padding pattern from HelpApp to three C# layout helpers and updated the DraftMarkdown CSS mobile query.

## API Changes

None.

## Files Modified

**Layout updates:**
- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — Cap() helper uses responsive padding
- `src/Ivy.Tendril/Apps/Drafts/ContentView.cs` — Cap() helper uses responsive padding
- `src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs` — Plan editing layout uses responsive padding

**CSS updates:**
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css` — Added padding-right: 1rem to mobile media query

---

## Commits

- 8b522eb8 Add mobile right padding to Review and Drafts content areas