### PR TITLE
Add Force Start action for blocked jobs

### DIFF
--- a/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
+++ b/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
@@ -99,6 +99,10 @@ public class UseStartJobTests
             return Guid.NewGuid().ToString();
         }
 
+        public void ForceStartJob(string id)
+        {
+        }
+
         public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false)
         {
         }

--- a/src/Ivy.Tendril.Test/InboxControllerTests.cs
+++ b/src/Ivy.Tendril.Test/InboxControllerTests.cs
@@ -85,6 +85,10 @@ public class InboxControllerTests
             return id;
         }
 
+        public void ForceStartJob(string id)
+        {
+        }
+
         public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false)
         {
         }

--- a/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
@@ -222,6 +222,8 @@ public class InboxWatcherServiceTests : IDisposable
             return $"job-{StartedJobs.Count:D3}";
         }
 
+        public void ForceStartJob(string id) { }
+
         public bool IsInboxFileTracked(string filePath) => TrackedReturnValue;
 
         public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) { }
@@ -361,6 +363,8 @@ public class InboxWatcherServiceTests : IDisposable
             return $"job-{StartedJobs.Count:D3}";
         }
 
+        public void ForceStartJob(string id) { }
+
         public bool IsInboxFileTracked(string filePath)
         {
             // Delete the file when InboxWatcherService checks if it's tracked
@@ -403,6 +407,8 @@ public class InboxWatcherServiceTests : IDisposable
             StartedJobs.Add((args, inboxFilePath));
             return $"job-{StartedJobs.Count:D3}";
         }
+
+        public void ForceStartJob(string id) { }
 
         public bool IsInboxFileTracked(string filePath) => false;
 

--- a/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -216,6 +216,11 @@ public class TendrilProcessStatusServiceTests : IDisposable
             throw new NotImplementedException();
         }
 
+        public void ForceStartJob(string id)
+        {
+            throw new NotImplementedException();
+        }
+
         public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false)
         {
             throw new NotImplementedException();

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -192,6 +192,12 @@ public partial class JobsApp
                         .Tooltip("Rerun this job"));
                 }
 
+                if (job?.Status is JobStatus.Blocked)
+                {
+                    actions.Add(new MenuItem("Force Start", Icon: Icons.Zap, Tag: "force-start-job")
+                        .Tooltip("Force start this blocked job"));
+                }
+
                 if (showDebug != null)
                 {
                     actions.Add(new MenuItem("Debug", Icon: Icons.Bug, Tag: "debug-job")
@@ -243,6 +249,14 @@ public partial class JobsApp
                             jobService.DeleteJob(job.Id);
                             jobService.StartJob(job.TypedArgs);
 
+                            refreshToken.Refresh();
+                        }
+                    }
+                    else if (tag == "force-start-job")
+                    {
+                        if (job.Status is JobStatus.Blocked)
+                        {
+                            jobService.ForceStartJob(job.Id);
                             refreshToken.Refresh();
                         }
                     }

--- a/src/Ivy.Tendril/Services/Jobs/IJobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/IJobService.cs
@@ -11,6 +11,7 @@ public interface IJobService : IDisposable
     event Action<JobNotification>? NotificationReady;
 
     string StartJob(JobArgsBase args, string? inboxFilePath = null);
+    void ForceStartJob(string id);
     void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false);
     void StopJob(string id);
     void DeleteJob(string id);

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -445,7 +445,33 @@ public class JobService : IJobService
         return StartJobInternal(args, inboxFilePath: null, skipDependencyCheck: true);
     }
 
-    private string StartJobInternal(JobArgsBase args, string? inboxFilePath, bool skipDependencyCheck = false)
+    public void ForceStartJob(string id)
+    {
+        if (!_jobs.TryGetValue(id, out var job)) return;
+        if (job.Status != JobStatus.Blocked) return;
+
+        if (job.TypedArgs == null)
+        {
+            RaiseNotification(new JobNotification(
+                "Force Start Failed",
+                $"{job.PlanFile}: original args were not preserved.",
+                false));
+            return;
+        }
+
+        var typedArgs = job.TypedArgs;
+        var planFolder = typedArgs.PlanFolder ?? "";
+
+        if (!_jobs.TryRemove(id, out _)) return;
+
+        if (typedArgs is ExecutePlanArgs or RetryPlanArgs && !string.IsNullOrEmpty(planFolder))
+            PlanYamlHelper.SetPlanStateByFolder(planFolder, nameof(PlanStatus.Building));
+
+        StartJobInternal(typedArgs, inboxFilePath: null, skipDependencyCheck: true, skipWaitForCheck: true);
+        RaiseJobsStructureChanged();
+    }
+
+    private string StartJobInternal(JobArgsBase args, string? inboxFilePath, bool skipDependencyCheck = false, bool skipWaitForCheck = false)
     {
         if (args is SyncRepoArgs syncRepoArgs)
         {
@@ -467,7 +493,7 @@ public class JobService : IJobService
         if (TryBlockForDependencies(job, skipDependencyCheck))
             return id;
 
-        if (TryBlockForWaitForJobs(job))
+        if (!skipWaitForCheck && TryBlockForWaitForJobs(job))
             return id;
 
         if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or ExpandPlanArgs or UpdatePlanArgs or SplitPlanArgs)


### PR DESCRIPTION
Adds a **Force Start** row action in the Jobs app for jobs in the `Blocked` status, letting users manually relaunch a job and bypass the dependency / wait-for-jobs checks instead of waiting for auto-unblock.

## Changes
- `IJobService`/`JobService`: new `ForceStartJob(id)` that removes the blocked job, sets the plan state to `Building` for ExecutePlan/RetryPlan jobs, and relaunches via `StartJobInternal` with `skipDependencyCheck` plus a new `skipWaitForCheck` flag.
- `JobsApp.DataTable`: Force Start (⚡ Zap) row action shown only for `Blocked` jobs.
- Tests: implemented `ForceStartJob` in the `IJobService` test fakes.

Build clean; 175 JobService tests pass.