### PR TITLE
Require human-readable plan titles in CreatePlan/SplitPlan promptware

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
@@ -39,10 +39,7 @@ public class PlanTabView(
             var annotatedContent = MarkdownHelper.AnnotateAllBrokenLinks(
                 selectedPlan.LatestRevisionContent,
                 planService.PlansDirectory);
-
-            // Placeholder for the pinned interactive element. It lives in the widget's
-            // StickyContent slot, which renders outside the markdown's scroll region, so
-            // it stays in place while the plan content scrolls.
+            
             var fixedElement = new Card(
                 Layout.Vertical().Gap(2)
                 | Text.Block("Actions").Bold()

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -36,6 +36,8 @@ Plans live under `planFolder` from `config.yaml`.
 - **ID**: 5-digit value from `.counter`
 - **SafeTitle**: Title-cased, first 60 chars of description, alphanumeric only, no spaces (e.g. `"Fix login bug"` – `FixLoginBug`)
 
+**SafeTitle is for the folder name only.** It is derived automatically from the title by the CLI — do not pass it anywhere. The plan's `title` field is a separate, **human-readable** string (Title Case *with spaces*). Never reuse the PascalCase SafeTitle form as the `title`.
+
 ## Modifying Plans — Use the CLI
 
 **IMPORTANT: Never read or write `plan.yaml` directly.** Always use `tendril plan` CLI commands. This ensures validation, atomic writes, timestamp updates, and database sync.
@@ -194,7 +196,7 @@ priority: 0
 | `state`        | Current plan state (see lifecycle below)         |
 | `project`      | Project name matching a `projects` entry in `config.yaml` |
 | `level`        | One of the levels defined in `config.yaml`       |
-| `title`        | Human-readable plan title                        |
+| `title`        | Human-readable plan title in **Title Case with spaces** (e.g. `Show File Details in Local Changes Dialog`). **Never** PascalCase / no-space form (`ShowFileDetailsInLocalChangesDialog`) — that form is reserved for the folder `SafeTitle` only. MUST be identical to the `# {title}` H1 heading in the revision markdown. |
 | `sessionId`    | Claude session ID from CreatePlan (for `claude --resume`) |
 | `repos`        | Affected repository paths (plain strings, e.g. `- D:\Repos\Foo` on Windows or `- /home/user/repos/Foo` on Linux — NOT objects) |
 | `created`      | UTC timestamp when the plan was created (use `CurrentTime` from firmware header) |

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -202,6 +202,10 @@ Create the plan using CLI commands according to the plan structure in the **Refe
 
 Use `tendril plan create` to allocate a plan ID, create the folder, and write `plan.yaml` in a single command:
 
+**Title format:** `<Title>` MUST be human-readable **Title Case with spaces** and normal capitalization. Do NOT use the PascalCase / no-space folder form — the CLI derives the folder `SafeTitle` from your title automatically.
+- ✅ `Show File Details in Local Changes Dialog`
+- ❌ `ShowFileDetailsInLocalChangesDialog`
+
 ```bash
 tendril plan create "<Title>" "<Project>" \
   --plans-dir "<TendrilPlansFolder>" \
@@ -240,6 +244,8 @@ tendril plan write-revision <PlanId> <<'EOF'
 <revision content here>
 EOF
 ```
+
+**The revision's first line is the `# {title}` H1 heading — it MUST be the exact same string you passed as `<Title>` to `tendril plan create` above** (human-readable Title Case, not the PascalCase folder form). The `plan.yaml` title and the spec H1 must always match.
 
 This reads from STDIN and auto-creates `Revisions/001.md` (or the next sequential number) in the plan folder. Do NOT use the Write or Edit tools to create revision files directly in `Revisions/`.
 

--- a/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -28,6 +28,10 @@ Report status: `tendril job status TendrilJobId --message "Creating split plans.
 
 For each distinct issue, use `tendril plan create` to allocate an ID, create the folder, and write `plan.yaml`:
 
+**Title format:** `<Title>` MUST be human-readable **Title Case with spaces** and normal capitalization. Do NOT use the PascalCase / no-space folder form — the CLI derives the folder `SafeTitle` from your title automatically.
+- ✅ `Show File Details in Local Changes Dialog`
+- ❌ `ShowFileDetailsInLocalChangesDialog`
+
 ```bash
 tendril plan create "<Title>" "<TendrilProject>" \
   --plans-dir "<TendrilPlansFolder>" \
@@ -59,6 +63,8 @@ tendril plan write-revision <PlanId> <<'EOF'
 <revision content here>
 EOF
 ```
+
+**The revision's first line is the `# {title}` H1 heading — it MUST be the exact same string you passed as `<Title>` to `tendril plan create` for that plan** (human-readable Title Case, not the PascalCase folder form). The `plan.yaml` title and the spec H1 must always match.
 
 The command reads from STDIN and auto-creates the next numbered revision file. Fill in Problem, Solution, Remaining Design Questions, Tests sections. Each plan must be fully self-contained. Do NOT use the Write or Edit tools to create revision files directly in `Revisions/`.
 


### PR DESCRIPTION
## Problem

Plan titles stored in `plan.yaml` were inconsistent — sometimes human-readable (`Add Cron Expression Parser Tool`), sometimes PascalCase with no spaces (`ShowFileDetailsInDirtyRepoDialog`). The PascalCase `SafeTitle` is meant for folder names only; the `title` field should be human-readable and match the revision's H1 heading.

Root cause was a promptware-guidance gap, not a code bug — the C# pipeline already stores the title verbatim and only PascalCases for the folder name.

## Changes

- **`Prompts/Plans.md`** (shared firmware reference, compiled into every plan-writing promptware): title must be Title Case with spaces, never the PascalCase folder form, and must equal the `# {title}` H1 in the revision markdown. Added a SafeTitle-is-folder-only note.
- **`Promptwares/CreatePlan/Program.md`** and **`Promptwares/SplitPlan/Program.md`**: inline title-format rule with good/bad examples at the `plan create` step, and the H1-must-match rule at the `write-revision` step.

Promptware guidance only — no code/validation guard, no backfill of existing plans.

## Note

Also includes a small unrelated whitespace/comment change in `PlanTabView.cs` that was already in the working tree.