### PR TITLE
Verifications: plan.yaml as single source of truth + UI card + status enum

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/03_Tutorial.md
+++ b/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/03_Tutorial.md
@@ -94,7 +94,7 @@ Add a `CLAUDE.md` or `AGENTS.md` file to your repo root with project conventions
 
 ## Step 4 — Create a Plan
 
-From the dashboard, click **New Plan** and describe what you want to build or fix. Tendril will run the `CreatePlan` promptware to draft a structured plan with a problem statement, proposed solution, and verification checklist.
+From the dashboard, click **New Plan** and describe what you want to build or fix. Tendril will run the `CreatePlan` promptware to draft a structured plan with a problem statement, proposed solution, and tests. Its verifications are seeded into the plan and shown in the Verifications card, where you can toggle which ones run.
 
 You can also create a plan from the CLI:
 

--- a/src/Ivy.Tendril.TeamIvyConfig/AGENTS.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/AGENTS.md
@@ -101,11 +101,9 @@ Technical approach with file paths and steps
 
 ## Tests
 New tests to write + test scope filter
-
-## Verification
-- [x] DotnetBuild
-- [x] DotnetTest
 ```
+
+Verifications are **not** part of the revision markdown — they live in `plan.yaml` (seeded at creation, toggled in the UI).
 
 ## Tendril CLI Reference
 

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
@@ -173,9 +173,7 @@ tendril plan create "<Title>" "<TendrilProject>" \
   --plans-dir "<TendrilPlansFolder>" \
   --level "Feature" \
   --initial-prompt "<cleaned task description>" \
-  --execution-profile "balanced" \
-  --verification "Build=Pending" \
-  --verification "Test=Pending"
+  --execution-profile "balanced"
 ```
 
 **IMPORTANT:** Always pass `--plans-dir` with the `TendrilPlansFolder` firmware value. This ensures the plan is created in the correct directory regardless of environment variable inheritance. The project name must be the exact name from the **Projects** section — repos are derived automatically from the project configuration.
@@ -195,7 +193,11 @@ Include optional flags as needed:
 - `--depends-on "<folder-name>"` — for blocking dependencies (see Section 4.4)
 - `--priority <number>` — if non-default priority
 
-Populate `--verification` flags from the project's verifications in the **Projects** section, all set to `Pending`.
+**Verifications are seeded automatically.** `tendril plan create` adds **every** verification of the project (in the **Projects** section), in their configured order, defaulting **Required → `Pending`** and **Optional → `Skipped`**. You do **not** need to pass `--verification` or ensure they are present.
+
+Adjust them as the task warrants (the user can also toggle them later in the UI; ExecutePlan runs only the `Pending` ones):
+- Enable an optional verification relevant to this task: `tendril plan set-verification <PlanId> <Name> Pending`.
+- Skip a verification you judge unnecessary: `tendril plan set-verification <PlanId> <Name> Skipped`.
 
 #### 4.2. Write the revision
 
@@ -354,29 +356,6 @@ The `## Tests` section MUST include two parts:
    - If the change is so broad that all tests are genuinely needed, explicitly state: "Run all tests (broad cross-cutting change)." and justify why.
    
    Never leave test scope unspecified — this causes the full suite to run unnecessarily.
-
-### 5. Verification Checklist
-
-In the `## Verification` section of the plan revision, generate a checklist from the project's verifications in the **Projects** section.
-
-For each verification assigned to the project:
-- **Required** → `- [x] VerificationName`
-- **Optional** → `- [ ] VerificationName`
-
-Example:
-```markdown
-## Verification
-
-- [x] Build
-- [x] Format
-- [x] Test
-- [x] Lint
-- [x] CheckResult
-```
-
-If the project has no verifications (e.g. `Auto`), leave the section empty or omit it.
-
-The user can edit the checklist before execution — unchecking a required verification or checking an optional one. ExecutePlan will run only the checked items.
 
 ### Rules
 

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
@@ -339,12 +339,7 @@ tendril plan add-commit <plan-id> abc1234
 tendril plan add-commit <plan-id> def5678
 ```
 
-Set verification statuses from the plan revision. Set checked items (`- [x]`) to `Pending` and unchecked items (`- [ ]`) to `Skipped`:
-
-```bash
-tendril plan set-verification <plan-id> Build Pending
-tendril plan set-verification <plan-id> Test Skipped
-```
+Verification statuses are already set in `plan.yaml` (seeded at plan creation, optionally adjusted by the user in the UI). Do **not** derive them from the plan revision — there is no `## Verification` section anymore. You only update each verification's status to `Pass`/`Fail` after running it (Step 7).
 
 If the plan references other plans (e.g. split-from, follow-up), add them via CLI.
 
@@ -354,13 +349,13 @@ If the plan references other plans (e.g. split-from, follow-up), add them via CL
 
 Create a `Verification/` directory in the plan folder if it doesn't exist.
 
-Check the `## Verification` section in the plan revision for checked items (`- [x]`). Skip unchecked items (`- [ ]`).
+Get the run-set via `tendril plan verification list <plan-id> --json` — it emits a JSON array of `{ name, status }` **in run order**. Run the entries whose `status` is `Pending`, in array order. Skip entries whose `status` is `Skipped`.
 
 **Delegated verifications:** Some verifications are implemented as separate promptwares (e.g., `IvyFrameworkVerification`). The **Projects** section marks delegated verifications. Delegated verifications MUST be run via `tendril promptware run <Name>` — you are FORBIDDEN from writing their report files or setting their status to Pass yourself. If the `tendril` CLI is unavailable and you cannot invoke the sub-promptware, you MUST set the verification to `Fail` with a report explaining the CLI failure. Never self-certify a delegated verification.
 
 **IMPORTANT — delegated invocation syntax:** The `tendril promptware run` CLI takes the plan folder as a **positional argument** (NOT a named flag like `--plan-folder`). You MUST also pass `--value` flags for each required firmware value. The exact command is in the verification's prompt (fetched via `tendril verification get <Name>`) — copy it character-for-character, only replacing angle-bracketed placeholders with actual paths. If the command is wrong, the child promptware receives no arguments and silently fails.
 
-For each checked verification:
+For each `Pending` verification (in listed order):
 
 1. Send a status message: `tendril job status TendrilJobId --message "Verifying: <Name>"`
 2. Fetch its full prompt: `tendril verification get <Name>`

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/RetryPlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/RetryPlan/Program.md
@@ -119,12 +119,7 @@ tendril plan add-commit <plan-id> abc1234
 tendril plan add-commit <plan-id> def5678
 ```
 
-Set verification statuses from the plan revision. Set checked items (`- [x]`) to `Pending` and unchecked items (`- [ ]`) to `Skipped`:
-
-```bash
-tendril plan set-verification <plan-id> Build Pending
-tendril plan set-verification <plan-id> Test Skipped
-```
+Verification statuses already live in `plan.yaml`. Do **not** derive them from the plan revision — there is no `## Verification` section. You only update each verification's status to `Pass`/`Fail` after running it (Step 6).
 
 **CRITICAL:** The `tendril plan add-commit` and `tendril plan set-verification` CLI commands are the ONLY mechanism that updates plan.yaml. You MUST call these commands.
 
@@ -132,11 +127,11 @@ tendril plan set-verification <plan-id> Test Skipped
 
 Create a `Verification/` directory in the plan folder if it doesn't exist.
 
-Check the `## Verification` section in the plan revision for checked items (`- [x]`). Skip unchecked items (`- [ ]`).
+Get the run-set via `tendril plan verification list <plan-id> --json` — it emits a JSON array of `{ name, status }` **in run order**. Run the entries whose `status` is `Pending`, in array order. Skip entries whose `status` is `Skipped`.
 
 **Delegated verifications:** Some verifications are implemented as separate promptwares. The **Projects** section marks delegated verifications. Delegated verifications MUST be run via `tendril promptware run <Name>` — you are FORBIDDEN from writing their report files or setting their status to Pass yourself.
 
-For each checked verification:
+For each `Pending` verification (in listed order):
 
 1. Send a status message: `tendril job status TendrilJobId --message "Verifying: <Name>"`
 2. Fetch its full prompt: `tendril verification get <Name>`

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -325,8 +325,6 @@ planTemplate: >
   **Test scope (dotnet test --filter):**
 
   `FullyQualifiedName~Namespace.SpecificTestClass` (or "No existing test coverage" \ "Run all tests — <justification>")
-
-  ## Verification
 editor:
   command: code
   label: VS Code

--- a/src/Ivy.Tendril.Test/ApplyProjectVerificationsTests.cs
+++ b/src/Ivy.Tendril.Test/ApplyProjectVerificationsTests.cs
@@ -1,0 +1,146 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class ApplyProjectVerificationsTests
+{
+    private static ProjectConfig Project() => new()
+    {
+        Name = "TestProject",
+        Verifications =
+        [
+            new ProjectVerificationRef { Name = "Build", Required = true },
+            new ProjectVerificationRef { Name = "Format", Required = true },
+            new ProjectVerificationRef { Name = "Lint", Required = false },
+            new ProjectVerificationRef { Name = "E2E", Required = false }
+        ]
+    };
+
+    private static Dictionary<string, VerificationStatus> NoOverrides() => new(StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void NoOverrides_SeedsFullSet_RequiredPending_OptionalSkipped_InProjectOrder()
+    {
+        var plan = new PlanYaml();
+
+        PlanCommandHelpers.ApplyProjectVerifications(plan, Project(), NoOverrides());
+
+        Assert.Equal(new[] { "Build", "Format", "Lint", "E2E" },
+            plan.Verifications.Select(v => v.Name).ToArray());
+        Assert.Equal(VerificationStatus.Pending, plan.Verifications[0].Status); // Build (required)
+        Assert.Equal(VerificationStatus.Pending, plan.Verifications[1].Status); // Format (required)
+        Assert.Equal(VerificationStatus.Skipped, plan.Verifications[2].Status); // Lint (optional)
+        Assert.Equal(VerificationStatus.Skipped, plan.Verifications[3].Status); // E2E (optional)
+    }
+
+    [Fact]
+    public void Overrides_Win_IncludingSkippingARequiredAndEnablingAnOptional()
+    {
+        var plan = new PlanYaml();
+        var overrides = new Dictionary<string, VerificationStatus>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Build"] = VerificationStatus.Skipped, // agent explicitly skips a required one
+            ["Lint"] = VerificationStatus.Pending   // agent enables an optional one
+        };
+
+        PlanCommandHelpers.ApplyProjectVerifications(plan, Project(), overrides);
+
+        Assert.Equal(VerificationStatus.Skipped, plan.Verifications.First(v => v.Name == "Build").Status);
+        Assert.Equal(VerificationStatus.Pending, plan.Verifications.First(v => v.Name == "Format").Status); // default
+        Assert.Equal(VerificationStatus.Pending, plan.Verifications.First(v => v.Name == "Lint").Status);
+        Assert.Equal(VerificationStatus.Skipped, plan.Verifications.First(v => v.Name == "E2E").Status); // default
+    }
+
+    [Fact]
+    public void OverrideNotInProjectConfig_IsAppendedAfterProjectSet()
+    {
+        var plan = new PlanYaml();
+        var overrides = new Dictionary<string, VerificationStatus>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["CustomCheck"] = VerificationStatus.Pending
+        };
+
+        PlanCommandHelpers.ApplyProjectVerifications(plan, Project(), overrides);
+
+        Assert.Equal(5, plan.Verifications.Count);
+        Assert.Equal("CustomCheck", plan.Verifications[^1].Name);
+        Assert.Equal(VerificationStatus.Pending, plan.Verifications[^1].Status);
+    }
+
+    [Fact]
+    public void ReplacesAnyExistingEntries()
+    {
+        var plan = new PlanYaml
+        {
+            Verifications = [new PlanVerificationEntry { Name = "Stale", Status = VerificationStatus.Pass }]
+        };
+
+        PlanCommandHelpers.ApplyProjectVerifications(plan, Project(), NoOverrides());
+
+        Assert.DoesNotContain(plan.Verifications, v => v.Name == "Stale");
+        Assert.Equal(4, plan.Verifications.Count);
+    }
+
+    [Fact]
+    public void EmptyProject_SeedsNothing()
+    {
+        var plan = new PlanYaml();
+        var emptyProject = new ProjectConfig { Name = "Auto" };
+
+        PlanCommandHelpers.ApplyProjectVerifications(plan, emptyProject, NoOverrides());
+
+        Assert.Empty(plan.Verifications);
+    }
+
+    // --- OrderByProjectConfig ---
+
+    [Fact]
+    public void OrderByProjectConfig_ReordersStoredEntriesToProjectOrder()
+    {
+        // Stored out of order (e.g. plan.yaml drifted)
+        var stored = new List<PlanVerificationEntry>
+        {
+            new() { Name = "E2E", Status = VerificationStatus.Pending },
+            new() { Name = "Build", Status = VerificationStatus.Pending },
+            new() { Name = "Lint", Status = VerificationStatus.Skipped },
+            new() { Name = "Format", Status = VerificationStatus.Pending }
+        };
+
+        var ordered = PlanCommandHelpers.OrderByProjectConfig(stored, Project().Verifications);
+
+        Assert.Equal(new[] { "Build", "Format", "Lint", "E2E" }, ordered.Select(v => v.Name).ToArray());
+    }
+
+    [Fact]
+    public void OrderByProjectConfig_UnknownEntries_SortToEnd_StablyKeepingRelativeOrder()
+    {
+        var stored = new List<PlanVerificationEntry>
+        {
+            new() { Name = "Custom1", Status = VerificationStatus.Pending },
+            new() { Name = "Lint", Status = VerificationStatus.Skipped },
+            new() { Name = "Custom2", Status = VerificationStatus.Pending },
+            new() { Name = "Build", Status = VerificationStatus.Pending }
+        };
+
+        var ordered = PlanCommandHelpers.OrderByProjectConfig(stored, Project().Verifications);
+
+        // Known ones first in config order, then unknowns in original relative order.
+        Assert.Equal(new[] { "Build", "Lint", "Custom1", "Custom2" }, ordered.Select(v => v.Name).ToArray());
+    }
+
+    [Fact]
+    public void OrderByProjectConfig_NullProjectConfig_PreservesOriginalOrder()
+    {
+        var stored = new List<PlanVerificationEntry>
+        {
+            new() { Name = "B", Status = VerificationStatus.Pending },
+            new() { Name = "A", Status = VerificationStatus.Pending }
+        };
+
+        var ordered = PlanCommandHelpers.OrderByProjectConfig(stored, null);
+
+        Assert.Equal(new[] { "B", "A" }, ordered.Select(v => v.Name).ToArray());
+    }
+}

--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -216,6 +216,10 @@ public class JobServiceCompletionGuardTests : IDisposable
         {
         }
 
+        public void SetVerificationStatus(string folderName, string name, VerificationStatus status)
+        {
+        }
+
         public void RevertRevision(string folderName)
         {
         }

--- a/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
@@ -345,6 +345,10 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         {
         }
 
+        public void SetVerificationStatus(string folderName, string name, VerificationStatus status)
+        {
+        }
+
         public void RevertRevision(string folderName)
         {
         }

--- a/src/Ivy.Tendril.Test/JobServicePlanYamlTests.cs
+++ b/src/Ivy.Tendril.Test/JobServicePlanYamlTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
@@ -73,8 +74,8 @@ public class JobServicePlanYamlTests : IDisposable
         Assert.Equal("abc1234", result.Commits[0]);
         Assert.Equal(2, result.Verifications.Count);
         Assert.Equal("DotnetBuild", result.Verifications[0].Name);
-        Assert.Equal("Pass", result.Verifications[0].Status);
-        Assert.Equal("Pending", result.Verifications[1].Status);
+        Assert.Equal(VerificationStatus.Pass, result.Verifications[0].Status);
+        Assert.Equal(VerificationStatus.Pending, result.Verifications[1].Status);
         Assert.Single(result.DependsOn);
         Assert.Equal("01100-OtherPlan", result.DependsOn[0]);
     }

--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -549,6 +549,10 @@ public class JobServiceRetryBlockedTests : IDisposable
         {
         }
 
+        public void SetVerificationStatus(string folderName, string name, VerificationStatus status)
+        {
+        }
+
         public void RevertRevision(string folderName)
         {
         }

--- a/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
@@ -68,6 +68,7 @@ public class JobServiceSplitPlanCompletionTests
 
         public void ResetToDraft(string folderName) { }
         public void ResetVerificationsForRetry(string folderName) { }
+        public void SetVerificationStatus(string folderName, string name, VerificationStatus status) { }
         public void RevertRevision(string folderName) { }
 
         public void RecoverStuckPlans() { }

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -619,14 +619,14 @@ public class PlanCliCommandTests : IDisposable
 
         var folder = PlanCommandHelpers.ResolvePlanFolder("20070");
         var plan = PlanCommandHelpers.ReadPlan(folder);
-        plan.Verifications.Add(new PlanVerificationEntry { Name = "DotnetBuild", Status = "Pass" });
+        plan.Verifications.Add(new PlanVerificationEntry { Name = "DotnetBuild", Status = VerificationStatus.Pass });
         plan.Updated = DateTime.UtcNow;
         PlanCommandHelpers.WritePlan(folder, plan);
 
         var result = ReadPlan("20070");
         Assert.Single(result.Verifications);
         Assert.Equal("DotnetBuild", result.Verifications[0].Name);
-        Assert.Equal("Pass", result.Verifications[0].Status);
+        Assert.Equal(VerificationStatus.Pass, result.Verifications[0].Status);
     }
 
     [Fact]
@@ -640,43 +640,29 @@ public class PlanCliCommandTests : IDisposable
             Repos = [_tempDir.Path],
             Created = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc),
             Updated = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc),
-            Verifications = [new PlanVerificationEntry { Name = "DotnetBuild", Status = "Pending" }]
+            Verifications = [new PlanVerificationEntry { Name = "DotnetBuild", Status = VerificationStatus.Pending }]
         });
 
         var folder = PlanCommandHelpers.ResolvePlanFolder("20071");
         var plan = PlanCommandHelpers.ReadPlan(folder);
         var verif = plan.Verifications.First(v => v.Name.Equals("DotnetBuild", StringComparison.OrdinalIgnoreCase));
-        verif.Status = "Pass";
+        verif.Status = VerificationStatus.Pass;
         plan.Updated = DateTime.UtcNow;
         PlanCommandHelpers.WritePlan(folder, plan);
 
         var result = ReadPlan("20071");
         Assert.Single(result.Verifications);
-        Assert.Equal("Pass", result.Verifications[0].Status);
-    }
-
-    [Fact]
-    public void PlanSetVerification_InvalidStatus_Throws()
-    {
-        CreatePlanFolder("20072", "InvalidVerifTest");
-
-        var folder = PlanCommandHelpers.ResolvePlanFolder("20072");
-        var plan = PlanCommandHelpers.ReadPlan(folder);
-        plan.Verifications.Add(new PlanVerificationEntry { Name = "DotnetBuild", Status = "BogusStatus" });
-
-        Assert.Throws<ArgumentException>(() =>
-            PlanCommandHelpers.WritePlan(folder, plan));
+        Assert.Equal(VerificationStatus.Pass, result.Verifications[0].Status);
     }
 
     [Fact]
     public void PlanSetVerification_AllValidStatuses()
     {
         CreatePlanFolder("20073", "AllStatusesTest");
-        var validStatuses = new[] { "Pending", "Pass", "Fail", "Skipped" };
 
         var folder = PlanCommandHelpers.ResolvePlanFolder("20073");
 
-        foreach (var status in validStatuses)
+        foreach (var status in Enum.GetValues<VerificationStatus>())
         {
             var plan = PlanCommandHelpers.ReadPlan(folder);
             plan.Verifications.Clear();
@@ -1001,7 +987,7 @@ public class PlanCliCommandTests : IDisposable
             Updated = new DateTime(2026, 3, 2, 14, 30, 0, DateTimeKind.Utc),
             Prs = ["https://github.com/org/repo/pull/1"],
             Commits = ["abc1234"],
-            Verifications = [new PlanVerificationEntry { Name = "Build", Status = "Pass" }],
+            Verifications = [new PlanVerificationEntry { Name = "Build", Status = VerificationStatus.Pass }],
             RelatedPlans = ["20199-OtherPlan"],
             DependsOn = ["20198-BasePlan"],
             Priority = 3,
@@ -1130,8 +1116,8 @@ public class PlanCliCommandTests : IDisposable
             Repos = [_tempDir.Path],
             Verifications =
             [
-                new PlanVerificationEntry { Name = "DotnetBuild", Status = "Pending" },
-                new PlanVerificationEntry { Name = "DotnetTest", Status = "Pending" }
+                new PlanVerificationEntry { Name = "DotnetBuild", Status = VerificationStatus.Pending },
+                new PlanVerificationEntry { Name = "DotnetTest", Status = VerificationStatus.Pending }
             ],
             RelatedPlans = ["20201-OtherPlan"],
             DependsOn = ["20202-BasePlan"],
@@ -1190,10 +1176,10 @@ public class PlanCliCommandTests : IDisposable
             Repos = [_tempDir.Path],
             Verifications =
             [
-                new PlanVerificationEntry { Name = "DotnetBuild", Status = "Pending" },
-                new PlanVerificationEntry { Name = "DotnetFormat", Status = "Pending" },
-                new PlanVerificationEntry { Name = "DotnetTest", Status = "Pending" },
-                new PlanVerificationEntry { Name = "CheckResult", Status = "Pending" }
+                new PlanVerificationEntry { Name = "DotnetBuild", Status = VerificationStatus.Pending },
+                new PlanVerificationEntry { Name = "DotnetFormat", Status = VerificationStatus.Pending },
+                new PlanVerificationEntry { Name = "DotnetTest", Status = VerificationStatus.Pending },
+                new PlanVerificationEntry { Name = "CheckResult", Status = VerificationStatus.Pending }
             ],
             Created = DateTime.UtcNow,
             Updated = DateTime.UtcNow
@@ -1202,7 +1188,7 @@ public class PlanCliCommandTests : IDisposable
 
         var result = PlanCommandHelpers.ReadPlan(planDir);
         Assert.Equal(4, result.Verifications.Count);
-        Assert.All(result.Verifications, v => Assert.Equal("Pending", v.Status));
+        Assert.All(result.Verifications, v => Assert.Equal(VerificationStatus.Pending, v.Status));
     }
 
     // ==================== PlanAddRelatedPlan ====================

--- a/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -33,7 +33,7 @@ public class PlanDatabaseServiceTests : IDisposable
             new List<string> { "D:\\Repos\\Test" },
             new List<string> { "abc123" },
             new List<string> { "https://github.com/test/pr/1" },
-            new List<PlanVerificationEntry> { new() { Name = "DotnetBuild", Status = "Pass" } },
+            new List<PlanVerificationEntry> { new() { Name = "DotnetBuild", Status = VerificationStatus.Pass } },
             new List<string>(),
             new List<string>(),
             DateTime.UtcNow.AddDays(-1),
@@ -1269,9 +1269,9 @@ public class PlanDatabaseServiceTests : IDisposable
                 new List<string>(),
                 new List<PlanVerificationEntry>
                 {
-                    new() { Name = "DotnetBuild", Status = "Pass" },
-                    new() { Name = "DotnetTest", Status = "Pass" },
-                    new() { Name = "DotnetFormat", Status = "Pass" }
+                    new() { Name = "DotnetBuild", Status = VerificationStatus.Pass },
+                    new() { Name = "DotnetTest", Status = VerificationStatus.Pass },
+                    new() { Name = "DotnetFormat", Status = VerificationStatus.Pass }
                 },
                 new List<string>(),
                 new List<string>(),
@@ -1365,7 +1365,7 @@ public class PlanDatabaseServiceTests : IDisposable
                 new List<string> { $"D:\\Repos\\Repo{i}" },
                 new List<string>(),
                 new List<string>(),
-                new List<PlanVerificationEntry> { new() { Name = "DotnetBuild", Status = "Pass" } },
+                new List<PlanVerificationEntry> { new() { Name = "DotnetBuild", Status = VerificationStatus.Pass } },
                 new List<string>(),
                 new List<string>(),
                 DateTime.UtcNow.AddDays(-1),
@@ -1387,7 +1387,7 @@ public class PlanDatabaseServiceTests : IDisposable
             Assert.Equal($"D:\\Repos\\Repo{plan.Id}", plan.Repos[0]);
             Assert.Single(plan.Verifications);
             Assert.Equal("DotnetBuild", plan.Verifications[0].Name);
-            Assert.Equal("Pass", plan.Verifications[0].Status);
+            Assert.Equal(VerificationStatus.Pass, plan.Verifications[0].Status);
         }
     }
 }

--- a/src/Ivy.Tendril.Test/PlanVerificationCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanVerificationCommandTests.cs
@@ -68,14 +68,14 @@ public class PlanVerificationCommandTests : IDisposable
         var planFolder = PlanCommandHelpers.ResolvePlanFolder("30001");
         var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-        plan.Verifications.Add(new PlanVerificationEntry { Name = "UnitTests", Status = "Pending" });
+        plan.Verifications.Add(new PlanVerificationEntry { Name = "UnitTests", Status = VerificationStatus.Pending });
         plan.Updated = DateTime.UtcNow;
         PlanCommandHelpers.WritePlan(planFolder, plan);
 
         var result = ReadPlan("30001");
         Assert.Single(result.Verifications);
         Assert.Equal("UnitTests", result.Verifications[0].Name);
-        Assert.Equal("Pending", result.Verifications[0].Status);
+        Assert.Equal(VerificationStatus.Pending, result.Verifications[0].Status);
     }
 
     [Fact]
@@ -85,8 +85,8 @@ public class PlanVerificationCommandTests : IDisposable
 
         var planFolder = PlanCommandHelpers.ResolvePlanFolder("30002");
         var plan = PlanCommandHelpers.ReadPlan(planFolder);
-        plan.Verifications.Add(new PlanVerificationEntry { Name = "UnitTests", Status = "Pending" });
-        plan.Verifications.Add(new PlanVerificationEntry { Name = "Integration", Status = "Pass" });
+        plan.Verifications.Add(new PlanVerificationEntry { Name = "UnitTests", Status = VerificationStatus.Pending });
+        plan.Verifications.Add(new PlanVerificationEntry { Name = "Integration", Status = VerificationStatus.Pass });
         PlanCommandHelpers.WritePlan(planFolder, plan);
 
         var result = ReadPlan("30002");
@@ -99,18 +99,18 @@ public class PlanVerificationCommandTests : IDisposable
     public void AddVerification_PreservesExisting()
     {
         CreatePlan("30003", "PreserveVerTest", [
-            new PlanVerificationEntry { Name = "Existing", Status = "Pass" }
+            new PlanVerificationEntry { Name = "Existing", Status = VerificationStatus.Pass }
         ]);
 
         var planFolder = PlanCommandHelpers.ResolvePlanFolder("30003");
         var plan = PlanCommandHelpers.ReadPlan(planFolder);
-        plan.Verifications.Add(new PlanVerificationEntry { Name = "New", Status = "Pending" });
+        plan.Verifications.Add(new PlanVerificationEntry { Name = "New", Status = VerificationStatus.Pending });
         PlanCommandHelpers.WritePlan(planFolder, plan);
 
         var result = ReadPlan("30003");
         Assert.Equal(2, result.Verifications.Count);
         Assert.Equal("Existing", result.Verifications[0].Name);
-        Assert.Equal("Pass", result.Verifications[0].Status);
+        Assert.Equal(VerificationStatus.Pass, result.Verifications[0].Status);
         Assert.Equal("New", result.Verifications[1].Name);
     }
 
@@ -120,8 +120,8 @@ public class PlanVerificationCommandTests : IDisposable
     public void RemoveVerification_RemovesEntry()
     {
         CreatePlan("30010", "RemoveVerTest", [
-            new PlanVerificationEntry { Name = "ToRemove", Status = "Pending" },
-            new PlanVerificationEntry { Name = "ToKeep", Status = "Pass" }
+            new PlanVerificationEntry { Name = "ToRemove", Status = VerificationStatus.Pending },
+            new PlanVerificationEntry { Name = "ToKeep", Status = VerificationStatus.Pass }
         ]);
 
         var planFolder = PlanCommandHelpers.ResolvePlanFolder("30010");
@@ -140,7 +140,7 @@ public class PlanVerificationCommandTests : IDisposable
     public void RemoveVerification_LastEntry_LeavesEmptyList()
     {
         CreatePlan("30011", "RemoveLastVer", [
-            new PlanVerificationEntry { Name = "Only", Status = "Fail" }
+            new PlanVerificationEntry { Name = "Only", Status = VerificationStatus.Fail }
         ]);
 
         var planFolder = PlanCommandHelpers.ResolvePlanFolder("30011");
@@ -158,27 +158,31 @@ public class PlanVerificationCommandTests : IDisposable
     public void SetVerificationStatus_UpdatesExisting()
     {
         CreatePlan("30020", "SetStatusTest", [
-            new PlanVerificationEntry { Name = "UnitTests", Status = "Pending" }
+            new PlanVerificationEntry { Name = "UnitTests", Status = VerificationStatus.Pending }
         ]);
 
         var planFolder = PlanCommandHelpers.ResolvePlanFolder("30020");
         var plan = PlanCommandHelpers.ReadPlan(planFolder);
-        plan.Verifications[0].Status = "Pass";
+        plan.Verifications[0].Status = VerificationStatus.Pass;
         plan.Updated = DateTime.UtcNow;
         PlanCommandHelpers.WritePlan(planFolder, plan);
 
         var result = ReadPlan("30020");
-        Assert.Equal("Pass", result.Verifications[0].Status);
+        Assert.Equal(VerificationStatus.Pass, result.Verifications[0].Status);
     }
 
     [Fact]
     public void SetVerificationStatus_AllStatuses()
     {
-        foreach (var status in new[] { "Pass", "Fail", "Pending", "Skipped" })
+        var statuses = new[]
         {
-            var id = $"3003{Array.IndexOf(new[] { "Pass", "Fail", "Pending", "Skipped" }, status)}";
+            VerificationStatus.Pass, VerificationStatus.Fail, VerificationStatus.Pending, VerificationStatus.Skipped
+        };
+        foreach (var status in statuses)
+        {
+            var id = $"3003{Array.IndexOf(statuses, status)}";
             CreatePlan(id, $"Status{status}", [
-                new PlanVerificationEntry { Name = "Test", Status = "Pending" }
+                new PlanVerificationEntry { Name = "Test", Status = VerificationStatus.Pending }
             ]);
 
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(id);
@@ -203,7 +207,7 @@ public class PlanVerificationCommandTests : IDisposable
 
         var planFolder = PlanCommandHelpers.ResolvePlanFolder("30040");
         var plan = PlanCommandHelpers.ReadPlan(planFolder);
-        plan.Verifications.Add(new PlanVerificationEntry { Name = "New", Status = "Pending" });
+        plan.Verifications.Add(new PlanVerificationEntry { Name = "New", Status = VerificationStatus.Pending });
         plan.Updated = DateTime.UtcNow;
         PlanCommandHelpers.WritePlan(planFolder, plan);
 
@@ -217,18 +221,35 @@ public class PlanVerificationCommandTests : IDisposable
     public void Verifications_SurviveRoundtrip()
     {
         CreatePlan("30050", "RoundtripTest", [
-            new PlanVerificationEntry { Name = "UnitTests", Status = "Pass" },
-            new PlanVerificationEntry { Name = "Integration", Status = "Fail" },
-            new PlanVerificationEntry { Name = "E2E", Status = "Skipped" }
+            new PlanVerificationEntry { Name = "UnitTests", Status = VerificationStatus.Pass },
+            new PlanVerificationEntry { Name = "Integration", Status = VerificationStatus.Fail },
+            new PlanVerificationEntry { Name = "E2E", Status = VerificationStatus.Skipped }
         ]);
 
         var result = ReadPlan("30050");
         Assert.Equal(3, result.Verifications.Count);
         Assert.Equal("UnitTests", result.Verifications[0].Name);
-        Assert.Equal("Pass", result.Verifications[0].Status);
+        Assert.Equal(VerificationStatus.Pass, result.Verifications[0].Status);
         Assert.Equal("Integration", result.Verifications[1].Name);
-        Assert.Equal("Fail", result.Verifications[1].Status);
+        Assert.Equal(VerificationStatus.Fail, result.Verifications[1].Status);
         Assert.Equal("E2E", result.Verifications[2].Name);
-        Assert.Equal("Skipped", result.Verifications[2].Status);
+        Assert.Equal(VerificationStatus.Skipped, result.Verifications[2].Status);
+    }
+
+    // --- Wire format: status must serialize as PascalCase string in plan.yaml ---
+
+    [Fact]
+    public void Verifications_SerializeAsPascalCaseStringsOnDisk()
+    {
+        CreatePlan("30060", "WireFormatTest", [
+            new PlanVerificationEntry { Name = "Build", Status = VerificationStatus.Pending },
+            new PlanVerificationEntry { Name = "Lint", Status = VerificationStatus.Skipped }
+        ]);
+
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder("30060");
+        var raw = File.ReadAllText(Path.Combine(planFolder, "plan.yaml"));
+
+        Assert.Contains("status: Pending", raw);
+        Assert.Contains("status: Skipped", raw);
     }
 }

--- a/src/Ivy.Tendril.Test/PlanYamlHelperVerificationTests.cs
+++ b/src/Ivy.Tendril.Test/PlanYamlHelperVerificationTests.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Test;
 
@@ -20,7 +21,7 @@ public class PlanYamlHelperVerificationTests
             Build succeeded.
             """;
 
-        Assert.Equal("Pass", PlanYamlHelper.ParseVerificationResultFromReport(content));
+        Assert.Equal(VerificationStatus.Pass, PlanYamlHelper.ParseVerificationResultFromReport(content));
     }
 
     [Fact]
@@ -39,7 +40,7 @@ public class PlanYamlHelperVerificationTests
             Build failed with 2 errors.
             """;
 
-        Assert.Equal("Fail", PlanYamlHelper.ParseVerificationResultFromReport(content));
+        Assert.Equal(VerificationStatus.Fail, PlanYamlHelper.ParseVerificationResultFromReport(content));
     }
 
     [Fact]
@@ -54,7 +55,7 @@ public class PlanYamlHelperVerificationTests
             # DotnetTest
             """;
 
-        Assert.Equal("Skipped", PlanYamlHelper.ParseVerificationResultFromReport(content));
+        Assert.Equal(VerificationStatus.Skipped, PlanYamlHelper.ParseVerificationResultFromReport(content));
     }
 
     [Fact]
@@ -72,7 +73,7 @@ public class PlanYamlHelperVerificationTests
             Build succeeded with 0 warnings and 0 errors.
             """;
 
-        Assert.Equal("Pass", PlanYamlHelper.ParseVerificationResultFromReport(content));
+        Assert.Equal(VerificationStatus.Pass, PlanYamlHelper.ParseVerificationResultFromReport(content));
     }
 
     [Fact]
@@ -90,7 +91,7 @@ public class PlanYamlHelperVerificationTests
             3 tests failed.
             """;
 
-        Assert.Equal("Fail", PlanYamlHelper.ParseVerificationResultFromReport(content));
+        Assert.Equal(VerificationStatus.Fail, PlanYamlHelper.ParseVerificationResultFromReport(content));
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Test.TestHelpers;
@@ -122,6 +123,58 @@ public class PlanReaderServiceTests
             Assert.Contains("abc1234", result);
             Assert.Contains("def5678", result);
             Assert.Contains(folderName, testWatcher.NotifiedFolders);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void SetVerificationStatus_TogglesStatus_PersistsAndPreservesOthers_NotifiesWatcher()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+        var testConfig = new TempDirConfigService(tempDir);
+        var testLogger = new TestLogger();
+        var testWatcher = new TestPlanWatcherService();
+
+        var service = new PlanReaderService(
+            testConfig,
+            testLogger,
+            planWatcherService: testWatcher);
+
+        var folderName = "01234-TestPlan";
+        var planFolder = Path.Combine(tempDir, folderName);
+        Directory.CreateDirectory(planFolder);
+
+        // repos must point at an existing directory to pass plan validation
+        var planYaml =
+            $"state: Draft\nproject: TestProject\ntitle: TestPlan\nrepos:\n- {tempDir.Replace("\\", "/")}\n" +
+            "created: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n" +
+            "verifications:\n- name: Build\n  status: Pending\n- name: Test\n  status: Pending\n";
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
+
+        try
+        {
+            // Act — skip Test, leave Build untouched
+            service.SetVerificationStatus(folderName, "Test", VerificationStatus.Skipped);
+
+            // Assert — written synchronously, so re-read straight away
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            Assert.Equal(VerificationStatus.Pending,
+                plan.Verifications.First(v => v.Name == "Build").Status);
+            Assert.Equal(VerificationStatus.Skipped,
+                plan.Verifications.First(v => v.Name == "Test").Status);
+            Assert.Contains(folderName, testWatcher.NotifiedFolders);
+
+            // Act again — toggle back to Pending
+            service.SetVerificationStatus(folderName, "Test", VerificationStatus.Pending);
+            plan = PlanCommandHelpers.ReadPlan(planFolder);
+            Assert.Equal(VerificationStatus.Pending,
+                plan.Verifications.First(v => v.Name == "Test").Status);
         }
         finally
         {

--- a/src/Ivy.Tendril.Test/Services/PlanValidationServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PlanValidationServiceTests.cs
@@ -311,7 +311,7 @@ public class PlanValidationServiceTests : IDisposable
         var plan = CreateValidPlan();
         plan.Verifications = new List<PlanVerificationEntry>
         {
-            new PlanVerificationEntry { Name = "", Status = "Pending" }
+            new PlanVerificationEntry { Name = "", Status = VerificationStatus.Pending }
         };
 
         var ex = Assert.Throws<ArgumentException>(() => PlanValidationService.Validate(plan));
@@ -320,40 +320,11 @@ public class PlanValidationServiceTests : IDisposable
     }
 
     [Fact]
-    public void Validate_ThrowsForVerificationWithEmptyStatus()
-    {
-        var plan = CreateValidPlan();
-        plan.Verifications = new List<PlanVerificationEntry>
-        {
-            new PlanVerificationEntry { Name = "Build", Status = "" }
-        };
-
-        var ex = Assert.Throws<ArgumentException>(() => PlanValidationService.Validate(plan));
-
-        Assert.Contains("empty status", ex.Message);
-    }
-
-    [Fact]
-    public void Validate_ThrowsForVerificationWithInvalidStatus()
-    {
-        var plan = CreateValidPlan();
-        plan.Verifications = new List<PlanVerificationEntry>
-        {
-            new PlanVerificationEntry { Name = "Build", Status = "InvalidStatus" }
-        };
-
-        var ex = Assert.Throws<ArgumentException>(() => PlanValidationService.Validate(plan));
-
-        Assert.Contains("Invalid status", ex.Message);
-        Assert.Contains("Build", ex.Message);
-    }
-
-    [Fact]
     public void Validate_AcceptsAllValidVerificationStatuses()
     {
-        var validStatuses = new[] { "Pending", "Pass", "Fail", "Skipped" };
-
-        foreach (var status in validStatuses)
+        // Status is a VerificationStatus enum, so every value is inherently valid —
+        // Validate() must accept all of them without throwing.
+        foreach (var status in Enum.GetValues<VerificationStatus>())
         {
             var plan = CreateValidPlan();
             plan.Verifications = new List<PlanVerificationEntry>

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -200,6 +200,7 @@ public class ContentView(
             editContent,
             openFile,
             planService,
+            config,
             annotations);
 
         if (planContentQuery.Loading)

--- a/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
@@ -14,6 +14,7 @@ public class PlanTabView(
     IState<string> editContentState,
     IState<string?> openFileState,
     IPlanReaderService planService,
+    IConfigService config,
     IState<ImmutableList<MarkdownAnnotation>> annotations) : ViewBase
 {
     public override object Build()
@@ -40,11 +41,7 @@ public class PlanTabView(
                 selectedPlan.LatestRevisionContent,
                 planService.PlansDirectory);
             
-            var fixedElement = new Card(
-                Layout.Vertical().Gap(2)
-                | Text.Block("Actions").Bold()
-                | new Button("Placeholder").Outline()
-            ).Width(Size.Px(280));
+            var fixedElement = new VerificationsCardView(selectedPlan, planService, config);
 
             Action<string> onLinkClick = FileSheet.CreateLinkClickHandler(openFileState, planId =>
             {

--- a/src/Ivy.Tendril/Apps/Drafts/VerificationsCardView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/VerificationsCardView.cs
@@ -1,0 +1,96 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
+
+namespace Ivy.Tendril.Apps.Drafts;
+
+/// <summary>
+///     Sticky-sidebar card listing a plan's verifications as checkboxes. Toggling a checkbox
+///     persists the new status (Pending when checked, Skipped when unchecked) to plan.yaml
+///     immediately. Editing is only allowed while the plan is in Draft — once it has run the
+///     checkboxes are disabled and show the real Pass/Fail/Skipped status. The list is the
+///     plan.yaml snapshot; the Required flag is read live from the project config.
+/// </summary>
+public class VerificationsCardView(
+    PlanFile selectedPlan,
+    IPlanReaderService planService,
+    IConfigService config) : ViewBase
+{
+    public override object Build()
+    {
+        var editable = selectedPlan.Status == PlanStatus.Draft;
+
+        var projectVerifications = config.GetProject(selectedPlan.Project)?.Verifications
+                                   ?? new List<ProjectVerificationRef>();
+
+        // Always present in project-config order, regardless of plan.yaml storage order.
+        var verifications = PlanCommandHelpers.OrderByProjectConfig(selectedPlan.Verifications, projectVerifications);
+
+        bool IsRequired(string name) => projectVerifications
+            .Any(pv => pv.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && pv.Required);
+
+        var inner = Layout.Vertical().Gap(1)
+                    | Text.Block("Verifications").Bold();
+
+        if (verifications.Count == 0)
+        {
+            inner |= Text.Muted("No verifications");
+        }
+        else
+        {
+            foreach (var v in verifications)
+                inner |= new VerificationRowView(
+                    v,
+                    IsRequired(v.Name),
+                    editable,
+                    status => planService.SetVerificationStatus(selectedPlan.FolderName, v.Name, status));
+        }
+
+        return new Card(inner).Width(Size.Px(280));
+    }
+}
+
+/// <summary>
+///     A single verification row: a checkbox bound to the verification's status plus a status
+///     badge. Kept as its own view so each row owns its checkbox state (no hooks in a loop).
+/// </summary>
+public class VerificationRowView(
+    PlanVerificationEntry verification,
+    bool required,
+    bool editable,
+    Action<VerificationStatus> onStatusChange) : ViewBase
+{
+    public override object Build()
+    {
+        var isChecked = UseState(verification.Status != VerificationStatus.Skipped);
+        var previousChecked = UseState(verification.Status != VerificationStatus.Skipped);
+
+        // Persist on user toggle (skip the initial render and disabled/non-editable rows).
+        UseEffect(() =>
+        {
+            if (!editable || isChecked.Value == previousChecked.Value) return;
+            previousChecked.Set(isChecked.Value);
+            onStatusChange(isChecked.Value ? VerificationStatus.Pending : VerificationStatus.Skipped);
+        }, isChecked);
+
+        // While editable the status tracks the checkbox (Pending/Skipped); once run it reflects
+        // the real persisted status (Pass/Fail/…).
+        var status = editable
+            ? (isChecked.Value ? VerificationStatus.Pending : VerificationStatus.Skipped)
+            : verification.Status;
+
+        var checkbox = isChecked.ToBoolInput(verification.Name, !editable);
+        if (editable && required && !isChecked.Value)
+            checkbox = checkbox.Invalid("This verification is required according to project settings");
+
+        var row = Layout.Horizontal().Gap(2).Width(Size.Full()) | checkbox;
+
+        // Only surface a badge for terminal outcomes; Pending/Skipped are conveyed by the checkbox.
+        if (status is VerificationStatus.Pass or VerificationStatus.Fail)
+            row |= new Badge(status.ToString()).Variant(
+                Constants.VerificationStatusBadgeVariants.GetValueOrDefault(status, BadgeVariant.Outline));
+
+        return row;
+    }
+}

--- a/src/Ivy.Tendril/Apps/Views/Tabs/VerificationsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/VerificationsTabView.cs
@@ -19,8 +19,8 @@ public class VerificationsTabView(
 
         return new TableBuilder<VerificationRow>(rows)
             .Order(t => t.Status, t => t.Name)
-            .Builder(t => t.Status, f => f.Func<VerificationRow, string>(status =>
-                new Badge(status).Variant(
+            .Builder(t => t.Status, f => f.Func<VerificationRow, VerificationStatus>(status =>
+                new Badge(status.ToString()).Variant(
                     Constants.VerificationStatusBadgeVariants.GetValueOrDefault(status, BadgeVariant.Outline))))
             .Builder(t => t.Name, f => f.Func<VerificationRow, string>(name =>
                 reportLookup.GetValueOrDefault(name)
@@ -30,5 +30,5 @@ public class VerificationsTabView(
             .ColumnWidth(t => t.Name, Size.Grow());
     }
 
-    private record VerificationRow(string Status, string Name, bool HasReport);
+    private record VerificationRow(VerificationStatus Status, string Name, bool HasReport);
 }

--- a/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
@@ -115,18 +115,18 @@ public class PlanCreateCommand : Command<PlanCreateSettings>
         foreach (var repoPath in resolvedProject.RepoPaths)
             plan.Repos.Add(repoPath);
 
+        // Seed the full project verification set (Required=Pending, Optional=Skipped);
+        // any Name=Status passed via --verification overrides that default.
+        var verificationOverrides = new Dictionary<string, VerificationStatus>(StringComparer.OrdinalIgnoreCase);
         if (settings.Verifications != null)
             foreach (var v in settings.Verifications)
             {
                 var eqIdx = v.IndexOf('=');
                 if (eqIdx < 0)
                     throw new ArgumentException($"Invalid verification format '{v}'. Expected Name=Status.");
-                plan.Verifications.Add(new PlanVerificationEntry
-                {
-                    Name = v[..eqIdx],
-                    Status = v[(eqIdx + 1)..]
-                });
+                verificationOverrides[v[..eqIdx]] = VerificationStatusExtensions.Parse(v[(eqIdx + 1)..]);
             }
+        PlanCommandHelpers.ApplyProjectVerifications(plan, resolvedProject, verificationOverrides);
 
         if (settings.RelatedPlans != null)
             foreach (var rp in settings.RelatedPlans)

--- a/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetVerificationCommand.cs
@@ -48,16 +48,17 @@ public class PlanSetVerificationCommand : Command<PlanSetVerificationSettings>
         var verification = plan.Verifications.FirstOrDefault(v =>
             v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
+        var status = VerificationStatusExtensions.Parse(settings.Status);
         if (verification != null)
         {
-            verification.Status = settings.Status;
+            verification.Status = status;
         }
         else
         {
             plan.Verifications.Add(new PlanVerificationEntry
             {
                 Name = settings.Name,
-                Status = settings.Status
+                Status = status
             });
         }
 

--- a/src/Ivy.Tendril/Commands/PlanVerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanVerificationCommand.cs
@@ -17,6 +17,10 @@ public class PlanVerificationListSettings : CommandSettings
     [Description("Filter by status (Pending, Pass, Fail, Skipped)")]
     public string? Status { get; set; }
 
+    [CommandOption("--json")]
+    [Description("Emit a machine-readable JSON array of { name, status } in run order")]
+    public bool Json { get; set; }
+
     public override Spectre.Console.ValidationResult Validate()
     {
         return CliValidation.Combine(
@@ -71,14 +75,32 @@ public class PlanVerificationRemoveSettings : CommandSettings
 
 public class PlanVerificationListCommand : Command<PlanVerificationListSettings>
 {
+    private readonly IConfigService _config;
+
+    public PlanVerificationListCommand(IConfigService config)
+    {
+        _config = config;
+    }
+
     protected override int Execute(CommandContext context, PlanVerificationListSettings settings, CancellationToken cancellationToken)
     {
         var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
         var plan = PlanCommandHelpers.ReadPlan(planFolder);
-        var verifications = plan.Verifications;
+
+        // Emit in project-config order — this is the run order ExecutePlan consumes.
+        var projectVerifications = _config.GetProject(plan.Project)?.Verifications;
+        var verifications = PlanCommandHelpers.OrderByProjectConfig(plan.Verifications, projectVerifications);
 
         if (!string.IsNullOrEmpty(settings.Status))
-            verifications = verifications.Where(v => v.Status.Equals(settings.Status, StringComparison.OrdinalIgnoreCase)).ToList();
+            verifications = verifications.Where(v => v.Status.ToString().Equals(settings.Status, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        if (settings.Json)
+        {
+            // Plain stdout (not AnsiConsole) so the output is clean, parseable JSON for agents.
+            var payload = verifications.Select(v => new { name = v.Name, status = v.Status });
+            Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(payload));
+            return 0;
+        }
 
         if (verifications.Count == 0)
         {
@@ -91,7 +113,7 @@ public class PlanVerificationListCommand : Command<PlanVerificationListSettings>
         table.AddColumn("Status");
 
         foreach (var v in verifications)
-            table.AddRow(v.Name.EscapeMarkup(), v.Status.EscapeMarkup());
+            table.AddRow(v.Name.EscapeMarkup(), v.Status.ToString().EscapeMarkup());
 
         AnsiConsole.Write(table);
         return 0;
@@ -118,7 +140,7 @@ public class PlanVerificationAddCommand : Command<PlanVerificationAddSettings>
         plan.Verifications.Add(new PlanVerificationEntry
         {
             Name = settings.Name,
-            Status = settings.Status ?? VerificationStatus.Pending
+            Status = settings.Status != null ? VerificationStatusExtensions.Parse(settings.Status) : VerificationStatus.Pending
         });
 
         plan.Updated = DateTime.UtcNow;

--- a/src/Ivy.Tendril/Constants.cs
+++ b/src/Ivy.Tendril/Constants.cs
@@ -39,7 +39,7 @@ public static class Constants
         [PlanStatus.Blocked] = BadgeVariant.Warning
     };
 
-    public static readonly Dictionary<string, BadgeVariant> VerificationStatusBadgeVariants = new()
+    public static readonly Dictionary<VerificationStatus, BadgeVariant> VerificationStatusBadgeVariants = new()
     {
         [VerificationStatus.Pass] = BadgeVariant.Success,
         [VerificationStatus.Fail] = BadgeVariant.Destructive,

--- a/src/Ivy.Tendril/Controllers/PlanController.cs
+++ b/src/Ivy.Tendril/Controllers/PlanController.cs
@@ -252,12 +252,13 @@ public class PlanController : ControllerBase
             var verification = plan.Verifications.FirstOrDefault(v =>
                 v.Name.Equals(request.Name, StringComparison.OrdinalIgnoreCase));
 
+            var status = VerificationStatusExtensions.Parse(request.Status);
             if (verification != null)
-                verification.Status = request.Status;
+                verification.Status = status;
             else
-                plan.Verifications.Add(new PlanVerificationEntry { Name = request.Name, Status = request.Status });
+                plan.Verifications.Add(new PlanVerificationEntry { Name = request.Name, Status = status });
 
-            return (true, $"Set verification '{request.Name}' to '{request.Status}'", 200);
+            return (true, $"Set verification '{request.Name}' to '{status}'", 200);
         });
 
     [HttpPost("{planId}/logs")]
@@ -435,9 +436,13 @@ public class PlanController : ControllerBase
             foreach (var repoPath in resolvedProject.RepoPaths)
                 plan.Repos.Add(repoPath);
 
+            // Seed the full project verification set (Required=Pending, Optional=Skipped);
+            // names passed in the request override that default to Pending.
+            var verificationOverrides = new Dictionary<string, VerificationStatus>(StringComparer.OrdinalIgnoreCase);
             if (request.Verifications != null)
                 foreach (var v in request.Verifications)
-                    plan.Verifications.Add(new PlanVerificationEntry { Name = v, Status = VerificationStatus.Pending });
+                    verificationOverrides[v] = VerificationStatus.Pending;
+            PlanCommandHelpers.ApplyProjectVerifications(plan, resolvedProject, verificationOverrides);
 
             if (request.RelatedPlans != null)
                 foreach (var rp in request.RelatedPlans)
@@ -585,7 +590,7 @@ public class PlanController : ControllerBase
             var verifications = plan.Verifications;
 
             if (!string.IsNullOrEmpty(status))
-                verifications = verifications.Where(v => v.Status.Equals(status, StringComparison.OrdinalIgnoreCase)).ToList();
+                verifications = verifications.Where(v => v.Status.ToString().Equals(status, StringComparison.OrdinalIgnoreCase)).ToList();
 
             return Ok(verifications.Select(v => new { name = v.Name, status = v.Status }));
         }
@@ -609,7 +614,7 @@ public class PlanController : ControllerBase
             plan.Verifications.Add(new PlanVerificationEntry
             {
                 Name = request.Name,
-                Status = request.Status ?? VerificationStatus.Pending
+                Status = request.Status != null ? VerificationStatusExtensions.Parse(request.Status) : VerificationStatus.Pending
             });
 
             return (true, $"Added verification '{request.Name}'", 200);

--- a/src/Ivy.Tendril/Helpers/CliValidation.cs
+++ b/src/Ivy.Tendril/Helpers/CliValidation.cs
@@ -20,7 +20,8 @@ public static class CliValidation
 
     public static readonly string[] ValidVerificationStatuses =
     [
-        VerificationStatus.Pending, VerificationStatus.Pass, VerificationStatus.Fail, VerificationStatus.Skipped
+        nameof(VerificationStatus.Pending), nameof(VerificationStatus.Pass),
+        nameof(VerificationStatus.Fail), nameof(VerificationStatus.Skipped)
     ];
 
     public static readonly string[] ValidRecommendationStates =

--- a/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
@@ -96,6 +96,62 @@ public static class PlanCommandHelpers
     }
 
     /// <summary>
+    ///     Seeds <paramref name="plan"/>.Verifications with the full project verification set, in
+    ///     project-config order (the order they run in). Each verification gets its explicit override
+    ///     status if one was supplied, otherwise the default: Required → Pending, Optional → Skipped.
+    ///     Any override name not present in the project config is appended afterward (custom/ad-hoc),
+    ///     preserving the order it was supplied in. Replaces any existing entries on the plan.
+    /// </summary>
+    public static void ApplyProjectVerifications(
+        PlanYaml plan, ProjectConfig project, IReadOnlyDictionary<string, VerificationStatus> overrides)
+    {
+        var seeded = new List<PlanVerificationEntry>();
+        var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var pv in project.Verifications)
+        {
+            var status = overrides.TryGetValue(pv.Name, out var overrideStatus)
+                ? overrideStatus
+                : pv.Required ? VerificationStatus.Pending : VerificationStatus.Skipped;
+            seeded.Add(new PlanVerificationEntry { Name = pv.Name, Status = status });
+            seenNames.Add(pv.Name);
+        }
+
+        // Explicit verifications that aren't part of the project config (custom/ad-hoc) are kept,
+        // appended after the project set in the order they were supplied.
+        foreach (var (name, status) in overrides)
+            if (!seenNames.Contains(name))
+            {
+                seeded.Add(new PlanVerificationEntry { Name = name, Status = status });
+                seenNames.Add(name);
+            }
+
+        plan.Verifications = seeded;
+    }
+
+    /// <summary>
+    ///     Orders verifications by their position in the project config (the authoritative run order),
+    ///     regardless of how they happen to be stored in plan.yaml. Verifications not present in the
+    ///     project config (custom, or since-removed) sort to the end, keeping their relative order.
+    ///     Used at the presentation (UI card) and execution (verification list) read points so order
+    ///     always follows the current project config even if plan.yaml drifted.
+    /// </summary>
+    public static List<PlanVerificationEntry> OrderByProjectConfig(
+        IEnumerable<PlanVerificationEntry> verifications,
+        IReadOnlyList<ProjectVerificationRef>? projectVerifications)
+    {
+        var order = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        if (projectVerifications != null)
+            for (var i = 0; i < projectVerifications.Count; i++)
+                order[projectVerifications[i].Name] = i;
+
+        // OrderBy is a stable sort, so unknown entries (all int.MaxValue) keep their original order.
+        return verifications
+            .OrderBy(v => order.TryGetValue(v.Name, out var idx) ? idx : int.MaxValue)
+            .ToList();
+    }
+
+    /// <summary>
     ///     Reads a plan.yaml file and deserializes it.
     /// </summary>
     public static PlanYaml ReadPlan(string planFolder)

--- a/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
@@ -209,7 +209,7 @@ internal static class PlanYamlHelper
     ///     Parses the result status from a verification report file.
     ///     Supports YAML frontmatter format (preferred) and legacy markdown format (fallback).
     /// </summary>
-    internal static string? ParseVerificationResultFromReport(string reportContent)
+    internal static VerificationStatus? ParseVerificationResultFromReport(string reportContent)
     {
         if (string.IsNullOrWhiteSpace(reportContent)) return null;
 
@@ -226,7 +226,9 @@ internal static class PlanYamlHelper
                     if (trimmed.StartsWith("result:", StringComparison.OrdinalIgnoreCase))
                     {
                         var value = trimmed["result:".Length..].Trim();
-                        if (value is VerificationStatus.Pass or VerificationStatus.Fail or VerificationStatus.Skipped) return value;
+                        if (VerificationStatusExtensions.TryParse(value, out var parsed)
+                            && parsed is VerificationStatus.Pass or VerificationStatus.Fail or VerificationStatus.Skipped)
+                            return parsed;
                     }
                 }
             }
@@ -234,7 +236,9 @@ internal static class PlanYamlHelper
 
         // Fallback: legacy markdown format  - **Result:** Pass
         var match = Regex.Match(reportContent, @"^-\s+\*\*Result:\*\*\s+(Pass|Fail|Skipped)", RegexOptions.Multiline);
-        return match.Success ? match.Groups[1].Value : null;
+        return match.Success && VerificationStatusExtensions.TryParse(match.Groups[1].Value, out var legacy)
+            ? legacy
+            : null;
     }
 
     internal static string? ExtractPlanIdFromFolder(string planFolder)

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -235,17 +235,18 @@ public sealed class PlanTools : AuthenticatedToolBase
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
+            var parsedStatus = VerificationStatusExtensions.Parse(status);
             var verification = plan.Verifications.FirstOrDefault(v =>
                 v.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
 
             if (verification != null)
-                verification.Status = status;
+                verification.Status = parsedStatus;
             else
-                plan.Verifications.Add(new PlanVerificationEntry { Name = name, Status = status });
+                plan.Verifications.Add(new PlanVerificationEntry { Name = name, Status = parsedStatus });
 
             plan.Updated = DateTime.UtcNow;
             PlanCommandHelpers.WritePlan(planFolder, plan);
-            return $"Set verification '{name}' to '{status}'";
+            return $"Set verification '{name}' to '{parsedStatus}'";
         });
     }
 
@@ -449,9 +450,13 @@ public sealed class PlanTools : AuthenticatedToolBase
             foreach (var repoPath in resolvedProject.RepoPaths)
                 plan.Repos.Add(repoPath);
 
+            // Seed the full project verification set (Required=Pending, Optional=Skipped);
+            // names passed to the tool override that default to Pending.
+            var verificationOverrides = new Dictionary<string, VerificationStatus>(StringComparer.OrdinalIgnoreCase);
             if (!string.IsNullOrEmpty(verifications))
                 foreach (var v in verifications.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-                    plan.Verifications.Add(new PlanVerificationEntry { Name = v, Status = VerificationStatus.Pending });
+                    verificationOverrides[v] = VerificationStatus.Pending;
+            PlanCommandHelpers.ApplyProjectVerifications(plan, resolvedProject, verificationOverrides);
 
             if (!string.IsNullOrEmpty(relatedPlans))
                 foreach (var rp in relatedPlans.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
@@ -577,7 +582,7 @@ public sealed class PlanTools : AuthenticatedToolBase
             var verifications = plan.Verifications;
 
             if (!string.IsNullOrEmpty(status))
-                verifications = verifications.Where(v => v.Status.Equals(status, StringComparison.OrdinalIgnoreCase)).ToList();
+                verifications = verifications.Where(v => v.Status.ToString().Equals(status, StringComparison.OrdinalIgnoreCase)).ToList();
 
             if (verifications.Count == 0)
                 return "No verifications found.";
@@ -605,7 +610,7 @@ public sealed class PlanTools : AuthenticatedToolBase
             plan.Verifications.Add(new PlanVerificationEntry
             {
                 Name = name,
-                Status = status ?? VerificationStatus.Pending
+                Status = status != null ? VerificationStatusExtensions.Parse(status) : VerificationStatus.Pending
             });
         }, $"Added verification '{name}'");
     }

--- a/src/Ivy.Tendril/Models/PlanModels.cs
+++ b/src/Ivy.Tendril/Models/PlanModels.cs
@@ -112,18 +112,36 @@ public static class PlanFilters
     }
 }
 
-public static class VerificationStatus
+/// <summary>
+///     Verification lifecycle status. Serialized to/from plan.yaml and JSON by its PascalCase
+///     member name (Pending/Pass/Fail/Skipped) — keep the names stable for wire compatibility.
+/// </summary>
+[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
+public enum VerificationStatus
 {
-    public const string Pending = nameof(Pending);
-    public const string Pass = nameof(Pass);
-    public const string Fail = nameof(Fail);
-    public const string Skipped = nameof(Skipped);
+    Pending,
+    Pass,
+    Fail,
+    Skipped
+}
+
+public static class VerificationStatusExtensions
+{
+    /// <summary>Case-insensitive parse that rejects numeric/undefined values.</summary>
+    public static bool TryParse(string? value, out VerificationStatus status) =>
+        Enum.TryParse(value, ignoreCase: true, out status) && Enum.IsDefined(status);
+
+    public static VerificationStatus Parse(string? value) =>
+        TryParse(value, out var status)
+            ? status
+            : throw new ArgumentException(
+                $"Invalid verification status '{value}'. Valid values: Pending, Pass, Fail, Skipped.");
 }
 
 public class PlanVerificationEntry
 {
     public string Name { get; set; } = "";
-    public string Status { get; set; } = VerificationStatus.Pending;
+    public VerificationStatus Status { get; set; } = VerificationStatus.Pending;
 }
 
 public class PlanYaml

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -101,11 +101,9 @@ Technical approach with file paths and steps
 
 ## Tests
 New tests to write + test scope filter
-
-## Verification
-- [x] DotnetBuild
-- [x] DotnetTest
 ```
+
+Verifications are **not** part of the revision markdown — they live in `plan.yaml` (seeded at creation, toggled in the UI).
 
 ## Tendril CLI Reference
 

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -268,17 +268,7 @@ Single integer in `{planFolder}/.counter`; managed by `tendril plan create`. Do 
 
 ## Verifications
 
-Each revision can include `## Verification` with checkboxes from `config.yaml`:
-
-```markdown
-## Verification
-
-- [x] DotnetBuild
-- [x] DotnetTest
-- [ ] FrameworkFrontendLint
-```
-
-`- [x]` = ExecutePlan will run; `- [ ]` = skipped. Definitions live in top-level `config.yaml` `verifications`; projects reference by name + `required`.
+Verifications live in `plan.yaml` (not in the revision markdown), each with a `Name` and a `Status` of `Pending | Pass | Fail | Skipped`. Every verification of the plan's project is seeded at creation, in the project's configured order (which is the order they run in). `Pending` = ExecutePlan will run it; `Skipped` = it won't. Users toggle Pending/Skipped from the Verifications card in the plan UI; the agent sets `Pass`/`Fail` via `tendril plan set-verification` after running each one. Definitions live in top-level `config.yaml` `verifications`; projects reference them by name + `required`.
 
 ## Notes
 

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -211,9 +211,7 @@ tendril plan create "<Title>" "<Project>" \
   --plans-dir "<TendrilPlansFolder>" \
   --level "Feature" \
   --initial-prompt "<cleaned task description>" \
-  --execution-profile "balanced" \
-  --verification "Build=Pending" \
-  --verification "Test=Pending"
+  --execution-profile "balanced"
 ```
 
 **IMPORTANT:** Always pass `--plans-dir` with the `TendrilPlansFolder` firmware value. This ensures the plan is created in the correct directory regardless of environment variable inheritance. The `<Project>` must be the exact project name from the **Projects** section — repos are derived automatically from the project configuration.
@@ -233,7 +231,11 @@ Include optional flags as needed:
 - `--depends-on "<folder-name>"` — for blocking dependencies (see Section 4.4)
 - `--priority <number>` — if non-default priority
 
-Populate `--verification` flags from the project's verifications in the **Projects** section, all set to `Pending`.
+**Verifications are seeded automatically.** `tendril plan create` adds **every** verification of the project (in the **Projects** section), in their configured order, defaulting **Required → `Pending`** and **Optional → `Skipped`**. You do **not** need to pass `--verification` or ensure they are present.
+
+Adjust them as the task warrants (the user can also toggle them later in the UI; ExecutePlan runs only the `Pending` ones):
+- Enable an optional verification relevant to this task: `tendril plan set-verification <PlanId> <Name> Pending`.
+- Skip a verification you judge unnecessary: `tendril plan set-verification <PlanId> <Name> Skipped`.
 
 #### 4.2. Write the revision
 
@@ -394,29 +396,6 @@ The `## Tests` section MUST include two parts:
    - If the change is so broad that all tests are genuinely needed, explicitly state: "Run all tests (broad cross-cutting change)." and justify why.
    
    Never leave test scope unspecified — this causes the full suite to run unnecessarily.
-
-### 5. Verification Checklist
-
-In the `## Verification` section of the plan revision, generate a checklist from the project's verifications in the **Projects** section.
-
-For each verification assigned to the project:
-- **Required** → `- [x] VerificationName`
-- **Optional** → `- [ ] VerificationName`
-
-Example:
-```markdown
-## Verification
-
-- [x] Build
-- [x] Format
-- [x] Test
-- [x] Lint
-- [x] CheckResult
-```
-
-If the project has no verifications (e.g. `Auto`), leave the section empty or omit it.
-
-The user can edit the checklist before execution — unchecking a required verification or checking an optional one. ExecutePlan will run only the checked items.
 
 ### Rules
 

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -352,12 +352,7 @@ tendril plan add-commit <plan-id> abc1234
 tendril plan add-commit <plan-id> def5678
 ```
 
-Set verification statuses from the plan revision. Set checked items (`- [x]`) to `Pending` and unchecked items (`- [ ]`) to `Skipped`:
-
-```bash
-tendril plan set-verification <plan-id> Build Pending
-tendril plan set-verification <plan-id> Test Skipped
-```
+Verification statuses are already set in `plan.yaml` (seeded at plan creation, optionally adjusted by the user in the UI). Do **not** derive them from the plan revision — there is no `## Verification` section anymore. You only update each verification's status to `Pass`/`Fail` after running it (Step 7).
 
 If the plan references other plans (e.g. split-from, follow-up), add them via CLI.
 
@@ -367,13 +362,13 @@ If the plan references other plans (e.g. split-from, follow-up), add them via CL
 
 Create a `Verification/` directory in the plan folder if it doesn't exist.
 
-Check the `## Verification` section in the plan revision for checked items (`- [x]`). Skip unchecked items (`- [ ]`).
+Get the run-set via `tendril plan verification list <plan-id> --json` — it emits a JSON array of `{ name, status }` **in run order**. Run the entries whose `status` is `Pending`, in array order. Skip entries whose `status` is `Skipped`.
 
 **Delegated verifications:** Some verifications are implemented as separate promptwares (e.g., `IvyFrameworkVerification`). The **Projects** section marks delegated verifications. Delegated verifications MUST be run via `tendril promptware run <Name>` — you are FORBIDDEN from writing their report files or setting their status to Pass yourself. If the `tendril` CLI is unavailable and you cannot invoke the sub-promptware, you MUST set the verification to `Fail` with a report explaining the CLI failure. Never self-certify a delegated verification.
 
 **IMPORTANT — delegated invocation syntax:** The `tendril promptware run` CLI takes the plan folder as a **positional argument** (NOT a named flag like `--plan-folder`). You MUST also pass `--value` flags for each required firmware value. The exact command is in the verification's prompt (fetched via `tendril verification get <Name>`) — copy it character-for-character, only replacing angle-bracketed placeholders with actual paths. If the command is wrong, the child promptware receives no arguments and silently fails.
 
-For each checked verification:
+For each `Pending` verification (in listed order):
 
 1. Send a status message: `tendril job status TendrilJobId --message "Verifying: <Name>"`
 2. Fetch its full prompt: `tendril verification get <Name>`

--- a/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
@@ -127,12 +127,7 @@ tendril plan add-commit <plan-id> abc1234
 tendril plan add-commit <plan-id> def5678
 ```
 
-Set verification statuses from the plan revision. Set checked items (`- [x]`) to `Pending` and unchecked items (`- [ ]`) to `Skipped`:
-
-```bash
-tendril plan set-verification <plan-id> Build Pending
-tendril plan set-verification <plan-id> Test Skipped
-```
+Verification statuses already live in `plan.yaml`. Do **not** derive them from the plan revision — there is no `## Verification` section. You only update each verification's status to `Pass`/`Fail` after running it (Step 6).
 
 **CRITICAL:** The `tendril plan add-commit` and `tendril plan set-verification` CLI commands are the ONLY mechanism that updates plan.yaml. You MUST call these commands.
 
@@ -140,11 +135,11 @@ tendril plan set-verification <plan-id> Test Skipped
 
 Create a `Verification/` directory in the plan folder if it doesn't exist.
 
-Check the `## Verification` section in the plan revision for checked items (`- [x]`). Skip unchecked items (`- [ ]`).
+Get the run-set via `tendril plan verification list <plan-id> --json` — it emits a JSON array of `{ name, status }` **in run order**. Run the entries whose `status` is `Pending`, in array order. Skip entries whose `status` is `Skipped`.
 
 **Delegated verifications:** Some verifications are implemented as separate promptwares. The **Projects** section marks delegated verifications. Delegated verifications MUST be run via `tendril promptware run <Name>` — you are FORBIDDEN from writing their report files or setting their status to Pass yourself.
 
-For each checked verification:
+For each `Pending` verification (in listed order):
 
 1. Send a status message: `tendril job status TendrilJobId --message "Verifying: <Name>"`
 2. Fetch its full prompt: `tendril verification get <Name>`

--- a/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
@@ -15,6 +15,7 @@ public interface IPlanReaderService
     void TransitionState(string folderName, PlanStatus newState);
     void ResetToDraft(string folderName);
     void ResetVerificationsForRetry(string folderName);
+    void SetVerificationStatus(string folderName, string name, VerificationStatus status);
     void SaveRevision(string folderName, string content);
     void RevertRevision(string folderName);
     string ReadLatestRevision(string folderName);

--- a/src/Ivy.Tendril/Services/Plans/PlanArtifactSyncer.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanArtifactSyncer.cs
@@ -75,7 +75,7 @@ internal class PlanArtifactSyncer
                 var result = PlanYamlHelper.ParseVerificationResultFromReport(content);
                 if (result != null)
                 {
-                    verification.Status = result;
+                    verification.Status = result.Value;
                     changed = true;
                 }
             }

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -1169,7 +1169,9 @@ public class PlanDatabaseService : IPlanDatabaseService
             list.Add(new PlanVerificationEntry
             {
                 Name = reader.GetString(nameOrdinal),
-                Status = reader.GetString(statusOrdinal)
+                Status = VerificationStatusExtensions.TryParse(reader.GetString(statusOrdinal), out var st)
+                    ? st
+                    : VerificationStatus.Pending
             });
         }
 
@@ -1189,7 +1191,9 @@ public class PlanDatabaseService : IPlanDatabaseService
             return new PlanVerificationEntry
             {
                 Name = reader.GetString(reader.GetOrdinal("Name")),
-                Status = reader.GetString(reader.GetOrdinal("Status"))
+                Status = VerificationStatusExtensions.TryParse(reader.GetString(reader.GetOrdinal("Status")), out var st)
+                    ? st
+                    : VerificationStatus.Pending
             };
         });
     }
@@ -1336,7 +1340,7 @@ public class PlanDatabaseService : IPlanDatabaseService
         {
             insertCmd.Parameters["@planId"].Value = planId;
             insertCmd.Parameters["@name"].Value = v.Name;
-            insertCmd.Parameters["@status"].Value = v.Status;
+            insertCmd.Parameters["@status"].Value = v.Status.ToString();
             insertCmd.ExecuteNonQuery();
         }
     }

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -306,11 +306,32 @@ public class PlanReaderService(
             planYaml.Updated = DateTime.UtcNow;
             foreach (var v in planYaml.Verifications)
             {
-                if (!v.Status.Equals(VerificationStatus.Skipped, StringComparison.OrdinalIgnoreCase))
+                if (v.Status != VerificationStatus.Skipped)
                     v.Status = VerificationStatus.Pending;
             }
             FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
         }, Path.Combine(PlansDirectory, folderName));
+    }
+
+    /// <summary>
+    ///     Sets a single verification's status on a plan and persists plan.yaml immediately.
+    ///     Written synchronously (not in the background) so the UI can re-read the value right
+    ///     after toggling. Reuses the same atomic/validated/file-locked write path as the CLI.
+    /// </summary>
+    public void SetVerificationStatus(string folderName, string name, VerificationStatus status)
+    {
+        var planFolder = Path.Combine(PlansDirectory, folderName);
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        var verification = plan.Verifications.FirstOrDefault(v =>
+            v.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+        if (verification != null)
+            verification.Status = status;
+        else
+            plan.Verifications.Add(new PlanVerificationEntry { Name = name, Status = status });
+
+        plan.Updated = DateTime.UtcNow;
+        PlanCommandHelpers.WritePlan(planFolder, plan, planWatcherService);
     }
 
     /// <summary>
@@ -795,7 +816,7 @@ public class PlanReaderService(
             // Reset verifications
             foreach (var v in planYaml.Verifications)
             {
-                if (!v.Status.Equals(VerificationStatus.Skipped, StringComparison.OrdinalIgnoreCase))
+                if (v.Status != VerificationStatus.Skipped)
                     v.Status = VerificationStatus.Pending;
             }
 

--- a/src/Ivy.Tendril/Services/Plans/PlanValidationService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanValidationService.cs
@@ -97,13 +97,7 @@ public static class PlanValidationService
                 if (string.IsNullOrWhiteSpace(verification.Name))
                     throw new ArgumentException("Verification entry has empty name");
 
-                if (string.IsNullOrWhiteSpace(verification.Status))
-                    throw new ArgumentException($"Verification '{verification.Name}' has empty status");
-
-                var validStatuses = new[] { VerificationStatus.Pending, VerificationStatus.Pass, VerificationStatus.Fail, VerificationStatus.Skipped };
-                if (!validStatuses.Contains(verification.Status, StringComparer.OrdinalIgnoreCase))
-                    throw new ArgumentException(
-                        $"Invalid status '{verification.Status}' for verification '{verification.Name}'. Valid statuses: {string.Join(", ", validStatuses)}");
+                // Status is a VerificationStatus enum — always valid once deserialized.
             }
         }
     }

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -265,5 +265,3 @@ planTemplate: >
   **Test scope:**
 
   Specify which tests to run using your test framework's syntax (e.g., `dotnet test --filter "..."`, `jest --testPathPattern=...`, `pytest tests/specific/`, or "No existing test coverage" / "Run all tests — <justification>")
-
-  ## Verification


### PR DESCRIPTION
## Summary
Moves verifications out of the plan revision markdown and makes **plan.yaml the single source of truth**, with a proper editing UI, deterministic seeding, stable run ordering, and a typed status.

## What changed
- **UI** — new `VerificationsCardView` in the Drafts plan tab: sticky card listing verifications as checkboxes (Pending↔Skipped), saved to plan.yaml immediately on click. Required+skipped shows the checkbox Invalid state; badges only for terminal Pass/Fail.
- **Save path** — `PlanReaderService.SetVerificationStatus` for immediate, validated writes.
- **Seeding** — every project verification is seeded into plan.yaml at creation (required=Pending, optional=Skipped) via `PlanCommandHelpers.ApplyProjectVerifications`, applied at all creation paths (controller, CLI, MCP). The agent only adjusts statuses afterward.
- **Ordering** — verifications always presented/run in project-config order via `OrderByProjectConfig`, applied in the card and in `tendril plan verification list` (the execution run-set source).
- **Agent contract** — `plan verification list --json` emits a machine-readable array; ExecutePlan/RetryPlan consume it instead of parsing a rendered table.
- **Typing** — `VerificationStatus` is now an enum (wire format preserved: YAML PascalCase, JSON via `JsonStringEnumConverter`); parsed at string boundaries.
- **Promptware** — stop authoring/reading the `## Verification` markdown checklist (core + TeamIvyConfig); swept stale references in prompts, docs, config templates.

## Tests
New tests for seeding, ordering, set-status, and YAML/JSON wire-format; existing tests updated to the enum; removed now-impossible invalid-status validation tests. Full suite green (one pre-existing parallelism flake in `*_NotifiesPlanWatcher`, unrelated).