### PR TITLE
Fix verification reorder not persisting in Edit Project dialog

### DIFF
--- a/src/Ivy.Tendril.Test/EditProjectDialogTests.cs
+++ b/src/Ivy.Tendril.Test/EditProjectDialogTests.cs
@@ -1,0 +1,125 @@
+using Ivy.Tendril.Apps.Settings.Dialogs;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class EditProjectDialogTests
+{
+    private static List<VerificationConfig> Defs(params string[] names) =>
+        names.Select(n => new VerificationConfig { Name = n }).ToList();
+
+    private static List<ProjectVerificationRef> Project(params string[] names) =>
+        names.Select(n => new ProjectVerificationRef { Name = n }).ToList();
+
+    [Fact]
+    public void OrderForDisplay_PutsProjectVerificationsFirstInProjectOrder()
+    {
+        // Global definitions are in a different order than the project's selection.
+        var all = Defs("Build", "Test", "Lint", "Format");
+        var project = Project("Lint", "Build");
+
+        var ordered = EditProjectDialog.OrderForDisplay(project, all);
+
+        // Enabled (project) ones first, in project order; then the rest in global order.
+        Assert.Equal(new[] { "Lint", "Build", "Test", "Format" }, ordered.Select(v => v.Name));
+    }
+
+    [Fact]
+    public void OrderForDisplay_NoProjectVerifications_KeepsGlobalOrder()
+    {
+        var all = Defs("Build", "Test", "Lint");
+
+        var ordered = EditProjectDialog.OrderForDisplay(Project(), all);
+
+        Assert.Equal(new[] { "Build", "Test", "Lint" }, ordered.Select(v => v.Name));
+    }
+
+    [Fact]
+    public void OrderForDisplay_IgnoresProjectVerificationsWithoutGlobalDefinition()
+    {
+        var all = Defs("Build", "Test");
+        var project = Project("Stale", "Test");
+
+        var ordered = EditProjectDialog.OrderForDisplay(project, all);
+
+        Assert.Equal(new[] { "Test", "Build" }, ordered.Select(v => v.Name));
+    }
+
+    [Fact]
+    public void ReorderProjectVerifications_ReordersEnabledItemsByNewIndices()
+    {
+        // Displayed: Lint, Build, Test, Format. Project has Lint & Build enabled.
+        var displayed = Defs("Lint", "Build", "Test", "Format");
+        var project = Project("Lint", "Build");
+
+        // User drags Build above Lint -> new order of displayed indices.
+        var newIndices = new[] { 1, 0, 2, 3 };
+
+        var result = EditProjectDialog.ReorderProjectVerifications(newIndices, displayed, project);
+
+        // Only enabled items, in their new relative order.
+        Assert.Equal(new[] { "Build", "Lint" }, result.Select(pv => pv.Name));
+    }
+
+    [Fact]
+    public void ReorderProjectVerifications_PreservesRequiredFlag()
+    {
+        var displayed = Defs("Build", "Test");
+        var project = new List<ProjectVerificationRef>
+        {
+            new() { Name = "Build", Required = true },
+            new() { Name = "Test", Required = false }
+        };
+
+        var result = EditProjectDialog.ReorderProjectVerifications(new[] { 1, 0 }, displayed, project);
+
+        Assert.Equal(new[] { "Test", "Build" }, result.Select(pv => pv.Name));
+        Assert.True(result.Single(pv => pv.Name == "Build").Required);
+        Assert.False(result.Single(pv => pv.Name == "Test").Required);
+    }
+
+    [Fact]
+    public void ReorderProjectVerifications_DraggingDisabledItemDoesNotAddItToProject()
+    {
+        // Test is disabled (not in project); dragging it must not enable it.
+        var displayed = Defs("Build", "Test", "Lint");
+        var project = Project("Build", "Lint");
+
+        // Move the disabled "Test" (index 1) to the front.
+        var result = EditProjectDialog.ReorderProjectVerifications(new[] { 1, 0, 2 }, displayed, project);
+
+        Assert.Equal(new[] { "Build", "Lint" }, result.Select(pv => pv.Name));
+        Assert.DoesNotContain(result, pv => pv.Name == "Test");
+    }
+
+    [Fact]
+    public void ReorderProjectVerifications_KeepsEnabledItemsMissingFromIndices()
+    {
+        var displayed = Defs("Build", "Test");
+        var project = Project("Build", "Test");
+
+        // Indices only reference one displayed item; the other enabled item must survive.
+        var result = EditProjectDialog.ReorderProjectVerifications(new[] { 1 }, displayed, project);
+
+        Assert.Equal(new[] { "Test", "Build" }, result.Select(pv => pv.Name));
+    }
+
+    [Fact]
+    public void ReorderThenDisplay_RoundTrip_PreservesNewOrderOnReopen()
+    {
+        // Simulates: reorder via drag -> save to project -> reopen dialog.
+        var all = Defs("Build", "Test", "Lint");
+        var project = Project("Build", "Test", "Lint");
+
+        var displayed = EditProjectDialog.OrderForDisplay(project, all);
+        Assert.Equal(new[] { "Build", "Test", "Lint" }, displayed.Select(v => v.Name));
+
+        // Drag Lint to the top.
+        var afterReorder = EditProjectDialog.ReorderProjectVerifications(new[] { 2, 0, 1 }, displayed, project);
+        Assert.Equal(new[] { "Lint", "Build", "Test" }, afterReorder.Select(pv => pv.Name));
+
+        // The Save button persists afterReorder into project.Verifications; reopening loads it back.
+        var displayedOnReopen = EditProjectDialog.OrderForDisplay(afterReorder, all);
+        Assert.Equal(new[] { "Lint", "Build", "Test" }, displayedOnReopen.Select(v => v.Name));
+    }
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/SortableVerificationList/SortableVerificationList.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/SortableVerificationList/SortableVerificationList.tsx
@@ -19,6 +19,8 @@ import { CSS } from "@dnd-kit/utilities";
 import { GripVertical } from "lucide-react";
 import "./sortable-verification-list.css";
 
+type IvyEventHandler = (eventName: string, widgetId: string, args: unknown[]) => void;
+
 interface VerificationItem {
   name: string;
   enabled: boolean;
@@ -26,11 +28,13 @@ interface VerificationItem {
 }
 
 interface SortableVerificationListProps {
+  id: string;
   itemsJson?: string;
-  onReorder?: (newIndices: number[]) => void;
-  onChange?: (item: VerificationItem) => void;
-  id?: string;
+  events?: string[];
+  eventHandler?: IvyEventHandler;
 }
+
+const EMPTY_EVENTS: string[] = [];
 
 function SortableItem({
   item,
@@ -83,9 +87,10 @@ function SortableItem({
 }
 
 export function SortableVerificationList({
+  id,
   itemsJson = "[]",
-  onReorder,
-  onChange,
+  events = EMPTY_EVENTS,
+  eventHandler,
 }: SortableVerificationListProps) {
   const [items, setItems] = React.useState<VerificationItem[]>(() => {
     try {
@@ -128,14 +133,20 @@ export function SortableVerificationList({
           originalItems.findIndex((orig) => orig.name === item.name),
         );
 
-        onReorder?.(reorderMapping);
+        // The C# OnReorder event carries a single string value (JSON array of indices).
+        if (eventHandler && events.includes("OnReorder")) {
+          eventHandler("OnReorder", id, [JSON.stringify(reorderMapping)]);
+        }
       }
     }
   };
 
   const handleChange = (updatedItem: VerificationItem) => {
     setItems((prev) => prev.map((item) => (item.name === updatedItem.name ? updatedItem : item)));
-    onChange?.(updatedItem);
+    // The C# OnChange event carries a single string value (JSON of the updated item).
+    if (eventHandler && events.includes("OnChange")) {
+      eventHandler("OnChange", id, [JSON.stringify(updatedItem)]);
+    }
   };
 
   return (

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs
@@ -99,8 +99,15 @@ public class EditProjectDialog(
             return draft with { Path = destPath };
         };
 
+        // Display order is driven by the PROJECT'S verification order (project.Verifications),
+        // not the global definition order, so the arrangement a user makes for this project is
+        // what they see when they reopen the dialog. Enabled verifications come first in their
+        // stored project order; verifications defined globally but not yet enabled for this
+        // project are appended afterwards so they can still be toggled on.
+        var displayedVerifications = OrderForDisplay(editVerifications.Value, _config.Settings.Verifications);
+
         var verificationsJson = JsonSerializer.Serialize(
-            _config.Settings.Verifications.Select(v =>
+            displayedVerifications.Select(v =>
             {
                 var projectVerif = editVerifications.Value.FirstOrDefault(pv => pv.Name == v.Name);
                 return new
@@ -119,28 +126,11 @@ public class EditProjectDialog(
                 var indices = JsonSerializer.Deserialize<int[]>(json);
                 if (indices == null) return;
 
-                var allVerifs = _config.Settings.Verifications.ToList();
-                var reorderedVerifs = indices.Select(i => allVerifs[i]).ToList();
-                _config.Settings.Verifications.Clear();
-                _config.Settings.Verifications.AddRange(reorderedVerifs);
-
-                // Reorder the project-level verifications to match the new global order
-                var currentProjectVerifs = editVerifications.Value;
-                var reorderedProjectVerifs = reorderedVerifs
-                    .Select(gv => currentProjectVerifs.FirstOrDefault(pv => pv.Name == gv.Name))
-                    .Where(pv => pv != null)
-                    .ToList();
-                editVerifications.Set(reorderedProjectVerifs!);
-
-                try
-                {
-                    _config.SaveSettings();
-                    _refreshToken.Refresh();
-                }
-                catch (Exception ex)
-                {
-                    _client.Toast($"Failed to reorder verifications: {ex.Message}", "Error");
-                }
+                // indices map into the currently displayed list. Rebuild the project's verification
+                // order from the enabled items in their new relative order; the project order is then
+                // persisted when the user clicks Save (see saveButton), so it survives a reopen.
+                editVerifications.Set(
+                    ReorderProjectVerifications(indices, displayedVerifications, editVerifications.Value));
             })
             .WithOnChange(json =>
             {
@@ -280,6 +270,71 @@ public class EditProjectDialog(
         return mainDialog;
     }
 
+    /// <summary>
+    /// Orders verifications for display in the Edit Project dialog: the project's enabled
+    /// verifications first, in their stored project order, followed by any globally-defined
+    /// verifications not yet enabled for this project (so they can still be toggled on).
+    /// Driving the display from the project order makes a saved reorder survive a reopen.
+    /// </summary>
+    internal static List<VerificationConfig> OrderForDisplay(
+        List<ProjectVerificationRef> projectVerifications,
+        List<VerificationConfig> allVerifications)
+    {
+        var byName = allVerifications.ToDictionary(v => v.Name);
+        var ordered = new List<VerificationConfig>();
+        var seen = new HashSet<string>();
+
+        // Enabled verifications, in the order the project stores them.
+        foreach (var pv in projectVerifications)
+        {
+            if (byName.TryGetValue(pv.Name, out var def) && seen.Add(pv.Name))
+                ordered.Add(def);
+        }
+
+        // Remaining globally-defined verifications not enabled for this project.
+        foreach (var def in allVerifications)
+        {
+            if (seen.Add(def.Name))
+                ordered.Add(def);
+        }
+
+        return ordered;
+    }
+
+    /// <summary>
+    /// Maps a drag-reorder of the displayed verification list back onto the project's verification
+    /// list. <paramref name="newIndices"/> is the new order expressed as indices into
+    /// <paramref name="displayed"/>. Only verifications enabled for the project are returned, in
+    /// their new relative order; disabled (available-pool) items are ignored since they are not
+    /// part of the project's stored order.
+    /// </summary>
+    internal static List<ProjectVerificationRef> ReorderProjectVerifications(
+        int[] newIndices,
+        List<VerificationConfig> displayed,
+        List<ProjectVerificationRef> projectVerifications)
+    {
+        var byName = projectVerifications.ToDictionary(pv => pv.Name);
+        var reordered = new List<ProjectVerificationRef>();
+        var seen = new HashSet<string>();
+
+        foreach (var i in newIndices)
+        {
+            if (i < 0 || i >= displayed.Count) continue;
+            var name = displayed[i].Name;
+            if (byName.TryGetValue(name, out var pv) && seen.Add(name))
+                reordered.Add(pv);
+        }
+
+        // Preserve any enabled verifications the indices didn't cover (defensive: keeps the
+        // project's selection intact even if the displayed list and indices ever disagree).
+        foreach (var pv in projectVerifications)
+        {
+            if (seen.Add(pv.Name))
+                reordered.Add(pv);
+        }
+
+        return reordered;
+    }
 }
 
 internal class ReviewActionsTableView(


### PR DESCRIPTION
Fixes #1242

## Summary

Drag-to-reorder of verifications in the **Edit Project** dialog never worked. PR #1249 attempted a fix but it was a no-op because the underlying event never reached the server. This PR addresses the two real defects.

### 1. Widget events never reached the server (frontend)
`SortableVerificationList.tsx` expected React-style `onReorder` / `onChange` callback props. But Ivy's external-widget framework does **not** pass those — it injects a generic `eventHandler(eventName, widgetId, args[])` plus an `events[]` list of enabled events (see `WidgetSerializer`/`AgentViewer`/`DraftMarkdown`). The callback props were always `undefined`, so dragging — and toggling enabled/required — silently did nothing; the C# `OnReorder`/`OnChange` handlers were never invoked.

Fix: wire the frontend to `eventHandler` + `events`, dispatching the event value as a single JSON string (matching how the C# handlers deserialize `e.Value`).

### 2. Display/persistence used global order, not project order (backend)
The dialog rendered the list from the **global** verification definitions and only persisted project order via the Save button, so even a working reorder would not survive reopening. `EditProjectDialog.cs` now drives both the displayed list and the reorder result from the **project's** verification order: enabled verifications first (in project order), then the remaining globally-defined ones. The reordered project list is persisted through the existing Save button.

## Tests
Adds `EditProjectDialogTests.cs` covering the ordering and reorder-mapping logic, including preserving the `Required` flag, ignoring dragged-but-disabled items, and the full **reorder → save → reopen** round-trip.

## Verification
- `dotnet build` clean (0 warnings/errors); 8 new tests pass.
- Manually verified end-to-end on a local dev server: reordering verifications for a project now persists to `config.yaml` and is reflected on reopen.

## Files Modified
- `src/Ivy.Tendril.Widgets/frontend/src/SortableVerificationList/SortableVerificationList.tsx`
- `src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs`
- `src/Ivy.Tendril.Test/EditProjectDialogTests.cs` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)