### PR TITLE
Detect repo default branch instead of assuming "main"

### DIFF
--- a/src/Ivy.Tendril.Test/Helpers/GitHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/GitHelperTests.cs
@@ -193,6 +193,20 @@ public class GitHelperTests : IDisposable
         Assert.Equal("development", GitHelper.ResolveDefaultBranch(clone));
     }
 
+    [Theory]
+    [InlineData("https://github.com/Ivy-Interactive/Ivy-Framework", "development")]
+    [InlineData("https://github.com/Ivy-Interactive/Tendril-Test-Runner", "main")]
+    [InlineData("https://github.com/nielsbosma/SeoTools-for-Excel-Connectors", "master")]
+    public async Task ResolveDefaultBranch_KnownRemoteUrl_DetectsDefaultBranch(string url, string expectedBranch)
+    {
+        // Skip when the remote is unreachable (offline) so we don't fail on connectivity,
+        // and don't false-pass: probing the expected branch confirms the network is up.
+        if (!await GitHelper.IsValidBranchAsync(url, expectedBranch))
+            return;
+
+        Assert.Equal(expectedBranch, GitHelper.ResolveDefaultBranch(url));
+    }
+
     /// <summary>
     /// Builds a bare remote whose default branch is <paramref name="defaultBranch"/> and clones it.
     /// Returns the clone path, or null if the git operations did not produce a usable clone.

--- a/src/Ivy.Tendril.Test/Helpers/GitHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/GitHelperTests.cs
@@ -153,6 +153,86 @@ public class GitHelperTests : IDisposable
         }
     }
 
+    [Fact]
+    public void ResolveDefaultBranch_EmptyPath_ReturnsMain()
+    {
+        Assert.Equal("main", GitHelper.ResolveDefaultBranch(""));
+    }
+
+    [Fact]
+    public void ResolveDefaultBranch_LocalRepoWithoutRemote_FallsBackToMain()
+    {
+        var repoPath = Path.Combine(_tempDir, "no-remote");
+        Directory.CreateDirectory(repoPath);
+        InitGitRepo(repoPath, "development");
+
+        // No origin remote and no origin/HEAD → graceful fallback.
+        Assert.Equal("main", GitHelper.ResolveDefaultBranch(repoPath));
+    }
+
+    [Fact]
+    public void ResolveDefaultBranch_CloneWithOriginHead_DetectsNonMainDefault()
+    {
+        var clone = SetUpRemoteAndClone("development");
+        if (clone == null) return; // git unavailable — skip
+
+        // origin/HEAD is set by clone → resolved via the local symbolic-ref.
+        Assert.Equal("development", GitHelper.ResolveDefaultBranch(clone));
+    }
+
+    [Fact]
+    public void ResolveDefaultBranch_CloneWithoutOriginHead_DetectsViaLsRemote()
+    {
+        var clone = SetUpRemoteAndClone("development");
+        if (clone == null) return; // git unavailable — skip
+
+        // Reproduce the bug condition: origin/HEAD not set up locally.
+        RunGit("symbolic-ref -d refs/remotes/origin/HEAD", clone);
+
+        // Must fall back to querying the remote, not assume "main".
+        Assert.Equal("development", GitHelper.ResolveDefaultBranch(clone));
+    }
+
+    /// <summary>
+    /// Builds a bare remote whose default branch is <paramref name="defaultBranch"/> and clones it.
+    /// Returns the clone path, or null if the git operations did not produce a usable clone.
+    /// </summary>
+    private string? SetUpRemoteAndClone(string defaultBranch)
+    {
+        var remote = Path.Combine(_tempDir, "remote.git");
+        Directory.CreateDirectory(remote);
+        RunGit($"init --bare -b {defaultBranch}", remote);
+
+        var work = Path.Combine(_tempDir, "work");
+        Directory.CreateDirectory(work);
+        RunGit($"init -b {defaultBranch}", work);
+        RunGit("config user.email \"test@example.com\"", work);
+        RunGit("config user.name \"Test User\"", work);
+        File.WriteAllText(Path.Combine(work, "a.txt"), "x");
+        RunGit("add -A", work);
+        RunGit("commit -m initial", work);
+        RunGit($"remote add origin \"{remote}\"", work);
+        RunGit($"push -u origin {defaultBranch}", work);
+
+        var clone = Path.Combine(_tempDir, "clone");
+        RunGit($"clone \"{remote}\" \"{clone}\"", _tempDir);
+
+        return Directory.Exists(Path.Combine(clone, ".git")) ? clone : null;
+    }
+
+    private static void RunGit(string args, string workingDir)
+    {
+        using var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("git", args)
+        {
+            WorkingDirectory = workingDir,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        });
+        p?.WaitForExit(15000);
+    }
+
     private static void InitGitRepo(string path, string branchName)
     {
         using var pInit = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("git", "init") { WorkingDirectory = path, CreateNoWindow = true });

--- a/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
@@ -53,10 +53,12 @@ public class ProjectRepoPickerView(
             isAdding.Set(true);
             try
             {
-                RepoRef? toAdd = draft;
+                // Detect and persist the repo's real default branch so the project config is
+                // explicit, rather than letting downstream steps assume "main".
+                RepoRef? toAdd = draft with { BaseBranch = await GitHelper.ResolveDefaultBranchAsync(path, tendrilHome) };
                 if (onAdd != null)
                 {
-                    toAdd = await onAdd(draft);
+                    toAdd = await onAdd(toAdd);
                     if (toAdd == null) return;
                 }
 

--- a/src/Ivy.Tendril/Commands/JobStartCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStartCommand.cs
@@ -152,7 +152,7 @@ public class JobStartCommand : Command<JobStartSettings>
 
             return new SyncRepoArgs(
                 settings.RepoPath,
-                settings.BaseBranch ?? "main");
+                settings.BaseBranch ?? GitHelper.ResolveDefaultBranch(settings.RepoPath));
         }
 
         if (string.IsNullOrEmpty(settings.PlanId))

--- a/src/Ivy.Tendril/Commands/ProjectCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectCommand.cs
@@ -455,18 +455,24 @@ public class ProjectAddRepoCommand : Command<ProjectAddRepoSettings>
         if (project.GetRepoRef(settings.RepoPath) != null)
             throw new InvalidOperationException($"Repository already exists in project: {settings.RepoPath}");
 
-        if (!string.IsNullOrWhiteSpace(settings.BaseBranch))
+        string? baseBranch = settings.BaseBranch;
+        if (!string.IsNullOrWhiteSpace(baseBranch))
         {
-            var isValid = Ivy.Tendril.Helpers.GitHelper.IsValidBranchAsync(settings.RepoPath, settings.BaseBranch, config.TendrilHome).GetAwaiter().GetResult();
+            var isValid = Ivy.Tendril.Helpers.GitHelper.IsValidBranchAsync(settings.RepoPath, baseBranch, config.TendrilHome).GetAwaiter().GetResult();
             if (!isValid)
-                throw new InvalidOperationException($"Branch '{settings.BaseBranch}' does not exist in repository: {settings.RepoPath}");
+                throw new InvalidOperationException($"Branch '{baseBranch}' does not exist in repository: {settings.RepoPath}");
+        }
+        else
+        {
+            // No branch supplied — detect and persist the repo's real default branch.
+            baseBranch = Ivy.Tendril.Helpers.GitHelper.ResolveDefaultBranch(settings.RepoPath, config.TendrilHome);
         }
 
         project.Repos.Add(new RepoRef
         {
             Path = settings.RepoPath,
             PrRule = settings.PrRule ?? "default",
-            BaseBranch = settings.BaseBranch
+            BaseBranch = baseBranch
         });
 
         config.SaveSettings();

--- a/src/Ivy.Tendril/Helpers/GitHelper.cs
+++ b/src/Ivy.Tendril/Helpers/GitHelper.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -7,6 +8,116 @@ namespace Ivy.Tendril.Helpers;
 
 public static class GitHelper
 {
+    private static readonly ConcurrentDictionary<string, string> _defaultBranchCache = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Resolves a repository's default branch as a bare name (e.g. "development").
+    /// Tries the local <c>origin/HEAD</c> symbolic ref first (fast, offline); if that is not set up,
+    /// queries the remote via <c>git ls-remote --symref</c>. Falls back to "main" only when neither
+    /// source yields an answer. Accepts a local clone path or a remote URL (the URL form works before
+    /// the repo is cloned). Successful detections are memoized per expanded path/url.
+    /// </summary>
+    public static string ResolveDefaultBranch(string repoPathOrUrl, string? tendrilHome = null)
+    {
+        if (string.IsNullOrWhiteSpace(repoPathOrUrl))
+            return "main";
+
+        var expanded = VariableExpansion.ExpandVariables(repoPathOrUrl, tendrilHome);
+        if (_defaultBranchCache.TryGetValue(expanded, out var cached))
+            return cached;
+
+        var detected = DetectDefaultBranch(expanded);
+        if (detected != null)
+            _defaultBranchCache[expanded] = detected;
+        return detected ?? "main";
+    }
+
+    /// <summary>Async wrapper around <see cref="ResolveDefaultBranch"/> for UI call sites.</summary>
+    public static Task<string> ResolveDefaultBranchAsync(string repoPathOrUrl, string? tendrilHome = null)
+        => Task.Run(() => ResolveDefaultBranch(repoPathOrUrl, tendrilHome));
+
+    private static string? DetectDefaultBranch(string expanded)
+    {
+        var kind = RepoPathValidator.Classify(expanded);
+        if (kind == RepoPathKind.Invalid)
+            return null;
+
+        if (kind == RepoPathKind.LocalPath)
+        {
+            if (!Directory.Exists(expanded))
+                return null;
+
+            // 1. Local origin/HEAD symbolic ref (fast, offline). Outputs e.g. "origin/development".
+            var local = RunGitCapture(expanded, "symbolic-ref --short refs/remotes/origin/HEAD", 5000);
+            if (!string.IsNullOrWhiteSpace(local))
+            {
+                var name = StripOriginPrefix(local.Trim());
+                if (!string.IsNullOrEmpty(name))
+                    return name;
+            }
+
+            // 2. origin/HEAD not set up locally — ask the remote directly.
+            return ParseSymrefHead(RunGitCapture(expanded, "ls-remote --symref origin HEAD", 10000));
+        }
+
+        // Remote URL (HttpUrl or SshUrl): query the remote directly, no clone required.
+        return ParseSymrefHead(RunGitCapture(null, $"ls-remote --symref \"{expanded}\" HEAD", 10000));
+    }
+
+    private static string StripOriginPrefix(string refName)
+        => refName.StartsWith("origin/", StringComparison.Ordinal) ? refName["origin/".Length..] : refName;
+
+    private static string? ParseSymrefHead(string? lsRemoteOutput)
+    {
+        if (string.IsNullOrEmpty(lsRemoteOutput))
+            return null;
+
+        // Format: "ref: refs/heads/<name>\tHEAD"
+        foreach (var line in lsRemoteOutput.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var match = Regex.Match(line, @"^ref:\s+refs/heads/(.+?)\s+HEAD\b");
+            if (match.Success)
+                return match.Groups[1].Value.Trim();
+        }
+        return null;
+    }
+
+    private static string? RunGitCapture(string? workingDir, string args, int timeoutMs)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("git", args)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            if (!string.IsNullOrEmpty(workingDir))
+                psi.WorkingDirectory = workingDir;
+
+            using var process = Process.Start(psi);
+            if (process == null) return null;
+
+            var outTask = process.StandardOutput.ReadToEndAsync();
+            var errTask = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(timeoutMs))
+            {
+                try { process.Kill(true); } catch { /* best effort */ }
+                return null;
+            }
+
+            var output = outTask.GetAwaiter().GetResult();
+            _ = errTask.GetAwaiter().GetResult();
+
+            return process.ExitCode == 0 ? output : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     public static string? ResolveRepoRootFromWorktree(string wtDir)
     {
         var gitFile = Path.Combine(wtDir, ".git");

--- a/src/Ivy.Tendril/Hooks/UsePreflightCheck.cs
+++ b/src/Ivy.Tendril/Hooks/UsePreflightCheck.cs
@@ -40,9 +40,10 @@ public static class UsePreflightCheckExtensions
 
                     foreach (var repo in project.Repos)
                     {
-                        var baseBranch = repo.BaseBranch ?? "main";
                         var expanded = Environment.ExpandEnvironmentVariables(repo.Path);
                         if (!checkedPaths.Add(expanded)) continue;
+
+                        var baseBranch = repo.BaseBranch ?? GitHelper.ResolveDefaultBranch(expanded, configService.TendrilHome);
 
                         var checkResult = gitService.GetRepoDirtyState(expanded, baseBranch);
                         if (checkResult.IsSuccess && checkResult.Value!.IsDirty)

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -595,7 +595,7 @@ internal class JobLauncher
             var repoRef = FindProjectRepoConfig(projectConfig, Path.GetFileName(expanded));
             var entry = new RepoConfigEntry(
                 expanded,
-                repoRef?.BaseBranch ?? "main",
+                repoRef?.BaseBranch ?? GitHelper.ResolveDefaultBranch(expanded, _configService?.TendrilHome),
                 repoRef?.PrRule ?? "default",
                 ReadOnly: false);
             AddRepoToConfigLines(lines, entry);
@@ -616,7 +616,7 @@ internal class JobLauncher
 
             var entry = new RepoConfigEntry(
                 expanded,
-                FindBaseBranchAcrossProjects(repoName),
+                FindBaseBranchAcrossProjects(repoName, expanded),
                 "default",
                 ReadOnly: true);
             AddRepoToConfigLines(lines, entry);
@@ -639,9 +639,10 @@ internal class JobLauncher
                 .Equals(repoName, StringComparison.OrdinalIgnoreCase));
     }
 
-    private string FindBaseBranchAcrossProjects(string repoName)
+    private string FindBaseBranchAcrossProjects(string repoName, string repoPath)
     {
-        if (_configService == null) return "main";
+        if (_configService == null)
+            return GitHelper.ResolveDefaultBranch(repoPath);
 
         foreach (var proj in _configService.Projects)
         {
@@ -652,7 +653,7 @@ internal class JobLauncher
                 return configured;
         }
 
-        return "main";
+        return GitHelper.ResolveDefaultBranch(repoPath, _configService.TendrilHome);
     }
 
     private ProjectInfo[]? BuildProjectInfos(JobItem job)

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -616,7 +616,9 @@ internal class JobLauncher
 
             var entry = new RepoConfigEntry(
                 expanded,
-                FindBaseBranchAcrossProjects(repoName, expanded),
+                // Pass the raw config path: ResolveDefaultBranch owns expansion, so pre-expanding here
+                // would just run env-var expansion twice on the same value.
+                FindBaseBranchAcrossProjects(repoName, depPath),
                 "default",
                 ReadOnly: true);
             AddRepoToConfigLines(lines, entry);
@@ -639,10 +641,11 @@ internal class JobLauncher
                 .Equals(repoName, StringComparison.OrdinalIgnoreCase));
     }
 
-    private string FindBaseBranchAcrossProjects(string repoName, string repoPath)
+    // repoConfigPath is the raw (unexpanded) config path; ResolveDefaultBranch expands it.
+    private string FindBaseBranchAcrossProjects(string repoName, string repoConfigPath)
     {
         if (_configService == null)
-            return GitHelper.ResolveDefaultBranch(repoPath);
+            return GitHelper.ResolveDefaultBranch(repoConfigPath);
 
         foreach (var proj in _configService.Projects)
         {
@@ -653,7 +656,7 @@ internal class JobLauncher
                 return configured;
         }
 
-        return GitHelper.ResolveDefaultBranch(repoPath, _configService.TendrilHome);
+        return GitHelper.ResolveDefaultBranch(repoConfigPath, _configService.TendrilHome);
     }
 
     private ProjectInfo[]? BuildProjectInfos(JobItem job)

--- a/src/Ivy.Tendril/Services/Plans/PlanArtifactSyncer.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanArtifactSyncer.cs
@@ -220,30 +220,5 @@ internal class PlanArtifactSyncer
     }
 
     private static string DetectBaseBranch(string repoRoot)
-    {
-        try
-        {
-            var psi = new ProcessStartInfo("git", "symbolic-ref refs/remotes/origin/HEAD")
-            {
-                WorkingDirectory = repoRoot,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            using var process = Process.Start(psi);
-            if (process == null) return "origin/main";
-            var output = process.StandardOutput.ReadToEnd().Trim();
-            process.WaitForExitOrKill(5000);
-
-            if (process.ExitCode == 0 && !string.IsNullOrEmpty(output))
-                return output.Replace("refs/remotes/", "");
-        }
-        catch
-        {
-        }
-
-        return "origin/main";
-    }
+        => "origin/" + GitHelper.ResolveDefaultBranch(repoRoot);
 }


### PR DESCRIPTION
## Problem

When a repo had no `baseBranch` configured, Tendril hardcoded the literal `"main"` in five places, so repos whose real default branch differs (e.g. `development`) had worktrees branched from `origin/main` and PRs opened against the wrong base. Fixes the "pushes to the wrong branch" reports (#1218, #1266; also resolves the no-config gap behind #1196).

## Change

- **`GitHelper.ResolveDefaultBranch`** — layered, git-only default-branch detection: local `git symbolic-ref refs/remotes/origin/HEAD` → `git ls-remote --symref` → `"main"` only as last resort. Works for both local clones and not-yet-cloned remote URLs; successful detections are memoized.
- **Detect-and-save at repo-add time** — `ProjectRepoPickerView` and `ProjectAddRepoCommand` now persist the detected default branch into `RepoRef.BaseBranch` when the user doesn't specify one, so project config is explicit going forward.
- **Runtime fallbacks** — replaced all five hardcoded `"main"` assumptions (`JobLauncher` ×2, `JobStartCommand`, `UsePreflightCheck`) with the resolver, covering repos already in config with a null `baseBranch`.
- **De-dup** — `PlanArtifactSyncer.DetectBaseBranch` now delegates to the shared resolver.

## Tests

- `GitHelperTests`: empty-path/no-remote fallback, clone with/without `origin/HEAD` (reproduces the bug → resolves `development` via `ls-remote`), and live-remote checks against Ivy-Framework (`development`), Tendril-Test-Runner (`main`), SeoTools-for-Excel-Connectors (`master`).

Created with the yolo-push skill.