### PR TITLE
Allow rerunning a job with feedback for the agent (#1254)

### DIFF
--- a/src/Ivy.Tendril.Test/RerunJobDialogTests.cs
+++ b/src/Ivy.Tendril.Test/RerunJobDialogTests.cs
@@ -1,0 +1,87 @@
+using Ivy.Tendril.Apps.Jobs.Dialogs;
+using Ivy.Tendril.Models;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class RerunJobDialogTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void BuildRerunArgs_NoFeedback_ReturnsOriginalArgs(string? feedback)
+    {
+        var original = new ExecutePlanArgs("/plans/00001-Test");
+
+        var result = RerunJobDialog.BuildRerunArgs(original, feedback);
+
+        Assert.Same(original, result);
+    }
+
+    [Fact]
+    public void BuildRerunArgs_ExecutePlanWithFeedback_BecomesRetryWithChangeRequest()
+    {
+        var original = new ExecutePlanArgs("/plans/00001-Test");
+
+        var result = RerunJobDialog.BuildRerunArgs(original, "fix the readme");
+
+        var retry = Assert.IsType<RetryPlanArgs>(result);
+        Assert.Equal("/plans/00001-Test", retry.FolderPath);
+        Assert.Equal("fix the readme", retry.ChangeRequest);
+    }
+
+    [Fact]
+    public void BuildRerunArgs_RetryPlanWithFeedback_KeepsRetryWithNewChangeRequest()
+    {
+        var original = new RetryPlanArgs("/plans/00001-Test", "old request");
+
+        var result = RerunJobDialog.BuildRerunArgs(original, "new request");
+
+        var retry = Assert.IsType<RetryPlanArgs>(result);
+        Assert.Equal("/plans/00001-Test", retry.FolderPath);
+        Assert.Equal("new request", retry.ChangeRequest);
+    }
+
+    [Fact]
+    public void BuildRerunArgs_UpdatePlanWithFeedback_BecomesUpdateWithInstructions()
+    {
+        var original = new UpdatePlanArgs("/plans/00001-Test", "old instructions");
+
+        var result = RerunJobDialog.BuildRerunArgs(original, "new instructions");
+
+        var update = Assert.IsType<UpdatePlanArgs>(result);
+        Assert.Equal("/plans/00001-Test", update.FolderPath);
+        Assert.Equal("new instructions", update.Instructions);
+    }
+
+    [Fact]
+    public void BuildRerunArgs_UnsupportedTypeWithFeedback_ReturnsOriginalArgs()
+    {
+        var original = new CreatePrArgs("/plans/00001-Test");
+
+        var result = RerunJobDialog.BuildRerunArgs(original, "some feedback");
+
+        Assert.Same(original, result);
+    }
+
+    [Theory]
+    [InlineData(typeof(ExecutePlanArgs), true)]
+    [InlineData(typeof(RetryPlanArgs), true)]
+    [InlineData(typeof(UpdatePlanArgs), true)]
+    [InlineData(typeof(ExpandPlanArgs), false)]
+    [InlineData(typeof(CreatePrArgs), false)]
+    public void SupportsFeedback_MatchesJobType(Type argsType, bool expected)
+    {
+        JobArgsBase args = argsType switch
+        {
+            _ when argsType == typeof(ExecutePlanArgs) => new ExecutePlanArgs("/plans/00001-Test"),
+            _ when argsType == typeof(RetryPlanArgs) => new RetryPlanArgs("/plans/00001-Test", "req"),
+            _ when argsType == typeof(UpdatePlanArgs) => new UpdatePlanArgs("/plans/00001-Test"),
+            _ when argsType == typeof(ExpandPlanArgs) => new ExpandPlanArgs("/plans/00001-Test"),
+            _ => new CreatePrArgs("/plans/00001-Test")
+        };
+
+        Assert.Equal(expected, RerunJobDialog.SupportsFeedback(args));
+    }
+}

--- a/src/Ivy.Tendril/Apps/Jobs/Dialogs/RerunJobDialog.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Dialogs/RerunJobDialog.cs
@@ -1,0 +1,110 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Jobs.Dialogs;
+
+/// <summary>
+/// Dialog shown when rerunning a failed/timed-out/stopped job. Lets the user
+/// optionally provide corrective feedback for the agent. For plan execution jobs
+/// the feedback is turned into a <see cref="RetryPlanArgs"/> change request; for
+/// update jobs it becomes new update instructions. When no feedback is provided the
+/// job is rerun with its original arguments.
+/// </summary>
+public class RerunJobDialog(
+    IState<bool> dialogOpen,
+    JobItem job,
+    IJobService jobService,
+    IPlanReaderService planService,
+    Action onRerun) : ViewBase
+{
+    public override object? Build()
+    {
+        var feedback = UseState("");
+        if (!dialogOpen.Value) return null;
+
+        var supportsFeedback = SupportsFeedback(job.TypedArgs);
+
+        void Close()
+        {
+            feedback.Set("");
+            dialogOpen.Set(false);
+        }
+
+        var body = supportsFeedback
+            ? Layout.Vertical()
+              | Text.P("Optionally tell the agent what went wrong or what to do differently. Leave empty to rerun unchanged.")
+              | feedback.ToTextareaInput("Feedback for the agent (optional)...").Rows(6).AutoFocus()
+            : Layout.Vertical()
+              | Text.P("Rerun this job with its original arguments?");
+
+        return new Dialog(
+            _ => Close(),
+            new DialogHeader($"Rerun {job.Type}"),
+            new DialogBody(body),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(Close),
+                new Button("Rerun").Primary().Icon(Icons.RotateCw).ShortcutKey("Ctrl+Enter").OnClick(() =>
+                {
+                    Rerun(feedback.Value);
+                    Close();
+                })
+            )
+        ).Width(Size.Rem(30));
+    }
+
+    private void Rerun(string feedbackText)
+    {
+        if (job.TypedArgs == null) return;
+
+        var newArgs = BuildRerunArgs(job.TypedArgs, feedbackText);
+        TransitionPlanState(newArgs);
+
+        jobService.DeleteJob(job.Id);
+        jobService.StartJob(newArgs);
+        onRerun();
+    }
+
+    internal static bool SupportsFeedback(JobArgsBase? args) =>
+        args is ExecutePlanArgs or RetryPlanArgs or UpdatePlanArgs;
+
+    internal static JobArgsBase BuildRerunArgs(JobArgsBase original, string? feedback)
+    {
+        if (string.IsNullOrWhiteSpace(feedback))
+            return original;
+
+        return original switch
+        {
+            ExecutePlanArgs e => new RetryPlanArgs(e.FolderPath, feedback),
+            RetryPlanArgs r => new RetryPlanArgs(r.FolderPath, feedback),
+            UpdatePlanArgs u => new UpdatePlanArgs(u.FolderPath, feedback),
+            _ => original
+        };
+    }
+
+    private void TransitionPlanState(JobArgsBase args)
+    {
+        var folder = args.PlanFolder;
+        if (string.IsNullOrEmpty(folder)) return;
+
+        var folderName = Path.GetFileName(folder);
+
+        var targetState = args switch
+        {
+            ExecutePlanArgs => PlanStatus.Building,
+            ExpandPlanArgs => PlanStatus.Building,
+            CreatePrArgs => PlanStatus.Building,
+            CreateIssueArgs => PlanStatus.Building,
+            RetryPlanArgs => PlanStatus.Executing,
+            UpdatePlanArgs => PlanStatus.Updating,
+            SplitPlanArgs => PlanStatus.Updating,
+            _ => (PlanStatus?)null
+        };
+
+        if (targetState == null) return;
+
+        if (args is RetryPlanArgs)
+            planService.ResetVerificationsForRetry(folderName);
+
+        planService.TransitionState(folderName, targetState.Value);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Jobs/Dialogs/RerunJobDialog.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Dialogs/RerunJobDialog.cs
@@ -88,15 +88,16 @@ public class RerunJobDialog(
 
         var folderName = Path.GetFileName(folder);
 
+        // Only transition the plan for the job types that already drive plan state on a
+        // fresh in-app start. CreatePr/CreateIssue/Split/SyncRepo are deliberately left
+        // untouched so rerunning them doesn't knock the plan out of its current state
+        // (e.g. ReadyForReview -> Building, hiding it from the Review queue).
         var targetState = args switch
         {
             ExecutePlanArgs => PlanStatus.Building,
             ExpandPlanArgs => PlanStatus.Building,
-            CreatePrArgs => PlanStatus.Building,
-            CreateIssueArgs => PlanStatus.Building,
             RetryPlanArgs => PlanStatus.Executing,
             UpdatePlanArgs => PlanStatus.Updating,
-            SplitPlanArgs => PlanStatus.Updating,
             _ => (PlanStatus?)null
         };
 

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -20,6 +20,7 @@ public partial class JobsApp
         Action<string> showOutput,
         Action<string> showPrompt,
         Action<string>? showDebug,
+        Action<string> showRerun,
         List<JobItem> jobs,
         Dictionary<string, string> projectColors,
         StackedProgress? jobsProgress,
@@ -236,20 +237,7 @@ public partial class JobsApp
                                 return ValueTask.CompletedTask;
                             }
 
-                            var folder = job.TypedArgs.PlanFolder;
-                            if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or ExpandPlanArgs && folder != null)
-                            {
-                                planService.TransitionState(Path.GetFileName(folder), PlanStatus.Building);
-                            }
-                            else if (job.TypedArgs is UpdatePlanArgs && folder != null)
-                            {
-                                planService.TransitionState(Path.GetFileName(folder), PlanStatus.Updating);
-                            }
-
-                            jobService.DeleteJob(job.Id);
-                            jobService.StartJob(job.TypedArgs);
-
-                            refreshToken.Refresh();
+                            showRerun(job.Id);
                         }
                     }
                     else if (tag == "force-start-job")

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Linq;
+using Ivy.Tendril.Apps.Jobs.Dialogs;
 using Ivy.Tendril.Apps.Jobs.Sheets;
 using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Helpers;
@@ -66,6 +67,14 @@ public partial class JobsApp : ViewBase
             ).Width(UxHelper.SheetWidth).Resizable();
         });
 
+        var (rerunDialog, showRerun) = UseTrigger<string>((isOpen, jobId) =>
+        {
+            if (!isOpen.Value) return null;
+            var job = jobService.GetJob(jobId);
+            if (job == null) return null;
+            return new RerunJobDialog(isOpen, job, jobService, planService, () => refreshToken.Refresh());
+        });
+
         UseEffect(() => JobsApp.JobChangeHookDisposable(jobService, refreshToken));
         UseInterval(() => JobsApp.AutoRefreshCheck(jobService, refreshToken), TimeSpan.FromSeconds(5));
 
@@ -79,11 +88,11 @@ public partial class JobsApp : ViewBase
         var jobsProgress = jobs.Count > 0 ? BuildStatusProgress(jobs, config) : null;
 
         var dataTable = JobsApp.BuildDataTable(nav, rows, refreshToken, updateStream, config, planService,
-            jobService, client, showPlan, showOutput, showPrompt, showDebug, jobs, projectColors, jobsProgress,
+            jobService, client, showPlan, showOutput, showPrompt, showDebug, showRerun, jobs, projectColors, jobsProgress,
             confirmDeleteOpen, deleteJobId);
 
         var layout = Layout.Vertical().Height(Size.Full());
 
-        return layout | new Fragment(dataTable, planSheet, outputSheet, promptSheet, debugSheet);
+        return layout | new Fragment(dataTable, planSheet, outputSheet, promptSheet, debugSheet, rerunDialog);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1254 — users could rerun a Failed/Timeout/Stopped job but had no way to give the agent corrective feedback about what went wrong.

"Rerun" now opens a dialog with an **optional** feedback box:
- **Empty feedback** → plain rerun with the original args (previous behavior preserved).
- **With feedback** → `ExecutePlan`/`RetryPlan` jobs become a `RetryPlanArgs` whose `ChangeRequest` the agent treats as its primary objective (same mechanism as the Review app's "Request Changes"); `UpdatePlan` jobs get new `UpdateInstructions`.
- Job types with no feedback slot (`CreatePr`, `Expand`, etc.) show a plain rerun confirm.

## Changes

- New `RerunJobDialog` (`Apps/Jobs/Dialogs/`) wired into `JobsApp` via `UseTrigger`; the "Rerun" row action now opens it instead of restarting immediately.
- Plan-state transition on rerun is limited to the execution/update job types that already drive plan state on a fresh start — `CreatePr`/`CreateIssue`/`Split` are left untouched so rerunning them no longer knocks the plan out of `ReadyForReview` and hides it from the Review queue.

## Tests

- 12 new unit tests for the feedback→args mapping (`RerunJobDialogTests`). Build clean, all green.