### PR TITLE
automate dependency installation and improve package manager / tool detection in review actions

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/UpdateProject/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/UpdateProject/Program.md
@@ -15,7 +15,10 @@ Project and verification configuration is available via `tendril project list` a
 
 - **CLI-only modifications.** You MUST use `tendril` CLI commands to modify configuration. Never edit config.yaml directly.
 - **Reuse existing verifications.** Before creating a new verification, check if a suitable one already exists with `tendril verification list`. Verifications are shared across projects.
-- **Stack detection.** Inspect the project's repositories to determine the tech stack (look for package.json, *.csproj, Cargo.toml, go.mod, requirements.txt, pyproject.toml, etc.).
+- **Stack detection.** Inspect the project's repositories to determine the tech stack.
+  - Look for configuration files: `package.json`, `*.csproj`, `Cargo.toml`, `go.mod`, `requirements.txt`, `pyproject.toml`, etc.
+  - If a `package.json` exists, identify the package manager: check if `pnpm-lock.yaml` is present, or if the `packageManager` field in `package.json` specifies `pnpm`. If not, check for `yarn.lock`. Otherwise, assume `npm`.
+  - Identify if the frontend uses Vite or Vite+ (`vite-plus`): check if `vite-plus` is listed in `package.json` dependencies or devDependencies, or if scripts call `vp`. If it uses Vite+ (`vite-plus`), use `vp` commands (e.g. `vp dev`). Otherwise, use `npm`/`pnpm`/`yarn` commands.
 - **Keep it minimal.** Only add verifications and review actions that are appropriate for the detected stack.
 
 ## Available CLI Commands
@@ -115,14 +118,19 @@ tendril project add-verification <project-name> CheckResult --required --after D
 ### 3. Setup Review Actions
 
 Review actions make it easy to start the application from a worktree during code review.
+To ensure the setup works out-of-the-box on fresh worktrees, review actions MUST automatically install dependencies before running the application (e.g. using `&&` to chain the installation and start commands).
 
 Inspect each repo to determine how to run the application. For website projects, prefer commands that open the browser automatically:
-- .NET project with a runnable entry point: `dotnet run --project Worktrees/<RepoName>/<path-to-project> --browse --find-available-port`
-- Vite or webpack-dev-server: `cd Worktrees/<RepoName> && npm run dev -- --open`
-- Angular CLI: `cd Worktrees/<RepoName> && ng serve --open`
-- Other Node.js app (no open support): `cd Worktrees/<RepoName> && npm run dev`
-- Python app: `cd Worktrees/<RepoName> && python -m <module>` or `flask run`
-- Static docs: `start Worktrees/<RepoName>/docs/index.html`
+- **.NET project** with a runnable entry point: `dotnet run --project Worktrees/<RepoName>/<path-to-project> --browse --find-available-port`
+- **Vite+ (`vite-plus`) project**: `cd Worktrees/<RepoName>/<path-to-frontend> && vp install && vp dev`
+- **Vite project**:
+  - Under `pnpm`: `cd Worktrees/<RepoName>/<path-to-frontend> && pnpm install && pnpm run dev -- --open`
+  - Under `npm`: `cd Worktrees/<RepoName>/<path-to-frontend> && npm install && npm run dev -- --open`
+  - Under `yarn`: `cd Worktrees/<RepoName>/<path-to-frontend> && yarn install && yarn run dev -- --open`
+- **Angular CLI**: `cd Worktrees/<RepoName>/<path> && npm install && ng serve --open` (adapt for `pnpm`/`yarn` if detected)
+- **Other Node.js app** (no open support): `cd Worktrees/<RepoName>/<path> && npm install && npm run dev` (adapt package manager as detected)
+- **Python app**: `cd Worktrees/<RepoName> && python -m pip install -r requirements.txt && python -m <module>` (or `flask run` / `uv run ...` / `poetry run ...` if detected)
+- **Static docs**: `start Worktrees/<RepoName>/docs/index.html`
 
 For each review action:
 - **name**: Short descriptive name (e.g. "App", "Docs", "Frontend", "API")

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/UpdateProject/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/UpdateProject/Program.md
@@ -72,9 +72,9 @@ For each detected tech stack, ensure the following verification definitions exis
 | .NET | DotnetFormat | Run `dotnet format` scoped to changed .cs files, commit fixes if any |
 | .NET | DotnetBuild | Run `dotnet build --warnaserror` in worktree, verify zero errors/warnings |
 | .NET | DotnetTest | Run `dotnet test` with filter from plan's Tests section |
-| JS/TS | NpmLint | Run `npm run lint` (or equivalent) on changed files |
-| JS/TS | NpmBuild | Run `npm run build` and verify success |
-| JS/TS | NpmTest | Run `npm test` with appropriate filter |
+| JS/TS | NpmLint | Run `npm run lint` / `pnpm lint` (or equivalent) on changed files |
+| JS/TS | NpmBuild | Run `npm run build` / `pnpm build` (or equivalent) and verify success |
+| JS/TS | NpmTest | Run `npm test` / `pnpm test` with appropriate filter |
 | Python | PythonLint | Run linter (black/ruff/flake8) on changed .py files |
 | Python | PythonTest | Run `pytest` with filter from plan's Tests section |
 | Rust | RustClippy | Run `cargo clippy -- -D warnings` |

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -144,7 +144,7 @@ projects:
   reviewActions:
   - name: App
     condition: Test-Path 'Worktrees\lots-of-dev-tools\package.json'
-    command: cd Worktrees\lots-of-dev-tools && npm run dev
+    command: cd Worktrees\lots-of-dev-tools && pnpm install && pnpm run dev
   hooks: []
   buildDependencies: []
 - name: Tendril-Services

--- a/src/Ivy.Tendril/Promptwares/UpdateProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdateProject/Program.md
@@ -15,7 +15,10 @@ Project and verification configuration is available via `tendril project list` a
 
 - **CLI-only modifications.** You MUST use `tendril` CLI commands to modify configuration. Never edit config.yaml directly.
 - **Reuse existing verifications.** Before creating a new verification, check if a suitable one already exists with `tendril verification list`. Verifications are shared across projects.
-- **Stack detection.** Inspect the project's repositories to determine the tech stack (look for package.json, *.csproj, Cargo.toml, go.mod, requirements.txt, pyproject.toml, etc.).
+- **Stack detection.** Inspect the project's repositories to determine the tech stack.
+  - Look for configuration files: `package.json`, `*.csproj`, `Cargo.toml`, `go.mod`, `requirements.txt`, `pyproject.toml`, etc.
+  - If a `package.json` exists, identify the package manager: check if `pnpm-lock.yaml` is present, or if the `packageManager` field in `package.json` specifies `pnpm`. If not, check for `yarn.lock`. Otherwise, assume `npm`.
+  - Identify if the frontend uses Vite or Vite+ (`vite-plus`): check if `vite-plus` is listed in `package.json` dependencies or devDependencies, or if scripts call `vp`. If it uses Vite+ (`vite-plus`), use `vp` commands (e.g. `vp dev`). Otherwise, use `npm`/`pnpm`/`yarn` commands.
 - **Keep it minimal.** Only add verifications and review actions that are appropriate for the detected stack.
 
 ## Available CLI Commands
@@ -115,14 +118,19 @@ tendril project add-verification <project-name> CheckResult --required --after D
 ### 3. Setup Review Actions
 
 Review actions make it easy to start the application from a worktree during code review.
+To ensure the setup works out-of-the-box on fresh worktrees, review actions MUST automatically install dependencies before running the application (e.g. using `&&` to chain the installation and start commands).
 
 Inspect each repo to determine how to run the application. For website projects, prefer commands that open the browser automatically:
-- .NET project with a runnable entry point: `dotnet run --project Worktrees/<RepoName>/<path-to-project> --browse --find-available-port`
-- Vite or webpack-dev-server: `cd Worktrees/<RepoName> && npm run dev -- --open`
-- Angular CLI: `cd Worktrees/<RepoName> && ng serve --open`
-- Other Node.js app (no open support): `cd Worktrees/<RepoName> && npm run dev`
-- Python app: `cd Worktrees/<RepoName> && python -m <module>` or `flask run`
-- Static docs: `start Worktrees/<RepoName>/docs/index.html`
+- **.NET project** with a runnable entry point: `dotnet run --project Worktrees/<RepoName>/<path-to-project> --browse --find-available-port`
+- **Vite+ (`vite-plus`) project**: `cd Worktrees/<RepoName>/<path-to-frontend> && vp install && vp dev`
+- **Vite project**:
+  - Under `pnpm`: `cd Worktrees/<RepoName>/<path-to-frontend> && pnpm install && pnpm run dev -- --open`
+  - Under `npm`: `cd Worktrees/<RepoName>/<path-to-frontend> && npm install && npm run dev -- --open`
+  - Under `yarn`: `cd Worktrees/<RepoName>/<path-to-frontend> && yarn install && yarn run dev -- --open`
+- **Angular CLI**: `cd Worktrees/<RepoName>/<path> && npm install && ng serve --open` (adapt for `pnpm`/`yarn` if detected)
+- **Other Node.js app** (no open support): `cd Worktrees/<RepoName>/<path> && npm install && npm run dev` (adapt package manager as detected)
+- **Python app**: `cd Worktrees/<RepoName> && python -m pip install -r requirements.txt && python -m <module>` (or `flask run` / `uv run ...` / `poetry run ...` if detected)
+- **Static docs**: `start Worktrees/<RepoName>/docs/index.html`
 
 For each review action:
 - **name**: Short descriptive name (e.g. "App", "Docs", "Frontend", "API")

--- a/src/Ivy.Tendril/Promptwares/UpdateProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdateProject/Program.md
@@ -72,9 +72,9 @@ For each detected tech stack, ensure the following verification definitions exis
 | .NET | DotnetFormat | Run `dotnet format` scoped to changed .cs files, commit fixes if any |
 | .NET | DotnetBuild | Run `dotnet build --warnaserror` in worktree, verify zero errors/warnings |
 | .NET | DotnetTest | Run `dotnet test` with filter from plan's Tests section |
-| JS/TS | NpmLint | Run `npm run lint` (or equivalent) on changed files |
-| JS/TS | NpmBuild | Run `npm run build` and verify success |
-| JS/TS | NpmTest | Run `npm test` with appropriate filter |
+| JS/TS | NpmLint | Run `npm run lint` / `pnpm lint` (or equivalent) on changed files |
+| JS/TS | NpmBuild | Run `npm run build` / `pnpm build` (or equivalent) and verify success |
+| JS/TS | NpmTest | Run `npm test` / `pnpm test` with appropriate filter |
 | Python | PythonLint | Run linter (black/ruff/flake8) on changed .py files |
 | Python | PythonTest | Run `pytest` with filter from plan's Tests section |
 | Rust | RustClippy | Run `cargo clippy -- -D warnings` |

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -203,11 +203,11 @@ verifications:
 
 # JavaScript/TypeScript:
 # - name: NpmBuild
-#   prompt: Run `npm run build` in the plan's worktree directory and verify it succeeds.
+#   prompt: Run `npm run build` / `pnpm build` in the plan's worktree directory and verify it succeeds.
 # - name: NpmLint
-#   prompt: Run `npm run lint` on changed files and fix any errors.
+#   prompt: Run `npm run lint` / `pnpm lint` on changed files and fix any errors.
 # - name: NpmTest
-#   prompt: Run `npm test` with the filter from the plan's **## Tests** section.
+#   prompt: Run `npm test` / `pnpm test` with the filter from the plan's **## Tests** section.
 
 # Python:
 # - name: PythonLint


### PR DESCRIPTION
Closes #1264. Closes #1253. Updates the UpdateProject promptware instructions to detect package managers (npm/pnpm/yarn) and Vite/Vite+ configurations properly and automatically install dependencies before running applications in review actions. Also updates the lots-of-dev-tools review action in config.yaml.