### PR TITLE
Fix #1257: new drafts not refreshing + harden flaky timing tests

### DIFF
--- a/src/Ivy.Tendril.Test/Helpers/RetryHelper.cs
+++ b/src/Ivy.Tendril.Test/Helpers/RetryHelper.cs
@@ -2,6 +2,32 @@ namespace Ivy.Tendril.Test.Helpers;
 
 public static class RetryHelper
 {
+    /// <summary>
+    ///     Synchronously polls <paramref name="condition" /> until it returns true or the timeout
+    ///     elapses. Use this instead of a fixed <c>Thread.Sleep</c> before an assertion on async /
+    ///     background / timer / file-watcher work — it removes load-sensitive flakiness by waiting
+    ///     for the observable result rather than guessing how long the work takes.
+    /// </summary>
+    /// <returns>True if the condition became true within the timeout; false otherwise.</returns>
+    public static bool WaitUntil(
+        Func<bool> condition,
+        TimeSpan? timeout = null,
+        TimeSpan? pollInterval = null)
+    {
+        var limit = timeout ?? TimeSpan.FromSeconds(10);
+        var interval = pollInterval ?? TimeSpan.FromMilliseconds(25);
+        var deadline = Environment.TickCount64 + (long)limit.TotalMilliseconds;
+
+        while (Environment.TickCount64 < deadline)
+        {
+            if (condition())
+                return true;
+            Thread.Sleep(interval);
+        }
+
+        return condition();
+    }
+
     public static async Task WaitUntilAsync(
         Func<Task<bool>> condition,
         TimeSpan timeout,

--- a/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
@@ -290,8 +290,9 @@ public class InboxWatcherServiceTests : IDisposable
         var jobService = new DeleteBeforeRenameJobService(filePath);
         using var watcher = new InboxWatcherService(config, jobService, NullLogger<InboxWatcherService>.Instance);
 
-        // Wait for async processing
-        Thread.Sleep(2000);
+        // The fake deletes the file during the watcher's tracked-check; once it's gone, processing
+        // has reached (and handled) the race. Poll for that instead of guessing a fixed delay.
+        RetryHelper.WaitUntil(() => !File.Exists(filePath), TimeSpan.FromSeconds(10));
 
         // No job should have been started, and no .processing file should exist
         Assert.Empty(jobService.StartedJobs);
@@ -318,15 +319,13 @@ public class InboxWatcherServiceTests : IDisposable
         var config = new ConfigService(new TendrilSettings(), _tempDir.Path);
         var jobService = new TimestampedJobService();
 
-        // Manually call ProcessExistingFiles (without creating watcher to avoid auto-processing)
-        var watcher = new InboxWatcherService(config, jobService, NullLogger<InboxWatcherService>.Instance);
+        // The constructor runs ProcessExistingFiles, which launches the 5 files with a 2s
+        // Thread.Sleep between each — so construction alone blocks ~8s.
+        var constructionStart = DateTime.UtcNow;
+        using var watcher = new InboxWatcherService(config, jobService, NullLogger<InboxWatcherService>.Instance);
 
         // Wait for all jobs to be started
-        var startTime = DateTime.UtcNow;
-        while (jobService.StartedJobs.Count < 5 && (DateTime.UtcNow - startTime).TotalSeconds < 15)
-        {
-            Thread.Sleep(100);
-        }
+        RetryHelper.WaitUntil(() => jobService.StartedJobs.Count >= 5, TimeSpan.FromSeconds(30));
 
         // Verify we got all 5 jobs
         Assert.Equal(5, jobService.StartedJobs.Count);
@@ -338,13 +337,14 @@ public class InboxWatcherServiceTests : IDisposable
             Assert.Contains(jobService.StartedJobs, job => job.InboxFilePath == processingPath);
         }
 
-        // Verify time between StartJob calls is approximately 2 seconds
-        for (int i = 1; i < jobService.StartJobTimestamps.Count; i++)
-        {
-            var delay = (jobService.StartJobTimestamps[i] - jobService.StartJobTimestamps[i - 1]).TotalMilliseconds;
-            // Allow some tolerance (1800ms to 2200ms) for system scheduling
-            Assert.InRange(delay, 1800, 2500);
-        }
+        // Verify the startup is staggered rather than a thundering herd. Per-gap timing is not a
+        // reliable signal: each StartJob is recorded after a fire-and-forget Task.Delay(500) whose
+        // continuation can be scheduled with arbitrary jitter under a loaded thread pool. What IS
+        // deterministic is the cumulative floor — the 4 × Thread.Sleep(2000) between launches is a
+        // wall-clock minimum (load can only lengthen it), so the 5 jobs must span at least ~8s.
+        var span = (jobService.StartJobTimestamps.Last() - constructionStart).TotalMilliseconds;
+        Assert.True(span >= 7000,
+            $"Expected staggered startup to span >= ~8s, but the 5 jobs started within {span}ms");
     }
 
     private class DeleteBeforeRenameJobService : IJobService

--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Test.Helpers;
 
 namespace Ivy.Tendril.Test;
 
@@ -478,8 +479,10 @@ public class JobServiceRetryBlockedTests : IDisposable
         depYaml = depYaml.Replace("state: Executing", "state: Completed");
         File.WriteAllText(depPlanPath, depYaml);
 
-        // Wait for the periodic check to run (60 second interval, but we'll wait up to 70 seconds)
-        await Task.Delay(TimeSpan.FromSeconds(70));
+        // Drive the periodic dependency re-check directly instead of waiting for the 60s timer
+        // (deterministic and instant — the timer body is identical to RunBlockedJobCheck).
+        service.RunBlockedJobCheck();
+        RetryHelper.WaitUntil(() => service.GetJob(blockedId) == null, TimeSpan.FromSeconds(10));
 
         // The blocked job should have been removed and restarted
         Assert.Null(service.GetJob(blockedId));

--- a/src/Ivy.Tendril.Test/PlanWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanWatcherServiceTests.cs
@@ -1,0 +1,121 @@
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Test.Helpers;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test;
+
+/// <summary>
+///     Covers the self-heal re-scan behaviour added for #1257: a brand-new plan folder fires the
+///     top-level FileSystemWatcher while still empty, then plan.yaml / Revisions land a moment
+///     later (writes inside the folder, which don't re-trigger the watcher). The staggered
+///     self-heal re-scans must surface the completed folder without waiting for the 30s poll.
+/// </summary>
+public class PlanWatcherServiceTests : IDisposable
+{
+    // Generous outer timeout: real FileSystemWatcher events are timing-dependent (especially on
+    // CI), so we assert eventual state rather than exact event counts/ordering.
+    private const int WatchTimeoutMs = 10_000;
+
+    private const string DraftYaml =
+        "state: Draft\nproject: Tendril\ntitle: Test Plan\nlevel: NiceToHave\nrepos: []\ncommits: []\nprs: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\n";
+
+    private readonly ConfigService _configService;
+    private readonly TempDirectoryFixture _tempDir = new();
+
+    public PlanWatcherServiceTests()
+    {
+        _configService = new ConfigService(new TendrilSettings(), _tempDir.Path);
+        // The (settings, home) test constructor does not run CreateRequiredDirectories, so create
+        // the Plans dir explicitly — otherwise PlanWatcherService's "directory missing" guard trips
+        // and no watcher/poll is set up. (Production uses the public ctor, which creates it.)
+        Directory.CreateDirectory(_configService.PlanFolder);
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        _tempDir.Dispose();
+    }
+
+    private string CreateEmptyPlanFolder(string folderName)
+    {
+        var dir = Path.Combine(_configService.PlanFolder, folderName);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static void WritePlanContent(string planDir)
+    {
+        File.WriteAllText(Path.Combine(planDir, "plan.yaml"), DraftYaml);
+        var revisionsDir = Path.Combine(planDir, "Revisions");
+        Directory.CreateDirectory(revisionsDir);
+        File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "# Test Plan Content");
+    }
+
+    [Fact]
+    public void SelfHeal_ReRaisesPlansChanged_AfterLateArrivingContent()
+    {
+        using var watcher = new PlanWatcherService(_configService, null, new[] { 50, 150, 300 });
+
+        var changeCount = 0;
+        var changesAfterContent = 0;
+        var contentWritten = new ManualResetEventSlim(false);
+
+        watcher.PlansChanged += _ =>
+        {
+            Interlocked.Increment(ref changeCount);
+            if (contentWritten.IsSet)
+                Interlocked.Increment(ref changesAfterContent);
+        };
+
+        // Folder appears empty first (mirrors `tendril plan create` creating the dir before
+        // writing plan.yaml / the first revision).
+        var planDir = CreateEmptyPlanFolder("01600-SelfHealPlan");
+
+        // Content lands shortly after — inside the folder, so it does NOT re-trigger the FSW.
+        Thread.Sleep(100);
+        WritePlanContent(planDir);
+        contentWritten.Set();
+
+        // The staggered self-heal burst must re-raise PlansChanged multiple times, with at least
+        // one rescan after the content landed. Poll for both outcomes rather than sampling at a
+        // single instant — under load the burst's timer callbacks arrive with arbitrary spacing.
+        Assert.True(
+            RetryHelper.WaitUntil(
+                () => Volatile.Read(ref changeCount) > 1 && Volatile.Read(ref changesAfterContent) >= 1,
+                TimeSpan.FromSeconds(15)),
+            "Expected multiple self-heal PlansChanged, including at least one after late-arriving content");
+    }
+
+    [Fact]
+    public void OutOfBandPlan_AppearsInDatabase_WithoutRestart()
+    {
+        var dbPath = Path.Combine(_tempDir.Path, "tendril.db");
+        var planReader = new PlanReaderService(_configService, NullLogger<PlanReaderService>.Instance);
+        using var database = new PlanDatabaseService(dbPath, NullLogger<PlanDatabaseService>.Instance);
+        // Self-heal delays straddle the content write: the 500ms debounce fires while the folder is
+        // still empty (and would be the ONLY rescan without this fix), so the plan only reaches the
+        // DB because a later self-heal rescan runs after the content lands. This makes the test a
+        // genuine regression guard for #1257 rather than something the plain debounce would pass.
+        using var watcher = new PlanWatcherService(_configService, null, new[] { 800, 2500 });
+        using var syncService = new PlanDatabaseSyncService(
+            planReader, database, watcher, NullLogger<PlanDatabaseSyncService>.Instance);
+
+        // Initial sync with no plans → enables database-backed reads.
+        syncService.PerformInitialSync();
+        Assert.True(syncService.IsInitialSyncComplete);
+        Assert.Empty(database.GetPlans());
+
+        // Create a plan out-of-band: empty folder first (FSW fires here, before content)...
+        var planDir = CreateEmptyPlanFolder("01601-OutOfBandPlan");
+        // ...then plan.yaml + revision well after the 500ms debounce would have fired empty.
+        Thread.Sleep(1500);
+        WritePlanContent(planDir);
+
+        // Without restart, a self-heal rescan must sync the new plan into the database.
+        Assert.True(
+            RetryHelper.WaitUntil(() => database.GetPlans().Count == 1, TimeSpan.FromMilliseconds(WatchTimeoutMs)),
+            "Expected the out-of-band plan to be synced into the database without a restart");
+    }
+}

--- a/src/Ivy.Tendril.Test/PlanYamlCorruptionTests.cs
+++ b/src/Ivy.Tendril.Test/PlanYamlCorruptionTests.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Test.Helpers;
 
 namespace Ivy.Tendril.Test;
 
@@ -88,7 +89,11 @@ public class PlanYamlCorruptionTests : IClassFixture<ConfigServiceFixture>
 
         // Act: Change state
         var beforeModTime = File.GetLastWriteTimeUtc(planYamlPath);
-        Thread.Sleep(10); // Ensure timestamp difference
+        // Wait until the wall clock has advanced past the current mtime by more than the Windows
+        // filesystem timestamp resolution (~15ms), so the next write is guaranteed a strictly newer
+        // mtime. A fixed 10ms sleep was below that resolution and could leave mtimes equal.
+        RetryHelper.WaitUntil(() => DateTime.UtcNow > beforeModTime.AddMilliseconds(20),
+            TimeSpan.FromSeconds(2));
         PlanYamlHelper.SetPlanStateByFolder(planFolder, "Building");
 
         // Assert: File was modified

--- a/src/Ivy.Tendril.Test/Services/GitServiceDirtyStateTests.cs
+++ b/src/Ivy.Tendril.Test/Services/GitServiceDirtyStateTests.cs
@@ -156,7 +156,9 @@ public class GitServiceDirtyStateTests : IDisposable
         Assert.True(result.IsSuccess);
         Assert.True(result.Value!.IsDirty);
         var reason = Assert.Single(result.Value!.Reasons, r => r.Reason == DirtyReason.AheadOfOrigin);
-        Assert.NotEmpty(reason.Files);
+        // AheadOfOrigin reports the unpushed commits (not files) — matches DirtyRepoDialog,
+        // which renders reason.Commits for this reason and reason.Files for the others.
+        Assert.NotEmpty(reason.Commits);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
@@ -9,7 +9,7 @@ namespace Ivy.Tendril.Test.Services;
 public class PlanReaderServiceTests
 {
     [Fact]
-    public void TransitionState_NotifiesPlanWatcher()
+    public async Task TransitionState_NotifiesPlanWatcher()
     {
         // Arrange
         var testConfig = new StubConfigService();
@@ -34,6 +34,9 @@ public class PlanReaderServiceTests
             // Act
             service.TransitionState(folderName, PlanStatus.ReadyForReview);
 
+            // Wait for the background plan.yaml write so the finally-block cleanup doesn't race it.
+            await service.FlushPendingWritesAsync();
+
             // Assert
             Assert.Contains(folderName, testWatcher.NotifiedFolders);
             Assert.Single(testWatcher.NotifiedFolders);
@@ -47,7 +50,7 @@ public class PlanReaderServiceTests
     }
 
     [Fact]
-    public void SaveRevision_NotifiesPlanWatcher()
+    public async Task SaveRevision_NotifiesPlanWatcher()
     {
         // Arrange
         var testConfig = new StubConfigService();
@@ -71,8 +74,9 @@ public class PlanReaderServiceTests
             // Act
             service.SaveRevision(folderName, content);
 
-            // Give background write a moment to complete
-            Thread.Sleep(100);
+            // Deterministically wait for the background write to finish (not a fixed sleep) so the
+            // assertions and the finally-block cleanup don't race the still-open file handle.
+            await service.FlushPendingWritesAsync();
 
             // Assert
             Assert.Contains(folderName, testWatcher.NotifiedFolders);

--- a/src/Ivy.Tendril.Test/WorktreeValidationTests.cs
+++ b/src/Ivy.Tendril.Test/WorktreeValidationTests.cs
@@ -73,7 +73,10 @@ projects:
         File.WriteAllText(Path.Combine(configDir, "config.yaml"), yaml);
 
         var testLogger = new TestLogger<ConfigService>();
-        var service = new ConfigService(logger: testLogger);
+        // Use the in-memory-settings ctor (not the public one) so construction doesn't read/write
+        // the shared default TENDRIL_HOME — that's a parallel-test race. SetTendrilHome below loads
+        // the real config from the isolated temp dir.
+        var service = new ConfigService(new TendrilSettings(), logger: testLogger);
         service.SetTendrilHome(configDir);
 
         service.ValidateRepoPathsAreNotWorktrees();
@@ -102,7 +105,10 @@ projects:
         File.WriteAllText(Path.Combine(configDir, "config.yaml"), yaml);
 
         var testLogger = new TestLogger<ConfigService>();
-        var service = new ConfigService(logger: testLogger);
+        // Use the in-memory-settings ctor (not the public one) so construction doesn't read/write
+        // the shared default TENDRIL_HOME — that's a parallel-test race. SetTendrilHome below loads
+        // the real config from the isolated temp dir.
+        var service = new ConfigService(new TendrilSettings(), logger: testLogger);
         service.SetTendrilHome(configDir);
 
         service.ValidateRepoPathsAreNotWorktrees();

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -248,6 +248,12 @@ public class JobService : IJobService
         RaiseJobsStructureChanged();
     }
 
+    /// <summary>
+    ///     Runs the blocked-job dependency re-check synchronously. Exposed for tests so they can
+    ///     drive the check deterministically instead of waiting for the 60s periodic timer.
+    /// </summary>
+    internal void RunBlockedJobCheck() => OnBlockedJobCheckTimer(null);
+
     private void OnBlockedJobCheckTimer(object? state)
     {
         try

--- a/src/Ivy.Tendril/Services/Plans/PlanWatcherService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanWatcherService.cs
@@ -6,15 +6,26 @@ namespace Ivy.Tendril.Services.Plans;
 
 public class PlanWatcherService : IPlanWatcherService
 {
+    // Default self-heal cadence: the top-level FSW fires when a plan folder first appears
+    // (still empty), but plan.yaml / Revisions land a moment later and writes *inside* the
+    // folder don't re-trigger the watcher. These staggered re-scans surface the now-complete
+    // folder within seconds instead of waiting for the 30s poll.
+    private static readonly int[] DefaultSelfHealDelaysMs = { 1000, 3000, 8000 };
+
     private readonly Timer _debounceTimer;
     private readonly FileSystemWatcher? _watcher;
     private readonly System.Threading.Timer? _pollTimer;
     private readonly ILogger<PlanWatcherService>? _logger;
+    private readonly int[] _selfHealDelaysMs;
+    private readonly object _selfHealLock = new();
+    private List<System.Threading.Timer> _selfHealTimers = new();
     private string? _pendingPlanFolder;
 
-    public PlanWatcherService(IConfigService config, ILogger<PlanWatcherService>? logger = null)
+    public PlanWatcherService(IConfigService config, ILogger<PlanWatcherService>? logger = null,
+        int[]? selfHealDelaysMs = null)
     {
         _logger = logger;
+        _selfHealDelaysMs = selfHealDelaysMs ?? DefaultSelfHealDelaysMs;
         _debounceTimer = new Timer(500);
         _debounceTimer.AutoReset = false;
         _debounceTimer.Elapsed += (_, _) =>
@@ -48,13 +59,25 @@ public class PlanWatcherService : IPlanWatcherService
             EnableRaisingEvents = true
         };
 
-        _watcher.Created += (_, _) => ScheduleDebounce(null);
+        // Created/Renamed/Error may indicate a new plan folder whose content (plan.yaml,
+        // first revision) is still being written; schedule self-heal re-scans so it surfaces
+        // promptly. Deleted needs no self-heal — there is no late-arriving content to wait for.
+        _watcher.Created += (_, _) =>
+        {
+            ScheduleDebounce(null);
+            ScheduleSelfHeal();
+        };
         _watcher.Deleted += (_, _) => ScheduleDebounce(null);
-        _watcher.Renamed += (_, _) => ScheduleDebounce(null);
+        _watcher.Renamed += (_, _) =>
+        {
+            ScheduleDebounce(null);
+            ScheduleSelfHeal();
+        };
         _watcher.Error += (_, e) =>
         {
             CrashLog.Write($"[{DateTime.UtcNow:O}] PlanWatcher FSW error: {e.GetException()}");
             ScheduleDebounce(null);
+            ScheduleSelfHeal();
         };
 
         // Poll as a safety net for external edits to plan.yaml or metadata files
@@ -85,6 +108,57 @@ public class PlanWatcherService : IPlanWatcherService
         _pollTimer?.Dispose();
         _watcher?.Dispose();
         _debounceTimer.Dispose();
+
+        lock (_selfHealLock)
+        {
+            foreach (var timer in _selfHealTimers)
+                timer.Dispose();
+            _selfHealTimers = new List<System.Threading.Timer>();
+        }
+    }
+
+    /// <summary>
+    ///     Schedules a short burst of full re-scans after a top-level folder event. A brand-new
+    ///     plan folder fires the FSW while still empty; its plan.yaml / first revision land a
+    ///     moment later, and those writes (inside the folder) don't re-trigger the watcher. These
+    ///     staggered re-scans pick up the completed folder within seconds rather than waiting for
+    ///     the 30s poll.
+    ///     <para>
+    ///     Trade-off: a single folder event now yields up to N+1 full re-scans (the debounce plus
+    ///     one per delay) instead of one. Plan-folder events are infrequent and each new event
+    ///     replaces the prior burst, so the extra I/O is bounded and acceptable.
+    ///     </para>
+    /// </summary>
+    private void ScheduleSelfHeal()
+    {
+        var newTimers = new List<System.Threading.Timer>(_selfHealDelaysMs.Length);
+        foreach (var delayMs in _selfHealDelaysMs)
+        {
+            // Fire an independent full rescan at each delay rather than routing through the
+            // debounce (which would coalesce the staggered timers into a single fire). Each
+            // rescan is a fresh chance to pick up content that landed after the last one.
+            var timer = new System.Threading.Timer(_ =>
+            {
+                try
+                {
+                    PlansChanged?.Invoke(null);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "Failed to invoke PlansChanged during self-heal");
+                    // Swallow to prevent unhandled exceptions on the timer's thread-pool
+                    // thread from terminating the process.
+                }
+            }, null, delayMs, Timeout.Infinite);
+            newTimers.Add(timer);
+        }
+
+        lock (_selfHealLock)
+        {
+            foreach (var timer in _selfHealTimers)
+                timer.Dispose();
+            _selfHealTimers = newTimers;
+        }
     }
 
     private void ScheduleDebounce(string? planFolder)


### PR DESCRIPTION
## #1257 — New drafts don't appear on the Drafts page until restart

A newly created plan folder fires the top-level `FileSystemWatcher` while still empty; the later writes *inside* the folder (`plan.yaml`, first revision) don't re-trigger it (watcher is `DirectoryName`-only, no subdirectories). So a draft created outside the GUI's job pipeline could take up to the 30s poll to appear.

**Fix:** after a `Created`/`Renamed`/`Error` event, `PlanWatcherService` schedules a short burst of staggered full re-scans (default +1s/+3s/+8s) so the completed folder is picked up within seconds. The 30s poll remains as the long-stop. Delays are injectable for deterministic tests.

Covered by new `PlanWatcherServiceTests` (a self-heal unit test + a DB-sync integration test that proves an out-of-band plan reaches the DB without a restart).

## Test-suite hardening (deterministic under parallel load)

Audited every timing primitive in the test project and fixed the genuinely flaky ones:

- **`JobService.RunBlockedJobCheck()`** (new internal) — lets the blocked-job dependency test drive the check directly instead of `await Task.Delay(70s)`.
- Fixed sleeps → poll-until-condition (new sync `RetryHelper.WaitUntil`): notify tests flush background writes; inbox race/stagger tests poll observable state; the stagger test asserts the deterministic cumulative-span floor instead of jitter-prone per-gap timing; the sub-resolution 10ms timestamp sleep uses a clock-advance wait.
- `GitServiceDirtyStateTests.AheadOfOrigin` asserts `reason.Commits` (what the code populates) rather than `reason.Files`.
- `WorktreeValidationTests` uses the in-memory-settings `ConfigService` ctor to avoid a shared default `TENDRIL_HOME` race.

Verified: 5 consecutive fully-green full-suite runs (1461 passed, 1 skipped, 0 failed). Worst single test dropped from ~70s to instant.