### PR TITLE
Send git commit SHA as commitId in bug reports

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -123,7 +123,8 @@ jobs:
           dotnet pack src/Ivy.Tendril/Ivy.Tendril.csproj \
             --configuration Release \
             --output ./nupkg \
-            /p:Version=${{ needs.version.outputs.version }}
+            /p:Version=${{ needs.version.outputs.version }} \
+            /p:CommitId=${{ github.sha }}
 
       - name: NuGet login
         uses: NuGet/login@v1
@@ -244,6 +245,7 @@ jobs:
             -p:PublishSingleFile=true \
             -p:ReadyToRun=false \
             -p:Version=${{ needs.version.outputs.version }} \
+            -p:CommitId=${{ github.sha }} \
             --self-contained true
 
       - name: Bundle PowerShell 7

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -109,6 +109,24 @@
     <None Include="../../README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
+  <Target Name="SetCommitId" BeforeTargets="GetAssemblyAttributes">
+    <!-- CI passes -p:CommitId=<sha>; locally fall back to git. Embedded as assembly metadata
+         and read at runtime by BugReportService to tag bug reports with the source revision. -->
+    <Exec Condition="'$(CommitId)' == ''"
+          Command="git rev-parse HEAD"
+          ConsoleToMSBuild="true"
+          ContinueOnError="true"
+          StandardOutputImportance="low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="CommitId" />
+    </Exec>
+    <ItemGroup Condition="'$(CommitId)' != ''">
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+        <_Parameter1>CommitId</_Parameter1>
+        <_Parameter2>$(CommitId)</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
+
   <Target Name="PackPromptwaresZip" BeforeTargets="PrepareForBuild" Condition="'$(Configuration)' == 'Release'">
     <Exec Command="pwsh -NoProfile -File &quot;$(MSBuildThisFileDirectory)pack-promptwares.ps1&quot; -IntermediateOutputPath &quot;$(IntermediateOutputPath).&quot;" />
     <ItemGroup>

--- a/src/Ivy.Tendril/Services/BugReportService.cs
+++ b/src/Ivy.Tendril/Services/BugReportService.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using System.Net.Http.Headers;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Helpers;
@@ -64,14 +65,25 @@ public sealed class BugReportService
             var version = typeof(BugReportService).Assembly.GetName().Version?.ToString(3) ?? "unknown";
             var osVersion = Environment.OSVersion.VersionString;
             var agent = _config.Settings.CodingAgent;
+            var commitId = GetCommitId();
 
-            return await UploadAsync(zipPath, description, osVersion, version, agent, ct);
+            return await UploadAsync(zipPath, description, osVersion, version, agent, commitId, ct);
         }
         finally
         {
             File.Delete(zipPath);
         }
     }
+
+    /// <summary>
+    ///     Reads the git commit the assembly was built from, embedded as <c>[AssemblyMetadata("CommitId", ...)]</c>
+    ///     by the <c>SetCommitId</c> MSBuild target. Returns <c>null</c> when no commit was embedded
+    ///     (e.g. a build with no git working tree), in which case the report is sent without a commit id.
+    /// </summary>
+    private static string? GetCommitId() =>
+        typeof(BugReportService).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == "CommitId")?.Value;
 
     private void AddSanitizedConfig(List<BugReportFile> files)
     {
@@ -212,7 +224,7 @@ public sealed class BugReportService
         return zipPath;
     }
 
-    private static async Task<BugReportResult?> UploadAsync(string zipPath, string description, string osVersion, string tendrilVersion, string agent, CancellationToken ct)
+    private static async Task<BugReportResult?> UploadAsync(string zipPath, string description, string osVersion, string tendrilVersion, string agent, string? commitId, CancellationToken ct)
     {
         using var httpClient = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
         using var form = new MultipartFormDataContent();
@@ -221,6 +233,9 @@ public sealed class BugReportService
         form.Add(new StringContent(osVersion), "osVersion");
         form.Add(new StringContent(tendrilVersion), "tendrilVersion");
         form.Add(new StringContent(agent), "agent");
+
+        if (!string.IsNullOrWhiteSpace(commitId))
+            form.Add(new StringContent(commitId), "commitId");
 
         var fileStream = File.OpenRead(zipPath);
         var fileContent = new StreamContent(fileStream);


### PR DESCRIPTION
## Summary
Tags bug reports with the source revision the client was built from, so a report can be traced back to exact code. Pairs with the backend's optional `commitId` field on `report-bug`.

- **Embed commit at build time** (`Ivy.Tendril.csproj`): a `SetCommitId` MSBuild target emits `[AssemblyMetadata("CommitId", …)]`. Uses CI-passed `-p:CommitId` when present, otherwise falls back to `git rev-parse HEAD` so local/dev builds are tagged too. Hooks `BeforeTargets="GetAssemblyAttributes"` and is tolerant of a missing git (no attribute → field omitted).
- **Read & send** (`BugReportService.cs`): `GetCommitId()` reads the embedded attribute; `UploadAsync` adds the optional `commitId` form field only when non-empty.
- **CI** (`publish-tendril.yml`): pass `-p:CommitId=${{ github.sha }}` to the `dotnet pack` and `dotnet publish` steps.

## Verification
- Local build → embeds current `git rev-parse HEAD`.
- `-p:CommitId=<sha>` override wins over git.
- Build still succeeds with no git (attribute omitted; report uploads without `commitId`).

Dev builds are tagged with their HEAD commit (last commit, not uncommitted working-tree state).