### PR TITLE
Fix #1272: make PR merge depend solely on PrMerge, not prRule

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md
@@ -2,9 +2,9 @@
 
 **Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined as verifications in the project configuration. Examples in this document use multiple tech stacks for illustration.
 
-Create GitHub pull requests and apply PR rules.
+Create GitHub pull requests, then merge them only when explicitly told to.
 
-**!CRITICAL: ALL steps are mandatory. Do not skip PR rule application.**
+**!CRITICAL: ALL steps are mandatory. Whether to merge is controlled entirely by the `PrMerge` firmware header value — never infer it from anything else.**
 
 ## Context
 
@@ -12,14 +12,9 @@ The firmware header contains:
 - **TendrilPlanFolder** — path to the plan folder
 - **CurrentTime** — current UTC timestamp
 - **SourceUrl** — (optional) GitHub issue or PR URL from plan.yaml
+- **`Pr*` flags** — the explicit PR options (see step 1). These are the *only* source of truth for what to do.
 
 The plan structure and CLI commands are in the **Reference Documents** section of your firmware.
-Project configuration (repos, `prRule` settings) is available from the firmware header.
-
-## PR Rules (per repo, from RepoConfigs header)
-
-- **`default`** — Create the PR and stop
-- **`yolo`** — Create PR → auto-merge with `--admin` → delete remote branch → pull default branch into the original local repo
 
 ## Execution Steps
 
@@ -33,9 +28,8 @@ Before processing, read `plan.yaml` and check the `state` field. After reading, 
 
 - Read `plan.yaml` from the plan folder (project, commits, repos)
 - Read the latest revision for the plan title and description
-- Find the `prRule` for each repo from the firmware header
-- **Check for custom options:** Read the following firmware header values (if present). These override the default behavior in subsequent steps. If not present, all flags default to the behavior defined by the repo's `prRule`.
-  - `PrMerge` — `true`/`false` (default: `true`)
+- **Read the PR option flags** from the firmware header. These drive every decision below. If a flag is absent, use the default shown:
+  - `PrMerge` — `true`/`false` (default: `true`) — **whether to merge the PR after creating it**
   - `PrDeleteBranch` — `true`/`false` (default: `true`)
   - `PrIncludeArtifacts` — `true`/`false` (default: `true`)
   - `PrAssignee` — GitHub username (default: none)
@@ -118,16 +112,14 @@ gh pr comment <pr-number> --repo <owner/repo> --body "<comment>"
 
 If no custom options or `comment` is empty, skip this step.
 
-### 4. Apply PR Rule
+### 4. Merge (only if `PrMerge` is `true`)
 
-**!MANDATORY** — look up the `prRule` for this repo in the `RepoConfigs` firmware header.
+**!STOP — MERGE GATE. The single deciding factor is the `PrMerge` firmware header value. Nothing else.**
 
-**Custom options override:** If custom options exist, the flags override the yolo behavior:
-- If `merge` is `false`: skip the entire merge step (treat as `default` rule regardless of prRule)
-- If `merge` is `true` but `deleteBranch` is `false`: merge without `--delete-branch` flag
-- If `merge` and `deleteBranch` are both `true`: behave exactly like `yolo`
+- **If `PrMerge` is `false`: do NOT merge.** Do **not** run `gh pr merge` under any circumstances. The PR stays open for manual review. Skip directly to step 5. (Do not look for any other rule or signal — there is none.)
+- **If `PrMerge` is `true` (or the flag is absent):** merge the PR using the flags below — always `--merge --admin`, plus `--delete-branch` only when `PrDeleteBranch` is `true` (default `true`).
 
-**Merge conflict handling (applies to ALL merge paths below):**
+**Merge conflict handling (applies only when merging):**
 
 Before calling `gh pr merge`, check for merge conflicts:
 
@@ -187,9 +179,9 @@ When the PR status is `CONFLICTING`, resolve the conflict locally before retryin
 
 **Important:** Only attempt conflict resolution **once**. If the second mergeability check still shows CONFLICTING, fail the execution — infinite retry loops waste tokens and time.
 
-**If `yolo` (and no custom options overriding):**
+**Merge command** (build `--delete-branch` from `PrDeleteBranch`):
 ```bash
-gh pr merge <pr-number> --repo <owner/repo> --merge --delete-branch --admin
+gh pr merge <pr-number> --repo <owner/repo> --merge [--delete-branch] --admin
 cd <original-repo-path>
 # Only pull if the local repo is clean (no uncommitted changes, on the default branch)
 if [ -z "$(git status --porcelain)" ] && [ "$(git symbolic-ref --short HEAD)" = "<default-branch>" ]; then
@@ -199,12 +191,9 @@ fi
 
 > **Note:** If `--merge` fails with "Merge commits are not allowed", retry with `--squash` instead.
 
-
-**If `default`:** PR stays open for manual review.
-
 ### 5. Clean Up Worktrees
 
-After successful `yolo` merges (or custom options with `merge: true`), clean up the worktrees to reclaim disk space:
+After a successful merge (`PrMerge: true`), clean up the worktrees to reclaim disk space:
 
 For each repo where the PR was merged:
 
@@ -212,7 +201,7 @@ For each repo where the PR was merged:
 tendril plan remove-worktree <TendrilPlanId> <repo-folder-name>
 ```
 
-**Skip cleanup** for repos using the `default` PR rule (or custom options with `merge: false`) — the worktree is still needed for potential review revisions.
+**Skip cleanup** when `PrMerge` is `false` — the worktree is still needed for potential review revisions.
 
 If cleanup fails, log a warning but do not fail the overall CreatePr execution.
 
@@ -226,13 +215,13 @@ Add each PR URL:
 tendril plan add-pr <plan-id> <pr-url>
 ```
 
-**Update state to Completed:** If ALL repos in the plan used the `yolo` prRule (or custom options with `merge: true`) and ALL PRs were successfully merged, update the state:
+**Update state to Completed:** If `PrMerge` is `true` and ALL PRs were successfully merged, update the state:
 
 ```bash
 tendril plan set <plan-id> state Completed
 ```
 
-If ANY repo used the `default` prRule (or custom options with `merge: false`), do NOT update the state — the plan remains open for manual review and potential revisions.
+If `PrMerge` is `false`, do NOT update the state — the plan remains open for manual review and potential revisions.
 
 ### Edge Case: Direct-to-Main (No PR Needed)
 

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
@@ -196,10 +196,8 @@ git worktree add "<TendrilPlanFolder>/Worktrees/<RepoName>" -b "tendril/<Tendril
 RepoConfigs: |
   - path: /home/user/repos/my-project
     baseBranch: main
-    prRule: yolo
   - path: /home/user/repos/shared-lib
     baseBranch: main
-    prRule: default
     readOnly: true
 ```
 If `baseBranch` is present for a repo, use it instead of auto-detecting. If absent, fall back to `git symbolic-ref refs/remotes/origin/HEAD`.
@@ -445,7 +443,7 @@ After all verifications pass:
 Worktrees are **not** cleaned up by ExecutePlan. They remain on disk so that CreatePr can push branches and create PRs directly from the worktree.
 
 **Cleanup happens later, in two places:**
-1. **CreatePr Step 5** — cleans up worktrees after PRs are created and (for yolo-rule repos) merged.
+1. **CreatePr Step 5** — cleans up worktrees after PRs are created and (when `PrMerge` is `true`) merged.
 2. **WorktreeCleanupService** — safety net that runs every 30 minutes and removes worktrees for plans in terminal states (Completed, Failed, Skipped) after a 10-minute grace period.
 
 **Git branches are preserved** until CreatePr consumes them — only the worktree filesystem directories are removed.

--- a/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
@@ -32,7 +32,54 @@ projects:
     repos:
       - path: D:\TestRepo
         prRule: default
+      - path: D:\YoloRepo
+        prRule: yolo
+        baseBranch: development
 ");
+    }
+
+    private JobLauncher CreateLauncher()
+    {
+        var configService = new ConfigService(new TendrilSettings());
+        configService.SetTendrilHome(_tempTendrilHome);
+        return new JobLauncher(configService, null,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance, _tempPromptsRoot);
+    }
+
+    private string? InvokeBuildRepoConfigsYaml(JobLauncher launcher, PlanYaml plan, string project)
+    {
+        var method = typeof(JobLauncher).GetMethod("BuildRepoConfigsYaml",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        return (string?)method?.Invoke(launcher, new object[] { plan, project });
+    }
+
+    // prRule is a UI-only concept (it decides whether the PR dialog is shown and its defaults).
+    // It must NOT leak into the firmware header — the CreatePr promptware acts solely on the
+    // explicit Pr* flags, and a stray "prRule: yolo" used to make the agent merge despite the
+    // user opting out (issue #1272).
+    [Fact]
+    public void BuildRepoConfigsYaml_DoesNotEmitPrRule_EvenForYoloRepo()
+    {
+        var launcher = CreateLauncher();
+        var plan = new PlanYaml { Project = "TestProject", Repos = { @"D:\YoloRepo" } };
+
+        var yaml = InvokeBuildRepoConfigsYaml(launcher, plan, "TestProject");
+
+        Assert.NotNull(yaml);
+        Assert.DoesNotContain("prRule", yaml);
+        Assert.DoesNotContain("yolo", yaml);
+    }
+
+    [Fact]
+    public void BuildRepoConfigsYaml_StillEmitsBaseBranch()
+    {
+        var launcher = CreateLauncher();
+        var plan = new PlanYaml { Project = "TestProject", Repos = { @"D:\YoloRepo" } };
+
+        var yaml = InvokeBuildRepoConfigsYaml(launcher, plan, "TestProject");
+
+        Assert.NotNull(yaml);
+        Assert.Contains("baseBranch: development", yaml);
     }
 
     public void Dispose()

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -288,7 +288,14 @@ public class ContentView(
             {
                 if (allYolo)
                 {
-                    jobService.StartJob(new CreatePrArgs(selectedPlan.FolderPath, SolveMergeConflicts: true));
+                    // "yolo" is purely a UI setting: skip the dialog and create the PR with the
+                    // merge-and-clean-up defaults. The promptware acts only on these explicit flags.
+                    jobService.StartJob(new CreatePrArgs(
+                        selectedPlan.FolderPath,
+                        SolveMergeConflicts: true,
+                        Merge: true,
+                        DeleteBranch: true,
+                        IncludeArtifacts: true));
                     planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
                     refreshPlans();
                 }

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -2,9 +2,9 @@
 
 **Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined as verifications in the project configuration. Examples in this document use multiple tech stacks for illustration.
 
-Create GitHub pull requests and apply PR rules.
+Create GitHub pull requests, then merge them only when explicitly told to.
 
-**!CRITICAL: ALL steps are mandatory. Do not skip PR rule application.**
+**!CRITICAL: ALL steps are mandatory. Whether to merge is controlled entirely by the `PrMerge` firmware header value — never infer it from anything else.**
 
 ## Context
 
@@ -12,14 +12,9 @@ The firmware header contains:
 - **TendrilPlanFolder** — path to the plan folder
 - **CurrentTime** — current UTC timestamp
 - **SourceUrl** — (optional) GitHub issue or PR URL from plan.yaml
+- **`Pr*` flags** — the explicit PR options (see step 1). These are the *only* source of truth for what to do.
 
 The plan structure and CLI commands are in the **Reference Documents** section of your firmware.
-Project configuration (repos, `prRule` settings) is available from the firmware header.
-
-## PR Rules (per repo, from RepoConfigs header)
-
-- **`default`** — Create the PR and stop
-- **`yolo`** — Create PR → auto-merge with `--admin` → delete remote branch → pull default branch into the original local repo
 
 ## Execution Steps
 
@@ -45,10 +40,9 @@ Before processing, read `plan.yaml` and check the `state` field. After reading, 
 
 - Read `plan.yaml` from the plan folder (project, commits, repos)
 - Read the latest revision for the plan title and description
-- Find the `prRule` for each repo from the firmware header
-- **Check for custom options:** Read the following firmware header values (if present). These override the default behavior in subsequent steps. If not present, all flags default to the behavior defined by the repo's `prRule`.
+- **Read the PR option flags** from the firmware header. These drive every decision below. If a flag is absent, use the default shown:
   - `PrSolveMergeConflicts` — `true`/`false` (default: `true`)
-  - `PrMerge` — `true`/`false` (default: `true`)
+  - `PrMerge` — `true`/`false` (default: `true`) — **whether to merge the PR after creating it**
   - `PrDeleteBranch` — `true`/`false` (default: `true`)
   - `PrIncludeArtifacts` — `true`/`false` (default: `true`)
   - `PrAssignee` — GitHub username (default: none)
@@ -227,22 +221,23 @@ This step runs regardless of whether a merge will be performed in step 4. Even i
 
 If `PrSolveMergeConflicts` is `false`, skip this step entirely — the PR may be left in a conflicting state.
 
-### 4. Apply PR Rule
+### 4. Merge (only if `PrMerge` is `true`)
 
-Report status: `tendril job status TendrilJobId --message "Applying PR rule..."`
+Report status: `tendril job status TendrilJobId --message "Applying merge options..."`
 
-**!MANDATORY** — look up the `prRule` for this repo in the `RepoConfigs` firmware header.
+**!STOP — MERGE GATE. The single deciding factor is the `PrMerge` firmware header value. Nothing else.**
 
-**Custom options override:** If custom options exist, the flags override the yolo behavior:
-- If `merge` is `false`: skip the entire merge step (treat as `default` rule regardless of prRule)
-- If `merge` is `true` but `deleteBranch` is `false`: merge without `--delete-branch` flag
-- If `merge` and `deleteBranch` are both `true`: behave exactly like `yolo`
+- **If `PrMerge` is `false`: do NOT merge.** Do **not** run `gh pr merge` under any circumstances. The PR stays open for manual review. Skip directly to step 5. (Do not look for any other rule or signal — there is none.)
+- **If `PrMerge` is `true` (or the flag is absent):** merge the PR using the flags below.
 
 **Note:** Merge conflict resolution is handled in step 3.7 if `PrSolveMergeConflicts` was `true`. By this step, the PR should already be conflict-free (if step 3.7 ran successfully).
 
-**If `yolo` (and no custom options overriding):**
+When merging, build the command from the flags:
+- Always pass `--merge --admin`.
+- Add `--delete-branch` **only if `PrDeleteBranch` is `true`** (default `true`).
+
 ```bash
-gh pr merge <pr-number> --repo <owner/repo> --merge --delete-branch --admin
+gh pr merge <pr-number> --repo <owner/repo> --merge [--delete-branch] --admin
 cd <original-repo-path>
 # Only pull if the local repo is clean (no uncommitted changes, on the default branch)
 if [ -z "$(git status --porcelain)" ] && [ "$(git symbolic-ref --short HEAD)" = "<default-branch>" ]; then
@@ -252,14 +247,11 @@ fi
 
 > **Note:** If `--merge` fails with "Merge commits are not allowed", retry with `--squash` instead.
 
-
-**If `default`:** PR stays open for manual review.
-
 ### 5. Clean Up Worktrees
 
 Report status: `tendril job status TendrilJobId --message "Cleaning up worktrees..."`
 
-After successful `yolo` merges (or custom options with `merge: true`), clean up the worktrees to reclaim disk space:
+After a successful merge (`PrMerge: true`), clean up the worktrees to reclaim disk space:
 
 For each repo where the PR was merged:
 
@@ -267,7 +259,7 @@ For each repo where the PR was merged:
 tendril plan remove-worktree <TendrilPlanId> <repo-folder-name>
 ```
 
-**Skip cleanup** for repos using the `default` PR rule (or custom options with `merge: false`) — the worktree is still needed for potential review revisions.
+**Skip cleanup** when `PrMerge` is `false` — the worktree is still needed for potential review revisions.
 
 If cleanup fails, log a warning but do not fail the overall CreatePr execution.
 
@@ -281,13 +273,13 @@ Add each PR URL:
 tendril plan add-pr <plan-id> <pr-url>
 ```
 
-**Update state to Completed:** If ALL repos in the plan used the `yolo` prRule (or custom options with `merge: true`) and ALL PRs were successfully merged, update the state:
+**Update state to Completed:** If `PrMerge` is `true` and ALL PRs were successfully merged, update the state:
 
 ```bash
 tendril plan set <plan-id> state Completed
 ```
 
-If ANY repo used the `default` prRule (or custom options with `merge: false`), do NOT update the state — the plan remains open for manual review and potential revisions.
+If `PrMerge` is `false`, do NOT update the state — the plan remains open for manual review and potential revisions.
 
 ### Edge Case: Direct-to-Main (No PR Needed)
 

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -190,10 +190,8 @@ git worktree add "<TendrilPlanFolder>/Worktrees/<RepoName>" -b "tendril/<Tendril
 RepoConfigs: |
   - path: /home/user/repos/my-project
     baseBranch: main
-    prRule: yolo
   - path: /home/user/repos/shared-lib
     baseBranch: main
-    prRule: default
     readOnly: true
 ```
 If `baseBranch` is present for a repo, use it instead of auto-detecting. If absent, fall back to `git symbolic-ref refs/remotes/origin/HEAD`.
@@ -462,7 +460,7 @@ After all verifications pass:
 Worktrees are **not** cleaned up by ExecutePlan. They remain on disk so that CreatePr can push branches and create PRs directly from the worktree.
 
 **Cleanup happens later, in two places:**
-1. **CreatePr Step 5** — cleans up worktrees after PRs are created and (for yolo-rule repos) merged.
+1. **CreatePr Step 5** — cleans up worktrees after PRs are created and (when `PrMerge` is `true`) merged.
 2. **WorktreeCleanupService** — safety net that runs every 30 minutes and removes worktrees for plans in terminal states (Completed, Failed, Skipped) after a 10-minute grace period.
 
 **Git branches are preserved** until CreatePr consumes them — only the worktree filesystem directories are removed.

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -21,7 +21,6 @@ internal record JobLaunchContext(
 internal record RepoConfigEntry(
     string Path,
     string BaseBranch,
-    string PrRule,
     bool ReadOnly);
 
 internal class JobLauncher
@@ -596,7 +595,6 @@ internal class JobLauncher
             var entry = new RepoConfigEntry(
                 expanded,
                 repoRef?.BaseBranch ?? GitHelper.ResolveDefaultBranch(expanded, _configService?.TendrilHome),
-                repoRef?.PrRule ?? "default",
                 ReadOnly: false);
             AddRepoToConfigLines(lines, entry);
         }
@@ -619,7 +617,6 @@ internal class JobLauncher
                 // Pass the raw config path: ResolveDefaultBranch owns expansion, so pre-expanding here
                 // would just run env-var expansion twice on the same value.
                 FindBaseBranchAcrossProjects(repoName, depPath),
-                "default",
                 ReadOnly: true);
             AddRepoToConfigLines(lines, entry);
         }
@@ -629,7 +626,6 @@ internal class JobLauncher
     {
         lines.Add($"- path: {entry.Path}");
         lines.Add($"  baseBranch: {entry.BaseBranch}");
-        lines.Add($"  prRule: {entry.PrRule}");
         if (entry.ReadOnly)
             lines.Add("  readOnly: true");
     }


### PR DESCRIPTION
## Problem

The CreatePr agent merged PRs that the user explicitly marked **don't merge** (`PrMerge: false`). Bug report job 00838 showed the firmware header carried both `PrMerge: false` *and* a conflicting `prRule: yolo` from `RepoConfigs`. The agent anchored on the prominent "MANDATORY" yolo rule, ran `gh pr merge --admin`, and never once reasoned about `PrMerge: false`.

Closes #1272.

## Fix — make `prRule` a UI-only concept

- **`JobLauncher`** no longer emits `prRule` into the `RepoConfigs` firmware header (only `baseBranch`/`readOnly` remain). Removed `PrRule` from `RepoConfigEntry`. The agent no longer sees a `yolo` rule to anchor on.
- **CreatePr promptware** (both the repo copy and the deployed TeamIvyConfig copy) now keys entirely off the always-present `Pr*` flags. Removed the "PR Rules" section and every `yolo`/`default`/`prRule` reference; step 4 leads with a hard merge gate: *the single deciding factor is `PrMerge`*.
- **`ContentView`** keeps `prRule` purely as the UI signal (auto-trigger vs. show the dialog); the auto path now passes explicit `Merge`/`DeleteBranch`/`IncludeArtifacts` flags.
- **ExecutePlan docs** drop the retired `prRule` example lines.

## Tests

New regressions assert `prRule` never leaks into the firmware header (even for a yolo-configured repo) while `baseBranch` still does. Full suite: **1464 passed, 1 skipped, 0 failed**.