### PR TITLE
Fix cancelled job unexpectedly transitioning to Review (#1259)

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/02_Concepts/01_Plans.md
+++ b/src/Ivy.Tendril.Docs/Docs/02_Concepts/01_Plans.md
@@ -32,10 +32,12 @@ A plan progresses through the following comprehensive set of states:
 | **Executing** | The `ExecutePlan` agent is actively implementing the plan in a worktree. |
 | **Updating** | The `UpdatePlan` agent is refining an existing, already-executed plan. |
 | **ReadyForReview** | Execution is complete, automated verifications passed. Ready for human review. |
-| **Failed** | The agent encountered a fatal error during implementation or verifications consistently failed. |
+| **Failed** | Automated verifications consistently failed after execution, or an interrupted execution could not be recovered. |
 | **Completed** | The plan has been reviewed, approved, and merged/PR'd successfully. |
 | **Skipped** | The plan was abandoned, discarded, or deemed unnecessary. |
 | **Icebox** | The plan has been shelved for later consideration. |
+
+> **Stopping or deleting a running job** returns the plan to the state it was in *before* the job started — e.g. a stopped `ExecutePlan` returns to `Draft`, a stopped `RetryPlan` returns to `ReadyForReview`. A stopped or failed run keeps its work product (worktree) so you can inspect or resume it; **deleting** an `ExecutePlan` job is the exception — it discards the work product (worktrees/artifacts) and resets the plan to a clean `Draft`.
 
 ## Creating a Plan
 

--- a/src/Ivy.Tendril.Docs/Docs/04_Apps/04_Jobs.md
+++ b/src/Ivy.Tendril.Docs/Docs/04_Apps/04_Jobs.md
@@ -30,6 +30,7 @@ Built-in terminal shows **stdout/stderr** from the agent (builds, logs, errors)â
 
 | Action | Effect |
 |--------|--------|
-| **Stop** | End the run; release worktree locks. |
+| **Stop** | End the run and return the plan to its previous state. The work product (worktree) is kept so you can resume. |
+| **Delete** | Remove the job from history. For an `ExecutePlan` job this also discards its work product and resets the plan to `Draft`. |
 | **Logs** | Open `logs/` for that plan. |
 | **Retry** | Re-run when a transition is stuck. |

--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -26,6 +26,154 @@ public class JobServiceCompletionGuardTests : IDisposable
             planReaderService: new StubPlanReaderService(plansDir));
     }
 
+    private (JobService Service, StubPlanReaderService Plan) CreateServiceWithStub(PlanStatus? currentStatus = null)
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+        var stub = new StubPlanReaderService(_tempDir.Path) { CurrentStatus = currentStatus };
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), planReaderService: stub);
+        return (service, stub);
+    }
+
+    [Fact]
+    public void StopJob_ExecutePlan_RevertsToPreviousDraft()
+    {
+        var (service, plan) = CreateServiceWithStub();
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
+        service.GetJob(id)!.PreviousPlanState = PlanStatus.Draft;
+
+        service.StopJob(id);
+
+        Assert.Equal(JobStatus.Stopped, service.GetJob(id)!.Status);
+        Assert.Contains(("test-plan", PlanStatus.Draft), plan.Transitions);
+        Assert.DoesNotContain(plan.Transitions, t => t.State == PlanStatus.ReadyForReview);
+        Assert.Empty(plan.ResetToDraftCalls);
+    }
+
+    [Fact]
+    public void StopJob_RetryPlan_RevertsToPreviousReview()
+    {
+        var (service, plan) = CreateServiceWithStub();
+        var id = service.CreateTestJob(new RetryPlanArgs("test-plan", "fix it"));
+        service.GetJob(id)!.PreviousPlanState = PlanStatus.ReadyForReview;
+
+        service.StopJob(id);
+
+        Assert.Contains(("test-plan", PlanStatus.ReadyForReview), plan.Transitions);
+        Assert.Empty(plan.ResetToDraftCalls);
+    }
+
+    [Fact]
+    public void StopJob_CreatePr_RevertsToPreviousReview()
+    {
+        var (service, plan) = CreateServiceWithStub();
+        var id = service.CreateTestJob(new CreatePrArgs("test-plan"));
+        // CreatePr starts from Review; snapshot lets it revert there (no fallback covers CreatePr).
+        service.GetJob(id)!.PreviousPlanState = PlanStatus.ReadyForReview;
+
+        service.StopJob(id);
+
+        Assert.Contains(("test-plan", PlanStatus.ReadyForReview), plan.Transitions);
+        Assert.DoesNotContain(plan.Transitions, t => t.State == PlanStatus.Building);
+    }
+
+    [Fact]
+    public void StopJob_UsesFallbackWhenSnapshotMissing()
+    {
+        var (service, plan) = CreateServiceWithStub();
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
+        // PreviousPlanState left null (e.g. after restart) → fallback map → Draft.
+
+        service.StopJob(id);
+
+        Assert.Contains(("test-plan", PlanStatus.Draft), plan.Transitions);
+    }
+
+    [Fact]
+    public void DeleteJob_ExecutePlan_NonTerminal_ResetsToDraft()
+    {
+        var (service, plan) = CreateServiceWithStub(currentStatus: PlanStatus.ReadyForReview);
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
+
+        service.DeleteJob(id);
+
+        Assert.Contains("test-plan", plan.ResetToDraftCalls);
+    }
+
+    [Fact]
+    public void DeleteJob_ExecutePlan_Terminal_DoesNotResetToDraft()
+    {
+        var (service, plan) = CreateServiceWithStub(currentStatus: PlanStatus.Completed);
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
+        service.GetJob(id)!.PreviousPlanState = PlanStatus.Draft;
+
+        service.DeleteJob(id);
+
+        Assert.Empty(plan.ResetToDraftCalls);
+    }
+
+    [Fact]
+    public void DeleteJob_RetryPlan_RevertsToReviewWithoutReset()
+    {
+        var (service, plan) = CreateServiceWithStub(currentStatus: PlanStatus.ReadyForReview);
+        var id = service.CreateTestJob(new RetryPlanArgs("test-plan", "again"));
+        service.GetJob(id)!.PreviousPlanState = PlanStatus.ReadyForReview;
+
+        service.DeleteJob(id);
+
+        Assert.Empty(plan.ResetToDraftCalls);
+        Assert.Contains(("test-plan", PlanStatus.ReadyForReview), plan.Transitions);
+    }
+
+    [Fact]
+    public void CompleteJob_CancelledExecutePlan_RevertsInsteadOfReview()
+    {
+        var (service, plan) = CreateServiceWithStub();
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
+        var job = service.GetJob(id)!;
+        job.PreviousPlanState = PlanStatus.Draft;
+        job.CancellationRequested = true;
+
+        // Completion path wins the race after cancellation was requested.
+        service.CompleteJob(id, 0);
+
+        Assert.Contains(("test-plan", PlanStatus.Draft), plan.Transitions);
+        Assert.DoesNotContain(plan.Transitions, t => t.State == PlanStatus.ReadyForReview);
+    }
+
+    [Fact]
+    public void CompleteJob_FailedExecutePlan_RevertsAndKeepsWorktree()
+    {
+        var (service, plan) = CreateServiceWithStub();
+        var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
+        service.GetJob(id)!.PreviousPlanState = PlanStatus.Draft;
+
+        service.CompleteJob(id, 1);
+
+        Assert.Equal(JobStatus.Failed, service.GetJob(id)!.Status);
+        Assert.Contains(("test-plan", PlanStatus.Draft), plan.Transitions);
+        Assert.DoesNotContain(plan.Transitions, t => t.State is PlanStatus.Failed or PlanStatus.ReadyForReview);
+    }
+
+    [Fact]
+    public void CompleteJob_SuccessWithIncompleteVerifications_TransitionsToFailed()
+    {
+        // The success path is now the only producer of PlanStatus.Failed: execution
+        // completed (exit 0) but a verification is still Pending.
+        var (service, plan) = CreateServiceWithStub();
+        var planFolder = Path.Combine(_tempDir.Path, "00777-VerFail");
+        Directory.CreateDirectory(planFolder);
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"),
+            "state: Executing\nproject: Test\nverifications:\n- name: DotnetBuild\n  status: Pending\n");
+
+        var id = service.CreateTestJob(new ExecutePlanArgs(planFolder));
+
+        service.CompleteJob(id, 0);
+
+        Assert.Contains(("00777-VerFail", PlanStatus.Failed), plan.Transitions);
+        Assert.DoesNotContain(plan.Transitions, t => t.State == PlanStatus.ReadyForReview);
+    }
+
     [Fact]
     public void CompleteJob_ConcurrentCalls_OnlyFirstCompletes()
     {
@@ -181,6 +329,13 @@ public class JobServiceCompletionGuardTests : IDisposable
         public event Action? CountsInvalidated;
 #pragma warning restore CS0067
 
+        // Recording hooks for plan-state assertions.
+        public readonly List<(string Folder, PlanStatus State)> Transitions = new();
+        public readonly List<string> ResetToDraftCalls = new();
+
+        // Status returned by GetPlanByFolder (simulates the plan's current state).
+        public PlanStatus? CurrentStatus { get; set; }
+
         public void RecoverStuckPlans()
         {
         }
@@ -196,7 +351,10 @@ public class JobServiceCompletionGuardTests : IDisposable
 
         public PlanFile? GetPlanByFolder(string folderPath)
         {
-            return null;
+            if (CurrentStatus is not { } status) return null;
+            var metadata = new PlanMetadata(0, "", "", "", status, [], [], [], [], [], [],
+                default, default, null, null);
+            return new PlanFile(metadata, "", folderPath, "", 1);
         }
 
         public List<PlanFile> GetIceboxPlans()
@@ -206,10 +364,12 @@ public class JobServiceCompletionGuardTests : IDisposable
 
         public void TransitionState(string folderName, PlanStatus newState)
         {
+            Transitions.Add((folderName, newState));
         }
 
         public void ResetToDraft(string folderName)
         {
+            ResetToDraftCalls.Add(folderName);
         }
 
         public void ResetVerificationsForRetry(string folderName)

--- a/src/Ivy.Tendril.Test/RerunDialogTests.cs
+++ b/src/Ivy.Tendril.Test/RerunDialogTests.cs
@@ -1,4 +1,4 @@
-using Ivy.Tendril.Apps.Review.Dialogs;
+using Ivy.Tendril.Services.Git;
 
 namespace Ivy.Tendril.Test;
 
@@ -18,7 +18,7 @@ public class ResetToDraftDialogTests
             File.WriteAllText(Path.Combine(artifactsDir, "summary.md"), "test");
             File.WriteAllText(Path.Combine(logsDir, "001.md"), "test");
 
-            ResetToDraftDialog.CleanPlanState(planDir);
+            WorktreeCleanupService.CleanPlanState(planDir);
 
             Assert.False(Directory.Exists(artifactsDir));
             Assert.False(Directory.Exists(logsDir));
@@ -39,7 +39,7 @@ public class ResetToDraftDialogTests
             var planDir = Path.Combine(tempDir, "00001-TestPlan");
             Directory.CreateDirectory(planDir);
 
-            var ex = Record.Exception(() => ResetToDraftDialog.CleanPlanState(planDir));
+            var ex = Record.Exception(() => WorktreeCleanupService.CleanPlanState(planDir));
             Assert.Null(ex);
         }
         finally
@@ -65,7 +65,7 @@ public class ResetToDraftDialogTests
             Directory.CreateDirectory(verificationDir);
             Directory.CreateDirectory(revisionsDir);
 
-            ResetToDraftDialog.CleanPlanState(planDir);
+            WorktreeCleanupService.CleanPlanState(planDir);
 
             Assert.False(Directory.Exists(artifactsDir));
             Assert.False(Directory.Exists(logsDir));
@@ -93,7 +93,7 @@ public class ResetToDraftDialogTests
             File.WriteAllText(Path.Combine(screenshotsDir, "img.png"), "test");
             File.WriteAllText(Path.Combine(sampleDir, "app.dll"), "test");
 
-            ResetToDraftDialog.CleanPlanState(planDir);
+            WorktreeCleanupService.CleanPlanState(planDir);
 
             Assert.False(Directory.Exists(Path.Combine(planDir, "Artifacts")));
         }
@@ -116,7 +116,7 @@ public class ResetToDraftDialogTests
             Directory.CreateDirectory(repoDir);
             File.WriteAllText(Path.Combine(repoDir, "dummy.txt"), "test");
 
-            ResetToDraftDialog.CleanPlanState(planDir);
+            WorktreeCleanupService.CleanPlanState(planDir);
 
             Assert.False(Directory.Exists(worktreesDir));
         }

--- a/src/Ivy.Tendril.Test/Services/JobCompletionAttachmentTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobCompletionAttachmentTests.cs
@@ -39,7 +39,6 @@ public class JobCompletionAttachmentTests : IDisposable
             planReaderService: null,
             telemetryService: null,
             planWatcherService: null,
-            worktreeLifecycleLogger: null,
             promptsRoot: _promptsRoot
         );
     }

--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -121,7 +121,7 @@ public class ActionBarView(
                 Metadata = selectedPlan.Metadata with { State = PlanStatus.Updating }
             };
             selectedPlanState.Set(optimisticPlan);
-            planService.TransitionState(selectedPlan.FolderName, PlanStatus.Updating);
+            // Plan state transition (and pre-state snapshot) handled by JobService.StartJob.
             jobService.StartJob(new SplitPlanArgs(selectedPlan.FolderPath));
             refreshPlans();
         }
@@ -134,7 +134,7 @@ public class ActionBarView(
                 Metadata = selectedPlan.Metadata with { State = PlanStatus.Building }
             };
             selectedPlanState.Set(optimisticPlan);
-            planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+            // Plan state transition (and pre-state snapshot) handled by JobService.StartJob.
             jobService.StartJob(new ExpandPlanArgs(selectedPlan.FolderPath));
             refreshPlans();
         }

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -43,7 +43,7 @@ public class ContentView(
 
         var processView = Context.UseTendrilProcess();
 
-        var (updateDialog, showUpdateDialog) = UseTrigger((isOpen) => !isOpen.Value ? null : new UpdatePlanDialog(isOpen, selectedPlan!, selectedPlanState, jobService, planService, refreshPlans));
+        var (updateDialog, showUpdateDialog) = UseTrigger((isOpen) => !isOpen.Value ? null : new UpdatePlanDialog(isOpen, selectedPlan!, selectedPlanState, jobService, refreshPlans));
 
         var (deleteDialog, showDeleteDialog) = UseTrigger((isOpen) => !isOpen.Value ? null : new DeletePlanDialog(isOpen, selectedPlan!, selectedPlanState, planService, refreshPlans));
 
@@ -479,7 +479,8 @@ public class ContentView(
         refreshPlans();
     }
 
-    // Optimistically update UI state before disk I/O
+    // Optimistically update UI state; the authoritative plan transition (and pre-state
+    // snapshot) is performed by JobService.StartJob.
     private void TransitionPlanOptimistically(PlanStatus status)
     {
         var optimisticPlan = selectedPlan! with
@@ -487,8 +488,6 @@ public class ContentView(
             Metadata = selectedPlan.Metadata with { State = status }
         };
         selectedPlanState.Set(optimisticPlan);
-
-        planService.TransitionState(selectedPlan.FolderName, status);
     }
 
     private bool HasActiveJob<TArgs>() where TArgs : JobArgsBase

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/UpdatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/UpdatePlanDialog.cs
@@ -8,12 +8,10 @@ public class UpdatePlanDialog(
     PlanFile selectedPlan,
     IState<PlanFile?> selectedPlanState,
     IJobService jobService,
-    IPlanReaderService planService,
     Action refreshPlans) : ViewBase
 {
     private readonly IState<bool> _dialogOpen = dialogOpen;
     private readonly IJobService _jobService = jobService;
-    private readonly IPlanReaderService _planService = planService;
     private readonly Action _refreshPlans = refreshPlans;
     private readonly PlanFile _selectedPlan = selectedPlan;
     private readonly IState<PlanFile?> _selectedPlanState = selectedPlanState;
@@ -65,7 +63,7 @@ public class UpdatePlanDialog(
                         };
                         _selectedPlanState.Set(optimisticPlan);
 
-                        _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Updating);
+                        // Plan transition (and pre-state snapshot) handled by JobService.StartJob.
                         _jobService.StartJob(new UpdatePlanArgs(_selectedPlan.FolderPath, updateText.Value));
                         _refreshPlans();
                         updateText.Set("");

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -165,7 +165,7 @@ public class ContentView(
     private void LaunchExecute()
     {
         if (selectedPlan is null) return;
-        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+        // Plan transition (and pre-state snapshot) handled by JobService.StartJob.
         jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath));
         refreshPlans();
     }
@@ -181,7 +181,7 @@ public class ContentView(
             syncJobIds.Add(jobId);
         }
 
-        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+        // Plan transition (and pre-state snapshot) handled by JobService.StartJob.
         jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath) { WaitForJobs = syncJobIds });
         refreshPlans();
     }

--- a/src/Ivy.Tendril/Apps/Jobs/Dialogs/RerunJobDialog.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Dialogs/RerunJobDialog.cs
@@ -14,7 +14,6 @@ public class RerunJobDialog(
     IState<bool> dialogOpen,
     JobItem job,
     IJobService jobService,
-    IPlanReaderService planService,
     Action onRerun) : ViewBase
 {
     public override object? Build()
@@ -57,8 +56,9 @@ public class RerunJobDialog(
         if (job.TypedArgs == null) return;
 
         var newArgs = BuildRerunArgs(job.TypedArgs, feedbackText);
-        TransitionPlanState(newArgs);
 
+        // Plan state transition (and pre-state snapshot) is handled centrally by
+        // JobService.StartJob.
         jobService.DeleteJob(job.Id);
         jobService.StartJob(newArgs);
         onRerun();
@@ -79,33 +79,5 @@ public class RerunJobDialog(
             UpdatePlanArgs u => new UpdatePlanArgs(u.FolderPath, feedback),
             _ => original
         };
-    }
-
-    private void TransitionPlanState(JobArgsBase args)
-    {
-        var folder = args.PlanFolder;
-        if (string.IsNullOrEmpty(folder)) return;
-
-        var folderName = Path.GetFileName(folder);
-
-        // Only transition the plan for the job types that already drive plan state on a
-        // fresh in-app start. CreatePr/CreateIssue/Split/SyncRepo are deliberately left
-        // untouched so rerunning them doesn't knock the plan out of its current state
-        // (e.g. ReadyForReview -> Building, hiding it from the Review queue).
-        var targetState = args switch
-        {
-            ExecutePlanArgs => PlanStatus.Building,
-            ExpandPlanArgs => PlanStatus.Building,
-            RetryPlanArgs => PlanStatus.Executing,
-            UpdatePlanArgs => PlanStatus.Updating,
-            _ => (PlanStatus?)null
-        };
-
-        if (targetState == null) return;
-
-        if (args is RetryPlanArgs)
-            planService.ResetVerificationsForRetry(folderName);
-
-        planService.TransitionState(folderName, targetState.Value);
     }
 }

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
@@ -72,7 +72,7 @@ public partial class JobsApp : ViewBase
             if (!isOpen.Value) return null;
             var job = jobService.GetJob(jobId);
             if (job == null) return null;
-            return new RerunJobDialog(isOpen, job, jobService, planService, () => refreshToken.Refresh());
+            return new RerunJobDialog(isOpen, job, jobService, () => refreshToken.Refresh());
         });
 
         UseEffect(() => JobsApp.JobChangeHookDisposable(jobService, refreshToken));

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -79,13 +79,13 @@ public class ContentView(
         var (suggestChangesDialog, showSuggestChangesDialog) = UseTrigger((isOpen) =>
         {
             if (!isOpen.Value) return null;
-            return new SuggestChangesDialog(isOpen, selectedPlanState.Value!, jobService, planService, refreshPlans);
+            return new SuggestChangesDialog(isOpen, selectedPlanState.Value!, jobService, refreshPlans);
         });
 
         var (customPrDialog, showCustomPrDialog) = UseTrigger((isOpen) =>
         {
             if (!isOpen.Value) return null;
-            return new CustomPrDialog(isOpen, selectedPlanState.Value!, jobService, planService, refreshPlans,
+            return new CustomPrDialog(isOpen, selectedPlanState.Value!, jobService, refreshPlans,
                 assigneesQuery, assigneesError);
         });
 
@@ -296,7 +296,7 @@ public class ContentView(
                         Merge: true,
                         DeleteBranch: true,
                         IncludeArtifacts: true));
-                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+                    // Plan transition (and pre-state snapshot) handled by JobService.StartJob.
                     refreshPlans();
                 }
                 else

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -8,7 +8,6 @@ public class CustomPrDialog(
     IState<bool> dialogOpen,
     PlanFile selectedPlan,
     IJobService jobService,
-    IPlanReaderService planService,
     Action refreshPlans,
     QueryResult<string[]> assigneesQuery,
     IState<string?> assigneesError) : ViewBase
@@ -87,7 +86,7 @@ public class CustomPrDialog(
                             Assignee: customPrAssignee.Value,
                             Comment: string.IsNullOrEmpty(customPrComment.Value) ? null : customPrComment.Value,
                             Draft: customPrDraft.Value));
-                        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Building);
+                        // Plan transition (and pre-state snapshot) handled by JobService.StartJob.
                         refreshPlans();
                         isCreating.Set(false);
                         customPrSolveMergeConflicts.Set(true);

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
@@ -51,7 +51,7 @@ public class ResetToDraftDialog(
                         {
                             try
                             {
-                                CleanPlanState(folderPath, _logger);
+                                WorktreeCleanupService.CleanPlanState(folderPath, _logger);
                             }
                             catch (Exception ex)
                             {
@@ -62,38 +62,5 @@ public class ResetToDraftDialog(
                 })
             )
         ).Width(Size.Rem(40));
-    }
-
-    internal static void CleanPlanState(string planFolderPath, ILogger? logger = null)
-    {
-        var artifactsDir = Path.Combine(planFolderPath, "Artifacts");
-        if (Directory.Exists(artifactsDir))
-        {
-            logger?.LogInformation("Cleaning artifacts directory: {Path}", artifactsDir);
-            WorktreeCleanupService.ForceDeleteDirectory(artifactsDir, logger);
-        }
-
-        var logsDir = Path.Combine(planFolderPath, "Logs");
-        if (Directory.Exists(logsDir))
-        {
-            logger?.LogInformation("Cleaning logs directory: {Path}", logsDir);
-            WorktreeCleanupService.ForceDeleteDirectory(logsDir, logger);
-        }
-
-        var verificationDir = Path.Combine(planFolderPath, "Verification");
-        if (Directory.Exists(verificationDir))
-        {
-            logger?.LogInformation("Cleaning verification directory: {Path}", verificationDir);
-            WorktreeCleanupService.ForceDeleteDirectory(verificationDir, logger);
-        }
-
-        WorktreeCleanupService.RemoveWorktrees(planFolderPath, logger);
-
-        var worktreesDir = Path.Combine(planFolderPath, "Worktrees");
-        if (Directory.Exists(worktreesDir))
-        {
-            logger?.LogInformation("Cleaning worktrees directory: {Path}", worktreesDir);
-            WorktreeCleanupService.ForceDeleteDirectory(worktreesDir, logger);
-        }
     }
 }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
@@ -8,12 +8,10 @@ public class SuggestChangesDialog(
     IState<bool> dialogOpen,
     PlanFile selectedPlan,
     IJobService jobService,
-    IPlanReaderService planService,
     Action refreshPlans) : ViewBase
 {
     private readonly IState<bool> _dialogOpen = dialogOpen;
     private readonly IJobService _jobService = jobService;
-    private readonly IPlanReaderService _planService = planService;
     private readonly Action _refreshPlans = refreshPlans;
     private readonly PlanFile _selectedPlan = selectedPlan;
 
@@ -49,8 +47,7 @@ public class SuggestChangesDialog(
                     {
                         isCreating.Set(true);
 
-                        _planService.ResetVerificationsForRetry(_selectedPlan.FolderName);
-                        _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Executing);
+                        // Verification reset + plan transition (and pre-state snapshot) handled by JobService.StartJob.
                         _jobService.StartJob(new RetryPlanArgs(_selectedPlan.FolderPath, suggestText.Value));
                         _refreshPlans();
                         isCreating.Set(false);

--- a/src/Ivy.Tendril/Controllers/JobController.cs
+++ b/src/Ivy.Tendril/Controllers/JobController.cs
@@ -6,7 +6,7 @@ namespace Ivy.Tendril.Controllers;
 
 [ApiController]
 [Route("api/jobs")]
-public class JobController(IJobService jobService, IPlanReaderService planReaderService) : ControllerBase
+public class JobController(IJobService jobService) : ControllerBase
 {
     private static string NormalizeJobId(string jobId) =>
         int.TryParse(jobId, out var num) ? num.ToString("D5") : jobId;
@@ -16,7 +16,8 @@ public class JobController(IJobService jobService, IPlanReaderService planReader
     {
         try
         {
-            TransitionPlanState(args);
+            // Plan state transition (and pre-state snapshot) is handled centrally
+            // by JobService.StartJob.
             var jobId = jobService.StartJob(args);
             return Ok(new { jobId, status = "Started" });
         }
@@ -47,32 +48,6 @@ public class JobController(IJobService jobService, IPlanReaderService planReader
 
     [HttpGet("health")]
     public IActionResult Health() => Ok(new { status = "ok", pid = Environment.ProcessId });
-
-    private void TransitionPlanState(JobArgsBase args)
-    {
-        if (args.PlanFolder == null) return;
-
-        var folderName = Path.GetFileName(args.PlanFolder);
-
-        var targetState = args switch
-        {
-            ExecutePlanArgs => PlanStatus.Building,
-            ExpandPlanArgs => PlanStatus.Building,
-            CreatePrArgs => PlanStatus.Building,
-            CreateIssueArgs => PlanStatus.Building,
-            RetryPlanArgs => PlanStatus.Executing,
-            UpdatePlanArgs => PlanStatus.Updating,
-            SplitPlanArgs => PlanStatus.Updating,
-            _ => (PlanStatus?)null
-        };
-
-        if (targetState == null) return;
-
-        if (args is RetryPlanArgs)
-            planReaderService.ResetVerificationsForRetry(folderName);
-
-        planReaderService.TransitionState(folderName, targetState.Value);
-    }
 }
 
 public record UpdateJobStatusRequest(string Message, string? PlanId = null, string? PlanTitle = null);

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -51,6 +51,16 @@ public record JobItem
     public int? DurationSeconds { get; set; }
     public JobArgsBase? TypedArgs { get; init; }
     public bool CancellationRequested { get; set; }
+
+    /// <summary>
+    /// Plan state captured at job start, before the start transition. On Stop/Delete/
+    /// Failed the plan is reverted to this "came-from" state. In-memory only (not
+    /// persisted); after an app restart the fallback mapping in
+    /// <see cref="Services.Jobs.JobCompletionHandler"/> is used instead.
+    /// </summary>
+    [JsonIgnore]
+    public PlanStatus? PreviousPlanState { get; set; }
+
     public string? SessionId { get; set; }
     public string Provider { get; init; } = "claude";
     public string? Model { get; set; }

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -119,7 +119,6 @@ internal static class ServiceRegistration
                 sp.GetRequiredService<ITelemetryService>(),
                 sp.GetRequiredService<IPlanWatcherService>(),
                 string.IsNullOrEmpty(cfg.TendrilHome) ? null : sp.GetRequiredService<IPlanDatabaseService>(),
-                sp.GetRequiredService<IWorktreeLifecycleLogger>(),
                 sp.GetRequiredService<IAgentRunner>());
         });
         server.Services.AddSingleton<IJobService>(sp => sp.GetRequiredService<JobService>());

--- a/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
@@ -148,6 +148,44 @@ public class WorktreeCleanupService : IStartable, IDisposable
     ///     applies mitigations (clear read-only attributes, shutdown build servers,
     ///     kill locking processes) before throwing.
     /// </remarks>
+    /// <summary>
+    ///     Removes a plan's execution work product: the Artifacts, Logs and Verification
+    ///     directories plus all git worktrees. Used when resetting a plan to a clean Draft
+    ///     (Reset to Draft, or deleting an ExecutePlan job).
+    /// </summary>
+    public static void CleanPlanState(string planFolderPath, ILogger? logger = null)
+    {
+        var artifactsDir = Path.Combine(planFolderPath, "Artifacts");
+        if (Directory.Exists(artifactsDir))
+        {
+            logger?.LogInformation("Cleaning artifacts directory: {Path}", artifactsDir);
+            ForceDeleteDirectory(artifactsDir, logger);
+        }
+
+        var logsDir = Path.Combine(planFolderPath, "Logs");
+        if (Directory.Exists(logsDir))
+        {
+            logger?.LogInformation("Cleaning logs directory: {Path}", logsDir);
+            ForceDeleteDirectory(logsDir, logger);
+        }
+
+        var verificationDir = Path.Combine(planFolderPath, "Verification");
+        if (Directory.Exists(verificationDir))
+        {
+            logger?.LogInformation("Cleaning verification directory: {Path}", verificationDir);
+            ForceDeleteDirectory(verificationDir, logger);
+        }
+
+        RemoveWorktrees(planFolderPath, logger);
+
+        var worktreesDir = Path.Combine(planFolderPath, "Worktrees");
+        if (Directory.Exists(worktreesDir))
+        {
+            logger?.LogInformation("Cleaning worktrees directory: {Path}", worktreesDir);
+            ForceDeleteDirectory(worktreesDir, logger);
+        }
+    }
+
     internal static void ForceDeleteDirectory(string path, ILogger? logger = null)
     {
         const int maxRetries = 3;

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -19,7 +19,6 @@ internal class JobCompletionHandler
     private readonly IPlanReaderService? _planReaderService;
     private readonly IPlanWatcherService? _planWatcherService;
     private readonly ITelemetryService? _telemetryService;
-    private readonly IWorktreeLifecycleLogger? _worktreeLifecycleLogger;
     private readonly string _promptsRoot;
     private readonly PlanArtifactSyncer _artifactSyncer;
     private readonly DependencyChecker _dependencyChecker;
@@ -31,7 +30,6 @@ internal class JobCompletionHandler
         IPlanReaderService? planReaderService,
         ITelemetryService? telemetryService,
         IPlanWatcherService? planWatcherService,
-        IWorktreeLifecycleLogger? worktreeLifecycleLogger,
         string promptsRoot)
     {
         _configService = configService;
@@ -40,7 +38,6 @@ internal class JobCompletionHandler
         _planReaderService = planReaderService;
         _telemetryService = telemetryService;
         _planWatcherService = planWatcherService;
-        _worktreeLifecycleLogger = worktreeLifecycleLogger;
         _promptsRoot = promptsRoot;
         _artifactSyncer = new PlanArtifactSyncer(configService, logger, planWatcherService);
         _dependencyChecker = new DependencyChecker(planReaderService);
@@ -67,8 +64,9 @@ internal class JobCompletionHandler
         NotifyPlanWatcher(job);
         ScheduleCostCalculation(job, jobs, persistJob, raisePropertyChanged);
 
-        if (job.Status is JobStatus.Failed or JobStatus.Timeout)
-            ScheduleWorktreeCleanup(job);
+        // Failed/Timeout is treated like Stop: the work product (worktree) is preserved
+        // so the user can inspect or resume. Worktree cleanup happens only on explicit
+        // user actions (Delete ExecutePlan, Complete Plan, Reset to Draft).
 
         HandleWaitForJobsDependents(job, jobs, raiseNotification, startJobSkipDepCheck, persistJob);
 
@@ -140,9 +138,11 @@ internal class JobCompletionHandler
 
     private void HandlePlanStateTransition(JobItem job, bool isSuccess)
     {
-        if (job.Status is JobStatus.Failed or JobStatus.Timeout)
+        // Stop/Delete/Failed/Timeout all revert the plan to where it came from.
+        // A cancelled job that the completion path won the race for is handled here too.
+        if (job.Status is JobStatus.Failed or JobStatus.Timeout || job.CancellationRequested)
         {
-            ResetPlanState(job);
+            RevertPlanStateToPrevious(job);
             return;
         }
 
@@ -614,21 +614,40 @@ internal class JobCompletionHandler
         return trashEntry != null;
     }
 
-    internal void ResetPlanState(JobItem job)
+    /// <summary>
+    ///     Reverts the plan to the state it had before the job started
+    ///     (<see cref="JobItem.PreviousPlanState"/>). Used by Stop, Delete, and
+    ///     Failed/Timeout. Falls back to a per-promptware "home" state when the snapshot
+    ///     was not captured (e.g. after an app restart).
+    /// </summary>
+    internal void RevertPlanStateToPrevious(JobItem job)
     {
         try
         {
-            if (job.TypedArgs is CreatePlanArgs or CreatePrArgs or CreateIssueArgs) return;
-
             var planFolder = job.TypedArgs?.PlanFolder ?? "";
-            var newState = job.TypedArgs is ExecutePlanArgs or RetryPlanArgs ? nameof(PlanStatus.Failed) : nameof(PlanStatus.Draft);
-            PlanYamlHelper.SetPlanStateByFolder(planFolder, newState);
+            if (string.IsNullOrEmpty(planFolder)) return;
+
+            var target = job.PreviousPlanState ?? FallbackPreviousState(job.TypedArgs);
+            if (target == null) return;
+
+            if (_planReaderService != null)
+                _planReaderService.TransitionState(Path.GetFileName(planFolder), target.Value);
+            else
+                PlanYamlHelper.SetPlanStateByFolder(planFolder, target.Value.ToString());
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to reset plan state for job {JobId}", job.Id);
+            _logger.LogWarning(ex, "Failed to revert plan state for job {JobId}", job.Id);
         }
     }
+
+    private static PlanStatus? FallbackPreviousState(JobArgsBase? args) => args switch
+    {
+        ExecutePlanArgs => PlanStatus.Draft,
+        RetryPlanArgs => PlanStatus.ReadyForReview,
+        ExpandPlanArgs or UpdatePlanArgs or SplitPlanArgs => PlanStatus.Draft,
+        _ => null
+    };
 
     internal void ResetPlanStateToBlocked(JobItem job)
     {
@@ -732,41 +751,6 @@ internal class JobCompletionHandler
         catch
         {
         }
-    }
-
-    private void ScheduleWorktreeCleanup(JobItem job)
-    {
-        if (job.TypedArgs is not (ExecutePlanArgs or RetryPlanArgs)) return;
-
-        var planFolder = job.TypedArgs?.PlanFolder ?? "";
-        if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder)) return;
-
-        var worktreesDir = Path.Combine(planFolder, "Worktrees");
-        if (!Directory.Exists(worktreesDir)) return;
-
-        ScheduleWorktreeRemoval(planFolder, worktreesDir);
-    }
-
-    private void ScheduleWorktreeRemoval(string planFolder, string worktreesDir)
-    {
-        var lifecycleLogger = _worktreeLifecycleLogger;
-        var logger = _logger;
-
-        Task.Run(async () =>
-        {
-            await Task.Delay(TimeSpan.FromSeconds(30));
-            try
-            {
-                WorktreeCleanupService.RemoveWorktrees(planFolder, lifecycleLogger: lifecycleLogger);
-
-                if (Directory.Exists(worktreesDir) && Directory.GetDirectories(worktreesDir).Length == 0)
-                    Directory.Delete(worktreesDir, false);
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Failed to cleanup worktrees for {PlanFolder}", Path.GetFileName(planFolder));
-            }
-        });
     }
 
     internal (bool Ok, string? BlockReason) CheckDependencies(string planFolder)

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -26,7 +26,6 @@ public class JobService : IJobService
     private TimeSpan _staleOutputTimeout;
     private readonly SynchronizationContext? _syncContext;
     private readonly ITelemetryService? _telemetryService;
-    private readonly IWorktreeLifecycleLogger? _worktreeLifecycleLogger;
     private readonly ILogger<JobService> _logger;
     private readonly JobLauncher _jobLauncher;
     private readonly JobCompletionHandler _completionHandler;
@@ -39,7 +38,6 @@ public class JobService : IJobService
         ITelemetryService? telemetryService = null,
         IPlanWatcherService? planWatcherService = null,
         IPlanDatabaseService? database = null,
-        IWorktreeLifecycleLogger? worktreeLifecycleLogger = null,
         IAgentRunner? agentRunner = null)
     {
         _syncContext = SynchronizationContext.Current;
@@ -50,7 +48,6 @@ public class JobService : IJobService
         _telemetryService = telemetryService;
         _planWatcherService = planWatcherService;
         _database = database;
-        _worktreeLifecycleLogger = worktreeLifecycleLogger;
         _jobTimeout = TimeSpan.FromMinutes(configService.Settings.JobTimeout);
         _staleOutputTimeout = TimeSpan.FromMinutes(configService.Settings.StaleOutputTimeout);
         _maxConcurrentJobs = configService.Settings.MaxConcurrentJobs;
@@ -62,7 +59,7 @@ public class JobService : IJobService
         _jobLauncher = new JobLauncher(configService, agentRunner, _logger, promptsRoot);
         _completionHandler = new JobCompletionHandler(
             configService, _logger, modelPricingService, planReaderService,
-            telemetryService, planWatcherService, worktreeLifecycleLogger, promptsRoot);
+            telemetryService, planWatcherService, promptsRoot);
         configService.SettingsReloaded += OnSettingsReloaded;
         JobIdAllocator.SeedIfNeeded(configService.TendrilHome, promptsRoot);
         LoadHistoricalJobs();
@@ -96,7 +93,7 @@ public class JobService : IJobService
         _jobLauncher = new JobLauncher(null, agentRunner!, _logger, promptsRoot);
         _completionHandler = new JobCompletionHandler(
             null, _logger, null, planReaderService, telemetryService,
-            null, null, promptsRoot);
+            null, promptsRoot);
         LoadHistoricalJobs();
         _blockedJobCheckTimer = new Timer(OnBlockedJobCheckTimer, null, TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(60));
     }
@@ -182,11 +179,16 @@ public class JobService : IJobService
     public void StopJob(string id)
     {
         if (!_jobs.TryGetValue(id, out var job)) return;
+
+        // Set the cancellation flag before claiming completion so a racing CompleteJob
+        // (process exiting at the same instant) still sees it and reverts the plan
+        // instead of transitioning it to ReadyForReview.
+        job.CancellationRequested = true;
+
         if (!job.TryClaimCompletion()) return;
 
         job.FlushParser();
         var wasRunning = job.Status == JobStatus.Running;
-        job.CancellationRequested = true;
         try
         {
             job.TimeoutCts?.Cancel();
@@ -219,7 +221,7 @@ public class JobService : IJobService
             _jobSlotSemaphore.Release();
 
         JobCompletionHandler.CleanupInboxFile(job);
-        _completionHandler.ResetPlanState(job);
+        _completionHandler.RevertPlanStateToPrevious(job);
 
         if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or CreatePrArgs)
             _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck);
@@ -240,12 +242,40 @@ public class JobService : IJobService
             removed.DisposeResources(_logger);
             try { _database?.DeleteJob(id); } catch { /* Best-effort */ }
 
+            ApplyDeletePlanState(removed);
+
             if (removed.TypedArgs is ExecutePlanArgs or RetryPlanArgs or CreatePrArgs)
                 _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck);
 
             _completionHandler.HandleWaitForJobsDependents(removed, _jobs, RaiseNotification, StartJobSkipDepCheck, PersistJob);
         }
         RaiseJobsStructureChanged();
+    }
+
+    /// <summary>
+    ///     Deleting a job reverts its plan to where it came from. For an ExecutePlan job
+    ///     (and only when the plan isn't already shipped) deleting discards the execution's
+    ///     work product entirely: the plan is reset to a clean Draft and worktrees/artifacts
+    ///     are removed.
+    /// </summary>
+    private void ApplyDeletePlanState(JobItem removed)
+    {
+        var planFolder = removed.TypedArgs?.PlanFolder;
+
+        if (removed.TypedArgs is ExecutePlanArgs && _planReaderService != null
+            && !string.IsNullOrEmpty(planFolder))
+        {
+            var current = _planReaderService.GetPlanByFolder(planFolder)?.Status;
+            var isTerminal = current is PlanStatus.Completed or PlanStatus.Skipped;
+            if (!isTerminal)
+            {
+                _planReaderService.ResetToDraft(Path.GetFileName(planFolder));
+                WorktreeCleanupService.CleanPlanState(planFolder, _logger);
+                return;
+            }
+        }
+
+        _completionHandler.RevertPlanStateToPrevious(removed);
     }
 
     /// <summary>
@@ -466,13 +496,10 @@ public class JobService : IJobService
         }
 
         var typedArgs = job.TypedArgs;
-        var planFolder = typedArgs.PlanFolder ?? "";
 
         if (!_jobs.TryRemove(id, out _)) return;
 
-        if (typedArgs is ExecutePlanArgs or RetryPlanArgs && !string.IsNullOrEmpty(planFolder))
-            PlanYamlHelper.SetPlanStateByFolder(planFolder, nameof(PlanStatus.Building));
-
+        // Plan transition is handled centrally by StartJobInternal.
         StartJobInternal(typedArgs, inboxFilePath: null, skipDependencyCheck: true, skipWaitForCheck: true);
         RaiseJobsStructureChanged();
     }
@@ -505,6 +532,11 @@ public class JobService : IJobService
         if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or ExpandPlanArgs or UpdatePlanArgs or SplitPlanArgs)
             _planReaderService?.FlushPendingWritesAsync().GetAwaiter().GetResult();
 
+        // Snapshot the plan's pre-job state and perform the start transition in one
+        // place (only once the job is actually starting, not while blocked) so
+        // Stop/Delete/Failed can revert the plan to where it came from.
+        CaptureAndTransitionPlanStateForStart(job);
+
         if (!_jobSlotSemaphore.Wait(0))
         {
             job.Status = JobStatus.Queued;
@@ -516,6 +548,43 @@ public class JobService : IJobService
 
         LaunchJob(job);
         return id;
+    }
+
+    /// <summary>
+    ///     Captures the plan's current ("came-from") state onto the job and transitions the
+    ///     plan into its in-progress state for the job type. Centralizing this here means
+    ///     Stop/Delete/Failed can revert the plan to <see cref="JobItem.PreviousPlanState"/>.
+    /// </summary>
+    private void CaptureAndTransitionPlanStateForStart(JobItem job)
+    {
+        var folder = job.TypedArgs?.PlanFolder;
+        if (string.IsNullOrEmpty(folder) || _planReaderService == null) return;
+
+        var target = job.TypedArgs switch
+        {
+            ExecutePlanArgs => PlanStatus.Building,
+            ExpandPlanArgs => PlanStatus.Building,
+            CreatePrArgs => PlanStatus.Building,
+            CreateIssueArgs => PlanStatus.Building,
+            RetryPlanArgs => PlanStatus.Executing,
+            UpdatePlanArgs => PlanStatus.Updating,
+            SplitPlanArgs => PlanStatus.Updating,
+            _ => (PlanStatus?)null
+        };
+        if (target == null) return;
+
+        // Skip transient/in-flight states so a re-start, force-start, or restart of a
+        // previously-blocked job doesn't snapshot Building/Executing/Updating/Blocked
+        // (the revert fallback map covers those cases).
+        var current = _planReaderService.GetPlanByFolder(folder)?.Status;
+        if (current is not (PlanStatus.Building or PlanStatus.Executing or PlanStatus.Updating or PlanStatus.Blocked))
+            job.PreviousPlanState = current;
+
+        var folderName = Path.GetFileName(folder);
+        if (job.TypedArgs is RetryPlanArgs)
+            _planReaderService.ResetVerificationsForRetry(folderName);
+
+        _planReaderService.TransitionState(folderName, target.Value);
     }
 
     private JobItem BuildJobItem(string id, JobArgsBase args, string? inboxFilePath)


### PR DESCRIPTION
Fixes #1259.

## Problem
Stopping a running plan-execution job could still leave the plan in `ReadyForReview` (a race where the completing process won), and stop/fail used inconsistent, DB-divergent state writes.

## Change
Stop, Delete and Failed/Timeout now **revert the plan to the state it had before the job started** (a snapshot captured centrally in `JobService.StartJob`). Only the cleanup differs per action.

| Action | → PlanState | Cleanup |
|---|---|---|
| Stop (any) | came-from | none (work preserved) |
| Delete ExecutePlan (non-terminal) | Draft | ResetToDraft + remove worktrees/artifacts |
| Delete Retry/other | came-from | none |
| Failed/Timeout | came-from | none (worktree kept, like Stop) |

### Highlights
- `StopJob` sets `CancellationRequested` **before** claiming completion, and `HandlePlanStateTransition` honours it — closing the race that produced the bug.
- New `JobItem.PreviousPlanState` snapshot + single `RevertPlanStateToPrevious` sink (with a per-promptware fallback map); all writes go through `TransitionState` (DB + YAML + watcher).
- Process failure no longer forces the *plan* into `Failed` — the failed *job* stays visible; `PlanStatus.Failed` is now produced only by the verification-failed path.
- Centralized the job-start plan transition into `JobService.StartJob` (removed duplication across the controller, `RerunJobDialog` and UI sites).
- Moved `CleanPlanState` into `WorktreeCleanupService`; removed dead worktree-cleanup code and unused `IWorktreeLifecycleLogger` wiring.

## Tests
10 new tests covering the Stop/Delete/Failed/cancellation-race matrix. Full suite: 1474 passed, 1 pre-existing skip, 0 failed. Docs updated (Plans, Jobs).