### PR TITLE
Add stale-worktree reaper to bound worktree disk usage (#1183)

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
@@ -440,15 +440,9 @@ After all verifications pass:
 
 ### 8.5. Worktree Lifecycle
 
-Worktrees are **not** cleaned up by ExecutePlan. They remain on disk so that CreatePr can push branches and create PRs directly from the worktree.
+Do **not** clean up worktrees in ExecutePlan. Leave them on disk so that CreatePr can push branches and create PRs directly from the worktree.
 
-**Cleanup happens later, in two places:**
-1. **CreatePr Step 5** — cleans up worktrees after PRs are created and (when `PrMerge` is `true`) merged.
-2. **WorktreeCleanupService** — safety net that runs every 30 minutes and removes worktrees for plans in terminal states (Completed, Failed, Skipped) after a 10-minute grace period.
-
-**Git branches are preserved** until CreatePr consumes them — only the worktree filesystem directories are removed.
-
-**Manual inspection:** If you need to inspect worktrees after failure, check the plan folder's `Worktrees/` directory before CreatePr runs. After PR creation, worktrees are cleaned up automatically. You can also temporarily pause WorktreeCleanupService if needed for extended debugging.
+Cleanup is handled elsewhere — by CreatePr after PRs are created/merged, and by the background `WorktreeCleanupService` (which retains a failed plan's worktree for later inspection, so failure is not a reason to remove it).
 
 ### 9. Plan State
 

--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1580,6 +1580,84 @@ maxConcurrentJobs: 10
     }
 
     [Fact]
+    public void ValidateSettings_WorktreeStaleReaperDays_Zero_UsesDefault()
+    {
+        var yaml = "\nworktreeStaleReaperDays: 0\n";
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+            Assert.Equal(7, service.Settings.WorktreeStaleReaperDays);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ValidateSettings_WorktreeCleanupIntervalMinutes_TooLarge_UsesDefault()
+    {
+        var yaml = "\nworktreeCleanupIntervalMinutes: 99999\n";
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+            Assert.Equal(30, service.Settings.WorktreeCleanupIntervalMinutes);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ValidateSettings_WorktreeTerminalGraceMinutes_Negative_UsesDefault()
+    {
+        var yaml = "\nworktreeTerminalGraceMinutes: -1\n";
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+            Assert.Equal(10, service.Settings.WorktreeTerminalGraceMinutes);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ValidateSettings_WorktreeSettings_Valid_NoChanges()
+    {
+        var yaml = @"
+worktreeCleanupIntervalMinutes: 60
+worktreeTerminalGraceMinutes: 0
+worktreeStaleReaperDays: 14
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+            Assert.Equal(60, service.Settings.WorktreeCleanupIntervalMinutes);
+            Assert.Equal(0, service.Settings.WorktreeTerminalGraceMinutes);
+            Assert.Equal(14, service.Settings.WorktreeStaleReaperDays);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void LoadConfig_WhenFileNotFound_ServiceInitializesWithDefaults()
     {
         var tempDir = _tempDir.Path;

--- a/src/Ivy.Tendril.Test/ExecutePlanWorktreeCleanupTests.cs
+++ b/src/Ivy.Tendril.Test/ExecutePlanWorktreeCleanupTests.cs
@@ -103,12 +103,16 @@ public class ExecutePlanWorktreeCleanupTests : IDisposable
     }
 
     [Fact]
-    public void GracePeriod_Is_Ten_Minutes()
+    public void DefaultGraceWindows_AreTenMinutesAndSevenDays()
     {
-        var field = typeof(WorktreeCleanupService)
-            .GetField("GracePeriod", BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(field);
-        var value = (TimeSpan)field!.GetValue(null)!;
-        Assert.Equal(TimeSpan.FromMinutes(10), value);
+        var terminal = typeof(WorktreeCleanupService)
+            .GetField("DefaultTerminalGrace", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(terminal);
+        Assert.Equal(TimeSpan.FromMinutes(10), (TimeSpan)terminal!.GetValue(null)!);
+
+        var stale = typeof(WorktreeCleanupService)
+            .GetField("DefaultStaleReaperPeriod", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(stale);
+        Assert.Equal(TimeSpan.FromDays(7), (TimeSpan)stale!.GetValue(null)!);
     }
 }

--- a/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -51,7 +51,9 @@ public class WorktreeCleanupServiceTests : IDisposable
     [Fact]
     public void RunCleanup_Skips_Active_State_Plans()
     {
-        var activeStates = new[] { "Draft", "Building", "Executing", "ReadyForReview", "Blocked" };
+        // Truly active/transient states are never reaped, regardless of age. (Draft and
+        // ReadyForReview are handled by the stale-reaper tests — they ARE reaped once idle.)
+        var activeStates = new[] { "Building", "Executing", "Updating", "Blocked" };
         foreach (var state in activeStates)
         {
             var dir = CreatePlan($"01{Array.IndexOf(activeStates, state):D3}-{state}Plan", state);
@@ -93,14 +95,15 @@ public class WorktreeCleanupServiceTests : IDisposable
     [Fact]
     public void RunCleanup_Respects_Grace_Period()
     {
-        // Plan just failed 5 minutes ago — should NOT be cleaned (grace period is 10 minutes)
+        // Plan failed 5 minutes ago — well within the stale-reaper window (default 7 days),
+        // so its worktree must be kept for recovery/inspection.
         var dir = CreatePlan("03000-RecentFail", "Failed", DateTime.UtcNow.AddMinutes(-5));
         CreateWorktreeDir(dir, "Repo");
 
         _service.RunCleanup();
 
         var worktreesDir = Path.Combine(dir, "Worktrees");
-        Assert.True(Directory.Exists(worktreesDir), "Recently failed plan should keep worktrees during grace period");
+        Assert.True(Directory.Exists(worktreesDir), "Recently failed plan should keep worktrees during recovery window");
     }
 
     [Fact]
@@ -512,6 +515,115 @@ public class WorktreeCleanupServiceTests : IDisposable
         var ex = Record.Exception(() => WorktreeCleanupService.RemoveWorktrees(dir, logger));
         Assert.Null(ex);
         Assert.False(Directory.Exists(worktreeDir), "Worktree should still be cleaned up");
+    }
+
+    [Fact]
+    public void RunCleanup_Reaps_StaleRecoveryStates_PastReaperWindow()
+    {
+        // Failed/Draft/ReadyForReview keep their worktree for recovery/resume, but once the
+        // plan has been idle past the reaper window the worktree is reclaimed.
+        var states = new[] { "Failed", "Draft", "ReadyForReview" };
+        foreach (var state in states)
+        {
+            var dir = CreatePlan($"15{Array.IndexOf(states, state):D3}-{state}Stale", state, DateTime.UtcNow.AddDays(-8));
+            CreateWorktreeDir(dir, "Repo");
+        }
+
+        _service.RunCleanup();
+
+        foreach (var state in states)
+        {
+            var worktreesDir = Path.Combine(_plansDir, $"15{Array.IndexOf(states, state):D3}-{state}Stale", "Worktrees");
+            Assert.False(Directory.Exists(worktreesDir), $"Idle {state} plan past the reaper window should have its worktree reaped");
+        }
+    }
+
+    [Fact]
+    public void RunCleanup_Keeps_StaleRecoveryStates_WithinReaperWindow()
+    {
+        var states = new[] { "Failed", "Draft", "ReadyForReview" };
+        foreach (var state in states)
+        {
+            var dir = CreatePlan($"16{Array.IndexOf(states, state):D3}-{state}Fresh", state, DateTime.UtcNow.AddHours(-2));
+            CreateWorktreeDir(dir, "Repo");
+        }
+
+        _service.RunCleanup();
+
+        foreach (var state in states)
+        {
+            var worktreesDir = Path.Combine(_plansDir, $"16{Array.IndexOf(states, state):D3}-{state}Fresh", "Worktrees");
+            Assert.True(Directory.Exists(worktreesDir), $"{state} plan within the reaper window should keep its worktree");
+        }
+    }
+
+    [Fact]
+    public void RunCleanup_NeverReaps_ActiveStates_EvenWhenOld()
+    {
+        var states = new[] { "Building", "Executing", "Updating", "Blocked" };
+        foreach (var state in states)
+        {
+            var dir = CreatePlan($"17{Array.IndexOf(states, state):D3}-{state}Old", state, DateTime.UtcNow.AddDays(-30));
+            CreateWorktreeDir(dir, "Repo");
+        }
+
+        _service.RunCleanup();
+
+        foreach (var state in states)
+        {
+            var worktreesDir = Path.Combine(_plansDir, $"17{Array.IndexOf(states, state):D3}-{state}Old", "Worktrees");
+            Assert.True(Directory.Exists(worktreesDir), $"Active {state} plan should never be reaped regardless of age");
+        }
+    }
+
+    [Fact]
+    public void Service_HonorsConfiguredStaleReaperPeriod()
+    {
+        using var service = new WorktreeCleanupService(_plansDir, NullLogger<WorktreeCleanupService>.Instance,
+            staleReaperPeriod: TimeSpan.FromDays(1));
+
+        var reapDir = CreatePlan("18000-FailedTwoDays", "Failed", DateTime.UtcNow.AddDays(-2));
+        CreateWorktreeDir(reapDir, "Repo");
+        var keepDir = CreatePlan("18001-FailedOneHour", "Failed", DateTime.UtcNow.AddHours(-1));
+        CreateWorktreeDir(keepDir, "Repo");
+
+        service.RunCleanup();
+
+        Assert.False(Directory.Exists(Path.Combine(reapDir, "Worktrees")), "Failed plan past the 1-day window should be reaped");
+        Assert.True(Directory.Exists(Path.Combine(keepDir, "Worktrees")), "Failed plan within the 1-day window should be kept");
+    }
+
+    [Fact]
+    public void CleanupPlanWorktrees_HonorsCustomStaleReaperPeriod()
+    {
+        var dir = CreatePlan("19000-CustomGrace", "Draft", DateTime.UtcNow.AddDays(-2));
+        CreateWorktreeDir(dir, "Repo");
+
+        // 5-day window: a 2-day-old Draft worktree is still within the window -> kept.
+        WorktreeCleanupService.CleanupPlanWorktrees(dir, staleReaperPeriod: TimeSpan.FromDays(5));
+        Assert.True(Directory.Exists(Path.Combine(dir, "Worktrees")), "Within custom window -> kept");
+
+        // 1-day window: the same 2-day-old worktree is now past the window -> reaped.
+        WorktreeCleanupService.CleanupPlanWorktrees(dir, staleReaperPeriod: TimeSpan.FromDays(1));
+        Assert.False(Directory.Exists(Path.Combine(dir, "Worktrees")), "Past custom window -> reaped");
+    }
+
+    [Fact]
+    public void ResolveGrace_MapsStatesToWindows()
+    {
+        var terminal = TimeSpan.FromMinutes(10);
+        var stale = TimeSpan.FromDays(7);
+
+        Assert.Equal(terminal, WorktreeCleanupService.ResolveGrace("Completed", terminal, stale));
+        Assert.Equal(terminal, WorktreeCleanupService.ResolveGrace("Skipped", terminal, stale));
+        Assert.Equal(terminal, WorktreeCleanupService.ResolveGrace("Icebox", terminal, stale));
+        Assert.Equal(stale, WorktreeCleanupService.ResolveGrace("Failed", terminal, stale));
+        Assert.Equal(stale, WorktreeCleanupService.ResolveGrace("Draft", terminal, stale));
+        Assert.Equal(stale, WorktreeCleanupService.ResolveGrace("ReadyForReview", terminal, stale));
+        Assert.Null(WorktreeCleanupService.ResolveGrace("Building", terminal, stale));
+        Assert.Null(WorktreeCleanupService.ResolveGrace("Executing", terminal, stale));
+        Assert.Null(WorktreeCleanupService.ResolveGrace("Updating", terminal, stale));
+        Assert.Null(WorktreeCleanupService.ResolveGrace("Blocked", terminal, stale));
     }
 
     private class LoggerAdapter(ILogger inner) : ILogger<WorktreeCleanupService>

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -318,7 +318,7 @@ public class ContentView(
                 refreshPlans();
 
                 // Fire and forget - clean up worktrees in the background
-                Task.Run(() => WorktreeCleanupService.RemoveWorktrees(selectedPlan.FolderPath));
+                WorktreeCleanupService.RemoveWorktreesInBackground(selectedPlan.FolderPath);
             }).ShortcutKey("m");
         }
 

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
 using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Review.Dialogs;
@@ -32,6 +33,10 @@ public class DiscardPlanDialog(
                     _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Skipped);
                     _refreshPlans();
                     _dialogOpen.Set(false);
+
+                    // Discard is an explicit "I don't want this" — reclaim the worktree promptly
+                    // instead of waiting for the background reaper.
+                    WorktreeCleanupService.RemoveWorktreesInBackground(_selectedPlan.FolderPath);
                 })
             )
         ).Width(Size.Rem(40));

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -457,15 +457,9 @@ After all verifications pass:
 
 ### 8.5. Worktree Lifecycle
 
-Worktrees are **not** cleaned up by ExecutePlan. They remain on disk so that CreatePr can push branches and create PRs directly from the worktree.
+Do **not** clean up worktrees in ExecutePlan. Leave them on disk so that CreatePr can push branches and create PRs directly from the worktree.
 
-**Cleanup happens later, in two places:**
-1. **CreatePr Step 5** — cleans up worktrees after PRs are created and (when `PrMerge` is `true`) merged.
-2. **WorktreeCleanupService** — safety net that runs every 30 minutes and removes worktrees for plans in terminal states (Completed, Failed, Skipped) after a 10-minute grace period.
-
-**Git branches are preserved** until CreatePr consumes them — only the worktree filesystem directories are removed.
-
-**Manual inspection:** If you need to inspect worktrees after failure, check the plan folder's `Worktrees/` directory before CreatePr runs. After PR creation, worktrees are cleaned up automatically. You can also temporarily pause WorktreeCleanupService if needed for extended debugging.
+Cleanup is handled elsewhere — by CreatePr after PRs are created/merged, and by the background `WorktreeCleanupService` (which retains a failed plan's worktree for later inspection, so failure is not a reason to remove it).
 
 ### 9. Plan State
 

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -151,7 +151,10 @@ internal static class ServiceRegistration
             var config = sp.GetRequiredService<IConfigService>();
             var logger = sp.GetRequiredService<ILogger<WorktreeCleanupService>>();
             var lifecycleLogger = sp.GetRequiredService<IWorktreeLifecycleLogger>();
-            return new WorktreeCleanupService(config.PlanFolder, logger, lifecycleLogger);
+            return new WorktreeCleanupService(config.PlanFolder, logger, lifecycleLogger,
+                terminalGrace: TimeSpan.FromMinutes(config.Settings.WorktreeTerminalGraceMinutes),
+                staleReaperPeriod: TimeSpan.FromDays(config.Settings.WorktreeStaleReaperDays),
+                timerInterval: TimeSpan.FromMinutes(config.Settings.WorktreeCleanupIntervalMinutes));
         });
         server.Services.AddSingleton<IStartable>(sp => sp.GetRequiredService<WorktreeCleanupService>());
         server.Services.AddSingleton<PrStatusSyncService>(sp =>

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -164,6 +164,11 @@ public class TendrilSettings
     public int StaleOutputTimeout { get; set; } = 10;
     public int GitTimeout { get; set; } = 10;
     public int MaxConcurrentJobs { get; set; } = 5;
+    // Background worktree reclamation (WorktreeCleanupService).
+    public int WorktreeCleanupIntervalMinutes { get; set; } = 30;
+    public int WorktreeTerminalGraceMinutes { get; set; } = 10;   // Completed/Skipped/Icebox
+    public int WorktreeStaleReaperDays { get; set; } = 7;         // Failed/Draft/ReadyForReview
+
     public List<ProjectConfig> Projects { get; set; } = new();
     public List<VerificationConfig> Verifications { get; set; } = new();
     public string PlanTemplate { get; set; } = "";
@@ -405,6 +410,30 @@ public class ConfigService : IConfigService, IDisposable
             _logger.LogWarning("MaxConcurrentJobs {Value} is out of bounds (1-100). Using default 5.",
                 Settings.MaxConcurrentJobs);
             Settings.MaxConcurrentJobs = 5;
+        }
+
+        // WorktreeCleanupIntervalMinutes: 1-1440 (24h)
+        if (Settings.WorktreeCleanupIntervalMinutes < 1 || Settings.WorktreeCleanupIntervalMinutes > 1440)
+        {
+            _logger.LogWarning("WorktreeCleanupIntervalMinutes {Value} is out of bounds (1-1440 minutes). Using default 30.",
+                Settings.WorktreeCleanupIntervalMinutes);
+            Settings.WorktreeCleanupIntervalMinutes = 30;
+        }
+
+        // WorktreeTerminalGraceMinutes: 0-1440 (0 = reclaim on next sweep)
+        if (Settings.WorktreeTerminalGraceMinutes < 0 || Settings.WorktreeTerminalGraceMinutes > 1440)
+        {
+            _logger.LogWarning("WorktreeTerminalGraceMinutes {Value} is out of bounds (0-1440 minutes). Using default 10.",
+                Settings.WorktreeTerminalGraceMinutes);
+            Settings.WorktreeTerminalGraceMinutes = 10;
+        }
+
+        // WorktreeStaleReaperDays: 1-365
+        if (Settings.WorktreeStaleReaperDays < 1 || Settings.WorktreeStaleReaperDays > 365)
+        {
+            _logger.LogWarning("WorktreeStaleReaperDays {Value} is out of bounds (1-365 days). Using default 7.",
+                Settings.WorktreeStaleReaperDays);
+            Settings.WorktreeStaleReaperDays = 7;
         }
     }
 

--- a/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
@@ -13,27 +13,56 @@ namespace Ivy.Tendril.Services.Git;
 public class WorktreeCleanupService : IStartable, IDisposable
 {
     private static readonly Regex SafeTitleRegex = new(@"^\d{5}-(.+)", RegexOptions.Compiled);
+
+    // Terminal states: the user is done with the plan, so its worktree is reclaimed promptly.
     private static readonly HashSet<string> TerminalStates = new(StringComparer.OrdinalIgnoreCase)
         { nameof(PlanStatus.Completed), nameof(PlanStatus.Skipped), nameof(PlanStatus.Icebox) };
 
-    private static readonly TimeSpan GracePeriod = TimeSpan.FromMinutes(10);
-    private static readonly TimeSpan TimerInterval = TimeSpan.FromMinutes(30);
+    // Non-terminal states that keep their worktree for recovery/resume (Failed = verifications
+    // failed; Draft/ReadyForReview = a stopped or reverted execution). The worktree is reaped
+    // only once the plan has been idle past the stale-reaper window. Re-executing recreates it.
+    private static readonly HashSet<string> StaleReapStates = new(StringComparer.OrdinalIgnoreCase)
+        { nameof(PlanStatus.Failed), nameof(PlanStatus.Draft), nameof(PlanStatus.ReadyForReview) };
+
+    private static readonly TimeSpan DefaultTerminalGrace = TimeSpan.FromMinutes(10);
+    private static readonly TimeSpan DefaultStaleReaperPeriod = TimeSpan.FromDays(7);
+    private static readonly TimeSpan DefaultTimerInterval = TimeSpan.FromMinutes(30);
 
     private readonly string _plansDirectory;
     private readonly ILogger<WorktreeCleanupService> _logger;
     private readonly IWorktreeLifecycleLogger? _lifecycleLogger;
+    private readonly TimeSpan _terminalGrace;
+    private readonly TimeSpan _staleReaperPeriod;
+    private readonly TimeSpan _timerInterval;
     private Timer? _timer;
 
-    public WorktreeCleanupService(string plansDirectory, ILogger<WorktreeCleanupService> logger, IWorktreeLifecycleLogger? lifecycleLogger = null)
+    public WorktreeCleanupService(string plansDirectory, ILogger<WorktreeCleanupService> logger,
+        IWorktreeLifecycleLogger? lifecycleLogger = null, TimeSpan? terminalGrace = null,
+        TimeSpan? staleReaperPeriod = null, TimeSpan? timerInterval = null)
     {
         _plansDirectory = plansDirectory;
         _logger = logger;
         _lifecycleLogger = lifecycleLogger;
+        _terminalGrace = terminalGrace ?? DefaultTerminalGrace;
+        _staleReaperPeriod = staleReaperPeriod ?? DefaultStaleReaperPeriod;
+        _timerInterval = timerInterval ?? DefaultTimerInterval;
     }
 
     public void Start()
     {
-        _timer = new Timer(_ => RunCleanup(), null, TimeSpan.FromMinutes(5), TimerInterval);
+        _timer = new Timer(_ => RunCleanup(), null, TimeSpan.FromMinutes(5), _timerInterval);
+    }
+
+    /// <summary>
+    ///     Resolves how long a plan in the given state must be idle before its worktree is reaped,
+    ///     or <c>null</c> for active/transient states (Building/Executing/Updating/Blocked) whose
+    ///     worktrees are never reaped.
+    /// </summary>
+    internal static TimeSpan? ResolveGrace(string state, TimeSpan terminalGrace, TimeSpan staleReaperPeriod)
+    {
+        if (TerminalStates.Contains(state)) return terminalGrace;
+        if (StaleReapStates.Contains(state)) return staleReaperPeriod;
+        return null;
     }
 
     public void Dispose()
@@ -52,7 +81,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
             {
                 try
                 {
-                    CleanupPlanWorktrees(dir, _logger, _lifecycleLogger);
+                    CleanupPlanWorktrees(dir, _logger, _lifecycleLogger, _terminalGrace, _staleReaperPeriod);
                 }
                 catch (Exception ex)
                 {
@@ -66,7 +95,8 @@ public class WorktreeCleanupService : IStartable, IDisposable
         }
     }
 
-    internal static void CleanupPlanWorktrees(string planFolderPath, ILogger? logger = null, IWorktreeLifecycleLogger? lifecycleLogger = null)
+    internal static void CleanupPlanWorktrees(string planFolderPath, ILogger? logger = null, IWorktreeLifecycleLogger? lifecycleLogger = null,
+        TimeSpan? terminalGrace = null, TimeSpan? staleReaperPeriod = null)
     {
         var worktreesDir = Path.Combine(planFolderPath, "Worktrees");
         if (!Directory.Exists(worktreesDir)) return;
@@ -91,9 +121,10 @@ public class WorktreeCleanupService : IStartable, IDisposable
 
         if (planYaml == null) return;
 
-        if (!TerminalStates.Contains(planYaml.State)) return;
+        var grace = ResolveGrace(planYaml.State, terminalGrace ?? DefaultTerminalGrace, staleReaperPeriod ?? DefaultStaleReaperPeriod);
+        if (grace is null) return;
 
-        if (DateTime.UtcNow - planYaml.Updated < GracePeriod) return;
+        if (DateTime.UtcNow - planYaml.Updated < grace.Value) return;
 
         var planId = WorktreeLifecycleLogger.ExtractPlanId(planFolderPath);
 
@@ -325,6 +356,26 @@ public class WorktreeCleanupService : IStartable, IDisposable
         }
     }
 
+    /// <summary>
+    ///     Fire-and-forget worktree removal for terminal-state UI actions (Complete / Discard) so
+    ///     disk is reclaimed promptly without blocking the UI thread. The background stale reaper
+    ///     remains the backstop if this fails.
+    /// </summary>
+    internal static void RemoveWorktreesInBackground(string planFolderPath, ILogger? logger = null)
+    {
+        Task.Run(() =>
+        {
+            try
+            {
+                RemoveWorktrees(planFolderPath, logger);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Background worktree cleanup failed for {PlanFolder}", Path.GetFileName(planFolderPath));
+            }
+        });
+    }
+
     internal static void RemoveWorktrees(string planFolderPath, ILogger? logger = null, IWorktreeLifecycleLogger? lifecycleLogger = null)
     {
         var worktreesDir = Path.Combine(planFolderPath, "Worktrees");
@@ -434,10 +485,5 @@ public class WorktreeCleanupService : IStartable, IDisposable
         {
             // Best-effort
         }
-    }
-
-    private void CleanupPlanWorktrees(string planFolderPath)
-    {
-        CleanupPlanWorktrees(planFolderPath, _logger, _lifecycleLogger);
     }
 }


### PR DESCRIPTION
## Problem
Closes #1183. Worktrees (carrying `node_modules`, ~0.5–1 GB each) accumulated for plans in recovery/resume states that the background GC never reclaimed. Post-#1289 the GC only reclaimed `Completed/Skipped/Icebox`, while **Failed** (verification-failed) and **stop/crash-reverted `Draft`/`ReadyForReview`** kept their worktrees indefinitely when abandoned.

## Change — stale-worktree reaper
`WorktreeCleanupService` now reclaims worktrees by plan state:
- **Terminal** (`Completed`/`Skipped`/`Icebox`) — short grace (default 10 min), unchanged.
- **Recovery/resume** (`Failed`/`Draft`/`ReadyForReview`) — worktree **retained** for inspection/resume, reaped only after the plan is idle past the stale-reaper window (default **7 days**). Re-execution recreates the worktree, so reaping an idle one is non-destructive.
- **Active/transient** (`Building`/`Executing`/`Updating`/`Blocked`) — never reaped.

Also:
- **Discard** button reclaims the worktree immediately (parity with **Complete**), via a shared `RemoveWorktreesInBackground` helper.
- Grace/window/interval configurable in `TendrilSettings` (`worktreeTerminalGraceMinutes`, `worktreeStaleReaperDays`, `worktreeCleanupIntervalMinutes`), validated + wired through DI.
- Removed a dead private `CleanupPlanWorktrees` wrapper; corrected the ExecutePlan promptware worktree-lifecycle note.

## Tests
Reaper boundary (within/past window across all state groups), active-states-never-reaped, configurable-window (ctor + static), `ResolveGrace` mapping, and 4 config-validation cases. Full suite: **1484 passed, 1 pre-existing skip, 0 failed**; build clean.

## Note
A `default`-PR-rule plan left in `ReadyForReview` will now have its worktree reaped after the idle window (previously kept indefinitely) — intended and safe (request-changes/retry recreates it); tunable via `worktreeStaleReaperDays`.