### PR TITLE
Rename plan states: Building -> Creating, ReadyForReview -> Review

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/03_Tutorial.md
+++ b/src/Ivy.Tendril.Docs/Docs/01_GettingStarted/03_Tutorial.md
@@ -115,7 +115,7 @@ Once you're happy with the draft, click **Execute** in the dashboard. Tendril's 
 
 Monitor progress in real time from the **Jobs** view. You can see status updates, token usage, and cost tracking as the agent works.
 
-If the agent succeeds and verifications pass, the plan moves to **ReadyForReview**.
+If the agent succeeds and verifications pass, the plan moves to **Review**.
 
 <Callout type="Info">
 If execution fails, the plan moves to **Failed**. Check the logs, fix any blockers, and retry — the worktree is preserved so the agent can pick up where it left off.
@@ -140,7 +140,7 @@ If something needs work, send the plan back to **Draft** to refine and re-execut
 You walked through the full Tendril loop:
 
 ```
-Draft → Building → Executing → ReadyForReview → Completed
+Draft → Creating → Executing → Review → Completed
 ```
 
 The agent worked in an isolated worktree, ran your verification suite, and the result is a reviewable diff — all tracked in a single plan folder on disk.

--- a/src/Ivy.Tendril.Docs/Docs/02_Concepts/01_Plans.md
+++ b/src/Ivy.Tendril.Docs/Docs/02_Concepts/01_Plans.md
@@ -28,16 +28,16 @@ A plan progresses through the following comprehensive set of states:
 |-------|-------------|
 | **Draft** | Initial state. The plan has been created/drafted but execution has not started. |
 | **Blocked** | The plan cannot proceed due to missing context, credentials, or user intervention. |
-| **Building** | The `CreatePlan` or `ExpandPlan` agent is actively drafting the technical details of the plan. |
+| **Creating** | The `CreatePlan` or `ExpandPlan` agent is actively drafting the technical details of the plan. |
 | **Executing** | The `ExecutePlan` agent is actively implementing the plan in a worktree. |
 | **Updating** | The `UpdatePlan` agent is refining an existing, already-executed plan. |
-| **ReadyForReview** | Execution is complete, automated verifications passed. Ready for human review. |
+| **Review** | Execution is complete, automated verifications passed. Ready for human review. |
 | **Failed** | Automated verifications consistently failed after execution, or an interrupted execution could not be recovered. |
 | **Completed** | The plan has been reviewed, approved, and merged/PR'd successfully. |
 | **Skipped** | The plan was abandoned, discarded, or deemed unnecessary. |
 | **Icebox** | The plan has been shelved for later consideration. |
 
-> **Stopping or deleting a running job** returns the plan to the state it was in *before* the job started — e.g. a stopped `ExecutePlan` returns to `Draft`, a stopped `RetryPlan` returns to `ReadyForReview`. A stopped or failed run keeps its work product (worktree) so you can inspect or resume it; **deleting** an `ExecutePlan` job is the exception — it discards the work product (worktrees/artifacts) and resets the plan to a clean `Draft`.
+> **Stopping or deleting a running job** returns the plan to the state it was in *before* the job started — e.g. a stopped `ExecutePlan` returns to `Draft`, a stopped `RetryPlan` returns to `Review`. A stopped or failed run keeps its work product (worktree) so you can inspect or resume it; **deleting** an `ExecutePlan` job is the exception — it discards the work product (worktrees/artifacts) and resets the plan to a clean `Draft`.
 
 ## Creating a Plan
 

--- a/src/Ivy.Tendril.Docs/Docs/04_Apps/02_Review.md
+++ b/src/Ivy.Tendril.Docs/Docs/04_Apps/02_Review.md
@@ -11,7 +11,7 @@ icon: ThumbsUp
 # Review
 
 <Ingress>
-Queue of finished work: **ReadyForReview** or **Failed** plans. Nothing merges without you.
+Queue of finished work: **Review** or **Failed** plans. Nothing merges without you.
 </Ingress>
 
 ## What shows up

--- a/src/Ivy.Tendril.TeamIvyConfig/AGENTS.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/AGENTS.md
@@ -29,10 +29,10 @@ Plans move through these states:
 | State | Meaning |
 |-------|---------|
 | `Draft` | Ready for review or action by the user |
-| `Building` | CreatePlan or ExpandPlan agent working |
+| `Creating` | CreatePlan or ExpandPlan agent working |
 | `Updating` | UpdatePlan or SplitPlan agent refining |
 | `Executing` | ExecutePlan agent implementing in a worktree |
-| `ReadyForReview` | Execution complete, awaiting human review |
+| `Review` | Execution complete, awaiting human review |
 | `Failed` | Agent errored or verifications consistently failed |
 | `Completed` | PR created and merged |
 | `Skipped` | Dismissed or split into child plans |
@@ -43,10 +43,10 @@ Plans move through these states:
 
 ```
 CreatePlan ──► Draft
-               ├─ ExpandPlan ──► Building ──► Draft
+               ├─ ExpandPlan ──► Creating ──► Draft
                ├─ UpdatePlan ──► Updating ──► Draft
                ├─ SplitPlan  ──► Updating ──► Skipped (original) + new Drafts
-               ├─ ExecutePlan ──► Executing ──► ReadyForReview or Failed
+               ├─ ExecutePlan ──► Executing ──► Review or Failed
                ├─ CreatePr (from Review) ──► Completed
                ├─ (manual) ──► Skipped / Icebox
                └─ (dependencies unmet) ──► Blocked ──► Draft (when unblocked)
@@ -54,7 +54,7 @@ CreatePlan ──► Draft
 
 **Key rules:**
 - `dependsOn` blocks execution until all dependencies are Completed AND their PRs merged
-- Verifications (Build, Test, Format, CheckResult) gate progress from Executing to ReadyForReview
+- Verifications (Build, Test, Format, CheckResult) gate progress from Executing to Review
 - Plans execute in isolated git worktrees, never in the original repos
 
 ## Promptwares
@@ -195,5 +195,5 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 
 - **Never read or write `plan.yaml` directly** -- always use `tendril plan` CLI commands.
 - Verification statuses: `Pending`, `Pass`, `Fail`, `Skipped`.
-- Plan states: `Draft`, `Building`, `Updating`, `Executing`, `ReadyForReview`, `Failed`, `Completed`, `Skipped`, `Blocked`, `Icebox`.
+- Plan states: `Draft`, `Creating`, `Updating`, `Executing`, `Review`, `Failed`, `Completed`, `Skipped`, `Blocked`, `Icebox`.
 - To create a plan interactively: use `tendril plan create "<title>"` then `tendril plan write-revision <id> <<'EOF' ... EOF` to add content.

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
@@ -65,8 +65,8 @@ Do NOT read or modify `.counter` directly. Plan IDs are allocated by the `tendri
   |---|---|
   | `Completed` (with merged PR) | Check for regression (Step 4), otherwise trash |
   | `Completed` (no PR, but commits exist) | Check for regression (Step 4), trash with note "no PR found" |
-  | `Draft` / `Building` / `Executing` | Trash, but note "plan in progress (state: X)" |
-  | `ReadyForReview` | Trash, note "awaiting review" |
+  | `Draft` / `Creating` / `Executing` | Trash, but note "plan in progress (state: X)" |
+  | `Review` | Trash, note "awaiting review" |
   | `Failed` | **Do NOT trash** — create the plan (the previous attempt failed) |
   | `Icebox` / `Skipped` | Trash with note "existing plan state: X" (issue is already covered) |
 

--- a/src/Ivy.Tendril.Test.End2End/AGENTS.md
+++ b/src/Ivy.Tendril.Test.End2End/AGENTS.md
@@ -7,7 +7,7 @@ Playwright-based E2E tests that drive Tendril as a black-box subprocess and veri
 ```bash
 # IMPORTANT: Pre-build both projects first to avoid MSBuild lock conflicts.
 # The test fixture uses `dotnet run` which triggers a build — if the test runner
-# is also building, MSBuild child nodes collide and restore gets cancelled.
+# is also Creating, MSBuild child nodes collide and restore gets cancelled.
 dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj
 dotnet build src/Ivy.Tendril.Test.End2End/
 
@@ -83,12 +83,12 @@ The tests use `Ivy-Interactive/Ivy-Templates` — a real dotnet project with `Pr
 | OnboardingTests | 1 | Full onboarding wizard: welcome → software check → agent selection → home setup → project setup → complete |
 | VerificationTests | 4 | Directory structure, config.yaml, tendril.db, dashboard loads |
 | PlanLifecycleTests | 1 | Plan creation via UI submits job (verifies job appears in Jobs grid) |
-| AgentExecutionTests | 1 | Full lifecycle: CreatePlan → Execute → CreatePR (plan reaches ReadyForReview, PR URL in plan.yaml) |
+| AgentExecutionTests | 1 | Full lifecycle: CreatePlan → Execute → CreatePR (plan reaches Review, PR URL in plan.yaml) |
 | CleanupTests | 2 | Fixture teardown, GitHub fork deletion |
 
 ## Common gotchas
 
-- **MSBuild lock conflicts**: The test fixture launches Tendril via `dotnet run`, which triggers a build. If the test runner is also building, MSBuild child nodes collide (`MSB4166: Child node exited prematurely`). Always pre-build both projects and run tests with `--no-build`.
+- **MSBuild lock conflicts**: The test fixture launches Tendril via `dotnet run`, which triggers a build. If the test runner is also Creating, MSBuild child nodes collide (`MSB4166: Child node exited prematurely`). Always pre-build both projects and run tests with `--no-build`.
 - **Plan folder names are CamelCase** (e.g., `00001-UppercaseAllStringLiteralsInProgramCs`). `FindPlanFolder` normalizes by removing hyphens for comparison.
 - **Plan IDs in sidebar are unpadded** — sidebar shows `#1`, not `#00001`. `GetPlanId` strips leading zeros.
 - **Plan folders appear before `plan.yaml` is written.** Always wait for `plan.yaml` to exist, not just the folder.
@@ -122,7 +122,7 @@ The tests use `Ivy-Interactive/Ivy-Templates` — a real dotnet project with `Pr
 - **"New Plan" button not found** — The sidebar failed to render (check for exceptions in Tendril stdout) or the button hasn't appeared yet (increase `WaitForAsync` timeout).
 - **"Plan not visible in sidebar"** — The plan folder exists but the UI hasn't refreshed. The test retries with reloads for 120s. If it still fails, the sidebar rendering may have changed.
 - **"plan.yaml not created"** — The coding agent failed or timed out. Check promptware logs for the agent's error output.
-- **"state: ReadyForReview not found"** — ExecutePlan didn't complete. Check if the agent errored, if verifications failed, or if the process was killed early.
+- **"state: Review not found"** — ExecutePlan didn't complete. Check if the agent errored, if verifications failed, or if the process was killed early.
 - **"PR URL not found in plan.yaml"** — CreatePR promptware failed. Check GitHub auth (`gh auth status`) and fork permissions.
 - **Port conflict in CleanupTests** — The `TendrilProcessFixture_CleansUpTempDirectories` test starts its own Tendril instance. If the main E2E fixture is still running, ports may collide even with `--find-available-port`. The test handles this gracefully via try/catch on `TimeoutException`.
 

--- a/src/Ivy.Tendril.Test.End2End/Helpers/PlanSetupHelper.cs
+++ b/src/Ivy.Tendril.Test.End2End/Helpers/PlanSetupHelper.cs
@@ -50,7 +50,7 @@ public static class PlanSetupHelper
         return planFolder;
     }
 
-    public static string CreateReadyForReviewPlan(
+    public static string CreateReviewPlan(
         string plansDir,
         string title,
         string project = "E2ETest")
@@ -66,7 +66,7 @@ public static class PlanSetupHelper
         var planYaml = $"""
             title: "{title}"
             description: "Test plan for PR creation"
-            state: ReadyForReview
+            state: Review
             project: {project}
             priority: 0
             created: {DateTime.UtcNow:yyyy-MM-ddTHH:mm:ssZ}

--- a/src/Ivy.Tendril.Test.End2End/Tests/AgentExecutionTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/AgentExecutionTests.cs
@@ -99,8 +99,8 @@ public class AgentExecutionTests : IAsyncLifetime
         var step2StartLine = _fixture.Tendril.StdoutLines.Count;
         await plans.ClickExecute();
 
-        await WaitForPlanState("Reverse", "ReadyForReview", timeout,
-            $"Step 2 (ExecutePlan) failed: plan #{planId} did not reach ReadyForReview, agent={agent}");
+        await WaitForPlanState("Reverse", "Review", timeout,
+            $"Step 2 (ExecutePlan) failed: plan #{planId} did not reach Review, agent={agent}");
 
         // Wait for the ExecutePlan job to finish (detect via stdout)
         await WaitForJobExit(timeout, step2StartLine);

--- a/src/Ivy.Tendril.Test.End2End/Tests/Promptware/CreatePrTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/Promptware/CreatePrTests.cs
@@ -33,7 +33,7 @@ public class CreatePrTests
             agent: agent);
 
         PromptwareAssertions.AssertExitSuccess(execResult, $"ExecutePlan ({agent})");
-        PromptwareAssertions.AssertPlanState(planFolder, "ReadyForReview");
+        PromptwareAssertions.AssertPlanState(planFolder, "Review");
 
         // Now create the PR
         var result = await _fixture.Runner.RunAsync(

--- a/src/Ivy.Tendril.Test.End2End/Tests/Promptware/ExecutePlanTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/Promptware/ExecutePlanTests.cs
@@ -12,7 +12,7 @@ public class ExecutePlanTests
 
     [Theory]
     [MemberData(nameof(AgentTestData.Agents), MemberType = typeof(AgentTestData))]
-    public async Task ExecutePlan_ImplementsPlan_TransitionsToReadyForReview(string agent)
+    public async Task ExecutePlan_ImplementsPlan_TransitionsToReview(string agent)
     {
         var cliLog = Path.Combine(_fixture.TendrilHome, $"execute-plan-{agent}.jsonl");
 
@@ -41,7 +41,7 @@ public class ExecutePlanTests
         CliLogAssertions.AssertAllCommandsSucceeded(cliLog);
 
         // Assert state transition
-        PromptwareAssertions.AssertPlanState(planFolder, "ReadyForReview");
+        PromptwareAssertions.AssertPlanState(planFolder, "Review");
     }
 
     [Theory]

--- a/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
+++ b/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
@@ -259,6 +259,38 @@ public class DatabaseMigratorTests : IDisposable
     }
 
     [Fact]
+    public void Migration015_RewritesLegacyPlanStates_AndLeavesOthers()
+    {
+        new Migration_001_InitialSchema().Apply(_connection);
+
+        using var insertCmd = _connection.CreateCommand();
+        insertCmd.CommandText = """
+                                INSERT INTO Plans (Id, Title, Project, Level, State, FolderPath, FolderName,
+                                                   YamlRaw, RevisionCount, LatestRevisionContent, Created, Updated)
+                                VALUES
+                                    (1, 'A', 'Tendril', 'NiceToHave', 'Building',        '/a', 'a', 'y', 1, 'c', '2026-01-01', '2026-01-01'),
+                                    (2, 'B', 'Tendril', 'NiceToHave', 'ReadyForReview',  '/b', 'b', 'y', 1, 'c', '2026-01-01', '2026-01-01'),
+                                    (3, 'C', 'Tendril', 'NiceToHave', 'Completed',       '/c', 'c', 'y', 1, 'c', '2026-01-01', '2026-01-01')
+                                """;
+        insertCmd.ExecuteNonQuery();
+
+        new Migration_015_RenamePlanStates().Apply(_connection);
+
+        Assert.Equal("Creating", GetState(1));
+        Assert.Equal("Review", GetState(2));
+        Assert.Equal("Completed", GetState(3));
+        Assert.Equal(15, GetUserVersion());
+    }
+
+    private string GetState(int planId)
+    {
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT State FROM Plans WHERE Id = @id;";
+        cmd.Parameters.AddWithValue("@id", planId);
+        return (string)cmd.ExecuteScalar()!;
+    }
+
+    [Fact]
     public void Migration006_CreatesCompositeIndex_AndDropsSingleColumnIndexes()
     {
         // Apply migrations 1 through 5 first to set up schema and individual indexes

--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -46,7 +46,7 @@ public class JobServiceCompletionGuardTests : IDisposable
 
         Assert.Equal(JobStatus.Stopped, service.GetJob(id)!.Status);
         Assert.Contains(("test-plan", PlanStatus.Draft), plan.Transitions);
-        Assert.DoesNotContain(plan.Transitions, t => t.State == PlanStatus.ReadyForReview);
+        Assert.DoesNotContain(plan.Transitions, t => t.State == PlanStatus.Review);
         Assert.Empty(plan.ResetToDraftCalls);
     }
 
@@ -55,11 +55,11 @@ public class JobServiceCompletionGuardTests : IDisposable
     {
         var (service, plan) = CreateServiceWithStub();
         var id = service.CreateTestJob(new RetryPlanArgs("test-plan", "fix it"));
-        service.GetJob(id)!.PreviousPlanState = PlanStatus.ReadyForReview;
+        service.GetJob(id)!.PreviousPlanState = PlanStatus.Review;
 
         service.StopJob(id);
 
-        Assert.Contains(("test-plan", PlanStatus.ReadyForReview), plan.Transitions);
+        Assert.Contains(("test-plan", PlanStatus.Review), plan.Transitions);
         Assert.Empty(plan.ResetToDraftCalls);
     }
 
@@ -69,12 +69,12 @@ public class JobServiceCompletionGuardTests : IDisposable
         var (service, plan) = CreateServiceWithStub();
         var id = service.CreateTestJob(new CreatePrArgs("test-plan"));
         // CreatePr starts from Review; snapshot lets it revert there (no fallback covers CreatePr).
-        service.GetJob(id)!.PreviousPlanState = PlanStatus.ReadyForReview;
+        service.GetJob(id)!.PreviousPlanState = PlanStatus.Review;
 
         service.StopJob(id);
 
-        Assert.Contains(("test-plan", PlanStatus.ReadyForReview), plan.Transitions);
-        Assert.DoesNotContain(plan.Transitions, t => t.State == PlanStatus.Building);
+        Assert.Contains(("test-plan", PlanStatus.Review), plan.Transitions);
+        Assert.DoesNotContain(plan.Transitions, t => t.State == PlanStatus.Creating);
     }
 
     [Fact]
@@ -92,7 +92,7 @@ public class JobServiceCompletionGuardTests : IDisposable
     [Fact]
     public void DeleteJob_ExecutePlan_NonTerminal_ResetsToDraft()
     {
-        var (service, plan) = CreateServiceWithStub(currentStatus: PlanStatus.ReadyForReview);
+        var (service, plan) = CreateServiceWithStub(currentStatus: PlanStatus.Review);
         var id = service.CreateTestJob(new ExecutePlanArgs("test-plan"));
 
         service.DeleteJob(id);
@@ -115,14 +115,14 @@ public class JobServiceCompletionGuardTests : IDisposable
     [Fact]
     public void DeleteJob_RetryPlan_RevertsToReviewWithoutReset()
     {
-        var (service, plan) = CreateServiceWithStub(currentStatus: PlanStatus.ReadyForReview);
+        var (service, plan) = CreateServiceWithStub(currentStatus: PlanStatus.Review);
         var id = service.CreateTestJob(new RetryPlanArgs("test-plan", "again"));
-        service.GetJob(id)!.PreviousPlanState = PlanStatus.ReadyForReview;
+        service.GetJob(id)!.PreviousPlanState = PlanStatus.Review;
 
         service.DeleteJob(id);
 
         Assert.Empty(plan.ResetToDraftCalls);
-        Assert.Contains(("test-plan", PlanStatus.ReadyForReview), plan.Transitions);
+        Assert.Contains(("test-plan", PlanStatus.Review), plan.Transitions);
     }
 
     [Fact]
@@ -138,7 +138,7 @@ public class JobServiceCompletionGuardTests : IDisposable
         service.CompleteJob(id, 0);
 
         Assert.Contains(("test-plan", PlanStatus.Draft), plan.Transitions);
-        Assert.DoesNotContain(plan.Transitions, t => t.State == PlanStatus.ReadyForReview);
+        Assert.DoesNotContain(plan.Transitions, t => t.State == PlanStatus.Review);
     }
 
     [Fact]
@@ -152,7 +152,7 @@ public class JobServiceCompletionGuardTests : IDisposable
 
         Assert.Equal(JobStatus.Failed, service.GetJob(id)!.Status);
         Assert.Contains(("test-plan", PlanStatus.Draft), plan.Transitions);
-        Assert.DoesNotContain(plan.Transitions, t => t.State is PlanStatus.Failed or PlanStatus.ReadyForReview);
+        Assert.DoesNotContain(plan.Transitions, t => t.State is PlanStatus.Failed or PlanStatus.Review);
     }
 
     [Fact]
@@ -171,7 +171,7 @@ public class JobServiceCompletionGuardTests : IDisposable
         service.CompleteJob(id, 0);
 
         Assert.Contains(("00777-VerFail", PlanStatus.Failed), plan.Transitions);
-        Assert.DoesNotContain(plan.Transitions, t => t.State == PlanStatus.ReadyForReview);
+        Assert.DoesNotContain(plan.Transitions, t => t.State == PlanStatus.Review);
     }
 
     [Fact]
@@ -335,6 +335,10 @@ public class JobServiceCompletionGuardTests : IDisposable
 
         // Status returned by GetPlanByFolder (simulates the plan's current state).
         public PlanStatus? CurrentStatus { get; set; }
+
+        public void MigratePlanStateNames()
+        {
+        }
 
         public void RecoverStuckPlans()
         {

--- a/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
@@ -126,7 +126,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         var id = service.StartJob(new CreateIssueArgs(planB, "owner/repo", "", "", ""));
         service.CompleteJob(id, 0);
 
-        // Verify plan.yaml was updated — Building then immediately Executing when job launches
+        // Verify plan.yaml was updated — Creating then immediately Executing when job launches
         var planYamlContent = File.ReadAllText(Path.Combine(planA, "plan.yaml"));
         Assert.Contains("state: Executing", planYamlContent);
     }
@@ -152,7 +152,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
     public void RetryBlockedDependents_WhenPlanNotInDraftState_DoesNotRequeue()
     {
         var planB = CreatePlanFolder("02300-PlanB", "Completed");
-        var planA = CreatePlanFolder("02301-PlanA", "Building", ["02300-PlanB"]);
+        var planA = CreatePlanFolder("02301-PlanA", "Creating", ["02300-PlanB"]);
 
         var service = CreateService();
 
@@ -309,6 +309,10 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
 #pragma warning disable CS0067
         public event Action? CountsInvalidated;
 #pragma warning restore CS0067
+
+        public void MigratePlanStateNames()
+        {
+        }
 
         public void RecoverStuckPlans()
         {

--- a/src/Ivy.Tendril.Test/JobServicePlanYamlTests.cs
+++ b/src/Ivy.Tendril.Test/JobServicePlanYamlTests.cs
@@ -207,7 +207,7 @@ public class JobServicePlanYamlTests : IDisposable
             var yamlContent = $"state: Draft\nproject: TestProject\nlevel: NiceToHave\ntitle: Test Plan\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\nrepos:\n- {repoDir}\nprs: []\ncommits: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\n";
             File.WriteAllText(Path.Combine(tempDir, "plan.yaml"), yamlContent);
 
-            JobService.SetPlanStateByFolder(tempDir, "ReadyForReview");
+            JobService.SetPlanStateByFolder(tempDir, "Review");
 
             var result = File.ReadAllText(Path.Combine(tempDir, "plan.yaml"));
             // Verify ISO 8601 format: yyyy-MM-ddTHH:mm:ss (with optional fractional seconds and Z)

--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -517,6 +517,10 @@ public class JobServiceRetryBlockedTests : IDisposable
         public event Action? CountsInvalidated;
 #pragma warning restore CS0067
 
+        public void MigratePlanStateNames()
+        {
+        }
+
         public void RecoverStuckPlans()
         {
         }

--- a/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
@@ -71,6 +71,7 @@ public class JobServiceSplitPlanCompletionTests
         public void SetVerificationStatus(string folderName, string name, VerificationStatus status) { }
         public void RevertRevision(string folderName) { }
 
+        public void MigratePlanStateNames() { }
         public void RecoverStuckPlans() { }
         public void RepairPlans() { }
         public List<PlanFile> GetPlans(PlanStatus? statusFilter = null) => [];

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -978,7 +978,7 @@ public class PlanCliCommandTests : IDisposable
     {
         var plan = new PlanYaml
         {
-            State = "ReadyForReview",
+            State = "Review",
             Project = "MyProject",
             Level = "Bug",
             Title = "Full Plan",
@@ -1010,7 +1010,7 @@ public class PlanCliCommandTests : IDisposable
         CreatePlanFolder("20110", "FullRoundtrip", plan);
 
         var result = ReadPlan("20110");
-        Assert.Equal("ReadyForReview", result.State);
+        Assert.Equal("Review", result.State);
         Assert.Equal("MyProject", result.Project);
         Assert.Equal("Bug", result.Level);
         Assert.Equal("Full Plan", result.Title);

--- a/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -95,7 +95,7 @@ public class TendrilProcessStatusServiceTests : IDisposable
     {
         CreatePlan("00001-DraftPlan", "Draft");
         CreatePlan("00002-AnotherDraft", "Draft");
-        CreatePlan("00003-ReviewPlan", "ReadyForReview");
+        CreatePlan("00003-ReviewPlan", "Review");
         CreatePlan("00004-FailedPlan", "Failed");
         CreatePlan("00005-IceboxPlan", "Icebox");
         CreatePlan("00006-CompletedPlan", "Completed");

--- a/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -148,14 +148,14 @@ public class PlanDatabaseServiceTests : IDisposable
     {
         _db.UpsertPlan(CreateTestPlan(1500, "Draft1"));
         _db.UpsertPlan(CreateTestPlan(1501, "Draft2"));
-        _db.UpsertPlan(CreateTestPlan(1502, "Review", PlanStatus.ReadyForReview));
+        _db.UpsertPlan(CreateTestPlan(1502, "Review", PlanStatus.Review));
         _db.UpsertPlan(CreateTestPlan(1503, "Failed", PlanStatus.Failed));
         _db.UpsertPlan(CreateTestPlan(1504, "Icebox", PlanStatus.Icebox));
         _db.UpsertPlan(CreateTestPlan(1505, "Completed", PlanStatus.Completed));
 
         var counts = _db.ComputePlanCounts();
         Assert.Equal(2, counts.Drafts);
-        Assert.Equal(1, counts.ReadyForReview);
+        Assert.Equal(1, counts.Review);
         Assert.Equal(1, counts.Failed);
         Assert.Equal(1, counts.Icebox);
     }
@@ -519,7 +519,7 @@ public class PlanDatabaseServiceTests : IDisposable
         _db.UpsertPlan(CreateTestPlan(1900, "Draft Tendril"));
         _db.UpsertPlan(CreateTestPlan(1901, "Completed Tendril", PlanStatus.Completed));
         _db.UpsertPlan(CreateTestPlan(1902, "Failed Tendril", PlanStatus.Failed));
-        _db.UpsertPlan(CreateTestPlan(1903, "Review Framework", PlanStatus.ReadyForReview,
+        _db.UpsertPlan(CreateTestPlan(1903, "Review Framework", PlanStatus.Review,
             "Framework"));
         _db.UpsertPlan(CreateTestPlan(1904, "InProgress Tendril", PlanStatus.Executing));
 
@@ -1216,7 +1216,7 @@ public class PlanDatabaseServiceTests : IDisposable
         for (int i = 0; i < 50; i++)
         {
             tasks.Add(Task.Run(() => _db.GetPlans()));
-            tasks.Add(Task.Run(() => _db.UpdatePlanState(1500, PlanStatus.Building)));
+            tasks.Add(Task.Run(() => _db.UpdatePlanState(1500, PlanStatus.Creating)));
         }
 
         // Verify: All operations complete without deadlock (5 second timeout)

--- a/src/Ivy.Tendril.Test/PlanReaderServiceComputePlanCountsTests.cs
+++ b/src/Ivy.Tendril.Test/PlanReaderServiceComputePlanCountsTests.cs
@@ -53,7 +53,7 @@ public class PlanReaderServiceComputePlanCountsTests : IDisposable
         var snapshot = _service.ComputePlanCounts();
 
         Assert.Equal(0, snapshot.Drafts);
-        Assert.Equal(0, snapshot.ReadyForReview);
+        Assert.Equal(0, snapshot.Review);
         Assert.Equal(0, snapshot.Failed);
         Assert.Equal(0, snapshot.Icebox);
         Assert.Equal(0, snapshot.PendingRecommendations);
@@ -64,7 +64,7 @@ public class PlanReaderServiceComputePlanCountsTests : IDisposable
     {
         CreatePlan("01001-Draft1", "Draft");
         CreatePlan("01002-Draft2", "Draft");
-        CreatePlan("01003-Review1", "ReadyForReview");
+        CreatePlan("01003-Review1", "Review");
         CreatePlan("01004-Failed1", "Failed");
         CreatePlan("01005-Icebox1", "Icebox");
         CreatePlan("01006-Icebox2", "Icebox");
@@ -73,7 +73,7 @@ public class PlanReaderServiceComputePlanCountsTests : IDisposable
         var snapshot = _service.ComputePlanCounts();
 
         Assert.Equal(2, snapshot.Drafts);
-        Assert.Equal(1, snapshot.ReadyForReview);
+        Assert.Equal(1, snapshot.Review);
         Assert.Equal(1, snapshot.Failed);
         Assert.Equal(2, snapshot.Icebox);
         Assert.Equal(0, snapshot.PendingRecommendations);
@@ -108,7 +108,7 @@ public class PlanReaderServiceComputePlanCountsTests : IDisposable
     public void ComputePlanCounts_MatchesIndividualMethods()
     {
         CreatePlan("01020-Draft", "Draft");
-        CreatePlan("01021-Review", "ReadyForReview");
+        CreatePlan("01021-Review", "Review");
         CreatePlan("01022-Failed", "Failed");
         CreatePlan("01023-Icebox", "Icebox");
         CreatePlan("01024-Completed", "Completed");
@@ -121,7 +121,7 @@ public class PlanReaderServiceComputePlanCountsTests : IDisposable
         var pendingRecs = _service.GetPendingRecommendationsCount();
 
         Assert.Equal(plans.Count(p => p.Status is PlanStatus.Draft or PlanStatus.Blocked), snapshot.Drafts);
-        Assert.Equal(plans.Count(p => p.Status == PlanStatus.ReadyForReview), snapshot.ReadyForReview);
+        Assert.Equal(plans.Count(p => p.Status == PlanStatus.Review), snapshot.Review);
         Assert.Equal(plans.Count(p => p.Status == PlanStatus.Failed), snapshot.Failed);
         Assert.Equal(plans.Count(p => p.Status == PlanStatus.Icebox), snapshot.Icebox);
         Assert.Equal(pendingRecs, snapshot.PendingRecommendations);

--- a/src/Ivy.Tendril.Test/PlanReaderServiceRecoveryTests.cs
+++ b/src/Ivy.Tendril.Test/PlanReaderServiceRecoveryTests.cs
@@ -53,7 +53,7 @@ public class PlanReaderServiceRecoveryTests : IDisposable
     [Fact]
     public void Building_Plans_Are_Recovered_To_Draft()
     {
-        CreatePlan("01100-BuildPlan", "Building");
+        CreatePlan("01100-BuildPlan", "Creating");
 
         _service.RecoverStuckPlans();
 
@@ -109,7 +109,7 @@ public class PlanReaderServiceRecoveryTests : IDisposable
     public void Multiple_Stuck_Plans_Are_All_Recovered()
     {
         CreatePlan("01200-Plan1", "Executing");
-        CreatePlan("01201-Plan2", "Building");
+        CreatePlan("01201-Plan2", "Creating");
         CreatePlan("01202-Plan3", "Updating");
         CreatePlan("01203-Plan4", "Draft");
         CreatePlan("01204-Plan5", "Failed");
@@ -121,5 +121,30 @@ public class PlanReaderServiceRecoveryTests : IDisposable
         Assert.Equal("Draft", ReadState("01202-Plan3"));
         Assert.Equal("Draft", ReadState("01203-Plan4"));
         Assert.Equal("Failed", ReadState("01204-Plan5"));
+    }
+
+    [Fact]
+    public void MigratePlanStateNames_RewritesLegacyStateNames()
+    {
+        CreatePlan("01300-Legacy1", "Building");
+        CreatePlan("01301-Legacy2", "ReadyForReview");
+
+        _service.MigratePlanStateNames();
+
+        Assert.Equal("Creating", ReadState("01300-Legacy1"));
+        Assert.Equal("Review", ReadState("01301-Legacy2"));
+    }
+
+    [Fact]
+    public void MigratePlanStateNames_LeavesCurrentStatesUntouched_AndIsIdempotent()
+    {
+        CreatePlan("01302-Current", "Draft");
+        CreatePlan("01303-Migrated", "Building");
+
+        _service.MigratePlanStateNames();
+        _service.MigratePlanStateNames(); // re-running is a no-op
+
+        Assert.Equal("Draft", ReadState("01302-Current"));
+        Assert.Equal("Creating", ReadState("01303-Migrated"));
     }
 }

--- a/src/Ivy.Tendril.Test/PlanYamlCorruptionTests.cs
+++ b/src/Ivy.Tendril.Test/PlanYamlCorruptionTests.cs
@@ -61,7 +61,7 @@ public class PlanYamlCorruptionTests : IClassFixture<ConfigServiceFixture>
         var planFolder = CreateTestPlan(initialPrompt: largePrompt);
 
         // Act: Change state multiple times
-        PlanYamlHelper.SetPlanStateByFolder(planFolder, "Building");
+        PlanYamlHelper.SetPlanStateByFolder(planFolder, "Creating");
         PlanYamlHelper.SetPlanStateByFolder(planFolder, "Draft");
 
         // Assert: plan.yaml is valid and intact
@@ -94,7 +94,7 @@ public class PlanYamlCorruptionTests : IClassFixture<ConfigServiceFixture>
         // mtime. A fixed 10ms sleep was below that resolution and could leave mtimes equal.
         RetryHelper.WaitUntil(() => DateTime.UtcNow > beforeModTime.AddMilliseconds(20),
             TimeSpan.FromSeconds(2));
-        PlanYamlHelper.SetPlanStateByFolder(planFolder, "Building");
+        PlanYamlHelper.SetPlanStateByFolder(planFolder, "Creating");
 
         // Assert: File was modified
         var afterModTime = File.GetLastWriteTimeUtc(planYamlPath);
@@ -106,7 +106,7 @@ public class PlanYamlCorruptionTests : IClassFixture<ConfigServiceFixture>
 
         // Verify content is valid
         var plan = PlanCommandHelpers.ReadPlan(planFolder);
-        Assert.Equal("Building", plan.State);
+        Assert.Equal("Creating", plan.State);
 
         // Cleanup
         Directory.Delete(planFolder, true);
@@ -122,7 +122,7 @@ public class PlanYamlCorruptionTests : IClassFixture<ConfigServiceFixture>
 
         // Act: Wait briefly then change state
         Thread.Sleep(100);
-        PlanYamlHelper.SetPlanStateByFolder(planFolder, "Building");
+        PlanYamlHelper.SetPlanStateByFolder(planFolder, "Creating");
 
         // Assert: Updated timestamp changed
         var updatedPlan = PlanCommandHelpers.ReadPlan(planFolder);

--- a/src/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PlanReaderServiceTests.cs
@@ -32,7 +32,7 @@ public class PlanReaderServiceTests
         try
         {
             // Act
-            service.TransitionState(folderName, PlanStatus.ReadyForReview);
+            service.TransitionState(folderName, PlanStatus.Review);
 
             // Wait for the background plan.yaml write so the finally-block cleanup doesn't race it.
             await service.FlushPendingWritesAsync();
@@ -109,7 +109,7 @@ public class PlanReaderServiceTests
         var planFolder = Path.Combine(tempDir, folderName);
         Directory.CreateDirectory(planFolder);
 
-        var planYaml = "state: ReadyForReview\nproject: TestProject\ncommits:\n- abc1234\n- def5678\nverifications:\n- name: Build\n  status: Pass\n- name: Test\n  status: Fail\n- name: Lint\n  status: Skipped\n- name: Format\n  status: Pending\n";
+        var planYaml = "state: Review\nproject: TestProject\ncommits:\n- abc1234\n- def5678\nverifications:\n- name: Build\n  status: Pass\n- name: Test\n  status: Fail\n- name: Lint\n  status: Skipped\n- name: Format\n  status: Pending\n";
         File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), planYaml);
 
         try

--- a/src/Ivy.Tendril.Test/Services/PlanValidationServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PlanValidationServiceTests.cs
@@ -104,7 +104,7 @@ public class PlanValidationServiceTests : IDisposable
     [Fact]
     public void Validate_AcceptsAllValidStates()
     {
-        var validStates = new[] { "Draft", "Building", "Updating", "Executing", "ReadyForReview", "Failed", "Completed", "Skipped", "Blocked", "Icebox" };
+        var validStates = new[] { "Draft", "Creating", "Updating", "Executing", "Review", "Failed", "Completed", "Skipped", "Blocked", "Icebox" };
 
         foreach (var state in validStates)
         {

--- a/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -52,8 +52,8 @@ public class WorktreeCleanupServiceTests : IDisposable
     public void RunCleanup_Skips_Active_State_Plans()
     {
         // Truly active/transient states are never reaped, regardless of age. (Draft and
-        // ReadyForReview are handled by the stale-reaper tests — they ARE reaped once idle.)
-        var activeStates = new[] { "Building", "Executing", "Updating", "Blocked" };
+        // Review are handled by the stale-reaper tests — they ARE reaped once idle.)
+        var activeStates = new[] { "Creating", "Executing", "Updating", "Blocked" };
         foreach (var state in activeStates)
         {
             var dir = CreatePlan($"01{Array.IndexOf(activeStates, state):D3}-{state}Plan", state);
@@ -520,9 +520,9 @@ public class WorktreeCleanupServiceTests : IDisposable
     [Fact]
     public void RunCleanup_Reaps_StaleRecoveryStates_PastReaperWindow()
     {
-        // Failed/Draft/ReadyForReview keep their worktree for recovery/resume, but once the
+        // Failed/Draft/Review keep their worktree for recovery/resume, but once the
         // plan has been idle past the reaper window the worktree is reclaimed.
-        var states = new[] { "Failed", "Draft", "ReadyForReview" };
+        var states = new[] { "Failed", "Draft", "Review" };
         foreach (var state in states)
         {
             var dir = CreatePlan($"15{Array.IndexOf(states, state):D3}-{state}Stale", state, DateTime.UtcNow.AddDays(-8));
@@ -541,7 +541,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     [Fact]
     public void RunCleanup_Keeps_StaleRecoveryStates_WithinReaperWindow()
     {
-        var states = new[] { "Failed", "Draft", "ReadyForReview" };
+        var states = new[] { "Failed", "Draft", "Review" };
         foreach (var state in states)
         {
             var dir = CreatePlan($"16{Array.IndexOf(states, state):D3}-{state}Fresh", state, DateTime.UtcNow.AddHours(-2));
@@ -560,7 +560,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     [Fact]
     public void RunCleanup_NeverReaps_ActiveStates_EvenWhenOld()
     {
-        var states = new[] { "Building", "Executing", "Updating", "Blocked" };
+        var states = new[] { "Creating", "Executing", "Updating", "Blocked" };
         foreach (var state in states)
         {
             var dir = CreatePlan($"17{Array.IndexOf(states, state):D3}-{state}Old", state, DateTime.UtcNow.AddDays(-30));
@@ -619,8 +619,8 @@ public class WorktreeCleanupServiceTests : IDisposable
         Assert.Equal(terminal, WorktreeCleanupService.ResolveGrace("Icebox", terminal, stale));
         Assert.Equal(stale, WorktreeCleanupService.ResolveGrace("Failed", terminal, stale));
         Assert.Equal(stale, WorktreeCleanupService.ResolveGrace("Draft", terminal, stale));
-        Assert.Equal(stale, WorktreeCleanupService.ResolveGrace("ReadyForReview", terminal, stale));
-        Assert.Null(WorktreeCleanupService.ResolveGrace("Building", terminal, stale));
+        Assert.Equal(stale, WorktreeCleanupService.ResolveGrace("Review", terminal, stale));
+        Assert.Null(WorktreeCleanupService.ResolveGrace("Creating", terminal, stale));
         Assert.Null(WorktreeCleanupService.ResolveGrace("Executing", terminal, stale));
         Assert.Null(WorktreeCleanupService.ResolveGrace("Updating", terminal, stale));
         Assert.Null(WorktreeCleanupService.ResolveGrace("Blocked", terminal, stale));

--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -131,7 +131,7 @@ public class ActionBarView(
             if (hasActiveExpandJob) return;
             var optimisticPlan = selectedPlan with
             {
-                Metadata = selectedPlan.Metadata with { State = PlanStatus.Building }
+                Metadata = selectedPlan.Metadata with { State = PlanStatus.Creating }
             };
             selectedPlanState.Set(optimisticPlan);
             // Plan state transition (and pre-state snapshot) handled by JobService.StartJob.

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -452,7 +452,7 @@ public class ContentView(
         // When chained behind an UpdatePlan job the plan is already Updating;
         // JobLauncher sets Executing once the blocked ExecutePlan launches.
         if (!hasWaits)
-            TransitionPlanOptimistically(PlanStatus.Building);
+            TransitionPlanOptimistically(PlanStatus.Creating);
 
         jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath) { WaitForJobs = hasWaits ? waitJobIds : null });
         refreshPlans();
@@ -473,7 +473,7 @@ public class ContentView(
         // When chained behind an UpdatePlan job the plan is already Updating;
         // JobLauncher sets Executing once the blocked ExecutePlan launches.
         if (!hasWaits)
-            TransitionPlanOptimistically(PlanStatus.Building);
+            TransitionPlanOptimistically(PlanStatus.Creating);
 
         jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath) { WaitForJobs = allWaitIds });
         refreshPlans();

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -120,7 +120,7 @@ public partial class JobsApp
                                     {
                                         nav.Navigate<DraftsApp>(new DraftsAppArgs(plan.FolderName));
                                     }
-                                    else if (plan.Status is PlanStatus.ReadyForReview or PlanStatus.Failed)
+                                    else if (plan.Status is PlanStatus.Review or PlanStatus.Failed)
                                     {
                                         nav.Navigate<ReviewApp>(new ReviewAppArgs(plan.FolderName));
                                     }

--- a/src/Ivy.Tendril/Apps/Review/ReviewApp.cs
+++ b/src/Ivy.Tendril/Apps/Review/ReviewApp.cs
@@ -68,8 +68,8 @@ public class ReviewApp : ViewBase
 
         var plans = planService.GetPlans()
             .Where(p => showCompleted.Value
-                ? p.Status is PlanStatus.ReadyForReview or PlanStatus.Failed or PlanStatus.Completed
-                : p.Status is PlanStatus.ReadyForReview or PlanStatus.Failed)
+                ? p.Status is PlanStatus.Review or PlanStatus.Failed or PlanStatus.Completed
+                : p.Status is PlanStatus.Review or PlanStatus.Failed)
             .Where(p => !activePlanFolders.Contains(p.FolderPath))
             .ToList();
         var filteredPlans = PlanFilters.ApplyFilters(plans, projectFilter.Value, levelFilter.Value, textFilter.Value).ToList();

--- a/src/Ivy.Tendril/Commands/DoctorCliCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCliCommand.cs
@@ -23,7 +23,7 @@ public class PlanDoctorSettings : CommandSettings
     public bool Prune { get; init; }
 
     [CommandOption("--state")]
-    [Description("Filter plans by state (Draft, Building, Updating, Executing, ReadyForReview, Failed, Completed, Skipped, Blocked, Icebox)")]
+    [Description("Filter plans by state (Draft, Creating, Updating, Executing, Review, Failed, Completed, Skipped, Blocked, Icebox)")]
     public string? State { get; init; }
 
     [CommandOption("--worktrees")]

--- a/src/Ivy.Tendril/Commands/PlanListCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanListCommand.cs
@@ -10,7 +10,7 @@ namespace Ivy.Tendril.Commands;
 public class PlanListSettings : CommandSettings
 {
     [CommandOption("--state")]
-    [Description("Filter by state (Draft, Building, Updating, Executing, ReadyForReview, Failed, Completed, Skipped, Blocked, Icebox)")]
+    [Description("Filter by state (Draft, Creating, Updating, Executing, Review, Failed, Completed, Skipped, Blocked, Icebox)")]
     public string? State { get; init; }
 
     [CommandOption("--project")]

--- a/src/Ivy.Tendril/Constants.cs
+++ b/src/Ivy.Tendril/Constants.cs
@@ -27,10 +27,10 @@ public static class Constants
 
     public static readonly Dictionary<PlanStatus, BadgeVariant> PlanStatusBadgeVariants = new()
     {
-        [PlanStatus.Building] = BadgeVariant.Info,
+        [PlanStatus.Creating] = BadgeVariant.Info,
         [PlanStatus.Updating] = BadgeVariant.Info,
         [PlanStatus.Executing] = BadgeVariant.Info,
-        [PlanStatus.ReadyForReview] = BadgeVariant.Success,
+        [PlanStatus.Review] = BadgeVariant.Success,
         [PlanStatus.Failed] = BadgeVariant.Destructive,
         [PlanStatus.Draft] = BadgeVariant.Outline,
         [PlanStatus.Completed] = BadgeVariant.Success,

--- a/src/Ivy.Tendril/Database/DashboardRepository.cs
+++ b/src/Ivy.Tendril/Database/DashboardRepository.cs
@@ -35,14 +35,14 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
                     SELECT
                         COUNT(*) AS TotalCount,
                         COALESCE(SUM(CASE WHEN State IN ('Draft', 'Blocked') THEN 1 ELSE 0 END), 0),
-                        COALESCE(SUM(CASE WHEN State IN ('Building', 'Executing', 'Updating') THEN 1 ELSE 0 END), 0),
-                        COALESCE(SUM(CASE WHEN State = 'ReadyForReview' THEN 1 ELSE 0 END), 0),
+                        COALESCE(SUM(CASE WHEN State IN ('Creating', 'Executing', 'Updating') THEN 1 ELSE 0 END), 0),
+                        COALESCE(SUM(CASE WHEN State = 'Review' THEN 1 ELSE 0 END), 0),
                         COALESCE(SUM(CASE WHEN State = 'Completed' THEN 1 ELSE 0 END), 0),
                         COALESCE(SUM(CASE WHEN State = 'Failed' THEN 1 ELSE 0 END), 0),
                         (SELECT CASE WHEN COUNT(DISTINCT p2.Id) > 0
                             THEN COALESCE(SUM(c2.Cost), 0) / COUNT(DISTINCT p2.Id) ELSE 0 END
                          FROM Costs c2 JOIN Plans p2 ON p2.Id = c2.PlanId
-                         WHERE p2.Created >= @cutoff AND p2.State IN ('Completed', 'Failed', 'ReadyForReview') {pfAlias2}
+                         WHERE p2.Created >= @cutoff AND p2.State IN ('Completed', 'Failed', 'Review') {pfAlias2}
                         ) AS AvgCost
                     FROM Plans WHERE Created >= @cutoff {pf}
                     """;
@@ -98,7 +98,7 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
                     cte_costs AS (
                         SELECT DATE(p.Updated) AS d, SUM(c.Cost) AS cost, SUM(c.Tokens) AS tokens
                         FROM Costs c JOIN Plans p ON p.Id = c.PlanId
-                        WHERE p.Updated >= @cutoff AND p.State IN ('Completed', 'Failed', 'ReadyForReview') {pfAlias}
+                        WHERE p.Updated >= @cutoff AND p.State IN ('Completed', 'Failed', 'Review') {pfAlias}
                         GROUP BY DATE(p.Updated)
                     ),
                     cte_days(day) AS (

--- a/src/Ivy.Tendril/Database/Migrations/Migration_015_RenamePlanStates.cs
+++ b/src/Ivy.Tendril/Database/Migrations/Migration_015_RenamePlanStates.cs
@@ -1,0 +1,22 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Database.Migrations;
+
+public class Migration_015_RenamePlanStates : IMigration
+{
+    public int Version => 15;
+    public string Description => "Rename plan states Building → Creating and ReadyForReview → Review";
+
+    public void Apply(SqliteConnection connection, ILogger? logger = null)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            UPDATE Plans SET State = 'Creating' WHERE State = 'Building';
+            UPDATE Plans SET State = 'Review'   WHERE State = 'ReadyForReview';
+
+            PRAGMA user_version = 15;
+            """;
+        cmd.ExecuteNonQuery();
+    }
+}

--- a/src/Ivy.Tendril/Helpers/CliValidation.cs
+++ b/src/Ivy.Tendril/Helpers/CliValidation.cs
@@ -7,8 +7,8 @@ public static class CliValidation
 {
     public static readonly string[] ValidStates =
     [
-        nameof(PlanStatus.Draft), nameof(PlanStatus.Building), nameof(PlanStatus.Updating),
-        nameof(PlanStatus.Executing), nameof(PlanStatus.ReadyForReview), nameof(PlanStatus.Failed),
+        nameof(PlanStatus.Draft), nameof(PlanStatus.Creating), nameof(PlanStatus.Updating),
+        nameof(PlanStatus.Executing), nameof(PlanStatus.Review), nameof(PlanStatus.Failed),
         nameof(PlanStatus.Completed), nameof(PlanStatus.Skipped), nameof(PlanStatus.Blocked),
         nameof(PlanStatus.Icebox)
     ];

--- a/src/Ivy.Tendril/Hooks/UsePlanNavigation.cs
+++ b/src/Ivy.Tendril/Hooks/UsePlanNavigation.cs
@@ -29,7 +29,7 @@ public static class UsePlanNavigationExtensions
 
             if (plan.Status is PlanStatus.Draft or PlanStatus.Blocked)
                 nav.Navigate<DraftsApp>(new DraftsAppArgs(plan.FolderName));
-            else if (plan.Status is PlanStatus.ReadyForReview or PlanStatus.Failed)
+            else if (plan.Status is PlanStatus.Review or PlanStatus.Failed)
                 nav.Navigate<ReviewApp>(new ReviewAppArgs(plan.FolderName));
             else
                 showPlanSheet(planFolder);

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -41,7 +41,7 @@ public sealed class PlanTools : AuthenticatedToolBase
 
     [McpServerTool(Name = "tendril_list_plans"), Description("Query plans by state, project, or date range")]
     public string ListPlans(
-        [Description("Filter by plan state (e.g., Draft, Executing, ReadyForReview, Failed, Completed)")] string? state = null,
+        [Description("Filter by plan state (e.g., Draft, Executing, Review, Failed, Completed)")] string? state = null,
         [Description("Filter by project name")] string? project = null,
         [Description("Filter plans created after this date (ISO 8601, e.g., 2026-04-01)")] string? since = null)
     {

--- a/src/Ivy.Tendril/Models/PlanModels.cs
+++ b/src/Ivy.Tendril/Models/PlanModels.cs
@@ -8,12 +8,12 @@ public record Link(string Title, string Href);
 public enum PlanStatus
 {
     Draft,
-    Building,
+    Creating,
     Updating,
     Executing,
     Completed,
     Failed,
-    ReadyForReview,
+    Review,
     Skipped,
     Icebox,
     Blocked

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -29,10 +29,10 @@ Plans move through these states:
 | State | Meaning |
 |-------|---------|
 | `Draft` | Ready for review or action by the user |
-| `Building` | CreatePlan or ExpandPlan agent working |
+| `Creating` | CreatePlan or ExpandPlan agent working |
 | `Updating` | UpdatePlan or SplitPlan agent refining |
 | `Executing` | ExecutePlan agent implementing in a worktree |
-| `ReadyForReview` | Execution complete, awaiting human review |
+| `Review` | Execution complete, awaiting human review |
 | `Failed` | Agent errored or verifications consistently failed |
 | `Completed` | PR created and merged |
 | `Skipped` | Dismissed or split into child plans |
@@ -43,10 +43,10 @@ Plans move through these states:
 
 ```
 CreatePlan ──► Draft
-               ├─ ExpandPlan ──► Building ──► Draft
+               ├─ ExpandPlan ──► Creating ──► Draft
                ├─ UpdatePlan ──► Updating ──► Draft
                ├─ SplitPlan  ──► Updating ──► Skipped (original) + new Drafts
-               ├─ ExecutePlan ──► Executing ──► ReadyForReview or Failed
+               ├─ ExecutePlan ──► Executing ──► Review or Failed
                ├─ CreatePr (from Review) ──► Completed
                ├─ (manual) ──► Skipped / Icebox
                └─ (dependencies unmet) ──► Blocked ──► Draft (when unblocked)
@@ -54,7 +54,7 @@ CreatePlan ──► Draft
 
 **Key rules:**
 - `dependsOn` blocks execution until all dependencies are Completed AND their PRs merged
-- Verifications (Build, Test, Format, CheckResult) gate progress from Executing to ReadyForReview
+- Verifications (Build, Test, Format, CheckResult) gate progress from Executing to Review
 - Plans execute in isolated git worktrees, never in the original repos
 
 ## Promptwares
@@ -237,5 +237,5 @@ When the user asks you to create a plan:
 - **Never read or write `plan.yaml` directly** -- always use `tendril plan` CLI commands.
 - **`tendril job start` and `tendril job status` require the Tendril server to be running.** They communicate via HTTP to the master instance (discovered via `TENDRIL_HOME/.master`).
 - Verification statuses: `Pending`, `Pass`, `Fail`, `Skipped`.
-- Plan states: `Draft`, `Building`, `Updating`, `Executing`, `ReadyForReview`, `Failed`, `Completed`, `Skipped`, `Blocked`, `Icebox`.
+- Plan states: `Draft`, `Creating`, `Updating`, `Executing`, `Review`, `Failed`, `Completed`, `Skipped`, `Blocked`, `Icebox`.
 - To create a new plan, start a CreatePlan job: `tendril job start CreatePlan --description "<description>" --project "<project>"` (see "Creating Plans Interactively"). Use the lower-level `tendril plan create` / `write-revision` commands only to edit an existing plan's content, never to create a new plan from a chat request.

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -219,19 +219,19 @@ priority: 0
 ```
 CreatePlan ──► Draft
                │
-               ├─ ExpandPlan ──► Building ──► Draft
+               ├─ ExpandPlan ──► Creating ──► Draft
                ├─ UpdatePlan ──► Updating ──► Draft
                ├─ SplitPlan  ──► Updating ──► Skipped
                │
                ├─ ExecutePlan (dependencies unmet)
-               │    Draft ──► Blocked ──► Draft (when unblocked) ──► Building ──► ...
+               │    Draft ──► Blocked ──► Draft (when unblocked) ──► Creating ──► ...
                │
                ├─ ExecutePlan (Execute button)
-               │    Draft ──► Building ──► Executing ──► ReadyForReview
+               │    Draft ──► Creating ──► Executing ──► Review
                │                                    └──► Failed
                │
                ├─ CreatePr (from Review app)
-               │    ReadyForReview ──► Completed
+               │    Review ──► Completed
                │
                ├─ (manual) ──► Skipped
                └─ (manual) ──► Icebox
@@ -240,10 +240,10 @@ CreatePlan ──► Draft
 | State            | Meaning                                    | Visible in      |
 |------------------|--------------------------------------------|-----------------|
 | `Draft`          | Ready for review/action                    | Plans           |
-| `Building`       | ExpandPlan or ExecutePlan in progress       | Jobs            |
+| `Creating`       | ExpandPlan or ExecutePlan in progress       | Jobs            |
 | `Updating`       | UpdatePlan or SplitPlan in progress         | Jobs            |
 | `Executing`      | ExecutePlan agent running                   | Jobs            |
-| `ReadyForReview` | ExecutePlan finished, awaiting human review | Review          |
+| `Review` | ExecutePlan finished, awaiting human review | Review          |
 | `Failed`         | ExecutePlan errored                         | Review          |
 | `Completed`      | PR created, plan done                       | —               |
 | `Skipped`        | Manually dismissed or split                 | —               |

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -92,8 +92,8 @@ Report status: `tendril job status TendrilJobId --message "Researching codebase.
   |---|---|
   | `Completed` (with merged PR) | Check for regression (Step 4), otherwise trash |
   | `Completed` (no PR, but commits exist) | Check for regression (Step 4), trash with note "no PR found" |
-  | `Draft` / `Building` / `Executing` | Trash, but note "plan in progress (state: X)" |
-  | `ReadyForReview` | Trash, note "awaiting review" |
+  | `Draft` / `Creating` / `Executing` | Trash, but note "plan in progress (state: X)" |
+  | `Review` | Trash, note "awaiting review" |
   | `Failed` | **Do NOT trash** — create the plan (the previous attempt failed) |
   | `Icebox` / `Skipped` | Trash with note "existing plan state: X" (issue is already covered) |
 

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -75,6 +75,7 @@ internal static class ServiceRegistration
                 sp.GetRequiredService<ILogger<PlanReaderService>>(),
                 sp.GetRequiredService<ITelemetryService>(),
                 sp.GetRequiredService<IWorktreeLifecycleLogger>());
+            planService.MigratePlanStateNames();
             planService.MigratePlanSubfolderCasing();
             planService.RepairPlans();
             planService.RecoverStuckPlans();

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -167,7 +167,7 @@ public class TendrilSettings
     // Background worktree reclamation (WorktreeCleanupService).
     public int WorktreeCleanupIntervalMinutes { get; set; } = 30;
     public int WorktreeTerminalGraceMinutes { get; set; } = 10;   // Completed/Skipped/Icebox
-    public int WorktreeStaleReaperDays { get; set; } = 7;         // Failed/Draft/ReadyForReview
+    public int WorktreeStaleReaperDays { get; set; } = 7;         // Failed/Draft/Review
 
     public List<ProjectConfig> Projects { get; set; } = new();
     public List<VerificationConfig> Verifications { get; set; } = new();

--- a/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
@@ -19,10 +19,10 @@ public class WorktreeCleanupService : IStartable, IDisposable
         { nameof(PlanStatus.Completed), nameof(PlanStatus.Skipped), nameof(PlanStatus.Icebox) };
 
     // Non-terminal states that keep their worktree for recovery/resume (Failed = verifications
-    // failed; Draft/ReadyForReview = a stopped or reverted execution). The worktree is reaped
+    // failed; Draft/Review = a stopped or reverted execution). The worktree is reaped
     // only once the plan has been idle past the stale-reaper window. Re-executing recreates it.
     private static readonly HashSet<string> StaleReapStates = new(StringComparer.OrdinalIgnoreCase)
-        { nameof(PlanStatus.Failed), nameof(PlanStatus.Draft), nameof(PlanStatus.ReadyForReview) };
+        { nameof(PlanStatus.Failed), nameof(PlanStatus.Draft), nameof(PlanStatus.Review) };
 
     private static readonly TimeSpan DefaultTerminalGrace = TimeSpan.FromMinutes(10);
     private static readonly TimeSpan DefaultStaleReaperPeriod = TimeSpan.FromDays(7);
@@ -55,7 +55,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
 
     /// <summary>
     ///     Resolves how long a plan in the given state must be idle before its worktree is reaped,
-    ///     or <c>null</c> for active/transient states (Building/Executing/Updating/Blocked) whose
+    ///     or <c>null</c> for active/transient states (Creating/Executing/Updating/Blocked) whose
     ///     worktrees are never reaped.
     /// </summary>
     internal static TimeSpan? ResolveGrace(string state, TimeSpan terminalGrace, TimeSpan staleReaperPeriod)

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -411,7 +411,7 @@ internal class JobCompletionHandler
 
             var hasIncomplete = planYaml.Verifications?
                 .Any(v => v.Status is VerificationStatus.Pending or VerificationStatus.Fail) ?? false;
-            var targetState = hasIncomplete ? PlanStatus.Failed : PlanStatus.ReadyForReview;
+            var targetState = hasIncomplete ? PlanStatus.Failed : PlanStatus.Review;
 
             var folderName = Path.GetFileName(planFolder);
             if (_planReaderService != null)
@@ -644,7 +644,7 @@ internal class JobCompletionHandler
     private static PlanStatus? FallbackPreviousState(JobArgsBase? args) => args switch
     {
         ExecutePlanArgs => PlanStatus.Draft,
-        RetryPlanArgs => PlanStatus.ReadyForReview,
+        RetryPlanArgs => PlanStatus.Review,
         ExpandPlanArgs or UpdatePlanArgs or SplitPlanArgs => PlanStatus.Draft,
         _ => null
     };

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -182,7 +182,7 @@ public class JobService : IJobService
 
         // Set the cancellation flag before claiming completion so a racing CompleteJob
         // (process exiting at the same instant) still sees it and reverts the plan
-        // instead of transitioning it to ReadyForReview.
+        // instead of transitioning it to Review.
         job.CancellationRequested = true;
 
         if (!job.TryClaimCompletion()) return;
@@ -562,10 +562,10 @@ public class JobService : IJobService
 
         var target = job.TypedArgs switch
         {
-            ExecutePlanArgs => PlanStatus.Building,
-            ExpandPlanArgs => PlanStatus.Building,
-            CreatePrArgs => PlanStatus.Building,
-            CreateIssueArgs => PlanStatus.Building,
+            ExecutePlanArgs => PlanStatus.Creating,
+            ExpandPlanArgs => PlanStatus.Creating,
+            CreatePrArgs => PlanStatus.Creating,
+            CreateIssueArgs => PlanStatus.Creating,
             RetryPlanArgs => PlanStatus.Executing,
             UpdatePlanArgs => PlanStatus.Updating,
             SplitPlanArgs => PlanStatus.Updating,
@@ -574,10 +574,10 @@ public class JobService : IJobService
         if (target == null) return;
 
         // Skip transient/in-flight states so a re-start, force-start, or restart of a
-        // previously-blocked job doesn't snapshot Building/Executing/Updating/Blocked
+        // previously-blocked job doesn't snapshot Creating/Executing/Updating/Blocked
         // (the revert fallback map covers those cases).
         var current = _planReaderService.GetPlanByFolder(folder)?.Status;
-        if (current is not (PlanStatus.Building or PlanStatus.Executing or PlanStatus.Updating or PlanStatus.Blocked))
+        if (current is not (PlanStatus.Creating or PlanStatus.Executing or PlanStatus.Updating or PlanStatus.Blocked))
             job.PreviousPlanState = current;
 
         var folderName = Path.GetFileName(folder);

--- a/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
+++ b/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
@@ -106,7 +106,7 @@ internal class DependencyChecker
             if (HasActiveJobForPlan(planFolder, jobs)) continue;
             if (!jobs.TryRemove(blockedJob.Id, out _)) continue;
 
-            PlanYamlHelper.SetPlanStateByFolder(planFolder, nameof(PlanStatus.Building));
+            PlanYamlHelper.SetPlanStateByFolder(planFolder, nameof(PlanStatus.Creating));
             startJobSkipDepCheck(blockedJob.TypedArgs!);
 
             raiseNotification(new JobNotification(
@@ -135,7 +135,7 @@ internal class DependencyChecker
                 var (allMet, _) = CheckDependencies(dir);
                 if (allMet)
                 {
-                    PlanYamlHelper.SetPlanStateByFolder(dir, nameof(PlanStatus.Building));
+                    PlanYamlHelper.SetPlanStateByFolder(dir, nameof(PlanStatus.Creating));
                     startJobSkipDepCheck(new ExecutePlanArgs(dir));
                 }
             }

--- a/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
@@ -7,6 +7,7 @@ public interface IPlanReaderService
     string PlansDirectory { get; }
     bool IsDatabaseReady { get; }
 
+    void MigratePlanStateNames();
     void RecoverStuckPlans();
     void RepairPlans();
     List<PlanFile> GetPlans(PlanStatus? statusFilter = null);

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -210,7 +210,7 @@ public class PlanDatabaseService : IPlanDatabaseService
             cmd.CommandText = """
                               SELECT
                                   COALESCE(SUM(CASE WHEN State IN ('Draft', 'Blocked') THEN 1 ELSE 0 END), 0) AS DraftCount,
-                                  COALESCE(SUM(CASE WHEN State = 'ReadyForReview' THEN 1 ELSE 0 END), 0) AS ReadyForReviewCount,
+                                  COALESCE(SUM(CASE WHEN State = 'Review' THEN 1 ELSE 0 END), 0) AS ReviewCount,
                                   COALESCE(SUM(CASE WHEN State = 'Failed' THEN 1 ELSE 0 END), 0) AS FailedCount,
                                   COALESCE(SUM(CASE WHEN State = 'Icebox' THEN 1 ELSE 0 END), 0) AS IceboxCount,
                                   (SELECT COUNT(*) FROM Recommendations WHERE State = 'Pending' AND SourcePlanStatus = 'Completed') AS PendingRecommendationsCount,
@@ -222,7 +222,7 @@ public class PlanDatabaseService : IPlanDatabaseService
             if (reader.Read())
             {
                 var draftOrdinal = reader.GetOrdinal("DraftCount");
-                var readyForReviewOrdinal = reader.GetOrdinal("ReadyForReviewCount");
+                var reviewOrdinal = reader.GetOrdinal("ReviewCount");
                 var failedOrdinal = reader.GetOrdinal("FailedCount");
                 var iceboxOrdinal = reader.GetOrdinal("IceboxCount");
                 var pendingRecsOrdinal = reader.GetOrdinal("PendingRecommendationsCount");
@@ -230,7 +230,7 @@ public class PlanDatabaseService : IPlanDatabaseService
 
                 return new PlanReaderService.PlanCountSnapshot(
                     reader.GetInt32(draftOrdinal),
-                    reader.GetInt32(readyForReviewOrdinal),
+                    reader.GetInt32(reviewOrdinal),
                     reader.GetInt32(failedOrdinal),
                     reader.GetInt32(iceboxOrdinal),
                     reader.GetInt32(pendingRecsOrdinal),

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseSyncService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseSyncService.cs
@@ -104,7 +104,7 @@ public class PlanDatabaseSyncService : IDisposable
     private void RecoverStuckPlansInDatabase(List<PlanFile> plans)
     {
         var stuckStates = new HashSet<PlanStatus>
-            { PlanStatus.Building, PlanStatus.Executing, PlanStatus.Updating, PlanStatus.Blocked };
+            { PlanStatus.Creating, PlanStatus.Executing, PlanStatus.Updating, PlanStatus.Blocked };
 
         var recovered = 0;
         foreach (var plan in plans)

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -82,13 +82,13 @@ public class PlanReaderService(
     }
 
     /// <summary>
-    ///     On startup, reset any plans stuck in transient states (Building, Executing, Updating)
+    ///     On startup, reset any plans stuck in transient states (Creating, Executing, Updating)
     ///     back to Failed. These are leftovers from a previous Tendril shutdown.
     /// </summary>
     public void RecoverStuckPlans()
     {
         var stuckStates = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            { nameof(PlanStatus.Building), nameof(PlanStatus.Executing), nameof(PlanStatus.Updating), nameof(PlanStatus.Blocked) };
+            { nameof(PlanStatus.Creating), nameof(PlanStatus.Executing), nameof(PlanStatus.Updating), nameof(PlanStatus.Blocked) };
 
         if (!Directory.Exists(PlansDirectory)) return;
 
@@ -120,6 +120,50 @@ public class PlanReaderService(
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "Failed to recover plan in {Folder}", Path.GetFileName(dir));
+            }
+    }
+
+    /// <summary>
+    ///     One-time, idempotent migration: rewrite legacy plan state names in plan.yaml files to
+    ///     their current spelling (Building → Creating, ReadyForReview → Review). Must run before
+    ///     <see cref="RecoverStuckPlans" />/<see cref="RepairPlans" /> and the database sync, which
+    ///     all compare against the new enum names. Re-running is a no-op once values are migrated.
+    /// </summary>
+    public void MigratePlanStateNames()
+    {
+        var renames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Building"] = nameof(PlanStatus.Creating),
+            ["ReadyForReview"] = nameof(PlanStatus.Review),
+        };
+
+        if (!Directory.Exists(PlansDirectory)) return;
+
+        foreach (var dir in Directory.GetDirectories(PlansDirectory))
+            try
+            {
+                var planYamlPath = Path.Combine(dir, "plan.yaml");
+                if (!File.Exists(planYamlPath)) continue;
+
+                var yaml = FileHelper.ReadAllText(planYamlPath);
+                var stateMatch = StateLineRegex.Match(yaml);
+                if (!stateMatch.Success) continue;
+
+                var state = stateMatch.Groups[1].Value.Trim();
+                if (!renames.TryGetValue(state, out var newState)) continue;
+
+                // Name-only migration: rewrite the state value but leave `updated:` untouched.
+                var updated = Regex.Replace(yaml, @"(?m)^state:\s*.*$", $"state: {newState}");
+                FileHelper.WriteAllText(planYamlPath, updated);
+                logger.LogInformation("Migrated plan state {Old} → {New} in {Folder}",
+                    state, newState, Path.GetFileName(dir));
+                planWatcherService?.NotifyChanged(Path.GetFileName(dir));
+                _planCountsCache.Invalidate();
+                _recommendationsCache.Invalidate();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to migrate plan state in {Folder}", Path.GetFileName(dir));
             }
     }
 
@@ -1151,7 +1195,7 @@ public class PlanReaderService(
                 {
                     case "draft": drafts++; break;
                     case "blocked": drafts++; break;
-                    case "readyforreview": reviews++; break;
+                    case "review": reviews++; break;
                     case "failed": failed++; break;
                     case "icebox": icebox++; break;
                 }
@@ -1268,7 +1312,7 @@ public class PlanReaderService(
 
     public record PlanCountSnapshot(
         int Drafts,
-        int ReadyForReview,
+        int Review,
         int Failed,
         int Icebox,
         int PendingRecommendations,

--- a/src/Ivy.Tendril/Services/Plans/PlanValidationService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanValidationService.cs
@@ -11,7 +11,7 @@ public static class PlanValidationService
 {
     private static readonly string[] ValidStates =
     [
-        nameof(PlanStatus.Draft), nameof(PlanStatus.Building), nameof(PlanStatus.Updating), nameof(PlanStatus.Executing), nameof(PlanStatus.ReadyForReview),
+        nameof(PlanStatus.Draft), nameof(PlanStatus.Creating), nameof(PlanStatus.Updating), nameof(PlanStatus.Executing), nameof(PlanStatus.Review),
         nameof(PlanStatus.Failed), nameof(PlanStatus.Completed), nameof(PlanStatus.Skipped), nameof(PlanStatus.Blocked), nameof(PlanStatus.Icebox)
     ];
 

--- a/src/Ivy.Tendril/Services/Plans/TendrilProcessStatusService.cs
+++ b/src/Ivy.Tendril/Services/Plans/TendrilProcessStatusService.cs
@@ -131,7 +131,7 @@ public class TendrilProcessStatusService : ITendrilProcessStatusService
                         p.FolderName.StartsWith(id + "-", StringComparison.OrdinalIgnoreCase));
                 if (!hasActiveJob) continue;
 
-                if (p.Status is PlanStatus.ReadyForReview or PlanStatus.Failed)
+                if (p.Status is PlanStatus.Review or PlanStatus.Failed)
                     prematureReviews++;
                 else if (p.Status is PlanStatus.Draft or PlanStatus.Blocked)
                     prematureDrafts++;
@@ -149,7 +149,7 @@ public class TendrilProcessStatusService : ITendrilProcessStatusService
         return new TendrilProcessStatus
         {
             DraftCount = Math.Max(0, snapshot.Drafts - prematureDrafts),
-            ReviewCount = Math.Max(0, snapshot.ReadyForReview + snapshot.Failed - prematureReviews),
+            ReviewCount = Math.Max(0, snapshot.Review + snapshot.Failed - prematureReviews),
             IceboxCount = snapshot.Icebox,
             JobCount = activeJobs.Count,
             TrashCount = trashCount,


### PR DESCRIPTION
Rewords two `PlanStatus` enum values for clarity (`Building`→`Creating`, `ReadyForReview`→`Review`). State machine and transitions are unchanged.

## What changed
- Enum members + all `PlanStatus`/`nameof` references, hardcoded SQL/string literals, CLI/MCP help text, the `PlanCountSnapshot.Review` property, and docs/prompts.
- **Data migration (both stores, idempotent):** new `PlanReaderService.MigratePlanStateNames()` rewrites legacy values in on-disk `plan.yaml` files (hooked first at startup, before recovery/repair and DB sync); `Migration_015_RenamePlanStates` updates `Plans.State` rows in SQLite.
- Tests updated to new names + new yaml/DB migration tests.

## Excluded intentionally
- `JobFailureAnalyzer` "Building" build-progress label (not a plan state).
- End2End "Review" app/sidebar navigation (unrelated to the enum).

## Verification
- Build clean (main, unit-test, End2End).
- Full unit suite: 1487 passed, 1 skipped (pre-existing), 0 failed.