### PR TITLE
Add schemaVersion to plan.yaml and a per-file plan migration framework

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -336,15 +336,11 @@ public class JobServiceCompletionGuardTests : IDisposable
         // Status returned by GetPlanByFolder (simulates the plan's current state).
         public PlanStatus? CurrentStatus { get; set; }
 
-        public void MigratePlanStateNames()
+        public void MigratePlans()
         {
         }
 
         public void RecoverStuckPlans()
-        {
-        }
-
-        public void RepairPlans()
         {
         }
 

--- a/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
@@ -310,15 +310,11 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         public event Action? CountsInvalidated;
 #pragma warning restore CS0067
 
-        public void MigratePlanStateNames()
+        public void MigratePlans()
         {
         }
 
         public void RecoverStuckPlans()
-        {
-        }
-
-        public void RepairPlans()
         {
         }
 

--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -517,15 +517,11 @@ public class JobServiceRetryBlockedTests : IDisposable
         public event Action? CountsInvalidated;
 #pragma warning restore CS0067
 
-        public void MigratePlanStateNames()
+        public void MigratePlans()
         {
         }
 
         public void RecoverStuckPlans()
-        {
-        }
-
-        public void RepairPlans()
         {
         }
 

--- a/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
@@ -71,9 +71,8 @@ public class JobServiceSplitPlanCompletionTests
         public void SetVerificationStatus(string folderName, string name, VerificationStatus status) { }
         public void RevertRevision(string folderName) { }
 
-        public void MigratePlanStateNames() { }
+        public void MigratePlans() { }
         public void RecoverStuckPlans() { }
-        public void RepairPlans() { }
         public List<PlanFile> GetPlans(PlanStatus? statusFilter = null) => [];
         public PlanFile? GetPlanByFolder(string folderPath) => null;
         public List<PlanFile> GetIceboxPlans() => [];

--- a/src/Ivy.Tendril.Test/PlanMigratorTests.cs
+++ b/src/Ivy.Tendril.Test/PlanMigratorTests.cs
@@ -1,0 +1,88 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Plans.Migrations;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test;
+
+public class PlanMigratorTests
+{
+    [Fact]
+    public void LatestVersion_MatchesPlanYamlCurrentSchemaVersion()
+    {
+        // PlanYaml.CurrentSchemaVersion is a compile-time const used to stamp newly-written plans; it
+        // must track the highest migration version or new plans would be re-migrated on every startup.
+        Assert.Equal(PlanYaml.CurrentSchemaVersion, new PlanMigrator().LatestVersion);
+    }
+
+    [Fact]
+    public void RealMigrations_AreSequentiallyNumberedFromOne()
+    {
+        // Construction validates the discovered set; this throwing would mean a gap/duplicate in the
+        // PlanMigration_NNN files.
+        var ex = Record.Exception(() => new PlanMigrator());
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Constructor_Throws_OnDuplicateVersions()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            new PlanMigrator([new FakeMigration(1), new FakeMigration(1)]));
+    }
+
+    [Fact]
+    public void Constructor_Throws_OnGapInSequence()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            new PlanMigrator([new FakeMigration(1), new FakeMigration(3)]));
+    }
+
+    [Fact]
+    public void RenameLegacyStateNames_MapsBuildingToCreating()
+    {
+        var migration = new PlanMigration_001_RenameLegacyStateNames();
+        var result = migration.Apply(Context("state: Building\nproject: Test\n", "Building"));
+
+        Assert.Contains("state: Creating", result);
+        Assert.DoesNotContain("Building", result);
+    }
+
+    [Fact]
+    public void RenameLegacyStateNames_LeavesUnknownStatesUntouched()
+    {
+        var migration = new PlanMigration_001_RenameLegacyStateNames();
+        const string yaml = "state: Draft\nproject: Test\n";
+
+        Assert.Equal(yaml, migration.Apply(Context(yaml, "Draft")));
+    }
+
+    [Fact]
+    public void NormalizeYamlStructure_FlattensObjectStyleRepos()
+    {
+        var migration = new PlanMigration_003_NormalizeYamlStructure();
+        const string yaml = "state: Draft\nrepos:\n  - name: r\n    path: C:\\repos\\r\n    branch: main\n";
+
+        var result = migration.Apply(Context(yaml, "Draft"));
+
+        // Object-style repo is flattened to a plain (quoted) path string; the structured sub-keys are dropped.
+        Assert.Contains("C:\\repos\\r", result);
+        Assert.DoesNotContain("name: r", result);
+        Assert.DoesNotContain("branch:", result);
+    }
+
+    private static PlanMigrationContext Context(string yaml, string state) => new()
+    {
+        PlanFolder = "unused",
+        FolderName = "00001-Test",
+        Yaml = yaml,
+        State = state,
+        Logger = NullLogger.Instance
+    };
+
+    private sealed class FakeMigration(int version) : IPlanMigration
+    {
+        public int Version => version;
+        public string Description => $"fake {version}";
+        public string Apply(PlanMigrationContext context) => context.Yaml;
+    }
+}

--- a/src/Ivy.Tendril.Test/PlanReaderServiceRecoveryTests.cs
+++ b/src/Ivy.Tendril.Test/PlanReaderServiceRecoveryTests.cs
@@ -1,4 +1,6 @@
 using System.Text.RegularExpressions;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -38,6 +40,15 @@ public class PlanReaderServiceRecoveryTests : IDisposable
         var yaml = File.ReadAllText(Path.Combine(_service.PlansDirectory, folderName, "plan.yaml"));
         var match = Regex.Match(yaml, @"(?m)^state:\s*(.+)$");
         return match.Success ? match.Groups[1].Value.Trim() : "";
+    }
+
+    private string ReadRaw(string folderName) =>
+        File.ReadAllText(Path.Combine(_service.PlansDirectory, folderName, "plan.yaml"));
+
+    private int? ReadSchemaVersion(string folderName)
+    {
+        var match = Regex.Match(ReadRaw(folderName), @"(?m)^schemaVersion:\s*(\d+)\s*$");
+        return match.Success ? int.Parse(match.Groups[1].Value) : null;
     }
 
     [Fact]
@@ -124,27 +135,69 @@ public class PlanReaderServiceRecoveryTests : IDisposable
     }
 
     [Fact]
-    public void MigratePlanStateNames_RewritesLegacyStateNames()
+    public void MigratePlans_RewritesLegacyStateNames()
     {
         CreatePlan("01300-Legacy1", "Building");
         CreatePlan("01301-Legacy2", "ReadyForReview");
 
-        _service.MigratePlanStateNames();
+        _service.MigratePlans();
 
         Assert.Equal("Creating", ReadState("01300-Legacy1"));
         Assert.Equal("Review", ReadState("01301-Legacy2"));
     }
 
     [Fact]
-    public void MigratePlanStateNames_LeavesCurrentStatesUntouched_AndIsIdempotent()
+    public void MigratePlans_LeavesCurrentStatesUntouched_AndIsIdempotent()
     {
         CreatePlan("01302-Current", "Draft");
         CreatePlan("01303-Migrated", "Building");
 
-        _service.MigratePlanStateNames();
-        _service.MigratePlanStateNames(); // re-running is a no-op
+        _service.MigratePlans();
+        _service.MigratePlans(); // re-running is a no-op (gated by stamped schemaVersion)
 
         Assert.Equal("Draft", ReadState("01302-Current"));
         Assert.Equal("Creating", ReadState("01303-Migrated"));
+    }
+
+    [Fact]
+    public void MigratePlans_StampsCurrentSchemaVersion_OnLegacyPlan()
+    {
+        // CreatePlan writes well-formed YAML with no schemaVersion (version 0). The structural repair is
+        // a no-op here, but we must still stamp the version so later startups skip the plan (constraint #3).
+        CreatePlan("01400-Legacy", "Draft");
+        Assert.Null(ReadSchemaVersion("01400-Legacy"));
+
+        _service.MigratePlans();
+
+        Assert.Equal(PlanYaml.CurrentSchemaVersion, ReadSchemaVersion("01400-Legacy"));
+        // The stamped file must still deserialize cleanly.
+        var plan = YamlHelper.Deserializer.Deserialize<PlanYaml>(ReadRaw("01400-Legacy"));
+        Assert.Equal("Draft", plan.State);
+    }
+
+    [Fact]
+    public void MigratePlans_SkipsPlanAlreadyAtCurrentVersion()
+    {
+        CreatePlan("01401-Current", "Draft");
+        _service.MigratePlans(); // first pass stamps the version
+        var afterFirst = ReadRaw("01401-Current");
+        Assert.Equal(PlanYaml.CurrentSchemaVersion, ReadSchemaVersion("01401-Current"));
+
+        _service.MigratePlans(); // second pass must be a no-op (gated by schemaVersion)
+
+        Assert.Equal(afterFirst, ReadRaw("01401-Current"));
+    }
+
+    [Fact]
+    public void MigratePlans_LeavesTerminalPlanUntouched()
+    {
+        CreatePlan("01402-Done", "Completed");
+        var before = ReadRaw("01402-Done");
+
+        _service.MigratePlans();
+
+        // Terminal plans are skipped entirely, so they are never rewritten or stamped.
+        Assert.Equal(before, ReadRaw("01402-Done"));
+        Assert.Null(ReadSchemaVersion("01402-Done"));
     }
 }

--- a/src/Ivy.Tendril.Test/PlanYamlCorruptionTests.cs
+++ b/src/Ivy.Tendril.Test/PlanYamlCorruptionTests.cs
@@ -113,6 +113,41 @@ public class PlanYamlCorruptionTests : IClassFixture<ConfigServiceFixture>
     }
 
     [Fact]
+    public void RepairPlanYaml_PreservesSchemaVersion()
+    {
+        // schemaVersion must survive the repair pass, otherwise the stamp gets stripped by the
+        // structure normalizer and the plan is re-repaired on every startup (constraint #2).
+        var malformed =
+            "schemaVersion: 1\n" +
+            "state: Draft\n" +
+            "repos:\n" +
+            "  - name: my-repo\n" +
+            "    path: C:\\repos\\my-repo\n" +
+            "    branch: main\n";
+
+        var repaired = Ivy.Tendril.Services.Plans.PlanYamlRepairService.RepairPlanYaml(malformed);
+
+        Assert.Matches(@"(?m)^schemaVersion:\s*1\s*$", repaired);
+        var plan = YamlHelper.Deserializer.Deserialize<PlanYaml>(repaired);
+        Assert.Equal(1, plan.SchemaVersion);
+        Assert.Equal("Draft", plan.State);
+    }
+
+    [Fact]
+    public void WritePlan_StampsCurrentSchemaVersion()
+    {
+        var planFolder = CreateTestPlan();
+
+        var raw = File.ReadAllText(Path.Combine(planFolder, "plan.yaml"));
+        Assert.Matches($@"(?m)^schemaVersion:\s*{PlanYaml.CurrentSchemaVersion}\s*$", raw);
+
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        Assert.Equal(PlanYaml.CurrentSchemaVersion, plan.SchemaVersion);
+
+        Directory.Delete(planFolder, true);
+    }
+
+    [Fact]
     public void SetPlanStateByFolder_UpdatesTimestamp()
     {
         // Arrange: Create a plan

--- a/src/Ivy.Tendril/AGENTS.md
+++ b/src/Ivy.Tendril/AGENTS.md
@@ -5,11 +5,11 @@
 When changing the `plan.yaml` structure (adding/removing/renaming fields, changing field types):
 
 1. **Update `Plans.md`** (`Prompts/Plans.md`) — this is the source of truth for the plan schema (embedded as an assembly resource)
-2. **Add a repair step** in `PlanReaderService.RepairPlans()` — this runs on every Tendril startup and must migrate all existing plans to the new format
+2. **Add a migration** — create a new `PlanMigration_NNN_*` class in `Services/Plans/Migrations/` implementing `IPlanMigration`, and bump `PlanYaml.CurrentSchemaVersion` to match. Migrations are auto-discovered and run by `PlanMigrator` on every startup; each non-terminal plan is brought up to the latest version, then stamped with its `schemaVersion` so it is skipped on later startups. Bumping the version forces a one-time re-sweep of all non-terminal plans.
 3. **Keep `PlanYaml.cs` in sync** — the deserialization model must match what `Plans.md` documents
 4. **Update promptware instructions** — any promptware that writes `plan.yaml` (CreatePlan, ExecutePlan, UpdatePlan, SplitPlan, ExpandPlan) must produce the new format
 
-Existing plans on disk are never recreated — they must be repaired in place. If `RepairPlans()` can't fix a plan, it will silently fail and that plan won't appear in the UI. Always test your repair logic against real plan files.
+Existing plans on disk are never recreated — they must be migrated in place. If a migration can't fix a plan it is logged and skipped, and that plan won't appear in the UI. Always test your migration against real plan files. Terminal plans (Completed/Skipped) are treated as immutable and are not migrated.
 
 ## Project Structure
 
@@ -210,6 +210,6 @@ tendril plan get <id>       # Show plan details
 ### Common Issues
 
 - **Plan counter collisions**: `$TENDRIL_PLANS/.counter` is protected by file-based locking in `tendril plan create`. If plans get duplicate IDs, check for concurrent access issues.
-- **Plans not appearing in UI**: Run `tendril doctor plans` to check for malformed `plan.yaml` files. `PlanReaderService.RepairPlans()` runs on startup but silently skips plans it can't fix.
+- **Plans not appearing in UI**: Run `tendril doctor plans` to check for malformed `plan.yaml` files. `PlanMigrator` (driven by `PlanReaderService.MigratePlans()`) runs on startup but logs and skips plans it can't fix.
 - **Build errors from locked files**: Tendril locks its own exe while running. Use `--no-dependencies` or stop the running instance before building.
 - **Missing `.raw.jsonl` logs**: These are written by `PromptwareLogWriter.WriteRawLog` on job completion. The Logs directory is created automatically by `FirmwareCompiler.GetLogFile`.

--- a/src/Ivy.Tendril/Models/PlanModels.cs
+++ b/src/Ivy.Tendril/Models/PlanModels.cs
@@ -146,6 +146,21 @@ public class PlanVerificationEntry
 
 public class PlanYaml
 {
+    /// <summary>
+    ///     Current plan.yaml schema version. Equals the highest <see cref="Services.Plans.Migrations.IPlanMigration" />
+    ///     version; adding a new migration file bumps this and forces a one-time re-sweep of all non-terminal
+    ///     plans on the next startup. Kept in sync by a unit test guard.
+    /// </summary>
+    public const int CurrentSchemaVersion = 3;
+
+    /// <summary>
+    ///     Schema version stamped into plan.yaml once a plan has been upgraded to the current
+    ///     structure. Legacy files lacking this field are treated as version 0. Defaults to
+    ///     <see cref="CurrentSchemaVersion" /> so newly-created plans are stamped current on write.
+    ///     NOTE: gating logic must read this from raw YAML text (absent ⇒ 0), not from this default.
+    /// </summary>
+    public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+
     public string State { get; set; } = nameof(PlanStatus.Draft);
     public string Project { get; set; } = "Auto";
     public string Level { get; set; } = "Feature";

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -75,9 +75,7 @@ internal static class ServiceRegistration
                 sp.GetRequiredService<ILogger<PlanReaderService>>(),
                 sp.GetRequiredService<ITelemetryService>(),
                 sp.GetRequiredService<IWorktreeLifecycleLogger>());
-            planService.MigratePlanStateNames();
-            planService.MigratePlanSubfolderCasing();
-            planService.RepairPlans();
+            planService.MigratePlans();
             planService.RecoverStuckPlans();
             return planService;
         });

--- a/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
@@ -7,9 +7,8 @@ public interface IPlanReaderService
     string PlansDirectory { get; }
     bool IsDatabaseReady { get; }
 
-    void MigratePlanStateNames();
+    void MigratePlans();
     void RecoverStuckPlans();
-    void RepairPlans();
     List<PlanFile> GetPlans(PlanStatus? statusFilter = null);
     PlanFile? GetPlanByFolder(string folderPath);
     List<PlanFile> GetIceboxPlans();

--- a/src/Ivy.Tendril/Services/Plans/Migrations/IPlanMigration.cs
+++ b/src/Ivy.Tendril/Services/Plans/Migrations/IPlanMigration.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services.Plans.Migrations;
+
+/// <summary>
+///     A single, versioned transformation that brings a plan from schema version
+///     <see cref="Version" /> - 1 up to <see cref="Version" />. The parallel to
+///     <see cref="Database.IMigration" /> for the SQLite database, but applied per-plan against
+///     the on-disk <c>plan.yaml</c> (and, where relevant, the plan folder).
+///
+///     Migrations are auto-discovered and run by <see cref="PlanMigrator" />. The runner reads the
+///     plan's current version from raw YAML (absent ⇒ 0), applies every pending migration in order,
+///     then stamps the new <c>schemaVersion</c>. Implementations therefore MUST NOT stamp the
+///     version themselves, and should be safe to run against any plan below their version.
+/// </summary>
+public interface IPlanMigration
+{
+    /// <summary>Target schema version. Must be sequential across migrations (1, 2, 3, ...).</summary>
+    int Version { get; }
+
+    /// <summary>Human-readable description of what this migration does.</summary>
+    string Description { get; }
+
+    /// <summary>
+    ///     Apply the migration to a single plan. May rewrite the YAML and/or touch the plan folder
+    ///     (e.g. rename subfolders). Returns the possibly-modified YAML text — return the input
+    ///     unchanged when there is nothing to do.
+    /// </summary>
+    string Apply(PlanMigrationContext context);
+}

--- a/src/Ivy.Tendril/Services/Plans/Migrations/PlanMigrationContext.cs
+++ b/src/Ivy.Tendril/Services/Plans/Migrations/PlanMigrationContext.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services.Plans.Migrations;
+
+/// <summary>
+///     Per-plan input handed to an <see cref="IPlanMigration" />. The <see cref="Yaml" /> is the
+///     current plan.yaml content (already carrying any edits from earlier migrations in the same run);
+///     migrations return the next version of it.
+/// </summary>
+public sealed class PlanMigrationContext
+{
+    /// <summary>Absolute path to the plan folder (e.g. <c>.../Plans/01234-Title</c>).</summary>
+    public required string PlanFolder { get; init; }
+
+    /// <summary>Plan folder name (e.g. <c>01234-Title</c>), useful for logging/notifications.</summary>
+    public required string FolderName { get; init; }
+
+    /// <summary>Current plan.yaml content to transform.</summary>
+    public required string Yaml { get; init; }
+
+    /// <summary>Parsed <c>state:</c> value, or empty if absent. Provided for convenience.</summary>
+    public required string State { get; init; }
+
+    public required ILogger Logger { get; init; }
+}

--- a/src/Ivy.Tendril/Services/Plans/Migrations/PlanMigration_001_RenameLegacyStateNames.cs
+++ b/src/Ivy.Tendril/Services/Plans/Migrations/PlanMigration_001_RenameLegacyStateNames.cs
@@ -1,0 +1,37 @@
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services.Plans.Migrations;
+
+/// <summary>
+///     Rewrites legacy plan state names to their current spelling. A name-only migration: it rewrites
+///     the <c>state:</c> value but leaves <c>updated:</c> untouched. Must run before stuck-plan recovery
+///     and the database sync, which compare against the current enum names.
+/// </summary>
+public sealed class PlanMigration_001_RenameLegacyStateNames : IPlanMigration
+{
+    private static readonly Dictionary<string, string> Renames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Building"] = nameof(PlanStatus.Creating),
+        ["ReadyForReview"] = nameof(PlanStatus.Review)
+    };
+
+    private static readonly Regex StateLineRegex = new(@"(?m)^state:\s*(.+)$", RegexOptions.Compiled);
+
+    public int Version => 1;
+    public string Description => "Rename legacy plan state names (Building → Creating, ReadyForReview → Review)";
+
+    public string Apply(PlanMigrationContext context)
+    {
+        var match = StateLineRegex.Match(context.Yaml);
+        if (!match.Success) return context.Yaml;
+
+        var state = match.Groups[1].Value.Trim();
+        if (!Renames.TryGetValue(state, out var newState)) return context.Yaml;
+
+        context.Logger.LogInformation("Migrated plan state {Old} → {New} in {Folder}",
+            state, newState, context.FolderName);
+        return Regex.Replace(context.Yaml, @"(?m)^state:\s*.*$", $"state: {newState}");
+    }
+}

--- a/src/Ivy.Tendril/Services/Plans/Migrations/PlanMigration_002_TitleCaseSubfolders.cs
+++ b/src/Ivy.Tendril/Services/Plans/Migrations/PlanMigration_002_TitleCaseSubfolders.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services.Plans.Migrations;
+
+/// <summary>
+///     Renames plan subfolders from lowercase to Title Case for consistency with TENDRIL_HOME folder
+///     naming (Inbox, Trash, Plans, ...). Matters on case-sensitive filesystems where readers expect
+///     <c>Revisions</c>/<c>Logs</c>/etc. Operates on the folder only; plan.yaml is returned unchanged.
+/// </summary>
+public sealed class PlanMigration_002_TitleCaseSubfolders : IPlanMigration
+{
+    private static readonly Dictionary<string, string> TitleCase = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["revisions"] = "Revisions",
+        ["logs"] = "Logs",
+        ["artifacts"] = "Artifacts",
+        ["verification"] = "Verification",
+        ["worktrees"] = "Worktrees"
+    };
+
+    public int Version => 2;
+    public string Description => "Title-case plan subfolders (revisions → Revisions, logs → Logs, ...)";
+
+    public string Apply(PlanMigrationContext context)
+    {
+        foreach (var subDir in Directory.GetDirectories(context.PlanFolder))
+        {
+            var actualName = Path.GetFileName(subDir);
+            if (!TitleCase.TryGetValue(actualName, out var desired)) continue;
+            if (actualName == desired) continue;
+
+            try
+            {
+                // Two-step move via a temp name so the rename is not a no-op on case-insensitive filesystems.
+                var tmpPath = subDir + "_tmp";
+                Directory.Move(subDir, tmpPath);
+                Directory.Move(tmpPath, Path.Combine(context.PlanFolder, desired));
+                context.Logger.LogDebug("Renamed {Old} → {New}", actualName, desired);
+            }
+            catch (Exception ex)
+            {
+                context.Logger.LogWarning(ex, "Failed to rename {Old} to {New}", subDir, desired);
+            }
+        }
+
+        return context.Yaml;
+    }
+}

--- a/src/Ivy.Tendril/Services/Plans/Migrations/PlanMigration_003_NormalizeYamlStructure.cs
+++ b/src/Ivy.Tendril/Services/Plans/Migrations/PlanMigration_003_NormalizeYamlStructure.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services.Plans.Migrations;
+
+/// <summary>
+///     Normalizes/repairs plan.yaml structure via <see cref="PlanYamlRepairService" />: object-style
+///     repos/commits/prs → plain strings, quoting fixes for Windows paths and embedded colons, empty
+///     list fields, non-numeric priority, etc. Handles the malformed YAML that agents occasionally emit.
+/// </summary>
+public sealed class PlanMigration_003_NormalizeYamlStructure : IPlanMigration
+{
+    public int Version => 3;
+    public string Description => "Normalize/repair plan.yaml structure";
+
+    public string Apply(PlanMigrationContext context)
+    {
+        var repaired = PlanYamlRepairService.RepairPlanYaml(context.Yaml);
+        if (repaired != context.Yaml)
+            context.Logger.LogInformation("Repaired plan.yaml structure in {Folder}", context.FolderName);
+        return repaired;
+    }
+}

--- a/src/Ivy.Tendril/Services/Plans/Migrations/PlanMigrator.cs
+++ b/src/Ivy.Tendril/Services/Plans/Migrations/PlanMigrator.cs
@@ -1,0 +1,143 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Services.Plans.Migrations;
+
+/// <summary>
+///     Discovers and runs the <see cref="IPlanMigration" /> set against on-disk plans. The per-plan
+///     parallel to <see cref="Database.DatabaseMigrator" />: migrations are auto-discovered via
+///     reflection, validated to be sequential, and each plan is brought up to <see cref="LatestVersion" />
+///     based on the <c>schemaVersion</c> read from its raw plan.yaml.
+///
+///     Terminal plans (Completed/Skipped) are immutable history and are skipped entirely — they are
+///     never migrated or stamped.
+/// </summary>
+public class PlanMigrator
+{
+    private static readonly Regex StateLineRegex = new(@"(?m)^state:\s*(.+)$", RegexOptions.Compiled);
+
+    private static readonly HashSet<string> TerminalStates = new(StringComparer.OrdinalIgnoreCase)
+        { nameof(PlanStatus.Completed), nameof(PlanStatus.Skipped) };
+
+    private readonly ILogger _logger;
+    private readonly List<IPlanMigration> _migrations;
+
+    public PlanMigrator(ILogger? logger = null)
+    {
+        _logger = logger ?? NullLogger<PlanMigrator>.Instance;
+        _migrations = LoadMigrations();
+    }
+
+    internal PlanMigrator(IEnumerable<IPlanMigration> migrations, ILogger? logger = null)
+    {
+        _logger = logger ?? NullLogger<PlanMigrator>.Instance;
+        _migrations = migrations.OrderBy(m => m.Version).ToList();
+        ValidateMigrationSequence(_migrations);
+    }
+
+    /// <summary>Highest migration version; the version every up-to-date plan is stamped with.</summary>
+    public int LatestVersion => _migrations.Count > 0 ? _migrations.Max(m => m.Version) : 0;
+
+    /// <summary>
+    ///     Migrates every plan folder under <paramref name="plansDirectory" />. <paramref name="onPlanChanged" />
+    ///     is invoked with the folder name after a plan is written (used to notify watchers / invalidate caches).
+    ///     Best-effort: a failure on one plan is logged and does not stop the others.
+    /// </summary>
+    public void MigratePlans(string plansDirectory, Action<string>? onPlanChanged = null)
+    {
+        if (!Directory.Exists(plansDirectory)) return;
+
+        foreach (var dir in Directory.GetDirectories(plansDirectory))
+            try
+            {
+                MigratePlan(dir, onPlanChanged);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to migrate plan in {Folder}", Path.GetFileName(dir));
+            }
+    }
+
+    /// <summary>
+    ///     Brings a single plan folder up to <see cref="LatestVersion" />. Returns true if plan.yaml was
+    ///     rewritten. Skips terminal plans, plans without a plan.yaml, and plans already at the latest version.
+    /// </summary>
+    public bool MigratePlan(string planFolder, Action<string>? onPlanChanged = null)
+    {
+        var planYamlPath = Path.Combine(planFolder, "plan.yaml");
+        if (!File.Exists(planYamlPath)) return false;
+
+        var yaml = FileHelper.ReadAllText(planYamlPath);
+
+        var stateMatch = StateLineRegex.Match(yaml);
+        var state = stateMatch.Success ? stateMatch.Groups[1].Value.Trim() : "";
+        if (TerminalStates.Contains(state)) return false;
+
+        var currentVersion = PlanSchemaVersion.Read(yaml);
+        if (currentVersion >= LatestVersion) return false;
+
+        var folderName = Path.GetFileName(planFolder);
+        var migrated = yaml;
+        foreach (var migration in _migrations.Where(m => m.Version > currentVersion).OrderBy(m => m.Version))
+            migrated = migration.Apply(new PlanMigrationContext
+            {
+                PlanFolder = planFolder,
+                FolderName = folderName,
+                Yaml = migrated,
+                State = state,
+                Logger = _logger
+            });
+
+        // Always write — even when every migration was a no-op — so the stamp lands and the plan is
+        // skipped on later startups.
+        migrated = PlanSchemaVersion.Stamp(migrated, LatestVersion);
+        FileHelper.WriteAllText(planYamlPath, migrated);
+        _logger.LogInformation("Migrated plan {Folder} to schema version {Version}", folderName, LatestVersion);
+        onPlanChanged?.Invoke(folderName);
+        return true;
+    }
+
+    private static List<IPlanMigration> LoadMigrations()
+    {
+        var migrationType = typeof(IPlanMigration);
+        var migrations = typeof(PlanMigrator).Assembly
+            .GetTypes()
+            .Where(t => migrationType.IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract)
+            .Select(t => (IPlanMigration)Activator.CreateInstance(t)!)
+            .OrderBy(m => m.Version)
+            .ToList();
+
+        ValidateMigrationSequence(migrations);
+
+        return migrations;
+    }
+
+    private static void ValidateMigrationSequence(List<IPlanMigration> migrations)
+    {
+        if (migrations.Count == 0) return;
+
+        var duplicates = migrations.GroupBy(m => m.Version)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+
+        if (duplicates.Count > 0)
+            throw new InvalidOperationException(
+                $"Duplicate plan migration versions found: {string.Join(", ", duplicates)}");
+
+        for (var i = 0; i < migrations.Count; i++)
+        {
+            var expected = i + 1;
+            var actual = migrations[i].Version;
+
+            if (actual != expected)
+                throw new InvalidOperationException(
+                    $"Plan migration sequence is invalid. Expected version {expected}, found {actual}. " +
+                    "Migrations must be numbered sequentially starting from 1.");
+        }
+    }
+}

--- a/src/Ivy.Tendril/Services/Plans/Migrations/PlanSchemaVersion.cs
+++ b/src/Ivy.Tendril/Services/Plans/Migrations/PlanSchemaVersion.cs
@@ -1,0 +1,30 @@
+using System.Text.RegularExpressions;
+
+namespace Ivy.Tendril.Services.Plans.Migrations;
+
+/// <summary>
+///     Reads and writes the <c>schemaVersion</c> marker in raw plan.yaml text.
+///
+///     Detection MUST work off the raw text (not the deserialized model): <see cref="Models.PlanYaml" />
+///     defaults <c>SchemaVersion</c> to the current version so new plans serialize as current, which
+///     means a legacy file missing the field would otherwise deserialize as already-current and never
+///     get migrated. Files without the line are treated as version 0.
+/// </summary>
+public static class PlanSchemaVersion
+{
+    private static readonly Regex LineRegex =
+        new(@"(?m)^schemaVersion:\s*(\d+)\s*$", RegexOptions.Compiled);
+
+    /// <summary>Returns the stamped schema version, or 0 for legacy files lacking the field.</summary>
+    public static int Read(string yaml) =>
+        LineRegex.Match(yaml) is { Success: true } m ? int.Parse(m.Groups[1].Value) : 0;
+
+    /// <summary>
+    ///     Replaces an existing <c>schemaVersion:</c> line or prepends one. Prepending is valid YAML
+    ///     because "schemaVersion" is preserved by <see cref="PlanYamlRepairService" />'s normalizer.
+    /// </summary>
+    public static string Stamp(string yaml, int version) =>
+        LineRegex.IsMatch(yaml)
+            ? LineRegex.Replace(yaml, $"schemaVersion: {version}")
+            : $"schemaVersion: {version}{Environment.NewLine}{yaml}";
+}

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using Ivy.Helpers;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Plans.Migrations;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Services.Plans;
@@ -16,9 +17,6 @@ public class PlanReaderService(
 {
     private static readonly Regex FolderNameRegex = new(@"^(\d{5})-(.+)$", RegexOptions.Compiled);
     private static readonly Regex StateLineRegex = new(@"(?m)^state:\s*(.+)$", RegexOptions.Compiled);
-
-    private static readonly HashSet<string> TerminalStates = new(StringComparer.OrdinalIgnoreCase)
-        { nameof(PlanStatus.Completed), nameof(PlanStatus.Skipped) };
 
     private readonly TimeCache<Dictionary<string, DashboardModels>> _dashboardCache =
         new(TimeSpan.FromSeconds(10));
@@ -42,43 +40,20 @@ public class PlanReaderService(
     public event Action? CountsInvalidated;
 
     /// <summary>
-    ///     On startup, rename plan subfolders from lowercase to Title Case for consistency
-    ///     with TENDRIL_HOME folder naming (Inbox, Trash, Plans, etc.).
+    ///     On startup, bring every non-terminal plan up to the current schema version by running the
+    ///     <see cref="Migrations.IPlanMigration" /> set (state-name renames, subfolder casing, YAML
+    ///     structure repair). Plans already at the latest version are skipped via their stamped
+    ///     <c>schemaVersion</c>. Must run before <see cref="RecoverStuckPlans" /> and the database sync,
+    ///     which compare against the current enum names.
     /// </summary>
-    public void MigratePlanSubfolderCasing()
+    public void MigratePlans()
     {
-        if (!Directory.Exists(PlansDirectory)) return;
-
-        var titleCase = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        new PlanMigrator(logger).MigratePlans(PlansDirectory, folderName =>
         {
-            ["revisions"] = "Revisions",
-            ["logs"] = "Logs",
-            ["artifacts"] = "Artifacts",
-            ["verification"] = "Verification",
-            ["worktrees"] = "Worktrees"
-        };
-
-        foreach (var dir in Directory.GetDirectories(PlansDirectory))
-        {
-            foreach (var subDir in Directory.GetDirectories(dir))
-            {
-                var actualName = Path.GetFileName(subDir);
-                if (!titleCase.TryGetValue(actualName, out var desired)) continue;
-                if (actualName == desired) continue;
-
-                try
-                {
-                    var tmpPath = subDir + "_tmp";
-                    Directory.Move(subDir, tmpPath);
-                    Directory.Move(tmpPath, Path.Combine(dir, desired));
-                    logger.LogDebug("Renamed {Old} → {New}", actualName, desired);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogWarning(ex, "Failed to rename {Old} to {New}", subDir, desired);
-                }
-            }
-        }
+            planWatcherService?.NotifyChanged(folderName);
+            _planCountsCache.Invalidate();
+            _recommendationsCache.Invalidate();
+        });
     }
 
     /// <summary>
@@ -121,100 +96,6 @@ public class PlanReaderService(
             {
                 logger.LogWarning(ex, "Failed to recover plan in {Folder}", Path.GetFileName(dir));
             }
-    }
-
-    /// <summary>
-    ///     One-time, idempotent migration: rewrite legacy plan state names in plan.yaml files to
-    ///     their current spelling (Building → Creating, ReadyForReview → Review). Must run before
-    ///     <see cref="RecoverStuckPlans" />/<see cref="RepairPlans" /> and the database sync, which
-    ///     all compare against the new enum names. Re-running is a no-op once values are migrated.
-    /// </summary>
-    public void MigratePlanStateNames()
-    {
-        var renames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["Building"] = nameof(PlanStatus.Creating),
-            ["ReadyForReview"] = nameof(PlanStatus.Review),
-        };
-
-        if (!Directory.Exists(PlansDirectory)) return;
-
-        foreach (var dir in Directory.GetDirectories(PlansDirectory))
-            try
-            {
-                var planYamlPath = Path.Combine(dir, "plan.yaml");
-                if (!File.Exists(planYamlPath)) continue;
-
-                var yaml = FileHelper.ReadAllText(planYamlPath);
-                var stateMatch = StateLineRegex.Match(yaml);
-                if (!stateMatch.Success) continue;
-
-                var state = stateMatch.Groups[1].Value.Trim();
-                if (!renames.TryGetValue(state, out var newState)) continue;
-
-                // Name-only migration: rewrite the state value but leave `updated:` untouched.
-                var updated = Regex.Replace(yaml, @"(?m)^state:\s*.*$", $"state: {newState}");
-                FileHelper.WriteAllText(planYamlPath, updated);
-                logger.LogInformation("Migrated plan state {Old} → {New} in {Folder}",
-                    state, newState, Path.GetFileName(dir));
-                planWatcherService?.NotifyChanged(Path.GetFileName(dir));
-                _planCountsCache.Invalidate();
-                _recommendationsCache.Invalidate();
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Failed to migrate plan state in {Folder}", Path.GetFileName(dir));
-            }
-    }
-
-    /// <summary>
-    ///     On startup, fix plan.yaml files that have structured repos (path: + prRule:)
-    ///     by normalizing them to plain path strings.
-    /// </summary>
-    public void RepairPlans()
-    {
-        try
-        {
-            if (!Directory.Exists(PlansDirectory)) return;
-
-            var failedFolders = new List<string>();
-
-            foreach (var dir in Directory.GetDirectories(PlansDirectory))
-                try
-                {
-                    var planYamlPath = Path.Combine(dir, "plan.yaml");
-                    if (!File.Exists(planYamlPath)) continue;
-
-                    var yaml = FileHelper.ReadAllText(planYamlPath);
-
-                    var stateMatch = StateLineRegex.Match(yaml);
-                    if (stateMatch.Success && TerminalStates.Contains(stateMatch.Groups[1].Value.Trim()))
-                        continue;
-
-                    var repaired = PlanYamlRepairService.RepairPlanYaml(yaml);
-
-                    if (repaired != yaml)
-                    {
-                        FileHelper.WriteAllText(planYamlPath, repaired);
-                        logger.LogInformation("Repaired plan.yaml in {Folder}", Path.GetFileName(dir));
-                        planWatcherService?.NotifyChanged(Path.GetFileName(dir));
-                        _planCountsCache.Invalidate();
-                        _recommendationsCache.Invalidate();
-                    }
-                }
-                catch
-                {
-                    failedFolders.Add(Path.GetFileName(dir));
-                }
-
-            if (failedFolders.Count > 0)
-                logger.LogWarning("Failed to repair {Count} plans due to file access errors: {Folders}.",
-                    failedFolders.Count, string.Join(", ", failedFolders));
-        }
-        catch
-        {
-            /* Best-effort repair on startup; individual plan errors are non-fatal */
-        }
     }
 
     /// <summary>
@@ -1068,7 +949,7 @@ public class PlanReaderService(
         {
             // Fall back to the repair pass for malformed agent-generated YAML.
             logger.LogWarning(ex, "Failed to parse plan YAML {PlanYamlPath}, attempting repair", planYamlPath);
-            var repaired = PlanYamlRepairService.RepairPlanYaml(yamlContent);
+            var repaired = PlanSchemaVersion.Stamp(PlanYamlRepairService.RepairPlanYaml(yamlContent), PlanYaml.CurrentSchemaVersion);
             if (repaired != yamlContent)
                 FileHelper.WriteAllText(planYamlPath, repaired);
 

--- a/src/Ivy.Tendril/Services/Plans/PlanYamlRepairService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanYamlRepairService.cs
@@ -6,6 +6,7 @@ public static class PlanYamlRepairService
 {
     private static readonly HashSet<string> TopLevelKeys = new(StringComparer.Ordinal)
     {
+        "schemaVersion",
         "state", "project", "level", "title", "sessionId",
         "repos", "created", "updated", "initialPrompt", "sourceUrl",
         "prs", "commits", "verifications", "relatedPlans", "dependsOn",


### PR DESCRIPTION
## What

Adds a `schemaVersion` field to `plan.yaml` and refactors the three structural plan-upgrade passes into a versioned, one-file-per-migration framework under `Services/Plans/Migrations/`, mirroring the existing database migrator (`IMigration`/`DatabaseMigrator`).

## Why

Previously, three per-plan passes (`MigratePlanStateNames`, `MigratePlanSubfolderCasing`, `RepairPlans`) walked **every** plan folder and re-ran on **every** startup, synchronously, scaling linearly with the plan corpus — and the repair shims could never be retired because plans carried no version. Stamping a `schemaVersion` lets the upgrade run **once per plan**, then be skipped, and gives future migrations a retirement mechanism (bump the version → one re-sweep).

## Changes

- `PlanYaml` gains `SchemaVersion` (defaults to current) + `CurrentSchemaVersion` const (now `3`).
- New `Services/Plans/Migrations/`: `IPlanMigration`, `PlanMigrationContext`, `PlanMigrator` (reflection discovery + sequential validation), `PlanSchemaVersion`, and `PlanMigration_001_RenameLegacyStateNames` / `_002_TitleCaseSubfolders` / `_003_NormalizeYamlStructure`.
- `PlanReaderService` now exposes a single `MigratePlans()` gated on the stamped version; `RecoverStuckPlans()` stays (crash recovery, not a migration).
- `schemaVersion` added to `PlanYamlRepairService.TopLevelKeys` so the stamp survives a future repair.
- Terminal (Completed/Skipped) plans are treated as immutable and skipped entirely.
- `AGENTS.md` updated to document the new migration workflow.

## Behavior change

Terminal plans no longer receive the state-name/casing passes (the state-name pass was already a no-op on them; casing is cosmetic and already applied on existing installs).

## Tests

`PlanMigratorTests` (drift guard that `CurrentSchemaVersion == PlanMigrator.LatestVersion`, sequence validation, per-migration units) + updated recovery/corruption tests. Full suite: 1499 passed, 1 skipped, 0 failed.