### PR TITLE
[00038] Fix scrollbar not aligned to border on onboarding content box

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -189,7 +189,7 @@ public class ProjectAgentStepView(
                       )
                         .Width(Size.Full())
                         .Height(Size.Units(100).Max(Size.Fraction(0.6f)))
-                        .Padding(4, 4, 2, 4)
+                        .Padding(4, 0, 2, 4)
                    : null!)
                | buttonArea
                | new Spacer().Height(Size.Units(4));


### PR DESCRIPTION
Fixes #1300

# Summary

## Changes

Removed the right padding from the onboarding content box so the scrollbar aligns flush with the border. Changed `.Padding(4, 4, 2, 4)` to `.Padding(4, 0, 2, 4)` in `ProjectAgentStepView.cs`.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs` — Changed padding values to remove right spacing

## Manual Testing

1. Launch the Tendril app
2. Navigate to the onboarding flow (first-time setup or trigger it manually)
3. Go to step 2 (project agent configuration)
4. Observe the scrollable content box displaying the AgentViewer output
5. Verify the scrollbar is now flush against the right border of the box with no gap

---

### Commits

- 5b3bb363 Remove right padding from onboarding content box to align scrollbar to border

---
Created using [Ivy Tendril](https://ivy.app).