### PR TITLE
[00560] Job Debug Sheet Hide Empty Permission Denials

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -71,7 +71,7 @@ public class JobDebugSheet(
             .Label(x => x.CliCommand, "Arguments")
             .Label(x => x.JobId, "Job Id")
             .Builder(x => x.PermissionDenials, f => f.Func((string denials) =>
-                new CodeBlock(denials)))
+                string.IsNullOrEmpty(denials) ? null : new CodeBlock(denials)))
             .Builder(x => x.PlanFolder, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .Builder(x => x.PlanLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .Builder(x => x.PromptwareLog, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))


### PR DESCRIPTION
# Summary

## Changes

Added a null-guard to the Permission Denials field builder in JobDebugSheet. When the denials string is empty, the builder now returns `null` instead of rendering an empty CodeBlock, eliminating unnecessary UI chrome for jobs without permission issues.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs** — Updated PermissionDenials builder to return null when string is empty

---

## Commits

- 4ddb0798 Hide empty permission denials in Job Debug Sheet