### PR TITLE
[00554] Add timeline under status dots and align IN/OUT to tool name

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
@@ -221,9 +221,26 @@
 
 /* ─── Tool use card (collapsed by default, no outer chrome) ─────────────── */
 .aov-tool {
+  position: relative;
   font-family: var(--aov-mono);
   padding: 2px 6px;
   border-radius: 4px;
+}
+
+/* Timeline connector between tool cards */
+.aov-body .aov-tool::after {
+  content: '';
+  position: absolute;
+  left: 25.5px;
+  top: calc(2px + 7px + 4px);
+  bottom: -6px;
+  width: 1px;
+  background: var(--aov-border);
+  pointer-events: none;
+}
+
+.aov-body .aov-tool:last-child::after {
+  display: none;
 }
 
 .aov-tool:hover {
@@ -297,7 +314,7 @@
 }
 
 .aov-tool-body {
-  padding: 4px 0 4px 22px;
+  padding: 4px 0 4px 37px;
   animation: aov-tool-expand 0.2s ease-out both;
 }
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
@@ -227,12 +227,17 @@
   border-radius: 4px;
 }
 
-/* Timeline connector between tool cards */
+/* Timeline connector between tool cards.
+   Dot geometry within the header (relative to .aov-tool left edge):
+   card pad-left 6 + chevron 14 + flex gap 8 = 28 → dot spans 28–35px, center 31.5px.
+   The line is 1px wide, so left: 31px centers it on the dot.
+   Vertically the dot center sits ~15px from the card top; the line starts just
+   below the dot and runs into the 4px inter-card gap to meet the next dot. */
 .aov-body .aov-tool::after {
   content: '';
   position: absolute;
-  left: 25.5px;
-  top: calc(2px + 7px + 4px);
+  left: 31px;
+  top: 21px;
   bottom: -6px;
   width: 1px;
   background: var(--aov-border);
@@ -342,7 +347,7 @@
   font-size: 11px;
   font-weight: 600;
   color: var(--aov-fg-muted);
-  text-align: center;
+  text-align: left;
   user-select: none;
 }
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
@@ -231,14 +231,14 @@
    Dot geometry within the header (relative to .aov-tool left edge):
    card pad-left 6 + chevron 14 + flex gap 8 = 28 → dot spans 28–35px, center 31.5px.
    The line is 1px wide, so left: 31px centers it on the dot.
-   Vertically the dot center sits ~15px from the card top; the line starts just
-   below the dot and runs into the 4px inter-card gap to meet the next dot. */
+   Vertically the dot center sits ~15px from the card top; the line keeps a gap
+   below this dot and stops short of the next dot rather than touching either. */
 .aov-body .aov-tool::after {
   content: '';
   position: absolute;
   left: 31px;
-  top: 21px;
-  bottom: -6px;
+  top: 24px;
+  bottom: -1px;
   width: 1px;
   background: var(--aov-border);
   pointer-events: none;


### PR DESCRIPTION
Fixes #1299

# Summary

## Changes

Added a vertical timeline connector between AgentViewer tool cards and aligned the expanded IN/OUT section content with the tool name text. The timeline is a 1px vertical line positioned at the center of status dots with appropriate gaps, and is hidden on the last card.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css**
  - Added `position: relative` to `.aov-tool` for timeline positioning
  - Added timeline connector using `.aov-tool::after` pseudo-element
  - Changed `.aov-tool-body` left padding from 22px to 37px

---

## Commits

- 2a6ceef9 - Add timeline connector and align IN/OUT to tool name in AgentViewer