### PR TITLE
[00558] Fix Job Debug Sheet Buttons Scrolling and Separator Width

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -120,9 +120,10 @@ public class JobDebugSheet(
             })
             | new Button("Report Bug").Icon(Icons.Bug).OnClick(() => showReportDialog.Set(true));
 
-        return Layout.Vertical()
-            | new HeaderLayout(header, detailsView)
-            | (showReportDialog.Value ? new ReportBugDialog(showReportDialog, jobId) : null);
+        return new Fragment(
+            new HeaderLayout(header, detailsView).Size(Size.Full()),
+            showReportDialog.Value ? new ReportBugDialog(showReportDialog, jobId) : null
+        );
     }
 
     private object PathDropDown(string path, Action<string> copyToClipboard, IClientProvider client)


### PR DESCRIPTION
# Summary

## Changes

Fixed the Job Debug sheet in the Jobs app so that the "Copy Details" and "Report Bug" buttons remain fixed at the top while the job details content scrolls beneath them. Also fixed the separator line to stretch full-width across the sheet.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs** — Added `.Size(Size.Full())` to `HeaderLayout` and replaced `Layout.Vertical()` wrapper with `Fragment` for proper layout containment

---

## Commits

- 071f457c Fix Job Debug Sheet buttons scrolling and separator width