### PR TITLE
[00557] Align scrollbar to right edge on onboarding setup page

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -193,7 +193,7 @@ public class ProjectAgentStepView(
                       )
                         .Width(Size.Full())
                         .Height(Size.Units(100).Max(Size.Fraction(0.6f)))
-                        .Padding(4, 4, 2, 4)
+                        .Padding(4, 4, 0, 4)
                    : null!)
                | buttonArea
                | new Spacer().Height(Size.Units(4));


### PR DESCRIPTION
Fixes #1300

# Summary

## Changes

Removed right padding from the Box component wrapping the AgentViewer on the "Welcome to Ivy Tendril" setup page, allowing the scrollbar to render flush against the container's right edge.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs` — Changed `.Padding(4, 4, 2, 4)` to `.Padding(4, 4, 0, 4)` on line 196

---

## Commits

- 90d96072