### PR TITLE
[00553] Defer agent step visibility until output stream ready

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -15,7 +15,8 @@ public class ProjectAgentStepView(
     Action onNext,
     Action? onSkip = null,
     bool skipAgent = false,
-    bool showHeader = true) : ViewBase
+    bool showHeader = true,
+    IState<bool>? setupTrigger = null) : ViewBase
 {
     public override object Build()
     {
@@ -31,6 +32,9 @@ public class ProjectAgentStepView(
         UseEffect(async () =>
         {
             if (session.Started.Value) return;
+
+            // If setupTrigger is provided, wait for it to be true
+            if (setupTrigger != null && !setupTrigger.Value) return;
 
             error.Set(null);
             isCloning.Set(true);
@@ -149,7 +153,7 @@ public class ProjectAgentStepView(
                 isCloning.Set(false);
                 isStepLoading.Set(false);
             }
-        }, [EffectTrigger.OnMount()]);
+        }, setupTrigger != null ? [setupTrigger] : [EffectTrigger.OnMount()]);
 
         var running = session.Running.Value || isCloning.Value;
 

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/AddProjectDialog.cs
@@ -30,6 +30,7 @@ public class AddProjectDialog(
         var verificationRefreshToken = UseState(0);
         var hasCreated = UseState(false);
         var skipAgent = UseState(false);
+        var setupTriggered = UseState(false);
 
         var session = new OnboardingVerificationSession(
             verificationStream,
@@ -59,9 +60,28 @@ public class AddProjectDialog(
                 isStepLoading.Set(false);
                 hasCreated.Set(false);
                 skipAgent.Set(false);
+                setupTriggered.Set(false);
                 session.Reset();
             }
         }, isOpen);
+
+        // Transition to step 1 when agent output is ready
+        UseEffect(() =>
+        {
+            if (session.HasOutput.Value && step.Value == 0 && setupTriggered.Value)
+            {
+                step.Set(1);
+            }
+        }, session.HasOutput);
+
+        // Transition to step 2 when skipAgent is enabled and setup is done
+        UseEffect(() =>
+        {
+            if (skipAgent.Value && setupTriggered.Value && step.Value == 0 && !session.Running.Value && !isStepLoading.Value)
+            {
+                step.Set(2);
+            }
+        }, [skipAgent, setupTriggered, step, session.Running, isStepLoading]);
 
         if (!isOpen.Value) return null;
 
@@ -99,12 +119,12 @@ public class AddProjectDialog(
                 onNext: () =>
                 {
                     skipAgent.Set(false);
-                    step.Set(1);
+                    setupTriggered.Set(true);
                 },
                 onSkip: () =>
                 {
                     skipAgent.Set(true);
-                    step.Set(1);
+                    setupTriggered.Set(true);
                 },
                 skipButtonText: "Manual Setup",
                 nextButtonText: "Create Project",
@@ -121,6 +141,7 @@ public class AddProjectDialog(
                     session.Reset();
                     isStepLoading.Set(false);
                     RemoveCommittedProject();
+                    setupTriggered.Set(false);
                     step.Set(0);
                 },
                 onNext: () =>
@@ -129,7 +150,8 @@ public class AddProjectDialog(
                 },
                 onSkip: null,
                 skipAgent: skipAgent.Value,
-                showHeader: false),
+                showHeader: false,
+                setupTrigger: setupTriggered),
             2 => new ProjectCrudStepView(
                 editName,
                 isStepLoading,


### PR DESCRIPTION
# Summary

## Changes

Modified the "Add a project" dialog flow to defer showing step 1 ("Setting up your project") until the agent output stream is ready to render. The user now remains on step 0 with loading indicators until the agent has produced output, eliminating the intermediate loading spinner state.

## API Changes

**AddProjectDialog.cs:**
- Added `setupTriggered` state variable to track setup process initiation
- Added two `UseEffect` hooks to handle step transitions based on agent output readiness
- Modified `onNext` and `onSkip` callbacks to set `setupTriggered` instead of directly advancing steps

**ProjectAgentStepView.cs:**
- Added optional `setupTrigger` parameter (default `null` for backward compatibility)
- Modified `UseEffect` to wait for `setupTrigger` to be true before starting setup
- Changed effect dependencies from `OnMount` to trigger on `setupTrigger` when provided

## Files Modified

**Dialog and UI:**
- `src/Ivy.Tendril/Apps/Settings/Dialogs/AddProjectDialog.cs` - Main dialog flow control
- `src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs` - Agent step view with trigger support

---

## Commits
- cddc88db Defer agent step visibility until output stream ready