### PR TITLE
[00552] Remove bottom spacer in ProjectAgentStepView when used in dialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -192,6 +192,6 @@ public class ProjectAgentStepView(
                         .Padding(4, 4, 2, 4)
                    : null!)
                | buttonArea
-               | new Spacer().Height(Size.Units(4));
+               | (showHeader ? (object)new Spacer().Height(Size.Units(4)) : null!);
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Added conditional rendering to the bottom spacer in `ProjectAgentStepView`. The spacer now only appears when `showHeader` is true (full onboarding flow), preventing unnecessary padding when the view is used inside `AddProjectDialog`.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs** — Modified bottom spacer to render conditionally based on `showHeader` parameter

---

## Commits

- 8f7c76c3 Conditionally render bottom spacer in ProjectAgentStepView