### PR TITLE
[00561] Job Debug Sheet Full Width Detail Content

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -127,7 +127,7 @@ public class JobDebugSheet(
 
     private object PathDropDown(string path, Action<string> copyToClipboard, IClientProvider client)
     {
-        return Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+        return Layout.Horizontal().Gap(2).Width(Size.Full()).AlignContent(Align.SpaceBetween)
             | Text.Block(path)
             | new Button().Icon(Icons.EllipsisVertical).Ghost().Small()
                 .WithDropDown(


### PR DESCRIPTION
# Summary

## Changes

Modified the `PathDropDown` helper in `JobDebugSheet.cs` to make detail content full width. The horizontal layout now spans the full width with space-between alignment, pushing the ellipsis menu button to the right edge of the screen.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs` — Updated `PathDropDown` layout to full width with space-between alignment

---

## Commits

- db40290c [00561] Job Debug Sheet Full Width Detail Content