### PR TITLE
[00559] Job Debug Sheet Copy Buttons Lack Clicked State

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -79,8 +79,18 @@ public class JobDebugSheet(
                 f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .Builder(x => x.WorkingDirectory, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .Builder(x => x.CliCommand, f => f.Func((string cmd) => new CodeBlock(cmd)))
-            .Builder(x => x.JobId, f => f.CopyToClipboard())
-            .Builder(x => x.PlanId, f => f.CopyToClipboard());
+            .Builder(x => x.JobId, f => f.Func((string id) =>
+                Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                | Text.Block(id)
+                | new Button().Icon(Icons.ClipboardCopy).Ghost().Small()
+                    .Tooltip("Copy job ID")
+                    .OnClick(() => copyToClipboard(id))))
+            .Builder(x => x.PlanId, f => f.Func((string id) =>
+                Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                | Text.Block(id)
+                | new Button().Icon(Icons.ClipboardCopy).Ghost().Small()
+                    .Tooltip("Copy plan ID")
+                    .OnClick(() => copyToClipboard(id))));
 
         var header = Layout.Horizontal().Gap(2)
             | new Button("Copy Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>


### PR DESCRIPTION
# Summary

## Changes

Replaced the `CopyToClipboard()` builder usage for Job ID and Plan ID fields in `JobDebugSheet.cs` with the standard manual button pattern that provides visual feedback when clicked. The copy buttons now use `Icons.ClipboardCopy` with `Ghost().Small()` styling and connect to the `UseClipboard()` hook, matching the pattern used in `DetailsTabView.cs`.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs` — Updated Job ID and Plan ID builders to use manual button pattern with clicked state feedback

---

**Commits:**
- 42309b2a