### PR TITLE
[00562] Add Backspace shortcut to Discard button in Review app

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -426,7 +426,7 @@ public class ContentView(
                     .OnClick(showResetToDraftDialog).CompactUp()
                 | new Button("Request Changes").Icon(Icons.MessageSquare).Outline().ShortcutKey("c")
                     .OnClick(showSuggestChangesDialog).CompactUp()
-                | new Button("Discard").Icon(Icons.Trash).Outline()
+                | new Button("Discard").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
                     .OnClick(showDiscardDialog).FullOnly()
                 | ActionBarResponsive.DropdownAtFull(
                     new Button().Icon(Icons.EllipsisVertical).Ghost(),


### PR DESCRIPTION
Fixes #1308

# Summary

## Changes

Added the Backspace keyboard shortcut to the Discard button in the Review app's action bar, making it consistent with similar actions throughout the application.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Review/ContentView.cs** — Added `.ShortcutKey("Backspace")` to the Discard button

---

## Commits

- c4db7860 Add Backspace shortcut to Discard button in Review app