### PR TITLE
[00563] Fix Sticky Verifications Panel Displacing Plan Content On Tablets

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -45,7 +45,7 @@
   padding: 0 1.5rem;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   .pmv-shell {
     flex-direction: column;
   }


### PR DESCRIPTION
Fixes #1313

# Summary

## Changes

Updated the CSS media query breakpoint in the sticky verifications panel from 768px to 1024px. This aligns the responsive layout with the framework's Wide breakpoint, ensuring the side-by-side layout only displays on viewports with sufficient horizontal space (≥1024px).

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css** — Changed media query from `max-width: 768px` to `max-width: 1024px` on line 48

---

## Commits

- a3e0e20d Fix sticky verifications panel displacing content on tablet viewports