### PR TITLE
[00564] Fix Drafts Details tab left padding not rendering

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -300,7 +300,7 @@ public class ContentView(
 
         object Cap(object inner) => Layout.Vertical().Scroll().HideScrollbar().Width(Size.Full()).Height(Size.Full())
             | (Layout.Vertical()
-                .Padding(new Responsive<Thickness?> { Default = new Thickness(6, 0, 0, 4), Mobile = new Thickness(6, 4, 0, 4) })
+                .Padding(6, 0, 0, 4)
                 .Width(Size.Full().Max(Size.Units(200))) | inner);
     }
 

--- a/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
@@ -40,7 +40,7 @@ public class PlanTabView(
             var annotatedContent = MarkdownHelper.AnnotateAllBrokenLinks(
                 selectedPlan.LatestRevisionContent,
                 planService.PlansDirectory);
-            
+
             var fixedElement = new VerificationsCardView(selectedPlan, planService, config);
 
             Action<string> onLinkClick = FileSheet.CreateLinkClickHandler(openFileState, planId =>

--- a/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs
@@ -25,7 +25,7 @@ public class PlanTabView(
             // full height, and 1.5rem left inset (Padding(6,…)) here.
             return Layout.Vertical().Scroll(Scroll.Vertical).Width(Size.Full()).Height(Size.Full())
                 | (Layout.Vertical()
-                    .Padding(new Responsive<Thickness?> { Default = new Thickness(6, 0, 0, 4), Mobile = new Thickness(6, 4, 0, 4) })
+                    .Padding(6, 0, 0, 4)
                     .Width(Size.Full().Max(Size.Units(200)))
                     | editContentState.ToCodeInput()
                         .Language(Languages.Markdown)


### PR DESCRIPTION
Fixes #1314

# Summary

## Changes

Fixed left padding not rendering in Drafts app Details tab by replacing `Responsive<Thickness?>` with flat `Thickness` values. The responsive padding serialized to breakpoint objects that the StackLayout frontend dropped, preventing any padding from rendering. Applied dotnet format to clean up trailing whitespace.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Drafts/ContentView.cs** — Changed `Cap()` helper padding from `Responsive<Thickness?>` to flat `Thickness`
- **src/Ivy.Tendril/Apps/Drafts/PlanTabView.cs** — Changed editing wrapper padding from `Responsive<Thickness?>` to flat `Thickness` and removed trailing whitespace

---

## Commits

- cc4bad42 Fix Drafts Details tab left padding not rendering
- ddbe282d Apply dotnet format