### PR TITLE
Add SQLite busy_timeout via shared connection factory (#1291)

### DIFF
--- a/src/Ivy.Tendril.Test/SqliteConnectionFactoryTests.cs
+++ b/src/Ivy.Tendril.Test/SqliteConnectionFactoryTests.cs
@@ -1,0 +1,95 @@
+using Ivy.Tendril.Database;
+using Microsoft.Data.Sqlite;
+
+namespace Ivy.Tendril.Test;
+
+public class SqliteConnectionFactoryTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new();
+    private readonly string _dbPath;
+
+    public SqliteConnectionFactoryTests()
+    {
+        _dbPath = Path.Combine(_tempDir.Path, $"factory-test-{Guid.NewGuid():N}.db");
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        _tempDir.Dispose();
+    }
+
+    [Fact]
+    public void OpenConfigured_AppliesBusyTimeoutAndWal()
+    {
+        using var connection = SqliteConnectionFactory.OpenConfigured(_dbPath);
+
+        Assert.Equal(SqliteConnectionFactory.BusyTimeoutMs, ReadPragma<long>(connection, "busy_timeout"));
+        Assert.Equal("wal", ReadPragma<string>(connection, "journal_mode"), ignoreCase: true);
+    }
+
+    [Fact]
+    public async Task ConcurrentWriters_SecondWriterWaitsThenSucceeds()
+    {
+        // Smoke test: two factory connections contending for the write lock serialize cleanly rather
+        // than deadlocking or erroring — writer B waits for A to commit, then its own write lands.
+        // (This exercises the WAL + busy_timeout path end-to-end; it is not an isolation test of the
+        // pragma, since Microsoft.Data.Sqlite's command-level retry would also absorb a brief wait.)
+        CreateTable();
+
+        // Writer A takes the write lock and holds it briefly on a background task.
+        using var writerA = SqliteConnectionFactory.OpenConfigured(_dbPath);
+        var txA = writerA.BeginTransaction();
+        Insert(writerA, txA, 1);
+
+        var release = Task.Run(async () =>
+        {
+            // Hold far under the 5s busy_timeout so writer B waits and then succeeds.
+            await Task.Delay(150);
+            txA.Commit();
+            writerA.Dispose();
+        });
+
+        using (var writerB = SqliteConnectionFactory.OpenConfigured(_dbPath))
+        {
+            Insert(writerB, transaction: null, value: 2);
+        }
+
+        await release;
+
+        Assert.Equal(2, CountRows());
+    }
+
+    private void CreateTable()
+    {
+        using var connection = SqliteConnectionFactory.OpenConfigured(_dbPath);
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "CREATE TABLE IF NOT EXISTS t (value INTEGER NOT NULL);";
+        cmd.ExecuteNonQuery();
+    }
+
+    private static void Insert(SqliteConnection connection, SqliteTransaction? transaction, int value)
+    {
+        using var cmd = connection.CreateCommand();
+        if (transaction != null)
+            cmd.Transaction = transaction;
+        cmd.CommandText = "INSERT INTO t (value) VALUES ($v);";
+        cmd.Parameters.AddWithValue("$v", value);
+        cmd.ExecuteNonQuery();
+    }
+
+    private int CountRows()
+    {
+        using var connection = SqliteConnectionFactory.OpenConfigured(_dbPath);
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT COUNT(*) FROM t;";
+        return Convert.ToInt32(cmd.ExecuteScalar());
+    }
+
+    private static T ReadPragma<T>(SqliteConnection connection, string pragma)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"PRAGMA {pragma};";
+        return (T)Convert.ChangeType(cmd.ExecuteScalar()!, typeof(T));
+    }
+}

--- a/src/Ivy.Tendril/Commands/DoctorChecks/DatabaseCheck.cs
+++ b/src/Ivy.Tendril/Commands/DoctorChecks/DatabaseCheck.cs
@@ -1,4 +1,3 @@
-using Microsoft.Data.Sqlite;
 using Ivy.Tendril.Database;
 
 namespace Ivy.Tendril.Commands.DoctorChecks;
@@ -31,11 +30,7 @@ internal class DatabaseCheck : IDoctorCheck
 
         try
         {
-            using var connection = new SqliteConnection($"Data Source={dbPath}");
-            connection.Open();
-            using var pragmaCmd = connection.CreateCommand();
-            pragmaCmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;";
-            pragmaCmd.ExecuteNonQuery();
+            using var connection = SqliteConnectionFactory.OpenConfigured(dbPath);
 
             using var integrityCmd = connection.CreateCommand();
             integrityCmd.CommandText = "PRAGMA integrity_check";

--- a/src/Ivy.Tendril/Commands/RunCommand.cs
+++ b/src/Ivy.Tendril/Commands/RunCommand.cs
@@ -1,7 +1,6 @@
 using Ivy.Tendril.Database;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -44,8 +43,7 @@ public class RunCommand : AsyncCommand<RunCommand.Settings>
 
         try
         {
-            using var connection = new SqliteConnection($"Data Source={dbPath}");
-            connection.Open();
+            using var connection = SqliteConnectionFactory.OpenConfigured(dbPath);
 
             var migrator = new DatabaseMigrator(connection);
             var current = migrator.GetCurrentVersion();

--- a/src/Ivy.Tendril/Database/DatabaseCommands.cs
+++ b/src/Ivy.Tendril/Database/DatabaseCommands.cs
@@ -84,13 +84,6 @@ public static class DatabaseCommands
         return 0;
     }
 
-    private static SqliteConnection OpenConnection(string dbPath)
-    {
-        var connection = new SqliteConnection($"Data Source={dbPath}");
-        connection.Open();
-        using var pragmaCmd = connection.CreateCommand();
-        pragmaCmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;";
-        pragmaCmd.ExecuteNonQuery();
-        return connection;
-    }
+    private static SqliteConnection OpenConnection(string dbPath) =>
+        SqliteConnectionFactory.OpenConfigured(dbPath);
 }

--- a/src/Ivy.Tendril/Database/SqliteConnectionFactory.cs
+++ b/src/Ivy.Tendril/Database/SqliteConnectionFactory.cs
@@ -1,0 +1,60 @@
+using Microsoft.Data.Sqlite;
+
+namespace Ivy.Tendril.Database;
+
+/// <summary>
+///     Centralizes creation of on-disk SQLite connections so every connection consistently enables
+///     WAL journaling and a busy timeout. The Tendril daemon holds a long-lived connection open; CLI
+///     commands (doctor, database, run) open their own connections to the same file.
+///     <para>
+///     Microsoft.Data.Sqlite leaves SQLite's own <c>busy_timeout</c> at 0 by default and instead
+///     retries on SQLITE_BUSY at the ADO layer up to the command timeout. That ADO retry does not
+///     cover lock escalation inside an explicit write transaction — exactly the path
+///     <see cref="Services.Plans.PlanDatabaseService" /> uses — where a contending writer would
+///     otherwise surface "database is locked" immediately. Setting <c>PRAGMA busy_timeout</c> makes
+///     SQLite's own busy handler wait for the lock to clear on every operation, including those.
+///     </para>
+/// </summary>
+public static class SqliteConnectionFactory
+{
+    /// <summary>
+    ///     How long (ms) a connection waits for a held lock before giving up with SQLITE_BUSY.
+    ///     busy_timeout is a per-connection setting, so it must be applied on every connection — which
+    ///     is exactly why connection creation is centralized here.
+    /// </summary>
+    public const int BusyTimeoutMs = 5000;
+
+    /// <summary>
+    ///     Opens a SQLite connection to <paramref name="databasePath"/> and applies the standard
+    ///     PRAGMAs. busy_timeout is set first so it governs the connection immediately, including the
+    ///     WAL journal-mode switch (which itself takes a database lock).
+    /// </summary>
+    /// <param name="databasePath">Path to the SQLite database file.</param>
+    /// <param name="readWriteCreate">
+    ///     When true (default), opens with <c>Mode=ReadWriteCreate</c> so the file is created if
+    ///     missing. Read-only callers can pass false.
+    /// </param>
+    public static SqliteConnection OpenConfigured(string databasePath, bool readWriteCreate = true)
+    {
+        var connectionString = readWriteCreate
+            ? $"Data Source={databasePath};Mode=ReadWriteCreate"
+            : $"Data Source={databasePath}";
+
+        var connection = new SqliteConnection(connectionString);
+        connection.Open();
+        ApplyPragmas(connection);
+        return connection;
+    }
+
+    /// <summary>
+    ///     Applies the standard PRAGMAs to an already-open connection. Exposed so callers that need to
+    ///     reopen a connection in place (e.g. after corruption recovery) can reuse the same settings.
+    /// </summary>
+    public static void ApplyPragmas(SqliteConnection connection)
+    {
+        using var pragmaCmd = connection.CreateCommand();
+        pragmaCmd.CommandText =
+            $"PRAGMA busy_timeout={BusyTimeoutMs}; PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;";
+        pragmaCmd.ExecuteNonQuery();
+    }
+}

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -51,6 +51,8 @@ public class PlanDatabaseService : IPlanDatabaseService
         var directory = Path.GetDirectoryName(databasePath);
         if (!string.IsNullOrEmpty(directory))
             Directory.CreateDirectory(directory);
+        // Open raw (no PRAGMAs yet) so the integrity check below runs before WAL is enabled — a
+        // corrupt DB must be detected and recreated before journal_mode=WAL is applied.
         _connection = new SqliteConnection($"Data Source={databasePath};Mode=ReadWriteCreate");
         _connection.Open();
 
@@ -84,9 +86,11 @@ public class PlanDatabaseService : IPlanDatabaseService
             _connection.Open();
         }
 
-        using var pragmaCmd = _connection.CreateCommand();
-        pragmaCmd.CommandText = "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;";
-        pragmaCmd.ExecuteNonQuery();
+        // Enable WAL + busy_timeout + foreign_keys. busy_timeout makes this connection's SQLite busy
+        // handler wait for the write lock — including during transactional lock escalation, which the
+        // ADO-layer SQLITE_BUSY retry does not cover — instead of surfacing "database is locked" when
+        // another process (e.g. a CLI command) contends for the same database file.
+        SqliteConnectionFactory.ApplyPragmas(_connection);
 
         var migrator = new DatabaseMigrator(_connection);
         migrator.ApplyMigrations();


### PR DESCRIPTION
## Context

Issue #1291: `tendril plan create` failed with "database is locked" when the daemon was running. The Tendril daemon holds a long-lived SQLite connection open while CLI commands (`doctor`, `database`, `run`) open their own connections to the same file. Connections enabled WAL but never set `PRAGMA busy_timeout`, so a writer contending for the lock — specifically during lock escalation inside an explicit write transaction, which Microsoft.Data.Sqlite's ADO-layer retry does **not** cover — surfaced "database is locked" immediately instead of waiting.

(The original CLI-side `plan create` symptom is already resolved on `development`, since the CLI no longer opens the DB. This hardens the remaining daemon/CLI contention paths.)

## Change

- **New `SqliteConnectionFactory`** — centralizes on-disk connection creation, applying `PRAGMA busy_timeout=5000; journal_mode=WAL; foreign_keys=ON` consistently.
- Routed all four connection sites through it: `PlanDatabaseService`, `DatabaseCheck`, `DatabaseCommands`, `RunCommand` (the last previously set no PRAGMAs at all).
- `PlanDatabaseService` keeps its open-raw → integrity-check → recover-if-corrupt ordering; only the post-recovery pragma pass changed (now adds `busy_timeout`).
- Removes duplicated connection setup and two now-unused `using` directives.

## Tests

- New `SqliteConnectionFactoryTests`: asserts the applied pragmas (`busy_timeout=5000`, `journal_mode=wal`) and a fast concurrent-writer serialization smoke test.
- Full unit suite: **1506 passed, 1 skipped (pre-existing), 0 failed**. Build clean (0 warnings); `dotnet format` clean.