### PR TITLE
Clarify Delete Branch option in Create PR dialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -30,6 +30,8 @@ public class CustomPrDialog(
 
         if (!dialogOpen.Value) return null;
 
+        var multipleBranches = selectedPlan.Repos.Count > 1;
+
         return new Dialog(
             _ =>
             {
@@ -48,7 +50,11 @@ public class CustomPrDialog(
                 Layout.Vertical().Gap(2)
                 | customPrSolveMergeConflicts.ToBoolInput("Solve Merge Conflicts").AutoFocus()
                 | customPrMerge.ToBoolInput("Merge")
-                | customPrDeleteBranch.ToBoolInput("Delete Branch")
+                | customPrDeleteBranch
+                    .ToBoolInput(multipleBranches ? "Delete branches" : "Delete branch")
+                    .Description(multipleBranches
+                        ? "Deletes the branches pushed to origin after successful merge."
+                        : "Deletes the branch pushed to origin after successful merge.")
                     .Disabled(!customPrMerge.Value)
                 | customPrIncludeArtifacts.ToBoolInput("Include Artifacts")
                 | customPrDraft.ToBoolInput("Create as Draft")


### PR DESCRIPTION
Addresses #1195.

The Create PR dialog's **Delete Branch** option named no branch, so users couldn't tell whether it removes the disposable per-plan branch or the long-lived base branch they keep building on.

**Changes** (`CustomPrDialog.cs`):
- Label adapts to how many repos the plan touches: `selectedPlan.Repos.Count > 1` → "Delete branches", else "Delete branch".
- Adds a `.Description()` clarifying it "Deletes the branch(es) pushed to origin after successful merge."

This is a copy-only change — no behavior change. The option still only controls `--delete-branch` on `gh pr merge` (the origin head branch); the base branch is never touched, and local worktrees/branches are cleaned up separately on merge regardless.