### PR TITLE
[00565] Add clickable image viewer to DraftMarkdown

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/package.json
+++ b/src/Ivy.Tendril.Widgets/frontend/package.json
@@ -20,6 +20,8 @@
     "remark-gfm": "4.0.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "25.9.0",
     "@types/react": "19.2.8",
     "@types/react-dom": "19.2.3",
@@ -31,7 +33,8 @@
     "tailwindcss": "3.4.19",
     "typescript": "5.9.3",
     "vite": "npm:@voidzero-dev/vite-plus-core@0.1.24",
-    "vite-plus": "0.1.24"
+    "vite-plus": "0.1.24",
+    "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.24"
   },
   "peerDependencies": {
     "react": "19.2.3",

--- a/src/Ivy.Tendril.Widgets/frontend/pnpm-lock.yaml
+++ b/src/Ivy.Tendril.Widgets/frontend/pnpm-lock.yaml
@@ -48,6 +48,12 @@ importers:
         specifier: 4.0.1
         version: 4.0.1
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/node':
         specifier: 25.9.0
         version: 25.9.0
@@ -84,8 +90,14 @@ importers:
       vite-plus:
         specifier: 0.1.24
         version: 0.1.24(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)
+      vitest:
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)'
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -108,6 +120,14 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
@@ -521,6 +541,32 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -832,6 +878,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -841,6 +895,13 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -927,6 +988,9 @@ packages:
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1134,6 +1198,12 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dompurify@3.4.8:
     resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
 
@@ -1253,6 +1323,10 @@ packages:
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
@@ -1305,6 +1379,9 @@ packages:
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
@@ -1426,6 +1503,10 @@ packages:
     resolution: {integrity: sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -1577,6 +1658,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -1737,6 +1822,10 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -1755,6 +1844,9 @@ packages:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
       react: ^19.2.3
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-markdown@9.1.0:
     resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
@@ -1778,6 +1870,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   refractor@5.0.0:
     resolution: {integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==}
@@ -1845,6 +1941,10 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -2027,6 +2127,8 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.5.0': {}
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@antfu/install-pkg@1.1.0':
@@ -2053,6 +2155,14 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/runtime@7.29.7': {}
 
@@ -2298,6 +2408,38 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -2559,6 +2701,10 @@ snapshots:
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.24':
     optional: true
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
@@ -2567,6 +2713,12 @@ snapshots:
       picomatch: 2.3.2
 
   arg@5.0.2: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   assertion-error@2.0.1: {}
 
@@ -2647,6 +2799,8 @@ snapshots:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
 
@@ -2871,6 +3025,10 @@ snapshots:
 
   dlv@1.1.3: {}
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dompurify@3.4.8:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -2994,6 +3152,8 @@ snapshots:
 
   import-meta-resolve@4.2.0: {}
 
+  indent-string@4.0.0: {}
+
   inline-style-parser@0.2.7: {}
 
   internmap@1.0.1: {}
@@ -3032,6 +3192,8 @@ snapshots:
   is-potential-custom-element-name@1.0.1: {}
 
   jiti@1.21.7: {}
+
+  js-tokens@4.0.0: {}
 
   jsdom@29.1.1:
     dependencies:
@@ -3136,6 +3298,8 @@ snapshots:
   lucide-react@0.511.0(react@19.2.3):
     dependencies:
       react: 19.2.3
+
+  lz-string@1.5.0: {}
 
   markdown-table@3.0.4: {}
 
@@ -3518,6 +3682,8 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  min-indent@1.0.1: {}
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -3678,6 +3844,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prismjs@1.30.0: {}
 
   property-information@7.1.0: {}
@@ -3690,6 +3862,8 @@ snapshots:
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-markdown@9.1.0(@types/react@19.2.8)(react@19.2.3):
     dependencies:
@@ -3728,6 +3902,11 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   refractor@5.0.0:
     dependencies:
@@ -3820,6 +3999,10 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   style-to-js@1.1.21:
     dependencies:

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
@@ -8,6 +8,7 @@ import type { MarkdownAnnotation } from "./annotationUtils";
 import { applyAnnotationHighlights, getPlainTextOffset } from "./annotationUtils";
 import { AddAnnotationPopover, EditAnnotationPopover, SelectionToolbar } from "./AnnotationPopover";
 import { AlertBlockquote } from "./AlertBlockquote";
+import { ImageRenderer } from "./ImageRenderer";
 import { isLocalFileUrl, transformLocalFileUrl } from "./localFiles";
 
 type IvyEventHandler = (eventName: string, widgetId: string, args: unknown[]) => void;
@@ -272,7 +273,7 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
           <Markdown
             remarkPlugins={[remarkGfm]}
             urlTransform={urlTransform}
-            components={{ a: anchor, code: CodeBlock, blockquote: AlertBlockquote }}
+            components={{ a: anchor, code: CodeBlock, blockquote: AlertBlockquote, img: ImageRenderer }}
           >
             {content}
           </Markdown>

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/ImageRenderer.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/ImageRenderer.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import { ImageRenderer } from "./ImageRenderer";
 
 describe("ImageRenderer", () => {
@@ -109,7 +110,7 @@ describe("ImageRenderer", () => {
 
   it("uses alt text as fallback in error state when no alt provided", async () => {
     render(<ImageRenderer src="https://example.com/broken.jpg" />);
-    const img = screen.getByAltText("");
+    const img = screen.getByRole("img");
 
     fireEvent.error(img);
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/ImageRenderer.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/ImageRenderer.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ImageRenderer } from "./ImageRenderer";
+
+describe("ImageRenderer", () => {
+  it("renders an img element with correct src and alt", () => {
+    render(<ImageRenderer src="https://example.com/test.jpg" alt="Test image" />);
+    const img = screen.getByRole("img", { name: "Test image" });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "https://example.com/test.jpg");
+  });
+
+  it("shows error placeholder when image fails to load", async () => {
+    render(<ImageRenderer src="https://example.com/broken.jpg" alt="Broken image" />);
+    const img = screen.getByRole("img", { name: "Broken image" });
+
+    fireEvent.error(img);
+
+    await waitFor(() => {
+      expect(screen.getByText("Broken image")).toBeInTheDocument();
+      expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    });
+  });
+
+  it("makes image clickable after successful load", async () => {
+    render(<ImageRenderer src="https://example.com/test.jpg" alt="Test image" />);
+    const img = screen.getByRole("img", { name: "Test image" });
+
+    fireEvent.load(img);
+
+    await waitFor(() => {
+      expect(img).toHaveClass("pmv-img-clickable");
+    });
+  });
+
+  it("opens overlay on image click", async () => {
+    render(<ImageRenderer src="https://example.com/test.jpg" alt="Test image" />);
+    const img = screen.getByRole("img", { name: "Test image" });
+
+    fireEvent.load(img);
+
+    await waitFor(() => {
+      expect(img).toHaveClass("pmv-img-clickable");
+    });
+
+    fireEvent.click(img);
+
+    await waitFor(() => {
+      const overlay = document.querySelector(".pmv-img-overlay");
+      expect(overlay).toBeInTheDocument();
+    });
+  });
+
+  it("closes overlay on backdrop click", async () => {
+    render(<ImageRenderer src="https://example.com/test.jpg" alt="Test image" />);
+    const img = screen.getByRole("img", { name: "Test image" });
+
+    fireEvent.load(img);
+    fireEvent.click(img);
+
+    await waitFor(() => {
+      const overlay = document.querySelector(".pmv-img-overlay");
+      expect(overlay).toBeInTheDocument();
+    });
+
+    const overlay = document.querySelector(".pmv-img-overlay")!;
+    fireEvent.click(overlay);
+
+    await waitFor(() => {
+      expect(document.querySelector(".pmv-img-overlay")).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes overlay on Escape key press", async () => {
+    render(<ImageRenderer src="https://example.com/test.jpg" alt="Test image" />);
+    const img = screen.getByRole("img", { name: "Test image" });
+
+    fireEvent.load(img);
+    fireEvent.click(img);
+
+    await waitFor(() => {
+      const overlay = document.querySelector(".pmv-img-overlay");
+      expect(overlay).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(document.querySelector(".pmv-img-overlay")).not.toBeInTheDocument();
+    });
+  });
+
+  it("displays title in error state", async () => {
+    render(
+      <ImageRenderer
+        src="https://example.com/broken.jpg"
+        alt="Broken image"
+        title="This is a title"
+      />
+    );
+    const img = screen.getByRole("img", { name: "Broken image" });
+
+    fireEvent.error(img);
+
+    await waitFor(() => {
+      expect(screen.getByText("This is a title")).toBeInTheDocument();
+    });
+  });
+
+  it("uses alt text as fallback in error state when no alt provided", async () => {
+    render(<ImageRenderer src="https://example.com/broken.jpg" />);
+    const img = screen.getByAltText("");
+
+    fireEvent.error(img);
+
+    await waitFor(() => {
+      expect(screen.getByText("Image failed to load")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/ImageRenderer.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/ImageRenderer.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ImageRenderer } from "./ImageRenderer";
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/ImageRenderer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/ImageRenderer.tsx
@@ -1,0 +1,101 @@
+import React, { useState, useCallback, useEffect } from "react";
+import { createPortal } from "react-dom";
+
+interface ImageRendererProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  src?: string;
+  alt?: string;
+  title?: string;
+}
+
+const BrokenImageIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+    <circle cx="8.5" cy="8.5" r="1.5" />
+    <polyline points="21 15 16 10 5 21" />
+    <line x1="3" y1="3" x2="21" y2="21" />
+  </svg>
+);
+
+export const ImageRenderer: React.FC<ImageRendererProps> = ({ src, alt, title, ...props }) => {
+  const [loadState, setLoadState] = useState<"loading" | "loaded" | "error">("loading");
+  const [isOverlayOpen, setIsOverlayOpen] = useState(false);
+
+  const handleLoad = useCallback(() => {
+    setLoadState("loaded");
+  }, []);
+
+  const handleError = useCallback(() => {
+    setLoadState("error");
+  }, []);
+
+  const handleImageClick = useCallback(() => {
+    if (loadState === "loaded") {
+      setIsOverlayOpen(true);
+    }
+  }, [loadState]);
+
+  const handleCloseOverlay = useCallback(() => {
+    setIsOverlayOpen(false);
+  }, []);
+
+  const handleBackdropClick = useCallback((e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      setIsOverlayOpen(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOverlayOpen) {
+        setIsOverlayOpen(false);
+      }
+    };
+
+    if (isOverlayOpen) {
+      document.addEventListener("keydown", handleEscape);
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "";
+    };
+  }, [isOverlayOpen]);
+
+  if (loadState === "error") {
+    return (
+      <div className="pmv-img-error">
+        <BrokenImageIcon />
+        <div className="pmv-img-error-text">{alt || "Image failed to load"}</div>
+        {title && <div className="pmv-img-error-title">{title}</div>}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <img
+        {...props}
+        src={src}
+        alt={alt}
+        title={title}
+        className={loadState === "loaded" ? "pmv-img-clickable" : ""}
+        onLoad={handleLoad}
+        onError={handleError}
+        onClick={handleImageClick}
+      />
+      {isOverlayOpen &&
+        createPortal(
+          <div className="pmv-img-overlay" onClick={handleBackdropClick}>
+            <button className="pmv-img-overlay-close" onClick={handleCloseOverlay} aria-label="Close">
+              ×
+            </button>
+            <img src={src} alt={alt} title={title} />
+          </div>,
+          document.body
+        )}
+    </>
+  );
+};

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -631,3 +631,86 @@
 .pmv-alert--caution .pmv-alert-header {
   color: hsl(0 84% 60%);
 }
+
+/* Image viewer */
+.pmv-img-clickable {
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.pmv-img-clickable:hover {
+  transform: scale(1.02);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.pmv-img-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: hsl(0 0% 96%);
+  border: 1px dashed var(--border);
+  border-radius: 0.375rem;
+  margin: 1rem auto;
+  color: var(--text-secondary);
+  max-width: 100%;
+}
+.pmv-img-error svg {
+  color: hsl(0 0% 60%);
+  margin-bottom: 0.75rem;
+}
+.pmv-img-error-text {
+  font-size: 0.875rem;
+  text-align: center;
+  word-break: break-word;
+}
+.pmv-img-error-title {
+  font-size: 0.75rem;
+  margin-top: 0.5rem;
+  color: var(--text-tertiary);
+  text-align: center;
+}
+
+.pmv-img-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 2rem;
+}
+.pmv-img-overlay img {
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+  border: none;
+  border-radius: 0;
+  margin: 0;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+.pmv-img-overlay-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: white;
+  font-size: 2rem;
+  line-height: 1;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease;
+}
+.pmv-img-overlay-close:hover {
+  background: rgba(255, 255, 255, 0.2);
+}


### PR DESCRIPTION
Fixes #1315

# Summary

## Changes

Added a clickable image viewer to the DraftMarkdown component. Images now display with proper error handling (styled placeholder instead of broken icon), are clickable to open in a fullscreen overlay with zoom capability, and include visual affordances like hover effects.

## API Changes

- **ImageRenderer** (new component) — Custom img renderer for react-markdown with error handling and fullscreen overlay
  - Props: `src`, `alt`, `title`, and standard img attributes
  - Handles `loading`, `loaded`, and `error` states
  - Opens fullscreen overlay on click (accessible via Escape key or backdrop click)

## Files Modified

**DraftMarkdown component:**
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/ImageRenderer.tsx` — New image renderer component
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/ImageRenderer.test.tsx` — Comprehensive unit tests
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx` — Registered ImageRenderer in components prop
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css` — Added styles for clickable images, error state, and overlay

---

**Commits:**
- aa314ff6 Add clickable image viewer to DraftMarkdown
- ee39e389 Add testing dependencies and fix unused import
- 2754d097 Fix test imports and selectors