### PR TITLE
Rename PR dialog "Assignee" field to "Reviewer" (#1311)

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md
@@ -32,7 +32,7 @@ Before processing, read `plan.yaml` and check the `state` field. After reading, 
   - `PrMerge` — `true`/`false` (default: `true`) — **whether to merge the PR after creating it**
   - `PrDeleteBranch` — `true`/`false` (default: `true`)
   - `PrIncludeArtifacts` — `true`/`false` (default: `true`)
-  - `PrAssignee` — GitHub username (default: none)
+  - `PrReviewer` — GitHub username to request as reviewer (default: none)
   - `PrComment` — Review comment text (default: none)
   - `PrDraft` — `true`/`false` (default: `false`)
 
@@ -100,7 +100,7 @@ EOF
   body="${issueLink}${summaryContent}\n\n---\n${commitsList}${artifactMarkdown}"
   ```
 - **Draft (custom options):** If custom options exist and `draft` is `true`, add `--draft` to the `gh pr create` command to create the PR in draft mode. If no custom options or `draft` is `false`, create as ready for review (default behavior).
-- **Assignee (custom options):** If custom options exist and `assignee` is non-empty, add `--assignee <assignee>` to the `gh pr create` command.
+- **Reviewer (custom options):** If custom options exist and `reviewer` is non-empty, add `--reviewer <reviewer>` to the `gh pr create` command.
 
 ### 3.5. Add PR Comment (custom options)
 

--- a/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
@@ -82,6 +82,51 @@ projects:
         Assert.Contains("baseBranch: development", yaml);
     }
 
+    private static Dictionary<string, string> InvokeAddCreatePrOptions(JobItem job)
+    {
+        var values = new Dictionary<string, string>();
+        var method = typeof(JobLauncher).GetMethod("AddCreatePrOptions",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        method?.Invoke(null, new object[] { job, values });
+        return values;
+    }
+
+    // The PR dialog's "Reviewer" field flows into CreatePrArgs.Reviewer and must reach the
+    // CreatePr promptware as the PrReviewer firmware value (issue #1311). It used to be the
+    // PrAssignee value, which emitted a GitHub assignee instead of a requested reviewer.
+    [Fact]
+    public void AddCreatePrOptions_EmitsPrReviewer_WhenReviewerSet()
+    {
+        var job = new JobItem
+        {
+            Id = "pr-1",
+            Type = "CreatePr",
+            TypedArgs = new CreatePrArgs(@"D:\Plans\01234-TestPlan", Reviewer: "octocat"),
+            Project = "TestProject"
+        };
+
+        var values = InvokeAddCreatePrOptions(job);
+
+        Assert.Equal("octocat", values["PrReviewer"]);
+        Assert.False(values.ContainsKey("PrAssignee"));
+    }
+
+    [Fact]
+    public void AddCreatePrOptions_OmitsPrReviewer_WhenReviewerNull()
+    {
+        var job = new JobItem
+        {
+            Id = "pr-2",
+            Type = "CreatePr",
+            TypedArgs = new CreatePrArgs(@"D:\Plans\01234-TestPlan"),
+            Project = "TestProject"
+        };
+
+        var values = InvokeAddCreatePrOptions(job);
+
+        Assert.False(values.ContainsKey("PrReviewer"));
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempTendrilHome))

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CustomPrDialog.cs
@@ -19,7 +19,7 @@ public class CustomPrDialog(
         var customPrMerge = UseState(false);
         var customPrDeleteBranch = UseState(false);
         var customPrIncludeArtifacts = UseState(false);
-        var customPrAssignee = UseState<string?>(null);
+        var customPrReviewer = UseState<string?>(null);
         var customPrComment = UseState("");
         var customPrDraft = UseState(false);
 
@@ -40,7 +40,7 @@ public class CustomPrDialog(
                 customPrMerge.Set(true);
                 customPrDeleteBranch.Set(true);
                 customPrIncludeArtifacts.Set(true);
-                customPrAssignee.Set(null);
+                customPrReviewer.Set(null);
                 customPrComment.Set("");
                 customPrDraft.Set(false);
                 dialogOpen.Set(false);
@@ -58,8 +58,8 @@ public class CustomPrDialog(
                     .Disabled(!customPrMerge.Value)
                 | customPrIncludeArtifacts.ToBoolInput("Include Artifacts")
                 | customPrDraft.ToBoolInput("Create as Draft")
-                | customPrAssignee.ToSelectInput((assigneesQuery.Value ?? Array.Empty<string>()).ToOptions())
-                    .Nullable().WithField().Label("Assignee")
+                | customPrReviewer.ToSelectInput((assigneesQuery.Value ?? Array.Empty<string>()).ToOptions())
+                    .Nullable().WithField().Label("Reviewer")
                 | (assigneesError.Value is { } err
                     ? Text.Danger(err).Small()
                     : null)
@@ -73,7 +73,7 @@ public class CustomPrDialog(
                     customPrMerge.Set(true);
                     customPrDeleteBranch.Set(true);
                     customPrIncludeArtifacts.Set(true);
-                    customPrAssignee.Set(null);
+                    customPrReviewer.Set(null);
                     customPrComment.Set("");
                     customPrDraft.Set(false);
                     dialogOpen.Set(false);
@@ -89,7 +89,7 @@ public class CustomPrDialog(
                             Merge: customPrMerge.Value,
                             DeleteBranch: customPrDeleteBranch.Value && customPrMerge.Value,
                             IncludeArtifacts: customPrIncludeArtifacts.Value,
-                            Assignee: customPrAssignee.Value,
+                            Reviewer: customPrReviewer.Value,
                             Comment: string.IsNullOrEmpty(customPrComment.Value) ? null : customPrComment.Value,
                             Draft: customPrDraft.Value));
                         // Plan transition (and pre-state snapshot) handled by JobService.StartJob.
@@ -99,7 +99,7 @@ public class CustomPrDialog(
                         customPrMerge.Set(true);
                         customPrDeleteBranch.Set(true);
                         customPrIncludeArtifacts.Set(true);
-                        customPrAssignee.Set(null);
+                        customPrReviewer.Set(null);
                         customPrComment.Set("");
                         customPrDraft.Set(false);
                         dialogOpen.Set(false);

--- a/src/Ivy.Tendril/Commands/JobStartCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStartCommand.cs
@@ -189,7 +189,7 @@ public class JobStartCommand : Command<JobStartSettings>
                 Merge: !settings.NoMerge,
                 DeleteBranch: !settings.NoDeleteBranch,
                 IncludeArtifacts: !settings.NoArtifacts,
-                Assignee: settings.Assignee,
+                Reviewer: settings.Assignee,
                 Comment: settings.Comment,
                 Draft: settings.Draft);
 

--- a/src/Ivy.Tendril/Models/JobArgs.cs
+++ b/src/Ivy.Tendril/Models/JobArgs.cs
@@ -76,7 +76,7 @@ public record CreatePrArgs(
     bool Merge = true,
     bool DeleteBranch = true,
     bool IncludeArtifacts = true,
-    string? Assignee = null,
+    string? Reviewer = null,
     string? Comment = null,
     bool Draft = false) : JobArgsBase
 {

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -45,7 +45,7 @@ Before processing, read `plan.yaml` and check the `state` field. After reading, 
   - `PrMerge` — `true`/`false` (default: `true`) — **whether to merge the PR after creating it**
   - `PrDeleteBranch` — `true`/`false` (default: `true`)
   - `PrIncludeArtifacts` — `true`/`false` (default: `true`)
-  - `PrAssignee` — GitHub username (default: none)
+  - `PrReviewer` — GitHub username to request as reviewer (default: none)
   - `PrComment` — Review comment text (default: none)
   - `PrDraft` — `true`/`false` (default: `false`)
 
@@ -141,7 +141,7 @@ EOF
   body="${issueLink}${summaryContent}\n\n---\n${commitsList}${artifactMarkdown}\n\n---\nCreated using [Ivy Tendril](https://ivy.app)."
   ```
 - **Draft (custom options):** If custom options exist and `draft` is `true`, add `--draft` to the `gh pr create` command to create the PR in draft mode. If no custom options or `draft` is `false`, create as ready for review (default behavior).
-- **Assignee (custom options):** If custom options exist and `assignee` is non-empty, add `--assignee <assignee>` to the `gh pr create` command.
+- **Reviewer (custom options):** If custom options exist and `reviewer` is non-empty, add `--reviewer <reviewer>` to the `gh pr create` command.
 
 ### 3.5. Add PR Comment (custom options)
 

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -429,8 +429,8 @@ internal class JobLauncher
         values["PrDeleteBranch"] = pr.DeleteBranch.ToString().ToLowerInvariant();
         values["PrIncludeArtifacts"] = pr.IncludeArtifacts.ToString().ToLowerInvariant();
         values["PrDraft"] = pr.Draft.ToString().ToLowerInvariant();
-        if (!string.IsNullOrEmpty(pr.Assignee))
-            values["PrAssignee"] = pr.Assignee;
+        if (!string.IsNullOrEmpty(pr.Reviewer))
+            values["PrReviewer"] = pr.Reviewer;
         if (!string.IsNullOrEmpty(pr.Comment))
             values["PrComment"] = pr.Comment;
     }


### PR DESCRIPTION
Fixes #1311.

The Custom PR dialog labeled its reviewer field **Assignee** and passed `--assignee` to `gh pr create`, which sets a GitHub *assignee* rather than requesting a *reviewer*. This renames both the label and the underlying behavior for the PR path so it requests a reviewer (`--reviewer`).

### Changes
- **CustomPrDialog**: state/label/arg `Assignee` → `Reviewer`
- **CreatePrArgs.Assignee** → `Reviewer` (`CreateIssueArgs` untouched)
- **JobStartCommand**: shared `--assignee` CLI flag now feeds `Reviewer` for create-pr
- **JobLauncher**: firmware var `PrAssignee` → `PrReviewer`
- **CreatePr promptware** (main + TeamIvyConfig): emit `--reviewer`
- Added JobLauncher tests for `PrReviewer` emission

Shared `GetAssigneesAsync` and the Issue/Import assignee paths are intentionally left unchanged (issues legitimately have assignees). The reviewer dropdown keeps using `GetAssigneesAsync` since `gh api .../assignees` returns repo collaborators — the valid reviewer set.

### Verification
- `dotnet build`: succeeded, 0 warnings/errors
- `dotnet test --filter JobLauncherTests`: 12/12 passed (incl. 2 new)