### PR TITLE
Remove timeline lines from agent output stream, add scrollbar padding

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
@@ -37,6 +37,8 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  /* Inner padding keeps content clear of the scrollbar on the right edge. */
+  padding: 4px 12px 4px 4px;
 }
 
 .aov-body > * {
@@ -225,27 +227,6 @@
   font-family: var(--aov-mono);
   padding: 2px 6px;
   border-radius: 4px;
-}
-
-/* Timeline connector between tool cards.
-   Dot geometry within the header (relative to .aov-tool left edge):
-   card pad-left 6 + chevron 14 + flex gap 8 = 28 → dot spans 28–35px, center 31.5px.
-   The line is 1px wide, so left: 31px centers it on the dot.
-   Vertically the dot center sits ~15px from the card top; the line keeps a gap
-   below this dot and stops short of the next dot rather than touching either. */
-.aov-body .aov-tool::after {
-  content: '';
-  position: absolute;
-  left: 31px;
-  top: 24px;
-  bottom: -1px;
-  width: 1px;
-  background: var(--aov-border);
-  pointer-events: none;
-}
-
-.aov-body .aov-tool:last-child::after {
-  display: none;
 }
 
 .aov-tool:hover {


### PR DESCRIPTION
## What

Two visual cleanups to the agent output stream (`AgentViewer`):

1. **Remove the timeline lines.** The vertical 1px connector lines drawn between tool-use cards (the `.aov-body .aov-tool::after` pseudo-element, plus its `:last-child` hide rule) are removed.
2. **Push content away from the scrollbar.** Added inner padding to the scrollable `.aov-body` container (`padding: 4px 12px 4px 4px`) so streamed content is no longer flush against the right-edge scrollbar.

## Why

The timeline connector lines added visual noise to the stream, and content sitting flush against the scrollbar felt cramped. This is a small, CSS-only polish pass.

## Changes

- `src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css` — only file touched (2 insertions, 21 deletions).

## Verification

- Frontend builds clean: `npm run build` in `src/Ivy.Tendril.Widgets/frontend` ✓
- Confirmed via search that the `.aov-tool::after` connector was the only timeline-line rendering in the agent output stream — the `TendrilProcessViewer` arrow connectors are a separate process-flow feature and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)