### PR TITLE
Always render agent output stream so loading indicator doesn't shift

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -166,7 +166,11 @@ public class ProjectAgentStepView(
                 .Disabled(running)
                 .OnClick(onNext);
 
-        var awaitingOutput = !isCloning.Value && session.Running.Value && !session.HasOutput.Value;
+        // The agent output stream always renders while the agent is running. Before any
+        // output arrives, the AgentViewer's own status label (below the stream) shows the
+        // "Starting…" loading indicator, so we don't render a separate Loading() above it —
+        // that avoided a layout shift when the bordered/padded Box swapped in on first output.
+        var showStream = !isCloning.Value && session.Running.Value;
 
         return Layout.Vertical()
                | (showHeader ? Text.H3("Setting up your project") : null!)
@@ -178,11 +182,7 @@ public class ProjectAgentStepView(
                | (isCloning.Value && progressValue.Value != null
                    ? (object)new Progress(progressValue.Value.Value)
                    : null!)
-               | (awaitingOutput
-                   ? (object)(Layout.Horizontal().Gap(2).AlignContent(Align.Left)
-                       | new Loading())
-                   : null!)
-               | (session.HasOutput.Value
+               | (showStream
                    ? (object)new Box(
                         new AgentViewer()
                             .Stream(session.Stream)

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/AddProjectDialog.cs
@@ -65,14 +65,18 @@ public class AddProjectDialog(
             }
         }, isOpen);
 
-        // Transition to step 1 when agent output is ready
+        // Transition to step 1 as soon as the agent run is triggered (not after first
+        // output). The ProjectAgentStepView's setup effect, which actually starts the run,
+        // only fires once that view is mounted — so this mount must happen up front. The
+        // AgentViewer then renders immediately and shows its own "Starting…" loading state
+        // below the stream until output arrives.
         UseEffect(() =>
         {
-            if (session.HasOutput.Value && step.Value == 0 && setupTriggered.Value)
+            if (setupTriggered.Value && !skipAgent.Value && step.Value == 0)
             {
                 step.Set(1);
             }
-        }, session.HasOutput);
+        }, [setupTriggered, skipAgent]);
 
         // Transition to step 2 when skipAgent is enabled and setup is done
         UseEffect(() =>


### PR DESCRIPTION
## Problem

During onboarding and **Add Project**, the agent setup step showed:

1. A standalone `Loading()` indicator while waiting for agent output, then
2. Swapped it for the bordered + padded `Box` containing the `AgentViewer` once `HasOutput` flipped.

Because the `Box` has a border and padding, the swap pushed the indicator inward — so the loader visibly **jumped** the moment the first output arrived.

## Fix

The `AgentViewer` already renders its own loading state: when the stream is empty it shows a **"Starting…"** status label with a spinner *below the stream*. So there's no need for a separate indicator.

- **`ProjectAgentStepView`** (shared by onboarding + add-project): always render the `AgentViewer` `Box` while the agent is running (dropped the `HasOutput` gate and the separate `Loading()`). The AgentViewer's own status label now serves as the loader, in its final position — no widget swap, no shift.
- **`AddProjectDialog`**: the step→agent-view transition was gated on `HasOutput`, but the run is started *inside* `ProjectAgentStepView`'s setup effect, which only fires once that view is mounted — a circular dependency. The transition now fires on the run trigger (`setupTriggered && !skipAgent`) so the view mounts up front and the AgentViewer (with its loading state) is visible immediately. The skip-agent path (step 0 → 2) is unchanged.

## Verification

- `dotnet build src/Ivy.Tendril` — 0 warnings, 0 errors
- `dotnet format --verify-no-changes` on both files — passes

Not yet verified in the running UI; happy to walk through both flows if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)