### PR TITLE
[00567] Hide Empty Rows In Job Debug Sheet

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/LinkListView.cs
+++ b/src/Ivy.Tendril/Apps/Views/LinkListView.cs
@@ -10,12 +10,12 @@ public class LinkListView(List<Link> links, Action<string> onLinkClick) : ViewBa
             return Text.Block("");
 
         var builder = Text.Rich().OnLinkClick(onLinkClick);
-        
+
         for (var i = 0; i < links.Count; i++)
         {
             var link = links[i];
             builder = builder.Link($"#{link.Title}", link.Href);
-            
+
             if (i < links.Count - 1)
                 builder = builder.Run(", ");
         }

--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -50,6 +50,7 @@ public class JobDebugSheet(
         };
 
         var detailsView = data.ToDetails()
+            .RemoveEmpty()
             .Multiline(x => x.PromptTitle)
             .Multiline(x => x.PermissionDenials)
             .Multiline(x => x.Status)

--- a/src/Ivy.Tendril/Services/Jobs/JobFailureAnalyzer.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobFailureAnalyzer.cs
@@ -23,7 +23,7 @@ internal static class JobFailureAnalyzer
         if (psError != null) return psError;
 
 
-        
+
         // 2. Check for transient git / GitHub (gh) failures. These are the real, actionable
         //    cause and must win over an incidental JSON "error" object further down the output
         //    (e.g. a `gh api` response body), which would otherwise be mislabeled as a Claude


### PR DESCRIPTION
# Summary

## Changes

Added `.RemoveEmpty()` to the details builder chain in `JobDebugSheet.cs` to hide rows with empty values. This prevents empty rows for Exit Code, Permission Denials, Arguments, and other fields from cluttering the debug sheet.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs** — Added `.RemoveEmpty()` call to details builder chain

---

## Commits

- 09bf195b Apply dotnet format
- e5450657 Hide empty rows in Job Debug Sheet