### PR TITLE
[00568] Fix Job Debug Sheet Copy Buttons Not Working

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -79,18 +79,8 @@ public class JobDebugSheet(
                 f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .Builder(x => x.WorkingDirectory, f => f.Func((string path) => PathDropDown(path, copyToClipboard, client)))
             .Builder(x => x.CliCommand, f => f.Func((string cmd) => new CodeBlock(cmd)))
-            .Builder(x => x.JobId, f => f.Func((string id) =>
-                Layout.Horizontal().Gap(2).AlignContent(Align.Center)
-                | Text.Block(id)
-                | new Button().Icon(Icons.ClipboardCopy).Ghost().Small()
-                    .Tooltip("Copy job ID")
-                    .OnClick(() => copyToClipboard(id))))
-            .Builder(x => x.PlanId, f => f.Func((string id) =>
-                Layout.Horizontal().Gap(2).AlignContent(Align.Center)
-                | Text.Block(id)
-                | new Button().Icon(Icons.ClipboardCopy).Ghost().Small()
-                    .Tooltip("Copy plan ID")
-                    .OnClick(() => copyToClipboard(id))));
+            .Builder(x => x.JobId, f => f.CopyToClipboard())
+            .Builder(x => x.PlanId, f => f.CopyToClipboard());
 
         var header = Layout.Horizontal().Gap(2)
             | new Button("Copy Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>


### PR DESCRIPTION
# Summary

## Changes

Fixed the Job ID and Plan ID copy buttons in `JobDebugSheet` by replacing manual `Func` builders with the framework's `CopyToClipboard()` builder. The buttons were non-functional because plain `Func` builders don't establish the view context required for event handler registration.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs** — Replaced manual button implementations with framework builder for Job ID and Plan ID fields

---

## Commits

- 53213eae Fix job debug sheet copy buttons using framework builder