### PR TITLE
Fix tunnel Deactivate requiring two clicks; optimistic UI

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/TunnelSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/TunnelSetupView.cs
@@ -58,7 +58,7 @@ public class TunnelSetupView : ViewBase
 
         if (isLoading.Value)
         {
-            form |= Callout.Info("Starting tunnel and waiting for it to become routable. This typically takes 15-30 seconds.", "Tunnel Starting...");
+            form |= Callout.Info("Starting tunnel and waiting for it to become routable. This typically takes 15-30 seconds.", "Tunnel Starting");
             form |= new Loading();
         }
         else if (isConnected.Value && tunnelUrl.Value is not null)
@@ -75,12 +75,14 @@ public class TunnelSetupView : ViewBase
             form |= Text.Block("Scan QR Code").Bold().Small();
             form |= new QRCode { Value = tunnelUrl.Value, PixelSize = 200, ErrorCorrectionLevel = QrErrorCorrectionLevel.Medium };
             form |= new Button("Deactivate").Secondary()
-                .OnClick(() =>
+                .OnClick(async () =>
                 {
-                    tunnelService.Deactivate();
+                    // Optimistically flip to the disconnected view immediately;
+                    // the actual teardown runs in the background below.
                     isConnected.Set(false);
                     tunnelUrl.Set(null);
                     client.Toast("Tunnel stopped", "Deactivated");
+                    await tunnelService.DeactivateAsync();
                 });
         }
         else

--- a/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
@@ -78,16 +78,24 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
         StartSupervisor();
     }
 
-    public void Deactivate()
+    public async Task DeactivateAsync()
     {
         _cts?.Cancel();
         _currentSession?.Stop();
+
+        var supervisorTask = _supervisorTask;
+        if (supervisorTask is not null)
+        {
+            // Never block the calling (UI dispatcher) thread: the supervisor's
+            // own event callbacks marshal back to it, so a synchronous .Wait()
+            // here deadlocks until it times out.
+            try { await supervisorTask.WaitAsync(TimeSpan.FromSeconds(5)); }
+            catch (TimeoutException) { }
+            catch (OperationCanceledException) { }
+        }
+
         _currentSession?.Dispose();
         _currentSession = null;
-
-        try { _supervisorTask?.Wait(TimeSpan.FromSeconds(5)); }
-        catch (AggregateException) { }
-
         _cts?.Dispose();
         _cts = null;
         _supervisorTask = null;
@@ -185,6 +193,7 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
                 TunnelConnected?.Invoke(url);
 
                 await _currentSession.WaitForExitAsync(ct);
+                if (ct.IsCancellationRequested) break;
                 _logger.LogWarning("Tunnel process exited unexpectedly");
                 TunnelDisconnected?.Invoke();
             }

--- a/src/Ivy.Tendril/Services/Tunnel/ICloudflaredService.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/ICloudflaredService.cs
@@ -10,5 +10,5 @@ public interface ICloudflaredService
     Task<bool> CheckInstalledAsync(CancellationToken ct = default);
     Task InstallAsync(CancellationToken ct = default);
     Task ActivateAsync(CancellationToken ct = default);
-    void Deactivate();
+    Task DeactivateAsync();
 }


### PR DESCRIPTION
## Problem
Pressing **Deactivate** on the Tunnel settings required two clicks to take effect.

`Deactivate()` was synchronous and blocked the Ivy dispatcher thread with `supervisorTask.Wait()`. Meanwhile the background tunnel supervisor's `TunnelDisconnected` callback marshalled its `state.Set(...)` updates back to that same blocked thread, so the first click's UI update was never flushed to the client. The second click worked only because the supervisor was already torn down.

## Fix
- `ICloudflaredService`: `void Deactivate()` → `Task DeactivateAsync()`.
- `CloudflaredService`: `await supervisorTask.WaitAsync(...)` instead of a blocking `.Wait()`, so the dispatcher thread is never held. Added `if (ct.IsCancellationRequested) break;` after `WaitForExitAsync` so an intentional stop no longer logs a spurious "exited unexpectedly", re-fires `TunnelDisconnected`, or triggers a restart.
- `TunnelSetupView`: async Deactivate handler that flips state **optimistically** (instant switch to the Activate view) before awaiting the background teardown — mirroring how Activate sets `isLoading` first.

Builds clean (0 warnings, 0 errors).
