### PR TITLE
[00570] Fix PathDropDown Width in JobDebugSheet

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -130,7 +130,7 @@ public class JobDebugSheet(
     private object PathDropDown(string path, Action<string> copyToClipboard, IClientProvider client)
     {
         return Layout.Horizontal().Gap(2).Width(Size.Full()).AlignContent(Align.SpaceBetween)
-            | Text.Block(path)
+            | Text.Block(path).Width(Size.Grow())
             | new Button().Icon(Icons.EllipsisVertical).Ghost().Small()
                 .WithDropDown(
                     new MenuItem("Copy to Clipboard", Icon: Icons.ClipboardCopy, Tag: "Copy")


### PR DESCRIPTION
# Summary

## Changes

Added `.Width(Size.Grow())` to the path text element in the `PathDropDown` method of `JobDebugSheet.cs`. This ensures the path text expands to fill available horizontal space, pushing the dropdown button to the far right edge regardless of whether the path wraps to multiple lines.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs** — Added width constraint to path text in PathDropDown method

---

## Commits

- 71e9f1b0 Fix PathDropDown width in JobDebugSheet