### PR TITLE
Tunnel: connecting state, wallpaper QR, and Open in Browser

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/TunnelSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/TunnelSetupView.cs
@@ -13,38 +13,25 @@ public class TunnelSetupView : ViewBase
         var tunnelService = UseService<ICloudflaredService>();
         var copyToClipboard = UseClipboard();
 
-        var isLoading = UseState(false);
         var error = UseState<string?>(null);
+        var status = UseState(tunnelService.Status);
         var tunnelUrl = UseState<string?>(tunnelService.TunnelUrl);
-        var isConnected = UseState(tunnelService.IsConnected);
         var (alertView, showAlert) = UseAlert();
 
         UseEffect(() =>
         {
-            void OnConnected(string url)
+            void OnStatusChanged(TunnelStatus newStatus)
             {
-                tunnelUrl.Set(url);
-                isConnected.Set(true);
-                isLoading.Set(false);
+                status.Set(newStatus);
+                tunnelUrl.Set(tunnelService.TunnelUrl);
             }
 
-            void OnDisconnected()
-            {
-                tunnelUrl.Set(null);
-                isConnected.Set(false);
-            }
+            tunnelService.StatusChanged += OnStatusChanged;
 
-            tunnelService.TunnelConnected += OnConnected;
-            tunnelService.TunnelDisconnected += OnDisconnected;
-
+            status.Set(tunnelService.Status);
             tunnelUrl.Set(tunnelService.TunnelUrl);
-            isConnected.Set(tunnelService.IsConnected);
 
-            return Disposable.Create(() =>
-            {
-                tunnelService.TunnelConnected -= OnConnected;
-                tunnelService.TunnelDisconnected -= OnDisconnected;
-            });
+            return Disposable.Create(() => tunnelService.StatusChanged -= OnStatusChanged);
         });
 
         var form = Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(120)))
@@ -56,22 +43,25 @@ public class TunnelSetupView : ViewBase
             form |= Callout.Error(error.Value, "Error");
         }
 
-        if (isLoading.Value)
+        if (status.Value == TunnelStatus.Connecting)
         {
             form |= Callout.Info("Starting tunnel and waiting for it to become routable. This typically takes 15-30 seconds.", "Tunnel Starting");
             form |= new Loading();
         }
-        else if (isConnected.Value && tunnelUrl.Value is not null)
+        else if (status.Value == TunnelStatus.Connected && tunnelUrl.Value is not null)
         {
             form |= Callout.Success("Your tunnel is running and accessible at the URL below.", "Tunnel Active");
             form |= Text.Block("Tunnel URL").Bold().Small();
             form |= Text.Monospaced(tunnelUrl.Value);
-            form |= new Button("Copy URL").Icon(Icons.ClipboardCopy).Outline()
-                .OnClick(() =>
-                {
-                    copyToClipboard(tunnelUrl.Value!);
-                    client.Toast("Tunnel URL copied to clipboard", "URL Copied");
-                });
+            form |= Layout.Horizontal()
+                   | new Button("Copy URL").Icon(Icons.ClipboardCopy).Outline()
+                       .OnClick(() =>
+                       {
+                           copyToClipboard(tunnelUrl.Value!);
+                           client.Toast("Tunnel URL copied to clipboard", "URL Copied");
+                       })
+                   | new Button("Open in Browser").Icon(Icons.ExternalLink).Outline()
+                       .OnClick(() => client.OpenUrl(tunnelUrl.Value!));
             form |= Text.Block("Scan QR Code").Bold().Small();
             form |= new QRCode { Value = tunnelUrl.Value, PixelSize = 200, ErrorCorrectionLevel = QrErrorCorrectionLevel.Medium };
             form |= new Button("Deactivate").Secondary()
@@ -79,7 +69,7 @@ public class TunnelSetupView : ViewBase
                 {
                     // Optimistically flip to the disconnected view immediately;
                     // the actual teardown runs in the background below.
-                    isConnected.Set(false);
+                    status.Set(TunnelStatus.Disabled);
                     tunnelUrl.Set(null);
                     client.Toast("Tunnel stopped", "Deactivated");
                     await tunnelService.DeactivateAsync();
@@ -88,24 +78,24 @@ public class TunnelSetupView : ViewBase
         else
         {
             form |= new Button("Activate").Primary()
-                .Loading(isLoading.Value)
-                .Disabled(isLoading.Value)
                 .OnClick(async () =>
                 {
-                    isLoading.Set(true);
                     error.Set(null);
+                    // Optimistically show the connecting state; the service drives
+                    // it to Connected (or back to Disabled on failure) via StatusChanged.
+                    status.Set(TunnelStatus.Connecting);
 
                     try
                     {
                         var installed = await tunnelService.CheckInstalledAsync();
                         if (!installed)
                         {
-                            isLoading.Set(false);
+                            status.Set(TunnelStatus.Disabled);
                             showAlert("Cloudflared is not installed. Would you like to download and install it?", async result =>
                             {
                                 if (result == AlertResult.Ok)
                                 {
-                                    isLoading.Set(true);
+                                    status.Set(TunnelStatus.Connecting);
                                     try
                                     {
                                         await tunnelService.InstallAsync();
@@ -114,8 +104,12 @@ public class TunnelSetupView : ViewBase
                                     catch (Exception ex)
                                     {
                                         error.Set($"Failed to install cloudflared: {ex.Message}");
-                                        isLoading.Set(false);
+                                        status.Set(TunnelStatus.Disabled);
                                     }
+                                }
+                                else
+                                {
+                                    status.Set(TunnelStatus.Disabled);
                                 }
                             });
                             return;
@@ -126,7 +120,7 @@ public class TunnelSetupView : ViewBase
                     catch (Exception ex)
                     {
                         error.Set($"Failed to start tunnel: {ex.Message}");
-                        isLoading.Set(false);
+                        status.Set(TunnelStatus.Disabled);
                     }
                 });
         }

--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -1,8 +1,11 @@
+using System.Reactive.Disposables;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.Plans;
+using Ivy.Tendril.Services.Tunnel;
 using Ivy.Widgets.ActivityHeatmap;
+using Ivy.Widgets.QRCode;
 
 namespace Ivy.Tendril.Apps;
 
@@ -13,8 +16,11 @@ public class WallpaperApp : ViewBase
     {
         var versionService = UseService<IVersionCheckService>();
         var planDbService = UseService<IPlanDatabaseService>();
+        var tunnelService = UseService<ICloudflaredService>();
         var versionInfo = UseState<VersionInfo?>(null);
         var dismissedVersion = UseState<string?>(null);
+        var tunnelStatus = UseState(tunnelService.Status);
+        var tunnelUrl = UseState<string?>(tunnelService.TunnelUrl);
 
         var processView = Context.UseTendrilProcess();
 
@@ -26,6 +32,22 @@ public class WallpaperApp : ViewBase
                 versionInfo.Set(info);
             });
         }, []);
+
+        UseEffect(() =>
+        {
+            void OnStatusChanged(TunnelStatus newStatus)
+            {
+                tunnelStatus.Set(newStatus);
+                tunnelUrl.Set(tunnelService.TunnelUrl);
+            }
+
+            tunnelService.StatusChanged += OnStatusChanged;
+
+            tunnelStatus.Set(tunnelService.Status);
+            tunnelUrl.Set(tunnelService.TunnelUrl);
+
+            return Disposable.Create(() => tunnelService.StatusChanged -= OnStatusChanged);
+        });
 
         // Query last 90 days of completed PRs
         var prData = planDbService.GetCompletedPrsByDay(90);
@@ -53,6 +75,21 @@ public class WallpaperApp : ViewBase
         {
             Layout.Center() | verticalLayout
         };
+
+        // Only show the tunnel QR once the tunnel is fully established and routable
+        // (Status == Connected), never during the Connecting phase.
+        if (tunnelStatus.Value == TunnelStatus.Connected && tunnelUrl.Value is { } tunnelAddress)
+        {
+            var tunnelQr = new FloatingPanel(
+                new Card(
+                    Layout.Vertical().Gap(2).AlignContent(Align.Center)
+                    | new QRCode { Value = tunnelAddress, PixelSize = 160, ErrorCorrectionLevel = QrErrorCorrectionLevel.Medium }
+                    | Text.Block("Scan to open Tendril on your phone").Muted().Small()
+                ).Header("Tunnel", null, Icons.QrCode)
+            ).AlignSelf(Align.TopRight).Offset(new Thickness(0, 8, 8, 0));
+
+            elements.Add(tunnelQr);
+        }
 
         if (versionInfo.Value?.HasUpdate == true && versionInfo.Value.LatestVersion != dismissedVersion.Value)
         {

--- a/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
@@ -16,6 +16,7 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
     private Task? _supervisorTask;
     private TunnelSession? _currentSession;
     private bool _isInstalled;
+    private TunnelStatus _status = TunnelStatus.Disabled;
 
     public CloudflaredService(
         IConfigService config,
@@ -32,11 +33,18 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
     }
 
     public string? TunnelUrl => _currentSession?.TunnelUrl;
-    public bool IsConnected => _currentSession?.IsRunning == true && TunnelUrl is not null;
+    public TunnelStatus Status => _status;
+    public bool IsConnected => _status == TunnelStatus.Connected;
     public bool IsInstalled => _isInstalled;
 
-    public event Action<string>? TunnelConnected;
-    public event Action? TunnelDisconnected;
+    public event Action<TunnelStatus>? StatusChanged;
+
+    private void SetStatus(TunnelStatus status)
+    {
+        if (_status == status) return;
+        _status = status;
+        StatusChanged?.Invoke(status);
+    }
 
     public void Start()
     {
@@ -104,7 +112,7 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
         _config.Settings.Tunnel.Enabled = false;
         _config.SaveSettings();
 
-        TunnelDisconnected?.Invoke();
+        SetStatus(TunnelStatus.Disabled);
     }
 
     private void StartSupervisor()
@@ -112,6 +120,7 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
         _cts?.Cancel();
         _cts?.Dispose();
         _cts = new CancellationTokenSource();
+        SetStatus(TunnelStatus.Connecting);
         _supervisorTask = Task.Run(() => SupervisorLoopAsync(_cts.Token));
     }
 
@@ -186,16 +195,17 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
         {
             try
             {
+                SetStatus(TunnelStatus.Connecting);
                 _currentSession = new TunnelSession(binaryPath, originUrl, _logger);
                 var url = await _currentSession.StartAsync(ct);
                 await WaitForTunnelHealthyAsync(url, ct);
                 consecutiveFailures = 0;
-                TunnelConnected?.Invoke(url);
+                SetStatus(TunnelStatus.Connected);
 
                 await _currentSession.WaitForExitAsync(ct);
                 if (ct.IsCancellationRequested) break;
                 _logger.LogWarning("Tunnel process exited unexpectedly");
-                TunnelDisconnected?.Invoke();
+                SetStatus(TunnelStatus.Connecting);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
@@ -204,6 +214,7 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
             catch (Exception ex)
             {
                 consecutiveFailures++;
+                SetStatus(TunnelStatus.Connecting);
                 _logger.LogWarning(ex, "Tunnel session failed (attempt {Count}/{Max})",
                     consecutiveFailures, maxRestarts);
             }
@@ -221,7 +232,10 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
         }
 
         if (consecutiveFailures >= maxRestarts)
+        {
             _logger.LogError("Tunnel exceeded max restarts ({Max}), giving up", maxRestarts);
+            SetStatus(TunnelStatus.Disabled);
+        }
     }
 
     public void Dispose()

--- a/src/Ivy.Tendril/Services/Tunnel/ICloudflaredService.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/ICloudflaredService.cs
@@ -3,10 +3,10 @@ namespace Ivy.Tendril.Services.Tunnel;
 public interface ICloudflaredService
 {
     string? TunnelUrl { get; }
+    TunnelStatus Status { get; }
     bool IsConnected { get; }
     bool IsInstalled { get; }
-    event Action<string>? TunnelConnected;
-    event Action? TunnelDisconnected;
+    event Action<TunnelStatus>? StatusChanged;
     Task<bool> CheckInstalledAsync(CancellationToken ct = default);
     Task InstallAsync(CancellationToken ct = default);
     Task ActivateAsync(CancellationToken ct = default);

--- a/src/Ivy.Tendril/Services/Tunnel/TunnelStatus.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/TunnelStatus.cs
@@ -1,0 +1,13 @@
+namespace Ivy.Tendril.Services.Tunnel;
+
+public enum TunnelStatus
+{
+    /// <summary>Tunnel is not running.</summary>
+    Disabled,
+
+    /// <summary>Tunnel process is starting and not yet routable. A URL may already exist but is not reachable.</summary>
+    Connecting,
+
+    /// <summary>Tunnel is fully established and verified routable.</summary>
+    Connected
+}


### PR DESCRIPTION
## What

Three related tunnel UX fixes, built on an explicit tunnel status model.

### 1. Show loading while the tunnel is starting
`IsConnected` previously went `true` the moment cloudflared *printed* its URL (in `StartAsync`), **before** the health check confirmed the tunnel was routable. So after a restart the settings view showed "Tunnel Active" while the tunnel wasn't actually reachable yet.

Introduced `TunnelStatus { Disabled, Connecting, Connected }`:
- `CloudflaredService` tracks status and raises a single `StatusChanged` event (replacing `TunnelConnected`/`TunnelDisconnected`). `Connected` is set **only after** `WaitForTunnelHealthyAsync` succeeds.
- `TunnelSetupView` renders by status: `Connecting` → loading spinner, `Connected` → URL/QR/Deactivate, `Disabled` → Activate.

### 2. Tunnel QR on the wallpaper
`WallpaperApp` shows the tunnel QR in a top-right floating panel, but **only when `Status == Connected`** (fully routable) — never during `Connecting`.

### 3. "Open in Browser" button
Added next to "Copy URL" in the tunnel settings, using `client.OpenUrl(...)`.

## Notes
Compiles clean (full build succeeds). No unit tests exist for `CloudflaredService` (only an HTTP-level E2E test, unaffected). Runtime state transitions are best verified in the running app.
