### PR TITLE
Tunnel: kill orphaned cloudflared, fix reactivate race and wallpaper menu

### DIFF
--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -14,9 +14,11 @@ public class WallpaperApp : ViewBase
 {
     public override object Build()
     {
+        var client = UseService<IClientProvider>();
         var versionService = UseService<IVersionCheckService>();
         var planDbService = UseService<IPlanDatabaseService>();
         var tunnelService = UseService<ICloudflaredService>();
+        var copyToClipboard = UseClipboard();
         var versionInfo = UseState<VersionInfo?>(null);
         var dismissedVersion = UseState<string?>(null);
         var tunnelStatus = UseState(tunnelService.Status);
@@ -80,12 +82,27 @@ public class WallpaperApp : ViewBase
         // (Status == Connected), never during the Connecting phase.
         if (tunnelStatus.Value == TunnelStatus.Connected && tunnelUrl.Value is { } tunnelAddress)
         {
+            var tunnelMenu = new Button().Icon(Icons.Ellipsis).Ghost().WithDropDown(
+                new MenuItem("Copy to Clipboard", Icon: Icons.ClipboardCopy, Tag: "copy").OnSelect(() =>
+                {
+                    copyToClipboard(tunnelAddress);
+                    client.Toast("Tunnel URL copied to clipboard", "URL Copied");
+                }),
+                new MenuItem("Open in Browser", Icon: Icons.ExternalLink, Tag: "open").OnSelect(() => client.OpenUrl(tunnelAddress)),
+                new MenuItem("Deactivate", Icon: Icons.Power, Tag: "deactivate").OnSelect(() =>
+                {
+                    // Optimistically remove the panel; the teardown runs in the background.
+                    tunnelStatus.Set(TunnelStatus.Disabled);
+                    client.Toast("Tunnel stopped", "Deactivated");
+                    _ = tunnelService.DeactivateAsync();
+                })
+            );
+
             var tunnelQr = new FloatingPanel(
                 new Card(
                     Layout.Vertical().Gap(2).AlignContent(Align.Center)
                     | new QRCode { Value = tunnelAddress, PixelSize = 160, ErrorCorrectionLevel = QrErrorCorrectionLevel.Medium }
-                    | Text.Block("Scan to open Tendril on your phone").Muted().Small()
-                ).Header("Tunnel", null, Icons.QrCode)
+                ).Header("Tunnel", null, tunnelMenu)
             ).AlignSelf(Align.TopRight).Offset(new Thickness(0, 8, 8, 0));
 
             elements.Add(tunnelQr);

--- a/src/Ivy.Tendril/Services/Tunnel/ChildProcessTracker.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/ChildProcessTracker.cs
@@ -1,0 +1,126 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace Ivy.Tendril.Services.Tunnel;
+
+/// <summary>
+///     Assigns child processes to a Windows Job Object configured to kill every assigned
+///     process when this (parent) process exits — including on crash, console close, or a
+///     forced kill where no graceful shutdown runs. This guarantees spawned cloudflared
+///     processes never outlive Tendril and accumulate as orphans across sessions.
+///     No-op on non-Windows platforms.
+/// </summary>
+internal static class ChildProcessTracker
+{
+    private const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
+
+    // Held for the lifetime of the process: when Tendril exits, the OS closes this last
+    // handle to the job, which (because of KILL_ON_JOB_CLOSE) terminates every member.
+    private static readonly IntPtr s_jobHandle;
+
+    static ChildProcessTracker()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        s_jobHandle = CreateJobObject(IntPtr.Zero, $"Tendril.Cloudflared.{Environment.ProcessId}");
+        if (s_jobHandle == IntPtr.Zero)
+            return;
+
+        var extendedInfo = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
+            {
+                LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+            }
+        };
+
+        var length = Marshal.SizeOf<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>();
+        var infoPtr = Marshal.AllocHGlobal(length);
+        try
+        {
+            Marshal.StructureToPtr(extendedInfo, infoPtr, false);
+            SetInformationJobObject(s_jobHandle, JobObjectInfoType.ExtendedLimitInformation,
+                infoPtr, (uint)length);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(infoPtr);
+        }
+    }
+
+    /// <summary>
+    ///     Assigns a process to the kill-on-close job. Best-effort: returns false if tracking
+    ///     is unavailable (non-Windows, or the assignment failed) so callers can fall back to
+    ///     explicit Stop()/Dispose() without failing the tunnel.
+    /// </summary>
+    public static bool AddProcess(Process process)
+    {
+        if (!OperatingSystem.IsWindows() || s_jobHandle == IntPtr.Zero)
+            return false;
+
+        try
+        {
+            return AssignProcessToJobObject(s_jobHandle, process.Handle);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string? name);
+
+    [SupportedOSPlatform("windows")]
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetInformationJobObject(IntPtr hJob, JobObjectInfoType infoType,
+        IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+    [SupportedOSPlatform("windows")]
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+
+    private enum JobObjectInfoType
+    {
+        ExtendedLimitInformation = 9
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IO_COUNTERS
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+    {
+        public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+        public IO_COUNTERS IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+}

--- a/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/CloudflaredService.cs
@@ -193,16 +193,18 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
 
         while (!ct.IsCancellationRequested && consecutiveFailures < maxRestarts)
         {
+            TunnelSession? session = null;
             try
             {
                 SetStatus(TunnelStatus.Connecting);
-                _currentSession = new TunnelSession(binaryPath, originUrl, _logger);
-                var url = await _currentSession.StartAsync(ct);
+                session = new TunnelSession(binaryPath, originUrl, _logger);
+                _currentSession = session;
+                var url = await session.StartAsync(ct);
                 await WaitForTunnelHealthyAsync(url, ct);
                 consecutiveFailures = 0;
                 SetStatus(TunnelStatus.Connected);
 
-                await _currentSession.WaitForExitAsync(ct);
+                await session.WaitForExitAsync(ct);
                 if (ct.IsCancellationRequested) break;
                 _logger.LogWarning("Tunnel process exited unexpectedly");
                 SetStatus(TunnelStatus.Connecting);
@@ -220,8 +222,12 @@ public sealed class CloudflaredService : ICloudflaredService, IStartable, IDispo
             }
             finally
             {
-                _currentSession?.Dispose();
-                _currentSession = null;
+                // Tear down only our own session. Guard the shared field so a
+                // superseded supervisor can never dispose or null a newer
+                // generation's session (which would kill a freshly started tunnel).
+                session?.Dispose();
+                if (ReferenceEquals(_currentSession, session))
+                    _currentSession = null;
             }
 
             if (ct.IsCancellationRequested) break;

--- a/src/Ivy.Tendril/Services/Tunnel/TunnelSession.cs
+++ b/src/Ivy.Tendril/Services/Tunnel/TunnelSession.cs
@@ -45,6 +45,12 @@ public sealed partial class TunnelSession : IDisposable
         _process = Process.Start(psi)
             ?? throw new InvalidOperationException("Failed to start cloudflared process");
 
+        // Tie the process lifetime to ours: if Tendril dies without a graceful shutdown
+        // (crash, console close, forced kill), the OS still terminates cloudflared instead
+        // of leaving it orphaned across sessions.
+        if (!ChildProcessTracker.AddProcess(_process) && OperatingSystem.IsWindows())
+            _logger.LogDebug("cloudflared process not tracked by job object (PID {Pid})", _process.Id);
+
         _process.ErrorDataReceived += OnStderrLine;
         _process.BeginErrorReadLine();
         _process.BeginOutputReadLine();


### PR DESCRIPTION
## Three related tunnel fixes

### 1. Orphaned cloudflared processes (main one)
`Stop()`/`Dispose()` only kill cloudflared when they actually run. On Windows a child isn't killed when its parent dies, so any non-graceful Tendril exit (crash, console close, IDE/terminal force-kill, memory watchdog) left cloudflared orphaned — they were piling up across sessions/days.

Added `ChildProcessTracker`: a Windows **Job Object** with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, created once per process. Every cloudflared process is assigned to it in `TunnelSession.StartAsync`, so the OS terminates them whenever Tendril dies **for any reason**. Best-effort; no-op on non-Windows (there we still rely on `Stop()`/`Dispose()`).

### 2. Deactivate → reactivate race
The old and new supervisor shared the `_currentSession` field, so a superseded supervisor's `finally` could dispose the **newly started** session — killing a fresh tunnel before it registered with Cloudflare's edge (`DNS_PROBE_FINISHED_NXDOMAIN`, while the UI reported "ready"). Each supervisor generation now owns a local session and only clears the shared field when it still references its own (`ReferenceEquals`).

### 3. Wallpaper tunnel dropdown did nothing
`WithDropDown`'s default handler routes a click by matching the selected value against each `MenuItem`'s `Tag`/`Label`; the items had no `Tag`, so nothing matched. Added explicit tags to **Copy to Clipboard** / **Open in Browser** / **Deactivate**.

## Notes
Builds clean. No unit tests for `CloudflaredService` (only an HTTP-level E2E test, unaffected). Best verified manually: deactivate→reactivate a few times (URLs should work), and hard-kill Tendril while a tunnel is active (cloudflared should die with it).
