### PR TITLE
[00571] Fix Plan Review Header Title Overflow

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -137,7 +137,7 @@ public class ContentView(
 
         var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
             | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
-                .BorderThickness(0).Padding(0).Width(Size.Fit());
+                .BorderThickness(0).Padding(0).Width(Size.Fit().Min(Size.Px(0)));
 
         if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
             desktopTitleLayout |= new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -253,7 +253,7 @@ public class ContentView(
     {
         var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
             | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
-                .BorderThickness(0).Padding(0).Width(Size.Fit());
+                .BorderThickness(0).Padding(0).Width(Size.Fit().Min(Size.Px(0)));
 
         if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
             desktopTitleLayout |= new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")


### PR DESCRIPTION
Fixes #1333

# Summary

## Changes

Fixed title overflow in Review and Drafts apps by adding `.Min(Size.Px(0))` to the title Box width constraints. This allows the ellipsis truncation to trigger when long plan titles would otherwise overflow and collide with action buttons.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Review/ContentView.cs** — Updated title Box width constraint
- **src/Ivy.Tendril/Apps/Drafts/ContentView.cs** — Updated title Box width constraint

---

## Commits

- 99ec293f