### PR TITLE
[00572] Add bottom padding to onboarding content

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -172,7 +172,7 @@ public class ProjectAgentStepView(
         // that avoided a layout shift when the bordered/padded Box swapped in on first output.
         var showStream = !isCloning.Value && session.Running.Value;
 
-        return Layout.Vertical()
+        return Layout.Vertical().Margin(0, 0, 0, 20)
                | (showHeader ? Text.H3("Setting up your project") : null!)
                | Text.Muted(isCloning.Value
                    ? (progressMessage.Value ?? "Setting up your project...")

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
@@ -91,7 +91,7 @@ public class ProjectCrudStepView(
             | new Button(nextButtonText).Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
                 .OnClick(onNext);
 
-        return Layout.Vertical()
+        return Layout.Vertical().Margin(0, 0, 0, 20)
                | (showHeader ? Text.H3("Review Harness") : null!)
                | Text.Muted("Review and edit the configuration generated for your project.")
                | (Layout.Vertical()

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -54,7 +54,7 @@ public class ProjectInputStepView(
                 .Disabled(!canContinue)
                 .OnClick(onNext);
 
-        return Layout.Vertical()
+        return Layout.Vertical().Margin(0, 0, 0, 20)
                | (showHeader ? Text.H3(title) : null!)
                | Text.Muted("A project groups one or more repositories together so Tendril can plan and verify changes across them.")
                | new ProjectRepoPickerView(selectedRepos, projectName)


### PR DESCRIPTION
Fixes #1348

# Summary

## Changes

Added bottom padding (20px) to three onboarding step views that were missing it. The root `Layout.Vertical()` call in `ProjectInputStepView`, `ProjectAgentStepView`, and `ProjectCrudStepView` now includes `.Margin(0, 0, 0, 20)`, matching the pattern already used by other onboarding steps.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs` — added `.Margin(0, 0, 0, 20)` to root layout
- `src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs` — added `.Margin(0, 0, 0, 20)` to root layout
- `src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs` — added `.Margin(0, 0, 0, 20)` to root layout

---

**Commits:**
- ec9d4deb Add bottom padding to onboarding step views