### PR TITLE
[00573] Filter onboarding agent list by registered agents

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -71,9 +71,6 @@ public class CodingAgentStepView(
         var client = UseService<IClientProvider>();
         var agentRunner = UseService<IAgentRunner>();
 
-        var registeredAgents = agentRunner.RegisteredAgents;
-        var visibleAgents = Agents.Where(a => registeredAgents.Contains(a.Key)).ToArray();
-
         var selectedAgent = UseState<string?>(null);
         var progressMessage = UseState<string?>(null);
         var progressValue = UseState<int?>(null);
@@ -82,6 +79,9 @@ public class CodingAgentStepView(
 
         var (installDialog, showInstallDialog) = UseTrigger<InstallDialogArgs>((isOpen, args) =>
             new InstallMissingDialog(isOpen, args));
+
+        var registeredAgents = agentRunner.RegisteredAgents;
+        var visibleAgents = Agents.Where(a => registeredAgents.Contains(a.Key)).ToArray();
 
         if (selectedAgent.Value is null)
         {

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -71,6 +71,9 @@ public class CodingAgentStepView(
         var client = UseService<IClientProvider>();
         var agentRunner = UseService<IAgentRunner>();
 
+        var registeredAgents = agentRunner.RegisteredAgents;
+        var visibleAgents = Agents.Where(a => registeredAgents.Contains(a.Key)).ToArray();
+
         var selectedAgent = UseState<string?>(null);
         var progressMessage = UseState<string?>(null);
         var progressValue = UseState<int?>(null);
@@ -82,7 +85,7 @@ public class CodingAgentStepView(
 
         if (selectedAgent.Value is null)
         {
-            return BuildPicker(agentKey =>
+            return BuildPicker(visibleAgents, agentKey =>
             {
                 selectedAgent.Set(agentKey);
                 _ = RunFlowAsync(agentKey);
@@ -226,11 +229,11 @@ public class CodingAgentStepView(
         }
     }
 
-    private static object BuildPicker(Action<string> onSelect, string? errorMessage)
+    private static object BuildPicker(AgentInfo[] agents, Action<string> onSelect, string? errorMessage)
     {
         var grid = Layout.Grid().Columns(3).Gap(2);
 
-        grid = Agents.Aggregate(grid, (current, a) => current | new Card(Layout.Horizontal().Gap(2).AlignContent(Align.Center).Padding(0) | a.Logo.ToIcon().Width(Size.Px(32)).Height(Size.Px(32)) | Text.Block(a.Label)).OnClick(() => onSelect(a.Key)));
+        grid = agents.Aggregate(grid, (current, a) => current | new Card(Layout.Horizontal().Gap(2).AlignContent(Align.Center).Padding(0) | a.Logo.ToIcon().Width(Size.Px(32)).Height(Size.Px(32)) | Text.Block(a.Label)).OnClick(() => onSelect(a.Key)));
 
         return Layout.Vertical().Margin(0, 0, 0, 20)
                | Text.H3("What is your coding agent?")


### PR DESCRIPTION
Fixes #1356

# Summary

## Changes

Modified `CodingAgentStepView.cs` to filter the onboarding agent picker by `IAgentRunner.RegisteredAgents`, matching the behavior already present in the settings view. Antigravity and other beta agents now only appear in onboarding when `--beta` is passed.

## API Changes

- **`BuildPicker`** method signature changed from `BuildPicker(Action<string>, string?)` to `BuildPicker(AgentInfo[], Action<string>, string?)` — internal method, no external API impact.

## Files Modified

- `src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs` — Added agent filtering logic and updated `BuildPicker` to accept filtered agent array

---

## Commits

- 69070f1f Filter onboarding agent list by registered agents
- 1d6e2d4b Fix Ivy hook ordering by moving filtering after hooks