### PR TITLE
[00575] Show toast when voice transcription returns empty result

### DIFF
--- a/src/Ivy.Widgets.ContentInputView/frontend/src/ContentInputView.tsx
+++ b/src/Ivy.Widgets.ContentInputView/frontend/src/ContentInputView.tsx
@@ -571,6 +571,10 @@ export const ContentInputView: React.FC<ContentInputViewProps> = ({
         onStatusChange: (status) => setVoiceStatus(status),
         onResult: (transcription) => {
           console.log("[ContentInputView] Transcription result received:", transcription);
+          if (transcription.trim() === "") {
+            setRecordError("The transcription did not contain enough information to generate a prompt. Please try again and speak clearly.");
+            return;
+          }
           setText((prev) => {
             const next = prev ? `${prev} ${transcription}` : transcription;
             console.log("[ContentInputView] Next text state:", next);


### PR DESCRIPTION
Fixes #1355

# Summary

## Changes

Added empty transcription validation in the voice recording onResult handler. When the API returns an empty transcription, the user now sees a clear error message via the existing error banner instead of silence.

## API Changes

None.

## Files Modified

- **src/Ivy.Widgets.ContentInputView/frontend/src/ContentInputView.tsx** — Added empty check in onResult callback with user-friendly error message

---

## Commits

- c4c035a18fbe4168f8a6a77a2829c89c5f06fec3