### PR TITLE
Wrap app content headers onto a second row on mobile

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -135,59 +135,67 @@ public class ContentView(
 
         var currentIndex = allPlans.FindIndex(p => p.FolderName == selectedPlan.FolderName);
 
-        var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
-            | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
-                .BorderThickness(0).Padding(0).Width(Size.Fit().Min(Size.Px(0)));
-
-        if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
-            desktopTitleLayout |= new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
-                .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
-
-        if (selectedPlan.DependsOn.Count > 0)
+        object BuildTitleArea()
         {
-            var depIds = string.Join(", ", selectedPlan.DependsOn.Select(d =>
+            var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
+                | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
+                    .BorderThickness(0).Padding(0).Width(Size.Fit().Min(Size.Px(0)));
+
+            if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
+                desktopTitleLayout |= new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
+                    .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
+
+            if (selectedPlan.DependsOn.Count > 0)
             {
-                var name = Path.GetFileName(d);
-                var dashIdx = name.IndexOf('-');
-                var idStr = dashIdx > 0 ? name[..dashIdx] : name;
-                return int.TryParse(idStr, out var id) ? $"#{id}" : idStr;
-            }));
-            desktopTitleLayout |= new Badge($"Depends on: {depIds}").Variant(BadgeVariant.Secondary);
+                var depIds = string.Join(", ", selectedPlan.DependsOn.Select(d =>
+                {
+                    var name = Path.GetFileName(d);
+                    var dashIdx = name.IndexOf('-');
+                    var idStr = dashIdx > 0 ? name[..dashIdx] : name;
+                    return int.TryParse(idStr, out var id) ? $"#{id}" : idStr;
+                }));
+                desktopTitleLayout |= new Badge($"Depends on: {depIds}").Variant(BadgeVariant.Secondary);
+            }
+
+            var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
+                .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
+
+            return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow())
+                   | desktopTitle
+                   | MobileItemPicker.Build(
+                           $"#{selectedPlan.Id} {selectedPlan.Title}",
+                           allPlans,
+                           p => $"#{p.Id} {p.Title}",
+                           p => p.FolderName == selectedPlan.FolderName,
+                           p => selectedPlanState.Set(p))
+                       .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
         }
 
-        var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
-            .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
+        object BuildControls()
+        {
+            var controls = Layout.Horizontal().Gap(2).AlignContent(Align.Right)
+                           | Text.Rich()
+                               .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
+                               .Muted("plans", word: true);
 
-        var titleArea = Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow())
-                        | desktopTitle
-                        | MobileItemPicker.Build(
-                                $"#{selectedPlan.Id} {selectedPlan.Title}",
-                                allPlans,
-                                p => $"#{p.Id} {p.Title}",
-                                p => p.FolderName == selectedPlan.FolderName,
-                                p => selectedPlanState.Set(p))
-                            .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
+            if (annotations.Value.Count > 0)
+                controls |= BuildAnnotationsUpdateButton(annotations);
 
-        var controls = Layout.Horizontal().Gap(2).AlignContent(Align.Right)
-                       | Text.Rich()
-                           .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
-                           .Muted("plans", word: true);
+            controls |= new Button("Execute").Icon(Icons.Rocket).Primary().ShortcutKey("x")
+                            .Loading(isCheckingPreflight)
+                            .Disabled(isCheckingPreflight)
+                            .OnClick(() => runPreflight(selectedPlan.Project, result =>
+                            {
+                                if (annotations.Value.Count > 0)
+                                    showAnnotationsDialog.Set(true);
+                                else
+                                    ContinueExecute(null, result, pendingWaitJobIds, showDirtyDialog);
+                            }));
 
-        if (annotations.Value.Count > 0)
-            controls |= BuildAnnotationsUpdateButton(annotations);
+            return controls;
+        }
 
-        controls |= new Button("Execute").Icon(Icons.Rocket).Primary().ShortcutKey("x")
-                        .Loading(isCheckingPreflight)
-                        .Disabled(isCheckingPreflight)
-                        .OnClick(() => runPreflight(selectedPlan.Project, result =>
-                        {
-                            if (annotations.Value.Count > 0)
-                                showAnnotationsDialog.Set(true);
-                            else
-                                ContinueExecute(null, result, pendingWaitJobIds, showDirtyDialog);
-                        }));
-
-        var header = ResponsiveHeader.Build(titleArea, controls);
+        var header = ResponsiveHeader.Build(BuildTitleArea, BuildControls);
 
         var content = Layout.Vertical().Height(Size.Full());
 

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -187,9 +187,7 @@ public class ContentView(
                                 ContinueExecute(null, result, pendingWaitJobIds, showDirtyDialog);
                         }));
 
-        var header = Layout.Horizontal().Height(Size.Px(40)).Width(Size.Full()).Gap(2).AlignContent(Align.Left)
-                     | titleArea
-                     | controls;
+        var header = ResponsiveHeader.Build(titleArea, controls);
 
         var content = Layout.Vertical().Height(Size.Full());
 

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -109,9 +109,7 @@ public class ContentView(
                            GoToNext();
                        });
 
-        var header = Layout.Horizontal().Height(Size.Px(40)).Width(Size.Full()).Gap(2).AlignContent(Align.Left)
-                     | titleArea
-                     | controls;
+        var header = ResponsiveHeader.Build(titleArea, controls);
 
         // Content
         var scrollableContent = Layout.Vertical().Width(Size.Full().Max(Size.Units(200))).Padding(6, 2, 6, 2);

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -71,26 +71,29 @@ public class ContentView(
         }
         var currentIndex = allRecommendations.FindIndex(r => r.PlanId == selectedRecommendation.PlanId && r.Title == selectedRecommendation.Title);
 
-        var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
-            | new Box(Text.Block($"#{selectedRecommendation.PlanId} {selectedRecommendation.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
-                .BorderThickness(0).Padding(0).Width(Size.Fit())
-            | new Badge(selectedRecommendation.Project).Variant(BadgeVariant.Outline)
-                .WithProjectColor(config, selectedRecommendation.Project);
+        object BuildTitleArea()
+        {
+            var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
+                | new Box(Text.Block($"#{selectedRecommendation.PlanId} {selectedRecommendation.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
+                    .BorderThickness(0).Padding(0).Width(Size.Fit())
+                | new Badge(selectedRecommendation.Project).Variant(BadgeVariant.Outline)
+                    .WithProjectColor(config, selectedRecommendation.Project);
 
-        var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
-            .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
+            var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
+                .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
 
-        var titleArea = Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow())
-                        | desktopTitle
-                        | MobileItemPicker.Build(
-                                $"#{selectedRecommendation.PlanId} {selectedRecommendation.Title}",
-                                allRecommendations,
-                                r => $"#{r.PlanId} {r.Title}",
-                                r => r.PlanId == selectedRecommendation.PlanId && r.Title == selectedRecommendation.Title,
-                                r => selectedState.Set(r))
-                            .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
+            return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow())
+                   | desktopTitle
+                   | MobileItemPicker.Build(
+                           $"#{selectedRecommendation.PlanId} {selectedRecommendation.Title}",
+                           allRecommendations,
+                           r => $"#{r.PlanId} {r.Title}",
+                           r => r.PlanId == selectedRecommendation.PlanId && r.Title == selectedRecommendation.Title,
+                           r => selectedState.Set(r))
+                       .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
+        }
 
-        var controls = Layout.Horizontal().Gap(2).AlignContent(Align.Right)
+        object BuildControls() => Layout.Horizontal().Gap(2).AlignContent(Align.Right)
                        | Text.Rich()
                            .Bold($"{(currentIndex == -1 ? "?" : (currentIndex + 1).ToString())}/{allRecommendations.Count}", word: true)
                            .Muted("recommendations", word: true)
@@ -109,7 +112,7 @@ public class ContentView(
                            GoToNext();
                        });
 
-        var header = ResponsiveHeader.Build(titleArea, controls);
+        var header = ResponsiveHeader.Build(BuildTitleArea, BuildControls);
 
         // Content
         var scrollableContent = Layout.Vertical().Width(Size.Full().Max(Size.Units(200))).Padding(6, 2, 6, 2);

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -322,11 +322,7 @@ public class ContentView(
             }).ShortcutKey("m");
         }
 
-        var header = Layout.Horizontal().Height(Size.Px(40)).Width(Size.Full()).Gap(2).AlignContent(Align.Left)
-                     | titleArea
-                     | controls;
-
-        return header;
+        return ResponsiveHeader.Build(titleArea, controls);
     }
 
     private object BuildActionBar(

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -251,78 +251,86 @@ public class ContentView(
         INavigator nav,
         ReviewAppArgs? args)
     {
-        var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
-            | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
-                .BorderThickness(0).Padding(0).Width(Size.Fit().Min(Size.Px(0)));
-
-        if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
-            desktopTitleLayout |= new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
-                .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
-
-        var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
-            .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
-
-        var titleArea = Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow())
-                        | desktopTitle
-                        | MobileItemPicker.Build(
-                                $"#{selectedPlan.Id} {selectedPlan.Title}",
-                                allPlans,
-                                p => $"#{p.Id} {p.Title}",
-                                p => p.FolderName == selectedPlan.FolderName,
-                                p => selectedPlanState.Set(p))
-                            .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
-
-        var controls = Layout.Horizontal().Gap(2).AlignContent(Align.Right)
-                       | Text.Rich()
-                           .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
-                           .Muted("plans", word: true);
-
-        if (selectedPlan.Commits.Count > 0)
+        object BuildTitleArea()
         {
-            var repoPaths = selectedPlan.GetEffectiveRepoPaths(config);
-            var project = config.GetProject(selectedPlan.Project);
-            var allYolo = repoPaths.All(rp =>
-                project?.GetRepoRef(rp)?.PrRule == "yolo");
+            var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
+                | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
+                    .BorderThickness(0).Padding(0).Width(Size.Fit().Min(Size.Px(0)));
 
-            var createPrBtn = new Button("Create PR").Icon(Icons.GitPullRequest).Primary().OnClick(() =>
+            if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
+                desktopTitleLayout |= new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
+                    .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
+
+            var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
+                .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
+
+            return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow())
+                   | desktopTitle
+                   | MobileItemPicker.Build(
+                           $"#{selectedPlan.Id} {selectedPlan.Title}",
+                           allPlans,
+                           p => $"#{p.Id} {p.Title}",
+                           p => p.FolderName == selectedPlan.FolderName,
+                           p => selectedPlanState.Set(p))
+                       .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
+        }
+
+        object BuildControls()
+        {
+            var controls = Layout.Horizontal().Gap(2).AlignContent(Align.Right)
+                           | Text.Rich()
+                               .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
+                               .Muted("plans", word: true);
+
+            if (selectedPlan.Commits.Count > 0)
             {
-                if (allYolo)
+                var repoPaths = selectedPlan.GetEffectiveRepoPaths(config);
+                var project = config.GetProject(selectedPlan.Project);
+                var allYolo = repoPaths.All(rp =>
+                    project?.GetRepoRef(rp)?.PrRule == "yolo");
+
+                var createPrBtn = new Button("Create PR").Icon(Icons.GitPullRequest).Primary().OnClick(() =>
                 {
-                    // "yolo" is purely a UI setting: skip the dialog and create the PR with the
-                    // merge-and-clean-up defaults. The promptware acts only on these explicit flags.
-                    jobService.StartJob(new CreatePrArgs(
-                        selectedPlan.FolderPath,
-                        SolveMergeConflicts: true,
-                        Merge: true,
-                        DeleteBranch: true,
-                        IncludeArtifacts: true));
-                    // Plan transition (and pre-state snapshot) handled by JobService.StartJob.
+                    if (allYolo)
+                    {
+                        // "yolo" is purely a UI setting: skip the dialog and create the PR with the
+                        // merge-and-clean-up defaults. The promptware acts only on these explicit flags.
+                        jobService.StartJob(new CreatePrArgs(
+                            selectedPlan.FolderPath,
+                            SolveMergeConflicts: true,
+                            Merge: true,
+                            DeleteBranch: true,
+                            IncludeArtifacts: true));
+                        // Plan transition (and pre-state snapshot) handled by JobService.StartJob.
+                        refreshPlans();
+                    }
+                    else
+                    {
+                        showCustomPrDialog();
+                    }
+                }).ShortcutKey("m");
+
+                controls |= allYolo
+                    ? createPrBtn.WithConfetti(AnimationTrigger.Click)
+                    : createPrBtn;
+            }
+            else
+            {
+                controls |= new Button("Complete Plan").Icon(Icons.CircleCheck).Primary().OnClick(() =>
+                {
+                    // Optimistic UI - update state and refresh immediately
+                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
                     refreshPlans();
-                }
-                else
-                {
-                    showCustomPrDialog();
-                }
-            }).ShortcutKey("m");
 
-            controls |= allYolo
-                ? createPrBtn.WithConfetti(AnimationTrigger.Click)
-                : createPrBtn;
-        }
-        else
-        {
-            controls |= new Button("Complete Plan").Icon(Icons.CircleCheck).Primary().OnClick(() =>
-            {
-                // Optimistic UI - update state and refresh immediately
-                planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
-                refreshPlans();
+                    // Fire and forget - clean up worktrees in the background
+                    WorktreeCleanupService.RemoveWorktreesInBackground(selectedPlan.FolderPath);
+                }).ShortcutKey("m");
+            }
 
-                // Fire and forget - clean up worktrees in the background
-                WorktreeCleanupService.RemoveWorktreesInBackground(selectedPlan.FolderPath);
-            }).ShortcutKey("m");
+            return controls;
         }
 
-        return ResponsiveHeader.Build(titleArea, controls);
+        return ResponsiveHeader.Build(BuildTitleArea, BuildControls);
     }
 
     private object BuildActionBar(

--- a/src/Ivy.Tendril/Apps/Views/ResponsiveHeader.cs
+++ b/src/Ivy.Tendril/Apps/Views/ResponsiveHeader.cs
@@ -1,0 +1,37 @@
+namespace Ivy.Tendril.Apps.Views;
+
+/// <summary>
+/// Builds the shared app content header used by the Recommendation, Draft, and Review apps.
+/// On desktop the title and the controls fit on a single row (title left, controls right).
+/// When the row runs out of horizontal room — e.g. on mobile — the controls (action buttons +
+/// counter) wrap onto a second row below the title + issue-link button.
+/// </summary>
+public static class ResponsiveHeader
+{
+    /// <summary>
+    /// Composes <paramref name="titleArea"/> (title text, issue/PR link, badges, mobile picker)
+    /// and <paramref name="controls"/> (counter + primary action buttons) into a header that
+    /// keeps both on one row when they fit and wraps the controls below the title when they
+    /// do not.
+    /// </summary>
+    /// <remarks>
+    /// We use <c>.Wrap()</c> rather than a responsive <c>Orientation</c>: the wire format
+    /// serializes a responsive <c>Orientation</c> onto the plain <c>orientation</c> prop, which
+    /// the StackLayout frontend reads as a single value and so never resolves per breakpoint
+    /// (the <c>responsiveOrientation</c> prop is never populated). <c>Wrap</c> is a plain boolean
+    /// the frontend honours at every breakpoint. <paramref name="titleArea"/> grows to fill the
+    /// first row, pushing <paramref name="controls"/> — itself one atomic horizontal block — onto
+    /// the next row as a unit. No fixed height: a single row is content-height, and a wrapped
+    /// header is free to grow taller.
+    /// </remarks>
+    public static object Build(object titleArea, object controls)
+    {
+        return Layout.Horizontal()
+                   .Wrap()
+                   .Width(Size.Full())
+                   .Gap(2)
+                   .AlignContent(Align.Left)
+               | titleArea
+               | controls;
+    }
+}

--- a/src/Ivy.Tendril/Apps/Views/ResponsiveHeader.cs
+++ b/src/Ivy.Tendril/Apps/Views/ResponsiveHeader.cs
@@ -2,36 +2,46 @@ namespace Ivy.Tendril.Apps.Views;
 
 /// <summary>
 /// Builds the shared app content header used by the Recommendation, Draft, and Review apps.
-/// On desktop the title and the controls fit on a single row (title left, controls right).
-/// When the row runs out of horizontal room — e.g. on mobile — the controls (action buttons +
-/// counter) wrap onto a second row below the title + issue-link button.
+/// On desktop the title and the controls sit on a single 40px row (title left, controls right).
+/// On mobile/tablet the header stacks: the title + issue-link button on the first row and the
+/// action buttons + counter on a row below.
 /// </summary>
 public static class ResponsiveHeader
 {
     /// <summary>
-    /// Composes <paramref name="titleArea"/> (title text, issue/PR link, badges, mobile picker)
-    /// and <paramref name="controls"/> (counter + primary action buttons) into a header that
-    /// keeps both on one row when they fit and wraps the controls below the title when they
-    /// do not.
+    /// Composes the title area (title text, issue/PR link, badges, mobile picker) and the
+    /// controls (counter + primary action buttons) into a breakpoint-aware header.
     /// </summary>
     /// <remarks>
-    /// We use <c>.Wrap()</c> rather than a responsive <c>Orientation</c>: the wire format
-    /// serializes a responsive <c>Orientation</c> onto the plain <c>orientation</c> prop, which
-    /// the StackLayout frontend reads as a single value and so never resolves per breakpoint
-    /// (the <c>responsiveOrientation</c> prop is never populated). <c>Wrap</c> is a plain boolean
-    /// the frontend honours at every breakpoint. <paramref name="titleArea"/> grows to fill the
-    /// first row, pushing <paramref name="controls"/> — itself one atomic horizontal block — onto
-    /// the next row as a unit. No fixed height: a single row is content-height, and a wrapped
-    /// header is free to grow taller.
+    /// Two layouts are emitted and toggled with <c>ShowOn</c>/<c>HideOn</c> — a horizontal row
+    /// for desktop/wide and a vertical stack for mobile/tablet — rather than flipping a single
+    /// layout's <c>Orientation</c> responsively. A responsive <c>Orientation</c> serializes onto
+    /// the plain <c>orientation</c> prop, which the StackLayout frontend reads as a single value
+    /// and never resolves per breakpoint, so it silently renders the same at every width.
+    /// Visibility (the prop behind <c>ShowOn</c>/<c>HideOn</c>) is resolved per breakpoint by the
+    /// renderer, so it is the reliable primitive here.
+    ///
+    /// The two layouts can't share widget instances, so the title area and controls are passed as
+    /// factories and built once per layout — the same approach the title area itself already uses
+    /// to render a desktop title and a mobile picker side by side.
     /// </remarks>
-    public static object Build(object titleArea, object controls)
+    public static object Build(Func<object> titleArea, Func<object> controls)
     {
-        return Layout.Horizontal()
-                   .Wrap()
-                   .Width(Size.Full())
-                   .Gap(2)
-                   .AlignContent(Align.Left)
-               | titleArea
-               | controls;
+        var desktop = new Box(
+                Layout.Horizontal().Height(Size.Px(40)).Width(Size.Full()).Gap(2).AlignContent(Align.Left)
+                | titleArea()
+                | controls())
+            .BorderThickness(0).Padding(0).Width(Size.Full())
+            .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
+
+        var mobile = new Box(
+                Layout.Vertical().Width(Size.Full()).Gap(2).AlignContent(Align.Left)
+                | titleArea()
+                | controls())
+            .BorderThickness(0).Padding(0).Width(Size.Full())
+            .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
+
+        return new Box(Layout.Vertical().Width(Size.Full()).Gap(0) | desktop | mobile)
+            .BorderThickness(0).Padding(0).Width(Size.Full());
     }
 }


### PR DESCRIPTION
## What

The **Recommendation**, **Draft**, and **Review** apps each render a content header as a fixed 40px-high horizontal row — title + issue/PR link on the left, counter + primary action buttons on the right. On narrow/mobile widths the two halves were locked onto a single non-wrapping row, so the buttons got squeezed/clipped.

Now the header **stacks on mobile/tablet**: the title + issue-link button stay on the first row, and the action buttons + counter drop to a second row below. Desktop is unchanged (single row).

## How

Extracted a shared `ResponsiveHeader.Build(titleArea, controls)` helper (`Apps/Views/ResponsiveHeader.cs`) and pointed all three apps at it. It emits **two layouts toggled by `ShowOn`/`HideOn`**:
- **Desktop/wide** — the original single 40px horizontal row (title left, controls right).
- **Mobile/tablet** — a vertical stack (title row, then controls row).

The title area and controls are passed as factories (`Func<object>`) and built once per layout, since the two layouts can't share widget instances. Each `ContentView` now builds them via `BuildTitleArea()` / `BuildControls()` local functions.

### Why `ShowOn`/`HideOn` and not a responsive `Orientation` or `.Wrap()`

- A responsive **`Orientation`** (Horizontal→Vertical at the mobile breakpoints) is silently dropped: it serializes onto the plain `orientation` prop, which the `StackLayout` frontend reads as a single value and never resolves per breakpoint (the `responsiveOrientation` prop is never populated). Verified with a throwaway render test against the real `StackLayoutWidget`. Same class of bug as multi-breakpoint responsive padding.
- **`.Wrap()`** (my first attempt) broke desktop: the title area has `Width(Size.Grow())`, so it filled the whole first row at *every* width and the controls always wrapped below — desktop looked identical to mobile.
- **Visibility** (`responsiveVisible`, the prop behind `ShowOn`/`HideOn`) *is* resolved per breakpoint by the renderer, so two breakpoint-gated layouts render deterministically. This mirrors how the title area already shows a desktop title and a mobile picker side by side.

## Verification

Ran the branch as an isolated `--web` instance and screenshotted all three apps with Playwright at **1400px** and **390px**:

| App | Desktop (1400px) | Mobile (390px) |
| --- | --- | --- |
| Review | title left · `1/14 plans` + `Create PR` right, one row | `#49 …` row 1 · `1/14 plans` + `Create PR` row 2 |
| Drafts | title left · `1/13 plans` + `Execute` right, one row | `#46 …` row 1 · `1/13 plans` + `Execute` row 2 |
| Recommendations | title + badge left · counter + `Decline`/`Accept` right, one row | `#00020 …` row 1 · counter + `Decline`/`Accept` row 2 |

`dotnet build` clean (`Ivy.Tendril` + `Ivy.Tendril.Test`); `dotnet format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)