### PR TITLE
Fix duplicate Default option in coding agent profile dropdowns

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -57,7 +57,9 @@ public class CodingAgentSetupView : ViewBase
 
         var models = modelsQuery.Value ?? [];
         var modelOptions = new[] { new Option<string>("Default", "default") }
-            .Concat(models.Select(m => new Option<string>(m.DisplayName, m.Id)))
+            .Concat(models
+                .Where(m => m.Id != "default")
+                .Select(m => new Option<string>(m.DisplayName, m.Id)))
             .ToArray<IAnyOption>();
 
         var hasProfileChanges =


### PR DESCRIPTION
## What

The "Profile Models" dropdowns (Deep / Balanced / Quick) in the Coding Agent settings listed both **Default** and **OpenCode Default** when OpenCode was selected.

## Why

`CodingAgentSetupView` prepends a hardcoded `("Default", "default")` option to the agent's catalog models. OpenCode's catalog uniquely includes a model with `Id = "default"` / `DisplayName = "OpenCode Default"`, so both entries (sharing the same `default` value) showed up. Other agents have no `default`-id model, so they were unaffected.

## Fix

Filter out catalog models whose `Id` is `"default"`, since the hardcoded "Default" option already represents that exact value. Only "Default" now appears for OpenCode; other agents are unchanged.