### PR TITLE
Expose tendril CLI to AgentApp PTY agent via shim

### DIFF
--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -1,6 +1,7 @@
 using Ivy.Hooks.Pty;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Helpers;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 using Ivy.Widgets.Xterm;
 using Xterm = Ivy.Widgets.Xterm;
@@ -121,11 +122,20 @@ public class AgentApp : ViewBase
 
     private static Dictionary<string, string>? GetEnvironment(IConfigService config)
     {
+        var env = new Dictionary<string, string>();
+
         var agentId = config.Settings.CodingAgent;
         var agentConfig = config.Settings.CodingAgents.FirstOrDefault(a =>
             AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
-        return agentConfig?.EnvironmentVariables is { Count: > 0 } d
-            ? new Dictionary<string, string>(d) : null;
+        if (agentConfig?.EnvironmentVariables is { Count: > 0 } d)
+            foreach (var (key, value) in d)
+                env[key] = value;
+
+        // Expose the `tendril` CLI (via shim) and the active config/plans to the agent running in
+        // the PTY, so it can run `tendril ...` even when no tendril binary is installed (e.g. in dev).
+        AgentProcessHelper.ApplyTendrilEnvironment(env, config);
+
+        return env.Count > 0 ? env : null;
     }
 
     private static string GetDefaultWorkDir(IConfigService config) =>

--- a/src/Ivy.Tendril/Helpers/AgentProcessHelper.cs
+++ b/src/Ivy.Tendril/Helpers/AgentProcessHelper.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Helpers;
 
@@ -29,29 +30,62 @@ public static class AgentProcessHelper
 
     public static void EnsureTendrilOnPath(ProcessStartInfo psi)
     {
+        var shimDir = EnsureTendrilShimDir();
+        if (shimDir != null)
+            PrependToPath(psi, shimDir);
+    }
+
+    /// <summary>
+    /// Returns a directory to prepend to PATH so a spawned process can invoke the <c>tendril</c>
+    /// CLI: either the directory of the running tendril executable, or a temp dir containing
+    /// generated shims that proxy to <c>dotnet exec Ivy.Tendril.dll</c> (used in dev, where no
+    /// tendril binary is installed). Returns null if neither can be located.
+    /// </summary>
+    public static string? EnsureTendrilShimDir()
+    {
         var processPath = Environment.ProcessPath;
         if (!string.IsNullOrEmpty(processPath) &&
             Path.GetFileNameWithoutExtension(processPath).Equals("tendril", StringComparison.OrdinalIgnoreCase))
-        {
-            PrependToPath(psi, Path.GetDirectoryName(processPath)!);
-            return;
-        }
+            return Path.GetDirectoryName(processPath);
 
         var baseDir = AppDomain.CurrentDomain.BaseDirectory;
         var dllPath = Path.Combine(baseDir, "Ivy.Tendril.dll");
-        if (File.Exists(dllPath))
+        if (!File.Exists(dllPath))
+            return null;
+
+        var shimDir = Path.Combine(Path.GetTempPath(), "tendril-shim");
+        FileHelper.EnsureDirectory(shimDir);
+
+        var cmdShim = Path.Combine(shimDir, "tendril.cmd");
+        File.WriteAllText(cmdShim, $"@dotnet exec \"{dllPath}\" %*\r\n");
+
+        var bashDllPath = dllPath.Replace('\\', '/');
+        var bashShim = Path.Combine(shimDir, "tendril");
+        File.WriteAllText(bashShim, $"#!/usr/bin/env bash\ndotnet exec '{bashDllPath}' \"$@\"\n");
+
+        return shimDir;
+    }
+
+    /// <summary>
+    /// Augments a PTY/process environment dictionary so a spawned coding agent can invoke the
+    /// <c>tendril</c> CLI (via shim) and resolve the active config/plans. Mirrors what
+    /// <see cref="EnsureTendrilOnPath"/> plus the TENDRIL_* vars do for ProcessStartInfo-based
+    /// launches, but for the dictionary handed to <c>UsePty</c>.
+    /// </summary>
+    public static void ApplyTendrilEnvironment(IDictionary<string, string> env, IConfigService config)
+    {
+        if (!string.IsNullOrEmpty(config.TendrilHome))
+            env["TENDRIL_HOME"] = config.TendrilHome;
+        env["TENDRIL_CONFIG"] = config.ConfigPath;
+        env["TENDRIL_PLANS"] = config.PlanFolder;
+
+        var shimDir = EnsureTendrilShimDir();
+        if (shimDir != null)
         {
-            var shimDir = Path.Combine(Path.GetTempPath(), "tendril-shim");
-            FileHelper.EnsureDirectory(shimDir);
-
-            var cmdShim = Path.Combine(shimDir, "tendril.cmd");
-            File.WriteAllText(cmdShim, $"@dotnet exec \"{dllPath}\" %*\r\n");
-
-            var bashDllPath = dllPath.Replace('\\', '/');
-            var bashShim = Path.Combine(shimDir, "tendril");
-            File.WriteAllText(bashShim, $"#!/usr/bin/env bash\ndotnet exec '{bashDllPath}' \"$@\"\n");
-
-            PrependToPath(psi, shimDir);
+            var current = env.TryGetValue("PATH", out var p) && !string.IsNullOrEmpty(p)
+                ? p
+                : Environment.GetEnvironmentVariable("PATH");
+            env["PATH"] = $"{shimDir}{Path.PathSeparator}{current}";
         }
     }
 


### PR DESCRIPTION
## What

The **Agent** app (`AgentApp`) launches a coding agent in a PTY via `Context.UsePty`. When running a plan with Claude in dev — where there is no installed `tendril` binary on PATH — the agent could not invoke `tendril ...` commands.

## Why

Promptware/job launches (`PromptwareRunner`, `JobLauncher`) already make `tendril` available by calling `AgentProcessHelper.EnsureTendrilOnPath` (creates a shim that proxies to `dotnet exec Ivy.Tendril.dll`) and setting `TENDRIL_HOME/CONFIG/PLANS` on their `ProcessStartInfo`. AgentApp's PTY path was the only launcher that skipped this — its `GetEnvironment` only returned the user's per-agent env vars.

## Fix

- Extracted the shim-dir creation out of `EnsureTendrilOnPath` into a reusable `EnsureTendrilShimDir()` (behavior of the existing `ProcessStartInfo` path is unchanged).
- Added `ApplyTendrilEnvironment(IDictionary<string,string>, IConfigService)` that sets `TENDRIL_HOME/CONFIG/PLANS` and prepends the shim dir to `PATH` — the dictionary-based equivalent of what promptwares do.
- `AgentApp.GetEnvironment` now applies it to the dictionary passed to `UsePty`. `UsePty` inherits the full parent environment and merges this dictionary on top, so the agent gets the `tendril` shim on PATH plus the active config/plans.

No Ivy-Framework changes were needed. Verified with `dotnet build` (0 warnings, 0 errors).