### PR TITLE
New Plan: bottom Sheet on mobile instead of Dialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -55,6 +55,10 @@ public class CreatePlanDialog(
         var configService = UseService<IConfigService>();
         var uploadSessionId = UseState(() => Guid.NewGuid().ToString("N"));
 
+        // Tracks the browser's active breakpoint so the surface can switch between a centered dialog
+        // and a bottom sheet on mobile. The (invisible) breakpointListener must be rendered for updates.
+        var (breakpoint, breakpointListener) = Context.UseBreakpoint();
+
         var uploadedFiles = UseState(new List<string>());
 
         var uploadContext = this.UseUpload(async (fileUpload, stream, token) =>
@@ -120,10 +124,7 @@ public class CreatePlanDialog(
             onClose();
         }
 
-        return new Dialog(
-            _ => HandleClose(),
-            new DialogHeader("Create New Plan"),
-            new DialogBody(
+        var bodyContent =
                 Layout.Vertical()
                 | exclusiveProjects.ToSelectInput(options).Variant(SelectInputVariant.Toggle).WithField().Label("Select Project(s)")
                 | selectedPriority.ToSelectInput(PriorityOptions).Variant(SelectInputVariant.Toggle).WithField().Label("Priority")
@@ -196,8 +197,21 @@ public class CreatePlanDialog(
                     .Placeholder("Enter task description...")
                     .WithField()
                     .Label("Describe the task for the new plan")
-                    .Required()
-            )
-        ).Width(Size.Rem(30));
+                    .Required();
+
+        object planSurface = breakpoint.Value == Breakpoint.Mobile
+            ? new Sheet(
+                _ => HandleClose(),
+                bodyContent,
+                title: "Create New Plan")
+                .Side(SheetSide.Bottom)
+                .Height(Size.Fit())
+            : new Dialog(
+                _ => HandleClose(),
+                new DialogHeader("Create New Plan"),
+                new DialogBody(bodyContent))
+                .Width(Size.Rem(30));
+
+        return new Fragment(breakpointListener, planSurface);
     }
 }

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -55,8 +55,6 @@ public class CreatePlanDialog(
         var configService = UseService<IConfigService>();
         var uploadSessionId = UseState(() => Guid.NewGuid().ToString("N"));
 
-        // Tracks the browser's active breakpoint so the surface can switch between a centered dialog
-        // and a bottom sheet on mobile. The (invisible) breakpointListener must be rendered for updates.
         var (breakpoint, breakpointListener) = Context.UseBreakpoint();
 
         var uploadedFiles = UseState(new List<string>());


### PR DESCRIPTION
## Summary

On mobile, the **Create New Plan** surface now slides up as a bottom `Sheet` instead of a centered `Dialog`. On tablet and larger it stays a `Dialog`, exactly as before.

The form body (project/priority toggles + `ContentInputView` with its upload/text state) is built once into a local and wrapped by whichever surface the active breakpoint selects — no duplicated state, no double-rendered uploads.

## How it works

Uses the new `Context.UseBreakpoint()` framework hook to read the browser's active breakpoint server-side:

```csharp
var (breakpoint, breakpointListener) = Context.UseBreakpoint(); // top of Build() — IVYHOOK005

object planSurface = breakpoint.Value == Breakpoint.Mobile
    ? new Sheet(_ => HandleClose(), bodyContent, title: "Create New Plan")
        .Side(SheetSide.Bottom).Height(Size.Fit())
    : new Dialog(_ => HandleClose(), new DialogHeader("Create New Plan"), new DialogBody(bodyContent))
        .Width(Size.Rem(30));

return new Fragment(breakpointListener, planSurface);
```

`Breakpoint.Mobile` is `< 640px`, so the sheet kicks in on phones while tablets keep the dialog.

## ⚠️ Blocked — draft

This depends on **Ivy-Framework#4637** (`UseBreakpoint`), which is not yet in the published `Ivy` NuGet package that this repo builds against. This PR will be red in CI until:

1. Ivy-Framework#4637 is merged, and
2. a new `Ivy` package is published and the version bumped in `Ivy.Tendril.csproj` (currently `1.2.67`).

Verified locally against the framework source (`-p:IvySource=true`): builds with **0 warnings / 0 errors**, and the existing `CreatePlanDialogTests` pass (4/4). Ready to un-draft the moment the framework ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)