### PR TITLE
Add Dialogs entry to Settings > Debug submenu

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -448,7 +448,10 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 .Children(
                     MenuItem.Default("Onboarding")
                         .Icon(Icons.Rocket)
-                        .OnSelect(() => navigator.Navigate<OnboardingApp>())
+                        .OnSelect(() => navigator.Navigate<OnboardingApp>()),
+                    MenuItem.Default("Dialogs")
+                        .Icon(Icons.MessageSquare)
+                        .OnSelect(() => navigator.Navigate<Apps.Debug.DialogsApp>())
                 ),
 #endif
         };


### PR DESCRIPTION
## What

`DialogsApp` (the DirtyRepoDialog test harness) was unreachable from the UI.

## Why

It's marked `[App(isVisible: false)]` so it never shows in the app list, and the **Settings → Debug** submenu in `TendrilAppShell` was hardcoded to only list **Onboarding**.

## Fix

Added a **Dialogs** menu item that navigates to `DialogsApp`, alongside Onboarding (DEBUG builds only, like the rest of that submenu).