### PR TITLE
[00587] Add word wrap to CodeBlock in Full Prompt sheet

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/Sheets/PromptSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Sheets/PromptSheet.cs
@@ -4,6 +4,6 @@ public class PromptSheet(string promptText) : ViewBase
 {
     public override object Build()
     {
-        return new CodeBlock(promptText, Languages.Text);
+        return new CodeBlock(promptText, Languages.Text).WrapLines();
     }
 }


### PR DESCRIPTION
Fixes #1371

# Summary

## Changes

Enabled word wrapping in the Full Prompt sheet's CodeBlock widget by adding the `.WrapLines()` method call. Long lines in prompt text will now wrap instead of being truncated.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Jobs/Sheets/PromptSheet.cs** — Added `.WrapLines()` to CodeBlock instantiation

---

## Commits

- e26612c2 Enable word wrap in Full Prompt sheet CodeBlock