### PR TITLE
Polish DirtyRepoDialog and add extensible dialog test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ x86/
 [Oo]ut/
 [Bb]uild[Ll]og.*
 
+# Source folder literally named "Debug" — not build output; keep it tracked.
+!src/Ivy.Tendril/Apps/Debug/
+
 ## NuGet
 *.nupkg
 **/[Pp]ackages/*

--- a/src/Ivy.Tendril/Apps/Debug/DialogsApp.cs
+++ b/src/Ivy.Tendril/Apps/Debug/DialogsApp.cs
@@ -1,0 +1,27 @@
+namespace Ivy.Tendril.Apps.Debug;
+
+// Debug-only harness for visually reviewing how the various Tendril dialogs render across
+// different input permutations. Each dialog gets its own *DebugView, wrapped in an Expandable
+// below — add a new entry here as more dialog harnesses are written.
+[App(icon: Icons.Bug, isVisible: false)]
+public class DialogsApp : ViewBase
+{
+    private record DialogTest(string Title, ViewBase View);
+
+    private static DialogTest[] Tests() =>
+    [
+        new("DirtyRepoDialog", new DirtyRepoDialogDebugView()),
+    ];
+
+    public override object Build()
+    {
+        var content = Layout.Vertical().Gap(2);
+        foreach (var test in Tests())
+            content |= new Expandable(test.Title, test.View);
+
+        return Layout.Vertical().Gap(6).Padding(8)
+               | Text.H2("Dialog Test Harness")
+               | Text.Muted("Expand a dialog to preview how it renders across input permutations.")
+               | content;
+    }
+}

--- a/src/Ivy.Tendril/Apps/Debug/DirtyRepoDialogDebugView.cs
+++ b/src/Ivy.Tendril/Apps/Debug/DirtyRepoDialogDebugView.cs
@@ -1,0 +1,196 @@
+using Ivy.Tendril.Apps.Views.Dialogs;
+using Ivy.Tendril.Hooks;
+using Ivy.Tendril.Services.Git;
+
+namespace Ivy.Tendril.Apps.Debug;
+
+// Visual test harness for DirtyRepoDialog: pick a scenario to preview how the dialog renders
+// that permutation of repo/dirty-state inputs.
+public class DirtyRepoDialogDebugView : ViewBase
+{
+    private record DirtyScenario(
+        string Title,
+        string Description,
+        PreflightResult Preflight,
+        string ProceedLabel,
+        string ContextMessage);
+
+    private const string CreateContext =
+        "The plan will be based on this state, but ExecutePlan will branch from origin/<baseBranch>. Commit and push first if these changes should be included in the plan.";
+
+    private const string ExecuteContext =
+        "These changes will NOT be included in this plan. The plan will execute against origin/<baseBranch>. If these changes are meant for this plan, commit and push them first.";
+
+    private static DirtyRepoResult Repo(params DirtyReasonDetail[] reasons) =>
+        new() { Reasons = reasons.ToList() };
+
+    private static DirtyReasonDetail UncommittedChanges(params string[] files) =>
+        new()
+        {
+            Reason = DirtyReason.UncommittedChanges,
+            Message = $"{files.Length} {(files.Length == 1 ? "file" : "files")} with uncommitted changes",
+            // Real GitService strips the `git status --porcelain` status prefix, so Files holds
+            // clean repo-relative paths (e.g. src/Program.cs).
+            Files = files.ToList()
+        };
+
+    private static DirtyReasonDetail UntrackedFiles(params string[] files) =>
+        new()
+        {
+            Reason = DirtyReason.UntrackedFiles,
+            Message = $"{files.Length} untracked {(files.Length == 1 ? "file" : "files")}",
+            Files = files.ToList()
+        };
+
+    private static DirtyReasonDetail AheadOfOrigin(params string[] commits) =>
+        new()
+        {
+            Reason = DirtyReason.AheadOfOrigin,
+            Message = $"{commits.Length} {(commits.Length == 1 ? "commit" : "commits")} ahead of origin",
+            Commits = commits.ToList()
+        };
+
+    private static DirtyReasonDetail NotOnExpectedBranch(string current, string expected) =>
+        new()
+        {
+            Reason = DirtyReason.NotOnExpectedBranch,
+            Message = $"On branch '{current}', expected '{expected}'"
+        };
+
+    private static DirtyReasonDetail InProgressOperation(string message) =>
+        new() { Reason = DirtyReason.InProgressOperation, Message = message };
+
+    private static DirtyReasonDetail DetachedHead() =>
+        new() { Reason = DirtyReason.DetachedHead, Message = "Detached HEAD" };
+
+    private static DirtyReasonDetail NoRemoteConfigured() =>
+        new() { Reason = DirtyReason.NoRemoteConfigured, Message = "No remote configured" };
+
+    private static PreflightResult Preflight(params (string Path, string BaseBranch, DirtyRepoResult Result)[] repos) =>
+        new(repos.Select(r => (r.Path, r.BaseBranch, r.Result)).ToList());
+
+    private static DirtyScenario[] BuildScenarios() =>
+    [
+        new(
+            "Single repo · few uncommitted changes",
+            "One repo with a handful of uncommitted files (under the 3-item cap).",
+            Preflight((@"C:\Repos\MyApp", "main", Repo(
+                UncommittedChanges("src/Program.cs", "README.md")))),
+            "Create Without Syncing", CreateContext),
+
+        new(
+            "Single repo · many uncommitted changes (+N more)",
+            "Exercises the '+N more' truncation when more than 3 files are dirty.",
+            Preflight((@"C:\Repos\MyApp", "main", Repo(
+                UncommittedChanges(
+                    "src/Program.cs", "src/Startup.cs", "src/Models/User.cs",
+                    "src/Models/Order.cs", "README.md", "global.json")))),
+            "Create Without Syncing", CreateContext),
+
+        new(
+            "Single repo · untracked files",
+            "Untracked files are shown verbatim (no porcelain status prefix).",
+            Preflight((@"C:\Repos\MyApp", "develop", Repo(
+                UntrackedFiles("notes.txt", "scratch/temp.log", "data/cache.bin")))),
+            "Execute Without Syncing", ExecuteContext),
+
+        new(
+            "Single repo · ahead of origin (commits)",
+            "Lists commits rather than files for the AheadOfOrigin reason.",
+            Preflight((@"C:\Repos\MyApp", "main", Repo(
+                AheadOfOrigin(
+                    "a1b2c3d Fix null ref in parser",
+                    "e4f5g6h Add retry logic",
+                    "i7j8k9l Bump dependencies",
+                    "m0n1o2p Tidy up logging")))),
+            "Create Without Syncing", CreateContext),
+
+        new(
+            "Single repo · not on expected branch",
+            "Branch-mismatch reason which carries only a message, no file/commit list.",
+            Preflight((@"C:\Repos\MyApp", "main", Repo(
+                NotOnExpectedBranch("feature/login", "main")))),
+            "Execute Without Syncing", ExecuteContext),
+
+        new(
+            "Single repo · multiple reasons",
+            "Several dirty reasons stacked in a single repo section.",
+            Preflight((@"C:\Repos\MyApp", "main", Repo(
+                NotOnExpectedBranch("feature/login", "main"),
+                UncommittedChanges("src/Auth.cs", "src/Login.cs"),
+                UntrackedFiles("debug.log"),
+                AheadOfOrigin("a1b2c3d WIP commit")))),
+            "Create Without Syncing", CreateContext),
+
+        new(
+            "Single repo · edge-case reasons",
+            "Detached HEAD, in-progress operation, and no remote configured.",
+            Preflight((@"C:\Repos\MyApp", "main", Repo(
+                DetachedHead(),
+                InProgressOperation("Rebase in progress"),
+                NoRemoteConfigured()))),
+            "Execute Without Syncing", ExecuteContext),
+
+        new(
+            "Multiple repos",
+            "Two repos each with their own reasons — tests repeated repo sections.",
+            Preflight(
+                (@"C:\Repos\Frontend", "main", Repo(
+                    UncommittedChanges("src/app.tsx", "package.json"))),
+                (@"C:\Repos\Backend", "develop", Repo(
+                    AheadOfOrigin("a1b2c3d Add endpoint"),
+                    UntrackedFiles("appsettings.Local.json")))),
+            "Create Without Syncing", CreateContext),
+
+        new(
+            "Many repos · long paths",
+            "Several repos with deep paths to check layout/width handling.",
+            Preflight(
+                (@"C:\Users\dev\source\repos\Company.Product.Web", "main", Repo(
+                    UncommittedChanges("src/Components/Dashboard/Widgets/ChartWidget.razor"))),
+                (@"C:\Users\dev\source\repos\Company.Product.Api", "main", Repo(
+                    UncommittedChanges("Controllers/v2/ReportingController.cs"))),
+                (@"C:\Users\dev\source\repos\Company.Product.Shared", "release/2026.06", Repo(
+                    NotOnExpectedBranch("hotfix/urgent", "release/2026.06")))),
+            "Execute Without Syncing", ExecuteContext),
+    ];
+
+    public override object Build()
+    {
+        var dialogOpen = UseState(false);
+        var selected = UseState<int?>(() => null);
+        var scenarios = BuildScenarios();
+
+        var buttons = Layout.Vertical();
+        for (var i = 0; i < scenarios.Length; i++)
+        {
+            var index = i;
+            var scenario = scenarios[i];
+            buttons |= Layout.Vertical().Gap(1)
+                       | new Button(scenario.Title)
+                           .Outline()
+                           .Icon(Icons.Eye)
+                           .OnClick(() =>
+                           {
+                               selected.Set(index);
+                               dialogOpen.Set(true);
+                           })
+                       | Text.Muted(scenario.Description);
+        }
+
+        object? dialog = null;
+        if (dialogOpen.Value && selected.Value is { } selectedIndex)
+        {
+            var scenario = scenarios[selectedIndex];
+            dialog = new DirtyRepoDialog(
+                dialogOpen,
+                scenario.Preflight,
+                scenario.ProceedLabel,
+                scenario.ContextMessage,
+                onSyncRepos: () => { },
+                onProceed: () => { });
+        }
+
+        return new Fragment(buttons, dialog);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -268,7 +268,7 @@ public class ContentView(
             ? new DirtyRepoDialog(
                 showDirtyDialog,
                 preflightResult,
-                proceedLabel: "Execute Anyway",
+                proceedLabel: "Create Without Syncing",
                 contextMessage: "These changes will NOT be included in this plan. The plan will execute against origin/<baseBranch>. If these changes are meant for this plan, commit and push them first.",
                 onSyncRepos: () =>
                 {

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -142,7 +142,7 @@ public class ContentView(
             ? new DirtyRepoDialog(
                 showDirtyDialog,
                 preflightResult,
-                proceedLabel: "Execute Anyway",
+                proceedLabel: "Execute Without Syncing",
                 contextMessage: "These changes will NOT be included in this plan. The plan will execute against origin/<baseBranch>. If these changes are meant for this plan, commit and push them first.",
                 onSyncRepos: () => LaunchWithSync(preflightResult),
                 onProceed: LaunchExecute)

--- a/src/Ivy.Tendril/Apps/Views/CreatePlanDialogLauncher.cs
+++ b/src/Ivy.Tendril/Apps/Views/CreatePlanDialogLauncher.cs
@@ -54,7 +54,7 @@ public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : View
             ? new DirtyRepoDialog(
                 showDirtyDialog,
                 preflightResult,
-                proceedLabel: "Create Anyway",
+                proceedLabel: "Create Without Syncing",
                 contextMessage: "The plan will be based on this state, but ExecutePlan will branch from origin/<baseBranch>. Commit and push first if these changes should be included in the plan.",
                 onSyncRepos: () => LaunchWithSync(pendingJobArgs.Value, preflightResult),
                 onProceed: () => LaunchCreatePlan(pendingJobArgs.Value))

--- a/src/Ivy.Tendril/Apps/Views/Dialogs/DirtyRepoDialog.cs
+++ b/src/Ivy.Tendril/Apps/Views/Dialogs/DirtyRepoDialog.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Services.Git;
 
@@ -11,50 +12,34 @@ public class DirtyRepoDialog(
     Action onSyncRepos,
     Action onProceed) : ViewBase
 {
+    private const int MaxItemsShown = 3;
+
     public override object? Build()
     {
         if (!dialogOpen.Value) return null;
 
-        var body = Layout.Vertical().Gap(3);
-
-        foreach (var (repoPath, baseBranch, dirtyState) in preflightResult.DirtyRepos)
+        var md = new StringBuilder();
+        var repos = preflightResult.DirtyRepos;
+        for (var r = 0; r < repos.Count; r++)
         {
-            var repoSection = Layout.Vertical().Gap(1);
-            repoSection |= Text.Block(Path.GetFileName(repoPath)).Bold();
-            repoSection |= Text.Muted(repoPath);
+            var (repoPath, baseBranch, dirtyState) = repos[r];
+            if (r > 0)
+                md.AppendLine();
+
+            md.AppendLine($"**{Path.GetFileName(repoPath)}**").AppendLine();
+            md.AppendLine($"`{repoPath}`").AppendLine();
 
             foreach (var reason in dirtyState.Reasons)
-            {
-                repoSection |= Text.Block($"• {FormatReason(reason)}");
+                AppendReason(md, reason, baseBranch);
 
-                // Show file/commit details
-                var items = reason.Reason == DirtyReason.AheadOfOrigin
-                    ? reason.Commits
-                    : reason.Files;
-
-                var displayCount = Math.Min(3, items.Count);
-                for (var i = 0; i < displayCount; i++)
-                {
-                    var item = items[i];
-                    // Strip leading status characters from uncommitted changes
-                    if (reason.Reason == DirtyReason.UncommittedChanges && item.Length > 3)
-                        item = item.Substring(3);
-
-                    repoSection |= Text.Muted($"  {item}");
-                }
-
-                if (items.Count > 3)
-                    repoSection |= Text.Muted($"  + {items.Count - 3} more");
-            }
-
-            repoSection |= Text.Markdown(contextMessage.Replace("origin/<baseBranch>", $"`origin/{baseBranch}`")).Muted();
-            body |= repoSection;
+            md.AppendLine();
+            md.AppendLine(contextMessage.Replace("origin/<baseBranch>", $"`origin/{baseBranch}`"));
         }
 
         return new Dialog(
             _ => dialogOpen.Set(false),
             new DialogHeader("Local Changes Detected"),
-            new DialogBody(body),
+            new DialogBody(Text.Markdown(md.ToString())),
             new DialogFooter(
                 Layout.Horizontal().Gap(2).Right()
                 | new Button("Cancel").Outline().OnClick(() => dialogOpen.Set(false))
@@ -72,13 +57,44 @@ public class DirtyRepoDialog(
         ).Width(Size.Rem(40));
     }
 
-    private static string FormatReason(DirtyReasonDetail detail) => detail.Reason switch
+    private static void AppendReason(StringBuilder md, DirtyReasonDetail reason, string baseBranch)
     {
-        DirtyReason.NotOnExpectedBranch => detail.Message,
+        md.AppendLine($"- {SummarizeReason(reason, baseBranch)}");
+
+        // AheadOfOrigin lists commit subjects; every other reason lists file paths.
+        var isCommits = reason.Reason == DirtyReason.AheadOfOrigin && reason.Commits.Count > 0;
+        var items = isCommits ? reason.Commits : reason.Files;
+
+        var shown = Math.Min(MaxItemsShown, items.Count);
+        for (var i = 0; i < shown; i++)
+            // File paths (repo-relative, e.g. src/Program.cs) render as inline code. For commits
+            // ("<sha> <subject>") only the sha is code; the subject stays plain text.
+            md.AppendLine(isCommits ? $"    - {FormatCommit(items[i])}" : $"    - `{items[i]}`");
+
+        if (items.Count > MaxItemsShown)
+            md.AppendLine($"    - +{items.Count - MaxItemsShown} more");
+    }
+
+    private static string FormatCommit(string commit)
+    {
+        var space = commit.IndexOf(' ');
+        return space <= 0
+            ? $"`{commit}`"
+            : $"`{commit[..space]}` {commit[(space + 1)..]}";
+    }
+
+    private static string SummarizeReason(DirtyReasonDetail detail, string baseBranch) => detail.Reason switch
+    {
+        DirtyReason.UncommittedChanges => detail.Files.Count == 1
+            ? "1 uncommitted change"
+            : $"{detail.Files.Count} uncommitted changes",
+        DirtyReason.UntrackedFiles => detail.Files.Count == 1
+            ? "1 untracked file"
+            : $"{detail.Files.Count} untracked files",
+        DirtyReason.AheadOfOrigin when detail.Commits.Count > 0 => detail.Commits.Count == 1
+            ? $"1 commit ahead of `origin/{baseBranch}`"
+            : $"{detail.Commits.Count} commits ahead of `origin/{baseBranch}`",
         DirtyReason.AheadOfOrigin => detail.Message,
-        DirtyReason.UncommittedChanges => detail.Message,
-        DirtyReason.UntrackedFiles => detail.Message,
-        DirtyReason.InProgressOperation => detail.Message,
         DirtyReason.DetachedHead => "Detached HEAD",
         DirtyReason.NoRemoteConfigured => "No remote configured",
         _ => detail.Message


### PR DESCRIPTION
## What

Polish for `DirtyRepoDialog` plus a refactor of its debug harness so more dialog tests can be added.

## Dialog rendering
- Entire content renders as **Markdown**: bold repo name, repo path and file paths as inline code, reasons as a bulleted list.
- Commit shas render as inline code while the subject stays plain text (`` `a1b2c3d` Fix null ref ``).
- Proper pluralization computed in the dialog — `1 uncommitted change` / `N uncommitted changes` (no lazy `(s)`). Doing it in the dialog (not per-`DirtyReasonDetail.Message`) keeps real and test data rendering identically.
- Dropped the `---` rule between repos.

## Bug fix
The dialog double-stripped `UncommittedChanges` paths — `GitService` already strips the `git status --porcelain` status prefix, so **live usage rendered `/Program.cs`** instead of `src/Program.cs`. The test harness hid it by injecting a fake ` M ` prefix. Removed the extra strip and made the harness emit realistic unprefixed paths, so both render correct repo-relative paths.

## Labels
Renamed proceed labels at the call sites to **Create/Execute Without Syncing**.

## Harness refactor
- Extracted `DirtyRepoDialogDebugView` (all the scenario builders + preview).
- `DialogsApp` is now a thin shell that wraps each dialog test in an `Expandable` — add a new `*DebugView` + one list entry to grow it.

## Tracking fix
`src/Ivy.Tendril/Apps/Debug/` was being matched by the `[Dd]ebug/` build-output rule in `.gitignore`, so `DialogsApp.cs` was never tracked. Added a negation to keep the source folder tracked (`DialogsApp.cs` is added in this PR).

Verified with `dotnet build` (0 errors).