### PR TITLE
Hide the Changes tab when there are no file changes

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -608,7 +608,7 @@ public class ContentView(
 
             var changesTabView = new ChangesTabView(planData.AllChanges, planContentQuery.Loading, planContentQuery.Error);
 
-            var tabNamesList = new List<string> { "summary", "plan", "details", "verifications", "git", "changes" };
+            var tabNamesList = new List<string> { "summary", "plan", "details", "verifications", "git" };
             var tabList = new List<Tab>
             {
                 new Tab("Summary", Cap(new SummaryTabView(planData.SummaryMarkdown, planContentQuery.Loading))),
@@ -621,8 +621,17 @@ public class ContentView(
                     selectedPlan.Verifications, planData.VerificationReports,
                     v => openVerification.Set(v)))).Badge(selectedPlan.Verifications.Count.ToString()),
                 new Tab("Git", Cap(gitTabView)).Badge((gitData.WorktreeSections.Count + selectedPlan.Commits.Count + selectedPlan.Prs.Count).ToString()),
-                new Tab("Changes", Layout.Vertical().Width(Size.Full()).Height(Size.Full().Min(Size.Px(0))) | changesTabView).Badge(changesTabView.FileCount > 0 ? changesTabView.FileCount.ToString() : "")
             };
+
+            // Only surface the Changes tab once there are actual file changes — no point showing
+            // an empty "No commits yet." tab before any work has landed.
+            if (changesTabView.FileCount > 0)
+            {
+                tabList.Add(new Tab("Changes",
+                        Layout.Vertical().Width(Size.Full()).Height(Size.Full().Min(Size.Px(0))) | changesTabView)
+                    .Badge(changesTabView.FileCount.ToString()));
+                tabNamesList.Add("changes");
+            }
 
             if (totalArtifacts > 0)
             {

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -65,8 +65,7 @@ public class DetailsTabView(
                         navigateToPlan(planId);
                 })))
             .Builder(x => x.Issue, f => f.Link(target: LinkTarget.Blank))
-            ;
-        //.RemoveEmpty();
+        .RemoveEmpty();
 
         return Layout.Vertical().Gap(4)
                | details


### PR DESCRIPTION
## What

The plan review's **Changes** tab showed an empty `No commits yet.` panel before any work had landed.

## Fix

Made the Changes tab conditional, matching the existing pattern for the **Artifacts** and **Recommendations** tabs — it's only added (tab + name) when `changesTabView.FileCount > 0`. It reappears automatically once there are real file changes. Tab ordering (after Git, before Artifacts/Recommendations) and the badge are preserved.

## Note

This branch also carries a pre-existing local-but-unpushed commit, `b98c96b9 refactor: enable removal of empty elements in DetailsTabView`, which was already on the local development branch.

Verified with `dotnet build` (0 errors).