### PR TITLE
[00589] Increase dropdown arrow hit box on ContentInputView split button

### DIFF
--- a/src/Ivy.Widgets.ContentInputView/frontend/src/content-input-view.css
+++ b/src/Ivy.Widgets.ContentInputView/frontend/src/content-input-view.css
@@ -477,7 +477,7 @@
 
 /* Arrow button on the right */
 .civ-split-btn-arrow {
-  width: 22px;
+  width: 32px;
   height: 100%;
   border-top-right-radius: var(--radius-buttons, 6px);
   border-bottom-right-radius: var(--radius-buttons, 6px);


### PR DESCRIPTION
Fixes #1372

# Summary

## Changes

Increased the width of the dropdown arrow button in the ContentInputView split button from 22px to 32px. This creates a larger clickable area that matches the button container height and aligns with adjacent button sizes, improving user interaction on both desktop and touch devices.

## API Changes

None.

## Files Modified

- **src/Ivy.Widgets.ContentInputView/frontend/src/content-input-view.css** — Changed `.civ-split-btn-arrow` width from 22px to 32px

---

## Commits

- cb0364ca Increase dropdown arrow width from 22px to 32px