### PR TITLE
[00588] Fix Verifications Card To Use Card Instead Of Box

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/VerificationsCardView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/VerificationsCardView.cs
@@ -30,8 +30,7 @@ public class VerificationsCardView(
         bool IsRequired(string name) => projectVerifications
             .Any(pv => pv.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && pv.Required);
 
-        var inner = Layout.Vertical().Gap(0)
-                    | new Box(Text.Block("Verifications").Bold()).Margin(0, 0, 0, 2);
+        var inner = Layout.Vertical().Gap(0);
 
         if (verifications.Count == 0)
         {
@@ -47,7 +46,7 @@ public class VerificationsCardView(
                     status => planService.SetVerificationStatus(selectedPlan.FolderName, v.Name, status));
         }
 
-        return new Box(inner).BorderThickness(0).Padding(0, 0, 0, 2).Width(Size.Px(280));
+        return new Card(inner).Header("Verifications").Width(Size.Px(280));
     }
 }
 


### PR DESCRIPTION
Fixes #1374

# Summary

## Changes

Replaced the `Box`-based rendering in `VerificationsCardView` with a `Card` component. Removed the unnecessary `Box` wrapper around the title text and changed the outer container from `Box` to `Card` with a header.

## API Changes

None — internal view rendering change only.

## Files Modified

- `src/Ivy.Tendril/Apps/Drafts/VerificationsCardView.cs` — Replaced `Box` with `Card`, removed inner box around title

---

## Commits

- 0ae9ad6b Replace Box with Card in VerificationsCardView
- a9c4f027 Merge latest development changes