### PR TITLE
[00585] Make File Tree Column Equal Width In Review Changes Tab

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
@@ -70,7 +70,7 @@ public class ChangesTabView(
 
         // Desktop/laptop: the file tree sits in a fixed-width sidebar beside the diffs.
         var treePanel = new Box(Layout.Vertical().Gap(2).Padding(1)
-                .Width(Size.Rem(12).Min(Size.Rem(12))).Scroll(Scroll.Auto).Height(Size.Full().Min(Size.Px(0)))
+                .Width(Size.Rem(14).Min(Size.Rem(14))).Scroll(Scroll.Auto).Height(Size.Full().Min(Size.Px(0)))
                 | tree)
             .BorderThickness(0).Padding(0).Width(Size.Auto()).Height(Size.Full().Min(Size.Px(0)))
             .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);


### PR DESCRIPTION
Fixes #1363

# Summary

## Changes

Increased the file tree column width from 12rem to 14rem in the Review app's Changes tab to create better visual balance with the diffs column.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs** — Updated tree panel width from `Size.Rem(12)` to `Size.Rem(14)`

---

## Commits

- 6e7abe20 Increase file tree column width from 12rem to 14rem