### PR TITLE
Chore: Increase publish-desktop workflow timeout

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -169,7 +169,7 @@ jobs:
   publish-desktop:
     needs: version
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Increases timeout-minutes to 120 for macOS notarization delays.