### PR TITLE
[00595] Fix inline code rendering in bullet points

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -184,6 +184,7 @@
   display: list-item;
 }
 .pmv-markdown li > p {
+  display: inline;
   margin: 0;
 }
 


### PR DESCRIPTION
Fixes Ivy-Interactive/Ivy-Framework#4640

## Problem

Inline code (backtick text) inside bullet points renders as a full-width block element instead of inline with the surrounding text in DraftMarkdown contexts.

## Solution

**Ivy-Tendril:** Added `display: inline;` to `.pmv-markdown li > p` in `draft-markdown.css` to handle cases where react-markdown wraps inline content in paragraphs inside list items.

---

## Commits

- 2cbd9bc9 Fix inline code rendering in DraftMarkdown list items