### PR TITLE
fix(verifications): shrink Status and Name columns to content (#1378)

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Tabs/VerificationsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/VerificationsTabView.cs
@@ -27,7 +27,8 @@ public class VerificationsTabView(
                     ? new Button(name).Inline().OnClick(() => openVerification(name))
                     : (object)Text.Block(name)))
             .Remove(t => t.HasReport)
-            .ColumnWidth(t => t.Name, Size.Grow());
+            .ColumnWidth(t => t.Status, Size.Fit())
+            .ColumnWidth(t => t.Name, Size.Fit());
     }
 
     private record VerificationRow(VerificationStatus Status, string Name, bool HasReport);


### PR DESCRIPTION
## Problem

The Verifications tab table stretches its `Status` and `Name` columns across the full width instead of shrinking them to content (see #1378). `Name` was explicitly set to `Size.Grow()` and `Status` had no width, so both filled the available space.

## Change

Size **both** columns with `Size.Fit()` in `VerificationsTabView`:

```diff
 .Remove(t => t.HasReport)
-.ColumnWidth(t => t.Name, Size.Grow());
+.ColumnWidth(t => t.Status, Size.Fit())
+.ColumnWidth(t => t.Name, Size.Fit());
```

When every column is content-sized, the framework renders the table at `fit-content` width and the columns collapse to their content.

## ⚠️ Draft — depends on framework fix

The visual shrink relies on **Ivy-Framework#4656** ("shrink table to fit when all columns are content-sized"). This code compiles against the current Ivy `1.2.67`, but the table won't actually shrink until #4656 is released and this repo bumps its Ivy version.

**Merge order:** land Ivy-Framework#4656 → release → bump Ivy here → mark this PR ready.

Fixes #1378

🤖 Generated with [Claude Code](https://claude.com/claude-code)