### PR TITLE
Guard plans against executing/merging in repos outside their project (#1340)

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md
@@ -48,8 +48,18 @@ For each worktree:
 
 1. `git remote get-url origin` (from the worktree) to get the GitHub remote
 2. Extract `owner/repo` from the remote URL
-3. `git rev-parse --abbrev-ref HEAD` to get the branch name
-4. `git push -u origin <branch>`
+3. **!MANDATORY project gate — do not skip.** Verify this worktree's repo is one the project
+   authorizes: its repo path/name must appear in the `RepoConfigs` firmware header (the project's
+   configured repos). If the worktree's repo is **NOT** in `RepoConfigs`, **abort this worktree**:
+   do **not** push, create a PR, or merge. Report the mismatch and fail the job for this repo:
+   ```bash
+   tendril job status TendrilJobId --message="ERROR: worktree repo <owner/repo> is not part of this project's RepoConfigs — refusing to push/merge. The plan was likely created in the wrong project."
+   ```
+   Then skip to the next worktree (or exit if this is the only one). This is the stop that prevents
+   merging a change into a repo outside the plan's project (#1340). Never push to a repo just because
+   a worktree for it exists on disk.
+4. `git rev-parse --abbrev-ref HEAD` to get the branch name
+5. `git push -u origin <branch>`
 
 > **Stale remote tracking refs warning:** A ref appearing in `git branch -a` as `remotes/origin/<branch>` does NOT guarantee the branch exists on GitHub. Always verify with `gh api repos/<owner>/<repo>/branches/<branch>` or `git ls-remote origin <branch>` before assuming the push succeeded.
 >

--- a/src/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -327,6 +327,77 @@ public class GithubServiceTests
         Assert.Null(result);
     }
 
+    [Theory]
+    [InlineData("https://github.com/Owner/Repo/issues/22", "Owner", "Repo")]
+    [InlineData("https://github.com/Owner/Repo/pull/7", "Owner", "Repo")]
+    [InlineData("https://github.com/nielsbosma/lots-of-dev-tools/issues/22", "nielsbosma", "lots-of-dev-tools")]
+    [InlineData("git@github.com:Owner/Repo/issues/3", "Owner", "Repo")]
+    public void ParseRepoConfigFromIssueOrPrUrl_Parses_Owner_Repo(string url, string owner, string name)
+    {
+        var repo = GithubService.ParseRepoConfigFromIssueOrPrUrl(url);
+        Assert.NotNull(repo);
+        Assert.Equal(owner, repo.Owner);
+        Assert.Equal(name, repo.Name);
+    }
+
+    [Theory]
+    [InlineData("https://github.com/Owner/Repo")]       // remote URL, not an issue/PR
+    [InlineData("https://github.com/Owner/Repo.git")]
+    [InlineData("https://example.com/Owner/Repo/issues/1")] // not github.com
+    [InlineData("not-a-url")]
+    [InlineData("")]
+    public void ParseRepoConfigFromIssueOrPrUrl_Returns_Null_For_NonIssueUrl(string url)
+    {
+        Assert.Null(GithubService.ParseRepoConfigFromIssueOrPrUrl(url));
+    }
+
+    [Fact]
+    public void FindProjectForGithubRepo_Returns_Owning_Project()
+    {
+        var tempDir = CreateTempGitRepo("https://github.com/Test-Owner/Test-Repo.git");
+        try
+        {
+            var settings = new TendrilSettings
+            {
+                Projects = [new ProjectConfig { Name = "P", Repos = [new RepoRef { Path = tempDir }] }]
+            };
+            var svc = new GithubService(new ConfigService(settings), NullLogger<GithubService>.Instance);
+
+            Assert.Equal("P", svc.FindProjectForGithubRepo("Test-Owner/Test-Repo")?.Name);
+            Assert.Null(svc.FindProjectForGithubRepo("Other-Owner/Other-Repo"));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void FindProjectForGithubRepo_Returns_Null_When_Ambiguous()
+    {
+        var temp1 = CreateTempGitRepo("https://github.com/Test-Owner/Test-Repo.git");
+        var temp2 = CreateTempGitRepo("https://github.com/Test-Owner/Test-Repo.git");
+        try
+        {
+            var settings = new TendrilSettings
+            {
+                Projects =
+                [
+                    new ProjectConfig { Name = "P1", Repos = [new RepoRef { Path = temp1 }] },
+                    new ProjectConfig { Name = "P2", Repos = [new RepoRef { Path = temp2 }] }
+                ]
+            };
+            var svc = new GithubService(new ConfigService(settings), NullLogger<GithubService>.Instance);
+
+            Assert.Null(svc.FindProjectForGithubRepo("Test-Owner/Test-Repo"));
+        }
+        finally
+        {
+            Directory.Delete(temp1, true);
+            Directory.Delete(temp2, true);
+        }
+    }
+
     private static string CreateTempGitRepo(string remoteUrl)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-github-test-{Guid.NewGuid()}");

--- a/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
@@ -197,11 +197,28 @@ public class PlanToolsTests : IDisposable
         var newRepo = Path.Combine(_tempDir, "repos", "AnotherRepo");
         Directory.CreateDirectory(newRepo);
 
-        var result = _planTools.AddRepo("00001", newRepo);
+        // The repo must belong to the plan's project for the add to be allowed (#1340 guard).
+        var planTools = NewPlanToolsWithProjectRepos(_repoDir, newRepo);
+        var result = planTools.AddRepo("00001", newRepo);
         Assert.Contains("Added repository", result);
 
-        var repos = _planTools.GetPlan("00001", "repos");
+        var repos = planTools.GetPlan("00001", "repos");
         Assert.Contains("AnotherRepo", repos);
+    }
+
+    [Fact]
+    public void AddRepo_OutsideProject_Refused()
+    {
+        CreateTestPlan();
+        var outsideRepo = Path.Combine(_tempDir, "repos", "OutsideRepo");
+        Directory.CreateDirectory(outsideRepo);
+
+        // The project only knows _repoDir, so OutsideRepo must be refused (#1340 guard).
+        var result = _planTools.AddRepo("00001", outsideRepo);
+        Assert.Contains("not part of project", result);
+
+        var repos = _planTools.GetPlan("00001", "repos");
+        Assert.DoesNotContain("OutsideRepo", repos);
     }
 
     [Fact]
@@ -218,13 +235,34 @@ public class PlanToolsTests : IDisposable
         CreateTestPlan();
         var extraRepo = Path.Combine(_tempDir, "repos", "ExtraRepo");
         Directory.CreateDirectory(extraRepo);
-        _planTools.AddRepo("00001", extraRepo);
 
-        var result = _planTools.RemoveRepo("00001", extraRepo);
+        var planTools = NewPlanToolsWithProjectRepos(_repoDir, extraRepo);
+        planTools.AddRepo("00001", extraRepo);
+
+        var result = planTools.RemoveRepo("00001", extraRepo);
         Assert.Contains("Removed repository", result);
 
-        var repos = _planTools.GetPlan("00001", "repos");
+        var repos = planTools.GetPlan("00001", "repos");
         Assert.DoesNotContain("ExtraRepo", repos);
+    }
+
+    // Builds a PlanTools whose "TestProject" authorizes the given repos, so AddRepo's project guard
+    // (#1340) permits adding them. The default _planTools only knows _repoDir.
+    private static PlanTools NewPlanToolsWithProjectRepos(params string[] repoPaths)
+    {
+        var settings = new TendrilSettings
+        {
+            Projects =
+            [
+                new ProjectConfig
+                {
+                    Name = "TestProject",
+                    Repos = repoPaths.Select(p => new RepoRef { Path = p }).ToList()
+                }
+            ]
+        };
+        var config = new ConfigService(settings);
+        return new PlanTools(new McpAuthenticationService(NullLogger<McpAuthenticationService>.Instance), config);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -3,8 +3,10 @@ using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Infrastructure;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
 using Ivy.Tendril.Services.Plans;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Test;
@@ -246,7 +248,11 @@ public class PlanCliCommandTests : IDisposable
 
         var services = new ServiceCollection();
         services.AddSingleton<IPlanWatcherService, NullPlanWatcherService>();
-        services.AddSingleton<IConfigService>(new TestPlanConfigService(repoDir, project));
+        var configService = new TestPlanConfigService(repoDir, project);
+        services.AddSingleton<IConfigService>(configService);
+        // PlanCreateCommand now depends on IGithubService (source-URL ↔ project guard). These tests
+        // create plans without a --source-url, so the guard no-ops and git is never invoked.
+        services.AddSingleton<IGithubService>(new GithubService(configService, NullLogger<GithubService>.Instance));
 
         var app = new CommandApp(new TypeRegistrar(services));
         app.Configure(config =>
@@ -255,6 +261,76 @@ public class PlanCliCommandTests : IDisposable
             config.AddBranch("plan", plan => plan.AddCommand<PlanCreateCommand>("create"));
         });
         return app;
+    }
+
+    // Builds an app exposing `plan add-repo` and `plan validate`, wired to a config whose <project>
+    // authorizes only the repo at repos/<project>. Used to drive the #1340 project/repo guard.
+    private CommandApp BuildPlanGuardApp(string project, out string inProjectRepo)
+    {
+        inProjectRepo = Path.Combine(_tempDir.Path, "repos", project);
+        Directory.CreateDirectory(inProjectRepo);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IPlanWatcherService, NullPlanWatcherService>();
+        services.AddSingleton<IConfigService>(new TestPlanConfigService(inProjectRepo, project));
+
+        var app = new CommandApp(new TypeRegistrar(services));
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("plan", plan =>
+            {
+                plan.AddCommand<PlanAddRepoCommand>("add-repo");
+                plan.AddCommand<PlanValidateCommand>("validate");
+            });
+        });
+        return app;
+    }
+
+    // #1340: `plan add-repo` must refuse a repo that isn't part of the plan's project.
+    [Fact]
+    public void PlanAddRepo_RepoOutsideProject_RefusedWithExitCode1()
+    {
+        var app = BuildPlanGuardApp("TestProject", out var inProjectRepo);
+        var outsideRepo = Path.Combine(_tempDir.Path, "repos", "Ivy-Framework");
+        Directory.CreateDirectory(outsideRepo);
+
+        CreatePlanFolder("00001", "Test", new PlanYaml
+        {
+            State = "Draft",
+            Project = "TestProject",
+            Title = "Test",
+            Repos = [inProjectRepo],
+            Created = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+            Updated = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)
+        });
+
+        var exit = app.Run(["plan", "add-repo", "00001", outsideRepo]);
+
+        Assert.Equal(1, exit);
+        Assert.DoesNotContain(outsideRepo, ReadPlan("00001").Repos);
+    }
+
+    // #1340: `plan validate` must fail a plan whose repo isn't part of its project.
+    [Fact]
+    public void PlanValidate_RepoOutsideProject_Throws()
+    {
+        var app = BuildPlanGuardApp("TestProject", out _);
+        var outsideRepo = Path.Combine(_tempDir.Path, "repos", "Ivy-Framework");
+        Directory.CreateDirectory(outsideRepo);
+
+        CreatePlanFolder("00002", "Test", new PlanYaml
+        {
+            State = "Draft",
+            Project = "TestProject",
+            Title = "Test",
+            Repos = [outsideRepo],
+            Created = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+            Updated = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)
+        });
+
+        var ex = Assert.Throws<ArgumentException>(() => app.Run(["plan", "validate", "00002"]));
+        Assert.Contains("not part of project", ex.Message);
     }
 
     // Regression for #1297 / #1303: `tendril plan create <title> <project>` must bind a

--- a/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
+++ b/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
@@ -244,6 +244,43 @@ public class PlanContentHelpersTests
     }
 
     [Fact]
+    public void GetAllChangesData_FallsBackToWorktree_AndFlagsUnlisted()
+    {
+        // Commit isn't in any configured repo (plan has none; StubConfigService returns no project),
+        // but a worktree under the plan folder contains it — the diff should come from there and be
+        // flagged as an unlisted worktree (#1340).
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-test-{Guid.NewGuid()}");
+        try
+        {
+            var worktree = Path.Combine(tempDir, "Worktrees", "Ivy-Framework");
+            Directory.CreateDirectory(worktree);
+
+            var gitService = new StubGitService(
+                "Worktree commit",
+                [("A", "file.cs")],
+                "diff --git a/file.cs b/file.cs\n+added");
+            var config = new StubConfigService();
+
+            var metadata = new PlanMetadata(
+                1, "Test", "Bug", "Test Plan", PlanStatus.Draft,
+                [], ["abc123"], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
+            var plan = new PlanFile(metadata, "", tempDir, "");
+
+            var result = PlanContentHelpers.GetAllChangesData(plan, config, gitService);
+
+            Assert.NotNull(result);
+            Assert.True(result.FromUnlistedWorktree);
+            Assert.EndsWith("Ivy-Framework", result.SourceRepoPath!);
+            Assert.Single(result.Files);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public void SplitDiffByFile_MultiFileDiff_SplitsCorrectly()
     {
         var diff = "diff --git a/src/Foo.cs b/src/Foo.cs\n"

--- a/src/Ivy.Tendril.Test/PlanControllerTests.cs
+++ b/src/Ivy.Tendril.Test/PlanControllerTests.cs
@@ -2,8 +2,10 @@ using System.Collections;
 using System.Text.Json;
 using Ivy.Tendril.Controllers;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ivy.Tendril.Test;
 
@@ -61,7 +63,9 @@ public class PlanControllerTests : IDisposable
 
     private PlanController CreateController()
     {
-        var controller = new PlanController(new NullPlanWatcherService(), new TestPlanConfigService(_repoDir));
+        var configService = new TestPlanConfigService(_repoDir);
+        var controller = new PlanController(new NullPlanWatcherService(), configService,
+            new GithubService(configService, NullLogger<GithubService>.Instance));
         controller.ControllerContext = new ControllerContext
         {
             HttpContext = new DefaultHttpContext()

--- a/src/Ivy.Tendril.Test/Services/JobLauncherProjectGuardTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobLauncherProjectGuardTests.cs
@@ -1,0 +1,88 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test.Services;
+
+[Collection("TendrilHome")]
+public class JobLauncherProjectGuardTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new();
+    private readonly string _originalHome;
+    private readonly string? _originalPlans;
+
+    public JobLauncherProjectGuardTests()
+    {
+        _originalHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        _originalPlans = Environment.GetEnvironmentVariable("TENDRIL_PLANS");
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", null);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalHome);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", _originalPlans);
+        _tempDir.Dispose();
+    }
+
+    // #1340 backstop: launching an ExecutePlan job whose plan references a repo outside the project
+    // must fail the job up front rather than execute in the wrong repo.
+    [Fact]
+    public void StartJob_RefusesExecute_WhenPlanRepoOutsideProject()
+    {
+        var inProject = Path.Combine(_tempDir.Path, "repos", "InProject");
+        Directory.CreateDirectory(inProject);
+        var outside = Path.Combine(_tempDir.Path, "repos", "Outside");
+        Directory.CreateDirectory(outside);
+
+        var settings = new TendrilSettings
+        {
+            JobTimeout = 30,
+            StaleOutputTimeout = 10,
+            Projects = [new ProjectConfig { Name = "TestProject", Repos = [new RepoRef { Path = inProject }] }]
+        };
+        var service = new JobService(new ConfigService(settings));
+
+        var planFolder = Path.Combine(_tempDir.Path, "plan-1");
+        Directory.CreateDirectory(planFolder);
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"),
+            $"state: Executing\nproject: TestProject\nlevel: NiceToHave\ntitle: Test Plan\n" +
+            $"created: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\nrepos:\n- {outside}\n" +
+            "prs: []\ncommits: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\n");
+
+        var id = service.StartJob(new ExecutePlanArgs(planFolder));
+        var job = service.GetJob(id)!;
+
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.Contains("not part of project", job.StatusMessage ?? "");
+    }
+
+    // A plan whose repo IS in the project must not be refused by the backstop. (It may still fail
+    // later for unrelated reasons, but never with the project-mismatch message.)
+    [Fact]
+    public void StartJob_DoesNotRefuse_WhenPlanRepoInProject()
+    {
+        var inProject = Path.Combine(_tempDir.Path, "repos", "InProject");
+        Directory.CreateDirectory(inProject);
+
+        var settings = new TendrilSettings
+        {
+            JobTimeout = 30,
+            StaleOutputTimeout = 10,
+            Projects = [new ProjectConfig { Name = "TestProject", Repos = [new RepoRef { Path = inProject }] }]
+        };
+        var service = new JobService(new ConfigService(settings));
+
+        var planFolder = Path.Combine(_tempDir.Path, "plan-2");
+        Directory.CreateDirectory(planFolder);
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"),
+            $"state: Executing\nproject: TestProject\nlevel: NiceToHave\ntitle: Test Plan\n" +
+            $"created: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\nrepos:\n- {inProject}\n" +
+            "prs: []\ncommits: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\n");
+
+        var id = service.StartJob(new ExecutePlanArgs(planFolder));
+        var job = service.GetJob(id)!;
+
+        Assert.DoesNotContain("not part of project", job.StatusMessage ?? "");
+    }
+}

--- a/src/Ivy.Tendril.Test/Services/PlanProjectRepoGuardTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PlanProjectRepoGuardTests.cs
@@ -1,0 +1,63 @@
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
+
+namespace Ivy.Tendril.Test.Services;
+
+public class PlanProjectRepoGuardTests
+{
+    private static ProjectConfig Project(params string[] repoPaths) =>
+        new() { Name = "Proj", Repos = repoPaths.Select(p => new RepoRef { Path = p }).ToList() };
+
+    [Fact]
+    public void Allows_Repo_In_Project()
+    {
+        var project = Project(@"C:\repos\Ivy-Tendril");
+        // No throw.
+        PlanProjectRepoGuard.EnsureReposBelongToProject([@"C:\repos\Ivy-Tendril"], project);
+    }
+
+    [Fact]
+    public void Allows_Build_Dependency()
+    {
+        var project = Project(@"C:\repos\Ivy-Tendril");
+        project.BuildDependencies = [@"C:\deps\Ivy-Framework"];
+        PlanProjectRepoGuard.EnsureReposBelongToProject([@"C:\deps\Ivy-Framework"], project);
+    }
+
+    [Fact]
+    public void Throws_For_Repo_Outside_Project()
+    {
+        var project = Project(@"C:\repos\Ivy-Tendril");
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            PlanProjectRepoGuard.EnsureReposBelongToProject([@"C:\repos\Ivy-Framework"], project));
+
+        Assert.Contains("Ivy-Framework", ex.Message);
+        Assert.Contains("Proj", ex.Message);
+    }
+
+    [Fact]
+    public void Matches_By_Folder_Name_Regardless_Of_Parent_Path()
+    {
+        // A plan may store a different absolute path with the same repo folder name; treated as in-project,
+        // matching how JobLauncher resolves project membership.
+        var project = Project(@"C:\repos\Ivy-Tendril");
+        PlanProjectRepoGuard.EnsureReposBelongToProject([@"D:\elsewhere\Ivy-Tendril"], project);
+    }
+
+    [Fact]
+    public void Reports_All_Offending_Repos()
+    {
+        var project = Project(@"C:\repos\Ivy-Tendril");
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            PlanProjectRepoGuard.EnsureReposBelongToProject(
+                [@"C:\repos\Ivy-Tendril", @"C:\repos\Ivy-Framework", @"C:\repos\Other"], project));
+
+        // Offending list (before "Allowed repos:") names the outside repos but not the in-project one.
+        var offendingSegment = ex.Message[..ex.Message.IndexOf("Allowed repos", StringComparison.Ordinal)];
+        Assert.Contains("Ivy-Framework", offendingSegment);
+        Assert.Contains("Other", offendingSegment);
+        Assert.DoesNotContain("Ivy-Tendril", offendingSegment);
+    }
+}

--- a/src/Ivy.Tendril.Test/Services/PlanSourceProjectGuardTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PlanSourceProjectGuardTests.cs
@@ -1,0 +1,102 @@
+using System.Diagnostics;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
+using Ivy.Tendril.Services.Plans;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test.Services;
+
+public class PlanSourceProjectGuardTests
+{
+    [Fact]
+    public void Throws_When_Issue_Repo_Not_In_Project()
+    {
+        var tendrilRepo = CreateTempGitRepo("https://github.com/Ivy-Interactive/Ivy-Tendril.git");
+        try
+        {
+            var project = new ProjectConfig { Name = "Ivy-Tendril", Repos = [new RepoRef { Path = tendrilRepo }] };
+            var github = NewGithub(project);
+
+            var ex = Assert.Throws<ArgumentException>(() =>
+                PlanSourceProjectGuard.EnsureSourceUrlMatchesProject(
+                    "https://github.com/nielsbosma/lots-of-dev-tools/issues/22", project, github));
+
+            Assert.Contains("lots-of-dev-tools", ex.Message);
+            Assert.Contains("Ivy-Tendril", ex.Message);
+        }
+        finally
+        {
+            Directory.Delete(tendrilRepo, true);
+        }
+    }
+
+    [Fact]
+    public void Allows_When_Issue_Repo_In_Project()
+    {
+        var repo = CreateTempGitRepo("https://github.com/Ivy-Interactive/Ivy-Tendril.git");
+        try
+        {
+            var project = new ProjectConfig { Name = "Ivy-Tendril", Repos = [new RepoRef { Path = repo }] };
+            var github = NewGithub(project);
+
+            // No throw — the issue's repo is the project's repo.
+            PlanSourceProjectGuard.EnsureSourceUrlMatchesProject(
+                "https://github.com/Ivy-Interactive/Ivy-Tendril/issues/5", project, github);
+        }
+        finally
+        {
+            Directory.Delete(repo, true);
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("https://example.com/not/a/github/issue")] // not a GitHub issue/PR URL
+    public void NoOp_When_No_Recognizable_Issue_Url(string? sourceUrl)
+    {
+        var project = new ProjectConfig { Name = "P", Repos = [new RepoRef { Path = @"C:\nope" }] };
+        var github = NewGithub(project);
+
+        // No throw regardless of project repos.
+        PlanSourceProjectGuard.EnsureSourceUrlMatchesProject(sourceUrl, project, github);
+    }
+
+    [Fact]
+    public void FailsOpen_When_Project_Repos_Unresolvable()
+    {
+        // The project's only repo path doesn't exist / has no git remote, so membership can't be
+        // determined — don't block creation.
+        var project = new ProjectConfig { Name = "P", Repos = [new RepoRef { Path = @"C:\nonexistent\xyz-999" }] };
+        var github = NewGithub(project);
+
+        PlanSourceProjectGuard.EnsureSourceUrlMatchesProject(
+            "https://github.com/nielsbosma/lots-of-dev-tools/issues/22", project, github);
+    }
+
+    private static GithubService NewGithub(params ProjectConfig[] projects) =>
+        new(new ConfigService(new TendrilSettings { Projects = projects.ToList() }), NullLogger<GithubService>.Instance);
+
+    private static string CreateTempGitRepo(string remoteUrl)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-srcguard-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+        RunGit(tempDir, "init");
+        RunGit(tempDir, $"remote add origin {remoteUrl}");
+        return tempDir;
+    }
+
+    private static void RunGit(string workingDir, string args)
+    {
+        var psi = new ProcessStartInfo("git", args)
+        {
+            WorkingDirectory = workingDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        using var process = Process.Start(psi)!;
+        process.WaitForExit();
+    }
+}

--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -400,16 +400,10 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         ).Width(Size.Rem(42));
     }
 
-    private string GetProjectForRepo(IGithubService githubService, string owner, string repo)
+    private static string GetProjectForRepo(IGithubService githubService, string owner, string repo)
     {
-        var repoPath = $"{owner}/{repo}";
-        var matchingProjects = _config.Settings.Projects
-            .Where(p => p.RepoPaths.Any(path =>
-                githubService.GetRepoConfigFromPathCached(path)?.FullName
-                    .Equals(repoPath, StringComparison.OrdinalIgnoreCase) ?? false))
-            .ToList();
-
-        return matchingProjects.Count == 1 ? matchingProjects[0].Name : "Auto";
+        // "Auto" defers project selection to the CreatePlan agent when zero or multiple projects match.
+        return githubService.FindProjectForGithubRepo($"{owner}/{repo}")?.Name ?? "Auto";
     }
 
     internal static string SanitizeFileName(string title)

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -598,7 +598,7 @@ public class ContentView(
                     recommendationsLayout |= new Separator();
                 }
 
-            var changesTabView = new ChangesTabView(planData.AllChanges, planContentQuery.Loading, planContentQuery.Error);
+            var changesTabView = new ChangesTabView(planData.AllChanges, planContentQuery.Loading, planContentQuery.Error, selectedPlan.Project);
 
             var tabNamesList = new List<string> { "summary", "plan", "details", "verifications", "git" };
             var tabList = new List<Tab>

--- a/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
@@ -7,7 +7,8 @@ namespace Ivy.Tendril.Apps.Views.Tabs;
 public class ChangesTabView(
     PlanContentHelpers.AllChangesData? changesData,
     bool loading,
-    Exception? error) : ViewBase
+    Exception? error,
+    string? projectName = null) : ViewBase
 {
     public int FileCount => changesData?.Files.Count ?? 0;
 
@@ -25,6 +26,20 @@ public class ChangesTabView(
                 ? $"Failed to load changes: {err.Message}"
                 : "No commits yet.";
             return Text.Muted(errorMsg);
+        }
+
+        // The diff was read from a worktree whose repo isn't part of the plan's project (#1340).
+        // Warn so the reviewer doesn't merge blind.
+        object? mismatchBanner = null;
+        if (changesData.FromUnlistedWorktree)
+        {
+            var repoLabel = string.IsNullOrEmpty(changesData.SourceRepoPath)
+                ? "a different repository"
+                : Path.GetFileName(changesData.SourceRepoPath!.TrimEnd('/', '\\'));
+            var projectLabel = string.IsNullOrEmpty(projectName) ? "this plan's project" : $"project '{projectName}'";
+            mismatchBanner = Callout.Warning(
+                $"These changes are in {repoLabel}, which is not part of {projectLabel}. " +
+                "The plan may have been created in the wrong project.", "Wrong project?");
         }
 
         var allFileDiffs = PlanContentHelpers.SplitDiffByFile(changesData);
@@ -95,10 +110,13 @@ public class ChangesTabView(
             | treePanel
             | diffsLayout;
 
-        return Layout.Vertical().Height(Size.Full().Min(Size.Px(0)))
-            | toolbar
-            | mobileFilePicker
-            | mainLayout;
+        var outer = Layout.Vertical().Height(Size.Full().Min(Size.Px(0)));
+        if (mismatchBanner != null)
+            outer |= mismatchBanner;
+        outer |= toolbar;
+        outer |= mobileFilePicker;
+        outer |= mainLayout;
+        return outer;
     }
 
     private static TreeNode BuildFileTree(IReadOnlyList<PlanContentHelpers.FileDiff> fileDiffs)

--- a/src/Ivy.Tendril/Commands/PlanAddRepoCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddRepoCommand.cs
@@ -1,6 +1,7 @@
 using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
 using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
@@ -27,10 +28,12 @@ public class PlanAddRepoSettings : CommandSettings
 public class PlanAddRepoCommand : Command<PlanAddRepoSettings>
 {
     private readonly IPlanWatcherService _planWatcher;
+    private readonly IConfigService _configService;
 
-    public PlanAddRepoCommand(IPlanWatcherService planWatcher)
+    public PlanAddRepoCommand(IPlanWatcherService planWatcher, IConfigService configService)
     {
         _planWatcher = planWatcher;
+        _configService = configService;
     }
 
     protected override int Execute(CommandContext context, PlanAddRepoSettings settings, CancellationToken cancellationToken)
@@ -42,6 +45,22 @@ public class PlanAddRepoCommand : Command<PlanAddRepoSettings>
         {
             Console.WriteLine($"Repository already in plan: {settings.RepoPath}");
             return 0;
+        }
+
+        // Refuse repos that don't belong to the plan's project (issue #1340). Skip when the
+        // project is unknown to config — there's nothing to validate against.
+        var project = _configService.GetProject(plan.Project);
+        if (project != null)
+        {
+            try
+            {
+                PlanProjectRepoGuard.EnsureReposBelongToProject([settings.RepoPath], project);
+            }
+            catch (ArgumentException ex)
+            {
+                Console.Error.WriteLine($"Error: {ex.Message}");
+                return 1;
+            }
         }
 
         plan.Repos.Add(settings.RepoPath);

--- a/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
+using Ivy.Tendril.Services.Plans;
 using Ivy.Tendril.Helpers;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -68,11 +70,13 @@ public class PlanCreateCommand : Command<PlanCreateSettings>
 {
     private readonly IPlanWatcherService _planWatcher;
     private readonly IConfigService _configService;
+    private readonly IGithubService _githubService;
 
-    public PlanCreateCommand(IPlanWatcherService planWatcher, IConfigService configService)
+    public PlanCreateCommand(IPlanWatcherService planWatcher, IConfigService configService, IGithubService githubService)
     {
         _planWatcher = planWatcher;
         _configService = configService;
+        _githubService = githubService;
     }
 
     protected override int Execute(CommandContext context, PlanCreateSettings settings, CancellationToken cancellationToken)
@@ -81,6 +85,7 @@ public class PlanCreateCommand : Command<PlanCreateSettings>
         try
         {
             resolvedProject = PlanProjectResolver.ResolveProject(settings.Project, _configService.Projects);
+            PlanSourceProjectGuard.EnsureSourceUrlMatchesProject(settings.SourceUrl, resolvedProject, _githubService);
         }
         catch (ArgumentException ex)
         {

--- a/src/Ivy.Tendril/Commands/PlanValidateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanValidateCommand.cs
@@ -20,12 +20,20 @@ public class PlanValidateSettings : CommandSettings
 
 public class PlanValidateCommand : Command<PlanValidateSettings>
 {
+    private readonly IConfigService _configService;
+
+    public PlanValidateCommand(IConfigService configService)
+    {
+        _configService = configService;
+    }
+
     protected override int Execute(CommandContext context, PlanValidateSettings settings, CancellationToken cancellationToken)
     {
         var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
         var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-        PlanValidationService.Validate(plan);
+        var project = _configService.GetProject(plan.Project);
+        PlanValidationService.Validate(plan, project: project);
 
         Console.WriteLine($"Plan {settings.PlanId} is valid");
         return 0;

--- a/src/Ivy.Tendril/Controllers/PlanController.cs
+++ b/src/Ivy.Tendril/Controllers/PlanController.cs
@@ -1,6 +1,7 @@
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Commands;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
 using Ivy.Tendril.Services.Plans;
 using Ivy.Tendril.Helpers;
 using Microsoft.AspNetCore.Mvc;
@@ -68,11 +69,13 @@ public class PlanController : ControllerBase
 {
     private readonly IPlanWatcherService _planWatcher;
     private readonly IConfigService _configService;
+    private readonly IGithubService _githubService;
 
-    public PlanController(IPlanWatcherService planWatcher, IConfigService configService)
+    public PlanController(IPlanWatcherService planWatcher, IConfigService configService, IGithubService githubService)
     {
         _planWatcher = planWatcher;
         _configService = configService;
+        _githubService = githubService;
     }
 
     private IActionResult ModifyPlanEndpoint(
@@ -406,6 +409,7 @@ public class PlanController : ControllerBase
         try
         {
             var resolvedProject = PlanProjectResolver.ResolveProject(request.Project, _configService.Projects);
+            PlanSourceProjectGuard.EnsureSourceUrlMatchesProject(request.SourceUrl, resolvedProject, _githubService);
 
             var plansDir = PlanCommandHelpers.GetPlansDirectory();
             var planId = PlanYamlHelper.AllocatePlanId(plansDir);

--- a/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
@@ -263,21 +263,24 @@ public static class PlanContentHelpers
         List<(string Status, string FilePath)> Files,
         int AddedCount,
         int ModifiedCount,
-        int DeletedCount
+        int DeletedCount,
+        // The repo/worktree the diff was read from, and whether that was a worktree NOT in the
+        // plan's configured repos (the work landed in a repo outside the plan's project — #1340).
+        string? SourceRepoPath = null,
+        bool FromUnlistedWorktree = false
     );
 
     public static AllChangesData? GetAllChangesData(PlanFile plan, IConfigService config, IGitService gitService)
     {
         if (plan.Commits.Count == 0) return null;
 
-        var repoPaths = plan.GetEffectiveRepoPaths(config);
         var firstCommit = plan.Commits.First();
         var lastCommit = plan.Commits.Last();
 
-        foreach (var repo in repoPaths)
+        AllChangesData? BuildFromRepo(string repo, bool fromUnlistedWorktree)
         {
             var titleResult = gitService.GetCommitTitle(repo, firstCommit);
-            if (!titleResult.IsSuccess) continue;
+            if (!titleResult.IsSuccess) return null;
 
             string? diff;
             List<(string Status, string FilePath)>? files;
@@ -302,7 +305,27 @@ public static class PlanContentHelpers
             var deleted = fileList.Count(f => f.Status == "D");
             var modified = fileList.Count - added - deleted;
 
-            return new AllChangesData(diff, fileList, added, modified, deleted);
+            return new AllChangesData(diff, fileList, added, modified, deleted, repo, fromUnlistedWorktree);
+        }
+
+        // Prefer the plan's / project's configured repos.
+        foreach (var repo in plan.GetEffectiveRepoPaths(config))
+        {
+            var result = BuildFromRepo(repo, fromUnlistedWorktree: false);
+            if (result != null) return result;
+        }
+
+        // Fall back to the plan's worktrees — the same source the Git tab reads (GitTabDataBuilder).
+        // A commit found here but not in the configured repos means the work landed in a repo outside
+        // the plan's project (#1340); surface the diff with a flag instead of showing "No commits yet.".
+        var worktreesDir = Path.Combine(plan.FolderPath, "Worktrees");
+        if (Directory.Exists(worktreesDir))
+        {
+            foreach (var worktree in Directory.GetDirectories(worktreesDir))
+            {
+                var result = BuildFromRepo(worktree, fromUnlistedWorktree: true);
+                if (result != null) return result;
+            }
         }
 
         return null;

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -181,6 +181,12 @@ public sealed class PlanTools : AuthenticatedToolBase
         {
             if (plan.Repos.Contains(repoPath, StringComparer.OrdinalIgnoreCase))
                 throw new InvalidOperationException($"Repository already in plan: {repoPath}");
+
+            // Refuse repos outside the plan's project (issue #1340).
+            var project = _configService.GetProject(plan.Project);
+            if (project != null)
+                PlanProjectRepoGuard.EnsureReposBelongToProject([repoPath], project);
+
             plan.Repos.Add(repoPath);
         }, $"Added repository: {repoPath}");
     }

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -7,6 +7,7 @@ using Ivy.Tendril.Commands;
 using Ivy.Tendril.Database;
 using Ivy.Tendril.Infrastructure;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
 using Ivy.Tendril.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -143,6 +144,11 @@ public class Program
             var configService = new ConfigService(Microsoft.Extensions.Logging.Abstractions.NullLogger<ConfigService>.Instance);
             cliServices.AddSingleton<IConfigService>(configService);
             cliServices.AddSingleton<ConfigService>(configService);
+
+            // Needed by `plan create` to validate that a source issue/PR URL belongs to the
+            // chosen project (PlanSourceProjectGuard). Resolves git remotes of project repos.
+            cliServices.AddSingleton<GithubService>();
+            cliServices.AddSingleton<IGithubService>(sp => sp.GetRequiredService<GithubService>());
 
             var app = ConfigureCliCommands(cliServices);
             var firstArg = filteredArgs[0];

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -63,8 +63,18 @@ For each worktree:
 
 1. `git remote get-url origin` (from the worktree) to get the GitHub remote
 2. Extract `owner/repo` from the remote URL
-3. `git rev-parse --abbrev-ref HEAD` to get the branch name
-4. `git push -u origin <branch>` — apply the **transient-error retry convention** above (a
+3. **!MANDATORY project gate — do not skip.** Verify this worktree's repo is one the project
+   authorizes: its repo path/name must appear in the `RepoConfigs` firmware header (the project's
+   configured repos). If the worktree's repo is **NOT** in `RepoConfigs`, **abort this worktree**:
+   do **not** push, create a PR, or merge. Report the mismatch and fail the job for this repo:
+   ```bash
+   tendril job status TendrilJobId --message="ERROR: worktree repo <owner/repo> is not part of this project's RepoConfigs — refusing to push/merge. The plan was likely created in the wrong project."
+   ```
+   Then skip to the next worktree (or exit if this is the only one). This is the stop that prevents
+   merging a change into a repo outside the plan's project (#1340). Never push to a repo just because
+   a worktree for it exists on disk.
+4. `git rev-parse --abbrev-ref HEAD` to get the branch name
+5. `git push -u origin <branch>` — apply the **transient-error retry convention** above (a
    first-attempt `git push` commonly fails transiently and succeeds on retry)
 
 > **Stale remote tracking refs warning:** A ref appearing in `git branch -a` as `remotes/origin/<branch>` does NOT guarantee the branch exists on GitHub. Always verify with `gh api repos/<owner>/<repo>/branches/<branch>` or `git ls-remote origin <branch>` before assuming the push succeeded.

--- a/src/Ivy.Tendril/Services/Git/GithubService.cs
+++ b/src/Ivy.Tendril/Services/Git/GithubService.cs
@@ -202,6 +202,58 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
         };
     }
 
+    /// <summary>
+    ///     Parses the <c>owner/name</c> from a GitHub issue or PR URL such as
+    ///     <c>https://github.com/{owner}/{repo}/issues/{n}</c> or <c>.../pull/{n}</c>.
+    ///     Returns null when the URL is not a recognizable GitHub issue/PR URL.
+    ///     Note this is distinct from <see cref="ParseRepoConfigFromUrl" />, which parses
+    ///     git remote URLs (ending in <c>owner/repo(.git)</c>) — that regex would mis-read
+    ///     an issue URL's trailing <c>issues/{n}</c> segments as the owner/repo.
+    /// </summary>
+    internal static RepoConfig? ParseRepoConfigFromIssueOrPrUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return null;
+
+        var match = Regex.Match(url,
+            @"github\.com[/:](?<owner>[^/]+)/(?<name>[^/]+)/(?:issues|pull)/\d+",
+            RegexOptions.IgnoreCase);
+        if (!match.Success) return null;
+
+        return new RepoConfig
+        {
+            Owner = match.Groups["owner"].Value,
+            Name = match.Groups["name"].Value
+        };
+    }
+
+    public ProjectConfig? FindProjectForGithubRepo(string ownerRepo)
+    {
+        if (string.IsNullOrWhiteSpace(ownerRepo)) return null;
+
+        var matches = _config.Settings.Projects
+            .Where(p => p.RepoPaths.Any(path =>
+                GetRepoConfigFromPathCached(path)?.FullName
+                    .Equals(ownerRepo, StringComparison.OrdinalIgnoreCase) ?? false))
+            .ToList();
+
+        // Exactly one project must own the repo; zero (unconfigured) or many (ambiguous) → no match.
+        return matches.Count == 1 ? matches[0] : null;
+    }
+
+    /// <summary>
+    ///     Resolves the <c>owner/name</c> of each of the project's configured repos (via their git
+    ///     remotes). Entries whose remote can't be resolved (no <c>origin</c>, offline) are omitted,
+    ///     so an empty result means "could not determine any" — callers should fail open in that case.
+    /// </summary>
+    public IReadOnlyList<string> GetResolvedGithubRepos(ProjectConfig project)
+    {
+        return project.RepoPaths
+            .Select(p => GetRepoConfigFromPathCached(p)?.FullName)
+            .Where(n => n is not null)
+            .Select(n => n!)
+            .ToList();
+    }
+
     private async Task<(T result, string? error)> ExecuteGhCliAsync<T>(
         string args,
         Func<string, T> parseOutput,

--- a/src/Ivy.Tendril/Services/Git/IGithubService.cs
+++ b/src/Ivy.Tendril/Services/Git/IGithubService.cs
@@ -12,6 +12,19 @@ public interface IGithubService
 {
     List<RepoConfig> GetRepos();
     RepoConfig? GetRepoConfigFromPathCached(string repoPath);
+
+    /// <summary>
+    ///     Returns the single configured project whose repos include the GitHub repo
+    ///     <paramref name="ownerRepo" /> (format <c>owner/name</c>), or null when zero or more
+    ///     than one project matches (unconfigured / ambiguous).
+    /// </summary>
+    ProjectConfig? FindProjectForGithubRepo(string ownerRepo);
+
+    /// <summary>
+    ///     The resolved <c>owner/name</c> of each of the project's repos. Repos whose remote can't
+    ///     be resolved are omitted; an empty list means none could be resolved (callers fail open).
+    /// </summary>
+    IReadOnlyList<string> GetResolvedGithubRepos(ProjectConfig project);
     Task<(List<string> assignees, string? error)> GetAssigneesAsync(string owner, string repo);
     Task<(List<string> labels, string? error)> GetLabelsAsync(string owner, string repo);
     Task<(Dictionary<string, string> statuses, string? error)> GetPrStatusesAsync(string owner, string repo);

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -4,6 +4,7 @@ using Ivy.Helpers;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Plans;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Services.Jobs;
@@ -62,6 +63,12 @@ internal class JobLauncher
 
     private void LaunchJob(JobLaunchContext ctx)
     {
+        // Defense in depth (#1340): refuse to launch a plan job that references a repo outside its
+        // project, before any state mutation. The creation/add-repo guards should prevent this, but
+        // pre-existing plans may have drifted.
+        if (!ValidateProjectReposOrFail(ctx))
+            return;
+
         PrepareJobForLaunch(ctx);
 
         if (!ValidateJobPrerequisites(ctx, out var psi, out var stdinContent))
@@ -73,6 +80,41 @@ internal class JobLauncher
 
         InitializeJobMonitoring(ctx, process);
         ctx.RaiseStructureChanged();
+    }
+
+    private bool ValidateProjectReposOrFail(JobLaunchContext ctx)
+    {
+        var job = ctx.Job;
+        if (job.TypedArgs is not (ExecutePlanArgs or RetryPlanArgs or CreatePrArgs))
+            return true;
+
+        var projectConfig = _configService?.GetProject(job.Project);
+        if (projectConfig == null)
+            return true; // Unknown project — nothing to validate against.
+
+        var planFolder = job.TypedArgs?.PlanFolder ?? "";
+        if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder))
+            return true;
+
+        var planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
+        if (planYaml?.Repos == null || planYaml.Repos.Count == 0)
+            return true;
+
+        try
+        {
+            PlanProjectRepoGuard.EnsureReposBelongToProject(planYaml.Repos, projectConfig);
+            return true;
+        }
+        catch (ArgumentException ex)
+        {
+            _logger.LogError("Job {JobId}: refusing launch — {Message}", job.Id, ex.Message);
+            job.Status = JobStatus.Failed;
+            job.StatusMessage = ex.Message;
+            job.CompletedAt = DateTime.UtcNow;
+            ctx.JobSlotSemaphore.Release();
+            ctx.RaiseStructureChanged();
+            return false;
+        }
     }
 
     private void PrepareJobForLaunch(JobLaunchContext ctx)

--- a/src/Ivy.Tendril/Services/Plans/PlanProjectRepoGuard.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanProjectRepoGuard.cs
@@ -1,0 +1,55 @@
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Services.Plans;
+
+/// <summary>
+///     Guards against a plan referencing a repository that isn't part of its project. Without this,
+///     a plan in project A can accumulate (or be created with) a repo from project B and end up
+///     executing / merging there (issue #1340).
+/// </summary>
+public static class PlanProjectRepoGuard
+{
+    /// <summary>
+    ///     Throws <see cref="ArgumentException" /> if any of <paramref name="repoPaths" /> is not part
+    ///     of <paramref name="project" />'s configured repos or build dependencies. Membership is by
+    ///     repo folder name (case-insensitive), matching how <c>JobLauncher.FindProjectRepoConfig</c>
+    ///     resolves project membership when building the firmware <c>RepoConfigs</c> — so the guard and
+    ///     the executor agree on what "belongs to the project" means.
+    /// </summary>
+    public static void EnsureReposBelongToProject(IEnumerable<string> repoPaths, ProjectConfig project)
+    {
+        var allowed = AllowedRepoNames(project);
+
+        // Fail open: a project with no repos configured gives nothing to validate against.
+        if (allowed.Count == 0)
+            return;
+
+        var offending = repoPaths
+            .Select(RepoName)
+            .Where(name => !string.IsNullOrEmpty(name) && !allowed.Contains(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (offending.Count == 0)
+            return;
+
+        var allowedList = allowed.Count > 0
+            ? string.Join(", ", allowed.OrderBy(n => n, StringComparer.OrdinalIgnoreCase))
+            : "(none)";
+        throw new ArgumentException(
+            $"Repo(s) [{string.Join(", ", offending)}] are not part of project '{project.Name}'. " +
+            $"Allowed repos: [{allowedList}].");
+    }
+
+    private static HashSet<string> AllowedRepoNames(ProjectConfig project)
+    {
+        var names = project.RepoPaths
+            .Concat(project.BuildDependencies)
+            .Select(RepoName)
+            .Where(n => !string.IsNullOrEmpty(n));
+        return new HashSet<string>(names, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string RepoName(string path) =>
+        Path.GetFileName(Environment.ExpandEnvironmentVariables(path).TrimEnd('/', '\\'));
+}

--- a/src/Ivy.Tendril/Services/Plans/PlanSourceProjectGuard.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanSourceProjectGuard.cs
@@ -1,0 +1,48 @@
+using Ivy.Tendril.Services.Git;
+
+namespace Ivy.Tendril.Services.Plans;
+
+/// <summary>
+///     Guards plan creation against a project mismatch: when a plan is created from a GitHub
+///     issue/PR <c>SourceUrl</c>, the issue's repo must belong to the chosen project. This is the
+///     cheapest place to catch "the plan was created in the wrong project" (issue #1340) — before
+///     any execution, worktree, or PR happens.
+/// </summary>
+public static class PlanSourceProjectGuard
+{
+    /// <summary>
+    ///     Throws <see cref="ArgumentException" /> when <paramref name="sourceUrl" /> is a GitHub
+    ///     issue/PR URL whose repo is not part of <paramref name="project" />.
+    ///     No-ops when there is no source URL, it isn't a GitHub issue/PR URL, or none of the
+    ///     project's repos could be resolved to a remote (fail open — don't block on offline/local-only
+    ///     repos). The error names the project that actually owns the repo, when one can be found.
+    /// </summary>
+    public static void EnsureSourceUrlMatchesProject(string? sourceUrl, ProjectConfig project, IGithubService github)
+    {
+        if (string.IsNullOrWhiteSpace(sourceUrl))
+            return;
+
+        var sourceRepo = GithubService.ParseRepoConfigFromIssueOrPrUrl(sourceUrl);
+        if (sourceRepo is null)
+            return;
+
+        var ownerRepo = sourceRepo.FullName;
+
+        var resolvedProjectRepos = github.GetResolvedGithubRepos(project);
+        if (resolvedProjectRepos.Count == 0)
+            return; // Fail open: can't determine the project's repos (no origin / offline).
+
+        var projectOwnsSource = resolvedProjectRepos
+            .Any(n => n.Equals(ownerRepo, StringComparison.OrdinalIgnoreCase));
+        if (projectOwnsSource)
+            return;
+
+        var owningProject = github.FindProjectForGithubRepo(ownerRepo);
+        var hint = owningProject is not null
+            ? $" It belongs to project '{owningProject.Name}' — create the plan there, or remove the source URL."
+            : " It is not part of any configured project — add the repo to this project, or remove the source URL.";
+
+        throw new ArgumentException(
+            $"Source issue/PR is in '{ownerRepo}', which is not part of project '{project.Name}'.{hint}");
+    }
+}

--- a/src/Ivy.Tendril/Services/Plans/PlanValidationService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanValidationService.cs
@@ -17,8 +17,10 @@ public static class PlanValidationService
 
     /// <summary>
     ///     Validates a PlanYaml object. Throws ArgumentException with detailed error message on failure.
+    ///     When <paramref name="project" /> is supplied, also enforces that every repo belongs to it
+    ///     (issue #1340) — callers that have config resolved should pass it.
     /// </summary>
-    public static void Validate(PlanYaml plan, string[]? configuredLevels = null)
+    public static void Validate(PlanYaml plan, string[]? configuredLevels = null, ProjectConfig? project = null)
     {
         // Required fields
         if (string.IsNullOrWhiteSpace(plan.State))
@@ -100,6 +102,10 @@ public static class PlanValidationService
                 // Status is a VerificationStatus enum — always valid once deserialized.
             }
         }
+
+        // Validate repos belong to the project (issue #1340), when the project is known.
+        if (project != null && plan.Repos != null)
+            PlanProjectRepoGuard.EnsureReposBelongToProject(plan.Repos, project);
     }
 
     private static void ValidateDate(DateTime date, string fieldName)


### PR DESCRIPTION
Guard plans against executing/merging in repos outside their project (#1340)

A plan created in the wrong project could execute and yolo-merge a PR into a
repo not belonging to that project, while the Review "Changes" tab showed
nothing. This adds layered guardrails plus a diagnosis fix:

- Creation: refuse a plan whose GitHub issue/PR source URL repo isn't part of
  the chosen project (PlanSourceProjectGuard), wired into plan create (CLI) and
  PlanController.CreatePlanDirect (REST). Reuses a shared owner/repo -> project
  matcher (IGithubService.FindProjectForGithubRepo).
- Repo drift: refuse repos outside the project at plan add-repo (CLI + MCP) and
  plan validate (PlanProjectRepoGuard).
- Execution: CreatePr promptware aborts any worktree whose repo isn't in
  RepoConfigs; JobLauncher backstop refuses to launch a plan job referencing a
  repo outside its project.
- Review: the Changes tab now falls back to scanning worktrees and warns when
  the diff comes from a repo outside the plan's project, instead of the
  misleading "No commits yet.".

Bug-report ZIP enrichment is tracked separately in #1387.
