### PR TITLE
Rename UpdateProject promptware to SetupProject

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.53</Version>
+    <Version>1.1.1</Version>
     <!-- Use local Ivy source by default for development if it exists, but use NuGet packages in CI, for release builds, or if local source is missing -->
     <IvySource Condition="'$(IvySource)' == '' And Exists('$(MSBuildThisFileDirectory)../../Ivy-Framework/src/Ivy/Ivy.csproj')">true</IvySource>
     <IvySource Condition="'$(IvySource)' == ''">false</IvySource>

--- a/src/Ivy.Tendril.Docs/Docs/05_ReleaseNotes/01_ReleaseNotes.md
+++ b/src/Ivy.Tendril.Docs/Docs/05_ReleaseNotes/01_ReleaseNotes.md
@@ -14,6 +14,67 @@ icon: ScrollText
 Version history, new features, improvements, and bug fixes for each Tendril release.
 </Ingress>
 
+## 1.1.1 (2026-06-25)
+
+### Features
+
+- **Voice & rich plan input** — New ContentInput widget brings voice transcription and file attachments to the Create Plan dialog; files upload over HTTP POST and are stored alongside the plan, with drag-and-drop support.
+- **Chat with Agent** — Beta AgentApp lets you chat directly with the coding agent over a PTY, with a "Chat with Agent" button in the New Plan dialog and the `tendril` CLI exposed to the agent via a shim.
+- **Plan annotations** — Annotate drafts in DraftsApp to drive annotation-based plan updates.
+- **Mobile & tablet support** — Tendril is now responsive across mobile, tablet, and desktop breakpoints, with adaptive headers, sheets, pickers, and process viewer.
+- **DraftMarkdown widget** — Renders Mermaid and Graphviz diagrams, callouts, local-file and clickable images, and inline text annotations.
+- **Velopack auto-updates** — Desktop app self-updates via Velopack, with installer name-collision prevention.
+- **Activity heatmap** — Wallpaper app shows a 90-day completed-PR activity heatmap.
+- **SyncRepo & preflight dirty-repo check** — New SyncRepo promptware plus a preflight check that detects and resolves dirty repository state before Execute and Create Plan.
+- **Job dependencies** — Job-level `WaitForJobs` blocking with cascade failure, periodic re-evaluation of blocked jobs, and a Force Start action for blocked jobs.
+- **Rerun with feedback** — Rerun a job with additional feedback for the agent.
+- **Revert revision** — Revert a specific plan revision directly from the Details tab.
+- **Stale-worktree reaper** — Bounds worktree disk usage by reaping stale worktrees left from prior runs.
+- **HTTP-based CLI/server IPC** — CLI and server communicate over HTTP with master election for reliable single-instance coordination.
+- **Bundled runtimes** — .NET 10 SDK and PowerShell 7 are bundled in installers and resolved dynamically at runtime when present.
+- **Repo guardrails** — Plans are guarded against executing or merging in repositories outside their project, and the repo's default branch is detected instead of assuming `main`.
+- **Plan migration framework** — Added `schemaVersion` to `plan.yaml` with a per-file plan migration framework.
+- **Coding agent environment variables** — Configure per-agent environment variables in Coding Agent settings.
+- **`tendril agent-instructions` command** — Output the agent instructions from the CLI.
+
+### Improvements
+
+- **Tunnel polish** — Connecting state, wallpaper QR code, Open in Browser, routable-before-Connected detection, orphaned `cloudflared` cleanup, and single-click deactivate with optimistic UI.
+- **Verifications as single source of truth** — `plan.yaml` is now the source of truth for verifications, with a dedicated UI card, status enum, and drag-and-drop ordering in the project edit dialog.
+- **Job Debug sheet** — Added working directory and CLI arguments, copy buttons for Plan/Job IDs, a Report Bug button, and promptware learnings (memory/tool writes); hides empty rows and permission denials.
+- **Plan state renames** — `Building → Creating` and `ReadyForReview → Review` for clearer lifecycle naming.
+- **CLI consolidation** — Single-channel logging, unified exception propagation, descriptive job-status output, and added Web API/MCP endpoints for full CLI parity.
+- **Recommendations simplified** — Removed the Risk field from recommendations across the UI and prompts.
+- **macOS standalone app** — Robust login-shell PATH and environment loading, correct packaged-app detection, and automatic global `tendril` symlink creation.
+- **Widget restructure** — Consolidated widgets into a unified `Ivy.Tendril.Widgets` project with per-widget frontend directories.
+- **Auto-merge workflow** — CI workflow automatically merges `main` back into `development` after release.
+- **Dependency security** — Upgraded `SQLitePCLRaw.lib.e_sqlite3` to 3.50.3 and pinned frontend dependencies (dompurify, vite-plus) to address known vulnerabilities.
+
+### Bug Fixes
+
+- Fixed `tendril plan create` dash-value argument parsing.
+- Fixed SQLite "database is locked" errors via a shared connection factory and `busy_timeout`.
+- Fixed cancelled/stopped/failed jobs reverting plans to their previous state.
+- Fixed PR merge depending on a stale `prRule` instead of the `PrMerge` flag.
+- Fixed drafts not refreshing after changes.
+- Fixed intermittent Create PR failures and misleading error messages.
+- Fixed Review and Drafts markdown left padding not rendering.
+- Fixed verification order not persisting in the Edit Project dialog.
+- Fixed job cost calculation to run for all statuses using inline result data.
+- Fixed `plan.yaml` lost-write race condition when accepting a recommendation.
+- Fixed crash when navigating to Drafts/Review with an invalid plan.
+- Fixed race condition in `WaitForJobs` unblocking and duplicate job detection.
+- Fixed IvyFrameworkVerification leaving zombie processes after test runs.
+- Fixed Copilot usage-metric parsing crashes with defensive parsing.
+- Fixed Spectre.Console crash from unescaped markup in doctor output.
+- Fixed onboarding startup crash on macOS and Windows when `TENDRIL_HOME` is empty.
+- Fixed duplicate Default option in coding agent profile model dropdowns.
+- Fixed missing Windows taskbar icon.
+- Fixed plan folder ACL permissions blocking ExecutePlan.
+- Fixed duplicate SyncRepo jobs being queued for the same repository.
+- Fixed ContentInput name collision after the framework added its own widget.
+- Fixed JS `SyntaxError` on older WebKit by targeting es2020.
+
 ## 1.0.39 (2026-05-28)
 
 ### Features

--- a/src/Ivy.Tendril.TeamIvyConfig/AGENTS.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/AGENTS.md
@@ -8,13 +8,13 @@ You are an interactive assistant for the human operator. Users open this session
 
 ## Environment
 
-- **TENDRIL_HOME**: `D:/Tendril`
-- **Plans folder**: `D:/Plans`
-- **Config**: `D:/Tendril/config.yaml`
-- **Database**: `D:/Tendril/tendril.db`
+- **TENDRIL_HOME**: `D:/Tendril/`
+- **Plans folder**: `D:/Plans/`
+- **Config**: `D:/Tendril//config.yaml`
+- **Database**: `D:/Tendril//tendril.db`
 
 ```
-D:/Tendril/
+D:/Tendril//
   config.yaml          # Projects, agents, verifications, promptware settings
   tendril.db           # SQLite database (plan state, jobs, costs)
   Plans/               # Plan folders ({ID}-{Title}/)
@@ -71,11 +71,11 @@ Autonomous agents that handle each pipeline stage. Each has a `Program.md` (inst
 | **RetryPlan** | Applies reviewer feedback to an already-executed plan's worktree |
 | **CreatePr** | Pushes branches, creates GitHub PRs, applies merge rules |
 | **CreateIssue** | Creates GitHub issues from plans |
-| **UpdateProject** | Sets up project verifications and review actions |
+| **SetupProject** | Sets up project verifications and review actions |
 
 ## Plan Structure
 
-Plans live in `D:/Plans/{ID}-{SafeTitle}/`:
+Plans live in `D:/Plans//{ID}-{SafeTitle}/`:
 
 ```
 00142-FixLoginBug/
@@ -166,11 +166,40 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 | `tendril verification remove <name>` | Remove verification definition |
 | `tendril verification set <name> <field> <value>` | Set verification field |
 
-### Promptware Commands
+### Job Commands
 
 | Command | Description |
 |---------|-------------|
-| `tendril promptware run <name>` | Run a promptware |
+| `tendril job start <Type> <plan-id> [options]` | Start a job on the running Tendril server |
+| `tendril job status <job-id> -m <message>` | Report job status to the server |
+
+**Job types and options for `tendril job start`:**
+
+| Type | Required | Optional |
+|------|----------|----------|
+| `ExecutePlan` | `<plan-id>` | `--note` |
+| `UpdatePlan` | `<plan-id>`, `--instructions` | — |
+| `SplitPlan` | `<plan-id>` | — |
+| `ExpandPlan` | `<plan-id>` | — |
+| `CreateIssue` | `<plan-id>`, `--repo` | `--assignee`, `--comment`, `--labels` |
+| `CreatePr` | `<plan-id>` | `--no-merge`, `--no-delete-branch`, `--no-artifacts`, `--assignee`, `--comment`, `--draft` |
+| `RetryPlan` | `<plan-id>`, `--change-request` | — |
+| `CreatePlan` | `--description`, `--project` | `--priority`, `--force`, `--source-path` |
+
+Examples:
+```bash
+tendril job start ExecutePlan 00042
+tendril job start RetryPlan 00042 --change-request="Fix the failing tests"
+tendril job start CreatePlan --description="Add dark mode" --project=MyProject
+```
+
+### Promptware Commands
+
+These commands are for internal use by other promptwares (e.g., a verification step that invokes a custom promptware). Do not use these to start jobs — use `tendril job start` instead.
+
+| Command | Description |
+|---------|-------------|
+| `tendril promptware run <name>` | Run a promptware directly (bypasses job service) |
 | `tendril promptware read-memory <name> <file>` | Read promptware memory |
 | `tendril promptware write-memory <name> <file>` | Write promptware memory (stdin) |
 | `tendril promptware write-tool <name> <file>` | Write promptware tool (stdin) |
@@ -191,9 +220,22 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 | `tendril project add-review-action <name>` | Add review action |
 | `tendril project remove-review-action <name> <action>` | Remove review action |
 
+## Creating Plans Interactively
+
+When the user asks you to create a plan:
+
+1. **Do the work the description implies, first.** If the description asks you to *suggest*, *research*, *investigate*, *compare*, or *decide* something, actually do that work before creating the plan. Explore the project's repos, read the relevant code, and produce concrete, specific proposals. For example, "Suggest a few dev tools we can add" means you go look at the project and come back with named tools and why — it does **not** mean creating a plan titled "Suggest dev tools to add".
+2. **Confirm scope when it's open-ended.** Briefly share what you found and what you propose, so the user can steer before you commit it to a plan.
+3. **Create the plan by starting a CreatePlan job** — do **not** run `tendril plan create` / `write-revision` yourself. Once the scope is concrete, start the job:
+   ```bash
+   tendril job start CreatePlan --description="<concrete, refined description>" --project="<project>"
+   ```
+   The CreatePlan promptware then researches, detects duplicates, and writes the full plan. Pass the specific description you developed (the concrete tools/steps you proposed), **not** the user's original vague request. Add `--priority <n>` or `--force` if appropriate. Report the job back to the user.
+
 ## Important Notes
 
 - **Never read or write `plan.yaml` directly** -- always use `tendril plan` CLI commands.
+- **`tendril job start` and `tendril job status` require the Tendril server to be running.** They communicate via HTTP to the master instance (discovered via `TENDRIL_HOME/.master`).
 - Verification statuses: `Pending`, `Pass`, `Fail`, `Skipped`.
 - Plan states: `Draft`, `Creating`, `Updating`, `Executing`, `Review`, `Failed`, `Completed`, `Skipped`, `Blocked`, `Icebox`.
-- To create a plan interactively: use `tendril plan create "<title>"` then `tendril plan write-revision <id> <<'EOF' ... EOF` to add content.
+- To create a new plan, start a CreatePlan job: `tendril job start CreatePlan --description="<description>" --project="<project>"` (see "Creating Plans Interactively"). Use the lower-level `tendril plan create` / `write-revision` commands only to edit an existing plan's content, never to create a new plan from a chat request.

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
@@ -1,4 +1,4 @@
-# UpdateProject
+# SetupProject
 
 Update a project's configuration using the Tendril CLI. Typically used after initial project creation to set up verifications and review actions based on the project's tech stack.
 

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -1,4 +1,4 @@
-codingAgent: claude
+codingAgent: codex
 jobTimeout: 30
 staleOutputTimeout: 10
 gitTimeout: 10
@@ -365,7 +365,7 @@ promptwares:
     profile: balanced
     allowedTools:
     - Bash(ivy *)
-  UpdateProject:
+  SetupProject:
     profile: deep
     allowedTools:
     - Bash(ivy *)

--- a/src/Ivy.Tendril.Test.End2End/Tests/Promptware/SetupProjectTests.cs
+++ b/src/Ivy.Tendril.Test.End2End/Tests/Promptware/SetupProjectTests.cs
@@ -4,20 +4,20 @@ using Ivy.Tendril.Test.End2End.Helpers;
 namespace Ivy.Tendril.Test.End2End.Tests.Promptware;
 
 [Collection("E2E-Promptware")]
-public class UpdateProjectTests
+public class SetupProjectTests
 {
     private readonly PromptwareTestFixture _fixture;
 
-    public UpdateProjectTests(PromptwareTestFixture fixture) => _fixture = fixture;
+    public SetupProjectTests(PromptwareTestFixture fixture) => _fixture = fixture;
 
     [Theory]
     [MemberData(nameof(AgentTestData.Agents), MemberType = typeof(AgentTestData))]
-    public async Task UpdateProject_ConfiguresVerifications(string agent)
+    public async Task SetupProject_ConfiguresVerifications(string agent)
     {
-        var cliLog = Path.Combine(_fixture.TendrilHome, $"update-project-{agent}.jsonl");
+        var cliLog = Path.Combine(_fixture.TendrilHome, $"setup-project-{agent}.jsonl");
 
         var result = await _fixture.Runner.RunAsync(
-            "UpdateProject",
+            "SetupProject",
             args: [],
             workingDir: _fixture.TestRepo.LocalClonePath,
             agent: agent,
@@ -28,7 +28,7 @@ public class UpdateProjectTests
                 ["TendrilProject"] = "E2ETest"
             });
 
-        PromptwareAssertions.AssertExitSuccess(result, $"UpdateProject ({agent})");
+        PromptwareAssertions.AssertExitSuccess(result, $"SetupProject ({agent})");
 
         // Assert expected CLI calls — should use project/verification commands
         var entries = CliLogAssertions.ReadLog(cliLog);
@@ -37,7 +37,7 @@ public class UpdateProjectTests
             e.Command.Contains("verification", StringComparison.OrdinalIgnoreCase));
 
         Assert.True(hasProjectOrVerificationCall,
-            $"UpdateProject ({agent}) should call tendril project or verification commands.\n" +
+            $"SetupProject ({agent}) should call tendril project or verification commands.\n" +
             $"Actual calls: [{string.Join(", ", entries.Select(e => $"\"{e.Command}\""))}]");
 
         CliLogAssertions.AssertAllCommandsSucceeded(cliLog);

--- a/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
@@ -459,14 +459,14 @@ public class AgentProviderFactoryTests
     [InlineData("antigravity")]
     [InlineData("copilot")]
     [InlineData("opencode")]
-    public void Resolve_UpdateProject_GetsBaseToolsForAllAgents(string agent)
+    public void Resolve_SetupProject_GetsBaseToolsForAllAgents(string agent)
     {
         var runner = CreateRunner();
         var settings = CreateSettings(
             agent,
             promptwares: new Dictionary<string, PromptwareConfig>
             {
-                ["UpdateProject"] = new() { Profile = "deep" }
+                ["SetupProject"] = new() { Profile = "deep" }
             },
             codingAgents: new List<AgentConfig>
             {
@@ -482,10 +482,10 @@ public class AgentProviderFactoryTests
 
         var jobContext = new Dictionary<string, string>
         {
-            ["PROMPTWARE_DIR"] = "/promptwares/UpdateProject"
+            ["PROMPTWARE_DIR"] = "/promptwares/SetupProject"
         };
 
-        var resolution = AgentProviderFactory.Resolve(runner, settings, "UpdateProject", jobContext: jobContext);
+        var resolution = AgentProviderFactory.Resolve(runner, settings, "SetupProject", jobContext: jobContext);
 
         Assert.Equal(agent, resolution.AgentId);
         var cli = runner.GetCli(agent);

--- a/src/Ivy.Tendril.Test/Commands/PromptwareDryRunTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareDryRunTests.cs
@@ -80,7 +80,7 @@ public class PromptwareDryRunTests : IDisposable
                 profile: balanced
               CreateIssue:
                 profile: balanced
-              UpdateProject:
+              SetupProject:
                 profile: deep
             projects:
             - name: TestProject
@@ -95,7 +95,7 @@ public class PromptwareDryRunTests : IDisposable
     private string CreateFallbackPromptwareDir()
     {
         var root = Path.Combine(_tempDir, "Promptwares");
-        foreach (var name in new[] { "CreatePlan", "ExecutePlan", "ExpandPlan", "UpdatePlan", "SplitPlan", "CreatePr", "CreateIssue", "UpdateProject" })
+        foreach (var name in new[] { "CreatePlan", "ExecutePlan", "ExpandPlan", "UpdatePlan", "SplitPlan", "CreatePr", "CreateIssue", "SetupProject" })
         {
             var dir = Path.Combine(root, name);
             Directory.CreateDirectory(dir);
@@ -294,12 +294,12 @@ public class PromptwareDryRunTests : IDisposable
         Assert.Contains("model: sonnet", output);
     }
 
-    // ==================== UpdateProject ====================
+    // ==================== SetupProject ====================
 
     [Fact]
-    public void UpdateProject_CompilesFirmware()
+    public void SetupProject_CompilesFirmware()
     {
-        var output = RunDryRun("UpdateProject", ["ProjectName=TestProject", "Instructions=Setup verifications"]);
+        var output = RunDryRun("SetupProject", ["ProjectName=TestProject", "Instructions=Setup verifications"]);
 
         Assert.Contains("ProjectName: TestProject", output);
         Assert.Contains("Instructions: Setup verifications", output);
@@ -307,9 +307,9 @@ public class PromptwareDryRunTests : IDisposable
     }
 
     [Fact]
-    public void UpdateProject_ResolvesDeepProfile()
+    public void SetupProject_ResolvesDeepProfile()
     {
-        var output = RunDryRun("UpdateProject", ["ProjectName=TestProject", "Instructions=Setup"]);
+        var output = RunDryRun("SetupProject", ["ProjectName=TestProject", "Instructions=Setup"]);
 
         Assert.Contains("model: opus", output);
         Assert.Contains("effort: max", output);
@@ -320,7 +320,7 @@ public class PromptwareDryRunTests : IDisposable
     [Fact]
     public void AllPromptwareNames_ResolveWithoutError()
     {
-        var promptwares = new[] { "CreatePlan", "ExecutePlan", "ExpandPlan", "UpdatePlan", "SplitPlan", "CreatePr", "CreateIssue", "UpdateProject" };
+        var promptwares = new[] { "CreatePlan", "ExecutePlan", "ExpandPlan", "UpdatePlan", "SplitPlan", "CreatePr", "CreateIssue", "SetupProject" };
 
         foreach (var name in promptwares)
         {

--- a/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareRunCommandTests.cs
@@ -27,11 +27,11 @@ public class PromptwareRunCommandTests : IDisposable
     {
         var settings = new PromptwareRunSettings
         {
-            Promptware = "UpdateProject",
+            Promptware = "SetupProject",
             Args = ["Setup verifications"]
         };
 
-        Assert.Equal("UpdateProject", settings.Promptware);
+        Assert.Equal("SetupProject", settings.Promptware);
         Assert.Single(settings.Args);
         Assert.Equal("Setup verifications", settings.Args[0]);
     }

--- a/src/Ivy.Tendril.Test/PromptwareHelperTests.cs
+++ b/src/Ivy.Tendril.Test/PromptwareHelperTests.cs
@@ -51,9 +51,9 @@ public class PromptwareHelperTests : IDisposable
         // Arrange
         var tempHome = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         var tempPromptwares = Path.Combine(tempHome, "Promptwares");
-        var tempUpdateProject = Path.Combine(tempPromptwares, "UpdateProject");
-        Directory.CreateDirectory(tempUpdateProject);
-        var programFile = Path.Combine(tempUpdateProject, "Program.md");
+        var tempSetupProject = Path.Combine(tempPromptwares, "SetupProject");
+        Directory.CreateDirectory(tempSetupProject);
+        var programFile = Path.Combine(tempSetupProject, "Program.md");
         File.WriteAllText(programFile, "# Program");
 
         Environment.SetEnvironmentVariable("TENDRIL_HOME", tempHome);
@@ -61,10 +61,10 @@ public class PromptwareHelperTests : IDisposable
         try
         {
             // Act
-            var result = PromptwareHelper.ResolvePromptwareFolder("UpdateProject", "");
+            var result = PromptwareHelper.ResolvePromptwareFolder("SetupProject", "");
 
             // Assert
-            Assert.Equal(tempUpdateProject, result);
+            Assert.Equal(tempSetupProject, result);
         }
         finally
         {

--- a/src/Ivy.Tendril.Test/SetupProjectPromptwareTests.cs
+++ b/src/Ivy.Tendril.Test/SetupProjectPromptwareTests.cs
@@ -6,20 +6,20 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Ivy.Tendril.Test;
 
 /// <summary>
-/// End-to-end tests for the UpdateProject promptware.
+/// End-to-end tests for the SetupProject promptware.
 /// These tests verify:
 /// 1. The promptware resolves correctly with --dry-run (firmware compilation)
 /// 2. The CLI commands the promptware would execute produce the expected config state
 ///    for various tech stacks (.NET, Node.js, Python, Rust, multi-stack)
 /// </summary>
 [Collection("TendrilHome")]
-public class UpdateProjectPromptwareTests : IDisposable
+public class SetupProjectPromptwareTests : IDisposable
 {
-    private readonly TempDirectoryFixture _tempDir = new("tendril-update-project-e2e");
+    private readonly TempDirectoryFixture _tempDir = new("tendril-setup-project-e2e");
     private readonly string _originalTendrilHome;
     private readonly string? _originalTendrilPlans;
 
-    public UpdateProjectPromptwareTests()
+    public SetupProjectPromptwareTests()
     {
         _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
         _originalTendrilPlans = Environment.GetEnvironmentVariable("TENDRIL_PLANS");
@@ -82,7 +82,7 @@ public class UpdateProjectPromptwareTests : IDisposable
             - name: CheckResult
               prompt: Verify the implementation matches the plan.
             promptwares:
-              UpdateProject:
+              SetupProject:
                 profile: deep
                 allowedTools:
                 - Read
@@ -98,14 +98,14 @@ public class UpdateProjectPromptwareTests : IDisposable
             codingAgent: claude
             """);
 
-        var promptwarePath = CreatePromptwareDir("UpdateProject");
+        var promptwarePath = CreatePromptwareDir("SetupProject");
 
         var command = new PromptwareRunCommand(CreateRunner(), NullLogger<PromptwareRunCommand>.Instance);
         var output = CaptureConsoleOutput(() =>
         {
             command.Run(new PromptwareRunSettings
             {
-                Promptware = "UpdateProject",
+                Promptware = "SetupProject",
                 DryRun = true,
                 ConfigPath = Path.Combine(_tempDir.Path, "config.yaml"),
                 PromptwarePath = promptwarePath,
@@ -129,7 +129,7 @@ public class UpdateProjectPromptwareTests : IDisposable
               - path: {repoPath}
             verifications: []
             promptwares:
-              UpdateProject:
+              SetupProject:
                 profile: deep
                 allowedTools:
                 - Read
@@ -143,14 +143,14 @@ public class UpdateProjectPromptwareTests : IDisposable
             codingAgent: claude
             """);
 
-        var promptwarePath = CreatePromptwareDir("UpdateProject");
+        var promptwarePath = CreatePromptwareDir("SetupProject");
 
         var command = new PromptwareRunCommand(CreateRunner(), NullLogger<PromptwareRunCommand>.Instance);
         var output = CaptureConsoleOutput(() =>
         {
             command.Run(new PromptwareRunSettings
             {
-                Promptware = "UpdateProject",
+                Promptware = "SetupProject",
                 DryRun = true,
                 ConfigPath = Path.Combine(_tempDir.Path, "config.yaml"),
                 PromptwarePath = promptwarePath,
@@ -425,7 +425,7 @@ public class UpdateProjectPromptwareTests : IDisposable
                 effort: max
             """);
 
-        // Simulate UpdateProject for App2 — should reuse existing verifications
+        // Simulate SetupProject for App2 — should reuse existing verifications
         var config = LoadConfig();
         var app2 = config.Settings.Projects.First(p => p.Name == "App2");
 

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -107,7 +107,7 @@ public class ProjectAgentStepView(
 
                 var handle = runner.Run(new PromptwareRunOptions
                 {
-                    Promptware = "UpdateProject",
+                    Promptware = "SetupProject",
                     Values = new Dictionary<string, string>
                     {
                         ["ProjectName"] = name,
@@ -142,7 +142,7 @@ public class ProjectAgentStepView(
                         session.Running.Set(false);
                         isStepLoading.Set(false);
                     }
-                });
+                }, progressCts.Token);
             }
             catch (Exception ex)
             {

--- a/src/Ivy.Tendril/Commands/PromptwareReadMemoryCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareReadMemoryCommand.cs
@@ -6,7 +6,7 @@ namespace Ivy.Tendril.Commands;
 
 public class PromptwareReadMemorySettings : CommandSettings
 {
-    [Description("Promptware name (e.g., UpdateProject)")]
+    [Description("Promptware name (e.g., SetupProject)")]
     [CommandArgument(0, "<name>")]
     public string Name { get; set; } = "";
 

--- a/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareRunCommand.cs
@@ -11,7 +11,7 @@ namespace Ivy.Tendril.Commands;
 
 public class PromptwareRunSettings : CommandSettings
 {
-    [Description("Promptware name (e.g., UpdateProject)")]
+    [Description("Promptware name (e.g., SetupProject)")]
     [CommandArgument(0, "<promptware>")]
     public string Promptware { get; set; } = "";
 

--- a/src/Ivy.Tendril/Constants.cs
+++ b/src/Ivy.Tendril/Constants.cs
@@ -69,7 +69,7 @@ public static class Constants
         [JobTypes.CreatePr] = Colors.Green,
         [JobTypes.CreateIssue] = Colors.Rose,
         [JobTypes.RetryPlan] = Colors.Orange,
-        [JobTypes.UpdateProject] = Colors.Slate,
+        [JobTypes.SetupProject] = Colors.Slate,
         [JobTypes.SyncRepo] = Colors.Amber
     };
 
@@ -86,12 +86,12 @@ public static class Constants
         public const string SplitPlan = "SplitPlan";
         public const string CreatePr = "CreatePr";
         public const string CreateIssue = "CreateIssue";
-        public const string UpdateProject = "UpdateProject";
+        public const string SetupProject = "SetupProject";
         public const string SyncRepo = "SyncRepo";
 
         public static readonly HashSet<string> BuiltIn = new(StringComparer.OrdinalIgnoreCase)
         {
-            CreatePlan, ExecutePlan, RetryPlan, ExpandPlan, UpdatePlan, SplitPlan, CreatePr, CreateIssue, UpdateProject, SyncRepo
+            CreatePlan, ExecutePlan, RetryPlan, ExpandPlan, UpdatePlan, SplitPlan, CreatePr, CreateIssue, SetupProject, SyncRepo
         };
     }
 }

--- a/src/Ivy.Tendril/Models/JobArgs.cs
+++ b/src/Ivy.Tendril/Models/JobArgs.cs
@@ -10,7 +10,7 @@ namespace Ivy.Tendril.Models;
 [JsonDerivedType(typeof(SplitPlanArgs), "SplitPlan")]
 [JsonDerivedType(typeof(CreatePrArgs), "CreatePr")]
 [JsonDerivedType(typeof(CreateIssueArgs), "CreateIssue")]
-[JsonDerivedType(typeof(UpdateProjectArgs), "UpdateProject")]
+[JsonDerivedType(typeof(SetupProjectArgs), "SetupProject")]
 [JsonDerivedType(typeof(SyncRepoArgs), "SyncRepo")]
 public abstract record JobArgsBase
 {
@@ -95,10 +95,10 @@ public record CreateIssueArgs(
     public override string PlanFolder => FolderPath;
 }
 
-public record UpdateProjectArgs(
+public record SetupProjectArgs(
     string FolderPath) : JobArgsBase
 {
-    public override string Type => Constants.JobTypes.UpdateProject;
+    public override string Type => Constants.JobTypes.SetupProject;
     public override string PlanFolder => FolderPath;
 }
 

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -71,7 +71,7 @@ Autonomous agents that handle each pipeline stage. Each has a `Program.md` (inst
 | **RetryPlan** | Applies reviewer feedback to an already-executed plan's worktree |
 | **CreatePr** | Pushes branches, creates GitHub PRs, applies merge rules |
 | **CreateIssue** | Creates GitHub issues from plans |
-| **UpdateProject** | Sets up project verifications and review actions |
+| **SetupProject** | Sets up project verifications and review actions |
 
 ## Plan Structure
 

--- a/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
@@ -1,4 +1,4 @@
-# UpdateProject
+# SetupProject
 
 Update a project's configuration using the Tendril CLI. Typically used after initial project creation to set up verifications and review actions based on the project's tech stack.
 

--- a/src/Ivy.Tendril/Services/AgentPromptCompiler.cs
+++ b/src/Ivy.Tendril/Services/AgentPromptCompiler.cs
@@ -18,8 +18,8 @@ public static class AgentPromptCompiler
         var template = Template.Value;
         if (template == null) return null;
 
-        var tendrilHome = config.TendrilHome.Replace('\\', '/');
-        var planFolder = config.PlanFolder.Replace('\\', '/');
+        var tendrilHome = config.TendrilHome.Replace('\\', '/').TrimEnd('/');
+        var planFolder = config.PlanFolder.Replace('\\', '/').TrimEnd('/');
 
         return template
             .Replace("{TENDRIL_HOME}", tendrilHome)

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -949,7 +949,7 @@ public class PlanDatabaseService : IPlanDatabaseService
             Constants.JobTypes.CreateIssue => new CreateIssueArgs(
                 args[0],
                 GetLegacyArg(args, "-Repo") ?? ""),
-            Constants.JobTypes.UpdateProject => new UpdateProjectArgs(args[0]),
+            Constants.JobTypes.SetupProject => new SetupProjectArgs(args[0]),
             _ => null
         };
 

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -109,7 +109,7 @@ promptwares:
     profile: balanced
   CreateIssue:
     profile: balanced
-  UpdateProject:
+  SetupProject:
     profile: deep
 
 # Projects — add your projects here. Each project groups repos, verifications, and context.

--- a/src/Ivy.Tendril/pack-promptwares.ps1
+++ b/src/Ivy.Tendril/pack-promptwares.ps1
@@ -24,7 +24,7 @@ $shippedTools = @{
     'SplitPlan'   = @()
     'UpdatePlan'  = @()
     'CreateIssue' = @()
-    'UpdateProject' = @()
+    'SetupProject' = @()
 }
 
 foreach ($pw in $shippedTools.Keys) {


### PR DESCRIPTION
Renames the `UpdateProject` promptware to `SetupProject` across the codebase:

- **Code**: `JobTypes` constant, JSON discriminator + `SetupProjectArgs` record, color map, `BuiltIn` set, `PlanDatabaseService` parse switch, onboarding runtime reference.
- **Promptware folders** (renamed via git mv, history preserved): both `src/Ivy.Tendril/Promptwares/` and `src/Ivy.Tendril.TeamIvyConfig/Promptwares/` trees + Program.md titles.
- **Config / packaging / docs**: config.yaml, example.config.yaml, pack-promptwares.ps1, AgentPrompt.md, AGENTS.md, command descriptions.
- **Tests**: renamed test files, classes, methods and string literals.

Note: the job-type/JSON discriminator string changed, so existing job rows of the old type in a live DB won't deserialize (clean rename, no back-compat alias).

Also bundles in-progress working-tree changes: 1.1.1 release notes + version bump, AgentPromptCompiler tweak, and a cancellation-token fix in ProjectAgentStepView.

Build: clean (0 warnings/0 errors). Unit tests pass.