### PR TITLE
Add stackHash property to project config + 'project set' CLI

### DIFF
--- a/src/Ivy.Tendril.Test/ProjectCommandTests.cs
+++ b/src/Ivy.Tendril.Test/ProjectCommandTests.cs
@@ -125,6 +125,21 @@ verifications: []
         Assert.Equal("New context", reloaded.Settings.Projects[0].Context);
     }
 
+    [Fact]
+    public void SetProject_UpdatesStackHash()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig { Name = "Test", StackHash = "abc123" });
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        config2.Settings.Projects[0].StackHash = "def456";
+        config2.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal("def456", reloaded.Settings.Projects[0].StackHash);
+    }
+
     // --- Add/Remove Repo ---
 
     [Fact]

--- a/src/Ivy.Tendril/Commands/ProjectCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectCommand.cs
@@ -56,13 +56,13 @@ public class ProjectRemoveSettings : CommandSettings
 
 public class ProjectSetSettings : CommandSettings
 {
-    private static readonly string[] ValidFields = ["name", "color", "context"];
+    private static readonly string[] ValidFields = ["name", "color", "context", "stackhash"];
 
     [Description("Project name")]
     [CommandArgument(0, "<name>")]
     public string Name { get; set; } = "";
 
-    [Description("Field name (name, color, context)")]
+    [Description("Field name (name, color, context, stackHash)")]
     [CommandArgument(1, "<field>")]
     public string Field { get; set; } = "";
 
@@ -316,6 +316,8 @@ public class ProjectGetCommand : Command<ProjectGetSettings>
             AnsiConsole.MarkupLine($"  Color: {project.Color.EscapeMarkup()}");
         if (!string.IsNullOrEmpty(project.Context))
             AnsiConsole.MarkupLine($"  Context: {project.Context.EscapeMarkup()}");
+        if (!string.IsNullOrEmpty(project.StackHash))
+            AnsiConsole.MarkupLine($"  StackHash: {project.StackHash.EscapeMarkup()}");
 
         if (project.Repos.Count > 0)
         {
@@ -431,8 +433,11 @@ public class ProjectSetCommand : Command<ProjectSetSettings>
             case "context":
                 match.Context = settings.Value;
                 break;
+            case "stackhash":
+                match.StackHash = settings.Value;
+                break;
             default:
-                throw new ArgumentException($"Unknown field: {settings.Field}. Valid fields: name, color, context");
+                throw new ArgumentException($"Unknown field: {settings.Field}. Valid fields: name, color, context, stackHash");
         }
 
         config.SaveSettings();

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -30,6 +30,7 @@ public record ProjectConfig
     public List<RepoRef> Repos { get; set; } = new();
     public List<ProjectVerificationRef> Verifications { get; set; } = new();
     public string Context { get; set; } = "";
+    public string? StackHash { get; set; }
     public List<ReviewActionConfig> ReviewActions { get; set; } = new();
     public List<PromptwareHookConfig> Hooks { get; set; } = new();
     public List<string> BuildDependencies { get; set; } = new();


### PR DESCRIPTION
Adds a `stackHash` string to project configuration and exposes it through the existing `tendril project set` command.

- **Model**: `ProjectConfig.StackHash` (nullable string, omitted from YAML until set).
- **CLI**: `tendril project set <project> stackHash <value>` — added to valid fields + switch case; `project get` now displays it.
- **Test**: `SetProject_UpdatesStackHash` round-trip.

Verified: build clean, ProjectCommandTests 18/18 pass, and end-to-end CLI run sets/persists `stackHash` in config.yaml.