### PR TITLE
Add project-analyzer command + stackHash telemetry; SetupProject integration

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
@@ -16,12 +16,17 @@ Project and verification configuration is available via `tendril project list` a
 - **CLI-only modifications.** You MUST use `tendril` CLI commands to modify configuration. Never edit config.yaml directly.
 - **Reuse existing verifications.** Before creating a new verification, check if a suitable one already exists with `tendril verification list`. Verifications are shared across projects.
 - **Stack detection.** Inspect the project's repositories to determine the tech stack.
-  - Look for configuration files: `package.json`, `*.csproj`, `Cargo.toml`, `go.mod`, `requirements.txt`, `pyproject.toml`, etc.
-  - If a `package.json` exists, identify the package manager: check if `pnpm-lock.yaml` is present, or if the `packageManager` field in `package.json` specifies `pnpm`. If not, check for `yarn.lock`. Otherwise, assume `npm`.
-  - Identify if the frontend uses Vite or Vite+ (`vite-plus`): check if `vite-plus` is listed in `package.json` dependencies or devDependencies, or if scripts call `vp`. If it uses Vite+ (`vite-plus`), use `vp` commands (e.g. `vp dev`). Otherwise, use `npm`/`pnpm`/`yarn` commands.
+    - Look for configuration files: `package.json`, `*.csproj`, `Cargo.toml`, `go.mod`, `requirements.txt`, `pyproject.toml`, etc.
+    - If a `package.json` exists, identify the package manager: check if `pnpm-lock.yaml` is present, or if the `packageManager` field in `package.json` specifies `pnpm`. If not, check for `yarn.lock`. Otherwise, assume `npm`.
+    - Identify if the frontend uses Vite or Vite+ (`vite-plus`): check if `vite-plus` is listed in `package.json` dependencies or devDependencies, or if scripts call `vp`. If it uses Vite+ (`vite-plus`), use `vp` commands (e.g. `vp dev`). Otherwise, use `npm`/`pnpm`/`yarn` commands.
 - **Keep it minimal.** Only add verifications and review actions that are appropriate for the detected stack.
 
 ## Available CLI Commands
+
+### Stack analysis
+```bash
+tendril project-analyzer <repo-path>   # prints a trimmed YAML stack report (supports . and relative paths)
+```
 
 ### Verifications (global definitions)
 ```bash
@@ -46,15 +51,20 @@ tendril project add-review-action <project-name> <name> --command="<cmd>" --cond
 tendril project remove-review-action <project-name> <name>
 ```
 
+### Stack hash
+```bash
+tendril project set <project-name> stackHash "<hash>"
+```
+
 ## Execution Steps
 
 ### 1. Gather Context
 
 1. Run `tendril verification list` to see existing global verification definitions.
 2. Run `tendril project list` to confirm the project exists.
-3. Read the project's repo(s) to detect the tech stack:
-   - List root files in each repo path to find build/config files
-   - Identify the primary stack(s): .NET, JavaScript/TypeScript, Python, Rust, Go, etc.
+3. Detect the tech stack of each repo. Prefer the analyzer over manual inspection:
+    - Run `tendril project-analyzer <repo-path>` (the path supports `.` and relative paths) for each repo.
+    - Use this report as the authoritative stack description for both the verifications/review actions below and the stack hash in Step 4.
 
 ### 2. Setup Verifications
 
@@ -65,7 +75,7 @@ For each detected tech stack, ensure the following verification definitions exis
 - Build: `DotnetBuild`, `NpmBuild`, `PythonBuild`, `RustBuild`, `GoBuild`
 - Test: `DotnetTest`, `NpmTest`, `PythonTest`, `RustTest`, `GoTest`
 
-**Standard verification prompts by stack:**
+**Example verification prompts by stack:**
 
 | Stack | Verification | Prompt guidance |
 |-------|-------------|-----------------|
@@ -124,9 +134,9 @@ Inspect each repo to determine how to run the application. For website projects,
 - **.NET project** with a runnable entry point: `dotnet run --project Worktrees/<RepoName>/<path-to-project> --browse --find-available-port`
 - **Vite+ (`vite-plus`) project**: `cd Worktrees/<RepoName>/<path-to-frontend> && vp install && vp dev`
 - **Vite project**:
-  - Under `pnpm`: `cd Worktrees/<RepoName>/<path-to-frontend> && pnpm install && pnpm run dev -- --open`
-  - Under `npm`: `cd Worktrees/<RepoName>/<path-to-frontend> && npm install && npm run dev -- --open`
-  - Under `yarn`: `cd Worktrees/<RepoName>/<path-to-frontend> && yarn install && yarn run dev -- --open`
+    - Under `pnpm`: `cd Worktrees/<RepoName>/<path-to-frontend> && pnpm install && pnpm run dev -- --open`
+    - Under `npm`: `cd Worktrees/<RepoName>/<path-to-frontend> && npm install && npm run dev -- --open`
+    - Under `yarn`: `cd Worktrees/<RepoName>/<path-to-frontend> && yarn install && yarn run dev -- --open`
 - **Angular CLI**: `cd Worktrees/<RepoName>/<path> && npm install && ng serve --open` (adapt for `pnpm`/`yarn` if detected)
 - **Other Node.js app** (no open support): `cd Worktrees/<RepoName>/<path> && npm install && npm run dev` (adapt package manager as detected)
 - **Python app**: `cd Worktrees/<RepoName> && python -m pip install -r requirements.txt && python -m <module>` (or `flask run` / `uv run ...` / `poetry run ...` if detected)
@@ -143,9 +153,58 @@ tendril project add-review-action <project-name> "<name>" \
   --condition="Test-Path \"Worktrees/<RepoName>/<path>\""
 ```
 
-### 4. Summary
+### 4. Set the Stack Hash
+
+Derive a single-line **Stack Descriptor Hash (SDH)** from the `tendril project-analyzer` report(s) you gathered in Step 1 and persist it on the project. The SDH is a canonical, similarity-preserving signature of the project's significant layers, the frameworks that build each layer, and its test technology: same stack → identical hash, similar stacks → similar strings. **The hash contains no spaces anywhere.**
+
+Map the analyzer YAML to the hash: each non-auxiliary, non-workspace-root `component` becomes a layer (use its dominant `language` and its `framework`/`orm`/`database`/`styling`/`testing`-category `technologies`); `infrastructure` feeds the `infra` segment; testing technologies across all components collapse into the trailing `test` segment. Ignore components flagged `isAuxiliary` and pure `isWorkspaceRoot` aggregators. (The analyzer already drops low-confidence and incidental signals, so everything in the report is fair game.)
+
+**Grammar**
+```
+hash    = segment ( "|" segment )*
+segment = role [ "(" lang ")" ] ":" token ( "+" token )*
+role    = "fe" | "mobile" | "desktop" | "be" | "fs" | "lib" | "db" | "infra" | "test"
+lang    = canonical language slug (omit for db/infra/test)
+token   = canonical technology slug
+```
+
+**Rules**
+
+1. **Fixed layer order** (omit absent layers): `fe, mobile, desktop, be, fs, lib, db, infra, test`. Use `fs` only when a single framework genuinely spans client+server (Rails, Laravel, Django MVC, Phoenix, Blazor Server, full-stack Next.js); otherwise split into `fe`+`be`. Use `lib` for a library/SDK/CLI repo with no app layer.
+2. **Defining tech only** — cap each layer to these slots (fewer is fine); slot order = token order:
+    - `fe`: ui-framework, meta-framework/builder, styling-system
+    - `mobile`: framework — `desktop`: framework
+    - `be`: web-framework, orm — `fs`: framework, orm
+    - `lib`: (none — language only)
+    - `db`: engines (most-central first) — `infra`: container/orchestration/iac — `test`: test frameworks
+      Drop icon sets, validation, state, routers, component kits, loggers, monitoring, analytics, CI providers, hosting brands. Include a `db` token only when backed by a real driver dependency (`psycopg`, `pg`, `mongoose`, a redis client), a compose/infra service, or a confident detection — never from an env-var placeholder or a default cache-driver config alone.
+3. **Token order:** by the slot order above (base/primary first), then alphabetical within a slot; `db` and `test` are alphabetical (no primary).
+4. **Base before meta** — a meta-framework implies and is preceded by its base, both included: `react+next`, `react+remix`, `react+gatsby`, `vue+nuxt`, `svelte+sveltekit`, `solid+solidstart`, `reactnative+expo`.
+5. **Normalize to canonical slugs:** lowercase, drop version, remove non-alphanumeric chars, then apply synonyms:
+    - Frameworks: Next.js→`next`, Nuxt→`nuxt`, SvelteKit→`sveltekit`, ASP.NET Core→`aspnetcore`, Entity Framework Core→`efcore`, React Native→`reactnative`, Spring Boot→`spring`, Ruby on Rails→`rails`, Express→`express`, NestJS→`nestjs`, Tailwind CSS→`tailwind`.
+    - Languages: TypeScript→`ts`, JavaScript→`js`, Python→`py`, Ruby→`rb`, Go→`go`, Rust→`rs`, Java→`java`, Kotlin→`kt`, C#→`cs`, PHP→`php`, Swift→`swift`, Dart→`dart`, Elixir→`ex`.
+    - DB: PostgreSQL→`postgres`, MySQL→`mysql`, MongoDB→`mongodb`, SQL Server→`mssql`, Redis→`redis`, SQLite→`sqlite`.
+6. **Test layer:** collect significant test frameworks across all layers into ONE trailing `test:` segment, alphabetical, deduped. Omit if none.
+7. **Multiplicity & determinism:** one segment per role. Multiple frontends/backends → merge significant tokens (deduped, ordered by Rules 3–4). Never emit versions, counts, paths, or spaces. Same input → identical output.
+
+**Reference examples**
+```
+fe(ts):react+next+tailwind|be(py):fastapi+sqlmodel|db:postgres|test:playwright+pytest
+fe(ts):react+vite+tailwind|be(py):fastapi|db:postgres+redis|test:vitest
+fs(py):django|db:postgres|test:pytest
+fe(cs):blazor|be(cs):aspnetcore+efcore|db:mssql|test:xunit
+be(go):gin+gorm|db:postgres
+mobile(dart):flutter|db:firebase
+lib(py)|test:pytest
+```
+
+Self-check before persisting: segments in Rule-1 order; absent layers omitted; only defining tokens, ordered by Rules 3–4 (base before meta); all slugs normalized; one alphabetical `test:` segment or none; **no spaces anywhere**. Then save it:
+```bash
+tendril project set <project-name> stackHash "<hash>"
+```
+
+### 5. Summary
 
 Print a summary of what was configured:
-- Verifications added (new global definitions + project references)
+- Verifications added
 - Review actions added
-- Any issues encountered

--- a/src/Ivy.Tendril.Test/BugReportServiceConfigTests.cs
+++ b/src/Ivy.Tendril.Test/BugReportServiceConfigTests.cs
@@ -99,4 +99,43 @@ projects:
         var config = Assert.Single(files, f => f.ZipEntryPath == "config.sanitized.yaml");
         Assert.DoesNotContain("secret", ReadContent(config));
     }
+
+    [Fact]
+    public void CollectFilesForJob_Includes_Plan_Context_And_Worktrees_Manifest()
+    {
+        var service = CreateService("codingAgent: claude\n");
+
+        // A plan folder owns the job when its Logs/ holds a "<jobId>-<action>.md" log.
+        var planFolder = Path.Combine(_tempDir.Path, "Plans", "00123-Demo");
+        var logsDir = Path.Combine(planFolder, "Logs");
+        Directory.CreateDirectory(logsDir);
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), "id: 123\nproject: Demo\n");
+        File.WriteAllText(Path.Combine(logsDir, "00123-ExecutePlan.md"), "# execute log");
+        Directory.CreateDirectory(Path.Combine(planFolder, "Worktrees", "Ivy-Framework"));
+
+        var files = service.CollectFilesForJob("123");
+
+        static string Entry(BugReportService.BugReportFile f) => f.ZipEntryPath.Replace('\\', '/');
+
+        Assert.Contains(files, f => Entry(f) == "plan.yaml");
+        Assert.Contains(files, f => Entry(f) == "Logs/00123-ExecutePlan.md");
+
+        // worktrees.txt lists each worktree dir's identity (git fields are "(unknown)" for a non-repo dir).
+        var manifest = Assert.Single(files, f => f.ZipEntryPath == "worktrees.txt");
+        Assert.Contains("Ivy-Framework", ReadContent(manifest));
+
+        // The worktree trees themselves stay excluded for size.
+        Assert.DoesNotContain(files, f => Entry(f).StartsWith("Worktrees/"));
+    }
+
+    [Fact]
+    public void CollectFilesForJob_Without_Plan_Omits_Plan_Context()
+    {
+        var service = CreateService("codingAgent: claude\n");
+
+        var files = service.CollectFilesForJob("999");
+
+        Assert.DoesNotContain(files, f => f.ZipEntryPath == "plan.yaml");
+        Assert.DoesNotContain(files, f => f.ZipEntryPath == "worktrees.txt");
+    }
 }

--- a/src/Ivy.Tendril.Test/Commands/ProjectAnalyzerCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/ProjectAnalyzerCommandTests.cs
@@ -1,0 +1,63 @@
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test.Commands;
+
+public class ProjectAnalyzerCommandTests
+{
+    private static string WriteFile(string dir, string relativePath, string content)
+    {
+        var full = Path.Combine(dir, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    [Fact]
+    public async Task AnalyzeToYaml_DetectsNodeStack_AndEmitsTrimmedReport()
+    {
+        using var tempDir = new TempDirectoryFixture("tendril-analyzer-test");
+
+        WriteFile(tempDir.Path, "package.json", """
+            {
+              "name": "demo-app",
+              "dependencies": { "react": "^18.2.0", "react-dom": "^18.2.0" },
+              "devDependencies": { "vite": "^5.0.0", "typescript": "^5.4.0", "vitest": "^1.4.0" }
+            }
+            """);
+        WriteFile(tempDir.Path, "tsconfig.json", "{ \"compilerOptions\": { \"strict\": true } }");
+        WriteFile(tempDir.Path, "src/main.tsx", "export const App = () => null;\n");
+
+        var yaml = await ProjectAnalyzerCommand.AnalyzeToYamlAsync(tempDir.Path);
+
+        Assert.False(string.IsNullOrWhiteSpace(yaml));
+
+        // Well-formed and round-trips through the deserializer.
+        var parsed = YamlHelper.Deserializer.Deserialize<Dictionary<string, object>>(yaml);
+        Assert.Contains("components", parsed.Keys);
+
+        // React is a defining framework detected from the dependency — must appear.
+        Assert.Contains("React", yaml);
+
+        // Incidental/noise fields from the full analyzer report must NOT be in the trimmed output.
+        Assert.DoesNotContain("manifests", yaml);
+        Assert.DoesNotContain("sizeBytes", yaml);
+        Assert.DoesNotContain("metadata", yaml);
+        Assert.DoesNotContain("evidence", yaml);
+
+        // Low-confidence signals are filtered out, so confidence values are only medium/high.
+        Assert.DoesNotContain("confidence: low", yaml);
+    }
+
+    [Fact]
+    public async Task AnalyzeToYaml_EmptyFolder_ReturnsWellFormedYaml()
+    {
+        using var tempDir = new TempDirectoryFixture("tendril-analyzer-empty");
+
+        var yaml = await ProjectAnalyzerCommand.AnalyzeToYamlAsync(tempDir.Path);
+
+        // No throw, and the result is valid YAML (possibly just "{}").
+        var parsed = YamlHelper.Deserializer.Deserialize<Dictionary<string, object>>(yaml ?? "");
+        Assert.NotNull(parsed);
+    }
+}

--- a/src/Ivy.Tendril/Commands/ProjectAnalyzerCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectAnalyzerCommand.cs
@@ -1,0 +1,147 @@
+using System.ComponentModel;
+using Ivy.StackAnalyzer;
+using Ivy.Tendril.Helpers;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class ProjectAnalyzerSettings : CommandSettings
+{
+    [Description("Folder to analyze (supports . and relative paths)")]
+    [CommandArgument(0, "<folderpath>")]
+    public string FolderPath { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(FolderPath, "folderpath");
+    }
+}
+
+/// <summary>
+///     Analyzes a folder with Ivy.StackAnalyzer and prints a trimmed YAML stack report.
+///     The output is deliberately minimal — only the fields the SetupProject promptware
+///     needs to derive a stack hash and choose verifications/review actions. Incidental
+///     libraries, CI providers, hosting brands, analytics, etc. and low-confidence signals
+///     are dropped so they never enter the stack hash.
+/// </summary>
+public sealed class ProjectAnalyzerCommand : AsyncCommand<ProjectAnalyzerSettings>
+{
+    // Technology categories that define a stack. Everything else is incidental noise.
+    private static readonly HashSet<TechCategory> DefiningCategories =
+    [
+        TechCategory.Framework,
+        TechCategory.Build,
+        TechCategory.Styling,
+        TechCategory.Orm,
+        TechCategory.Database,
+        TechCategory.Testing,
+        TechCategory.Iac,
+    ];
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, ProjectAnalyzerSettings settings, CancellationToken cancellationToken)
+    {
+        var path = PathHelper.ResolvePath(settings.FolderPath);
+        if (!Directory.Exists(path))
+        {
+            AnsiConsole.MarkupLine($"[red]Folder not found:[/] {path.EscapeMarkup()}");
+            return 1;
+        }
+
+        Console.Write(await AnalyzeToYamlAsync(path, cancellationToken));
+        return 0;
+    }
+
+    /// <summary>
+    ///     Analyzes an absolute folder path and returns the trimmed YAML stack report.
+    ///     Exposed for testing; the command resolves/validates the path before calling this.
+    /// </summary>
+    public static async Task<string> AnalyzeToYamlAsync(string resolvedPath, CancellationToken cancellationToken = default)
+    {
+        var detection = await new Analyzer().AnalyzeAsync(resolvedPath, cancellationToken);
+
+        var components = detection.Components
+            .Select(ToComponentReport)
+            .Where(c => c is not null)
+            .Select(c => c!)
+            .ToList();
+
+        var infrastructure = detection.Infrastructure
+            .Select(i => new InfraReport { Kind = i.Kind, Category = Slug(i.Category) })
+            .ToList();
+
+        var report = new StackReport
+        {
+            Languages = ProjectLanguages(detection.Languages),
+            Components = components.Count > 0 ? components : null,
+            Infrastructure = infrastructure.Count > 0 ? infrastructure : null,
+        };
+
+        return YamlHelper.SerializerCompact.Serialize(report);
+    }
+
+    private static ComponentReport? ToComponentReport(Ivy.StackAnalyzer.Component component)
+    {
+        var technologies = component.Technologies
+            .Where(t => t.Confidence != Confidence.Low && DefiningCategories.Contains(t.Category))
+            .Select(t => new TechReport { Name = t.Name, Category = Slug(t.Category), Confidence = Slug(t.Confidence) })
+            .ToList();
+
+        var languages = ProjectLanguages(component.Languages);
+
+        // Drop aggregator/empty components that carry no stack signal at all.
+        if (technologies.Count == 0 && languages is null)
+            return null;
+
+        return new ComponentReport
+        {
+            RelativePath = component.RelativePath,
+            IsWorkspaceRoot = component.IsWorkspaceRoot ? true : null,
+            IsAuxiliary = component.IsAuxiliary ? true : null,
+            Languages = languages,
+            Technologies = technologies.Count > 0 ? technologies : null,
+        };
+    }
+
+    // Significant languages (code + markup), dominant first. Data/prose (JSON, Markdown) dropped.
+    private static List<string>? ProjectLanguages(IReadOnlyList<LanguageStat> languages)
+    {
+        var list = languages
+            .Where(l => l.Type is LanguageType.Programming or LanguageType.Markup)
+            .OrderByDescending(l => l.Percent)
+            .Select(l => l.Name)
+            .ToList();
+        return list.Count > 0 ? list : null;
+    }
+
+    private static string Slug(Enum value) => value.ToString().ToLowerInvariant();
+
+    private sealed class StackReport
+    {
+        public List<string>? Languages { get; set; }
+        public List<ComponentReport>? Components { get; set; }
+        public List<InfraReport>? Infrastructure { get; set; }
+    }
+
+    private sealed class ComponentReport
+    {
+        public string RelativePath { get; set; } = "";
+        public bool? IsWorkspaceRoot { get; set; }
+        public bool? IsAuxiliary { get; set; }
+        public List<string>? Languages { get; set; }
+        public List<TechReport>? Technologies { get; set; }
+    }
+
+    private sealed class TechReport
+    {
+        public string Name { get; set; } = "";
+        public string Category { get; set; } = "";
+        public string Confidence { get; set; } = "";
+    }
+
+    private sealed class InfraReport
+    {
+        public string Kind { get; set; } = "";
+        public string Category { get; set; } = "";
+    }
+}

--- a/src/Ivy.Tendril/Helpers/GitHelper.cs
+++ b/src/Ivy.Tendril/Helpers/GitHelper.cs
@@ -82,7 +82,7 @@ public static class GitHelper
         return null;
     }
 
-    private static string? RunGitCapture(string? workingDir, string args, int timeoutMs)
+    internal static string? RunGitCapture(string? workingDir, string args, int timeoutMs)
     {
         try
         {

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -42,6 +42,7 @@
 
   <!-- PackageReferences -->
   <ItemGroup>
+    <PackageReference Include="Ivy.StackAnalyzer" Version="1.0.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.4.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
@@ -54,7 +55,7 @@
     <PackageReference Include="Spectre.Console.Cli" Version="1.0.0-alpha.0.16" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
-    <PackageReference Include="YamlDotNet" Version="16.3.0" />
+    <PackageReference Include="YamlDotNet" Version="17.0.0" />
   </ItemGroup>
 
   <!-- Ivy Framework (source) -->

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -338,7 +338,7 @@ public class Program
         {
             "doctor", "db-version", "db-migrate", "db-reset",
             "update-promptwares", "job", "plan", "promptware",
-            "trash", "verification", "project", "models",
+            "trash", "verification", "project", "project-analyzer", "models",
             "version", "--version", "report-bug", "reset", "update",
             "--help", "-h", "run"
         };
@@ -446,6 +446,10 @@ public class Program
             // Doctor command
             config.AddCommand<DoctorCliCommand>("doctor")
                 .WithDescription("System health check");
+
+            // Project analyzer command
+            config.AddCommand<ProjectAnalyzerCommand>("project-analyzer")
+                .WithDescription("Analyze a folder and print a YAML stack report");
 
             // Run command
             config.AddCommand<RunCommand>("run")

--- a/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
@@ -23,6 +23,11 @@ Project and verification configuration is available via `tendril project list` a
 
 ## Available CLI Commands
 
+### Stack analysis
+```bash
+tendril project-analyzer <repo-path>   # prints a trimmed YAML stack report (supports . and relative paths)
+```
+
 ### Verifications (global definitions)
 ```bash
 tendril verification list
@@ -46,15 +51,20 @@ tendril project add-review-action <project-name> <name> --command="<cmd>" --cond
 tendril project remove-review-action <project-name> <name>
 ```
 
+### Stack hash
+```bash
+tendril project set <project-name> stackHash "<hash>"
+```
+
 ## Execution Steps
 
 ### 1. Gather Context
 
 1. Run `tendril verification list` to see existing global verification definitions.
 2. Run `tendril project list` to confirm the project exists.
-3. Read the project's repo(s) to detect the tech stack:
-   - List root files in each repo path to find build/config files
-   - Identify the primary stack(s): .NET, JavaScript/TypeScript, Python, Rust, Go, etc.
+3. Detect the tech stack of each repo. Prefer the analyzer over manual inspection:
+   - Run `tendril project-analyzer <repo-path>` (the path supports `.` and relative paths) for each repo. 
+   - Use this report as the authoritative stack description for both the verifications/review actions below and the stack hash in Step 4.
 
 ### 2. Setup Verifications
 
@@ -65,7 +75,7 @@ For each detected tech stack, ensure the following verification definitions exis
 - Build: `DotnetBuild`, `NpmBuild`, `PythonBuild`, `RustBuild`, `GoBuild`
 - Test: `DotnetTest`, `NpmTest`, `PythonTest`, `RustTest`, `GoTest`
 
-**Standard verification prompts by stack:**
+**Example verification prompts by stack:**
 
 | Stack | Verification | Prompt guidance |
 |-------|-------------|-----------------|
@@ -143,9 +153,58 @@ tendril project add-review-action <project-name> "<name>" \
   --condition="Test-Path \"Worktrees/<RepoName>/<path>\""
 ```
 
-### 4. Summary
+### 4. Set the Stack Hash
+
+Derive a single-line **Stack Descriptor Hash (SDH)** from the `tendril project-analyzer` report(s) you gathered in Step 1 and persist it on the project. The SDH is a canonical, similarity-preserving signature of the project's significant layers, the frameworks that build each layer, and its test technology: same stack → identical hash, similar stacks → similar strings. **The hash contains no spaces anywhere.**
+
+Map the analyzer YAML to the hash: each non-auxiliary, non-workspace-root `component` becomes a layer (use its dominant `language` and its `framework`/`orm`/`database`/`styling`/`testing`-category `technologies`); `infrastructure` feeds the `infra` segment; testing technologies across all components collapse into the trailing `test` segment. Ignore components flagged `isAuxiliary` and pure `isWorkspaceRoot` aggregators. (The analyzer already drops low-confidence and incidental signals, so everything in the report is fair game.)
+
+**Grammar**
+```
+hash    = segment ( "|" segment )*
+segment = role [ "(" lang ")" ] ":" token ( "+" token )*
+role    = "fe" | "mobile" | "desktop" | "be" | "fs" | "lib" | "db" | "infra" | "test"
+lang    = canonical language slug (omit for db/infra/test)
+token   = canonical technology slug
+```
+
+**Rules**
+
+1. **Fixed layer order** (omit absent layers): `fe, mobile, desktop, be, fs, lib, db, infra, test`. Use `fs` only when a single framework genuinely spans client+server (Rails, Laravel, Django MVC, Phoenix, Blazor Server, full-stack Next.js); otherwise split into `fe`+`be`. Use `lib` for a library/SDK/CLI repo with no app layer.
+2. **Defining tech only** — cap each layer to these slots (fewer is fine); slot order = token order:
+   - `fe`: ui-framework, meta-framework/builder, styling-system
+   - `mobile`: framework — `desktop`: framework
+   - `be`: web-framework, orm — `fs`: framework, orm
+   - `lib`: (none — language only)
+   - `db`: engines (most-central first) — `infra`: container/orchestration/iac — `test`: test frameworks
+   Drop icon sets, validation, state, routers, component kits, loggers, monitoring, analytics, CI providers, hosting brands. Include a `db` token only when backed by a real driver dependency (`psycopg`, `pg`, `mongoose`, a redis client), a compose/infra service, or a confident detection — never from an env-var placeholder or a default cache-driver config alone.
+3. **Token order:** by the slot order above (base/primary first), then alphabetical within a slot; `db` and `test` are alphabetical (no primary).
+4. **Base before meta** — a meta-framework implies and is preceded by its base, both included: `react+next`, `react+remix`, `react+gatsby`, `vue+nuxt`, `svelte+sveltekit`, `solid+solidstart`, `reactnative+expo`.
+5. **Normalize to canonical slugs:** lowercase, drop version, remove non-alphanumeric chars, then apply synonyms:
+   - Frameworks: Next.js→`next`, Nuxt→`nuxt`, SvelteKit→`sveltekit`, ASP.NET Core→`aspnetcore`, Entity Framework Core→`efcore`, React Native→`reactnative`, Spring Boot→`spring`, Ruby on Rails→`rails`, Express→`express`, NestJS→`nestjs`, Tailwind CSS→`tailwind`.
+   - Languages: TypeScript→`ts`, JavaScript→`js`, Python→`py`, Ruby→`rb`, Go→`go`, Rust→`rs`, Java→`java`, Kotlin→`kt`, C#→`cs`, PHP→`php`, Swift→`swift`, Dart→`dart`, Elixir→`ex`.
+   - DB: PostgreSQL→`postgres`, MySQL→`mysql`, MongoDB→`mongodb`, SQL Server→`mssql`, Redis→`redis`, SQLite→`sqlite`.
+6. **Test layer:** collect significant test frameworks across all layers into ONE trailing `test:` segment, alphabetical, deduped. Omit if none.
+7. **Multiplicity & determinism:** one segment per role. Multiple frontends/backends → merge significant tokens (deduped, ordered by Rules 3–4). Never emit versions, counts, paths, or spaces. Same input → identical output.
+
+**Reference examples**
+```
+fe(ts):react+next+tailwind|be(py):fastapi+sqlmodel|db:postgres|test:playwright+pytest
+fe(ts):react+vite+tailwind|be(py):fastapi|db:postgres+redis|test:vitest
+fs(py):django|db:postgres|test:pytest
+fe(cs):blazor|be(cs):aspnetcore+efcore|db:mssql|test:xunit
+be(go):gin+gorm|db:postgres
+mobile(dart):flutter|db:firebase
+lib(py)|test:pytest
+```
+
+Self-check before persisting: segments in Rule-1 order; absent layers omitted; only defining tokens, ordered by Rules 3–4 (base before meta); all slugs normalized; one alphabetical `test:` segment or none; **no spaces anywhere**. Then save it:
+```bash
+tendril project set <project-name> stackHash "<hash>"
+```
+
+### 5. Summary
 
 Print a summary of what was configured:
-- Verifications added (new global definitions + project references)
+- Verifications added
 - Review actions added
-- Any issues encountered

--- a/src/Ivy.Tendril/Services/BugReportService.cs
+++ b/src/Ivy.Tendril/Services/BugReportService.cs
@@ -37,9 +37,83 @@ public sealed class BugReportService
         var files = new List<BugReportFile>();
         var normalized = NormalizeJobId(jobId);
         CollectPromptwareLogFiles([normalized], files);
+
+        // Make the job report self-sufficient for plan-context debugging: include the parent plan's
+        // plan.yaml and Logs/* (the ExecutePlan log records which worktree the job operated on) plus a
+        // synthesized identity for each worktree. Worktree trees themselves stay excluded for size.
+        var planFolder = ResolvePlanFolderForJob(normalized);
+        if (planFolder != null)
+        {
+            CollectPlanFiles(planFolder, files);
+            var worktrees = BuildWorktreesManifest(planFolder);
+            if (worktrees != null)
+                files.Add(worktrees);
+        }
+
         AddSanitizedConfig(files);
         return files;
     }
+
+    /// <summary>
+    ///     Finds the plan folder that owns <paramref name="normalizedJobId" /> by scanning each plan's
+    ///     <c>Logs/</c> directory for a <c>&lt;jobId&gt;-&lt;action&gt;.md</c> log (the naming used by
+    ///     <c>PlanReaderService.AddLog</c>). Returns <c>null</c> when the job has no plan or none can be located.
+    /// </summary>
+    private string? ResolvePlanFolderForJob(string normalizedJobId)
+    {
+        var plansRoot = _config.PlanFolder;
+        if (string.IsNullOrEmpty(plansRoot) || !Directory.Exists(plansRoot))
+            return null;
+
+        foreach (var planDir in Directory.GetDirectories(plansRoot))
+        {
+            var logsDir = Path.Combine(planDir, "Logs");
+            if (!Directory.Exists(logsDir)) continue;
+
+            if (Directory.EnumerateFiles(logsDir, $"{normalizedJobId}-*.md").Any())
+                return planDir;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    ///     Builds <c>worktrees.txt</c>: for each <c>Worktrees/&lt;dir&gt;</c> under the plan, the git remote
+    ///     origin url, the HEAD branch, and the HEAD sha. This is the identity needed to spot a project/repo
+    ///     mismatch (e.g. plan project vs. the repo the worktree actually points at) without bundling the trees.
+    ///     Returns <c>null</c> when the plan has no worktrees.
+    /// </summary>
+    private static BugReportFile? BuildWorktreesManifest(string planFolder)
+    {
+        var worktreesDir = Path.Combine(planFolder, "Worktrees");
+        if (!Directory.Exists(worktreesDir))
+            return null;
+
+        var dirs = Directory.GetDirectories(worktreesDir);
+        if (dirs.Length == 0)
+            return null;
+
+        var sb = new System.Text.StringBuilder();
+        foreach (var wtDir in dirs)
+        {
+            var remote = GitField(wtDir, "remote get-url origin");
+            var branch = GitField(wtDir, "rev-parse --abbrev-ref HEAD");
+            var sha = GitField(wtDir, "rev-parse HEAD");
+
+            sb.AppendLine(Path.GetFileName(wtDir));
+            sb.AppendLine($"  remote: {remote}");
+            sb.AppendLine($"  branch: {branch}");
+            sb.AppendLine($"  HEAD:   {sha}");
+            sb.AppendLine();
+        }
+
+        return new BugReportFile(string.Empty, "worktrees.txt", System.Text.Encoding.UTF8.GetBytes(sb.ToString()));
+    }
+
+    private static string GitField(string workingDir, string args) =>
+        GitHelper.RunGitCapture(workingDir, args, 5000)?.Trim() is { Length: > 0 } value
+            ? value
+            : "(unknown)";
 
     public List<BugReportFile> CollectFilesForPlan(string planFolder)
     {
@@ -226,7 +300,8 @@ public sealed class BugReportService
 
     private static async Task<BugReportResult?> UploadAsync(string zipPath, string description, string osVersion, string tendrilVersion, string agent, string? commitId, CancellationToken ct)
     {
-        using var httpClient = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
+        using var httpClient = new HttpClient();
+        httpClient.Timeout = TimeSpan.FromMinutes(5);
         using var form = new MultipartFormDataContent();
 
         form.Add(new StringContent(description), "description");

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -185,12 +185,17 @@ internal class JobCompletionHandler
         {
             var planFolder = job.TypedArgs?.PlanFolder ?? "";
             var level = "Feature";
+            string? stackHash = null;
             if (Directory.Exists(planFolder))
             {
                 var plan = PlanYamlHelper.ReadPlanYaml(planFolder);
-                if (plan != null) level = plan.Level;
+                if (plan != null)
+                {
+                    level = plan.Level;
+                    stackHash = _configService?.GetProject(plan.Project)?.StackHash;
+                }
             }
-            _telemetryService?.TrackPlanCreated(new PlanCreatedContext(level, job.DurationSeconds, job.Provider));
+            _telemetryService?.TrackPlanCreated(new PlanCreatedContext(level, job.DurationSeconds, job.Provider, stackHash));
         }
         else if (job.TypedArgs is CreatePrArgs)
         {

--- a/src/Ivy.Tendril/Services/Telemetry/ITelemetryService.cs
+++ b/src/Ivy.Tendril/Services/Telemetry/ITelemetryService.cs
@@ -23,7 +23,8 @@ public record AppStartContext(
 public record PlanCreatedContext(
     string Level,
     int? DurationSeconds,
-    string? Agent = null);
+    string? Agent = null,
+    string? StackHash = null);
 
 public record PrCreatedContext(
     int? DurationSeconds,

--- a/src/Ivy.Tendril/Services/Telemetry/TelemetryService.cs
+++ b/src/Ivy.Tendril/Services/Telemetry/TelemetryService.cs
@@ -124,6 +124,7 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
                 ["duration_seconds"] = context.DurationSeconds ?? 0
             };
             if (context.Agent != null) properties["agent"] = context.Agent;
+            if (context.StackHash != null) properties["stack_hash"] = context.StackHash;
             _client?.Capture(_distinctId, "plan_created", properties);
             _logger?.LogDebug("Tracked plan_created event");
         }


### PR DESCRIPTION
## What

- **`tendril project-analyzer <folderpath>`** — new CLI command (supports `.` and relative paths) that analyzes a folder with the `Ivy.StackAnalyzer` NuGet package and prints a **trimmed** YAML stack report (per-component languages/technologies with confidence, infra), filtering out low-confidence and non-defining categories. Bumps `YamlDotNet` 16.3.0 → 17.0.0 to match the package's requirement.
- **stackHash telemetry** — when a plan is created, the project's `stackHash` (if set) is sent as a `stack_hash` property on the `plan_created` PostHog event (omitted when unset, mirroring the existing `agent` property convention).
- **SetupProject promptware** — `Program.md` now uses `project-analyzer` as the authoritative stack source for both verifications/review-actions and stack-hash derivation (both canonical and TeamIvyConfig copies kept in sync).
- Also bundles pre-existing in-progress `BugReportService` changes + a `GitHelper` visibility tweak that were already in the working tree.

## Verification
- Build clean (0/0).
- New `ProjectAnalyzerCommandTests` pass; 265 config/YAML + 188 telemetry/job tests pass.
- Manual CLI runs confirm `.`/relative paths and missing-folder handling.