### PR TITLE
Update the original PR when a plan is based on a PR (#1359)

### DIFF
--- a/src/Ivy.Tendril.Test/PlanFileTests.cs
+++ b/src/Ivy.Tendril.Test/PlanFileTests.cs
@@ -1,0 +1,35 @@
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Test;
+
+public class PlanFileTests
+{
+    private static PlanFile CreatePlanWithSourceUrl(string? sourceUrl)
+    {
+        var metadata = new PlanMetadata(
+            1, "Test", "Bug", "Test Plan", PlanStatus.Review,
+            [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, sourceUrl);
+        return new PlanFile(metadata, "", "D:/plans/00001-TestPlan", "");
+    }
+
+    [Fact]
+    public void IsPullRequestSource_WithPullUrl_ReturnsTrue()
+    {
+        var plan = CreatePlanWithSourceUrl("https://github.com/owner/repo/pull/123");
+        Assert.True(plan.IsPullRequestSource);
+    }
+
+    [Fact]
+    public void IsPullRequestSource_WithIssueUrl_ReturnsFalse()
+    {
+        var plan = CreatePlanWithSourceUrl("https://github.com/owner/repo/issues/123");
+        Assert.False(plan.IsPullRequestSource);
+    }
+
+    [Fact]
+    public void IsPullRequestSource_WithNullSource_ReturnsFalse()
+    {
+        var plan = CreatePlanWithSourceUrl(null);
+        Assert.False(plan.IsPullRequestSource);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -258,7 +258,7 @@ public class ContentView(
                     .BorderThickness(0).Padding(0).Width(Size.Fit().Min(Size.Px(0)));
 
             if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
-                desktopTitleLayout |= new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
+                desktopTitleLayout |= new Button(selectedPlan.IsPullRequestSource ? "PR" : "Issue")
                     .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
 
             var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
@@ -289,9 +289,28 @@ public class ContentView(
                 var allYolo = repoPaths.All(rp =>
                     project?.GetRepoRef(rp)?.PrRule == "yolo");
 
-                var createPrBtn = new Button("Create PR").Icon(Icons.GitPullRequest).Primary().OnClick(() =>
+                // When the plan's source is an existing PR, the CTA updates that PR instead of
+                // opening a second one. There's nothing to configure for an update (no new branch,
+                // no merge/delete choices), so we skip the Custom PR dialog and push directly.
+                var isPrUpdate = selectedPlan.IsPullRequestSource;
+
+                var createPrBtn = new Button(isPrUpdate ? "Update PR" : "Create PR")
+                    .Icon(Icons.GitPullRequest).Primary().OnClick(() =>
                 {
-                    if (allYolo)
+                    if (isPrUpdate)
+                    {
+                        // Push the fix onto the original PR's branch and leave the PR open for
+                        // review. ExecutePlan already based the worktree on the PR's head branch,
+                        // so CreatePr's push updates the existing PR (no new PR is created).
+                        jobService.StartJob(new CreatePrArgs(
+                            selectedPlan.FolderPath,
+                            SolveMergeConflicts: true,
+                            Merge: false,
+                            DeleteBranch: false,
+                            IncludeArtifacts: true));
+                        refreshPlans();
+                    }
+                    else if (allYolo)
                     {
                         // "yolo" is purely a UI setting: skip the dialog and create the PR with the
                         // merge-and-clean-up defaults. The promptware acts only on these explicit flags.
@@ -310,7 +329,7 @@ public class ContentView(
                     }
                 }).ShortcutKey("m");
 
-                controls |= allYolo
+                controls |= (allYolo && !isPrUpdate)
                     ? createPrBtn.WithConfetti(AnimationTrigger.Click)
                     : createPrBtn;
             }

--- a/src/Ivy.Tendril/Models/PlanModels.cs
+++ b/src/Ivy.Tendril/Models/PlanModels.cs
@@ -59,6 +59,10 @@ public record PlanFile(
     public DateTime Updated => Metadata.Updated;
     public string? InitialPrompt => Metadata.InitialPrompt;
     public string? SourceUrl => Metadata.SourceUrl;
+
+    /// <summary>True when the plan's source is a GitHub pull request (vs. an issue or none).</summary>
+    public bool IsPullRequestSource => SourceUrl?.Contains("/pull/") == true;
+
     public string FolderName => Path.GetFileName(FolderPath);
 }
 

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -51,7 +51,17 @@ C) Unrelated tickets (→ delegate steps below)
 
 If it references related plans with `[number]` syntax (e.g. `[01205]`), find and read those plan files from `TendrilPlansFolder` for context.
 
-**Extract Source URL**: Check if the task description contains a GitHub PR URL (`https://github.com/{owner}/{repo}/pull/{number}`) or issue URL (`https://github.com/{owner}/{repo}/issues/{number}`). If found, store it as `sourceUrl` in plan.yaml. Use `gh pr view <url> --json title,body` or `gh issue view <url> --json title,body` to fetch the title and body for additional context when writing the plan.
+**Extract Source URL**: Check if the task description contains a GitHub PR URL (`https://github.com/{owner}/{repo}/pull/{number}`) or issue URL (`https://github.com/{owner}/{repo}/issues/{number}`). If found, store it as `sourceUrl` in plan.yaml.
+
+- **Issue URL**: `gh issue view <url> --json title,body,comments` — fetch the title, body, and comments for context when writing the plan.
+- **PR URL**: the plan must be based on the **review feedback on the PR**, not just its description. Fetch the full conversation:
+  ```bash
+  # Title, body, top-level conversation comments, and review summaries (with their state: APPROVED / CHANGES_REQUESTED / COMMENTED)
+  gh pr view <url> --json title,body,comments,reviews
+  # Inline (line-level) review comments — the specific code feedback. These are the most important.
+  gh api "repos/{owner}/{repo}/pulls/{number}/comments" --paginate
+  ```
+  Treat every **unresolved review comment** and every **"changes requested"** point as a requirement the plan MUST address. In the plan revision, incorporate this feedback explicitly: in `## Problem`, summarize what the reviewers asked for (quote/attribute the key comments); in `## Solution`, map each comment to a concrete change, referencing the exact files and lines the inline comments point at (`path` + `line` from the API response). Do not silently drop a reviewer comment — if one is out of scope or already resolved, say so. This plan will update the **same PR** (ExecutePlan bases the worktree on the PR's branch), so it is iterating on that PR, not opening a new one.
 
 **Format screenshot paths**: If the task description contains file paths to images (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`), include them in the plan revision as markdown images using `file:///` URLs. Convert backslashes to forward slashes. Example: a path like `D:\Screenshots\2026-05-07_17-16.png` in the description becomes `![screenshot](file:///D:/Screenshots/2026-05-07_17-16.png)` in the revision.
 

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -55,7 +55,7 @@ Report status: `tendril job status TendrilJobId --message="Pushing branches..."`
 
 Check `<TendrilPlanFolder>/Worktrees/` for each repo worktree.
 
-> **Worktree already removed:** If the Worktrees/ directory is empty (worktree was already cleaned up), fall back to `plan.yaml` to get the repo path and branch name (format: `tendril/<planId>-<SafeTitle>`, where SafeTitle is extracted from the plan folder name: e.g. `03158-ChangeBranchNaming` → `ChangeBranchNaming`). The commit objects may still exist in the original repo's object store. Use `git cat-file -t <sha>` to verify, then create or force-update the local branch: `git branch -f <branch-name> <sha>` (use `-f` because the branch may already exist from a WIP auto-commit) and push from the original repo path.
+> **Worktree already removed:** If the Worktrees/ directory is empty (worktree was already cleaned up), fall back to `plan.yaml` to get the repo path and branch name. The branch is normally `tendril/<planId>-<SafeTitle>` (SafeTitle extracted from the plan folder name: e.g. `03158-ChangeBranchNaming` → `ChangeBranchNaming`). **Exception — PR-source plans:** if `SourceUrl` is an open same-repo pull request, ExecutePlan based the worktree on the PR's head branch, so the branch is the PR's `headRefName`, not the `tendril/…` pattern — resolve it via `gh pr view <number> --repo <owner/repo> --json headRefName`. The commit objects may still exist in the original repo's object store. Use `git cat-file -t <sha>` to verify, then create or force-update the local branch: `git branch -f <branch-name> <sha>` (use `-f` because the branch may already exist from a WIP auto-commit) and push from the original repo path.
 >
 > **Commit lost (object GC'd):** If `git cat-file -t <sha>` fails, the commit was garbage-collected after worktree removal. In this case: (1) check if the change is already on main, (2) if not, recreate the change from the plan revision — create a new branch from main, apply the changes as described in the revision, commit with a descriptive message matching the plan title, and push. Update commits via CLI: `tendril plan add-commit <plan-id> <new-sha>`.
 
@@ -116,7 +116,24 @@ Apply the **transient-error retry convention** to every `gh` command in this ste
 3.5–6): retry transient/network/`5xx`/`429` failures up to 3 times with backoff; fail fast on
 genuine errors (auth, invalid repo, validation).
 
-For each pushed branch:
+**!CRITICAL — create is idempotent. Never open a second PR for a branch that already has one.**
+For each pushed branch, first check whether an open PR already targets it:
+
+```bash
+EXISTING=$(gh pr list --repo <owner/repo> --head <branch> --state open --json number,url -q '.[0]')
+```
+
+- **If `EXISTING` is non-empty → UPDATE path (do NOT run `gh pr create`).** The `git push` in step 2
+  already pushed the new commits onto the PR's branch, which updates the existing PR. Capture its
+  `number` and `url`. Do **not** overwrite the PR title/body. Report
+  `tendril job status TendrilJobId --message="Updated existing PR #<number>"`. If `PrComment` is set,
+  add it via step 3.5. Then continue to step 3.7 (conflict resolution) and step 4 (merge gate) as
+  normal — they apply to updated PRs too.
+  > This is the case for plans whose `SourceUrl` is a PR: ExecutePlan based the worktree on the PR's
+  > head branch, so the branch already has an open PR and we update it in place instead of opening a
+  > second one.
+
+- **If `EXISTING` is empty → CREATE path (default).** For each pushed branch:
 
 ```bash
 gh pr create [--draft] --repo <owner/repo> --base <default-branch> --head <branch> --assignee @me --title "<title>" --body "$(cat <<'EOF'
@@ -283,6 +300,10 @@ Add each PR URL:
 ```bash
 tendril plan add-pr <plan-id> <pr-url>
 ```
+
+> **Idempotent:** on the UPDATE path the PR URL is usually already in the plan's `prs` list (and may
+> equal `SourceUrl`). Read `plan.yaml` first and only run `add-pr` if the URL is not already present —
+> do not add a duplicate.
 
 **Update state to Completed:** If `PrMerge` is `true` and ALL PRs were successfully merged, update the state:
 

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -163,19 +163,48 @@ This handles stale directories, locked files, and branch cleanup automatically w
 
 **Note on stale directories:** If a stale worktree directory exists and you run `git -C <stale-dir> status`, git silently walks up the parent chain and reports the state of the main repo — making it look like the "worktree" is simply on `main`. Do not trust that output. Before assuming a prior worktree is intact, verify with `git -C <main-repo> worktree list | grep <path>` or check that `<worktree-path>/.git` exists.
 
-1. Create worktree branching from the remote default branch:
+1. **PR-source check (decide the worktree's base branch).** If the `SourceUrl` firmware header is a
+   GitHub **pull request** URL (`https://github.com/<owner>/<repo>/pull/<number>`) **and** it points
+   at *this* worktree's repo, the worktree should be based on the PR's branch so the fix updates the
+   original PR instead of opening a second one. Otherwise, fall back to the standard base-branch flow.
 
 ```bash
 cd <original-repo-path>
 git fetch origin
+
+# Default: standard plan branch off the base branch.
 PLAN_FOLDER_NAME=$(basename "<TendrilPlanFolder>")
 PLAN_ID=$(echo "$PLAN_FOLDER_NAME" | grep -oP '^\d+')
 SAFE_TITLE=$(echo "$PLAN_FOLDER_NAME" | sed 's/^[0-9]\+-//')
 BRANCH_NAME="tendril/$PLAN_ID-$SAFE_TITLE"
-git worktree add "<TendrilPlanFolder>/Worktrees/<repo-folder-name>" -b "$BRANCH_NAME" "origin/<resolved-base-branch>"
+WORKTREE_REF="origin/<resolved-base-branch>"     # what to base the worktree on
+WORKTREE_NEW_FLAG="-b"                            # create a fresh branch by default
+
+# PR-source override: only when SourceUrl is a PR for THIS repo's owner/repo.
+if [[ -n "$SOURCE_URL" && "$SOURCE_URL" =~ github\.com/([^/]+/[^/]+)/pull/([0-9]+) ]]; then
+  PR_REPO="${BASH_REMATCH[1]}"; PR_NUMBER="${BASH_REMATCH[2]}"
+  ORIGIN_REPO=$(git remote get-url origin | sed -E 's#.*github\.com[:/]([^/]+/[^/]+?)(\.git)?$#\1#')
+  if [[ "$PR_REPO" == "$ORIGIN_REPO" ]]; then
+    PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$PR_REPO" --json headRefName,state,isCrossRepository 2>/dev/null)
+    PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
+    PR_FORK=$(echo "$PR_JSON" | jq -r '.isCrossRepository')
+    PR_HEAD=$(echo "$PR_JSON" | jq -r '.headRefName')
+    if [[ "$PR_STATE" == "OPEN" && "$PR_FORK" == "false" && -n "$PR_HEAD" && "$PR_HEAD" != "null" ]]; then
+      git fetch origin "$PR_HEAD"
+      BRANCH_NAME="$PR_HEAD"
+      WORKTREE_REF="origin/$PR_HEAD"
+      WORKTREE_NEW_FLAG="-B"                      # check out / reset the existing PR branch
+      tendril job status TendrilJobId --message="Basing worktree on PR #$PR_NUMBER branch '$PR_HEAD' (will update the existing PR)."
+    else
+      tendril job status TendrilJobId --message="PR #$PR_NUMBER is not updatable (state=$PR_STATE, fork=$PR_FORK) — falling back to a new branch + new PR."
+    fi
+  fi
+fi
+
+git worktree add "<TendrilPlanFolder>/Worktrees/<repo-folder-name>" "$WORKTREE_NEW_FLAG" "$BRANCH_NAME" "$WORKTREE_REF"
 ```
 
-Example:
+Example (standard, no PR source):
 
 ```bash
 cd <RepoPath>
@@ -183,7 +212,12 @@ git fetch origin
 git worktree add "<TendrilPlanFolder>/Worktrees/<RepoName>" -b "tendril/<TendrilPlanId>-<SafeTitle>" origin/<resolved-base-branch>
 ```
 
-**Important:** Always branch from `origin/<resolved-base-branch>`, not local HEAD. This ensures the PR only contains the plan's commits, not any unpushed local work. The `<resolved-base-branch>` comes from either the `RepoConfigs` firmware header (if `baseBranch` is configured) or auto-detection.
+**Important:** Unless the PR-source override applied above, always branch from
+`origin/<resolved-base-branch>`, not local HEAD. This ensures the PR only contains the plan's
+commits, not any unpushed local work. The `<resolved-base-branch>` comes from either the
+`RepoConfigs` firmware header (if `baseBranch` is configured) or auto-detection. When the PR-source
+override applies, the worktree is instead based on the PR's head branch so commits land on top of
+the existing PR — never force-cut a new branch over the PR's history.
 
 **Note on `RepoConfigs`:** The firmware header may include a `RepoConfigs` value injected by Tendril. It contains per-repo configuration:
 ```yaml


### PR DESCRIPTION
Fixes #1359.

When a plan is created from a PR link, then fixed, the PR flow now **updates that PR** instead of opening a second one — and the plan is based on the PR's **review comments**, not just its title/body.

## Changes
- **CreatePlan**: for a PR `sourceUrl`, fetch conversation + review summaries (`gh pr view --json comments,reviews`) and inline review comments (`pulls/{n}/comments` API); base the plan's `## Problem` / `## Solution` on that feedback.
- **ExecutePlan**: base the worktree on the PR's head branch when the source is an open, same-repo PR, so commits land on top of the existing PR. Falls back to a fresh `tendril/` branch for issue / closed / fork sources.
- **CreatePr**: idempotent — if an open PR already targets the pushed branch, update it (push only) instead of `gh pr create`; `add-pr` is dedupe-safe.
- **Review UI**: show an **"Update PR"** CTA (`Merge=false`, no dialog) when the plan's source is a PR. Adds `PlanFile.IsPullRequestSource` helper + unit tests.

## Verification
- `dotnet build` clean; `PlanFileTests` (3) and `PromptwareDryRunTests` (22) pass.
- Live end-to-end run against a real PR not yet performed.