### PR TITLE
[00608] Remove Enlarge Hover Effect on Images in Markdown Widget

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -636,11 +636,6 @@
 /* Image viewer */
 .pmv-img-clickable {
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-.pmv-img-clickable:hover {
-  transform: scale(1.02);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 .pmv-img-error {


### PR DESCRIPTION
# Summary

## Changes

Removed the hover enlarge effect on images in the DraftMarkdown widget. Images no longer scale up or display a box shadow on hover, but still show a pointer cursor and retain full click-to-enlarge functionality.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css** — Removed transition property from `.pmv-img-clickable` and deleted the `.pmv-img-clickable:hover` rule entirely

## Manual Testing

1. Open the Tendril app and navigate to any view that displays markdown with images (e.g., a plan revision or documentation)
2. Hover over an image in the markdown content
3. Observe that the image no longer scales up or shows a shadow effect (only cursor changes to pointer)
4. Click on the image to verify the full-screen overlay still opens correctly

---

## Commits
- 44fd1e51 Remove image hover enlarge effect in markdown widget

---
Created using [Ivy Tendril](https://ivy.app).