### PR TITLE
[00602] Fix Clear Failed Removing Timed Out Jobs

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
@@ -83,12 +83,12 @@ public class JobServiceDeletionTests
         service.ClearFailedJobs();
 
         Assert.Null(service.GetJob("failed-1"));
-        Assert.Null(service.GetJob("timeout-1"));
+        Assert.NotNull(service.GetJob("timeout-1"));
         Assert.NotNull(service.GetJob("blocked-1"));
         Assert.NotNull(service.GetJob("completed-1"));
         Assert.Empty(db.DeletedJobIds);
         Assert.Contains(db.UpsertedJobs, j => j.Id == "failed-1" && j.Cleared);
-        Assert.Contains(db.UpsertedJobs, j => j.Id == "timeout-1" && j.Cleared);
+        Assert.DoesNotContain(db.UpsertedJobs, j => j.Id == "timeout-1" && j.Cleared);
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Helpers/GitHelper.cs
+++ b/src/Ivy.Tendril/Helpers/GitHelper.cs
@@ -180,21 +180,21 @@ public static class GitHelper
                 return false;
             });
         }
-            return await Task.Run(() =>
+        return await Task.Run(() =>
+        {
+            var output = RunGitCapture(null, $"ls-remote --heads \"{expandedPath}\" \"{branchName}\"", 10000);
+            if (output != null)
             {
-                var output = RunGitCapture(null, $"ls-remote --heads \"{expandedPath}\" \"{branchName}\"", 10000);
-                if (output != null)
+                var lines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var line in lines)
                 {
-                    var lines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-                    foreach (var line in lines)
-                    {
-                        if (line.Contains($"refs/heads/{branchName}"))
-                            return true;
-                    }
+                    if (line.Contains($"refs/heads/{branchName}"))
+                        return true;
                 }
+            }
 
-                return false;
-            });
+            return false;
+        });
     }
 
     private static bool RunGitShowRef(string repoPath, string refName)

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -326,7 +326,7 @@ public class JobService : IJobService
         => ClearJobsByStatus(j => j.Status == JobStatus.Completed);
 
     public void ClearFailedJobs()
-        => ClearJobsByStatus(j => j.Status is JobStatus.Failed or JobStatus.Timeout);
+        => ClearJobsByStatus(j => j.Status == JobStatus.Failed);
 
     public void ClearAllJobs()
         => ClearJobsByStatus(j => j.Status is not JobStatus.Running and not JobStatus.Queued);


### PR DESCRIPTION
Fixes #1423

# Summary

## Changes

Fixed `ClearFailedJobs` to only clear jobs with `Failed` status, excluding `Timeout` jobs. Updated the corresponding test to verify timeout jobs are preserved.

## API Changes

**Modified:**
- `JobService.ClearFailedJobs()` — now only clears jobs with `JobStatus.Failed` (previously also cleared `JobStatus.Timeout`)

## Files Modified

- `src/Ivy.Tendril/Services/Jobs/JobService.cs` — changed predicate from `Failed or Timeout` to `Failed` only
- `src/Ivy.Tendril.Test/JobServiceDeletionTests.cs` — updated assertions to verify timeout jobs are NOT cleared

## Manual Testing

1. Run the Tendril app and create some test jobs
2. Manually fail some jobs and let others timeout
3. Click the "Clear Failed" button in the Jobs app
4. Verify that only Failed jobs are removed, while Timeout jobs remain visible
5. Click "Clear All" to verify it still clears both Failed and Timeout jobs as expected

---
**Commits:**
- cb130002 Fix ClearFailedJobs to exclude Timeout status
- 097ad480 Apply dotnet format

---
Created using [Ivy Tendril](https://ivy.app).