### PR TITLE
[00601] Fix Changes Tab Missing Right Spacing

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
@@ -106,7 +106,7 @@ public class ChangesTabView(
         if (hideFormatting.Value && hiddenCount > 0)
             toolbar |= Text.Muted($"{fileDiffs.Count} of {allFileDiffs.Count} files (hiding {hiddenCount} formatting-only)").Small();
 
-        var mainLayout = Layout.Horizontal().Height(Size.Full().Min(Size.Px(0))).Padding(0, 0, 0, 2)
+        var mainLayout = Layout.Horizontal().Height(Size.Full().Min(Size.Px(0))).Padding(0, 0, 2, 2)
             | treePanel
             | diffsLayout;
 

--- a/src/Ivy.Tendril/Helpers/GitHelper.cs
+++ b/src/Ivy.Tendril/Helpers/GitHelper.cs
@@ -180,21 +180,21 @@ public static class GitHelper
                 return false;
             });
         }
-            return await Task.Run(() =>
+        return await Task.Run(() =>
+        {
+            var output = RunGitCapture(null, $"ls-remote --heads \"{expandedPath}\" \"{branchName}\"", 10000);
+            if (output != null)
             {
-                var output = RunGitCapture(null, $"ls-remote --heads \"{expandedPath}\" \"{branchName}\"", 10000);
-                if (output != null)
+                var lines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var line in lines)
                 {
-                    var lines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-                    foreach (var line in lines)
-                    {
-                        if (line.Contains($"refs/heads/{branchName}"))
-                            return true;
-                    }
+                    if (line.Contains($"refs/heads/{branchName}"))
+                        return true;
                 }
+            }
 
-                return false;
-            });
+            return false;
+        });
     }
 
     private static bool RunGitShowRef(string repoPath, string refName)


### PR DESCRIPTION
Fixes #1420

# Summary

## Changes

Added 2px right padding to the Changes tab main layout in ChangesTabView. The padding parameter was changed from `Padding(0, 0, 0, 2)` to `Padding(0, 0, 2, 2)` to provide proper spacing on the right side of the diff content, matching the bottom padding already in place.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs` — Updated mainLayout padding

## Manual Testing

1. Launch the Tendril Review app
2. Navigate to a plan with file changes and open the Changes tab
3. Observe that the diff content has proper spacing on the right side and does not extend to the edge
4. Compare with other tabs to verify consistent spacing

---

## Commits

- 37744517 Add right padding to Changes tab main layout
- 4119a38f Apply dotnet format

---
Created using [Ivy Tendril](https://ivy.app).