### PR TITLE
[00598] Fix Misaligned Hover Effect on Custom Button in New Plan Dialog

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/content-input.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/content-input.css
@@ -481,6 +481,11 @@
   margin: 0 !important;
 }
 
+.civ-split-btn-left:hover:not(:disabled) {
+  transform: none;
+  opacity: 1;
+}
+
 /* Arrow button on the right */
 .civ-split-btn-arrow {
   width: 32px;


### PR DESCRIPTION
Fixes #1398

# Summary

## Changes

Fixed the misaligned hover effect on the custom split button in the New Plan dialog by overriding the inherited `translateY(-1px)` transform from `.civ-submit-btn-labeled:hover`. The left button now stays vertically aligned with the container and arrow button on hover.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril.Widgets/frontend/src/ContentInput/content-input.css** — Added CSS rule to neutralize hover transform for `.civ-split-btn-left`

## Manual Testing

1. Run the Tendril app
2. Open the "New Plan" dialog
3. Hover over the split button (labeled "Create" with a dropdown arrow)
4. Observe that the left button and arrow button remain vertically aligned during hover, with no upward shift

---

**Commits:**
- d339552 - [00598] Fix misaligned hover effect on custom button in New Plan dialog

---
Created using [Ivy Tendril](https://ivy.app).