### PR TITLE
[00611] Add KBD Element Styling to Markdown Widget

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -225,6 +225,26 @@
   font-weight: 600;
 }
 
+/* Keyboard shortcuts (KBD) */
+.pmv-markdown kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  height: 20px;
+  min-width: 20px;
+  padding: 0 5px;
+  font-size: 0.75rem;
+  font-weight: 400;
+  font-family: inherit;
+  line-height: 1;
+  border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
+  border-radius: 0.25rem;
+  background: var(--muted);
+  color: var(--foreground);
+  vertical-align: baseline;
+}
+
 /* Code blocks */
 .pmv-code-block {
   position: relative;


### PR DESCRIPTION
Fixes #1431

# Summary

## Changes

Added CSS styling for `<kbd>` elements in markdown content to match the Ivy Framework Kbd component appearance with bordered keycap styling.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css** — Added `.pmv-markdown kbd` rule after inline code section

## Manual Testing

1. Open any markdown widget that contains `<kbd>` elements (e.g., keyboard shortcuts documentation)
2. Verify that kbd elements render with:
   - Bordered inline box appearance
   - Muted background color
   - 20px height with proper padding
   - Centered content alignment
3. Compare visual styling to Ivy Framework Kbd component to ensure consistency

---

## Commits

- `142dde81` Add KBD element styling to markdown widget

---
Created using [Ivy Tendril](https://ivy.app).