### PR TITLE
[00610] Fix Markdown Inline Code Wrapping

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -217,12 +217,15 @@
 /* Inline code */
 .pmv-markdown code {
   position: relative;
+  display: inline;
   border-radius: 0.25rem;
   background: var(--muted);
   padding: 0.05rem 0.25rem;
   font-family: "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo,
     Consolas, monospace;
   font-weight: 600;
+  white-space: normal;
+  word-break: break-word;
 }
 
 /* Code blocks */


### PR DESCRIPTION
Fixes #1430

# Summary

## Changes

Added three CSS properties to `.pmv-markdown code` rule in draft-markdown.css to fix inline code wrapping behavior: `display: inline`, `white-space: normal`, and `word-break: break-word`.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css` — Added wrapping properties to inline code style

## Manual Testing

1. Run the Tendril app and open a page with the DraftMarkdown widget
2. Enter markdown with inline code in a paragraph: `This is some text with \`very-long-inline-code-that-should-wrap-in-narrow-viewports\` in the middle of it`
3. Resize the viewport to a narrow width (or inspect in responsive mode)
4. Observe that the inline code wraps naturally with the surrounding text instead of overflowing

---

**Commits:**
- 56e5a489 Fix inline code wrapping in markdown widget

---
Created using [Ivy Tendril](https://ivy.app).