### PR TITLE
[00612] Fix Annotation Highlight Text Color in Dark Mode

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -384,6 +384,7 @@
 @media (prefers-color-scheme: dark) {
   .pmv-annotation-highlight {
     background: hsl(48 80% 20% / 0.5);
+    color: hsl(0 0% 95%);
   }
 }
 


### PR DESCRIPTION
Fixes #1432

# Summary

## Changes

Added a light text color (`color: hsl(0 0% 95%)`) to the `.pmv-annotation-highlight` CSS class in dark mode to improve readability of highlighted text against the amber background.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css** — Added color property to dark mode annotation highlight

## Manual Testing

1. Open the Tendril app and enable dark mode (system preference or browser dev tools)
2. Navigate to a page with markdown content that supports annotations
3. Select text and add an annotation/comment to create a `.pmv-annotation-highlight` element
4. Observe that the highlighted text now displays in light gray/white color instead of inheriting the default dark text color
5. Verify the text is readable against the amber background (`hsl(48 80% 20% / 0.5)`)

---

Commits:
- b49bb3b: [00612] Fix Annotation Highlight Text Color in Dark Mode

---
Created using [Ivy Tendril](https://ivy.app).