### PR TITLE
[00613] Remove Stale Rebase Head File From Ivy Tendril Repo

### DIFF
--- a/remove-stale-rebase-head.sh
+++ b/remove-stale-rebase-head.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Plan 00613: Remove Stale REBASE_HEAD File
+#
+# This script removes the stale REBASE_HEAD file from the main Ivy-Tendril repository.
+# The file is a leftover from a previous rebase operation that didn't clean up properly,
+# causing Tendril to incorrectly report "rebase in progress" during preflight checks.
+
+REPO_PATH="/home/joel/.tendril/Repos/Ivy-Tendril"
+REBASE_HEAD_FILE="$REPO_PATH/.git/REBASE_HEAD"
+
+echo "Checking for stale REBASE_HEAD file..."
+
+if [ -f "$REBASE_HEAD_FILE" ]; then
+    echo "Found REBASE_HEAD file:"
+    cat "$REBASE_HEAD_FILE"
+    echo ""
+    echo "Removing stale file..."
+    rm "$REBASE_HEAD_FILE"
+
+    if [ ! -f "$REBASE_HEAD_FILE" ]; then
+        echo "✓ Successfully removed REBASE_HEAD file"
+        echo ""
+        echo "Verifying git status..."
+        cd "$REPO_PATH"
+        git status
+    else
+        echo "✗ Failed to remove REBASE_HEAD file"
+        exit 1
+    fi
+else
+    echo "REBASE_HEAD file not found (already removed or never existed)"
+fi


### PR DESCRIPTION
# Summary

## Changes

Removed the stale `REBASE_HEAD` file from the Ivy-Tendril repository's `.git/` directory. This file was a leftover from a previous rebase operation (dated 2026-06-23, pointing to commit `85ada004`) that was causing Tendril to incorrectly report "rebase in progress" during preflight checks. Created a cleanup script documenting the fix.

## API Changes

None.

## Files Modified

- **remove-stale-rebase-head.sh** — New executable script that removes the stale REBASE_HEAD file and verifies the cleanup

## Manual Testing

1. Run Tendril's preflight check on the Ivy-Tendril repository
2. Verify it no longer reports "rebase in progress" or dirty state
3. Confirm `git status` shows clean state in the main repo
4. Verify no `REBASE_HEAD`, `MERGE_HEAD`, or `CHERRY_PICK_HEAD` files exist in `/home/joel/.tendril/Repos/Ivy-Tendril/.git/`

---

## Commits

- a7218855 Add script to remove stale REBASE_HEAD file

---
Created using [Ivy Tendril](https://ivy.app).