### PR TITLE
chore: update Ivy package dependencies to 1.3.1

### DIFF
--- a/src/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
+++ b/src/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
@@ -17,9 +17,9 @@
     </ItemGroup>
     <ItemGroup Condition="'$(IvySource)' != 'true'">
         <PackageReference Include="Ivy" Version="$(IvyPackageVersion)" Condition="'$(IvyPackageVersion)' != ''" />
-        <PackageReference Include="Ivy" Version="1.2.72" Condition="'$(IvyPackageVersion)' == ''" />
+        <PackageReference Include="Ivy" Version="1.3.1" Condition="'$(IvyPackageVersion)' == ''" />
         <PackageReference Include="Ivy.Docs.Helpers" Version="$(IvyPackageVersion)" Condition="'$(IvyPackageVersion)' != ''" />
-        <PackageReference Include="Ivy.Docs.Helpers" Version="1.2.72" Condition="'$(IvyPackageVersion)' == ''" />
+        <PackageReference Include="Ivy.Docs.Helpers" Version="1.3.1" Condition="'$(IvyPackageVersion)' == ''" />
     </ItemGroup>
 
     <ItemGroup>
@@ -65,7 +65,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Ivy.Analyser" Version="1.2.72" Condition="'$(IvyPackageVersion)' == ''">
+        <PackageReference Include="Ivy.Analyser" Version="1.3.1" Condition="'$(IvyPackageVersion)' == ''">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
+++ b/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
@@ -40,7 +40,7 @@
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy/Ivy.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy" Version="1.2.72" />
+    <PackageReference Include="Ivy" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Ivy.Tendril.Updater/Ivy.Tendril.Updater.csproj
+++ b/src/Ivy.Tendril.Updater/Ivy.Tendril.Updater.csproj
@@ -27,7 +27,7 @@
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy/Ivy.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy" Version="1.2.72" />
+    <PackageReference Include="Ivy" Version="1.3.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' == 'true'">
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Analyser/Ivy.Analyser.csproj">
@@ -38,7 +38,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -48,7 +48,7 @@
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Desktop/Ivy.Desktop.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy.Desktop" Version="1.2.72" />
+    <PackageReference Include="Ivy.Desktop" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj
+++ b/src/Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy" Version="1.2.72" />
+    <PackageReference Include="Ivy" Version="1.3.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -71,14 +71,14 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Desktop" Version="1.2.72" />
-    <PackageReference Include="Ivy.Hooks.Pty" Version="1.2.72" />
-    <PackageReference Include="Ivy.Widgets.ActivityHeatmap" Version="1.2.72" />
-    <PackageReference Include="Ivy.Widgets.AnimatedStatusLabel" Version="1.2.72" />
-    <PackageReference Include="Ivy.Widgets.DiffView" Version="1.2.72" />
-    <PackageReference Include="Ivy.Widgets.QRCode" Version="1.2.72" />
-    <PackageReference Include="Ivy.Widgets.Xterm" Version="1.2.72" />
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Desktop" Version="1.3.1" />
+    <PackageReference Include="Ivy.Hooks.Pty" Version="1.3.1" />
+    <PackageReference Include="Ivy.Widgets.ActivityHeatmap" Version="1.3.1" />
+    <PackageReference Include="Ivy.Widgets.AnimatedStatusLabel" Version="1.3.1" />
+    <PackageReference Include="Ivy.Widgets.DiffView" Version="1.3.1" />
+    <PackageReference Include="Ivy.Widgets.QRCode" Version="1.3.1" />
+    <PackageReference Include="Ivy.Widgets.Xterm" Version="1.3.1" />
   </ItemGroup>
 
   <!-- Ivy Analyser -->
@@ -91,7 +91,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Updates all Ivy Framework packages in the Ivy-Tendril repository to the latest release version 1.3.1.