### PR TITLE
[00614] Remove Show Completed Checkbox from Review App

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ReviewApp.cs
+++ b/src/Ivy.Tendril/Apps/Review/ReviewApp.cs
@@ -21,7 +21,6 @@ public class ReviewApp : ViewBase
         var projectFilter = UseState<string?>(null);
         var levelFilter = UseState<string?>(null);
         var textFilter = UseState<string?>("");
-        var showCompleted = UseState(false);
         var filtersOpen = UseState(false);
         var refreshToken = UseRefreshToken();
 
@@ -67,9 +66,7 @@ public class ReviewApp : ViewBase
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var plans = planService.GetPlans()
-            .Where(p => showCompleted.Value
-                ? p.Status is PlanStatus.Review or PlanStatus.Failed or PlanStatus.Completed
-                : p.Status is PlanStatus.Review or PlanStatus.Failed)
+            .Where(p => p.Status is PlanStatus.Review or PlanStatus.Failed)
             .Where(p => !activePlanFolders.Contains(p.FolderPath))
             .ToList();
         var filteredPlans = PlanFilters.ApplyFilters(plans, projectFilter.Value, levelFilter.Value, textFilter.Value).ToList();
@@ -98,7 +95,7 @@ public class ReviewApp : ViewBase
 
         previousPlans.Value = filteredPlans;
 
-        var sidebar = new SidebarView(plans, selectedPlanState, projectFilter, levelFilter, textFilter, filtersOpen, showCompleted, configService);
+        var sidebar = new SidebarView(plans, selectedPlanState, projectFilter, levelFilter, textFilter, filtersOpen, configService);
 
         var content = new ContentView(selectedPlanState, filteredPlans, planService, jobService,
             RefreshPlans, configService, gitService);

--- a/src/Ivy.Tendril/Apps/Review/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/SidebarView.cs
@@ -12,7 +12,6 @@ public class SidebarView(
     IState<string?> levelFilter,
     IState<string?> textFilter,
     IState<bool> filtersOpen,
-    IState<bool> showCompleted,
     IConfigService config) : ViewBase
 {
     private object BuildHeader()
@@ -45,8 +44,7 @@ public class SidebarView(
                 | projectFilter.ToSelectInput(projectCounts).Placeholder("All Projects").Nullable()
                     .WithField().Label("Project")
                 | levelFilter.ToSelectInput(levelOptions.ToOptions()).Placeholder("All Levels").Nullable()
-                    .WithField().Label("Level")
-                | showCompleted.ToBoolInput("Show Completed");
+                    .WithField().Label("Level");
         }
 
         return header;


### PR DESCRIPTION
Fixes #1424

# Summary

## Changes

Removed the "Show Completed" checkbox from the Review app sidebar filters. The app now displays only plans with status `Review` or `Failed`, eliminating corner cases where completed plans would appear with non-functional action buttons.

## API Changes

**ReviewApp.cs:**
- Removed `showCompleted` state variable
- Simplified plan filtering logic to always filter to `Review` or `Failed` status only
- Updated `SidebarView` constructor call to remove `showCompleted` parameter

**SidebarView.cs:**
- Removed `showCompleted` constructor parameter
- Removed checkbox UI rendering

## Files Modified

- `src/Ivy.Tendril/Apps/Review/ReviewApp.cs` — Removed showCompleted state and simplified plan filtering
- `src/Ivy.Tendril/Apps/Review/SidebarView.cs` — Removed showCompleted parameter and checkbox UI

## Manual Testing

1. Run the Tendril app and navigate to the Review tab
2. Open the filters panel in the sidebar (click the chevron button next to the search box)
3. Verify that the "Show Completed" checkbox is no longer visible
4. Verify that only plans with status "Review" or "Failed" appear in the list (no completed plans)
5. If there are completed plans in the system, confirm they do not appear in the Review app's plan list

---
## Commits

- 9e411b53 Remove Show Completed checkbox from Review app

---
Created using [Ivy Tendril](https://ivy.app).