### PR TITLE
[00615] Fix ClearFailedJobs Test Assertion After Timeout Exclusion

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
@@ -150,7 +150,7 @@ public class JobServiceTimeoutTests : IDisposable
     }
 
     [Fact]
-    public void ClearFailedJobs_RemovesFailedAndTimeoutJobs()
+    public void ClearFailedJobs_RemovesOnlyFailedJobs()
     {
         var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
 
@@ -168,7 +168,7 @@ public class JobServiceTimeoutTests : IDisposable
         Assert.NotNull(service.GetJob(runningId));
         Assert.NotNull(service.GetJob(completedId));
         Assert.Null(service.GetJob(failedId));
-        Assert.Null(service.GetJob(timeoutId));
+        Assert.NotNull(service.GetJob(timeoutId));
     }
 
     [Fact]


### PR DESCRIPTION
# Summary

## Changes

Fixed the `ClearFailedJobs_RemovesFailedAndTimeoutJobs` test in `JobServiceTimeoutTests.cs` to align with the current behavior where `ClearFailedJobs()` only removes Failed jobs, not Timeout jobs (changed in commit cb130002).

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril.Test/JobServiceTimeoutTests.cs**
  - Renamed test method from `ClearFailedJobs_RemovesFailedAndTimeoutJobs` to `ClearFailedJobs_RemovesOnlyFailedJobs`
  - Changed assertion at line 171 from `Assert.Null(service.GetJob(timeoutId))` to `Assert.NotNull(service.GetJob(timeoutId))`

## Manual Testing

N/A — internal test fix with no user-facing behavior. The fix ensures unit tests correctly verify that `ClearFailedJobs()` only removes jobs with `JobStatus.Failed`, leaving `JobStatus.Timeout` jobs intact.

---

**Commits:**
- dd7ac0ac Fix ClearFailedJobs test to reflect current behavior

---
Created using [Ivy Tendril](https://ivy.app).