### PR TITLE
Brand sidebar/tab with configured coding agent

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexPtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexPtyTests.cs
@@ -8,7 +8,7 @@ public class CodexPtyTests
     private readonly CodexPty _pty = new();
 
     [Fact]
-    public void BuildPtySpec_FullAuto_IncludesFullAutoFlag()
+    public void BuildPtySpec_FullAuto_UsesSandboxAndApprovalFlags()
     {
         var config = new AgentPtyConfig
         {
@@ -18,11 +18,14 @@ public class CodexPtyTests
 
         var spec = _pty.BuildPtySpec(config);
 
-        Assert.Contains("--full-auto", spec.CommandLine);
+        // The interactive TUI has no `--full-auto` shorthand.
+        Assert.DoesNotContain("--full-auto", spec.CommandLine);
+        AssertFlagValue(spec.CommandLine.ToList(), "--sandbox", "workspace-write");
+        AssertFlagValue(spec.CommandLine.ToList(), "--ask-for-approval", "never");
     }
 
     [Fact]
-    public void BuildPtySpec_DefaultPermission_OmitsFullAutoFlag()
+    public void BuildPtySpec_DefaultPermission_OmitsApprovalFlags()
     {
         var config = new AgentPtyConfig
         {
@@ -33,5 +36,15 @@ public class CodexPtyTests
         var spec = _pty.BuildPtySpec(config);
 
         Assert.DoesNotContain("--full-auto", spec.CommandLine);
+        Assert.DoesNotContain("--sandbox", spec.CommandLine);
+        Assert.DoesNotContain("--ask-for-approval", spec.CommandLine);
+    }
+
+    private static void AssertFlagValue(List<string> args, string flag, string expectedValue)
+    {
+        var idx = args.IndexOf(flag);
+        Assert.True(idx >= 0, $"Expected flag {flag} to be present.");
+        Assert.True(idx + 1 < args.Count, $"Expected a value after {flag}.");
+        Assert.Equal(expectedValue, args[idx + 1]);
     }
 }

--- a/src/Ivy.Tendril.Agents.Test/Gemini/GeminiCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Gemini/GeminiCliTests.cs
@@ -16,7 +16,7 @@ public class GeminiCliTests
     [Fact]
     public void DisplayName_IsGeminiCli()
     {
-        Assert.Equal("Gemini CLI", _cli.DisplayName);
+        Assert.Equal("Gemini", _cli.DisplayName);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Gemini/GeminiPtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Gemini/GeminiPtyTests.cs
@@ -1,0 +1,40 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Gemini;
+
+namespace Ivy.Tendril.Agents.Test.Gemini;
+
+public class GeminiPtyTests
+{
+    private readonly GeminiPty _pty = new();
+
+    [Fact]
+    public void BuildPtySpec_FullAuto_UsesYoloFlag()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            PermissionMode = PermissionMode.FullAuto,
+        };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        // The interactive TUI uses --yolo; --approval-mode is headless-only and
+        // missing from older gemini builds.
+        Assert.Contains("--yolo", spec.CommandLine);
+        Assert.DoesNotContain("--approval-mode", spec.CommandLine);
+    }
+
+    [Fact]
+    public void BuildPtySpec_DefaultPermission_OmitsYoloFlag()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            PermissionMode = PermissionMode.Default,
+        };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.DoesNotContain("--yolo", spec.CommandLine);
+    }
+}

--- a/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodePtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodePtyTests.cs
@@ -8,8 +8,10 @@ public class OpenCodePtyTests
     private readonly OpenCodePty _pty = new();
 
     [Fact]
-    public void BuildPtySpec_FullAuto_SkipsPermissions()
+    public void BuildPtySpec_FullAuto_OmitsSkipPermissions()
     {
+        // The interactive TUI rejects --dangerously-skip-permissions (it only
+        // exists on the `run` subcommand), so FullAuto must not add it.
         var config = new AgentPtyConfig
         {
             WorkingDirectory = "/tmp/test",
@@ -18,7 +20,7 @@ public class OpenCodePtyTests
 
         var spec = _pty.BuildPtySpec(config);
 
-        Assert.Contains("--dangerously-skip-permissions", spec.CommandLine);
+        Assert.DoesNotContain("--dangerously-skip-permissions", spec.CommandLine);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents/AGENTS.md
+++ b/src/Ivy.Tendril.Agents/AGENTS.md
@@ -1,6 +1,6 @@
 # Ivy.Tendril.Agents
 
-Cross-platform .NET 10 library for orchestrating coding agent CLIs. Provides a unified API to spawn, stream events from, and manage sessions with Claude Code, GitHub Copilot, Codex, Gemini CLI, and OpenCode.
+Cross-platform .NET 10 library for orchestrating coding agent CLIs. Provides a unified API to spawn, stream events from, and manage sessions with Claude Code, GitHub Copilot, Codex, Gemini, and OpenCode.
 
 ## Architecture
 

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexPty.cs
@@ -47,8 +47,15 @@ public sealed class CodexPty : IAgentPty
         var args = new List<string> { "codex" };
 
         // FullAuto → run without approval prompts (workspace-write sandbox).
+        // The interactive TUI has no `--full-auto` shorthand (that lived on the
+        // legacy top-level CLI); compose it from the sandbox + approval flags.
         if (config.PermissionMode == PermissionMode.FullAuto)
-            args.Add("--full-auto");
+        {
+            args.Add("--sandbox");
+            args.Add("workspace-write");
+            args.Add("--ask-for-approval");
+            args.Add("never");
+        }
 
         if (!string.IsNullOrEmpty(config.Model))
         {

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiCli.cs
@@ -5,7 +5,7 @@ namespace Ivy.Tendril.Agents.Providers.Gemini;
 public sealed class GeminiCli : IAgentCli
 {
     public string Id => AgentId.Gemini;
-    public string DisplayName => "Gemini CLI";
+    public string DisplayName => "Gemini";
 
     public AgentCapabilities Capabilities =>
         AgentCapabilities.StdinPrompt |

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiHealthCheck.cs
@@ -76,7 +76,7 @@ public sealed class GeminiHealthCheck : IAgentHealthCheck
 
     public AgentOnboardingInfo GetOnboardingInfo() => new()
     {
-        DisplayName = "Gemini CLI",
+        DisplayName = "Gemini",
         InstallCommand = "npm install -g @google/gemini-cli",
         InstallUrl = "https://github.com/google-gemini/gemini-cli",
         AuthCommand = "gemini auth",

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiPty.cs
@@ -5,7 +5,7 @@ namespace Ivy.Tendril.Agents.Providers.Gemini;
 public sealed class GeminiPty : IAgentPty
 {
     public string Id => AgentId.Gemini;
-    public string DisplayName => "Gemini CLI";
+    public string DisplayName => "Gemini";
 
     public AgentCapabilities Capabilities =>
         AgentCapabilities.ModelSelection |
@@ -33,11 +33,11 @@ public sealed class GeminiPty : IAgentPty
     {
         var args = new List<string> { "gemini" };
 
+        // FullAuto → auto-approve every action. The interactive TUI uses the
+        // `--yolo` switch (the granular `--approval-mode` flag exists only on
+        // newer headless builds, so `--yolo` is what works across versions).
         if (config.PermissionMode == PermissionMode.FullAuto)
-        {
-            args.Add("--approval-mode");
-            args.Add("yolo");
-        }
+            args.Add("--yolo");
 
         if (!string.IsNullOrEmpty(config.Model))
         {

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodePty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodePty.cs
@@ -55,9 +55,11 @@ public sealed class OpenCodePty : IAgentPty
     {
         var args = new List<string> { "opencode" };
 
-        // FullAuto → run without permission prompts.
-        if (config.PermissionMode == PermissionMode.FullAuto)
-            args.Add("--dangerously-skip-permissions");
+        // NOTE: the interactive TUI (the default `opencode` command) has no
+        // permission-bypass flag — `--dangerously-skip-permissions` exists only
+        // on the `run` subcommand. Passing it to the TUI makes opencode reject
+        // the argument and print help, so FullAuto adds no flag here; the user
+        // approves actions in the TUI (or configures a yolo agent).
 
         if (!string.IsNullOrEmpty(config.Model))
         {

--- a/src/Ivy.Tendril.TeamIvyConfig/AGENTS.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/AGENTS.md
@@ -8,13 +8,13 @@ You are an interactive assistant for the human operator. Users open this session
 
 ## Environment
 
-- **TENDRIL_HOME**: `D:/Tendril/`
-- **Plans folder**: `D:/Plans/`
-- **Config**: `D:/Tendril//config.yaml`
-- **Database**: `D:/Tendril//tendril.db`
+- **TENDRIL_HOME**: `D:/Tendril`
+- **Plans folder**: `D:/Plans`
+- **Config**: `D:/Tendril/config.yaml`
+- **Database**: `D:/Tendril/tendril.db`
 
 ```
-D:/Tendril//
+D:/Tendril/
   config.yaml          # Projects, agents, verifications, promptware settings
   tendril.db           # SQLite database (plan state, jobs, costs)
   Plans/               # Plan folders ({ID}-{Title}/)
@@ -75,7 +75,7 @@ Autonomous agents that handle each pipeline stage. Each has a `Program.md` (inst
 
 ## Plan Structure
 
-Plans live in `D:/Plans//{ID}-{SafeTitle}/`:
+Plans live in `D:/Plans/{ID}-{SafeTitle}/`:
 
 ```
 00142-FixLoginBug/

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -1,4 +1,4 @@
-codingAgent: codex
+codingAgent: gemini
 jobTimeout: 30
 staleOutputTimeout: 10
 gitTimeout: 10

--- a/src/Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj
+++ b/src/Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj
@@ -24,10 +24,6 @@
     <WidgetsFrontendSourceFiles Include="frontend/tsconfig.json" />
     <WidgetsFrontendSourceFiles Include="frontend/vite.widget.ts" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <Folder Include="Questions\" />
-  </ItemGroup>
 
   <Target Name="WidgetsNpmInstall" BeforeTargets="WidgetsBuildFrontend" Inputs="frontend/package.json;frontend/pnpm-lock.yaml" Outputs="frontend/node_modules/.modules.yaml">
     <Exec Command="npx --prefer-offline -y pnpm@10.33.0 install --config.confirmModulesPurge=false" WorkingDirectory="frontend" />

--- a/src/Ivy.Tendril.Widgets/UserQuestionViewer.cs
+++ b/src/Ivy.Tendril.Widgets/UserQuestionViewer.cs
@@ -27,7 +27,7 @@ public class UserQuestionViewer(IState<ImmutableList<UserQuestion>> questions) :
             return Layout.Vertical().Padding(4)
                    | Text.Muted("No questions to answer.");
 
-        var tabs = list.Select((q, i) => BuildTab(q, i)).ToArray();
+        var tabs = list.Select(BuildTab).ToArray();
 
         return Layout.Tabs(tabs)
             .Variant(TabsVariant.Tabs)

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -3,6 +3,7 @@ using System.Reactive.Disposables;
 using System.Text.Json;
 using Ivy.Core;
 using Ivy.Core.Apps;
+using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.AppShell.Dialogs;
 using Ivy.Tendril.Apps;
 using Ivy.Tendril.Apps.Onboarding;
@@ -74,7 +75,25 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         return item;
     }
 
-    private static MenuItem[] BuildMenuItems(IAppRepository repo, TendrilProcessStatus status)
+    // The Agent app id (and its menu-item Tag) collapses to "agent" via AppHelpers.GetApp.
+    private const string AgentAppId = "agent";
+
+    // Re-brand the generic "Agent" menu item to the configured coding agent (e.g. "Claude Code"
+    // with the Claude icon), so the sidebar matches what actually launches.
+    private static MenuItem BrandAgentItem(MenuItem item, string agentId, IAgentRunner runner)
+    {
+        if (item.Tag is string tag && tag == AgentAppId)
+        {
+            var (label, icon) = AgentBranding.For(agentId, runner);
+            item = item.Label(label).Icon(icon);
+        }
+        if (item.Children is { Length: > 0 })
+            item = item with { Children = item.Children.Select(c => BrandAgentItem(c, agentId, runner)).ToArray() };
+        return item;
+    }
+
+    private static MenuItem[] BuildMenuItems(IAppRepository repo, TendrilProcessStatus status,
+        IConfigService config, IAgentRunner runner)
     {
         var badges = new Dictionary<string, int>
         {
@@ -85,7 +104,11 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             ["recommendations"] = status.RecommendationsCount,
             ["trash"] = status.TrashCount
         };
-        return repo.GetMenuItems().Select(m => AddBadge(m, badges)).ToArray();
+        var agentId = config.Settings.CodingAgent;
+        return repo.GetMenuItems()
+            .Select(m => AddBadge(m, badges))
+            .Select(m => BrandAgentItem(m, agentId, runner))
+            .ToArray();
     }
 
     public override object Build()
@@ -99,7 +122,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var client = UseService<IClientProvider>();
         var currentApp = UseState<AppHost?>();
         var statusService = UseService<ITendrilProcessStatusService>();
-        var menuItems = UseState(() => BuildMenuItems(appRepository, statusService.Current));
+        var agentRunner = UseService<IAgentRunner>();
+        var menuItems = UseState(() => BuildMenuItems(appRepository, statusService.Current, config, agentRunner));
         var status = UseState(() => statusService.Current);
         var sidebarOpen = UseState(settings.SidebarOpen);
         var args = UseService<AppContext>();
@@ -134,8 +158,18 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             });
         });
 
-        UseEffect(() => { menuItems.Set(BuildMenuItems(appRepository, status.Value)); },
+        UseEffect(() => { menuItems.Set(BuildMenuItems(appRepository, status.Value, config, agentRunner)); },
             appRepository.Reloaded.ToTrigger(), status);
+
+        // Rebuild the menu when settings are saved (e.g. the coding agent changes), so the
+        // branded "Agent" item updates immediately without needing a reload.
+        UseEffect(() =>
+        {
+            void OnSettingsReloaded(object? sender, EventArgs e) =>
+                menuItems.Set(BuildMenuItems(appRepository, status.Value, config, agentRunner));
+            config.SettingsReloaded += OnSettingsReloaded;
+            return Disposable.Create(() => config.SettingsReloaded -= OnSettingsReloaded);
+        });
 
         var jobService = UseService<IJobService>();
 
@@ -183,10 +217,23 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 SidebarOpen = false
             };
 
+        // The Agent app's descriptor title/icon are the generic "Agent"/terminal; brand them
+        // to the configured coding agent so tabs and the browser title stay consistent.
+        (string Title, Icons? Icon) BrandedAppDisplay(AppDescriptor app)
+        {
+            if (app.Id == AgentAppId)
+            {
+                var (label, icon) = AgentBranding.For(config.Settings.CodingAgent, agentRunner);
+                return (label, icon);
+            }
+            return (app.Title, app.Icon);
+        }
+
         void SetAppTitle(string appId)
         {
             var app = appRepository.GetAppOrDefault(appId);
-            if (app.Title is { } title) client.SetTitle(title, serverArgs.Metadata.Title);
+            var (title, _) = BrandedAppDisplay(app);
+            if (title is { } t) client.SetTitle(t, serverArgs.Metadata.Title);
         }
 
         bool IsErrorApp(string? appId)
@@ -283,9 +330,10 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             var tabId = Guid.NewGuid().ToString();
             var appHost = navigateArgs.ToAppHost(args.ConnectionId);
             var app = appRepository.GetAppOrDefault(effectiveAppId);
+            var (tabTitle, tabIcon) = BrandedAppDisplay(app);
 
-            var newTabs = tabs.Value.Add(new TabState(tabId, app.Id, app.Title, appHost,
-                app.Icon, Guid.NewGuid().ToString()));
+            var newTabs = tabs.Value.Add(new TabState(tabId, app.Id, tabTitle, appHost,
+                tabIcon, Guid.NewGuid().ToString()));
             tabs.Set(newTabs);
             selectedIndex.Set(newTabs.Length - 1);
             SetAppTitle(app.Id);

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -1,5 +1,6 @@
 using Ivy;
 using Ivy.Core.Hooks;
+using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Widgets;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
@@ -29,7 +30,7 @@ public class CreatePlanDialog(
         _ => 0
     };
 
-    // Builds the seed prompt for the "Continue with Agent" flow. The description is
+    // Builds the seed prompt for the "Continue with <agent>" flow. The description is
     // trimmed, a single project reads "the project X", multiple read "the projects X or Y",
     // and "Auto" lets the agent pick the project itself.
     internal static string BuildAgentPrompt(string[] projects, string description)
@@ -53,10 +54,9 @@ public class CreatePlanDialog(
         var selectedProjects = UseState(_defaultProjects);
         var selectedPriority = UseState("Normal");
         var configService = UseService<IConfigService>();
+        var agentRunner = UseService<IAgentRunner>();
         var uploadSessionId = UseState(() => Guid.NewGuid().ToString("N"));
-
         var (breakpoint, breakpointListener) = Context.UseBreakpoint();
-
         var uploadedFiles = UseState(new List<string>());
 
         var uploadContext = this.UseUpload(async (fileUpload, stream, token) =>
@@ -81,6 +81,9 @@ public class CreatePlanDialog(
             var newList = new List<string>(uploadedFiles.Value) { filePath };
             uploadedFiles.Set(newList);
         });
+
+        // e.g. "Continue with Claude Code" — branded to the configured coding agent.
+        var continueLabel = $"Continue with {AgentBranding.For(configService.Settings.CodingAgent, agentRunner).Label}";
 
         var exclusiveProjects = new ConvertedState<string[], string[]>(
             selectedProjects,
@@ -145,7 +148,7 @@ public class CreatePlanDialog(
                     },
                     OnMenuAction = e =>
                     {
-                        if (e.Value == "Continue with Agent")
+                        if (e.Value == continueLabel)
                         {
                             if (string.IsNullOrWhiteSpace(createPlanText.Value)) return ValueTask.CompletedTask;
                             var projects = selectedProjects.Value.Any()
@@ -191,7 +194,7 @@ public class CreatePlanDialog(
                 }
                     .Bind(createPlanText)
                     .SubmitLabel("Create")
-                    .MenuOptions("Continue with Agent")
+                    .MenuOptions(continueLabel)
                     .Placeholder("Enter task description...")
                     .WithField()
                     .Label("Describe the task for the new plan")

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -57,12 +57,12 @@ public class CodingAgentStepView(
 
     private static readonly AgentInfo[] Agents =
     [
-        new("claude",   "Claude",   Icons.ClaudeCode),
-        new("copilot",  "Copilot",  Icons.Copilot),
-        new("codex",    "Codex",    Icons.OpenAI),
-        new("gemini",   "Gemini",   Icons.Gemini),
-        new("antigravity", "Antigravity", Icons.Antigravity),
-        new("opencode", "OpenCode", Icons.OpenCode)
+        new("claude",   "Claude",   AgentBranding.IconFor("claude")),
+        new("copilot",  "Copilot",  AgentBranding.IconFor("copilot")),
+        new("codex",    "Codex",    AgentBranding.IconFor("codex")),
+        new("gemini",   "Gemini",   AgentBranding.IconFor("gemini")),
+        new("antigravity", "Antigravity", AgentBranding.IconFor("antigravity")),
+        new("opencode", "OpenCode", AgentBranding.IconFor("opencode"))
     ];
 
     public override object Build()

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Apps.Settings.Dialogs;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps.Settings;
@@ -10,12 +11,12 @@ public class CodingAgentSetupView : ViewBase
 
     private static readonly AgentInfo[] Agents =
     [
-        new("claude", "Claude", Icons.ClaudeCode),
-        new("copilot", "Copilot", Icons.Copilot),
-        new("codex", "Codex", Icons.OpenAI),
-        new("gemini", "Gemini", Icons.Gemini),
-        new("antigravity", "Antigravity", Icons.Antigravity),
-        new("opencode", "OpenCode", Icons.OpenCode)
+        new("claude", "Claude", AgentBranding.IconFor("claude")),
+        new("copilot", "Copilot", AgentBranding.IconFor("copilot")),
+        new("codex", "Codex", AgentBranding.IconFor("codex")),
+        new("gemini", "Gemini", AgentBranding.IconFor("gemini")),
+        new("antigravity", "Antigravity", AgentBranding.IconFor("antigravity")),
+        new("opencode", "OpenCode", AgentBranding.IconFor("opencode"))
     ];
 
     public override object Build()

--- a/src/Ivy.Tendril/Helpers/AgentBranding.cs
+++ b/src/Ivy.Tendril/Helpers/AgentBranding.cs
@@ -1,0 +1,60 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+/// Shared display metadata (icon + name) for coding agents, so the sidebar, tabs,
+/// dialogs and setup views all brand the configured agent consistently. The icon
+/// map lives here as the single source of truth; the display name comes from the
+/// agent's CLI via <see cref="IAgentRunner.GetCli"/>.
+/// </summary>
+public static class AgentBranding
+{
+    /// <summary>Icon to use when the agent id is unknown or empty.</summary>
+    public const Icons DefaultIcon = Icons.Terminal;
+
+    /// <summary>Display name to use when the agent id can't be resolved.</summary>
+    public const string DefaultLabel = "Agent";
+
+    /// <summary>Maps a coding agent id to its logo icon, falling back to <see cref="DefaultIcon"/>.</summary>
+    public static Icons IconFor(string? agentId)
+    {
+        if (string.IsNullOrWhiteSpace(agentId))
+            return DefaultIcon;
+
+        return AgentProviderFactory.NormalizeAgentName(agentId) switch
+        {
+            AgentId.Claude => Icons.ClaudeCode,
+            AgentId.Copilot => Icons.Copilot,
+            AgentId.Codex => Icons.OpenAI,
+            AgentId.Gemini => Icons.Gemini,
+            AgentId.Antigravity => Icons.Antigravity,
+            AgentId.OpenCode => Icons.OpenCode,
+            _ => DefaultIcon,
+        };
+    }
+
+    /// <summary>
+    /// Returns the configured agent's display name (e.g. "Claude Code") and icon,
+    /// falling back gracefully to <see cref="DefaultLabel"/>/<see cref="DefaultIcon"/>
+    /// for unknown or unregistered agents.
+    /// </summary>
+    public static (string Label, Icons Icon) For(string? agentId, IAgentRunner runner)
+    {
+        var icon = IconFor(agentId);
+
+        if (string.IsNullOrWhiteSpace(agentId))
+            return (DefaultLabel, icon);
+
+        try
+        {
+            var displayName = runner.GetCli(AgentProviderFactory.NormalizeAgentName(agentId)).DisplayName;
+            return (string.IsNullOrWhiteSpace(displayName) ? DefaultLabel : displayName, icon);
+        }
+        catch
+        {
+            return (DefaultLabel, icon);
+        }
+    }
+}


### PR DESCRIPTION
Shows the configured coding agent's name and icon (e.g. "Claude Code") in the sidebar nav, the opened Agent tab, the browser title, and the "Continue with <agent>" menu in the Create Plan dialog — instead of the generic "Agent"/terminal label.

- New shared `AgentBranding` helper is the single source of truth for agent icons; reused by the settings and onboarding agent pickers.
- The sidebar menu rebuilds on settings save (`SettingsReloaded`), so the label/icon update immediately when the coding agent changes.
- Includes misc Codex/Gemini/OpenCode provider and test updates present in the working tree.