### PR TITLE
[00616] Fix Gemini Text Output Hard Line Break Formatting

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Gemini/GeminiEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Gemini/GeminiEventParserTests.cs
@@ -237,4 +237,70 @@ public class GeminiEventParserTests
     {
         _parser.Reset();
     }
+
+    [Fact]
+    public void ParseLine_MessageEvent_HardWrappedProse_UnwrapsToSingleParagraph()
+    {
+        var json = """{"type":"message","role":"assistant","content":"This is a long sentence that has been\nwrapped at column boundaries by the\nterminal output formatter."}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Single(events);
+        var text = Assert.IsType<TextEvent>(events[0]);
+        Assert.Equal("This is a long sentence that has been wrapped at column boundaries by the terminal output formatter.", text.Text);
+    }
+
+    [Fact]
+    public void ParseLine_MessageEvent_ParagraphBoundary_PreservesDoubleNewline()
+    {
+        var json = """{"type":"message","role":"assistant","content":"First paragraph here.\n\nSecond paragraph here."}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Single(events);
+        var text = Assert.IsType<TextEvent>(events[0]);
+        Assert.Equal("First paragraph here.\n\nSecond paragraph here.", text.Text);
+    }
+
+    [Fact]
+    public void ParseLine_MessageEvent_CodeBlock_PreservesNewlines()
+    {
+        var json = """{"type":"message","role":"assistant","content":"Here is code:\n```csharp\nvar x = 1;\nvar y = 2;\n```\nDone."}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Single(events);
+        var text = Assert.IsType<TextEvent>(events[0]);
+        Assert.Equal("Here is code:\n```csharp\nvar x = 1;\nvar y = 2;\n```\nDone.", text.Text);
+    }
+
+    [Fact]
+    public void ParseLine_MessageEvent_ListItems_PreservesNewlines()
+    {
+        var json = """{"type":"message","role":"assistant","content":"Here are items:\n- First item\n- Second item\n* Third item"}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Single(events);
+        var text = Assert.IsType<TextEvent>(events[0]);
+        Assert.Equal("Here are items:\n- First item\n- Second item\n* Third item", text.Text);
+    }
+
+    [Fact]
+    public void ParseLine_MessageEvent_Headings_PreservesNewlines()
+    {
+        var json = """{"type":"message","role":"assistant","content":"# Main Heading\nSome text here.\n## Subheading\nMore text."}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Single(events);
+        var text = Assert.IsType<TextEvent>(events[0]);
+        Assert.Equal("# Main Heading\nSome text here.\n## Subheading\nMore text.", text.Text);
+    }
+
+    [Fact]
+    public void ParseLine_MessageEvent_InlineCodeAcrossWrap_Preserved()
+    {
+        var json = """{"type":"message","role":"assistant","content":"Since `PrMerge` is being called\nfrom multiple places, you need to handle it."}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Single(events);
+        var text = Assert.IsType<TextEvent>(events[0]);
+        Assert.Equal("Since `PrMerge` is being called from multiple places, you need to handle it.", text.Text);
+    }
 }

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiEventParser.cs
@@ -136,12 +136,104 @@ public sealed class GeminiEventParser : IEventParser
         if (string.IsNullOrEmpty(content))
             return Empty;
 
+        var unwrapped = UnwrapHardWraps(content);
+
         return [new TextEvent
         {
             Kind = AgentEventKind.Text,
-            Text = content,
+            Text = unwrapped,
             RawLine = rawLine,
         }];
+    }
+
+    private static string UnwrapHardWraps(string content)
+    {
+        if (string.IsNullOrEmpty(content))
+            return content;
+
+        var lines = content.Split('\n');
+        if (lines.Length <= 1)
+            return content;
+
+        var result = new StringBuilder();
+        var inCodeBlock = false;
+        var previousWasProse = false;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var trimmedLine = line.TrimStart();
+
+            // Track code block boundaries
+            if (trimmedLine.StartsWith("```", StringComparison.Ordinal) ||
+                trimmedLine.StartsWith("~~~", StringComparison.Ordinal))
+            {
+                if (result.Length > 0 && !inCodeBlock)
+                    result.Append('\n');
+                result.Append(line);
+                result.Append('\n');
+                inCodeBlock = !inCodeBlock;
+                previousWasProse = false;
+                continue;
+            }
+
+            // Preserve code block content exactly
+            if (inCodeBlock)
+            {
+                result.Append(line);
+                result.Append('\n');
+                previousWasProse = false;
+                continue;
+            }
+
+            // Track blank lines (paragraph boundaries)
+            var isBlank = string.IsNullOrWhiteSpace(line);
+            if (isBlank)
+            {
+                // Preserve paragraph breaks
+                result.Append('\n');
+                result.Append('\n');
+                previousWasProse = false;
+                continue;
+            }
+
+            // Check if this line is structural
+            var isHeading = trimmedLine.StartsWith('#');
+            var isListItem = trimmedLine.StartsWith("- ", StringComparison.Ordinal) ||
+                             trimmedLine.StartsWith("* ", StringComparison.Ordinal) ||
+                             trimmedLine.StartsWith("+ ", StringComparison.Ordinal) ||
+                             (trimmedLine.Length > 0 && char.IsDigit(trimmedLine[0]) &&
+                              trimmedLine.Contains(". ", StringComparison.Ordinal));
+
+            var isStructural = isHeading || isListItem;
+            var isProse = !isStructural;
+
+            // First line
+            if (result.Length == 0)
+            {
+                result.Append(line);
+                previousWasProse = isProse;
+                continue;
+            }
+
+            // Only join if both previous and current are prose
+            if (previousWasProse && isProse)
+            {
+                result.Append(' ');
+                result.Append(line);
+                previousWasProse = true;
+            }
+            else
+            {
+                // Only add newline if the result doesn't already end with one
+                if (result.Length > 0 && result[result.Length - 1] != '\n')
+                    result.Append('\n');
+                result.Append(line);
+                previousWasProse = isProse;
+            }
+        }
+
+        return result.ToString();
     }
 
     private static IReadOnlyList<AgentEvent> ParseToolUse(JsonElement root, string rawLine)


### PR DESCRIPTION
Fixes #1408

# Summary

## Changes

Added text unwrapping logic to `GeminiEventParser` to fix hard line break formatting issues in Gemini text output. The Gemini CLI pre-formats text with hard line breaks at column boundaries, which caused fragmented paragraphs and split inline code spans when rendered as Markdown.

## API Changes

- Added static method `UnwrapHardWraps(string content)` in `GeminiEventParser` class
- Modified `ParseMessage` method to call `UnwrapHardWraps` before creating `TextEvent`

## Files Modified

**Implementation:**
- `src/Ivy.Tendril.Agents/Providers/Gemini/GeminiEventParser.cs` — Added unwrapping logic

**Tests:**
- `src/Ivy.Tendril.Agents.Test/Gemini/GeminiEventParserTests.cs` — Added 6 new tests covering all unwrapping scenarios

## Manual Testing

1. Run a Gemini agent session that produces text output with paragraphs
2. Observe the rendered text in the AgentViewer
3. Verify that:
   - Prose paragraphs render as continuous text (not fragmented by hard wraps)
   - Paragraph breaks (double newlines) are preserved
   - Code blocks render correctly with proper line breaks
   - List items render on separate lines
   - Headings render on separate lines
   - Inline code spans that were split across lines are now joined correctly

---
**Commits:**
- b0675d47 Add text unwrapping for Gemini hard-wrapped output

---
Created using [Ivy Tendril](https://ivy.app).