### PR TITLE
Fix Next button disabled after setup agent completes (#1450)

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -215,6 +215,7 @@ public class ProjectAgentStepView(
                 error.Set($"Failed to set up project: {ex.Message}");
                 isCloning.Set(false);
                 isStepLoading.Set(false);
+                session.Running.Set(false);
             }
         }, setupTrigger != null ? [setupTrigger, EffectTrigger.OnMount()] : [EffectTrigger.OnMount()]);
 
@@ -235,6 +236,21 @@ public class ProjectAgentStepView(
         // that avoided a layout shift when the bordered/padded Box swapped in on first output.
         var showStream = !isCloning.Value && (session.Running.Value || session.HasOutput.Value);
 
+        var viewer = new AgentViewer()
+            .Stream(session.Stream)
+            .AutoScroll(true)
+            .ShowStatusLabel(true)
+            .Width(Size.Full())
+            .Height(Size.Full()) with
+        {
+            OnComplete = _ =>
+            {
+                session.Running.Set(false);
+                isStepLoading.Set(false);
+                return ValueTask.CompletedTask;
+            }
+        };
+
         return Layout.Vertical().Margin(0, 0, 0, 2)
                | (showHeader ? Text.H3("Setting up your project") : null!)
                | Text.Muted(isCloning.Value
@@ -249,14 +265,7 @@ public class ProjectAgentStepView(
                    ? (object)new Progress(progressValue.Value.Value)
                    : null!)
                | (showStream
-                   ? (object)new Box(
-                        new AgentViewer()
-                            .Stream(session.Stream)
-                            .AutoScroll(true)
-                            .ShowStatusLabel(true)
-                            .Width(Size.Full())
-                            .Height(Size.Full())
-                      )
+                   ? (object)new Box(viewer)
                         .Width(Size.Full())
                         .Height(Size.Units(100).Max(Size.Fraction(0.6f)))
                         .Padding(4, 4, 0, 4)


### PR DESCRIPTION
## Problem

During onboarding, after the `SetupProject` agent finishes (the `AgentViewer` shows "Completed" with token counts), the **Next** button stays greyed out and unclickable, blocking the setup flow. Reported on Codex CLI runs. Fixes #1450.

**Root cause:** The Next button is disabled by `session.Running.Value`, which is only cleared in the `finally` of a background task that awaits `handle.Completion`. That completion ultimately awaits `process.WaitForExitAsync` in `PromptwareRunner.PipeOutputAndLog` **with no timeout**. The agent can emit its terminal `result` event (which is what makes the `AgentViewer` render "Completed") while keeping the output pipe open, so `session.Running` never transitions to `false` and the button stays disabled. The "config doesn't persist" symptom is a *consequence* of never reaching the `finally` (which calls `ReloadSettings()`), not a serialization bug — the CLI commands persist correctly.

## Fix

`src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs`

1. **Wire `AgentViewer.OnComplete`.** The frontend `AgentViewer` raises `OnComplete` the moment it parses a terminal `result` event from the stream. The handler now clears `session.Running` / `isStepLoading`, so the button enables as soon as the agent reports completion — independent of process exit. The background task's `finally` still runs `ReloadSettings()` whenever the process eventually exits, so config reload is unaffected; both paths clearing the flags is idempotent.

2. **Clear `session.Running` in the error path.** The outer `catch` already reset `isStepLoading` but not `session.Running`; an exception after `Running.Set(true)` could otherwise leave the button permanently disabled.

## Deviations from the original (Codex) plan

- **Did not add a wall-clock timeout to `PipeOutputAndLog`.** The proposed flat 2-minute `CancelAfter` conflated stale-output vs. total-runtime semantics and would kill legitimately long agent runs. The `OnComplete` fix resolves the UI symptom without that risk.
- **Did not add a new `ProjectCommandTests` test.** `AddVerification_AddsToProject` already covers the CLI write → fresh-`ConfigService` reload round-trip.

## Verification

- `dotnet build src/Ivy.Tendril` — succeeded, 0 warnings/errors
- `dotnet build src/Ivy.Tendril.Test` — succeeded
- `dotnet test --filter ProjectCommandTests` — 18/18 passed
- `dotnet format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)