### PR TITLE
Remove dead state-reset code from UseTrigger-mounted dialogs

### DIFF
--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -118,17 +118,6 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         var hasRepo = !string.IsNullOrEmpty(selectedRepo.Value);
         var filtersLoading = hasRepo && (assigneesQuery.Loading || labelsQuery.Loading);
 
-        void ResetDialogState()
-        {
-            fetchedIssueGroups.Set(null);
-            selectedIssueNumbers.Set([]);
-            errorMessage.Set(null);
-            searchQuery.Set("");
-            selectedAssignees.Set(Array.Empty<string>());
-            selectedLabels.Set(Array.Empty<string>());
-            selectedRepo.Set(null);
-        }
-
         void SelectAllInGroup(IReadOnlyList<GitHubIssue> issues)
         {
             var next = new HashSet<int>(selectedIssueNumbers.Value);
@@ -265,7 +254,6 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 }
 
                 client.Toast($"Imported {importedCount} issue{(importedCount == 1 ? "" : "s")} to Inbox", "Import Complete");
-                ResetDialogState();
                 _dialogOpen.Set(false);
             }
             catch (Exception ex)
@@ -347,11 +335,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         var selectedForImport = selectedIssueNumbers.Value.Count;
 
         return new Dialog(
-            _ =>
-            {
-                ResetDialogState();
-                _dialogOpen.Set(false);
-            },
+            _ => _dialogOpen.Set(false),
             new DialogHeader("Import Issues from GitHub"),
             new DialogBody(
                 Layout.Vertical().Gap(3)
@@ -382,11 +366,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 | issuesPanel
             ),
             new DialogFooter(
-                new Button("Cancel").Outline().OnClick(() =>
-                {
-                    ResetDialogState();
-                    _dialogOpen.Set(false);
-                }),
+                new Button("Cancel").Outline().OnClick(() => _dialogOpen.Set(false)),
                 new Button(selectedForImport > 0
                         ? $"Import Selected ({selectedForImport})"
                         : "Import Selected")

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/UpdatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/UpdatePlanDialog.cs
@@ -30,12 +30,7 @@ public class UpdatePlanDialog(
             j.TypedArgs.PlanFolder.Equals(_selectedPlan.FolderPath, StringComparison.OrdinalIgnoreCase));
 
         return new Dialog(
-            _ =>
-            {
-                updateText.Set("");
-                isCreating.Set(false);
-                _dialogOpen.Set(false);
-            },
+            _ => _dialogOpen.Set(false),
             new DialogHeader($"Update Plan #{_selectedPlan.Id}"),
             new DialogBody(
                 Layout.Vertical()
@@ -44,12 +39,7 @@ public class UpdatePlanDialog(
                 | updateText.ToTextareaInput("Enter update instructions...").Rows(6).AutoFocus()
             ),
             new DialogFooter(
-                new Button("Cancel").Outline().OnClick(() =>
-                {
-                    updateText.Set("");
-                    isCreating.Set(false);
-                    _dialogOpen.Set(false);
-                }),
+                new Button("Cancel").Outline().OnClick(() => _dialogOpen.Set(false)),
                 new Button("Submit Update").Primary().Disabled(hasActiveJob || isCreating.Value || string.IsNullOrWhiteSpace(updateText.Value)).ShortcutKey("Ctrl+Enter").OnClick(() =>
                 {
                     if (!string.IsNullOrWhiteSpace(updateText.Value) && !isCreating.Value)
@@ -66,8 +56,6 @@ public class UpdatePlanDialog(
                         // Plan transition (and pre-state snapshot) handled by JobService.StartJob.
                         _jobService.StartJob(new UpdatePlanArgs(_selectedPlan.FolderPath, updateText.Value));
                         _refreshPlans();
-                        updateText.Set("");
-                        isCreating.Set(false);
                         _dialogOpen.Set(false);
                     }
                 })

--- a/src/Ivy.Tendril/Apps/Jobs/Dialogs/RerunJobDialog.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Dialogs/RerunJobDialog.cs
@@ -23,11 +23,7 @@ public class RerunJobDialog(
 
         var supportsFeedback = SupportsFeedback(job.TypedArgs);
 
-        void Close()
-        {
-            feedback.Set("");
-            dialogOpen.Set(false);
-        }
+        void Close() => dialogOpen.Set(false);
 
         var body = supportsFeedback
             ? Layout.Vertical()

--- a/src/Ivy.Tendril/Apps/Recommendations/Dialogs/AcceptWithNotesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/Dialogs/AcceptWithNotesDialog.cs
@@ -19,11 +19,7 @@ public class AcceptWithNotesDialog(
         if (!_dialogOpen.Value) return null;
 
         return new Dialog(
-            _ =>
-            {
-                notesText.Set("");
-                _dialogOpen.Set(false);
-            },
+            _ => _dialogOpen.Set(false),
             new DialogHeader("Accept with Notes"),
             new DialogBody(
                 Layout.Vertical().Gap(2)
@@ -32,15 +28,10 @@ public class AcceptWithNotesDialog(
                 | notesText.ToTextareaInput("Enter your notes...").Rows(6).AutoFocus()
             ),
             new DialogFooter(
-                new Button("Cancel").Outline().OnClick(() =>
-                {
-                    notesText.Set("");
-                    _dialogOpen.Set(false);
-                }),
+                new Button("Cancel").Outline().OnClick(() => _dialogOpen.Set(false)),
                 new Button("Accept").Primary().ShortcutKey("Ctrl+Enter").OnClick(() =>
                 {
                     _onAccept(notesText.Value);
-                    notesText.Set("");
                     _dialogOpen.Set(false);
                 })
             )

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
@@ -25,11 +25,7 @@ public class ResetToDraftDialog(
         if (!_dialogOpen.Value) return null;
 
         return new Dialog(
-            _ =>
-            {
-                isResetting.Set(false);
-                _dialogOpen.Set(false);
-            },
+            _ => _dialogOpen.Set(false),
             new DialogHeader($"Reset Plan #{_selectedPlan.Id} to Draft"),
             new DialogBody(
                 Text.P("Are you sure you want to reset this plan? Will remove all worktrees and artifacts.")

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/SuggestChangesDialog.cs
@@ -22,12 +22,7 @@ public class SuggestChangesDialog(
         if (!_dialogOpen.Value) return null;
 
         return new Dialog(
-            _ =>
-            {
-                isCreating.Set(false);
-                suggestText.Set("");
-                _dialogOpen.Set(false);
-            },
+            _ => _dialogOpen.Set(false),
             new DialogHeader($"Request Changes for Plan #{_selectedPlan.Id}"),
             new DialogBody(
                 Layout.Vertical()
@@ -35,12 +30,7 @@ public class SuggestChangesDialog(
                 | suggestText.ToTextareaInput("Enter your suggestions...").Rows(6).AutoFocus()
             ),
             new DialogFooter(
-                new Button("Cancel").Outline().OnClick(() =>
-                {
-                    isCreating.Set(false);
-                    suggestText.Set("");
-                    _dialogOpen.Set(false);
-                }),
+                new Button("Cancel").Outline().OnClick(() => _dialogOpen.Set(false)),
                 new Button("Request Changes").Primary().Disabled(isCreating.Value || string.IsNullOrWhiteSpace(suggestText.Value)).ShortcutKey("Ctrl+Enter").OnClick(() =>
                 {
                     if (!string.IsNullOrWhiteSpace(suggestText.Value) && !isCreating.Value)
@@ -50,8 +40,6 @@ public class SuggestChangesDialog(
                         // Verification reset + plan transition (and pre-state snapshot) handled by JobService.StartJob.
                         _jobService.StartJob(new RetryPlanArgs(_selectedPlan.FolderPath, suggestText.Value));
                         _refreshPlans();
-                        isCreating.Set(false);
-                        suggestText.Set("");
                         _dialogOpen.Set(false);
                     }
                 })


### PR DESCRIPTION
Follow-up to the CreatePrDialog cleanup. These dialogs are mounted via `UseTrigger`, which unmounts the dialog view (disposing all its `UseState`) when closed and remounts a fresh instance on the next open. The state resets performed right before closing were therefore dead code — writing to state about to be discarded.

Each close handler now only sets its open-state to false.

**Cleaned:**
- `ImportIssuesDialog` — removed 3 `ResetDialogState()` calls + the now-unused helper
- `UpdatePlanDialog` — 3 reset blocks
- `SuggestChangesDialog` — 3 reset blocks
- `AcceptWithNotesDialog` — 3 `notesText` resets
- `RerunJobDialog` — `feedback` reset in `Close()`
- `ResetToDraftDialog` — `isResetting` reset in onClose

Left untouched: `CreateIssueDialog` (mixed local + parent-owned state) and `AgentTestDialog` (persistently mounted, resets are load-bearing).