### PR TITLE
[00620] Remove Separators in Import Issues Dialog

### DIFF
--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -329,7 +329,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                                     .Disabled(groupSelectedCount == 0)
                                     .OnClick(() => SelectNoneInGroup(groupIssues)))
                         | (groupIssues.Count > 0
-                            ? new List(issueRows).Width(Size.Full())
+                            ? (Layout.Vertical().Gap(0).Width(Size.Full()) | issueRows)
                             : Text.Muted("No issues for this assignee."));
                 }
 


### PR DESCRIPTION
Fixes #1463

# Summary

## Changes

Removed visual separator lines between issue items in the "Import Issues from GitHub" dialog by replacing the `List` widget with `Layout.Vertical().Gap(0)`, eliminating the hardcoded border styling.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs** — Changed line 332 to use Layout instead of List widget

## Manual Testing

1. Launch Tendril application
2. Open the "Import Issues from GitHub" dialog (via the relevant menu/action)
3. Observe that issue items are displayed without horizontal separator lines between them
4. Verify that the dialog still functions correctly (selection, filtering, etc.)

---

## Commits

- f23fe1d3 Remove separators in Import Issues dialog

---
Created using [Ivy Tendril](https://ivy.app).