### PR TITLE
[00617] Auto-Focus Text Input When New Plan Dialog Opens

### DIFF
--- a/src/Ivy.Tendril.Widgets/ContentInput.cs
+++ b/src/Ivy.Tendril.Widgets/ContentInput.cs
@@ -65,6 +65,9 @@ public static class ContentInputExtensions
     public static ContentInput SubmitLabel(this ContentInput w, string? label) =>
         w with { SubmitLabel = label };
 
+    public static ContentInput AutoFocus(this ContentInput w) =>
+        w with { AutoFocus = true };
+
     public static ContentInput UploadUrl(this ContentInput w, string? url) =>
         w with { UploadUrl = url };
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx
@@ -99,6 +99,7 @@ interface ContentInputProps {
   attachedFiles?: AttachedFile[];
   submitLabel?: string;
   menuOptions?: string[];
+  autoFocus?: boolean;
   onIvyEvent?: (eventName: string, id: string, argumentsArray: unknown[]) => void;
   eventHandler?: (eventName: string, id: string, argumentsArray: unknown[]) => void;
   events?: string[];
@@ -137,6 +138,7 @@ export const ContentInput: React.FC<ContentInputProps> = ({
   uploadUrl,
   selectedModel = "Build",
   attachedFiles = [],
+  autoFocus = false,
   submitLabel,
   menuOptions = [],
   onIvyEvent,
@@ -167,6 +169,12 @@ export const ContentInput: React.FC<ContentInputProps> = ({
   useEffect(() => {
     filesRef.current = files;
   }, [files]);
+
+  useEffect(() => {
+    if (autoFocus && textareaRef.current) {
+      textareaRef.current.focus();
+    }
+  }, [autoFocus]);
 
   const isImageFile = (path: string) => {
     const ext = path.split(".").pop()?.toLowerCase();

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -132,6 +132,7 @@ public class CreatePlanDialog(
                 | new Ivy.Tendril.Widgets.ContentInput
                 {
                     UploadUrl = uploadContext.Value.UploadUrl,
+                    AutoFocus = true,
                     OnSubmit = e =>
                     {
                         if (!string.IsNullOrWhiteSpace(createPlanText.Value) && !isCreating.Value)


### PR DESCRIPTION
Fixes #1446

# Summary

## Changes

Implemented auto-focus for the ContentInput widget in CreatePlanDialog. The text input now automatically receives focus when the New Plan dialog opens, eliminating the need for users to manually click the field before typing.

## API Changes

**ContentInput.tsx:**
- Added `autoFocus?: boolean` prop to `ContentInputProps` interface

**ContentInput.cs:**
- Added `AutoFocus()` extension method to `ContentInputExtensions`

## Files Modified

**Frontend:**
- `src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx` — Added autoFocus prop and useEffect hook to focus textarea on mount

**Backend:**
- `src/Ivy.Tendril.Widgets/ContentInput.cs` — Added AutoFocus extension method
- `src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs` — Chained .AutoFocus() on ContentInput instance

## Manual Testing

1. Launch the Tendril app
2. Click the "New Plan" button in the Drafts view
3. Observe that the text input field is immediately focused (cursor should be blinking in the textarea)
4. Type directly without clicking the field first
5. Test on both desktop (Dialog) and mobile (Sheet) breakpoints
6. Verify other dialogs with auto-focus (UpdatePlanDialog, SuggestChangesDialog) still work correctly

---

## Commits

- f30fdefc Auto-focus ContentInput in CreatePlanDialog
- 88bfe73a Auto-focus ContentInput in CreatePlanDialog

---
Created using [Ivy Tendril](https://ivy.app).