### PR TITLE
[00621] Fix Responsive Header Text Overlap in Drafts View

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -137,7 +137,7 @@ public class ContentView(
 
         object BuildTitleArea()
         {
-            var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
+            var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full().Min(Size.Px(0)))
                 | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
                     .BorderThickness(0).Padding(0).Width(Size.Fit().Min(Size.Px(0)));
 
@@ -160,7 +160,7 @@ public class ContentView(
             var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
                 .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
 
-            return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow())
+            return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow().Min(Size.Px(0)))
                    | desktopTitle
                    | MobileItemPicker.Build(
                            $"#{selectedPlan.Id} {selectedPlan.Title}",

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -73,7 +73,7 @@ public class ContentView(
 
         object BuildTitleArea()
         {
-            var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
+            var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full().Min(Size.Px(0)))
                 | new Box(Text.Block($"#{selectedRecommendation.PlanId} {selectedRecommendation.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
                     .BorderThickness(0).Padding(0).Width(Size.Fit())
                 | new Badge(selectedRecommendation.Project).Variant(BadgeVariant.Outline)
@@ -82,7 +82,7 @@ public class ContentView(
             var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
                 .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
 
-            return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow())
+            return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow().Min(Size.Px(0)))
                    | desktopTitle
                    | MobileItemPicker.Build(
                            $"#{selectedRecommendation.PlanId} {selectedRecommendation.Title}",

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -253,7 +253,7 @@ public class ContentView(
     {
         object BuildTitleArea()
         {
-            var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
+            var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full().Min(Size.Px(0)))
                 | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
                     .BorderThickness(0).Padding(0).Width(Size.Fit().Min(Size.Px(0)));
 
@@ -264,7 +264,7 @@ public class ContentView(
             var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
                 .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
 
-            return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow())
+            return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow().Min(Size.Px(0)))
                    | desktopTitle
                    | MobileItemPicker.Build(
                            $"#{selectedPlan.Id} {selectedPlan.Title}",


### PR DESCRIPTION
Fixes #1457

# Summary

## Changes

Fixed responsive header text overlap in the Drafts, Review, and Recommendations views by adding `.Min(Size.Px(0))` to the outer title area wrapper and desktop title layout. This propagates `min-width: 0` through the full flex ancestor chain, allowing long plan titles to truncate with ellipsis instead of overflowing into the controls area on narrow viewports.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Drafts/ContentView.cs` — Added `.Min(Size.Px(0))` to outer title area and desktop title layout
- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — Added `.Min(Size.Px(0))` to outer title area and desktop title layout
- `src/Ivy.Tendril/Apps/Recommendations/ContentView.cs` — Added `.Min(Size.Px(0))` to outer title area and desktop title layout

## Manual Testing

1. Launch the Tendril app
2. Navigate to the Drafts view
3. Select a plan with a long title
4. Resize the browser window to ~800px width (or use browser dev tools to simulate a narrow viewport)
5. Verify the plan title truncates with ellipsis instead of overlapping the "X/Y plans" counter and Execute button
6. Repeat for the Review view (select a plan with a long title)
7. Repeat for the Recommendations view (select a recommendation with a long title)
8. Verify the mobile/tablet breakpoint still shows the MobileItemPicker correctly

---

## Commits

- 75dc64b7 Fix responsive header text overlap in Drafts, Review, and Recommendations

---
Created using [Ivy Tendril](https://ivy.app).