### PR TITLE
Deliver agent chat prompt via CLI arg + handle first-run trust modals

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityPtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityPtyTests.cs
@@ -1,0 +1,55 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Antigravity;
+
+namespace Ivy.Tendril.Agents.Test.Antigravity;
+
+public class AntigravityPtyTests
+{
+    private readonly AntigravityPty _pty = new();
+
+    [Fact]
+    public void BuildPtySpec_FullAuto_SkipsPermissions()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            PermissionMode = PermissionMode.FullAuto,
+        };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.Contains("--dangerously-skip-permissions", spec.CommandLine);
+    }
+
+    [Fact]
+    public void BuildPtySpec_InitialPrompt_PassedViaInteractiveFlag()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            InitialPrompt = "do the thing",
+        };
+
+        var args = _pty.BuildPtySpec(config).CommandLine.ToList();
+
+        var idx = args.IndexOf("-i");
+        Assert.True(idx >= 0, "Expected -i flag.");
+        Assert.Equal("do the thing", args[idx + 1]);
+    }
+
+    [Fact]
+    public void BuildPtySpec_NoInitialPrompt_OmitsInteractiveFlag()
+    {
+        var config = new AgentPtyConfig { WorkingDirectory = "/tmp/test" };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.DoesNotContain("-i", spec.CommandLine);
+    }
+
+    [Fact]
+    public void ContextFileName_IsAgentsMd()
+    {
+        Assert.Equal("AGENTS.md", _pty.ContextFileName);
+    }
+}

--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudePtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudePtyTests.cs
@@ -386,4 +386,34 @@ public class ClaudePtyTests
 
         Assert.DoesNotContain("--session-id", spec.CommandLine);
     }
+
+    [Fact]
+    public void BuildPtySpec_InitialPrompt_IsTrailingPositionalArg()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            InitialPrompt = "do the thing",
+        };
+
+        var args = _pty.BuildPtySpec(config).CommandLine.ToList();
+
+        Assert.Equal("do the thing", args[^1]);
+    }
+
+    [Fact]
+    public void BuildPtySpec_NoInitialPrompt_HasNoTrailingPrompt()
+    {
+        var config = new AgentPtyConfig { WorkingDirectory = "/tmp/test" };
+
+        var args = _pty.BuildPtySpec(config).CommandLine.ToList();
+
+        Assert.DoesNotContain("do the thing", args);
+    }
+
+    [Fact]
+    public void ContextFileName_IsNull_ClaudeUsesSystemPromptFlag()
+    {
+        Assert.Null(_pty.ContextFileName);
+    }
 }

--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexPtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexPtyTests.cs
@@ -40,6 +40,50 @@ public class CodexPtyTests
         Assert.DoesNotContain("--ask-for-approval", spec.CommandLine);
     }
 
+    [Fact]
+    public void BuildPtySpec_InitialPrompt_IsTrailingPositionalArg()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            PermissionMode = PermissionMode.FullAuto,
+            InitialPrompt = "do the thing",
+        };
+
+        var args = _pty.BuildPtySpec(config).CommandLine.ToList();
+
+        // The Codex TUI takes [PROMPT] as the final positional argument (after all options).
+        Assert.Equal("do the thing", args[^1]);
+    }
+
+    [Fact]
+    public void BuildPtySpec_NoInitialPrompt_HasNoTrailingPrompt()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            PermissionMode = PermissionMode.Default,
+        };
+
+        var args = _pty.BuildPtySpec(config).CommandLine.ToList();
+
+        Assert.Equal("codex", args[^1]);
+    }
+
+    [Fact]
+    public void ContextFileName_IsAgentsMd()
+    {
+        Assert.Equal("AGENTS.md", _pty.ContextFileName);
+    }
+
+    [Fact]
+    public void GetActivityPatterns_HasTrustPrompt()
+    {
+        var patterns = _pty.GetActivityPatterns()!;
+        Assert.False(string.IsNullOrEmpty(patterns.TrustPromptPattern));
+        Assert.Equal("\r", patterns.TrustAcceptInput);
+    }
+
     private static void AssertFlagValue(List<string> args, string flag, string expectedValue)
     {
         var idx = args.IndexOf(flag);

--- a/src/Ivy.Tendril.Agents.Test/Copilot/CopilotPtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Copilot/CopilotPtyTests.cs
@@ -38,4 +38,44 @@ public class CopilotPtyTests
         Assert.DoesNotContain("--allow-all-paths", spec.CommandLine);
         Assert.DoesNotContain("--allow-all-urls", spec.CommandLine);
     }
+
+    [Fact]
+    public void BuildPtySpec_InitialPrompt_PassedViaInteractiveFlag()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            InitialPrompt = "do the thing",
+        };
+
+        var args = _pty.BuildPtySpec(config).CommandLine.ToList();
+
+        var idx = args.IndexOf("-i");
+        Assert.True(idx >= 0, "Expected -i flag.");
+        Assert.Equal("do the thing", args[idx + 1]);
+    }
+
+    [Fact]
+    public void BuildPtySpec_NoInitialPrompt_OmitsInteractiveFlag()
+    {
+        var config = new AgentPtyConfig { WorkingDirectory = "/tmp/test" };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.DoesNotContain("-i", spec.CommandLine);
+    }
+
+    [Fact]
+    public void ContextFileName_IsAgentsMd()
+    {
+        Assert.Equal("AGENTS.md", _pty.ContextFileName);
+    }
+
+    [Fact]
+    public void GetActivityPatterns_HasTrustPrompt()
+    {
+        var patterns = _pty.GetActivityPatterns()!;
+        Assert.False(string.IsNullOrEmpty(patterns.TrustPromptPattern));
+        Assert.Equal("\r", patterns.TrustAcceptInput);
+    }
 }

--- a/src/Ivy.Tendril.Agents.Test/Gemini/GeminiPtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Gemini/GeminiPtyTests.cs
@@ -37,4 +37,36 @@ public class GeminiPtyTests
 
         Assert.DoesNotContain("--yolo", spec.CommandLine);
     }
+
+    [Fact]
+    public void BuildPtySpec_AlwaysAddsSkipTrust()
+    {
+        var config = new AgentPtyConfig { WorkingDirectory = "/tmp/test" };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.Contains("--skip-trust", spec.CommandLine);
+    }
+
+    [Fact]
+    public void BuildPtySpec_InitialPrompt_PassedViaInteractiveFlag()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            InitialPrompt = "do the thing",
+        };
+
+        var args = _pty.BuildPtySpec(config).CommandLine.ToList();
+
+        var idx = args.IndexOf("-i");
+        Assert.True(idx >= 0, "Expected -i flag.");
+        Assert.Equal("do the thing", args[idx + 1]);
+    }
+
+    [Fact]
+    public void ContextFileName_IsGeminiMd()
+    {
+        Assert.Equal("GEMINI.md", _pty.ContextFileName);
+    }
 }

--- a/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodePtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodePtyTests.cs
@@ -36,4 +36,36 @@ public class OpenCodePtyTests
 
         Assert.DoesNotContain("--dangerously-skip-permissions", spec.CommandLine);
     }
+
+    [Fact]
+    public void BuildPtySpec_InitialPrompt_PassedViaPromptFlag()
+    {
+        var config = new AgentPtyConfig
+        {
+            WorkingDirectory = "/tmp/test",
+            InitialPrompt = "do the thing",
+        };
+
+        var args = _pty.BuildPtySpec(config).CommandLine.ToList();
+
+        var idx = args.IndexOf("--prompt");
+        Assert.True(idx >= 0, "Expected --prompt flag.");
+        Assert.Equal("do the thing", args[idx + 1]);
+    }
+
+    [Fact]
+    public void BuildPtySpec_NoInitialPrompt_OmitsPromptFlag()
+    {
+        var config = new AgentPtyConfig { WorkingDirectory = "/tmp/test" };
+
+        var spec = _pty.BuildPtySpec(config);
+
+        Assert.DoesNotContain("--prompt", spec.CommandLine);
+    }
+
+    [Fact]
+    public void ContextFileName_IsAgentsMd()
+    {
+        Assert.Equal("AGENTS.md", _pty.ContextFileName);
+    }
 }

--- a/src/Ivy.Tendril.Agents/Abstractions/IAgentPty.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/IAgentPty.cs
@@ -4,6 +4,13 @@ public interface IAgentPty : IAgentDescriptor
 {
     AgentPtySpec BuildPtySpec(AgentPtyConfig config);
     AgentActivityPatterns? GetActivityPatterns();
+
+    /// <summary>
+    /// File the agent reads from the working directory for project/system instructions
+    /// (e.g. "AGENTS.md", "GEMINI.md"). Null when the agent takes its system prompt via a
+    /// command-line flag instead (Claude uses --append-system-prompt-file).
+    /// </summary>
+    string? ContextFileName { get; }
 }
 
 public sealed record AgentPtyConfig
@@ -14,6 +21,14 @@ public sealed record AgentPtyConfig
     public bool AppendSystemPrompt { get; init; }
     public PermissionMode PermissionMode { get; init; } = PermissionMode.FullAuto;
     public string? SessionId { get; init; }
+
+    /// <summary>
+    /// Initial task to deliver to the agent. Passed as a command-line argument (positional or
+    /// via the agent's interactive-prompt flag) so the agent auto-runs it on launch — avoids the
+    /// fragile "paste into the TUI" approach and Windows arg-quoting issues (argv is an array).
+    /// </summary>
+    public string? InitialPrompt { get; init; }
+
     public IReadOnlyDictionary<string, string> EnvironmentVariables { get; init; } = new Dictionary<string, string>();
     public IReadOnlyList<string> ExtraArguments { get; init; } = [];
     public IReadOnlyList<McpServerConfig> McpServers { get; init; } = [];
@@ -34,4 +49,14 @@ public sealed record AgentActivityPatterns
     public string? IdlePattern { get; init; }
     public string? ErrorPattern { get; init; }
     public string? PermissionPromptPattern { get; init; }
+
+    /// <summary>
+    /// Regex matching a first-run "trust this folder?" interstitial that intercepts input before
+    /// the agent accepts the prompt. When set, the host should send <see cref="TrustAcceptInput"/>
+    /// once on first match to dismiss it. Null for agents that have no such modal.
+    /// </summary>
+    public string? TrustPromptPattern { get; init; }
+
+    /// <summary>Keystroke(s) that accept the trust prompt (default: Enter on the highlighted "Yes").</summary>
+    public string? TrustAcceptInput { get; init; }
 }

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityPty.cs
@@ -16,6 +16,8 @@ public sealed class AntigravityPty : IAgentPty
     public TransportKind SupportedTransports => TransportKind.Pty;
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles => [];
 
+    public string? ContextFileName => "AGENTS.md";
+
     public string? TranslateToolName(string canonicalTool) => null;
 
     public string? ReverseTranslateToolName(string nativeTool) => null;
@@ -40,6 +42,13 @@ public sealed class AntigravityPty : IAgentPty
 
         if (config.PermissionMode == PermissionMode.FullAuto)
             args.Add("--dangerously-skip-permissions");
+
+        // Initial task: -i (--prompt-interactive) runs the prompt then continues interactively.
+        if (!string.IsNullOrEmpty(config.InitialPrompt))
+        {
+            args.Add("-i");
+            args.Add(config.InitialPrompt);
+        }
 
         foreach (var arg in config.ExtraArguments)
             args.Add(arg);

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudePty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudePty.cs
@@ -24,6 +24,9 @@ public sealed class ClaudePty : IAgentPty
     public TransportKind SupportedTransports => TransportKind.Pty;
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles => [];
 
+    // Claude takes its system prompt via --append-system-prompt-file, not a context file.
+    public string? ContextFileName => null;
+
     private static readonly FrozenDictionary<string, string> ToolNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         [CanonicalTools.Read] = "Read",
@@ -104,6 +107,10 @@ public sealed class ClaudePty : IAgentPty
 
         foreach (var arg in config.ExtraArguments)
             args.Add(arg);
+
+        // Initial task as the final positional arg — Claude auto-submits it on launch.
+        if (!string.IsNullOrEmpty(config.InitialPrompt))
+            args.Add(config.InitialPrompt);
 
         var env = new Dictionary<string, string>(GetDefaultEnvironment());
         foreach (var (key, value) in config.EnvironmentVariables)

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexPty.cs
@@ -19,6 +19,8 @@ public sealed class CodexPty : IAgentPty
     public TransportKind SupportedTransports => TransportKind.Pty;
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles => [];
 
+    public string? ContextFileName => "AGENTS.md";
+
     private static readonly FrozenDictionary<string, string> ToolNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         [CanonicalTools.Bash] = "bash",
@@ -66,6 +68,10 @@ public sealed class CodexPty : IAgentPty
         foreach (var arg in config.ExtraArguments)
             args.Add(arg);
 
+        // Initial task as the trailing positional [PROMPT] — must come after all options.
+        if (!string.IsNullOrEmpty(config.InitialPrompt))
+            args.Add(config.InitialPrompt);
+
         var env = new Dictionary<string, string>(GetDefaultEnvironment());
         foreach (var (key, value) in config.EnvironmentVariables)
             env[key] = value;
@@ -83,5 +89,8 @@ public sealed class CodexPty : IAgentPty
         WorkingPattern = @"⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|●",
         IdlePattern = @">\s*$",
         ErrorPattern = @"Error:|error:|ERR!",
+        // First-run "Do you trust the contents of this directory?" prompt; default "Yes" → Enter.
+        TrustPromptPattern = @"Do you trust|trust the contents",
+        TrustAcceptInput = "\r",
     };
 }

--- a/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotPty.cs
@@ -21,6 +21,8 @@ public sealed class CopilotPty : IAgentPty
     public TransportKind SupportedTransports => TransportKind.Pty;
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles => [];
 
+    public string? ContextFileName => "AGENTS.md";
+
     private static readonly string ShellToolName =
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "powershell" : "bash";
 
@@ -76,6 +78,14 @@ public sealed class CopilotPty : IAgentPty
             args.Add(config.Model);
         }
 
+        // Initial task: -i starts interactive mode AND auto-executes the prompt
+        // (the first-run trust modal, if any, is handled by the host before it runs).
+        if (!string.IsNullOrEmpty(config.InitialPrompt))
+        {
+            args.Add("-i");
+            args.Add(config.InitialPrompt);
+        }
+
         foreach (var arg in config.ExtraArguments)
             args.Add(arg);
 
@@ -97,5 +107,8 @@ public sealed class CopilotPty : IAgentPty
         IdlePattern = @">\s*$",
         ErrorPattern = @"Error:|error:|ERR!",
         PermissionPromptPattern = @"Allow|Deny|approve|reject",
+        // First-run "Confirm folder trust" modal; default selection is "Yes" → Enter.
+        TrustPromptPattern = @"trust the files|Do you trust|Confirm folder trust",
+        TrustAcceptInput = "\r",
     };
 }

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiPty.cs
@@ -16,6 +16,9 @@ public sealed class GeminiPty : IAgentPty
     public TransportKind SupportedTransports => TransportKind.Pty;
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles => [];
 
+    // Gemini reads GEMINI.md (NOT AGENTS.md) for project/system instructions.
+    public string? ContextFileName => "GEMINI.md";
+
     public string? TranslateToolName(string canonicalTool) => null;
 
     public string? ReverseTranslateToolName(string nativeTool) => null;
@@ -39,10 +42,21 @@ public sealed class GeminiPty : IAgentPty
         if (config.PermissionMode == PermissionMode.FullAuto)
             args.Add("--yolo");
 
+        // Trust the workspace for this session so the first-run trust prompt never appears
+        // (more explicit than GEMINI_CLI_TRUST_WORKSPACE; both are harmless together).
+        args.Add("--skip-trust");
+
         if (!string.IsNullOrEmpty(config.Model))
         {
             args.Add("--model");
             args.Add(config.Model);
+        }
+
+        // Initial task: -i (--prompt-interactive) executes the prompt then continues interactively.
+        if (!string.IsNullOrEmpty(config.InitialPrompt))
+        {
+            args.Add("-i");
+            args.Add(config.InitialPrompt);
         }
 
         foreach (var arg in config.ExtraArguments)

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodePty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodePty.cs
@@ -21,6 +21,8 @@ public sealed class OpenCodePty : IAgentPty
     public TransportKind SupportedTransports => TransportKind.Pty;
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles => [];
 
+    public string? ContextFileName => "AGENTS.md";
+
     private static readonly FrozenDictionary<string, string> ToolMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         [CanonicalTools.Read] = "read",
@@ -69,6 +71,13 @@ public sealed class OpenCodePty : IAgentPty
 
         // OpenCode's --session resumes an existing session; it does not accept
         // caller-assigned IDs for new sessions (unlike Claude's --session-id).
+
+        // Initial task: --prompt opens the TUI and auto-submits the message.
+        if (!string.IsNullOrEmpty(config.InitialPrompt))
+        {
+            args.Add("--prompt");
+            args.Add(config.InitialPrompt);
+        }
 
         foreach (var arg in config.ExtraArguments)
             args.Add(arg);

--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Text.RegularExpressions;
 using Ivy.Hooks.Pty;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Helpers;
@@ -17,43 +19,50 @@ public class AgentApp : ViewBase
         var agentRunner = UseService<IAgentRunner>();
         var args = UseArgs<AgentAppArgs>();
 
+        // The initial task is delivered as a command-line argument (see each provider's
+        // BuildPtySpec) so the agent auto-runs it on launch — no fragile "wait then paste"
+        // and no Windows arg-quoting issues (argv is passed as an array). The only thing we
+        // still drive from here is the first-run "trust this folder?" modal that some agents
+        // (Copilot, Codex) show before they accept the queued prompt.
+        //
+        // Ivy hooks must come first (IVYHOOK005), so the trust regex/keystroke are stashed in a
+        // ref populated after UsePty; OnOutput fires asynchronously, by which point it is set.
+        var trustHandled = UseRef(false);
+        var trustBuffer = UseRef(new StringBuilder());
+        var sendInput = UseRef<Action<string>?>(null);
+        var trust = UseRef<(Regex? Regex, string Accept)>((null, "\r"));
+
         var ptyHandle = Context.UsePty(
-            GetCommandLine(configService, agentRunner),
+            GetCommandLine(configService, agentRunner, args?.Prompt),
             GetWorkDir(configService, agentRunner),
-            new PtyOptions { Environment = GetEnvironment(configService) }
-        );
-
-        var promptSent = UseRef(false);
-
-        // Deliver the prompt once the agent is ready. We type it in (rather than pass it
-        // as a CLI argument) because Windows command-line quoting mangles prompts that
-        // contain quotes or backslash paths. Sending it as a bracketed paste lets the
-        // agent ingest arbitrary content atomically, then Enter submits it. A second
-        // Enter guards against the first being swallowed (a no-op on an empty buffer).
-        Context.UseEffect(async () =>
-        {
-            if (string.IsNullOrEmpty(args?.Prompt) || promptSent.Value)
-                return (IDisposable?)null;
-
-            // Wait for agent to be ready (simple delay approach)
-            await Task.Delay(2000); // 2 second delay
-
-            if (!promptSent.Value)
+            new PtyOptions
             {
-                promptSent.Value = true;
-                ptyHandle.HandleInput("\u001b[200~" + args.Prompt + "\u001b[201~");
-                // The paste takes a moment to settle before the agent accepts an Enter
-                // as "submit" (an Enter sent too early is absorbed). Retry over a longer
-                // window; once submitted, further Enters hit an empty buffer and no-op.
-                for (var i = 0; i < 3; i++)
+                Environment = GetEnvironment(configService),
+                OnOutput = text =>
                 {
-                    await Task.Delay(800);
-                    ptyHandle.HandleInput("\r");
+                    var (regex, accept) = trust.Value;
+                    if (regex == null || trustHandled.Value) return;
+                    // Keep a small rolling window of recent output; accept on first match.
+                    var sb = trustBuffer.Value;
+                    sb.Append(text);
+                    if (sb.Length > 8192) sb.Remove(0, sb.Length - 8192);
+                    if (!regex.IsMatch(sb.ToString())) return;
+                    var send = sendInput.Value;
+                    if (send == null) return; // PTY not wired yet; retry on next chunk
+                    trustHandled.Value = true;
+                    send(accept);
                 }
             }
+        );
 
-            return (IDisposable?)null;
-        }, EffectTrigger.OnMount());
+        // Wire the input sink + trust pattern now that the handle exists (OnOutput is supplied first).
+        sendInput.Value = ptyHandle.HandleInput;
+        var patterns = GetActivityPatterns(configService, agentRunner);
+        trust.Value = (
+            patterns?.TrustPromptPattern is { Length: > 0 } trustPattern
+                ? new Regex(trustPattern, RegexOptions.IgnoreCase)
+                : null,
+            patterns?.TrustAcceptInput is { Length: > 0 } accept ? accept : "\r");
 
         var terminal = new Xterm.Terminal()
             .Stream(ptyHandle.Stream)
@@ -69,7 +78,7 @@ public class AgentApp : ViewBase
             .RemoveParentPadding();
     }
 
-    private static string[] GetCommandLine(IConfigService config, IAgentRunner runner)
+    private static string[] GetCommandLine(IConfigService config, IAgentRunner runner, string? initialPrompt)
     {
         var agentId = config.Settings.CodingAgent;
         var cli = runner.GetCli(agentId);
@@ -89,6 +98,7 @@ public class AgentApp : ViewBase
             SystemPrompt = systemPrompt,
             AppendSystemPrompt = true,
             Model = model,
+            InitialPrompt = initialPrompt,
         });
         return spec?.ResolveCommand().CommandLine.ToArray() ?? [cli.Id];
     }
@@ -98,13 +108,14 @@ public class AgentApp : ViewBase
         if (string.IsNullOrEmpty(systemPrompt) || string.IsNullOrEmpty(workDir))
             return;
 
-        // Claude handles system prompt via --system-prompt / --append-system-prompt flags.
-        // All other agents (OpenCode, Gemini, Codex, Copilot, Antigravity) read AGENTS.md from cwd.
-        if (pty?.Id != AgentId.Claude)
-        {
-            var path = Path.Combine(workDir, "AGENTS.md");
-            File.WriteAllText(path, systemPrompt);
-        }
+        // Each agent declares the file it reads for project/system instructions (AGENTS.md,
+        // GEMINI.md, …). When ContextFileName is null the agent takes its system prompt via a
+        // command-line flag instead (Claude → --append-system-prompt-file) and needs no file.
+        var contextFile = pty?.ContextFileName;
+        if (string.IsNullOrEmpty(contextFile))
+            return;
+
+        File.WriteAllText(Path.Combine(workDir, contextFile), systemPrompt);
     }
 
     private static string GetWorkDir(IConfigService config, IAgentRunner runner)


### PR DESCRIPTION
## Problem

The New-Plan **Chat with Agent** PTY delivered the initial task *blind* (wait 2s → bracketed paste → 3× Enter). Copilot's first-run **Confirm folder trust** modal intercepted the paste so the task never ran (reported bug). Separately, Gemini never received the system prompt because `AGENTS.md` was written but Gemini reads `GEMINI.md`.

## Fix

Deliver the initial task as a **command-line argument** so the agent auto-runs it on launch (no keystroke timing; no Windows arg-quoting issues since argv is an array), plus a **conditional trust-modal handler** and a **per-agent context file**.

| Agent | Initial prompt | Trust | Context file |
|-------|----------------|-------|--------------|
| Claude | trailing positional | `--dangerously-skip-permissions` | none (`--append-system-prompt-file`) |
| Copilot | `-i` | in-PTY modal → Enter | AGENTS.md |
| Gemini | `-i` | `--skip-trust` | **GEMINI.md** |
| Codex | trailing positional | in-PTY modal → Enter | AGENTS.md |
| OpenCode | `--prompt` | none | AGENTS.md |
| Antigravity | `-i` | (unverified — not signed in) | AGENTS.md |

### Changes
- **Abstractions** (`IAgentPty.cs`): `AgentPtyConfig.InitialPrompt`; `AgentActivityPatterns.TrustPromptPattern`/`TrustAcceptInput`; `IAgentPty.ContextFileName`.
- **Providers**: each `BuildPtySpec` appends the prompt the agent's way; Gemini adds `--skip-trust`; Copilot/Codex declare trust patterns.
- **`AgentApp.cs`**: removed the blind paste; threads `InitialPrompt`; one-shot `OnOutput` trust handler; writes system prompt to `ContextFileName`. Hooks kept at top of `Build()` (IVYHOOK005), trust regex in a ref set after `UsePty`.

## Verification
- 62 PTY unit tests pass (new `InitialPrompt`/`ContextFileName`/`TrustPrompt` tests included).
- End-to-end via a PTY harness (`Coding-Agent-Experiments`): validated per-agent recipes for Claude, Copilot (incl. exact production arg order in a fresh untrusted folder — trust auto-accepted, task ran), Gemini, Codex, OpenCode.
- Antigravity recipe added from `--help`; end-to-end unverified (machine not signed in).