### PR TITLE
Change icon for 'Stop' menu item in JobsApp.DataTable

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -183,7 +183,7 @@ public partial class JobsApp
 
                 if (job?.Status is JobStatus.Running or JobStatus.Queued)
                 {
-                    actions.Add(new MenuItem("Stop", Icon: Icons.Square, Tag: "stop-job")
+                    actions.Add(new MenuItem("Stop", Icon: Icons.Ban, Tag: "stop-job")
                         .Tooltip("Stop this running job"));
                 }
 


### PR DESCRIPTION
The Square-icon is confusing; it looks like a checkbox a user should click on to select something instead of ending the process. The Ban-icon is a better visual indicator of the serious action.

Other Icon suggestion is: Pause (https://lucide.dev/icons/pause), but that goes against the "Stop"-intent.

<img width="417" height="352" alt="Tendril-stop" src="https://github.com/user-attachments/assets/e204908d-0869-4d92-89c8-346cdacea686" />
