### PR TITLE
[00623] Remove Unused AutoFocus Extension From ContentInput

### DIFF
--- a/src/Ivy.Tendril.Widgets/ContentInput.cs
+++ b/src/Ivy.Tendril.Widgets/ContentInput.cs
@@ -65,9 +65,6 @@ public static class ContentInputExtensions
     public static ContentInput SubmitLabel(this ContentInput w, string? label) =>
         w with { SubmitLabel = label };
 
-    public static ContentInput AutoFocus(this ContentInput w) =>
-        w with { AutoFocus = true };
-
     public static ContentInput UploadUrl(this ContentInput w, string? url) =>
         w with { UploadUrl = url };
 


### PR DESCRIPTION
# Summary

## Changes

Removed the unused `ContentInputExtensions.AutoFocus()` method from ContentInput.cs. This extension method was unreachable because `IAnyInput.AutoFocus()` takes precedence during method resolution, making the ContentInput-specific version impossible to call in fluent chains.

## API Changes

**Removed:**
- `ContentInput.AutoFocus()` extension method

**Note:** This removal has no impact on consumers since the method was unreachable. The `AutoFocus` property can still be set directly in object initializers (`new ContentInput { AutoFocus = true }`).

## Files Modified

- `src/Ivy.Tendril.Widgets/ContentInput.cs` — Removed unused AutoFocus extension method

## Manual Testing

N/A — internal change with no user-facing behavior. The removed method was dead code that could never be called due to method resolution rules.

---

**Commits:**
- b0a6a03a Remove unused AutoFocus extension from ContentInput

---
Created using [Ivy Tendril](https://ivy.app).