### PR TITLE
[00619] Remove Gap Between Review Actions and Tabs

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -545,7 +545,7 @@ public class ContentView(
             var reviewActions = projectConfig?.ReviewActions ?? new List<ReviewActionConfig>();
             if (reviewActions.Count > 0)
             {
-                var actionsBar = Layout.Horizontal().Gap(2).Padding(2).Height(Size.Fit());
+                var actionsBar = Layout.Horizontal().Gap(0).Padding(2).Height(Size.Fit());
                 for (var i = 0; i < reviewActions.Count; i++)
                 {
                     var action = reviewActions[i];


### PR DESCRIPTION
Fixes #1448

# Summary

## Changes

Removed the vertical gap between the review action buttons and the tab navigation in the Review app. Changed the actions bar gap value from 2 to 0 in ContentView.cs line 548.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Review/ContentView.cs** — Changed `.Gap(2)` to `.Gap(0)` in the actions bar layout

## Manual Testing

1. Build and run the Ivy Tendril application
2. Navigate to the Review app
3. Open any plan that has review actions configured
4. Observe the spacing between the action buttons at the top and the tab navigation (Summary, Plan, Details, etc.)
5. Verify there is no visible gap between these two elements — they should appear tightly stacked

---

## Commits

- dfd4d95a Remove gap between review actions and tabs

---
Created using [Ivy Tendril](https://ivy.app).