### PR TITLE
fix: create-plan screen twitches to top on tab navigation (#1465)

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx
@@ -105,6 +105,18 @@ interface ContentInputProps {
   events?: string[];
 }
 
+const findScrollableParent = (el: HTMLElement): HTMLElement | null => {
+  let node: HTMLElement | null = el.parentElement;
+  while (node) {
+    const overflowY = getComputedStyle(node).overflowY;
+    if ((overflowY === "auto" || overflowY === "scroll") && node.scrollHeight > node.clientHeight) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+};
+
 const fileRegExp = /\s?\[file:\s*([^\]]+)\]/g;
 
 const parseValue = (val: string) => {
@@ -248,9 +260,22 @@ export const ContentInput: React.FC<ContentInputProps> = ({
   // Textarea Auto-Growing Height
   useEffect(() => {
     const textarea = textareaRef.current;
-    if (textarea) {
-      textarea.style.height = "auto";
-      textarea.style.height = `${textarea.scrollHeight}px`;
+    if (!textarea) return;
+
+    const scrollParent = findScrollableParent(textarea);
+    const savedScrollTop = scrollParent?.scrollTop ?? 0;
+
+    const maxHeight = parseFloat(getComputedStyle(textarea).maxHeight) || Infinity;
+    textarea.style.height = "auto";
+    const next = Math.min(textarea.scrollHeight, maxHeight);
+    textarea.style.height = `${next}px`;
+    textarea.style.overflowY = textarea.scrollHeight > maxHeight ? "auto" : "hidden";
+
+    // Resetting height to "auto" reflows the dialog's scroll container, which can
+    // yank it to the top (tab navigation) or scroll the freshly pasted text out of
+    // view. Restore the position the container had before we touched the height.
+    if (scrollParent && scrollParent.scrollTop !== savedScrollTop) {
+      scrollParent.scrollTop = savedScrollTop;
     }
   }, [text, files]);
 


### PR DESCRIPTION
## Summary
Fixes #1465 — on macOS, tabbing through the "Create new plan" screen made the view twitch to the top of the menu, rendering text unreadable.

## Root cause
The `ContentInput` textarea auto-grow effect set `height = "auto"` before measuring `scrollHeight`. That momentary reflow collapsed/expanded the textarea, which in turn reflowed the dialog's scroll container and snapped its `scrollTop` to 0 during tab navigation (and scrolled freshly-pasted text out of view).

## Fix
- Walk up to the nearest scrollable ancestor and save its `scrollTop` before touching the textarea height, then restore it afterward.
- Respect the textarea's `maxHeight`: clamp the computed height and toggle `overflowY` (`auto`/`hidden`) instead of growing unbounded.

## Testing
- `tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)