### PR TITLE
feat: one-click Velopack update + Check for updates in Settings

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -120,6 +120,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var selectedIndex = UseState<int?>();
         var appRepository = UseService<IAppRepository>();
         var client = UseService<IClientProvider>();
+        var versionService = UseService<IVersionCheckService>();
         var currentApp = UseState<AppHost?>();
         var statusService = UseService<ITendrilProcessStatusService>();
         var agentRunner = UseService<IAgentRunner>();
@@ -480,6 +481,40 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 .Tag("$import-issues")
                 .Icon(Icons.Download)
                 .OnSelect(showImportIssuesDialog),
+            MenuItem.Default("Check for updates")
+                .Tag("$check-updates")
+                .Icon(Icons.CircleArrowUp)
+                .OnSelect(() =>
+                {
+                    _ = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            var info = await versionService.CheckForUpdatesAsync(forceRefresh: true);
+                            if (info.HasUpdate)
+                            {
+                                client.Toast(
+                                    $"v{info.LatestVersion} is available (you have v{info.CurrentVersion}).",
+                                    "Update available").Info();
+                            }
+                            else if (info.LatestVersion == null)
+                            {
+                                client.Toast("Couldn't check for updates. Please try again later.", "Update check failed")
+                                    .Destructive();
+                            }
+                            else
+                            {
+                                client.Toast($"You're on the latest version (v{info.CurrentVersion}).", "Up to date")
+                                    .Success();
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            client.Toast($"Couldn't check for updates: {ex.Message}", "Update check failed")
+                                .Destructive();
+                        }
+                    });
+                }),
             MenuItem.Default("Theme")
                 .Tag("$theme")
                 .Icon(Icons.SunMoon)

--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -211,7 +211,9 @@ public class WallpaperApp : ViewBase
 
                 await versionService.StartUpdateAsync(progress);
 
-                // Reached only when no restart occurred (already up to date or self-update unavailable).
+                // Reached only when no update was applied (already up to date, or
+                // self-update unavailable for this install type) — otherwise the app
+                // exits to apply and restart.
                 updateProgress.Set(null);
             }
             catch (Exception ex)

--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -1,7 +1,5 @@
 using System;
-using System.IO;
 using System.Threading.Tasks;
-using Ivy.Tendril.Helpers;
 using System.Reactive.Disposables;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Hooks;
@@ -127,7 +125,7 @@ public class WallpaperApp : ViewBase
                     | Layout.Horizontal().Gap(2)
                         | new Button("Retry", () =>
                             {
-                                TriggerUpdate(versionInfo.Value?.LatestVersion, updateProgress, updateStatus, updateError);
+                                TriggerUpdate(versionService, updateProgress, updateStatus, updateError);
                             })
                             .Small()
                         | new Button("Dismiss", () =>
@@ -157,27 +155,34 @@ public class WallpaperApp : ViewBase
                     ? "irm https://cdn.ivy.app/install-tendril.ps1 | iex"
                     : "curl -sSf https://cdn.ivy.app/install-tendril.sh | sh";
 
+                var dismissButton = new Button("Dismiss", () =>
+                    {
+                        var latest = versionInfo.Value!.LatestVersion;
+                        dismissedVersion.Set(latest);
+                        config.Settings.DismissedUpdateVersion = latest;
+                        config.SaveSettings();
+                    })
+                    .Variant(ButtonVariant.Secondary)
+                    .Small();
+
+                var actions = Layout.Horizontal().Gap(2);
+                if (versionService.CanSelfUpdate)
+                {
+                    actions |= new Button("Update Now", () =>
+                        {
+                            TriggerUpdate(versionService, updateProgress, updateStatus, updateError);
+                        })
+                        .Small();
+                }
+                actions |= dismissButton;
+
                 content = Layout.Vertical()
                     | Text.Rich()
                         .Bold($"v{versionInfo.Value!.LatestVersion}")
                         .Run($" is available (you have v{versionInfo.Value.CurrentVersion})")
                         .Small()
                     | new CodeBlock(updateCommand, Languages.Bash)
-                    | Layout.Horizontal().Gap(2)
-                        | new Button("Update Now", () =>
-                            {
-                                TriggerUpdate(versionInfo.Value.LatestVersion, updateProgress, updateStatus, updateError);
-                            })
-                            .Small()
-                        | new Button("Dismiss", () =>
-                            {
-                                var latest = versionInfo.Value!.LatestVersion;
-                                dismissedVersion.Set(latest);
-                                config.Settings.DismissedUpdateVersion = latest;
-                                config.SaveSettings();
-                            })
-                            .Variant(ButtonVariant.Secondary)
-                            .Small();
+                    | actions;
             }
 
             var notification = new FloatingPanel(
@@ -190,7 +195,7 @@ public class WallpaperApp : ViewBase
         return new Fragment(elements.ToArray());
     }
 
-    private void TriggerUpdate(string? latestVersion, IState<int?> updateProgress, IState<string?> updateStatus, IState<string?> updateError)
+    private void TriggerUpdate(IVersionCheckService versionService, IState<int?> updateProgress, IState<string?> updateStatus, IState<string?> updateError)
     {
         updateProgress.Set(0);
         updateStatus.Set("Starting update...");
@@ -200,62 +205,14 @@ public class WallpaperApp : ViewBase
         {
             try
             {
-                var includeBeta = Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1";
-                var source = new Velopack.Sources.GithubSource("https://github.com/Ivy-Interactive/Ivy-Tendril", null, includeBeta);
-                var mgr = new Velopack.UpdateManager(source);
+                var progress = new UpdateProgress(
+                    p => updateProgress.Set(p),
+                    s => updateStatus.Set(s));
 
-                if (mgr.IsInstalled)
-                {
-                    updateStatus.Set("Checking for updates...");
-                    var updateInfo = await mgr.CheckForUpdatesAsync();
-                    if (updateInfo == null)
-                    {
-                        updateStatus.Set("No update available.");
-                        updateProgress.Set(null);
-                        return;
-                    }
+                await versionService.StartUpdateAsync(progress);
 
-                    updateStatus.Set("Downloading update package...");
-                    await mgr.DownloadUpdatesAsync(updateInfo, progress =>
-                    {
-                        updateProgress.Set(progress);
-                    });
-
-                    updateStatus.Set("Applying updates and restarting...");
-                    mgr.ApplyUpdatesAndRestart(updateInfo);
-                }
-                else
-                {
-                    updateStatus.Set("Fetching latest version...");
-                    var versionStr = latestVersion;
-                    if (string.IsNullOrEmpty(versionStr))
-                    {
-                        versionStr = await UpdateHelper.GetLatestVersionAsync();
-                    }
-
-                    if (string.IsNullOrEmpty(versionStr))
-                    {
-                        throw new InvalidOperationException("Could not determine the latest version.");
-                    }
-
-                    var (filename, downloadUrl) = UpdateHelper.GetInstallerInfo(versionStr);
-                    var tempFilePath = Path.Combine(Path.GetTempPath(), filename);
-
-                    updateStatus.Set($"Downloading {filename}...");
-                    await UpdateHelper.DownloadFileWithProgressAsync(downloadUrl, tempFilePath, (read, total) =>
-                    {
-                        if (total > 0)
-                        {
-                            updateProgress.Set((int)((double)read / total * 100));
-                        }
-                    });
-
-                    updateStatus.Set("Launching installer...");
-                    UpdateHelper.LaunchInstaller(tempFilePath);
-                    
-                    // Exit the app to let the installer do its work
-                    Environment.Exit(0);
-                }
+                // Reached only when no restart occurred (already up to date or self-update unavailable).
+                updateProgress.Set(null);
             }
             catch (Exception ex)
             {

--- a/src/Ivy.Tendril/Services/IVersionCheckService.cs
+++ b/src/Ivy.Tendril/Services/IVersionCheckService.cs
@@ -2,7 +2,11 @@ namespace Ivy.Tendril.Services;
 
 public interface IVersionCheckService
 {
-    Task<VersionInfo> CheckForUpdatesAsync();
+    Task<VersionInfo> CheckForUpdatesAsync(bool forceRefresh = false);
+
+    bool CanSelfUpdate { get; }
+
+    Task StartUpdateAsync(UpdateProgress progress, CancellationToken cancellationToken = default);
 }
 
 public record VersionInfo(
@@ -10,3 +14,7 @@ public record VersionInfo(
     string? LatestVersion,
     bool HasUpdate,
     DateTime? LastChecked);
+
+public record UpdateProgress(
+    Action<int> OnProgress,
+    Action<string> OnStatus);

--- a/src/Ivy.Tendril/Services/VersionCheckService.cs
+++ b/src/Ivy.Tendril/Services/VersionCheckService.cs
@@ -24,7 +24,12 @@ public class VersionCheckService(IHttpClientFactory httpClientFactory) : IVersio
 
         try
         {
-            latestVersion = await FetchLatestVersionAsync();
+            // Velopack installs check the same release feed they update from, so the
+            // "update available" banner and the actual update agree on what's latest.
+            // Other install types (raw dotnet tool, legacy) fall back to the NuGet feed.
+            latestVersion = CanSelfUpdate
+                ? await FetchLatestVelopackVersionAsync()
+                : await FetchLatestVersionAsync();
         }
         catch
         {
@@ -82,6 +87,21 @@ public class VersionCheckService(IHttpClientFactory httpClientFactory) : IVersio
         return highestString;
     }
 
+    private static IUpdateSource BuildUpdateSource()
+    {
+        var includeBeta = Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1";
+        return new GithubSource("https://github.com/Ivy-Interactive/Ivy-Tendril", null, includeBeta);
+    }
+
+    private static async Task<string?> FetchLatestVelopackVersionAsync()
+    {
+        var mgr = new UpdateManager(BuildUpdateSource());
+        var updateInfo = await mgr.CheckForUpdatesAsync();
+        // No newer release means we're already current — report the current version (not null),
+        // so callers can distinguish "up to date" from "couldn't check" (which stays null).
+        return updateInfo?.TargetFullRelease.Version.ToString() ?? GetCurrentVersion();
+    }
+
     public async Task StartUpdateAsync(UpdateProgress progress, CancellationToken cancellationToken = default)
     {
         if (!CanSelfUpdate)
@@ -90,9 +110,7 @@ public class VersionCheckService(IHttpClientFactory httpClientFactory) : IVersio
             return;
         }
 
-        var includeBeta = Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1";
-        var source = new GithubSource("https://github.com/Ivy-Interactive/Ivy-Tendril", null, includeBeta);
-        var mgr = new UpdateManager(source);
+        var mgr = new UpdateManager(BuildUpdateSource());
 
         progress.OnStatus("Checking for updates...");
         var updateInfo = await mgr.CheckForUpdatesAsync();
@@ -106,6 +124,10 @@ public class VersionCheckService(IHttpClientFactory httpClientFactory) : IVersio
         await mgr.DownloadUpdatesAsync(updateInfo, p => progress.OnProgress(p), cancellationToken);
 
         progress.OnStatus("Applying updates and restarting...");
-        mgr.ApplyUpdatesAndRestart(updateInfo);
+        // Launch the external updater and tell it to wait for us to exit, then apply the
+        // update and restart the app. Preferred over ApplyUpdatesAndRestart, which kills
+        // the app immediately rather than letting us shut down gracefully first.
+        mgr.WaitExitThenApplyUpdates(updateInfo.TargetFullRelease, silent: false, restart: true);
+        Environment.Exit(0);
     }
 }

--- a/src/Ivy.Tendril/Services/VersionCheckService.cs
+++ b/src/Ivy.Tendril/Services/VersionCheckService.cs
@@ -1,4 +1,7 @@
 using System.Text.Json;
+using Velopack;
+using Velopack.Locators;
+using Velopack.Sources;
 
 namespace Ivy.Tendril.Services;
 
@@ -9,9 +12,11 @@ public class VersionCheckService(IHttpClientFactory httpClientFactory) : IVersio
     private VersionInfo? _cachedResult;
     private DateTime _lastCheckTime = DateTime.MinValue;
 
-    public async Task<VersionInfo> CheckForUpdatesAsync()
+    public bool CanSelfUpdate => VelopackLocator.Current?.CurrentlyInstalledVersion != null;
+
+    public async Task<VersionInfo> CheckForUpdatesAsync(bool forceRefresh = false)
     {
-        if (_cachedResult != null && DateTime.UtcNow - _lastCheckTime < CacheDuration)
+        if (!forceRefresh && _cachedResult != null && DateTime.UtcNow - _lastCheckTime < CacheDuration)
             return _cachedResult;
 
         var currentVersion = GetCurrentVersion();
@@ -75,5 +80,32 @@ public class VersionCheckService(IHttpClientFactory httpClientFactory) : IVersio
         }
 
         return highestString;
+    }
+
+    public async Task StartUpdateAsync(UpdateProgress progress, CancellationToken cancellationToken = default)
+    {
+        if (!CanSelfUpdate)
+        {
+            progress.OnStatus("Automatic update isn't available for this install type. Run the command shown to update, then restart.");
+            return;
+        }
+
+        var includeBeta = Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1";
+        var source = new GithubSource("https://github.com/Ivy-Interactive/Ivy-Tendril", null, includeBeta);
+        var mgr = new UpdateManager(source);
+
+        progress.OnStatus("Checking for updates...");
+        var updateInfo = await mgr.CheckForUpdatesAsync();
+        if (updateInfo == null)
+        {
+            progress.OnStatus("You are already on the latest version.");
+            return;
+        }
+
+        progress.OnStatus("Downloading update package...");
+        await mgr.DownloadUpdatesAsync(updateInfo, p => progress.OnProgress(p), cancellationToken);
+
+        progress.OnStatus("Applying updates and restarting...");
+        mgr.ApplyUpdatesAndRestart(updateInfo);
     }
 }


### PR DESCRIPTION
## Summary

Consolidates the in-app update experience onto a single **Velopack** self-update backend and adds a **Check for updates** action to the Settings dropdown. This is PR 1 of 2 — behavior/UX only, nothing is deleted here.

The in-app update toast already had an "Update Now" button, but it sat alongside three overlapping update mechanisms (Velopack self-update, an installer re-download fallback, and a never-invoked separate updater GUI). This PR makes the toast drive **one** backend and exposes the same check from Settings.

## Changes

- **`VersionCheckService` / `IVersionCheckService`**
  - `bool CanSelfUpdate` — true only for Velopack installs (`VelopackLocator.Current?.CurrentlyInstalledVersion != null`).
  - `Task StartUpdateAsync(UpdateProgress, CancellationToken)` — the Velopack-only download + `ApplyUpdatesAndRestart` flow, shared by the toast and (the trigger for) Settings.
  - `CheckForUpdatesAsync(bool forceRefresh = false)` — lets "Check for updates" bypass the 15-minute cache.
- **`WallpaperApp` (update toast)** — refactored to call `StartUpdateAsync`; the **Update Now** button is now gated on `CanSelfUpdate` (non-Velopack installs see version info + the copy-paste install command, but no button that can't work); the installer-redownload branch is removed from the UI. Progress / error / dismiss states preserved.
- **`TendrilAppShell`** — new **Check for updates** item in the Settings dropdown; force-refreshes the version check and reports the result via a toast (available / up-to-date / failed).

## Result

The only thing a user does to update is click **Update Now** (Velopack downloads and restarts the app) — or, for non-Velopack installs, run the shown command. The CLI `tendril update` is unchanged.

## Notes

- The CLI fallback (installer re-download for non-Velopack installs) is intentionally kept — acceptable in a terminal context.
- **PR 2 (follow-up)** removes the dead `Ivy.Tendril.Updater` project and its build/embed plumbing.

## Verification

- `dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj` → succeeds, 0 warnings / 0 errors.
- Not yet smoke-tested in a running app (requires a real Velopack install to exercise `CanSelfUpdate`).

Refs #1454, #1368

🤖 Generated with [Claude Code](https://claude.com/claude-code)
