### PR TITLE
Fix macOS codesigning JIT entitlements (#48)

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -501,22 +501,45 @@ jobs:
               fi
             done
 
+            # Create a temporary entitlements file for JIT support in bundled runtimes
+            cat <<EOF > "$RUNNER_TEMP/entitlements.plist"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
             # Pre-sign native Mach-O binaries in the runner's keychain (inside-out order)
             echo "Pre-signing internal binaries to avoid codesign --deep errors on nested SDK folders..."
             # 1. Sign all native dynamic libraries/files first (excluding the main executable)
             find "$APP_DIR" -depth -type f ! -name "Ivy.Tendril" | while read -r file; do
               if file "$file" | grep -q "Mach-O"; then
-                echo "Signing library: $file"
-                codesign --force --options runtime --timestamp --keychain "$RUNNER_TEMP/app-signing.keychain-db" --sign "$VPK_SIGN_APP_IDENTITY" "$file"
+                if file -b "$file" | grep -q "executable"; then
+                  echo "Signing internal executable: $file"
+                  codesign --force --options runtime --entitlements "$RUNNER_TEMP/entitlements.plist" --timestamp --keychain "$RUNNER_TEMP/app-signing.keychain-db" --sign "$VPK_SIGN_APP_IDENTITY" "$file"
+                else
+                  echo "Signing library: $file"
+                  codesign --force --options runtime --timestamp --keychain "$RUNNER_TEMP/app-signing.keychain-db" --sign "$VPK_SIGN_APP_IDENTITY" "$file"
+                fi
               fi
             done
 
             # 2. Sign the main executable last
             MAIN_EXE_PATH="$APP_DIR/Contents/MacOS/Ivy.Tendril"
             if [ -f "$MAIN_EXE_PATH" ]; then
-              echo "Signing main executable: $MAIN_EXE_PATH"
-              codesign --force --options runtime --timestamp --keychain "$RUNNER_TEMP/app-signing.keychain-db" --sign "$VPK_SIGN_APP_IDENTITY" "$MAIN_EXE_PATH"
+              echo "Signing main executable with entitlements: $MAIN_EXE_PATH"
+              codesign --force --options runtime --entitlements "$RUNNER_TEMP/entitlements.plist" --timestamp --keychain "$RUNNER_TEMP/app-signing.keychain-db" --sign "$VPK_SIGN_APP_IDENTITY" "$MAIN_EXE_PATH"
             fi
+
+            rm -f "$RUNNER_TEMP/entitlements.plist"
 
             PACK_DIR="$APP_DIR"
           fi


### PR DESCRIPTION
This PR fixes the macOS codesigning issue (#48) where nested runtimes (dotnet/PowerShell) are signed without entitlements, causing them to be terminated with SIGKILL under Hardened Runtime. It generates a temporary entitlements plist and signs all Mach-O executables with it.