### PR TITLE
Fix timed-out job showing $0.0000 cost instead of the actual charge (#1426)

### DIFF
--- a/src/Ivy.Tendril.Test/Services/JobCostResolutionTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobCostResolutionTests.cs
@@ -1,0 +1,65 @@
+using Ivy.Tendril.Services.Jobs;
+using Ivy.Tendril.Services.Telemetry;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Services;
+
+public class JobCostResolutionTests
+{
+    // #1426: a timed-out run reports token usage but no cost inline; the pricing fallback derives
+    // the real charge from tokens × model price. The derived cost must win over the inline $0.
+    [Fact]
+    public void ResolveJobCost_InlineTokensButZeroCost_UsesPricedCost()
+    {
+        var priced = new CostCalculation { TotalTokens = 1549, TotalCost = 0.0058 };
+
+        var (tokens, cost) = JobCompletionHandler.ResolveJobCost((1549, 0m), priced);
+
+        Assert.Equal(1549, tokens);
+        Assert.Equal(0.0058m, cost);
+    }
+
+    [Fact]
+    public void ResolveJobCost_PositiveInlineCost_KeepsInlineCost()
+    {
+        var (tokens, cost) = JobCompletionHandler.ResolveJobCost((1000, 0.02m), priced: null);
+
+        Assert.Equal(1000, tokens);
+        Assert.Equal(0.02m, cost);
+    }
+
+    [Fact]
+    public void ResolveJobCost_NoPriceableCost_KeepsTokensAndLeavesCostNull()
+    {
+        // No session file / un-priceable model: priced is empty. Never surface a misleading $0.0000.
+        var priced = new CostCalculation { TotalTokens = 0, TotalCost = 0.0 };
+
+        var (tokens, cost) = JobCompletionHandler.ResolveJobCost((1549, 0m), priced);
+
+        Assert.Equal(1549, tokens);
+        Assert.Null(cost);
+    }
+
+    [Fact]
+    public void ResolveJobCost_NoInline_UsesPricedTokensAndCost()
+    {
+        var priced = new CostCalculation { TotalTokens = 1500, TotalCost = 0.025 };
+
+        var (tokens, cost) = JobCompletionHandler.ResolveJobCost(inline: null, priced);
+
+        Assert.Equal(1500, tokens);
+        Assert.Equal(0.025m, cost);
+    }
+
+    [Fact]
+    public void ResolveJobCost_PrefersPricedTokenCount_WhenPresent()
+    {
+        // Pricing re-parses the full session (incl. subagents), so its token count wins.
+        var priced = new CostCalculation { TotalTokens = 4200, TotalCost = 0.031 };
+
+        var (tokens, cost) = JobCompletionHandler.ResolveJobCost((1549, 0m), priced);
+
+        Assert.Equal(4200, tokens);
+        Assert.Equal(0.031m, cost);
+    }
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx
@@ -30,7 +30,9 @@ export const ResultSummary: React.FC<ResultSummaryProps> = ({ wire }) => {
         </div>
       )}
       <div className="aov-result-stats">
-        {usage?.cost_usd != null && <span>Cost: ${usage.cost_usd.toFixed(4)}</span>}
+        {usage?.cost_usd != null && usage.cost_usd > 0 && (
+          <span>Cost: ${usage.cost_usd.toFixed(4)}</span>
+        )}
         {wire.duration_ms != null && (
           <span>Duration: {(wire.duration_ms / 1000).toFixed(1)}s</span>
         )}

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -230,14 +230,24 @@ internal class JobCompletionHandler
             return;
 
         var inlineCost = ExtractCostFromOutputLines(job.OutputLines.ToArray());
-        if (inlineCost != null)
+
+        // Fast path: only trust the agent-reported inline cost when it is actually positive.
+        // A timed-out/interrupted run emits token usage but no cost, so a zero inline cost must
+        // fall through to the pricing fallback below (which derives cost from tokens × model price).
+        if (inlineCost is { cost: > 0 })
         {
             ApplyCost(job, persistJob, raisePropertyChanged, inlineCost.Value.tokens, inlineCost.Value.cost);
             return;
         }
 
         if (_modelPricingService == null)
+        {
+            // No pricing service to derive cost from: still surface the tokens we have (cost stays
+            // null rather than a misleading $0.0000).
+            if (inlineCost is { tokens: > 0 })
+                ApplyCost(job, persistJob, raisePropertyChanged, inlineCost.Value.tokens, cost: null);
             return;
+        }
 
         var sessionId = job.SessionId;
         var jobPlanFolder = job.TypedArgs?.PlanFolder;
@@ -252,18 +262,19 @@ internal class JobCompletionHandler
             try
             {
                 var costCalc = _modelPricingService.CalculateSessionCost(sessionId, provider);
-                if (costCalc.TotalCost > 0 || costCalc.TotalTokens > 0)
+                var (tokens, cost) = ResolveJobCost(inlineCost, costCalc);
+                if (tokens > 0 || cost is > 0)
                 {
                     if (jobs.TryGetValue(jobId, out var j))
                     {
-                        j.Cost = (decimal)costCalc.TotalCost;
-                        j.Tokens = costCalc.TotalTokens;
+                        j.Cost = cost;
+                        j.Tokens = tokens;
                         persistJob(j);
                         raisePropertyChanged();
                     }
 
                     if (jobPlanFolder != null)
-                        PlanYamlHelper.LogCostToCsv(jobPlanFolder, jobType, costCalc.TotalTokens, costCalc.TotalCost);
+                        PlanYamlHelper.LogCostToCsv(jobPlanFolder, jobType, tokens, (double)(cost ?? 0m));
                 }
             }
             catch (Exception ex)
@@ -273,12 +284,37 @@ internal class JobCompletionHandler
         });
     }
 
+    /// <summary>
+    /// Reconciles the agent-reported inline cost with the pricing-derived session cost.
+    /// Prefers any positive cost (inline first, then priced); carries the best available token
+    /// count; leaves cost null when neither source has a positive cost so the UI shows nothing
+    /// instead of a misleading $0.0000 next to a positive token count.
+    /// </summary>
+    internal static (int tokens, decimal? cost) ResolveJobCost(
+        (int tokens, decimal cost)? inline, CostCalculation? priced)
+    {
+        var inlineTokens = inline?.tokens ?? 0;
+        var inlineCost = inline?.cost ?? 0m;
+        var pricedTokens = priced?.TotalTokens ?? 0;
+        var pricedCost = priced is not null ? (decimal)priced.TotalCost : 0m;
+
+        // The pricing path re-parses the full session (including subagents), so prefer its token
+        // count when present; otherwise fall back to the inline count.
+        var tokens = pricedTokens > 0 ? pricedTokens : inlineTokens;
+
+        decimal? cost = inlineCost > 0 ? inlineCost
+            : pricedCost > 0 ? pricedCost
+            : null;
+
+        return (tokens, cost);
+    }
+
     private void ApplyCost(
         JobItem job,
         Action<JobItem> persistJob,
         Action raisePropertyChanged,
         int tokens,
-        decimal cost)
+        decimal? cost)
     {
         job.Cost = cost;
         job.Tokens = tokens;
@@ -287,7 +323,7 @@ internal class JobCompletionHandler
 
         var jobPlanFolder = job.TypedArgs?.PlanFolder;
         if (jobPlanFolder != null)
-            PlanYamlHelper.LogCostToCsv(jobPlanFolder, job.Type, tokens, (double)cost);
+            PlanYamlHelper.LogCostToCsv(jobPlanFolder, job.Type, tokens, (double)(cost ?? 0m));
     }
 
     private static (int tokens, decimal cost)? ExtractCostFromOutputLines(IReadOnlyList<string> outputLines)


### PR DESCRIPTION
## Summary
A job that timed out displayed **Cost: \$0.0000** despite consuming ~1,549 tokens (issue #1426).

`JobCompletionHandler.ScheduleCostCalculation` accepted the agent-reported inline cost whenever it was non-null. A timed-out/interrupted run reports token `usage` but no `total_cost_usd`, so the inline path returned `(tokens, 0)`, persisted `Cost = 0`, and **returned before the pricing fallback** (which derives cost from tokens × model price) ever ran.

## Changes
- **`JobCompletionHandler.cs`** — the inline fast path only wins when its cost is actually positive (`inlineCost is { cost: > 0 }`); a zero/absent inline cost falls through to the pricing-based `CalculateSessionCost`. New pure helper `ResolveJobCost(inline, priced)` prefers any positive cost, carries the best token count, and leaves cost `null` when nothing can be priced (UI shows blank, not a misleading `$0.0000`).
- **`result-summary.tsx`** — AgentViewer renders the Cost line only when `cost_usd > 0`.
- **`JobCostResolutionTests.cs`** — 5 unit tests covering the #1426 case and edge cases.

## Verification
- `Ivy.Tendril` builds clean (0 warnings/errors).
- New `JobCostResolutionTests` (5), existing `ModelPricingServiceTests` (3), and `ClaudeSessionCostParserTests` (19) pass.
- Frontend `tsc --noEmit` passes.

Fixes #1426