### PR TITLE
Record CreatePr PRs and complete plan when the agent skips its closeout

### DIFF
--- a/src/Ivy.Tendril.Test/Services/JobCompletionCreatePrTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobCompletionCreatePrTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.IO;
+using System.Linq;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Jobs;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Services;
+
+/// <summary>
+///     Covers the CreatePr safety net in <see cref="JobCompletionHandler.ReconcileCreatePrResult" />:
+///     when the agent creates a PR but skips the Program.md step-6 closeout, Tendril must still
+///     record the PR URL and mark the plan Completed so it surfaces in the Pull Requests app instead
+///     of being stranded in Drafts — while ignoring PR URLs that don't belong to this plan's repos.
+/// </summary>
+public class JobCompletionCreatePrTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new();
+    private readonly string _planFolder;
+    private readonly string _repoDir;
+    private const string PrUrl = "https://github.com/nielsbosma/lots-of-dev-tools/pull/26";
+
+    public JobCompletionCreatePrTests()
+    {
+        _planFolder = Path.Combine(_tempDir.Path, "00015-AddJWTTesterTool");
+        // Folder name must equal the PR URL's repo segment for the safety net to trust the URL.
+        _repoDir = Path.Combine(_tempDir.Path, "lots-of-dev-tools");
+        Directory.CreateDirectory(_planFolder);
+        Directory.CreateDirectory(_repoDir);
+    }
+
+    public void Dispose() => _tempDir.Dispose();
+
+    private JobCompletionHandler CreateHandler() => new(
+        configService: null,
+        logger: NullLogger.Instance,
+        modelPricingService: null,
+        planReaderService: null,
+        telemetryService: null,
+        planWatcherService: null,
+        promptsRoot: _tempDir.Path);
+
+    private void WritePlan(string state, string[]? prs = null, bool withRepo = true, string[]? commits = null)
+    {
+        var plan = new PlanYaml
+        {
+            State = state,
+            Project = "lots-of-dev-tools",
+            Title = "Add JWT Tester Tool",
+        };
+        if (withRepo) plan.Repos.Add(_repoDir);
+        if (prs != null) plan.Prs.AddRange(prs);
+        if (commits != null) plan.Commits.AddRange(commits);
+        PlanCommandHelpers.WritePlan(_planFolder, plan);
+    }
+
+    private JobItem JobWithOutput(params string[] outputLines)
+    {
+        var job = new JobItem
+        {
+            Id = "00145",
+            TypedArgs = new CreatePrArgs(_planFolder, Merge: false),
+        };
+        foreach (var line in outputLines)
+            job.OutputLines.Enqueue(line);
+        return job;
+    }
+
+    [Fact]
+    public void RecordsMissingPr_AndSetsCompleted_WhenAgentSkippedCloseout()
+    {
+        WritePlan(nameof(PlanStatus.Review)); // agent left it in Review with no PR recorded
+        var job = JobWithOutput($"Created PR {PrUrl}#issuecomment-4851921040");
+
+        CreateHandler().ReconcileCreatePrResult(job);
+
+        var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+        Assert.Equal(nameof(PlanStatus.Completed), plan.State);
+        Assert.Equal(new[] { PrUrl }, plan.Prs); // trailing #issuecomment stripped, base URL recorded
+    }
+
+    [Fact]
+    public void SetsCompleted_EvenWhenPlanWasStuckInDraft()
+    {
+        WritePlan(nameof(PlanStatus.Draft));
+        var job = JobWithOutput($"opened {PrUrl}");
+
+        CreateHandler().ReconcileCreatePrResult(job);
+
+        var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+        Assert.Equal(nameof(PlanStatus.Completed), plan.State);
+        Assert.Contains(PrUrl, plan.Prs);
+    }
+
+    [Fact]
+    public void CompletesWithoutDuplicating_WhenAgentRecordedPrButNotState()
+    {
+        // Agent recorded the PR with a /files suffix but left the plan in Review.
+        WritePlan(nameof(PlanStatus.Review), prs: new[] { PrUrl + "/files" });
+        var job = JobWithOutput($"existing {PrUrl}");
+
+        CreateHandler().ReconcileCreatePrResult(job);
+
+        var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+        Assert.Equal(nameof(PlanStatus.Completed), plan.State);
+        Assert.Single(plan.Prs); // canonical dedup: same PR #26 not re-added despite different form
+    }
+
+    [Fact]
+    public void NoOp_WhenAlreadyRecordedAndCompleted()
+    {
+        WritePlan(nameof(PlanStatus.Completed), prs: new[] { PrUrl });
+        var job = JobWithOutput($"existing {PrUrl}");
+
+        CreateHandler().ReconcileCreatePrResult(job);
+
+        var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+        Assert.Equal(nameof(PlanStatus.Completed), plan.State);
+        Assert.Single(plan.Prs);
+    }
+
+    [Fact]
+    public void LeavesStateUnchanged_WhenNoPrInOutput()
+    {
+        WritePlan(nameof(PlanStatus.Review)); // e.g. aborted run
+        var job = JobWithOutput("no pull request was created");
+
+        CreateHandler().ReconcileCreatePrResult(job);
+
+        var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+        Assert.Equal(nameof(PlanStatus.Review), plan.State);
+        Assert.Empty(plan.Prs);
+    }
+
+    [Fact]
+    public void IgnoresForeignRepoPr_NotBelongingToThisPlan()
+    {
+        WritePlan(nameof(PlanStatus.Review)); // repo is lots-of-dev-tools
+        // A PR URL for a different repo merely echoed in the transcript (e.g. plan.SourceUrl or a
+        // referenced PR) must not be recorded or force-complete the plan.
+        var job = JobWithOutput("see https://github.com/nielsbosma/some-other-repo/pull/99");
+
+        CreateHandler().ReconcileCreatePrResult(job);
+
+        var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+        Assert.Equal(nameof(PlanStatus.Review), plan.State);
+        Assert.Empty(plan.Prs);
+    }
+
+    [Fact]
+    public void DoesNotScavengePrUrls_WhenPlanHasNoRepos()
+    {
+        // Direct-to-main plans have no repos and open no PR; a referenced PR URL must be ignored.
+        WritePlan(nameof(PlanStatus.Completed), withRepo: false, commits: new[] { "abc1234" });
+        var job = JobWithOutput($"related {PrUrl}");
+
+        CreateHandler().ReconcileCreatePrResult(job);
+
+        var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+        Assert.Empty(plan.Prs);
+    }
+}

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -135,12 +135,25 @@ EXISTING=$(gh pr list --repo <owner/repo> --head <branch> --state open --json nu
 
 - **If `EXISTING` is empty → CREATE path (default).** For each pushed branch:
 
+**!SHELL SAFETY — use file-based args. Do NOT pipe the body through `--body "$(cat <<'EOF' …)"`
+or interpolate a multi-line body inline.** On some hosts (opencode / Windows) that mangles the
+command and fails with `unknown argument "…"; please quote all values that have spaces`, burning
+retries. Write the body to a temp file and pass `--body-file`:
+
 ```bash
-gh pr create [--draft] --repo <owner/repo> --base <default-branch> --head <branch> --assignee @me --title "<title>" --body "$(cat <<'EOF'
-<body content>
-EOF
-)"
+# $body is already assembled per the Body rules below
+printf '%s' "$body" > "$TMPDIR/pr-body.md"   # or any writable temp path
+gh pr create [--draft] --repo <owner/repo> --base <default-branch> --head <branch> \
+  --assignee @me --title "[<planId>] <plan title>" --body-file "$TMPDIR/pr-body.md"
 ```
+
+- The **title is a single `--title "…"` value** — never let the shell split it into multiple args.
+  If a host still splits it, assign it to a variable first and pass the variable:
+  ```bash
+  TITLE="[<planId>] <plan title>"
+  gh pr create --repo <owner/repo> --base <default-branch> --head <branch> \
+    --assignee @me --title "$TITLE" --body-file "$TMPDIR/pr-body.md"
+  ```
 
 - **Base branch:**
   1. Read plan.yaml and get the project name
@@ -168,7 +181,7 @@ EOF
   body="${issueLink}${summaryContent}\n\n---\n${commitsList}${artifactMarkdown}\n\n---\nCreated using [Ivy Tendril](https://ivy.app)."
   ```
 - **Draft (custom options):** If custom options exist and `draft` is `true`, add `--draft` to the `gh pr create` command to create the PR in draft mode. If no custom options or `draft` is `false`, create as ready for review (default behavior).
-- **Reviewer (custom options):** If custom options exist and `reviewer` is non-empty, add `--reviewer <reviewer>` to the `gh pr create` command.
+- **Reviewer (custom options):** If custom options exist and `reviewer` is non-empty, add `--reviewer <reviewer>` to the `gh pr create` command. **Never pass a bare `--reviewer` with no value** — that fails with `flag needs an argument: --reviewer`. Omit the flag entirely when `PrReviewer` is empty.
 - **Assignee:** Always pass `--assignee @me` so the PR is assigned to the current (gh-authenticated) user. If assignment fails (e.g. the account cannot self-assign on a given repo), this is non-fatal — log a warning and continue; do not fail PR creation.
 
 ### 3.5. Add PR Comment (custom options)
@@ -291,7 +304,12 @@ tendril plan remove-worktree <TendrilPlanId> <repo-folder-name>
 
 If cleanup fails, log a warning but do not fail the overall CreatePr execution.
 
-### 6. Update Plan via CLI
+### 6. Update Plan via CLI — MANDATORY CLOSEOUT
+
+**!STOP — YOU ARE NOT DONE until this step is complete.** Creating the PR is not the finish line.
+Whether or not earlier steps were messy, retried, or partially failed, you MUST finish by:
+(1) recording every created/updated PR URL, and (2) setting the plan state to `Completed`. A run
+that stops before this leaves the PR invisible in Tendril and the plan stuck in Drafts.
 
 Use the CLI to update the plan — **never edit plan.yaml directly**.
 
@@ -305,13 +323,13 @@ tendril plan add-pr <plan-id> <pr-url>
 > equal `SourceUrl`). Read `plan.yaml` first and only run `add-pr` if the URL is not already present —
 > do not add a duplicate.
 
-**Update state to Completed:** If `PrMerge` is `true` and ALL PRs were successfully merged, update the state:
+**Set state to Completed:** Once a PR exists (created **or** updated) for the plan, set the state to
+`Completed` — **regardless of `PrMerge`**. A plan that has a PR is done; merge status is tracked
+separately as PR status and does not affect plan state.
 
 ```bash
 tendril plan set <plan-id> state Completed
 ```
-
-If `PrMerge` is `false`, do NOT update the state — the plan remains open for manual review and potential revisions.
 
 ### Edge Case: Direct-to-Main (No PR Needed)
 
@@ -323,7 +341,12 @@ Some plans create new repos and push directly to main (e.g., repo scaffolding). 
 
 ### Rules
 
-- **ALL 7 steps are mandatory** (including 2.5) — do not stop after creating the PR
+- **ALL 7 steps are mandatory** (including 2.5) — do not stop after creating the PR. In
+  particular, **step 6 is a required closeout**: record every PR URL via `tendril plan add-pr` and
+  set the plan state to `Completed`. A run that creates a PR but skips step 6 is a **failed** run.
+- **Final summary must be verifiable:** end by echoing each recorded PR URL and the final plan
+  state (e.g. `Recorded PR: <url> — plan 00015 state: Completed`) so an incomplete closeout is
+  self-evident.
 - One PR per repo worktree that has commits
 - Skip worktrees with no commits ahead of the base branch
 - Use `gh` CLI for all GitHub operations

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -167,6 +167,9 @@ internal class JobCompletionHandler
             case CreatePlanArgs:
                 VerifyCreatePlanResult(job);
                 break;
+            case CreatePrArgs:
+                ReconcileCreatePrResult(job);
+                break;
         }
     }
 
@@ -533,6 +536,98 @@ internal class JobCompletionHandler
             _logger.LogWarning(ex, "Failed to set plan state to {State} for job {JobId}", state, job.Id);
         }
     }
+
+    private static readonly Regex GitHubPrUrlPattern = new(
+        @"https?://github\.com/(?<owner>[^/\s]+)/(?<repo>[^/\s]+)/pull/(?<number>\d+)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    ///     Safety net for CreatePr. The agent is supposed to record each PR URL via
+    ///     `tendril plan add-pr` and set the plan to Completed (Program.md step 6), but a rushed or
+    ///     weak provider can stop after opening the PR and skip that closeout — leaving the PR
+    ///     invisible in the Pull Requests app (which filters on Prs.Count > 0) and the plan stuck in
+    ///     Drafts. Here we parse PR URLs from the job output, record the ones missing from plan.yaml,
+    ///     and mark the plan Completed. A plan that has a PR is Completed regardless of PrMerge; merge
+    ///     is tracked separately as PR status.
+    ///
+    ///     Only PR URLs whose repo matches one of this plan's repos are trusted — a foreign or
+    ///     SourceUrl PR merely echoed in the transcript must not be recorded or force-complete the
+    ///     plan. Plans with no repos (e.g. direct-to-main scaffolding, which opens no PR) are left
+    ///     untouched. No-ops cleanly when the agent already did the closeout.
+    /// </summary>
+    internal void ReconcileCreatePrResult(JobItem job)
+    {
+        try
+        {
+            var planFolder = job.TypedArgs?.PlanFolder ?? "";
+            if (string.IsNullOrEmpty(planFolder) || !Directory.Exists(planFolder))
+                return;
+
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+            // Repos configured for this plan, by folder name — the only repos a PR may target.
+            var planRepoNames = plan.Repos
+                .Select(r => Path.GetFileName(r.TrimEnd('/', '\\')))
+                .Where(n => !string.IsNullOrEmpty(n))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            // Canonical identity (owner/repo#number) of PRs already recorded, so a differently
+            // formatted duplicate (trailing slash, /files suffix, ...) isn't re-added.
+            var recordedKeys = plan.Prs
+                .Select(p => GitHubPrUrlPattern.Match(p))
+                .Where(m => m.Success)
+                .Select(CanonicalPrKey)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            // Scan the output line-by-line (no whole-transcript allocation), keeping the canonical
+            // base URL for each in-scope, not-yet-recorded PR.
+            var added = new List<string>();
+            if (planRepoNames.Count > 0)
+            {
+                var seen = new HashSet<string>(recordedKeys, StringComparer.OrdinalIgnoreCase);
+                foreach (var line in job.OutputLines)
+                foreach (Match m in GitHubPrUrlPattern.Matches(line))
+                {
+                    if (!planRepoNames.Contains(m.Groups["repo"].Value)) continue;
+                    if (!seen.Add(CanonicalPrKey(m))) continue;
+                    added.Add(m.Value);
+                }
+            }
+
+            // Nothing to record and no PR on the plan → leave state to whatever the agent set.
+            if (plan.Prs.Count == 0 && added.Count == 0)
+                return;
+
+            var alreadyCompleted = string.Equals(plan.State, nameof(PlanStatus.Completed),
+                StringComparison.OrdinalIgnoreCase);
+
+            // Agent already recorded every PR and set Completed — no reconciliation needed.
+            if (added.Count == 0 && alreadyCompleted)
+                return;
+
+            if (added.Count > 0)
+            {
+                foreach (var url in added)
+                    plan.Prs.Add(url);
+                plan.Updated = DateTime.UtcNow;
+                PlanCommandHelpers.WritePlan(planFolder, plan, _planWatcherService);
+                job.EnqueueSystemOutput(
+                    $"[Tendril] Recorded {added.Count} PR(s) the agent left unrecorded: {string.Join(", ", added)}");
+            }
+
+            // Route the state change through the shared path so it emits telemetry, updates the DB
+            // for instant UI feedback, and invalidates the counts cache like every other case.
+            if (!alreadyCompleted)
+                SetPlanState(job, nameof(PlanStatus.Completed));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to reconcile CreatePr result for job {JobId}", job.Id);
+        }
+    }
+
+    private static string CanonicalPrKey(Match m) =>
+        $"{m.Groups["owner"].Value}/{m.Groups["repo"].Value}#{m.Groups["number"].Value}".ToLowerInvariant();
 
     private void VerifyCreatePlanResult(JobItem job)
     {


### PR DESCRIPTION
## Problem

A `CreatePr` run that opens a PR but skips the Program.md step-6 closeout (observed with weaker providers that burn their budget on `gh pr create` quote-escaping failures) left the PR unrecorded in `plan.yaml` and the plan stranded in **Drafts** — invisible in the Pull Requests app, which filters on `Prs.Count > 0`.

## Fix (two layers)

**`Promptwares/CreatePr/Program.md`**
- Create the PR with file-based args (`--body-file` + single `--title`, `$env` fallback) to kill the shell quote-escaping that burns retries; never pass a bare `--reviewer`.
- Step 6 is now a mandatory `!STOP` closeout; the final summary must echo the recorded PR URL + state.
- A plan with a PR is `Completed` — regardless of `PrMerge`.

**`Services/Jobs/JobCompletionHandler.cs`**
- New `ReconcileCreatePrResult` safety net: on successful CreatePr completion, records any PR URL from job output **belonging to one of the plan's repos** and routes the plan to `Completed` via the shared state-transition path (telemetry + DB + cache parity).
- Repo-scoped so a foreign/`SourceUrl` PR merely echoed in the transcript is ignored; canonical `owner/repo#number` dedup; per-line scan (no whole-transcript allocation).

## Tests
`JobCompletionCreatePrTests` — 7 tests (record+complete, stuck-in-Draft, canonical dedup, foreign-repo ignore, no-repos no-scavenge, no-op when already done, no-PR unchanged). All green.