### PR TITLE
Fix missing gaps between review action buttons in ReviewApp

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -545,7 +545,7 @@ public class ContentView(
             var reviewActions = projectConfig?.ReviewActions ?? new List<ReviewActionConfig>();
             if (reviewActions.Count > 0)
             {
-                var actionsBar = Layout.Horizontal().Gap(0).Padding(2).Height(Size.Fit());
+                var actionsBar = Layout.Horizontal().Gap(2).Padding(2).Height(Size.Fit());
                 for (var i = 0; i < reviewActions.Count; i++)
                 {
                     var action = reviewActions[i];


### PR DESCRIPTION
The horizontal layout holding the review action buttons in the ReviewApp used `.Gap(0)`, so multiple action buttons rendered flush against each other with no spacing.

Changed to `.Gap(2)` to match the sibling control/title bars in the same view (`ContentView.cs`).