### PR TITLE
Auto-refresh inbox tabs via subscriptions instead of polling

### DIFF
--- a/src/Ivy.Tendril.Test/PlanWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanWatcherServiceTests.cs
@@ -89,6 +89,23 @@ public class PlanWatcherServiceTests : IDisposable
     }
 
     [Fact]
+    public void PlansChanged_ThrowingSubscriber_DoesNotStarveLaterSubscribers()
+    {
+        using var watcher = new PlanWatcherService(_configService, null, Array.Empty<int>());
+
+        var laterSubscriberInvoked = new ManualResetEventSlim(false);
+        watcher.PlansChanged += _ => throw new InvalidOperationException("stale handler");
+        watcher.PlansChanged += _ => laterSubscriberInvoked.Set();
+
+        watcher.NotifyChanged("01602-IsolationPlan");
+
+        // A multicast Invoke stops at the first throwing handler; RaisePlansChanged must
+        // isolate each subscriber so handlers added later (recently opened tabs) still fire.
+        Assert.True(laterSubscriberInvoked.Wait(TimeSpan.FromMilliseconds(WatchTimeoutMs)),
+            "Expected the subscriber added after a throwing handler to still receive PlansChanged");
+    }
+
+    [Fact]
     public void OutOfBandPlan_AppearsInDatabase_WithoutRestart()
     {
         var dbPath = Path.Combine(_tempDir.Path, "tendril.db");

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -481,7 +481,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 .Tag("$import-issues")
                 .Icon(Icons.Download)
                 .OnSelect(showImportIssuesDialog),
-            MenuItem.Default("Check for updates")
+            MenuItem.Default("Check for Updates")
                 .Tag("$check-updates")
                 .Icon(Icons.CircleArrowUp)
                 .OnSelect(() =>

--- a/src/Ivy.Tendril/Apps/Drafts/DraftsApp.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/DraftsApp.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Disposables;
+using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
@@ -13,7 +14,6 @@ public class DraftsApp : ViewBase
         var jobService = UseService<IJobService>();
         var configService = UseService<IConfigService>();
         var gitService = UseService<IGitService>();
-        var planWatcher = UseService<IPlanWatcherService>();
         var args = UseArgs<DraftsAppArgs>();
         var nav = UseNavigation();
         var selectedPlanState = UseState<PlanFile?>(null);
@@ -23,16 +23,7 @@ public class DraftsApp : ViewBase
         var filtersOpen = UseState(false);
         var refreshToken = UseRefreshToken();
 
-        UseEffect(() =>
-        {
-            void OnChanged(string? _)
-            {
-                refreshToken.Refresh();
-            }
-
-            planWatcher.PlansChanged += OnChanged;
-            return Disposable.Create(() => planWatcher.PlansChanged -= OnChanged);
-        });
+        Context.UseInboxAutoRefresh(refreshToken);
 
         UseEffect(() =>
         {

--- a/src/Ivy.Tendril/Apps/Icebox/IceboxApp.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/IceboxApp.cs
@@ -1,4 +1,4 @@
-using System.Reactive.Disposables;
+using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
@@ -12,7 +12,6 @@ public class IceboxApp : ViewBase
         var planService = UseService<IPlanReaderService>();
         var jobService = UseService<IJobService>();
         var configService = UseService<IConfigService>();
-        var planWatcher = UseService<IPlanWatcherService>();
         var selectedPlanState = UseState<PlanFile?>(null);
         var projectFilter = UseState<string?>(null);
         var levelFilter = UseState<string?>(null);
@@ -20,16 +19,7 @@ public class IceboxApp : ViewBase
         var filtersOpen = UseState(false);
         var refreshToken = UseRefreshToken();
 
-        UseEffect(() =>
-        {
-            void OnChanged(string? _)
-            {
-                refreshToken.Refresh();
-            }
-
-            planWatcher.PlansChanged += OnChanged;
-            return Disposable.Create(() => planWatcher.PlansChanged -= OnChanged);
-        });
+        Context.UseInboxAutoRefresh(refreshToken);
 
         var previousPlans = UseRef(new List<PlanFile>());
         var plans = planService.GetPlans(PlanStatus.Icebox);

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -183,7 +183,7 @@ public partial class JobsApp
 
                 if (job?.Status is JobStatus.Running or JobStatus.Queued)
                 {
-                    actions.Add(new MenuItem("Stop", Icon: Icons.Ban, Tag: "stop-job")
+                    actions.Add(new MenuItem("Stop", Icon: Icons.Pause, Tag: "stop-job")
                         .Tooltip("Stop this running job"));
                 }
 

--- a/src/Ivy.Tendril/Apps/Recommendations/RecommendationsApp.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/RecommendationsApp.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Apps.Recommendations;
@@ -16,7 +17,7 @@ public class RecommendationsApp : ViewBase
         var textFilter = UseState<string?>("");
         var filtersOpen = UseState(false);
 
-        UseInterval(() => refreshToken.Refresh(), TimeSpan.FromMinutes(1));
+        Context.UseInboxAutoRefresh(refreshToken);
 
         var recommendations = planService.GetRecommendations();
 

--- a/src/Ivy.Tendril/Apps/Review/ReviewApp.cs
+++ b/src/Ivy.Tendril/Apps/Review/ReviewApp.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Disposables;
+using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
@@ -14,7 +15,6 @@ public class ReviewApp : ViewBase
         var jobService = UseService<IJobService>();
         var configService = UseService<IConfigService>();
         var gitService = UseService<IGitService>();
-        var planWatcher = UseService<IPlanWatcherService>();
         var args = UseArgs<ReviewAppArgs>();
         var nav = UseNavigation();
         var selectedPlanState = UseState<PlanFile?>(null);
@@ -24,16 +24,7 @@ public class ReviewApp : ViewBase
         var filtersOpen = UseState(false);
         var refreshToken = UseRefreshToken();
 
-        UseEffect(() =>
-        {
-            void OnChanged(string? _)
-            {
-                refreshToken.Refresh();
-            }
-
-            planWatcher.PlansChanged += OnChanged;
-            return Disposable.Create(() => planWatcher.PlansChanged -= OnChanged);
-        });
+        Context.UseInboxAutoRefresh(refreshToken);
 
         UseEffect(() =>
         {

--- a/src/Ivy.Tendril/Apps/Trash/TrashApp.cs
+++ b/src/Ivy.Tendril/Apps/Trash/TrashApp.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Trash.Dialogs;
 using Ivy.Tendril.Apps.Views;
+using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Apps.Views.Sheets;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
@@ -38,7 +39,7 @@ public class TrashApp : ViewBase
             return new DeleteTrashFileDialog(isOpen, selected, selectedFile, refreshToken);
         });
 
-        UseInterval(() => refreshToken.Refresh(), TimeSpan.FromSeconds(10));
+        Context.UseInboxAutoRefresh(refreshToken);
 
         var trashDir = Path.Combine(configService.TendrilHome, "Trash");
         var files = LoadTrashFiles(trashDir);

--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -44,9 +44,9 @@ public class JobDebugSheet(
             PlanLog = GetPlanLogPath(job) ?? "",
             PromptwareLog = GetPromptwareLogPath(job) ?? "",
             PromptwareRawLog = GetPromptwareRawLogPath(job) ?? "",
-            ExitCode = job.ExitCode?.ToString() ?? "",
             WorkingDirectory = job.WorkingDirectory ?? "",
-            CliCommand = job.CliCommand ?? ""
+            CliCommand = job.CliCommand ?? "",
+            ExitCode = job.ExitCode?.ToString() ?? "",
         };
 
         var detailsView = data.ToDetails()
@@ -58,7 +58,7 @@ public class JobDebugSheet(
             .Multiline(x => x.PlanLog)
             .Multiline(x => x.PromptwareLog)
             .Multiline(x => x.PromptwareRawLog)
-            .Multiline(x => x.SessionId)
+            .Multiline(x => x.WorkingDirectory)
             .Multiline(x => x.CliCommand)
             .Label(x => x.PromptTitle, "Prompt/Title")
             .Label(x => x.PlanId, "Plan Id")

--- a/src/Ivy.Tendril/Hooks/UseInboxAutoRefresh.cs
+++ b/src/Ivy.Tendril/Hooks/UseInboxAutoRefresh.cs
@@ -1,0 +1,38 @@
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+
+namespace Ivy.Tendril.Hooks;
+
+public static class UseInboxAutoRefreshExtensions
+{
+    /// <summary>
+    ///     Refreshes the view whenever plan/job/trash state changes. Subscribes to the debounced
+    ///     <see cref="ITendrilProcessStatusService.Status" /> observable (the same signal the
+    ///     sidebar badges use, fed by PlansChanged, CountsInvalidated, JobsStructureChanged and
+    ///     the Trash watcher) plus <see cref="IPlanWatcherService.PlansChanged" /> directly, which
+    ///     covers content changes where the counts stay equal (Status dedupes by record equality).
+    /// </summary>
+    public static void UseInboxAutoRefresh(this IViewContext context, RefreshToken refreshToken)
+    {
+        var statusService = context.UseService<ITendrilProcessStatusService>();
+        var planWatcher = context.UseService<IPlanWatcherService>();
+
+        context.UseEffect(() =>
+        {
+            // Skip(1): the BehaviorSubject replays the current value on subscribe.
+            var subscription = statusService.Status.Skip(1).Subscribe(_ => refreshToken.Refresh());
+
+            void OnChanged(string? _)
+            {
+                refreshToken.Refresh();
+            }
+
+            planWatcher.PlansChanged += OnChanged;
+            return Disposable.Create(() =>
+            {
+                subscription.Dispose();
+                planWatcher.PlansChanged -= OnChanged;
+            });
+        });
+    }
+}

--- a/src/Ivy.Tendril/Services/Plans/PlanWatcherService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanWatcherService.cs
@@ -30,18 +30,9 @@ public class PlanWatcherService : IPlanWatcherService
         _debounceTimer.AutoReset = false;
         _debounceTimer.Elapsed += (_, _) =>
         {
-            try
-            {
-                var folder = _pendingPlanFolder;
-                _pendingPlanFolder = null;
-                PlansChanged?.Invoke(folder);
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning(ex, "Failed to invoke PlansChanged event");
-                // Swallow to prevent unhandled exceptions on the timer's thread-pool
-                // thread from terminating the process.
-            }
+            var folder = _pendingPlanFolder;
+            _pendingPlanFolder = null;
+            RaisePlansChanged(folder);
         };
 
         var planFolder = config.PlanFolder;
@@ -137,19 +128,8 @@ public class PlanWatcherService : IPlanWatcherService
             // Fire an independent full rescan at each delay rather than routing through the
             // debounce (which would coalesce the staggered timers into a single fire). Each
             // rescan is a fresh chance to pick up content that landed after the last one.
-            var timer = new System.Threading.Timer(_ =>
-            {
-                try
-                {
-                    PlansChanged?.Invoke(null);
-                }
-                catch (Exception ex)
-                {
-                    _logger?.LogWarning(ex, "Failed to invoke PlansChanged during self-heal");
-                    // Swallow to prevent unhandled exceptions on the timer's thread-pool
-                    // thread from terminating the process.
-                }
-            }, null, delayMs, Timeout.Infinite);
+            var timer = new System.Threading.Timer(_ => RaisePlansChanged(null),
+                null, delayMs, Timeout.Infinite);
             newTimers.Add(timer);
         }
 
@@ -159,6 +139,30 @@ public class PlanWatcherService : IPlanWatcherService
                 timer.Dispose();
             _selfHealTimers = newTimers;
         }
+    }
+
+    /// <summary>
+    ///     Invokes each PlansChanged subscriber in isolation. A multicast Invoke stops at the
+    ///     first throwing handler (e.g. one left behind by a disposed view), which would silently
+    ///     starve every subscriber added after it — typically the most recently opened tabs.
+    ///     Catching per handler also keeps unhandled exceptions off the timers' thread-pool
+    ///     threads, which would otherwise terminate the process.
+    /// </summary>
+    private void RaisePlansChanged(string? planFolder)
+    {
+        var handlers = PlansChanged;
+        if (handlers == null)
+            return;
+
+        foreach (var handler in handlers.GetInvocationList().Cast<Action<string?>>())
+            try
+            {
+                handler(planFolder);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "PlansChanged subscriber threw");
+            }
     }
 
     private void ScheduleDebounce(string? planFolder)

--- a/src/Ivy.Tendril/Services/Plans/TendrilProcessStatusService.cs
+++ b/src/Ivy.Tendril/Services/Plans/TendrilProcessStatusService.cs
@@ -39,17 +39,18 @@ public class TendrilProcessStatusService : ITendrilProcessStatusService
 
         if (!string.IsNullOrEmpty(config.TendrilHome))
         {
+            // Create the directory up front — a watcher can only be attached to an existing
+            // directory, and Trash views rely on this signal alone (no polling).
             var trashDir = Path.Combine(config.TendrilHome, "Trash");
-            if (Directory.Exists(trashDir))
+            Directory.CreateDirectory(trashDir);
+            _trashWatcher = new FileSystemWatcher(trashDir, "*.md")
             {
-                _trashWatcher = new FileSystemWatcher(trashDir, "*.md")
-                {
-                    NotifyFilter = NotifyFilters.FileName,
-                    EnableRaisingEvents = true
-                };
-                _trashWatcher.Created += (_, _) => ScheduleRefresh();
-                _trashWatcher.Deleted += (_, _) => ScheduleRefresh();
-            }
+                NotifyFilter = NotifyFilters.FileName,
+                EnableRaisingEvents = true
+            };
+            _trashWatcher.Created += (_, _) => ScheduleRefresh();
+            _trashWatcher.Deleted += (_, _) => ScheduleRefresh();
+            _trashWatcher.Renamed += (_, _) => ScheduleRefresh();
         }
     }
 

--- a/src/scripts/DisableGit.ps1
+++ b/src/scripts/DisableGit.ps1
@@ -1,0 +1,111 @@
+<#
+.SYNOPSIS
+Temporarily break git authentication on a repo to reproduce the ExecutePlan
+worktree-fetch failure, then restore it.
+
+.DESCRIPTION
+Makes `git fetch origin` fail with `fatal: Authentication failed` on demand.
+
+Because the Ivy-Tendril remote is a *public* repo, anonymous fetch normally
+succeeds regardless of credentials, so a bad token alone does not break it.
+Instead this script:
+  * points 'origin' at a non-existent repo path (adds an '-authfail' suffix),
+    which forces GitHub to demand authentication, and
+  * sets repo-local credential config (helper='', interactive=never,
+    core.askpass=echo) so that forced auth challenge fails non-interactively
+    -- no Credential Manager dialog, no hang, deterministic exit 128.
+
+The original 'origin' URL is stored in git config
+(tendril.disable-git.original-url) and everything is restored with -Revert.
+
+.PARAMETER Revert
+Restore the original 'origin' URL and clear all state this script set.
+
+.PARAMETER RepoPath
+Target repository (default: current directory).
+
+.EXAMPLE
+./DisableGit.ps1                       # break auth in the current repo
+./DisableGit.ps1 -Revert               # restore
+./DisableGit.ps1 -RepoPath D:\Repos\Foo
+#>
+param(
+    [switch]$Revert,
+    [string]$RepoPath = "."
+)
+
+$ErrorActionPreference = "Stop"
+# git returns non-zero for benign cases (config --get / --unset on a missing
+# key); don't let those become terminating errors when run via `pwsh -File`.
+$PSNativeCommandUseErrorActionPreference = $false
+
+$ConfigKey = "tendril.disable-git.original-url"
+
+# Named 'Invoke-Git', NOT 'Git': PowerShell command lookup is case-insensitive
+# and functions outrank executables, so a function named 'Git' would shadow
+# git.exe and every `& git` call would recurse into itself.
+function Invoke-Git { param([string[]]$GitArgs) & git -C $repoRoot @GitArgs }
+
+# Resolve repo root
+$repoRoot = (& git -C $RepoPath rev-parse --show-toplevel 2>$null)
+if (-not $repoRoot) {
+    Write-Host "Error: '$RepoPath' is not inside a git repository." -ForegroundColor Red
+    exit 1
+}
+$repoRoot = $repoRoot.Trim()
+Write-Host "Repo: $repoRoot" -ForegroundColor Blue
+
+$saved = (Invoke-Git @("config", "--local", "--get", $ConfigKey) 2>$null)
+
+if ($Revert) {
+    if (-not $saved) {
+        Write-Host "Nothing to revert: git auth was not disabled by this script." -ForegroundColor Yellow
+        exit 0
+    }
+    Invoke-Git @("remote", "set-url", "origin", $saved) | Out-Null
+    Invoke-Git @("config", "--local", "--unset", "credential.helper") 2>$null | Out-Null
+    Invoke-Git @("config", "--local", "--unset", "credential.interactive") 2>$null | Out-Null
+    Invoke-Git @("config", "--local", "--unset", "core.askpass") 2>$null | Out-Null
+    Invoke-Git @("config", "--local", "--unset", $ConfigKey) 2>$null | Out-Null
+    Write-Host "Restored 'origin' -> $saved" -ForegroundColor Green
+    Write-Host "Git authentication re-enabled." -ForegroundColor Green
+    exit 0
+}
+
+# --- Disable path ---
+if ($saved) {
+    Write-Host "Already disabled (saved original: $saved). Run with -Revert to restore first." -ForegroundColor Yellow
+    exit 1
+}
+
+$current = (Invoke-Git @("remote", "get-url", "origin") 2>$null)
+if (-not $current) {
+    Write-Host "Error: repo has no 'origin' remote." -ForegroundColor Red
+    exit 1
+}
+$current = $current.Trim()
+if ($current -notmatch '^https://.*github\.com/') {
+    Write-Host "Error: 'origin' is not an HTTPS github.com URL ($current). This script only handles HTTPS remotes." -ForegroundColor Red
+    exit 1
+}
+
+# Point origin at a non-existent repo so GitHub forces an auth challenge even
+# though the real repo is public.
+if ($current -match '\.git$') {
+    $broken = $current -replace '\.git$', '-authfail.git'
+} else {
+    $broken = "$current-authfail"
+}
+
+Invoke-Git @("config", "--local", $ConfigKey, $current) | Out-Null
+Invoke-Git @("remote", "set-url", "origin", $broken) | Out-Null
+# Make the forced auth challenge fail non-interactively.
+Invoke-Git @("config", "--local", "credential.helper", "") | Out-Null
+Invoke-Git @("config", "--local", "credential.interactive", "never") | Out-Null
+Invoke-Git @("config", "--local", "core.askpass", "echo") | Out-Null
+
+Write-Host "Disabled git auth for 'origin':" -ForegroundColor Green
+Write-Host "  was: $current"
+Write-Host "  now: $broken"
+Write-Host "`n``git fetch origin`` will now fail with 'Authentication failed' (exit 128)." -ForegroundColor Yellow
+Write-Host "Run './DisableGit.ps1 -Revert' to restore." -ForegroundColor Yellow


### PR DESCRIPTION
## Problem

Inbox tabs (Drafts, Review, Icebox, Recommendations, Trash) showed a stale empty state when a plan arrived while the tab was open — the tab had to be closed and reopened to see new plans.

## Root causes

1. `PlanWatcherService` raised `PlansChanged` as a single multicast `Invoke` inside one try/catch: a throwing subscriber (e.g. a handler left behind by a dead tab/session) silently starved every subscriber added after it — typically the most recently opened tabs. Sidebar badges survived because `TendrilProcessStatusService` subscribes first and also listens to `CountsInvalidated`.
2. `RecommendationsApp` and `TrashApp` had no event subscription at all — only 60s/10s `UseInterval` polling.

## Changes

- `PlanWatcherService.RaisePlansChanged`: invoke each subscriber in isolation with per-handler logging (debounce + self-heal paths)
- New `UseInboxAutoRefresh` hook: subscribes to the debounced `TendrilProcessStatusService.Status` observable (same signal the badges use) plus `PlansChanged` directly (covers content changes where counts stay equal)
- All five inbox apps use the hook; `UseInterval` polls removed from Recommendations/Trash
- `TendrilProcessStatusService`: Trash watcher is always created (dir created up front) and reacts to renames
- Regression test: a throwing `PlansChanged` subscriber no longer blocks later subscribers

## Verification

- Full test suite: 1555 passed (4 pre-existing network-dependent `VersionCheckServiceTests` failures, unrelated)
- E2E: ran Tendril with isolated `TENDRIL_HOME`/`TENDRIL_PLANS`, opened the empty Review tab, dropped a Review-state plan folder out-of-band — tab swapped from "No plans to review" to the plan list within ~5s without any tab interaction

Also includes small working-tree tweaks: JobDebugSheet field order/multiline fix, icon/label polish, DisableGit.ps1 script.