### PR TITLE
Hide Tunnel QR on small screens; nest Loading in tunnel-starting callout

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/TunnelSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/TunnelSetupView.cs
@@ -45,8 +45,11 @@ public class TunnelSetupView : ViewBase
 
         if (status.Value == TunnelStatus.Connecting)
         {
-            form |= Callout.Info("Starting tunnel and waiting for it to become routable. This typically takes 15-30 seconds.", "Tunnel Starting");
-            form |= new Loading();
+            var calloutContent = Layout.Vertical()
+                                 | Text.Block(
+                                     "Starting tunnel and waiting for it to become routable. This typically takes 15-30 seconds.")
+                                 | new Loading();
+            form |= Callout.Info(calloutContent, "Tunnel Starting");
         }
         else if (status.Value == TunnelStatus.Connected && tunnelUrl.Value is not null)
         {

--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -108,7 +108,10 @@ public class WallpaperApp : ViewBase
                 new Card(
                     new QRCode { Value = tunnelAddress, PixelSize = 160, ErrorCorrectionLevel = QrErrorCorrectionLevel.Medium }
                 ).Header("Tunnel", null, tunnelMenu)
-            ).AlignSelf(Align.TopRight).Offset(new Thickness(0, 8, 8, 0));
+            )
+            .AlignSelf(Align.TopRight)
+            .Offset(new Thickness(0, 8, 8, 0))
+            .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
 
             elements.Add(tunnelQr);
         }


### PR DESCRIPTION
## What
- **WallpaperApp**: hide the top-right Tunnel QR `FloatingPanel` on the Mobile and Tablet breakpoints (`.HideOn(Breakpoint.Mobile, Breakpoint.Tablet)`, i.e. width < 768px) so it no longer crowds the centered wallpaper content on small screens.
- **TunnelSetupView**: move the `Loading` spinner inside the "Tunnel Starting" `Callout` content instead of rendering it as a separate sibling.

## Why
On mobile/tablet the fixed 160px Tunnel panel overlapped the centered content. Desktop/Wide behavior is unchanged.

## Verification
Builds clean (`dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj`). Uses the existing `HideOn`/`Breakpoint` responsive pattern already used elsewhere in the app.