### PR TITLE
Add optional GitHub username to bug reports

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/Dialogs/ReportBugDialog.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Dialogs/ReportBugDialog.cs
@@ -9,6 +9,7 @@ public class ReportBugDialog(IState<bool> isOpen, string jobId) : ViewBase
         var client = UseService<IClientProvider>();
         var config = UseService<IConfigService>();
         var description = UseState("");
+        var githubUser = UseState("");
         var isSubmitting = UseState(false);
 
         async Task Submit()
@@ -20,7 +21,7 @@ public class ReportBugDialog(IState<bool> isOpen, string jobId) : ViewBase
             {
                 var service = new BugReportService(config);
                 var files = service.CollectFilesForJob(jobId);
-                var result = await service.SubmitReportAsync(description.Value, files);
+                var result = await service.SubmitReportAsync(description.Value, files, githubUser.Value);
 
                 if (result != null)
                 {
@@ -49,8 +50,11 @@ public class ReportBugDialog(IState<bool> isOpen, string jobId) : ViewBase
                 Layout.Vertical().Gap(2)
                 | Text.Muted("Describe the issue. Job logs and a sanitized copy of your config (secrets removed) will be attached to a public GitHub issue.")
                 | description.ToTextareaInput()
-                    .Placeholder("What went wrong?")
+                    .Placeholder("What went wrong? How can we reproduce this?")
                     .Rows(4)
+                    .Disabled(isSubmitting.Value)
+                | githubUser.ToTextInput()
+                    .Placeholder("Your GitHub Username (Optional)")
                     .Disabled(isSubmitting.Value)),
             new DialogFooter(
                 new Button("Cancel").Ghost().OnClick(() => isOpen.Set(false)).Disabled(isSubmitting.Value),

--- a/src/Ivy.Tendril/Commands/ReportBugCommand.cs
+++ b/src/Ivy.Tendril/Commands/ReportBugCommand.cs
@@ -20,6 +20,10 @@ public class ReportBugSettings : CommandSettings
     [Description("Bug description")]
     public string? Description { get; set; }
 
+    [CommandOption("--github-user")]
+    [Description("Your GitHub username (optional, so we can follow up on the issue)")]
+    public string? GithubUser { get; set; }
+
     [CommandOption("-y|--yes")]
     [Description("Skip confirmation prompt")]
     public bool Yes { get; set; }
@@ -75,7 +79,7 @@ public class ReportBugCommand : Command<ReportBugSettings>
         }
 
         AnsiConsole.MarkupLine("[dim]Uploading bug report...[/]");
-        var result = service.SubmitReportAsync(description, files, cancellationToken).GetAwaiter().GetResult();
+        var result = service.SubmitReportAsync(description, files, settings.GithubUser, cancellationToken).GetAwaiter().GetResult();
 
         if (result == null)
             throw new InvalidOperationException("Upload failed.");

--- a/src/Ivy.Tendril/Services/BugReportService.cs
+++ b/src/Ivy.Tendril/Services/BugReportService.cs
@@ -131,7 +131,7 @@ public sealed class BugReportService
         return files;
     }
 
-    public async Task<BugReportResult?> SubmitReportAsync(string description, IReadOnlyList<BugReportFile> files, CancellationToken ct = default)
+    public async Task<BugReportResult?> SubmitReportAsync(string description, IReadOnlyList<BugReportFile> files, string? githubUser = null, CancellationToken ct = default)
     {
         var zipPath = CreateZip(files);
         try
@@ -141,7 +141,7 @@ public sealed class BugReportService
             var agent = _config.Settings.CodingAgent;
             var commitId = GetCommitId();
 
-            return await UploadAsync(zipPath, description, osVersion, version, agent, commitId, ct);
+            return await UploadAsync(zipPath, description, osVersion, version, agent, commitId, githubUser, ct);
         }
         finally
         {
@@ -298,7 +298,7 @@ public sealed class BugReportService
         return zipPath;
     }
 
-    private static async Task<BugReportResult?> UploadAsync(string zipPath, string description, string osVersion, string tendrilVersion, string agent, string? commitId, CancellationToken ct)
+    private static async Task<BugReportResult?> UploadAsync(string zipPath, string description, string osVersion, string tendrilVersion, string agent, string? commitId, string? githubUser, CancellationToken ct)
     {
         using var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromMinutes(5);
@@ -311,6 +311,9 @@ public sealed class BugReportService
 
         if (!string.IsNullOrWhiteSpace(commitId))
             form.Add(new StringContent(commitId), "commitId");
+
+        if (!string.IsNullOrWhiteSpace(githubUser))
+            form.Add(new StringContent(githubUser.Trim()), "githubUser");
 
         var fileStream = File.OpenRead(zipPath);
         var fileContent = new StreamContent(fileStream);


### PR DESCRIPTION
Adds an optional "Your GitHub Username" input to the Report Bug dialog and a matching `--github-user` option to the `report-bug` CLI command.

The value is forwarded through `BugReportService.SubmitReportAsync` to the new optional `githubUser` form field on the report-bug endpoint, and is only sent when non-empty (mirroring the existing `commitId` handling). Existing callers and empty submissions behave exactly as before.