### PR TITLE
Add first-class promptware failure reporting via `tendril job fail`

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
@@ -78,6 +78,7 @@ if [ -f .git ] && grep -q "gitdir:" .git; then
     echo "ERROR: Repository at <repo-path> is itself a worktree."
     echo "ExecutePlan cannot create worktrees inside worktrees."
     echo "Check that project repo paths point to main repositories, not worktrees."
+    tendril job fail TendrilJobId --message="Cannot create worktrees: repository at <repo-path> is itself a git worktree. Update the project's repo path to point at the main repository."
     exit 1
 fi
 
@@ -89,6 +90,7 @@ if git rev-parse --is-inside-work-tree 2>/dev/null && [ -f "$PLANS_DIR_PARENT/.g
         echo "ERROR: TENDRIL_HOME ($TENDRIL_HOME) is inside a git worktree."
         echo "Plans and their worktrees cannot be created inside worktrees."
         echo "Move your Tendril installation outside the worktree or use a different Plans directory."
+        tendril job fail TendrilJobId --message="Cannot create worktrees: TENDRIL_HOME ($TENDRIL_HOME) is inside a git worktree. Move the Tendril installation or Plans directory outside the worktree."
         exit 1
     fi
 fi
@@ -210,6 +212,7 @@ If `baseBranch` is present for a repo, use it instead of auto-detecting. If abse
 if [ ! -f "<TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git" ]; then
     echo "ERROR: Worktree creation failed - .git file missing at <TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git"
     echo "This indicates git worktree add did not fully initialize the worktree."
+    tendril job fail TendrilJobId --message="Worktree creation failed for <repo-folder-name>: .git file missing after 'git worktree add' — the worktree was not fully initialized."
     exit 1
 fi
 cat "<TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git"

--- a/src/Ivy.Tendril.Test/Commands/JobFailCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/JobFailCommandTests.cs
@@ -1,0 +1,36 @@
+using Ivy.Tendril.Commands;
+
+namespace Ivy.Tendril.Test.Commands;
+
+public class JobFailCommandTests
+{
+    [Fact]
+    public void Validate_MissingMessage_Fails()
+    {
+        var settings = new JobFailSettings { JobId = "00001", Message = "" };
+
+        var result = settings.Validate();
+
+        Assert.False(result.Successful);
+    }
+
+    [Fact]
+    public void Validate_MissingJobId_Fails()
+    {
+        var settings = new JobFailSettings { JobId = "", Message = "Worktree creation failed" };
+
+        var result = settings.Validate();
+
+        Assert.False(result.Successful);
+    }
+
+    [Fact]
+    public void Validate_JobIdAndMessage_Succeeds()
+    {
+        var settings = new JobFailSettings { JobId = "00001", Message = "Worktree creation failed" };
+
+        var result = settings.Validate();
+
+        Assert.True(result.Successful);
+    }
+}

--- a/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
+++ b/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
@@ -147,6 +147,11 @@ public class UseStartJobTests
             return false;
         }
 
+        public bool ReportJobFailure(string id, string message)
+        {
+            return false;
+        }
+
         public bool IsInboxFileTracked(string filePath)
         {
             return false;

--- a/src/Ivy.Tendril.Test/InboxControllerTests.cs
+++ b/src/Ivy.Tendril.Test/InboxControllerTests.cs
@@ -133,6 +133,11 @@ public class InboxControllerTests
             return false;
         }
 
+        public bool ReportJobFailure(string id, string message)
+        {
+            return false;
+        }
+
         public bool IsInboxFileTracked(string filePath)
         {
             return false;

--- a/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
@@ -236,6 +236,7 @@ public class InboxWatcherServiceTests : IDisposable
         public List<JobItem> GetJobsForPlan(string planFile) => new();
         public JobItem? GetJob(string id) => null;
         public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => false;
+        public bool ReportJobFailure(string id, string message) => false;
         public void Dispose() { }
 
 #pragma warning disable CS0067
@@ -386,6 +387,7 @@ public class InboxWatcherServiceTests : IDisposable
         public List<JobItem> GetJobsForPlan(string planFile) => new();
         public JobItem? GetJob(string id) => null;
         public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => false;
+        public bool ReportJobFailure(string id, string message) => false;
         public void Dispose() { }
 
 #pragma warning disable CS0067
@@ -422,6 +424,7 @@ public class InboxWatcherServiceTests : IDisposable
         public List<JobItem> GetJobsForPlan(string planFile) => new();
         public JobItem? GetJob(string id) => null;
         public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => false;
+        public bool ReportJobFailure(string id, string message) => false;
         public void Dispose() { }
 
 #pragma warning disable CS0067

--- a/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
@@ -197,6 +197,61 @@ public class JobServiceFailureReasonTests : IDisposable
     }
 
     [Fact]
+    public void ReportJobFailure_SetsReportedFailureReason()
+    {
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var id = service.CreateTestJob(new ExecutePlanArgs(Path.GetTempPath()));
+
+        var ok = service.ReportJobFailure(id, "Worktree creation failed");
+
+        Assert.True(ok);
+        Assert.Equal("Worktree creation failed", service.GetJob(id)!.ReportedFailureReason);
+    }
+
+    [Fact]
+    public void ReportJobFailure_UnknownJob_ReturnsFalse()
+    {
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+
+        Assert.False(service.ReportJobFailure("99999", "nope"));
+    }
+
+    [Fact]
+    public void CompleteJob_NonZeroExit_WithReportedFailureReason_PrefersReportedReason()
+    {
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var id = service.CreateTestJob(new ExecutePlanArgs(Path.GetTempPath()));
+        var job = service.GetJob(id)!;
+        // The promptware first reported progress via `tendril job status`, then declared a
+        // failure via `tendril job fail`. The declared reason must win over both the stale
+        // progress message and the output-scraping heuristic.
+        job.StatusMessage = "Checking dependencies...";
+        job.ReportedFailureReason = "Worktree creation failed: .git missing";
+        job.OutputLines.Enqueue("[stderr] fatal: some unrelated git noise");
+
+        service.CompleteJob(id, 1);
+
+        job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.Equal("Worktree creation failed: .git missing", job.StatusMessage);
+    }
+
+    [Fact]
+    public void CompleteJob_NonZeroExit_NoReportedReason_FallsBackToScraper()
+    {
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var id = service.CreateTestJob(new ExecutePlanArgs(Path.GetTempPath()));
+        var job = service.GetJob(id)!;
+        job.OutputLines.Enqueue("[stderr] something went wrong");
+
+        service.CompleteJob(id, 1);
+
+        job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.Contains("something went wrong", job.StatusMessage);
+    }
+
+    [Fact]
     public void CompleteJob_ZeroExitCode_WithoutErrorEvent_RemainsCompleted()
     {
         var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));

--- a/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -256,6 +256,11 @@ public class TendrilProcessStatusServiceTests : IDisposable
             throw new NotImplementedException();
         }
 
+        public bool ReportJobFailure(string id, string message)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsInboxFileTracked(string filePath)
         {
             throw new NotImplementedException();

--- a/src/Ivy.Tendril/Commands/JobFailCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobFailCommand.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using Ivy.Tendril.Helpers;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class JobFailSettings : CommandSettings
+{
+    [Description("Job ID (e.g., job-001)")]
+    [CommandArgument(0, "<job-id>")]
+    public string JobId { get; set; } = "";
+
+    [Description("Descriptive failure message (what failed and why)")]
+    [CommandOption("--message|-m")]
+    public string Message { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        var jobIdResult = CliValidation.RequireNonEmpty(JobId, "job-id");
+        return jobIdResult.Successful
+            ? CliValidation.RequireNonEmpty(Message, "message")
+            : jobIdResult;
+    }
+}
+
+public class JobFailCommand : Command<JobFailSettings>
+{
+    protected override int Execute(CommandContext context, JobFailSettings settings, CancellationToken cancellationToken)
+    {
+        MasterClient.PutJson($"api/jobs/{settings.JobId}/fail", new { message = settings.Message }, cancellationToken);
+
+        // This only records the failure reason. The promptware is still responsible
+        // for exiting non-zero (e.g. `exit 1`) to actually fail the job.
+        Console.WriteLine($"Failure reported for job {settings.JobId}");
+        return 0;
+    }
+}

--- a/src/Ivy.Tendril/Commands/JobStatusCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStatusCommand.cs
@@ -1,6 +1,4 @@
 using System.ComponentModel;
-using System.Text;
-using System.Text.Json;
 using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
@@ -32,23 +30,12 @@ public class JobStatusSettings : CommandSettings
 
 public class JobStatusCommand : Command<JobStatusSettings>
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
     protected override int Execute(CommandContext context, JobStatusSettings settings, CancellationToken cancellationToken)
     {
-        var discovery = MasterClient.Discover();
-        using var client = MasterClient.CreateHttpClient(discovery);
-
-        var payload = new { message = settings.Message, planId = settings.PlanId, planTitle = settings.PlanTitle };
-        var json = JsonSerializer.Serialize(payload, JsonOptions);
-        var content = new StringContent(json, Encoding.UTF8, "application/json");
-
-        var response = client.PutAsync($"{discovery.BaseUrl}/api/jobs/{settings.JobId}/status", content, cancellationToken)
-            .GetAwaiter().GetResult();
-        response.EnsureSuccessStatusCode();
+        MasterClient.PutJson(
+            $"api/jobs/{settings.JobId}/status",
+            new { message = settings.Message, planId = settings.PlanId, planTitle = settings.PlanTitle },
+            cancellationToken);
 
         Console.WriteLine($"Status updated for job {settings.JobId}");
         return 0;

--- a/src/Ivy.Tendril/Controllers/JobController.cs
+++ b/src/Ivy.Tendril/Controllers/JobController.cs
@@ -46,8 +46,19 @@ public class JobController(IJobService jobService) : ControllerBase
         return Ok(new { status = "Updated" });
     }
 
+    [HttpPut("{jobId}/fail")]
+    public IActionResult ReportJobFailure(string jobId, [FromBody] ReportJobFailureRequest request)
+    {
+        if (!jobService.ReportJobFailure(NormalizeJobId(jobId), request.Message))
+            return NotFound(new { error = "Job not found" });
+
+        return Ok(new { status = "Failure reported" });
+    }
+
     [HttpGet("health")]
     public IActionResult Health() => Ok(new { status = "ok", pid = Environment.ProcessId });
 }
 
 public record UpdateJobStatusRequest(string Message, string? PlanId = null, string? PlanTitle = null);
+
+public record ReportJobFailureRequest(string Message);

--- a/src/Ivy.Tendril/Helpers/MasterClient.cs
+++ b/src/Ivy.Tendril/Helpers/MasterClient.cs
@@ -41,6 +41,24 @@ public static class MasterClient
         return client;
     }
 
+    /// <summary>
+    /// Discovers the running Tendril server and issues a JSON PUT to the given relative path
+    /// (e.g. "api/jobs/00001/status"), throwing on a non-success status. Shared by the CLI
+    /// commands that report job state so the discover/serialize/PUT convention lives in one place.
+    /// </summary>
+    public static void PutJson(string relativePath, object payload, CancellationToken cancellationToken = default)
+    {
+        var discovery = Discover();
+        using var client = CreateHttpClient(discovery);
+
+        var json = JsonSerializer.Serialize(payload, JsonOptions);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = client.PutAsync($"{discovery.BaseUrl}/{relativePath.TrimStart('/')}", content, cancellationToken)
+            .GetAwaiter().GetResult();
+        response.EnsureSuccessStatusCode();
+    }
+
     public static DiscoveryResult Discover(string? tendrilHome = null)
     {
         tendrilHome ??= Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -100,6 +100,10 @@ public record JobItem
     public string? ReportedPlanId { get; set; }
     public string? ReportedPlanTitle { get; set; }
 
+    // Explicit failure reason declared by the promptware via `tendril job fail`.
+    // When set, this wins over the output-scraping heuristic in SetCompletionStatus.
+    public string? ReportedFailureReason { get; set; }
+
     // Agent launch details (persisted)
     public string? WorkingDirectory { get; set; }
     public string? CliCommand { get; set; }

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -492,6 +492,8 @@ public class Program
             {
                 job.AddCommand<JobStatusCommand>("status")
                     .WithDescription("Report job status (message, planId, planTitle)");
+                job.AddCommand<JobFailCommand>("fail")
+                    .WithDescription("Report a job failure with a descriptive message");
                 job.AddCommand<JobStartCommand>("start")
                     .WithDescription("Start a job via the running Tendril server");
             });

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -68,6 +68,7 @@ if [ -f .git ] && grep -q "gitdir:" .git; then
     echo "ERROR: Repository at <repo-path> is itself a worktree."
     echo "ExecutePlan cannot create worktrees inside worktrees."
     echo "Check that project repo paths point to main repositories, not worktrees."
+    tendril job fail TendrilJobId --message="Cannot create worktrees: repository at <repo-path> is itself a git worktree. Update the project's repo path to point at the main repository."
     exit 1
 fi
 
@@ -79,6 +80,7 @@ if git rev-parse --is-inside-work-tree 2>/dev/null && [ -f "$PLANS_DIR_PARENT/.g
         echo "ERROR: TENDRIL_HOME ($TENDRIL_HOME) is inside a git worktree."
         echo "Plans and their worktrees cannot be created inside worktrees."
         echo "Move your Tendril installation outside the worktree or use a different Plans directory."
+        tendril job fail TendrilJobId --message="Cannot create worktrees: TENDRIL_HOME ($TENDRIL_HOME) is inside a git worktree. Move the Tendril installation or Plans directory outside the worktree."
         exit 1
     fi
 fi
@@ -238,6 +240,7 @@ If `baseBranch` is present for a repo, use it instead of auto-detecting. If abse
 if [ ! -f "<TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git" ]; then
     echo "ERROR: Worktree creation failed - .git file missing at <TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git"
     echo "This indicates git worktree add did not fully initialize the worktree."
+    tendril job fail TendrilJobId --message="Worktree creation failed for <repo-folder-name>: .git file missing after 'git worktree add' — the worktree was not fully initialized."
     exit 1
 fi
 cat "<TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git"

--- a/src/Ivy.Tendril/Services/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/FirmwareCompiler.cs
@@ -97,6 +97,8 @@ public static class FirmwareCompiler
         {
             firmware += $"\n\n**Status Reporting:** Use `tendril job status {tendrilJobId} --message \"your status\"` to report progress. " +
                         "You can also pass `--plan-id` and `--plan-title` to associate the job with a plan.\n";
+            firmware += $"\n**Failure Reporting:** On any unrecoverable failure, call `tendril job fail {tendrilJobId} --message \"<what failed and why>\"` before you `exit 1`, " +
+                        "so the failure reason is reported cleanly instead of being guessed from your output.\n";
         }
 
         // Include Program.md inline

--- a/src/Ivy.Tendril/Services/Jobs/IJobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/IJobService.cs
@@ -22,5 +22,6 @@ public interface IJobService : IDisposable
     List<JobItem> GetJobsForPlan(string planFile);
     JobItem? GetJob(string id);
     bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null);
+    bool ReportJobFailure(string id, string message);
     bool IsInboxFileTracked(string filePath);
 }

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -164,6 +164,13 @@ public class JobService : IJobService
                     job.StatusMessage = errorMessage;
                 }
             }
+            else if (!string.IsNullOrEmpty(job.ReportedFailureReason))
+            {
+                // A reason explicitly declared by the promptware via `tendril job fail`
+                // wins outright — including over any progress message previously set via
+                // `tendril job status` (which would otherwise leave a stale message shown).
+                job.StatusMessage = job.ReportedFailureReason;
+            }
             else
             {
                 job.StatusMessage ??= ExtractFailureReason(job.OutputLines.ToList(), job.Type);
@@ -369,6 +376,19 @@ public class JobService : IJobService
             job.ReportedPlanId = planId;
         if (!string.IsNullOrEmpty(planTitle))
             job.ReportedPlanTitle = planTitle;
+
+        RaiseJobsPropertyChanged();
+        return true;
+    }
+
+    public bool ReportJobFailure(string id, string message)
+    {
+        if (!_jobs.TryGetValue(id, out var job))
+            return false;
+
+        // Record the reason only; the job process is still running and the terminal
+        // state transition still happens later in CompleteJob/SetCompletionStatus.
+        job.ReportedFailureReason = message;
 
         RaiseJobsPropertyChanged();
         return true;


### PR DESCRIPTION
## What

Gives promptwares a first-class way to report a hard failure (e.g. a worktree that couldn't be created) instead of `exit 1`-and-hope-the-host-guesses.

- **New CLI command** `tendril job fail <job-id> --message "..."` → `PUT /api/jobs/{id}/fail` → `JobService.ReportJobFailure` records it on `JobItem.ReportedFailureReason`.
- **`SetCompletionStatus`** now uses the declared reason when the job completes non-zero, winning over any stale progress message set via `tendril job status` and over the `ExtractFailureReason` output-scraper (which stays as the fallback for promptwares that just `exit 1`).
- **Firmware** injects a "Failure Reporting" instruction into every promptware; **ExecutePlan `Program.md`** wires the call into the worktree-isolation and worktree-creation failure paths (main + TeamIvyConfig copies).
- **Cleanup:** shared discover/serialize/PUT boilerplate extracted into `MasterClient.PutJson`; both `JobStatusCommand` and `JobFailCommand` route through it.

## Why

The old path relied on `JobFailureAnalyzer.ExtractFailureReason` heuristically scraping output, which often surfaced an unrelated line (e.g. a stray `fatal:`) instead of the real cause.

## Tests

- `JobServiceFailureReasonTests`: declared reason wins over a prior progress message and over scraping; falls back to the scraper when no reason is reported; `ReportJobFailure` set/not-found.
- `JobFailCommandTests`: settings validation.
- Updated `IJobService` test stubs for the new interface member.