### PR TITLE
Make job deletion optimistic (background worktree cleanup)

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -97,6 +97,12 @@ public class JobServiceCompletionGuardTests : IDisposable
 
         service.DeleteJob(id);
 
+        // Cleanup + ResetToDraft now run on a background thread (optimistic delete), so the
+        // reset lands after DeleteJob returns rather than synchronously.
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (plan.ResetToDraftCalls.Count == 0 && DateTime.UtcNow < deadline)
+            Thread.Sleep(10);
+
         Assert.Contains("test-plan", plan.ResetToDraftCalls);
     }
 

--- a/src/Ivy.Tendril/Promptwares/AnalyzeFailed.ps1
+++ b/src/Ivy.Tendril/Promptwares/AnalyzeFailed.ps1
@@ -1,0 +1,149 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Finds every failed Bash / PowerShell command across all promptware raw.jsonl logs and dumps them.
+
+.DESCRIPTION
+    Each promptware run records a raw stream-json transcript at *.raw.jsonl (one JSON object per line).
+    A shell invocation is an assistant "tool_use" block (name Bash/PowerShell/Shell) carrying the command;
+    its result comes back later as a user "tool_result" block referencing the same tool_use_id.
+
+    A command counts as FAILED when its tool_result is flagged is_error==true, or its output reports a
+    non-zero exit code ("Exit code 1", "Exit code: 2", ...). Failures are matched back to the originating
+    command via tool_use_id, so non-shell errors (a failed Read, Grep, etc.) are never misreported.
+
+.PARAMETER Path
+    Root to search. Defaults to the script's own directory (the Promptwares folder).
+
+.PARAMETER FullOutput
+    Print the complete error output for each failure instead of a trimmed preview.
+
+.EXAMPLE
+    ./AnalyzeFailed.ps1
+    ./AnalyzeFailed.ps1 -Path ./ExecutePlan -FullOutput
+#>
+[CmdletBinding()]
+param(
+    [string] $Path = $PSScriptRoot,
+    [switch] $FullOutput
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Tool names that represent a shell command invocation.
+$shellTools = @('Bash', 'PowerShell', 'Shell')
+# Non-zero exit code reported inside the output text (covers "Exit code 1" and "Exit code: 1").
+$exitCodeRegex = 'Exit code:?\s+[1-9]'
+
+$logFiles = Get-ChildItem -Path $Path -Recurse -Filter '*.raw.jsonl' -File | Sort-Object FullName
+if (-not $logFiles) {
+    Write-Host "No raw.jsonl files found under $Path"
+    return
+}
+
+$allFailures = [System.Collections.Generic.List[object]]::new()
+
+foreach ($file in $logFiles) {
+    # Pass 1: map tool_use_id -> shell command info.
+    $commands = @{}
+    # Pass 2 collects failing tool_results (may appear before or after we saw the tool_use in a stream,
+    # so buffer them and resolve against $commands afterwards).
+    $results = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($line in [System.IO.File]::ReadLines($file.FullName)) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+
+        try { $obj = $line | ConvertFrom-Json } catch { continue }
+
+        # message.content is an array of blocks on both assistant and user turns.
+        # Guard every hop: system/result lines carry no message, and content is
+        # sometimes a plain string rather than an array of blocks.
+        if ($obj.PSObject.Properties.Name -notcontains 'message') { continue }
+        $message = $obj.message
+        if ($null -eq $message -or $message.PSObject.Properties.Name -notcontains 'content') { continue }
+        $content = $message.content
+        if ($null -eq $content -or $content -isnot [System.Array]) { continue }
+
+        foreach ($block in $content) {
+            switch ($block.type) {
+                'tool_use' {
+                    if ($shellTools -contains $block.name) {
+                        $toolInput = $block.input
+                        $cmdText = if ($toolInput.PSObject.Properties.Name -contains 'command') { $toolInput.command } else { '' }
+                        $descText = if ($toolInput.PSObject.Properties.Name -contains 'description') { $toolInput.description } else { '' }
+                        $commands[$block.id] = [pscustomobject]@{
+                            Tool        = $block.name
+                            Command     = $cmdText
+                            Description = $descText
+                        }
+                    }
+                }
+                'tool_result' {
+                    $text = if ($block.content -is [string]) { $block.content } else { ($block.content | Out-String) }
+                    $isError = ($block.PSObject.Properties.Name -contains 'is_error' -and $block.is_error -eq $true)
+                    $nonZeroExit = ($text -match $exitCodeRegex)
+                    if ($isError -or $nonZeroExit) {
+                        $results.Add([pscustomobject]@{
+                            Id      = $block.tool_use_id
+                            Output  = $text
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    # Resolve failing results against shell commands only.
+    foreach ($r in $results) {
+        if ($commands.ContainsKey($r.Id)) {
+            $cmd = $commands[$r.Id]
+            $allFailures.Add([pscustomobject]@{
+                File        = $file.FullName
+                Tool        = $cmd.Tool
+                Command     = $cmd.Command
+                Description = $cmd.Description
+                Output      = ($r.Output).Trim()
+            })
+        }
+    }
+}
+
+if (-not $allFailures) {
+    Write-Host "Scanned $($logFiles.Count) log file(s). No failed Bash/PowerShell commands found."
+    return
+}
+
+# Dump grouped by file.
+foreach ($group in $allFailures | Group-Object File) {
+    $rel = Resolve-Path -Relative -Path $group.Name -ErrorAction SilentlyContinue
+    if (-not $rel) { $rel = $group.Name }
+    Write-Host ''
+    Write-Host ('=' * 100) -ForegroundColor DarkGray
+    Write-Host "$rel  ($($group.Count) failed)" -ForegroundColor Cyan
+    Write-Host ('=' * 100) -ForegroundColor DarkGray
+
+    foreach ($f in $group.Group) {
+        Write-Host ''
+        Write-Host "[$($f.Tool)] $($f.Description)" -ForegroundColor Yellow
+        Write-Host "  $ $($f.Command)" -ForegroundColor White
+        $out = $f.Output
+        if (-not $FullOutput -and $out.Length -gt 800) {
+            $out = $out.Substring(0, 800) + "`n  ... [truncated, use -FullOutput for full text]"
+        }
+        foreach ($ln in ($out -split "`r?`n")) {
+            Write-Host "  | $ln" -ForegroundColor DarkYellow
+        }
+    }
+}
+
+# Summary.
+Write-Host ''
+Write-Host ('-' * 100) -ForegroundColor DarkGray
+Write-Host "Total: $($allFailures.Count) failed command(s) across $(($allFailures | Group-Object File).Count) file(s) (scanned $($logFiles.Count) log file(s))." -ForegroundColor Green
+
+Write-Host ''
+Write-Host "By tool:" -ForegroundColor Green
+$allFailures | Group-Object Tool | Sort-Object Count -Descending | ForEach-Object {
+    Write-Host ("  {0,-12} {1}" -f $_.Name, $_.Count)
+}

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -276,8 +276,35 @@ public class JobService : IJobService
             var isTerminal = current is PlanStatus.Completed or PlanStatus.Skipped;
             if (!isTerminal)
             {
-                _planReaderService.ResetToDraft(Path.GetFileName(planFolder));
-                WorktreeCleanupService.CleanPlanState(planFolder, _logger);
+                // Optimistic delete: the job is already gone from the UI, so reclaim the plan's
+                // worktrees and artifacts on a background thread and return immediately instead of
+                // blocking the UI on git subprocesses and multi-second directory deletes. Order
+                // matters: ResetToDraft (which flips the plan to a runnable Draft) runs only AFTER
+                // cleanup finishes, so an immediate re-execution can't race the still-running
+                // deletes and have its fresh worktree removed out from under it.
+                var planReaderService = _planReaderService;
+                string folderPath = planFolder;
+                var folderName = Path.GetFileName(folderPath);
+                Task.Run(() =>
+                {
+                    try
+                    {
+                        WorktreeCleanupService.CleanPlanState(folderPath, _logger);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Background plan-state cleanup failed for {PlanFolder}", folderName);
+                        RaiseNotification(new JobNotification("Cleanup incomplete",
+                            $"Couldn't fully remove worktrees and artifacts for {folderName}; some disk space may not be reclaimed until it is cleared manually.",
+                            false));
+                    }
+                    finally
+                    {
+                        // Reset to Draft regardless of cleanup success so the plan stays usable;
+                        // done after cleanup so its directories are gone before it becomes runnable.
+                        planReaderService.ResetToDraft(folderName);
+                    }
+                });
                 return;
             }
         }

--- a/src/scripts/DisableGit.ps1
+++ b/src/scripts/DisableGit.ps1
@@ -18,20 +18,20 @@ Instead this script:
 The original 'origin' URL is stored in git config
 (tendril.disable-git.original-url) and everything is restored with -Revert.
 
+.PARAMETER RepoPath
+Target repository (required).
+
 .PARAMETER Revert
 Restore the original 'origin' URL and clear all state this script set.
 
-.PARAMETER RepoPath
-Target repository (default: current directory).
-
 .EXAMPLE
-./DisableGit.ps1                       # break auth in the current repo
-./DisableGit.ps1 -Revert               # restore
-./DisableGit.ps1 -RepoPath D:\Repos\Foo
+./DisableGit.ps1 D:\Repos\Foo          # break auth in that repo
+./DisableGit.ps1 D:\Repos\Foo -Revert  # restore
 #>
 param(
-    [switch]$Revert,
-    [string]$RepoPath = "."
+    [Parameter(Mandatory, Position = 0)]
+    [string]$RepoPath,
+    [switch]$Revert
 )
 
 $ErrorActionPreference = "Stop"
@@ -108,4 +108,4 @@ Write-Host "Disabled git auth for 'origin':" -ForegroundColor Green
 Write-Host "  was: $current"
 Write-Host "  now: $broken"
 Write-Host "`n``git fetch origin`` will now fail with 'Authentication failed' (exit 128)." -ForegroundColor Yellow
-Write-Host "Run './DisableGit.ps1 -Revert' to restore." -ForegroundColor Yellow
+Write-Host "Run './DisableGit.ps1 $RepoPath -Revert' to restore." -ForegroundColor Yellow


### PR DESCRIPTION
## Optimistic job deletion (background worktree cleanup)

Deleting an `ExecutePlan` job whose plan is non-terminal previously blocked the UI thread on `git worktree remove` and recursive Windows directory deletes (seconds, worst case tens of seconds), leaving the confirm dialog and job row on screen until cleanup finished.

`JobService.ApplyDeletePlanState` now runs cleanup on a background task, so `DeleteJob` returns immediately and the Jobs UI updates optimistically via the existing `JobsStructureChanged -> refreshToken.Refresh()` bridge.

- Cleanup runs **before** `ResetToDraft`, so the plan only becomes re-runnable after its worktree/artifact directories are gone — closing a race where an immediate re-execution would collide with the still-running deletes.
- Cleanup failures are surfaced via the existing `NotificationReady` destructive toast instead of being silently swallowed.
- Test `DeleteJob_ExecutePlan_NonTerminal_ResetsToDraft` polls for the now-asynchronous reset.

## Tooling (unrelated, bundled)

- `DisableGit.ps1`: `RepoPath` is now a required positional parameter (safer than defaulting to the current directory for a git-auth footgun); docs/examples updated.
- `AnalyzeFailed.ps1`: new promptware helper that scans `*.raw.jsonl` logs for failed shell commands.

Verified: `dotnet build` clean; targeted test suites (deletion, worktree cleanup, completion-guard) pass (84 tests).
