### PR TITLE
Add 'New Project' link to Create Plan dialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -7,7 +7,7 @@ using Ivy.Tendril.Helpers;
 using System;
 using System.IO;
 using Ivy.Tendril.Apps.Agent;
-using Ivy.Tendril.Apps.Settings.Dialogs;
+using Ivy.Tendril.Apps.Settings;
 
 namespace Ivy.Tendril.Apps.Drafts.Dialogs;
 
@@ -56,14 +56,11 @@ public class CreatePlanDialog(
         var selectedPriority = UseState("Normal");
         var configService = UseService<IConfigService>();
         var agentRunner = UseService<IAgentRunner>();
-        var client = UseService<IClientProvider>();
-        var refreshToken = UseRefreshToken();
         var uploadSessionId = UseState(() => Guid.NewGuid().ToString("N"));
         var (breakpoint, breakpointListener) = Context.UseBreakpoint();
         var uploadedFiles = UseState(new List<string>());
-        var isAddProjectOpen = UseState(false);
 
-        var uploadContext = this.UseUpload(async (fileUpload, stream, token) =>
+        var uploadContext = UseUpload(async (fileUpload, stream, token) =>
         {
             var tempDir = Path.Combine(configService.TendrilHome, "Attachments", uploadSessionId.Value);
             Directory.CreateDirectory(tempDir);
@@ -135,9 +132,10 @@ public class CreatePlanDialog(
                 | (Layout.Vertical().Gap(0)
                     | (Layout.Horizontal().Width(Size.Full()).AlignContent(Align.SpaceBetween)
                         | Text.Block("Select Project(s)").Small().Bold()
-                        | new Button().Icon(Icons.Plus).Ghost().Small().Tooltip("Add Project").OnClick(() =>
+                        | new Button("New Project").Ghost().Icon(Icons.Plus).OnClick(() =>
                         {
-                            isAddProjectOpen.Set(true);
+                            HandleClose();
+                            nav.Navigate<SettingsApp>(new SettingsAppArgs(SettingsApp.TagProjects));
                         }))
                     | exclusiveProjects.ToSelectInput(options).Variant(SelectInputVariant.Toggle))
                 | selectedPriority.ToSelectInput(PriorityOptions).Variant(SelectInputVariant.Toggle).WithField().Label("Priority")
@@ -145,7 +143,7 @@ public class CreatePlanDialog(
                 {
                     UploadUrl = uploadContext.Value.UploadUrl,
                     AutoFocus = true,
-                    OnSubmit = e =>
+                    OnSubmit = _ =>
                     {
                         if (!string.IsNullOrWhiteSpace(createPlanText.Value) && !isCreating.Value)
                         {
@@ -226,6 +224,6 @@ public class CreatePlanDialog(
                 new DialogBody(bodyContent))
                 .Width(Size.Rem(30));
 
-        return new Fragment(breakpointListener, planSurface, new AddProjectDialog(isAddProjectOpen, configService, client, refreshToken));
+        return new Fragment(breakpointListener, planSurface);
     }
 }

--- a/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
@@ -17,7 +17,7 @@ public class SettingsApp : ViewBase
     private const string TagLevels = "levels";
     private const string TagVerifications = "verifications";
     private const string TagPromptwares = "promptwares";
-    private const string TagProjects = "projects";
+    internal const string TagProjects = "projects";
     private const string TagTunnel = "tunnel";
     private const string TagAdvanced = "advanced";
     private const string TagOpenConfig = "open-config";
@@ -28,7 +28,8 @@ public class SettingsApp : ViewBase
         var navigator = UseNavigation();
         var client = UseService<IClientProvider>();
         var httpContextAccessor = UseService<IHttpContextAccessor>();
-        var selected = UseState(TagCodingAgent);
+        var args = UseArgs<SettingsAppArgs>();
+        var selected = UseState(() => args?.Section ?? TagCodingAgent);
         Context.TryUseService<DesktopWindow>(out var desktopWindow);
         var isDesktop = desktopWindow != null;
         var capturedHost = ConfigYamlUiHelper.CaptureHost(httpContextAccessor);

--- a/src/Ivy.Tendril/Apps/Settings/SettingsAppArgs.cs
+++ b/src/Ivy.Tendril/Apps/Settings/SettingsAppArgs.cs
@@ -1,0 +1,3 @@
+namespace Ivy.Tendril.Apps.Settings;
+
+public record SettingsAppArgs(string? Section = null);


### PR DESCRIPTION
Replaces the ghost plus-icon in the Create Plan dialog's **Select Project(s)** header with an explicit **New Project** button.

Instead of opening the inline `AddProjectDialog` wizard, it now closes the Create Plan dialog and navigates to **Settings → Projects** (`ProjectsSetupView`).

- New `SettingsAppArgs` record enables deep-linking a Settings section via `UseArgs`.
- `SettingsApp` seeds its selected tab from the args (falls back to Coding Agent).
- `CreatePlanDialog` drops the now-unused inline wizard wiring (`isAddProjectOpen`, `client`, `refreshToken`, `AddProjectDialog`).