### PR TITLE
Add Claude Fable 5 as a selectable Claude model

### DIFF
--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
@@ -31,6 +31,15 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
     [
         new()
         {
+            Id = "claude-fable-5", DisplayName = "Claude Fable",
+            Capabilities = FullCaps,
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
+            Provider = "anthropic",
+            InputPerMillion = 10.00m, OutputPerMillion = 50.00m,
+            CacheWritePerMillion = 12.50m, CacheReadPerMillion = 1.00m,
+        },
+        new()
+        {
             Id = "opus", DisplayName = "Claude Opus",
             Capabilities = FullCaps,
             ContextWindow = 200_000, MaxOutputTokens = 32_000,


### PR DESCRIPTION
Adds Claude Fable 5 (`claude-fable-5`) as an option in the Coding Agent → Profile Models dropdowns for Claude.

A single `ModelInfo` entry was added at the top of `ClaudeModelCatalog.GetStaticModels()`. Because the Profile Models dropdown and `ModelPricingProvider` both read from the catalog, Fable now appears as a selectable model (Default, Claude Fable, Claude Opus, Claude Sonnet, Claude Haiku) and is cost-tracked automatically — no UI or pricing code changes needed.

- `Id = "claude-fable-5"` (passed verbatim as `--model` to the Claude CLI)
- `DisplayName = "Claude Fable"`
- FullCaps, 1M context / 128K output, $10/$50 per MTok pricing