### PR TITLE
Add FieldToolsDemo experiment

### DIFF
--- a/src/experiments/FieldToolsDemo/FieldToolsApp.cs
+++ b/src/experiments/FieldToolsDemo/FieldToolsApp.cs
@@ -1,0 +1,100 @@
+namespace FieldToolsDemo;
+
+[App(title: "Field Tools", icon: Icons.TextSelect)]
+public class FieldToolsApp : ViewBase
+{
+    public override object? Build()
+    {
+        return Layout.Tabs(
+            new Tab("Top", new TopSample()),
+            new Tab("Left", new LeftSample())
+        ).Variant(TabsVariant.Content);
+    }
+}
+
+// Tools rendered on the right of the label row when LabelPosition = Top.
+public class TopSample : ViewBase
+{
+    public override object? Build()
+    {
+        var name = UseState<string>();
+        var description = UseState<string>();
+        var priority = UseState("Normal");
+
+        return Layout.Vertical().Gap(6).Padding(4)
+            | Text.H3("LabelPosition.Top — tools on the right of the label")
+
+            // A simple single-button tool.
+            | name.ToTextInput()
+                .Placeholder("Enter your name")
+                .WithField()
+                .Label("Name")
+                .Tools(new Button("Clear", _ => name.Set("")).Variant(ButtonVariant.Ghost).Small())
+
+            // A simple single-button tool.
+            | name.ToTextInput()
+                .Placeholder("Enter your name")
+                .WithField()
+                .Label("Name")
+            
+            // A priority selector with a multi-button tools slot.
+            | priority.ToSelectInput(new[] { "Normal", "High", "Urgent" }.ToOptions())
+                .Variant(SelectInputVariant.Toggle)
+                .WithField()
+                .Label("Priority")
+                .Tools(
+                    Layout.Horizontal().Gap(1)
+                        | new Button("Reset", _ => priority.Set("Normal")).Small()
+                        | new Button(null, icon: Icons.Star).Variant(ButtonVariant.Ghost).Small()
+                )
+
+            // A deliberately tall tools slot to prove the label->input padding stays constant.
+            | description.ToTextareaInput()
+                .Placeholder("Enter task description...")
+                .WithField()
+                .Label("Describe the task for the new plan")
+                .Required()
+                .Tools(
+                    new Card(
+                        Layout.Vertical().Gap(1)
+                            | Text.Muted("Tall tools block")
+                            | new Button("A").Variant(ButtonVariant.Ghost).Small()
+                            | new Button("B").Variant(ButtonVariant.Ghost).Small()
+                    )
+                );
+    }
+}
+
+// Tools rendered below the label when LabelPosition = Left.
+public class LeftSample : ViewBase
+{
+    public override object? Build()
+    {
+        var email = UseState<string>();
+        var notes = UseState<string>();
+
+        return Layout.Vertical().Gap(6).Padding(4)
+            | Text.H3("LabelPosition.Left — tools below the label")
+
+            | email.ToTextInput()
+                .Variant(TextInputVariant.Email)
+                .Placeholder("you@example.com")
+                .WithField()
+                .Label("Work Email")
+                .LabelPosition(LabelPosition.Left)
+                .Description("We'll send updates here")
+                .Required()
+                .Tools(new Button("Verify", _ => { }).Variant(ButtonVariant.Outline).Small())
+
+            | notes.ToTextareaInput()
+                .Placeholder("Notes...")
+                .WithField()
+                .Label("Notes")
+                .LabelPosition(LabelPosition.Left)
+                .Tools(
+                    Layout.Vertical().Gap(1)
+                        | new Button("Clear", _ => notes.Set("")).Variant(ButtonVariant.Ghost).Small()
+                        | Text.Muted("2 tools")
+                );
+    }
+}

--- a/src/experiments/FieldToolsDemo/FieldToolsDemo.csproj
+++ b/src/experiments/FieldToolsDemo/FieldToolsDemo.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>CS8618;CS8603;CS8602;CS8604;CS8625;CS9113</NoWarn>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>FieldToolsDemo</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Ivy-Framework\src\Ivy\Ivy.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/experiments/FieldToolsDemo/GlobalUsings.cs
+++ b/src/experiments/FieldToolsDemo/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using Ivy;
+global using Ivy.Apps;
+global using Ivy.Core;
+global using Ivy.Views;

--- a/src/experiments/FieldToolsDemo/Program.cs
+++ b/src/experiments/FieldToolsDemo/Program.cs
@@ -1,0 +1,12 @@
+using Ivy;
+
+var server = new Server();
+server.UseCulture("en-US");
+#if DEBUG
+server.UseHotReload();
+#endif
+server.AddAppsFromAssembly();
+var appShellSettings = new AppShellSettings()
+    .UseTabs(preventDuplicates: true);
+server.UseAppShell(appShellSettings);
+await server.RunAsync();


### PR DESCRIPTION
Standalone Ivy app under `src/experiments/FieldToolsDemo` demonstrating the new `Field.Tools(...)` slot (added in Ivy-Framework #4696).

Two tabs:
- **Top** — tools right-aligned on the label row; includes a plain field next to a tooled one to show padding is identical, plus a deliberately tall tools block.
- **Left** — tools rendered below the label.