### PR TITLE
feat: generate and package secure localhost HTTPS certs for macOS/Windows desktop

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -219,6 +219,18 @@ jobs:
             -p:CommitId=${{ github.sha }} \
             --self-contained true
 
+      - name: Generate HTTPS Certificates
+        shell: bash
+        run: |
+          PUBLISH_DIR="./publish/desktop/${{ matrix.rid }}"
+          mkdir -p "$PUBLISH_DIR/certs"
+          if [[ "${{ matrix.rid }}" == win-* ]]; then
+            "$PUBLISH_DIR/Ivy.Tendril.exe" generate-certs "$PUBLISH_DIR/certs"
+          else
+            chmod +x "$PUBLISH_DIR/Ivy.Tendril"
+            "$PUBLISH_DIR/Ivy.Tendril" generate-certs "$PUBLISH_DIR/certs"
+          fi
+
       - name: Bundle PowerShell 7
         shell: bash
         run: |
@@ -412,6 +424,9 @@ jobs:
             if [ -f "$APP_DIR/Contents/MacOS/config.yaml" ]; then
               mv "$APP_DIR/Contents/MacOS/config.yaml" "$APP_DIR/Contents/Resources/"
             fi
+            if [ -d "$APP_DIR/Contents/MacOS/certs" ]; then
+              mv "$APP_DIR/Contents/MacOS/certs" "$APP_DIR/Contents/Resources/"
+            fi
 
             # Copy icon
             cp "$ICON_PATH" "$APP_DIR/Contents/Resources/icon.icns"
@@ -522,6 +537,37 @@ jobs:
             --delta None \
             $( [[ "${{ matrix.rid }}" == osx-* ]] && echo "--bundleId com.ivy.tendril" ) \
             --channel ${{ matrix.rid }}
+
+      - name: Inject Postinstall Script into macOS Package
+        if: startsWith(matrix.rid, 'osx-')
+        run: |
+          # Unpack the generated .pkg
+          pkgutil --expand-full releases/IvyTendril-${{ matrix.rid }}-Setup.pkg expanded-pkg
+          
+          # Create Scripts folder if not exists
+          mkdir -p expanded-pkg/Scripts
+          
+          # Write the postinstall script
+          cat << 'EOF' > expanded-pkg/Scripts/postinstall
+#!/bin/bash
+# Path to the installed app's certificate
+CERT_PATH="$3/Applications/Ivy Tendril.app/Contents/Resources/certs/localhost.crt"
+if [ -f "$CERT_PATH" ]; then
+  echo "Trusting Ivy Tendril localhost certificate system-wide..."
+  security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$CERT_PATH"
+fi
+exit 0
+EOF
+          chmod +x expanded-pkg/Scripts/postinstall
+          
+          # Repack the package
+          pkgutil --flatten expanded-pkg releases/IvyTendril-${{ matrix.rid }}-Setup-Unsigned.pkg
+          rm -rf expanded-pkg
+
+          # Re-sign the repacked package
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$RUNNER_TEMP/app-signing.keychain-db"
+          productsign --sign "${{ secrets.MACOS_SIGN_INSTALL_IDENTITY }}" --keychain "$RUNNER_TEMP/app-signing.keychain-db" releases/IvyTendril-${{ matrix.rid }}-Setup-Unsigned.pkg releases/IvyTendril-${{ matrix.rid }}-Setup.pkg
+          rm releases/IvyTendril-${{ matrix.rid }}-Setup-Unsigned.pkg
 
       - name: Rename Installer Setup Packages
         run: |

--- a/src/Ivy.Tendril/Commands/GenerateCertsCommand.cs
+++ b/src/Ivy.Tendril/Commands/GenerateCertsCommand.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel;
+using System.IO;
+using System.Threading;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class GenerateCertsCommand : Command<GenerateCertsCommand.Settings>
+{
+    public class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<OUTPUT_DIR>")]
+        [Description("Directory where the localhost.pfx and localhost.crt certificates should be written")]
+        public string OutputDir { get; set; } = string.Empty;
+    }
+
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var outputDir = Path.GetFullPath(settings.OutputDir);
+            Directory.CreateDirectory(outputDir);
+
+            var pfxPath = Path.Combine(outputDir, "localhost.pfx");
+            var crtPath = Path.Combine(outputDir, "localhost.crt");
+
+            // Generate and save certificates using Ivy.Desktop's helper
+            Ivy.Desktop.CertificateHelper.GenerateAndSaveCertificate(pfxPath, crtPath);
+
+            AnsiConsole.MarkupLine($"[green]Successfully generated certificates at:[/] {outputDir}");
+            return 0;
+        }
+        catch (System.Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]Error generating certificates:[/] {ex.Message}");
+            return 1;
+        }
+    }
+}

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -340,7 +340,7 @@ public class Program
             "update-promptwares", "job", "plan", "promptware",
             "trash", "verification", "project", "project-analyzer", "models",
             "version", "--version", "report-bug", "reset", "update",
-            "--help", "-h", "run"
+            "--help", "-h", "run", "generate-certs"
         };
         return cliCommands.Contains(firstArg);
     }

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -451,6 +451,11 @@ public class Program
             config.AddCommand<ProjectAnalyzerCommand>("project-analyzer")
                 .WithDescription("Analyze a folder and print a YAML stack report");
 
+            // Generate certificates command (hidden, for build time)
+            config.AddCommand<GenerateCertsCommand>("generate-certs")
+                .WithDescription("Generate self-signed localhost certificate for desktop HTTPS")
+                .IsHidden();
+
             // Run command
             config.AddCommand<RunCommand>("run")
                 .WithDescription("Run the Tendril web server in the foreground");

--- a/src/build_local_installer.sh
+++ b/src/build_local_installer.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+set -e
+
+# Directories
+REPO_DIR="/Users/rorychatt/git/ivy/Ivy-Tendril"
+PUBLISH_DIR="$REPO_DIR/src/publish/desktop/osx-arm64"
+APP_DIR="$REPO_DIR/src/publish/desktop/IvyTendril.app"
+RELEASES_DIR="$REPO_DIR/src/releases"
+
+echo "=== 1. Publishing Ivy.Tendril for osx-arm64 ==="
+cd "$REPO_DIR"
+dotnet publish src/Ivy.Tendril/Ivy.Tendril.csproj \
+  -c Release \
+  -r osx-arm64 \
+  -o "$PUBLISH_DIR" \
+  -p:PublishSingleFile=true \
+  -p:ReadyToRun=false \
+  -p:Version=1.0.99 \
+  --self-contained true
+
+echo "=== 2. Generating Certificates ==="
+mkdir -p "$PUBLISH_DIR/certs"
+chmod +x "$PUBLISH_DIR/Ivy.Tendril"
+"$PUBLISH_DIR/Ivy.Tendril" generate-certs "$PUBLISH_DIR/certs"
+
+echo "=== 3. Creating .app Bundle Structure ==="
+rm -rf "$APP_DIR"
+mkdir -p "$APP_DIR/Contents/MacOS"
+mkdir -p "$APP_DIR/Contents/Resources"
+
+cp -R "$PUBLISH_DIR"/* "$APP_DIR/Contents/MacOS/"
+
+if [ -d "$APP_DIR/Contents/MacOS/certs" ]; then
+  mv "$APP_DIR/Contents/MacOS/certs" "$APP_DIR/Contents/Resources/"
+fi
+if [ -f "$APP_DIR/Contents/MacOS/example.config.yaml" ]; then
+  mv "$APP_DIR/Contents/MacOS/example.config.yaml" "$APP_DIR/Contents/Resources/"
+fi
+
+# Copy icon
+cp src/Ivy.Tendril/Assets/icon.icns "$APP_DIR/Contents/Resources/icon.icns"
+
+# Info.plist
+cat << 'EOF' > "$APP_DIR/Contents/Info.plist"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>Ivy Tendril</string>
+    <key>CFBundleExecutable</key>
+    <string>Ivy.Tendril</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.ivy.tendril</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Ivy Tendril</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.99</string>
+    <key>CFBundleVersion</key>
+    <string>1.0.99</string>
+    <key>CFBundleIconFile</key>
+    <string>icon.icns</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.15</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+# Clean debugging files
+find "$APP_DIR" -name "*.pdb" -delete
+find "$APP_DIR/Contents/MacOS" -name "*.xml" -delete
+
+echo "=== 4. Packing Installer with Velopack ==="
+rm -rf "$RELEASES_DIR"
+mkdir -p "$RELEASES_DIR"
+
+vpk pack \
+  --packId IvyTendril \
+  --packVersion 1.0.99 \
+  --packDir "$APP_DIR" \
+  --mainExe Ivy.Tendril \
+  --outputDir "$RELEASES_DIR" \
+  --icon src/Ivy.Tendril/Assets/icon.icns \
+  --noPortable \
+  --bundleId com.ivy.tendril \
+  --channel osx-arm64
+
+echo "=== 5. Injecting Postinstall Script into macOS PKG ==="
+# Find the generated pkg
+PKG_PATH=$(find "$RELEASES_DIR" -name "*.pkg")
+if [ -z "$PKG_PATH" ]; then
+  echo "Error: No .pkg package found in releases!"
+  exit 1
+fi
+
+pkgutil --expand-full "$PKG_PATH" expanded-pkg
+mkdir -p expanded-pkg/Scripts
+
+cat << 'EOF' > expanded-pkg/Scripts/postinstall
+#!/bin/bash
+# Path to the installed app's certificate
+CERT_PATH="$3/Applications/Ivy Tendril.app/Contents/Resources/certs/localhost.crt"
+if [ -f "$CERT_PATH" ]; then
+  echo "Trusting Ivy Tendril localhost certificate system-wide..."
+  security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$CERT_PATH"
+fi
+exit 0
+EOF
+chmod +x expanded-pkg/Scripts/postinstall
+
+pkgutil --flatten expanded-pkg "$PKG_PATH"
+rm -rf expanded-pkg
+
+echo "=== Build Complete! ==="
+echo "Local installer package created at: $PKG_PATH"


### PR DESCRIPTION
Reverts the macOS HTTP fallback workaround and properly configures certificate generation, packaging, and automatic OS-level trusting. Unpacks the macOS installer .pkg at build time, injects a postinstall script to trust the certificate system-wide, and repacks and re-signs it. Fixes #1554.