### PR TITLE
fix(ci): fix syntax error in macOS postinstall script

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -544,7 +544,7 @@ jobs:
           
           # Write the postinstall script
           echo '#!/bin/bash
-          # Path to the installed app's certificate
+          # Path to the installed app certificate
           CERT_PATH="$3/Applications/Ivy Tendril.app/Contents/Resources/certs/localhost.crt"
           if [ -f "$CERT_PATH" ]; then
             echo "Trusting Ivy Tendril localhost certificate system-wide..."


### PR DESCRIPTION
This PR fixes the unexpected EOF syntax error in the macOS postinstall script generation by removing the single quote from the comment.