### PR TITLE
Add tendril config get/set to CLI and MCP

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/00_Overview.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/00_Overview.md
@@ -10,6 +10,7 @@ searchHints:
   - run
   - doctor
   - version
+  - config
 ---
 
 # CLI Overview
@@ -23,6 +24,7 @@ Tendril CLI gives you complete control over your workflow without touching the U
 - **Plans** — create, list, update, and inspect plans; manage repos, worktrees, verifications, and recommendations
 - **Projects** — configure projects, their repos, build dependencies, and review actions
 - **Verifications** — define and manage reusable verification checks
+- **Config** — read and update top-level settings stored in `config.yaml`
 - **Database** — run migrations, inspect schema versions, or reset the database
 - **Agents** — run and manage promptwares and their memory
 
@@ -159,3 +161,4 @@ Refreshes the embedded promptware templates from the bundled source. Run after u
 - [Verification commands](03_Verification.md) — manage global verification definitions
 - [Database commands](04_Database.md) — migrations, schema version, and reset
 - [Other commands](05_Other.md) — promptware, job, trash, MCP, and utilities
+- [Config commands](06_Config.md) — read and update top-level `config.yaml` settings

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/06_Config.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/06_Config.md
@@ -1,0 +1,65 @@
+---
+searchHints:
+  - config
+  - configuration
+  - settings
+  - jobTimeout
+  - codingAgent
+  - planTemplate
+---
+
+# config
+
+<Ingress>
+Get and set top-level Tendril settings stored in `config.yaml` — the same values you can edit under Settings in the UI.
+</Ingress>
+
+## Commands
+
+```terminal
+>tendril config get <key>
+>tendril config set <key> <value>
+>tendril config set <key> --file <path>
+>tendril config set <key> --stdin
+```
+
+- **get** — prints the raw value to stdout (no formatting), so it round-trips cleanly to a file
+- **set** — writes the value and validates it before saving. Provide the value inline, or via `--file` / `--stdin` for long or multiline values
+
+## Keys
+
+| Key | Type | Bounds |
+|-----|------|--------|
+| `codingAgent` | string | — |
+| `jobTimeout` | int (minutes) | 1–480 |
+| `staleOutputTimeout` | int (minutes) | 1–60 |
+| `gitTimeout` | int (minutes) | 1–30 |
+| `maxConcurrentJobs` | int | 1–100 |
+| `planTemplate` | string (may be multiline) | — |
+
+Out-of-range or non-integer values are rejected before anything is written, so a bad value never clobbers the current one.
+
+## Examples
+
+```terminal
+># Read a value
+>tendril config get jobTimeout
+
+># Set a scalar value
+>tendril config set jobTimeout 60
+>tendril config set codingAgent claude
+
+># Set a long/multiline plan template from a file
+>tendril config set planTemplate --file plan-template.md
+
+># ...or from stdin
+>cat plan-template.md | tendril config set planTemplate --stdin
+
+># Round-trip the template back out
+>tendril config get planTemplate > plan-template.md
+```
+
+<Callout type="Tip">
+Use `--file` or `--stdin` for `planTemplate`: passing a long, multiline value inline is fragile in the shell, and values that begin with `-` confuse argument parsing.
+
+</Callout>

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/03_MCP.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/03_MCP.md
@@ -8,6 +8,8 @@ searchHints:
   - tendril_get_plan
   - tendril_list_plans
   - tendril_plan_set
+  - tendril_get_config
+  - tendril_set_config
 ---
 
 # MCP Server
@@ -61,6 +63,13 @@ All tools are prefixed with `tendril_` and provide the same capabilities as the 
 | `tendril_plan_rec_accept` | `planId`, `title`, `notes` (optional) | Accept a recommendation. Sets state to `Accepted` or `AcceptedWithNotes` if notes provided |
 | `tendril_plan_rec_decline` | `planId`, `title`, `reason` (optional) | Decline a recommendation with optional reason |
 | `tendril_plan_rec_remove` | `planId`, `title` | Permanently remove a recommendation |
+
+### Configuration
+
+| Tool | Parameters | Description |
+|------|------------|-------------|
+| `tendril_get_config` | `key` | Get a top-level config value. Supported keys: `codingAgent`, `jobTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate` |
+| `tendril_set_config` | `key`, `value` | Set a top-level config value. Integer fields are bounds-checked; `planTemplate` may be long or multiline. Same keys as `tendril_get_config` |
 
 ## Claude Code Configuration
 

--- a/src/Ivy.Tendril.TeamIvyConfig/AGENTS.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/AGENTS.md
@@ -220,6 +220,17 @@ These commands are for internal use by other promptwares (e.g., a verification s
 | `tendril project add-review-action <name>` | Add review action |
 | `tendril project remove-review-action <name> <action>` | Remove review action |
 
+### Config Commands
+
+Read/write top-level settings in `config.yaml`. Valid keys: `codingAgent`, `jobTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate`.
+
+| Command | Description |
+|---------|-------------|
+| `tendril config get <key>` | Print a config value (raw, to stdout) |
+| `tendril config set <key> <value>` | Set a config value (validated before saving) |
+| `tendril config set <key> --file <path>` | Set from a file — use for long/multiline `planTemplate` |
+| `tendril config set <key> --stdin` | Set from stdin — use for long/multiline `planTemplate` |
+
 ## Creating Plans Interactively
 
 When the user asks you to create a plan:

--- a/src/Ivy.Tendril.TeamIvyConfig/GEMINI.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/GEMINI.md
@@ -220,6 +220,17 @@ These commands are for internal use by other promptwares (e.g., a verification s
 | `tendril project add-review-action <name>` | Add review action |
 | `tendril project remove-review-action <name> <action>` | Remove review action |
 
+### Config Commands
+
+Read/write top-level settings in `config.yaml`. Valid keys: `codingAgent`, `jobTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate`.
+
+| Command | Description |
+|---------|-------------|
+| `tendril config get <key>` | Print a config value (raw, to stdout) |
+| `tendril config set <key> <value>` | Set a config value (validated before saving) |
+| `tendril config set <key> --file <path>` | Set from a file — use for long/multiline `planTemplate` |
+| `tendril config set <key> --stdin` | Set from stdin — use for long/multiline `planTemplate` |
+
 ## Creating Plans Interactively
 
 When the user asks you to create a plan:

--- a/src/Ivy.Tendril.Test/ConfigCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigCliCommandTests.cs
@@ -1,0 +1,212 @@
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+[Collection("TendrilHome")]
+public class ConfigCliCommandTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("tendril-config-cmd-test");
+    private readonly string _originalTendrilHome;
+
+    public ConfigCliCommandTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+
+        File.WriteAllText(Path.Combine(_tempDir.Path, "config.yaml"), "projects: []\nverifications: []\n");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+    }
+
+    private static ConfigService CreateConfig() => new();
+
+    // --- Round-trip: set persists and get reads it back ---
+
+    [Fact]
+    public void Set_JobTimeout_Persists()
+    {
+        var config = CreateConfig();
+        ConfigSetCommand.ApplyField(config.Settings, "jobTimeout", "45");
+        config.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal(45, reloaded.Settings.JobTimeout);
+        Assert.Equal("45", ConfigGetCommand.ReadField(reloaded.Settings, "jobTimeout"));
+    }
+
+    [Fact]
+    public void Set_CodingAgent_Persists()
+    {
+        var config = CreateConfig();
+        ConfigSetCommand.ApplyField(config.Settings, "codingAgent", "codex");
+        config.SaveSettings();
+
+        Assert.Equal("codex", CreateConfig().Settings.CodingAgent);
+    }
+
+    [Fact]
+    public void Set_CodingAgent_KnownAgent_StoresCanonicalId()
+    {
+        var agents = TestAgentRunner.Create().RegisteredAgents;
+        var config = CreateConfig();
+        // Mixed-case input resolves to the canonical registered id.
+        ConfigSetCommand.ApplyField(config.Settings, "codingAgent", "Claude", agents);
+        config.SaveSettings();
+
+        Assert.Equal("claude", CreateConfig().Settings.CodingAgent);
+    }
+
+    [Fact]
+    public void Set_CodingAgent_UnknownAgent_Throws()
+    {
+        var agents = TestAgentRunner.Create().RegisteredAgents;
+        var ex = Assert.Throws<ArgumentException>(
+            () => ConfigSetCommand.ApplyField(CreateConfig().Settings, "codingAgent", "notarealagent", agents));
+        Assert.Contains("Valid agents", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("staleOutputTimeout", "20")]
+    [InlineData("gitTimeout", "5")]
+    [InlineData("maxConcurrentJobs", "8")]
+    public void Set_IntFields_Persist(string key, string value)
+    {
+        var config = CreateConfig();
+        ConfigSetCommand.ApplyField(config.Settings, key, value);
+        config.SaveSettings();
+
+        Assert.Equal(value, ConfigGetCommand.ReadField(CreateConfig().Settings, key));
+    }
+
+    [Fact]
+    public void Set_PlanTemplate_MultilineValue_Persists()
+    {
+        var template = "# Plan\n\n- step [one]\n- step two with -flag\n";
+        var config = CreateConfig();
+        ConfigSetCommand.ApplyField(config.Settings, "planTemplate", template);
+        config.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal(template, reloaded.Settings.PlanTemplate);
+        Assert.Equal(template, ConfigGetCommand.ReadField(reloaded.Settings, "planTemplate"));
+    }
+
+    [Fact]
+    public void Set_PlanTemplate_WithSlashesAndUrls_RoundTripsUnchanged()
+    {
+        // Prose template: forward slashes, a URL, and a // comment must survive verbatim
+        // (previously ConfigService path-normalized this at load, mangling it).
+        var template = "See src/Ivy.Tendril/Foo.cs and https://example.com/x\n// a comment";
+        var config = CreateConfig();
+        ConfigSetCommand.ApplyField(config.Settings, "planTemplate", template);
+        config.SaveSettings();
+
+        Assert.Equal(template, ConfigGetCommand.ReadField(CreateConfig().Settings, "planTemplate"));
+    }
+
+    [Fact]
+    public void Set_UnrelatedField_DoesNotCorruptPlanTemplate()
+    {
+        var template = "paths like src/a/b and urls https://x.y/z\n// comment";
+        var config = CreateConfig();
+        ConfigSetCommand.ApplyField(config.Settings, "planTemplate", template);
+        config.SaveSettings();
+
+        // Setting an unrelated field reloads + re-saves the whole config; the template must survive.
+        var config2 = CreateConfig();
+        ConfigSetCommand.ApplyField(config2.Settings, "jobTimeout", "60");
+        config2.SaveSettings();
+
+        Assert.Equal(template, ConfigGetCommand.ReadField(CreateConfig().Settings, "planTemplate"));
+    }
+
+    // --- Bounds / parsing: rejected up front, before any write ---
+
+    [Theory]
+    [InlineData("jobTimeout", "999")]
+    [InlineData("jobTimeout", "0")]
+    [InlineData("gitTimeout", "31")]
+    [InlineData("staleOutputTimeout", "0")]
+    [InlineData("maxConcurrentJobs", "101")]
+    public void Set_OutOfRange_Throws(string key, string value)
+    {
+        Assert.Throws<ArgumentException>(() => ConfigSetCommand.ApplyField(CreateConfig().Settings, key, value));
+    }
+
+    [Fact]
+    public void Set_NonInteger_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => ConfigSetCommand.ApplyField(CreateConfig().Settings, "jobTimeout", "soon"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Set_CodingAgent_Empty_Throws(string value)
+    {
+        Assert.Throws<ArgumentException>(() => ConfigSetCommand.ApplyField(CreateConfig().Settings, "codingAgent", value));
+    }
+
+    [Fact]
+    public void Set_OutOfRange_DoesNotOverwriteExistingValue()
+    {
+        var config = CreateConfig();
+        ConfigSetCommand.ApplyField(config.Settings, "jobTimeout", "45");
+        config.SaveSettings();
+
+        var config2 = CreateConfig();
+        Assert.Throws<ArgumentException>(() => ConfigSetCommand.ApplyField(config2.Settings, "jobTimeout", "999"));
+
+        // The bad value never reached disk.
+        Assert.Equal(45, CreateConfig().Settings.JobTimeout);
+    }
+
+    // --- Unknown fields ---
+
+    [Fact]
+    public void Set_UnknownField_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => ConfigSetCommand.ApplyField(CreateConfig().Settings, "bogus", "x"));
+    }
+
+    [Fact]
+    public void Get_UnknownField_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => ConfigGetCommand.ReadField(CreateConfig().Settings, "bogus"));
+    }
+
+    // --- Validation on the Spectre settings objects ---
+
+    [Fact]
+    public void GetSettings_Validate_RejectsUnknownKey()
+    {
+        Assert.False(new ConfigGetSettings { Key = "bogus" }.Validate().Successful);
+        Assert.True(new ConfigGetSettings { Key = "jobTimeout" }.Validate().Successful);
+    }
+
+    [Fact]
+    public void SetSettings_Validate_RejectsUnknownKey()
+    {
+        Assert.False(new ConfigSetSettings { Key = "bogus", Value = "1" }.Validate().Successful);
+    }
+
+    [Fact]
+    public void SetSettings_Validate_RejectsMultipleValueSources()
+    {
+        Assert.False(new ConfigSetSettings { Key = "jobTimeout", Value = "1", Stdin = true }.Validate().Successful);
+        Assert.False(new ConfigSetSettings { Key = "planTemplate", Value = "x", FilePath = "f.txt" }.Validate().Successful);
+    }
+
+    [Fact]
+    public void SetSettings_Validate_AllowsSingleSource()
+    {
+        Assert.True(new ConfigSetSettings { Key = "jobTimeout", Value = "45" }.Validate().Successful);
+        Assert.True(new ConfigSetSettings { Key = "planTemplate", FilePath = "f.txt" }.Validate().Successful);
+        Assert.True(new ConfigSetSettings { Key = "planTemplate", Stdin = true }.Validate().Successful);
+    }
+}

--- a/src/Ivy.Tendril.Test/Mcp/ConfigToolsTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/ConfigToolsTests.cs
@@ -1,0 +1,149 @@
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Mcp;
+using Ivy.Tendril.Mcp.Tools;
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test.Mcp;
+
+[Collection("TendrilHome")]
+public class ConfigToolsTests : IDisposable
+{
+    private readonly string _originalTendrilHome;
+    private readonly string? _originalToken;
+    private readonly string _tempDir;
+    private readonly IConfigService _configService;
+    private readonly ConfigTools _tools;
+
+    public ConfigToolsTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"tendril-config-mcp-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        _originalToken = Environment.GetEnvironmentVariable("TENDRIL_MCP_TOKEN");
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir);
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", null);
+
+        File.WriteAllText(Path.Combine(_tempDir, "config.yaml"), "projects: []\nverifications: []\n");
+        _configService = new ConfigService();
+        _tools = new ConfigTools(
+            new McpAuthenticationService(NullLogger<McpAuthenticationService>.Instance),
+            _configService,
+            TestAgentRunner.Create());
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        Environment.SetEnvironmentVariable("TENDRIL_MCP_TOKEN", _originalToken);
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void SetConfig_UpdatesAndPersists()
+    {
+        var result = _tools.SetConfig("jobTimeout", "45");
+        Assert.StartsWith("Updated jobTimeout", result);
+
+        // Live singleton reflects it immediately...
+        Assert.Equal("45", _tools.GetConfig("jobTimeout"));
+        // ...and it was written to disk.
+        Assert.Equal(45, new ConfigService().Settings.JobTimeout);
+    }
+
+    [Fact]
+    public void SetConfig_PlanTemplate_MultilineRoundTrips()
+    {
+        var template = "# Plan\n\n- step [one]\n- step two with -flag\n";
+        _tools.SetConfig("planTemplate", template);
+
+        Assert.Equal(template, _tools.GetConfig("planTemplate"));
+        Assert.Equal(template, new ConfigService().Settings.PlanTemplate);
+    }
+
+    [Fact]
+    public void SetConfig_PlanTemplate_WithSlashesAndUrls_RoundTripsUnchanged()
+    {
+        var template = "See src/Ivy.Tendril/Foo.cs and https://example.com/x\n// a comment";
+        _tools.SetConfig("planTemplate", template);
+
+        Assert.Equal(template, _tools.GetConfig("planTemplate"));
+        Assert.Equal(template, new ConfigService().Settings.PlanTemplate);
+    }
+
+    [Fact]
+    public void SetConfig_CodingAgent_Empty_ReturnsError()
+    {
+        Assert.StartsWith("Error:", _tools.SetConfig("codingAgent", ""));
+    }
+
+    [Fact]
+    public void SetConfig_CodingAgent_UnknownAgent_ReturnsError()
+    {
+        var result = _tools.SetConfig("codingAgent", "notarealagent");
+        Assert.StartsWith("Error:", result);
+        Assert.Contains("Valid agents", result);
+    }
+
+    [Fact]
+    public void SetConfig_CodingAgent_KnownAgent_Persists()
+    {
+        Assert.StartsWith("Updated", _tools.SetConfig("codingAgent", "claude"));
+        Assert.Equal("claude", _tools.GetConfig("codingAgent"));
+    }
+
+    [Fact]
+    public void SetConfig_CodingAgent_MixedCase_ConfirmationReflectsCanonicalId()
+    {
+        // Input 'Claude' is stored (and reported) as the canonical 'claude'.
+        Assert.Equal("Updated codingAgent to 'claude'", _tools.SetConfig("codingAgent", "Claude"));
+        Assert.Equal("claude", _tools.GetConfig("codingAgent"));
+    }
+
+    [Fact]
+    public void GetConfig_ReturnsCurrentValue()
+    {
+        _tools.SetConfig("codingAgent", "codex");
+        Assert.Equal("codex", _tools.GetConfig("codingAgent"));
+    }
+
+    [Theory]
+    [InlineData("jobTimeout", "999")]
+    [InlineData("gitTimeout", "0")]
+    [InlineData("maxConcurrentJobs", "101")]
+    public void SetConfig_OutOfRange_ReturnsErrorAndKeepsPriorValue(string key, string value)
+    {
+        // Establish a known-good value first.
+        _tools.SetConfig(key, "7");
+
+        var result = _tools.SetConfig(key, value);
+        Assert.StartsWith("Error:", result);
+
+        // The rejected value never overwrote the good one, on disk or in memory.
+        Assert.Equal("7", _tools.GetConfig(key));
+        Assert.Equal("7", ConfigGetCommand.ReadField(new ConfigService().Settings, key));
+    }
+
+    [Fact]
+    public void SetConfig_NonInteger_ReturnsError()
+    {
+        Assert.StartsWith("Error:", _tools.SetConfig("jobTimeout", "soon"));
+    }
+
+    [Fact]
+    public void SetConfig_UnknownKey_ReturnsError()
+    {
+        var result = _tools.SetConfig("bogus", "x");
+        Assert.StartsWith("Error:", result);
+        Assert.Contains("Valid fields", result);
+    }
+
+    [Fact]
+    public void GetConfig_UnknownKey_ReturnsError()
+    {
+        var result = _tools.GetConfig("bogus");
+        Assert.StartsWith("Error:", result);
+        Assert.Contains("Valid fields", result);
+    }
+}

--- a/src/Ivy.Tendril/AGENTS.md
+++ b/src/Ivy.Tendril/AGENTS.md
@@ -69,6 +69,8 @@ The server runs over stdio and exposes these tools:
 - **`tendril_list_plans`** — Query plans by state, project, or date range (returns up to 50 results)
 - **`tendril_inbox`** — Create a new plan by writing to the Tendril inbox (picked up by InboxWatcherService)
 - **`tendril_transition_plan`** — Change a plan's state (e.g., Draft → Executing)
+- **`tendril_get_config`** — Get a top-level config value (`codingAgent`, `jobTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate`)
+- **`tendril_set_config`** — Set a top-level config value (integer fields are bounds-checked)
 
 ### Authentication
 
@@ -123,6 +125,7 @@ Add to `~/.claude/mcp.json`:
 - `Commands/McpCommand.cs` — Command handler that intercepts `tendril mcp` args
 - `Mcp/TendrilMcpServer.cs` — Configures and runs the MCP server using the `ModelContextProtocol` SDK
 - `Mcp/Tools/PlanTools.cs` — Tool definitions for plan queries and inbox creation
+- `Mcp/Tools/ConfigTools.cs` — Tool definitions for reading/writing top-level config (shares the CLI's field switch)
 
 The MCP server reads plans directly from the filesystem via `TENDRIL_HOME/Plans/` and writes inbox items to `TENDRIL_HOME/Inbox/`. It does not require the Tendril web server to be running.
 

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -128,16 +128,16 @@ public class CreatePlanDialog(
         }
 
         var bodyContent =
-                Layout.Vertical()
-                | (Layout.Vertical().Gap(0)
-                    | (Layout.Horizontal().Width(Size.Full()).AlignContent(Align.SpaceBetween)
-                        | Text.Block("Select Project(s)").Small().Bold()
-                        | new Button("New Project").Ghost().Icon(Icons.Plus).OnClick(() =>
-                        {
-                            HandleClose();
-                            nav.Navigate<SettingsApp>(new SettingsAppArgs(SettingsApp.TagProjects));
-                        }))
-                    | exclusiveProjects.ToSelectInput(options).Variant(SelectInputVariant.Toggle))
+                Layout.Vertical().Margin(0,2,0,0)
+                | exclusiveProjects.ToSelectInput(options)
+                    .Variant(SelectInputVariant.Toggle)
+                    .WithField()
+                    .Label("Select Project(s)")
+                    .Tools(new Button("New Project").Icon(Icons.Plus).Small().Ghost().OnClick(() =>
+                    {
+                        HandleClose();
+                        nav.Navigate<SettingsApp>(new SettingsAppArgs(SettingsApp.TagProjects));
+                    }))
                 | selectedPriority.ToSelectInput(PriorityOptions).Variant(SelectInputVariant.Toggle).WithField().Label("Priority")
                 | new Ivy.Tendril.Widgets.ContentInput
                 {

--- a/src/Ivy.Tendril/Commands/ConfigCommand.cs
+++ b/src/Ivy.Tendril/Commands/ConfigCommand.cs
@@ -1,0 +1,150 @@
+using System.ComponentModel;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+// --- Settings ---
+
+public class ConfigGetSettings : CommandSettings
+{
+    internal static readonly string[] ValidFields =
+        ["codingAgent", "jobTimeout", "staleOutputTimeout", "gitTimeout", "maxConcurrentJobs", "planTemplate"];
+
+    [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate)")]
+    [CommandArgument(0, "<key>")]
+    public string Key { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.ValidateField(Key, ValidFields);
+    }
+}
+
+public class ConfigSetSettings : CommandSettings
+{
+    [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate)")]
+    [CommandArgument(0, "<key>")]
+    public string Key { get; set; } = "";
+
+    [Description("New value. Omit when using --file or --stdin. Use --file/--stdin for long or multiline values.")]
+    [CommandArgument(1, "[value]")]
+    public string Value { get; set; } = "";
+
+    [CommandOption("-f|--file")]
+    [Description("Read the value verbatim from this file (good for multiline planTemplate)")]
+    public string? FilePath { get; set; }
+
+    [CommandOption("--stdin")]
+    [Description("Read the value verbatim from standard input")]
+    public bool Stdin { get; set; }
+
+    /// <summary>Number of value sources the user supplied (inline arg / --file / --stdin).</summary>
+    public int SourceCount =>
+        (Stdin ? 1 : 0) + (!string.IsNullOrEmpty(FilePath) ? 1 : 0) + (!string.IsNullOrEmpty(Value) ? 1 : 0);
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        if (SourceCount > 1)
+            return Spectre.Console.ValidationResult.Error(
+                "Provide the value in exactly one way: an inline <value>, --file, or --stdin.");
+
+        return CliValidation.ValidateField(Key, ConfigGetSettings.ValidFields);
+    }
+}
+
+// --- Commands ---
+
+public class ConfigGetCommand : Command<ConfigGetSettings>
+{
+    protected override int Execute(CommandContext context, ConfigGetSettings settings, CancellationToken cancellationToken)
+    {
+        var config = new ConfigService();
+        // Write raw (like VerificationGetCommand) so values containing '[' or newlines
+        // round-trip cleanly, e.g. `tendril config get planTemplate > tpl.txt`.
+        Console.Write(ReadField(config.Settings, settings.Key));
+        return 0;
+    }
+
+    internal static string ReadField(TendrilSettings s, string field) => field.ToLowerInvariant() switch
+    {
+        "codingagent" => s.CodingAgent,
+        "jobtimeout" => s.JobTimeout.ToString(),
+        "staleoutputtimeout" => s.StaleOutputTimeout.ToString(),
+        "gittimeout" => s.GitTimeout.ToString(),
+        "maxconcurrentjobs" => s.MaxConcurrentJobs.ToString(),
+        "plantemplate" => s.PlanTemplate,
+        _ => throw new ArgumentException(UnknownFieldMessage(field))
+    };
+
+    internal static string UnknownFieldMessage(string field) =>
+        $"Unknown field: {field}. Valid fields: {string.Join(", ", ConfigGetSettings.ValidFields)}";
+}
+
+public class ConfigSetCommand(IAgentRunner runner) : Command<ConfigSetSettings>
+{
+    protected override int Execute(CommandContext context, ConfigSetSettings settings, CancellationToken cancellationToken)
+    {
+        var value = settings.Stdin ? Console.In.ReadToEnd()
+            : !string.IsNullOrEmpty(settings.FilePath) ? File.ReadAllText(settings.FilePath)
+            : settings.Value;
+
+        var config = new ConfigService();
+        // throws on bad int / out-of-range / unknown coding agent, before any write
+        ApplyField(config.Settings, settings.Key, value, runner.RegisteredAgents);
+        config.SaveSettings();
+
+        // Report the value actually stored (e.g. the canonical coding-agent id), not the raw input.
+        var stored = ConfigGetCommand.ReadField(config.Settings, settings.Key);
+        var summary = stored.Length <= 60 && !stored.Contains('\n') ? $"to '{stored}'" : $"({stored.Length} chars)";
+        Console.WriteLine($"Updated {settings.Key} {summary}");
+        return 0;
+    }
+
+    // Bounds mirror ConfigService.ValidateSettings() so a value written here survives a reload
+    // instead of being silently reset to a default. Pass validCodingAgents (the runner's
+    // RegisteredAgents) to validate the codingAgent value; omit it to skip that check.
+    internal static void ApplyField(TendrilSettings s, string field, string value,
+        IReadOnlyCollection<string>? validCodingAgents = null)
+    {
+        switch (field.ToLowerInvariant())
+        {
+            case "codingagent": s.CodingAgent = ValidateCodingAgent(value, validCodingAgents); break;
+            case "jobtimeout": s.JobTimeout = ParseBoundedInt(value, "jobTimeout", 1, 480); break;
+            case "staleoutputtimeout": s.StaleOutputTimeout = ParseBoundedInt(value, "staleOutputTimeout", 1, 60); break;
+            case "gittimeout": s.GitTimeout = ParseBoundedInt(value, "gitTimeout", 1, 30); break;
+            case "maxconcurrentjobs": s.MaxConcurrentJobs = ParseBoundedInt(value, "maxConcurrentJobs", 1, 100); break;
+            case "plantemplate": s.PlanTemplate = value; break;
+            default: throw new ArgumentException(ConfigGetCommand.UnknownFieldMessage(field));
+        }
+    }
+
+    // Rejects empty and, when the known-agent set is supplied, unknown agents. Returns the
+    // canonical registered id (preserving the runner's casing) so it resolves via GetCli later.
+    internal static string ValidateCodingAgent(string value, IReadOnlyCollection<string>? validCodingAgents)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("codingAgent cannot be empty.");
+
+        if (validCodingAgents is not { Count: > 0 })
+            return value;
+
+        var match = validCodingAgents.FirstOrDefault(a => a.Equals(value, StringComparison.OrdinalIgnoreCase));
+        if (match == null)
+            throw new ArgumentException(
+                $"Unknown coding agent '{value}'. Valid agents: {string.Join(", ", validCodingAgents.OrderBy(a => a, StringComparer.OrdinalIgnoreCase))}");
+
+        return match;
+    }
+
+    internal static int ParseBoundedInt(string value, string field, int min, int max)
+    {
+        if (!int.TryParse(value.Trim(), out var n))
+            throw new ArgumentException($"{field} must be an integer, got '{value}'.");
+        if (n < min || n > max)
+            throw new ArgumentException($"{field} must be between {min} and {max}, got {n}.");
+        return n;
+    }
+}

--- a/src/Ivy.Tendril/Helpers/VariableExpansion.cs
+++ b/src/Ivy.Tendril/Helpers/VariableExpansion.cs
@@ -58,7 +58,12 @@ public static class VariableExpansion
     /// <summary>
     ///     Expand variables in a string value.
     /// </summary>
-    public static string ExpandVariables(string value, string? tendrilHome)
+    /// <param name="normalizePaths">
+    ///     When true (default), path separators are normalized (forward slashes → backslashes on Windows,
+    ///     double separators collapsed). Pass false for prose values (e.g. plan templates, prompts) where
+    ///     slash normalization would corrupt the text — those should expand variables only.
+    /// </param>
+    public static string ExpandVariables(string value, string? tendrilHome, bool normalizePaths = true)
     {
         if (string.IsNullOrEmpty(value)) return value;
 
@@ -74,7 +79,8 @@ public static class VariableExpansion
 
         // Normalize path separators: convert forward slashes to backslashes on Windows,
         // and remove any double slashes that might have been created during expansion
-        value = NormalizePath(value);
+        if (normalizePaths)
+            value = NormalizePath(value);
 
         return value;
     }

--- a/src/Ivy.Tendril/Mcp/TendrilMcpServer.cs
+++ b/src/Ivy.Tendril/Mcp/TendrilMcpServer.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Agents;
 using Ivy.Tendril.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -18,6 +19,10 @@ public class TendrilMcpServer
             // Register authentication service
             builder.Services.AddSingleton<McpAuthenticationService>();
             builder.Services.AddSingleton<IConfigService>(new ConfigService());
+
+            // Agent infrastructure supplies IAgentRunner (registered agents) for config validation.
+            // Include beta providers so config validation accepts every real agent id.
+            builder.Services.AddAgentInfrastructure(opts => opts.IncludeBetaProviders = true);
 
             builder.Services
                 .AddMcpServer(options =>

--- a/src/Ivy.Tendril/Mcp/Tools/ConfigTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/ConfigTools.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Services;
+using ModelContextProtocol.Server;
+
+namespace Ivy.Tendril.Mcp.Tools;
+
+[McpServerToolType]
+public sealed class ConfigTools : AuthenticatedToolBase
+{
+    private readonly IConfigService _configService;
+    private readonly IAgentRunner _runner;
+
+    public ConfigTools(McpAuthenticationService authService, IConfigService configService, IAgentRunner runner) : base(authService)
+    {
+        _configService = configService;
+        _runner = runner;
+    }
+
+    [McpServerTool(Name = "tendril_get_config"), Description("Get a top-level Tendril config value")]
+    public string GetConfig(
+        [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate)")] string key)
+    {
+        // Reuses the same field switch as `tendril config get` so the two surfaces never drift.
+        return ExecuteAuthenticated(() => ConfigGetCommand.ReadField(_configService.Settings, key));
+    }
+
+    [McpServerTool(Name = "tendril_set_config"), Description("Set a top-level Tendril config value")]
+    public string SetConfig(
+        [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate)")] string key,
+        [Description("New value. Integer fields are bounds-checked; planTemplate may be long or multiline.")] string value)
+    {
+        return ExecuteAuthenticated(() =>
+        {
+            // ApplyField throws on unknown key / bad int / out-of-range / unknown coding agent, before any write.
+            ConfigSetCommand.ApplyField(_configService.Settings, key, value, _runner.RegisteredAgents);
+            _configService.SaveSettings();
+
+            // Report the value actually stored (e.g. the canonical coding-agent id), not the raw input.
+            var stored = ConfigGetCommand.ReadField(_configService.Settings, key);
+            var summary = stored.Length <= 60 && !stored.Contains('\n') ? $"to '{stored}'" : $"({stored.Length} chars)";
+            return $"Updated {key} {summary}";
+        });
+    }
+}

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -338,7 +338,7 @@ public class Program
         {
             "doctor", "db-version", "db-migrate", "db-reset",
             "update-promptwares", "job", "plan", "promptware",
-            "trash", "verification", "project", "project-analyzer", "models",
+            "trash", "verification", "project", "project-analyzer", "models", "config",
             "version", "--version", "report-bug", "reset", "update",
             "--help", "-h", "run"
         };
@@ -625,6 +625,14 @@ public class Program
                     .WithDescription("Add a review action to a project");
                 project.AddCommand<ProjectRemoveReviewActionCommand>("remove-review-action")
                     .WithDescription("Remove a review action from a project");
+            });
+
+            config.AddBranch("config", cfg =>
+            {
+                cfg.AddCommand<ConfigGetCommand>("get")
+                    .WithDescription("Get a top-level config value");
+                cfg.AddCommand<ConfigSetCommand>("set")
+                    .WithDescription("Set a top-level config value");
             });
         });
         return app;

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -88,7 +88,7 @@ Plans live in `{PLAN_FOLDER}/{ID}-{SafeTitle}/`:
 
 **plan.yaml key fields:** state, project, level, title, repos, verifications, dependsOn, relatedPlans, commits, prs, executionProfile, sourceUrl
 
-**Revision format:**
+**Revision format (illustrative):** a plan revision is markdown that typically looks like this:
 
 ```markdown
 # Title
@@ -103,7 +103,14 @@ Technical approach with file paths and steps
 New tests to write + test scope filter
 ```
 
-Verifications are **not** part of the revision markdown — they live in `plan.yaml` (seeded at creation, toggled in the UI).
+This is only an illustration of what a plan looks like — **do not author a new plan yourself in this shape.** 
+
+New-plan content is written by the `CreatePlan` job using the project's configured **Plan Template** (see "Creating Plans Interactively"). 
+
+Use `tendril plan write-revision` only to edit the content of an **existing** plan.
+
+**Note:** the illustration above may not match the actual template — the user can configure a different **Plan Template** on the Plans settings page. To see the real configured template, run `tendril config get planTemplate`. 
+You normally don't need to: the `CreatePlan` job applies it for you. Only consult it when editing an existing plan's revision and you need to match the project's structure.
 
 ## Tendril CLI Reference
 
@@ -126,7 +133,7 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 | Command | Description |
 |---------|-------------|
 | `tendril plan list` | List plans (supports filters) |
-| `tendril plan create <title>` | Create a new plan |
+| `tendril plan create <title>` | Low-level create of the plan folder/yaml — **edit-only primitive, not for creating a plan from a chat request** (start a `CreatePlan` job instead) |
 | `tendril plan update <plan-id>` | Update plan from stdin |
 | `tendril plan set <plan-id> <field> <value>` | Set a plan field |
 | `tendril plan get <plan-id> [field]` | Get plan data |
@@ -141,7 +148,7 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 | `tendril plan add-depends-on <plan-id> <folder>` | Add dependency |
 | `tendril plan remove-depends-on <plan-id> <folder>` | Remove dependency |
 | `tendril plan add-log <plan-id> <action>` | Add execution log entry |
-| `tendril plan write-revision <plan-id>` | Write revision from stdin |
+| `tendril plan write-revision <plan-id>` | Write revision from stdin — **only to edit an existing plan; never to create a new plan** (start a `CreatePlan` job instead) |
 | `tendril plan cleanup <plan-id>` | Remove worktrees |
 | `tendril plan set-verification <plan-id> <name> <status>` | Set verification status |
 
@@ -220,17 +227,26 @@ These commands are for internal use by other promptwares (e.g., a verification s
 | `tendril project add-review-action <name>` | Add review action |
 | `tendril project remove-review-action <name> <action>` | Remove review action |
 
+### Config Commands
+
+| Command | Description |
+|---------|-------------|
+| `tendril config get <key>` | Print a top-level config value |
+| `tendril config set <key> <value>` | Set a top-level config value (use `--file`/`--stdin` for multiline values) |
+
+Valid keys: `codingAgent`, `jobTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate`. Example: `tendril config get planTemplate` prints the configured Plan Template.
+
 ## Creating Plans Interactively
 
 When the user asks you to create a plan:
 
 1. **Do the work the description implies, first.** If the description asks you to *suggest*, *research*, *investigate*, *compare*, or *decide* something, actually do that work before creating the plan. Explore the project's repos, read the relevant code, and produce concrete, specific proposals. For example, "Suggest a few dev tools we can add" means you go look at the project and come back with named tools and why — it does **not** mean creating a plan titled "Suggest dev tools to add".
 2. **Confirm scope when it's open-ended.** Briefly share what you found and what you propose, so the user can steer before you commit it to a plan.
-3. **Create the plan by starting a CreatePlan job** — do **not** run `tendril plan create` / `write-revision` yourself. Once the scope is concrete, start the job:
+3. **You MUST create the plan by starting a `CreatePlan` job.** Never create a new plan by writing its content yourself — do **not** run `tendril plan create` / `write-revision`, and do **not** hand-author the plan markdown. Once the scope is concrete, start the job:
    ```bash
    tendril job start CreatePlan --description="<concrete, refined description>" --project="<project>"
    ```
-   The CreatePlan promptware then researches, detects duplicates, and writes the full plan. Pass the specific description you developed (the concrete tools/steps you proposed), **not** the user's original vague request. Add `--priority <n>` or `--force` if appropriate. Report the job back to the user.
+   This is non-negotiable: the `CreatePlan` job applies the project's configured **Plan Template** and runs duplicate detection and research. If you hand-write the plan instead, the configured template and those steps are silently skipped and the plan comes out malformed. The job's promptware then writes the full plan. Pass the specific description you developed (the concrete tools/steps you proposed), **not** the user's original vague request. Add `--priority <n>` or `--force` if appropriate. Report the job back to the user.
 
 ## Important Notes
 

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -899,7 +899,9 @@ public class ConfigService : IConfigService
 
         // Scalar expansions
         Settings.CodingAgent = ExpandVar(Settings.CodingAgent);
-        Settings.PlanTemplate = ExpandVar(Settings.PlanTemplate);
+        // PlanTemplate is prose, not a path: it must NOT be path-normalized (that corrupts slashes/URLs)
+        // and must stay raw on disk so get/set round-trips cleanly. It is expanded at point of use in
+        // JobLauncher (with normalizePaths: false) instead.
 
         // Expand nested objects
         ExpandLlmConfig();

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -311,8 +311,10 @@ internal class JobLauncher
 
         var customInstructions = ResolveCustomInstructions(job.Type);
         var projects = BuildProjectInfos(job);
+        // Expand variables at point of use (Settings holds the raw template). normalizePaths: false —
+        // the template is prose injected into the prompt, so slashes/URLs must be preserved.
         var planTemplate = PlanWritingTypes.Contains(job.Type)
-            ? _configService.Settings.PlanTemplate
+            ? VariableExpansion.ExpandVariables(_configService.Settings.PlanTemplate, _configService.TendrilHome, normalizePaths: false)
             : null;
         var prompt = FirmwareCompiler.Compile(new FirmwareContext(programFolder, values, customInstructions, projects, planTemplate));
         job.CompiledPrompt = prompt;


### PR DESCRIPTION
## What

Adds a `tendril config get/set` CLI group and `tendril_get_config` / `tendril_set_config` MCP tools to read/write top-level `config.yaml` settings — closing the gap where the CLI/MCP couldn't do what the Settings UI does.

Keys: `codingAgent`, `jobTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate`. CLI and MCP share one field switch (`ConfigCommand.ReadField`/`ApplyField`) — no parallel drift.

## Highlights

- **Validated writes:** int bounds mirror `ConfigService.ValidateSettings`; `codingAgent` is validated against the registered agents and stored as the canonical id; empty `codingAgent` rejected. Confirmation reports the value actually stored.
- **Long values:** `set` accepts `--file`/`--stdin` for multiline `planTemplate`; `get` writes raw so it round-trips cleanly.
- **Bug fix (data loss):** `planTemplate` was path-normalized and re-persisted at load, so any save (even an unrelated field, or the UI) corrupted slashes/URLs. It now stays raw in `Settings` and is expanded at point of use in `JobLauncher`; `VariableExpansion.ExpandVariables` gained a `normalizePaths` opt-out.
- MCP host now registers agent infrastructure so `ConfigTools` can validate.
- Docs: new CLI Config page, MCP Configuration tools table, AGENTS/GEMINI references.

Also includes a Create Plan dialog layout tweak and AgentPrompt plan-creation guidance updates.

## Tests

New `ConfigCliCommandTests` + `ConfigToolsTests` (get/set round-trips, slash/URL round-trip, unrelated-set-preserves-template, bounds/empty/unknown rejection, codingAgent validation + canonicalization). Full suite green apart from pre-existing, machine-cache-dependent `VersionCheckServiceTests`.