### PR TITLE
fix: resolve issue link button overlapping and wrapping in responsive header

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -135,15 +135,11 @@ public class ContentView(
 
         var currentIndex = allPlans.FindIndex(p => p.FolderName == selectedPlan.FolderName);
 
-        object BuildTitleArea()
+        object BuildTitleArea(bool isMobile)
         {
             var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full().Min(Size.Px(0)))
-                | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
-                    .BorderThickness(0).Padding(0).Width(Size.Fit().Min(Size.Px(0)));
-
-            if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
-                desktopTitleLayout |= new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
-                    .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
+                | Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis)
+                    .Width(Size.Grow().Min(Size.Px(0)));
 
             if (selectedPlan.DependsOn.Count > 0)
             {
@@ -158,6 +154,7 @@ public class ContentView(
             }
 
             var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
+                .Width(Size.Full().Min(Size.Px(0)))
                 .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
 
             return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow().Min(Size.Px(0)))
@@ -171,17 +168,18 @@ public class ContentView(
                        .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
         }
 
-        object BuildControls()
+        object BuildControls(bool isMobile)
         {
-            var controls = Layout.Horizontal().Gap(2).AlignContent(Align.Right)
+            var rightSide = Layout.Horizontal().Gap(2).AlignContent(Align.Right)
                            | Text.Rich()
+                               .NoWrap()
                                .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
                                .Muted("plans", word: true);
 
             if (annotations.Value.Count > 0)
-                controls |= BuildAnnotationsUpdateButton(annotations);
+                rightSide |= BuildAnnotationsUpdateButton(annotations);
 
-            controls |= new Button("Execute").Icon(Icons.Rocket).Primary().ShortcutKey("x")
+            rightSide |= new Button("Execute").Icon(Icons.Rocket).Primary().ShortcutKey("x")
                             .Loading(isCheckingPreflight)
                             .Disabled(isCheckingPreflight)
                             .OnClick(() => runPreflight(selectedPlan.Project, result =>
@@ -192,7 +190,21 @@ public class ContentView(
                                     ContinueExecute(null, result, pendingWaitJobIds, showDirtyDialog);
                             }));
 
-            return controls;
+            if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
+            {
+                var leftSide = Layout.Horizontal().Gap(2).AlignContent(Align.Left)
+                               | new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
+                                   .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
+
+                return Layout.Horizontal()
+                       .Width(isMobile ? Size.Full() : Size.Fit())
+                       .AlignContent(isMobile ? Align.SpaceBetween : Align.Right)
+                       .Gap(2)
+                       | leftSide
+                       | rightSide;
+            }
+
+            return rightSide;
         }
 
         var header = ResponsiveHeader.Build(BuildTitleArea, BuildControls);

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -72,15 +72,16 @@ public class ContentView(
         }
         var currentIndex = allRecommendations.FindIndex(r => r.PlanId == selectedRecommendation.PlanId && r.Title == selectedRecommendation.Title);
 
-        object BuildTitleArea()
+        object BuildTitleArea(bool isMobile)
         {
             var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full().Min(Size.Px(0)))
-                | new Box(Text.Block($"#{selectedRecommendation.PlanId} {selectedRecommendation.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
-                    .BorderThickness(0).Padding(0).Width(Size.Fit())
+                | Text.Block($"#{selectedRecommendation.PlanId} {selectedRecommendation.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis)
+                    .Width(Size.Grow().Min(Size.Px(0)))
                 | new Badge(selectedRecommendation.Project).Variant(BadgeVariant.Outline)
                     .WithProjectColor(config, selectedRecommendation.Project);
 
             var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
+                .Width(Size.Full().Min(Size.Px(0)))
                 .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
 
             return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow().Min(Size.Px(0)))
@@ -94,7 +95,7 @@ public class ContentView(
                        .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
         }
 
-        object BuildControls() => Layout.Horizontal().Gap(2).AlignContent(Align.Right)
+        object BuildControls(bool isMobile) => Layout.Horizontal().Gap(2).AlignContent(Align.Right)
                        | Text.Rich()
                            .Bold($"{(currentIndex == -1 ? "?" : (currentIndex + 1).ToString())}/{allRecommendations.Count}", word: true)
                            .Muted("recommendations", word: true)

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -251,17 +251,14 @@ public class ContentView(
         INavigator nav,
         ReviewAppArgs? args)
     {
-        object BuildTitleArea()
+        object BuildTitleArea(bool isMobile)
         {
             var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full().Min(Size.Px(0)))
-                | new Box(Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis))
-                    .BorderThickness(0).Padding(0).Width(Size.Fit().Min(Size.Px(0)));
-
-            if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
-                desktopTitleLayout |= new Button(selectedPlan.IsPullRequestSource ? "PR" : "Issue")
-                    .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
+                | Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis)
+                    .Width(Size.Grow().Min(Size.Px(0)));
 
             var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
+                .Width(Size.Full().Min(Size.Px(0)))
                 .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
 
             return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow().Min(Size.Px(0)))
@@ -275,10 +272,11 @@ public class ContentView(
                        .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
         }
 
-        object BuildControls()
+        object BuildControls(bool isMobile)
         {
-            var controls = Layout.Horizontal().Gap(2).AlignContent(Align.Right)
+            var rightSide = Layout.Horizontal().Gap(2).AlignContent(Align.Right)
                            | Text.Rich()
+                               .NoWrap()
                                .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
                                .Muted("plans", word: true);
 
@@ -329,13 +327,13 @@ public class ContentView(
                     }
                 }).ShortcutKey("m");
 
-                controls |= (allYolo && !isPrUpdate)
+                rightSide |= (allYolo && !isPrUpdate)
                     ? createPrBtn.WithConfetti(AnimationTrigger.Click)
                     : createPrBtn;
             }
             else
             {
-                controls |= new Button("Complete Plan").Icon(Icons.CircleCheck).Primary().OnClick(() =>
+                rightSide |= new Button("Complete Plan").Icon(Icons.CircleCheck).Primary().OnClick(() =>
                 {
                     // Optimistic UI - update state and refresh immediately
                     planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
@@ -346,7 +344,21 @@ public class ContentView(
                 }).ShortcutKey("m");
             }
 
-            return controls;
+            if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
+            {
+                var leftSide = Layout.Horizontal().Gap(2).AlignContent(Align.Left)
+                               | new Button(selectedPlan.IsPullRequestSource ? "PR" : "Issue")
+                                   .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
+
+                return Layout.Horizontal()
+                       .Width(isMobile ? Size.Full() : Size.Fit())
+                       .AlignContent(isMobile ? Align.SpaceBetween : Align.Right)
+                       .Gap(2)
+                       | leftSide
+                       | rightSide;
+            }
+
+            return rightSide;
         }
 
         return ResponsiveHeader.Build(BuildTitleArea, BuildControls);

--- a/src/Ivy.Tendril/Apps/Views/ResponsiveHeader.cs
+++ b/src/Ivy.Tendril/Apps/Views/ResponsiveHeader.cs
@@ -25,19 +25,19 @@ public static class ResponsiveHeader
     /// factories and built once per layout — the same approach the title area itself already uses
     /// to render a desktop title and a mobile picker side by side.
     /// </remarks>
-    public static object Build(Func<object> titleArea, Func<object> controls)
+    public static object Build(Func<bool, object> titleArea, Func<bool, object> controls)
     {
         var desktop = new Box(
                 Layout.Horizontal().Height(Size.Px(40)).Width(Size.Full()).Gap(2).AlignContent(Align.Left)
-                | titleArea()
-                | controls())
+                | titleArea(false)
+                | controls(false))
             .BorderThickness(0).Padding(0).Width(Size.Full())
             .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
 
         var mobile = new Box(
                 Layout.Vertical().Width(Size.Full()).Gap(2).AlignContent(Align.Left)
-                | titleArea()
-                | controls())
+                | titleArea(true)
+                | controls(true))
             .BorderThickness(0).Padding(0).Width(Size.Full())
             .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
 


### PR DESCRIPTION
This PR fixes the responsive header layout where the issue link button would wrap to a second line or overlap with the title on medium/narrower screen widths.