### PR TITLE
fix: add Backspace shortcut for Delete action in Drafts app (#1507)

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -182,7 +182,7 @@ public class ActionBarView(
                    .OnClick(StartSplit).Disabled(hasActiveSplitJob).FullOnly()
                | new Button("Expand").Icon(Icons.UnfoldVertical).Outline()
                    .OnClick(StartExpand).Disabled(hasActiveExpandJob).FullOnly()
-               | new Button("Delete").Icon(Icons.Trash).Outline()
+               | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
                    .OnClick(showDeleteDialog).FullOnly()
                // Full-tier dropdown: standard overflow items only
                | ActionBarResponsive.DropdownAtFull(


### PR DESCRIPTION
Fixes #1507 by adding the Backspace shortcut to the Delete action button in DraftsApp.