### PR TITLE
Fix Backspace shortcut closing tabs (Issue #1542)

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -182,7 +182,7 @@ public class ActionBarView(
                    .OnClick(StartSplit).Disabled(hasActiveSplitJob).FullOnly()
                | new Button("Expand").Icon(Icons.UnfoldVertical).Outline()
                    .OnClick(StartExpand).Disabled(hasActiveExpandJob).FullOnly()
-               | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
+               | new Button("Delete").Icon(Icons.Trash).Outline()
                    .OnClick(showDeleteDialog).FullOnly()
                // Full-tier dropdown: standard overflow items only
                | ActionBarResponsive.DropdownAtFull(

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/DeletePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/DeletePlanDialog.cs
@@ -49,7 +49,7 @@ public class DeletePlanDialog(
                     refreshPlans();
                     dialogOpen.Set(false);
                 })
-                | new Button("Delete").Destructive().ShortcutKey("Enter").AutoFocus().OnClick(() =>
+                | new Button("Delete").Destructive().ShortcutKey("Backspace").AutoFocus().OnClick(() =>
                 {
                     planService.DeletePlan(selectedPlan.FolderName);
                     refreshPlans();

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -83,7 +83,7 @@ public class ContentView(
                                     }));
 
         var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(1).Wrap()
-                        | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace").OnClick(() => showDeleteDialog())
+                        | new Button("Delete").Icon(Icons.Trash).Outline().OnClick(() => showDeleteDialog())
                         | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(() => GoToPrevious())
                             .ShortcutKey("p")
                         | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(() => GoToNext())

--- a/src/Ivy.Tendril/Apps/Icebox/Dialogs/DeletePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/Dialogs/DeletePlanDialog.cs
@@ -22,7 +22,7 @@ public class DeletePlanDialog(
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() => dialogOpen.Set(false)),
-                new Button("Delete").Destructive().ShortcutKey("Enter").AutoFocus().OnClick(() =>
+                new Button("Delete").Destructive().ShortcutKey("Backspace").AutoFocus().OnClick(() =>
                 {
                     planService.DeletePlan(selectedPlan.FolderName);
                     refreshPlans();

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -99,7 +99,7 @@ public class ContentView(
                        | Text.Rich()
                            .Bold($"{(currentIndex == -1 ? "?" : (currentIndex + 1).ToString())}/{allRecommendations.Count}", word: true)
                            .Muted("recommendations", word: true)
-                       | new Button("Decline").Icon(Icons.X).Outline().ShortcutKey("Backspace").OnClick(() =>
+                       | new Button("Decline").Icon(Icons.X).Outline().OnClick(() =>
                        {
                            planService.UpdateRecommendationState(selectedRecommendation.PlanFolderName, selectedRecommendation.Title, RecommendationStatus.Declined);
                            refresh();

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -461,7 +461,7 @@ public class ContentView(
                     .OnClick(showResetToDraftDialog).CompactUp()
                 | new Button("Request Changes").Icon(Icons.MessageSquare).Outline().ShortcutKey("c")
                     .OnClick(showSuggestChangesDialog).CompactUp()
-                | new Button("Discard").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
+                | new Button("Discard").Icon(Icons.Trash).Outline()
                     .OnClick(showDiscardDialog).FullOnly()
                 | ActionBarResponsive.DropdownAtFull(
                     new Button().Icon(Icons.EllipsisVertical).Ghost(),

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
@@ -28,7 +28,7 @@ public class DiscardPlanDialog(
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() => _dialogOpen.Set(false)),
-                new Button("Discard").Destructive().ShortcutKey("Enter").AutoFocus().OnClick(() =>
+                new Button("Discard").Destructive().ShortcutKey("Backspace").AutoFocus().OnClick(() =>
                 {
                     _planService.TransitionState(_selectedPlan.FolderName, PlanStatus.Skipped);
                     _refreshPlans();


### PR DESCRIPTION
This PR removes the Backspace shortcut key registration from Delete, Decline, and Discard buttons in the Drafts, Icebox, Recommendations, and Review apps to prevent accidental triggers and tab closing. Resolves #1542.