### PR TITLE
Add SyncRepo untracked-changes policy (Stash/Commit/PullRequest)

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -173,6 +173,18 @@ projects:
     command: dotnet run --project Worktrees\Ivy-Tendril-Services\Ivy.Tendril.Services.Admin --browse --find-available-port
   hooks: []
   buildDependencies: []
+- name: BS-Website
+  color: Green
+  meta: {}
+  repos:
+  - path: D:\Tendril\Repos\BS-Website
+    prRule: default
+    baseBranch: main
+  verifications: []
+  context: ''
+  reviewActions: []
+  hooks: []
+  buildDependencies: []
 verifications:
 - name: FrameworkDotnetBuild
   prompt: >
@@ -233,61 +245,116 @@ verifications:
 
     <any gaps between plan and implementation, or "None"> ```
 - name: CodeReview
-  prompt: >
-    Perform a code review of all files changed by this plan's commits.
+  prompt: >-
+    Perform a code review of all changes made by this plan's commits, using Claude Code's built-in `\code-review` skill. Always fix major findings; log minor concerns as plan recommendations.
 
-    **Step 1: Identify changed files** Get the list of changed files from all commits made during this execution: - If there are worktrees in `<TendrilPlanFolder>\Worktrees\`, check each one for commits - Otherwise, check the current working directory - Use `git log --oneline --all --author="<execution-agent>" --since="<plan-execution-start>"` to find commits - Use `git diff --name-only <before>..<after>` to list changed files for each commit range
 
-    **Step 2: CodeScene Analysis (if available)** Check if CodeScene CLI is available using the codescene MCP tools. If available: 1. Run `mcp__codescene__pre_commit_code_health_safeguard` on the git repository to get quality gate results for all staged\modified files 2. For each changed source file (.cs, .ts, .tsx, .js), run `mcp__codescene__code_health_review` to get detailed Code Health scores and code smell findings 3. Document findings with:
-       - File path
-       - Code Health score (1.0-10.0 scale: Red 1.0-3.9, Yellow 4.0-8.9, Green 9.0-9.9, Optimal 10.0)
-       - Specific code smells found
-       - Quality gate pass\fail status
+    **Step 1: Locate the changes**
 
-    **Step 3: Manual Review** For each changed source file (.cs, .ts, .tsx, .js), review for: - Dead code or unused imports - Code duplication (within the file or with nearby files) - Overly complex methods - Poor naming or unclear intent - Missing error handling at system boundaries - Inconsistent patterns vs. the rest of the codebase - Unnecessary abstractions or over-engineering - Backwards-compatibility code that is no longer needed
+    - The plan folder is `<TendrilPlanFolder>`. The plan id is the folder's name (e.g. `03683-Example`).
 
-    **Step 4: Fix Issues** If fixable issues are found (from either CodeScene or manual review), fix them directly in the appropriate worktree or working directory — stage and commit the fixes.
+    - Find the worktree(s) under `<TendrilPlanFolder>\Worktrees\`. The code produced by this plan lives on the plan's branch there. If there are no worktrees, use the current working directory.
 
-    **Step 5: Write Report** Write the verification report to `<TendrilPlanFolder>\Verification\CodeReview.md` with format: ``` # CodeReview
+    - `cd` into the worktree so the review sees this plan's diff (the plan branch against its base branch).
 
-    - **Date:** <timestamp> - **Result:** Pass | Fail - **Attempts:** 1
 
-    ## CodeScene Analysis
+    **Step 2: Run the \code-review skill**
 
-    **CLI Available:** Yes\No
+    - Invoke the `\code-review` skill via the Skill tool at `high` effort: `\code-review high`.
 
-    ### Quality Gates
+    - Do NOT pass `--fix` (that would apply every finding indiscriminately — we want per-severity handling below) and do NOT pass `--comment`.
 
-    | File | Score | Gate | Issues | |------|-------|------|--------| | <path> | <score> | Pass\Fail | <count> |
+    - Let the skill produce its findings (it reports them via ReportFindings, most-severe first). Collect them.
 
-    ### Code Smells by File
 
-    <for each file with Code Health < 9.0, list specific smells found>
+    **Step 3: Classify findings by severity**
 
-    ## Manual Review
+    - **Major** = anything that is or could be wrong: correctness bugs, security issues, crashes, data loss, broken behavior, resource leaks, incorrect logic, missing error handling at a real boundary. When a finding's severity is ambiguous, treat it as major.
 
-    ### Files Reviewed
+    - **Minor** = optional cleanups that don't change behavior: naming, style, simplification, minor duplication, readability, micro-efficiency, nitpicks.
 
-    | File | Issues | Fixed | |------|--------|-------| | <path> | <count> | Yes\No |
 
-    ### Issues Found
+    **Step 4: Always fix major findings**
 
-    <list each issue with file, line, description, and whether it was fixed>
+    - Fix every major finding directly in the worktree.
 
-    ## Fixes Applied
+    - Stage and commit the fixes (`git add` + `git commit`) with a clear message, e.g. `code-review: fix <short description>`. One commit per logical fix, or a single grouped commit — your judgement.
 
-    <list commits created to fix issues, or "None">
+    - Re-run a quick sanity check (build\relevant tests) if a fix is non-trivial and the tooling is readily available.
+
+
+    **Step 5: Log minor concerns as recommendations — do NOT fix them**
+
+    - For each minor concern, add a plan recommendation:
+      `tendril plan rec add "<plan-id>" "<short imperative title>"`
+    - Then attach detail (file:line + what to change) via:
+      `tendril plan rec set "<plan-id>" "<short imperative title>" description "<detail>"`
+    - Use the plan id derived in Step 1 (the plan folder name works as the id).
+
+    - Do not edit code for minor concerns — they are left for the human to accept or decline.
+
+
+    **Step 6: Write the report**
+
+    Write the verification report to `<TendrilPlanFolder>\Verification\CodeReview.md` in this format:
+
+    ```
+
+    # CodeReview
+
+
+    - **Date:** <timestamp>
+
+    - **Result:** Pass | Fail
+
+    - **Attempts:** 1
+
+
+    ## Review Method
+
+
+    Ran Claude Code `\code-review high` in <worktree path>.
+
+
+    ## Major Findings (fixed)
+
+
+    | File:Line | Finding | Fix commit |
+
+    |-----------|---------|------------|
+
+    | <path:line> | <description> | <sha or "—"> |
+
+
+    (or "None")
+
+
+    ## Minor Concerns (logged as recommendations)
+
+
+    | File:Line | Concern | Recommendation title |
+
+    |-----------|---------|----------------------|
+
+    | <path:line> | <description> | <rec title> |
+
+
+    (or "None")
+
 
     ## Summary
 
-    <overall assessment combining CodeScene metrics and manual findings> ```
 
-    **Step 6: Determine Result** - Result is **Pass** if:
-      - All CodeScene quality gates pass (or CodeScene not available)
-      - No unfixable manual review issues remain
-    - Result is **Fail** if:
-      - Any CodeScene quality gate fails with unresolved degradations
-      - Manual review found issues that could not be auto-fixed (e.g. design-level concerns requiring human decision)
+    <overall assessment: what was reviewed, what was fixed, what was deferred to recommendations>
+
+    ```
+
+
+    **Step 7: Determine Result**
+
+    - **Pass** — the review completed and all major findings were fixed and committed (minor concerns logged as recommendations do not fail the verification).
+
+    - **Fail** — a major finding could not be fixed automatically (e.g. it needs a human design decision), or the `\code-review` skill could not run. Describe the blocker in the Summary.
 - name: NewWidgetChecklist
   prompt: >
     Verify all 6 required elements exist for any new widget created by this plan: 1. Backend widget class — src\Ivy\Widgets\<WidgetName>.cs with [Prop]\[Event] attributes, [JsonIgnore] on delegates, Has* booleans 2. Frontend React component — src\frontend\src\widgets\<widgetName>\<WidgetName>Widget.tsx 3. Index export — src\frontend\src\widgets\<widgetName>\index.ts 4. Widget map registration — import + entry in src\frontend\src\widgets\widgetMap.ts 5. Sample app — src\Ivy.Samples.Shared\Apps\Widgets\<WidgetName>App.cs 6. Documentation page — src\Ivy.Docs.Shared\Docs\02_Widgets\<category>\<WidgetName>.md Check each file exists and follows conventions. Report which elements are present vs missing.
@@ -376,8 +443,7 @@ promptwares:
 codingAgents:
 - name: claude
   arguments: ''
-  environmentVariables:
-    CLAUDE_CODE_USE_BEDROCK: 1
+  environmentVariables: {}
   profiles:
   - name: deep
     model: opus
@@ -478,6 +544,7 @@ tunnel:
   maxRestarts: 10
 telemetry: true
 desktopNotifications: true
+dismissedUpdateVersion: 1.1.8
 levels:
 - name: Bug
   color: Red

--- a/src/Ivy.Tendril/Apps/Debug/DirtyRepoDialogDebugView.cs
+++ b/src/Ivy.Tendril/Apps/Debug/DirtyRepoDialogDebugView.cs
@@ -187,7 +187,7 @@ public class DirtyRepoDialogDebugView : ViewBase
                 scenario.Preflight,
                 scenario.ProceedLabel,
                 scenario.ContextMessage,
-                onSyncRepos: () => { },
+                onSyncRepos: _ => { },
                 onProceed: () => { });
         }
 

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -270,9 +270,9 @@ public class ContentView(
                 preflightResult,
                 proceedLabel: "Create Without Syncing",
                 contextMessage: "These changes will NOT be included in this plan. The plan will execute against origin/<baseBranch>. If these changes are meant for this plan, commit and push them first.",
-                onSyncRepos: () =>
+                onSyncRepos: policy =>
                 {
-                    LaunchWithSync(preflightResult, pendingWaitJobIds.Value);
+                    LaunchWithSync(preflightResult, pendingWaitJobIds.Value, policy);
                     pendingWaitJobIds.Set((List<string>?)null);
                 },
                 onProceed: () =>
@@ -464,7 +464,8 @@ public class ContentView(
         refreshPlans();
     }
 
-    private void LaunchWithSync(PreflightResult preflight, List<string>? waitJobIds = null)
+    private void LaunchWithSync(PreflightResult preflight, List<string>? waitJobIds = null,
+        UntrackedChangesPolicy policy = UntrackedChangesPolicy.Stash)
     {
         if (selectedPlan is null) return;
 
@@ -472,7 +473,7 @@ public class ContentView(
         var allWaitIds = hasWaits ? new List<string>(waitJobIds!) : new List<string>();
         foreach (var (repoPath, baseBranch, _) in preflight.DirtyRepos)
         {
-            var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch, selectedPlan.FolderPath));
+            var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch, selectedPlan.FolderPath, policy));
             allWaitIds.Add(jobId);
         }
 

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -144,7 +144,7 @@ public class ContentView(
                 preflightResult,
                 proceedLabel: "Execute Without Syncing",
                 contextMessage: "These changes will NOT be included in this plan. The plan will execute against origin/<baseBranch>. If these changes are meant for this plan, commit and push them first.",
-                onSyncRepos: () => LaunchWithSync(preflightResult),
+                onSyncRepos: policy => LaunchWithSync(preflightResult, policy),
                 onProceed: LaunchExecute)
             : null;
 
@@ -170,14 +170,14 @@ public class ContentView(
         refreshPlans();
     }
 
-    private void LaunchWithSync(PreflightResult preflight)
+    private void LaunchWithSync(PreflightResult preflight, UntrackedChangesPolicy policy)
     {
         if (selectedPlan is null) return;
 
         var syncJobIds = new List<string>();
         foreach (var (repoPath, baseBranch, _) in preflight.DirtyRepos)
         {
-            var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch, selectedPlan.FolderPath));
+            var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch, selectedPlan.FolderPath, policy));
             syncJobIds.Add(jobId);
         }
 

--- a/src/Ivy.Tendril/Apps/Icebox/Dialogs/DeletePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/Dialogs/DeletePlanDialog.cs
@@ -29,6 +29,6 @@ public class DeletePlanDialog(
                     dialogOpen.Set(false);
                 })
             )
-        ).Width(Size.Rem(40));
+        );
     }
 }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/DiscardPlanDialog.cs
@@ -39,6 +39,6 @@ public class DiscardPlanDialog(
                     WorktreeCleanupService.RemoveWorktreesInBackground(_selectedPlan.FolderPath);
                 })
             )
-        ).Width(Size.Rem(40));
+        );
     }
 }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/ResetToDraftDialog.cs
@@ -57,6 +57,6 @@ public class ResetToDraftDialog(
                     }
                 })
             )
-        ).Width(Size.Rem(40));
+        );
     }
 }

--- a/src/Ivy.Tendril/Apps/Trash/Dialogs/DeleteTrashFileDialog.cs
+++ b/src/Ivy.Tendril/Apps/Trash/Dialogs/DeleteTrashFileDialog.cs
@@ -34,6 +34,6 @@ public class DeleteTrashFileDialog(
                     _refreshToken.Refresh();
                 })
             )
-        ).Width(Size.Rem(40));
+        );
     }
 }

--- a/src/Ivy.Tendril/Apps/Views/CreatePlanDialogLauncher.cs
+++ b/src/Ivy.Tendril/Apps/Views/CreatePlanDialogLauncher.cs
@@ -56,7 +56,7 @@ public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : View
                 preflightResult,
                 proceedLabel: "Create Without Syncing",
                 contextMessage: "The plan will be based on this state, but ExecutePlan will branch from origin/<baseBranch>. Commit and push first if these changes should be included in the plan.",
-                onSyncRepos: () => LaunchWithSync(pendingJobArgs.Value, preflightResult),
+                onSyncRepos: policy => LaunchWithSync(pendingJobArgs.Value, preflightResult, policy),
                 onProceed: () => LaunchCreatePlan(pendingJobArgs.Value))
             : null;
 
@@ -72,12 +72,12 @@ public class CreatePlanDialogLauncher(Func<Action, object> renderTrigger) : View
             pendingJobArgs.Set(null);
         }
 
-        void LaunchWithSync(CreatePlanArgs args, PreflightResult preflight)
+        void LaunchWithSync(CreatePlanArgs args, PreflightResult preflight, UntrackedChangesPolicy policy)
         {
             var syncJobIds = new List<string>();
             foreach (var (repoPath, baseBranch, _) in preflight.DirtyRepos)
             {
-                var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch));
+                var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch, UntrackedChangesPolicy: policy));
                 syncJobIds.Add(jobId);
             }
 

--- a/src/Ivy.Tendril/Apps/Views/Dialogs/DirtyRepoDialog.cs
+++ b/src/Ivy.Tendril/Apps/Views/Dialogs/DirtyRepoDialog.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Ivy.Tendril.Hooks;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Services.Git;
 
 namespace Ivy.Tendril.Apps.Views.Dialogs;
@@ -9,14 +10,23 @@ public class DirtyRepoDialog(
     PreflightResult preflightResult,
     string proceedLabel,
     string contextMessage,
-    Action onSyncRepos,
+    Action<UntrackedChangesPolicy> onSyncRepos,
     Action onProceed) : ViewBase
 {
     private const int MaxItemsShown = 3;
 
     public override object? Build()
     {
+        // Hooks must run unconditionally before any early return so state survives re-renders.
+        var showPolicy = UseState(false);
+
         if (!dialogOpen.Value) return null;
+
+        var hasUncommitted = HasReason(DirtyReason.UncommittedChanges);
+        var hasUntracked = HasReason(DirtyReason.UntrackedFiles);
+
+        if (showPolicy.Value)
+            return BuildPolicyDialog(hasUncommitted, hasUntracked);
 
         var md = new StringBuilder();
         var repos = preflightResult.DirtyRepos;
@@ -43,19 +53,72 @@ public class DirtyRepoDialog(
             new DialogFooter(
                 Layout.Horizontal().Gap(2).Right()
                 | new Button("Cancel").Outline().OnClick(() => dialogOpen.Set(false))
-                | new Button(proceedLabel).Outline().OnClick(() =>
+                | new Button(proceedLabel).Primary().OnClick(() =>
                 {
                     dialogOpen.Set(false);
                     onProceed();
                 })
                 | new Button("Sync Repos").Primary().Icon(Icons.RefreshCw).OnClick(() =>
                 {
-                    dialogOpen.Set(false);
-                    onSyncRepos();
+                    // If there is local work to reconcile, ask how to handle it; otherwise
+                    // (only ahead-of-origin / branch-mismatch etc.) sync straight away.
+                    if (hasUncommitted || hasUntracked)
+                    {
+                        showPolicy.Set(true);
+                    }
+                    else
+                    {
+                        dialogOpen.Set(false);
+                        onSyncRepos(UntrackedChangesPolicy.Stash);
+                    }
                 })
             )
-        ).Width(Size.Rem(40));
+        );
     }
+
+    private object BuildPolicyDialog(bool hasUncommitted, bool hasUntracked)
+    {
+        // Each repo syncs to its own base branch; only name a specific branch when they all
+        // share one, otherwise refer to them generically (never fabricate a joined name).
+        var branches = preflightResult.DirtyRepos.Select(r => r.BaseBranch).Distinct().ToList();
+        var target = branches.Count == 1 ? $"`{branches[0]}`" : "each repo's base branch";
+
+        var subject = (hasUncommitted, hasUntracked) switch
+        {
+            (true, true) => "your uncommitted changes and untracked files",
+            (false, true) => "your untracked files",
+            _ => "your uncommitted changes"
+        };
+
+        var description =
+            $"How should SyncRepo handle {subject}. " +
+            $"Commits will be pushed to {target} and merge issues will be resolved.";
+
+        return new Dialog(
+            _ => dialogOpen.Set(false),
+            new DialogHeader("SyncRepo"),
+            new DialogBody(Text.Markdown(description)),
+            new DialogFooter(
+                Layout.Horizontal().Gap(2).Right()
+                | new Button("Cancel").Outline().OnClick(() => dialogOpen.Set(false))
+                | new Button("Stash Changes").Outline().Icon(Icons.Archive)
+                    .OnClick(() => SyncWith(UntrackedChangesPolicy.Stash))
+                | new Button("Create Commit").Outline().Icon(Icons.GitCommitHorizontal)
+                    .OnClick(() => SyncWith(UntrackedChangesPolicy.Commit))
+                | new Button("Create Pull Request").Primary().Icon(Icons.GitPullRequest)
+                    .OnClick(() => SyncWith(UntrackedChangesPolicy.PullRequest))
+            )
+        );
+
+        void SyncWith(UntrackedChangesPolicy policy)
+        {
+            dialogOpen.Set(false);
+            onSyncRepos(policy);
+        }
+    }
+
+    private bool HasReason(DirtyReason reason) =>
+        preflightResult.DirtyRepos.Any(r => r.DirtyState.Reasons.Any(x => x.Reason == reason));
 
     private static void AppendReason(StringBuilder md, DirtyReasonDetail reason, string baseBranch)
     {

--- a/src/Ivy.Tendril/Apps/Views/Tabs/VerificationsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/VerificationsTabView.cs
@@ -27,6 +27,7 @@ public class VerificationsTabView(
                     ? new Button(name).Inline().OnClick(() => openVerification(name))
                     : (object)Text.Block(name)))
             .Remove(t => t.HasReport)
+            .AlignContent(t => t.Status, Align.Left)
             .ColumnWidth(t => t.Status, Size.Fit())
             .ColumnWidth(t => t.Name, Size.Fit());
     }

--- a/src/Ivy.Tendril/Commands/JobStartCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStartCommand.cs
@@ -73,6 +73,10 @@ public class JobStartSettings : CommandSettings
     [CommandOption("--base-branch")]
     public string? BaseBranch { get; set; }
 
+    [Description("How SyncRepo handles local changes: Stash (default), Commit, or PullRequest")]
+    [CommandOption("--untracked-policy")]
+    public string? UntrackedPolicy { get; set; }
+
     [Description("Skip merge for CreatePr")]
     [CommandOption("--no-merge")]
     public bool NoMerge { get; set; }
@@ -150,9 +154,17 @@ public class JobStartCommand : Command<JobStartSettings>
             if (string.IsNullOrEmpty(settings.RepoPath))
                 throw new ArgumentException("--repo-path is required for SyncRepo");
 
+            var policy = UntrackedChangesPolicy.Stash;
+            if (!string.IsNullOrEmpty(settings.UntrackedPolicy)
+                && (!Enum.TryParse(settings.UntrackedPolicy, ignoreCase: true, out policy)
+                    || !Enum.IsDefined(policy)))
+                throw new ArgumentException(
+                    $"Invalid --untracked-policy '{settings.UntrackedPolicy}'. Valid values: Stash, Commit, PullRequest");
+
             return new SyncRepoArgs(
                 settings.RepoPath,
-                settings.BaseBranch ?? GitHelper.ResolveDefaultBranch(settings.RepoPath));
+                settings.BaseBranch ?? GitHelper.ResolveDefaultBranch(settings.RepoPath),
+                UntrackedChangesPolicy: policy);
         }
 
         if (string.IsNullOrEmpty(settings.PlanId))

--- a/src/Ivy.Tendril/Models/JobArgs.cs
+++ b/src/Ivy.Tendril/Models/JobArgs.cs
@@ -104,9 +104,22 @@ public record SetupProjectArgs(
 
 public record SyncRepoArgs(
     string RepoPath,
-    string BaseBranch = "main",
-    string? PlanFolderPath = null) : JobArgsBase
+    string BaseBranch,
+    string? PlanFolderPath = null,
+    UntrackedChangesPolicy UntrackedChangesPolicy = UntrackedChangesPolicy.Stash) : JobArgsBase
 {
     public override string Type => Constants.JobTypes.SyncRepo;
     public override string? PlanFolder => PlanFolderPath;
+}
+
+// How SyncRepo should treat uncommitted changes and/or untracked files when syncing a repo.
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum UntrackedChangesPolicy
+{
+    // Preserve local work in a named stash (default; never loses work).
+    Stash,
+    // Group changes into logical commits and push them to the base branch.
+    Commit,
+    // Group changes into logical commits on a new branch and open a pull request.
+    PullRequest
 }

--- a/src/Ivy.Tendril/Promptwares/SyncRepo/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SyncRepo/Program.md
@@ -7,11 +7,12 @@ Get a local repository to a clean, up-to-date state on the expected base branch 
 The firmware header contains:
 - **RepoPath** — absolute path to the repository
 - **BaseBranch** — the branch the repo should be on (e.g. "main", "development")
+- **UntrackedChangesPolicy** — how to handle uncommitted changes and untracked files: `Stash`, `Commit`, or `PullRequest` (see step 5)
 - **TendrilJobId** — for status reporting
 
 ## Rules
 
-- **Never discard work.** Uncommitted changes are stashed, not reset. Unpushed commits are pushed, not dropped. Detached HEAD commits get a rescue branch.
+- **Never discard work.** Local work is preserved according to **UntrackedChangesPolicy** (stashed, committed, or turned into a pull request) — never `reset`. Unpushed commits are pushed, not dropped. Detached HEAD commits get a rescue branch.
 - **Fail explicitly.** If a step cannot be resolved automatically (e.g. rebase conflicts, diverged state), report the issue clearly and stop. Do not leave the repo in a partially-synced state.
 - **Report all actions.** Log what was done (stashed, pushed, switched branch, etc.) so the user has a trail.
 - **No submodule recursion** for now — skip if submodules are present.
@@ -67,9 +68,9 @@ git symbolic-ref --short HEAD
 ```
 
 If not on BaseBranch:
-1. If there are uncommitted changes, stash them first:
+1. If there are uncommitted changes on the current branch, stash them first so the branch switch is clean. Use a representative message of the form `SyncRepo: <representative description of content>` (these are the previous branch's changes — describe them, don't use a generic label):
    ```bash
-   git stash push -m "SyncRepo: auto-stash before branch switch"
+   git stash push --include-untracked -m "SyncRepo: <representative description of content>"
    ```
 2. Switch:
    ```bash
@@ -78,33 +79,68 @@ If not on BaseBranch:
 
 Log: "Switched from {old-branch} to BaseBranch."
 
-### 5. Stash Uncommitted Changes
+> The **UntrackedChangesPolicy** in step 5 applies to local changes present on **BaseBranch**. Changes stashed here to leave a different branch are always preserved as a stash and surfaced in step 8.
 
-Check for staged or unstaged changes to tracked files:
+### 5. Handle Local Changes (per UntrackedChangesPolicy)
+
+First detect what local work exists:
 ```bash
-git status --porcelain
+git status --porcelain          # tracked changes: lines NOT starting with ??
+git ls-files --others --exclude-standard   # untracked files (not ignored)
 ```
 
-If output is non-empty (excluding lines starting with `??`):
+If there are **no** uncommitted changes and **no** untracked files, skip this step entirely.
+
+Otherwise branch on **UntrackedChangesPolicy** from the firmware header:
+
+#### Policy: `Stash`
+
+Stash tracked changes and untracked files together so nothing is lost. The stash message MUST follow the form `SyncRepo: <representative description of content>` — inspect the changed files and write a short human description of what the changes are about (e.g. `SyncRepo: config.yaml project reordering`, `SyncRepo: WIP auth refactor + scratch notes`). Do NOT use a generic message like "uncommitted changes".
+
 ```bash
-git stash push -m "SyncRepo: uncommitted changes"
+git stash push --include-untracked -m "SyncRepo: <representative description of content>"
 ```
-Log: "Stashed uncommitted changes ({n} files)."
+Log: "Stashed local changes: {message}."
 
-### 6. Stash Untracked Files
+#### Policy: `Commit`
 
-Check for untracked files (not ignored):
+Commit the local work onto **BaseBranch** and let the push in step 6 deliver it to origin.
+
+1. Stage untracked files as needed (`git add <paths>`), then group all changes into **logical commits** — one commit per coherent unit of work, not one giant commit. Inspect the diff and cluster by feature/area/intent.
+2. Use clear, conventional, descriptive commit messages that summarize each group (e.g. `Reorder projects in TeamIvy config`, `Add --open flag to dev review action`). Never use placeholder messages like "wip" or "changes".
+3. If changes are trivial or all clearly one unit, a single well-named commit is fine.
+
 ```bash
-git ls-files --others --exclude-standard
+git add <paths for group 1>
+git commit -m "<good message for group 1>"
+git add <paths for group 2>
+git commit -m "<good message for group 2>"
+# ...one commit per logical group
 ```
+Log: "Committed local changes in {n} logical commit(s)." The commits are pushed to `origin/BaseBranch` in step 6.
 
-If output is non-empty:
-```bash
-git stash push --include-untracked -m "SyncRepo: untracked files"
-```
-Log: "Stashed {n} untracked files."
+#### Policy: `PullRequest`
 
-### 7. Push Local Commits
+Put the local work on a dedicated branch and open a pull request instead of pushing to **BaseBranch**.
+
+1. Create and switch to a new branch off the current **BaseBranch**, e.g. `git checkout -b syncrepo/<short-topic>` (name it after what the changes are about).
+2. Group the changes into **logical commits** with good messages, exactly as in the `Commit` policy above.
+3. Push the branch and open a PR targeting **BaseBranch**:
+   ```bash
+   git push -u origin syncrepo/<short-topic>
+   gh pr create --base BaseBranch --head syncrepo/<short-topic> --title "<descriptive title>" --body "<summary of the changes>"
+   ```
+4. If `gh` is unavailable or PR creation fails, FAIL clearly: "Could not open pull request; branch syncrepo/<short-topic> pushed with your changes." (the work is safe on the pushed branch).
+5. **Switch back to BaseBranch** so the remaining sync steps run on the right branch (your work is safe on the pushed branch / PR):
+   ```bash
+   git checkout BaseBranch
+   ```
+
+Log: "Opened pull request from syncrepo/<short-topic> into BaseBranch."
+
+> Note: after the `PullRequest` policy the working tree is clean, HEAD is back on **BaseBranch**, and BaseBranch carries no new local commits, so steps 6–7 simply fast-forward BaseBranch to origin. (If you skip the checkout back to BaseBranch, step 9's "Confirm on BaseBranch" will fail.)
+
+### 6. Push Local Commits
 
 Check if ahead of origin:
 ```bash
@@ -129,7 +165,7 @@ git push origin BaseBranch
 
 Log: "Pushed {n} local commits to origin."
 
-### 8. Pull Latest from Origin
+### 7. Pull Latest from Origin
 
 ```bash
 git fetch origin
@@ -140,7 +176,7 @@ If fast-forward fails → FAIL: "Cannot fast-forward BaseBranch to match origin.
 
 Log: "Updated to latest origin/BaseBranch."
 
-### 9. Report Stashes
+### 8. Report Stashes
 
 ```bash
 git stash list
@@ -149,7 +185,7 @@ git stash list
 If stashes exist, log a warning listing them:
 "WARNING: Repo has {n} stash(es). Review and drop when no longer needed."
 
-### 10. Final Verification
+### 9. Final Verification
 
 Run the same checks as IsDirtyRepo:
 - Confirm on BaseBranch

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -407,6 +407,7 @@ internal class JobLauncher
         {
             values["RepoPath"] = syncArgs.RepoPath;
             values["BaseBranch"] = syncArgs.BaseBranch;
+            values["UntrackedChangesPolicy"] = syncArgs.UntrackedChangesPolicy.ToString();
             return (values, null, null);
         }
 


### PR DESCRIPTION
Adds a policy that lets SyncRepo decide how to handle a repo's local work instead of always stashing.

## Changes
- **`UntrackedChangesPolicy`** (`Stash` | `Commit` | `PullRequest`) on `SyncRepoArgs`.
- **Second-stage "SyncRepo" dialog** — when the user clicks *Sync Repos* in the "Local Changes Detected" dialog and a repo has uncommitted or untracked changes, they pick `Stash Changes` / `Create Commit` / `Create Pull Request`. If nothing is stashable (only ahead-of-origin / branch mismatch) it syncs directly.
- Policy is threaded through all three launch sites (CreatePlan, Icebox/Execute, Drafts) and mapped into the firmware header in `JobLauncher`.
- **SyncRepo promptware** now branches on the policy: stash with a representative name (`SyncRepo: <description>`), grouped logical commits pushed to the base branch, or a PR on a `syncrepo/<topic>` branch (checking back out to the base branch afterwards).
- **CLI** `--untracked-policy` option with range validation.

## Notes
- Also carries concurrent working-tree changes present in the tree: TeamIvy `config.yaml` verification updates and confirmation-dialog restyling.
- Builds clean (0 warnings / 0 errors).