### PR TITLE
[00022] Add File Based Content Input to Promptware Write Commands

### DIFF
--- a/src/Ivy.Tendril/Commands/ConfigCommand.cs
+++ b/src/Ivy.Tendril/Commands/ConfigCommand.cs
@@ -41,9 +41,7 @@ public class ConfigSetSettings : CommandSettings
     [Description("Read the value verbatim from standard input")]
     public bool Stdin { get; set; }
 
-    /// <summary>Number of value sources the user supplied (inline arg / --file / --stdin).</summary>
-    public int SourceCount =>
-        (Stdin ? 1 : 0) + (!string.IsNullOrEmpty(FilePath) ? 1 : 0) + (!string.IsNullOrEmpty(Value) ? 1 : 0);
+    public int SourceCount => CliValidation.CountSources(Stdin, FilePath, Value);
 
     public override Spectre.Console.ValidationResult Validate()
     {

--- a/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
@@ -14,6 +14,10 @@ public class PromptwareWriteMemorySettings : CommandSettings
     [CommandArgument(1, "<filename>")]
     public string Filename { get; set; } = "";
 
+    [Description("Read content from file instead of STDIN")]
+    [CommandOption("--file|-f")]
+    public string? FilePath { get; set; }
+
     public override Spectre.Console.ValidationResult Validate()
     {
         return CliValidation.Combine(
@@ -36,9 +40,11 @@ public class PromptwareWriteMemoryCommand : Command<PromptwareWriteMemorySetting
         var filename = Path.GetFileName(settings.Filename);
         var filePath = Path.Combine(memoryDir, filename);
 
-        var content = ConsoleHelper.ReadStdinWithTimeout();
+        var content = !string.IsNullOrEmpty(settings.FilePath)
+            ? File.ReadAllText(settings.FilePath)
+            : ConsoleHelper.ReadStdinWithTimeout();
         if (string.IsNullOrWhiteSpace(content))
-            throw new ArgumentException("No content provided (pipe to STDIN)");
+            throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
 
         File.WriteAllText(filePath, content);
         Console.Write(filePath);

--- a/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
@@ -40,9 +40,7 @@ public class PromptwareWriteMemoryCommand : Command<PromptwareWriteMemorySetting
         var filename = Path.GetFileName(settings.Filename);
         var filePath = Path.Combine(memoryDir, filename);
 
-        var content = !string.IsNullOrEmpty(settings.FilePath)
-            ? File.ReadAllText(settings.FilePath)
-            : ConsoleHelper.ReadStdinWithTimeout();
+        var content = ConsoleHelper.ResolveContent(settings.FilePath, () => ConsoleHelper.ReadStdinWithTimeout());
         if (string.IsNullOrWhiteSpace(content))
             throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
 

--- a/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
@@ -14,6 +14,10 @@ public class PromptwareWriteToolSettings : CommandSettings
     [CommandArgument(1, "<filename>")]
     public string Filename { get; set; } = "";
 
+    [Description("Read content from file instead of STDIN")]
+    [CommandOption("--file|-f")]
+    public string? FilePath { get; set; }
+
     public override Spectre.Console.ValidationResult Validate()
     {
         return CliValidation.Combine(
@@ -36,9 +40,11 @@ public class PromptwareWriteToolCommand : Command<PromptwareWriteToolSettings>
         var filename = Path.GetFileName(settings.Filename);
         var filePath = Path.Combine(toolsDir, filename);
 
-        var content = ConsoleHelper.ReadStdinWithTimeout();
+        var content = !string.IsNullOrEmpty(settings.FilePath)
+            ? File.ReadAllText(settings.FilePath)
+            : ConsoleHelper.ReadStdinWithTimeout();
         if (string.IsNullOrWhiteSpace(content))
-            throw new ArgumentException("No content provided (pipe to STDIN)");
+            throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
 
         File.WriteAllText(filePath, content);
         Console.Write(filePath);

--- a/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
@@ -40,9 +40,7 @@ public class PromptwareWriteToolCommand : Command<PromptwareWriteToolSettings>
         var filename = Path.GetFileName(settings.Filename);
         var filePath = Path.Combine(toolsDir, filename);
 
-        var content = !string.IsNullOrEmpty(settings.FilePath)
-            ? File.ReadAllText(settings.FilePath)
-            : ConsoleHelper.ReadStdinWithTimeout();
+        var content = ConsoleHelper.ResolveContent(settings.FilePath, () => ConsoleHelper.ReadStdinWithTimeout());
         if (string.IsNullOrWhiteSpace(content))
             throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
 

--- a/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
+++ b/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
@@ -34,9 +34,7 @@ public class TrashWriteCommand : Command<TrashWriteSettings>
         var filename = Path.GetFileName(settings.Filename);
         var filePath = Path.Combine(trashDir, filename);
 
-        var content = !string.IsNullOrEmpty(settings.FilePath)
-            ? File.ReadAllText(settings.FilePath)
-            : ConsoleHelper.ReadStdinWithTimeout();
+        var content = ConsoleHelper.ResolveContent(settings.FilePath, () => ConsoleHelper.ReadStdinWithTimeout());
         if (string.IsNullOrWhiteSpace(content))
             throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
 

--- a/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
+++ b/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
@@ -10,6 +10,10 @@ public class TrashWriteSettings : CommandSettings
     [CommandArgument(0, "<filename>")]
     public string Filename { get; set; } = "";
 
+    [Description("Read content from file instead of STDIN")]
+    [CommandOption("--file|-f")]
+    public string? FilePath { get; set; }
+
     public override Spectre.Console.ValidationResult Validate()
     {
         return CliValidation.RequireNonEmpty(Filename, "filename");
@@ -30,9 +34,11 @@ public class TrashWriteCommand : Command<TrashWriteSettings>
         var filename = Path.GetFileName(settings.Filename);
         var filePath = Path.Combine(trashDir, filename);
 
-        var content = ConsoleHelper.ReadStdinWithTimeout();
+        var content = !string.IsNullOrEmpty(settings.FilePath)
+            ? File.ReadAllText(settings.FilePath)
+            : ConsoleHelper.ReadStdinWithTimeout();
         if (string.IsNullOrWhiteSpace(content))
-            throw new ArgumentException("No content provided (pipe to STDIN)");
+            throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
 
         File.WriteAllText(filePath, content);
         Console.Write(filePath);

--- a/src/Ivy.Tendril/Commands/VerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/VerificationCommand.cs
@@ -18,6 +18,10 @@ public class VerificationAddSettings : CommandSettings
     [Description("Verification prompt (reads from stdin if omitted)")]
     public string? Prompt { get; set; }
 
+    [CommandOption("--file|-f")]
+    [Description("Read the prompt verbatim from this file (good for long/multiline prompts)")]
+    public string? FilePath { get; set; }
+
     public override Spectre.Console.ValidationResult Validate()
     {
         return CliValidation.RequireNonEmpty(Name, "name");
@@ -60,16 +64,30 @@ public class VerificationSetSettings : CommandSettings
     [CommandArgument(1, "<field>")]
     public string Field { get; set; } = "";
 
-    [Description("Field value")]
-    [CommandArgument(2, "<value>")]
+    [Description("New value. Omit when using --file or --stdin. Use --file/--stdin for long or multiline prompts.")]
+    [CommandArgument(2, "[value]")]
     public string Value { get; set; } = "";
+
+    [CommandOption("-f|--file")]
+    [Description("Read the value verbatim from this file (good for multiline prompt)")]
+    public string? FilePath { get; set; }
+
+    [CommandOption("--stdin")]
+    [Description("Read the value verbatim from standard input")]
+    public bool Stdin { get; set; }
+
+    public int SourceCount =>
+        (Stdin ? 1 : 0) + (!string.IsNullOrEmpty(FilePath) ? 1 : 0) + (!string.IsNullOrEmpty(Value) ? 1 : 0);
 
     public override Spectre.Console.ValidationResult Validate()
     {
+        if (SourceCount > 1)
+            return Spectre.Console.ValidationResult.Error(
+                "Provide the value in exactly one way: an inline <value>, --file, or --stdin.");
+
         return CliValidation.Combine(
             CliValidation.RequireNonEmpty(Name, "name"),
-            CliValidation.ValidateField(Field, ValidFields),
-            CliValidation.RequireNonEmpty(Value, "value")
+            CliValidation.ValidateField(Field, ValidFields)
         );
     }
 }
@@ -127,12 +145,15 @@ public class VerificationAddCommand : Command<VerificationAddSettings>
         if (config.Settings.Verifications.Any(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
             throw new InvalidOperationException($"Verification already exists: {settings.Name}");
 
-        var prompt = settings.Prompt;
+        var prompt = !string.IsNullOrEmpty(settings.FilePath)
+            ? File.ReadAllText(settings.FilePath)
+            : settings.Prompt;
+
         if (string.IsNullOrEmpty(prompt))
         {
             if (!Console.IsInputRedirected)
-                throw new ArgumentException("Provide --prompt or pipe content via stdin");
-            prompt = Console.In.ReadToEnd().Trim();
+                throw new ArgumentException("Provide --prompt, --file, or pipe content via stdin");
+            prompt = ConsoleHelper.ReadStdinWithTimeout().Trim();
         }
 
         config.Settings.Verifications.Add(new VerificationConfig
@@ -176,20 +197,28 @@ public class VerificationSetCommand : Command<VerificationSetSettings>
         if (match == null)
             throw new InvalidOperationException($"Verification not found: {settings.Name}");
 
+        var value = settings.Stdin ? ConsoleHelper.ReadStdinWithTimeout()
+            : !string.IsNullOrEmpty(settings.FilePath) ? File.ReadAllText(settings.FilePath)
+            : settings.Value;
+
+        if (string.IsNullOrEmpty(value))
+            throw new ArgumentException("value is required (use an inline <value>, --file, or --stdin)");
+
         switch (settings.Field.ToLower())
         {
             case "name":
-                match.Name = settings.Value;
+                match.Name = value;
                 break;
             case "prompt":
-                match.Prompt = settings.Value;
+                match.Prompt = value;
                 break;
             default:
                 throw new ArgumentException($"Unknown field: {settings.Field}. Valid fields: name, prompt");
         }
 
         config.SaveSettings();
-        Console.WriteLine($"Updated verification {settings.Field} to '{settings.Value}'");
+        var summary = value.Length <= 60 && !value.Contains('\n') ? $"to '{value}'" : $"({value.Length} chars)";
+        Console.WriteLine($"Updated verification {settings.Field} {summary}");
         return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/VerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/VerificationCommand.cs
@@ -145,9 +145,7 @@ public class VerificationAddCommand : Command<VerificationAddSettings>
         if (config.Settings.Verifications.Any(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
             throw new InvalidOperationException($"Verification already exists: {settings.Name}");
 
-        var prompt = !string.IsNullOrEmpty(settings.FilePath)
-            ? File.ReadAllText(settings.FilePath)
-            : settings.Prompt;
+        var prompt = ConsoleHelper.ResolveContent(settings.FilePath, () => settings.Prompt);
 
         if (string.IsNullOrEmpty(prompt))
         {
@@ -197,9 +195,9 @@ public class VerificationSetCommand : Command<VerificationSetSettings>
         if (match == null)
             throw new InvalidOperationException($"Verification not found: {settings.Name}");
 
-        var value = settings.Stdin ? ConsoleHelper.ReadStdinWithTimeout()
-            : !string.IsNullOrEmpty(settings.FilePath) ? File.ReadAllText(settings.FilePath)
-            : settings.Value;
+        var value = settings.Stdin
+            ? ConsoleHelper.ReadStdinWithTimeout()
+            : ConsoleHelper.ResolveContent(settings.FilePath, () => settings.Value);
 
         if (string.IsNullOrEmpty(value))
             throw new ArgumentException("value is required (use an inline <value>, --file, or --stdin)");

--- a/src/Ivy.Tendril/Commands/VerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/VerificationCommand.cs
@@ -76,8 +76,7 @@ public class VerificationSetSettings : CommandSettings
     [Description("Read the value verbatim from standard input")]
     public bool Stdin { get; set; }
 
-    public int SourceCount =>
-        (Stdin ? 1 : 0) + (!string.IsNullOrEmpty(FilePath) ? 1 : 0) + (!string.IsNullOrEmpty(Value) ? 1 : 0);
+    public int SourceCount => CliValidation.CountSources(Stdin, FilePath, Value);
 
     public override Spectre.Console.ValidationResult Validate()
     {

--- a/src/Ivy.Tendril/Helpers/CliValidation.cs
+++ b/src/Ivy.Tendril/Helpers/CliValidation.cs
@@ -77,4 +77,8 @@ public static class CliValidation
                 return r;
         return SpectreValidation.Success();
     }
+
+    /// <summary>Number of value sources supplied (inline arg / --file / --stdin), for the "exactly one" rule.</summary>
+    public static int CountSources(bool stdin, string? filePath, string value) =>
+        (stdin ? 1 : 0) + (!string.IsNullOrEmpty(filePath) ? 1 : 0) + (!string.IsNullOrEmpty(value) ? 1 : 0);
 }

--- a/src/Ivy.Tendril/Helpers/ConsoleHelper.cs
+++ b/src/Ivy.Tendril/Helpers/ConsoleHelper.cs
@@ -14,4 +14,7 @@ public static class ConsoleHelper
                 "Pipe content to this command or use a file-based alternative.");
         return readTask.Result;
     }
+
+    public static string? ResolveContent(string? filePath, Func<string?> fallback) =>
+        !string.IsNullOrEmpty(filePath) ? File.ReadAllText(filePath) : fallback();
 }


### PR DESCRIPTION
Fixes #1545

# Summary

## Changes

Added a `--file|-f` option to `tendril promptware write-memory`, `tendril promptware write-tool`, and `tendril trash write` so content can be read from a file instead of only STDIN. Also reworked `tendril config verification add`/`set` to support the same file-based input, and converted `verification set`'s `<value>` from a required positional argument into an optional one alongside `--file`/`--stdin`, mirroring the existing `tendril config set` pattern. This removes the need for shell-specific heredoc syntax and fixes the Spectre.Console.Cli leading-dash parsing bug for verification prompt values starting with `-`.

## API Changes

- `tendril promptware write-memory <name> <filename> [--file|-f <path>]` — new `--file`/`-f` option; falls back to STDIN if omitted.
- `tendril promptware write-tool <name> <filename> [--file|-f <path>]` — same.
- `tendril trash write <filename> [--file|-f <path>]` — same.
- `tendril config verification add <name> [--prompt|-p <text>] [--file|-f <path>]` — new `--file`/`-f` option, checked before `--prompt`, both fall back to STDIN.
- `tendril config verification set <name> <field> [value] [--file|-f <path>] [--stdin]` — `value` is now an **optional** positional argument (previously required). Errors if more than one of `value`/`--file`/`--stdin` is supplied, or if none resolve to a non-empty value.
- Error messages for the four write commands now read "No content provided (use --file or pipe to STDIN)" instead of "(pipe to STDIN)".

## Files Modified

- `src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs`
- `src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs`
- `src/Ivy.Tendril/Commands/TrashWriteCommand.cs`
- `src/Ivy.Tendril/Commands/VerificationCommand.cs`

## Manual Testing

1. Run `echo "test content" > /tmp/test.md` then `tendril promptware write-memory SomePromptware test.md --file /tmp/test.md`. Confirm the file is written to the promptware's `Memory/` folder with the expected content, and no STDIN piping was needed.
2. Run `tendril config verification add MyCheck --file /tmp/prompt.md` with a multiline prompt file. Confirm it's added without needing a heredoc.
3. Run `tendril config verification set MyCheck prompt --file /tmp/newprompt.md` and separately `tendril config verification set MyCheck prompt "-starts-with-dash"` (inline value starting with `-`). Confirm both succeed — the second previously broke under the old required-positional-argument parsing.
4. Run `tendril config verification set MyCheck prompt "inline" --file /tmp/x.md` together and confirm it's rejected with "Provide the value in exactly one way...".

## Fix: Extract shared file-or-fallback content resolution helper

Per reviewer feedback, the `!string.IsNullOrEmpty(settings.FilePath) ? File.ReadAllText(settings.FilePath) : <fallback>` pattern was duplicated across five call sites. Added `ConsoleHelper.ResolveContent(string? filePath, Func<string?> fallback)`, which reads the file when `filePath` is set and lazily invokes `fallback()` otherwise (lazy evaluation is required so STDIN isn't read when a file is supplied). All five call sites now delegate to this helper.

### Files Modified

- `src/Ivy.Tendril/Helpers/ConsoleHelper.cs` — added `ResolveContent` helper.
- `src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs`
- `src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs`
- `src/Ivy.Tendril/Commands/TrashWriteCommand.cs`
- `src/Ivy.Tendril/Commands/VerificationCommand.cs` — both `VerificationAddCommand` and `VerificationSetCommand`.

**Note:** No user-facing behavior changed; this is an internal refactor only.

## Fix: Deduplicate the SourceCount validation property

Per reviewer feedback, `VerificationSetSettings.SourceCount` and `ConfigSetSettings.SourceCount` were byte-for-byte identical implementations of the "exactly one value source" rule. Added `CliValidation.CountSources(bool stdin, string? filePath, string value)` and updated both settings classes to delegate to it, so the rule can no longer drift between the two commands.

### Files Modified

- `src/Ivy.Tendril/Helpers/CliValidation.cs` — added `CountSources` helper.
- `src/Ivy.Tendril/Commands/ConfigCommand.cs` — `ConfigSetSettings.SourceCount` now delegates to `CliValidation.CountSources`.
- `src/Ivy.Tendril/Commands/VerificationCommand.cs` — `VerificationSetSettings.SourceCount` now delegates to `CliValidation.CountSources`.

**Note:** No user-facing behavior changed; this is an internal refactor only.

---
## Commits

- f3843d19 Extract shared CliValidation.CountSources helper (plan 00022)
- 9687397f Extract shared ConsoleHelper.ResolveContent helper for plan 00022
- 34cf749e Add --file/--stdin options to config verification add/set
- 8033f1d7 Add --file option to promptware write-memory, write-tool, and trash write

---
Created using [Ivy Tendril](https://ivy.app).
