### PR TITLE
[00023] List Available Verifications on Not Found

### DIFF
--- a/src/Ivy.Tendril.Test/VerificationCommandTests.cs
+++ b/src/Ivy.Tendril.Test/VerificationCommandTests.cs
@@ -1,4 +1,6 @@
+using Ivy.Tendril.Commands;
 using Ivy.Tendril.Services;
+using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Test;
 
@@ -154,6 +156,44 @@ verifications: []
             .FirstOrDefault(v => v.Name.Equals("NonExistent", StringComparison.OrdinalIgnoreCase));
 
         Assert.Null(match);
+    }
+
+    // --- Get Verification: Not Found Error Lists Available ---
+
+    private static CommandApp BuildVerificationGetApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("verification", verification =>
+            {
+                verification.AddCommand<VerificationGetCommand>("get");
+            });
+        });
+        return app;
+    }
+
+    [Fact]
+    public void GetVerification_NotFound_ListsAvailable()
+    {
+        var config = CreateConfig();
+        config.Settings.Verifications.Add(new VerificationConfig { Name = "DotnetBuild", Prompt = "dotnet build" });
+        config.SaveSettings();
+
+        var app = BuildVerificationGetApp();
+        var ex = Assert.Throws<InvalidOperationException>(() => app.Run(["verification", "get", "Build"]));
+
+        Assert.Contains("Available: DotnetBuild", ex.Message);
+    }
+
+    [Fact]
+    public void GetVerification_NotFound_EmptyList_ListsAvailable()
+    {
+        var app = BuildVerificationGetApp();
+        var ex = Assert.Throws<InvalidOperationException>(() => app.Run(["verification", "get", "xyzzy"]));
+
+        Assert.Contains("Available: ", ex.Message);
     }
 
     // --- Roundtrip ---

--- a/src/Ivy.Tendril/Commands/PlanVerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanVerificationCommand.cs
@@ -169,7 +169,7 @@ public class PlanVerificationRemoveCommand : Command<PlanVerificationRemoveSetti
             .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
         if (match == null)
-            throw new InvalidOperationException($"Verification not found: {settings.Name}");
+            CliValidation.ThrowVerificationNotFound(settings.Name, plan.Verifications.Select(v => v.Name));
 
         plan.Verifications.Remove(match);
         plan.Updated = DateTime.UtcNow;

--- a/src/Ivy.Tendril/Commands/ProjectCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectCommand.cs
@@ -533,7 +533,7 @@ public class ProjectAddVerificationCommand : Command<ProjectAddVerificationSetti
             var afterIndex = project.Verifications
                 .FindIndex(v => v.Name.Equals(settings.After, StringComparison.OrdinalIgnoreCase));
             if (afterIndex < 0)
-                throw new InvalidOperationException($"Verification not found for --after: {settings.After}");
+                CliValidation.ThrowVerificationNotFound(settings.After, project.Verifications.Select(v => v.Name));
             project.Verifications.Insert(afterIndex + 1, newRef);
         }
         else
@@ -562,7 +562,7 @@ public class ProjectRemoveVerificationCommand : Command<ProjectRemoveVerificatio
             .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
 
         if (match == null)
-            throw new InvalidOperationException($"Verification not found in project: {settings.VerificationName}");
+            CliValidation.ThrowVerificationNotFound(settings.VerificationName, project.Verifications.Select(v => v.Name));
 
         project.Verifications.Remove(match);
         config.SaveSettings();
@@ -590,7 +590,7 @@ public class ProjectMoveVerificationCommand : Command<ProjectMoveVerificationSet
             .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
 
         if (item == null)
-            throw new InvalidOperationException($"Verification not found in project: {settings.VerificationName}");
+            CliValidation.ThrowVerificationNotFound(settings.VerificationName, project.Verifications.Select(v => v.Name));
 
         project.Verifications.Remove(item);
 

--- a/src/Ivy.Tendril/Commands/VerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/VerificationCommand.cs
@@ -111,7 +111,7 @@ public class VerificationGetCommand : Command<VerificationGetSettings>
             .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
         if (match == null)
-            throw new InvalidOperationException($"Verification not found: {settings.Name}");
+            CliValidation.ThrowVerificationNotFound(settings.Name, config.Settings.Verifications.Select(v => v.Name));
 
         Console.Write(match.Prompt);
         return 0;
@@ -156,7 +156,7 @@ public class VerificationRemoveCommand : Command<VerificationRemoveSettings>
             .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
         if (match == null)
-            throw new InvalidOperationException($"Verification not found: {settings.Name}");
+            CliValidation.ThrowVerificationNotFound(settings.Name, config.Settings.Verifications.Select(v => v.Name));
 
         config.Settings.Verifications.Remove(match);
         config.SaveSettings();
@@ -174,7 +174,7 @@ public class VerificationSetCommand : Command<VerificationSetSettings>
             .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
         if (match == null)
-            throw new InvalidOperationException($"Verification not found: {settings.Name}");
+            CliValidation.ThrowVerificationNotFound(settings.Name, config.Settings.Verifications.Select(v => v.Name));
 
         switch (settings.Field.ToLower())
         {

--- a/src/Ivy.Tendril/Helpers/CliValidation.cs
+++ b/src/Ivy.Tendril/Helpers/CliValidation.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Ivy.Tendril.Models;
 using SpectreValidation = Spectre.Console.ValidationResult;
 
@@ -76,5 +77,11 @@ public static class CliValidation
             if (!r.Successful)
                 return r;
         return SpectreValidation.Success();
+    }
+
+    [DoesNotReturn]
+    public static void ThrowVerificationNotFound(string name, IEnumerable<string> available)
+    {
+        throw new InvalidOperationException($"Verification not found: '{name}'. Available: {string.Join(", ", available)}");
     }
 }


### PR DESCRIPTION
Fixes #1544

# Summary

## Changes

Added a `CliValidation.ThrowVerificationNotFound` helper that throws `"Verification not found: '{name}'. Available: {names}"`, and replaced all 7 bare `InvalidOperationException` throws across `VerificationCommand`, `PlanVerificationCommand`, and `ProjectCommand` with calls to it. A CLI or agent that passes a wrong/hallucinated verification name now sees the full list of valid names instead of a dead end.

## API Changes

- New: `Ivy.Tendril.Helpers.CliValidation.ThrowVerificationNotFound(string name, IEnumerable<string> available)` — throws `InvalidOperationException` listing available verification names. Marked `[DoesNotReturn]`.
- Changed error message text for 7 CLI commands: `tendril verification get/remove/set`, `tendril plan verification remove`, `tendril project verification --after/remove/move`. Previously `"Verification not found: <name>"` / `"Verification not found in project: <name>"` / `"Verification not found for --after: <name>"`; now uniformly `"Verification not found: '<name>'. Available: <name1>, <name2>, ..."`.

## Files Modified

- `src/Ivy.Tendril/Helpers/CliValidation.cs` — new `ThrowVerificationNotFound` helper
- `src/Ivy.Tendril/Commands/VerificationCommand.cs` — 3 call sites (get, remove, set)
- `src/Ivy.Tendril/Commands/PlanVerificationCommand.cs` — 1 call site (remove from plan)
- `src/Ivy.Tendril/Commands/ProjectCommand.cs` — 3 call sites (--after lookup, remove from project, move in project)
- `src/Ivy.Tendril.Test/VerificationCommandTests.cs` — 2 new tests exercising the real CLI parser via `CommandApp`

## Manual Testing

1. Run the CLI: `tendril verification get Build` (assuming a project with `DotnetBuild` configured, not `Build`).
2. Observe the error now reads: `Verification not found: 'Build'. Available: DotnetBuild, DotnetFormat, DotnetTest, CodeReview, CheckResult` (or whatever verifications are configured) instead of a bare `Verification not found: Build` with no recovery path.
3. Repeat with `tendril plan verification remove <plan-id> <bad-name>` and `tendril project verification remove <project> <bad-name>` — same pattern, scoped to the plan's or project's own verification list.

---
## Commits
- ffcd79c7 List available verifications on not-found error (#1544)
- 4188bace Add tests for verification not-found error message

---
Created using [Ivy Tendril](https://ivy.app).
