### PR TITLE
[00024] Add Plan Get Revision CLI Command

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
@@ -176,6 +176,12 @@ Appends a numbered log entry to `Logs/` (e.g. `003-ExecutePlan.md`) and prints t
 
 Writes a numbered revision file to `Revisions/` (e.g. `002.md`) from stdin or `--file`. Prints the path to stdout.
 
+```terminal
+>tendril plan get-revision <plan-id> [--latest] [--number <n>]
+```
+
+Prints revision content to stdout — the latest revision by default, or a specific numbered revision with `--number`.
+
 ## Recommendations
 
 ```terminal

--- a/src/Ivy.Tendril.Test/PlanGetRevisionCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanGetRevisionCommandTests.cs
@@ -1,0 +1,143 @@
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Test;
+
+[Collection("TendrilHome")]
+public class PlanGetRevisionCommandTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new();
+    private readonly string _originalTendrilHome;
+    private readonly string? _originalTendrilPlans;
+    private readonly string _plansDir;
+
+    public PlanGetRevisionCommandTests()
+    {
+        _plansDir = Path.Combine(_tempDir.Path, "Plans");
+        Directory.CreateDirectory(_plansDir);
+
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        _originalTendrilPlans = Environment.GetEnvironmentVariable("TENDRIL_PLANS");
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", null);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", _originalTendrilPlans);
+        _tempDir.Dispose();
+    }
+
+    private string CreatePlanFolder(string id, string title)
+    {
+        var folderName = $"{id}-{title}";
+        var planDir = Path.Combine(_plansDir, folderName);
+        Directory.CreateDirectory(planDir);
+
+        var plan = new PlanYaml
+        {
+            State = "Draft",
+            Project = "TestProject",
+            Title = title,
+            Repos = [_tempDir.Path],
+            Created = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+            Updated = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)
+        };
+        var yaml = YamlHelper.Serializer.Serialize(plan);
+        File.WriteAllText(Path.Combine(planDir, "plan.yaml"), yaml);
+        return planDir;
+    }
+
+    private static CommandApp BuildApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("plan", plan => plan.AddCommand<PlanGetRevisionCommand>("get-revision"));
+        });
+        return app;
+    }
+
+    private static string CaptureStdout(Action action)
+    {
+        var original = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        return writer.ToString();
+    }
+
+    [Fact]
+    public void GetRevision_DefaultInvocation_PrintsLatestRevisionContent()
+    {
+        var planDir = CreatePlanFolder("40001", "LatestTest");
+        var revisionsDir = Path.Combine(planDir, "Revisions");
+        Directory.CreateDirectory(revisionsDir);
+        File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "# First revision");
+        File.WriteAllText(Path.Combine(revisionsDir, "002.md"), "# Second revision");
+
+        var app = BuildApp();
+        var output = CaptureStdout(() =>
+        {
+            var exit = app.Run(["plan", "get-revision", "40001"]);
+            Assert.Equal(0, exit);
+        });
+
+        Assert.Equal("# Second revision", output);
+    }
+
+    [Fact]
+    public void GetRevision_ExplicitNumber_PrintsThatRevisionContent()
+    {
+        var planDir = CreatePlanFolder("40002", "NumberTest");
+        var revisionsDir = Path.Combine(planDir, "Revisions");
+        Directory.CreateDirectory(revisionsDir);
+        File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "# First revision");
+        File.WriteAllText(Path.Combine(revisionsDir, "002.md"), "# Second revision");
+
+        var app = BuildApp();
+        var output = CaptureStdout(() =>
+        {
+            var exit = app.Run(["plan", "get-revision", "40002", "--number=1"]);
+            Assert.Equal(0, exit);
+        });
+
+        Assert.Equal("# First revision", output);
+    }
+
+    [Fact]
+    public void GetRevision_NoRevisionsExist_Throws()
+    {
+        CreatePlanFolder("40003", "NoRevisionsTest");
+
+        var app = BuildApp();
+        Assert.Throws<FileNotFoundException>(() =>
+            app.Run(["plan", "get-revision", "40003"]));
+    }
+
+    [Fact]
+    public void GetRevision_NonExistentNumber_Throws()
+    {
+        var planDir = CreatePlanFolder("40004", "MissingNumberTest");
+        var revisionsDir = Path.Combine(planDir, "Revisions");
+        Directory.CreateDirectory(revisionsDir);
+        File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "# First revision");
+
+        var app = BuildApp();
+        Assert.Throws<FileNotFoundException>(() =>
+            app.Run(["plan", "get-revision", "40004", "--number=9"]));
+    }
+}

--- a/src/Ivy.Tendril/Commands/PlanGetRevisionCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanGetRevisionCommand.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel;
+using Ivy.Tendril.Helpers;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class PlanGetRevisionSettings : CommandSettings
+{
+    [Description("Plan ID or folder path")]
+    [CommandArgument(0, "<plan-id>")]
+    public string PlanId { get; set; } = "";
+
+    [Description("Print the latest revision (default behavior)")]
+    [CommandOption("--latest")]
+    public bool Latest { get; set; }
+
+    [Description("Print a specific numbered revision (e.g. 2 for 002.md)")]
+    [CommandOption("--number|-n")]
+    public int? Number { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(PlanId, "plan-id");
+    }
+}
+
+public class PlanGetRevisionCommand : Command<PlanGetRevisionSettings>
+{
+    protected override int Execute(CommandContext context, PlanGetRevisionSettings settings, CancellationToken cancellationToken)
+    {
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+        var revisionsDir = Path.Combine(planFolder, "Revisions");
+
+        string filePath;
+        if (settings.Number.HasValue)
+        {
+            filePath = Path.Combine(revisionsDir, $"{settings.Number.Value:D3}.md");
+            if (!File.Exists(filePath))
+                throw new FileNotFoundException($"Revision {settings.Number.Value:D3} not found for plan {settings.PlanId}", filePath);
+        }
+        else
+        {
+            filePath = FindLatestRevision(revisionsDir)
+                ?? throw new FileNotFoundException($"No revisions found for plan {settings.PlanId} in {revisionsDir}");
+        }
+
+        Console.Write(FileHelper.ReadAllText(filePath));
+        return 0;
+    }
+
+    private static string? FindLatestRevision(string revisionsDir)
+    {
+        if (!Directory.Exists(revisionsDir))
+            return null;
+
+        string? latestFile = null;
+        var latestNumber = -1;
+        foreach (var file in Directory.GetFiles(revisionsDir, "*.md"))
+        {
+            var name = Path.GetFileNameWithoutExtension(file);
+            if (int.TryParse(name, out var num) && num > latestNumber)
+            {
+                latestNumber = num;
+                latestFile = file;
+            }
+        }
+
+        return latestFile;
+    }
+}

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -538,6 +538,8 @@ public class Program
                     .WithDescription("Write a log entry");
                 plan.AddCommand<PlanWriteRevisionCommand>("write-revision")
                     .WithDescription("Write a revision file from STDIN");
+                plan.AddCommand<PlanGetRevisionCommand>("get-revision")
+                    .WithDescription("Print revision content");
                 plan.AddCommand<PlanValidateCommand>("validate")
                     .WithDescription("Validate plan health");
                 plan.AddCommand<PlanCleanupCommand>("cleanup")

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -149,6 +149,7 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 | `tendril plan remove-depends-on <plan-id> <folder>` | Remove dependency |
 | `tendril plan add-log <plan-id> <action>` | Add execution log entry |
 | `tendril plan write-revision <plan-id>` | Write revision from stdin — **only to edit an existing plan; never to create a new plan** (start a `CreatePlan` job instead) |
+| `tendril plan get-revision <plan-id> [--number <n>]` | Print revision content (latest by default, or a specific numbered revision) |
 | `tendril plan cleanup <plan-id>` | Remove worktrees |
 | `tendril plan set-verification <plan-id> <name> <status>` | Set verification status |
 

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -26,7 +26,7 @@ The launcher sets the working directory to the project's primary repo.
 ### 1. Read Plan
 
 - Read `plan.yaml` from the plan folder (project, repos, title)
-- Read the latest revision from `Revisions/` (highest numbered .md file)
+- Read the latest revision: `tendril plan get-revision <TendrilPlanId>`
 - Extract the plan ID from the folder name (e.g. `01105` from `01105-TestPlan`)
 - Report plan context to Jobs UI: `tendril job status TendrilJobId --message="Reading plan..." --plan-id=<plan-id> --plan-title="<title>"`
 

--- a/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
@@ -16,7 +16,7 @@ Project configuration is available from the firmware header.
 ### 1. Read the Plan
 
 - Read `plan.yaml` from the plan folder
-- Read the latest revision from `Revisions/` (highest numbered .md file)
+- Read the latest revision: `tendril plan get-revision <TendrilPlanId>`
 - Identify sections with investigative/exploratory language ("Investigate...", "Check if...", "Research...", "Explore...")
 - Report plan context to Jobs UI: `tendril job status TendrilJobId --message="Expanding plan..." --plan-id=<plan-id> --plan-title="<title>"`
 

--- a/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
@@ -28,7 +28,7 @@ Read the ChangeRequest carefully before starting implementation. The original pl
 ### 1. Read Plan
 
 - Read `plan.yaml` from the plan folder (project, repos, title)
-- Read the latest revision from `Revisions/` (highest numbered .md file)
+- Read the latest revision: `tendril plan get-revision <TendrilPlanId>`
 - Extract the plan ID from the folder name (e.g. `00012` from `00012-AddNewsletterSignupToHelpApp`)
 - Report plan context to Jobs UI: `tendril job status TendrilJobId --message="Retrying plan..." --plan-id=<plan-id> --plan-title="<title>"`
 

--- a/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -18,7 +18,7 @@ The plans directory path can be derived from the plan folder's parent directory.
 ### 1. Read the Plan
 
 - Read `plan.yaml` via `tendril plan get <plan-id>` from the plan folder
-- Read the latest revision from `Revisions/` (highest numbered .md file)
+- Read the latest revision: `tendril plan get-revision <TendrilPlanId>`
 - Identify distinct issues/tasks that should be separate plans
 - Report plan context to Jobs UI: `tendril job status TendrilJobId --message="Splitting plan..." --plan-id=<plan-id> --plan-title="<title>"`
 

--- a/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
@@ -16,7 +16,7 @@ Project configuration is available from the firmware header.
 
 ### 1. Read the Plan
 
-- Read the latest revision from `Revisions/` (highest numbered .md file)
+- Read the latest revision: `tendril plan get-revision <TendrilPlanId>`
 - Get the plan title: `tendril plan get <TendrilPlanId> title`
 - Report plan context to Jobs UI: `tendril job status TendrilJobId --message="Updating plan..." --plan-id=<plan-id> --plan-title="<title>"`
 

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -182,7 +182,7 @@ verifications:
 - name: CheckResult
   prompt: >
     Verify the implementation matches what was requested in the plan.
-    1. Read the plan revision from `<TendrilPlanFolder>/revisions/` (latest numbered .md file)
+    1. Read the plan revision: `tendril plan get-revision <PlanId>`
     2. Review all commits made by this execution
     3. Compare the plan's Problem and Solution sections against the actual changes
     4. Write the verification report to `<TendrilPlanFolder>/verification/CheckResult.md`


### PR DESCRIPTION
Fixes #1557

# Summary

## Changes

Added a `tendril plan get-revision <plan-id> [--latest] [--number|-n <n>]` CLI command that prints a plan revision's content directly to stdout, replacing the previous "list `Revisions/`, find the highest-numbered file, then Read it" pattern that caused agents to hit `EISDIR` errors when they tried to `Read` the directory path directly. Updated five promptware `Program.md` files, the `CheckResult` verification prompt template, the interactive agent's system prompt, and the CLI reference docs to use the new command.

## API Changes

- New CLI command: `tendril plan get-revision <plan-id> [--latest] [--number|-n <n>]` — prints the latest revision's content by default, or a specific numbered revision with `--number`/`-n`. Exits 0 on success; throws `FileNotFoundException` if no revisions exist or the requested number isn't found.
- New class: `Ivy.Tendril.Commands.PlanGetRevisionCommand` (and its `PlanGetRevisionSettings`).

## Files Modified

- `src/Ivy.Tendril/Commands/PlanGetRevisionCommand.cs` — new command implementation
- `src/Ivy.Tendril/Program.cs` — registers `plan get-revision`
- `src/Ivy.Tendril.Test/PlanGetRevisionCommandTests.cs` — new test class (4 tests)
- `src/Ivy.Tendril/Promptwares/{UpdatePlan,ExecutePlan,SplitPlan,RetryPlan,ExpandPlan}/Program.md` — replaced the "Read the latest revision from `Revisions/`" instruction with `tendril plan get-revision <TendrilPlanId>`
- `src/Ivy.Tendril/example.config.yaml` — `CheckResult` verification prompt now uses the CLI command
- `src/Ivy.Tendril/Prompts/AgentPrompt.md` — documents `plan get-revision` in the Plan Commands table
- `src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md` — documents `plan get-revision` in the CLI reference

## Manual Testing

1. Create or open an existing plan with at least two revisions (e.g. `tendril plan write-revision <plan-id>` twice).
2. Run `tendril plan get-revision <plan-id>` — it should print the latest revision's markdown content to stdout (no `EISDIR` error, no directory listing needed).
3. Run `tendril plan get-revision <plan-id> --number=1` — it should print revision `001.md`'s content instead.
4. Run `tendril plan get-revision <plan-id> --number=99` (a non-existent revision) — it should exit non-zero with a "Revision not found" error.

---
Commits:
- 6f7a4001 Add tendril plan get-revision CLI command
- 187396be Use plan get-revision in promptwares and docs

---
Created using [Ivy Tendril](https://ivy.app).
