### PR TITLE
[00029] Accumulate Cost Across OpenCode Steps

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeEventParserTests.cs
@@ -189,6 +189,36 @@ public class OpenCodeEventParserTests
     }
 
     [Fact]
+    public void ParseLine_MultipleStepFinish_AccumulatesCostAcrossSteps()
+    {
+        _parser.ParseLine("""{"type":"step_finish","part":{"reason":"tool-calls","cost":0.010,"tokens":{"input":1000,"output":100}}}""");
+        _parser.ParseLine("""{"type":"step_finish","part":{"reason":"tool-calls","cost":0.020,"tokens":{"input":2000,"output":200}}}""");
+        var events = _parser.ParseLine("""{"type":"step_finish","part":{"reason":"stop","cost":0.005,"tokens":{"input":500,"output":50}}}""");
+
+        Assert.Single(events);
+        var result = Assert.IsType<ResultEvent>(events[0]);
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Usage);
+        Assert.Equal(3500, result.Usage.InputTokens);
+        Assert.Equal(350, result.Usage.OutputTokens);
+        Assert.Equal(0.035m, result.Usage.CostUsd);
+    }
+
+    [Fact]
+    public void ParseLine_StepFinish_ToolCalls_AccumulatesButDoesNotEmit()
+    {
+        var events = _parser.ParseLine("""{"type":"step_finish","part":{"reason":"tool-calls","cost":0.012,"tokens":{"input":14000,"output":134}}}""");
+        Assert.Empty(events);
+
+        var stopEvents = _parser.ParseLine("""{"type":"step_finish","part":{"reason":"stop"}}""");
+        var result = Assert.IsType<ResultEvent>(stopEvents[0]);
+        Assert.NotNull(result.Usage);
+        Assert.Equal(14000, result.Usage.InputTokens);
+        Assert.Equal(134, result.Usage.OutputTokens);
+        Assert.Equal(0.012m, result.Usage.CostUsd);
+    }
+
+    [Fact]
     public void ParseLine_Error_ReturnsErrorEvent()
     {
         var json = """{"type":"error","error":{"data":{"message":"rate limit exceeded","isRetryable":true,"statusCode":429}}}""";
@@ -331,5 +361,31 @@ public class OpenCodeEventParserTests
         // Now BuildResult should respect exit code, not _hasError
         var result = _parser.BuildResult([], 0);
         Assert.True(result!.IsSuccess);
+    }
+
+    [Fact]
+    public void Reset_ClearsAccumulatedCostAndTokens()
+    {
+        _parser.ParseLine("""{"type":"step_finish","part":{"reason":"tool-calls","cost":0.012,"tokens":{"input":14000,"output":134}}}""");
+
+        _parser.Reset();
+
+        var result = _parser.BuildResult([], 0);
+        Assert.Null(result!.Usage);
+    }
+
+    [Fact]
+    public void BuildResult_NoResultEvent_IncludesAccumulatedUsage()
+    {
+        // Simulate a process killed mid-session: only intermediate step_finish events were seen
+        _parser.ParseLine("""{"type":"step_finish","part":{"reason":"tool-calls","cost":0.012,"tokens":{"input":14000,"output":134}}}""");
+
+        var result = _parser.BuildResult([], 1);
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Usage);
+        Assert.Equal(14000, result.Usage.InputTokens);
+        Assert.Equal(134, result.Usage.OutputTokens);
+        Assert.Equal(0.012m, result.Usage.CostUsd);
     }
 }

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeEventParser.cs
@@ -13,6 +13,9 @@ public sealed class OpenCodeEventParser : IEventParser
     private static readonly IReadOnlyList<AgentEvent> Empty = Array.Empty<AgentEvent>();
 
     private bool _hasError;
+    private int _accumulatedInputTokens;
+    private int _accumulatedOutputTokens;
+    private decimal _accumulatedCost;
 
     public IReadOnlyList<AgentEvent> ParseLine(string rawLine)
     {
@@ -68,17 +71,30 @@ public sealed class OpenCodeEventParser : IEventParser
             }
         }
 
+        AgentUsage? usage = (_accumulatedInputTokens > 0 || _accumulatedOutputTokens > 0 || _accumulatedCost > 0)
+            ? new AgentUsage
+            {
+                InputTokens = _accumulatedInputTokens,
+                OutputTokens = _accumulatedOutputTokens,
+                CostUsd = _accumulatedCost,
+            }
+            : null;
+
         return new ResultEvent
         {
             Kind = AgentEventKind.Result,
             IsSuccess = !_hasError && exitCode == 0,
             ExitCode = exitCode,
+            Usage = usage,
         };
     }
 
     public void Reset()
     {
         _hasError = false;
+        _accumulatedInputTokens = 0;
+        _accumulatedOutputTokens = 0;
+        _accumulatedCost = 0;
     }
 
     private static string? PeekType(ref Utf8JsonReader reader)
@@ -185,9 +201,19 @@ public sealed class OpenCodeEventParser : IEventParser
         return events;
     }
 
-    private static IReadOnlyList<AgentEvent> ParseStepFinish(JsonElement root, string rawLine)
+    private IReadOnlyList<AgentEvent> ParseStepFinish(JsonElement root, string rawLine)
     {
         if (!root.TryGetProperty("part", out var part)) return Empty;
+
+        // Accumulate cost/tokens from every step_finish, regardless of reason
+        if (part.TryGetProperty("cost", out var cProp))
+            _accumulatedCost += cProp.GetDecimal();
+
+        if (part.TryGetProperty("tokens", out var tokens))
+        {
+            _accumulatedInputTokens += tokens.TryGetProperty("input", out var it) ? it.GetInt32() : 0;
+            _accumulatedOutputTokens += tokens.TryGetProperty("output", out var ot) ? ot.GetInt32() : 0;
+        }
 
         var reason = part.TryGetProperty("reason", out var rProp) ? rProp.GetString() : null;
 
@@ -196,22 +222,12 @@ public sealed class OpenCodeEventParser : IEventParser
         if (reason is not ("stop" or "error"))
             return Empty;
 
-        var cost = part.TryGetProperty("cost", out var cProp) ? cProp.GetDecimal() : (decimal?)null;
-
-        int inputTokens = 0;
-        int outputTokens = 0;
-        if (part.TryGetProperty("tokens", out var tokens))
-        {
-            inputTokens = tokens.TryGetProperty("input", out var it) ? it.GetInt32() : 0;
-            outputTokens = tokens.TryGetProperty("output", out var ot) ? ot.GetInt32() : 0;
-        }
-
-        AgentUsage? usage = (inputTokens > 0 || outputTokens > 0 || cost > 0)
+        AgentUsage? usage = (_accumulatedInputTokens > 0 || _accumulatedOutputTokens > 0 || _accumulatedCost > 0)
             ? new AgentUsage
             {
-                InputTokens = inputTokens,
-                OutputTokens = outputTokens,
-                CostUsd = cost,
+                InputTokens = _accumulatedInputTokens,
+                OutputTokens = _accumulatedOutputTokens,
+                CostUsd = _accumulatedCost,
             }
             : null;
 


### PR DESCRIPTION
Fixes #1536

# Summary

## Changes

`OpenCodeEventParser` now accumulates cost and token totals across every `step_finish` event
(previously only the final step's incremental values were captured), fixing the empty Cost column
for OpenCode jobs. The terminal `ResultEvent` carries the session's cumulative cost/tokens, and
`BuildResult` falls back to the accumulated totals if the process is killed before a terminal event
arrives.

## API Changes

None — `OpenCodeEventParser`'s public surface (`IEventParser` implementation) is unchanged. Internal
behavior change only: `ParseStepFinish` is now a private instance method (was `private static`) since
it accesses the new accumulator fields.

## Files Modified

- `src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeEventParser.cs` — accumulator fields, `ParseStepFinish`, `Reset`, `BuildResult`
- `src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeEventParserTests.cs` — 4 new tests covering accumulation, suppression, reset, and the `BuildResult` fallback

## Manual Testing

1. Run an OpenCode job in Tendril that involves multiple LLM turns (e.g. a multi-step plan execution).
2. Open the Jobs table and check the Cost column for that job.
3. Expect a non-empty cost value reflecting the sum of all steps' costs, not just the final step's
   (previously tiny or zero) incremental cost.

---
- 341b103f Add tests for OpenCode cost accumulation (Plan 00029)
- 02f6375a Accumulate cost/tokens across OpenCode step_finish events (Plan 00029)

---
Created using [Ivy Tendril](https://ivy.app).
