### PR TITLE
[00028] Fix Copilot Model Validation Not Detecting Not Available Error

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Copilot/CopilotFailureAnalyzerTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Copilot/CopilotFailureAnalyzerTests.cs
@@ -109,6 +109,8 @@ public class CopilotFailureAnalyzerTests
     [InlineData("invalid model specified")]
     [InlineData("model not found")]
     [InlineData("model does not exist")]
+    [InlineData("not available")]
+    [InlineData("Model \"gpt-5.2\" from --model flag is not available.")]
     public void Analyze_InvalidModel_ReturnsInvalidModel(string stderrLine)
     {
         var ctx = new FailureContext

--- a/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotFailureAnalyzer.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotFailureAnalyzer.cs
@@ -45,7 +45,7 @@ public sealed class CopilotFailureAnalyzer : IFailureAnalyzer
             };
         }
 
-        if (ContainsAny(stderr, "model", "invalid model", "not found", "does not exist"))
+        if (ContainsAny(stderr, "model", "invalid model", "not found", "does not exist", "not available"))
         {
             return new FailureAnalysis
             {

--- a/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotHealthCheck.cs
@@ -76,7 +76,9 @@ public sealed class CopilotHealthCheck : IAgentHealthCheck
 
         if (stderr.Contains("model", StringComparison.OrdinalIgnoreCase) &&
             (stderr.Contains("invalid", StringComparison.OrdinalIgnoreCase) ||
-             stderr.Contains("not found", StringComparison.OrdinalIgnoreCase)))
+             stderr.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
+             stderr.Contains("does not exist", StringComparison.OrdinalIgnoreCase) ||
+             stderr.Contains("not available", StringComparison.OrdinalIgnoreCase)))
             return new ModelValidationResult
             {
                 Status = ModelValidationStatus.InvalidModel,


### PR DESCRIPTION
Fixes #1405

# Summary

## Changes

`CopilotHealthCheck.ValidateModelAsync` and `CopilotFailureAnalyzer.Analyze` previously only recognized "invalid" and "not found" in Copilot CLI stderr, so a rejected model (whose error says "is not available") was misclassified as `Unknown`/generic failure instead of `InvalidModel`. Both now also match `"not available"` and `"does not exist"`, aligning with the Claude and Codex provider analyzers.

## API Changes

None. Internal stderr-matching logic only; no public signatures changed.

## Files Modified

- `src/Ivy.Tendril.Agents/Providers/Copilot/CopilotHealthCheck.cs` — added `"not available"`/`"does not exist"` to the invalid-model stderr match.
- `src/Ivy.Tendril.Agents/Providers/Copilot/CopilotFailureAnalyzer.cs` — added `"not available"` to the invalid-model stderr match.
- `src/Ivy.Tendril.Agents.Test/Copilot/CopilotFailureAnalyzerTests.cs` — added inline test cases for `"not available"` and the exact reported error string.

## Manual Testing

1. In Tendril's Configuration, select the Copilot agent and set its model to one the CLI currently rejects (e.g. `gpt-5.2` on a Copilot subscription that no longer offers it).
2. Click "Test Agent".
3. The health check should now report a red `InvalidModel` failure with the CLI's own "... is not available" error message, instead of a yellow "Unknown" warning.

---
- ea511e8b Fix Copilot model validation to detect not available error

---
Created using [Ivy Tendril](https://ivy.app).
