### PR TITLE
[00038] Fix Swapped PR Descriptions in Concurrent CreatePr Jobs

### DIFF
--- a/src/Ivy.Tendril.Test/PromptwareDeployerTests.cs
+++ b/src/Ivy.Tendril.Test/PromptwareDeployerTests.cs
@@ -169,4 +169,24 @@ public class PromptwareDeployerTests : IDisposable
         // Assert
         Assert.True(Directory.Exists(normalDir));
     }
+
+    // Regression guard for #1551: concurrent CreatePr jobs share $TMPDIR, so a fixed
+    // body-file name like pr-body.md is a last-writer-wins race that swaps PR bodies
+    // between plans. The fix requires a unique temp file per invocation (mktemp).
+    [Fact]
+    public void CreatePrProgram_UsesUniqueTempFileForPrBody()
+    {
+        var sourcePromptwarePath = Path.GetFullPath(
+            Path.Combine(System.AppContext.BaseDirectory, "..", "..", "..", "..", "Ivy.Tendril", "Promptwares"));
+        var programFile = Path.Combine(sourcePromptwarePath, "CreatePr", "Program.md");
+
+        Assert.True(File.Exists(programFile), $"Expected to find {programFile}");
+        var content = File.ReadAllText(programFile);
+
+        Assert.Contains("mktemp", content);
+        // The fixed literal is still mentioned in prose as a "don't do this" example,
+        // so guard against the actual broken usage rather than the bare substring.
+        Assert.DoesNotContain("> \"$TMPDIR/pr-body.md\"", content);
+        Assert.DoesNotContain("--body-file \"$TMPDIR/pr-body.md\"", content);
+    }
 }

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -138,21 +138,30 @@ EXISTING=$(gh pr list --repo <owner/repo> --head <branch> --state open --json nu
 **!SHELL SAFETY — use file-based args. Do NOT pipe the body through `--body "$(cat <<'EOF' …)"`
 or interpolate a multi-line body inline.** On some hosts (opencode / Windows) that mangles the
 command and fails with `unknown argument "…"; please quote all values that have spaces`, burning
-retries. Write the body to a temp file and pass `--body-file`:
+retries. Write the body to a **unique** temp file (use `mktemp` — never a fixed/shared name, because
+concurrent CreatePr jobs share `$TMPDIR`) and pass `--body-file`:
 
 ```bash
-# $body is already assembled per the Body rules below
-printf '%s' "$body" > "$TMPDIR/pr-body.md"   # or any writable temp path
+# $body is already assembled per the Body rules below. Write it to a UNIQUE temp
+# file — NEVER a fixed/shared name. Up to MaxConcurrentJobs CreatePr jobs run at
+# once and share $TMPDIR, so a fixed path like $TMPDIR/pr-body.md is a
+# last-writer-wins race that swaps PR bodies between plans (#1551).
+body_file=$(mktemp)
+printf '%s' "$body" > "$body_file"
 gh pr create [--draft] --repo <owner/repo> --base <default-branch> --head <branch> \
-  --assignee @me --title "[<planId>] <plan title>" --body-file "$TMPDIR/pr-body.md"
+  --assignee @me --title "[<planId>] <plan title>" --body-file "$body_file"
+rm -f "$body_file"
 ```
 
 - The **title is a single `--title "…"` value** — never let the shell split it into multiple args.
   If a host still splits it, assign it to a variable first and pass the variable:
   ```bash
   TITLE="[<planId>] <plan title>"
+  body_file=$(mktemp)
+  printf '%s' "$body" > "$body_file"
   gh pr create --repo <owner/repo> --base <default-branch> --head <branch> \
-    --assignee @me --title "$TITLE" --body-file "$TMPDIR/pr-body.md"
+    --assignee @me --title "$TITLE" --body-file "$body_file"
+  rm -f "$body_file"
   ```
 
 - **Base branch:**


### PR DESCRIPTION
Fixes #1551

# Summary

## Changes

Fixed a race condition in the `CreatePr` promptware (issue #1551) where concurrent `CreatePr` jobs
wrote the PR body to a fixed, shared temp file (`$TMPDIR/pr-body.md`), causing last-writer-wins swaps
between concurrently-created PRs. `Program.md` now generates a unique temp file per invocation via
`mktemp`, and cleans it up afterward with `rm -f`.

## API Changes

None. This is a change to the `CreatePr` promptware's prompt (`src/Ivy.Tendril/Promptwares/CreatePr/Program.md`), not to any C# public API.

## Files Modified

- `src/Ivy.Tendril/Promptwares/CreatePr/Program.md` — replaced the fixed `$TMPDIR/pr-body.md` body-file path with a per-invocation `mktemp` file (prose note + both `gh pr create` examples), plus `rm -f` cleanup.
- `src/Ivy.Tendril.Test/PromptwareDeployerTests.cs` — added `CreatePrProgram_UsesUniqueTempFileForPrBody`, a regression guard that reads the real `CreatePr/Program.md` and asserts it uses `mktemp` and no longer contains the broken fixed-path usage.

## Manual Testing

N/A — internal change with no user-facing behavior. This only affects the LLM-facing prompt text used
by the `CreatePr` promptware; there is no UI or runtime code path to exercise manually. Correctness is
covered by the new regression test (`CreatePrProgram_UsesUniqueTempFileForPrBody`), which will fail if
the shared-temp-file pattern is ever reintroduced.

---
- 0f637622 Plan 00038: use mktemp for CreatePr body file to fix concurrent-job swap (#1551)
- 61349223 Plan 00038: add regression guard test for CreatePr body-file uniqueness

---
Created using [Ivy Tendril](https://ivy.app).
