### PR TITLE
[00051] Fix Shared Event Parser Race by Isolating Parsers Per Session

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs
@@ -67,19 +67,6 @@ public class AntigravityEventParserTests
     }
 
     [Fact]
-    public void Reset_ResetsInitializedState()
-    {
-        _parser.ParseLine("Line 1");
-        _parser.Reset();
-
-        // After reset, the next line should trigger SessionInit again
-        var events = _parser.ParseLine("Line 2");
-        Assert.Equal(2, events.Count);
-        Assert.IsType<SessionInitEvent>(events[0]);
-        Assert.IsType<TextEvent>(events[1]);
-    }
-
-    [Fact]
     public void BuildResult_WithExistingResultEvent_UpdatesExitCode()
     {
         var events = new List<AgentEvent>

--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudeEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudeEventParserTests.cs
@@ -455,12 +455,6 @@ public class ClaudeEventParserTests
     }
 
     [Fact]
-    public void Reset_DoesNotThrow()
-    {
-        _parser.Reset();
-    }
-
-    [Fact]
     public void AgentId_IsClaude()
     {
         Assert.Equal(Ivy.Tendril.Agents.Abstractions.AgentId.Claude, _parser.AgentId);

--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexEventParserTests.cs
@@ -262,12 +262,6 @@ public class CodexEventParserTests
     }
 
     [Fact]
-    public void Reset_DoesNotThrow()
-    {
-        _parser.Reset();
-    }
-
-    [Fact]
     public void ParseLine_UnicodeContent_ParsesCorrectly()
     {
         var json = """{"type":"item.completed","item":{"id":"i1","type":"agent_message","text":"こんにちは世界"}}""";

--- a/src/Ivy.Tendril.Agents.Test/Copilot/CopilotEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Copilot/CopilotEventParserTests.cs
@@ -298,9 +298,4 @@ public class CopilotEventParserTests
         Assert.Equal(0, result.ExitCode);
     }
 
-    [Fact]
-    public void Reset_DoesNotThrow()
-    {
-        _parser.Reset();
-    }
 }

--- a/src/Ivy.Tendril.Agents.Test/Gemini/GeminiEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Gemini/GeminiEventParserTests.cs
@@ -233,12 +233,6 @@ public class GeminiEventParserTests
     }
 
     [Fact]
-    public void Reset_IsCallable()
-    {
-        _parser.Reset();
-    }
-
-    [Fact]
     public void ParseLine_MessageEvent_HardWrappedProse_UnwrapsToSingleParagraph()
     {
         var json = """{"type":"message","role":"assistant","content":"This is a long sentence that has been\nwrapped at column boundaries by the\nterminal output formatter."}""";

--- a/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeEventParserTests.cs
@@ -350,31 +350,6 @@ public class OpenCodeEventParserTests
     }
 
     [Fact]
-    public void Reset_ClearsHasErrorState()
-    {
-        // Set _hasError
-        _parser.ParseLine("""{"type":"error","error":{"data":{"message":"fail","isRetryable":false,"statusCode":500}}}""");
-
-        // Reset clears it
-        _parser.Reset();
-
-        // Now BuildResult should respect exit code, not _hasError
-        var result = _parser.BuildResult([], 0);
-        Assert.True(result!.IsSuccess);
-    }
-
-    [Fact]
-    public void Reset_ClearsAccumulatedCostAndTokens()
-    {
-        _parser.ParseLine("""{"type":"step_finish","part":{"reason":"tool-calls","cost":0.012,"tokens":{"input":14000,"output":134}}}""");
-
-        _parser.Reset();
-
-        var result = _parser.BuildResult([], 0);
-        Assert.Null(result!.Usage);
-    }
-
-    [Fact]
     public void BuildResult_NoResultEvent_IncludesAccumulatedUsage()
     {
         // Simulate a process killed mid-session: only intermediate step_finish events were seen
@@ -387,5 +362,17 @@ public class OpenCodeEventParserTests
         Assert.Equal(14000, result.Usage.InputTokens);
         Assert.Equal(134, result.Usage.OutputTokens);
         Assert.Equal(0.012m, result.Usage.CostUsd);
+    }
+
+    [Fact]
+    public void CreateFresh_ReturnsIndependentInstance()
+    {
+        _parser.ParseLine("""{"type":"step_finish","part":{"reason":"tool-calls","cost":0.012,"tokens":{"input":14000,"output":134}}}""");
+
+        var fresh = _parser.CreateFresh();
+        var result = fresh.BuildResult([], 0);
+
+        Assert.NotNull(result);
+        Assert.Null(result.Usage);
     }
 }

--- a/src/Ivy.Tendril.Agents.Test/Runtime/AgentRunnerRegistrationTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Runtime/AgentRunnerRegistrationTests.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Providers.Claude;
+using Ivy.Tendril.Agents.Providers.OpenCode;
 using Ivy.Tendril.Agents.Runtime;
 
 namespace Ivy.Tendril.Agents.Test.Runtime;
@@ -137,5 +138,17 @@ public class AgentRunnerRegistrationTests
 
         Assert.Single(runner.RegisteredAgents);
         Assert.Equal(AgentId.Claude, runner.RegisteredAgents[0]);
+    }
+
+    [Fact]
+    public void GetParser_ReturnsFreshInstancePerCall()
+    {
+        var runner = new AgentRunner();
+        runner.Register(new OpenCodeCli(), new OpenCodeEventParser(), new OpenCodeHealthCheck());
+
+        var first = runner.GetParser(AgentId.OpenCode);
+        var second = runner.GetParser(AgentId.OpenCode);
+
+        Assert.NotSame(first, second);
     }
 }

--- a/src/Ivy.Tendril.Agents/Abstractions/IEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/IEventParser.cs
@@ -6,7 +6,7 @@ public interface IEventParser
     IReadOnlyList<AgentEvent> ParseLine(string rawLine);
     IReadOnlyList<AgentEvent> Flush();
     ResultEvent? BuildResult(IReadOnlyList<AgentEvent> events, int exitCode);
-    void Reset();
+    IEventParser CreateFresh();
 }
 
 public interface IFailureAnalyzer

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityEventParser.cs
@@ -71,8 +71,5 @@ public sealed class AntigravityEventParser : IEventParser
         };
     }
 
-    public void Reset()
-    {
-        _initialized = false;
-    }
+    public IEventParser CreateFresh() => new AntigravityEventParser();
 }

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeEventParser.cs
@@ -78,7 +78,7 @@ public sealed class ClaudeEventParser : IEventParser
         };
     }
 
-    public void Reset() { }
+    public IEventParser CreateFresh() => new ClaudeEventParser();
 
     private static string? PeekType(ref Utf8JsonReader reader)
     {

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexEventParser.cs
@@ -71,7 +71,7 @@ public sealed class CodexEventParser : IEventParser
         };
     }
 
-    public void Reset() { }
+    public IEventParser CreateFresh() => new CodexEventParser();
 
     private static string? PeekType(ref Utf8JsonReader reader)
     {

--- a/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotEventParser.cs
@@ -90,7 +90,7 @@ public sealed class CopilotEventParser : IEventParser
         };
     }
 
-    public void Reset() { }
+    public IEventParser CreateFresh() => new CopilotEventParser();
 
     private static string? PeekType(ref Utf8JsonReader reader)
     {

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiEventParser.cs
@@ -73,7 +73,7 @@ public sealed class GeminiEventParser : IEventParser
         };
     }
 
-    public void Reset() { }
+    public IEventParser CreateFresh() => new GeminiEventParser();
 
     private static string? PeekType(ref Utf8JsonReader reader)
     {

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeEventParser.cs
@@ -89,13 +89,7 @@ public sealed class OpenCodeEventParser : IEventParser
         };
     }
 
-    public void Reset()
-    {
-        _hasError = false;
-        _accumulatedInputTokens = 0;
-        _accumulatedOutputTokens = 0;
-        _accumulatedCost = 0;
-    }
+    public IEventParser CreateFresh() => new OpenCodeEventParser();
 
     private static string? PeekType(ref Utf8JsonReader reader)
     {

--- a/src/Ivy.Tendril.Agents/Runtime/AgentRunner.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/AgentRunner.cs
@@ -297,9 +297,8 @@ public sealed class AgentRunner(ILogger<AgentRunner> logger, ConcurrencyOptions?
 
     public IEventParser GetParser(string agentId)
     {
-        if (!_parsers.TryGetValue(agentId, out var parser))
+        if (!_parsers.TryGetValue(agentId, out var prototype))
             throw new ArgumentException($"No event parser registered for agent '{agentId}'", nameof(agentId));
-        parser.Reset();
-        return parser;
+        return prototype.CreateFresh();
     }
 }


### PR DESCRIPTION
# Summary

## Changes

Fixed a race condition where `AgentRunner` kept one shared `IEventParser` instance per agent id and reused
it across concurrent sessions via `Reset()`, corrupting `_hasError` and the accumulated cost/token totals
when two jobs of the same agent type ran simultaneously. Replaced the reset-and-reuse pattern with
create-fresh-per-session: `AgentRunner.GetParser` now returns a brand-new parser instance from a write-once
prototype instead of mutating and returning the shared one.

## API Changes

- `IEventParser.Reset()` removed; `IEventParser.CreateFresh()` added, returning a new independent instance.
- All six parser implementations (`OpenCodeEventParser`, `AntigravityEventParser`, `ClaudeEventParser`,
  `CodexEventParser`, `GeminiEventParser`, `CopilotEventParser`) implement `CreateFresh()` as `new XxxParser()`
  instead of `Reset()`.
- `AgentRunner.GetParser(string agentId)` behavior change: now returns a fresh instance per call instead of
  the same shared, reset instance. `Register` overloads are unchanged.

## Files Modified

- `src/Ivy.Tendril.Agents/Abstractions/IEventParser.cs` — interface change
- `src/Ivy.Tendril.Agents/Runtime/AgentRunner.cs` — `GetParser` now calls `CreateFresh()`
- `src/Ivy.Tendril.Agents/Providers/{OpenCode,Antigravity,Claude,Codex,Gemini,Copilot}/*EventParser.cs` — `Reset()` → `CreateFresh()`
- `src/Ivy.Tendril.Agents.Test/Runtime/AgentRunnerRegistrationTests.cs` — new `GetParser_ReturnsFreshInstancePerCall` regression test
- `src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeEventParserTests.cs` — new `CreateFresh_ReturnsIndependentInstance` test
- 6 parser test files — removed 7 obsolete `Reset()`-specific tests

## Manual Testing

N/A — internal fix to session-scoped parser lifecycle with no user-facing UI surface. Correctness is covered
by the two new regression tests: `AgentRunnerRegistrationTests.GetParser_ReturnsFreshInstancePerCall` proves
two `GetParser` calls for the same agent id return distinct instances, and
`OpenCodeEventParserTests.CreateFresh_ReturnsIndependentInstance` proves a fresh instance doesn't inherit
another instance's accumulated cost/token state.

---
Commits:
- 5ce4fb7e Fix shared event parser race by isolating parsers per session
- c199e9d9 Add parser-per-session regression tests, remove obsolete Reset() tests

---
Created using [Ivy Tendril](https://ivy.app).
