### PR TITLE
[00049] Allow Submitting Content Input With Only A File Attached

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+vi.mock("pdfjs-dist", () => ({ GlobalWorkerOptions: {}, getDocument: vi.fn() }));
+vi.mock("pdfjs-dist/build/pdf.worker.mjs?url", () => ({ default: "" }));
+
+import { ContentInput } from "./ContentInput";
+
+describe("ContentInput", () => {
+  it("enables the submit button when only a file is attached (no text)", () => {
+    render(<ContentInput id="civ-1" value=" [file: /tmp/foo.png]" />);
+    const submitButton = screen.getByTitle("Send");
+    expect(submitButton).toBeEnabled();
+  });
+
+  it("dispatches OnSubmit with a value containing the file reference when clicked", () => {
+    const onIvyEvent = vi.fn();
+    render(<ContentInput id="civ-1" value=" [file: /tmp/foo.png]" onIvyEvent={onIvyEvent} />);
+
+    const submitButton = screen.getByTitle("Send");
+    fireEvent.click(submitButton);
+
+    expect(onIvyEvent).toHaveBeenCalledWith(
+      "OnSubmit",
+      "civ-1",
+      expect.arrayContaining([
+        expect.objectContaining({
+          value: expect.stringContaining("[file: /tmp/foo.png]"),
+        }),
+      ])
+    );
+  });
+
+  it("keeps the submit button disabled when there is no text and no file", () => {
+    render(<ContentInput id="civ-1" value="" />);
+    const submitButton = screen.getByTitle("Send");
+    expect(submitButton).toBeDisabled();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx
@@ -396,8 +396,11 @@ export const ContentInput: React.FC<ContentInputProps> = ({
     };
   }, []);
 
+  const canSubmit = (text.trim().length > 0 || files.length > 0) && voiceStatus === "idle";
+
   const handleSubmit = () => {
     if (voiceStatus !== "idle") return;
+    if (!text.trim() && files.length === 0) return;
     const fullText = text + files.map((f) => ` [file: ${f}]`).join("");
     if (dispatchEvent) {
       dispatchEvent("OnSubmit", id, [
@@ -808,13 +811,13 @@ export const ContentInput: React.FC<ContentInputProps> = ({
             {/* Submit Button or Split Button */}
             {menuOptions && menuOptions.length > 0 ? (
               <div
-                className={`civ-split-btn-container ${!text.trim() || voiceStatus !== "idle" ? "disabled" : ""}`}
+                className={`civ-split-btn-container ${!canSubmit ? "disabled" : ""}`}
                 ref={menuRef}
               >
                 <button
                   className="civ-submit-btn civ-submit-btn-labeled civ-split-btn-left"
                   onClick={handleSubmit}
-                  disabled={!text.trim() || voiceStatus !== "idle"}
+                  disabled={!canSubmit}
                   type="button"
                   title={submitLabel || "Send"}
                 >
@@ -824,7 +827,7 @@ export const ContentInput: React.FC<ContentInputProps> = ({
                 <button
                   className="civ-split-btn-arrow"
                   onClick={() => setMenuOpen(!menuOpen)}
-                  disabled={!text.trim() || voiceStatus !== "idle"}
+                  disabled={!canSubmit}
                   type="button"
                   title="More options"
                 >
@@ -856,7 +859,7 @@ export const ContentInput: React.FC<ContentInputProps> = ({
               <button
                 className={`civ-submit-btn ${submitLabel ? "civ-submit-btn-labeled" : ""}`}
                 onClick={handleSubmit}
-                disabled={!text.trim() || voiceStatus !== "idle"}
+                disabled={!canSubmit}
                 type="button"
                 title={submitLabel || "Send"}
               >


### PR DESCRIPTION
# Summary

## Changes

The `ContentInput` widget's submit control was disabled whenever the textarea was empty, even if a
file was attached, making it impossible to create a plan/issue from a file alone. Added a `canSubmit`
derived flag that treats an attached file as valid content (alongside typed text), wired it into all
four disabled-state checks, and added a guard in `handleSubmit` so a truly empty submit (no text, no
files) still cannot fire.

## API Changes

None. The change is internal to the `ContentInput` React component's render logic; no props, exports,
or public APIs changed.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx` — added `canSubmit`, updated the
  four submit-disabled conditions, added an empty-submit guard in `handleSubmit`.
- `src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.test.tsx` (new) — vitest component
  tests covering file-only submission.

## Manual Testing

1. Run the Tendril app and open the Drafts view's "Create Plan" content input.
2. Attach a file (e.g. drag a screenshot or click the attach button) without typing any text.
3. Observe the Create/Send button (and its dropdown arrow, if menu options are present) becomes
   enabled.
4. Click Create/Send — the plan/issue should be created using just the file reference (` [file: <path>]`)
   as the content.
5. Clear the file and confirm the button is disabled again with no text and no file attached.

---
- 3a0c6a52 Allow ContentInput submit when only a file is attached (plan 00049)
- c0ec299a Add ContentInput test for file-only submission (plan 00049)

---
Created using [Ivy Tendril](https://ivy.app).
