### PR TITLE
[00047] Fix Static HTML Review Action to Use Cross-Platform Open Command

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
@@ -130,7 +130,9 @@ tendril project add-verification <project-name> CheckResult --required --after=D
 Review actions make it easy to start the application from a worktree during code review.
 To ensure the setup works out-of-the-box on fresh worktrees, review actions MUST automatically install dependencies before running the application (e.g. using `&&` to chain the installation and start commands).
 
-Review-action commands execute inside `pwsh` on the reviewer's OS (see `PlatformHelper.RunPowerShellAction`), so they MUST use cross-platform PowerShell. Never emit the Windows-only `start`; to open a file/URL use `Start-Process` on Windows, `open` on macOS, `xdg-open` on Linux. Avoid unescaped `$` in the command — on macOS the action passes through a bash wrapper that would expand it.
+Review-action commands execute inside `pwsh` on the reviewer's OS, so they MUST use cross-platform PowerShell. 
+
+Never emit the Windows-only `start`; to open a file/URL use `Start-Process` on Windows, `open` on macOS, `xdg-open` on Linux. Avoid unescaped `$` in the command — on macOS the action passes through a bash wrapper that would expand it.
 
 Inspect each repo to determine how to run the application. For website projects, prefer commands that open the browser automatically:
 - **.NET project** with a runnable entry point: `dotnet run --project Worktrees/<RepoName>/<path-to-project> --browse --find-available-port`

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
@@ -130,6 +130,8 @@ tendril project add-verification <project-name> CheckResult --required --after=D
 Review actions make it easy to start the application from a worktree during code review.
 To ensure the setup works out-of-the-box on fresh worktrees, review actions MUST automatically install dependencies before running the application (e.g. using `&&` to chain the installation and start commands).
 
+Review-action commands execute inside `pwsh` on the reviewer's OS (see `PlatformHelper.RunPowerShellAction`), so they MUST use cross-platform PowerShell. Never emit the Windows-only `start`; to open a file/URL use `Start-Process` on Windows, `open` on macOS, `xdg-open` on Linux. Avoid unescaped `$` in the command — on macOS the action passes through a bash wrapper that would expand it.
+
 Inspect each repo to determine how to run the application. For website projects, prefer commands that open the browser automatically:
 - **.NET project** with a runnable entry point: `dotnet run --project Worktrees/<RepoName>/<path-to-project> --browse --find-available-port`
 - **Vite+ (`vite-plus`) project**: `cd Worktrees/<RepoName>/<path-to-frontend> && vp install && vp dev`
@@ -140,7 +142,12 @@ Inspect each repo to determine how to run the application. For website projects,
 - **Angular CLI**: `cd Worktrees/<RepoName>/<path> && npm install && ng serve --open` (adapt for `pnpm`/`yarn` if detected)
 - **Other Node.js app** (no open support): `cd Worktrees/<RepoName>/<path> && npm install && npm run dev` (adapt package manager as detected)
 - **Python app**: `cd Worktrees/<RepoName> && python -m pip install -r requirements.txt && python -m <module>` (or `flask run` / `uv run ...` / `poetry run ...` if detected)
-- **Static docs**: `start Worktrees/<RepoName>/docs/index.html`
+- **Static HTML / docs (no dev server)**: open the entry file with the current OS's default handler — the SetupProject agent runs on the machine that will review, so emit the command for the current OS:
+  - **Windows**: `Start-Process "Worktrees/<RepoName>/docs/index.html"`
+  - **macOS**: `open "Worktrees/<RepoName>/docs/index.html"`
+  - **Linux**: `xdg-open "Worktrees/<RepoName>/docs/index.html"`
+
+  (Adjust the `docs/index.html` sub-path to wherever the repo's entry HTML actually lives.)
 
 For each review action:
 - **name**: Short descriptive name (e.g. "App", "Docs", "Frontend", "API")

--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -145,7 +145,7 @@ projects:
         command: 'dotnet run --browse'
       - name: Open Docs
         condition: ''
-        command: 'start docs/index.html'
+        command: 'open docs/index.html'
 ";
 
         var tempDir = CreateTempConfigFile(yaml);
@@ -165,7 +165,7 @@ projects:
 
             Assert.Equal("Open Docs", project.ReviewActions[1].Name);
             Assert.Empty(project.ReviewActions[1].Condition);
-            Assert.Contains("start docs", project.ReviewActions[1].Command);
+            Assert.Contains("open docs", project.ReviewActions[1].Command);
             Assert.Contains("index.html", project.ReviewActions[1].Command);
         }
         finally

--- a/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
@@ -130,7 +130,9 @@ tendril project add-verification <project-name> CheckResult --required --after=D
 Review actions make it easy to start the application from a worktree during code review.
 To ensure the setup works out-of-the-box on fresh worktrees, review actions MUST automatically install dependencies before running the application (e.g. using `&&` to chain the installation and start commands).
 
-Review-action commands execute inside `pwsh` on the reviewer's OS (see `PlatformHelper.RunPowerShellAction`), so they MUST use cross-platform PowerShell. Never emit the Windows-only `start`; to open a file/URL use `Start-Process` on Windows, `open` on macOS, `xdg-open` on Linux. Avoid unescaped `$` in the command — on macOS the action passes through a bash wrapper that would expand it.
+Review-action commands execute inside `pwsh` on the reviewer's OS, so they MUST use cross-platform PowerShell. 
+
+Never emit the Windows-only `start`; to open a file/URL use `Start-Process` on Windows, `open` on macOS, `xdg-open` on Linux. Avoid unescaped `$` in the command — on macOS the action passes through a bash wrapper that would expand it.
 
 Inspect each repo to determine how to run the application. For website projects, prefer commands that open the browser automatically:
 - **.NET project** with a runnable entry point: `dotnet run --project Worktrees/<RepoName>/<path-to-project> --browse --find-available-port`

--- a/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
@@ -130,6 +130,8 @@ tendril project add-verification <project-name> CheckResult --required --after=D
 Review actions make it easy to start the application from a worktree during code review.
 To ensure the setup works out-of-the-box on fresh worktrees, review actions MUST automatically install dependencies before running the application (e.g. using `&&` to chain the installation and start commands).
 
+Review-action commands execute inside `pwsh` on the reviewer's OS (see `PlatformHelper.RunPowerShellAction`), so they MUST use cross-platform PowerShell. Never emit the Windows-only `start`; to open a file/URL use `Start-Process` on Windows, `open` on macOS, `xdg-open` on Linux. Avoid unescaped `$` in the command — on macOS the action passes through a bash wrapper that would expand it.
+
 Inspect each repo to determine how to run the application. For website projects, prefer commands that open the browser automatically:
 - **.NET project** with a runnable entry point: `dotnet run --project Worktrees/<RepoName>/<path-to-project> --browse --find-available-port`
 - **Vite+ (`vite-plus`) project**: `cd Worktrees/<RepoName>/<path-to-frontend> && vp install && vp dev`
@@ -140,7 +142,12 @@ Inspect each repo to determine how to run the application. For website projects,
 - **Angular CLI**: `cd Worktrees/<RepoName>/<path> && npm install && ng serve --open` (adapt for `pnpm`/`yarn` if detected)
 - **Other Node.js app** (no open support): `cd Worktrees/<RepoName>/<path> && npm install && npm run dev` (adapt package manager as detected)
 - **Python app**: `cd Worktrees/<RepoName> && python -m pip install -r requirements.txt && python -m <module>` (or `flask run` / `uv run ...` / `poetry run ...` if detected)
-- **Static docs**: `start Worktrees/<RepoName>/docs/index.html`
+- **Static HTML / docs (no dev server)**: open the entry file with the current OS's default handler — the SetupProject agent runs on the machine that will review, so emit the command for the current OS:
+  - **Windows**: `Start-Process "Worktrees/<RepoName>/docs/index.html"`
+  - **macOS**: `open "Worktrees/<RepoName>/docs/index.html"`
+  - **Linux**: `xdg-open "Worktrees/<RepoName>/docs/index.html"`
+
+  (Adjust the `docs/index.html` sub-path to wherever the repo's entry HTML actually lives.)
 
 For each review action:
 - **name**: Short descriptive name (e.g. "App", "Docs", "Frontend", "API")


### PR DESCRIPTION
Fixes #1495

# Summary

## Changes

The SetupProject promptware instructions (`src/Ivy.Tendril/Promptwares/SetupProject/Program.md` and the mirrored `src/Ivy.Tendril.TeamIvyConfig` copy) generated a static-HTML review action using the Windows-only `start` command, which fails on macOS/Linux since review actions always run in `pwsh` (#1495). Both files now emit OS-specific open commands (`Start-Process` on Windows, `open` on macOS, `xdg-open` on Linux) and include a portability note warning against `start` and unescaped `$` in review-action commands.

## API Changes

None. This is a prose-only change to promptware instructions consumed by an LLM agent — no C# application code paths changed.

## Files Modified

- `src/Ivy.Tendril/Promptwares/SetupProject/Program.md` — replaced the Windows-only `start` static-docs example with OS-specific guidance; added a portability note to the review-action preamble.
- `src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md` — identical fix (mirrored copy).
- `src/Ivy.Tendril.Test/ConfigServiceTests.cs` — updated the static-docs sample fixture/assertions from `start docs/index.html` to `open docs/index.html` so tests no longer propagate the old pattern.

## Manual Testing

N/A — internal change with no user-facing behavior. The fix only affects the prose instructions that the SetupProject agent reads when generating a project's review actions; there's no UI or runtime code path to exercise directly. Confidence comes from `DotnetTest` (91/91 passing, including the `ConfigServiceTests` fixture verifying the new `open docs` sample round-trips through YAML correctly) and manual inspection confirming both `Program.md` copies now match. To fully validate end-to-end, a future SetupProject run against a static-HTML-only repo on macOS/Linux should be observed to produce an `open`/`xdg-open` review action instead of `start`.

---
## Commits
- d494d22d Refactor review-action commands to ensure cross-platform compatibility in PowerShell
- ec4139c6 Update ConfigServiceTests static-docs sample to cross-platform open command
- 969bdc34 Fix Static HTML Review Action to Use Cross-Platform Open Command

---
Created using [Ivy Tendril](https://ivy.app).
