### PR TITLE
[00034] Make Discarding a Draft Plan Optimistic With Background Cleanup

### DIFF
--- a/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -167,6 +167,23 @@ public class WorktreeCleanupServiceTests : IDisposable
     }
 
     [Fact]
+    public void DeletePlanFolderInBackground_Deletes_Folder_And_Worktrees()
+    {
+        var dir = CreatePlan("08001-DeleteInBackgroundTest", "Draft", DateTime.UtcNow.AddHours(-2));
+        var worktreeDir = Path.Combine(dir, "Worktrees", "TestRepo");
+        Directory.CreateDirectory(worktreeDir);
+        File.WriteAllText(Path.Combine(worktreeDir, "file.txt"), "test");
+
+        WorktreeCleanupService.DeletePlanFolderInBackground(dir);
+
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (Directory.Exists(dir) && DateTime.UtcNow < deadline)
+            Thread.Sleep(50);
+
+        Assert.False(Directory.Exists(dir), "Plan folder should be deleted by background deletion");
+    }
+
+    [Fact]
     public void CleanupPlanWorktrees_ForceDeletes_Orphan_Without_GitFile()
     {
         // Worktree directory with no .git file — RemoveWorktrees skips it,

--- a/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
@@ -376,6 +376,30 @@ public class WorktreeCleanupService : IStartable, IDisposable
         });
     }
 
+    /// <summary>
+    ///     Fire-and-forget permanent deletion of an entire plan folder (worktrees + all
+    ///     contents) for terminal UI delete actions, so slow disk I/O never blocks the
+    ///     plan-write pipeline.
+    /// </summary>
+    internal static void DeletePlanFolderInBackground(string planFolderPath, ILogger? logger = null,
+        IWorktreeLifecycleLogger? lifecycleLogger = null)
+    {
+        Task.Run(() =>
+        {
+            try
+            {
+                if (!Directory.Exists(planFolderPath)) return;
+                RemoveWorktrees(planFolderPath, logger, lifecycleLogger);
+                ForceDeleteDirectory(planFolderPath, logger);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex, "Background plan-folder deletion failed for {PlanFolder}",
+                    Path.GetFileName(planFolderPath));
+            }
+        });
+    }
+
     internal static void RemoveWorktrees(string planFolderPath, ILogger? logger = null, IWorktreeLifecycleLogger? lifecycleLogger = null)
     {
         var worktreesDir = Path.Combine(planFolderPath, "Worktrees");

--- a/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
@@ -389,6 +389,22 @@ public class WorktreeCleanupService : IStartable, IDisposable
             try
             {
                 if (!Directory.Exists(planFolderPath)) return;
+
+                // Briefly acquire+release the per-folder cross-process lock before deleting, so
+                // any plan.yaml write already in flight (or queued) for this folder finishes
+                // first instead of racing the delete. We can't hold the lock for the whole
+                // deletion below — the lock file itself lives inside the folder being deleted,
+                // so Directory.Delete would fail trying to remove a file we still have open.
+                try
+                {
+                    using (PlanFileLock.Acquire(planFolderPath)) { }
+                }
+                catch (TimeoutException ex)
+                {
+                    logger?.LogWarning(ex, "Timed out waiting for plan lock before deleting {PlanFolder}; proceeding anyway",
+                        Path.GetFileName(planFolderPath));
+                }
+
                 RemoveWorktrees(planFolderPath, logger, lifecycleLogger);
                 ForceDeleteDirectory(planFolderPath, logger);
             }

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -425,14 +425,10 @@ public class PlanReaderService(
         _recommendationsCache.Invalidate();
         CountsInvalidated?.Invoke();
 
-        // Delete folder in background (can be slow due to git worktree removal).
+        // Delete folder out-of-band (NOT via _writeQueue) so slow worktree/directory
+        // removal never blocks other plan writes.
         var folderPath = Path.Combine(PlansDirectory, folderName);
-        WriteFileInBackground(() =>
-        {
-            if (!Directory.Exists(folderPath)) return;
-            WorktreeCleanupService.RemoveWorktrees(folderPath, logger, worktreeLifecycleLogger);
-            WorktreeCleanupService.ForceDeleteDirectory(folderPath, logger);
-        });
+        WorktreeCleanupService.DeletePlanFolderInBackground(folderPath, logger, worktreeLifecycleLogger);
     }
 
     /// <summary>


### PR DESCRIPTION
# Summary

## Changes

Deleting a Draft (or Icebox) plan's folder/worktrees no longer runs through `PlanReaderService`'s global `_writeQueue` semaphore, so the slow disk I/O (git worktree removal, recursive directory delete with retries) can no longer block every other queued plan write app-wide. The DB delete and cache invalidation remain synchronous, preserving the already-instant optimistic UI update. To close a race this introduced between the now-unsynchronized delete and any still-queued write to the same folder, the delete briefly acquires and releases the existing per-folder `PlanFileLock` right before starting cleanup, without holding it through the deletion itself.

## API Changes

- New `internal static void WorktreeCleanupService.DeletePlanFolderInBackground(string planFolderPath, ILogger? logger = null, IWorktreeLifecycleLogger? lifecycleLogger = null)` — fire-and-forget deletion of an entire plan folder (worktrees + all contents), mirroring the existing `RemoveWorktreesInBackground`.
- `PlanReaderService.DeletePlan` now calls this new helper instead of wrapping cleanup in `WriteFileInBackground`. No change to its public signature or behavior from a caller's perspective.

## Files Modified

- `src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs` — added `DeletePlanFolderInBackground`.
- `src/Ivy.Tendril/Services/Plans/PlanReaderService.cs` — `DeletePlan` calls the new helper instead of `WriteFileInBackground`.
- `src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs` — added `DeletePlanFolderInBackground_Deletes_Folder_And_Worktrees`.

## Manual Testing

1. Run Tendril and open the Drafts app.
2. Create or select a Draft plan that has a `Worktrees/` folder with some content (or any Draft plan).
3. Click **Delete** and confirm in `DeletePlanDialog`.
4. Observe: the plan disappears from the Drafts list immediately (already the case before this change).
5. While the deletion is still cleaning up in the background (e.g. for a plan with a large worktree), immediately try another plan action elsewhere — e.g. toggle a verification, move another plan to Icebox, or edit a different plan's content. It should complete instantly instead of hanging until the delete's folder cleanup finishes (this is the behavior this plan fixes).
6. Confirm the plan folder is eventually removed from disk (`D:\Plans\<id>-<title>` no longer exists).

---
- f35679e6 code-review: drain in-flight plan.yaml writes before background delete
- 117e6bc8 Make plan-folder deletion background instead of write-queue-gated

---
Created using [Ivy Tendril](https://ivy.app).
