### PR TITLE
[00050] Batch-Select and Implement Recommendations in Review

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -486,5 +486,9 @@ public class JobServiceCompletionGuardTests : IDisposable
         public void AcceptRecommendationAndRetry(string folderName, string recommendationTitle)
         {
         }
+
+        public void AcceptRecommendationsAndRetry(string folderName, IReadOnlyCollection<string> titles)
+        {
+        }
     }
 }

--- a/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
@@ -449,5 +449,9 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         public void AcceptRecommendationAndRetry(string folderName, string recommendationTitle)
         {
         }
+
+        public void AcceptRecommendationsAndRetry(string folderName, IReadOnlyCollection<string> titles)
+        {
+        }
     }
 }

--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -656,5 +656,9 @@ public class JobServiceRetryBlockedTests : IDisposable
         public void AcceptRecommendationAndRetry(string folderName, string recommendationTitle)
         {
         }
+
+        public void AcceptRecommendationsAndRetry(string folderName, IReadOnlyCollection<string> titles)
+        {
+        }
     }
 }

--- a/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
@@ -97,5 +97,6 @@ public class JobServiceSplitPlanCompletionTests
         public Task FlushPendingWritesAsync() => Task.CompletedTask;
         public List<RecommendationYaml> GetRecommendationsForPlan(string folderName) => [];
         public void AcceptRecommendationAndRetry(string folderName, string recommendationTitle) { }
+        public void AcceptRecommendationsAndRetry(string folderName, IReadOnlyCollection<string> titles) { }
     }
 }

--- a/src/Ivy.Tendril.Test/RecommendationServiceTests.cs
+++ b/src/Ivy.Tendril.Test/RecommendationServiceTests.cs
@@ -408,4 +408,73 @@ public class RecommendationServiceTests : IDisposable
         Assert.Equal("Accepted", result2[0].State);
         Assert.NotSame(result1, result2);
     }
+
+    private string CreatePlanWithRecommendationsAndVerifications(string folderName, string recommendationsYaml,
+        string verificationsYaml, string state = "Completed")
+    {
+        var dir = Path.Combine(_plansDir, folderName);
+        Directory.CreateDirectory(dir);
+
+        string Indent(string yaml) => string.Join("\n",
+            yaml.Split('\n').Select(l => string.IsNullOrWhiteSpace(l) ? l : "  " + l));
+
+        var planYaml =
+            $"state: {state}\nproject: Tendril\ntitle: Test Plan\nrepos: []\ncommits: []\nprs: []\n" +
+            $"verifications:\n{Indent(verificationsYaml)}\nrelatedPlans: []\ndependsOn: []\n" +
+            $"created: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\nrecommendations:\n{Indent(recommendationsYaml)}\n";
+        File.WriteAllText(Path.Combine(dir, "plan.yaml"), planYaml);
+
+        var revisionsDir = Path.Combine(dir, "Revisions");
+        Directory.CreateDirectory(revisionsDir);
+        File.WriteAllText(Path.Combine(revisionsDir, "001.md"), "# Test");
+
+        return dir;
+    }
+
+    [Fact]
+    public async Task AcceptRecommendationsAndRetry_AcceptsAllAndTransitions()
+    {
+        var recsYaml = "- title: Rec1\n  description: First\n  state: Pending\n" +
+                        "- title: Rec2\n  description: Second\n  state: Pending\n" +
+                        "- title: Rec3\n  description: Third\n  state: Pending\n";
+        var verificationsYaml = "- name: DotnetBuild\n  status: Pass\n" +
+                                 "- name: DotnetFormat\n  status: Skipped\n";
+        var folderPath = CreatePlanWithRecommendationsAndVerifications(
+            "01670-BatchAccept", recsYaml, verificationsYaml);
+
+        _service.AcceptRecommendationsAndRetry("01670-BatchAccept", new[] { "Rec1", "Rec2" });
+        await _service.FlushPendingWritesAsync();
+
+        var plan = _service.GetPlanByFolder(folderPath);
+        Assert.NotNull(plan);
+        Assert.Equal(PlanStatus.Executing, plan!.Status);
+
+        var recs = _service.GetRecommendationsForPlan("01670-BatchAccept");
+        Assert.Equal("Accepted", recs.First(r => r.Title == "Rec1").State);
+        Assert.Equal("Accepted", recs.First(r => r.Title == "Rec2").State);
+        Assert.Equal("Pending", recs.First(r => r.Title == "Rec3").State);
+
+        var build = plan.Verifications.First(v => v.Name == "DotnetBuild");
+        var format = plan.Verifications.First(v => v.Name == "DotnetFormat");
+        Assert.Equal(VerificationStatus.Pending, build.Status);
+        Assert.Equal(VerificationStatus.Skipped, format.Status);
+    }
+
+    [Fact]
+    public async Task AcceptRecommendationsAndRetry_SingleTitle_MatchesSingleRecMethod()
+    {
+        var recsYaml = "- title: Rec1\n  description: First\n  state: Pending\n";
+        var verificationsYaml = "- name: DotnetBuild\n  status: Pass\n";
+        var folderPath = CreatePlanWithRecommendationsAndVerifications(
+            "01671-BatchAcceptSingle", recsYaml, verificationsYaml);
+
+        _service.AcceptRecommendationsAndRetry("01671-BatchAcceptSingle", new[] { "Rec1" });
+        await _service.FlushPendingWritesAsync();
+
+        var plan = _service.GetPlanByFolder(folderPath);
+        Assert.NotNull(plan);
+        Assert.Equal(PlanStatus.Executing, plan!.Status);
+        var recs = _service.GetRecommendationsForPlan("01671-BatchAcceptSingle");
+        Assert.Equal("Accepted", recs.First(r => r.Title == "Rec1").State);
+    }
 }

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Reactive.Disposables;
+using System.Text;
 using Ivy.Core;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Apps.Jobs;
@@ -34,6 +35,7 @@ public class ContentView(
         var openFile = UseState<string?>(null);
         var openCommit = UseState<string?>(null);
         var syncingWorktrees = UseState(new HashSet<string>());
+        var selectedRecTitles = UseState(() => new HashSet<string>());
         var args = UseArgs<ReviewAppArgs>();
         var nav = UseNavigation();
 
@@ -205,6 +207,9 @@ public class ContentView(
             return Disposable.Empty;
         }, [localRefresh]);
 
+        UseEffect(() => { selectedRecTitles.Set(new HashSet<string>()); return Disposable.Empty; },
+            selectedPlanState);
+
         var tabNames = new[] { "summary", "plan", "details", "verifications", "git", "changes", "Artifacts", "recommendations" };
         var selectedTabIndex = Array.IndexOf(tabNames, args?.Tab ?? "summary");
         if (selectedTabIndex < 0) selectedTabIndex = 0;
@@ -220,15 +225,17 @@ public class ContentView(
 
         var currentIndex = allPlans.FindIndex(p => p.FolderName == selectedPlanState.Value.FolderName);
         var planData = planContentQuery.Value;
+        var pendingRecs = planData.Recommendations.Where(r => r.State == RecommendationStatus.Pending).ToList();
 
-        var header = BuildHeader(selectedPlanState.Value, allPlans, currentIndex, client, showCreatePrDialog, nav, args);
+        var header = BuildHeader(selectedPlanState.Value, allPlans, currentIndex, client, showCreatePrDialog, nav,
+            args, selectedRecTitles, pendingRecs, planContentQuery.Mutator.Revalidate);
         var actionBar = BuildActionBar(
             selectedPlanState.Value, showResetToDraftDialog, showSuggestChangesDialog, showDiscardDialog,
             showCreatePrDialog, copyToClipboard, client, logger, nav, args);
         var content = BuildContent(
             selectedPlanState.Value, planData, planContentQuery, selectedTabIndex, tabNames, openVerification,
             openCommit, openFile, openArtifact, artifactContentQuery, assigneesQuery,
-            assigneesError, syncingWorktrees,
+            assigneesError, syncingWorktrees, selectedRecTitles, pendingRecs,
             client, copyToClipboard, logger, nav, args, showDebugJob);
 
         var mainLayout = new HeaderLayout(
@@ -249,7 +256,10 @@ public class ContentView(
         IClientProvider client,
         Action showCreatePrDialog,
         INavigator nav,
-        ReviewAppArgs? args)
+        ReviewAppArgs? args,
+        IState<HashSet<string>> selectedRecTitles,
+        List<RecommendationYaml> pendingRecs,
+        Action revalidate)
     {
         object BuildTitleArea(bool isMobile)
         {
@@ -274,6 +284,8 @@ public class ContentView(
 
         object BuildControls(bool isMobile)
         {
+            var hasSelection = selectedRecTitles.Value.Count > 0;
+
             var rightSide = Layout.Horizontal().Gap(2).AlignContent(Align.Right)
                            | Text.Rich()
                                .NoWrap()
@@ -293,7 +305,7 @@ public class ContentView(
                 var isPrUpdate = selectedPlan.IsPullRequestSource;
 
                 var createPrBtn = new Button(isPrUpdate ? "Update PR" : "Create PR")
-                    .Icon(Icons.GitPullRequest).Primary().OnClick(() =>
+                    .Icon(Icons.GitPullRequest).OnClick(() =>
                 {
                     if (isPrUpdate)
                     {
@@ -326,14 +338,15 @@ public class ContentView(
                         showCreatePrDialog();
                     }
                 }).ShortcutKey("m");
+                createPrBtn = hasSelection ? createPrBtn.Outline() : createPrBtn.Primary();
 
-                rightSide |= (allYolo && !isPrUpdate)
+                rightSide |= (allYolo && !isPrUpdate && !hasSelection)
                     ? createPrBtn.WithConfetti(AnimationTrigger.Click)
                     : createPrBtn;
             }
             else
             {
-                rightSide |= new Button("Complete Plan").Icon(Icons.CircleCheck).Primary().OnClick(() =>
+                var completePlanBtn = new Button("Complete Plan").Icon(Icons.CircleCheck).OnClick(() =>
                 {
                     // Optimistic UI - update state and refresh immediately
                     planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
@@ -342,6 +355,30 @@ public class ContentView(
                     // Fire and forget - clean up worktrees in the background
                     WorktreeCleanupService.RemoveWorktreesInBackground(selectedPlan.FolderPath);
                 }).ShortcutKey("m");
+                rightSide |= hasSelection ? completePlanBtn.Outline() : completePlanBtn.Primary();
+            }
+
+            if (hasSelection)
+            {
+                var count = selectedRecTitles.Value.Count;
+                rightSide |= new Button($"Implement Recommendations ({count})")
+                    .Icon(Icons.Play).Primary()
+                    .OnClick(() =>
+                    {
+                        var titles = selectedRecTitles.Value.ToList();
+                        var selected = pendingRecs.Where(r => titles.Contains(r.Title)).ToList();
+                        if (selected.Count == 0) return;
+
+                        // Single job for the whole batch, never one StartJob call per recommendation.
+                        var changeRequest = BuildRecommendationChangeRequest(selected);
+                        planService.AcceptRecommendationsAndRetry(selectedPlan.FolderName, titles);
+                        jobService.StartJob(new RetryPlanArgs(selectedPlan.FolderPath, changeRequest));
+                        client.Toast($"Started RetryPlan for {selected.Count} recommendation(s)", "Implementing Recommendations");
+
+                        selectedRecTitles.Set(new HashSet<string>());
+                        refreshPlans();
+                        revalidate();
+                    });
             }
 
             if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
@@ -488,6 +525,8 @@ public class ContentView(
         QueryResult<string[]> assigneesQuery,
         IState<string?> assigneesError,
         IState<HashSet<string>> syncingWorktrees,
+        IState<HashSet<string>> selectedRecTitles,
+        List<RecommendationYaml> pendingRecs,
         IClientProvider client,
         Action<string> copyToClipboard,
         ILogger<ContentView> logger,
@@ -586,46 +625,13 @@ public class ContentView(
                 content |= actionsBar;
             }
 
-            var pendingRecs = planData.Recommendations.Where(r => r.State == RecommendationStatus.Pending).ToList();
             var recommendationsLayout = Layout.Vertical().Padding(2);
             if (pendingRecs.Count == 0)
                 recommendationsLayout |= Text.Muted("No recommendations.");
             else
                 foreach (var rec in pendingRecs)
                 {
-                    var titleRow = Layout.Horizontal().Gap(2).AlignContent(Align.Left)
-                                   | Text.Block(rec.Title).Bold();
-
-                    if (rec.Impact is { } impact)
-                        titleRow |= new Badge($"Impact: {impact}").Variant(impact switch
-                        {
-                            "High" => BadgeVariant.Success,
-                            "Medium" => BadgeVariant.Warning,
-                            _ => BadgeVariant.Outline
-                        });
-
-                    var card = Layout.Vertical().Gap(1)
-                               | titleRow
-                               | new Markdown(MarkdownHelper.PrepareForDisplay(rec.Description, config)).DangerouslyAllowLocalFiles().Article();
-
-                    var recTitle = rec.Title;
-                    var buttonRow = Layout.Horizontal().Gap(1).Wrap()
-                                    | new Button("Accept").Icon(Icons.Check).Primary().OnClick(() =>
-                                    {
-                                        planService.AcceptRecommendationAndRetry(selectedPlan.FolderName, recTitle);
-                                        jobService.StartJob(new RetryPlanArgs(selectedPlan.FolderPath, rec.Description));
-                                        refreshPlans();
-                                        planContentQuery.Mutator.Revalidate();
-                                    })
-                                    | new Button("Decline").Icon(Icons.X).Outline().OnClick(() =>
-                                    {
-                                        planService.UpdateRecommendationState(selectedPlan.FolderName, recTitle, RecommendationStatus.Declined);
-                                        refreshPlans();
-                                        planContentQuery.Mutator.Revalidate();
-                                    });
-
-                    recommendationsLayout |= card;
-                    recommendationsLayout |= buttonRow;
+                    recommendationsLayout |= new RecommendationRowView(rec, selectedRecTitles, config);
                     recommendationsLayout |= new Separator();
                 }
 
@@ -715,6 +721,21 @@ public class ContentView(
                     .Padding(8, 2, 0, 4)
                     .Width(Size.Full().Max(Size.Units(200))) | inner);
         }
+    }
+
+    private static string BuildRecommendationChangeRequest(List<RecommendationYaml> recs)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Implement the following {recs.Count} recommendation(s) from the review:");
+        sb.AppendLine();
+        for (var i = 0; i < recs.Count; i++)
+        {
+            sb.AppendLine($"## {i + 1}. {recs[i].Title}");
+            sb.AppendLine();
+            sb.AppendLine(recs[i].Description);
+            sb.AppendLine();
+        }
+        return sb.ToString().TrimEnd();
     }
 
     internal static bool ValidateArtifactPath(string filePath, string planFolderPath)

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -292,6 +292,29 @@ public class ContentView(
                                .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
                                .Muted("plans", word: true);
 
+            if (hasSelection)
+            {
+                var count = selectedRecTitles.Value.Count;
+                rightSide |= new Button("Implement Recommendations")
+                    .Icon(Icons.Rocket).Badge(count.ToString()).Primary()
+                    .OnClick(() =>
+                    {
+                        var titles = selectedRecTitles.Value.ToList();
+                        var selected = pendingRecs.Where(r => titles.Contains(r.Title)).ToList();
+                        if (selected.Count == 0) return;
+
+                        // Single job for the whole batch, never one StartJob call per recommendation.
+                        var changeRequest = BuildRecommendationChangeRequest(selected);
+                        planService.AcceptRecommendationsAndRetry(selectedPlan.FolderName, titles);
+                        jobService.StartJob(new RetryPlanArgs(selectedPlan.FolderPath, changeRequest));
+                        client.Toast($"Started RetryPlan for {selected.Count} recommendation(s)", "Implementing Recommendations");
+
+                        selectedRecTitles.Set(new HashSet<string>());
+                        refreshPlans();
+                        revalidate();
+                    });
+            }
+
             if (selectedPlan.Commits.Count > 0)
             {
                 var repoPaths = selectedPlan.GetEffectiveRepoPaths(config);
@@ -356,29 +379,6 @@ public class ContentView(
                     WorktreeCleanupService.RemoveWorktreesInBackground(selectedPlan.FolderPath);
                 }).ShortcutKey("m");
                 rightSide |= hasSelection ? completePlanBtn.Outline() : completePlanBtn.Primary();
-            }
-
-            if (hasSelection)
-            {
-                var count = selectedRecTitles.Value.Count;
-                rightSide |= new Button($"Implement Recommendations ({count})")
-                    .Icon(Icons.Play).Primary()
-                    .OnClick(() =>
-                    {
-                        var titles = selectedRecTitles.Value.ToList();
-                        var selected = pendingRecs.Where(r => titles.Contains(r.Title)).ToList();
-                        if (selected.Count == 0) return;
-
-                        // Single job for the whole batch, never one StartJob call per recommendation.
-                        var changeRequest = BuildRecommendationChangeRequest(selected);
-                        planService.AcceptRecommendationsAndRetry(selectedPlan.FolderName, titles);
-                        jobService.StartJob(new RetryPlanArgs(selectedPlan.FolderPath, changeRequest));
-                        client.Toast($"Started RetryPlan for {selected.Count} recommendation(s)", "Implementing Recommendations");
-
-                        selectedRecTitles.Set(new HashSet<string>());
-                        refreshPlans();
-                        revalidate();
-                    });
             }
 
             if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
@@ -629,10 +629,11 @@ public class ContentView(
             if (pendingRecs.Count == 0)
                 recommendationsLayout |= Text.Muted("No recommendations.");
             else
-                foreach (var rec in pendingRecs)
+                for (var i = 0; i < pendingRecs.Count; i++)
                 {
-                    recommendationsLayout |= new RecommendationRowView(rec, selectedRecTitles, config);
-                    recommendationsLayout |= new Separator();
+                    recommendationsLayout |= new RecommendationRowView(pendingRecs[i], selectedRecTitles, config);
+                    if (i < pendingRecs.Count - 1)
+                        recommendationsLayout |= new Separator();
                 }
 
             var changesTabView = new ChangesTabView(planData.AllChanges, planContentQuery.Loading, planContentQuery.Error, selectedPlan.Project);

--- a/src/Ivy.Tendril/Apps/Review/RecommendationRowView.cs
+++ b/src/Ivy.Tendril/Apps/Review/RecommendationRowView.cs
@@ -28,20 +28,21 @@ public class RecommendationRowView(
             selectedTitles.Set(set);
         }, isChecked);
 
-        var titleRow = Layout.Horizontal().Gap(2).AlignContent(Align.Left)
+        var titleRow = Layout.Horizontal().Gap(2).AlignContent(Align.TopLeft)
                        | isChecked.ToBoolInput()
                        | Text.Block(rec.Title).Bold();
 
+        var content = Layout.Vertical().Gap(1) | titleRow;
+
         if (rec.Impact is { } impact)
-            titleRow |= new Badge($"Impact: {impact}").Variant(impact switch
+            content |= new Badge($"Impact: {impact}").Variant(impact switch
             {
                 "High" => BadgeVariant.Success,
                 "Medium" => BadgeVariant.Warning,
                 _ => BadgeVariant.Outline
             });
 
-        return Layout.Vertical().Gap(1)
-               | titleRow
+        return content
                | new Markdown(MarkdownHelper.PrepareForDisplay(rec.Description, config))
                    .DangerouslyAllowLocalFiles().Article();
     }

--- a/src/Ivy.Tendril/Apps/Review/RecommendationRowView.cs
+++ b/src/Ivy.Tendril/Apps/Review/RecommendationRowView.cs
@@ -1,0 +1,48 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Apps.Review;
+
+/// <summary>
+///     A single recommendation row: a checkbox bound to the shared selection set, plus title,
+///     optional impact badge, and description. Kept as its own view so each row owns its checkbox
+///     state (no hooks in a loop) — mirrors the VerificationRowView pattern.
+/// </summary>
+public class RecommendationRowView(
+    RecommendationYaml rec,
+    IState<HashSet<string>> selectedTitles,
+    IConfigService config) : ViewBase
+{
+    public override object Build()
+    {
+        var isChecked = UseState(() => selectedTitles.Value.Contains(rec.Title));
+        var previous = UseState(isChecked.Value);
+
+        UseEffect(() =>
+        {
+            if (isChecked.Value == previous.Value) return;
+            previous.Set(isChecked.Value);
+            var set = new HashSet<string>(selectedTitles.Value);
+            if (isChecked.Value) set.Add(rec.Title); else set.Remove(rec.Title);
+            selectedTitles.Set(set);
+        }, isChecked);
+
+        var titleRow = Layout.Horizontal().Gap(2).AlignContent(Align.Left)
+                       | isChecked.ToBoolInput()
+                       | Text.Block(rec.Title).Bold();
+
+        if (rec.Impact is { } impact)
+            titleRow |= new Badge($"Impact: {impact}").Variant(impact switch
+            {
+                "High" => BadgeVariant.Success,
+                "Medium" => BadgeVariant.Warning,
+                _ => BadgeVariant.Outline
+            });
+
+        return Layout.Vertical().Gap(1)
+               | titleRow
+               | new Markdown(MarkdownHelper.PrepareForDisplay(rec.Description, config))
+                   .DangerouslyAllowLocalFiles().Article();
+    }
+}

--- a/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
@@ -38,6 +38,7 @@ public interface IPlanReaderService
 
     List<RecommendationYaml> GetRecommendationsForPlan(string folderName);
     void AcceptRecommendationAndRetry(string folderName, string recommendationTitle);
+    void AcceptRecommendationsAndRetry(string folderName, IReadOnlyCollection<string> titles);
 
     void SyncPlanArtifacts(string planFolder);
     PlanFile? GetPlanByFolderFromDisk(string folderPath) => GetPlanByFolder(folderPath);

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -763,6 +763,66 @@ public class PlanReaderService(
         }, Path.Combine(PlansDirectory, folderName));
     }
 
+    public void AcceptRecommendationsAndRetry(string folderName, IReadOnlyCollection<string> titles)
+    {
+        var planId = ExtractPlanId(folderName);
+
+        // Track state transition in telemetry.
+        if (planId.HasValue)
+        {
+            var currentPlan = GetPlanByFolder(Path.Combine(PlansDirectory, folderName));
+            var oldState = currentPlan?.Status.ToString() ?? "Unknown";
+            telemetryService?.TrackPlanStateTransition(oldState, PlanStatus.Executing.ToString());
+        }
+
+        // Update database atomically for all mutations.
+        if (planId.HasValue && _database != null)
+        {
+            _database.UpdatePlanState(planId.Value, PlanStatus.Executing);
+            foreach (var title in titles)
+                _database.UpdateRecommendationState(planId.Value, title, RecommendationStatus.Accepted, null);
+        }
+
+        _planCountsCache.Invalidate();
+        _recommendationsCache.Invalidate();
+        CountsInvalidated?.Invoke();
+        planWatcherService?.NotifyChanged(folderName);
+
+        // Single background write that performs all mutations atomically on disk.
+        WriteFileInBackground(() =>
+        {
+            var planYamlPath = Path.Combine(PlansDirectory, folderName, "plan.yaml");
+            if (!File.Exists(planYamlPath)) return;
+
+            var yaml = FileHelper.ReadAllText(planYamlPath);
+            var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
+
+            // Reset verifications
+            foreach (var v in planYaml.Verifications)
+            {
+                if (v.Status != VerificationStatus.Skipped)
+                    v.Status = VerificationStatus.Pending;
+            }
+
+            // Transition state
+            planYaml.State = PlanStatus.Executing.ToString();
+            planYaml.Updated = DateTime.UtcNow;
+
+            // Accept recommendations
+            foreach (var title in titles)
+            {
+                var rec = planYaml.Recommendations?.FirstOrDefault(r => r.Title == title);
+                if (rec != null)
+                {
+                    rec.State = RecommendationStatus.Accepted;
+                    rec.DeclineReason = null;
+                }
+            }
+
+            FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
+        }, Path.Combine(PlansDirectory, folderName));
+    }
+
     public void SyncPlanArtifacts(string planFolder)
     {
         var syncer = new PlanArtifactSyncer(config, logger, planWatcherService);


### PR DESCRIPTION
Fixes #1127

# Summary

## Changes

In the Review app's Recommendations tab, each recommendation row now shows a checkbox instead of
Accept/Decline buttons. Selecting one or more recommendations reveals a primary "Implement
Recommendations (x)" button in the header (next to Create PR/Update PR/Complete Plan, which switch to
outline styling while a selection is active); clicking it accepts all selected recommendations and
fires exactly one `RetryPlan` job whose change request folds every selected recommendation together.

## API Changes

- New `IPlanReaderService.AcceptRecommendationsAndRetry(string folderName, IReadOnlyCollection<string> titles)` — batched variant of the existing `AcceptRecommendationAndRetry(string, string)`, which is unchanged and still used by the standalone Recommendations app and REST/CLI/MCP single-accept surfaces.
- New public view `Ivy.Tendril.Apps.Review.RecommendationRowView` (checkbox + title + optional impact badge + description for a single recommendation row).

## Files Modified

- `src/Ivy.Tendril/Apps/Review/RecommendationRowView.cs` (new) — per-row checkbox component.
- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — selection state, header Implement button + outline CTA logic, content tab now renders `RecommendationRowView` instead of Accept/Decline.
- `src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs` / `PlanReaderService.cs` — new batched accept-and-retry method.
- `src/Ivy.Tendril.Test/JobService*Tests.cs` (4 files) — no-op stubs for the new interface method.
- `src/Ivy.Tendril.Test/RecommendationServiceTests.cs` — 2 new tests covering the batched method.

## Manual Testing

1. Run the Tendril app and open the Review app with a completed plan that has 2+ pending recommendations.
2. On the Recommendations tab, confirm each row shows a checkbox (no Accept/Decline buttons) and check 2 of them.
3. Confirm a primary "Implement Recommendations (2)" button appears in the header, and the existing Create PR/Update PR/Complete Plan button switches from primary to outline styling.
4. Click "Implement Recommendations (2)" — confirm a toast appears, the plan transitions to Executing, and exactly one job starts in the Jobs app (not two).
5. Switch to a different plan and back — confirm the selection was cleared (no stale checkboxes/button).

## Fix: Review feedback on header/row layout and button styling

Addressed reviewer feedback (screenshot annotations) on the batch-select UI: the Implement
Recommendations button now sits to the left of the Create PR/Complete Plan button, the row
checkbox is top-aligned with the title instead of vertically centered, the Impact badge moved to
its own line above the description instead of sharing the title row, the separator after the last
recommendation row was removed, the selection count now uses `Button.Badge()` instead of being
embedded in the button label, and the button icon changed from `Icons.Play` to `Icons.Rocket` to
match the Execute button elsewhere in the app.

### Files Modified

- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — reordered the header buttons, switched the
  Implement button to `.Badge()` + `Icons.Rocket`, and only render a `Separator` between
  recommendation rows (not after the last one).
- `src/Ivy.Tendril/Apps/Review/RecommendationRowView.cs` — top-align the checkbox/title row and
  move the Impact badge below the title row instead of inline with it.

---

## Commits

- 770659e1 Add batch-select and implement for Review recommendations
- d38a564f Add tests for AcceptRecommendationsAndRetry
- 5c56fdc3 Address review feedback on batch-select recommendations UI (plan 00050)

---
Created using [Ivy Tendril](https://ivy.app).
