### PR TITLE
[00030] Auto Reload Config on External File Changes

### DIFF
--- a/src/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
+++ b/src/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
@@ -342,6 +342,10 @@ public class BackgroundServiceActivatorTests : IAsyncLifetime
         {
             return content;
         }
+
+        public void Dispose()
+        {
+        }
     }
 
     private class MockStartable : IStartable

--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1675,4 +1675,114 @@ editor:
         var result = ConfigService.IsCommandAvailable("definitely-not-a-real-command-xyz-999");
         Assert.False(result);
     }
+
+    [Fact]
+    public async Task ConfigService_ReloadsSettings_WhenFileChangedExternally()
+    {
+        var yaml = @"
+verifications:
+  - name: Build
+    prompt: Original prompt
+";
+        var tempDir = CreateTempConfigFile(yaml);
+
+        try
+        {
+            PathHelper.DefaultTendrilHomeOverride = tempDir;
+            using var service = new ConfigService();
+            Assert.Equal("Original prompt", service.Settings.Verifications.Single().Prompt);
+
+            // Simulate an external process (e.g. `tendril verification set`) overwriting config.yaml.
+            File.WriteAllText(Path.Combine(tempDir, "config.yaml"), @"
+verifications:
+  - name: Build
+    prompt: Updated prompt
+");
+
+            var reloaded = await WaitForConditionAsync(
+                () => service.Settings.Verifications.Single().Prompt == "Updated prompt");
+
+            Assert.True(reloaded, "ConfigService did not pick up the external config.yaml change within the timeout.");
+        }
+        finally
+        {
+            PathHelper.DefaultTendrilHomeOverride = null;
+        }
+    }
+
+    [Fact]
+    public async Task ConfigService_DoesNotDoubleReload_OnInternalSave()
+    {
+        var yaml = @"
+jobTimeout: 30
+";
+        var tempDir = CreateTempConfigFile(yaml);
+
+        try
+        {
+            PathHelper.DefaultTendrilHomeOverride = tempDir;
+            using var service = new ConfigService();
+
+            var reloadCount = 0;
+            service.SettingsReloaded += (_, _) => Interlocked.Increment(ref reloadCount);
+
+            service.Settings.JobTimeout = 45;
+            service.SaveSettings();
+
+            // SaveSettings() reloads synchronously once. Give the watcher's debounce window a
+            // chance to fire so a double-reload (if the self-write suppression regressed) would show up.
+            await Task.Delay(600);
+
+            Assert.Equal(1, reloadCount);
+        }
+        finally
+        {
+            PathHelper.DefaultTendrilHomeOverride = null;
+        }
+    }
+
+    [Fact]
+    public async Task ConfigService_Dispose_StopsWatching()
+    {
+        var yaml = @"
+verifications:
+  - name: Build
+    prompt: Original prompt
+";
+        var tempDir = CreateTempConfigFile(yaml);
+
+        try
+        {
+            PathHelper.DefaultTendrilHomeOverride = tempDir;
+            var service = new ConfigService();
+            service.Dispose();
+
+            File.WriteAllText(Path.Combine(tempDir, "config.yaml"), @"
+verifications:
+  - name: Build
+    prompt: Updated prompt
+");
+
+            var reloaded = await WaitForConditionAsync(
+                () => service.Settings.Verifications.Single().Prompt == "Updated prompt",
+                timeout: TimeSpan.FromMilliseconds(800));
+
+            Assert.False(reloaded, "ConfigService kept watching config.yaml after Dispose().");
+        }
+        finally
+        {
+            PathHelper.DefaultTendrilHomeOverride = null;
+        }
+    }
+
+    private static async Task<bool> WaitForConditionAsync(Func<bool> condition, TimeSpan? timeout = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(3));
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(50);
+        }
+        return condition();
+    }
 }

--- a/src/Ivy.Tendril.Test/GitServiceTests.cs
+++ b/src/Ivy.Tendril.Test/GitServiceTests.cs
@@ -55,6 +55,7 @@ public class GitServiceTests
         public void CompleteOnboarding(string tendrilHome) { }
         public void OpenInEditor(string path) { }
         public string PolishMarkdown(string content) => content;
+        public void Dispose() { }
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
@@ -222,5 +222,6 @@ public class JobServiceConcurrencyTests
         public void CompleteOnboarding(string tendrilHome) { }
         public void OpenInEditor(string path) { }
         public string PolishMarkdown(string content) => content;
+        public void Dispose() { }
     }
 }

--- a/src/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs
+++ b/src/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs
@@ -101,4 +101,8 @@ public class StubConfigService : IConfigService
     {
         return content;
     }
+
+    public void Dispose()
+    {
+    }
 }

--- a/src/Ivy.Tendril.Test/TestPlanConfigService.cs
+++ b/src/Ivy.Tendril.Test/TestPlanConfigService.cs
@@ -53,4 +53,5 @@ internal class TestPlanConfigService : IConfigService
     public void CompleteOnboarding(string tendrilHome) { }
     public void OpenInEditor(string path) { }
     public string PolishMarkdown(string content) => content;
+    public void Dispose() { }
 }

--- a/src/Ivy.Tendril/Apps/Settings/LevelsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/LevelsSetupView.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
 
@@ -13,6 +14,13 @@ public class LevelsSetupView : ViewBase
         var (triggerView, showTrigger) = UseTrigger((IState<bool> isOpen, int? existingIndex) =>
             new EditLevelDialogContent(isOpen, existingIndex, config, client, refreshToken));
         var (alertView, showAlert) = UseAlert();
+
+        UseEffect(() =>
+        {
+            void OnSettingsReloaded(object? sender, EventArgs e) => refreshToken.Refresh();
+            config.SettingsReloaded += OnSettingsReloaded;
+            return Disposable.Create(() => config.SettingsReloaded -= OnSettingsReloaded);
+        });
 
         // Use levels in config.yaml order (not alphabetically sorted).
         var levels = config.Settings.Levels;

--- a/src/Ivy.Tendril/Apps/Settings/ProjectsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/ProjectsSetupView.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using Ivy.Tendril.Apps.Settings.Dialogs;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
@@ -13,6 +14,13 @@ public class ProjectsSetupView : ViewBase
         var refreshToken = UseRefreshToken();
         var editIndex = UseState<int?>(-1);
         var isAddOpen = UseState(false);
+
+        UseEffect(() =>
+        {
+            void OnSettingsReloaded(object? sender, EventArgs e) => refreshToken.Refresh();
+            config.SettingsReloaded += OnSettingsReloaded;
+            return Disposable.Create(() => config.SettingsReloaded -= OnSettingsReloaded);
+        });
 
         var projects = config.Settings.Projects;
         var allVerifications = config.Settings.Verifications.Select(v => v.Name).ToList();

--- a/src/Ivy.Tendril/Apps/Settings/PromptwaresSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/PromptwaresSetupView.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 
@@ -13,6 +14,13 @@ public class PromptwaresSetupView : ViewBase
         var (triggerView, showTrigger) = UseTrigger((IState<bool> isOpen, string? existingKey) =>
             new EditPromptwareDialogContent(isOpen, existingKey, config, client, refreshToken));
         var (alertView, showAlert) = UseAlert();
+
+        UseEffect(() =>
+        {
+            void OnSettingsReloaded(object? sender, EventArgs e) => refreshToken.Refresh();
+            config.SettingsReloaded += OnSettingsReloaded;
+            return Disposable.Create(() => config.SettingsReloaded -= OnSettingsReloaded);
+        });
 
         var promptwares = config.Settings.Promptwares;
 

--- a/src/Ivy.Tendril/Apps/Settings/RawConfigEditorView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/RawConfigEditorView.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
 
@@ -10,11 +11,30 @@ public class RawConfigEditorView : ViewBase
         var config = UseService<IConfigService>();
         var client = UseService<IClientProvider>();
 
-        var yamlText = UseState(LoadYaml(config));
+        // loadedYaml tracks the content last loaded from disk (mount, Save, Reload, or an
+        // external-reload pickup below), so hasChanges reflects edits the user made since then
+        // rather than a snapshot re-read from disk on every Build().
+        var loadedYaml = UseState(LoadYaml(config));
+        var yamlText = UseState(loadedYaml.Value);
         var errorMessage = UseState<string?>(null);
 
-        var originalYaml = LoadYaml(config);
-        var hasChanges = yamlText.Value != originalYaml;
+        var hasChanges = yamlText.Value != loadedYaml.Value;
+
+        // Only pull in an externally-reloaded config.yaml when the user has no unsaved edits —
+        // otherwise an external CLI write would silently clobber text they're mid-edit on.
+        UseEffect(() =>
+        {
+            void OnSettingsReloaded(object? sender, EventArgs e)
+            {
+                if (yamlText.Value != loadedYaml.Value) return;
+                var fresh = LoadYaml(config);
+                loadedYaml.Set(fresh);
+                yamlText.Set(fresh);
+                errorMessage.Set(null);
+            }
+            config.SettingsReloaded += OnSettingsReloaded;
+            return Disposable.Create(() => config.SettingsReloaded -= OnSettingsReloaded);
+        });
 
         // CodeInput fills height reliably in web layout; plain textarea ignores flex grow.
         // Button row: never use AlignContent(Align.Right) on Horizontal — that aligns on the
@@ -39,6 +59,7 @@ public class RawConfigEditorView : ViewBase
                           {
                               FileHelper.WriteAllText(config.ConfigPath, yamlText.Value ?? "");
                               config.ReloadSettings();
+                              loadedYaml.Set(yamlText.Value ?? "");
                               client.Toast("config.yaml saved and reloaded", "Saved");
                           }
                           catch (Exception ex)
@@ -49,7 +70,9 @@ public class RawConfigEditorView : ViewBase
                   | new Button("Reload from disk").Outline()
                       .OnClick(() =>
                       {
-                          yamlText.Set(LoadYaml(config));
+                          var fresh = LoadYaml(config);
+                          loadedYaml.Set(fresh);
+                          yamlText.Set(fresh);
                           errorMessage.Set(null);
                       }));
     }

--- a/src/Ivy.Tendril/Apps/Settings/VerificationsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/VerificationsSetupView.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Disposables;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
 
@@ -13,6 +14,13 @@ public class VerificationsSetupView : ViewBase
         var (triggerView, showTrigger) = UseTrigger((IState<bool> isOpen, int? existingIndex) =>
             new EditVerificationDialogContent(isOpen, existingIndex, config, client, refreshToken));
         var (alertView, showAlert) = UseAlert();
+
+        UseEffect(() =>
+        {
+            void OnSettingsReloaded(object? sender, EventArgs e) => refreshToken.Refresh();
+            config.SettingsReloaded += OnSettingsReloaded;
+            return Disposable.Create(() => config.SettingsReloaded -= OnSettingsReloaded);
+        });
 
         var verifications = config.Settings.Verifications;
         var projects = config.Settings.Projects;

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -192,7 +192,7 @@ public class TendrilSettings
 
 public record ConfigParseError(string Message, string FilePath, Exception? InnerException);
 
-public class ConfigService : IConfigService
+public class ConfigService : IConfigService, IDisposable
 {
     private readonly bool _explicitHome;
     private readonly ILogger<ConfigService> _logger;
@@ -201,6 +201,9 @@ public class ConfigService : IConfigService
     private ProjectConfig? _pendingProject;
     private string? _pendingTendrilHome;
     private List<VerificationConfig>? _pendingVerificationDefinitions;
+    private FileSystemWatcher? _configWatcher;
+    private System.Timers.Timer? _reloadDebounceTimer;
+    private volatile bool _suppressNextReload;
 
     internal ConfigService(TendrilSettings settings, string? tendrilHome = null, ILogger<ConfigService>? logger = null)
     {
@@ -233,6 +236,56 @@ public class ConfigService : IConfigService
 
         Settings = loadResult.Config;
         FinalizeConfiguration();
+        InitializeConfigWatcher();
+    }
+
+    /// <summary>
+    ///     Watches <see cref="ConfigPath"/> for external writes (e.g. CLI CRUD commands running as
+    ///     a separate process) and reloads settings so the running TUI reflects them without a
+    ///     restart. Follows the same debounced-FSW pattern as <see cref="Plans.PlanWatcherService"/>.
+    /// </summary>
+    private void InitializeConfigWatcher()
+    {
+        var directory = Path.GetDirectoryName(ConfigPath);
+        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+            return;
+
+        _reloadDebounceTimer = new System.Timers.Timer(300) { AutoReset = false };
+        _reloadDebounceTimer.Elapsed += (_, _) => OnReloadDebounceElapsed();
+
+        _configWatcher = new FileSystemWatcher(directory, Path.GetFileName(ConfigPath))
+        {
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime,
+            EnableRaisingEvents = true
+        };
+        _configWatcher.Changed += (_, _) => RestartDebounceTimer();
+        _configWatcher.Created += (_, _) => RestartDebounceTimer();
+    }
+
+    private void RestartDebounceTimer()
+    {
+        if (_reloadDebounceTimer == null) return;
+        _reloadDebounceTimer.Stop();
+        _reloadDebounceTimer.Start();
+    }
+
+    private void OnReloadDebounceElapsed()
+    {
+        // Internal SaveSettings() already reloaded synchronously; skip the redundant reload
+        // triggered by the watcher observing that same write.
+        if (_suppressNextReload)
+        {
+            _suppressNextReload = false;
+            return;
+        }
+
+        ReloadSettings();
+    }
+
+    public void Dispose()
+    {
+        _configWatcher?.Dispose();
+        _reloadDebounceTimer?.Dispose();
     }
 
     private (bool Success, TendrilSettings Config) TryLoadConfig()
@@ -479,6 +532,7 @@ public class ConfigService : IConfigService
                 $"Generated YAML failed validation and was not saved: {ex.Message}", ex);
         }
 
+        _suppressNextReload = true;
         FileHelper.WriteAllText(ConfigPath, yaml);
         CreateConfigBackup();
     }

--- a/src/Ivy.Tendril/Services/IConfigService.cs
+++ b/src/Ivy.Tendril/Services/IConfigService.cs
@@ -1,6 +1,6 @@
 namespace Ivy.Tendril.Services;
 
-public interface IConfigService
+public interface IConfigService : IDisposable
 {
     TendrilSettings Settings { get; }
     string TendrilHome { get; }


### PR DESCRIPTION
Fixes #447

# Summary

## Changes

Added a debounced `FileSystemWatcher` to `ConfigService` that detects external writes to
`config.yaml` (e.g. from `tendril verification set`, `tendril config set`, `tendril project add`) and
reloads settings automatically, so a running Tendril TUI reflects CLI-driven changes without needing a
restart. Settings views that display config data now refresh when a reload happens, and the raw
config editor only pulls in an external change when the user has no unsaved edits.

## API Changes

- `IConfigService` now extends `IDisposable`.
- `ConfigService` now implements `IDisposable` — `Dispose()` releases the new `FileSystemWatcher` and
  debounce `Timer`.
- No other public API changes.

## Files Modified

- **Core:** `src/Ivy.Tendril/Services/ConfigService.cs`, `src/Ivy.Tendril/Services/IConfigService.cs` —
  FileSystemWatcher + 300ms debounce timer, self-write suppression flag, `IDisposable`.
- **UI:** `src/Ivy.Tendril/Apps/Settings/VerificationsSetupView.cs`, `ProjectsSetupView.cs`,
  `PromptwaresSetupView.cs`, `LevelsSetupView.cs` — subscribe to `SettingsReloaded` and refresh.
  `RawConfigEditorView.cs` — auto-pulls external reloads only when there are no unsaved local edits.
- **Tests:** `src/Ivy.Tendril.Test/ConfigServiceTests.cs` — 3 new tests covering the reload, the
  self-write-suppression, and `Dispose()`. `StubConfigService.cs`, `TestPlanConfigService.cs`, and 3
  file-local test doubles updated with a no-op `Dispose()` to satisfy the interface change.

## Manual Testing

1. Run the Tendril TUI (`Run.ps1` or `dotnet run` from `src/Ivy.Tendril`).
2. Open **Settings → Verifications** (or Projects/Promptwares/Levels) and leave it open.
3. In a separate terminal, run a CLI command that edits `config.yaml`, e.g.
   `tendril verification set <name> prompt "New prompt text"` (or edit `config.yaml` directly with an
   external editor and save).
4. Within ~1 second, the open Settings view should update to show the new value with no manual
   refresh or app restart.
5. Also verify: open **Settings → Raw Config Editor**, start editing the YAML without saving, then
   make an external CLI change to `config.yaml`. The editor should NOT overwrite your in-progress
   edit; only the "Reload from disk" button should pull in the external change in that case.

---

## Commits

- 552962dd Auto-reload config.yaml on external file changes (Plan 00030)
- 875cd2dc Add ConfigService external-reload watcher tests (Plan 00030)

---
Created using [Ivy Tendril](https://ivy.app).
