### PR TITLE
[00062] Persist Required Toggle for Verifications in Edit Project Dialog

### DIFF
--- a/src/Ivy.Tendril.Test/EditProjectDialogTests.cs
+++ b/src/Ivy.Tendril.Test/EditProjectDialogTests.cs
@@ -122,4 +122,49 @@ public class EditProjectDialogTests
         var displayedOnReopen = EditProjectDialog.OrderForDisplay(afterReorder, all);
         Assert.Equal(new[] { "Lint", "Build", "Test" }, displayedOnReopen.Select(v => v.Name));
     }
+
+    [Fact]
+    public void ApplyVerificationChange_TogglingRequired_SetsRequiredFlag()
+    {
+        var current = new List<ProjectVerificationRef>
+        {
+            new() { Name = "DotnetTest", Required = false }
+        };
+
+        var result = EditProjectDialog.ApplyVerificationChange(
+            """{"name":"DotnetTest","enabled":true,"required":true}""", current);
+
+        Assert.True(result.Single(v => v.Name == "DotnetTest").Required);
+    }
+
+    [Fact]
+    public void ApplyVerificationChange_EnablingVerification_AddsToProject()
+    {
+        var result = EditProjectDialog.ApplyVerificationChange(
+            """{"name":"Build","enabled":true,"required":false}""", new List<ProjectVerificationRef>());
+
+        Assert.Contains(result, v => v.Name == "Build");
+    }
+
+    [Fact]
+    public void ApplyVerificationChange_DisablingVerification_RemovesFromProject()
+    {
+        var current = Project("Build");
+
+        var result = EditProjectDialog.ApplyVerificationChange(
+            """{"name":"Build","enabled":false,"required":false}""", current);
+
+        Assert.DoesNotContain(result, v => v.Name == "Build");
+    }
+
+    [Fact]
+    public void ApplyVerificationChange_CamelCaseJson_BindsRequiredTrue()
+    {
+        var current = Project("Build");
+
+        var result = EditProjectDialog.ApplyVerificationChange(
+            """{"name":"Build","enabled":true,"required":true}""", current);
+
+        Assert.True(result.Single(v => v.Name == "Build").Required);
+    }
 }

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs
@@ -23,6 +23,9 @@ public class EditProjectDialog(
     private readonly IClientProvider _client = client;
     private readonly RefreshToken _refreshToken = refreshToken;
 
+    private static readonly JsonSerializerOptions VerificationJsonOptions =
+        new() { PropertyNameCaseInsensitive = true };
+
     public override object? Build()
     {
         var editName = UseState("");
@@ -132,29 +135,7 @@ public class EditProjectDialog(
                 editVerifications.Set(
                     ReorderProjectVerifications(indices, displayedVerifications, editVerifications.Value));
             })
-            .WithOnChange(json =>
-            {
-                var item = JsonSerializer.Deserialize<VerificationItem>(json);
-                if (item == null) return;
-
-                var list = new List<ProjectVerificationRef>(editVerifications.Value);
-                var existing = list.FirstOrDefault(v => v.Name == item.Name);
-
-                if (item.Enabled && existing == null)
-                {
-                    list.Add(new ProjectVerificationRef { Name = item.Name, Required = item.Required });
-                }
-                else if (!item.Enabled && existing != null)
-                {
-                    list.Remove(existing);
-                }
-                else if (existing != null)
-                {
-                    existing.Required = item.Required;
-                }
-
-                editVerifications.Set(list);
-            });
+            .WithOnChange(json => editVerifications.Set(ApplyVerificationChange(json, editVerifications.Value)));
 
         var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
         var hasInvalidRepos = RepoPathValidator.HasInvalidLocalRepos(editRepos.Value, tendrilHome);
@@ -334,6 +315,29 @@ public class EditProjectDialog(
         }
 
         return reordered;
+    }
+
+    /// <summary>
+    /// Applies a single enable/disable/required change from the verification list widget's
+    /// <c>OnChange</c> event (a camelCase JSON payload, e.g. <c>{"name":"DotnetTest","enabled":true,"required":true}</c>)
+    /// to the project's verification list.
+    /// </summary>
+    internal static List<ProjectVerificationRef> ApplyVerificationChange(
+        string json, List<ProjectVerificationRef> current)
+    {
+        var list = new List<ProjectVerificationRef>(current);
+        var item = JsonSerializer.Deserialize<VerificationItem>(json, VerificationJsonOptions);
+        if (item == null || string.IsNullOrEmpty(item.Name)) return list;
+
+        var existing = list.FirstOrDefault(v => v.Name == item.Name);
+        if (item.Enabled && existing == null)
+            list.Add(new ProjectVerificationRef { Name = item.Name, Required = item.Required });
+        else if (!item.Enabled && existing != null)
+            list.Remove(existing);
+        else if (existing != null)
+            existing.Required = item.Required;
+
+        return list;
     }
 }
 


### PR DESCRIPTION
# Summary

## Changes

Fixed a bug in **Settings → Edit Project → Verifications** where toggling a verification's Required checkbox (and enabling/disabling a verification) appeared to work but reverted after Save. The `OnChange` handler deserialized the widget's camelCase JSON payload with a case-sensitive `JsonSerializer.Deserialize` call, so every field silently bound to its default and the update logic never fired. Fixed by deserializing with `PropertyNameCaseInsensitive = true` and extracting the logic into a testable helper.

## API Changes

Added `internal static List<ProjectVerificationRef> ApplyVerificationChange(string json, List<ProjectVerificationRef> current)` to `EditProjectDialog` (internal helper, reachable by tests via `InternalsVisibleTo`). No public API changes.

## Files Modified

- `src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs` — cached `JsonSerializerOptions`, extracted `ApplyVerificationChange` helper, fixed the `OnChange` deserialize call
- `src/Ivy.Tendril.Test/EditProjectDialogTests.cs` — 4 new regression tests covering required-toggle, enable, disable, and camelCase binding

## Manual Testing

1. Run Tendril and open **Settings → Edit Project** for any project.
2. Go to the **Verifications** tab, toggle a verification's **Required** checkbox (or enable/disable a verification).
3. Click **Save**, then reopen **Edit Project** for the same project.
4. The Required/enabled state should reflect the change made in step 2 (previously it reverted to the prior state).

---
## Commits

- cf32488de58726ea97731e5a74eb54f2cfeaa975 Fix required-toggle persistence in Edit Project verifications list

---
Created using [Ivy Tendril](https://ivy.app).
