### PR TITLE
[00055] Parse Claude Code Result Errors Into Clean Job Failure Messages

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudeFailureAnalyzerTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudeFailureAnalyzerTests.cs
@@ -239,6 +239,29 @@ public class ClaudeFailureAnalyzerTests
     }
 
     [Fact]
+    public void Analyze_SessionLimitInLastResultResponse_ReturnsRateLimit()
+    {
+        var resultEvent = new ResultEvent
+        {
+            Kind = AgentEventKind.Result,
+            Response = "You have hit your session limit, resets 4pm (Europe/Stockholm)",
+            IsSuccess = false,
+        };
+
+        var ctx = new FailureContext
+        {
+            Events = [resultEvent],
+            AgentId = AgentId.Claude,
+            ExitCode = 1,
+        };
+
+        var result = _analyzer.Analyze(ctx);
+
+        Assert.Equal(FailureKind.RateLimit, result.Kind);
+        Assert.True(result.IsRetryable);
+    }
+
+    [Fact]
     public void Analyze_MultiplePermissionDenials_CountsCorrectly()
     {
         var denials = new List<PermissionDenialEvent>

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeFailureAnalyzer.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeFailureAnalyzer.cs
@@ -20,8 +20,10 @@ public sealed class ClaudeFailureAnalyzer : IFailureAnalyzer
         }
 
         var stderr = string.Join("\n", context.StderrLines);
+        var lastResultResponse = context.Events.OfType<ResultEvent>().LastOrDefault()?.Response ?? "";
 
-        if (ContainsAny(stderr, "rate limit", "429", "too many requests"))
+        if (ContainsAny(stderr, "rate limit", "429", "too many requests", "session limit", "usage limit")
+            || ContainsAny(lastResultResponse, "rate limit", "session limit", "usage limit"))
         {
             return new FailureAnalysis
             {

--- a/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
@@ -278,6 +278,7 @@ public class JobServiceFailureReasonTests : IDisposable
 
         var result = JobService.ExtractFailureReason(lines, "test");
 
+        Assert.StartsWith("Claude usage limit reached:", result);
         Assert.Contains("session limit", result);
         Assert.Contains("resets 4pm", result);
         Assert.DoesNotContain("\"kind\"", result);

--- a/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
@@ -267,4 +267,85 @@ public class JobServiceFailureReasonTests : IDisposable
         Assert.Equal(JobStatus.Completed, job.Status);
         Assert.Null(job.StatusMessage);
     }
+
+    [Fact]
+    public void ExtractFailureReason_FailedResultEvent_SessionLimit_ReturnsCleanMessage()
+    {
+        var lines = new List<string>
+        {
+            """{"kind":"result","response":"You have hit your session limit, resets 4pm (Europe/Stockholm)","is_success":false,"duration_ms":557}"""
+        };
+
+        var result = JobService.ExtractFailureReason(lines, "test");
+
+        Assert.Contains("session limit", result);
+        Assert.Contains("resets 4pm", result);
+        Assert.DoesNotContain("\"kind\"", result);
+        Assert.DoesNotContain("is_success", result);
+    }
+
+    [Fact]
+    public void ExtractFailureReason_FailedResultEvent_Generic_ReturnsSanitizedFirstLine()
+    {
+        var lines = new List<string>
+        {
+            """{"kind":"result","response":"Something went wrong during the run.\nMore details here.","is_success":false}"""
+        };
+
+        var result = JobService.ExtractFailureReason(lines, "test");
+
+        Assert.Equal("Something went wrong during the run.", result);
+    }
+
+    [Fact]
+    public void CompleteJob_NonZeroExit_SessionLimitResult_MarksFailedWithCleanMessage()
+    {
+        // Regression for CreatePlan job 00292, which failed with the raw serialized
+        // ResultEvent JSON blob shown as the job's failure reason instead of Claude's message.
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var id = service.CreateTestJob(new ExecutePlanArgs(Path.GetTempPath()));
+        var job = service.GetJob(id)!;
+        job.OutputLines.Enqueue(
+            """{"kind":"result","response":"You have hit your session limit, resets 4pm (Europe/Stockholm)","is_success":false,"duration_ms":557}""");
+
+        service.CompleteJob(id, 1);
+
+        job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.Contains("session limit", job.StatusMessage);
+        Assert.Contains("resets 4pm", job.StatusMessage);
+    }
+
+    [Fact]
+    public void CompleteJob_ZeroExitCode_FailedSessionLimitResult_MarksFailedWithCleanMessage()
+    {
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var id = service.CreateTestJob(new ExecutePlanArgs(Path.GetTempPath()));
+        var job = service.GetJob(id)!;
+        job.OutputLines.Enqueue(
+            """{"kind":"result","response":"You have hit your session limit, resets 4pm (Europe/Stockholm)","is_success":false,"duration_ms":557}""");
+
+        service.CompleteJob(id, 0);
+
+        job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.Contains("session limit", job.StatusMessage);
+    }
+
+    [Fact]
+    public void CompleteJob_ZeroExitCode_SuccessfulResultEvent_RemainsCompleted()
+    {
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var planFolder = CreateValidPlanFolder();
+        var id = service.StartJob(new ExecutePlanArgs(planFolder));
+        var job = service.GetJob(id)!;
+        job.OutputLines.Enqueue(
+            """{"kind":"result","response":"All done","is_success":true,"duration_ms":557}""");
+
+        service.CompleteJob(id, 0);
+
+        job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Completed, job.Status);
+        Assert.Null(job.StatusMessage);
+    }
 }

--- a/src/Ivy.Tendril/Services/Jobs/JobFailureAnalyzer.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobFailureAnalyzer.cs
@@ -191,7 +191,7 @@ internal static class JobFailureAnalyzer
     }
 
     private static readonly Regex UsageLimitPattern = new(
-        @"hit your (?:session|usage) limit|usage limit reached|limit reached|\bresets\b",
+        @"hit your (?:session|usage) limit|usage limit reached|limit reached",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     private static string FormatFailedResultMessage(string response)
@@ -199,7 +199,7 @@ internal static class JobFailureAnalyzer
         var firstLine = response
             .Split('\n')
             .Select(l => l.Trim())
-            .FirstOrDefault(l => l.Length > 0) ?? response.Trim();
+            .First(l => l.Length > 0);
 
         var sanitized = SanitizeForDisplay(firstLine);
         if (sanitized.Length > 300)

--- a/src/Ivy.Tendril/Services/Jobs/JobFailureAnalyzer.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobFailureAnalyzer.cs
@@ -12,6 +12,12 @@ internal static class JobFailureAnalyzer
         if (outputLines.Count == 0)
             return "Unknown error (exit code non-zero)";
 
+        // 0. Check for a terminal event in the agent's JSON stream (ErrorEvent, or a
+        //    ResultEvent with IsSuccess:false). This is a structured, authoritative signal
+        //    straight from the agent, so it wins over the text-scraping heuristics below.
+        var terminalEventMessage = TryExtractErrorEvent(outputLines);
+        if (terminalEventMessage != null) return terminalEventMessage;
+
         // 1. Check for PowerShell terminating errors
         var psError = FindPattern(outputLines, [
             @"At line:\d+",
@@ -175,10 +181,33 @@ internal static class JobFailureAnalyzer
         var serializer = new JsonEventSerializer();
         foreach (var line in outputLines.Reverse())
         {
-            if (serializer.Deserialize(line) is ErrorEvent { Message.Length: > 0 } e)
+            var evt = serializer.Deserialize(line);
+            if (evt is ErrorEvent { Message.Length: > 0 } e)
                 return SanitizeForDisplay(e.Message);
+            if (evt is ResultEvent { IsSuccess: false } r && !string.IsNullOrWhiteSpace(r.Response))
+                return FormatFailedResultMessage(r.Response);
         }
         return null;
+    }
+
+    private static readonly Regex UsageLimitPattern = new(
+        @"hit your (?:session|usage) limit|usage limit reached|limit reached|\bresets\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static string FormatFailedResultMessage(string response)
+    {
+        var firstLine = response
+            .Split('\n')
+            .Select(l => l.Trim())
+            .FirstOrDefault(l => l.Length > 0) ?? response.Trim();
+
+        var sanitized = SanitizeForDisplay(firstLine);
+        if (sanitized.Length > 300)
+            sanitized = sanitized[..300];
+
+        return UsageLimitPattern.IsMatch(sanitized)
+            ? $"Claude usage limit reached: {sanitized}"
+            : sanitized;
     }
 
     internal static string? TryReadFailureArtifact(List<string> outputLines)


### PR DESCRIPTION
# Summary

## Changes

When Claude Code emits a terminal `result` event with `is_success:false` (e.g. a session/usage-limit
message), the job's failure status now shows the sanitized `Response` text instead of the raw
serialized JSON blob — including a normalized, stable `"Claude usage limit reached: ..."` prefix when
the text matches session/usage-limit phrasing. `ClaudeFailureAnalyzer` (currently not on the live
completion path) now also classifies session/usage-limit text as `RateLimit`/retryable.

## API Changes

None public. Internal changes:
- `Ivy.Tendril.Services.Jobs.JobFailureAnalyzer.TryExtractErrorEvent(IEnumerable<string>)` now also
  matches a failed `ResultEvent` (previously only `ErrorEvent`).
- New private `JobFailureAnalyzer.FormatFailedResultMessage(string)` helper.
- `JobFailureAnalyzer.ExtractFailureReason` now checks the JSON terminal-event signal first (step 0),
  before its existing text-pattern heuristics.
- `Ivy.Tendril.Agents.Providers.Claude.ClaudeFailureAnalyzer.Analyze` now also matches
  session/usage-limit phrasing (in stderr and in the last `ResultEvent.Response`) for its
  `FailureKind.RateLimit` classification.

## Files Modified

- `src/Ivy.Tendril/Services/Jobs/JobFailureAnalyzer.cs` — generalized terminal-event extraction,
  added usage-limit normalization
- `src/Ivy.Tendril.Agents/Providers/Claude/ClaudeFailureAnalyzer.cs` — extended rate-limit detection
- `src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs` — 5 new tests, incl. a regression test for
  CreatePlan job 00292
- `src/Ivy.Tendril.Agents.Test/Claude/ClaudeFailureAnalyzerTests.cs` — 1 new test

## Manual Testing

1. Run a job whose agent output includes a line like
   `{"kind":"result","response":"You have hit your session limit, resets 4pm (Europe/Stockholm)","is_success":false,"duration_ms":557}`
   with a non-zero (or zero) process exit code.
2. Observe the job's failure status in the Jobs UI.
3. Expected: the status message reads
   `Claude usage limit reached: You have hit your session limit, resets 4pm (Europe/Stockholm)`
   instead of the raw JSON blob.

---
- fe1925f5 code-review: fix overly-broad usage-limit regex
- 42c7734d Add tests for failed ResultEvent job failure parsing
- f6adef3d Parse failed ResultEvent into clean job failure messages

---
Created using [Ivy Tendril](https://ivy.app).
