### PR TITLE
[00035] Harmonize Long-Form Text Input Across CLI Write Commands

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
@@ -96,10 +96,10 @@ Updates a single field and bumps the `updated` timestamp automatically.
 #### plan update
 
 ```terminal
->cat revised.yaml | tendril plan update <plan-id>
+>cat revised.yaml | tendril plan update <plan-id> --stdin
 ```
 
-Replaces the entire `plan.yaml` content from stdin.
+Replaces the entire `plan.yaml` content from `--file` or `--stdin` (required — `--stdin` is not implicit).
 
 #### plan validate
 
@@ -170,7 +170,7 @@ Removes a single worktree from `Worktrees/<repo-name>`. Attempts `git worktree r
 Appends a numbered log entry to `Logs/` (e.g. `003-ExecutePlan.md`) and prints the path to stdout.
 
 ```terminal
->cat revision.md | tendril plan write-revision <plan-id>
+>cat revision.md | tendril plan write-revision <plan-id> --stdin
 >tendril plan write-revision <plan-id> --file revision.md
 ```
 
@@ -196,7 +196,7 @@ Prints revision content to stdout — the latest revision by default, or a speci
 Manage recommendations stored in a plan's YAML.
 
 - **list** — filter by state: `Pending`, `Accepted`, `AcceptedWithNotes`, `Declined`
-- **add** — impact levels: `Small`, `Medium`, `High`; reads description from stdin if `-d` is omitted
+- **add** — impact levels: `Small`, `Medium`, `High`; provide `--description`, `--file`, or `--stdin`
 - **set** — supported fields: `title`, `description`, `state`, `impact`, `declineReason`
 - **accept** — sets state to `Accepted`, or `AcceptedWithNotes` if `--notes` is provided
 - **decline** — sets state to `Declined` with an optional reason

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/03_Verification.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/03_Verification.md
@@ -25,7 +25,7 @@ Manage global verification definitions stored in `config.yaml`. These can be ref
 
 - **list** — shows all definitions with a preview of the prompt
 - **get** — prints the full prompt to stdout
-- **add** — reads prompt from stdin if `--prompt` is omitted
+- **add** — provide `--prompt`, `--file`, or `--stdin`
 - **set** — supported fields: `name`, `prompt`
 
 ## Examples
@@ -35,7 +35,7 @@ Manage global verification definitions stored in `config.yaml`. These can be ref
 >tendril verification add BuildPasses --prompt "Run dotnet build and confirm exit code 0"
 
 ># Add from file
->cat prompt.md | tendril verification add BuildPasses
+>cat prompt.md | tendril verification add BuildPasses --stdin
 
 ># Update the prompt
 >tendril verification set BuildPasses prompt "Run dotnet build --no-restore and check for errors"

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/05_Other.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/05_Other.md
@@ -38,8 +38,8 @@ Runs a promptware by name.
 
 ```terminal
 >tendril promptware read-memory <name> <filename>
->cat content.md | tendril promptware write-memory <name> <filename>
->cat tool.md | tendril promptware write-tool <name> <filename>
+>cat content.md | tendril promptware write-memory <name> <filename> --stdin
+>cat tool.md | tendril promptware write-tool <name> <filename> --stdin
 ```
 
 Read and write files in a promptware's `Memory/` and `Tools/` directories. Used by agents to persist and reload learned patterns and custom tool definitions. Write commands print the file path to stdout.
@@ -47,7 +47,7 @@ Read and write files in a promptware's `Memory/` and `Tools/` directories. Used 
 ```terminal
 >tendril promptware read-memory ExecutePlan cli-quirks.md
 >echo "Always use --force when cleaning worktrees" | \
->  tendril promptware write-memory ExecutePlan cli-quirks.md
+>  tendril promptware write-memory ExecutePlan cli-quirks.md --stdin
 ```
 
 ## job
@@ -101,8 +101,8 @@ Reports a status update to the running Tendril server for a job in progress. Use
 #### trash write
 
 ```terminal
->cat content.md | tendril trash write <filename>
+>cat content.md | tendril trash write <filename> --stdin
 ```
 
-Writes a file to `$TENDRIL_HOME/Trash/` from stdin. Used by agents to soft-delete content (e.g. duplicate plan files) instead of permanently removing it. Prints the written file path to stdout.
+Writes a file to `$TENDRIL_HOME/Trash/` from `--file` or `--stdin`. Used by agents to soft-delete content (e.g. duplicate plan files) instead of permanently removing it. Prints the written file path to stdout.
 

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -1442,4 +1442,190 @@ public class PlanCliCommandTests : IDisposable
 
         return writer.ToString();
     }
+
+    // ==================== PlanWriteRevision (--file / --stdin) ====================
+
+    private static CommandApp BuildPlanWriteRevisionApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("plan", plan => plan.AddCommand<PlanWriteRevisionCommand>("write-revision"));
+        });
+        return app;
+    }
+
+    [Fact]
+    public void PlanWriteRevision_File_ReadsFromFile()
+    {
+        CreatePlanFolder("20300", "WriteRevFile");
+        var file = Path.Combine(_tempDir.Path, "revision-file.md");
+        File.WriteAllText(file, "Revision from file");
+
+        var app = BuildPlanWriteRevisionApp();
+        var exit = app.Run(["plan", "write-revision", "20300", "--file", file]);
+
+        Assert.Equal(0, exit);
+        var folder = PlanCommandHelpers.ResolvePlanFolder("20300");
+        var revisionPath = Directory.GetFiles(Path.Combine(folder, "Revisions")).Single();
+        Assert.Contains("Revision from file", File.ReadAllText(revisionPath));
+    }
+
+    [Fact]
+    public void PlanWriteRevision_Stdin_ReadsPipedInput()
+    {
+        CreatePlanFolder("20301", "WriteRevStdin");
+        var app = BuildPlanWriteRevisionApp();
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader("Revision from stdin"));
+        try
+        {
+            var exit = app.Run(["plan", "write-revision", "20301", "--stdin"]);
+            Assert.Equal(0, exit);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        var folder = PlanCommandHelpers.ResolvePlanFolder("20301");
+        var revisionPath = Directory.GetFiles(Path.Combine(folder, "Revisions")).Single();
+        Assert.Contains("Revision from stdin", File.ReadAllText(revisionPath));
+    }
+
+    [Fact]
+    public void PlanWriteRevision_MultipleSources_FailsValidation()
+    {
+        Assert.False(new PlanWriteRevisionSettings { PlanId = "1", FilePath = "f.md", Stdin = true }.Validate().Successful);
+
+        var app = BuildPlanWriteRevisionApp();
+        Assert.Throws<CommandRuntimeException>(() =>
+            app.Run(["plan", "write-revision", "1", "--file", "f.md", "--stdin"]));
+    }
+
+    [Fact]
+    public void PlanWriteRevision_NoSource_ThrowsAndNeverReadsStdin()
+    {
+        CreatePlanFolder("20302", "WriteRevNoSource");
+        var app = BuildPlanWriteRevisionApp();
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader("SENTINEL-SHOULD-NOT-BE-READ"));
+        try
+        {
+            var ex = Assert.Throws<ArgumentException>(() => app.Run(["plan", "write-revision", "20302"]));
+            Assert.Contains("--file or --stdin", ex.Message);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        var folder = PlanCommandHelpers.ResolvePlanFolder("20302");
+        var revisionsDir = Path.Combine(folder, "Revisions");
+        if (Directory.Exists(revisionsDir))
+            Assert.Empty(Directory.GetFiles(revisionsDir));
+    }
+
+    // ==================== PlanUpdate (--file / --stdin) ====================
+
+    private CommandApp BuildPlanUpdateApp()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IPlanWatcherService, NullPlanWatcherService>();
+
+        var app = new CommandApp(new TypeRegistrar(services));
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("plan", plan => plan.AddCommand<PlanUpdateCommand>("update"));
+        });
+        return app;
+    }
+
+    [Fact]
+    public void PlanUpdate_File_ReadsFromFile()
+    {
+        CreatePlanFolder("20310", "UpdateFileTest");
+        var yaml = YamlHelper.Serializer.Serialize(new PlanYaml
+        {
+            State = "Completed",
+            Project = "TestProject",
+            Title = "UpdateFileTest",
+            Repos = [_tempDir.Path],
+            Created = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+            Updated = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)
+        });
+        var file = Path.Combine(_tempDir.Path, "updated-plan.yaml");
+        File.WriteAllText(file, yaml);
+
+        var app = BuildPlanUpdateApp();
+        var exit = app.Run(["plan", "update", "20310", "--file", file]);
+
+        Assert.Equal(0, exit);
+        Assert.Equal("Completed", ReadPlan("20310").State);
+    }
+
+    [Fact]
+    public void PlanUpdate_Stdin_ReadsPipedInput()
+    {
+        CreatePlanFolder("20311", "UpdateStdinTest");
+        var yaml = YamlHelper.Serializer.Serialize(new PlanYaml
+        {
+            State = "Completed",
+            Project = "TestProject",
+            Title = "UpdateStdinTest",
+            Repos = [_tempDir.Path],
+            Created = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+            Updated = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)
+        });
+
+        var app = BuildPlanUpdateApp();
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader(yaml));
+        try
+        {
+            var exit = app.Run(["plan", "update", "20311", "--stdin"]);
+            Assert.Equal(0, exit);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        Assert.Equal("Completed", ReadPlan("20311").State);
+    }
+
+    [Fact]
+    public void PlanUpdate_MultipleSources_FailsValidation()
+    {
+        Assert.False(new PlanUpdateSettings { PlanId = "1", FilePath = "f.yaml", Stdin = true }.Validate().Successful);
+
+        var app = BuildPlanUpdateApp();
+        Assert.Throws<CommandRuntimeException>(() =>
+            app.Run(["plan", "update", "1", "--file", "f.yaml", "--stdin"]));
+    }
+
+    [Fact]
+    public void PlanUpdate_NoSource_ThrowsAndNeverReadsStdin()
+    {
+        CreatePlanFolder("20312", "UpdateNoSourceTest");
+        var app = BuildPlanUpdateApp();
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader("SENTINEL-SHOULD-NOT-BE-READ"));
+        try
+        {
+            var ex = Assert.Throws<ArgumentException>(() => app.Run(["plan", "update", "20312"]));
+            Assert.Contains("--file or --stdin", ex.Message);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        Assert.Equal("Draft", ReadPlan("20312").State);
+    }
 }

--- a/src/Ivy.Tendril.Test/PlanRecCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanRecCommandTests.cs
@@ -1,5 +1,9 @@
+using Ivy.Tendril.Commands;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Infrastructure;
 using Ivy.Tendril.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Test;
 
@@ -409,5 +413,109 @@ public class PlanRecCommandTests : IDisposable
         var result = ReadPlan("10080");
         Assert.Equal("Fix: \"quotes\" & <brackets>", result.Recommendations![0].Title);
         Assert.Contains("Line1", result.Recommendations[0].Description);
+    }
+
+    // ==================== PlanRecAdd CLI (-d / --file / --stdin) ====================
+
+    private CommandApp BuildPlanRecAddApp()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IPlanWatcherService, NullPlanWatcherService>();
+
+        var app = new CommandApp(new TypeRegistrar(services));
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("plan", plan => plan.AddBranch("rec", rec => rec.AddCommand<PlanRecAddCommand>("add")));
+        });
+        return app;
+    }
+
+    [Fact]
+    public void PlanRecAdd_InlineDescription_AddsRecommendation()
+    {
+        CreatePlan("10090", "InlineDescTest");
+        var app = BuildPlanRecAddApp();
+
+        var exit = app.Run(["plan", "rec", "add", "10090", "Inline Rec", "-d", "Inline description text"]);
+
+        Assert.Equal(0, exit);
+        var result = ReadPlan("10090");
+        Assert.Equal("Inline description text", result.Recommendations!.Single().Description);
+    }
+
+    [Fact]
+    public void PlanRecAdd_File_ReadsFromFile()
+    {
+        CreatePlan("10091", "FileDescTest");
+        var file = Path.Combine(_tempDir, "rec-description.md");
+        File.WriteAllText(file, "Description from file");
+        var app = BuildPlanRecAddApp();
+
+        var exit = app.Run(["plan", "rec", "add", "10091", "File Rec", "--file", file]);
+
+        Assert.Equal(0, exit);
+        var result = ReadPlan("10091");
+        Assert.Equal("Description from file", result.Recommendations!.Single().Description);
+    }
+
+    [Fact]
+    public void PlanRecAdd_Stdin_ReadsPipedInput()
+    {
+        CreatePlan("10092", "StdinDescTest");
+        var app = BuildPlanRecAddApp();
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader("Description from stdin"));
+        try
+        {
+            var exit = app.Run(["plan", "rec", "add", "10092", "Stdin Rec", "--stdin"]);
+            Assert.Equal(0, exit);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        var result = ReadPlan("10092");
+        Assert.Equal("Description from stdin", result.Recommendations!.Single().Description);
+    }
+
+    [Fact]
+    public void PlanRecAdd_MultipleSources_FailsValidation()
+    {
+        Assert.False(new PlanRecAddSettings
+        {
+            PlanId = "1",
+            Title = "T",
+            Description = "inline",
+            Stdin = true
+        }.Validate().Successful);
+
+        var app = BuildPlanRecAddApp();
+        Assert.Throws<CommandRuntimeException>(() =>
+            app.Run(["plan", "rec", "add", "1", "T", "-d", "inline", "--stdin"]));
+    }
+
+    [Fact]
+    public void PlanRecAdd_NoSource_ThrowsAndNeverReadsStdin()
+    {
+        CreatePlan("10093", "NoSourceTest");
+        var app = BuildPlanRecAddApp();
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader("SENTINEL-SHOULD-NOT-BE-READ"));
+        try
+        {
+            var ex = Assert.Throws<ArgumentException>(() => app.Run(["plan", "rec", "add", "10093", "No Source Rec"]));
+            Assert.Contains("--description, --file, or --stdin", ex.Message);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        var result = ReadPlan("10093");
+        Assert.Empty(result.Recommendations!);
     }
 }

--- a/src/Ivy.Tendril.Test/PromptwareWriteCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PromptwareWriteCommandTests.cs
@@ -1,0 +1,192 @@
+using Ivy.Tendril.Commands;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Test;
+
+[Collection("TendrilHome")]
+public class PromptwareWriteCommandTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("tendril-promptware-write-test");
+    private readonly string _originalTendrilHome;
+
+    public PromptwareWriteCommandTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+
+        var promptwareDir = Path.Combine(_tempDir.Path, "Promptwares", "TestPromptware");
+        Directory.CreateDirectory(promptwareDir);
+        File.WriteAllText(Path.Combine(promptwareDir, "Program.md"), "# Program");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+    }
+
+    private static CommandApp BuildApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("promptware", promptware =>
+            {
+                promptware.AddCommand<PromptwareWriteMemoryCommand>("write-memory");
+                promptware.AddCommand<PromptwareWriteToolCommand>("write-tool");
+            });
+        });
+        return app;
+    }
+
+    // --- write-memory ---
+
+    [Fact]
+    public void WriteMemory_File_ReadsFromFile()
+    {
+        var file = Path.Combine(_tempDir.Path, "content.md");
+        File.WriteAllText(file, "Memory from file");
+        var app = BuildApp();
+
+        var exit = app.Run(["promptware", "write-memory", "TestPromptware", "pattern.md", "--file", file]);
+
+        Assert.Equal(0, exit);
+        var written = Path.Combine(_tempDir.Path, "Promptwares", "TestPromptware", "Memory", "pattern.md");
+        Assert.Equal("Memory from file", File.ReadAllText(written));
+    }
+
+    [Fact]
+    public void WriteMemory_Stdin_ReadsPipedInput()
+    {
+        var app = BuildApp();
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader("Memory from stdin"));
+        try
+        {
+            var exit = app.Run(["promptware", "write-memory", "TestPromptware", "pattern-stdin.md", "--stdin"]);
+            Assert.Equal(0, exit);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        var written = Path.Combine(_tempDir.Path, "Promptwares", "TestPromptware", "Memory", "pattern-stdin.md");
+        Assert.Equal("Memory from stdin", File.ReadAllText(written));
+    }
+
+    [Fact]
+    public void WriteMemory_MultipleSources_FailsValidation()
+    {
+        Assert.False(new PromptwareWriteMemorySettings
+        {
+            Name = "TestPromptware",
+            Filename = "f.md",
+            FilePath = "f.md",
+            Stdin = true
+        }.Validate().Successful);
+
+        var app = BuildApp();
+        Assert.Throws<CommandRuntimeException>(() =>
+            app.Run(["promptware", "write-memory", "TestPromptware", "f.md", "--file", "f.md", "--stdin"]));
+    }
+
+    [Fact]
+    public void WriteMemory_NoSource_ThrowsAndNeverReadsStdin()
+    {
+        var app = BuildApp();
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader("SENTINEL-SHOULD-NOT-BE-READ"));
+        try
+        {
+            var ex = Assert.Throws<ArgumentException>(() =>
+                app.Run(["promptware", "write-memory", "TestPromptware", "no-source.md"]));
+            Assert.Contains("--file or --stdin", ex.Message);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        var written = Path.Combine(_tempDir.Path, "Promptwares", "TestPromptware", "Memory", "no-source.md");
+        Assert.False(File.Exists(written));
+    }
+
+    // --- write-tool ---
+
+    [Fact]
+    public void WriteTool_File_ReadsFromFile()
+    {
+        var file = Path.Combine(_tempDir.Path, "tool-content.md");
+        File.WriteAllText(file, "Tool from file");
+        var app = BuildApp();
+
+        var exit = app.Run(["promptware", "write-tool", "TestPromptware", "tool.md", "--file", file]);
+
+        Assert.Equal(0, exit);
+        var written = Path.Combine(_tempDir.Path, "Promptwares", "TestPromptware", "Tools", "tool.md");
+        Assert.Equal("Tool from file", File.ReadAllText(written));
+    }
+
+    [Fact]
+    public void WriteTool_Stdin_ReadsPipedInput()
+    {
+        var app = BuildApp();
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader("Tool from stdin"));
+        try
+        {
+            var exit = app.Run(["promptware", "write-tool", "TestPromptware", "tool-stdin.md", "--stdin"]);
+            Assert.Equal(0, exit);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        var written = Path.Combine(_tempDir.Path, "Promptwares", "TestPromptware", "Tools", "tool-stdin.md");
+        Assert.Equal("Tool from stdin", File.ReadAllText(written));
+    }
+
+    [Fact]
+    public void WriteTool_MultipleSources_FailsValidation()
+    {
+        Assert.False(new PromptwareWriteToolSettings
+        {
+            Name = "TestPromptware",
+            Filename = "f.md",
+            FilePath = "f.md",
+            Stdin = true
+        }.Validate().Successful);
+
+        var app = BuildApp();
+        Assert.Throws<CommandRuntimeException>(() =>
+            app.Run(["promptware", "write-tool", "TestPromptware", "f.md", "--file", "f.md", "--stdin"]));
+    }
+
+    [Fact]
+    public void WriteTool_NoSource_ThrowsAndNeverReadsStdin()
+    {
+        var app = BuildApp();
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader("SENTINEL-SHOULD-NOT-BE-READ"));
+        try
+        {
+            var ex = Assert.Throws<ArgumentException>(() =>
+                app.Run(["promptware", "write-tool", "TestPromptware", "no-source.md"]));
+            Assert.Contains("--file or --stdin", ex.Message);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        var written = Path.Combine(_tempDir.Path, "Promptwares", "TestPromptware", "Tools", "no-source.md");
+        Assert.False(File.Exists(written));
+    }
+}

--- a/src/Ivy.Tendril.Test/TrashWriteCommandTests.cs
+++ b/src/Ivy.Tendril.Test/TrashWriteCommandTests.cs
@@ -1,0 +1,100 @@
+using Ivy.Tendril.Commands;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Test;
+
+[Collection("TendrilHome")]
+public class TrashWriteCommandTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("tendril-trash-write-test");
+    private readonly string _originalTendrilHome;
+
+    public TrashWriteCommandTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+    }
+
+    private static CommandApp BuildApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("trash", trash => trash.AddCommand<TrashWriteCommand>("write"));
+        });
+        return app;
+    }
+
+    [Fact]
+    public void Write_File_ReadsFromFile()
+    {
+        var file = Path.Combine(_tempDir.Path, "content.md");
+        File.WriteAllText(file, "Trash content from file");
+        var app = BuildApp();
+
+        var exit = app.Run(["trash", "write", "DuplicateTitle.md", "--file", file]);
+
+        Assert.Equal(0, exit);
+        var written = Path.Combine(_tempDir.Path, "Trash", "DuplicateTitle.md");
+        Assert.Equal("Trash content from file", File.ReadAllText(written));
+    }
+
+    [Fact]
+    public void Write_Stdin_ReadsPipedInput()
+    {
+        var app = BuildApp();
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader("Trash content from stdin"));
+        try
+        {
+            var exit = app.Run(["trash", "write", "StdinTitle.md", "--stdin"]);
+            Assert.Equal(0, exit);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        var written = Path.Combine(_tempDir.Path, "Trash", "StdinTitle.md");
+        Assert.Equal("Trash content from stdin", File.ReadAllText(written));
+    }
+
+    [Fact]
+    public void Write_MultipleSources_FailsValidation()
+    {
+        Assert.False(new TrashWriteSettings { Filename = "f.md", FilePath = "f.md", Stdin = true }.Validate().Successful);
+
+        var app = BuildApp();
+        Assert.Throws<CommandRuntimeException>(() =>
+            app.Run(["trash", "write", "f.md", "--file", "f.md", "--stdin"]));
+    }
+
+    [Fact]
+    public void Write_NoSource_ThrowsAndNeverReadsStdin()
+    {
+        var app = BuildApp();
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader("SENTINEL-SHOULD-NOT-BE-READ"));
+        try
+        {
+            var ex = Assert.Throws<ArgumentException>(() => app.Run(["trash", "write", "NoSource.md"]));
+            Assert.Contains("--file or --stdin", ex.Message);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        var written = Path.Combine(_tempDir.Path, "Trash", "NoSource.md");
+        Assert.False(File.Exists(written));
+    }
+}

--- a/src/Ivy.Tendril.Test/VerificationCommandTests.cs
+++ b/src/Ivy.Tendril.Test/VerificationCommandTests.cs
@@ -213,4 +213,95 @@ verifications: []
         Assert.Equal("Build", reloaded.Settings.Verifications[1].Name);
         Assert.Equal("Verify the project builds", reloaded.Settings.Verifications[1].Prompt);
     }
+
+    // --- Add Verification CLI (-p / --file / --stdin) ---
+
+    private static CommandApp BuildVerificationAddApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("verification", verification => verification.AddCommand<VerificationAddCommand>("add"));
+        });
+        return app;
+    }
+
+    [Fact]
+    public void VerificationAdd_InlinePrompt_AddsDefinition()
+    {
+        var app = BuildVerificationAddApp();
+
+        var exit = app.Run(["verification", "add", "InlinePromptTest", "-p", "Inline prompt text"]);
+
+        Assert.Equal(0, exit);
+        var reloaded = CreateConfig();
+        Assert.Equal("Inline prompt text", reloaded.Settings.Verifications.Single().Prompt);
+    }
+
+    [Fact]
+    public void VerificationAdd_File_ReadsFromFile()
+    {
+        var file = Path.Combine(_tempDir.Path, "prompt.md");
+        File.WriteAllText(file, "Prompt from file");
+        var app = BuildVerificationAddApp();
+
+        var exit = app.Run(["verification", "add", "FilePromptTest", "--file", file]);
+
+        Assert.Equal(0, exit);
+        var reloaded = CreateConfig();
+        Assert.Equal("Prompt from file", reloaded.Settings.Verifications.Single().Prompt);
+    }
+
+    [Fact]
+    public void VerificationAdd_Stdin_ReadsPipedInput()
+    {
+        var app = BuildVerificationAddApp();
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader("Prompt from stdin"));
+        try
+        {
+            var exit = app.Run(["verification", "add", "StdinPromptTest", "--stdin"]);
+            Assert.Equal(0, exit);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        var reloaded = CreateConfig();
+        Assert.Equal("Prompt from stdin", reloaded.Settings.Verifications.Single().Prompt);
+    }
+
+    [Fact]
+    public void VerificationAdd_MultipleSources_FailsValidation()
+    {
+        Assert.False(new VerificationAddSettings { Name = "X", Prompt = "inline", FilePath = "f.md" }.Validate().Successful);
+
+        var app = BuildVerificationAddApp();
+        Assert.Throws<CommandRuntimeException>(() =>
+            app.Run(["verification", "add", "MultiSourceTest", "-p", "inline", "--file", "f.md"]));
+    }
+
+    [Fact]
+    public void VerificationAdd_NoSource_ThrowsAndNeverReadsStdin()
+    {
+        var app = BuildVerificationAddApp();
+
+        var originalIn = Console.In;
+        Console.SetIn(new StringReader("SENTINEL-SHOULD-NOT-BE-READ"));
+        try
+        {
+            var ex = Assert.Throws<ArgumentException>(() => app.Run(["verification", "add", "NoSourceTest"]));
+            Assert.Contains("--prompt, --file, or --stdin", ex.Message);
+        }
+        finally
+        {
+            Console.SetIn(originalIn);
+        }
+
+        var reloaded = CreateConfig();
+        Assert.Empty(reloaded.Settings.Verifications);
+    }
 }

--- a/src/Ivy.Tendril/Commands/ConfigCommand.cs
+++ b/src/Ivy.Tendril/Commands/ConfigCommand.cs
@@ -45,9 +45,9 @@ public class ConfigSetSettings : CommandSettings
 
     public override Spectre.Console.ValidationResult Validate()
     {
-        if (SourceCount > 1)
-            return Spectre.Console.ValidationResult.Error(
-                "Provide the value in exactly one way: an inline <value>, --file, or --stdin.");
+        var sourceValidation = CliValidation.ValidateSingleSource(SourceCount, "an inline <value>, --file, or --stdin");
+        if (!sourceValidation.Successful)
+            return sourceValidation;
 
         return CliValidation.ValidateField(Key, ConfigGetSettings.ValidFields);
     }
@@ -85,9 +85,7 @@ public class ConfigSetCommand(IAgentRunner runner) : Command<ConfigSetSettings>
 {
     protected override int Execute(CommandContext context, ConfigSetSettings settings, CancellationToken cancellationToken)
     {
-        var value = settings.Stdin ? Console.In.ReadToEnd()
-            : !string.IsNullOrEmpty(settings.FilePath) ? File.ReadAllText(settings.FilePath)
-            : settings.Value;
+        var value = ConsoleHelper.ResolveInput(settings.Stdin, settings.FilePath, settings.Value);
 
         var config = new ConfigService();
         // throws on bad int / out-of-range / unknown coding agent, before any write

--- a/src/Ivy.Tendril/Commands/PlanRecCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRecCommand.cs
@@ -37,15 +37,29 @@ public class PlanRecAddSettings : CommandSettings
     public string Title { get; set; } = "";
 
     [CommandOption("-d|--description")]
-    [Description("Recommendation description (reads from stdin if omitted)")]
+    [Description("Recommendation description (inline; use --file/--stdin for long text)")]
     public string? Description { get; set; }
+
+    [CommandOption("-f|--file")]
+    [Description("Read the description verbatim from this file (good for long/multiline text)")]
+    public string? FilePath { get; set; }
+
+    [CommandOption("--stdin")]
+    [Description("Read the description verbatim from standard input")]
+    public bool Stdin { get; set; }
 
     [CommandOption("--impact")]
     [Description("Impact level (Small, Medium, High)")]
     public string? Impact { get; set; }
 
+    public int SourceCount => CliValidation.CountSources(Stdin, FilePath, Description ?? "");
+
     public override Spectre.Console.ValidationResult Validate()
     {
+        var sourceValidation = CliValidation.ValidateSingleSource(SourceCount, "--description, --file, or --stdin");
+        if (!sourceValidation.Successful)
+            return sourceValidation;
+
         return CliValidation.Combine(
             CliValidation.RequireNonEmpty(PlanId, "plan-id"),
             CliValidation.RequireNonEmpty(Title, "title"),
@@ -210,13 +224,9 @@ public class PlanRecAddCommand : Command<PlanRecAddSettings>
         if (plan.Recommendations.Any(r => r.Title.Equals(settings.Title, StringComparison.OrdinalIgnoreCase)))
             throw new InvalidOperationException($"Recommendation already exists: {settings.Title}");
 
-        var description = settings.Description;
-        if (string.IsNullOrEmpty(description))
-        {
-            if (!Console.IsInputRedirected)
-                throw new ArgumentException("Provide --description or pipe content via stdin");
-            description = Console.In.ReadToEnd().Trim();
-        }
+        var description = ConsoleHelper.ResolveInput(settings.Stdin, settings.FilePath, settings.Description);
+        if (string.IsNullOrWhiteSpace(description))
+            throw new ArgumentException("Provide --description, --file, or --stdin");
 
         plan.Recommendations.Add(new RecommendationYaml
         {

--- a/src/Ivy.Tendril/Commands/PlanUpdateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanUpdateCommand.cs
@@ -12,8 +12,22 @@ public class PlanUpdateSettings : CommandSettings
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
 
+    [CommandOption("-f|--file")]
+    [Description("Read the YAML content from this file")]
+    public string? FilePath { get; set; }
+
+    [CommandOption("--stdin")]
+    [Description("Read the YAML content from standard input")]
+    public bool Stdin { get; set; }
+
+    public int SourceCount => CliValidation.CountSources(Stdin, FilePath, "");
+
     public override Spectre.Console.ValidationResult Validate()
     {
+        var sourceValidation = CliValidation.ValidateSingleSource(SourceCount, "--file or --stdin");
+        if (!sourceValidation.Successful)
+            return sourceValidation;
+
         return CliValidation.RequireNonEmpty(PlanId, "plan-id");
     }
 }
@@ -31,9 +45,9 @@ public class PlanUpdateCommand : Command<PlanUpdateSettings>
     {
         var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
 
-        var yaml = ConsoleHelper.ReadStdinWithTimeout();
+        var yaml = ConsoleHelper.ResolveInput(settings.Stdin, settings.FilePath, null);
         if (string.IsNullOrWhiteSpace(yaml))
-            throw new ArgumentException("No YAML content provided on STDIN");
+            throw new ArgumentException("No YAML content provided (use --file or --stdin)");
 
         var plan = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml);
         if (plan == null)

--- a/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
@@ -11,12 +11,22 @@ public class PlanWriteRevisionSettings : CommandSettings
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
 
-    [Description("Read content from file instead of STDIN")]
+    [Description("Read content from this file")]
     [CommandOption("--file|-f")]
     public string? FilePath { get; set; }
 
+    [CommandOption("--stdin")]
+    [Description("Read content from standard input")]
+    public bool Stdin { get; set; }
+
+    public int SourceCount => CliValidation.CountSources(Stdin, FilePath, "");
+
     public override Spectre.Console.ValidationResult Validate()
     {
+        var sourceValidation = CliValidation.ValidateSingleSource(SourceCount, "--file or --stdin");
+        if (!sourceValidation.Successful)
+            return sourceValidation;
+
         return CliValidation.RequireNonEmpty(PlanId, "plan-id");
     }
 }
@@ -27,11 +37,9 @@ public class PlanWriteRevisionCommand : Command<PlanWriteRevisionSettings>
     {
         var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
 
-        var content = !string.IsNullOrEmpty(settings.FilePath)
-            ? File.ReadAllText(settings.FilePath)
-            : ConsoleHelper.ReadStdinWithTimeout();
+        var content = ConsoleHelper.ResolveInput(settings.Stdin, settings.FilePath, null);
         if (string.IsNullOrWhiteSpace(content))
-            throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
+            throw new ArgumentException("No content provided (use --file or --stdin)");
 
         var filePath = RevisionWriter.WriteNext(planFolder, content, new ConfigService());
         Console.Write(filePath);

--- a/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
@@ -14,12 +14,22 @@ public class PromptwareWriteMemorySettings : CommandSettings
     [CommandArgument(1, "<filename>")]
     public string Filename { get; set; } = "";
 
-    [Description("Read content from file instead of STDIN")]
+    [Description("Read content from this file")]
     [CommandOption("--file|-f")]
     public string? FilePath { get; set; }
 
+    [CommandOption("--stdin")]
+    [Description("Read content from standard input")]
+    public bool Stdin { get; set; }
+
+    public int SourceCount => CliValidation.CountSources(Stdin, FilePath, "");
+
     public override Spectre.Console.ValidationResult Validate()
     {
+        var sourceValidation = CliValidation.ValidateSingleSource(SourceCount, "--file or --stdin");
+        if (!sourceValidation.Successful)
+            return sourceValidation;
+
         return CliValidation.Combine(
             CliValidation.RequireNonEmpty(Name, "name"),
             CliValidation.RequireNonEmpty(Filename, "filename")
@@ -40,9 +50,9 @@ public class PromptwareWriteMemoryCommand : Command<PromptwareWriteMemorySetting
         var filename = Path.GetFileName(settings.Filename);
         var filePath = Path.Combine(memoryDir, filename);
 
-        var content = ConsoleHelper.ResolveContent(settings.FilePath, () => ConsoleHelper.ReadStdinWithTimeout());
+        var content = ConsoleHelper.ResolveInput(settings.Stdin, settings.FilePath, null);
         if (string.IsNullOrWhiteSpace(content))
-            throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
+            throw new ArgumentException("No content provided (use --file or --stdin)");
 
         File.WriteAllText(filePath, content);
         Console.Write(filePath);

--- a/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
@@ -14,12 +14,22 @@ public class PromptwareWriteToolSettings : CommandSettings
     [CommandArgument(1, "<filename>")]
     public string Filename { get; set; } = "";
 
-    [Description("Read content from file instead of STDIN")]
+    [Description("Read content from this file")]
     [CommandOption("--file|-f")]
     public string? FilePath { get; set; }
 
+    [CommandOption("--stdin")]
+    [Description("Read content from standard input")]
+    public bool Stdin { get; set; }
+
+    public int SourceCount => CliValidation.CountSources(Stdin, FilePath, "");
+
     public override Spectre.Console.ValidationResult Validate()
     {
+        var sourceValidation = CliValidation.ValidateSingleSource(SourceCount, "--file or --stdin");
+        if (!sourceValidation.Successful)
+            return sourceValidation;
+
         return CliValidation.Combine(
             CliValidation.RequireNonEmpty(Name, "name"),
             CliValidation.RequireNonEmpty(Filename, "filename")
@@ -40,9 +50,9 @@ public class PromptwareWriteToolCommand : Command<PromptwareWriteToolSettings>
         var filename = Path.GetFileName(settings.Filename);
         var filePath = Path.Combine(toolsDir, filename);
 
-        var content = ConsoleHelper.ResolveContent(settings.FilePath, () => ConsoleHelper.ReadStdinWithTimeout());
+        var content = ConsoleHelper.ResolveInput(settings.Stdin, settings.FilePath, null);
         if (string.IsNullOrWhiteSpace(content))
-            throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
+            throw new ArgumentException("No content provided (use --file or --stdin)");
 
         File.WriteAllText(filePath, content);
         Console.Write(filePath);

--- a/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
+++ b/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
@@ -10,12 +10,22 @@ public class TrashWriteSettings : CommandSettings
     [CommandArgument(0, "<filename>")]
     public string Filename { get; set; } = "";
 
-    [Description("Read content from file instead of STDIN")]
+    [Description("Read content from this file")]
     [CommandOption("--file|-f")]
     public string? FilePath { get; set; }
 
+    [CommandOption("--stdin")]
+    [Description("Read content from standard input")]
+    public bool Stdin { get; set; }
+
+    public int SourceCount => CliValidation.CountSources(Stdin, FilePath, "");
+
     public override Spectre.Console.ValidationResult Validate()
     {
+        var sourceValidation = CliValidation.ValidateSingleSource(SourceCount, "--file or --stdin");
+        if (!sourceValidation.Successful)
+            return sourceValidation;
+
         return CliValidation.RequireNonEmpty(Filename, "filename");
     }
 }
@@ -34,9 +44,9 @@ public class TrashWriteCommand : Command<TrashWriteSettings>
         var filename = Path.GetFileName(settings.Filename);
         var filePath = Path.Combine(trashDir, filename);
 
-        var content = ConsoleHelper.ResolveContent(settings.FilePath, () => ConsoleHelper.ReadStdinWithTimeout());
+        var content = ConsoleHelper.ResolveInput(settings.Stdin, settings.FilePath, null);
         if (string.IsNullOrWhiteSpace(content))
-            throw new ArgumentException("No content provided (use --file or pipe to STDIN)");
+            throw new ArgumentException("No content provided (use --file or --stdin)");
 
         File.WriteAllText(filePath, content);
         Console.Write(filePath);

--- a/src/Ivy.Tendril/Commands/VerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/VerificationCommand.cs
@@ -15,15 +15,25 @@ public class VerificationAddSettings : CommandSettings
     public string Name { get; set; } = "";
 
     [CommandOption("-p|--prompt")]
-    [Description("Verification prompt (reads from stdin if omitted)")]
+    [Description("Verification prompt (inline; use --file/--stdin for long text)")]
     public string? Prompt { get; set; }
 
     [CommandOption("--file|-f")]
     [Description("Read the prompt verbatim from this file (good for long/multiline prompts)")]
     public string? FilePath { get; set; }
 
+    [CommandOption("--stdin")]
+    [Description("Read the prompt verbatim from standard input")]
+    public bool Stdin { get; set; }
+
+    public int SourceCount => CliValidation.CountSources(Stdin, FilePath, Prompt ?? "");
+
     public override Spectre.Console.ValidationResult Validate()
     {
+        var sourceValidation = CliValidation.ValidateSingleSource(SourceCount, "--prompt, --file, or --stdin");
+        if (!sourceValidation.Successful)
+            return sourceValidation;
+
         return CliValidation.RequireNonEmpty(Name, "name");
     }
 }
@@ -80,9 +90,9 @@ public class VerificationSetSettings : CommandSettings
 
     public override Spectre.Console.ValidationResult Validate()
     {
-        if (SourceCount > 1)
-            return Spectre.Console.ValidationResult.Error(
-                "Provide the value in exactly one way: an inline <value>, --file, or --stdin.");
+        var sourceValidation = CliValidation.ValidateSingleSource(SourceCount, "an inline <value>, --file, or --stdin");
+        if (!sourceValidation.Successful)
+            return sourceValidation;
 
         return CliValidation.Combine(
             CliValidation.RequireNonEmpty(Name, "name"),
@@ -144,14 +154,9 @@ public class VerificationAddCommand : Command<VerificationAddSettings>
         if (config.Settings.Verifications.Any(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
             throw new InvalidOperationException($"Verification already exists: {settings.Name}");
 
-        var prompt = ConsoleHelper.ResolveContent(settings.FilePath, () => settings.Prompt);
-
-        if (string.IsNullOrEmpty(prompt))
-        {
-            if (!Console.IsInputRedirected)
-                throw new ArgumentException("Provide --prompt, --file, or pipe content via stdin");
-            prompt = ConsoleHelper.ReadStdinWithTimeout().Trim();
-        }
+        var prompt = ConsoleHelper.ResolveInput(settings.Stdin, settings.FilePath, settings.Prompt);
+        if (string.IsNullOrWhiteSpace(prompt))
+            throw new ArgumentException("Provide --prompt, --file, or --stdin");
 
         config.Settings.Verifications.Add(new VerificationConfig
         {
@@ -194,9 +199,7 @@ public class VerificationSetCommand : Command<VerificationSetSettings>
         if (match == null)
             CliValidation.ThrowVerificationNotFound(settings.Name, config.Settings.Verifications.Select(v => v.Name));
 
-        var value = settings.Stdin
-            ? ConsoleHelper.ReadStdinWithTimeout()
-            : ConsoleHelper.ResolveContent(settings.FilePath, () => settings.Value);
+        var value = ConsoleHelper.ResolveInput(settings.Stdin, settings.FilePath, settings.Value);
 
         if (string.IsNullOrEmpty(value))
             throw new ArgumentException("value is required (use an inline <value>, --file, or --stdin)");

--- a/src/Ivy.Tendril/Helpers/CliValidation.cs
+++ b/src/Ivy.Tendril/Helpers/CliValidation.cs
@@ -88,4 +88,12 @@ public static class CliValidation
     /// <summary>Number of value sources supplied (inline arg / --file / --stdin), for the "exactly one" rule.</summary>
     public static int CountSources(bool stdin, string? filePath, string value) =>
         (stdin ? 1 : 0) + (!string.IsNullOrEmpty(filePath) ? 1 : 0) + (!string.IsNullOrEmpty(value) ? 1 : 0);
+
+    // Shared "provide long-form input exactly one way" rule.
+    // inlineSources names the allowed sources, e.g.
+    // "an inline <value>, --file, or --stdin" or "--prompt, --file, or --stdin".
+    public static SpectreValidation ValidateSingleSource(int sourceCount, string inlineSources) =>
+        sourceCount > 1
+            ? SpectreValidation.Error($"Provide the value in exactly one way: {inlineSources}.")
+            : SpectreValidation.Success();
 }

--- a/src/Ivy.Tendril/Helpers/ConsoleHelper.cs
+++ b/src/Ivy.Tendril/Helpers/ConsoleHelper.cs
@@ -17,4 +17,11 @@ public static class ConsoleHelper
 
     public static string? ResolveContent(string? filePath, Func<string?> fallback) =>
         !string.IsNullOrEmpty(filePath) ? File.ReadAllText(filePath) : fallback();
+
+    // Resolves long-form command input from exactly one explicit source.
+    // STDIN is read ONLY when stdin is true (never as an implicit fallback).
+    public static string ResolveInput(bool stdin, string? filePath, string? inlineValue) =>
+        stdin ? ReadStdinWithTimeout()
+        : !string.IsNullOrEmpty(filePath) ? File.ReadAllText(filePath)
+        : inlineValue ?? "";
 }

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -511,7 +511,7 @@ public class Program
                 plan.AddCommand<PlanCreateCommand>("create")
                     .WithDescription("Create a new plan");
                 plan.AddCommand<PlanUpdateCommand>("update")
-                    .WithDescription("Update plan from STDIN");
+                    .WithDescription("Update plan from a file or STDIN");
                 plan.AddCommand<PlanSetCommand>("set")
                     .WithDescription("Set a single field");
                 plan.AddCommand<PlanAddRepoCommand>("add-repo")
@@ -537,7 +537,7 @@ public class Program
                 plan.AddCommand<PlanAddLogCommand>("add-log")
                     .WithDescription("Write a log entry");
                 plan.AddCommand<PlanWriteRevisionCommand>("write-revision")
-                    .WithDescription("Write a revision file from STDIN");
+                    .WithDescription("Write a revision file from a file or STDIN");
                 plan.AddCommand<PlanGetRevisionCommand>("get-revision")
                     .WithDescription("Print revision content");
                 plan.AddCommand<PlanValidateCommand>("validate")
@@ -599,7 +599,7 @@ public class Program
             config.AddBranch("trash", trash =>
             {
                 trash.AddCommand<TrashWriteCommand>("write")
-                    .WithDescription("Write a file to Trash from STDIN");
+                    .WithDescription("Write a file to Trash from a file or STDIN");
             });
 
             config.AddBranch("project", project =>

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -134,7 +134,7 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 |---------|-------------|
 | `tendril plan list` | List plans (supports filters) |
 | `tendril plan create <title>` | Low-level create of the plan folder/yaml — **edit-only primitive, not for creating a plan from a chat request** (start a `CreatePlan` job instead) |
-| `tendril plan update <plan-id>` | Update plan from stdin |
+| `tendril plan update <plan-id>` | Update plan from a file or stdin (--file/--stdin) |
 | `tendril plan set <plan-id> <field> <value>` | Set a plan field |
 | `tendril plan get <plan-id> [field]` | Get plan data |
 | `tendril plan validate <plan-id>` | Validate plan health |
@@ -148,7 +148,7 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 | `tendril plan add-depends-on <plan-id> <folder>` | Add dependency |
 | `tendril plan remove-depends-on <plan-id> <folder>` | Remove dependency |
 | `tendril plan add-log <plan-id> <action>` | Add execution log entry |
-| `tendril plan write-revision <plan-id>` | Write revision from stdin — **only to edit an existing plan; never to create a new plan** (start a `CreatePlan` job instead) |
+| `tendril plan write-revision <plan-id>` | Write revision from a file or stdin (--file/--stdin) — **only to edit an existing plan; never to create a new plan** (start a `CreatePlan` job instead) |
 | `tendril plan get-revision <plan-id> [--number <n>]` | Print revision content (latest by default, or a specific numbered revision) |
 | `tendril plan cleanup <plan-id>` | Remove worktrees |
 | `tendril plan set-verification <plan-id> <name> <status>` | Set verification status |
@@ -209,8 +209,8 @@ These commands are for internal use by other promptwares (e.g., a verification s
 |---------|-------------|
 | `tendril promptware run <name>` | Run a promptware directly (bypasses job service) |
 | `tendril promptware read-memory <name> <file>` | Read promptware memory |
-| `tendril promptware write-memory <name> <file>` | Write promptware memory (stdin) |
-| `tendril promptware write-tool <name> <file>` | Write promptware tool (stdin) |
+| `tendril promptware write-memory <name> <file>` | Write promptware memory (--file/--stdin) |
+| `tendril promptware write-tool <name> <file>` | Write promptware tool (--file/--stdin) |
 
 ### Project Commands
 

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -147,12 +147,12 @@ Options:
 ### Writing revisions
 
 ```bash
-tendril plan write-revision <plan-id> <<'EOF'
+tendril plan write-revision <plan-id> --stdin <<'EOF'
 <revision content>
 EOF
 ```
 
-Reads content from STDIN and writes it to `revisions/<NNN>.md` in the plan folder. Auto-increments from the highest existing revision. Outputs the file path.
+Reads content from STDIN (when `--stdin` is passed) or `--file`, and writes it to `revisions/<NNN>.md` in the plan folder. Auto-increments from the highest existing revision. Outputs the file path.
 
 ### Writing execution logs
 

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -79,7 +79,7 @@ The **Projects** section of your firmware lists all available projects with thei
 **If `TendrilProject: Auto`**:
 - Analyze the task description to infer the correct project from the **Projects** section
 - Match based on keywords, repo paths, or component names in the description
-- **If no project matches**: Report final status via `tendril job status TendrilJobId --message="Could not determine project from task description. Available projects: <list>"`, write trash file via `tendril trash write <SafeTitle>.md <<'EOF'...EOF` explaining that the project could not be determined, list the available project names, then exit without creating a plan
+- **If no project matches**: Report final status via `tendril job status TendrilJobId --message="Could not determine project from task description. Available projects: <list>"`, write trash file via `tendril trash write <SafeTitle>.md --stdin <<'EOF'...EOF` explaining that the project could not be determined, list the available project names, then exit without creating a plan
 - Use the matched project's context to scope your research
 
 ### 2. Plan ID
@@ -137,7 +137,7 @@ Report status: `tendril job status TendrilJobId --message="Researching codebase.
   Then write a trash file using the CLI (where `<SafeTitle>` is the title with spaces replaced by hyphens and special characters removed), then exit without creating a plan folder:
 
   ```bash
-  tendril trash write <SafeTitle>.md <<'EOF'
+  tendril trash write <SafeTitle>.md --stdin <<'EOF'
   ---
   date: <CurrentTime>
   originalRequest: "<the task description text>"
@@ -198,7 +198,7 @@ For each assertion found:
 
 **Decision:**
 - **All validations pass** → Proceed to Step 4, include validated code blocks in plan with `**Current implementation**` headers
-- **Any validation fails** → Report final status via `tendril job status TendrilJobId --message="Code state validation failed: <brief description of what changed>"`, write trash file via `tendril trash write <SafeTitle>.md <<'EOF'...EOF` explaining the validation failure, then exit without creating a plan
+- **Any validation fails** → Report final status via `tendril job status TendrilJobId --message="Code state validation failed: <brief description of what changed>"`, write trash file via `tendril trash write <SafeTitle>.md --stdin <<'EOF'...EOF` explaining the validation failure, then exit without creating a plan
 
 This catches stale plans before they enter the review queue, reducing wasted review time.
 
@@ -254,7 +254,7 @@ Adjust them as the task warrants (the user can also toggle them later in the UI;
 Write the revision content via CLI:
 
 ```bash
-tendril plan write-revision <PlanId> <<'EOF'
+tendril plan write-revision <PlanId> --stdin <<'EOF'
 <revision content here>
 EOF
 ```

--- a/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
@@ -52,7 +52,7 @@ Report status: `tendril job status TendrilJobId --message="Writing expanded revi
 
 - Write the new revision via CLI (number auto-incremented):
   ```bash
-  tendril plan write-revision <plan-id> <<'EOF'
+  tendril plan write-revision <plan-id> --stdin <<'EOF'
   <expanded revision content here>
   EOF
   ```

--- a/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -61,7 +61,7 @@ Do NOT read or modify `.counter` directly — `tendril plan create` handles ID a
 After creating each plan, write the revision via CLI:
 
 ```bash
-tendril plan write-revision <PlanId> <<'EOF'
+tendril plan write-revision <PlanId> --stdin <<'EOF'
 <revision content here>
 EOF
 ```

--- a/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
@@ -52,7 +52,7 @@ Report status: `tendril job status TendrilJobId --message="Applying changes..."`
 
 - Write the new revision via CLI (number auto-incremented):
   ```bash
-  tendril plan write-revision <plan-id> <<'EOF'
+  tendril plan write-revision <plan-id> --stdin <<'EOF'
   <updated revision content here>
   EOF
   ```


### PR DESCRIPTION
# Summary

## Changes

Harmonized long-form text input across every Tendril CLI write command that used to read STDIN implicitly. `plan write-revision`, `plan update`, `plan rec add`, `verification add`, `promptware write-memory`, `promptware write-tool`, and `trash write` now all expose the same `-f|--file` and `--stdin` pair (alongside their existing domain-specific inline options), resolve content from exactly one explicit source via a new shared `ConsoleHelper.ResolveInput` helper, and never touch standard input unless `--stdin` is passed. Promptware programs, the agent system prompt, and the CLI reference docs were updated so every piped/heredoc example that feeds these commands passes `--stdin` explicitly.

## API Changes

- New `Ivy.Tendril.Helpers.ConsoleHelper.ResolveInput(bool stdin, string? filePath, string? inlineValue)` — resolves content from stdin/file/inline, reading stdin only when `stdin` is true.
- New `Ivy.Tendril.Helpers.CliValidation.ValidateSingleSource(int sourceCount, string inlineSources)` — shared "provide exactly one way" validation message.
- CLI: `tendril plan update <plan-id>` gains `-f|--file` and `--stdin` (previously STDIN-only, no flags).
- CLI: `tendril plan write-revision <plan-id>` gains `--stdin` (previously had `--file` with an implicit STDIN fallback).
- CLI: `tendril plan rec add <plan-id> <title>` gains `-f|--file` and `--stdin` (previously only `-d|--description` with an implicit STDIN fallback).
- CLI: `tendril verification add <name>` gains `--stdin` (previously had `-p|--prompt` and `--file` with an implicit STDIN fallback).
- CLI: `tendril promptware write-memory`, `tendril promptware write-tool`, `tendril trash write` gain `--stdin` (previously had `--file` with an implicit STDIN fallback).
- Behavior change: none of the above commands read STDIN anymore unless `--stdin` is explicitly passed — running them with no source now fails fast with a clear error instead of blocking on STDIN (up to 5s) or hanging indefinitely.

## Files Modified

- `src/Ivy.Tendril/Helpers/ConsoleHelper.cs`, `CliValidation.cs` — new shared helpers
- `src/Ivy.Tendril/Commands/ConfigCommand.cs`, `VerificationCommand.cs`, `PlanRecCommand.cs`, `PlanUpdateCommand.cs`, `PlanWriteRevisionCommand.cs`, `PromptwareWriteMemoryCommand.cs`, `PromptwareWriteToolCommand.cs`, `TrashWriteCommand.cs` — routed through the shared helpers
- `src/Ivy.Tendril/Program.cs` — softened 3 command registration descriptions
- `src/Ivy.Tendril/Promptwares/{CreatePlan,ExpandPlan,SplitPlan,UpdatePlan}/Program.md`, `src/Ivy.Tendril/Prompts/{AgentPrompt.md,Plans.md}` — added `--stdin` to piped/heredoc examples
- `src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/{01_Plan,03_Verification,05_Other}.md` — CLI reference doc updates
- `src/Ivy.Tendril.Test/{PlanCliCommandTests,PlanRecCommandTests,VerificationCommandTests}.cs` — new CLI-level tests for the changed commands
- `src/Ivy.Tendril.Test/{PromptwareWriteCommandTests,TrashWriteCommandTests}.cs` (new files) — CLI-level tests for the previously-untested `promptware write-*` and `trash write` commands

## Manual Testing

1. Run `tendril plan rec add <plan-id> "Test rec" --stdin` with no piped input attached to a terminal — it should fail immediately with `Provide --description, --file, or --stdin` (not hang for 5 seconds).
2. Run `echo "hello" | tendril trash write test.md --stdin` — it should write `hello` to `$TENDRIL_HOME/Trash/test.md` and print the path.
3. Run `tendril verification add MyCheck --prompt "inline text" --file somefile.md` — it should fail with `Provide the value in exactly one way: --prompt, --file, or --stdin.`
4. Run `tendril plan update <plan-id> --file updated.yaml` — it should replace the plan's YAML from the file without touching STDIN.

---
Commits:
- 7e629437 Harmonize long-form text input across CLI write commands (tendril/00035)
- 513349f0 Update promptware programs, system prompt, and CLI docs for --stdin (tendril/00035)
- f14b7146 Add --file/--stdin CLI tests for harmonized write commands (tendril/00035)

---
Created using [Ivy Tendril](https://ivy.app).
