### PR TITLE
[00066] Fix Implement Recommendations Button Not Responding in Review

### DIFF
--- a/src/Ivy.Tendril.Test/ContentViewTests.cs
+++ b/src/Ivy.Tendril.Test/ContentViewTests.cs
@@ -193,4 +193,33 @@ public class ContentViewTests
         Assert.False(ReviewContentView.ValidateVerificationPath(
             "../secrets/key", "D:/plans/001"));
     }
+
+    [Fact]
+    public void SelectRecommendationsToImplement_WithMatchingTitles_ReturnsSelectedRecs()
+    {
+        var recs = new List<RecommendationYaml>
+        {
+            new() { Title = "R1" },
+            new() { Title = "R2" },
+            new() { Title = "R3" },
+        };
+
+        var selected = ReviewContentView.SelectRecommendationsToImplement(recs, ["R1", "R3"]);
+
+        Assert.Equal(["R1", "R3"], selected.Select(r => r.Title));
+    }
+
+    [Fact]
+    public void SelectRecommendationsToImplement_WithNoMatchingTitles_ReturnsEmpty()
+    {
+        var recs = new List<RecommendationYaml>
+        {
+            new() { Title = "R1" },
+            new() { Title = "R2" },
+        };
+
+        var selected = ReviewContentView.SelectRecommendationsToImplement(recs, ["Unknown"]);
+
+        Assert.Empty(selected);
+    }
 }

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -228,7 +228,7 @@ public class ContentView(
         var pendingRecs = planData.Recommendations.Where(r => r.State == RecommendationStatus.Pending).ToList();
 
         var header = BuildHeader(selectedPlanState.Value, allPlans, currentIndex, client, showCreatePrDialog, nav,
-            args, selectedRecTitles, pendingRecs, planContentQuery.Mutator.Revalidate);
+            args, selectedRecTitles);
         var actionBar = BuildActionBar(
             selectedPlanState.Value, showResetToDraftDialog, showSuggestChangesDialog, showDiscardDialog,
             showCreatePrDialog, copyToClipboard, client, logger, nav, args);
@@ -257,9 +257,7 @@ public class ContentView(
         Action showCreatePrDialog,
         INavigator nav,
         ReviewAppArgs? args,
-        IState<HashSet<string>> selectedRecTitles,
-        List<RecommendationYaml> pendingRecs,
-        Action revalidate)
+        IState<HashSet<string>> selectedRecTitles)
     {
         object BuildTitleArea(bool isMobile)
         {
@@ -291,29 +289,6 @@ public class ContentView(
                                .NoWrap()
                                .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
                                .Muted("plans", word: true);
-
-            if (hasSelection)
-            {
-                var count = selectedRecTitles.Value.Count;
-                rightSide |= new Button("Implement Recommendations")
-                    .Icon(Icons.Rocket).Badge(count.ToString()).Primary()
-                    .OnClick(() =>
-                    {
-                        var titles = selectedRecTitles.Value.ToList();
-                        var selected = pendingRecs.Where(r => titles.Contains(r.Title)).ToList();
-                        if (selected.Count == 0) return;
-
-                        // Single job for the whole batch, never one StartJob call per recommendation.
-                        var changeRequest = BuildRecommendationChangeRequest(selected);
-                        planService.AcceptRecommendationsAndRetry(selectedPlan.FolderName, titles);
-                        jobService.StartJob(new RetryPlanArgs(selectedPlan.FolderPath, changeRequest));
-                        client.Toast($"Started RetryPlan for {selected.Count} recommendation(s)", "Implementing Recommendations");
-
-                        selectedRecTitles.Set(new HashSet<string>());
-                        refreshPlans();
-                        revalidate();
-                    });
-            }
 
             if (selectedPlan.Commits.Count > 0)
             {
@@ -626,6 +601,15 @@ public class ContentView(
             }
 
             var recommendationsLayout = Layout.Vertical().Padding(2);
+            if (selectedRecTitles.Value.Count > 0)
+            {
+                var count = selectedRecTitles.Value.Count;
+                recommendationsLayout |= Layout.Horizontal().Gap(2).AlignContent(Align.Right)
+                    | new Button("Implement Recommendations")
+                        .Icon(Icons.Rocket).Badge(count.ToString()).Primary()
+                        .OnClick(() => ImplementSelectedRecommendations(
+                            selectedPlan, pendingRecs, selectedRecTitles, client, planContentQuery.Mutator.Revalidate));
+            }
             if (pendingRecs.Count == 0)
                 recommendationsLayout |= Text.Muted("No recommendations.");
             else
@@ -723,6 +707,36 @@ public class ContentView(
                     .Width(Size.Full().Max(Size.Units(200))) | inner);
         }
     }
+
+    private void ImplementSelectedRecommendations(
+        PlanFile selectedPlan,
+        List<RecommendationYaml> pendingRecs,
+        IState<HashSet<string>> selectedRecTitles,
+        IClientProvider client,
+        Action revalidate)
+    {
+        var titles = selectedRecTitles.Value.ToList();
+        var selected = SelectRecommendationsToImplement(pendingRecs, titles);
+        if (selected.Count == 0)
+        {
+            client.Toast("Select at least one recommendation to implement.", "Nothing Selected");
+            return;
+        }
+
+        // Single job for the whole batch, never one StartJob call per recommendation.
+        var changeRequest = BuildRecommendationChangeRequest(selected);
+        planService.AcceptRecommendationsAndRetry(selectedPlan.FolderName, titles);
+        jobService.StartJob(new RetryPlanArgs(selectedPlan.FolderPath, changeRequest));
+        client.Toast($"Started RetryPlan for {selected.Count} recommendation(s)", "Implementing Recommendations");
+
+        selectedRecTitles.Set(new HashSet<string>());
+        refreshPlans();
+        revalidate();
+    }
+
+    internal static List<RecommendationYaml> SelectRecommendationsToImplement(
+        IEnumerable<RecommendationYaml> pendingRecs, IReadOnlyCollection<string> selectedTitles)
+        => pendingRecs.Where(r => selectedTitles.Contains(r.Title)).ToList();
 
     private static string BuildRecommendationChangeRequest(List<RecommendationYaml> recs)
     {


### PR DESCRIPTION
# Summary

## Changes

Fixed the "Implement Recommendations" button in the Review app's Recommendations tab, which previously did nothing when clicked. The button was defined inside `BuildHeader`'s `BuildControls` local function, which `ResponsiveHeader.Build` invokes twice per render (desktop + mobile) — its `OnClick` handler never fired. Moved the button into the Recommendations tab body (`BuildContent`), which has a single build site per render, and added user feedback (a toast) when the button is clicked with an empty/stale selection instead of silently no-oping.

## API Changes

- `ContentView.BuildHeader(...)` — dropped the now-unused `pendingRecs` and `revalidate` parameters.
- Added `private void ImplementSelectedRecommendations(PlanFile, List<RecommendationYaml>, IState<HashSet<string>>, IClientProvider, Action)` to `Ivy.Tendril.Apps.Review.ContentView`.
- Added `internal static List<RecommendationYaml> SelectRecommendationsToImplement(IEnumerable<RecommendationYaml>, IReadOnlyCollection<string>)` to `Ivy.Tendril.Apps.Review.ContentView`.

## Files Modified

- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — relocated the button, added the two new members, wired the toast for the empty-selection path.
- `src/Ivy.Tendril.Test/ContentViewTests.cs` — added `SelectRecommendationsToImplement_WithMatchingTitles_ReturnsSelectedRecs` and `SelectRecommendationsToImplement_WithNoMatchingTitles_ReturnsEmpty`.

## Manual Testing

1. Run the Tendril TUI/app and open the Review app on a completed plan that has pending recommendations.
2. Go to the Recommendations tab and tick one or more recommendation checkboxes.
3. Confirm an "Implement Recommendations" button (with a count badge) appears above the recommendation list inside the tab, and click it.
4. Confirm a toast appears ("Started RetryPlan for N recommendation(s)"), a new RetryPlan job shows up in the Jobs view, and the plan transitions to Executing.
5. As a regression check, verify the header row (desktop and mobile) no longer shows an Implement Recommendations button — only Create PR / Complete Plan remain there.

This was not exercised interactively in a running app during this non-interactive execution; verification relied on build, the plan's specified unit tests, and manual code/diff review (see `Verification/CheckResult.md` and `Verification/CodeReview.md`).

---
- Fix Implement Recommendations button not responding in Review (plan 00066) (7fb0ed63)

---
Created using [Ivy Tendril](https://ivy.app).
