### PR TITLE
[00063] Add Investigate With Agent Button to Job Debug Sheet

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -59,7 +59,7 @@ public class ContentView(
             if (!isOpen.Value) return null;
             return new Sheet(
                 () => isOpen.Set(false),
-                new JobDebugSheet(jobId, jobService, planService, config),
+                new JobDebugSheet(jobId, jobService, planService, config, () => isOpen.Set(false)),
                 "Job Debug"
             ).Width(UxHelper.SheetWidth).Resizable();
         });

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
@@ -62,7 +62,7 @@ public partial class JobsApp : ViewBase
             if (!isOpen.Value) return null;
             return new Sheet(
                 () => isOpen.Set(false),
-                new JobDebugSheet(jobId, jobService, planService, config),
+                new JobDebugSheet(jobId, jobService, planService, config, () => isOpen.Set(false)),
                 "Job Debug"
             ).Width(UxHelper.SheetWidth).Resizable();
         });

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -104,7 +104,7 @@ public class ContentView(
             if (!isOpen.Value) return null;
             return new Sheet(
                 () => isOpen.Set(false),
-                new JobDebugSheet(jobId, jobService, planService, config),
+                new JobDebugSheet(jobId, jobService, planService, config, () => isOpen.Set(false)),
                 "Job Debug"
             ).Width(UxHelper.SheetWidth).Resizable();
         });

--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -1,4 +1,6 @@
 using System.Text.RegularExpressions;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Apps.Agent;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Jobs.Dialogs;
 using Ivy.Tendril.Helpers;
@@ -11,13 +13,16 @@ public class JobDebugSheet(
     string jobId,
     IJobService jobService,
     IPlanReaderService planService,
-    IConfigService config) : ViewBase
+    IConfigService config,
+    Action closeSheet) : ViewBase
 {
     public override object Build()
     {
         var copyToClipboard = UseClipboard();
         var client = UseService<IClientProvider>();
         var showReportDialog = UseState(false);
+        var nav = UseNavigation();
+        var agentRunner = UseService<IAgentRunner>();
 
         var job = jobService.GetJob(jobId);
         if (job is null)
@@ -84,43 +89,53 @@ public class JobDebugSheet(
             .Builder(x => x.JobId, f => f.CopyToClipboard())
             .Builder(x => x.PlanId, f => f.CopyToClipboard());
 
+        // Shared "Copy Details" text — reused by the Copy Details button and the
+        // "Investigate with <agent>" prompt so the two stay identical.
+        var copyDetails = string.Join("\n", new List<(string Label, string Value)>
+            {
+                ("Job Id", data.JobId),
+                ("Plan Id", data.PlanId),
+                ("Prompt/Title", data.PromptTitle),
+                ("Status", data.Status),
+                ("Type", data.Type),
+                ("Project", data.Project),
+                ("Provider", data.Provider),
+                ("Model", data.Model),
+                ("Session Id", data.SessionId),
+                ("Started", data.Started),
+                ("Completed", data.Completed),
+                ("Duration", data.Duration),
+                ("Cost", data.Cost),
+                ("Tokens", data.Tokens),
+                ("Exit Code", data.ExitCode),
+                ("Working Directory", data.WorkingDirectory),
+                ("Arguments", data.CliCommand),
+                ("Permission Denials", data.PermissionDenials),
+                ("Plan Folder", data.PlanFolder),
+                ("Plan Log", data.PlanLog),
+                ("Promptware Log", data.PromptwareLog),
+                ("Promptware Raw Log", data.PromptwareRawLog),
+            }
+            .Where(l => !string.IsNullOrEmpty(l.Value))
+            .Select(l => $"{l.Label}: {l.Value}"));
+
+        var agentBranding = AgentBranding.For(config.Settings.CodingAgent, agentRunner);
+
         var header = Layout.Horizontal().Gap(2)
             | new Button("Copy Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>
             {
-                var lines = new List<(string Label, string Value)>
-                {
-                    ("Job Id", data.JobId),
-                    ("Plan Id", data.PlanId),
-                    ("Prompt/Title", data.PromptTitle),
-                    ("Status", data.Status),
-                    ("Type", data.Type),
-                    ("Project", data.Project),
-                    ("Provider", data.Provider),
-                    ("Model", data.Model),
-                    ("Session Id", data.SessionId),
-                    ("Started", data.Started),
-                    ("Completed", data.Completed),
-                    ("Duration", data.Duration),
-                    ("Cost", data.Cost),
-                    ("Tokens", data.Tokens),
-                    ("Exit Code", data.ExitCode),
-                    ("Working Directory", data.WorkingDirectory),
-                    ("Arguments", data.CliCommand),
-                    ("Permission Denials", data.PermissionDenials),
-                    ("Plan Folder", data.PlanFolder),
-                    ("Plan Log", data.PlanLog),
-                    ("Promptware Log", data.PromptwareLog),
-                    ("Promptware Raw Log", data.PromptwareRawLog),
-                };
-
-                var formatted = string.Join("\n", lines
-                    .Where(l => !string.IsNullOrEmpty(l.Value))
-                    .Select(l => $"{l.Label}: {l.Value}"));
-
-                copyToClipboard(formatted);
+                copyToClipboard(copyDetails);
                 client.Toast("Job details copied to clipboard", "Copied");
             })
-            | new Button("Report Bug").Icon(Icons.Bug).OnClick(() => showReportDialog.Set(true));
+            | new Button("Report Bug").Icon(Icons.Bug).OnClick(() => showReportDialog.Set(true))
+            | new Button($"Investigate with {agentBranding.Label}").Icon(agentBranding.Icon).Outline().OnClick(() =>
+            {
+                var prompt =
+                    "I want to investigate the following job for what might have gone wrong of what we can improve.\n\n"
+                    + copyDetails;
+                nav.Navigate<AgentApp>(new AgentAppArgs(prompt));
+                closeSheet();
+            });
 
         return new Fragment(
             new HeaderLayout(header, detailsView).Size(Size.Full()),


### PR DESCRIPTION
# Summary

## Changes

Added an "Investigate with `<Agent>`" button to the Job Debug sheet's header, next to Copy Details and Report Bug. Clicking it opens the Agent tab pre-seeded with an investigation prompt containing the exact same job details that the Copy Details button copies, then closes the debug sheet.

## API Changes

- `JobDebugSheet` constructor now takes an additional `Action closeSheet` parameter (all 3 call sites updated: `JobsApp.cs`, `Apps/Drafts/ContentView.cs`, `Apps/Review/ContentView.cs`).

## Files Modified

- `src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs` — new `closeSheet` constructor param, `nav`/`agentRunner` hooks, extracted shared `copyDetails` local, new "Investigate with `<Agent>`" header button.
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.cs`, `src/Ivy.Tendril/Apps/Drafts/ContentView.cs`, `src/Ivy.Tendril/Apps/Review/ContentView.cs` — pass `() => isOpen.Set(false)` as the new `closeSheet` argument at each `JobDebugSheet` call site.

## Manual Testing

1. Run the Tendril app and open the Jobs app (or Drafts/Review, which also open the Job Debug sheet).
2. Click a job to open its Debug sheet.
3. Confirm the header now shows three buttons: Copy Details, Report Bug, and "Investigate with `<Agent>`" (agent name/icon reflect the configured coding agent).
4. Click "Investigate with `<Agent>`" — the Debug sheet should close and the Agent tab should open with the terminal auto-running a prompt starting with "I want to investigate the following job for what might have gone wrong of what we can improve." followed by the same details Copy Details produces.
5. Click Copy Details separately and confirm the clipboard content matches the details portion of the Investigate prompt exactly.

---
- d4496384 Add Investigate with Agent button to Job Debug sheet

---
Created using [Ivy Tendril](https://ivy.app).
