### PR TITLE
[00060] Move Issue Link Next to Title in Drafts and Review

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -137,9 +137,17 @@ public class ContentView(
 
         object BuildTitleArea(bool isMobile)
         {
+            object SourceButton() => new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
+                .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
+
+            var hasSourceUrl = !string.IsNullOrEmpty(selectedPlan.SourceUrl);
+
             var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full().Min(Size.Px(0)))
                 | Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis)
-                    .Width(Size.Grow().Min(Size.Px(0)));
+                    .Width(Size.Shrink().Min(Size.Px(0)));
+
+            if (hasSourceUrl)
+                desktopTitleLayout |= SourceButton();
 
             if (selectedPlan.DependsOn.Count > 0)
             {
@@ -157,15 +165,25 @@ public class ContentView(
                 .Width(Size.Full().Min(Size.Px(0)))
                 .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
 
+            var mobileTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
+                | MobileItemPicker.Build(
+                        $"#{selectedPlan.Id} {selectedPlan.Title}",
+                        allPlans,
+                        p => $"#{p.Id} {p.Title}",
+                        p => p.FolderName == selectedPlan.FolderName,
+                        p => selectedPlanState.Set(p))
+                    .Width(Size.Grow().Min(Size.Px(0)));
+
+            if (hasSourceUrl)
+                mobileTitleLayout |= SourceButton();
+
+            var mobileTitle = new Box(mobileTitleLayout).BorderThickness(0).Padding(0)
+                .Width(Size.Full().Min(Size.Px(0)))
+                .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
+
             return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow().Min(Size.Px(0)))
                    | desktopTitle
-                   | MobileItemPicker.Build(
-                           $"#{selectedPlan.Id} {selectedPlan.Title}",
-                           allPlans,
-                           p => $"#{p.Id} {p.Title}",
-                           p => p.FolderName == selectedPlan.FolderName,
-                           p => selectedPlanState.Set(p))
-                       .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
+                   | mobileTitle;
         }
 
         object BuildControls(bool isMobile)
@@ -190,21 +208,7 @@ public class ContentView(
                                     ContinueExecute(null, result, pendingWaitJobIds, showDirtyDialog);
                             }));
 
-            if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
-            {
-                var leftSide = Layout.Horizontal().Gap(2).AlignContent(Align.Left)
-                               | new Button(selectedPlan.SourceUrl.Contains("/pull/") ? "PR" : "Issue")
-                                   .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
-
-                return Layout.Horizontal()
-                       .Width(isMobile ? Size.Full() : Size.Fit())
-                       .AlignContent(isMobile ? Align.SpaceBetween : Align.Right)
-                       .Gap(2)
-                       | leftSide
-                       | rightSide;
-            }
-
-            return rightSide;
+            return rightSide.Width(isMobile ? Size.Full() : Size.Fit());
         }
 
         var header = ResponsiveHeader.Build(BuildTitleArea, BuildControls);

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -263,23 +263,41 @@ public class ContentView(
     {
         object BuildTitleArea(bool isMobile)
         {
+            object SourceButton() => new Button(selectedPlan.IsPullRequestSource ? "PR" : "Issue")
+                .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
+
+            var hasSourceUrl = !string.IsNullOrEmpty(selectedPlan.SourceUrl);
+
             var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full().Min(Size.Px(0)))
                 | Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis)
-                    .Width(Size.Grow().Min(Size.Px(0)));
+                    .Width(Size.Shrink().Min(Size.Px(0)));
+
+            if (hasSourceUrl)
+                desktopTitleLayout |= SourceButton();
 
             var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
                 .Width(Size.Full().Min(Size.Px(0)))
                 .HideOn(Breakpoint.Mobile, Breakpoint.Tablet);
 
+            var mobileTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
+                | MobileItemPicker.Build(
+                        $"#{selectedPlan.Id} {selectedPlan.Title}",
+                        allPlans,
+                        p => $"#{p.Id} {p.Title}",
+                        p => p.FolderName == selectedPlan.FolderName,
+                        p => selectedPlanState.Set(p))
+                    .Width(Size.Grow().Min(Size.Px(0)));
+
+            if (hasSourceUrl)
+                mobileTitleLayout |= SourceButton();
+
+            var mobileTitle = new Box(mobileTitleLayout).BorderThickness(0).Padding(0)
+                .Width(Size.Full().Min(Size.Px(0)))
+                .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
+
             return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow().Min(Size.Px(0)))
                    | desktopTitle
-                   | MobileItemPicker.Build(
-                           $"#{selectedPlan.Id} {selectedPlan.Title}",
-                           allPlans,
-                           p => $"#{p.Id} {p.Title}",
-                           p => p.FolderName == selectedPlan.FolderName,
-                           p => selectedPlanState.Set(p))
-                       .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
+                   | mobileTitle;
         }
 
         object BuildControls(bool isMobile)
@@ -381,21 +399,7 @@ public class ContentView(
                 rightSide |= hasSelection ? completePlanBtn.Outline() : completePlanBtn.Primary();
             }
 
-            if (!string.IsNullOrEmpty(selectedPlan.SourceUrl))
-            {
-                var leftSide = Layout.Horizontal().Gap(2).AlignContent(Align.Left)
-                               | new Button(selectedPlan.IsPullRequestSource ? "PR" : "Issue")
-                                   .Icon(Icons.ExternalLink).Ghost().OnClick(() => client.OpenUrl(selectedPlan.SourceUrl));
-
-                return Layout.Horizontal()
-                       .Width(isMobile ? Size.Full() : Size.Fit())
-                       .AlignContent(isMobile ? Align.SpaceBetween : Align.Right)
-                       .Gap(2)
-                       | leftSide
-                       | rightSide;
-            }
-
-            return rightSide;
+            return rightSide.Width(isMobile ? Size.Full() : Size.Fit());
         }
 
         return ResponsiveHeader.Build(BuildTitleArea, BuildControls);


### PR DESCRIPTION
# Summary

## Changes

The Issue/PR link in the Drafts and Review app headers now renders immediately to the right of the plan title (desktop and mobile), instead of on the far right of the header next to the counter and primary action button. The title text now shrinks to its content instead of growing to fill the row, so the button hugs it rather than being pushed to the far edge.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — moved the Issue/PR button from `BuildControls` into `BuildTitleArea`; `BuildControls` now returns only the counter + action buttons.
- `src/Ivy.Tendril/Apps/Drafts/ContentView.cs` — same move; kept this file's `/pull/`-based PR-vs-Issue label rule and the `Depends on:` badge ordering after the button.

## Manual Testing

1. Run the Tendril app and open the Drafts view for a plan that has a `sourceUrl` set (an Issue or PR link).
2. On a desktop-width window, confirm the "Issue" (or "PR") button now appears directly to the right of the plan title, not on the far right of the header.
3. Narrow the window to mobile/tablet width and confirm the button still appears next to the title row (not in the counter/action row below).
4. Confirm the far-right controls row shows only the plan counter (`N/M plans`) and the primary action button (Execute / Create PR), with no duplicate Issue/PR button there.
5. Repeat steps 1-4 in the Review app for a completed plan with a `sourceUrl`.
6. Open a plan with no `sourceUrl` and confirm no button renders and the title/controls layout is otherwise unchanged.
7. Open a plan with a very long title and confirm it still truncates with an ellipsis rather than pushing the button off-screen.

---
## Commits
- 3524e6b1 Move Issue/PR link next to plan title in Drafts and Review headers

---
Created using [Ivy Tendril](https://ivy.app).