### PR TITLE
[00064] Allow List Item Titles to Wrap Fully Instead of Truncating with an Ellipsis

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/SidebarView.cs
@@ -78,9 +78,7 @@ public class SidebarView(
             }
             badges |= new Badge(plan.Level).Color(config.GetLevelColor(plan.Level) ?? Colors.Gray).Small();
 
-            return new ListItem($"#{plan.Id} {plan.Title}")
-                .Content(badges)
-                .OnClick(() => selectedPlanState.Set(clickablePlan));
+            return SidebarListRow.Build($"#{plan.Id} {plan.Title}", badges, () => selectedPlanState.Set(clickablePlan));
         }));
 
         return new HeaderLayout(BuildHeader(), content);

--- a/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
@@ -65,12 +65,12 @@ public class SidebarView(
         var content = new List(filteredList.Select(plan =>
         {
             var clickablePlan = plan;
-            return new ListItem($"#{plan.Id} {plan.Title}")
-                .Content(Layout.Horizontal().Gap(1)
-                         | new Badge(plan.Project).Variant(BadgeVariant.Outline).Small()
-                             .WithProjectColor(config, plan.Project)
-                         | new Badge(plan.Level).Color(config.GetLevelColor(plan.Level) ?? Colors.Gray).Small())
-                .OnClick(() => selectedPlanState.Set(clickablePlan));
+            var badges = Layout.Horizontal().Gap(1)
+                | new Badge(plan.Project).Variant(BadgeVariant.Outline).Small()
+                    .WithProjectColor(config, plan.Project)
+                | new Badge(plan.Level).Color(config.GetLevelColor(plan.Level) ?? Colors.Gray).Small();
+
+            return SidebarListRow.Build($"#{plan.Id} {plan.Title}", badges, () => selectedPlanState.Set(clickablePlan));
         }));
 
         return new HeaderLayout(BuildHeader(), content);

--- a/src/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -79,8 +79,7 @@ public class SidebarView(
                 ? rec.Description[..120] + "..."
                 : rec.Description;
 
-            return new ListItem($"#{rec.PlanId} {rec.Title}", preview)
-                .OnClick(() => selectedState.Set(clickableRec));
+            return SidebarListRow.Build($"#{rec.PlanId} {rec.Title}", Text.Muted(preview).Small(), () => selectedState.Set(clickableRec));
         }));
 
         return new HeaderLayout(BuildHeader(), content);

--- a/src/Ivy.Tendril/Apps/Review/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/SidebarView.cs
@@ -67,15 +67,14 @@ public class SidebarView(
             var verificationsPassed = plan.Verifications.Count > 0
                                       && plan.Verifications.All(v => v.Status is VerificationStatus.Pass or VerificationStatus.Skipped);
 
-            return new ListItem($"#{plan.Id} {plan.Title}")
-                .Content(Layout.Horizontal().Gap(1)
-                         | new Badge(plan.Project).Variant(BadgeVariant.Outline).Small()
-                             .WithProjectColor(config, plan.Project)
-                         | (!verificationsPassed
-                             ? new Badge("Unverified").Variant(BadgeVariant.Warning).Small()
-                             : null)
-                )
-                .OnClick(() => selectedPlanState.Set(clickablePlan));
+            var badges = Layout.Horizontal().Gap(1)
+                | new Badge(plan.Project).Variant(BadgeVariant.Outline).Small()
+                    .WithProjectColor(config, plan.Project)
+                | (!verificationsPassed
+                    ? new Badge("Unverified").Variant(BadgeVariant.Warning).Small()
+                    : null);
+
+            return SidebarListRow.Build($"#{plan.Id} {plan.Title}", badges, () => selectedPlanState.Set(clickablePlan));
         }));
 
         return new HeaderLayout(BuildHeader(), content);

--- a/src/Ivy.Tendril/Apps/Trash/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Trash/SidebarView.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Apps.Views;
+using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Trash;
 
@@ -42,11 +43,11 @@ public class SidebarView(
         var content = new List(filteredList.Select(f =>
         {
             var item = f;
-            return new ListItem(item.FileName.Replace(".md", ""))
-                .Content(Layout.Horizontal().Gap(1)
-                         | new Badge(item.Project).Variant(BadgeVariant.Outline).Small()
-                         | Text.Muted(item.Date.ToString("yyyy-MM-dd")).Small())
-                .OnClick(() => selectedFile.Set(item.FilePath));
+            var badges = Layout.Horizontal().Gap(1)
+                | new Badge(item.Project).Variant(BadgeVariant.Outline).Small()
+                | Text.Muted(item.Date.ToString("yyyy-MM-dd")).Small();
+
+            return SidebarListRow.Build(item.FileName.Replace(".md", ""), badges, () => selectedFile.Set(item.FilePath));
         }));
 
         return new HeaderLayout(BuildHeader(), content);

--- a/src/Ivy.Tendril/Helpers/SidebarListRow.cs
+++ b/src/Ivy.Tendril/Helpers/SidebarListRow.cs
@@ -1,0 +1,13 @@
+namespace Ivy.Tendril.Helpers;
+
+public static class SidebarListRow
+{
+    public static object Build(string title, object content, Action onClick)
+    {
+        var row = Layout.Vertical().Gap(1)
+            | Text.Literal(title)
+            | content;
+
+        return new Button().Ghost().Width(Size.Full()).Content(row).OnClick(onClick);
+    }
+}


### PR DESCRIPTION
# Summary

## Changes

Added a new `SidebarListRow.Build(title, content, onClick)` helper in `Ivy.Tendril` that renders a list-item title with `Text.Literal` (which wraps naturally across as many lines as needed, with no clamp or ellipsis) inside a full-width, Ghost-styled `Button`. All five plan sidebars — Drafts, Review, Recommendations, Trash, and Icebox — were switched from the shared `ListItem` widget (which truncates titles to a single line) to this new helper, so long plan/recommendation titles are now fully visible instead of being cut off mid-word.

## API Changes

- New public class `Ivy.Tendril.Helpers.SidebarListRow` with static method `Build(string title, object content, Action onClick)`.

## Files Modified

- `src/Ivy.Tendril/Helpers/SidebarListRow.cs` (new)
- `src/Ivy.Tendril/Apps/Drafts/SidebarView.cs`
- `src/Ivy.Tendril/Apps/Review/SidebarView.cs`
- `src/Ivy.Tendril/Apps/Recommendations/SidebarView.cs`
- `src/Ivy.Tendril/Apps/Trash/SidebarView.cs`
- `src/Ivy.Tendril/Apps/Icebox/SidebarView.cs`

## Manual Testing

1. Run Tendril and open the Drafts, Review, Recommendations, Trash, and Icebox sidebars.
2. Confirm a long plan/recommendation title now wraps across as many lines as it needs, with no truncation or ellipsis.
3. Confirm a short title still looks unchanged (single line, same spacing).
4. Confirm an unusually long title makes only its own row taller, without disturbing sibling rows in the virtualized list.
5. Confirm each row is still fully clickable (clicking anywhere in the row selects the item) and hover/focus affordance still shows (via the `Button`'s Ghost variant).
6. Confirm titles render at normal (not bold) font weight.

## Fix: Titles still not wrapping, rendered bold (per reviewer screenshot)

The reviewer's follow-up screenshot showed titles still stuck on one line
and rendered bold. Root cause: `Text.Literal(title)` renders a bare `<span>`
with no whitespace/font-weight class of its own when not explicitly set, so
it was inheriting `whitespace-nowrap` and `font-medium` from the ancestor
`Button` (Ivy Framework's shared button base classes) via ordinary CSS
inheritance — the "plain, unstyled span" the original plan describes only
behaves that way in isolation, not nested inside another styled element.
Fixed in `Ivy.Framework`'s `TextBlockWidget.tsx` by giving the `"Literal"`
variant an explicit `whitespace-normal`/`font-normal` default so it no
longer depends on its container. A first attempt applied the whitespace
default to every variant, which broke `TableCellWidget`'s default
ellipsis-truncation behavior (Block-variant cells rely on inheriting an
ambient `nowrap`); a follow-up commit scoped the fix to the `"Literal"`
variant only, restoring table truncation while keeping the title fix.

### Files Modified

- `Ivy-Framework`: `src/frontend/src/widgets/primitives/TextBlockWidget.tsx` (2 commits: `aa6251e29`, `a4ed50742`)

**Note:** Manual testing item 6 above (normal font weight) was added for
this fix; items 1-5 are unchanged and still apply.

---
Commits:
- 5acb6596 Allow list item titles to wrap fully instead of truncating with an ellipsis (plan 00064)

---
Created using [Ivy Tendril](https://ivy.app).
