### PR TITLE
Refine Recommendations list and title card

### DIFF
--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -74,11 +74,22 @@ public class ContentView(
 
         object BuildTitleArea(bool isMobile)
         {
-            var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full().Min(Size.Px(0)))
-                | Text.Block($"#{selectedRecommendation.PlanId} {selectedRecommendation.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis)
-                    .Width(Size.Grow().Min(Size.Px(0)))
+            var badgeRow = Layout.Horizontal().Gap(1).AlignContent(Align.Left)
                 | new Badge(selectedRecommendation.Project).Variant(BadgeVariant.Outline)
                     .WithProjectColor(config, selectedRecommendation.Project);
+
+            if (selectedRecommendation.Impact is { } impact)
+                badgeRow |= new Badge(impact).Variant(impact switch
+                {
+                    "High" => BadgeVariant.Success,
+                    "Medium" => BadgeVariant.Warning,
+                    _ => BadgeVariant.Outline
+                });
+
+            var desktopTitleLayout = Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Full().Min(Size.Px(0)))
+                | Text.Block($"#{selectedRecommendation.ShortPlanId} {selectedRecommendation.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis)
+                    .Width(Size.Grow().Min(Size.Px(0)))
+                | badgeRow;
 
             var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
                 .Width(Size.Full().Min(Size.Px(0)))
@@ -87,9 +98,9 @@ public class ContentView(
             return Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Grow().Min(Size.Px(0)))
                    | desktopTitle
                    | MobileItemPicker.Build(
-                           $"#{selectedRecommendation.PlanId} {selectedRecommendation.Title}",
+                           $"#{selectedRecommendation.ShortPlanId} {selectedRecommendation.Title}",
                            allRecommendations,
-                           r => $"#{r.PlanId} {r.Title}",
+                           r => $"#{r.ShortPlanId} {r.Title}",
                            r => r.PlanId == selectedRecommendation.PlanId && r.Title == selectedRecommendation.Title,
                            r => selectedState.Set(r))
                        .ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
@@ -119,17 +130,9 @@ public class ContentView(
         // Content
         var scrollableContent = Layout.Vertical().Width(Size.Full().Max(Size.Units(200))).Padding(6, 2, 6, 2);
 
-        // Source plan info and Impact badge
+        // Source plan info
         var metaRow = Layout.Horizontal().Gap(2).AlignContent(Align.Left)
-                      | Text.Muted($"Plan #{selectedRecommendation.PlanId}: {selectedRecommendation.PlanTitle}");
-
-        if (selectedRecommendation.Impact is { } impact)
-            metaRow |= new Badge($"Impact: {impact}").Variant(impact switch
-            {
-                "High" => BadgeVariant.Success,
-                "Medium" => BadgeVariant.Warning,
-                _ => BadgeVariant.Outline
-            });
+                      | Text.Muted($"Plan #{selectedRecommendation.ShortPlanId}: {selectedRecommendation.PlanTitle}");
 
         scrollableContent |= Layout.Vertical().Gap(1)
                              | Text.Block("Source Plan").Bold()

--- a/src/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -75,11 +75,7 @@ public class SidebarView(
         {
             var clickableRec = rec;
 
-            var preview = rec.Description.Length > 120
-                ? rec.Description[..120] + "..."
-                : rec.Description;
-
-            return SidebarListRow.Build($"#{rec.PlanId} {rec.Title}", Text.Muted(preview).Small(), () => selectedState.Set(clickableRec));
+            return SidebarListRow.Build($"#{rec.ShortPlanId} {rec.Title}", () => selectedState.Set(clickableRec));
         }));
 
         return new HeaderLayout(BuildHeader(), content);

--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -90,7 +90,7 @@ public class JobDebugSheet(
             .Builder(x => x.PlanId, f => f.CopyToClipboard());
 
         // Shared "Copy Details" text — reused by the Copy Details button and the
-        // "Investigate with <agent>" prompt so the two stay identical.
+        // "Debug with <agent>" prompt so the two stay identical.
         var copyDetails = string.Join("\n", new List<(string Label, string Value)>
             {
                 ("Job Id", data.JobId),
@@ -122,20 +122,23 @@ public class JobDebugSheet(
         var agentBranding = AgentBranding.For(config.Settings.CodingAgent, agentRunner);
 
         var header = Layout.Horizontal().Gap(2)
-            | new Button("Copy Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>
-            {
-                copyToClipboard(copyDetails);
-                client.Toast("Job details copied to clipboard", "Copied");
-            })
-            | new Button("Report Bug").Icon(Icons.Bug).OnClick(() => showReportDialog.Set(true))
-            | new Button($"Investigate with {agentBranding.Label}").Icon(agentBranding.Icon).Outline().OnClick(() =>
-            {
-                var prompt =
-                    "I want to investigate the following job for what might have gone wrong of what we can improve.\n\n"
-                    + copyDetails;
-                nav.Navigate<AgentApp>(new AgentAppArgs(prompt));
-                closeSheet();
-            });
+                     | new Button("Copy Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>
+                     {
+                         copyToClipboard(copyDetails);
+                         client.Toast("Job details copied to clipboard", "Copied");
+                     })
+                     | new Button("Report Bug").Icon(Icons.Bug).OnClick(() => showReportDialog.Set(true));
+        
+        #if DEBUG
+        header |= new Button($"Debug with {agentBranding.Label}").Icon(agentBranding.Icon).Outline().OnClick(() =>
+        {
+            var prompt =
+                "I want to debug the following job for what might have gone wrong of what we can improve. Use the /tendril-debug-job skill if available. \n\n"
+                + copyDetails;
+            nav.Navigate<AgentApp>(new AgentAppArgs(prompt));
+            closeSheet();
+        });
+        #endif
 
         return new Fragment(
             new HeaderLayout(header, detailsView).Size(Size.Full()),

--- a/src/Ivy.Tendril/Helpers/SidebarListRow.cs
+++ b/src/Ivy.Tendril/Helpers/SidebarListRow.cs
@@ -10,4 +10,9 @@ public static class SidebarListRow
 
         return new Button().Ghost().Width(Size.Full()).Content(row).OnClick(onClick);
     }
+
+    public static object Build(string title, Action onClick)
+    {
+        return new Button().Ghost().Width(Size.Full()).Content(Text.Literal(title)).OnClick(onClick);
+    }
 }

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -106,6 +106,10 @@
     <None Include="../../README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Apps\Review\Tabs\" />
+  </ItemGroup>
+
   <Target Name="SetCommitId" BeforeTargets="GetAssemblyAttributes">
     <!-- CI passes -p:CommitId=<sha>; locally fall back to git. Embedded as assembly metadata
          and read at runtime by BugReportService to tag bug reports with the source revision. -->

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -1266,4 +1266,9 @@ public record Recommendation(
     PlanStatus SourcePlanStatus,
     string? DeclineReason = null,
     string? Impact = null
-);
+)
+{
+    /// <summary>Plan id without leading zeros, e.g. "60" for "00060".</summary>
+    public string ShortPlanId =>
+        PlanId.TrimStart('0') is { Length: > 0 } trimmed ? trimmed : PlanId;
+}


### PR DESCRIPTION
## Recommendations app
- Drop the description preview from sidebar list rows (title only).
- Show plan ids in short form (`#60`) instead of zero-padded (`#00060`) via a new `Recommendation.ShortPlanId` helper.
- Move the project badge out of the title bar and into a badge row in the title card, alongside a new Impact badge (raw value, color-coded).
- Remove the `Impact: ...` badge from the Source Plan content section.

## Misc
- Gate the JobDebugSheet "Debug with <agent>" button behind `#if DEBUG`.
- Add the `Apps\Review\Tabs\` folder include to the csproj.