### PR TITLE
Job Debug agent focus prompt + recommendation row badges

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/Dialogs/DebugWithAgentDialog.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Dialogs/DebugWithAgentDialog.cs
@@ -1,0 +1,32 @@
+namespace Ivy.Tendril.Apps.Jobs.Dialogs;
+
+public class DebugWithAgentDialog(
+    IState<bool> isOpen,
+    (string Label, Icons Icon) branding,
+    Action<string?> onConfirm) : ViewBase
+{
+    public override object Build()
+    {
+        var focus = UseState("");
+
+        void Confirm()
+        {
+            isOpen.Set(false);
+            onConfirm(string.IsNullOrWhiteSpace(focus.Value) ? null : focus.Value.Trim());
+        }
+
+        return new Dialog(
+            _ => isOpen.Set(false),
+            new DialogHeader($"Debug with {branding.Label}"),
+            new DialogBody(
+                focus.ToTextareaInput("Anything particular you want to look for? (Optional)")
+                    .Rows(3)
+                    .AutoFocus()),
+            new DialogFooter(
+                new Button("Cancel").Ghost().OnClick(() => isOpen.Set(false)),
+                new Button($"Debug with {branding.Label}").Primary().Icon(branding.Icon)
+                    .ShortcutKey("Ctrl+Enter")
+                    .OnClick(Confirm))
+        ).Width(Size.Rem(32));
+    }
+}

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -74,22 +74,11 @@ public class ContentView(
 
         object BuildTitleArea(bool isMobile)
         {
-            var badgeRow = Layout.Horizontal().Gap(1).AlignContent(Align.Left)
-                | new Badge(selectedRecommendation.Project).Variant(BadgeVariant.Outline)
-                    .WithProjectColor(config, selectedRecommendation.Project);
-
-            if (selectedRecommendation.Impact is { } impact)
-                badgeRow |= new Badge(impact).Variant(impact switch
-                {
-                    "High" => BadgeVariant.Success,
-                    "Medium" => BadgeVariant.Warning,
-                    _ => BadgeVariant.Outline
-                });
-
+            // Project/Impact badges live on each sidebar row (see SidebarView), so the header
+            // title stays badge-free.
             var desktopTitleLayout = Layout.Vertical().Gap(1).AlignContent(Align.Left).Width(Size.Full().Min(Size.Px(0)))
                 | Text.Block($"#{selectedRecommendation.ShortPlanId} {selectedRecommendation.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis)
-                    .Width(Size.Grow().Min(Size.Px(0)))
-                | badgeRow;
+                    .Width(Size.Grow().Min(Size.Px(0)));
 
             var desktopTitle = new Box(desktopTitleLayout).BorderThickness(0).Padding(0)
                 .Width(Size.Full().Min(Size.Px(0)))

--- a/src/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -52,6 +52,8 @@ public class SidebarView(
 
     public override object Build()
     {
+        var config = UseService<IConfigService>();
+
         var filtered = recommendations
             .Where(r => projectFilter.Value == null || r.Project == projectFilter.Value)
             .Where(r => impactFilter.Value == null || r.Impact == impactFilter.Value)
@@ -75,7 +77,20 @@ public class SidebarView(
         {
             var clickableRec = rec;
 
-            return SidebarListRow.Build($"#{rec.ShortPlanId} {rec.Title}", () => selectedState.Set(clickableRec));
+            // Mirror the detail header's badge row (Project + Impact) so each row is self-describing.
+            var badges = Layout.Horizontal().Gap(1)
+                | new Badge(rec.Project).Variant(BadgeVariant.Outline).Small()
+                    .WithProjectColor(config, rec.Project);
+            if (rec.Impact is { } impact)
+                badges |= new Badge(impact).Variant(impact switch
+                {
+                    "High" => BadgeVariant.Success,
+                    "Medium" => BadgeVariant.Warning,
+                    _ => BadgeVariant.Outline
+                }).Small();
+
+            return SidebarListRow.Build($"#{rec.ShortPlanId} {rec.Title}", badges,
+                () => selectedState.Set(clickableRec));
         }));
 
         return new HeaderLayout(BuildHeader(), content);

--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -20,39 +20,40 @@ public class JobDebugSheet(
     {
         var copyToClipboard = UseClipboard();
         var client = UseService<IClientProvider>();
-        var showReportDialog = UseState(false);
         var nav = UseNavigation();
         var agentRunner = UseService<IAgentRunner>();
+
+        var (reportBugDialog, showReportBugDialog) = UseTrigger((isOpen) =>
+            !isOpen.Value ? null : new ReportBugDialog(isOpen, jobId));
+
+        #if DEBUG
+        var (debugAgentDialog, showDebugAgentDialog) = UseTrigger((isOpen) =>
+        {
+            if (!isOpen.Value) return null;
+            var job = jobService.GetJob(jobId);
+            if (job is null) return null;
+            // Snapshot branding + details while the job is live, so confirming always navigates
+            // even if the job is evicted between opening the dialog and clicking the button.
+            var branding = AgentBranding.For(config.Settings.CodingAgent, agentRunner);
+            var details = FormatCopyDetails(BuildData(job));
+            return new DebugWithAgentDialog(isOpen, branding, focus =>
+            {
+                var prompt =
+                    "I want to debug the following job for what might have gone wrong of what we can improve. Use the /tendril-debug-job skill if available. \n\n";
+                if (!string.IsNullOrEmpty(focus))
+                    prompt += $"In particular, focus on: {focus}\n\n";
+                prompt += details;
+                nav.Navigate<AgentApp>(new AgentAppArgs(prompt));
+                closeSheet();
+            });
+        });
+        #endif
 
         var job = jobService.GetJob(jobId);
         if (job is null)
             return Text.P("Job not found.");
 
-        var data = new
-        {
-            JobId = job.Id,
-            PlanId = GetPlanId(job),
-            PromptTitle = JobsApp.GetFullPrompt(job, planService) ?? "",
-            Status = $"{job.Status}{(job.StatusMessage != null ? $": {job.StatusMessage}" : "")}",
-            job.Type,
-            job.Project,
-            job.Provider,
-            Model = job.Model ?? "",
-            SessionId = job.SessionId ?? "",
-            Started = job.StartedAt?.ToString("u") ?? "",
-            Completed = job.CompletedAt?.ToString("u") ?? "",
-            Duration = job.DurationSeconds.HasValue ? $"{job.DurationSeconds}s" : "",
-            Cost = job.Cost.HasValue ? $"${job.Cost:F4}" : "",
-            Tokens = job.Tokens.HasValue ? $"{job.Tokens:N0}" : "",
-            PermissionDenials = FormatPermissionDenials(job),
-            PlanFolder = GetPlanFolderPath(job) ?? "",
-            PlanLog = GetPlanLogPath(job) ?? "",
-            PromptwareLog = GetPromptwareLogPath(job) ?? "",
-            PromptwareRawLog = GetPromptwareRawLogPath(job) ?? "",
-            WorkingDirectory = job.WorkingDirectory ?? "",
-            CliCommand = job.CliCommand ?? "",
-            ExitCode = job.ExitCode?.ToString() ?? "",
-        };
+        var data = BuildData(job);
 
         var detailsView = data.ToDetails()
             .RemoveEmpty()
@@ -89,9 +90,93 @@ public class JobDebugSheet(
             .Builder(x => x.JobId, f => f.CopyToClipboard())
             .Builder(x => x.PlanId, f => f.CopyToClipboard());
 
-        // Shared "Copy Details" text — reused by the Copy Details button and the
-        // "Debug with <agent>" prompt so the two stay identical.
-        var copyDetails = string.Join("\n", new List<(string Label, string Value)>
+        // Copy/debug text is projected from the same `data` model the details view renders,
+        // so the field values stay in sync with the sheet (labels are defined per-view; the
+        // `.Label()` API takes lambda expressions and can't be shared with the copy projection).
+        var copyDetails = FormatCopyDetails(data);
+
+        var agentBranding = AgentBranding.For(config.Settings.CodingAgent, agentRunner);
+
+        var header = Layout.Horizontal().Gap(2)
+                     | new Button("Copy Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>
+                     {
+                         copyToClipboard(copyDetails);
+                         client.Toast("Job details copied to clipboard", "Copied");
+                     })
+                     | new Button("Report Bug").Icon(Icons.Bug).OnClick(() => showReportBugDialog());
+
+        #if DEBUG
+        header |= new Button($"Debug with {agentBranding.Label}").Icon(agentBranding.Icon).Outline()
+            .OnClick(() => showDebugAgentDialog());
+        #endif
+
+        return new Fragment(
+            new HeaderLayout(header, detailsView).Size(Size.Full()),
+            reportBugDialog
+            #if DEBUG
+            , debugAgentDialog
+            #endif
+        );
+    }
+
+    // Master model for the sheet: the details view renders it, and FormatCopyDetails projects it
+    // to text. Property order here is the details-view display order.
+    private sealed record JobDebugData
+    {
+        public required string JobId { get; init; }
+        public required string PlanId { get; init; }
+        public required string PromptTitle { get; init; }
+        public required string Status { get; init; }
+        public required string Type { get; init; }
+        public required string Project { get; init; }
+        public required string Provider { get; init; }
+        public required string Model { get; init; }
+        public required string SessionId { get; init; }
+        public required string Started { get; init; }
+        public required string Completed { get; init; }
+        public required string Duration { get; init; }
+        public required string Cost { get; init; }
+        public required string Tokens { get; init; }
+        public required string PermissionDenials { get; init; }
+        public required string PlanFolder { get; init; }
+        public required string PlanLog { get; init; }
+        public required string PromptwareLog { get; init; }
+        public required string PromptwareRawLog { get; init; }
+        public required string WorkingDirectory { get; init; }
+        public required string CliCommand { get; init; }
+        public required string ExitCode { get; init; }
+    }
+
+    private JobDebugData BuildData(JobItem job) => new()
+    {
+        JobId = job.Id,
+        PlanId = GetPlanId(job),
+        PromptTitle = JobsApp.GetFullPrompt(job, planService) ?? "",
+        Status = $"{job.Status}{(job.StatusMessage != null ? $": {job.StatusMessage}" : "")}",
+        Type = job.Type,
+        Project = job.Project,
+        Provider = job.Provider,
+        Model = job.Model ?? "",
+        SessionId = job.SessionId ?? "",
+        Started = job.StartedAt?.ToString("u") ?? "",
+        Completed = job.CompletedAt?.ToString("u") ?? "",
+        Duration = job.DurationSeconds.HasValue ? $"{job.DurationSeconds}s" : "",
+        Cost = job.Cost.HasValue ? $"${job.Cost:F4}" : "",
+        Tokens = job.Tokens.HasValue ? $"{job.Tokens:N0}" : "",
+        PermissionDenials = FormatPermissionDenials(job),
+        PlanFolder = GetPlanFolderPath(job) ?? "",
+        PlanLog = GetPlanLogPath(job) ?? "",
+        PromptwareLog = GetPromptwareLogPath(job) ?? "",
+        PromptwareRawLog = GetPromptwareRawLogPath(job) ?? "",
+        WorkingDirectory = job.WorkingDirectory ?? "",
+        CliCommand = job.CliCommand ?? "",
+        ExitCode = job.ExitCode?.ToString() ?? "",
+    };
+
+    // Projects the master model to the copied/debug text. Labels mirror the details-view labels;
+    // paths and logs are grouped last for a readable paste.
+    private static string FormatCopyDetails(JobDebugData data) =>
+        string.Join("\n", new (string Label, string Value)[]
             {
                 ("Job Id", data.JobId),
                 ("Plan Id", data.PlanId),
@@ -118,33 +203,6 @@ public class JobDebugSheet(
             }
             .Where(l => !string.IsNullOrEmpty(l.Value))
             .Select(l => $"{l.Label}: {l.Value}"));
-
-        var agentBranding = AgentBranding.For(config.Settings.CodingAgent, agentRunner);
-
-        var header = Layout.Horizontal().Gap(2)
-                     | new Button("Copy Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>
-                     {
-                         copyToClipboard(copyDetails);
-                         client.Toast("Job details copied to clipboard", "Copied");
-                     })
-                     | new Button("Report Bug").Icon(Icons.Bug).OnClick(() => showReportDialog.Set(true));
-        
-        #if DEBUG
-        header |= new Button($"Debug with {agentBranding.Label}").Icon(agentBranding.Icon).Outline().OnClick(() =>
-        {
-            var prompt =
-                "I want to debug the following job for what might have gone wrong of what we can improve. Use the /tendril-debug-job skill if available. \n\n"
-                + copyDetails;
-            nav.Navigate<AgentApp>(new AgentAppArgs(prompt));
-            closeSheet();
-        });
-        #endif
-
-        return new Fragment(
-            new HeaderLayout(header, detailsView).Size(Size.Full()),
-            showReportDialog.Value ? new ReportBugDialog(showReportDialog, jobId) : null
-        );
-    }
 
     private object PathDropDown(string path, Action<string> copyToClipboard, IClientProvider client)
     {


### PR DESCRIPTION
## Job Debug sheet
- **Debug with <agent>** now opens a dialog first, with an optional *"Anything particular you want to look for?"* textbox. The note is folded into the agent prompt (`In particular, focus on: ...`); leaving it blank keeps the previous behavior. New `DebugWithAgentDialog`. (DEBUG builds only.)
- Both dialogs (Report Bug + Debug with Agent) now use the `UseTrigger` pattern with hooks at the top of `Build()`, satisfying the Ivy rules-of-hooks analyzer.
- Unified the details view and the copy/debug text onto a single `JobDebugData` record, so field values are computed once. The confirm path snapshots details while the job is live, so it always navigates even if the job is evicted after the dialog opens.

## Recommendations
- Show the **Project** + **Impact** badges on each sidebar row (matching the Drafts/Icebox/Review sidebars) and removed them from the detail-header title.
