### PR TITLE
Restore Implement Recommendations header CTA and fix Job Debug plan log

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -228,8 +228,12 @@ public class ContentView(
         var planData = planContentQuery.Value;
         var pendingRecs = planData.Recommendations.Where(r => r.State == RecommendationStatus.Pending).ToList();
 
+        void ImplementRecommendations() => ImplementSelectedRecommendations(
+            selectedPlanState.Value!, pendingRecs, selectedRecTitles, client,
+            planContentQuery.Mutator.Revalidate);
+
         var header = BuildHeader(selectedPlanState.Value, allPlans, currentIndex, client, showCreatePrDialog, nav,
-            args, selectedRecTitles);
+            args, selectedRecTitles, ImplementRecommendations);
         var actionBar = BuildActionBar(
             selectedPlanState.Value, showResetToDraftDialog, showSuggestChangesDialog, showDiscardDialog,
             showCreatePrDialog, copyToClipboard, client, logger, nav, args);
@@ -258,7 +262,8 @@ public class ContentView(
         Action showCreatePrDialog,
         INavigator nav,
         ReviewAppArgs? args,
-        IState<HashSet<string>> selectedRecTitles)
+        IState<HashSet<string>> selectedRecTitles,
+        Action onImplementRecommendations)
     {
         object BuildTitleArea(bool isMobile)
         {
@@ -373,6 +378,17 @@ public class ContentView(
                     WorktreeCleanupService.RemoveWorktreesInBackground(selectedPlan.FolderPath);
                 }).ShortcutKey("m");
                 rightSide |= hasSelection ? completePlanBtn.Outline() : completePlanBtn.Primary();
+            }
+
+            if (hasSelection)
+            { 
+                var count = selectedRecTitles.Value.Count;
+                var label = count > 1 ? "Implement Recommendations" : "Implement Recommendation";
+                rightSide |= new Button(label)
+                    .Badge(count.ToString())
+                    .Icon(Icons.Rocket)
+                    .Primary()
+                    .OnClick(onImplementRecommendations);
             }
 
             return rightSide.Width(isMobile ? Size.Full() : Size.Fit());
@@ -558,9 +574,7 @@ public class ContentView(
 
             content |= new ReviewActionsBarView(selectedPlan, planData.ReviewActionStates, config, logger);
 
-            var recommendationsTab = new RecommendationsTabView(pendingRecs, selectedRecTitles, config,
-                onImplement: () => ImplementSelectedRecommendations(
-                    selectedPlan, pendingRecs, selectedRecTitles, client, planContentQuery.Mutator.Revalidate));
+            var recommendationsTab = new RecommendationsTabView(pendingRecs, selectedRecTitles, config);
 
             var changesTabView = new ChangesTabView(planData.AllChanges, planContentQuery.Loading, planContentQuery.Error, selectedPlan.Project);
 
@@ -669,7 +683,11 @@ public class ContentView(
         var changeRequest = BuildRecommendationChangeRequest(selected);
         planService.AcceptRecommendationsAndRetry(selectedPlan.FolderName, titles);
         jobService.StartJob(new RetryPlanArgs(selectedPlan.FolderPath, changeRequest));
-        client.Toast($"Started RetryPlan for {selected.Count} recommendation(s)", "Implementing Recommendations");
+        var message = selected.Count == 1
+            ? "Started RetryPlan for recommendation"
+            : $"Started RetryPlan for {selected.Count} recommendations";
+        var title = selected.Count == 1 ? "Implementing Recommendation" : "Implementing Recommendations";
+        client.Toast(message, title);
 
         selectedRecTitles.Set(new HashSet<string>());
         refreshPlans();

--- a/src/Ivy.Tendril/Apps/Review/Tabs/RecommendationsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Review/Tabs/RecommendationsTabView.cs
@@ -5,30 +5,19 @@ using Ivy.Tendril.Services;
 namespace Ivy.Tendril.Apps.Review.Tabs;
 
 /// <summary>
-///     The "Recommendations" tab in the Review app: an optional "Implement Recommendations"
-///     button (shown once at least one row is checked, badged with the count) over the list of
-///     pending recommendation rows. The button raises <paramref name="onImplement"/>; the actual
-///     job-starting logic stays in ContentView. Each row owns its own checkbox via
+///     The "Recommendations" tab in the Review app: the list of pending recommendation rows.
+///     The "Implement Recommendations" call-to-action lives in the header controls (it acts on
+///     the shared selection set), not here. Each row owns its own checkbox via
 ///     <see cref="RecommendationRowView"/>.
 /// </summary>
 public class RecommendationsTabView(
     List<RecommendationYaml> pendingRecs,
     IState<HashSet<string>> selectedRecTitles,
-    IConfigService config,
-    Action onImplement) : ViewBase
+    IConfigService config) : ViewBase
 {
     public override object Build()
     {
         var layout = Layout.Vertical().Padding(2);
-
-        if (selectedRecTitles.Value.Count > 0)
-        {
-            var count = selectedRecTitles.Value.Count;
-            layout |= Layout.Horizontal().Gap(2).AlignContent(Align.Right)
-                | new Button("Implement Recommendations")
-                    .Icon(Icons.Rocket).Badge(count.ToString()).Primary()
-                    .OnClick(onImplement);
-        }
 
         if (pendingRecs.Count == 0)
         {

--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -272,9 +272,7 @@ public class JobDebugSheet(
         return !string.IsNullOrEmpty(fallback) && Directory.Exists(fallback) ? fallback : null;
     }
 
-    private string? GetPlanLogPath(JobItem job) => FindInLogsDir(job, "*.md");
-
-    private string? FindInLogsDir(JobItem job, string pattern, bool orderByLatest = true)
+    private string? GetPlanLogPath(JobItem job)
     {
         var folder = GetPlanFolderPath(job);
         if (string.IsNullOrEmpty(folder)) return null;
@@ -282,11 +280,26 @@ public class JobDebugSheet(
         var logsDir = Path.Combine(folder, "Logs");
         if (!Directory.Exists(logsDir)) return null;
 
-        var files = Directory.GetFiles(logsDir, pattern);
-        return orderByLatest
-            ? files.OrderByDescending(File.GetLastWriteTimeUtc).FirstOrDefault()
-            : files.FirstOrDefault();
+        // Plan-folder logs are named "{jobId}-{action}.md" (PlanReaderService.AddLog), so tie the
+        // Plan Log to THIS job instead of guessing the newest file — a RetryPlan job must not show
+        // an earlier ExecutePlan job's log.
+        if (!string.IsNullOrEmpty(job.Id))
+        {
+            var own = Directory.GetFiles(logsDir, $"{job.Id}-*.md")
+                .OrderByDescending(File.GetLastWriteTimeUtc)
+                .FirstOrDefault();
+            if (own != null) return own;
+        }
+
+        // Fallback for legacy logs written without a job-id prefix (just "{action}.md"). Ignore
+        // other jobs' id-prefixed logs so we show nothing rather than a wrong job's log.
+        return Directory.GetFiles(logsDir, "*.md")
+            .Where(f => !JobIdPrefixedLogRegex.IsMatch(Path.GetFileName(f)))
+            .OrderByDescending(File.GetLastWriteTimeUtc)
+            .FirstOrDefault();
     }
+
+    private static readonly Regex JobIdPrefixedLogRegex = new(@"^\d{5}-", RegexOptions.Compiled);
 
     private string? GetPromptwareLogPath(JobItem job)
     {


### PR DESCRIPTION
**Review app**
- Move the primary `Implement Recommendations (N)` button back into the header controls, beside Create PR / Complete Plan. It had been left only in the tab content while the header's `hasSelection` dimming logic remained — so selecting recommendations dimmed the CTA with nothing primary replacing it. Reuses the existing `ImplementSelectedRecommendations` helper.
- Drop the redundant button from `RecommendationsTabView` (tab shows the list only).
- Fix the lazy `(s)` toast: proper singular/plural for the RetryPlan message and title.

**Job Debug sheet**
- Tie the **Plan Log** field to the specific job. Plan-folder logs are named `{jobId}-{action}.md` (`PlanReaderService.AddLog`), but `GetPlanLogPath` returned the newest `.md` in the folder — so a RetryPlan job showed an earlier ExecutePlan job's log. Now matches `{job.Id}-*.md` first, falling back only to legacy non-prefixed logs. Removed the unused `FindInLogsDir` helper.

Compiles clean (0 warnings/errors).