### PR TITLE
[00036] List Available Options on Project CLI Not-Found Errors

### DIFF
--- a/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
@@ -271,6 +271,7 @@ public class PlanToolsTests : IDisposable
         CreateTestPlan();
         var result = _planTools.RemoveRepo("00001", @"D:\Repos\NonExistent");
         Assert.Contains("Error:", result);
+        Assert.Contains($"Available: {_repoDir}", result);
     }
 
     // --- AddPr ---

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -281,6 +281,7 @@ public class PlanCliCommandTests : IDisposable
             config.AddBranch("plan", plan =>
             {
                 plan.AddCommand<PlanAddRepoCommand>("add-repo");
+                plan.AddCommand<PlanRemoveRepoCommand>("remove-repo");
                 plan.AddCommand<PlanValidateCommand>("validate");
             });
         });
@@ -309,6 +310,28 @@ public class PlanCliCommandTests : IDisposable
 
         Assert.Equal(1, exit);
         Assert.DoesNotContain(outsideRepo, ReadPlan("00001").Repos);
+    }
+
+    // `plan remove-repo` must list the plan's actual repos when the given path isn't one of them.
+    [Fact]
+    public void PlanRemoveRepo_NotFound_ListsAvailable()
+    {
+        var app = BuildPlanGuardApp("TestProject", out var inProjectRepo);
+        var missingRepo = Path.Combine(_tempDir.Path, "repos", "Missing");
+
+        CreatePlanFolder("00003", "Test", new PlanYaml
+        {
+            State = "Draft",
+            Project = "TestProject",
+            Title = "Test",
+            Repos = [inProjectRepo],
+            Created = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+            Updated = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)
+        });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => app.Run(["plan", "remove-repo", "00003", missingRepo]));
+
+        Assert.Contains($"Available: {inProjectRepo}", ex.Message);
     }
 
     // #1340: `plan validate` must fail a plan whose repo isn't part of its project.

--- a/src/Ivy.Tendril.Test/ProjectCommandTests.cs
+++ b/src/Ivy.Tendril.Test/ProjectCommandTests.cs
@@ -441,6 +441,7 @@ verifications: []
                 project.AddCommand<ProjectRemoveRepoCommand>("remove-repo");
                 project.AddCommand<ProjectRemoveBuildDepCommand>("remove-build-dep");
                 project.AddCommand<ProjectRemoveReviewActionCommand>("remove-review-action");
+                project.AddCommand<ProjectMoveVerificationCommand>("move-verification");
             });
         });
         return app;
@@ -512,5 +513,53 @@ verifications: []
             () => app.Run(["project", "remove-build-dep", "Test", "Missing"]));
 
         Assert.Contains("Available: Framework", ex.Message);
+    }
+
+    [Fact]
+    public void MoveVerification_BeforeTargetNotFound_ListsAvailable()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Test",
+            Verifications = [
+                new ProjectVerificationRef { Name = "Lint" },
+                new ProjectVerificationRef { Name = "Build" }
+            ]
+        });
+        config.SaveSettings();
+
+        var app = BuildProjectApp();
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => app.Run(["project", "move-verification", "Test", "Lint", "--before", "Missing"]));
+
+        Assert.Contains("Available: Build, Lint", ex.Message);
+
+        var reloaded = CreateConfig();
+        Assert.Equal(2, reloaded.Settings.Projects[0].Verifications.Count);
+    }
+
+    [Fact]
+    public void MoveVerification_AfterTargetNotFound_ListsAvailable()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Test",
+            Verifications = [
+                new ProjectVerificationRef { Name = "Lint" },
+                new ProjectVerificationRef { Name = "Build" }
+            ]
+        });
+        config.SaveSettings();
+
+        var app = BuildProjectApp();
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => app.Run(["project", "move-verification", "Test", "Lint", "--after", "Missing"]));
+
+        Assert.Contains("Available: Build, Lint", ex.Message);
+
+        var reloaded = CreateConfig();
+        Assert.Equal(2, reloaded.Settings.Projects[0].Verifications.Count);
     }
 }

--- a/src/Ivy.Tendril.Test/ProjectCommandTests.cs
+++ b/src/Ivy.Tendril.Test/ProjectCommandTests.cs
@@ -1,4 +1,6 @@
+using Ivy.Tendril.Commands;
 using Ivy.Tendril.Services;
+using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Test;
 
@@ -423,5 +425,92 @@ verifications: []
         var reloaded = CreateConfig();
         Assert.Single(reloaded.Settings.Projects[0].BuildDependencies);
         Assert.Equal("Keep", reloaded.Settings.Projects[0].BuildDependencies[0]);
+    }
+
+    // --- Not Found Errors List Available Options ---
+
+    private static CommandApp BuildProjectApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("project", project =>
+            {
+                project.AddCommand<ProjectGetCommand>("get");
+                project.AddCommand<ProjectRemoveRepoCommand>("remove-repo");
+                project.AddCommand<ProjectRemoveBuildDepCommand>("remove-build-dep");
+                project.AddCommand<ProjectRemoveReviewActionCommand>("remove-review-action");
+            });
+        });
+        return app;
+    }
+
+    [Fact]
+    public void GetProject_NotFound_ListsAvailable()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig { Name = "Tendril" });
+        config.SaveSettings();
+
+        var app = BuildProjectApp();
+        var ex = Assert.Throws<InvalidOperationException>(() => app.Run(["project", "get", "Missing"]));
+
+        Assert.Contains("Available: Tendril", ex.Message);
+    }
+
+    [Fact]
+    public void RemoveRepo_NotFound_ListsAvailable()
+    {
+        var seededPath = Path.Combine(_tempDir.Path, "SeededRepo");
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Test",
+            Repos = [new RepoRef { Path = seededPath }]
+        });
+        config.SaveSettings();
+
+        var app = BuildProjectApp();
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => app.Run(["project", "remove-repo", "Test", Path.Combine(_tempDir.Path, "OtherRepo")]));
+
+        Assert.Contains($"Available: {seededPath}", ex.Message);
+    }
+
+    [Fact]
+    public void RemoveReviewAction_NotFound_ListsAvailable()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Test",
+            ReviewActions = [new ReviewActionConfig { Name = "Deploy" }]
+        });
+        config.SaveSettings();
+
+        var app = BuildProjectApp();
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => app.Run(["project", "remove-review-action", "Test", "Missing"]));
+
+        Assert.Contains("Available: Deploy", ex.Message);
+    }
+
+    [Fact]
+    public void RemoveBuildDep_NotFound_ListsAvailable()
+    {
+        var config = CreateConfig();
+        config.Settings.Projects.Add(new ProjectConfig
+        {
+            Name = "Test",
+            BuildDependencies = ["Framework"]
+        });
+        config.SaveSettings();
+
+        var app = BuildProjectApp();
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => app.Run(["project", "remove-build-dep", "Test", "Missing"]));
+
+        Assert.Contains("Available: Framework", ex.Message);
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanRemoveRepoCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveRepoCommand.cs
@@ -40,7 +40,7 @@ public class PlanRemoveRepoCommand : Command<PlanRemoveRepoSettings>
 
         var removed = plan.Repos.RemoveAll(r => r.Equals(settings.RepoPath, StringComparison.OrdinalIgnoreCase));
         if (removed == 0)
-            throw new InvalidOperationException($"Repository not found in plan: {settings.RepoPath}");
+            CliValidation.ThrowRepoNotFound(settings.RepoPath, plan.Repos);
 
         plan.Updated = DateTime.UtcNow;
 

--- a/src/Ivy.Tendril/Commands/ProjectCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectCommand.cs
@@ -602,7 +602,7 @@ public class ProjectMoveVerificationCommand : Command<ProjectMoveVerificationSet
             if (targetIndex < 0)
             {
                 project.Verifications.Add(item);
-                throw new InvalidOperationException($"Target verification not found for --before: {settings.Before}");
+                CliValidation.ThrowVerificationTargetNotFound("before", settings.Before, project.Verifications.Select(v => v.Name));
             }
             insertIndex = targetIndex;
         }
@@ -613,7 +613,7 @@ public class ProjectMoveVerificationCommand : Command<ProjectMoveVerificationSet
             if (targetIndex < 0)
             {
                 project.Verifications.Add(item);
-                throw new InvalidOperationException($"Target verification not found for --after: {settings.After}");
+                CliValidation.ThrowVerificationTargetNotFound("after", settings.After, project.Verifications.Select(v => v.Name));
             }
             insertIndex = targetIndex + 1;
         }

--- a/src/Ivy.Tendril/Commands/ProjectCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectCommand.cs
@@ -309,7 +309,7 @@ public class ProjectGetCommand : Command<ProjectGetSettings>
             .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
         if (project == null)
-            throw new InvalidOperationException($"Project not found: {settings.Name}");
+            CliValidation.ThrowProjectNotFound(settings.Name, config.Settings.Projects.Select(p => p.Name));
 
         AnsiConsole.MarkupLine($"[bold]{project.Name.EscapeMarkup()}[/]");
         if (!string.IsNullOrEmpty(project.Color))
@@ -402,7 +402,7 @@ public class ProjectRemoveCommand : Command<ProjectRemoveSettings>
             .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
         if (match == null)
-            throw new InvalidOperationException($"Project not found: {settings.Name}");
+            CliValidation.ThrowProjectNotFound(settings.Name, config.Settings.Projects.Select(p => p.Name));
 
         config.Settings.Projects.Remove(match);
         config.SaveSettings();
@@ -420,7 +420,7 @@ public class ProjectSetCommand : Command<ProjectSetSettings>
             .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
         if (match == null)
-            throw new InvalidOperationException($"Project not found: {settings.Name}");
+            CliValidation.ThrowProjectNotFound(settings.Name, config.Settings.Projects.Select(p => p.Name));
 
         switch (settings.Field.ToLower())
         {
@@ -455,7 +455,7 @@ public class ProjectAddRepoCommand : Command<ProjectAddRepoSettings>
             .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
         if (project == null)
-            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
+            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
 
         if (project.GetRepoRef(settings.RepoPath) != null)
             throw new InvalidOperationException($"Repository already exists in project: {settings.RepoPath}");
@@ -495,11 +495,11 @@ public class ProjectRemoveRepoCommand : Command<ProjectRemoveRepoSettings>
             .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
         if (project == null)
-            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
+            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
 
         var match = project.GetRepoRef(settings.RepoPath);
         if (match == null)
-            throw new InvalidOperationException($"Repository not found in project: {settings.RepoPath}");
+            CliValidation.ThrowRepoNotFound(settings.RepoPath, project.Repos.Select(r => r.Path));
 
         project.Repos.Remove(match);
         config.SaveSettings();
@@ -517,7 +517,7 @@ public class ProjectAddVerificationCommand : Command<ProjectAddVerificationSetti
             .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
         if (project == null)
-            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
+            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
 
         if (project.Verifications.Any(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase)))
             throw new InvalidOperationException($"Verification already exists in project: {settings.VerificationName}");
@@ -556,7 +556,7 @@ public class ProjectRemoveVerificationCommand : Command<ProjectRemoveVerificatio
             .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
         if (project == null)
-            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
+            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
 
         var match = project.Verifications
             .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
@@ -584,7 +584,7 @@ public class ProjectMoveVerificationCommand : Command<ProjectMoveVerificationSet
             .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
         if (project == null)
-            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
+            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
 
         var item = project.Verifications
             .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
@@ -638,7 +638,7 @@ public class ProjectAddBuildDepCommand : Command<ProjectAddBuildDepSettings>
             .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
         if (project == null)
-            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
+            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
 
         if (project.BuildDependencies.Contains(settings.Dependency, StringComparer.OrdinalIgnoreCase))
             throw new InvalidOperationException($"Build dependency already exists: {settings.Dependency}");
@@ -659,11 +659,11 @@ public class ProjectRemoveBuildDepCommand : Command<ProjectRemoveBuildDepSetting
             .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
         if (project == null)
-            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
+            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
 
         var removed = project.BuildDependencies.RemoveAll(d => d.Equals(settings.Dependency, StringComparison.OrdinalIgnoreCase));
         if (removed == 0)
-            throw new InvalidOperationException($"Build dependency not found: {settings.Dependency}");
+            CliValidation.ThrowBuildDependencyNotFound(settings.Dependency, project.BuildDependencies);
 
         config.SaveSettings();
         Console.WriteLine($"Removed build dependency: {settings.Dependency}");
@@ -680,7 +680,7 @@ public class ProjectAddReviewActionCommand : Command<ProjectAddReviewActionSetti
             .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
         if (project == null)
-            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
+            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
 
         if (project.ReviewActions.Any(r => r.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
             throw new InvalidOperationException($"Review action already exists: {settings.Name}");
@@ -707,13 +707,13 @@ public class ProjectRemoveReviewActionCommand : Command<ProjectRemoveReviewActio
             .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
         if (project == null)
-            throw new InvalidOperationException($"Project not found: {settings.ProjectName}");
+            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
 
         var match = project.ReviewActions
             .FirstOrDefault(r => r.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
         if (match == null)
-            throw new InvalidOperationException($"Review action not found: {settings.Name}");
+            CliValidation.ThrowReviewActionNotFound(settings.Name, project.ReviewActions.Select(r => r.Name));
 
         project.ReviewActions.Remove(match);
         config.SaveSettings();

--- a/src/Ivy.Tendril/Helpers/CliValidation.cs
+++ b/src/Ivy.Tendril/Helpers/CliValidation.cs
@@ -104,6 +104,10 @@ public static class CliValidation
     public static void ThrowBuildDependencyNotFound(string name, IEnumerable<string> available) =>
         ThrowNotFound("Build dependency", name, available);
 
+    [DoesNotReturn]
+    public static void ThrowVerificationTargetNotFound(string optionName, string name, IEnumerable<string> available) =>
+        ThrowNotFound($"Target verification for --{optionName}", name, available);
+
     /// <summary>Number of value sources supplied (inline arg / --file / --stdin), for the "exactly one" rule.</summary>
     public static int CountSources(bool stdin, string? filePath, string value) =>
         (stdin ? 1 : 0) + (!string.IsNullOrEmpty(filePath) ? 1 : 0) + (!string.IsNullOrEmpty(value) ? 1 : 0);

--- a/src/Ivy.Tendril/Helpers/CliValidation.cs
+++ b/src/Ivy.Tendril/Helpers/CliValidation.cs
@@ -80,10 +80,29 @@ public static class CliValidation
     }
 
     [DoesNotReturn]
-    public static void ThrowVerificationNotFound(string name, IEnumerable<string> available)
-    {
-        throw new InvalidOperationException($"Verification not found: '{name}'. Available: {string.Join(", ", available)}");
-    }
+    private static void ThrowNotFound(string entity, string name, IEnumerable<string> available) =>
+        throw new InvalidOperationException(
+            $"{entity} not found: '{name}'. Available: {string.Join(", ", available)}");
+
+    [DoesNotReturn]
+    public static void ThrowVerificationNotFound(string name, IEnumerable<string> available) =>
+        ThrowNotFound("Verification", name, available);
+
+    [DoesNotReturn]
+    public static void ThrowProjectNotFound(string name, IEnumerable<string> available) =>
+        ThrowNotFound("Project", name, available);
+
+    [DoesNotReturn]
+    public static void ThrowRepoNotFound(string path, IEnumerable<string> available) =>
+        ThrowNotFound("Repository", path, available);
+
+    [DoesNotReturn]
+    public static void ThrowReviewActionNotFound(string name, IEnumerable<string> available) =>
+        ThrowNotFound("Review action", name, available);
+
+    [DoesNotReturn]
+    public static void ThrowBuildDependencyNotFound(string name, IEnumerable<string> available) =>
+        ThrowNotFound("Build dependency", name, available);
 
     /// <summary>Number of value sources supplied (inline arg / --file / --stdin), for the "exactly one" rule.</summary>
     public static int CountSources(bool stdin, string? filePath, string value) =>

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -200,7 +200,7 @@ public sealed class PlanTools : AuthenticatedToolBase
         {
             var removed = plan.Repos.RemoveAll(r => r.Equals(repoPath, StringComparison.OrdinalIgnoreCase));
             if (removed == 0)
-                throw new InvalidOperationException($"Repository not found in plan: {repoPath}");
+                CliValidation.ThrowRepoNotFound(repoPath, plan.Repos);
         }, $"Removed repository: {repoPath}");
     }
 


### PR DESCRIPTION
# Summary

## Changes

Extended `CliValidation` with a shared `ThrowNotFound` core plus four new `[DoesNotReturn]` helpers (`ThrowProjectNotFound`, `ThrowRepoNotFound`, `ThrowReviewActionNotFound`, `ThrowBuildDependencyNotFound`) mirroring the existing `ThrowVerificationNotFound`. Replaced all 15 bare `"X not found: {name}"` throws in `ProjectCommand.cs` with calls to these helpers so an agent or user that mistypes/hallucinates a name now sees the list of valid options and can self-correct, instead of hitting a dead end.

## API Changes

- New public methods on `Ivy.Tendril.Helpers.CliValidation`:
  - `ThrowProjectNotFound(string name, IEnumerable<string> available)`
  - `ThrowRepoNotFound(string path, IEnumerable<string> available)`
  - `ThrowReviewActionNotFound(string name, IEnumerable<string> available)`
  - `ThrowBuildDependencyNotFound(string name, IEnumerable<string> available)`
- Error message format for the affected `tendril project` CLI commands changed from `"X not found: {name}"` to `"X not found: '{name}'. Available: {list}"` (matches the existing `Verification not found` format). No commands, arguments, or return codes changed.

## Files Modified

- `src/Ivy.Tendril/Helpers/CliValidation.cs` — refactored `ThrowVerificationNotFound` onto a shared private `ThrowNotFound` core; added 4 new public wrappers.
- `src/Ivy.Tendril/Commands/ProjectCommand.cs` — replaced 15 bare not-found throws across `ProjectGetCommand`, `ProjectRemoveCommand`, `ProjectSetCommand`, `ProjectAddRepoCommand`, `ProjectRemoveRepoCommand`, `ProjectAddVerificationCommand`, `ProjectRemoveVerificationCommand`, `ProjectMoveVerificationCommand`, `ProjectAddBuildDepCommand`, `ProjectRemoveBuildDepCommand`, `ProjectAddReviewActionCommand`, `ProjectRemoveReviewActionCommand`.
- `src/Ivy.Tendril.Test/ProjectCommandTests.cs` — added 4 tests covering the new not-found error messages via a `CommandApp` harness.

## Manual Testing

1. Run `tendril project get MissingName` (with at least one project configured, e.g. `Tendril`) — the error should read `Project not found: 'MissingName'. Available: Tendril` instead of the old bare `Project not found: MissingName`.
2. Run `tendril project remove-repo Tendril /some/wrong/path` — the error should list the project's actual repo paths under `Available:`.
3. Run `tendril project remove-review-action Tendril MissingAction` — the error should list the project's configured review action names under `Available:`.
4. Run `tendril project remove-build-dep Tendril MissingDep` — the error should list the project's configured build dependency names under `Available:`.

## Fix: Apply same not-found UX fix to --before/--after in ProjectMoveVerificationCommand

Addressed the accepted recommendation for `ProjectMoveVerificationCommand`'s `--before`/`--after` not-found throws (ProjectCommand.cs ~605/617), which had the same dead-end UX but needed custom handling due to option-specific wording and a rollback-insert side effect. Added `CliValidation.ThrowVerificationTargetNotFound(optionName, name, available)`, which reuses the shared `ThrowNotFound` core to produce `"Target verification for --before/--after not found: '{name}'. Available: {list}"`, and called it from both sites after the existing `project.Verifications.Add(item)` rollback.

### Files Modified

- `src/Ivy.Tendril/Helpers/CliValidation.cs` — added `ThrowVerificationTargetNotFound(string optionName, string name, IEnumerable<string> available)`.
- `src/Ivy.Tendril/Commands/ProjectCommand.cs` — replaced the bare `--before`/`--after` target-not-found throws in `ProjectMoveVerificationCommand` with calls to the new helper.
- `src/Ivy.Tendril.Test/ProjectCommandTests.cs` — added `MoveVerification_BeforeTargetNotFound_ListsAvailable` and `MoveVerification_AfterTargetNotFound_ListsAvailable`, and registered `ProjectMoveVerificationCommand` on the test `CommandApp`.

**Note:** Manual testing step: run `tendril project move-verification Tendril DotnetBuild --before Missing` — the error should read `Target verification for --before not found: 'Missing'. Available: <list of verification names>` instead of the old bare message, and the verification list order should be unaffected (rollback re-insert still restores the moved item to its original slot).

## Fix: Reuse ThrowRepoNotFound in PlanRemoveRepoCommand and PlanTools

Addressed the reviewer's out-of-scope callout: the plan-level `remove-repo` paths (`PlanRemoveRepoCommand.cs` and the `tendril_plan_remove_repo` MCP tool) had the identical bare `"Repository not found in plan: {path}"` dead-end. Both now call the existing `CliValidation.ThrowRepoNotFound(path, plan.Repos)` helper, so the error lists the plan's actual repo paths instead of leaving the caller with no recovery path.

### Files Modified

- `src/Ivy.Tendril/Commands/PlanRemoveRepoCommand.cs` — replaced the bare throw with `CliValidation.ThrowRepoNotFound`.
- `src/Ivy.Tendril/Mcp/Tools/PlanTools.cs` — replaced the bare throw in `RemoveRepo` with `CliValidation.ThrowRepoNotFound`.
- `src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs` — strengthened `RemoveRepo_NotFound_ReturnsError` to assert the `Available:` list is present.
- `src/Ivy.Tendril.Test/PlanCliCommandTests.cs` — registered `PlanRemoveRepoCommand` on the test `CommandApp` and added `PlanRemoveRepo_NotFound_ListsAvailable`.

**Note:** Manual testing step: run `tendril plan remove-repo <plan-id> /some/wrong/path` — the error should list the plan's actual repo paths under `Available:` instead of the old bare message. The MCP tool `tendril_plan_remove_repo` behaves the same way, returned as `Error: Repository not found: '...'. Available: ...`.

---
## Commits

- b172c6ec List available options on project CLI not-found errors
- 2a806b96 Add tests for project CLI not-found error messages
- 9c8e82cf Apply not-found UX fix to --before/--after in ProjectMoveVerificationCommand
- 00776a82 Reuse ThrowRepoNotFound in PlanRemoveRepoCommand and PlanTools

---
Created using [Ivy Tendril](https://ivy.app).
