### PR TITLE
[00057] Fix Markdown Widget Rendering Prose Dollar Signs as LaTeX Math

### DIFF
--- a/src/experiments/LatexMarkdownFix/GlobalUsings.cs
+++ b/src/experiments/LatexMarkdownFix/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using Ivy;
+global using Ivy.Apps;
+global using Ivy.Core;
+global using Ivy.Views;

--- a/src/experiments/LatexMarkdownFix/LatexMarkdownFix.csproj
+++ b/src/experiments/LatexMarkdownFix/LatexMarkdownFix.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>CS8618;CS8603;CS8602;CS8604;CS8625;CS9113</NoWarn>
+    <GenerateProgramFile>false</GenerateProgramFile>
+    <RootNamespace>LatexMarkdownFix</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Ivy-Framework\src\Ivy\Ivy.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/experiments/LatexMarkdownFix/LatexMarkdownFixApp.cs
+++ b/src/experiments/LatexMarkdownFix/LatexMarkdownFixApp.cs
@@ -1,0 +1,14 @@
+namespace LatexMarkdownFix;
+
+[App(title: "Latex Markdown Fix", icon: Icons.Sigma)]
+public class LatexMarkdownFixApp : ViewBase
+{
+    public override object? Build()
+    {
+        return Layout.Vertical().Gap(6).Padding(4)
+            | Text.H3("Prose dollar signs (misrendered as math before the fix)")
+            | Text.Markdown("bash expands any $ (e.g. $env:PORT, or vars like $IsMacOS) so $ survives")
+            | Text.H3("Real math still works")
+            | Text.Markdown("$$E = mc^2$$");
+    }
+}

--- a/src/experiments/LatexMarkdownFix/Program.cs
+++ b/src/experiments/LatexMarkdownFix/Program.cs
@@ -1,0 +1,12 @@
+using Ivy;
+
+var server = new Server();
+server.UseCulture("en-US");
+#if DEBUG
+server.UseHotReload();
+#endif
+server.AddAppsFromAssembly();
+var appShellSettings = new AppShellSettings()
+    .UseTabs(preventDuplicates: true);
+server.UseAppShell(appShellSettings);
+await server.RunAsync();


### PR DESCRIPTION
# Summary

## Changes

Fixed the Ivy `Markdown` widget so a single `$` in prose (shell variables like `$env:PORT`, prices, etc.) is always literal text; math now requires `$$...$$` for both inline and block expressions. Updated docs and the Markdown sample app's math examples to the new `$$` convention, and added a standalone runnable example demonstrating the fix.

## API Changes

None. This is a rendering behavior change, not a public API change — however it is a **breaking change in Markdown content semantics**: any existing Markdown content that relied on single-`$`-delimited inline math (`$E = mc^2$`) will now render the dollar signs as literal text instead of KaTeX. Authors must switch to `$$...$$`.

## Files Modified

- `src/frontend/src/components/MarkdownRenderer.tsx` (Ivy-Framework) — disabled `remark-math`'s `singleDollarTextMath`, tightened the `hasMath` detection regex to require `$$`
- `src/frontend/src/components/MarkdownRenderer.test.tsx` (Ivy-Framework, new) — verifies prose dollars stay literal and `$$...$$` still renders as KaTeX
- `src/Ivy.Docs.Shared/Docs/02_Widgets/01_Primitives/14_Markdown.md` (Ivy-Framework) — updated math examples and prose to the `$$` convention
- `src/Ivy.Samples.Shared/Apps/Widgets/Primitives/MarkdownApp.cs` (Ivy-Framework) — updated the `MathTab`'s inline math examples to `$$` (found via repo-wide grep, not originally cited by the plan)
- `src/experiments/LatexMarkdownFix/` (this repo, new) — standalone Ivy app demonstrating before/after behavior, modeled on `FieldToolsDemo`

## Manual Testing

1. Run `dotnet run` from `src/experiments/LatexMarkdownFix` (in this repo).
2. Open the app in a browser and select the "Latex Markdown Fix" tab.
3. Observe: the first block ("bash expands any $ (e.g. $env:PORT, or vars like $IsMacOS) so $ survives") renders as plain readable text — no collapsed spaces or serif italic math formatting.
4. Observe: the second block (`$$E = mc^2$$`) still renders as KaTeX math.
5. Alternatively, in the Ivy-Framework repo's `src/frontend`, run `pnpm vp exec vitest run src/components/MarkdownRenderer.test.tsx` to confirm both automated assertions pass.

## Fix: RichTextMarkdownParser had the same single-dollar-as-math bug

Per reviewer feedback (accepted recommendation), `src/Ivy/Views/RichTextMarkdownParser.cs` (Ivy-Framework repo) — a separate C# streaming markdown parser used for the RichText/streaming-LLM-output widget (not the Markdown widget) — had the identical bug: any single `$` opened inline math and greedily paired with the next `$` on the line. Applied the same convention: a lone `$` is now literal text; inline math requires `$$...$$`.

This companion PR (Ivy-Framework) is [Ivy-Interactive/Ivy-Framework#4706](https://github.com/Ivy-Interactive/Ivy-Framework/pull/4706).

---
## Commits in this repo (Ivy-Tendril)
- 9935aceb Add LatexMarkdownFix experiment demonstrating prose dollar sign fix

---
Created using [Ivy Tendril](https://ivy.app).
