### PR TITLE
[00040] Fix Simultaneous Job Blocked and Unblocked Notifications for WaitForJobs Blocks

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -449,6 +449,48 @@ public class JobServiceRetryBlockedTests : IDisposable
 
 
     [Fact]
+    public void RetryBlockedJobs_WhenBlockedOnWaitForJobs_DoesNotChurnOrEmitSpuriousNotifications()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var planFolder = CreatePlanFolder("Draft");
+
+        var planReader = new FakePlanReaderService(_tempDir.Path);
+        var service = new JobService(
+            TimeSpan.FromMinutes(30),
+            TimeSpan.FromMinutes(10),
+            planReaderService: planReader);
+
+        // Long-running dependency job (stays Running)
+        var depId = service.CreateTestJob(new CreatePlanArgs("Dep job", "Auto"));
+        Assert.Equal(JobStatus.Running, service.GetJob(depId)!.Status);
+
+        // The waiting job blocks on the sibling job, not on plan-level dependsOn
+        var waitingId = service.StartJob(new ExecutePlanArgs(planFolder) { WaitForJobs = [depId] });
+        var waitingJob = service.GetJob(waitingId);
+        Assert.NotNull(waitingJob);
+        Assert.Equal(JobStatus.Blocked, waitingJob.Status);
+
+        var notifications = new List<JobNotification>();
+        service.NotificationReady += n => notifications.Add(n);
+
+        // Drive the 60-second blocked-job-check timer body deterministically
+        service.RunBlockedJobCheck();
+
+        // The job must be left exactly as it was — no churn, still blocked on the same dependency
+        var stillWaiting = service.GetJob(waitingId);
+        Assert.NotNull(stillWaiting);
+        Assert.Equal(JobStatus.Blocked, stillWaiting.Status);
+        Assert.Contains(depId, stillWaiting.StatusMessage);
+
+        Assert.DoesNotContain(notifications, n => n.Title == "Job Unblocked");
+        Assert.DoesNotContain(notifications, n => n.Title == "Job Blocked");
+
+        // Cleanup
+        Directory.Delete(planFolder, true);
+    }
+
+    [Fact]
     public async Task PeriodicCheck_WhenDependencySatisfiedExternally_UnblocksJob()
     {
         SynchronizationContext.SetSynchronizationContext(null);

--- a/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
+++ b/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
@@ -100,6 +100,12 @@ internal class DependencyChecker
             var planFolder = blockedJob.TypedArgs?.PlanFolder ?? "";
             if (string.IsNullOrEmpty(planFolder)) continue;
 
+            // A job blocked on sibling jobs (WaitForJobs) is retried by
+            // JobCompletionHandler.HandleWaitForJobsDependents when those jobs finish — not here.
+            // Restarting it while its WaitForJobs are still pending would immediately re-block it,
+            // producing a spurious "Job Unblocked" + "Job Blocked" notification pair (issue #1538).
+            if (HasPendingWaitForJobs(blockedJob, jobs)) continue;
+
             var (ok, _) = CheckDependencies(planFolder);
             if (!ok) continue;
 
@@ -161,6 +167,16 @@ internal class DependencyChecker
             j.Status is JobStatus.Blocked or JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
             j.TypedArgs?.PlanFolder != null &&
             j.TypedArgs.PlanFolder.Equals(dir, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool HasPendingWaitForJobs(JobItem job, ConcurrentDictionary<string, JobItem> jobs)
+    {
+        if (job.WaitForJobIds is not { Count: > 0 })
+            return false;
+
+        return job.WaitForJobIds.Any(id =>
+            jobs.TryGetValue(id, out var dep) &&
+            dep.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending or JobStatus.Blocked);
     }
 
     private static bool HasActiveJobForPlan(string planFolder, ConcurrentDictionary<string, JobItem> jobs)


### PR DESCRIPTION
Fixes #1538

# Summary

## Changes

Fixed `DependencyChecker.RetryBlockedJobs` incorrectly restarting jobs that were blocked purely on
sibling `WaitForJobs`, which caused a spurious "Job Unblocked" notification immediately followed by
a "Job Blocked" one as the job re-blocked itself (issue #1538). The method now skips any blocked job
that still has pending `WaitForJobs`, leaving it owned by `JobCompletionHandler.HandleWaitForJobsDependents`.

## API Changes

Added a new private helper `DependencyChecker.HasPendingWaitForJobs(JobItem job, ConcurrentDictionary<string, JobItem> jobs)`. Internal only — no public API changes.

## Files Modified

- `src/Ivy.Tendril/Services/Plans/DependencyChecker.cs` — added the `HasPendingWaitForJobs` guard in `RetryBlockedJobs` and the corresponding helper method
- `src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs` — added `RetryBlockedJobs_WhenBlockedOnWaitForJobs_DoesNotChurnOrEmitSpuriousNotifications` regression test

## Manual Testing

N/A — internal job-orchestration bugfix with no directly observable UI beyond notification behavior.
To confirm in the running app: start a job with `WaitForJobs` pointing at a still-running sibling job
so it becomes `Blocked`, wait for the 60-second blocked-job-check timer to fire (or trigger another
job completion), and verify no "Job Unblocked"/"Job Blocked" toast pair appears while the sibling job
is still running — the job should stay `Blocked` silently until the sibling job finishes, at which
point exactly one "all blocking jobs completed, starting" notification fires.

---
Commits:
- 919cb47d [00040] Skip WaitForJobs-blocked jobs in RetryBlockedJobs
- 254bf136 [00040] Add regression test for WaitForJobs-blocked jobs in RetryBlockedJobs

---
Created using [Ivy Tendril](https://ivy.app).
