### PR TITLE
[00052] Replace Plan Created Line With Verifications List in Plan Create Output

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
@@ -184,7 +184,10 @@ The command outputs:
 ```
 PlanId: <ID>
 Directory: <TendrilPlansFolder>/<ID>-<SafeTitle>
-Plan created: <ID>-<SafeTitle>
+Verifications:
+<Name>:<Status>
+<Name>:<Status>
+...
 ```
 
 Parse `PlanId` and `Directory` from the output — use these for all subsequent operations.

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SplitPlan/Program.md
@@ -41,7 +41,7 @@ tendril plan create "<Title>" "<TendrilProject>" \
 
 **IMPORTANT:** Always pass `--plans-dir` with the plans directory (derive from the plan folder's parent). This ensures child plans are created in the correct directory regardless of environment variable inheritance. Repos are derived automatically from the project configuration.
 
-The command outputs `PlanId`, `Directory`, and `Plan created` lines. Parse the `Directory` to write the revision file.
+The command outputs `PlanId`, `Directory`, and a `Verifications` section. Parse the `Directory` to write the revision file.
 
 Include optional flags as needed (always use the `--option=value` form):
 - `--source-url="<url>"` — if the original plan had a sourceUrl

--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -290,15 +290,16 @@ public class JobServiceCompletionGuardTests : IDisposable
     }
 
     [Fact]
-    public void CompleteJob_CreatePlan_UpdatesPlanFileWhenOutputContainsPlanCreated()
+    public void CompleteJob_CreatePlan_UpdatesPlanFileWhenOutputContainsPlanId()
     {
         var service = CreateServiceWithPlanReader(_tempDir.Path);
         var id = service.CreateTestJob(new CreatePlanArgs("Fix login bug", "Tendril"));
+        Directory.CreateDirectory(Path.Combine(_tempDir.Path, "02353-FixLoginBug"));
 
         var job = service.GetJob(id);
         Assert.NotNull(job);
         job.EnqueueOutput("{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"Processing...\"}]}}");
-        job.EnqueueOutput("{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"Plan created: 02353-FixLoginBug\"}]}}");
+        job.EnqueueOutput("{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"PlanId: 02353\"}]}}");
 
         service.CompleteJob(id, 0);
 

--- a/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
@@ -537,9 +537,33 @@ public class PlanToolsTests : IDisposable
 
         var result = _planTools.PlanCreate("Direct Plan Test", project: "TestProject");
 
-        Assert.Contains("Plan created:", result);
         Assert.Contains("PlanId:", result);
         Assert.Contains("Directory:", result);
+        Assert.Contains("Verifications:", result);
+        Assert.DoesNotContain("Plan created:", result);
+    }
+
+    [Fact]
+    public void PlanCreate_PrintsVerifications_AndOmitsPlanCreatedLine()
+    {
+        var plansDir = Path.Combine(_tempDir, "Plans");
+        Directory.CreateDirectory(plansDir);
+
+        var configService = new TestPlanConfigService(_repoDir, "TestProject",
+        [
+            new ProjectVerificationRef { Name = "DotnetBuild", Required = true },
+            new ProjectVerificationRef { Name = "DotnetTest", Required = false }
+        ]);
+        var planTools = new PlanTools(new McpAuthenticationService(NullLogger<McpAuthenticationService>.Instance), configService);
+
+        var result = planTools.PlanCreate("Verify Plan Test", project: "TestProject");
+
+        Assert.Contains("PlanId:", result);
+        Assert.Contains("Directory:", result);
+        Assert.Contains("Verifications:", result);
+        Assert.Contains("DotnetBuild:Pending", result);
+        Assert.Contains("DotnetTest:Skipped", result);
+        Assert.DoesNotContain("Plan created:", result);
     }
 
     [Fact]
@@ -556,8 +580,6 @@ public class PlanToolsTests : IDisposable
             executionProfile: "deep",
             sourceUrl: "https://github.com/org/repo/issues/1",
             verifications: "DotnetBuild,DotnetTest");
-
-        Assert.Contains("Plan created:", result);
 
         var planId = result.Split('\n')
             .First(l => l.StartsWith("PlanId:"))

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -241,14 +241,14 @@ public class PlanCliCommandTests : IDisposable
     // Builds a real Spectre.Console.Cli app exposing `plan create`, wired to a config
     // service that knows <project> (with an existing repo). Mirrors how Program.cs
     // registers the command, so tests exercise the actual argument parser.
-    private CommandApp BuildPlanCreateApp(string project)
+    private CommandApp BuildPlanCreateApp(string project, IReadOnlyList<ProjectVerificationRef>? verifications = null)
     {
         var repoDir = Path.Combine(_tempDir.Path, "repos", project);
         Directory.CreateDirectory(repoDir);
 
         var services = new ServiceCollection();
         services.AddSingleton<IPlanWatcherService, NullPlanWatcherService>();
-        var configService = new TestPlanConfigService(repoDir, project);
+        var configService = new TestPlanConfigService(repoDir, project, verifications);
         services.AddSingleton<IConfigService>(configService);
         // PlanCreateCommand now depends on IGithubService (source-URL ↔ project guard). These tests
         // create plans without a --source-url, so the guard no-ops and git is never invoked.
@@ -392,6 +392,32 @@ public class PlanCliCommandTests : IDisposable
         var plan = PlanCommandHelpers.ReadPlan(planFolder);
         Assert.Equal("Ivy-Framework", plan.Project);
         Assert.Equal(initialPrompt, plan.InitialPrompt);
+    }
+
+    [Fact]
+    public void PlanCreate_CommandApp_PrintsVerifications_AndOmitsPlanCreatedLine()
+    {
+        var app = BuildPlanCreateApp("Ivy-Framework",
+        [
+            new ProjectVerificationRef { Name = "DotnetBuild", Required = true },
+            new ProjectVerificationRef { Name = "DotnetTest", Required = false }
+        ]);
+
+        var exit = 0;
+        var output = CaptureStdout(() => exit = app.Run(new[]
+        {
+            "plan", "create", "Emit Verifications", "Ivy-Framework",
+            $"--plans-dir={_plansDir}", "--level=Feature",
+            "--initial-prompt=Add verifications output", "--execution-profile=balanced"
+        }));
+
+        Assert.Equal(0, exit);
+        Assert.Contains("PlanId:", output);
+        Assert.Contains("Directory:", output);
+        Assert.Contains("Verifications:", output);
+        Assert.Contains("DotnetBuild:Pending", output);   // Required -> Pending
+        Assert.Contains("DotnetTest:Skipped", output);     // Optional -> Skipped
+        Assert.DoesNotContain("Plan created:", output);
     }
 
     // ==================== PlanGet ====================

--- a/src/Ivy.Tendril.Test/TestPlanConfigService.cs
+++ b/src/Ivy.Tendril.Test/TestPlanConfigService.cs
@@ -6,14 +6,16 @@ internal class TestPlanConfigService : IConfigService
 {
     private readonly List<ProjectConfig> _projects;
 
-    public TestPlanConfigService(string repoDir, string projectName = "TestProject")
+    public TestPlanConfigService(string repoDir, string projectName = "TestProject",
+        IReadOnlyList<ProjectVerificationRef>? verifications = null)
     {
         _projects =
         [
             new ProjectConfig
             {
                 Name = projectName,
-                Repos = [new RepoRef { Path = repoDir }]
+                Repos = [new RepoRef { Path = repoDir }],
+                Verifications = verifications?.ToList() ?? []
             }
         ];
     }

--- a/src/Ivy.Tendril/AGENTS.md
+++ b/src/Ivy.Tendril/AGENTS.md
@@ -185,8 +185,8 @@ Jobs flow through: `Pending → Queued → Running → Completed/Failed/Timeout/
 
 **CreatePlan verification** (`VerifyCreatePlanResult` in `JobService.cs`) runs after the agent exits with code 0 and can **change Completed → Failed** if:
 
-1. Agent output doesn't contain `"Plan created: <folder>"` marker
-2. No plan folder matching `AllocatedPlanId` exists on disk (`FindPlanFolderById`)
+1. Agent output doesn't contain a `"PlanId: <id>"` line resolving to a folder on disk (`FindPlanFolderById`)
+2. No plan folder matching `AllocatedPlanId` exists on disk either (`FindPlanFolderById`)
 3. No trash entry for that ID exists either (`FindTrashEntryById`)
 
 When debugging a failed CreatePlan, check in order:

--- a/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
@@ -156,7 +156,9 @@ public class PlanCreateCommand : Command<PlanCreateSettings>
 
         Console.WriteLine($"PlanId: {planId}");
         Console.WriteLine($"Directory: {planFolder}");
-        Console.WriteLine($"Plan created: {folderName}");
+        Console.WriteLine("Verifications:");
+        foreach (var v in plan.Verifications)
+            Console.WriteLine($"{v.Name}:{v.Status}");
         return 0;
     }
 }

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Models;
@@ -470,7 +471,10 @@ public sealed class PlanTools : AuthenticatedToolBase
                     plan.DependsOn.Add(PlanCommandHelpers.ResolvePlanFolderName(dep));
 
             PlanCommandHelpers.WritePlan(planFolder, plan);
-            return $"Plan created: {folderName}\nPlanId: {planId}\nDirectory: {planFolder}";
+
+            var lines = new List<string> { $"PlanId: {planId}", $"Directory: {planFolder}", "Verifications:" };
+            lines.AddRange(plan.Verifications.Select(v => $"{v.Name}:{v.Status}"));
+            return string.Join('\n', lines);
         });
     }
 

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Models;

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -131,7 +131,10 @@ Outputs:
 ```
 PlanId: <ID>
 Directory: <TendrilPlansFolder>/<ID>-<SafeTitle>
-Plan created: <ID>-<SafeTitle>
+Verifications:
+<Name>:<Status>
+<Name>:<Status>
+...
 ```
 
 Options:

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -232,7 +232,10 @@ The command outputs:
 ```
 PlanId: <ID>
 Directory: <TendrilPlansFolder>/<ID>-<SafeTitle>
-Plan created: <ID>-<SafeTitle>
+Verifications:
+<Name>:<Status>
+<Name>:<Status>
+...
 ```
 
 Parse `PlanId` and `Directory` from the output — use these for all subsequent operations.

--- a/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -47,7 +47,7 @@ tendril plan create "<Title>" "<TendrilProject>" \
 
 **IMPORTANT:** Always pass `--plans-dir` with the plans directory (derive from the plan folder's parent). This ensures child plans are created in the correct directory regardless of environment variable inheritance. Repos are derived automatically from the project configuration.
 
-The command outputs `PlanId`, `Directory`, and `Plan created` lines. Parse the `Directory` to write the revision file.
+The command outputs `PlanId`, `Directory`, and a `Verifications` section. Parse the `Directory` to write the revision file.
 
 Include optional flags as needed (always use the `--option=value` form):
 - `--source-url="<url>"` — if the original plan had a sourceUrl

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -637,7 +637,7 @@ internal class JobCompletionHandler
             if (plansDir == null || !Directory.Exists(plansDir)) return;
 
             if (TryVerifyByReportedId(job, plansDir) ||
-                TryVerifyByOutputRegex(job) ||
+                TryVerifyByOutputRegex(job, plansDir) ||
                 TryVerifyByFilesystem(job, plansDir))
             {
                 MoveAttachmentsToPlanFolder(job);
@@ -756,16 +756,21 @@ internal class JobCompletionHandler
         return false;
     }
 
-    private static bool TryVerifyByOutputRegex(JobItem job)
+    private static bool TryVerifyByOutputRegex(JobItem job, string plansDir)
     {
+        // `tendril plan create` no longer prints a `Plan created: <folder>` marker (see
+        // PlanCreateCommand.Execute), but it always prints `PlanId: <id>` — resolve that ID to
+        // its folder the same way TryVerifyByReportedId does, so this fallback still works
+        // independently of the agent calling `tendril job status --plan-id`.
         var outputText = string.Join("\n", job.OutputLines);
-        var createdMatch = Regex.Match(outputText, @"Plan created:\s*([\w-]+)");
-        if (createdMatch.Success)
-        {
-            job.PlanFile = createdMatch.Groups[1].Value;
-            return true;
-        }
-        return false;
+        var planIdMatch = Regex.Match(outputText, @"PlanId:\s*([\w-]+)");
+        if (!planIdMatch.Success) return false;
+
+        var folder = PlanYamlHelper.FindPlanFolderById(plansDir, planIdMatch.Groups[1].Value);
+        if (folder == null) return false;
+
+        job.PlanFile = folder;
+        return true;
     }
 
     private static bool IsDuplicatePlan(JobItem job)

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -586,12 +586,12 @@ internal class JobCompletionHandler
             {
                 var seen = new HashSet<string>(recordedKeys, StringComparer.OrdinalIgnoreCase);
                 foreach (var line in job.OutputLines)
-                foreach (Match m in GitHubPrUrlPattern.Matches(line))
-                {
-                    if (!planRepoNames.Contains(m.Groups["repo"].Value)) continue;
-                    if (!seen.Add(CanonicalPrKey(m))) continue;
-                    added.Add(m.Value);
-                }
+                    foreach (Match m in GitHubPrUrlPattern.Matches(line))
+                    {
+                        if (!planRepoNames.Contains(m.Groups["repo"].Value)) continue;
+                        if (!seen.Add(CanonicalPrKey(m))) continue;
+                        added.Add(m.Value);
+                    }
             }
 
             // Nothing to record and no PR on the plan → leave state to whatever the agent set.


### PR DESCRIPTION
# Summary

## Changes

`tendril plan create` no longer prints a `Plan created: {folderName}` line; it now prints a
`Verifications:` section listing every seeded verification as `Name:Status` after the `Directory:`
line. A code-review pass also found and fixed a regression this change would have caused in
CreatePlan job-completion detection: the `Plan created:` marker was the only stdout-based fallback
independent of the agent reporting its plan ID, so its removal was patched by switching that
fallback to resolve the still-present `PlanId:` line to a folder on disk.

## API Changes

- **CLI output** (`tendril plan create`): stdout no longer contains a `Plan created: <folder>` line.
  It now contains, after `Directory:`, a `Verifications:` header followed by one `<Name>:<Status>`
  line per verification seeded on the plan (in project-configured order). `<Status>` is one of
  `Pending`, `Pass`, `Fail`, `Skipped`.
- The `tendril_plan_create` MCP tool (`PlanTools.cs`) was originally left unchanged in this plan's
  main change; it was subsequently updated in a retry (see "Fix" section below) to mirror the same
  new format, per the "Mirror New Plan Create Output In MCP Tool" recommendation.
- `JobCompletionHandler.TryVerifyByOutputRegex` (internal) now matches `PlanId:\s*([\w-]+)` instead
  of `Plan created:\s*([\w-]+)`, resolving the captured ID to a plan folder via
  `PlanYamlHelper.FindPlanFolderById` rather than using the captured text directly as the folder name.

## Files Modified

**Behavior:**
- `src/Ivy.Tendril/Commands/PlanCreateCommand.cs` — new stdout format
- `src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs` — `TryVerifyByOutputRegex` fallback fix

**Tests:**
- `src/Ivy.Tendril.Test/PlanCliCommandTests.cs` — new test, `BuildPlanCreateApp` accepts an optional verification set
- `src/Ivy.Tendril.Test/TestPlanConfigService.cs` — accepts an optional verification set
- `src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs` — regression test updated for the new marker

**Docs:**
- `src/Ivy.Tendril/AGENTS.md`
- `src/Ivy.Tendril/Prompts/Plans.md`
- `src/Ivy.Tendril/Promptwares/CreatePlan/Program.md` + `src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md`
- `src/Ivy.Tendril/Promptwares/SplitPlan/Program.md` + `src/Ivy.Tendril.TeamIvyConfig/Promptwares/SplitPlan/Program.md`

## Manual Testing

1. Run `tendril plan create "Test Plan" <ProjectName> --plans-dir=<dir> --level=Feature --initial-prompt="test" --execution-profile=balanced` from a built `Ivy.Tendril.dll`.
2. Observe stdout: it should print `PlanId:`, `Directory:`, then `Verifications:` followed by one
   `Name:Status` line per verification configured on the project — and should **not** contain a
   `Plan created:` line.
3. To exercise the job-completion fallback fix specifically: launch a CreatePlan job through the
   Jobs UI where the agent creates a plan but never calls `tendril job status --plan-id=<id>` before
   exiting. The job should still complete successfully (not fall through to `Failed: No plan
   created`) because the `PlanId:` line in its output now resolves to the real plan folder.

## Fix: Mirror new plan create output in the MCP tool

Per reviewer feedback, the `tendril_plan_create` MCP tool (`PlanTools.cs`) was left unchanged in the
main change to limit scope. This retry brings it in line with the CLI: it now returns `PlanId:`,
`Directory:`, and a `Verifications:` section (one `Name:Status` line per seeded verification),
dropping the old `Plan created: {folderName}` line. `PlanToolsTests.cs` was updated to match, plus a
new test asserting the full `Name:Status` output for a configured verification set.

### Files Modified

- `src/Ivy.Tendril/Mcp/Tools/PlanTools.cs` — `PlanCreate` returns the new format
- `src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs` — assertions updated; new
  `PlanCreate_PrintsVerifications_AndOmitsPlanCreatedLine` test added

**Note:** No user-facing behavior beyond the MCP tool's own return string changed.

---
## Commits
- 16792124 Replace 'Plan created' line with Verifications list in plan create output
- 7675ddd1 Add test coverage for new plan create Verifications output
- 9b620e28 Sync promptware docs with new plan create output format
- f12ed778 code-review: fix broken CreatePlan job-completion fallback
- ae9292a2 Mirror new plan create output format in tendril_plan_create MCP tool
- a2ede382 Plan 00052: dotnet format fix (nested foreach indentation)
- 8c6fed57 code-review: remove redundant System.Linq using in PlanTools.cs

---
Created using [Ivy Tendril](https://ivy.app).
