### PR TITLE
[00067] Add Discuss With Agent Menu Item in Drafts and Review

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -1,3 +1,5 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Apps.Agent;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
@@ -27,6 +29,9 @@ public class ActionBarView(
     public override object Build()
     {
         var client = UseService<IClientProvider>();
+        var nav = UseNavigation();
+        var agentRunner = UseService<IAgentRunner>();
+        var (agentLabel, agentIcon) = AgentBranding.For(config.Settings.CodingAgent, agentRunner);
 
         if (isEditingState.Value)
         {
@@ -53,6 +58,9 @@ public class ActionBarView(
         // Standard overflow menu items (always at bottom of dropdowns)
         var standardOverflowItems = new[]
         {
+            new MenuItem($"Discuss with {agentLabel}", Icon: agentIcon, Tag: "DiscussWithAgent")
+                .OnSelect(() => nav.Navigate<AgentApp>(new AgentAppArgs(
+                    $"User wants to discuss the plan {selectedPlan.FolderPath} currently in Draft mode."))),
             new MenuItem("Create Issue", Icon: Icons.Github, Tag: "CreateIssue").OnSelect(showCreateIssueDialog),
             new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
                 .OnSelect(() => { PlatformHelper.OpenInFileManager(selectedPlan.FolderPath); }),

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -2,7 +2,9 @@ using System.Diagnostics;
 using System.Reactive.Disposables;
 using System.Text;
 using Ivy.Core;
+using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Apps.Agent;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Review.Dialogs;
 using Ivy.Tendril.Apps.Review.Tabs;
@@ -43,6 +45,7 @@ public class ContentView(
         var processView = Context.UseTendrilProcess();
 
         var githubService = UseService<IGithubService>();
+        var agentRunner = UseService<IAgentRunner>();
         var assigneesError = UseState<string?>(null);
         var assigneesQuery = UseQuery<string[], string>(
             selectedPlanState.Value?.Project ?? "",
@@ -236,7 +239,7 @@ public class ContentView(
             args, selectedRecTitles, ImplementRecommendations);
         var actionBar = BuildActionBar(
             selectedPlanState.Value, showResetToDraftDialog, showSuggestChangesDialog, showDiscardDialog,
-            showCreatePrDialog, copyToClipboard, client, logger, nav, args);
+            showCreatePrDialog, copyToClipboard, client, logger, nav, args, agentRunner);
         var content = BuildContent(
             selectedPlanState.Value, planData, planContentQuery, selectedTabIndex, tabNames, openVerification,
             openCommit, openFile, openArtifact, artifactContentQuery, assigneesQuery,
@@ -381,7 +384,7 @@ public class ContentView(
             }
 
             if (hasSelection)
-            { 
+            {
                 var count = selectedRecTitles.Value.Count;
                 var label = count > 1 ? "Implement Recommendations" : "Implement Recommendation";
                 rightSide |= new Button(label)
@@ -407,11 +410,17 @@ public class ContentView(
         IClientProvider client,
         ILogger<ContentView> logger,
         INavigator nav,
-        ReviewAppArgs? args)
+        ReviewAppArgs? args,
+        IAgentRunner agentRunner)
     {
+        var (agentLabel, agentIcon) = AgentBranding.For(config.Settings.CodingAgent, agentRunner);
+
         // Standard overflow menu items
         var standardOverflowItems = new[]
         {
+            new MenuItem($"Discuss with {agentLabel}", Icon: agentIcon, Tag: "DiscussWithAgent")
+                .OnSelect(() => nav.Navigate<AgentApp>(new AgentAppArgs(
+                    $"User wants to discuss the plan {selectedPlan.FolderPath} currently in Review mode."))),
             new MenuItem("Create PR", Icon: Icons.GitPullRequest, Tag: "CreatePR").OnSelect(showCreatePrDialog),
             new MenuItem("Set Completed", Icon: Icons.CircleCheck, Tag: "SetCompleted").OnSelect(() =>
             {


### PR DESCRIPTION
## Problem

The Drafts and Review action-bar overflow menus (the `⋮` dropdown) let the user open a plan in the file manager, terminal, or editor, but offer no way to start a conversation about the plan with the configured coding agent. This adds a **"Discuss with `<Agent>`"** item — branded with the current agent's display name and icon — that opens the Agent terminal pre-seeded with a prompt describing the plan and its current state (Draft or Review).

## Solution

Reuses the existing `AgentBranding.For` helper and `AgentApp` navigation (same building blocks as the "Chat with `<agent>`" flow in `CreatePlanDialog`):

- Added a `"Discuss with {agentLabel}"` `MenuItem` as the first entry of `standardOverflowItems` in both `ActionBarView.cs` (Drafts) and `ContentView.cs` (Review), branded via `AgentBranding.For(config.Settings.CodingAgent, agentRunner)`.
- Selecting it navigates to `AgentApp` with a prompt: `User wants to discuss the plan <PlanDirectory> currently in Draft mode.` (Drafts) or `... in Review mode.` (Review).
- Pure UI wiring — no new tests added; verified via `DotnetBuild`/`DotnetFormat` plus manual verification of the menu item and navigation.

---
## Commits
- f1a8af20 Add "Discuss with <Agent>" menu item in Drafts and Review

---
Created using [Ivy Tendril](https://ivy.app).
