### PR TITLE
[00059] Standardize Verification Report Headers on YAML Frontmatter

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
@@ -124,11 +124,13 @@ After reading the plan revision, scan it for code validation markers to detect s
 4. **Write validation report** — Create `<TendrilPlanFolder>/Verification/PreExecution.md`:
 
 ```markdown
+---
+result: Pass
+date: <CurrentTime>
+---
 # PreExecution
 
-- **Date:** <CurrentTime>
-- **Result:** Pass / Fail / Skipped
-- **Blocks Found:** <number>
+**Blocks Found:** <number>
 
 ## Validation Blocks
 

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Program.md
@@ -489,12 +489,14 @@ Confirm all expected files exist before writing the report.
 Write to `<VerificationDir>/IvyFrameworkVerification.md`:
 
 ```markdown
+---
+result: Pass
+date: <CurrentTime>
+---
 # IvyFrameworkVerification
 
-- **Plan:** <planId> — <title>
-- **Date:** <CurrentTime>
-- **Result:** Pass / Fail
-- **Test Project:** <path to temp project>
+**Plan:** <planId> — <title>
+**Test Project:** <path to temp project>
 
 ## What was tested
 

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -211,9 +211,19 @@ verifications:
        - Are all described changes present?
        - Are there unexpected\unrelated changes?
        - Do the changes solve the stated problem?
-    5. If the plan has a **Tests** section, verify those tests were actually written 6. Write the verification report to `<TendrilPlanFolder>\verification\CheckResult.md` Report format: ``` # CheckResult
+    5. If the plan has a **Tests** section, verify those tests were actually written 6. Write the verification report to `<TendrilPlanFolder>\verification\CheckResult.md` Report format: ```
 
-    - **Date:** <CurrentTime> - **Result:** Pass \ Fail - **Attempts:** 1
+    ---
+
+    result: Pass
+
+    date: <CurrentTime>
+
+    attempts: 1
+
+    ---
+
+    # CheckResult
 
     ## Requested vs Delivered | Requirement | Status | Notes | |-------------|--------|-------| | <from plan> | Done \ Missing \ Partial | <details> |
 
@@ -288,14 +298,17 @@ verifications:
 
     ```
 
+    ---
+
+    result: Pass
+
+    date: <timestamp>
+
+    attempts: 1
+
+    ---
+
     # CodeReview
-
-
-    - **Date:** <timestamp>
-
-    - **Result:** Pass | Fail
-
-    - **Attempts:** 1
 
 
     ## Review Method

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -116,11 +116,13 @@ After reading the plan revision, scan it for code validation markers to detect s
 4. **Write validation report** — Create `<TendrilPlanFolder>/Verification/PreExecution.md`:
 
 ```markdown
+---
+result: Pass
+date: <CurrentTime>
+---
 # PreExecution
 
-- **Date:** <CurrentTime>
-- **Result:** Pass / Fail / Skipped
-- **Blocks Found:** <number>
+**Blocks Found:** <number>
 
 ## Validation Blocks
 


### PR DESCRIPTION
# Summary

## Changes

Converted the four verification/validation report templates that rendered their metadata as a plain markdown bullet list (CheckResult, CodeReview, PreExecution ×2 copies, IvyFrameworkVerification) to the canonical YAML frontmatter format (`---`/`result`/`date`[/`attempts`]/`---`/`# Name`), so the plan UI renders them as a structured metadata card like DotnetBuild/DotnetFormat/DotnetTest instead of body text. This also fixes a latent bug: the `config.yaml` CheckResult verification consumer that reads `Result` from a report's frontmatter can now find it in the IvyFrameworkVerification report too.

## API Changes

None. These are prompt/report-template text changes in `config.yaml` and `Program.md` files — no C# code, CLI commands, or config schema changed.

## Files Modified

- `src/Ivy.Tendril.TeamIvyConfig/config.yaml` — CheckResult and CodeReview report templates converted to frontmatter.
- `src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md` — PreExecution report template converted to frontmatter.
- `src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md` — same PreExecution edit (second copy).
- `src/Ivy.Tendril.TeamIvyConfig/Promptwares/IvyFrameworkVerification/Program.md` — report template converted to frontmatter; `Plan`/`Test Project` moved into the body.

## Manual Testing

- Run `tendril verification get CheckResult` and `tendril verification get CodeReview` (or parse `config.yaml` with a YAML library) and confirm both prompts still render/parse without error, and the embedded report-format example shows `---`/`result:`/`date:`/`attempts:`/`---`/`# Name` on separate lines.
- Execute a plan through ExecutePlan and open its Verification/CheckResult.md, CodeReview.md, and PreExecution.md (and IvyFrameworkVerification.md if that verification runs) in the plan UI — each should render its Date/Result/Attempts metadata as a frontmatter card, not a bullet list in the body.

---
- df693c0a Standardize IvyFrameworkVerification report header on YAML frontmatter (plan 00059)
- 8f6a81b7 Standardize PreExecution report header on YAML frontmatter (plan 00059)
- 4d054483 Standardize CheckResult/CodeReview report headers on YAML frontmatter (plan 00059)

---
Created using [Ivy Tendril](https://ivy.app).
