### PR TITLE
[00068] Fix False Nothing Selected Error When Implementing Recommendations

### DIFF
--- a/src/Ivy.Tendril.Test/ContentViewTests.cs
+++ b/src/Ivy.Tendril.Test/ContentViewTests.cs
@@ -195,7 +195,7 @@ public class ContentViewTests
     }
 
     [Fact]
-    public void SelectRecommendationsToImplement_WithMatchingTitles_ReturnsSelectedRecs()
+    public void ResolvePendingSelection_WithPendingMatchingTitles_ReturnsThem()
     {
         var recs = new List<RecommendationYaml>
         {
@@ -204,13 +204,27 @@ public class ContentViewTests
             new() { Title = "R3" },
         };
 
-        var selected = ReviewContentView.SelectRecommendationsToImplement(recs, ["R1", "R3"]);
+        var selected = ReviewContentView.ResolvePendingSelection(recs, ["R1", "R3"]);
 
         Assert.Equal(["R1", "R3"], selected.Select(r => r.Title));
     }
 
     [Fact]
-    public void SelectRecommendationsToImplement_WithNoMatchingTitles_ReturnsEmpty()
+    public void ResolvePendingSelection_ExcludesNonPending()
+    {
+        var recs = new List<RecommendationYaml>
+        {
+            new() { Title = "R1", State = RecommendationStatus.Pending },
+            new() { Title = "R2", State = RecommendationStatus.Accepted },
+        };
+
+        var selected = ReviewContentView.ResolvePendingSelection(recs, ["R1", "R2"]);
+
+        Assert.Equal(["R1"], selected.Select(r => r.Title));
+    }
+
+    [Fact]
+    public void ResolvePendingSelection_WithNoMatchingTitles_ReturnsEmpty()
     {
         var recs = new List<RecommendationYaml>
         {
@@ -218,7 +232,7 @@ public class ContentViewTests
             new() { Title = "R2" },
         };
 
-        var selected = ReviewContentView.SelectRecommendationsToImplement(recs, ["Unknown"]);
+        var selected = ReviewContentView.ResolvePendingSelection(recs, ["Unknown"]);
 
         Assert.Empty(selected);
     }

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -232,7 +232,7 @@ public class ContentView(
         var pendingRecs = planData.Recommendations.Where(r => r.State == RecommendationStatus.Pending).ToList();
 
         void ImplementRecommendations() => ImplementSelectedRecommendations(
-            selectedPlanState.Value!, pendingRecs, selectedRecTitles, client,
+            selectedPlanState.Value!, selectedRecTitles, client,
             planContentQuery.Mutator.Revalidate);
 
         var header = BuildHeader(selectedPlanState.Value, allPlans, currentIndex, client, showCreatePrDialog, nav,
@@ -690,16 +690,24 @@ public class ContentView(
 
     private void ImplementSelectedRecommendations(
         PlanFile selectedPlan,
-        List<RecommendationYaml> pendingRecs,
         IState<HashSet<string>> selectedRecTitles,
         IClientProvider client,
         Action revalidate)
     {
         var titles = selectedRecTitles.Value.ToList();
-        var selected = SelectRecommendationsToImplement(pendingRecs, titles);
-        if (selected.Count == 0)
+        if (titles.Count == 0)
         {
             client.Toast("Select at least one recommendation to implement.", "Nothing Selected");
+            return;
+        }
+
+        var selected = ResolvePendingSelection(
+            planService.GetRecommendationsForPlan(selectedPlan.FolderName), titles);
+        if (selected.Count == 0)
+        {
+            client.Toast(
+                "Selected recommendations are no longer pending. Refresh and try again.",
+                "Nothing to Implement");
             return;
         }
 
@@ -718,9 +726,10 @@ public class ContentView(
         revalidate();
     }
 
-    internal static List<RecommendationYaml> SelectRecommendationsToImplement(
-        IEnumerable<RecommendationYaml> pendingRecs, IReadOnlyCollection<string> selectedTitles)
-        => pendingRecs.Where(r => selectedTitles.Contains(r.Title)).ToList();
+    internal static List<RecommendationYaml> ResolvePendingSelection(
+        IEnumerable<RecommendationYaml> allRecs, IReadOnlyCollection<string> selectedTitles)
+        => allRecs.Where(r => r.State == RecommendationStatus.Pending
+                              && selectedTitles.Contains(r.Title)).ToList();
 
     private static string BuildRecommendationChangeRequest(List<RecommendationYaml> recs)
     {


### PR DESCRIPTION
# Summary

## Changes

Fixed a false "Nothing Selected" toast on the Review app's Recommendations tab: the "Implement Recommendations" button previously validated checked titles against a `pendingRecs` list captured in a possibly-stale `Build()` closure, which could disagree with the badge's live selection count. `ImplementSelectedRecommendations` now re-reads recommendations from `IPlanReaderService.GetRecommendationsForPlan` at click time via a new `ResolvePendingSelection` helper, so the action always validates against current data.

## API Changes

- Removed `ContentView.SelectRecommendationsToImplement(IEnumerable<RecommendationYaml>, IReadOnlyCollection<string>)` (internal static).
- Added `ContentView.ResolvePendingSelection(IEnumerable<RecommendationYaml>, IReadOnlyCollection<string>)` (internal static) — filters to `RecommendationStatus.Pending` entries matching the selected titles.
- `ContentView.ImplementSelectedRecommendations` no longer takes a `pendingRecs` parameter; it fetches live recommendations from `planService.GetRecommendationsForPlan` internally. If the selection resolves to zero pending recommendations (e.g. already implemented elsewhere), it now shows a distinct "Nothing to Implement" toast instead of reusing "Nothing Selected".

## Files Modified

- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — click-time re-read fix described above.
- `src/Ivy.Tendril.Test/ContentViewTests.cs` — replaced the two `SelectRecommendationsToImplement` tests with three `ResolvePendingSelection` tests (matching pending titles, excludes non-pending state, no matching titles).

## Manual Testing

1. Open a completed plan in the Review app with 2+ pending recommendations.
2. Check two recommendations in the Recommendations tab; confirm the tab badge shows "2".
3. Click "Implement Recommendations" in the header.
4. Confirm a RetryPlan job starts and no false "Nothing Selected" toast appears.

---
## Commits
- f207c892 Fix false Nothing Selected error when implementing recommendations

---
Created using [Ivy Tendril](https://ivy.app).
