### PR TITLE
[00053] Fix Jobs Hanging Forever in Starting State

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceTimeoutTests.cs
@@ -371,6 +371,50 @@ codingAgent: claude
         service.CompleteJob(id, 0);
     }
 
+    // Regression for #plan-00053: a job stranded Running with no monitor ever armed (e.g. because
+    // the launch hung before JobMonitor.Start ran) previously had no path to completion — none of
+    // the per-job watchdogs exist to rescue it. RunStuckJobCheck is the global safety net that scans
+    // all Running jobs using StartedAt as the baseline, independent of whether a monitor ever started.
+    [Fact]
+    public void RunStuckJobCheck_StaleRunningJobWithNoMonitor_ReapsAsTimeoutWithStaleReason()
+    {
+        var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+
+        // Simulate a job stuck in "Starting…": launched long ago, never emitted any output.
+        job.StartedAt = DateTime.UtcNow.AddMinutes(-20);
+        job.LastOutputAt = null;
+
+        service.RunStuckJobCheck();
+
+        job = service.GetJob(id);
+        Assert.NotNull(job);
+        Assert.Equal(JobStatus.Timeout, job.Status);
+        Assert.Contains("No output for 10 minutes", job.StatusMessage);
+        Assert.NotNull(job.CompletedAt);
+    }
+
+    [Fact]
+    public void RunStuckJobCheck_FreshRunningJobWithinGraceWindow_IsNotReaped()
+    {
+        var service = CreateService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+
+        var id = service.CreateTestJob(new ExecutePlanArgs(_tempDir.Path));
+        var job = service.GetJob(id);
+        Assert.NotNull(job);
+        // StartedAt defaults to "now" from CreateTestJob and LastOutputAt is null — well within
+        // the stale-output timeout plus grace, so the reaper must leave it alone.
+
+        service.RunStuckJobCheck();
+
+        job = service.GetJob(id);
+        Assert.NotNull(job);
+        Assert.Equal(JobStatus.Running, job.Status);
+    }
+
     [Fact]
     public void Constructor_AcceptsLogger()
     {

--- a/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
@@ -206,6 +206,63 @@ projects:
         Assert.False(result);
     }
 
+    // Regression for #plan-00053: any unhandled exception during the synchronous launch window
+    // (e.g. a "before" hook throwing) used to leave the job stuck Running in "Starting…" forever
+    // with a leaked concurrency slot and no timeout watchdog ever armed to rescue it. The launch
+    // path must now fail the job cleanly and release its slot — and since the plan-to-Executing
+    // transition happens only after the agent process actually starts, the plan must never have
+    // been touched here at all.
+    [Fact]
+    public void LaunchJob_UnhandledExceptionDuringLaunch_FailsJobAndDoesNotStrandPlanExecuting()
+    {
+        var launcher = CreateLauncher();
+
+        var planFolder = Path.Combine(_tempTendrilHome, "Plans", "00001-TestPlan");
+        Directory.CreateDirectory(planFolder);
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), @"
+schemaVersion: 3
+state: Draft
+project: TestProject
+title: Test Plan
+");
+
+        var jobs = new ConcurrentDictionary<string, JobItem>();
+        var job = new JobItem
+        {
+            Id = "launch-fail-1",
+            Type = "ExecutePlan",
+            TypedArgs = new ExecutePlanArgs(planFolder),
+            Project = "TestProject",
+            Status = JobStatus.Queued
+        };
+        jobs[job.Id] = job;
+
+        using var semaphore = new SemaphoreSlim(1, 1);
+        semaphore.Wait(); // The caller acquires the slot before invoking LaunchJob, as real callers do.
+
+        var structureChangedRaised = false;
+
+        launcher.LaunchJob(
+            job, jobs, semaphore, TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            runHooks: (_, _, _, _, _) => throw new InvalidOperationException("boom"),
+            completeJob: (_, _, _, _) => { },
+            raiseStructureChanged: () => structureChangedRaised = true);
+
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.NotNull(job.CompletedAt);
+        Assert.Contains("boom", job.StatusMessage);
+        Assert.True(structureChangedRaised);
+
+        // Slot released — not leaked. A subsequent job can still acquire it.
+        Assert.Equal(1, semaphore.CurrentCount);
+        Assert.True(semaphore.Wait(0));
+
+        // The plan must never be left stranded in Executing.
+        var plan = PlanYamlHelper.ReadPlanYaml(planFolder);
+        Assert.NotNull(plan);
+        Assert.NotEqual(nameof(PlanStatus.Executing), plan.State);
+    }
+
     [Fact]
     public async Task RunStaleOutputWatchdog_DoesNotFlagRecentOutput()
     {

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -64,6 +64,7 @@ internal class JobLauncher
 
     private void LaunchJob(JobLaunchContext ctx)
     {
+        Process? process = null;
         try
         {
             // Defense in depth (#1340): refuse to launch a plan job that references a repo outside its
@@ -77,7 +78,7 @@ internal class JobLauncher
             if (!ValidateJobPrerequisites(ctx, out var psi, out var stdinContent))
                 return;
 
-            var process = StartAgentProcess(ctx, psi, stdinContent);
+            process = StartAgentProcess(ctx, psi, stdinContent);
             if (process == null)
                 return;
 
@@ -92,7 +93,7 @@ internal class JobLauncher
         }
         catch (Exception ex)
         {
-            HandleLaunchFailure(ctx, ex);
+            HandleLaunchFailure(ctx, ex, process);
         }
     }
 
@@ -100,10 +101,26 @@ internal class JobLauncher
     // hook throwing, or an exception inside TryBuildAgentProcessStart other than the Win32Exception
     // StartAgentProcess already guards) so the job fails visibly instead of hanging in Starting
     // forever with no timeout watchdog ever created to rescue it.
-    private void HandleLaunchFailure(JobLaunchContext ctx, Exception ex)
+    private void HandleLaunchFailure(JobLaunchContext ctx, Exception ex, Process? process)
     {
         var job = ctx.Job;
         _logger.LogError(ex, "Job {JobId}: Unhandled exception during launch", job.Id);
+
+        // The agent process may have already started (e.g. if the failure is in TransitionPlanToExecuting,
+        // which runs after StartAgentProcess succeeds) — no monitor exists yet to ever reap it, so kill it
+        // here rather than leaking a real OS process.
+        if (process != null)
+        {
+            try
+            {
+                if (!process.HasExited)
+                    process.Kill(entireProcessTree: true);
+            }
+            catch (Exception killEx)
+            {
+                _logger.LogWarning(killEx, "Job {JobId}: Failed to kill orphaned process during launch failure", job.Id);
+            }
+        }
 
         job.Status = JobStatus.Failed;
         job.StatusMessage = $"Launch failed: {ex.Message}";

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -64,22 +64,60 @@ internal class JobLauncher
 
     private void LaunchJob(JobLaunchContext ctx)
     {
-        // Defense in depth (#1340): refuse to launch a plan job that references a repo outside its
-        // project, before any state mutation. The creation/add-repo guards should prevent this, but
-        // pre-existing plans may have drifted.
-        if (!ValidateProjectReposOrFail(ctx))
-            return;
+        try
+        {
+            // Defense in depth (#1340): refuse to launch a plan job that references a repo outside its
+            // project, before any state mutation. The creation/add-repo guards should prevent this, but
+            // pre-existing plans may have drifted.
+            if (!ValidateProjectReposOrFail(ctx))
+                return;
 
-        PrepareJobForLaunch(ctx);
+            PrepareJobForLaunch(ctx);
 
-        if (!ValidateJobPrerequisites(ctx, out var psi, out var stdinContent))
-            return;
+            if (!ValidateJobPrerequisites(ctx, out var psi, out var stdinContent))
+                return;
 
-        var process = StartAgentProcess(ctx, psi, stdinContent);
-        if (process == null)
-            return;
+            var process = StartAgentProcess(ctx, psi, stdinContent);
+            if (process == null)
+                return;
 
-        InitializeJobMonitoring(ctx, process);
+            // Only now — after the child process genuinely exists — does the plan move to Executing.
+            // Every failure path above (repo guard, hook failures, prompt/process build errors) runs
+            // before this point, so a throw there never strands the plan in Executing in the first
+            // place; the catch below only needs to fail the job, not revert plan state.
+            TransitionPlanToExecuting(ctx);
+
+            InitializeJobMonitoring(ctx, process);
+            ctx.RaiseStructureChanged();
+        }
+        catch (Exception ex)
+        {
+            HandleLaunchFailure(ctx, ex);
+        }
+    }
+
+    // Catches anything unhandled between "job marked Running" and "monitor armed" (e.g. a "before"
+    // hook throwing, or an exception inside TryBuildAgentProcessStart other than the Win32Exception
+    // StartAgentProcess already guards) so the job fails visibly instead of hanging in Starting
+    // forever with no timeout watchdog ever created to rescue it.
+    private void HandleLaunchFailure(JobLaunchContext ctx, Exception ex)
+    {
+        var job = ctx.Job;
+        _logger.LogError(ex, "Job {JobId}: Unhandled exception during launch", job.Id);
+
+        job.Status = JobStatus.Failed;
+        job.StatusMessage = $"Launch failed: {ex.Message}";
+        job.CompletedAt = DateTime.UtcNow;
+
+        try
+        {
+            ctx.JobSlotSemaphore.Release();
+        }
+        catch (SemaphoreFullException)
+        {
+            // Already at max capacity — nothing to release.
+        }
+
         ctx.RaiseStructureChanged();
     }
 
@@ -131,12 +169,19 @@ internal class JobLauncher
         ctx.RunHooks("before", type, planFolderForHooks, job.Project, job);
 
         if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs && !string.IsNullOrEmpty(job.TypedArgs?.PlanFolder))
-        {
             EnsurePlanFolderWritable(job.TypedArgs!.PlanFolder!);
-            PlanYamlHelper.SetPlanStateByFolder(job.TypedArgs!.PlanFolder!, nameof(PlanStatus.Executing));
-        }
 
         job.SessionId = Guid.NewGuid().ToString();
+    }
+
+    // Deliberately called only after StartAgentProcess succeeds (see LaunchJob) — moved out of
+    // PrepareJobForLaunch so the plan isn't flipped to Executing until an agent process genuinely
+    // exists, shrinking the window in which a launch failure could strand the plan there.
+    private static void TransitionPlanToExecuting(JobLaunchContext ctx)
+    {
+        var job = ctx.Job;
+        if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs && !string.IsNullOrEmpty(job.TypedArgs?.PlanFolder))
+            PlanYamlHelper.SetPlanStateByFolder(job.TypedArgs!.PlanFolder!, nameof(PlanStatus.Executing));
     }
 
     private bool ValidateJobPrerequisites(

--- a/src/Ivy.Tendril/Services/Jobs/JobMonitor.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobMonitor.cs
@@ -59,6 +59,15 @@ internal class JobMonitor
         catch (ObjectDisposedException)
         {
             _logger.LogDebug("Job {JobId}: Monitor task exiting (CTS disposed, job completed elsewhere)", _id);
+
+            // Normally the CTS is only disposed once the job has already been completed elsewhere.
+            // If it somehow got disposed while the job is still Running, don't return silently — that
+            // would leave the job stranded with no monitor left to ever complete it.
+            if (_ctx.Jobs.TryGetValue(_id, out var job) && job.Status == JobStatus.Running)
+            {
+                _logger.LogWarning("Job {JobId}: CTS disposed but job still Running — completing as timeout", _id);
+                _ctx.CompleteJob(_id, null, true, false);
+            }
         }
         catch (Exception ex)
         {

--- a/src/Ivy.Tendril/Services/Jobs/JobMonitor.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobMonitor.cs
@@ -66,6 +66,17 @@ internal class JobMonitor
             if (_ctx.Jobs.TryGetValue(_id, out var job) && job.Status == JobStatus.Running)
             {
                 _logger.LogWarning("Job {JobId}: CTS disposed but job still Running — completing as timeout", _id);
+
+                try
+                {
+                    if (!_process.HasExited)
+                        _process.Kill(entireProcessTree: true);
+                }
+                catch (Exception killEx)
+                {
+                    _logger.LogWarning(killEx, "Job {JobId}: Failed to kill process during CTS-disposed recovery", _id);
+                }
+
                 _ctx.CompleteJob(_id, null, true, false);
             }
         }

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -357,13 +357,65 @@ public class JobService : IJobService
         try
         {
             var hasBlocked = _jobs.Values.Any(j => j.Status == JobStatus.Blocked);
-            if (!hasBlocked) return;
-
-            _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck);
+            if (hasBlocked)
+                _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck);
         }
         catch
         {
             // Best-effort — don't crash on timer callback
+        }
+
+        try
+        {
+            RunStuckJobCheck();
+        }
+        catch
+        {
+            // Best-effort — don't crash on timer callback
+        }
+    }
+
+    // Extra margin on top of the configured timeouts before a job is reaped, so a legitimately
+    // slow-but-progressing job isn't killed the instant it crosses the nominal threshold.
+    private static readonly TimeSpan StuckJobReapGrace = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    ///     Global safety net for jobs stranded Running with no path to completion — e.g. a launch
+    ///     that hung before <see cref="JobMonitor" /> ever armed its watchdogs (the "Starting…"
+    ///     forever bug). Unlike the per-job stale-output/hard-timeout watchdogs (armed only once
+    ///     <see cref="JobMonitor.Start" /> runs), this scans every Running job independent of whether
+    ///     its monitor ever started, using <see cref="JobItem.StartedAt" /> as the baseline. Runs on
+    ///     the existing 60s timer; exposed internally so tests can drive it deterministically.
+    /// </summary>
+    internal void RunStuckJobCheck()
+    {
+        var now = DateTime.UtcNow;
+
+        foreach (var job in _jobs.Values.Where(j => j.Status == JobStatus.Running).ToArray())
+        {
+            if (!job.StartedAt.HasValue) continue;
+
+            var staleAnchor = job.LastOutputAt ?? job.StartedAt.Value;
+            var isStale = _staleOutputTimeout > TimeSpan.Zero
+                          && now - staleAnchor > _staleOutputTimeout + StuckJobReapGrace;
+            var isHardCapped = now - job.StartedAt.Value > _jobTimeout + TimeSpan.FromMinutes(5) + StuckJobReapGrace;
+
+            if (!isStale && !isHardCapped) continue;
+
+            _logger.LogWarning(
+                "Job {JobId}: Reaped by stuck-job check ({Reason})", job.Id, isStale ? "stale output" : "hard cap");
+
+            try
+            {
+                if (job.Process is { HasExited: false })
+                    job.Process.Kill(entireProcessTree: true);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Job {JobId}: Failed to kill process during stuck-job reap", job.Id);
+            }
+
+            CompleteJob(job.Id, null, timedOut: true, staleOutput: isStale);
         }
     }
 


### PR DESCRIPTION
# Summary

## Changes

Jobs could get stranded `Running` forever in the "Starting…" UI state: the launch path marked a job
`Running` (and its plan `Executing`) before `JobMonitor.Start()` ever armed the stale-output/hard
timeout watchdogs, so any unhandled exception in that window left the job un-rescuable. Fixed by
wrapping `JobLauncher.LaunchJob`'s body in try/catch (failing the job cleanly and releasing its
concurrency slot on any exception), moving the plan-to-Executing transition to after the agent
process actually starts (so most launch failures never touch plan state), adding a global
`RunStuckJobCheck` reaper in `JobService` that scans all `Running` jobs on the existing 60s timer
independent of whether their monitor ever armed, and hardening `JobMonitor`'s
`ObjectDisposedException` handler to complete a still-`Running` job instead of returning silently.
A follow-up fix (found during this execution's own code-review pass) also kills the orphaned agent
process if a launch failure occurs after the process already started.

## API Changes

- `JobService.RunStuckJobCheck()` — new `internal` method; global stuck-job reaper, exposed for
  deterministic testing. Called automatically from the existing 60s blocked-job-check timer.
- `JobLauncher`: new private `TransitionPlanToExecuting` and `HandleLaunchFailure` methods (internal
  implementation detail, not part of any public surface).

## Files Modified

- `src/Ivy.Tendril/Services/Jobs/JobLauncher.cs` — guarded launch path, moved plan-to-Executing
  transition, added launch-failure handling with process cleanup.
- `src/Ivy.Tendril/Services/Jobs/JobService.cs` — added `RunStuckJobCheck` reaper, wired into the
  existing periodic timer.
- `src/Ivy.Tendril/Services/Jobs/JobMonitor.cs` — hardened `ObjectDisposedException` recovery to
  complete a still-Running job (with process kill) instead of returning silently.
- `src/Ivy.Tendril.Test/Services/JobLauncherTests.cs`, `src/Ivy.Tendril.Test/JobServiceTimeoutTests.cs`
  — new regression tests for both safety nets.

## Manual Testing

1. In the Jobs view, trigger a launch failure (e.g. temporarily make a "before" hook throw, or
   corrupt a plan's `plan.yaml` so it can't be read) and start an `ExecutePlan` job against it.
2. Observe the job immediately shows `Failed` with a `"Launch failed: ..."` message instead of
   hanging in "Starting…" — and the plan itself is not stuck in the `Executing` state.
3. Start another job of the same type right after — it should launch normally (the concurrency slot
   was not leaked).
4. (Harder to reproduce manually) A job artificially left `Running` with no output for longer than
   `staleOutputTimeout` + 2 minutes will be automatically reaped by the background reaper within the
   next 60-second timer tick, transitioning to `Timeout` with a "No output for N minutes" message.

---
## Commits

- 1dbc7150 [00053] Guard job launch path and add stuck-job reaper
- 296b2c27 [00053] Add tests for launch-failure handling and stuck-job reaper
- f76eb6cb code-review: kill orphaned process when launch fails after process start

---
Created using [Ivy Tendril](https://ivy.app).
