### PR TITLE
[00039] Preserve Completed Plan State When Deleting Its Finished Job

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -116,6 +116,31 @@ public class JobServiceCompletionGuardTests : IDisposable
         service.DeleteJob(id);
 
         Assert.Empty(plan.ResetToDraftCalls);
+        Assert.Empty(plan.Transitions);
+    }
+
+    [Fact]
+    public void DeleteJob_CompletedPlan_NonExecuteJob_DoesNotRevertState()
+    {
+        var (service, plan) = CreateServiceWithStub(currentStatus: PlanStatus.Completed);
+        var id = service.CreateTestJob(new CreatePrArgs("test-plan"));
+        service.GetJob(id)!.PreviousPlanState = PlanStatus.Review;
+
+        service.DeleteJob(id);
+
+        Assert.Empty(plan.Transitions);
+    }
+
+    [Fact]
+    public void DeleteJob_SkippedPlan_DoesNotRevertState()
+    {
+        var (service, plan) = CreateServiceWithStub(currentStatus: PlanStatus.Skipped);
+        var id = service.CreateTestJob(new CreatePrArgs("test-plan"));
+        service.GetJob(id)!.PreviousPlanState = PlanStatus.Review;
+
+        service.DeleteJob(id);
+
+        Assert.Empty(plan.Transitions);
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -297,21 +297,27 @@ public class JobService : IJobService
     }
 
     /// <summary>
-    ///     Deleting a job reverts its plan to where it came from. For an ExecutePlan job
-    ///     (and only when the plan isn't already shipped) deleting discards the execution's
-    ///     work product entirely: the plan is reset to a clean Draft and worktrees/artifacts
-    ///     are removed.
+    ///     Deleting a job reverts its plan to where it came from. Terminal plans (Completed
+    ///     or Skipped — already shipped) are immutable: only the job history entry is removed,
+    ///     state and records are left untouched. For a non-terminal ExecutePlan job, deleting
+    ///     discards the execution's work product entirely: the plan is reset to a clean Draft
+    ///     and worktrees/artifacts are removed.
     /// </summary>
     private void ApplyDeletePlanState(JobItem removed)
     {
         var planFolder = removed.TypedArgs?.PlanFolder;
 
-        if (removed.TypedArgs is ExecutePlanArgs && _planReaderService != null
-            && !string.IsNullOrEmpty(planFolder))
+        if (_planReaderService != null && !string.IsNullOrEmpty(planFolder))
         {
             var current = _planReaderService.GetPlanByFolder(planFolder)?.Status;
-            var isTerminal = current is PlanStatus.Completed or PlanStatus.Skipped;
-            if (!isTerminal)
+
+            // Terminal plans (PR created, or manually Skipped) are immutable: deleting a
+            // finished history job must not move them backward. Remove the job only; leave
+            // state and records untouched.
+            if (current is PlanStatus.Completed or PlanStatus.Skipped)
+                return;
+
+            if (removed.TypedArgs is ExecutePlanArgs)
             {
                 // Optimistic delete: the job is already gone from the UI, so reclaim the plan's
                 // worktrees and artifacts on a background thread and return immediately instead of


### PR DESCRIPTION
Fixes #1561

# Summary

## Changes

Fixed a bug (issue #1561) where deleting a finished job from the Jobs history on an already-`Completed` (or `Skipped`) plan wrongly reverted the plan's state back to `Draft`. `ApplyDeletePlanState` in `JobService.cs` now checks the plan's terminal state before considering any job-type branch and returns immediately for terminal plans, so the delete is history-only and never touches plan state or records.

## API Changes

None. `ApplyDeletePlanState` is a private method; its external behavior contract (delete a job) is unchanged — only the (previously buggy) side effect on terminal plans is corrected.

## Files Modified

- `src/Ivy.Tendril/Services/Jobs/JobService.cs` — hoisted the `Completed`/`Skipped` terminal check in `ApplyDeletePlanState` to guard the entire method instead of only the `ExecutePlanArgs` cleanup branch.
- `src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs` — strengthened `DeleteJob_ExecutePlan_Terminal_DoesNotResetToDraft` to assert no state transitions occur, and added `DeleteJob_CompletedPlan_NonExecuteJob_DoesNotRevertState` and `DeleteJob_SkippedPlan_DoesNotRevertState` covering non-`ExecutePlan` job types.

## Manual Testing

1. Run the Tendril TUI/app.
2. Execute a plan to completion so it reaches `Completed` state (PR created) — or find an existing `Completed` plan with a job still in its Jobs history.
3. In the Jobs view, delete the finished `ExecutePlan` job (or a `CreatePr`/`RetryPlan` job) associated with that `Completed` plan.
4. Observe: the plan should remain `Completed` and stay out of the Drafts list — it should NOT reappear in Drafts or increment the sidebar Drafts badge.
5. As a control, delete a job on a non-terminal plan (e.g. `Review` or `Executing`) and confirm it still reverts to its previous state as before (unchanged behavior).

---
- be778ce0 Test Plan 00039: cover terminal-plan guard for delete on any job type
- d7d0089f Fix Plan 00039: hoist terminal-plan guard to cover full delete path

---
Created using [Ivy Tendril](https://ivy.app).
