### PR TITLE
[00037] Fix plan.yaml Read-During-Write Race Crashing Job Launch

### DIFF
--- a/src/Ivy.Tendril.Test/PlanCommandHelpersReadPlanRaceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCommandHelpersReadPlanRaceTests.cs
@@ -1,0 +1,57 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test;
+
+public class PlanCommandHelpersReadPlanRaceTests : IDisposable
+{
+    private readonly string _planFolder;
+
+    public PlanCommandHelpersReadPlanRaceTests()
+    {
+        _planFolder = Path.Combine(Path.GetTempPath(), $"tendril-readplan-race-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_planFolder);
+        File.WriteAllText(Path.Combine(_planFolder, "plan.yaml"), PlanYaml("Test Plan"));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_planFolder))
+            Directory.Delete(_planFolder, true);
+    }
+
+    private static string PlanYaml(string title) =>
+        $"state: Draft\nproject: Test\ntitle: {title}\nupdated: 2026-01-01T00:00:00Z\n";
+
+    [Fact]
+    public async Task ReadPlan_ConcurrentTruncatingWrites_NeverReturnsEmptyOrThrows()
+    {
+        var yamlPath = Path.Combine(_planFolder, "plan.yaml");
+        using var stopSignal = new CancellationTokenSource();
+
+        // Mirrors PlanReaderService.ExecuteWithLock: acquire the same PlanFileLock and rewrite
+        // plan.yaml via the non-atomic truncate+write FileHelper.WriteAllText, on a background thread.
+        var writer = Task.Run(() =>
+        {
+            while (!stopSignal.IsCancellationRequested)
+            {
+                using var _ = PlanFileLock.Acquire(_planFolder);
+                FileHelper.WriteAllText(yamlPath, PlanYaml("Test Plan"));
+            }
+        });
+
+        var deadline = DateTime.UtcNow.AddSeconds(1);
+        var readCount = 0;
+        while (DateTime.UtcNow < deadline)
+        {
+            var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+            Assert.NotNull(plan);
+            Assert.Equal("Test Plan", plan.Title);
+            readCount++;
+        }
+
+        stopSignal.Cancel();
+        await writer;
+
+        Assert.True(readCount > 0);
+    }
+}

--- a/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
@@ -151,6 +151,9 @@ public static class PlanCommandHelpers
             .ToList();
     }
 
+    private const int ReadPlanMaxRetries = 5;
+    private const int ReadPlanRetryDelayMs = 50;
+
     /// <summary>
     ///     Reads a plan.yaml file and deserializes it.
     /// </summary>
@@ -160,8 +163,25 @@ public static class PlanCommandHelpers
         if (!File.Exists(yamlPath))
             throw new FileNotFoundException($"plan.yaml not found at {yamlPath}");
 
-        var content = FileHelper.ReadAllText(yamlPath);
-        var plan = YamlHelper.Deserializer.Deserialize<PlanYaml>(content);
+        // Coordinate with writers (PlanReaderService / WritePlan) that hold this lock while
+        // performing a non-atomic truncate+write, so we never read a mid-write empty file.
+        using var _ = PlanFileLock.Acquire(planFolder);
+
+        PlanYaml? plan = null;
+        for (var attempt = 0; attempt < ReadPlanMaxRetries; attempt++)
+        {
+            var content = FileHelper.ReadAllText(yamlPath);
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                plan = YamlHelper.Deserializer.Deserialize<PlanYaml>(content);
+                if (plan != null)
+                    break;
+            }
+
+            if (attempt < ReadPlanMaxRetries - 1)
+                Thread.Sleep(ReadPlanRetryDelayMs);
+        }
+
         if (plan == null)
             throw new InvalidOperationException($"Failed to deserialize plan.yaml at {yamlPath}");
 

--- a/src/Ivy.Tendril/Hooks/UsePreflightCheck.cs
+++ b/src/Ivy.Tendril/Hooks/UsePreflightCheck.cs
@@ -1,3 +1,4 @@
+using Ivy.Helpers;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.Git;
@@ -29,32 +30,42 @@ public static class UsePreflightCheckExtensions
 
             Task.Run(() =>
             {
-                var projectNames = ProjectHelper.ParseProjects(projectValue);
-                var dirtyRepos = new List<(string, string, DirtyRepoResult)>();
-                var checkedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-                foreach (var projectName in projectNames)
+                try
                 {
-                    var project = configService.GetProject(projectName);
-                    if (project is null) continue;
+                    var projectNames = ProjectHelper.ParseProjects(projectValue);
+                    var dirtyRepos = new List<(string, string, DirtyRepoResult)>();
+                    var checkedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-                    foreach (var repo in project.Repos)
+                    foreach (var projectName in projectNames)
                     {
-                        var expanded = Environment.ExpandEnvironmentVariables(repo.Path);
-                        if (!checkedPaths.Add(expanded)) continue;
+                        var project = configService.GetProject(projectName);
+                        if (project is null) continue;
 
-                        var baseBranch = repo.BaseBranch ?? GitHelper.ResolveDefaultBranch(expanded, configService.TendrilHome);
+                        foreach (var repo in project.Repos)
+                        {
+                            var expanded = Environment.ExpandEnvironmentVariables(repo.Path);
+                            if (!checkedPaths.Add(expanded)) continue;
 
-                        var checkResult = gitService.GetRepoDirtyState(expanded, baseBranch);
-                        if (checkResult.IsSuccess && checkResult.Value!.IsDirty)
-                            dirtyRepos.Add((expanded, baseBranch, checkResult.Value));
+                            var baseBranch = repo.BaseBranch ?? GitHelper.ResolveDefaultBranch(expanded, configService.TendrilHome);
+
+                            var checkResult = gitService.GetRepoDirtyState(expanded, baseBranch);
+                            if (checkResult.IsSuccess && checkResult.Value!.IsDirty)
+                                dirtyRepos.Add((expanded, baseBranch, checkResult.Value));
+                        }
                     }
-                }
 
-                var preflightResult = new PreflightResult(dirtyRepos);
-                result.Set(preflightResult);
-                isChecking.Set(false);
-                onComplete(preflightResult);
+                    var preflightResult = new PreflightResult(dirtyRepos);
+                    result.Set(preflightResult);
+                    onComplete(preflightResult);
+                }
+                catch (Exception ex)
+                {
+                    CrashLog.Write($"[{DateTime.UtcNow:O}] Preflight check failed: {ex}");
+                }
+                finally
+                {
+                    isChecking.Set(false);
+                }
             });
         }
     }


### PR DESCRIPTION
# Summary

## Changes

Fixed a read-during-write race where `PlanCommandHelpers.ReadPlan` could read `plan.yaml` mid-truncate
during a background rewrite by `PlanReaderService`, deserialize an empty file to `null`, and throw an
`InvalidOperationException` that crashed job launch. `ReadPlan` now acquires the same `PlanFileLock`
every writer already holds (serializing reads against writes) plus a bounded retry as defense-in-depth.
Also hardened `UsePreflightCheck`'s background check so an exception there can no longer become an
unobserved task exception or leave the Execute button's spinner stuck forever. The plan's third fix item
(making `JobLauncher.LaunchJob` fail cleanly and release its job-slot semaphore on an unhandled
exception) was found already implemented and tested by a prior, overlapping plan (00041, merged
2026-07-06) — verified present, not re-implemented.

## API Changes

None — both changes are internal robustness fixes with no public API surface change.

## Files Modified

- `src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs` — `ReadPlan` now acquires `PlanFileLock` and retries (up to 5x, 50ms) on empty/null content before throwing.
- `src/Ivy.Tendril/Hooks/UsePreflightCheck.cs` — wrapped the background check in try/catch/finally; logs failures via `CrashLog` and always resets `isChecking`.
- `src/Ivy.Tendril.Test/PlanCommandHelpersReadPlanRaceTests.cs` (new) — regression test reproducing the race via a concurrent writer loop using the same lock/truncate pattern as production code.

## Manual Testing

N/A — internal robustness fix with no directly observable UI change. The regression test
(`PlanCommandHelpersReadPlanRaceTests`) exercises the fix end-to-end: it was confirmed to fail with the
exact reported `InvalidOperationException: Failed to deserialize plan.yaml` on the pre-fix code, and to
pass after the fix, by temporarily reverting the fix commit during this execution and re-running the
test both ways.

---
## Commits

- 3f48a87e Prevent unobserved exception and stuck spinner in UsePreflightCheck (Plan 00037)
- 2351d43a Fix plan.yaml read-during-write race in ReadPlan (Plan 00037)

---
Created using [Ivy Tendril](https://ivy.app).
