### PR TITLE
[00071] Use Short Enter Symbol in ContentInput Shortcut Label

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.test.tsx
@@ -40,7 +40,7 @@ describe("ContentInput", () => {
 
   it("renders the enter symbol (↵) in the shortcut label on non-Mac platforms", () => {
     render(<ContentInput id="civ-1" value="test" />);
-    const shortcut = screen.getByText((content, element) => {
+    const shortcut = screen.getByText((_content, element) => {
       return element?.classList.contains("civ-submit-shortcut") ?? false;
     });
     expect(shortcut.textContent).toContain("↵");

--- a/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.test.tsx
@@ -37,4 +37,12 @@ describe("ContentInput", () => {
     const submitButton = screen.getByTitle("Send");
     expect(submitButton).toBeDisabled();
   });
+
+  it("renders the enter symbol (↵) in the shortcut label on non-Mac platforms", () => {
+    render(<ContentInput id="civ-1" value="test" />);
+    const shortcut = screen.getByText((content, element) => {
+      return element?.classList.contains("civ-submit-shortcut") ?? false;
+    });
+    expect(shortcut.textContent).toContain("↵");
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.test.tsx
@@ -39,10 +39,9 @@ describe("ContentInput", () => {
   });
 
   it("renders the enter symbol (↵) in the shortcut label on non-Mac platforms", () => {
-    render(<ContentInput id="civ-1" value="test" />);
-    const shortcut = screen.getByText((_content, element) => {
-      return element?.classList.contains("civ-submit-shortcut") ?? false;
-    });
-    expect(shortcut.textContent).toContain("↵");
+    render(<ContentInput id="civ-1" value="test" submitLabel="Send" />);
+    const shortcut = document.querySelector(".civ-submit-shortcut");
+    expect(shortcut).toBeTruthy();
+    expect(shortcut?.textContent).toContain("↵");
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx
@@ -137,7 +137,12 @@ const renderShortcut = (isMac: boolean) => {
       </>
     );
   }
-  return "Ctrl+Enter";
+  return (
+    <>
+      <span>Ctrl</span>
+      <span className="civ-shortcut-enter">↵</span>
+    </>
+  );
 };
 
 export const ContentInput: React.FC<ContentInputProps> = ({


### PR DESCRIPTION
Fixes #\n\n# Summary

## Changes

Updated the ContentInput widget's keyboard shortcut label to consistently use the short enter symbol (`↵`) instead of the word "Enter" on Windows/Linux platforms. The shortcut now displays as `Ctrl+↵` to match the macOS rendering of `⌘↵`.

## API Changes

None.

## Files Modified

**Frontend:**
- `src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.tsx` - Modified `renderShortcut` function to return JSX structure with symbol instead of plain string
- `src/Ivy.Tendril.Widgets/frontend/src/ContentInput/ContentInput.test.tsx` - Added test to verify enter symbol rendering

## Manual Testing

1. Run the Tendril application on a Windows or Linux machine
2. Open any dialog that uses the ContentInput widget with a submit button label (e.g., the main chat interface with "Send" label enabled)
3. Observe the keyboard shortcut displayed on the submit button
4. **Expected:** The shortcut should display as `Ctrl+↵` (with the enter symbol), not `Ctrl+Enter` (with the word "Enter")
5. **Verify:** The symbol matches the visual style of other keyboard shortcuts in the application

**Note:** On macOS, the shortcut already displayed correctly as `⌘↵` before this change.

---

**Commits:**
- dc93404a Fix test to provide submitLabel for shortcut rendering
- 968a11f7 Fix TypeScript unused parameter warning in test
- cb61ec3e Use short enter symbol (↵) in ContentInput shortcut label

---
Created using [Ivy Tendril](https://ivy.app).