### PR TITLE
[00075] Fix Project Setup Step Loading State and Layout Stability

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -33,7 +33,7 @@ public class ProjectAgentStepView(
         var progressValue = UseState<int?>(null);
         var error = UseState<string?>(null);
         var authCode = UseState<string?>(null);
-        var isCloning = UseState(false);
+        var isCloning = UseState(!session.Started.Value);
 
         UseEffect(async () =>
         {
@@ -254,7 +254,7 @@ public class ProjectAgentStepView(
             }
         };
 
-        return Layout.Vertical().Margin(0, 0, 0, 2)
+        return Layout.Vertical().Margin(0, 0, 0, 2).Height(Size.Fit().Min(Size.Units(60)))
                | (showHeader ? Text.H3("Setting up your project") : null!)
                | Text.Muted(isCloning.Value
                    ? (progressMessage.Value ?? "Setting up your project...")
@@ -264,8 +264,10 @@ public class ProjectAgentStepView(
                | (authCode.Value != null
                    ? (object)Text.Markdown($"**Device code:** `{authCode.Value}` — enter this in your browser if prompted.")
                    : null!)
-               | (isCloning.Value && progressValue.Value != null
-                   ? (object)new Progress(progressValue.Value.Value)
+               | (isCloning.Value
+                   ? (progressValue.Value != null
+                       ? (object)new Progress(progressValue.Value.Value)
+                       : (object)new Loading())
                    : null!)
                | (showStream
                    ? (object)new Box(viewer)


### PR DESCRIPTION
Fixes #1581

# Summary

## Changes

Fixed three UX issues in the project setup onboarding step: set a minimum height to prevent layout jank during content transitions, initialized the loading state to show immediately on mount (eliminating the brief delay before the spinner appears), and added a Loading fallback for the initial cloning phase before progress animation starts.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs**
  - Added `.Height(Size.Fit().Min(Size.Units(60)))` to step container layout
  - Changed `isCloning` initial state from `false` to `!session.Started.Value`
  - Added `Loading()` fallback when cloning but progress hasn't started

## Manual Testing

1. Open the Tendril onboarding flow (e.g., on first launch or via "New Project")
2. Proceed through the initial steps to reach the "Project Setup" step
3. Observe the step immediately on mount:
   - The step should show a loading indicator instantly (no delay before spinner appears)
   - The "Next" button should be disabled from the first render frame
   - The step height should remain stable (no visible layout shifts when content changes from loading → agent stream → complete)
4. Let the setup complete and verify the "Next" button becomes enabled only after the agent finishes

---
## Commits

- a2a38ce1 Fix project setup step loading state and layout stability

---
Created using [Ivy Tendril](https://ivy.app).
