### PR TITLE
[00044] Persist Job Output Across Restart

### DIFF
--- a/src/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
+++ b/src/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
@@ -96,7 +96,7 @@ public class BackgroundServiceActivatorTests : IAsyncLifetime
             var planReader = new PlanReaderService(config, NullLogger<PlanReaderService>.Instance);
             var database = sp.GetRequiredService<IPlanDatabaseService>();
             var watcher = sp.GetRequiredService<IPlanWatcherService>();
-            return new PlanDatabaseSyncService(planReader, database, watcher,
+            return new PlanDatabaseSyncService(planReader, database, watcher, config,
                 NullLogger<PlanDatabaseSyncService>.Instance);
         });
 
@@ -226,7 +226,7 @@ public class BackgroundServiceActivatorTests : IAsyncLifetime
             var planReader = new PlanReaderService(config, NullLogger<PlanReaderService>.Instance);
             var database = sp.GetRequiredService<IPlanDatabaseService>();
             var watcher = sp.GetRequiredService<IPlanWatcherService>();
-            return new PlanDatabaseSyncService(planReader, database, watcher,
+            return new PlanDatabaseSyncService(planReader, database, watcher, config,
                 NullLogger<PlanDatabaseSyncService>.Instance);
         });
 

--- a/src/Ivy.Tendril.Test/JobEventWireStoreTests.cs
+++ b/src/Ivy.Tendril.Test/JobEventWireStoreTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Concurrent;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Test;
+
+public class JobEventWireStoreTests : IDisposable
+{
+    private readonly string _tendrilHome;
+
+    public JobEventWireStoreTests()
+    {
+        _tendrilHome = Path.Combine(Path.GetTempPath(), $"tendril-eventwire-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tendrilHome);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tendrilHome))
+                Directory.Delete(_tendrilHome, true);
+        }
+        catch
+        {
+            // Best-effort cleanup
+        }
+    }
+
+    [Fact]
+    public void Write_ThenRead_RoundTripsLinesInOrder()
+    {
+        var job = new JobItem { Id = "job-1" };
+        job.OutputLines.Enqueue("line-1");
+        job.OutputLines.Enqueue("line-2");
+        job.OutputLines.Enqueue("line-3");
+
+        JobEventWireStore.Write(_tendrilHome, job);
+        var result = JobEventWireStore.Read(_tendrilHome, "job-1");
+
+        Assert.NotNull(result);
+        Assert.Equal(new[] { "line-1", "line-2", "line-3" }, result!.ToArray());
+    }
+
+    [Fact]
+    public void Write_WithEmptyOutputLines_DoesNotCreateFile()
+    {
+        var job = new JobItem { Id = "job-empty", OutputLines = new ConcurrentQueue<string>() };
+
+        JobEventWireStore.Write(_tendrilHome, job);
+
+        Assert.False(File.Exists(JobEventWireStore.GetFilePath(_tendrilHome, "job-empty")));
+    }
+
+    [Fact]
+    public void Read_MissingFile_ReturnsNull()
+    {
+        var result = JobEventWireStore.Read(_tendrilHome, "nonexistent-job");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Delete_MissingFile_DoesNotThrow()
+    {
+        var exception = Record.Exception(() => JobEventWireStore.Delete(_tendrilHome, "nonexistent-job"));
+
+        Assert.Null(exception);
+    }
+}

--- a/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reflection;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
@@ -101,6 +102,77 @@ public class JobServiceDeletionTests
         service.DeleteJob("job-1");
 
         Assert.Null(service.GetJob("job-1"));
+    }
+
+    [Fact]
+    public void DeleteJob_RemovesEventWireFileFromDisk()
+    {
+        var tendrilHome = Path.Combine(Path.GetTempPath(), $"tendril-delete-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tendrilHome);
+        try
+        {
+            var db = new FakeDatabaseService();
+            var config = new FakeConfigService(tendrilHome);
+            var service = new JobService(config, database: db);
+
+            var job = new JobItem { Id = "job-with-output", Status = JobStatus.Completed };
+            job.OutputLines.Enqueue("some output");
+            JobEventWireStore.Write(tendrilHome, job);
+            AddJobDirectly(service, job);
+
+            Assert.True(File.Exists(JobEventWireStore.GetFilePath(tendrilHome, "job-with-output")));
+
+            service.DeleteJob("job-with-output");
+
+            Assert.False(File.Exists(JobEventWireStore.GetFilePath(tendrilHome, "job-with-output")));
+        }
+        finally
+        {
+            try { Directory.Delete(tendrilHome, true); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    private class FakeConfigService : IConfigService
+    {
+        public FakeConfigService(string tendrilHome)
+        {
+            TendrilHome = tendrilHome;
+        }
+
+        public TendrilSettings Settings => new();
+        public string TendrilHome { get; }
+        public string ConfigPath => "";
+        public string PlanFolder => "";
+        public List<ProjectConfig> Projects => [];
+        public List<LevelConfig> Levels => [];
+        public string[] LevelNames => [];
+        public EditorConfig Editor => new() { Command = "code", Label = "VS Code" };
+        public bool NeedsOnboarding => false;
+        public ConfigParseError? ParseError => null;
+
+        public ProjectConfig? GetProject(string name) => null;
+        public Colors? GetLevelColor(string level) => null;
+        public Colors? GetProjectColor(string projectName) => null;
+        public void SaveSettings() { }
+        public void ReloadSettings() { }
+        public bool TryAutoHeal() => false;
+        public void ResetToDefaults() { }
+        public void RetryLoadConfig() { }
+#pragma warning disable CS0067
+        public event EventHandler? SettingsReloaded;
+#pragma warning restore CS0067
+        public void SetPendingCodingAgent(string name) { }
+        public string? GetPendingCodingAgent() => null;
+        public void SetPendingTendrilHome(string path) { }
+        public string? GetPendingTendrilHome() => null;
+        public void SetPendingProject(ProjectConfig project) { }
+        public ProjectConfig? GetPendingProject() => null;
+        public void SetPendingVerificationDefinitions(List<VerificationConfig> definitions) { }
+        public List<VerificationConfig>? GetPendingVerificationDefinitions() => null;
+        public void CompleteOnboarding(string tendrilHome) { }
+        public void OpenInEditor(string path) { }
+        public string PolishMarkdown(string content) => content;
+        public void Dispose() { }
     }
 
     private class FakeDatabaseService : IPlanDatabaseService
@@ -242,8 +314,9 @@ public class JobServiceDeletionTests
             return new List<JobItem>();
         }
 
-        public void PurgeOldJobs(int keepCount = 500)
+        public List<string> PurgeOldJobs(int keepCount = 500)
         {
+            return new List<string>();
         }
 
         public Dictionary<string, string> GetAllPrStatuses()

--- a/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
@@ -68,6 +69,120 @@ public class JobServiceStartupTests
             database: db));
 
         Assert.Null(exception);
+    }
+
+    [Fact]
+    public void GetJob_AfterRestart_RehydratesOutputFromEventWireFile()
+    {
+        var tendrilHome = Path.Combine(Path.GetTempPath(), $"tendril-restart-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tendrilHome);
+        try
+        {
+            // The EventWire file is what PersistJob would have written during the original run.
+            var originalJob = new JobItem { Id = "job-restart" };
+            originalJob.OutputLines.Enqueue("hello");
+            originalJob.OutputLines.Enqueue("world");
+            JobEventWireStore.Write(tendrilHome, originalJob);
+
+            // The SQLite row as it comes back on reload: metadata only, no output (matches production —
+            // OutputLines is never a database column).
+            var db = new FakeDatabaseService
+            {
+                Jobs = { new JobItem { Id = "job-restart", Status = JobStatus.Completed, Type = "ExecutePlan" } }
+            };
+
+            // Act: construct a fresh JobService over the same TendrilHome (simulating restart).
+            var config = new FakeConfigService(tendrilHome);
+            var service = new JobService(config, database: db);
+            var reloaded = service.GetJob("job-restart");
+
+            Assert.NotNull(reloaded);
+            Assert.Equal(new[] { "hello", "world" }, reloaded!.OutputLines.ToArray());
+        }
+        finally
+        {
+            try { Directory.Delete(tendrilHome, true); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    [Fact]
+    public void GetJob_HydratesOutputAtMostOnce()
+    {
+        var tendrilHome = Path.Combine(Path.GetTempPath(), $"tendril-hydrate-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tendrilHome);
+        try
+        {
+            var originalJob = new JobItem { Id = "job-hydrate" };
+            originalJob.OutputLines.Enqueue("only-line");
+            JobEventWireStore.Write(tendrilHome, originalJob);
+
+            var db = new FakeDatabaseService
+            {
+                Jobs = { new JobItem { Id = "job-hydrate", Status = JobStatus.Completed, Type = "ExecutePlan" } }
+            };
+
+            var config = new FakeConfigService(tendrilHome);
+            var service = new JobService(config, database: db);
+
+            var first = service.GetJob("job-hydrate");
+            Assert.NotNull(first);
+            Assert.Single(first!.OutputLines);
+
+            // Delete the backing file — if GetJob re-read from disk on every call, the
+            // second call would come back empty instead of using the cached, hydrated lines.
+            JobEventWireStore.Delete(tendrilHome, "job-hydrate");
+
+            var second = service.GetJob("job-hydrate");
+            Assert.NotNull(second);
+            Assert.Single(second!.OutputLines);
+        }
+        finally
+        {
+            try { Directory.Delete(tendrilHome, true); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    private class FakeConfigService : IConfigService
+    {
+        public FakeConfigService(string tendrilHome)
+        {
+            TendrilHome = tendrilHome;
+        }
+
+        public TendrilSettings Settings => new();
+        public string TendrilHome { get; }
+        public string ConfigPath => "";
+        public string PlanFolder => "";
+        public List<ProjectConfig> Projects => [];
+        public List<LevelConfig> Levels => [];
+        public string[] LevelNames => [];
+        public EditorConfig Editor => new() { Command = "code", Label = "VS Code" };
+        public bool NeedsOnboarding => false;
+        public ConfigParseError? ParseError => null;
+
+        public ProjectConfig? GetProject(string name) => null;
+        public Colors? GetLevelColor(string level) => null;
+        public Colors? GetProjectColor(string projectName) => null;
+        public void SaveSettings() { }
+        public void ReloadSettings() { }
+        public bool TryAutoHeal() => false;
+        public void ResetToDefaults() { }
+        public void RetryLoadConfig() { }
+#pragma warning disable CS0067
+        public event EventHandler? SettingsReloaded;
+#pragma warning restore CS0067
+        public void SetPendingCodingAgent(string name) { }
+        public string? GetPendingCodingAgent() => null;
+        public void SetPendingTendrilHome(string path) { }
+        public string? GetPendingTendrilHome() => null;
+        public void SetPendingProject(ProjectConfig project) { }
+        public ProjectConfig? GetPendingProject() => null;
+        public void SetPendingVerificationDefinitions(List<VerificationConfig> definitions) { }
+        public List<VerificationConfig>? GetPendingVerificationDefinitions() => null;
+        public void CompleteOnboarding(string tendrilHome) { }
+        public void OpenInEditor(string path) { }
+        public string PolishMarkdown(string content) => content;
+        public void Dispose() { }
     }
 
     private class FakeDatabaseService : IPlanDatabaseService
@@ -205,8 +320,9 @@ public class JobServiceStartupTests
         {
         }
 
-        public void PurgeOldJobs(int keepCount = 500)
+        public List<string> PurgeOldJobs(int keepCount = 500)
         {
+            return new List<string>();
         }
 
         public Dictionary<string, string> GetAllPrStatuses()

--- a/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -932,7 +932,7 @@ public class PlanDatabaseServiceTests : IDisposable
 
         Assert.Equal(600, _db.GetRecentJobs(1000).Count);
 
-        _db.PurgeOldJobs();
+        var purgedIds = _db.PurgeOldJobs();
 
         var remaining = _db.GetRecentJobs(1000);
         Assert.Equal(500, remaining.Count);
@@ -943,6 +943,13 @@ public class PlanDatabaseServiceTests : IDisposable
         // The newest jobs should remain
         Assert.Contains(remaining, j => j.Id == "job-0599");
         Assert.Contains(remaining, j => j.Id == "job-0100");
+
+        // The returned id list matches the removed rows, not the retained ones
+        Assert.Equal(100, purgedIds.Count);
+        Assert.Contains("job-0000", purgedIds);
+        Assert.Contains("job-0099", purgedIds);
+        Assert.DoesNotContain("job-0599", purgedIds);
+        Assert.DoesNotContain("job-0100", purgedIds);
     }
 
     [Fact]
@@ -960,10 +967,11 @@ public class PlanDatabaseServiceTests : IDisposable
                 CompletedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMinutes(i)
             });
 
-        _db.PurgeOldJobs();
+        var purgedIds = _db.PurgeOldJobs();
 
         var remaining = _db.GetRecentJobs(1000);
         Assert.Equal(10, remaining.Count);
+        Assert.Empty(purgedIds);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/PlanDatabaseSyncServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseSyncServiceTests.cs
@@ -23,7 +23,7 @@ public class PlanDatabaseSyncServiceTests : IDisposable
         _database = new PlanDatabaseService(_dbPath, NullLogger<PlanDatabaseService>.Instance);
         _watcher = new PlanWatcherService(configService);
         _syncService = new PlanDatabaseSyncService(
-            _planReader, _database, _watcher,
+            _planReader, _database, _watcher, configService,
             NullLogger<PlanDatabaseSyncService>.Instance);
     }
 

--- a/src/Ivy.Tendril.Test/PlanWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanWatcherServiceTests.cs
@@ -117,7 +117,7 @@ public class PlanWatcherServiceTests : IDisposable
         // genuine regression guard for #1257 rather than something the plain debounce would pass.
         using var watcher = new PlanWatcherService(_configService, null, new[] { 800, 2500 });
         using var syncService = new PlanDatabaseSyncService(
-            planReader, database, watcher, NullLogger<PlanDatabaseSyncService>.Instance);
+            planReader, database, watcher, _configService, NullLogger<PlanDatabaseSyncService>.Instance);
 
         // Initial sync with no plans → enables database-backed reads.
         syncService.PerformInitialSync();

--- a/src/Ivy.Tendril/Helpers/JobEventWireStore.cs
+++ b/src/Ivy.Tendril/Helpers/JobEventWireStore.cs
@@ -1,0 +1,53 @@
+using System.Collections.Concurrent;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Helpers;
+
+public static class JobEventWireStore
+{
+    public static string GetFilePath(string tendrilHome, string jobId)
+    {
+        var jobsDir = Path.Combine(tendrilHome, "Jobs");
+        Directory.CreateDirectory(jobsDir);
+        return Path.Combine(jobsDir, jobId + ".eventwire.jsonl");
+    }
+
+    public static void Write(string tendrilHome, JobItem job)
+    {
+        if (job.OutputLines.IsEmpty) return;
+        try
+        {
+            File.WriteAllLines(GetFilePath(tendrilHome, job.Id), job.OutputLines);
+        }
+        catch
+        {
+            /* Best-effort persistence */
+        }
+    }
+
+    public static ConcurrentQueue<string>? Read(string tendrilHome, string jobId)
+    {
+        var path = GetFilePath(tendrilHome, jobId);
+        if (!File.Exists(path)) return null;
+        try
+        {
+            return new ConcurrentQueue<string>(File.ReadAllLines(path));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static void Delete(string tendrilHome, string jobId)
+    {
+        try
+        {
+            File.Delete(GetFilePath(tendrilHome, jobId));
+        }
+        catch
+        {
+            /* Best-effort cleanup */
+        }
+    }
+}

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -28,7 +28,9 @@ public record JobItem
     /// Maximum number of output lines retained per job during execution.
     /// Lines beyond this limit are discarded (not just hidden from display).
     /// Memory is freed when EvictStaleJobs() removes completed jobs after 1 hour.
-    /// Output is not persisted to SQLite—this in-memory queue is the only retention.
+    /// Completed-job output is persisted as a per-job EventWire file under
+    /// &lt;TendrilHome&gt;/Jobs/ (see JobEventWireStore) and rehydrated on demand;
+    /// this in-memory queue remains the fast path during a live run.
     /// </summary>
     private const int MaxOutputLines = 10_000;
     private int _completionGuard;
@@ -91,6 +93,12 @@ public record JobItem
     public int? ProcessId { get; set; }
     public string? StatusMessage { get; set; }
     public ConcurrentQueue<string> OutputLines { get; set; } = new();
+
+    /// <summary>
+    /// Guards against re-reading the EventWire file from disk on every GetJob call
+    /// once this job's output has been hydrated (or confirmed to have none).
+    /// </summary>
+    [JsonIgnore] public bool OutputHydrated { get; set; }
     public DateTime? LastOutputAt { get; set; }
     public CancellationTokenSource? TimeoutCts { get; set; }
     private volatile bool _staleOutputDetected;

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -95,8 +95,9 @@ internal static class ServiceRegistration
             var planReader = sp.GetRequiredService<PlanReaderService>();
             var database = sp.GetRequiredService<IPlanDatabaseService>();
             var watcher = sp.GetRequiredService<IPlanWatcherService>();
+            var configService = sp.GetRequiredService<IConfigService>();
             var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
-            return new PlanDatabaseSyncService(planReader, database, watcher,
+            return new PlanDatabaseSyncService(planReader, database, watcher, configService,
                 loggerFactory.CreateLogger<PlanDatabaseSyncService>());
         });
         server.Services.AddSingleton<ITelemetryService>(sp =>

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -285,6 +285,7 @@ public class JobService : IJobService
         {
             removed.DisposeResources(_logger);
             try { _database?.DeleteJob(id); } catch { /* Best-effort */ }
+            if (_configService != null) JobEventWireStore.Delete(_configService.TendrilHome, id);
 
             ApplyDeletePlanState(removed);
 
@@ -485,7 +486,14 @@ public class JobService : IJobService
 
     public JobItem? GetJob(string id)
     {
-        return _jobs.GetValueOrDefault(id) ?? _database?.GetJobById(id);
+        var job = _jobs.GetValueOrDefault(id) ?? _database?.GetJobById(id);
+        if (job is { OutputHydrated: false } && job.Status != JobStatus.Running
+            && job.OutputLines.IsEmpty && _configService != null)
+        {
+            job.OutputLines = JobEventWireStore.Read(_configService.TendrilHome, id) ?? job.OutputLines;
+            job.OutputHydrated = true;
+        }
+        return job;
     }
 
     public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null)
@@ -565,6 +573,8 @@ public class JobService : IJobService
         try
         {
             _database?.UpsertJob(job);
+            if (_configService != null)
+                JobEventWireStore.Write(_configService.TendrilHome, job);
         }
         catch
         {

--- a/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
@@ -49,7 +49,7 @@ public interface IPlanDatabaseService : IDisposable
     List<JobItem> GetRecentJobs(int limit = 100);
     JobItem? GetJobById(string id);
     List<JobItem> GetJobsForPlan(string planFile);
-    void PurgeOldJobs(int keepCount = 500);
+    List<string> PurgeOldJobs(int keepCount = 500);
     void DeleteJob(string id);
 
     // PR statuses

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -778,21 +778,42 @@ public class PlanDatabaseService : IPlanDatabaseService
         };
     }
 
-    public void PurgeOldJobs(int keepCount = 500)
+    public List<string> PurgeOldJobs(int keepCount = 500)
     {
         using (new WriteLockHandle(_lock))
         {
-            using var cmd = _connection.CreateCommand();
-            cmd.CommandText = """
-                              DELETE FROM Jobs
-                              WHERE Id NOT IN (
-                                  SELECT Id FROM Jobs
-                                  ORDER BY CompletedAt DESC
-                                  LIMIT @keepCount
-                              )
-                              """;
-            cmd.Parameters.AddWithValue("@keepCount", keepCount);
-            cmd.ExecuteNonQuery();
+            var purgedIds = new List<string>();
+            using (var selectCmd = _connection.CreateCommand())
+            {
+                selectCmd.CommandText = """
+                                        SELECT Id FROM Jobs
+                                        WHERE Id NOT IN (
+                                            SELECT Id FROM Jobs
+                                            ORDER BY CompletedAt DESC
+                                            LIMIT @keepCount
+                                        )
+                                        """;
+                selectCmd.Parameters.AddWithValue("@keepCount", keepCount);
+                using var reader = selectCmd.ExecuteReader();
+                while (reader.Read())
+                    purgedIds.Add(reader.GetString(0));
+            }
+
+            using (var deleteCmd = _connection.CreateCommand())
+            {
+                deleteCmd.CommandText = """
+                                        DELETE FROM Jobs
+                                        WHERE Id NOT IN (
+                                            SELECT Id FROM Jobs
+                                            ORDER BY CompletedAt DESC
+                                            LIMIT @keepCount
+                                        )
+                                        """;
+                deleteCmd.Parameters.AddWithValue("@keepCount", keepCount);
+                deleteCmd.ExecuteNonQuery();
+            }
+
+            return purgedIds;
         }
     }
 

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseSyncService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseSyncService.cs
@@ -9,6 +9,7 @@ namespace Ivy.Tendril.Services.Plans;
 public class PlanDatabaseSyncService : IDisposable
 {
     private readonly IPlanDatabaseService _database;
+    private readonly IConfigService _configService;
     private readonly ILogger<PlanDatabaseSyncService> _logger;
     private readonly PlanReaderService _planReader;
     private readonly IPlanWatcherService _watcher;
@@ -19,11 +20,13 @@ public class PlanDatabaseSyncService : IDisposable
         PlanReaderService planReader,
         IPlanDatabaseService database,
         IPlanWatcherService watcher,
+        IConfigService configService,
         ILogger<PlanDatabaseSyncService> logger)
     {
         _planReader = planReader;
         _database = database;
         _watcher = watcher;
+        _configService = configService;
         _logger = logger;
 
         _watcher.PlansChanged += OnPlansChanged;
@@ -62,7 +65,9 @@ public class PlanDatabaseSyncService : IDisposable
                 SyncPlanRecommendations(plan);
             }
 
-            _database.PurgeOldJobs();
+            var purgedJobIds = _database.PurgeOldJobs();
+            foreach (var jobId in purgedJobIds)
+                JobEventWireStore.Delete(_configService.TendrilHome, jobId);
             _database.SetLastSyncTime(DateTime.UtcNow);
             _isInitialSyncComplete = true;
 


### PR DESCRIPTION
Fixes #1541

# Summary

## Changes

Job output ("No output available." after a Tendril restart, issue #1541) now survives a restart. Completed
jobs' `OutputLines` are written to a per-job EventWire file under `<TendrilHome>/Jobs/<id>.eventwire.jsonl`
when a job is persisted, and lazily rehydrated from that file the first time `GetJob` is called for a
non-running job whose in-memory output is empty. Jobs purged from the `Jobs` table on startup (beyond the
500-row retention limit) now have their EventWire files cleaned up too, and `DeleteJob` removes a job's file
immediately.

## API Changes

- New public class `Ivy.Tendril.Helpers.JobEventWireStore` with static `GetFilePath`, `Write`, `Read`, `Delete`.
- `JobItem` (`Ivy.Tendril.Models`): new `[JsonIgnore] bool OutputHydrated` property.
- `IPlanDatabaseService.PurgeOldJobs(int keepCount = 500)` signature changed from `void` to `List<string>` (returns the ids of purged rows).
- `PlanDatabaseSyncService` constructor now requires an additional `IConfigService configService` parameter.

## Files Modified

- **New:** `src/Ivy.Tendril/Helpers/JobEventWireStore.cs`
- **Core wiring:** `src/Ivy.Tendril/Models/JobModels.cs`, `src/Ivy.Tendril/Services/Jobs/JobService.cs` (PersistJob, GetJob, DeleteJob)
- **Purge cleanup:** `src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs`, `src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs`, `src/Ivy.Tendril/Services/Plans/PlanDatabaseSyncService.cs`, `src/Ivy.Tendril/ServiceRegistration.cs`
- **Tests:** `src/Ivy.Tendril.Test/JobEventWireStoreTests.cs` (new), `JobServiceStartupTests.cs`, `JobServiceDeletionTests.cs`, `PlanDatabaseServiceTests.cs`, plus mechanical call-site updates in `PlanDatabaseSyncServiceTests.cs`, `PlanWatcherServiceTests.cs`, `BackgroundServiceActivatorTests.cs`

## Manual Testing

1. Run Tendril and execute (or otherwise complete) a job so it produces some output and reaches `Completed`.
2. Open the Jobs app and confirm the job's Output panel shows its output normally.
3. Restart the Tendril process entirely (not just reload the UI).
4. Reopen the Jobs app, find the same job in history, and open its Output panel again.
5. Expected: the output is shown exactly as before the restart, instead of "No output available." — confirm by comparing a line or two of output text against what was visible in step 2.
6. Delete that job from the Jobs app and confirm re-opening it (if still reachable via plan history) no longer shows output, and the file `<TendrilHome>/Jobs/<jobId>.eventwire.jsonl` no longer exists on disk.

---

## Commits

- 0a4fec34 Add JobEventWireStore for persisting job output to disk
- 8869027e Persist and rehydrate job output via JobEventWireStore
- 0d82bd76 Clean up EventWire files for jobs purged from the database
- 95b4b201 Add tests for job output restart persistence

---
Created using [Ivy Tendril](https://ivy.app).
