### PR TITLE
feat(desktop): update Ivy to 1.3.8 and configure proper About section

### DIFF
--- a/.github/workflows/publish-tendril.yml
+++ b/.github/workflows/publish-tendril.yml
@@ -398,7 +398,7 @@ jobs:
             export VPK_KEYCHAIN="$RUNNER_TEMP/app-signing.keychain-db"
             export VPK_SIGN_DISABLE_DEEP="true"
 
-            APP_DIR="./publish/desktop/IvyTendril.app"
+            APP_DIR="./publish/desktop/Ivy Tendril.app"
             rm -rf "$APP_DIR"
             mkdir -p "$APP_DIR/Contents/MacOS"
             mkdir -p "$APP_DIR/Contents/Resources"
@@ -523,6 +523,7 @@ jobs:
 
           vpk pack \
             --packId IvyTendril \
+            --packTitle "Ivy Tendril" \
             --packVersion ${{ needs.version.outputs.version }} \
             --packDir "$PACK_DIR" \
             --mainExe $EXE_NAME \
@@ -546,10 +547,10 @@ jobs:
           echo '#!/bin/sh
           rm -rf /tmp/velopack/IvyTendril
           sudo -u "$USER" rm -rf ~/Library/Caches/velopack/IvyTendril
-          sudo -u "$USER" env VELOPACK_FIRSTRUN=1 open "$2/IvyTendril.app/"
+          sudo -u "$USER" env VELOPACK_FIRSTRUN=1 open "$2/Ivy Tendril.app/"
 
           # Path to the installed app certificate
-          CERT_PATH="$3/Applications/IvyTendril.app/Contents/Resources/certs/localhost.crt"
+          CERT_PATH="$3/Applications/Ivy Tendril.app/Contents/Resources/certs/localhost.crt"
           if [ -f "$CERT_PATH" ]; then
             echo "Trusting Ivy Tendril localhost certificate system-wide..."
             security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$CERT_PATH"

--- a/src/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
+++ b/src/Ivy.Tendril.Docs/Ivy.Tendril.Docs.csproj
@@ -17,9 +17,9 @@
     </ItemGroup>
     <ItemGroup Condition="'$(IvySource)' != 'true'">
         <PackageReference Include="Ivy" Version="$(IvyPackageVersion)" Condition="'$(IvyPackageVersion)' != ''" />
-        <PackageReference Include="Ivy" Version="1.3.6" Condition="'$(IvyPackageVersion)' == ''" />
+        <PackageReference Include="Ivy" Version="1.3.8" Condition="'$(IvyPackageVersion)' == ''" />
         <PackageReference Include="Ivy.Docs.Helpers" Version="$(IvyPackageVersion)" Condition="'$(IvyPackageVersion)' != ''" />
-        <PackageReference Include="Ivy.Docs.Helpers" Version="1.3.6" Condition="'$(IvyPackageVersion)' == ''" />
+        <PackageReference Include="Ivy.Docs.Helpers" Version="1.3.8" Condition="'$(IvyPackageVersion)' == ''" />
     </ItemGroup>
 
     <ItemGroup>
@@ -65,7 +65,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Ivy.Analyser" Version="1.3.6" Condition="'$(IvyPackageVersion)' == ''">
+        <PackageReference Include="Ivy.Analyser" Version="1.3.8" Condition="'$(IvyPackageVersion)' == ''">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
+++ b/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
@@ -40,7 +40,7 @@
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy/Ivy.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy" Version="1.3.6" />
+    <PackageReference Include="Ivy" Version="1.3.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj
+++ b/src/Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy" Version="1.3.6" />
+    <PackageReference Include="Ivy" Version="1.3.8" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -67,14 +67,14 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy" Version="1.3.6" />
-    <PackageReference Include="Ivy.Desktop" Version="1.3.6" />
-    <PackageReference Include="Ivy.Hooks.Pty" Version="1.3.6" />
-    <PackageReference Include="Ivy.Widgets.ActivityHeatmap" Version="1.3.6" />
-    <PackageReference Include="Ivy.Widgets.AnimatedStatusLabel" Version="1.3.6" />
-    <PackageReference Include="Ivy.Widgets.DiffView" Version="1.3.6" />
-    <PackageReference Include="Ivy.Widgets.QRCode" Version="1.3.6" />
-    <PackageReference Include="Ivy.Widgets.Xterm" Version="1.3.6" />
+    <PackageReference Include="Ivy" Version="1.3.8" />
+    <PackageReference Include="Ivy.Desktop" Version="1.3.8" />
+    <PackageReference Include="Ivy.Hooks.Pty" Version="1.3.8" />
+    <PackageReference Include="Ivy.Widgets.ActivityHeatmap" Version="1.3.8" />
+    <PackageReference Include="Ivy.Widgets.AnimatedStatusLabel" Version="1.3.8" />
+    <PackageReference Include="Ivy.Widgets.DiffView" Version="1.3.8" />
+    <PackageReference Include="Ivy.Widgets.QRCode" Version="1.3.8" />
+    <PackageReference Include="Ivy.Widgets.Xterm" Version="1.3.8" />
   </ItemGroup>
 
   <!-- Ivy Analyser -->
@@ -87,7 +87,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' != 'true'">
-    <PackageReference Include="Ivy.Analyser" Version="1.3.6">
+    <PackageReference Include="Ivy.Analyser" Version="1.3.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -277,7 +277,7 @@ public class Program
                 .AboutWebsite("https://github.com/Ivy-Interactive/Ivy-Tendril")
                 .AboutLicense("Apache-2.0")
                 .AboutAuthor("Ivy Interactive")
-                .AboutComments("Tendril is the developer desktop shell for the Ivy agent framework.")
+                .AboutComments("Tendril is an end-to-end AI coding agent orchestrator built on the Ivy Framework that manages AI coding plans, tracks costs, and automates pull request generation.")
                 .OnReady(w =>
                 {
                     if (server.ServiceProvider is { } sp)

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -274,7 +274,7 @@ public class Program
                 .AboutName("Ivy Tendril")
                 .AboutVersion(versionString)
                 .AboutCopyright("© 2026 Ivy Interactive")
-                .AboutWebsite("https://github.com/Ivy-Interactive/Ivy-Tendril")
+                .AboutWebsite("https://ivy.app")
                 .AboutLicense("Apache-2.0")
                 .AboutAuthor("Ivy Interactive")
                 .AboutComments("Tendril is an end-to-end AI coding agent orchestrator built on the Ivy Framework that manages AI coding plans, tracks costs, and automates pull request generation.")

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -262,12 +262,22 @@ public class Program
                 : OperatingSystem.IsMacOS() ? "Ivy.Tendril.Assets.icon.icns"
                 : "Ivy.Tendril.Assets.icon.png";
 
+            var version = typeof(Program).Assembly.GetName().Version;
+            var versionString = version?.ToString(3) ?? "1.1.12";
+
             var window = new DesktopWindow(server)
                 .Title("Ivy Tendril")
                 .AppId("Ivy Tendril")
                 .Size(1800, 1200)
                 .UseDpiScaling(false)
                 .Icon(typeof(Program), iconResource)
+                .AboutName("Ivy Tendril")
+                .AboutVersion(versionString)
+                .AboutCopyright("© 2026 Ivy Interactive")
+                .AboutWebsite("https://github.com/Ivy-Interactive/Ivy-Tendril")
+                .AboutLicense("Apache-2.0")
+                .AboutAuthor("Ivy Interactive")
+                .AboutComments("Tendril is the developer desktop shell for the Ivy agent framework.")
                 .OnReady(w =>
                 {
                     if (server.ServiceProvider is { } sp)

--- a/src/build_local_installer.sh
+++ b/src/build_local_installer.sh
@@ -4,7 +4,7 @@ set -e
 # Directories
 REPO_DIR="/Users/rorychatt/git/ivy/Ivy-Tendril"
 PUBLISH_DIR="$REPO_DIR/src/publish/desktop/osx-arm64"
-APP_DIR="$REPO_DIR/src/publish/desktop/IvyTendril.app"
+APP_DIR="$REPO_DIR/src/publish/desktop/Ivy Tendril.app"
 RELEASES_DIR="$REPO_DIR/src/releases"
 
 echo "=== 1. Publishing Ivy.Tendril for osx-arm64 ==="
@@ -84,6 +84,7 @@ mkdir -p "$RELEASES_DIR"
 
 vpk pack \
   --packId IvyTendril \
+  --packTitle "Ivy Tendril" \
   --packVersion 1.0.99 \
   --packDir "$APP_DIR" \
   --mainExe Ivy.Tendril \
@@ -108,10 +109,10 @@ cat << 'EOF' > expanded-pkg/1.pkg/Scripts/postinstall
 #!/bin/sh
 rm -rf /tmp/velopack/IvyTendril
 sudo -u "$USER" rm -rf ~/Library/Caches/velopack/IvyTendril
-sudo -u "$USER" env VELOPACK_FIRSTRUN=1 open "$2/IvyTendril.app/"
+sudo -u "$USER" env VELOPACK_FIRSTRUN=1 open "$2/Ivy Tendril.app/"
 
 # Path to the installed app certificate
-CERT_PATH="$3/Applications/IvyTendril.app/Contents/Resources/certs/localhost.crt"
+CERT_PATH="$3/Applications/Ivy Tendril.app/Contents/Resources/certs/localhost.crt"
 if [ -f "$CERT_PATH" ]; then
   echo "Trusting Ivy Tendril localhost certificate system-wide..."
   security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$CERT_PATH"


### PR DESCRIPTION
Updates Ivy packages to version 1.3.8 and configures the Mac 'About App' dialog using the new fluent API in DesktopWindow.