### PR TITLE
[00648] Fix Inline Code Styling in DraftMarkdown and Markdown

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
@@ -174,7 +174,8 @@
   border: 1px solid var(--aov-border);
   border-radius: 4px;
   padding: 1px 5px;
-  font-size: 14px;
+  font-size: 0.9em;
+  font-weight: 500;
 }
 
 .aov-markdown pre {

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -235,7 +235,8 @@
   padding: 0.05rem 0.25rem;
   font-family: "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo,
     Consolas, monospace;
-  font-weight: 600;
+  font-size: 0.9em;
+  font-weight: 500;
   white-space: normal;
   word-break: break-word;
 }


### PR DESCRIPTION
Fixes #1593

# Summary

## Changes

Reduced the visual prominence of inline code elements in DraftMarkdown and AgentViewer by adjusting font size to 0.9em and font weight to 500. This improves readability by making inline code less dominant while maintaining its distinction through monospace font and background color.

## API Changes

None.

## Files Modified

**Frontend styling:**
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css` — Updated `.pmv-markdown code` styling
- `src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css` — Updated `.aov-markdown code` styling

## Manual Testing

1. Launch Tendril and navigate to the Plans view
2. Open any plan containing markdown with inline code (e.g., plan 00648 itself contains examples like `git worktree add`, `tendril plan remove-worktree`)
3. Observe that inline code elements:
   - Appear slightly smaller than surrounding body text (90% size)
   - Use medium font weight (500) instead of bold (600)
   - Remain visually distinct via monospace font and background color
4. Open the Agent Output view for any agent execution
5. Verify the same styling improvements apply to inline code in agent output markdown
6. Verify code blocks within `<pre>` elements remain unchanged

---

## Commits

- a1ca4d01 Reduce inline code font size and weight in DraftMarkdown and AgentViewer

---
Created using [Ivy Tendril](https://ivy.app).
