### PR TITLE
[00647] Reduce Excessive Spacing in Review App Content Area

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs
@@ -25,7 +25,7 @@ public class ReviewActionsBarView(
         if (reviewActions.Count == 0)
             return null;
 
-        var actionsBar = Layout.Horizontal().Gap(2).Padding(2).Height(Size.Fit());
+        var actionsBar = Layout.Horizontal().Gap(2).Padding(2, 2, 2, 0).Height(Size.Fit());
         for (var i = 0; i < reviewActions.Count; i++)
         {
             var action = reviewActions[i];


### PR DESCRIPTION
Fixes #1527

# Summary

## Changes

Reduced excessive vertical spacing in the Review app by removing bottom padding from the review actions bar. The actions bar previously had 2 units of padding on all sides, which created a 4-unit gap when combined with the tabs wrapper's top padding. Now the actions bar only has padding on the left, top, and right sides.

## API Changes

None.

## Files Modified

**Review App Components:**
- `src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs` — Changed actions bar padding from `Padding(2)` to `Padding(2, 2, 2, 0)` to remove bottom padding

## Manual Testing

1. Launch the Tendril Review app
2. Open any plan that has review actions configured (e.g., a plan with "▷ App" button)
3. Observe the vertical spacing between the review actions bar and the tab navigation
4. Expected result: The spacing should be visibly reduced compared to before, with the actions bar sitting closer to the tabs
5. Verify that the top spacing (between the header and actions bar) is still present
6. Verify that the action buttons are properly aligned with appropriate horizontal edge padding

---
**Commits:**
- a448b0e6 Reduce excessive spacing in Review app content area

---
Created using [Ivy Tendril](https://ivy.app).
