### PR TITLE
[00637] Test Ping

### DIFF
--- a/src/Ivy.Tendril.Test/PingControllerTests.cs
+++ b/src/Ivy.Tendril.Test/PingControllerTests.cs
@@ -1,0 +1,18 @@
+using Ivy.Tendril.Controllers;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ivy.Tendril.Test;
+
+public class PingControllerTests
+{
+    [Fact]
+    public void Get_ReturnsOkWithPong()
+    {
+        var controller = new PingController();
+
+        var result = controller.Get();
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("pong", okResult.Value);
+    }
+}

--- a/src/Ivy.Tendril/Controllers/PingController.cs
+++ b/src/Ivy.Tendril/Controllers/PingController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ivy.Tendril.Controllers;
+
+[ApiController]
+[Route("api/ping")]
+public class PingController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get()
+    {
+        return Ok("pong");
+    }
+}


### PR DESCRIPTION
# Summary

## Changes

Added a simple `/ping` endpoint that returns "pong" with HTTP 200 status for health checking and connectivity verification. The implementation includes a minimal controller and a unit test to verify the endpoint's behavior.

## API Changes

**New public API:**
- `PingController` — controller class with `[Route("api/ping")]`
- `PingController.Get()` — HTTP GET endpoint returning `IActionResult` with "pong" body

## Files Modified

**New files:**
- `src/Ivy.Tendril/Controllers/PingController.cs` — minimal controller implementation
- `src/Ivy.Tendril.Test/PingControllerTests.cs` — test verifying endpoint response

## Manual Testing

1. Run the Tendril app: `dotnet run --project src/Ivy.Tendril`
2. Send a GET request to the ping endpoint: `curl http://localhost:5000/api/ping`
3. Verify the response is HTTP 200 with body `"pong"`

Alternatively, open a browser and navigate to `http://localhost:5000/api/ping` — you should see the text "pong" displayed.

---
## Commits
- d9ed688f Add ping endpoint for health checking

---
Created using [Ivy Tendril](https://ivy.app).
