### PR TITLE
[00639] Show Install Dialog When Agent CLI Is Missing During Onboarding

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -145,14 +145,6 @@ public class CodingAgentStepView(
                     progressValue.Set(null);
                     progressMessage.Set(null);
 
-                    if (missing.Key == agentKey)
-                    {
-                        isStepLoading.Set(false);
-                        error.Set("Please make sure your agent is present and you are authorized.");
-                        selectedAgent.Set(null);
-                        return;
-                    }
-
                     var tcs = new TaskCompletionSource<bool>();
                     showInstallDialog(new InstallDialogArgs(missing, tcs));
                     var resumed = await tcs.Task;

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -129,11 +129,14 @@ public class ProjectAgentStepView(
                         progressMessage.Set(null);
 
                         var agentCheck = new SoftwareCheck(
-                            agentKey,
                             info.DisplayName,
-                            () => Task.FromResult(installStatus.IsInstalled),
-                            installStatus.Message ?? $"{info.DisplayName} is not installed.",
-                            info.InstallUrl);
+                            agentKey,
+                            info.InstallUrl ?? "",
+                            true,
+                            () => Task.FromResult(installStatus.IsInstalled))
+                        {
+                            LastError = installStatus.Error
+                        };
 
                         var tcs = new TaskCompletionSource<bool>();
                         showInstallDialog(new InstallDialogArgs(agentCheck, tcs));

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -35,6 +35,9 @@ public class ProjectAgentStepView(
         var authCode = UseState<string?>(null);
         var isCloning = UseState(false);
 
+        var (installDialog, showInstallDialog) = UseTrigger<InstallDialogArgs>((isOpen, args) =>
+            new InstallMissingDialog(isOpen, args));
+
         UseEffect(async () =>
         {
             if (session.Started.Value) return;
@@ -124,9 +127,39 @@ public class ProjectAgentStepView(
                         await agentCheckCts.CancelAsync();
                         progressValue.Set(null);
                         progressMessage.Set(null);
-                        error.Set($"Please make sure your agent ({info.DisplayName}) is present and you are authorized.");
-                        isStepLoading.Set(false);
-                        return;
+
+                        var agentCheck = new SoftwareCheck(
+                            agentKey,
+                            info.DisplayName,
+                            () => Task.FromResult(installStatus.IsInstalled),
+                            installStatus.Message ?? $"{info.DisplayName} is not installed.",
+                            info.InstallUrl);
+
+                        var tcs = new TaskCompletionSource<bool>();
+                        showInstallDialog(new InstallDialogArgs(agentCheck, tcs));
+                        var resumed = await tcs.Task;
+
+                        if (!resumed)
+                        {
+                            isStepLoading.Set(false);
+                            return;
+                        }
+
+                        // Re-check installation after user dismisses dialog
+                        progressMessage.Set($"Checking {info.DisplayName} installation...");
+                        agentCheckCts = new CancellationTokenSource();
+                        _ = UxHelper.AnimateProgressAsync(progressValue, agentCheckCts.Token);
+
+                        installStatus = await healthCheck.CheckInstallAsync();
+                        if (!installStatus.IsInstalled)
+                        {
+                            await agentCheckCts.CancelAsync();
+                            progressValue.Set(null);
+                            progressMessage.Set(null);
+                            error.Set($"Please make sure your agent ({info.DisplayName}) is present and you are authorized.");
+                            isStepLoading.Set(false);
+                            return;
+                        }
                     }
 
                     if (agentKey != "opencode")
@@ -274,6 +307,7 @@ public class ProjectAgentStepView(
                         .Padding(4, 4, 0, 4)
                    : null!)
                | buttonArea
-               | (showHeader ? (object)new Spacer().Height(Size.Units(4)) : null!);
+               | (showHeader ? (object)new Spacer().Height(Size.Units(4)) : null!)
+               | installDialog;
     }
 }


### PR DESCRIPTION
Fixes #1668

# Summary

## Changes

Removed special-case handling that bypassed the install dialog when agent CLIs are missing during onboarding. Both CodingAgentStepView and ProjectAgentStepView now show the `InstallMissingDialog` with the agent name, install URL, and error details when the agent binary is not found, providing actionable guidance instead of a generic error message.

## API Changes

None.

## Files Modified

**Onboarding Views:**
- `src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs` - Removed special-case agent check that bypassed install dialog (lines 148-154)
- `src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs` - Added install dialog trigger pattern, replaced generic error with dialog display, added re-check loop

## Manual Testing

1. **Launch Tendril onboarding** and proceed to the coding agent selection step (step 1)
2. **Select a coding agent** that is NOT installed on your system (or temporarily rename/remove the agent's binary from PATH, e.g., `claude`, `gh copilot`)
3. **Observe the InstallMissingDialog** should appear with:
   - The agent's display name (e.g., "Claude Code")
   - Error details explaining the agent is not found
   - An "Install" button that opens the agent's install URL in a browser
   - A "Cancel" button that returns to the agent picker
   - An "OK" button that re-checks installation status
4. **Click "Install"** to verify the browser opens to the correct install page
5. **Click "OK" without installing** to verify the error persists and the dialog reappears
6. **Install the agent** (or restore its PATH), click "OK", and verify onboarding proceeds to authentication
7. **Repeat steps 2-6 for the project setup step** (step 3) to verify the same dialog behavior when setting up a new project

---
- e012220d Show install dialog when agent CLI is missing during onboarding
- 20001065 Fix SoftwareCheck constructor parameter order

---
Created using [Ivy Tendril](https://ivy.app).
