### PR TITLE
[00638] Fix Review App Tabs to Use Client-Side Navigation

### DIFF
--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -39,6 +39,7 @@ public class ContentView(
         var openCommit = UseState<string?>(null);
         var syncingWorktrees = UseState(new HashSet<string>());
         var selectedRecTitles = UseState(() => new HashSet<string>());
+        var selectedTab = UseState(0);
         var args = UseArgs<ReviewAppArgs>();
         var nav = UseNavigation();
 
@@ -211,12 +212,10 @@ public class ContentView(
             return Disposable.Empty;
         }, [localRefresh]);
 
+        UseEffect(() => { selectedTab.Set(0); return Disposable.Empty; }, selectedPlanState);
+
         UseEffect(() => { selectedRecTitles.Set(new HashSet<string>()); return Disposable.Empty; },
             selectedPlanState);
-
-        var tabNames = new[] { "summary", "plan", "details", "git", "changes", "Artifacts", "recommendations" };
-        var selectedTabIndex = Array.IndexOf(tabNames, args?.Tab ?? "summary");
-        if (selectedTabIndex < 0) selectedTabIndex = 0;
 
         if (selectedPlanState.Value is null)
         {
@@ -640,14 +639,20 @@ public class ContentView(
             }
 
             var actualTabNames = tabNamesList.ToArray();
-            var actualSelectedTabIndex = Array.IndexOf(actualTabNames, args?.Tab ?? "summary");
-            if (actualSelectedTabIndex < 0) actualSelectedTabIndex = 0;
 
-            var tabs = Layout.Tabs(tabList.ToArray()).OnSelect(v =>
+            // Honor deep-linked tab from URL on initial load
+            if (args?.Tab is { } requestedTab && selectedTab.Value == 0)
             {
-                if (v >= 0 && v < actualTabNames.Length && selectedPlanState.Value != null)
-                    nav.Navigate<ReviewApp>(new ReviewAppArgs(selectedPlanState.Value.FolderName, actualTabNames[v]));
-            }).SelectedIndex(actualSelectedTabIndex).Variant(TabsVariant.Content).RemoveParentPadding();
+                var deepLinkIndex = Array.IndexOf(actualTabNames, requestedTab);
+                if (deepLinkIndex >= 0)
+                    selectedTab.Set(deepLinkIndex);
+            }
+
+            var tabs = Layout.Tabs(tabList.ToArray())
+                .OnSelect(v => selectedTab.Set(v))
+                .SelectedIndex(selectedTab.Value)
+                .Variant(TabsVariant.Content)
+                .RemoveParentPadding();
 
             content |= (Layout.Vertical().Padding(2).Height(Size.Full()) | tabs);
         }

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -240,7 +240,7 @@ public class ContentView(
             selectedPlanState.Value, showResetToDraftDialog, showSuggestChangesDialog, showDiscardDialog,
             showCreatePrDialog, copyToClipboard, client, logger, nav, args, agentRunner);
         var content = BuildContent(
-            selectedPlanState.Value, planData, planContentQuery, selectedTabIndex, tabNames, openVerification,
+            selectedPlanState.Value, planData, planContentQuery, selectedTab, openVerification,
             openCommit, openFile, openArtifact, artifactContentQuery, assigneesQuery,
             assigneesError, syncingWorktrees, selectedRecTitles, pendingRecs,
             client, copyToClipboard, logger, nav, args, showDebugJob);
@@ -519,8 +519,7 @@ public class ContentView(
         PlanFile selectedPlan,
         PlanContentData planData,
         QueryResult<PlanContentData> planContentQuery,
-        int selectedTabIndex,
-        string[] tabNames,
+        IState<int> selectedTab,
         IState<string?> openVerification,
         IState<string?> openCommit,
         IState<string?> openFile,


### PR DESCRIPTION
Fixes #1674

# Summary

## Changes

Refactored the Review app's tab navigation to use local state management instead of URL-based routing. This eliminates full page refreshes when switching between tabs (summary, plan, details, verifications, git, changes, artifacts, recommendations), matching the pattern already used in the Drafts app.

## API Changes

**Modified:**
- `ContentView.BuildContent()` — Changed method signature from `(int selectedTabIndex, string[] tabNames, ...)` to `(IState<int> selectedTab, ...)`

## Files Modified

**UI Components:**
- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — Refactored tab state management and navigation

## Manual Testing

1. **Launch the app** — Run `tendril` and navigate to the Review app
2. **Select a plan** — Click on any plan in the sidebar
3. **Switch between tabs** — Click on different tabs (Summary, Plan, Details, Verifications, Git, Changes, Artifacts, Recommendations)
4. **Observe** — Tab content should update instantly without a full page refresh. The browser should NOT show a loading indicator or flash during tab switches.
5. **Test deep linking** — Directly navigate to a URL with a specific tab parameter (e.g., `?tab=verifications`). The app should open to that tab on initial load.
6. **Test plan switching** — Select a different plan from the sidebar. The tab should reset to "Summary" (the first tab).
7. **Verify scroll position** — Switch tabs, scroll down in one tab, switch to another tab, then return. Scroll position is NOT preserved (this is a framework behavior, not part of this fix).
## Commits

- 4fafe406 Fix Review app tabs to use client-side navigation
- 6a1e4638 Fix BuildContent method signature for selectedTab


---
Created using [Ivy Tendril](https://ivy.app).