### PR TITLE
[00636] Fix Annotation Highlight Text Color in Dark Theme

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -414,17 +414,15 @@
 /* ─── Annotation highlights ────────────────────────────────────────────── */
 .pmv-annotation-highlight {
   background: hsl(48 96% 76% / 0.7);
+  color: var(--foreground);
   border-radius: 0.125rem;
   cursor: pointer;
   padding: 0 0 0.125rem;
   display: inline;
 }
 
-@media (prefers-color-scheme: dark) {
-  .pmv-annotation-highlight {
-    background: hsl(48 80% 20% / 0.5);
-    color: hsl(0 0% 95%);
-  }
+:root.dark .pmv-annotation-highlight {
+  background: hsl(48 80% 20% / 0.5);
 }
 
 /* ─── Annotation popovers ─────────────────────────────────────────────── */


### PR DESCRIPTION
Fixes #1432

# Summary

## Changes

Fixed annotation highlight text color in dark theme by replacing OS-level `prefers-color-scheme` media query with class-based dark mode selector (`:root.dark`) and adding `var(--foreground)` CSS variable for adaptive text color.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css**
  - Replaced `@media (prefers-color-scheme: dark)` with `:root.dark` selector
  - Added `color: var(--foreground)` to base `.pmv-annotation-highlight` rule
  - Removed hardcoded dark theme text color

## Manual Testing

1. Open the Plans app and navigate to any plan with a revision containing annotation comments
2. In **light theme**: annotation-highlighted text should render with dark foreground color (readable against the light yellow highlight background)
3. Switch to **dark theme** via the theme toggle
4. In **dark theme**: annotation-highlighted text should render with white/light foreground color (readable against the darker highlight background)
5. Verify the highlight background remains visible and distinguishable in both themes\n## Commits\n\n- 4008ab15 Fix annotation highlight text color in dark theme

---
Created using [Ivy Tendril](https://ivy.app).