### PR TITLE
[00644] Next Button Not Disabled During Add Project Agentic Setup

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -222,7 +222,7 @@ public class ProjectAgentStepView(
             }
         }, setupTrigger != null ? [setupTrigger, EffectTrigger.OnMount()] : [EffectTrigger.OnMount()]);
 
-        var running = session.Running.Value || isCloning.Value;
+        var running = session.Running.Value || isCloning.Value || (setupTrigger != null && setupTrigger.Value && !session.Started.Value);
 
         var buttonArea = Layout.Horizontal().Width(Size.Full())
             | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
@@ -237,7 +237,8 @@ public class ProjectAgentStepView(
         // output arrives, the AgentViewer's own status label (below the stream) shows the
         // "Starting…" loading indicator, so we don't render a separate Loading() above it —
         // that avoided a layout shift when the bordered/padded Box swapped in on first output.
-        var showStream = !isCloning.Value && (session.Running.Value || session.HasOutput.Value);
+        var aboutToStart = setupTrigger != null && setupTrigger.Value && !session.Started.Value;
+        var showStream = !isCloning.Value && (session.Running.Value || session.HasOutput.Value || aboutToStart);
 
         var viewer = new AgentViewer()
             .Stream(session.Stream)


### PR DESCRIPTION
Fixes #1526

# Summary

## Changes

Fixed two timing issues in the "Setting up your project" dialog: the Next button is now disabled immediately when the dialog opens (eliminating a brief flash of enabled state), and the loading indicator appears immediately instead of after a noticeable delay.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs` — Updated `running` and `showStream` boolean expressions to include `setupTrigger` state

## Manual Testing

1. Launch the Tendril application
2. Click "Add Project" to open the onboarding flow
3. Fill in project details and click "Create Project"
4. Observe the "Setting up your project" step:
   - The Next button should be disabled immediately when the step appears (no brief flash of enabled state)
   - The AgentViewer loading indicator should appear immediately (no delay before seeing "Starting…" or the stream)
5. Wait for the agent setup to complete and verify the Next button becomes enabled
6. Click Back to return to the previous step, then click Next again to re-enter step 1
7. Verify the button is still disabled immediately and the loading indicator still appears without delay

---
- d25db3fd Fix Next button and loading indicator timing in ProjectAgentStepView

---
Created using [Ivy Tendril](https://ivy.app).
