### PR TITLE
[00649] Fix Code Blocks Without Language Tag Rendering as Inline in DraftMarkdown

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/CodeBlock.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/CodeBlock.tsx
@@ -81,6 +81,25 @@ export const CodeBlock: React.FC<React.HTMLAttributes<HTMLElement>> = ({ classNa
       </div>
     );
   }
+
+  // No language match - check if block-level (multi-line) or inline
+  const isBlock = String(children).includes("\n");
+  if (isBlock) {
+    return (
+      <div className="pmv-code-block">
+        <button
+          className={`pmv-code-copy${copied ? " pmv-code-copy--copied" : ""}`}
+          onClick={handleCopy}
+          aria-label="Copy to clipboard"
+        >
+          {copied ? <CheckIcon /> : <CopyIcon />}
+        </button>
+        <pre style={codeBlockPreStyle}>
+          <code>{children}</code>
+        </pre>
+      </div>
+    );
+  }
   return (
     <code className={className} {...rest}>
       {children}

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -287,12 +287,15 @@
   font-size: 0.875rem;
   line-height: 1.5;
 }
-.pmv-code-block code {
+.pmv-code-block code,
+.pmv-markdown pre code {
   background: none;
   padding: 0;
   font-weight: 400;
   border-radius: 0;
   font-size: inherit;
+  display: block;
+  white-space: pre;
 }
 .pmv-code-copy {
   position: absolute;


### PR DESCRIPTION
Fixes #1574

# Summary

## Changes

Fixed code blocks without language tags to render as block-level elements with preserved whitespace and copy buttons, matching the behavior of language-tagged code blocks. The CodeBlock component now detects multi-line content and applies the proper wrapper and styling.

## API Changes

None. All changes are internal to the DraftMarkdown widget rendering logic.

## Files Modified

**Frontend components:**
- `src/Ivy.Tendril.Widgets/frontend/src/CodeBlock.tsx` — Added block detection logic and rendering path for code blocks without language tags
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css` — Added `display: block` and `white-space: pre` to code block styling

## Manual Testing

1. Open the Plans app and navigate to any plan revision view
2. Find a plan that contains a code block without a language tag (triple backticks with no language specified)
3. Verify the code block:
   - Renders as a block-level element (not collapsed onto one line)
   - Preserves all newlines and whitespace
   - Shows a copy button in the top-right corner when hovering
   - Has the same visual styling as language-tagged code blocks (border, background, padding)
4. Test inline code (single backticks) to ensure it still renders inline correctly

---

**Commits:**
- 9ca3c24d Fix code blocks without language tags rendering as inline

---
Created using [Ivy Tendril](https://ivy.app).
