### PR TITLE
[00650] Fix AgentOutputView Auto Scroll to Bottom on New Content

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/use-auto-scroll.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/use-auto-scroll.ts
@@ -18,11 +18,15 @@ export function useAutoScroll(options: UseAutoScrollOptions = {}) {
   const lastContentHeight = useRef(0);
   const userHasScrolled = useRef(false);
   const prevEnabledRef = useRef(enabled);
+  const isProgrammaticScroll = useRef(false);
+  const autoScrollRef = useRef(true);
 
   const [scrollState, setScrollState] = useState<ScrollState>({
     isAtBottom: true,
     autoScrollEnabled: true,
   });
+
+  autoScrollRef.current = scrollState.autoScrollEnabled;
 
   const checkIsAtBottom = useCallback(
     (element: HTMLElement) => {
@@ -37,6 +41,8 @@ export function useAutoScroll(options: UseAutoScrollOptions = {}) {
     (instant?: boolean) => {
       if (!scrollRef.current) return;
 
+      isProgrammaticScroll.current = true;
+
       const targetScrollTop = scrollRef.current.scrollHeight - scrollRef.current.clientHeight;
 
       if (instant) {
@@ -47,6 +53,10 @@ export function useAutoScroll(options: UseAutoScrollOptions = {}) {
           behavior: smooth ? "smooth" : "auto",
         });
       }
+
+      requestAnimationFrame(() => {
+        isProgrammaticScroll.current = false;
+      });
 
       setScrollState({
         isAtBottom: true,
@@ -59,6 +69,10 @@ export function useAutoScroll(options: UseAutoScrollOptions = {}) {
 
   const handleScroll = useCallback(() => {
     if (!scrollRef.current) return;
+
+    if (isProgrammaticScroll.current) {
+      return;
+    }
 
     const atBottom = checkIsAtBottom(scrollRef.current);
 
@@ -84,21 +98,21 @@ export function useAutoScroll(options: UseAutoScrollOptions = {}) {
     const hasNewContent = currentHeight !== lastContentHeight.current;
 
     if (hasNewContent) {
-      if (enabled && scrollState.autoScrollEnabled) {
+      if (enabled && autoScrollRef.current) {
         requestAnimationFrame(() => {
           scrollToBottom(lastContentHeight.current === 0);
         });
       }
       lastContentHeight.current = currentHeight;
     }
-  }, [content, scrollState.autoScrollEnabled, scrollToBottom, enabled]);
+  }, [content, scrollToBottom, enabled]);
 
   useEffect(() => {
     const element = scrollRef.current;
     if (!element) return;
 
     const resizeObserver = new ResizeObserver(() => {
-      if (enabled && scrollState.autoScrollEnabled) {
+      if (enabled && autoScrollRef.current) {
         scrollToBottom(true);
       }
     });
@@ -130,7 +144,7 @@ export function useAutoScroll(options: UseAutoScrollOptions = {}) {
       resizeObserver.disconnect();
       mutationObserver.disconnect();
     };
-  }, [scrollState.autoScrollEnabled, scrollToBottom, enabled]);
+  }, [scrollToBottom, enabled]);
 
   useEffect(() => {
     if (enabled && !prevEnabledRef.current) {


### PR DESCRIPTION
Fixes #1524

# Summary

## Changes

Fixed the AgentViewer auto-scroll behavior to prevent false disengagement during programmatic scrolls. The hook now uses a guard flag and ref-based dependency tracking to ensure auto-scroll remains active when new content streams in during job execution.

## API Changes

None. Internal behavior fix with no public API changes.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/use-auto-scroll.ts` — Added programmatic scroll guard, converted state dependencies to refs

## Manual Testing

1. Start a job that produces streaming output (e.g., ExecutePlan or ExpandPlan)
2. Open the job output sheet in the Jobs view
3. Observe that the view auto-scrolls to the bottom as new lines appear (should not stall mid-stream)
4. Manually scroll up partway through the output
5. Confirm auto-scroll disengages (the view stays at your scroll position)
6. Scroll back to the bottom
7. Confirm auto-scroll re-engages (new lines continue to auto-scroll the view)

---
- Fix AgentOutputView auto-scroll false disengagement during programmatic scrolls (481d4165)

---
Created using [Ivy Tendril](https://ivy.app).
