### PR TITLE
fix: sync commits from every plan worktree, not just plan.Repos matches

### DIFF
--- a/src/Ivy.Tendril.Test/PlanArtifactSyncerTests.cs
+++ b/src/Ivy.Tendril.Test/PlanArtifactSyncerTests.cs
@@ -1,0 +1,114 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services.Plans;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test;
+
+public class PlanArtifactSyncerTests : IDisposable
+{
+    private readonly string _tempDir = Path.Combine(Path.GetTempPath(), "PlanArtifactSyncerTests_" + Guid.NewGuid().ToString("N")[..8]);
+
+    public PlanArtifactSyncerTests()
+    {
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            try { Directory.Delete(_tempDir, true); } catch { }
+        }
+    }
+
+    private static void RunGitFor(string args, string workingDir)
+    {
+        using var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("git", args)
+        {
+            WorkingDirectory = workingDir,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        });
+        p?.WaitForExit(15000);
+    }
+
+    private string? SetUpRepoWithWorktree(string planFolder, string worktreeFolderName, string branchName, string baseBranch = "main")
+    {
+        var remote = Path.Combine(_tempDir, $"remote-{Guid.NewGuid():N}.git");
+        Directory.CreateDirectory(remote);
+        RunGitFor($"init --bare -b {baseBranch}", remote);
+
+        var repo = Path.Combine(_tempDir, $"repo-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(repo);
+        RunGitFor($"init -b {baseBranch}", repo);
+        RunGitFor("config user.email \"test@example.com\"", repo);
+        RunGitFor("config user.name \"Test User\"", repo);
+        File.WriteAllText(Path.Combine(repo, "a.txt"), "base");
+        RunGitFor("add -A", repo);
+        RunGitFor("commit -m initial", repo);
+        RunGitFor($"remote add origin \"{remote}\"", repo);
+        RunGitFor($"push -u origin {baseBranch}", repo);
+        RunGitFor($"remote set-head origin {baseBranch}", repo);
+
+        if (!Directory.Exists(Path.Combine(repo, ".git")))
+            return null;
+
+        var worktreesDir = Path.Combine(planFolder, "Worktrees");
+        Directory.CreateDirectory(worktreesDir);
+        var worktreePath = Path.Combine(worktreesDir, worktreeFolderName);
+        RunGitFor($"worktree add -b {branchName} \"{worktreePath}\" {baseBranch}", repo);
+
+        if (!File.Exists(Path.Combine(worktreePath, ".git")))
+            return null;
+
+        File.WriteAllText(Path.Combine(worktreePath, "b.txt"), "change");
+        RunGitFor("add -A", worktreePath);
+        RunGitFor("commit -m \"agent change\"", worktreePath);
+
+        return repo;
+    }
+
+    private string CreatePlanFolder(string project, string configuredRepoPath)
+    {
+        var planFolder = Path.Combine(_tempDir, "00001-TestPlan");
+        Directory.CreateDirectory(planFolder);
+        Directory.CreateDirectory(configuredRepoPath);
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"),
+            $"state: Review\nproject: {project}\ntitle: Test Plan\nrepos:\n  - {configuredRepoPath}\nupdated: {DateTime.UtcNow:o}\n");
+        return planFolder;
+    }
+
+    [Fact]
+    public void SyncPlanArtifacts_WorktreeFolderNameMismatchesPlanRepos_StillSyncsCommits()
+    {
+        var configuredRepo = Path.Combine(_tempDir, "configured-repo-name");
+        var planFolder = CreatePlanFolder("Test", configuredRepo);
+        var branchName = "tendril/00001-TestPlan";
+        var repo = SetUpRepoWithWorktree(planFolder, "actual-worktree-folder", branchName);
+        if (repo == null) return;
+
+        var syncer = new PlanArtifactSyncer(configService: null, NullLogger.Instance, planWatcherService: null);
+        syncer.SyncPlanArtifacts(planFolder);
+
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        Assert.Single(plan.Commits);
+    }
+
+    [Fact]
+    public void SyncPlanArtifacts_WorktreeFolderNameMatchesPlanRepos_SyncsCommits()
+    {
+        var configuredRepo = Path.Combine(_tempDir, "matching-repo");
+        var planFolder = CreatePlanFolder("Test", configuredRepo);
+        var branchName = "tendril/00001-TestPlan";
+        var repo = SetUpRepoWithWorktree(planFolder, "matching-repo", branchName);
+        if (repo == null) return;
+
+        var syncer = new PlanArtifactSyncer(configService: null, NullLogger.Instance, planWatcherService: null);
+        syncer.SyncPlanArtifacts(planFolder);
+
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+        Assert.Single(plan.Commits);
+    }
+}

--- a/src/Ivy.Tendril/Services/Plans/PlanArtifactSyncer.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanArtifactSyncer.cs
@@ -98,12 +98,9 @@ internal class PlanArtifactSyncer
         if (planId == null || safeTitle == null) return false;
 
         var branchName = $"tendril/{planId}-{safeTitle}";
-        var planRepoNames = new HashSet<string>(
-            plan.Repos.Select(r => Path.GetFileName(Environment.ExpandEnvironmentVariables(r))),
-            StringComparer.OrdinalIgnoreCase);
 
         var changed = false;
-        foreach (var wtDir in IterateWorktrees(worktreesDir, planRepoNames))
+        foreach (var wtDir in IterateWorktrees(worktreesDir))
         {
             var commits = ExtractCommitsFromWorktree(wtDir, branchName, plan);
             changed |= AddCommitsToPlan(plan, commits);
@@ -112,14 +109,10 @@ internal class PlanArtifactSyncer
         return changed;
     }
 
-    private static IEnumerable<string> IterateWorktrees(string worktreesDir, HashSet<string> planRepoNames)
+    private static IEnumerable<string> IterateWorktrees(string worktreesDir)
     {
         foreach (var wtDir in Directory.GetDirectories(worktreesDir))
         {
-            var wtName = Path.GetFileName(wtDir);
-            if (planRepoNames.Count > 0 && !planRepoNames.Contains(wtName))
-                continue;
-
             var gitFile = Path.Combine(wtDir, ".git");
             if (File.Exists(gitFile))
                 yield return wtDir;


### PR DESCRIPTION
Fixes #1670.

**Symptom:** After confirming a plan, the review app showed no diff/Changes tab even though the agent had committed.

**Root cause:** `PlanArtifactSyncer.IterateWorktrees` filtered worktree directories under `<PlanFolder>/Worktrees/` by folder name against `plan.Repos` — a snapshot taken at plan-creation time. When the worktree folder name the agent actually worked in didn't match (project pointing at a different/renamed repo, or config changed after plan creation), the worktree was silently skipped, `plan.Commits` stayed empty, and `PlanContentHelpers.GetAllChangesData` returned null before its #1340 "wrong project" fallback could run — so the Changes tab vanished instead of showing the warning banner.

**Fix:** Remove the name filter so all plan worktrees are scanned for commits — consistent with `GitTabDataBuilder`, which already scans all worktrees. Commit attribution remains safe via branch scoping (`git log origin/<base>..tendril/<planFolderName>`) and per-hash dedup. This makes the existing #1340 "wrong project" banner reachable in the mismatch scenario.

**Note on #281:** the removed filter was originally added to suppress phantom commits from read-only build-dependency worktrees. Verified: a dep worktree cut fresh from `origin/<base>` yields zero commits from the branch-scoped log, so no phantom commits reappear in the normal case. If an agent ever commits into a dep worktree, that commit now surfaces via the #1340 unlisted-worktree banner rather than being silently suppressed.

**Testing:** New regression test `SyncPlanArtifacts_WorktreeFolderNameMismatchesPlanRepos_StillSyncsCommits` using a real git repo + worktree fixture — verified it fails against pre-fix code and passes post-fix, plus a matching-name control test. Full suite: 1757 passed, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)