### PR TITLE
[1433] Collapse footer actions responsively so buttons don't clip

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -151,7 +151,10 @@ public class ActionBarView(
         // content pane (Split/Expand/Delete) + standard overflow. See the pane-width note
         // on ActionBarResponsive: the Draft footer's content pane is narrower than the
         // viewport by the sidebar + drafts-list pane to its left, so even at the Wide
-        // viewport tier only Previous/Next/Edit/Update safely fit inline.
+        // viewport tier only Previous/Next/Edit/Update fit inline at typical Wide widths
+        // (verified at the #1433 repro's ~1456px); Breakpoint.Wide is unbounded below
+        // 1024px, so a pane at the narrow end of that band (roughly 1024–1300px viewport)
+        // can still clip this set — there is no tier gate below Wide to fall back to.
         var paneCompactDropdownItems = new List<MenuItem>
         {
             new MenuItem("Split", Icon: Icons.Scissors, Tag: "Split")
@@ -188,6 +191,14 @@ public class ActionBarView(
         // Pane-Minimal tier (viewport <1024px): Previous, Next inline; everything else in dropdown.
         // Split/Expand/Delete never get an inline slot at any viewport width — the pane is
         // never wide enough to guarantee they fit, so they're always dropdown-only.
+        //
+        // The framework only registers a Button's ShortcutKey while that Button is mounted
+        // (useShortcut's cleanup runs on unmount), and ShowOn/HideOn/PaneCompactUp/etc. truly
+        // unmount the widget rather than just hiding it with CSS (see MemoizedWidget in
+        // widgetRenderer.tsx: `if (visible === false) return null`). Since Delete never gets
+        // an inline slot at any tier, its Backspace shortcut has to live on an icon-only Button
+        // that stays mounted at every tier instead — MenuItem.Shortcut is display-only (just a
+        // Kbd hint) and never registers a keyboard handler.
         return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(goToPrevious)
                    .ShortcutKey("p").AlwaysVisible()
@@ -197,6 +208,11 @@ public class ActionBarView(
                    .OnClick(() => isEditingState.Set(true)).PaneCompactUp()
                | new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")
                    .OnClick(showUpdateDialog).PaneCompactUp()
+               // Icon-only, always-mounted carrier for the Backspace shortcut — Delete itself
+               // is dropdown-only at every tier (see note above), so this keeps the keyboard
+               // shortcut alive without reintroducing a labeled inline button that can clip.
+               | new Button().Icon(Icons.Trash).Ghost().ShortcutKey("Backspace")
+                   .Tooltip("Delete").OnClick(showDeleteDialog).AlwaysVisible()
                // Pane-Compact-tier dropdown: Split, Expand, Delete + standard overflow
                | ActionBarResponsive.DropdownAtPaneCompact(
                    new Button().Icon(Icons.EllipsisVertical).Ghost(),

--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -147,8 +147,12 @@ public class ActionBarView(
             refreshPlans();
         }
 
-        // Compact-tier dropdown items: buttons that don't fit at the Compact tier + standard overflow
-        var compactDropdownItems = new List<MenuItem>
+        // Pane-Compact-tier dropdown items: buttons that never get an inline slot in the
+        // content pane (Split/Expand/Delete) + standard overflow. See the pane-width note
+        // on ActionBarResponsive: the Draft footer's content pane is narrower than the
+        // viewport by the sidebar + drafts-list pane to its left, so even at the Wide
+        // viewport tier only Previous/Next/Edit/Update safely fit inline.
+        var paneCompactDropdownItems = new List<MenuItem>
         {
             new MenuItem("Split", Icon: Icons.Scissors, Tag: "Split")
                 .OnSelect(StartSplit).Disabled(hasActiveSplitJob),
@@ -156,10 +160,10 @@ public class ActionBarView(
                 .OnSelect(StartExpand).Disabled(hasActiveExpandJob),
             new MenuItem("Delete", Icon: Icons.Trash, Tag: "Delete").OnSelect(showDeleteDialog)
         };
-        compactDropdownItems.AddRange(standardOverflowItems);
+        paneCompactDropdownItems.AddRange(standardOverflowItems);
 
-        // Minimal-tier dropdown items: all action buttons + standard overflow
-        var minimalDropdownItems = new List<MenuItem>
+        // Pane-Minimal-tier dropdown items: all action buttons + standard overflow
+        var paneMinimalDropdownItems = new List<MenuItem>
         {
             new MenuItem("Edit", Icon: Icons.Pencil, Tag: "Edit")
                 .OnSelect(() => isEditingState.Set(true)),
@@ -171,38 +175,35 @@ public class ActionBarView(
                 .OnSelect(StartExpand).Disabled(hasActiveExpandJob),
             new MenuItem("Delete", Icon: Icons.Trash, Tag: "Delete").OnSelect(showDeleteDialog)
         };
-        minimalDropdownItems.AddRange(standardOverflowItems);
+        paneMinimalDropdownItems.AddRange(standardOverflowItems);
 
-        // Action bar without .Wrap() - single row layout with progressive collapse.
-        // Full tier (>=1024px): all buttons inline + overflow-only dropdown.
-        // Compact tier (768-1023px): Previous, Next, Edit, Update inline; Split/Expand/Delete in dropdown.
-        // Minimal tier (<768px): Previous, Next inline; everything else in dropdown.
+        // Action bar without .Wrap() - the footer slot is fixed-height, so wrapping could
+        // push content out; a single row with progressive collapse is required instead.
+        //
+        // These tiers are keyed to the CONTENT PANE, not the raw viewport — see the
+        // pane-width note on ActionBarResponsive. The pane is narrower than the viewport
+        // by the app sidebar + drafts-list pane to its left, so the budget for each tier
+        // is shifted down by one viewport step from what a full-width bar would use:
+        // Pane-Compact tier (viewport >=1024px / Wide): Previous, Next, Edit, Update inline; Split/Expand/Delete in dropdown.
+        // Pane-Minimal tier (viewport <1024px): Previous, Next inline; everything else in dropdown.
+        // Split/Expand/Delete never get an inline slot at any viewport width — the pane is
+        // never wide enough to guarantee they fit, so they're always dropdown-only.
         return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(goToPrevious)
                    .ShortcutKey("p").AlwaysVisible()
                | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(goToNext)
                    .ShortcutKey("n").AlwaysVisible()
                | new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
-                   .OnClick(() => isEditingState.Set(true)).CompactUp()
+                   .OnClick(() => isEditingState.Set(true)).PaneCompactUp()
                | new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")
-                   .OnClick(showUpdateDialog).CompactUp()
-               | new Button("Split").Icon(Icons.Scissors).Outline()
-                   .OnClick(StartSplit).Disabled(hasActiveSplitJob).FullOnly()
-               | new Button("Expand").Icon(Icons.UnfoldVertical).Outline()
-                   .OnClick(StartExpand).Disabled(hasActiveExpandJob).FullOnly()
-               | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
-                   .OnClick(showDeleteDialog).FullOnly()
-               // Full-tier dropdown: standard overflow items only
-               | ActionBarResponsive.DropdownAtFull(
+                   .OnClick(showUpdateDialog).PaneCompactUp()
+               // Pane-Compact-tier dropdown: Split, Expand, Delete + standard overflow
+               | ActionBarResponsive.DropdownAtPaneCompact(
                    new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                   standardOverflowItems)
-               // Compact-tier dropdown: Split, Expand, Delete + standard overflow
-               | ActionBarResponsive.DropdownAtCompact(
+                   paneCompactDropdownItems.ToArray())
+               // Pane-Minimal-tier dropdown: all action buttons + standard overflow
+               | ActionBarResponsive.DropdownAtPaneMinimal(
                    new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                   compactDropdownItems.ToArray())
-               // Minimal-tier dropdown: all action buttons + standard overflow
-               | ActionBarResponsive.DropdownAtMinimal(
-                   new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                   minimalDropdownItems.ToArray());
+                   paneMinimalDropdownItems.ToArray());
     }
 }

--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -147,15 +147,9 @@ public class ActionBarView(
             refreshPlans();
         }
 
-        // Pane-Compact-tier dropdown items: buttons that never get an inline slot in the
-        // content pane (Split/Expand/Delete) + standard overflow. See the pane-width note
-        // on ActionBarResponsive: the Draft footer's content pane is narrower than the
-        // viewport by the sidebar + drafts-list pane to its left, so even at the Wide
-        // viewport tier only Previous/Next/Edit/Update fit inline at typical Wide widths
-        // (verified at the #1433 repro's ~1456px); Breakpoint.Wide is unbounded below
-        // 1024px, so a pane at the narrow end of that band (roughly 1024–1300px viewport)
-        // can still clip this set — there is no tier gate below Wide to fall back to.
-        var paneCompactDropdownItems = new List<MenuItem>
+        // Compact-tier dropdown items: buttons hidden at the Compact tier (Split/Expand/Delete)
+        // + standard overflow
+        var compactDropdownItems = new List<MenuItem>
         {
             new MenuItem("Split", Icon: Icons.Scissors, Tag: "Split")
                 .OnSelect(StartSplit).Disabled(hasActiveSplitJob),
@@ -163,10 +157,10 @@ public class ActionBarView(
                 .OnSelect(StartExpand).Disabled(hasActiveExpandJob),
             new MenuItem("Delete", Icon: Icons.Trash, Tag: "Delete").OnSelect(showDeleteDialog)
         };
-        paneCompactDropdownItems.AddRange(standardOverflowItems);
+        compactDropdownItems.AddRange(standardOverflowItems);
 
-        // Pane-Minimal-tier dropdown items: all action buttons + standard overflow
-        var paneMinimalDropdownItems = new List<MenuItem>
+        // Minimal-tier dropdown items: all action buttons + standard overflow
+        var minimalDropdownItems = new List<MenuItem>
         {
             new MenuItem("Edit", Icon: Icons.Pencil, Tag: "Edit")
                 .OnSelect(() => isEditingState.Set(true)),
@@ -178,48 +172,42 @@ public class ActionBarView(
                 .OnSelect(StartExpand).Disabled(hasActiveExpandJob),
             new MenuItem("Delete", Icon: Icons.Trash, Tag: "Delete").OnSelect(showDeleteDialog)
         };
-        paneMinimalDropdownItems.AddRange(standardOverflowItems);
+        minimalDropdownItems.AddRange(standardOverflowItems);
 
-        // Action bar without .Wrap() - the footer slot is fixed-height, so wrapping could
-        // push content out; a single row with progressive collapse is required instead.
+        // Full tier (container ≥1024px): all buttons inline; Compact (768–1023): Edit/Update
+        // inline, rest in dropdown; Minimal (<768): Previous/Next + dropdown. Wrap() is the
+        // clipping guard: the drafts-list pane and resizable sidebars can squeeze the footer
+        // below what a tier's inline set needs, in which case the row wraps instead of
+        // clipping (#1433) — the footer slot grows with its content.
         //
-        // These tiers are keyed to the CONTENT PANE, not the raw viewport — see the
-        // pane-width note on ActionBarResponsive. The pane is narrower than the viewport
-        // by the app sidebar + drafts-list pane to its left, so the budget for each tier
-        // is shifted down by one viewport step from what a full-width bar would use:
-        // Pane-Compact tier (viewport >=1024px / Wide): Previous, Next, Edit, Update inline; Split/Expand/Delete in dropdown.
-        // Pane-Minimal tier (viewport <1024px): Previous, Next inline; everything else in dropdown.
-        // Split/Expand/Delete never get an inline slot at any viewport width — the pane is
-        // never wide enough to guarantee they fit, so they're always dropdown-only.
-        //
-        // The framework only registers a Button's ShortcutKey while that Button is mounted
-        // (useShortcut's cleanup runs on unmount), and ShowOn/HideOn/PaneCompactUp/etc. truly
-        // unmount the widget rather than just hiding it with CSS (see MemoizedWidget in
-        // widgetRenderer.tsx: `if (visible === false) return null`). Since Delete never gets
-        // an inline slot at any tier, its Backspace shortcut has to live on an icon-only Button
-        // that stays mounted at every tier instead — MenuItem.Shortcut is display-only (just a
-        // Kbd hint) and never registers a keyboard handler.
-        return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
+        // The Backspace shortcut needs a mounted Button at every tier (ShowOn/HideOn truly
+        // unmount, which deregisters ShortcutKey; MenuItem shortcuts are display-only), so
+        // below Full an icon-only stand-in carries it while the labeled Delete is unmounted.
+        return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Wrap()
                | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(goToPrevious)
                    .ShortcutKey("p").AlwaysVisible()
                | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(goToNext)
                    .ShortcutKey("n").AlwaysVisible()
                | new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
-                   .OnClick(() => isEditingState.Set(true)).PaneCompactUp()
+                   .OnClick(() => isEditingState.Set(true)).CompactUp()
                | new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")
-                   .OnClick(showUpdateDialog).PaneCompactUp()
-               // Icon-only, always-mounted carrier for the Backspace shortcut — Delete itself
-               // is dropdown-only at every tier (see note above), so this keeps the keyboard
-               // shortcut alive without reintroducing a labeled inline button that can clip.
+                   .OnClick(showUpdateDialog).CompactUp()
+               | new Button("Split").Icon(Icons.Scissors).Outline()
+                   .OnClick(StartSplit).Disabled(hasActiveSplitJob).FullOnly()
+               | new Button("Expand").Icon(Icons.UnfoldVertical).Outline()
+                   .OnClick(StartExpand).Disabled(hasActiveExpandJob).FullOnly()
+               | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
+                   .OnClick(showDeleteDialog).FullOnly()
                | new Button().Icon(Icons.Trash).Ghost().ShortcutKey("Backspace")
-                   .Tooltip("Delete").OnClick(showDeleteDialog).AlwaysVisible()
-               // Pane-Compact-tier dropdown: Split, Expand, Delete + standard overflow
-               | ActionBarResponsive.DropdownAtPaneCompact(
+                   .Tooltip("Delete").OnClick(showDeleteDialog).BelowFull()
+               | ActionBarResponsive.DropdownAtFull(
                    new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                   paneCompactDropdownItems.ToArray())
-               // Pane-Minimal-tier dropdown: all action buttons + standard overflow
-               | ActionBarResponsive.DropdownAtPaneMinimal(
+                   standardOverflowItems)
+               | ActionBarResponsive.DropdownAtCompact(
                    new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                   paneMinimalDropdownItems.ToArray());
+                   compactDropdownItems.ToArray())
+               | ActionBarResponsive.DropdownAtMinimal(
+                   new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                   minimalDropdownItems.ToArray());
     }
 }

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -470,66 +470,53 @@ public class ContentView(
             })
         };
 
-        // Pane-Compact-tier dropdown: Discard + standard overflow. See the pane-width note
-        // on ActionBarResponsive: the Review footer's content pane is narrower than the
-        // viewport by the sidebar + drafts-list pane to its left, so Discard never gets a
-        // safe inline slot at any viewport width.
-        var paneCompactDropdownItems = new List<MenuItem>
+        // Compact-tier dropdown: Discard + standard overflow
+        var compactDropdownItems = new List<MenuItem>
         {
             new MenuItem("Discard", Icon: Icons.Trash, Tag: "Discard").OnSelect(showDiscardDialog)
         };
-        paneCompactDropdownItems.AddRange(standardOverflowItems);
+        compactDropdownItems.AddRange(standardOverflowItems);
 
-        // Pane-Minimal-tier dropdown: all action buttons + standard overflow
-        var paneMinimalDropdownItems = new List<MenuItem>
+        // Minimal-tier dropdown: all action buttons + standard overflow
+        var minimalDropdownItems = new List<MenuItem>
         {
             new MenuItem("Reset to Draft", Icon: Icons.RotateCcw, Tag: "ResetToDraft").OnSelect(showResetToDraftDialog),
             new MenuItem("Request Changes", Icon: Icons.MessageSquare, Tag: "RequestChanges").OnSelect(showSuggestChangesDialog),
             new MenuItem("Discard", Icon: Icons.Trash, Tag: "Discard").OnSelect(showDiscardDialog)
         };
-        paneMinimalDropdownItems.AddRange(standardOverflowItems);
+        minimalDropdownItems.AddRange(standardOverflowItems);
 
-        // Action bar without .Wrap() - the footer slot is fixed-height, so wrapping could
-        // push content out; a single row with progressive collapse is required instead.
+        // Full tier (container ≥1024px): all buttons inline; Compact (768–1023): Reset to
+        // Draft/Request Changes inline, Discard in dropdown; Minimal (<768): Previous/Next +
+        // dropdown. Wrap() is the clipping guard: the plans-list pane and resizable sidebars
+        // can squeeze the footer below what a tier's inline set needs, in which case the row
+        // wraps instead of clipping (#1433) — the footer slot grows with its content.
         //
-        // These tiers are keyed to the CONTENT PANE, not the raw viewport — see the
-        // pane-width note on ActionBarResponsive. The pane is narrower than the viewport
-        // by the app sidebar + drafts-list pane to its left, so the budget for each tier
-        // is shifted down by one viewport step from what a full-width bar would use:
-        // Pane-Compact tier (viewport >=1024px / Wide): Previous, Next, Reset to Draft, Request Changes inline; Discard in dropdown.
-        // Pane-Minimal tier (viewport <1024px): Previous, Next inline; everything else in dropdown.
-        // Discard never gets an inline slot at any viewport width — the pane is never wide
-        // enough to guarantee it fits, so it's always dropdown-only.
-        //
-        // The framework only registers a Button's ShortcutKey while that Button is mounted
-        // (useShortcut's cleanup runs on unmount), and ShowOn/HideOn/PaneCompactUp/etc. truly
-        // unmount the widget rather than just hiding it with CSS (see MemoizedWidget in
-        // widgetRenderer.tsx: `if (visible === false) return null`). Since Discard never gets
-        // an inline slot at any tier, its Backspace shortcut has to live on an icon-only Button
-        // that stays mounted at every tier instead — MenuItem.Shortcut is display-only (just a
-        // Kbd hint) and never registers a keyboard handler.
-        return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
+        // The Backspace shortcut needs a mounted Button at every tier (ShowOn/HideOn truly
+        // unmount, which deregisters ShortcutKey; MenuItem shortcuts are display-only), so
+        // below Full an icon-only stand-in carries it while the labeled Discard is unmounted.
+        return Layout.Horizontal().AlignContent(Align.Left).Gap(2).Wrap()
                 | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(() => GoToPrevious(nav, args))
                     .ShortcutKey("p").AlwaysVisible()
                 | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(() => GoToNext(nav, args))
                     .ShortcutKey("n").AlwaysVisible()
                 | new Button("Reset to Draft").Icon(Icons.RotateCcw).Outline().ShortcutKey("r")
-                    .OnClick(showResetToDraftDialog).PaneCompactUp()
+                    .OnClick(showResetToDraftDialog).CompactUp()
                 | new Button("Request Changes").Icon(Icons.MessageSquare).Outline().ShortcutKey("c")
-                    .OnClick(showSuggestChangesDialog).PaneCompactUp()
-                // Icon-only, always-mounted carrier for the Backspace shortcut — Discard itself
-                // is dropdown-only at every tier (see note above), so this keeps the keyboard
-                // shortcut alive without reintroducing a labeled inline button that can clip.
+                    .OnClick(showSuggestChangesDialog).CompactUp()
+                | new Button("Discard").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
+                    .OnClick(showDiscardDialog).FullOnly()
                 | new Button().Icon(Icons.Trash).Ghost().ShortcutKey("Backspace")
-                    .Tooltip("Discard").OnClick(showDiscardDialog).AlwaysVisible()
-                // Pane-Compact-tier dropdown: Discard + standard overflow
-                | ActionBarResponsive.DropdownAtPaneCompact(
+                    .Tooltip("Discard").OnClick(showDiscardDialog).BelowFull()
+                | ActionBarResponsive.DropdownAtFull(
                     new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                    paneCompactDropdownItems.ToArray())
-                // Pane-Minimal-tier dropdown: all action buttons + standard overflow
-                | ActionBarResponsive.DropdownAtPaneMinimal(
+                    standardOverflowItems)
+                | ActionBarResponsive.DropdownAtCompact(
                     new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                    paneMinimalDropdownItems.ToArray());
+                    compactDropdownItems.ToArray())
+                | ActionBarResponsive.DropdownAtMinimal(
+                    new Button().Icon(Icons.EllipsisVertical).Ghost(),
+                    minimalDropdownItems.ToArray());
     }
 
     private object BuildContent(

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -500,6 +500,14 @@ public class ContentView(
         // Pane-Minimal tier (viewport <1024px): Previous, Next inline; everything else in dropdown.
         // Discard never gets an inline slot at any viewport width — the pane is never wide
         // enough to guarantee it fits, so it's always dropdown-only.
+        //
+        // The framework only registers a Button's ShortcutKey while that Button is mounted
+        // (useShortcut's cleanup runs on unmount), and ShowOn/HideOn/PaneCompactUp/etc. truly
+        // unmount the widget rather than just hiding it with CSS (see MemoizedWidget in
+        // widgetRenderer.tsx: `if (visible === false) return null`). Since Discard never gets
+        // an inline slot at any tier, its Backspace shortcut has to live on an icon-only Button
+        // that stays mounted at every tier instead — MenuItem.Shortcut is display-only (just a
+        // Kbd hint) and never registers a keyboard handler.
         return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                 | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(() => GoToPrevious(nav, args))
                     .ShortcutKey("p").AlwaysVisible()
@@ -509,6 +517,11 @@ public class ContentView(
                     .OnClick(showResetToDraftDialog).PaneCompactUp()
                 | new Button("Request Changes").Icon(Icons.MessageSquare).Outline().ShortcutKey("c")
                     .OnClick(showSuggestChangesDialog).PaneCompactUp()
+                // Icon-only, always-mounted carrier for the Backspace shortcut — Discard itself
+                // is dropdown-only at every tier (see note above), so this keeps the keyboard
+                // shortcut alive without reintroducing a labeled inline button that can clip.
+                | new Button().Icon(Icons.Trash).Ghost().ShortcutKey("Backspace")
+                    .Tooltip("Discard").OnClick(showDiscardDialog).AlwaysVisible()
                 // Pane-Compact-tier dropdown: Discard + standard overflow
                 | ActionBarResponsive.DropdownAtPaneCompact(
                     new Button().Icon(Icons.EllipsisVertical).Ghost(),

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -470,49 +470,53 @@ public class ContentView(
             })
         };
 
-        // Full-tier dropdown: standard overflow items only (all buttons shown inline)
-        var fullDropdownItems = standardOverflowItems;
-
-        // Compact-tier dropdown: Discard + standard overflow
-        var compactDropdownItems = new List<MenuItem>
+        // Pane-Compact-tier dropdown: Discard + standard overflow. See the pane-width note
+        // on ActionBarResponsive: the Review footer's content pane is narrower than the
+        // viewport by the sidebar + drafts-list pane to its left, so Discard never gets a
+        // safe inline slot at any viewport width.
+        var paneCompactDropdownItems = new List<MenuItem>
         {
             new MenuItem("Discard", Icon: Icons.Trash, Tag: "Discard").OnSelect(showDiscardDialog)
         };
-        compactDropdownItems.AddRange(standardOverflowItems);
+        paneCompactDropdownItems.AddRange(standardOverflowItems);
 
-        // Minimal-tier dropdown: all action buttons + standard overflow
-        var minimalDropdownItems = new List<MenuItem>
+        // Pane-Minimal-tier dropdown: all action buttons + standard overflow
+        var paneMinimalDropdownItems = new List<MenuItem>
         {
             new MenuItem("Reset to Draft", Icon: Icons.RotateCcw, Tag: "ResetToDraft").OnSelect(showResetToDraftDialog),
             new MenuItem("Request Changes", Icon: Icons.MessageSquare, Tag: "RequestChanges").OnSelect(showSuggestChangesDialog),
             new MenuItem("Discard", Icon: Icons.Trash, Tag: "Discard").OnSelect(showDiscardDialog)
         };
-        minimalDropdownItems.AddRange(standardOverflowItems);
+        paneMinimalDropdownItems.AddRange(standardOverflowItems);
 
-        // Action bar without .Wrap() - single row with progressive collapse.
-        // Full (>=1024px): Previous, Next, Reset to Draft, Request Changes, Discard inline + overflow dropdown.
-        // Compact (768-1023px): Previous, Next, Reset to Draft, Request Changes inline; Discard in dropdown.
-        // Minimal (<768px): Previous, Next inline; everything else in dropdown.
+        // Action bar without .Wrap() - the footer slot is fixed-height, so wrapping could
+        // push content out; a single row with progressive collapse is required instead.
+        //
+        // These tiers are keyed to the CONTENT PANE, not the raw viewport — see the
+        // pane-width note on ActionBarResponsive. The pane is narrower than the viewport
+        // by the app sidebar + drafts-list pane to its left, so the budget for each tier
+        // is shifted down by one viewport step from what a full-width bar would use:
+        // Pane-Compact tier (viewport >=1024px / Wide): Previous, Next, Reset to Draft, Request Changes inline; Discard in dropdown.
+        // Pane-Minimal tier (viewport <1024px): Previous, Next inline; everything else in dropdown.
+        // Discard never gets an inline slot at any viewport width — the pane is never wide
+        // enough to guarantee it fits, so it's always dropdown-only.
         return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                 | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(() => GoToPrevious(nav, args))
                     .ShortcutKey("p").AlwaysVisible()
                 | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(() => GoToNext(nav, args))
                     .ShortcutKey("n").AlwaysVisible()
                 | new Button("Reset to Draft").Icon(Icons.RotateCcw).Outline().ShortcutKey("r")
-                    .OnClick(showResetToDraftDialog).CompactUp()
+                    .OnClick(showResetToDraftDialog).PaneCompactUp()
                 | new Button("Request Changes").Icon(Icons.MessageSquare).Outline().ShortcutKey("c")
-                    .OnClick(showSuggestChangesDialog).CompactUp()
-                | new Button("Discard").Icon(Icons.Trash).Outline().ShortcutKey("Backspace")
-                    .OnClick(showDiscardDialog).FullOnly()
-                | ActionBarResponsive.DropdownAtFull(
+                    .OnClick(showSuggestChangesDialog).PaneCompactUp()
+                // Pane-Compact-tier dropdown: Discard + standard overflow
+                | ActionBarResponsive.DropdownAtPaneCompact(
                     new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                    fullDropdownItems)
-                | ActionBarResponsive.DropdownAtCompact(
+                    paneCompactDropdownItems.ToArray())
+                // Pane-Minimal-tier dropdown: all action buttons + standard overflow
+                | ActionBarResponsive.DropdownAtPaneMinimal(
                     new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                    compactDropdownItems.ToArray())
-                | ActionBarResponsive.DropdownAtMinimal(
-                    new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                    minimalDropdownItems.ToArray());
+                    paneMinimalDropdownItems.ToArray());
     }
 
     private object BuildContent(

--- a/src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs
@@ -10,12 +10,10 @@ namespace Ivy.Tendril.Apps.Review;
 ///     <see cref="ReviewActionConfig"/>, disabled when its precomputed condition isn't met,
 ///     otherwise running the action's PowerShell command in the plan folder. Renders nothing
 ///     (returns null) when the project defines no review actions, so callers can compose it
-///     unconditionally. The action list is unbounded, so only the first
-///     <see cref="MaxInlineAtWide"/> actions are ever shown inline, and only at the Wide
-///     breakpoint (see <see cref="ActionBarResponsive"/>); every other action — and
-///     everything at every narrower breakpoint — collapses into a single overflow dropdown
-///     that stays visible at Wide too, so an arbitrarily long or long-labeled action list
-///     can never clip the bar.
+///     unconditionally. All actions render inline at the Wide breakpoint on a wrapping row
+///     (an arbitrarily long list flows onto extra rows instead of clipping); at narrower
+///     breakpoints everything collapses into a single dropdown
+///     (see <see cref="ActionBarResponsive"/>).
 /// </summary>
 public class ReviewActionsBarView(
     PlanFile selectedPlan,
@@ -23,8 +21,6 @@ public class ReviewActionsBarView(
     IConfigService config,
     ILogger logger) : ViewBase
 {
-    private const int MaxInlineAtWide = 4;
-
     public override object? Build()
     {
         var projectConfig = config.GetProject(selectedPlan.Project);
@@ -40,25 +36,16 @@ public class ReviewActionsBarView(
             }
         }
 
-        // The action list is project-configured and unbounded (arbitrary count, arbitrary
-        // label length), so a fixed number of inline buttons can never be guaranteed to fit
-        // even at the Wide breakpoint: cap the inline set at MaxInlineAtWide and always keep
-        // every action reachable via the dropdown, which stays visible at Wide too whenever
-        // there's overflow. Below Wide, no actions are shown inline at all.
-        var actionsBar = Layout.Horizontal().Gap(2).Padding(2, 2, 2, 0).Height(Size.Fit());
+        var actionsBar = Layout.Horizontal().Gap(2).Padding(2, 2, 2, 0).Height(Size.Fit()).Wrap();
         var dropdownItems = new List<MenuItem>();
-        var hasOverflowAtWide = reviewActions.Count > MaxInlineAtWide;
         for (var i = 0; i < reviewActions.Count; i++)
         {
             var action = reviewActions[i];
             var conditionMet = i < reviewActionStates.Count && reviewActionStates[i].ConditionMet;
 
-            if (i < MaxInlineAtWide)
-            {
-                var btn = new Button(action.Name).Icon(Icons.Play).Outline();
-                btn = conditionMet ? btn.OnClick(() => Run(action)) : btn.Disabled();
-                actionsBar |= btn.FullOnly();
-            }
+            var btn = new Button(action.Name).Icon(Icons.Play).Outline();
+            btn = conditionMet ? btn.OnClick(() => Run(action)) : btn.Disabled();
+            actionsBar |= btn.FullOnly();
 
             // Tag carries the loop index so duplicate action names don't misroute clicks or
             // collide as React keys (MenuItem.GetSelectHandler dispatches on the first Tag match).
@@ -71,10 +58,9 @@ public class ReviewActionsBarView(
             dropdownItems.Add(menuItem);
         }
 
-        var dropdownTrigger = new Button().Icon(Icons.EllipsisVertical).Ghost();
-        actionsBar |= hasOverflowAtWide
-            ? dropdownTrigger.WithDropDown(dropdownItems.ToArray())
-            : ActionBarResponsive.DropdownBelowWide(dropdownTrigger, dropdownItems.ToArray());
+        actionsBar |= ActionBarResponsive.DropdownBelowWide(
+            new Button().Icon(Icons.EllipsisVertical).Ghost(),
+            dropdownItems.ToArray());
 
         return actionsBar;
     }

--- a/src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs
@@ -10,7 +10,9 @@ namespace Ivy.Tendril.Apps.Review;
 ///     <see cref="ReviewActionConfig"/>, disabled when its precomputed condition isn't met,
 ///     otherwise running the action's PowerShell command in the plan folder. Renders nothing
 ///     (returns null) when the project defines no review actions, so callers can compose it
-///     unconditionally.
+///     unconditionally. The action list is unbounded, so buttons are only shown inline at the
+///     Wide breakpoint (see <see cref="ActionBarResponsive"/>); at every narrower breakpoint
+///     all actions collapse into a single overflow dropdown to avoid clipping.
 /// </summary>
 public class ReviewActionsBarView(
     PlanFile selectedPlan,
@@ -25,31 +27,40 @@ public class ReviewActionsBarView(
         if (reviewActions.Count == 0)
             return null;
 
+        void Run(ReviewActionConfig action)
+        {
+            if (!PlatformHelper.RunPowerShellAction(action.Command, selectedPlan.FolderPath, logger))
+            {
+                logger.LogWarning("Failed to run review action {ActionName}: pwsh not found", action.Name);
+            }
+        }
+
+        // The action list is project-configured and unbounded (arbitrary count, arbitrary
+        // label length), so a fixed number of inline buttons can never be guaranteed to fit.
+        // Inline buttons are only shown on a wide desktop monitor (>=1024px); at every other
+        // breakpoint all actions collapse into a single dropdown so the bar never overflows.
         var actionsBar = Layout.Horizontal().Gap(2).Padding(2, 2, 2, 0).Height(Size.Fit());
+        var dropdownItems = new List<MenuItem>();
         for (var i = 0; i < reviewActions.Count; i++)
         {
             var action = reviewActions[i];
             var conditionMet = i < reviewActionStates.Count && reviewActionStates[i].ConditionMet;
 
             var btn = new Button(action.Name).Icon(Icons.Play).Outline();
-            if (!conditionMet)
-            {
-                btn = btn.Disabled();
-            }
-            else
-            {
-                var actionCapture = action;
-                btn = btn.OnClick(() =>
-                {
-                    if (!PlatformHelper.RunPowerShellAction(actionCapture.Command, selectedPlan.FolderPath, logger))
-                    {
-                        logger.LogWarning("Failed to run review action {ActionName}: pwsh not found", actionCapture.Name);
-                    }
-                });
-            }
+            btn = conditionMet ? btn.OnClick(() => Run(action)) : btn.Disabled();
+            actionsBar |= btn.WideOnly();
 
-            actionsBar |= btn;
+            var menuItem = new MenuItem(action.Name, Icon: Icons.Play, Tag: action.Name).Disabled(!conditionMet);
+            if (conditionMet)
+            {
+                menuItem = menuItem.OnSelect(() => Run(action));
+            }
+            dropdownItems.Add(menuItem);
         }
+
+        actionsBar |= ActionBarResponsive.DropdownBelowWide(
+            new Button().Icon(Icons.EllipsisVertical).Ghost(),
+            dropdownItems.ToArray());
 
         return actionsBar;
     }

--- a/src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs
@@ -10,9 +10,12 @@ namespace Ivy.Tendril.Apps.Review;
 ///     <see cref="ReviewActionConfig"/>, disabled when its precomputed condition isn't met,
 ///     otherwise running the action's PowerShell command in the plan folder. Renders nothing
 ///     (returns null) when the project defines no review actions, so callers can compose it
-///     unconditionally. The action list is unbounded, so buttons are only shown inline at the
-///     Wide breakpoint (see <see cref="ActionBarResponsive"/>); at every narrower breakpoint
-///     all actions collapse into a single overflow dropdown to avoid clipping.
+///     unconditionally. The action list is unbounded, so only the first
+///     <see cref="MaxInlineAtWide"/> actions are ever shown inline, and only at the Wide
+///     breakpoint (see <see cref="ActionBarResponsive"/>); every other action — and
+///     everything at every narrower breakpoint — collapses into a single overflow dropdown
+///     that stays visible at Wide too, so an arbitrarily long or long-labeled action list
+///     can never clip the bar.
 /// </summary>
 public class ReviewActionsBarView(
     PlanFile selectedPlan,
@@ -20,6 +23,8 @@ public class ReviewActionsBarView(
     IConfigService config,
     ILogger logger) : ViewBase
 {
+    private const int MaxInlineAtWide = 4;
+
     public override object? Build()
     {
         var projectConfig = config.GetProject(selectedPlan.Project);
@@ -36,21 +41,29 @@ public class ReviewActionsBarView(
         }
 
         // The action list is project-configured and unbounded (arbitrary count, arbitrary
-        // label length), so a fixed number of inline buttons can never be guaranteed to fit.
-        // Inline buttons are only shown on a wide desktop monitor (>=1024px); at every other
-        // breakpoint all actions collapse into a single dropdown so the bar never overflows.
+        // label length), so a fixed number of inline buttons can never be guaranteed to fit
+        // even at the Wide breakpoint: cap the inline set at MaxInlineAtWide and always keep
+        // every action reachable via the dropdown, which stays visible at Wide too whenever
+        // there's overflow. Below Wide, no actions are shown inline at all.
         var actionsBar = Layout.Horizontal().Gap(2).Padding(2, 2, 2, 0).Height(Size.Fit());
         var dropdownItems = new List<MenuItem>();
+        var hasOverflowAtWide = reviewActions.Count > MaxInlineAtWide;
         for (var i = 0; i < reviewActions.Count; i++)
         {
             var action = reviewActions[i];
             var conditionMet = i < reviewActionStates.Count && reviewActionStates[i].ConditionMet;
 
-            var btn = new Button(action.Name).Icon(Icons.Play).Outline();
-            btn = conditionMet ? btn.OnClick(() => Run(action)) : btn.Disabled();
-            actionsBar |= btn.WideOnly();
+            if (i < MaxInlineAtWide)
+            {
+                var btn = new Button(action.Name).Icon(Icons.Play).Outline();
+                btn = conditionMet ? btn.OnClick(() => Run(action)) : btn.Disabled();
+                actionsBar |= btn.FullOnly();
+            }
 
-            var menuItem = new MenuItem(action.Name, Icon: Icons.Play, Tag: action.Name).Disabled(!conditionMet);
+            // Tag carries the loop index so duplicate action names don't misroute clicks or
+            // collide as React keys (MenuItem.GetSelectHandler dispatches on the first Tag match).
+            var menuItem = new MenuItem(action.Name, Icon: Icons.Play, Tag: $"{i}:{action.Name}")
+                .Disabled(!conditionMet);
             if (conditionMet)
             {
                 menuItem = menuItem.OnSelect(() => Run(action));
@@ -58,9 +71,10 @@ public class ReviewActionsBarView(
             dropdownItems.Add(menuItem);
         }
 
-        actionsBar |= ActionBarResponsive.DropdownBelowWide(
-            new Button().Icon(Icons.EllipsisVertical).Ghost(),
-            dropdownItems.ToArray());
+        var dropdownTrigger = new Button().Icon(Icons.EllipsisVertical).Ghost();
+        actionsBar |= hasOverflowAtWide
+            ? dropdownTrigger.WithDropDown(dropdownItems.ToArray())
+            : ActionBarResponsive.DropdownBelowWide(dropdownTrigger, dropdownItems.ToArray());
 
         return actionsBar;
     }

--- a/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
+++ b/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
@@ -13,13 +13,38 @@ namespace Ivy.Tendril.Helpers;
 ///   <item><c>Desktop</c> → 768px ≤ width &lt; 1024px</item>
 ///   <item><c>Wide</c>    → width ≥ 1024px</item>
 /// </list>
-/// A normal/large desktop monitor (≥1024px) therefore resolves to <c>Wide</c>, NOT
-/// <c>Desktop</c>. The three collapse tiers used by the action bars map to bands as:
+/// These bands are measured against the browser VIEWPORT, not the element's own
+/// rendered width. The Draft and Review footers, however, live in the CONTENT PANE,
+/// which is narrower than the viewport by roughly the app sidebar (~420px) plus —
+/// for these two apps specifically — a list pane (~350px) to its left. A ~1456px-wide
+/// viewport (comfortably <c>Wide</c>) can therefore leave a content pane only as wide
+/// as a much narrower viewport would give a full-width layout, so a naive "show
+/// everything at Wide" tier still clips (see issue #1433).
+///
+/// To account for this, the footer helpers below shift the button budget down by one
+/// viewport tier from what the numbers alone would suggest: a set that would safely
+/// fit a full-width element at <c>Desktop</c> is only shown inline once the viewport
+/// reaches <c>Wide</c>, and there is no viewport tier at which the widest, Full-tier-only
+/// button set is safe — those items are always reachable via the dropdown instead of
+/// ever being guaranteed inline. Do not "simplify" this back to the naive
+/// viewport-only mapping; it will reproduce the clipping bug.
 /// <list type="bullet">
-///   <item><b>Full</b> tier (everything visible) → <c>Wide</c></item>
-///   <item><b>Compact</b> tier (some buttons collapsed) → <c>Desktop</c></item>
-///   <item><b>Minimal</b> tier (most buttons collapsed) → <c>Mobile</c> + <c>Tablet</c></item>
+///   <item><b>Pane-Compact</b> tier (Previous/Next + a couple of primary actions inline) → <c>Wide</c> only</item>
+///   <item><b>Pane-Minimal</b> tier (only Previous/Next inline) → <c>Mobile</c> + <c>Tablet</c> + <c>Desktop</c></item>
 /// </list>
+///
+/// The project-configured review-actions row (<see cref="Apps.Review.ReviewActionsBarView"/>)
+/// has an unbounded, arbitrary-length item list, so even the Wide tier caps how many
+/// render inline and keeps the dropdown reachable at every breakpoint, including Wide.
+///
+/// <see cref="CompactUp"/>/<see cref="DropdownAtFull"/>/<see cref="DropdownAtCompact"/>/
+/// <see cref="DropdownAtMinimal"/> below are the plain, viewport-only tiers (no pane-width
+/// adjustment), kept only because <c>Apps.Recommendations.ContentView</c> still uses them.
+/// NOTE: Recommendations sits behind the same app-sidebar + list-pane geometry as Draft/Review
+/// (see <c>RecommendationsApp</c>'s <c>SidebarLayout</c> composition), so it likely has the
+/// same Wide-tier clipping risk as issue #1433 — it just wasn't in that issue's repro and is
+/// out of scope for this fix. Prefer the Pane-* helpers below for any bar in a SidebarLayout
+/// content pane; the plain viewport-only helpers are not proven safe for that geometry.
 /// </summary>
 public static class ActionBarResponsive
 {
@@ -33,8 +58,10 @@ public static class ActionBarResponsive
     }
 
     /// <summary>
-    /// Shows button only at the Full tier — a wide desktop monitor (width ≥1024px).
-    /// Hidden at the Compact and Minimal tiers, where the button collapses into a dropdown.
+    /// Shows button only at the Wide tier (viewport width ≥1024px). Hidden at every other
+    /// breakpoint, where the button collapses into a dropdown. Used for rows built from an
+    /// arbitrary, unbounded item count (e.g. project-configured actions), where fixed
+    /// button-count tiers can't safely guarantee everything fits below Wide.
     /// </summary>
     public static Button FullOnly(this Button btn)
     {
@@ -42,9 +69,54 @@ public static class ActionBarResponsive
     }
 
     /// <summary>
-    /// Shows button at the Compact tier and up — a wide monitor or the 768–1023px band
-    /// (<c>Desktop</c> + <c>Wide</c>). Hidden only at the Minimal tier (&lt;768px), where
-    /// the button collapses into a dropdown.
+    /// Creates a dropdown menu visible at every breakpoint except Wide (i.e. <c>Mobile</c> +
+    /// <c>Tablet</c> + <c>Desktop</c>, width &lt;1024px). Pairs with <see cref="FullOnly"/> for
+    /// rows with an arbitrary, unbounded item count: buttons are shown inline only on a wide
+    /// desktop monitor, everything else collapses into this single dropdown.
+    /// </summary>
+    public static DropDownMenu DropdownBelowWide(Button trigger, params MenuItem[] items)
+    {
+        return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet, Breakpoint.Desktop);
+    }
+
+    /// <summary>
+    /// Shows button only once the viewport reaches the Pane-Compact tier (<c>Wide</c>,
+    /// ≥1024px). Used for the Draft/Review footers, whose CONTENT PANE is narrower than
+    /// the viewport by the sidebar + list pane to its left (see the pane-width note on
+    /// this class); a button set that would fit a full-width element at <c>Desktop</c>
+    /// only fits the pane once the viewport itself reaches <c>Wide</c>.
+    /// </summary>
+    public static Button PaneCompactUp(this Button btn)
+    {
+        return btn.ShowOn(Breakpoint.Wide);
+    }
+
+    /// <summary>
+    /// Creates a dropdown menu visible only at the Pane-Compact tier (<c>Wide</c>,
+    /// ≥1024px). Holds the buttons not shown inline at this tier plus the standard
+    /// overflow items.
+    /// </summary>
+    public static DropDownMenu DropdownAtPaneCompact(Button trigger, params MenuItem[] items)
+    {
+        return trigger.WithDropDown(items).ShowOn(Breakpoint.Wide);
+    }
+
+    /// <summary>
+    /// Creates a dropdown menu visible at the Pane-Minimal tier (viewport width &lt;1024px,
+    /// i.e. <c>Mobile</c> + <c>Tablet</c> + <c>Desktop</c>). Holds every action button not
+    /// always-visible plus the standard overflow items — nothing beyond Previous/Next fits
+    /// the content pane below the Wide viewport tier.
+    /// </summary>
+    public static DropDownMenu DropdownAtPaneMinimal(Button trigger, params MenuItem[] items)
+    {
+        return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet, Breakpoint.Desktop);
+    }
+
+    /// <summary>
+    /// Plain viewport-only tier (no pane-width adjustment): shows button at the Compact tier
+    /// and up — a wide monitor or the 768–1023px band (<c>Desktop</c> + <c>Wide</c>). Hidden
+    /// only at the Minimal tier (&lt;768px). Kept for <c>Apps.Recommendations.ContentView</c>;
+    /// see the pane-width caveat on this class before reusing it elsewhere.
     /// </summary>
     public static Button CompactUp(this Button btn)
     {
@@ -52,8 +124,9 @@ public static class ActionBarResponsive
     }
 
     /// <summary>
-    /// Creates a dropdown menu visible only at the Full tier (width ≥1024px). Holds the
-    /// standard overflow items when all action buttons are shown inline.
+    /// Plain viewport-only tier: dropdown visible only at the Full/Wide tier (width ≥1024px).
+    /// Kept for <c>Apps.Recommendations.ContentView</c>; see the pane-width caveat on this
+    /// class before reusing it elsewhere.
     /// </summary>
     public static DropDownMenu DropdownAtFull(Button trigger, params MenuItem[] items)
     {
@@ -61,8 +134,9 @@ public static class ActionBarResponsive
     }
 
     /// <summary>
-    /// Creates a dropdown menu visible only at the Compact tier (768–1023px band).
-    /// Holds the buttons collapsed at this tier plus the standard overflow items.
+    /// Plain viewport-only tier: dropdown visible only at the Compact tier (768–1023px band).
+    /// Kept for <c>Apps.Recommendations.ContentView</c>; see the pane-width caveat on this
+    /// class before reusing it elsewhere.
     /// </summary>
     public static DropDownMenu DropdownAtCompact(Button trigger, params MenuItem[] items)
     {
@@ -70,34 +144,12 @@ public static class ActionBarResponsive
     }
 
     /// <summary>
-    /// Creates a dropdown menu visible only at the Minimal tier (width &lt;768px,
-    /// i.e. <c>Mobile</c> + <c>Tablet</c>). Holds the buttons collapsed at this tier
-    /// plus the standard overflow items.
+    /// Plain viewport-only tier: dropdown visible only at the Minimal tier (width &lt;768px,
+    /// i.e. <c>Mobile</c> + <c>Tablet</c>). Kept for <c>Apps.Recommendations.ContentView</c>;
+    /// see the pane-width caveat on this class before reusing it elsewhere.
     /// </summary>
     public static DropDownMenu DropdownAtMinimal(Button trigger, params MenuItem[] items)
     {
         return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
-    }
-
-    /// <summary>
-    /// Shows button only at the Wide tier (width ≥1024px). Hidden at every other
-    /// breakpoint, where the button collapses into a dropdown. Used for rows built from an
-    /// arbitrary, unbounded item count (e.g. project-configured actions), where fixed
-    /// button-count tiers can't safely guarantee everything fits below Wide.
-    /// </summary>
-    public static Button WideOnly(this Button btn)
-    {
-        return btn.ShowOn(Breakpoint.Wide);
-    }
-
-    /// <summary>
-    /// Creates a dropdown menu visible at every breakpoint except Wide (i.e. <c>Mobile</c> +
-    /// <c>Tablet</c> + <c>Desktop</c>, width &lt;1024px). Pairs with <see cref="WideOnly"/> for
-    /// rows with an arbitrary, unbounded item count: buttons are shown inline only on a wide
-    /// desktop monitor, everything else collapses into this single dropdown.
-    /// </summary>
-    public static DropDownMenu DropdownBelowWide(Button trigger, params MenuItem[] items)
-    {
-        return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet, Breakpoint.Desktop);
     }
 }

--- a/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
+++ b/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
@@ -22,12 +22,16 @@ namespace Ivy.Tendril.Helpers;
 /// everything at Wide" tier still clips (see issue #1433).
 ///
 /// To account for this, the footer helpers below shift the button budget down by one
-/// viewport tier from what the numbers alone would suggest: a set that would safely
-/// fit a full-width element at <c>Desktop</c> is only shown inline once the viewport
-/// reaches <c>Wide</c>, and there is no viewport tier at which the widest, Full-tier-only
-/// button set is safe — those items are always reachable via the dropdown instead of
-/// ever being guaranteed inline. Do not "simplify" this back to the naive
-/// viewport-only mapping; it will reproduce the clipping bug.
+/// viewport tier from what the numbers alone would suggest: a set that would fit a
+/// full-width element at <c>Desktop</c> is only shown inline once the viewport reaches
+/// <c>Wide</c>, and there is no viewport tier at which the widest, Full-tier-only button
+/// set is safe — those items are always reachable via the dropdown instead of ever being
+/// guaranteed inline. This still isn't watertight: <c>Wide</c> is unbounded above, so a
+/// pane at the narrow end of that band (roughly a 1024–1300px viewport, well short of the
+/// #1433 repro's ~1456px) can still clip the Pane-Compact-tier inline set — there's no
+/// lower tier to fall back to once <c>Wide</c> is reached. Do not "simplify" this back to
+/// the naive viewport-only mapping; it will reproduce the clipping bug, and don't read the
+/// Wide tier as a guarantee either.
 /// <list type="bullet">
 ///   <item><b>Pane-Compact</b> tier (Previous/Next + a couple of primary actions inline) → <c>Wide</c> only</item>
 ///   <item><b>Pane-Minimal</b> tier (only Previous/Next inline) → <c>Mobile</c> + <c>Tablet</c> + <c>Desktop</c></item>

--- a/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
+++ b/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
@@ -78,4 +78,26 @@ public static class ActionBarResponsive
     {
         return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
     }
+
+    /// <summary>
+    /// Shows button only at the Wide tier (width ≥1024px). Hidden at every other
+    /// breakpoint, where the button collapses into a dropdown. Used for rows built from an
+    /// arbitrary, unbounded item count (e.g. project-configured actions), where fixed
+    /// button-count tiers can't safely guarantee everything fits below Wide.
+    /// </summary>
+    public static Button WideOnly(this Button btn)
+    {
+        return btn.ShowOn(Breakpoint.Wide);
+    }
+
+    /// <summary>
+    /// Creates a dropdown menu visible at every breakpoint except Wide (i.e. <c>Mobile</c> +
+    /// <c>Tablet</c> + <c>Desktop</c>, width &lt;1024px). Pairs with <see cref="WideOnly"/> for
+    /// rows with an arbitrary, unbounded item count: buttons are shown inline only on a wide
+    /// desktop monitor, everything else collapses into this single dropdown.
+    /// </summary>
+    public static DropDownMenu DropdownBelowWide(Button trigger, params MenuItem[] items)
+    {
+        return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet, Breakpoint.Desktop);
+    }
 }

--- a/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
+++ b/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
@@ -1,54 +1,18 @@
 namespace Ivy.Tendril.Helpers;
 
 /// <summary>
-/// Helper for creating responsive action bars with progressive button collapse.
-/// Buttons collapse into dropdown menus as screen size decreases.
+/// Helpers for responsive action bars with progressive button collapse.
 ///
-/// IMPORTANT — breakpoint bands (see <see cref="Breakpoint"/> and the frontend
-/// <c>use-responsive.ts</c>): a breakpoint name maps to a width *band*, not a
-/// "this width and up" range:
-/// <list type="bullet">
-///   <item><c>Mobile</c>  → width &lt; 640px</item>
-///   <item><c>Tablet</c>  → 640px ≤ width &lt; 768px</item>
-///   <item><c>Desktop</c> → 768px ≤ width &lt; 1024px</item>
-///   <item><c>Wide</c>    → width ≥ 1024px</item>
-/// </list>
-/// These bands are measured against the browser VIEWPORT, not the element's own
-/// rendered width. The Draft and Review footers, however, live in the CONTENT PANE,
-/// which is narrower than the viewport by roughly the app sidebar (~420px) plus —
-/// for these two apps specifically — a list pane (~350px) to its left. A ~1456px-wide
-/// viewport (comfortably <c>Wide</c>) can therefore leave a content pane only as wide
-/// as a much narrower viewport would give a full-width layout, so a naive "show
-/// everything at Wide" tier still clips (see issue #1433).
+/// Breakpoints resolve against the APP CONTENT CONTAINER, not the raw viewport: the
+/// framework's AppHostWidget mounts a container-scoped BreakpointProvider, so an expanded
+/// app sidebar already narrows the measured width (see use-responsive.ts). Bands:
+/// Mobile &lt;640, Tablet 640–767, Desktop 768–1023, Wide ≥1024 (unbounded above).
 ///
-/// To account for this, the footer helpers below shift the button budget down by one
-/// viewport tier from what the numbers alone would suggest: a set that would fit a
-/// full-width element at <c>Desktop</c> is only shown inline once the viewport reaches
-/// <c>Wide</c>, and there is no viewport tier at which the widest, Full-tier-only button
-/// set is safe — those items are always reachable via the dropdown instead of ever being
-/// guaranteed inline. This still isn't watertight: <c>Wide</c> is unbounded above, so a
-/// pane at the narrow end of that band (roughly a 1024–1300px viewport, well short of the
-/// #1433 repro's ~1456px) can still clip the Pane-Compact-tier inline set — there's no
-/// lower tier to fall back to once <c>Wide</c> is reached. Do not "simplify" this back to
-/// the naive viewport-only mapping; it will reproduce the clipping bug, and don't read the
-/// Wide tier as a guarantee either.
-/// <list type="bullet">
-///   <item><b>Pane-Compact</b> tier (Previous/Next + a couple of primary actions inline) → <c>Wide</c> only</item>
-///   <item><b>Pane-Minimal</b> tier (only Previous/Next inline) → <c>Mobile</c> + <c>Tablet</c> + <c>Desktop</c></item>
-/// </list>
-///
-/// The project-configured review-actions row (<see cref="Apps.Review.ReviewActionsBarView"/>)
-/// has an unbounded, arbitrary-length item list, so even the Wide tier caps how many
-/// render inline and keeps the dropdown reachable at every breakpoint, including Wide.
-///
-/// <see cref="CompactUp"/>/<see cref="DropdownAtFull"/>/<see cref="DropdownAtCompact"/>/
-/// <see cref="DropdownAtMinimal"/> below are the plain, viewport-only tiers (no pane-width
-/// adjustment), kept only because <c>Apps.Recommendations.ContentView</c> still uses them.
-/// NOTE: Recommendations sits behind the same app-sidebar + list-pane geometry as Draft/Review
-/// (see <c>RecommendationsApp</c>'s <c>SidebarLayout</c> composition), so it likely has the
-/// same Wide-tier clipping risk as issue #1433 — it just wasn't in that issue's repro and is
-/// out of scope for this fix. Prefer the Pane-* helpers below for any bar in a SidebarLayout
-/// content pane; the plain viewport-only helpers are not proven safe for that geometry.
+/// A tier can still never GUARANTEE its inline set fits: inner list panes (e.g. the
+/// Draft/Review SidebarLayout) eat into the container, and sidebars are user-resizable
+/// (200–600px). Always pair these tiers with <c>.Wrap()</c> on the bar — FooterLayout's
+/// footer slot grows with its content, so a wrapped second row is the safe fallback where
+/// a single row would clip (issue #1433).
 /// </summary>
 public static class ActionBarResponsive
 {
@@ -62,65 +26,8 @@ public static class ActionBarResponsive
     }
 
     /// <summary>
-    /// Shows button only at the Wide tier (viewport width ≥1024px). Hidden at every other
-    /// breakpoint, where the button collapses into a dropdown. Used for rows built from an
-    /// arbitrary, unbounded item count (e.g. project-configured actions), where fixed
-    /// button-count tiers can't safely guarantee everything fits below Wide.
-    /// </summary>
-    public static Button FullOnly(this Button btn)
-    {
-        return btn.ShowOn(Breakpoint.Wide);
-    }
-
-    /// <summary>
-    /// Creates a dropdown menu visible at every breakpoint except Wide (i.e. <c>Mobile</c> +
-    /// <c>Tablet</c> + <c>Desktop</c>, width &lt;1024px). Pairs with <see cref="FullOnly"/> for
-    /// rows with an arbitrary, unbounded item count: buttons are shown inline only on a wide
-    /// desktop monitor, everything else collapses into this single dropdown.
-    /// </summary>
-    public static DropDownMenu DropdownBelowWide(Button trigger, params MenuItem[] items)
-    {
-        return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet, Breakpoint.Desktop);
-    }
-
-    /// <summary>
-    /// Shows button only once the viewport reaches the Pane-Compact tier (<c>Wide</c>,
-    /// ≥1024px). Used for the Draft/Review footers, whose CONTENT PANE is narrower than
-    /// the viewport by the sidebar + list pane to its left (see the pane-width note on
-    /// this class); a button set that would fit a full-width element at <c>Desktop</c>
-    /// only fits the pane once the viewport itself reaches <c>Wide</c>.
-    /// </summary>
-    public static Button PaneCompactUp(this Button btn)
-    {
-        return btn.ShowOn(Breakpoint.Wide);
-    }
-
-    /// <summary>
-    /// Creates a dropdown menu visible only at the Pane-Compact tier (<c>Wide</c>,
-    /// ≥1024px). Holds the buttons not shown inline at this tier plus the standard
-    /// overflow items.
-    /// </summary>
-    public static DropDownMenu DropdownAtPaneCompact(Button trigger, params MenuItem[] items)
-    {
-        return trigger.WithDropDown(items).ShowOn(Breakpoint.Wide);
-    }
-
-    /// <summary>
-    /// Creates a dropdown menu visible at the Pane-Minimal tier (viewport width &lt;1024px,
-    /// i.e. <c>Mobile</c> + <c>Tablet</c> + <c>Desktop</c>). Holds every action button not
-    /// always-visible plus the standard overflow items — nothing beyond Previous/Next fits
-    /// the content pane below the Wide viewport tier.
-    /// </summary>
-    public static DropDownMenu DropdownAtPaneMinimal(Button trigger, params MenuItem[] items)
-    {
-        return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet, Breakpoint.Desktop);
-    }
-
-    /// <summary>
-    /// Plain viewport-only tier (no pane-width adjustment): shows button at the Compact tier
-    /// and up — a wide monitor or the 768–1023px band (<c>Desktop</c> + <c>Wide</c>). Hidden
-    /// only at the Minimal tier (&lt;768px). Kept for <c>Apps.Recommendations.ContentView</c>;
-    /// see the pane-width caveat on this class before reusing it elsewhere.
+    /// Shows button at the Compact tier and up (container ≥768px, i.e. Desktop + Wide).
+    /// Hidden at the Minimal tier, where it collapses into a dropdown.
     /// </summary>
     public static Button CompactUp(this Button btn)
     {
@@ -128,9 +35,28 @@ public static class ActionBarResponsive
     }
 
     /// <summary>
-    /// Plain viewport-only tier: dropdown visible only at the Full/Wide tier (width ≥1024px).
-    /// Kept for <c>Apps.Recommendations.ContentView</c>; see the pane-width caveat on this
-    /// class before reusing it elsewhere.
+    /// Shows button only at the Full tier (container ≥1024px, Wide). At narrower tiers it
+    /// collapses into a dropdown.
+    /// </summary>
+    public static Button FullOnly(this Button btn)
+    {
+        return btn.ShowOn(Breakpoint.Wide);
+    }
+
+    /// <summary>
+    /// Shows button at every tier except Full (container &lt;1024px). Complement of
+    /// <see cref="FullOnly"/> — used for a shortcut-carrying stand-in that must stay
+    /// mounted while its labeled Full-tier counterpart is unmounted (ShowOn/HideOn truly
+    /// unmount, which deregisters a Button's ShortcutKey; MenuItem shortcuts are
+    /// display-only).
+    /// </summary>
+    public static Button BelowFull(this Button btn)
+    {
+        return btn.ShowOn(Breakpoint.Mobile, Breakpoint.Tablet, Breakpoint.Desktop);
+    }
+
+    /// <summary>
+    /// Dropdown visible only at the Full tier (Wide). Holds the standard overflow items.
     /// </summary>
     public static DropDownMenu DropdownAtFull(Button trigger, params MenuItem[] items)
     {
@@ -138,9 +64,8 @@ public static class ActionBarResponsive
     }
 
     /// <summary>
-    /// Plain viewport-only tier: dropdown visible only at the Compact tier (768–1023px band).
-    /// Kept for <c>Apps.Recommendations.ContentView</c>; see the pane-width caveat on this
-    /// class before reusing it elsewhere.
+    /// Dropdown visible only at the Compact tier (Desktop, 768–1023px). Holds the buttons
+    /// not shown inline at this tier plus the standard overflow items.
     /// </summary>
     public static DropDownMenu DropdownAtCompact(Button trigger, params MenuItem[] items)
     {
@@ -148,12 +73,21 @@ public static class ActionBarResponsive
     }
 
     /// <summary>
-    /// Plain viewport-only tier: dropdown visible only at the Minimal tier (width &lt;768px,
-    /// i.e. <c>Mobile</c> + <c>Tablet</c>). Kept for <c>Apps.Recommendations.ContentView</c>;
-    /// see the pane-width caveat on this class before reusing it elsewhere.
+    /// Dropdown visible only at the Minimal tier (container &lt;768px, Mobile + Tablet).
+    /// Holds every action button not always-visible plus the standard overflow items.
     /// </summary>
     public static DropDownMenu DropdownAtMinimal(Button trigger, params MenuItem[] items)
     {
         return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
+    }
+
+    /// <summary>
+    /// Dropdown visible at every tier except Full (container &lt;1024px). Pairs with
+    /// <see cref="FullOnly"/> buttons for bars whose entire item set collapses into one
+    /// dropdown below the Full tier.
+    /// </summary>
+    public static DropDownMenu DropdownBelowWide(Button trigger, params MenuItem[] items)
+    {
+        return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet, Breakpoint.Desktop);
     }
 }


### PR DESCRIPTION
Fixes #1433

## Problem
Draft and Review footer buttons clipped off-screen at certain widths (issue screenshot: Delete cut off at a ~1456px window). A first fix attempt collapsed the footers into pane-shifted tiers, but it was built on a wrong premise — that Ivy breakpoints are viewport-keyed. They aren't: `AppHostWidget` mounts a container-scoped `BreakpointProvider` (Ivy ≥ 1.2.67), so `ShowOn` already accounts for the app sidebar. The over-correction capped every footer at 4 inline buttons and `ReviewActionsBarView` at 4 actions no matter how wide the screen.

## Approach
Generous tiers + wrap as the clipping guard:
- **Wide** (app container ≥1024px): everything inline — all 7 Draft footer buttons, all 5 Review footer buttons, and every project-configured review action.
- **Desktop** (768–1023px): middle set inline, rest in a dropdown.
- **Below**: Previous/Next + dropdown.
- **`.Wrap()` on every bar**: the drafts/plans list pane and user-resizable sidebars (200–600px) can squeeze a bar below what its tier's inline set needs — the row then wraps onto a second line instead of clipping. `FooterLayout`'s footer slot is `flex-none`, so it grows with wrapped content (the earlier "fixed-height footer" claim was wrong).

Kept from the earlier iteration:
- Backspace Delete/Discard shortcut via an icon-only carrier button, now mounted only below Wide (`BelowFull`) where the labeled button — which carries the shortcut at Wide — is unmounted.
- Index-prefixed MenuItem tags in `ReviewActionsBarView` so duplicate action names don't misroute clicks.

## Verification
- Ran the app from this branch against a scratch `TENDRIL_HOME` (project with 7 review actions, plans in Draft and Review) and exercised it in a browser at 1800 / 1300 / 1150 / 980 / 700 px:
  - 1800px: all 7 Draft footer buttons, all 7 review actions, full Review footer inline
  - 1300px (the previously-clipping squeeze band): bars wrap to a second row, nothing clipped
  - 980px: tiers collapse into dropdowns (all 7 actions present), Backspace carrier visible
  - 700px: minimal footer, single row
- dotnet build: 0 warnings, 0 errors
- Full test suite: 1755 passed / 0 failed
- dotnet format: only pre-existing violations in files this PR doesn't touch (`ProcessCheckHelper.cs`, `BugReportService.cs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)