### PR TITLE
[1433] Migrate Recommendations footer to pane-aware responsive tiers

### DIFF
--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -173,47 +173,66 @@ public class ContentView(
                 showPlan(fullPath);
         }
 
-        // Full-tier dropdown: standard overflow items only (all buttons shown inline)
-        var fullDropdownItems = standardOverflowItems;
-
-        // Compact-tier dropdown: View Plan + standard overflow
-        var compactDropdownItems = new List<MenuItem>
+        // Pane-Compact-tier dropdown: View Plan + standard overflow. See the pane-width note
+        // on ActionBarResponsive: the Recommendations footer's content pane is narrower than
+        // the viewport by the app sidebar + recommendations-list pane to its left, so even at
+        // the Wide viewport tier only Previous/Next/Accept with Notes fit inline.
+        var paneCompactDropdownItems = new List<MenuItem>
         {
             new MenuItem("View Plan", Icon: Icons.ExternalLink, Tag: "ViewPlan").OnSelect(ViewPlan)
         };
-        compactDropdownItems.AddRange(standardOverflowItems);
+        paneCompactDropdownItems.AddRange(standardOverflowItems);
 
-        // Minimal-tier dropdown: Accept with Notes, View Plan + standard overflow
-        var minimalDropdownItems = new List<MenuItem>
+        // Pane-Minimal-tier dropdown: all action buttons + standard overflow
+        var paneMinimalDropdownItems = new List<MenuItem>
         {
             new MenuItem("Accept with Notes", Icon: Icons.CircleCheck, Tag: "AcceptWithNotes")
                 .OnSelect(() => showNotesDialog()),
             new MenuItem("View Plan", Icon: Icons.ExternalLink, Tag: "ViewPlan").OnSelect(ViewPlan)
         };
-        minimalDropdownItems.AddRange(standardOverflowItems);
+        paneMinimalDropdownItems.AddRange(standardOverflowItems);
 
-        // Action bar without .Wrap() - single row with progressive collapse.
-        // Full (>=1024px): Previous, Next, Accept with Notes, View Plan inline + overflow dropdown.
-        // Compact (768-1023px): Previous, Next, Accept with Notes inline; View Plan in dropdown.
-        // Minimal (<768px): Previous, Next inline; everything else in dropdown.
+        // Action bar without .Wrap() - the footer slot is fixed-height, so wrapping could
+        // push content out; a single row with progressive collapse is required instead.
+        //
+        // These tiers are keyed to the CONTENT PANE, not the raw viewport — see the
+        // pane-width note on ActionBarResponsive. The pane is narrower than the viewport
+        // by the app sidebar + recommendations-list pane to its left, so the budget for
+        // each tier is shifted down by one viewport step from what a full-width bar would use:
+        // Pane-Compact tier (viewport >=1024px / Wide): Previous, Next, Accept with Notes inline; View Plan in dropdown.
+        // Pane-Minimal tier (viewport <1024px): Previous, Next inline; everything else in dropdown.
+        // View Plan never gets an inline slot at any viewport width — the pane is never wide
+        // enough to guarantee it fits, so it's always dropdown-only.
+        //
+        // The framework only registers a Button's ShortcutKey while that Button is mounted
+        // (useShortcut's cleanup runs on unmount), and ShowOn/HideOn/PaneCompactUp/etc. truly
+        // unmount the widget rather than just hiding it with CSS (see MemoizedWidget in
+        // widgetRenderer.tsx: `if (visible === false) return null`). Accept with Notes carries
+        // a ShortcutKey and is dropdown-only below the Pane-Compact tier, so its shortcut has
+        // to live on an icon-only Button that stays mounted at every tier instead —
+        // MenuItem.Shortcut is display-only (just a Kbd hint) and never registers a keyboard
+        // handler.
         var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                         | new Button("Previous").Icon(Icons.ChevronLeft).Outline().ShortcutKey("p")
                             .OnClick(GoToPrevious).AlwaysVisible()
                         | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().ShortcutKey("n")
                             .OnClick(GoToNext).AlwaysVisible()
-                        | new Button("Accept with Notes").Icon(Icons.CircleCheck).Outline().ShortcutKey("w")
-                            .OnClick(() => showNotesDialog()).CompactUp()
-                        | new Button("View Plan").Icon(Icons.ExternalLink).Outline()
-                            .OnClick(ViewPlan).FullOnly()
-                        | ActionBarResponsive.DropdownAtFull(
+                        | new Button("Accept with Notes").Icon(Icons.CircleCheck).Outline()
+                            .OnClick(() => showNotesDialog()).PaneCompactUp()
+                        // Icon-only, always-mounted carrier for the "w" shortcut — Accept with
+                        // Notes itself is dropdown-only below the Pane-Compact tier (see note
+                        // above), so this keeps the keyboard shortcut alive without
+                        // reintroducing a labeled inline button that can clip.
+                        | new Button().Icon(Icons.CircleCheck).Ghost().ShortcutKey("w")
+                            .Tooltip("Accept with Notes").OnClick(() => showNotesDialog()).AlwaysVisible()
+                        // Pane-Compact-tier dropdown: View Plan + standard overflow
+                        | ActionBarResponsive.DropdownAtPaneCompact(
                             new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                            fullDropdownItems)
-                        | ActionBarResponsive.DropdownAtCompact(
+                            paneCompactDropdownItems.ToArray())
+                        // Pane-Minimal-tier dropdown: all action buttons + standard overflow
+                        | ActionBarResponsive.DropdownAtPaneMinimal(
                             new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                            compactDropdownItems.ToArray())
-                        | ActionBarResponsive.DropdownAtMinimal(
-                            new Button().Icon(Icons.EllipsisVertical).Ghost(),
-                            minimalDropdownItems.ToArray());
+                            paneMinimalDropdownItems.ToArray());
 
         var mainLayout = new HeaderLayout(
             header,

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -204,27 +204,16 @@ public class ContentView(
         // View Plan never gets an inline slot at any viewport width — the pane is never wide
         // enough to guarantee it fits, so it's always dropdown-only.
         //
-        // The framework only registers a Button's ShortcutKey while that Button is mounted
-        // (useShortcut's cleanup runs on unmount), and ShowOn/HideOn/PaneCompactUp/etc. truly
-        // unmount the widget rather than just hiding it with CSS (see MemoizedWidget in
-        // widgetRenderer.tsx: `if (visible === false) return null`). Accept with Notes carries
-        // a ShortcutKey and is dropdown-only below the Pane-Compact tier, so its shortcut has
-        // to live on an icon-only Button that stays mounted at every tier instead —
-        // MenuItem.Shortcut is display-only (just a Kbd hint) and never registers a keyboard
-        // handler.
+        // Accept with Notes carries its ShortcutKey directly and is dropdown-only below the
+        // Pane-Compact tier, so "w" stops working below that tier — the same tradeoff Draft
+        // makes for Edit("E")/Update("u") and Review makes for Reset("r")/Request Changes("c").
         var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(2)
                         | new Button("Previous").Icon(Icons.ChevronLeft).Outline().ShortcutKey("p")
                             .OnClick(GoToPrevious).AlwaysVisible()
                         | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().ShortcutKey("n")
                             .OnClick(GoToNext).AlwaysVisible()
-                        | new Button("Accept with Notes").Icon(Icons.CircleCheck).Outline()
+                        | new Button("Accept with Notes").Icon(Icons.CircleCheck).Outline().ShortcutKey("w")
                             .OnClick(() => showNotesDialog()).PaneCompactUp()
-                        // Icon-only, always-mounted carrier for the "w" shortcut — Accept with
-                        // Notes itself is dropdown-only below the Pane-Compact tier (see note
-                        // above), so this keeps the keyboard shortcut alive without
-                        // reintroducing a labeled inline button that can clip.
-                        | new Button().Icon(Icons.CircleCheck).Ghost().ShortcutKey("w")
-                            .Tooltip("Accept with Notes").OnClick(() => showNotesDialog()).AlwaysVisible()
                         // Pane-Compact-tier dropdown: View Plan + standard overflow
                         | ActionBarResponsive.DropdownAtPaneCompact(
                             new Button().Icon(Icons.EllipsisVertical).Ghost(),

--- a/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
+++ b/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
@@ -14,9 +14,9 @@ namespace Ivy.Tendril.Helpers;
 ///   <item><c>Wide</c>    → width ≥ 1024px</item>
 /// </list>
 /// These bands are measured against the browser VIEWPORT, not the element's own
-/// rendered width. The Draft and Review footers, however, live in the CONTENT PANE,
-/// which is narrower than the viewport by roughly the app sidebar (~420px) plus —
-/// for these two apps specifically — a list pane (~350px) to its left. A ~1456px-wide
+/// rendered width. The Draft, Review, and Recommendations footers, however, live in the
+/// CONTENT PANE, which is narrower than the viewport by roughly the app sidebar (~420px)
+/// plus — for these apps specifically — a list pane (~350px) to its left. A ~1456px-wide
 /// viewport (comfortably <c>Wide</c>) can therefore leave a content pane only as wide
 /// as a much narrower viewport would give a full-width layout, so a naive "show
 /// everything at Wide" tier still clips (see issue #1433).
@@ -40,15 +40,9 @@ namespace Ivy.Tendril.Helpers;
 /// The project-configured review-actions row (<see cref="Apps.Review.ReviewActionsBarView"/>)
 /// has an unbounded, arbitrary-length item list, so even the Wide tier caps how many
 /// render inline and keeps the dropdown reachable at every breakpoint, including Wide.
-///
-/// <see cref="CompactUp"/>/<see cref="DropdownAtFull"/>/<see cref="DropdownAtCompact"/>/
-/// <see cref="DropdownAtMinimal"/> below are the plain, viewport-only tiers (no pane-width
-/// adjustment), kept only because <c>Apps.Recommendations.ContentView</c> still uses them.
-/// NOTE: Recommendations sits behind the same app-sidebar + list-pane geometry as Draft/Review
-/// (see <c>RecommendationsApp</c>'s <c>SidebarLayout</c> composition), so it likely has the
-/// same Wide-tier clipping risk as issue #1433 — it just wasn't in that issue's repro and is
-/// out of scope for this fix. Prefer the Pane-* helpers below for any bar in a SidebarLayout
-/// content pane; the plain viewport-only helpers are not proven safe for that geometry.
+/// That row is also the last caller of the plain, viewport-only <see cref="FullOnly"/> /
+/// <see cref="DropdownBelowWide"/> pair below — its item count is unbounded, so it can't
+/// use fixed button-count Pane-* tiers the way Drafts/Review/Recommendations footers do.
 /// </summary>
 public static class ActionBarResponsive
 {
@@ -85,10 +79,10 @@ public static class ActionBarResponsive
 
     /// <summary>
     /// Shows button only once the viewport reaches the Pane-Compact tier (<c>Wide</c>,
-    /// ≥1024px). Used for the Draft/Review footers, whose CONTENT PANE is narrower than
-    /// the viewport by the sidebar + list pane to its left (see the pane-width note on
-    /// this class); a button set that would fit a full-width element at <c>Desktop</c>
-    /// only fits the pane once the viewport itself reaches <c>Wide</c>.
+    /// ≥1024px). Used for the Draft/Review/Recommendations footers, whose CONTENT PANE is
+    /// narrower than the viewport by the sidebar + list pane to its left (see the
+    /// pane-width note on this class); a button set that would fit a full-width element
+    /// at <c>Desktop</c> only fits the pane once the viewport itself reaches <c>Wide</c>.
     /// </summary>
     public static Button PaneCompactUp(this Button btn)
     {
@@ -114,46 +108,5 @@ public static class ActionBarResponsive
     public static DropDownMenu DropdownAtPaneMinimal(Button trigger, params MenuItem[] items)
     {
         return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet, Breakpoint.Desktop);
-    }
-
-    /// <summary>
-    /// Plain viewport-only tier (no pane-width adjustment): shows button at the Compact tier
-    /// and up — a wide monitor or the 768–1023px band (<c>Desktop</c> + <c>Wide</c>). Hidden
-    /// only at the Minimal tier (&lt;768px). Kept for <c>Apps.Recommendations.ContentView</c>;
-    /// see the pane-width caveat on this class before reusing it elsewhere.
-    /// </summary>
-    public static Button CompactUp(this Button btn)
-    {
-        return btn.ShowOn(Breakpoint.Desktop, Breakpoint.Wide);
-    }
-
-    /// <summary>
-    /// Plain viewport-only tier: dropdown visible only at the Full/Wide tier (width ≥1024px).
-    /// Kept for <c>Apps.Recommendations.ContentView</c>; see the pane-width caveat on this
-    /// class before reusing it elsewhere.
-    /// </summary>
-    public static DropDownMenu DropdownAtFull(Button trigger, params MenuItem[] items)
-    {
-        return trigger.WithDropDown(items).ShowOn(Breakpoint.Wide);
-    }
-
-    /// <summary>
-    /// Plain viewport-only tier: dropdown visible only at the Compact tier (768–1023px band).
-    /// Kept for <c>Apps.Recommendations.ContentView</c>; see the pane-width caveat on this
-    /// class before reusing it elsewhere.
-    /// </summary>
-    public static DropDownMenu DropdownAtCompact(Button trigger, params MenuItem[] items)
-    {
-        return trigger.WithDropDown(items).ShowOn(Breakpoint.Desktop);
-    }
-
-    /// <summary>
-    /// Plain viewport-only tier: dropdown visible only at the Minimal tier (width &lt;768px,
-    /// i.e. <c>Mobile</c> + <c>Tablet</c>). Kept for <c>Apps.Recommendations.ContentView</c>;
-    /// see the pane-width caveat on this class before reusing it elsewhere.
-    /// </summary>
-    public static DropDownMenu DropdownAtMinimal(Button trigger, params MenuItem[] items)
-    {
-        return trigger.WithDropDown(items).ShowOn(Breakpoint.Mobile, Breakpoint.Tablet);
     }
 }


### PR DESCRIPTION
Follow-up to #1433 / stacked on #1687 — merge #1687 first (GitHub will retarget this PR to development automatically when the base branch merges).

**Problem:** Recommendations ContentView footer (Previous/Next/Accept with Notes/View Plan) still used the viewport-only tiers behind the identical SidebarLayout pane geometry as Drafts/Review, so it had the same latent Wide-breakpoint clipping found in #1433.

**Changes:** Migrated the action bar to PaneCompactUp/DropdownAtPaneCompact/DropdownAtPaneMinimal mirroring the Draft/Review pattern; Accept with Notes keeps ShortcutKey("w") on the labeled button (works at the Pane-Compact tier, same tradeoff as Draft's Edit/Update); removed the now caller-less legacy helpers CompactUp/DropdownAtFull/DropdownAtCompact/DropdownAtMinimal from ActionBarResponsive.cs and updated its header comment.

**Verification:** dotnet build green (0 warnings, NuGet Ivy), dotnet format clean, Recommendation/ActionBar tests 65 passed / 0 failed, review + verification pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)