### PR TITLE
fix: show agent loading state during onboarding project setup spin-up

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -258,7 +258,11 @@ public class ProjectAgentStepView(
             }
         }, setupTrigger != null ? [setupTrigger, EffectTrigger.OnMount()] : [EffectTrigger.OnMount()]);
 
-        var running = session.Running.Value || isCloning.Value || (setupTrigger != null && setupTrigger.Value && !session.Started.Value);
+        // With no setupTrigger the run starts on mount, so the step counts as
+        // about-to-start from the moment it renders until the session has started.
+        var aboutToStart = (setupTrigger == null || setupTrigger.Value) && !session.Started.Value;
+
+        var running = session.Running.Value || isCloning.Value || aboutToStart;
 
         var buttonArea = Layout.Horizontal().Width(Size.Full())
             | new Button("Back").Outline().Large().Icon(Icons.ArrowLeft)
@@ -273,7 +277,6 @@ public class ProjectAgentStepView(
         // output arrives, the AgentViewer's own status label (below the stream) shows the
         // "Starting…" loading indicator, so we don't render a separate Loading() above it —
         // that avoided a layout shift when the bordered/padded Box swapped in on first output.
-        var aboutToStart = setupTrigger != null && setupTrigger.Value && !session.Started.Value;
         var showStream = !isCloning.Value && (session.Running.Value || session.HasOutput.Value || aboutToStart);
 
         var viewer = new AgentViewer()


### PR DESCRIPTION
## Summary
Fixes #1689 — the noticeable dead period during onboarding when the agent is spinning up.

The Add Project dialog (Configuration app) was already fixed in d25db3fd / cdc3b391 by rendering the AgentViewer (with its own "Starting…" status) as soon as the run is triggered — but that about-to-start state was keyed on `setupTrigger`, which only the dialog passes. `OnboardingApp` mounts the same `ProjectAgentStepView` **without** a `setupTrigger`, so in onboarding, after the cloning phase finished, nothing indicated progress during the agent health check, auth verification, and runner spin-up — and the Next button was briefly enabled.

## Change
With no `setupTrigger` the run starts on mount, so the step now counts as about-to-start from first render until the session has started. This makes onboarding match the dialog: the AgentViewer's "Starting…" indicator shows immediately and Next stays disabled through spin-up. Dialog behavior is unchanged (`setupTrigger == null || setupTrigger.Value` reduces to the previous expression when a trigger is passed).

## Testing
- `dotnet build Ivy.Tendril` — clean, 0 warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)