### PR TITLE
[00651] Add Actionable Buttons to Update Available Notification

### DIFF
--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -200,8 +200,8 @@ public class WallpaperApp : ViewBase
                 }
                 else
                 {
-                    verticalContent |= Text.Block("Run this command in your terminal to update:").Small()
-                        | new CodeBlock(updateCommand, Languages.Bash);
+                    verticalContent |= Text.Block("Run this command in your terminal to update:").Small();
+                    verticalContent |= new CodeBlock(updateCommand, Languages.Bash);
                 }
 
                 verticalContent |= actions;

--- a/src/Ivy.Tendril/Apps/WallpaperApp.cs
+++ b/src/Ivy.Tendril/Apps/WallpaperApp.cs
@@ -177,15 +177,35 @@ public class WallpaperApp : ViewBase
                         })
                         .Small();
                 }
+                else
+                {
+                    actions |= new Button("Copy Command", () =>
+                        {
+                            copyToClipboard(updateCommand);
+                            client.Toast("Update command copied to clipboard", "Copied");
+                        })
+                        .Small();
+                }
                 actions |= dismissButton;
 
-                content = Layout.Vertical()
+                var verticalContent = Layout.Vertical()
                     | Text.Rich()
                         .Bold($"v{versionInfo.Value!.LatestVersion}")
                         .Run($" is available (you have v{versionInfo.Value.CurrentVersion})")
-                        .Small()
-                    | new CodeBlock(updateCommand, Languages.Bash)
-                    | actions;
+                        .Small();
+
+                if (versionService.CanSelfUpdate)
+                {
+                    verticalContent |= Text.Block("Click Update Now to download and install automatically. Tendril will restart.").Small();
+                }
+                else
+                {
+                    verticalContent |= Text.Block("Run this command in your terminal to update:").Small()
+                        | new CodeBlock(updateCommand, Languages.Bash);
+                }
+
+                verticalContent |= actions;
+                content = verticalContent;
             }
 
             var notification = new FloatingPanel(


### PR DESCRIPTION
Fixes #1532

# Summary

## Changes

Enhanced the WallpaperApp update notification panel with actionable buttons and clear instructional text for both Velopack and non-Velopack installs. Velopack users now see explanatory text about automatic updates, while non-Velopack users get a "Copy Command" button that puts the update command on their clipboard with a confirmation toast.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/WallpaperApp.cs` — Enhanced update notification UI with conditional content for different install types

## Manual Testing

1. Launch Tendril (non-Velopack install)
2. Open Settings and click "Check for updates" in the sidebar
3. If an update is available, observe the floating notification in the bottom-right corner
4. **For non-Velopack installs:** Verify the notification shows:
   - Text: "Run this command in your terminal to update:"
   - A code block with the update command
   - A "Copy Command" button (primary action)
   - A "Dismiss" button (secondary action)
5. Click "Copy Command" and verify:
   - A toast appears: "Update command copied to clipboard"
   - The command is available in the system clipboard
6. **For Velopack installs:** Verify the notification shows:
   - Text: "Click Update Now to download and install automatically. Tendril will restart."
   - An "Update Now" button (primary action)
   - A "Dismiss" button (secondary action)
   - No code block (Velopack users don't need terminal commands)

---
## Commits
- 443dc1f4 Add actionable buttons to update available notification
- e58549ae Fix build error in layout pipe operator usage

---
Created using [Ivy Tendril](https://ivy.app).
