### PR TITLE
feat: highlight selected sidebar list item with filled background

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/SidebarView.cs
@@ -78,7 +78,8 @@ public class SidebarView(
             }
             badges |= new Badge(plan.Level).Color(config.GetLevelColor(plan.Level) ?? Colors.Gray).Small();
 
-            return SidebarListRow.Build($"#{plan.Id} {plan.Title}", badges, () => selectedPlanState.Set(clickablePlan));
+            return SidebarListRow.Build($"#{plan.Id} {plan.Title}", badges, () => selectedPlanState.Set(clickablePlan),
+                plan.FolderName == selectedPlanState.Value?.FolderName);
         }));
 
         return new HeaderLayout(BuildHeader(), content);

--- a/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
@@ -70,7 +70,8 @@ public class SidebarView(
                     .WithProjectColor(config, plan.Project)
                 | new Badge(plan.Level).Color(config.GetLevelColor(plan.Level) ?? Colors.Gray).Small();
 
-            return SidebarListRow.Build($"#{plan.Id} {plan.Title}", badges, () => selectedPlanState.Set(clickablePlan));
+            return SidebarListRow.Build($"#{plan.Id} {plan.Title}", badges, () => selectedPlanState.Set(clickablePlan),
+                plan.FolderName == selectedPlanState.Value?.FolderName);
         }));
 
         return new HeaderLayout(BuildHeader(), content);

--- a/src/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/SidebarView.cs
@@ -90,7 +90,7 @@ public class SidebarView(
                 }).Small();
 
             return SidebarListRow.Build($"#{rec.ShortPlanId} {rec.Title}", badges,
-                () => selectedState.Set(clickableRec));
+                () => selectedState.Set(clickableRec), Equals(rec, selectedState.Value));
         }));
 
         return new HeaderLayout(BuildHeader(), content);

--- a/src/Ivy.Tendril/Apps/Review/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/SidebarView.cs
@@ -74,7 +74,8 @@ public class SidebarView(
                     ? new Badge("Unverified").Variant(BadgeVariant.Warning).Small()
                     : null);
 
-            return SidebarListRow.Build($"#{plan.Id} {plan.Title}", badges, () => selectedPlanState.Set(clickablePlan));
+            return SidebarListRow.Build($"#{plan.Id} {plan.Title}", badges, () => selectedPlanState.Set(clickablePlan),
+                plan.FolderName == selectedPlanState.Value?.FolderName);
         }));
 
         return new HeaderLayout(BuildHeader(), content);

--- a/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
@@ -20,7 +20,6 @@ public class SettingsApp : ViewBase
     internal const string TagProjects = "projects";
     private const string TagTunnel = "tunnel";
     private const string TagAdvanced = "advanced";
-    private const string TagOpenConfig = "open-config";
 
     public override object Build()
     {
@@ -34,46 +33,31 @@ public class SettingsApp : ViewBase
         var isDesktop = desktopWindow != null;
         var capturedHost = ConfigYamlUiHelper.CaptureHost(httpContextAccessor);
 
-        var children = new List<MenuItem>
+        var sections = new List<(string Label, string Tag, Icons Icon)>
         {
-            MenuItem.Default("Coding Agent", TagCodingAgent).Icon(Icons.Bot),
-            MenuItem.Default("Plans", TagPlans).Icon(Icons.Feather),
-            MenuItem.Default("Appearance", TagAppearance).Icon(Icons.Sun),
-            MenuItem.Default("Projects", TagProjects).Icon(Icons.Folder),
-            MenuItem.Default("Verifications", TagVerifications).Icon(Icons.CircleCheck),
-            MenuItem.Default("Promptwares", TagPromptwares).Icon(Icons.Wand),
-            MenuItem.Default("Levels", TagLevels).Icon(Icons.ListOrdered),
-            MenuItem.Default("Notifications", TagNotifications).Icon(Icons.Bell),
-            MenuItem.Default("Security", TagSecurity).Icon(Icons.Lock),
+            ("Coding Agent", TagCodingAgent, Icons.Bot),
+            ("Plans", TagPlans, Icons.Feather),
+            ("Appearance", TagAppearance, Icons.Sun),
+            ("Projects", TagProjects, Icons.Folder),
+            ("Verifications", TagVerifications, Icons.CircleCheck),
+            ("Promptwares", TagPromptwares, Icons.Wand),
+            ("Levels", TagLevels, Icons.ListOrdered),
+            ("Notifications", TagNotifications, Icons.Bell),
+            ("Security", TagSecurity, Icons.Lock),
+            ("Tunnel", TagTunnel, Icons.Globe),
+            ("Advanced", TagAdvanced, Icons.Cog),
         };
 
-        children.Add(MenuItem.Default("Tunnel", TagTunnel).Icon(Icons.Globe));
-        children.Add(MenuItem.Default("Advanced", TagAdvanced).Icon(Icons.Cog));
-        children.Add(MenuItem.Default("Open config.yaml", TagOpenConfig).Icon(Icons.FileText));
+        var rows = sections
+            .Select(s => SidebarListRow.Build(s.Label, s.Icon, () => selected.Set(s.Tag), selected.Value == s.Tag))
+            .Append(SidebarListRow.Build("Open config.yaml", Icons.FileText,
+                () => ConfigYamlUiHelper.OpenOrNavigate(config, navigator, client, isDesktop, capturedHost)));
 
-        var menuItems = new[]
-        {
-            MenuItem.Default("Configuration")
-                .Icon(Icons.Settings2)
-                .Expanded()
-                .Children(children.ToArray())
-        };
+        var sidebarHeader = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Height(Size.Px(40))
+            | Icons.Settings2.ToIcon()
+            | Text.Literal("Configuration");
 
-        void OnSelect(Event<SidebarMenu, object> @event)
-        {
-            if (@event.Value is not string tag) return;
-            switch (tag)
-            {
-                case TagOpenConfig:
-                    ConfigYamlUiHelper.OpenOrNavigate(config, navigator, client, isDesktop, capturedHost);
-                    break;
-                default:
-                    selected.Set(tag);
-                    break;
-            }
-        }
-
-        var sidebar = new SidebarMenu(OnSelect, menuItems);
+        var sidebar = new HeaderLayout(sidebarHeader, new List(rows));
 
         object content = selected.Value switch
         {
@@ -91,10 +75,6 @@ public class SettingsApp : ViewBase
             _ => new CodingAgentSetupView()
         };
 
-        var sections = children
-            .Where(m => m.Tag is string t && t != TagOpenConfig)
-            .Select(m => (Tag: (string)m.Tag!, Label: m.Label ?? ""))
-            .ToList();
         var currentLabel = sections.FirstOrDefault(s => s.Tag == selected.Value).Label ?? "Configuration";
 
         var mobileHeader = MobileItemPicker.Build(

--- a/src/Ivy.Tendril/Apps/Trash/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Trash/SidebarView.cs
@@ -47,7 +47,8 @@ public class SidebarView(
                 | new Badge(item.Project).Variant(BadgeVariant.Outline).Small()
                 | Text.Muted(item.Date.ToString("yyyy-MM-dd")).Small();
 
-            return SidebarListRow.Build(item.FileName.Replace(".md", ""), badges, () => selectedFile.Set(item.FilePath));
+            return SidebarListRow.Build(item.FileName.Replace(".md", ""), badges, () => selectedFile.Set(item.FilePath),
+                item.FilePath == selectedFile.Value);
         }));
 
         return new HeaderLayout(BuildHeader(), content);

--- a/src/Ivy.Tendril/Helpers/SidebarListRow.cs
+++ b/src/Ivy.Tendril/Helpers/SidebarListRow.cs
@@ -16,6 +16,15 @@ public static class SidebarListRow
         return BuildButton(Text.Literal(title), onClick, isSelected);
     }
 
+    public static object Build(string title, Icons icon, Action onClick, bool isSelected = false)
+    {
+        var row = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full())
+            | icon.ToIcon()
+            | Text.Literal(title);
+
+        return BuildButton(row, onClick, isSelected);
+    }
+
     private static Button BuildButton(object content, Action onClick, bool isSelected)
     {
         var button = new Button().Width(Size.Full()).Content(content).OnClick(onClick);

--- a/src/Ivy.Tendril/Helpers/SidebarListRow.cs
+++ b/src/Ivy.Tendril/Helpers/SidebarListRow.cs
@@ -2,17 +2,23 @@ namespace Ivy.Tendril.Helpers;
 
 public static class SidebarListRow
 {
-    public static object Build(string title, object content, Action onClick)
+    public static object Build(string title, object content, Action onClick, bool isSelected = false)
     {
         var row = Layout.Vertical().Gap(1)
             | Text.Literal(title)
             | content;
 
-        return new Button().Ghost().Width(Size.Full()).Content(row).OnClick(onClick);
+        return BuildButton(row, onClick, isSelected);
     }
 
-    public static object Build(string title, Action onClick)
+    public static object Build(string title, Action onClick, bool isSelected = false)
     {
-        return new Button().Ghost().Width(Size.Full()).Content(Text.Literal(title)).OnClick(onClick);
+        return BuildButton(Text.Literal(title), onClick, isSelected);
+    }
+
+    private static Button BuildButton(object content, Action onClick, bool isSelected)
+    {
+        var button = new Button().Width(Size.Full()).Content(content).OnClick(onClick);
+        return isSelected ? button.Secondary() : button.Ghost();
     }
 }


### PR DESCRIPTION
## What

Selected items in the master-detail sidebar lists (Review, Drafts, Icebox, Trash, Recommendations) and the selected section in SettingsApp now get a persistent highlighted background until another item is selected.

## Why

- Sidebar list rows rendered as Ghost buttons, so there was no visual indication of which plan/file/recommendation was currently selected — e.g. in ReviewApp you couldn't tell which draft app the content pane belonged to.
- The Settings sidebar used the framework `SidebarMenu`, whose active-item highlight is derived from the URL app id — section tags never match it, so the selected section was never highlighted either.

## How

- `SidebarListRow.Build` (the shared helper behind the sidebars) takes a new `isSelected` flag: selected rows render as a `Secondary` button (filled `bg-secondary`), unselected rows stay `Ghost`. `bg-secondary` is exactly what the framework's own sidebar uses for its active item, so the look is consistent.
- Each sidebar passes its selection state: Review/Drafts/Icebox compare by plan `FolderName`, Trash by file path, Recommendations by record equality.
- SettingsApp's sidebar is rebuilt with the same `SidebarListRow` pattern (new icon-capable overload), keeping the "Configuration" header, the section icons, and the "Open config.yaml" action row.

## Notes for reviewers

- Ivy 1.3.8's `ListItem`/`SidebarMenu` widgets have no app-controllable selected state, hence the button-variant approach on the Tendril side. A `Selected` prop in Ivy-Framework would be the longer-term home for this.
- The highlight follows the existing auto-reselect behavior (first-item auto-select, selection surviving a plan leaving the filtered list) since the sidebars rebuild on any selection change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)