### PR TITLE
feat: Slack bot plugin with one-click setup + Tendril plugin hosting

### DIFF
--- a/docs/slack-bot.md
+++ b/docs/slack-bot.md
@@ -1,0 +1,39 @@
+# Slack Bot
+
+Tendril ships with a bundled Slack bot plugin. It lets you create plans, execute them, and receive job notifications directly from Slack. It connects over Slack Socket Mode (an outbound websocket), so it works from any machine — no public URL, tunnel, or webhook configuration required.
+
+## Setup
+
+1. Open the **Plugins** app in Tendril. The **Slack Bot** plugin is pre-installed and waiting for configuration.
+2. Click **Create Slack App**. Slack opens in your browser with a fully pre-configured app manifest — bot user, `/tendril` slash command, permissions, and Socket Mode are all pre-filled. Pick your workspace and click **Create**, then **Install to Workspace**.
+3. Copy two tokens into the wizard:
+   - **Bot User OAuth Token** (`xoxb-…`) from *OAuth & Permissions*.
+   - **App-Level Token** (`xapp-…`) from *Basic Information → App-Level Tokens* (generate one with the `connections:write` scope).
+4. Click **Validate & Continue** — Tendril verifies both tokens against Slack.
+5. Pick a channel for job notifications, optionally restrict who may run commands, and click **Save & Start Bot**.
+
+The bot connects immediately and reconnects automatically whenever Tendril restarts.
+
+## Commands
+
+Use `/tendril` in any channel, mention the bot (`@tendril …`), or DM it:
+
+| Command | Effect |
+| --- | --- |
+| `new <description>` | Create a plan from a description |
+| `new project:Name <description>` | Create a plan in a specific project |
+| `run <planId>` | Execute a plan |
+| `plans [state]` | List recent plans, optionally filtered by state |
+| `projects` | List configured projects |
+| `status <jobId>` | Show job status |
+| `help` | Show available commands |
+
+Job completion notifications (success or failure) are posted to the configured notification channel.
+
+## Access control
+
+By default any workspace member can run commands. To restrict access, set **Allowed Slack user IDs** in the plugin configuration to a comma-separated list of Slack user IDs (e.g. `U0123ABC, U0456DEF`). You can find a user's ID in their Slack profile under *… → Copy member ID*.
+
+## Configuration storage
+
+Plugin configuration (including tokens) is stored in `TENDRIL_HOME/plugin-config/Ivy.Tendril.Plugin.Slack.json`. Delete this file to reset the plugin.

--- a/src/Ivy.Tendril.Plugin.Abstractions/ITendrilApi.cs
+++ b/src/Ivy.Tendril.Plugin.Abstractions/ITendrilApi.cs
@@ -1,0 +1,24 @@
+namespace Ivy.Tendril.Plugins;
+
+public interface ITendrilApi
+{
+    string StartCreatePlan(string description, string? project = null);
+    string StartExecutePlan(string planId, string? note = null);
+    TendrilJobStatus? GetJob(string jobId);
+    IReadOnlyList<TendrilPlanSummary> ListPlans(string? state = null, string? project = null, int limit = 20);
+    IReadOnlyList<string> ListProjects();
+}
+
+public record TendrilJobStatus(
+    string Id,
+    string Type,
+    string Status,
+    string? StatusMessage,
+    string? PlanFile);
+
+public record TendrilPlanSummary(
+    string Id,
+    string? Title,
+    string? State,
+    string? Project,
+    string? Level);

--- a/src/Ivy.Tendril.Plugin.Abstractions/ITendrilMessagingChannel.cs
+++ b/src/Ivy.Tendril.Plugin.Abstractions/ITendrilMessagingChannel.cs
@@ -1,0 +1,11 @@
+namespace Ivy.Tendril.Plugins;
+
+public interface ITendrilMessagingChannel
+{
+    string Id { get; }
+    Task StartAsync(ITendrilApi api, CancellationToken cancellationToken);
+    Task StopAsync(CancellationToken cancellationToken);
+    Task SendNotificationAsync(TendrilNotification notification, CancellationToken cancellationToken);
+}
+
+public record TendrilNotification(string Title, string Message, bool IsSuccess);

--- a/src/Ivy.Tendril.Plugin.Abstractions/Ivy.Tendril.Plugin.Abstractions.csproj
+++ b/src/Ivy.Tendril.Plugin.Abstractions/Ivy.Tendril.Plugin.Abstractions.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Ivy.Tendril.Plugins</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>Ivy.Tendril.Plugin.Abstractions</PackageId>
+    <IsPackable>true</IsPackable>
+    <Company>Ivy</Company>
+    <Description>Contracts for building Ivy Tendril plugins</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Ivy-Interactive/Ivy-Tendril</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Ivy-Interactive/Ivy-Tendril</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IvySource)' == 'true'">
+    <ProjectReference Include="../../../Ivy-Framework/src/Ivy.Plugin.Abstractions/Ivy.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IvySource)' != 'true'">
+    <PackageReference Include="Ivy.Plugin.Abstractions" Version="1.3.8" />
+  </ItemGroup>
+</Project>

--- a/src/Ivy.Tendril.Plugin.Slack/Ivy.Tendril.Plugin.Slack.csproj
+++ b/src/Ivy.Tendril.Plugin.Slack/Ivy.Tendril.Plugin.Slack.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Ivy.Tendril.Plugins.Slack</RootNamespace>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>Ivy.Tendril.Plugin.Slack</PackageId>
+    <IsPackable>true</IsPackable>
+    <Company>Ivy</Company>
+    <Description>Slack bot plugin for Ivy Tendril</Description>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Ivy-Interactive/Ivy-Tendril</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Ivy-Interactive/Ivy-Tendril</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Ivy.Tendril.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Ivy.Tendril.Plugin.Abstractions/Ivy.Tendril.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IvySource)' == 'true'">
+    <ProjectReference Include="../../../Ivy-Framework/src/Ivy/Ivy.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IvySource)' != 'true'">
+    <PackageReference Include="Ivy" Version="1.3.8" />
+  </ItemGroup>
+</Project>

--- a/src/Ivy.Tendril.Plugin.Slack/SlackAppManifest.cs
+++ b/src/Ivy.Tendril.Plugin.Slack/SlackAppManifest.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+
+namespace Ivy.Tendril.Plugins.Slack;
+
+public static class SlackAppManifest
+{
+    public static string BuildManifestJson(string appName = "Tendril")
+    {
+        var manifest = new
+        {
+            display_information = new
+            {
+                name = appName,
+                description = "Control Ivy Tendril from Slack: create plans, run jobs, get notifications.",
+                background_color = "#1a1d21"
+            },
+            features = new
+            {
+                bot_user = new { display_name = appName.ToLowerInvariant(), always_online = true },
+                slash_commands = new[]
+                {
+                    new
+                    {
+                        command = "/tendril",
+                        description = "Control Ivy Tendril",
+                        usage_hint = "new <description> | plans | run <id> | status <jobId> | help",
+                        should_escape = false
+                    }
+                }
+            },
+            oauth_config = new
+            {
+                scopes = new
+                {
+                    bot = new[]
+                    {
+                        "chat:write",
+                        "commands",
+                        "app_mentions:read",
+                        "channels:read",
+                        "channels:join",
+                        "im:history"
+                    }
+                }
+            },
+            settings = new
+            {
+                event_subscriptions = new { bot_events = new[] { "app_mention", "message.im" } },
+                interactivity = new { is_enabled = false },
+                org_deploy_enabled = false,
+                socket_mode_enabled = true,
+                token_rotation_enabled = false
+            }
+        };
+
+        return JsonSerializer.Serialize(manifest, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    public static string BuildCreateAppUrl(string manifestJson) =>
+        "https://api.slack.com/apps?new_app=1&manifest_json=" + Uri.EscapeDataString(manifestJson);
+}

--- a/src/Ivy.Tendril.Plugin.Slack/SlackChannelSettings.cs
+++ b/src/Ivy.Tendril.Plugin.Slack/SlackChannelSettings.cs
@@ -1,0 +1,32 @@
+using Ivy.Plugins;
+
+namespace Ivy.Tendril.Plugins.Slack;
+
+public record SlackChannelSettings(
+    string BotToken,
+    string AppToken,
+    string? DefaultChannel,
+    IReadOnlySet<string> AllowedUsers)
+{
+    public static class Keys
+    {
+        public const string BotToken = "BotToken";
+        public const string AppToken = "AppToken";
+        public const string DefaultChannel = "DefaultChannel";
+        public const string AllowedUsers = "AllowedUsers";
+    }
+
+    public static SlackChannelSettings FromConfig(IIvyPluginConfig config) => new(
+        config.GetValue(Keys.BotToken) ?? "",
+        config.GetValue(Keys.AppToken) ?? "",
+        config.GetValue(Keys.DefaultChannel),
+        ParseAllowedUsers(config.GetValue(Keys.AllowedUsers)));
+
+    public static IReadOnlySet<string> ParseAllowedUsers(string? value) =>
+        (value ?? "")
+        .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    public bool IsUserAllowed(string userId) =>
+        AllowedUsers.Count == 0 || AllowedUsers.Contains(userId);
+}

--- a/src/Ivy.Tendril.Plugin.Slack/SlackCommandHandler.cs
+++ b/src/Ivy.Tendril.Plugin.Slack/SlackCommandHandler.cs
@@ -1,0 +1,109 @@
+using Ivy.Tendril.Plugins;
+
+namespace Ivy.Tendril.Plugins.Slack;
+
+public static class SlackCommandHandler
+{
+    public const string HelpText =
+        """
+        *Tendril commands:*
+        • `new <description>` — create a plan from a description
+        • `new [project] <description>` — create a plan in a project (use `project:Name`)
+        • `run <planId>` — execute a plan
+        • `plans [state]` — list recent plans, optionally filtered by state
+        • `projects` — list configured projects
+        • `status <jobId>` — show job status
+        • `help` — show this message
+        """;
+
+    public static string Execute(string text, ITendrilApi api)
+    {
+        try
+        {
+            return ExecuteCore(text, api);
+        }
+        catch (Exception ex)
+        {
+            return $":warning: {ex.Message}";
+        }
+    }
+
+    private static string ExecuteCore(string text, ITendrilApi api)
+    {
+        var trimmed = (text ?? "").Trim();
+        if (trimmed.Length == 0)
+            return HelpText;
+
+        var space = trimmed.IndexOf(' ');
+        var command = (space < 0 ? trimmed : trimmed[..space]).ToLowerInvariant();
+        var rest = space < 0 ? "" : trimmed[(space + 1)..].Trim();
+
+        return command switch
+        {
+            "new" or "plan" or "create" => CreatePlan(rest, api),
+            "run" or "execute" => ExecutePlan(rest, api),
+            "plans" or "list" => ListPlans(rest, api),
+            "projects" => ListProjects(api),
+            "status" or "job" => JobStatus(rest, api),
+            _ => HelpText
+        };
+    }
+
+    private static string CreatePlan(string rest, ITendrilApi api)
+    {
+        if (rest.Length == 0)
+            return "Usage: `new <description>` (optionally prefix with `project:Name`)";
+
+        string? project = null;
+        if (rest.StartsWith("project:", StringComparison.OrdinalIgnoreCase))
+        {
+            var space = rest.IndexOf(' ');
+            if (space < 0)
+                return "Usage: `new project:Name <description>`";
+            project = rest["project:".Length..space];
+            rest = rest[(space + 1)..].Trim();
+        }
+
+        var jobId = api.StartCreatePlan(rest, project);
+        return $":seedling: Plan creation started (job `{jobId}`{(project != null ? $", project *{project}*" : "")}). I'll post here when it finishes.";
+    }
+
+    private static string ExecutePlan(string rest, ITendrilApi api)
+    {
+        if (rest.Length == 0)
+            return "Usage: `run <planId>`";
+        var jobId = api.StartExecutePlan(rest);
+        return $":rocket: Executing plan `{rest}` (job `{jobId}`). I'll post here when it finishes.";
+    }
+
+    private static string ListPlans(string rest, ITendrilApi api)
+    {
+        var state = rest.Length > 0 ? rest : null;
+        var plans = api.ListPlans(state, limit: 15);
+        if (plans.Count == 0)
+            return state == null ? "No plans found." : $"No plans in state *{state}*.";
+
+        var lines = plans.Select(p =>
+            $"• `{p.Id}` *{p.Title ?? "(untitled)"}* — {p.State ?? "?"}{(p.Project != null ? $" · {p.Project}" : "")}");
+        return string.Join("\n", lines);
+    }
+
+    private static string ListProjects(ITendrilApi api)
+    {
+        var projects = api.ListProjects();
+        return projects.Count == 0
+            ? "No projects configured."
+            : "*Projects:*\n" + string.Join("\n", projects.Select(p => $"• {p}"));
+    }
+
+    private static string JobStatus(string rest, ITendrilApi api)
+    {
+        if (rest.Length == 0)
+            return "Usage: `status <jobId>`";
+        var job = api.GetJob(rest);
+        if (job == null)
+            return $"Job `{rest}` not found.";
+        var message = string.IsNullOrEmpty(job.StatusMessage) ? "" : $"\n> {job.StatusMessage}";
+        return $"*{job.Type}* `{job.Id}` — {job.Status}{(job.PlanFile != null ? $" · {job.PlanFile}" : "")}{message}";
+    }
+}

--- a/src/Ivy.Tendril.Plugin.Slack/SlackMessagingChannel.cs
+++ b/src/Ivy.Tendril.Plugin.Slack/SlackMessagingChannel.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using Ivy.Tendril.Plugins;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Plugins.Slack;
+
+public class SlackMessagingChannel(SlackChannelSettings settings, ILogger? logger = null) : ITendrilMessagingChannel
+{
+    private readonly ILogger _logger = logger ?? CreateDefaultLogger();
+    private ITendrilApi? _api;
+    private SlackWebApiClient? _botClient;
+    private string _botUserId = "";
+
+    public string Id => "slack";
+
+    private static ILogger CreateDefaultLogger() =>
+        LoggerFactory.Create(b => b.AddConsole()).CreateLogger<SlackMessagingChannel>();
+
+    public async Task StartAsync(ITendrilApi api, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(settings.BotToken) || string.IsNullOrEmpty(settings.AppToken))
+        {
+            _logger.LogWarning("Slack channel not started: BotToken or AppToken missing");
+            return;
+        }
+
+        _api = api;
+        _botClient = new SlackWebApiClient(settings.BotToken);
+        using var appClient = new SlackWebApiClient(settings.AppToken);
+
+        var auth = await CallAuthTestAsync(cancellationToken);
+        if (auth == null) return;
+
+        _logger.LogInformation("Slack channel connected to workspace {Team} as {BotUser}", auth.TeamName, auth.BotUser);
+
+        var socketClient = new SlackSocketModeClient(appClient, HandleEnvelopeAsync, _logger);
+        await socketClient.RunAsync(cancellationToken);
+    }
+
+    private async Task<SlackAuthInfo?> CallAuthTestAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _botClient!.CallAsync("auth.test", null, cancellationToken);
+            _botUserId = result.TryGetProperty("user_id", out var userId) ? userId.GetString() ?? "" : "";
+            return new SlackAuthInfo(
+                result.TryGetProperty("team", out var team) ? team.GetString() ?? "" : "",
+                result.TryGetProperty("user", out var user) ? user.GetString() ?? "" : "",
+                result.TryGetProperty("team_id", out var teamId) ? teamId.GetString() ?? "" : "");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Slack auth.test failed; channel not started");
+            return null;
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _botClient?.Dispose();
+        _botClient = null;
+        return Task.CompletedTask;
+    }
+
+    public async Task SendNotificationAsync(TendrilNotification notification, CancellationToken cancellationToken)
+    {
+        if (_botClient == null || string.IsNullOrEmpty(settings.DefaultChannel))
+            return;
+
+        var emoji = notification.IsSuccess ? ":white_check_mark:" : ":x:";
+        await _botClient.PostMessageAsync(
+            settings.DefaultChannel,
+            $"{emoji} *{notification.Title}*\n{notification.Message}",
+            cancellationToken: cancellationToken);
+    }
+
+    private async Task<object?> HandleEnvelopeAsync(SlackEnvelope envelope)
+    {
+        if (_api == null || _botClient == null)
+            return null;
+
+        switch (envelope.Type)
+        {
+            case "slash_commands":
+                return HandleSlashCommand(envelope.Payload);
+            case "events_api":
+                await HandleEventAsync(envelope.Payload);
+                return null;
+            default:
+                return null;
+        }
+    }
+
+    private object? HandleSlashCommand(JsonElement payload)
+    {
+        var userId = GetString(payload, "user_id");
+        var text = GetString(payload, "text");
+
+        if (!settings.IsUserAllowed(userId))
+            return new { response_type = "ephemeral", text = ":no_entry: You are not authorized to control Tendril." };
+
+        var reply = SlackCommandHandler.Execute(text, _api!);
+        return new { response_type = "in_channel", text = reply };
+    }
+
+    private async Task HandleEventAsync(JsonElement payload)
+    {
+        if (!payload.TryGetProperty("event", out var slackEvent))
+            return;
+
+        var eventType = GetString(slackEvent, "type");
+        if (eventType is not ("app_mention" or "message"))
+            return;
+
+        var userId = GetString(slackEvent, "user");
+        if (eventType == "message")
+        {
+            if (GetString(slackEvent, "channel_type") != "im") return;
+            if (slackEvent.TryGetProperty("bot_id", out _)) return;
+            if (userId == _botUserId || userId.Length == 0) return;
+        }
+
+        var channel = GetString(slackEvent, "channel");
+        var threadTs = GetString(slackEvent, "thread_ts");
+        if (threadTs.Length == 0 && eventType == "app_mention")
+            threadTs = GetString(slackEvent, "ts");
+
+        var text = GetString(slackEvent, "text");
+        if (_botUserId.Length > 0)
+            text = text.Replace($"<@{_botUserId}>", "", StringComparison.OrdinalIgnoreCase).Trim();
+
+        var reply = settings.IsUserAllowed(userId)
+            ? SlackCommandHandler.Execute(text, _api!)
+            : ":no_entry: You are not authorized to control Tendril.";
+
+        await _botClient!.PostMessageAsync(channel, reply, threadTs.Length > 0 ? threadTs : null);
+    }
+
+    private static string GetString(JsonElement element, string property) =>
+        element.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() ?? ""
+            : "";
+}

--- a/src/Ivy.Tendril.Plugin.Slack/SlackPlugin.cs
+++ b/src/Ivy.Tendril.Plugin.Slack/SlackPlugin.cs
@@ -1,0 +1,41 @@
+using Ivy.Plugins;
+using Ivy.Tendril.Plugins;
+using Ivy.Tendril.Plugins.Slack;
+using Microsoft.Extensions.DependencyInjection;
+
+[assembly: IvyPlugin(typeof(SlackPlugin))]
+
+namespace Ivy.Tendril.Plugins.Slack;
+
+public class SlackPlugin : IIvyPlugin
+{
+    public const string PluginId = "Ivy.Tendril.Plugin.Slack";
+
+    public PluginManifest Manifest { get; } = new()
+    {
+        Id = PluginId,
+        Title = "Slack Bot",
+        Version = typeof(SlackPlugin).Assembly.GetName().Version ?? new Version(1, 0, 0),
+        Icon = PluginIcon.Named("MessageCircle")
+    };
+
+    public PluginConfigurationSchema? ConfigurationSchema { get; } = new SchemaBuilder()
+        .AddSecret(SlackChannelSettings.Keys.BotToken,
+            description: "Bot User OAuth Token (xoxb-…)", isRequired: true)
+        .AddSecret(SlackChannelSettings.Keys.AppToken,
+            description: "App-Level Token with connections:write scope (xapp-…)", isRequired: true)
+        .AddString(SlackChannelSettings.Keys.DefaultChannel,
+            description: "Channel ID where job notifications are posted (e.g. C0123456789)")
+        .AddString(SlackChannelSettings.Keys.AllowedUsers,
+            description: "Comma-separated Slack user IDs allowed to run commands (empty = everyone)")
+        .Build();
+
+    public object? BuildConfigurationView(IIvyPluginConfig configWriter) =>
+        new SlackSetupWizardView(configWriter);
+
+    public void Configure(IIvyPluginContext context)
+    {
+        var settings = SlackChannelSettings.FromConfig(context.Config);
+        context.Services.AddSingleton<ITendrilMessagingChannel>(new SlackMessagingChannel(settings));
+    }
+}

--- a/src/Ivy.Tendril.Plugin.Slack/SlackSetupWizardView.cs
+++ b/src/Ivy.Tendril.Plugin.Slack/SlackSetupWizardView.cs
@@ -1,0 +1,174 @@
+using Ivy;
+using Ivy.Plugins;
+using static Ivy.Layout;
+using static Ivy.Text;
+
+namespace Ivy.Tendril.Plugins.Slack;
+
+public class SlackSetupWizardView(IIvyPluginConfig config) : ViewBase
+{
+    public override object? Build()
+    {
+        var client = UseService<IClientProvider>();
+        var step = UseState(0);
+        var botToken = UseState(config.GetValue(SlackChannelSettings.Keys.BotToken) ?? "");
+        var appToken = UseState(config.GetValue(SlackChannelSettings.Keys.AppToken) ?? "");
+        var defaultChannel = UseState(config.GetValue(SlackChannelSettings.Keys.DefaultChannel) ?? "");
+        var allowedUsers = UseState(config.GetValue(SlackChannelSettings.Keys.AllowedUsers) ?? "");
+        var channelOptions = UseState<List<SlackChannelInfo>?>((List<SlackChannelInfo>?)null);
+        var validationResult = UseState<string?>((string?)null);
+        var validationError = UseState<string?>((string?)null);
+        var saved = UseState(false);
+
+        var stepper = new Stepper(
+            onSelect: e => { step.Set(e.Value); return ValueTask.CompletedTask; },
+            selectedIndex: step.Value,
+            new StepperItem("create", Icon: Icons.Slack, Label: "Create App"),
+            new StepperItem("connect", Icon: Icons.Key, Label: "Connect"),
+            new StepperItem("channel", Icon: Icons.Bell, Label: "Notifications"));
+
+        object stepContent = step.Value switch
+        {
+            0 => BuildCreateAppStep(client, step),
+            1 => BuildConnectStep(botToken, appToken, validationResult, validationError, channelOptions, step),
+            _ => BuildChannelStep(botToken, appToken, defaultChannel, allowedUsers, channelOptions, saved)
+        };
+
+        return Vertical().Gap(5)
+            | stepper
+            | new Card(content: stepContent)
+            | (saved.Value ? Callout.Success("The Slack bot is connected and will start automatically.", title: "Slack bot installed") : null);
+    }
+
+    private static object BuildCreateAppStep(IClientProvider client, IState<int> step)
+    {
+        var manifestJson = SlackAppManifest.BuildManifestJson();
+        var createUrl = SlackAppManifest.BuildCreateAppUrl(manifestJson);
+
+        return Vertical().Gap(4)
+            | H2("Create your Slack app")
+            | Muted("One click creates a pre-configured Slack app — bot user, /tendril command, and permissions included.")
+            | (Vertical().Gap(2)
+                | P("1. Click the button below — Slack opens with everything pre-filled.")
+                | P("2. Pick your workspace and click Create.")
+                | P("3. On the app page, click Install to Workspace and approve."))
+            | (Horizontal().Gap(2)
+                | new Button("Create Slack App", onClick: _ => { client.OpenUrl(createUrl); return ValueTask.CompletedTask; }, icon: Icons.ExternalLink)
+                | new Button("Next →", onClick: _ => { step.Set(1); return ValueTask.CompletedTask; }, variant: ButtonVariant.Outline))
+            | new Expandable(
+                "Manual setup (copy manifest)",
+                Vertical().Gap(2)
+                    | Muted("Paste this manifest at api.slack.com/apps → Create New App → From a manifest:")
+                    | Code(manifestJson));
+    }
+
+    private static object BuildConnectStep(
+        IState<string> botToken,
+        IState<string> appToken,
+        IState<string?> validationResult,
+        IState<string?> validationError,
+        IState<List<SlackChannelInfo>?> channelOptions,
+        IState<int> step)
+    {
+        async ValueTask Validate()
+        {
+            validationError.Set((string?)null);
+            validationResult.Set((string?)null);
+            try
+            {
+                using var botClient = new SlackWebApiClient(botToken.Value.Trim());
+                var auth = await botClient.AuthTestAsync();
+
+                using var appClient = new SlackWebApiClient(appToken.Value.Trim());
+                await appClient.OpenSocketUrlAsync();
+
+                try
+                {
+                    channelOptions.Set(await botClient.ListChannelsAsync());
+                }
+                catch (SlackApiException)
+                {
+                    channelOptions.Set(new List<SlackChannelInfo>());
+                }
+
+                validationResult.Set($"Connected to {auth.TeamName} as @{auth.BotUser}");
+                step.Set(2);
+            }
+            catch (SlackApiException ex)
+            {
+                validationError.Set(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                validationError.Set($"Connection failed: {ex.Message}");
+            }
+        }
+
+        return Vertical().Gap(4)
+            | H2("Connect the bot")
+            | Muted("From your new app's page on api.slack.com, copy two tokens:")
+            | (Vertical().Gap(2)
+                | P("1. OAuth & Permissions → Bot User OAuth Token (starts with xoxb-).")
+                | P("2. Basic Information → App-Level Tokens → Generate Token with the connections:write scope (starts with xapp-)."))
+            | new Field(botToken.ToTextInput(variant: TextInputVariant.Password, placeholder: "xoxb-..."), label: "Bot User OAuth Token", required: true)
+            | new Field(appToken.ToTextInput(variant: TextInputVariant.Password, placeholder: "xapp-..."), label: "App-Level Token", required: true)
+            | (validationError.Value is { } error ? Callout.Error(error, title: "Validation failed") : null)
+            | (validationResult.Value is { } okText ? Callout.Success(okText, title: "Connected") : null)
+            | (Horizontal().Gap(2)
+                | new Button("← Back", onClick: _ => { step.Set(0); return ValueTask.CompletedTask; }, variant: ButtonVariant.Outline)
+                | new Button("Validate & Continue", onClick: async _ => await Validate(), icon: Icons.Plug));
+    }
+
+    private object BuildChannelStep(
+        IState<string> botToken,
+        IState<string> appToken,
+        IState<string> defaultChannel,
+        IState<string> allowedUsers,
+        IState<List<SlackChannelInfo>?> channelOptions,
+        IState<bool> saved)
+    {
+        var channels = channelOptions.Value;
+
+        IAnyInput channelInput = channels is { Count: > 0 }
+            ? defaultChannel.ToSelectInput(
+                channels.Select(c => new Option<string>($"#{c.Name}", c.Id)).ToArray(),
+                placeholder: "Pick a channel for notifications...")
+            : defaultChannel.ToTextInput(placeholder: "C0123456789");
+
+        async ValueTask SaveAsync()
+        {
+            var channelId = defaultChannel.Value.Trim();
+            if (channelId.Length > 0)
+            {
+                try
+                {
+                    using var botClient = new SlackWebApiClient(botToken.Value.Trim());
+                    await botClient.JoinChannelAsync(channelId);
+                }
+                catch (Exception)
+                {
+                }
+            }
+
+            config.SetValue(SlackChannelSettings.Keys.BotToken, botToken.Value.Trim());
+            config.SetValue(SlackChannelSettings.Keys.AppToken, appToken.Value.Trim());
+            if (channelId.Length > 0)
+                config.SetValue(SlackChannelSettings.Keys.DefaultChannel, channelId);
+            else
+                config.RemoveValue(SlackChannelSettings.Keys.DefaultChannel);
+            if (allowedUsers.Value.Trim().Length > 0)
+                config.SetValue(SlackChannelSettings.Keys.AllowedUsers, allowedUsers.Value.Trim());
+            else
+                config.RemoveValue(SlackChannelSettings.Keys.AllowedUsers);
+            config.Save();
+            saved.Set(true);
+        }
+
+        return Vertical().Gap(4)
+            | H2("Notifications & access")
+            | Muted("Choose where job notifications are posted and who may run commands.")
+            | new Field(channelInput, label: "Notification channel")
+            | new Field(allowedUsers.ToTextInput(placeholder: "U0123ABC, U0456DEF (empty = everyone)"), label: "Allowed Slack user IDs")
+            | new Button("Save & Start Bot", onClick: async _ => await SaveAsync(), icon: Icons.Check);
+    }
+}

--- a/src/Ivy.Tendril.Plugin.Slack/SlackSocketModeClient.cs
+++ b/src/Ivy.Tendril.Plugin.Slack/SlackSocketModeClient.cs
@@ -1,0 +1,124 @@
+using System.Buffers;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Plugins.Slack;
+
+public record SlackEnvelope(string Type, string? EnvelopeId, JsonElement Payload);
+
+public class SlackSocketModeClient(
+    SlackWebApiClient appClient,
+    Func<SlackEnvelope, Task<object?>> envelopeHandler,
+    ILogger logger)
+{
+    public async Task RunAsync(CancellationToken cancellationToken)
+    {
+        var backoffSeconds = 1;
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                var url = await appClient.OpenSocketUrlAsync(cancellationToken);
+                logger.LogInformation("Slack Socket Mode connecting");
+                await RunConnectionAsync(url, cancellationToken);
+                backoffSeconds = 1;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Slack Socket Mode connection error, reconnecting in {Backoff}s", backoffSeconds);
+                await Task.Delay(TimeSpan.FromSeconds(backoffSeconds), cancellationToken);
+                backoffSeconds = Math.Min(backoffSeconds * 2, 60);
+            }
+        }
+    }
+
+    private async Task RunConnectionAsync(string url, CancellationToken cancellationToken)
+    {
+        using var socket = new ClientWebSocket();
+        await socket.ConnectAsync(new Uri(url), cancellationToken);
+
+        var buffer = ArrayPool<byte>.Shared.Rent(64 * 1024);
+        try
+        {
+            var message = new MemoryStream();
+            while (socket.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
+            {
+                message.SetLength(0);
+                WebSocketReceiveResult result;
+                do
+                {
+                    result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                        return;
+                    message.Write(buffer, 0, result.Count);
+                } while (!result.EndOfMessage);
+
+                var text = Encoding.UTF8.GetString(message.GetBuffer(), 0, (int)message.Length);
+                var shouldReconnect = await HandleMessageAsync(socket, text, cancellationToken);
+                if (shouldReconnect)
+                    return;
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private async Task<bool> HandleMessageAsync(ClientWebSocket socket, string text, CancellationToken cancellationToken)
+    {
+        JsonElement json;
+        try
+        {
+            json = JsonDocument.Parse(text).RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            logger.LogWarning("Slack Socket Mode received invalid JSON");
+            return false;
+        }
+
+        var type = json.TryGetProperty("type", out var typeProp) ? typeProp.GetString() ?? "" : "";
+        if (type == "disconnect")
+        {
+            logger.LogInformation("Slack requested reconnect");
+            return true;
+        }
+
+        var envelopeId = json.TryGetProperty("envelope_id", out var idProp) ? idProp.GetString() : null;
+        var payload = json.TryGetProperty("payload", out var payloadProp) ? payloadProp : default;
+
+        object? ackPayload = null;
+        if (type is "events_api" or "slash_commands" or "interactive")
+        {
+            try
+            {
+                ackPayload = await envelopeHandler(new SlackEnvelope(type, envelopeId, payload));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Slack envelope handler failed for {Type}", type);
+            }
+        }
+
+        if (envelopeId != null)
+        {
+            var ack = ackPayload == null
+                ? JsonSerializer.Serialize(new { envelope_id = envelopeId })
+                : JsonSerializer.Serialize(new { envelope_id = envelopeId, payload = ackPayload });
+            await socket.SendAsync(
+                new ArraySegment<byte>(Encoding.UTF8.GetBytes(ack)),
+                WebSocketMessageType.Text,
+                endOfMessage: true,
+                cancellationToken);
+        }
+
+        return false;
+    }
+}

--- a/src/Ivy.Tendril.Plugin.Slack/SlackWebApiClient.cs
+++ b/src/Ivy.Tendril.Plugin.Slack/SlackWebApiClient.cs
@@ -1,0 +1,106 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Ivy.Tendril.Plugins.Slack;
+
+public record SlackAuthInfo(string TeamName, string BotUser, string TeamId);
+public record SlackChannelInfo(string Id, string Name);
+
+public class SlackApiException(string method, string error) : Exception($"Slack API {method} failed: {error}")
+{
+    public string SlackError { get; } = error;
+}
+
+public class SlackWebApiClient(string token, HttpMessageHandler? handler = null) : IDisposable
+{
+    private readonly HttpClient _http = new(handler ?? new HttpClientHandler(), disposeHandler: handler == null)
+    {
+        BaseAddress = new Uri("https://slack.com/api/"),
+        Timeout = TimeSpan.FromSeconds(30)
+    };
+
+    public async Task<SlackAuthInfo> AuthTestAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await CallAsync("auth.test", null, cancellationToken);
+        return new SlackAuthInfo(
+            result.TryGetProperty("team", out var team) ? team.GetString() ?? "" : "",
+            result.TryGetProperty("user", out var user) ? user.GetString() ?? "" : "",
+            result.TryGetProperty("team_id", out var teamId) ? teamId.GetString() ?? "" : "");
+    }
+
+    public async Task<string> OpenSocketUrlAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await CallAsync("apps.connections.open", null, cancellationToken);
+        return result.GetProperty("url").GetString()
+               ?? throw new SlackApiException("apps.connections.open", "missing url");
+    }
+
+    public async Task PostMessageAsync(string channel, string text, string? threadTs = null, CancellationToken cancellationToken = default)
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["channel"] = channel,
+            ["text"] = text,
+            ["unfurl_links"] = false
+        };
+        if (threadTs != null)
+            payload["thread_ts"] = threadTs;
+        await CallAsync("chat.postMessage", payload, cancellationToken);
+    }
+
+    public async Task<List<SlackChannelInfo>> ListChannelsAsync(CancellationToken cancellationToken = default)
+    {
+        var channels = new List<SlackChannelInfo>();
+        string? cursor = null;
+        do
+        {
+            var query = "conversations.list?types=public_channel&exclude_archived=true&limit=200"
+                        + (cursor != null ? $"&cursor={Uri.EscapeDataString(cursor)}" : "");
+            var result = await CallAsync(query, null, cancellationToken);
+            foreach (var channel in result.GetProperty("channels").EnumerateArray())
+                channels.Add(new SlackChannelInfo(
+                    channel.GetProperty("id").GetString() ?? "",
+                    channel.GetProperty("name").GetString() ?? ""));
+            cursor = result.TryGetProperty("response_metadata", out var meta) &&
+                     meta.TryGetProperty("next_cursor", out var next)
+                ? next.GetString()
+                : null;
+        } while (!string.IsNullOrEmpty(cursor) && channels.Count < 1000);
+
+        return channels.OrderBy(c => c.Name).ToList();
+    }
+
+    public async Task JoinChannelAsync(string channelId, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await CallAsync("conversations.join", new Dictionary<string, object?> { ["channel"] = channelId }, cancellationToken);
+        }
+        catch (SlackApiException ex) when (ex.SlackError is "already_in_channel" or "method_not_supported_for_channel_type")
+        {
+        }
+    }
+
+    internal async Task<JsonElement> CallAsync(string method, Dictionary<string, object?>? payload, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, method);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (payload != null)
+            request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+
+        using var response = await _http.SendAsync(request, cancellationToken);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        var json = JsonDocument.Parse(body).RootElement.Clone();
+
+        if (!json.TryGetProperty("ok", out var ok) || !ok.GetBoolean())
+        {
+            var error = json.TryGetProperty("error", out var err) ? err.GetString() ?? "unknown" : "unknown";
+            throw new SlackApiException(method, error);
+        }
+
+        return json;
+    }
+
+    public void Dispose() => _http.Dispose();
+}

--- a/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
+++ b/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <ProjectReference Include="../Ivy.Tendril/Ivy.Tendril.csproj" />
     <ProjectReference Include="../Ivy.Tendril.Agents/Ivy.Tendril.Agents.csproj" />
+    <ProjectReference Include="../Ivy.Tendril.Plugin.Slack/Ivy.Tendril.Plugin.Slack.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IvySource)' == 'true'">
     <ProjectReference Include="../../../Ivy-Framework/src/Ivy/Ivy.csproj" />

--- a/src/Ivy.Tendril.Test/Plugins/MessagingChannelServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Plugins/MessagingChannelServiceTests.cs
@@ -1,0 +1,170 @@
+using Ivy.Plugins;
+using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Plugins;
+using Ivy.Tendril.Services.Jobs;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test.Plugins;
+
+public class MessagingChannelServiceTests
+{
+    private class FakeChannel : ITendrilMessagingChannel
+    {
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<TendrilNotification> Notified { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public ITendrilApi? Api { get; private set; }
+
+        public string Id => "fake";
+
+        public Task StartAsync(ITendrilApi api, CancellationToken cancellationToken)
+        {
+            Api = api;
+            Started.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task SendNotificationAsync(TendrilNotification notification, CancellationToken cancellationToken)
+        {
+            Notified.TrySetResult(notification);
+            return Task.CompletedTask;
+        }
+    }
+
+    private class FakePluginServiceProvider(params object[] services) : IPluginServiceProvider
+    {
+        public T? GetService<T>() where T : class => services.OfType<T>().FirstOrDefault();
+        public IEnumerable<T> GetServices<T>() where T : class => services.OfType<T>();
+    }
+
+    private class FakePluginManager : IPluginManager
+    {
+        public IReadOnlyList<string> GetActivePluginIds() => [];
+        public PluginManifest? GetPluginManifest(string pluginId) => null;
+        public PluginConfigurationSchema? GetPluginSchema(string pluginId) => null;
+        public object? BuildPluginConfigurationView(string pluginId, IIvyPluginConfig config) => null;
+        public IReadOnlyList<PluginCandidate> GetUnloadedPlugins() => [];
+        public IReadOnlyList<UnconfiguredPlugin> GetUnconfiguredPlugins() => [];
+        public bool UnloadPlugin(string pluginId) => false;
+        public bool LoadPlugin(string pluginPath) => false;
+        public bool ReloadPlugin(string pluginId) => false;
+        public bool ReconfigurePlugin(string pluginId) => false;
+        public event Action<string>? PluginLoaded { add { } remove { } }
+        public event Action<string>? PluginUnloaded;
+        public event Action<string>? PluginReloaded { add { } remove { } }
+        public event Action<string>? PluginActivated { add { } remove { } }
+        public event Action<string>? PluginDeactivated { add { } remove { } }
+
+        public void RaiseUnloaded(string pluginId) => PluginUnloaded?.Invoke(pluginId);
+    }
+
+    private class FakeJobService : IJobService
+    {
+        public event Action? JobsChanged { add { } remove { } }
+        public event Action? JobsStructureChanged { add { } remove { } }
+        public event Action? JobPropertyChanged { add { } remove { } }
+        public event Action<JobNotification>? NotificationReady;
+
+        public void RaiseNotification(JobNotification notification) => NotificationReady?.Invoke(notification);
+
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null) => "job-1";
+        public void ForceStartJob(string id) { }
+        public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) { }
+        public void StopJob(string id) { }
+        public void DeleteJob(string id) { }
+        public void ClearCompletedJobs() { }
+        public void ClearFailedJobs() { }
+        public void ClearAllJobs() { }
+        public List<JobItem> GetJobs() => [];
+        public List<JobItem> GetJobsForPlan(string planFile) => [];
+        public JobItem? GetJob(string id) => null;
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => false;
+        public bool ReportJobFailure(string id, string message) => false;
+        public bool IsInboxFileTracked(string filePath) => false;
+        public void Dispose() { }
+    }
+
+    private class FakeTendrilApi : ITendrilApi
+    {
+        public string StartCreatePlan(string description, string? project = null) => "job-1";
+        public string StartExecutePlan(string planId, string? note = null) => "job-2";
+        public TendrilJobStatus? GetJob(string jobId) => null;
+        public IReadOnlyList<TendrilPlanSummary> ListPlans(string? state = null, string? project = null, int limit = 20) => [];
+        public IReadOnlyList<string> ListProjects() => [];
+    }
+
+    [Fact]
+    public async Task Start_StartsRegisteredChannelsWithApi()
+    {
+        var channel = new FakeChannel();
+        var api = new FakeTendrilApi();
+        using var service = new MessagingChannelService(
+            new FakePluginServiceProvider(channel),
+            new FakePluginManager(),
+            new FakeJobService(),
+            api,
+            NullLogger<MessagingChannelService>.Instance);
+
+        service.Start();
+
+        await channel.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Same(api, channel.Api);
+    }
+
+    [Fact]
+    public async Task NotificationReady_FansOutToRunningChannels()
+    {
+        var channel = new FakeChannel();
+        var jobService = new FakeJobService();
+        using var service = new MessagingChannelService(
+            new FakePluginServiceProvider(channel),
+            new FakePluginManager(),
+            jobService,
+            new FakeTendrilApi(),
+            NullLogger<MessagingChannelService>.Instance);
+
+        service.Start();
+        await channel.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        jobService.RaiseNotification(new JobNotification("CreatePlan Completed", "00042-Plan", true));
+
+        var notification = await channel.Notified.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal("CreatePlan Completed", notification.Title);
+        Assert.True(notification.IsSuccess);
+    }
+
+    [Fact]
+    public async Task PluginUnloaded_StopsRemovedChannels()
+    {
+        var channel = new FakeChannel();
+        var provider = new RemovablePluginServiceProvider(channel);
+        var pluginManager = new FakePluginManager();
+        var jobService = new FakeJobService();
+        using var service = new MessagingChannelService(
+            provider,
+            pluginManager,
+            jobService,
+            new FakeTendrilApi(),
+            NullLogger<MessagingChannelService>.Instance);
+
+        service.Start();
+        await channel.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        provider.Clear();
+        pluginManager.RaiseUnloaded("some-plugin");
+
+        jobService.RaiseNotification(new JobNotification("Title", "Message", true));
+        await Task.Delay(200);
+        Assert.False(channel.Notified.Task.IsCompleted);
+    }
+
+    private class RemovablePluginServiceProvider(params object[] services) : IPluginServiceProvider
+    {
+        private readonly List<object> _services = services.ToList();
+        public void Clear() => _services.Clear();
+        public T? GetService<T>() where T : class => _services.OfType<T>().FirstOrDefault();
+        public IEnumerable<T> GetServices<T>() where T : class => _services.OfType<T>().ToList();
+    }
+}

--- a/src/Ivy.Tendril.Test/Plugins/SlackAppManifestTests.cs
+++ b/src/Ivy.Tendril.Test/Plugins/SlackAppManifestTests.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using Ivy.Tendril.Plugins.Slack;
+
+namespace Ivy.Tendril.Test.Plugins;
+
+public class SlackAppManifestTests
+{
+    [Fact]
+    public void BuildManifestJson_IsValidJsonWithSocketModeAndSlashCommand()
+    {
+        var json = SlackAppManifest.BuildManifestJson();
+        var root = JsonDocument.Parse(json).RootElement;
+
+        Assert.True(root.GetProperty("settings").GetProperty("socket_mode_enabled").GetBoolean());
+        Assert.Equal("/tendril", root.GetProperty("features").GetProperty("slash_commands")[0].GetProperty("command").GetString());
+
+        var scopes = root.GetProperty("oauth_config").GetProperty("scopes").GetProperty("bot")
+            .EnumerateArray().Select(s => s.GetString()).ToList();
+        Assert.Contains("chat:write", scopes);
+        Assert.Contains("commands", scopes);
+        Assert.Contains("app_mentions:read", scopes);
+
+        var events = root.GetProperty("settings").GetProperty("event_subscriptions").GetProperty("bot_events")
+            .EnumerateArray().Select(s => s.GetString()).ToList();
+        Assert.Contains("app_mention", events);
+    }
+
+    [Fact]
+    public void BuildCreateAppUrl_UrlEncodesManifest()
+    {
+        var url = SlackAppManifest.BuildCreateAppUrl(SlackAppManifest.BuildManifestJson());
+
+        Assert.StartsWith("https://api.slack.com/apps?new_app=1&manifest_json=", url);
+        Assert.DoesNotContain("\"", url[url.IndexOf('=')..]);
+        Assert.DoesNotContain("\n", url);
+    }
+
+    [Fact]
+    public void BuildManifestJson_CustomAppName_IsUsed()
+    {
+        var json = SlackAppManifest.BuildManifestJson("MyBot");
+        var root = JsonDocument.Parse(json).RootElement;
+        Assert.Equal("MyBot", root.GetProperty("display_information").GetProperty("name").GetString());
+    }
+}

--- a/src/Ivy.Tendril.Test/Plugins/SlackChannelSettingsTests.cs
+++ b/src/Ivy.Tendril.Test/Plugins/SlackChannelSettingsTests.cs
@@ -1,0 +1,34 @@
+using Ivy.Tendril.Plugins.Slack;
+
+namespace Ivy.Tendril.Test.Plugins;
+
+public class SlackChannelSettingsTests
+{
+    [Fact]
+    public void ParseAllowedUsers_SplitsAndTrims()
+    {
+        var users = SlackChannelSettings.ParseAllowedUsers(" U0123 , U0456,U0789 ");
+        Assert.Equal(3, users.Count);
+        Assert.Contains("U0123", users);
+        Assert.Contains("U0789", users);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void IsUserAllowed_NoAllowlist_AllowsEveryone(string? allowedUsers)
+    {
+        var settings = new SlackChannelSettings("xoxb", "xapp", null, SlackChannelSettings.ParseAllowedUsers(allowedUsers));
+        Assert.True(settings.IsUserAllowed("U_ANYONE"));
+    }
+
+    [Fact]
+    public void IsUserAllowed_WithAllowlist_RestrictsAccess()
+    {
+        var settings = new SlackChannelSettings("xoxb", "xapp", null, SlackChannelSettings.ParseAllowedUsers("U0123,U0456"));
+        Assert.True(settings.IsUserAllowed("U0123"));
+        Assert.True(settings.IsUserAllowed("u0123"));
+        Assert.False(settings.IsUserAllowed("U_INTRUDER"));
+    }
+}

--- a/src/Ivy.Tendril.Test/Plugins/SlackCommandHandlerTests.cs
+++ b/src/Ivy.Tendril.Test/Plugins/SlackCommandHandlerTests.cs
@@ -1,0 +1,169 @@
+using Ivy.Tendril.Plugins;
+using Ivy.Tendril.Plugins.Slack;
+
+namespace Ivy.Tendril.Test.Plugins;
+
+public class SlackCommandHandlerTests
+{
+    private class FakeTendrilApi : ITendrilApi
+    {
+        public List<(string Description, string? Project)> CreatedPlans { get; } = [];
+        public List<string> ExecutedPlans { get; } = [];
+        public TendrilJobStatus? Job { get; set; }
+        public List<TendrilPlanSummary> Plans { get; set; } = [];
+        public List<string> Projects { get; set; } = [];
+
+        public string StartCreatePlan(string description, string? project = null)
+        {
+            CreatedPlans.Add((description, project));
+            return "job-1";
+        }
+
+        public string StartExecutePlan(string planId, string? note = null)
+        {
+            ExecutedPlans.Add(planId);
+            return "job-2";
+        }
+
+        public TendrilJobStatus? GetJob(string jobId) => Job;
+
+        public IReadOnlyList<TendrilPlanSummary> ListPlans(string? state = null, string? project = null, int limit = 20) =>
+            Plans.Where(p => state == null || string.Equals(p.State, state, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        public IReadOnlyList<string> ListProjects() => Projects;
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("help")]
+    [InlineData("bogus command")]
+    public void Execute_HelpOrUnknown_ReturnsHelp(string text)
+    {
+        var reply = SlackCommandHandler.Execute(text, new FakeTendrilApi());
+        Assert.Contains("Tendril commands", reply);
+    }
+
+    [Fact]
+    public void Execute_New_StartsCreatePlanJob()
+    {
+        var api = new FakeTendrilApi();
+        var reply = SlackCommandHandler.Execute("new Add dark mode to settings", api);
+
+        var created = Assert.Single(api.CreatedPlans);
+        Assert.Equal("Add dark mode to settings", created.Description);
+        Assert.Null(created.Project);
+        Assert.Contains("job-1", reply);
+    }
+
+    [Fact]
+    public void Execute_NewWithProject_PassesProject()
+    {
+        var api = new FakeTendrilApi();
+        SlackCommandHandler.Execute("new project:WebApp Fix login redirect", api);
+
+        var created = Assert.Single(api.CreatedPlans);
+        Assert.Equal("Fix login redirect", created.Description);
+        Assert.Equal("WebApp", created.Project);
+    }
+
+    [Fact]
+    public void Execute_Run_ExecutesPlan()
+    {
+        var api = new FakeTendrilApi();
+        var reply = SlackCommandHandler.Execute("run 00042", api);
+
+        Assert.Equal("00042", Assert.Single(api.ExecutedPlans));
+        Assert.Contains("job-2", reply);
+    }
+
+    [Fact]
+    public void Execute_RunWithoutId_ReturnsUsage()
+    {
+        var api = new FakeTendrilApi();
+        var reply = SlackCommandHandler.Execute("run", api);
+
+        Assert.Empty(api.ExecutedPlans);
+        Assert.Contains("Usage", reply);
+    }
+
+    [Fact]
+    public void Execute_Plans_ListsPlans()
+    {
+        var api = new FakeTendrilApi
+        {
+            Plans =
+            [
+                new TendrilPlanSummary("00001", "First plan", "Draft", "WebApp", "Feature"),
+                new TendrilPlanSummary("00002", "Second plan", "Done", null, null)
+            ]
+        };
+        var reply = SlackCommandHandler.Execute("plans", api);
+
+        Assert.Contains("First plan", reply);
+        Assert.Contains("Second plan", reply);
+    }
+
+    [Fact]
+    public void Execute_PlansWithState_Filters()
+    {
+        var api = new FakeTendrilApi
+        {
+            Plans =
+            [
+                new TendrilPlanSummary("00001", "First plan", "Draft", null, null),
+                new TendrilPlanSummary("00002", "Second plan", "Done", null, null)
+            ]
+        };
+        var reply = SlackCommandHandler.Execute("plans draft", api);
+
+        Assert.Contains("First plan", reply);
+        Assert.DoesNotContain("Second plan", reply);
+    }
+
+    [Fact]
+    public void Execute_Status_ShowsJob()
+    {
+        var api = new FakeTendrilApi
+        {
+            Job = new TendrilJobStatus("job-9", "CreatePlan", "Running", "Working on it", null)
+        };
+        var reply = SlackCommandHandler.Execute("status job-9", api);
+
+        Assert.Contains("job-9", reply);
+        Assert.Contains("Running", reply);
+    }
+
+    [Fact]
+    public void Execute_StatusUnknownJob_ReportsNotFound()
+    {
+        var reply = SlackCommandHandler.Execute("status nope", new FakeTendrilApi());
+        Assert.Contains("not found", reply);
+    }
+
+    [Fact]
+    public void Execute_Projects_ListsProjects()
+    {
+        var api = new FakeTendrilApi { Projects = ["WebApp", "Backend"] };
+        var reply = SlackCommandHandler.Execute("projects", api);
+
+        Assert.Contains("WebApp", reply);
+        Assert.Contains("Backend", reply);
+    }
+
+    [Fact]
+    public void Execute_ApiThrows_ReturnsErrorMessage()
+    {
+        var api = new ThrowingApi();
+        var reply = SlackCommandHandler.Execute("run 42", api);
+        Assert.Contains("boom", reply);
+    }
+
+    private class ThrowingApi : ITendrilApi
+    {
+        public string StartCreatePlan(string description, string? project = null) => throw new InvalidOperationException("boom");
+        public string StartExecutePlan(string planId, string? note = null) => throw new InvalidOperationException("boom");
+        public TendrilJobStatus? GetJob(string jobId) => throw new InvalidOperationException("boom");
+        public IReadOnlyList<TendrilPlanSummary> ListPlans(string? state = null, string? project = null, int limit = 20) => throw new InvalidOperationException("boom");
+        public IReadOnlyList<string> ListProjects() => throw new InvalidOperationException("boom");
+    }
+}

--- a/src/Ivy.Tendril.Test/Plugins/TendrilPluginConfigFactoryTests.cs
+++ b/src/Ivy.Tendril.Test/Plugins/TendrilPluginConfigFactoryTests.cs
@@ -1,0 +1,72 @@
+using Ivy.Tendril.Plugins;
+
+namespace Ivy.Tendril.Test.Plugins;
+
+public class TendrilPluginConfigFactoryTests : IDisposable
+{
+    private readonly string _tempHome = Path.Combine(Path.GetTempPath(), "tendril-plugin-config-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempHome))
+            Directory.Delete(_tempHome, recursive: true);
+    }
+
+    [Fact]
+    public void SetValue_Save_PersistsAndReloads()
+    {
+        var factory = new TendrilPluginConfigFactory(_tempHome);
+        var config = factory.Create("my-plugin");
+        config.SetValue("BotToken", "xoxb-123");
+        config.SetValue("Channel", "C042");
+        config.Save();
+
+        var reloaded = factory.Create("my-plugin");
+        Assert.Equal("xoxb-123", reloaded.GetValue("BotToken"));
+        Assert.Equal("C042", reloaded.GetValue("Channel"));
+    }
+
+    [Fact]
+    public void GetValue_MissingKey_ReturnsNull()
+    {
+        var config = new TendrilPluginConfigFactory(_tempHome).Create("my-plugin");
+        Assert.Null(config.GetValue("Nope"));
+    }
+
+    [Fact]
+    public void RemoveValue_RemovesPersistedKey()
+    {
+        var factory = new TendrilPluginConfigFactory(_tempHome);
+        var config = factory.Create("my-plugin");
+        config.SetValue("Key", "value");
+        config.Save();
+
+        config.RemoveValue("Key");
+        config.Save();
+
+        Assert.Null(factory.Create("my-plugin").GetValue("Key"));
+    }
+
+    [Fact]
+    public void Create_CorruptConfigFile_ReturnsEmptyConfig()
+    {
+        var factory = new TendrilPluginConfigFactory(_tempHome);
+        Directory.CreateDirectory(factory.ConfigDirectory);
+        File.WriteAllText(Path.Combine(factory.ConfigDirectory, "my-plugin.json"), "{not json");
+
+        Assert.Null(factory.Create("my-plugin").GetValue("Key"));
+    }
+
+    [Fact]
+    public void Create_PluginIdWithPathSeparators_SanitizesFileName()
+    {
+        var factory = new TendrilPluginConfigFactory(_tempHome);
+        var config = factory.Create("weird/../plugin");
+        config.SetValue("Key", "value");
+        config.Save();
+
+        var files = Directory.GetFiles(factory.ConfigDirectory);
+        Assert.Single(files);
+        Assert.Equal("value", factory.Create("weird/../plugin").GetValue("Key"));
+    }
+}

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -36,6 +36,20 @@
     <EmbeddedResource Include="../Tendril.svg" Link="Assets/Tendril.svg" />
   </ItemGroup>
 
+  <!-- Bundled plugins: built first (ProjectReference below), then embedded so
+       BundledPluginDeployer can install them into TENDRIL_HOME/plugins at startup -->
+  <ItemGroup>
+    <ProjectReference Include="../Ivy.Tendril.Plugin.Slack/Ivy.Tendril.Plugin.Slack.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <Private>false</Private>
+      <PrivateAssets>all</PrivateAssets>
+    </ProjectReference>
+    <EmbeddedResource Include="../Ivy.Tendril.Plugin.Slack/bin/$(Configuration)/net10.0/Ivy.Tendril.Plugin.Slack.dll"
+                      LogicalName="Ivy.Tendril.BundledPlugins.Ivy.Tendril.Plugin.Slack.Ivy.Tendril.Plugin.Slack.dll" />
+    <EmbeddedResource Include="../Ivy.Tendril.Plugin.Slack/bin/$(Configuration)/net10.0/Ivy.Tendril.Plugin.Slack.deps.json"
+                      LogicalName="Ivy.Tendril.BundledPlugins.Ivy.Tendril.Plugin.Slack.Ivy.Tendril.Plugin.Slack.deps.json" />
+  </ItemGroup>
+
   <!-- PackageReferences -->
   <ItemGroup>
     <PackageReference Include="Ivy.StackAnalyzer" Version="1.0.1" />
@@ -96,6 +110,7 @@
   <!-- Tendril ProjectReferences -->
   <ItemGroup>
     <ProjectReference Include="../Ivy.Tendril.Agents/Ivy.Tendril.Agents.csproj" />
+    <ProjectReference Include="../Ivy.Tendril.Plugin.Abstractions/Ivy.Tendril.Plugin.Abstractions.csproj" />
     <ProjectReference Include="../Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj" />
   </ItemGroup>
 

--- a/src/Ivy.Tendril/Ivy.Tendril.slnx
+++ b/src/Ivy.Tendril/Ivy.Tendril.slnx
@@ -5,6 +5,8 @@
     <Platform Name="x86" />
   </Configurations>
   <Project Path="Ivy.Tendril.csproj" />
+  <Project Path="../Ivy.Tendril.Plugin.Abstractions/Ivy.Tendril.Plugin.Abstractions.csproj" />
+  <Project Path="../Ivy.Tendril.Plugin.Slack/Ivy.Tendril.Plugin.Slack.csproj" />
   <Project Path="../Ivy.Tendril.Widgets/.samples/Ivy.Tendril.Widgets.Samples.csproj" />
   <Project Path="../Ivy.Tendril.Widgets/Ivy.Tendril.Widgets.csproj" />
   <Project Path="../Ivy.Tendril.Test/Ivy.Tendril.Test.csproj" />

--- a/src/Ivy.Tendril/Plugins/BundledPluginDeployer.cs
+++ b/src/Ivy.Tendril/Plugins/BundledPluginDeployer.cs
@@ -1,0 +1,48 @@
+using System.Reflection;
+
+namespace Ivy.Tendril.Plugins;
+
+public static class BundledPluginDeployer
+{
+    private const string VersionFileName = ".version";
+    private const string ResourcePrefix = "Ivy.Tendril.BundledPlugins.";
+
+    private static readonly (string PluginName, string[] Files)[] BundledPlugins =
+    [
+        ("Ivy.Tendril.Plugin.Slack", ["Ivy.Tendril.Plugin.Slack.dll", "Ivy.Tendril.Plugin.Slack.deps.json"])
+    ];
+
+    public static void Deploy(string pluginsDirectory)
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var hostVersion = assembly.GetName().Version?.ToString() ?? "0.0.0";
+        var resourceNames = assembly.GetManifestResourceNames();
+
+        foreach (var (pluginName, files) in BundledPlugins)
+        {
+            var targetDir = Path.Combine(pluginsDirectory, pluginName);
+            var versionFile = Path.Combine(targetDir, VersionFileName);
+
+            if (File.Exists(versionFile) && File.ReadAllText(versionFile).Trim() == hostVersion)
+                continue;
+
+            var resources = files
+                .Select(file => (File: file, Resource: $"{ResourcePrefix}{pluginName}.{file}"))
+                .Where(r => resourceNames.Contains(r.Resource))
+                .ToList();
+
+            if (resources.Count != files.Length)
+                continue;
+
+            Directory.CreateDirectory(targetDir);
+            foreach (var (file, resource) in resources)
+            {
+                using var stream = assembly.GetManifestResourceStream(resource)!;
+                using var target = File.Create(Path.Combine(targetDir, file));
+                stream.CopyTo(target);
+            }
+
+            File.WriteAllText(versionFile, hostVersion);
+        }
+    }
+}

--- a/src/Ivy.Tendril/Plugins/MessagingChannelService.cs
+++ b/src/Ivy.Tendril/Plugins/MessagingChannelService.cs
@@ -1,0 +1,161 @@
+using Ivy.Plugins;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Jobs;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Plugins;
+
+public class MessagingChannelService(
+    IPluginServiceProvider pluginServiceProvider,
+    IPluginManager pluginManager,
+    IJobService jobService,
+    ITendrilApi tendrilApi,
+    ILogger<MessagingChannelService> logger,
+    TendrilPluginConfigFactory? configFactory = null) : IStartable, IDisposable
+{
+    private readonly Lock _lock = new();
+    private readonly Dictionary<ITendrilMessagingChannel, CancellationTokenSource> _runningChannels = new();
+    private bool _started;
+
+    public void Start()
+    {
+        lock (_lock)
+        {
+            if (_started) return;
+            _started = true;
+        }
+
+        jobService.NotificationReady += OnNotificationReady;
+        pluginManager.PluginActivated += OnPluginStateChanged;
+        pluginManager.PluginDeactivated += OnPluginStateChanged;
+        pluginManager.PluginUnloaded += OnPluginStateChanged;
+        pluginManager.PluginReloaded += OnPluginStateChanged;
+        if (configFactory != null)
+            configFactory.ConfigSaved += OnPluginStateChanged;
+
+        SyncChannels();
+    }
+
+    private void OnPluginStateChanged(string pluginId) => SyncChannels();
+
+    private void SyncChannels()
+    {
+        List<ITendrilMessagingChannel> current;
+        try
+        {
+            current = pluginServiceProvider.GetServices<ITendrilMessagingChannel>().ToList();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to resolve messaging channels from plugins");
+            return;
+        }
+
+        List<(ITendrilMessagingChannel Channel, CancellationTokenSource Cts)> toStop = new();
+        List<(ITendrilMessagingChannel Channel, CancellationTokenSource Cts)> toStart = new();
+
+        lock (_lock)
+        {
+            foreach (var (channel, cts) in _runningChannels.Where(kv => !current.Contains(kv.Key)).ToList())
+            {
+                _runningChannels.Remove(channel);
+                toStop.Add((channel, cts));
+            }
+
+            foreach (var channel in current.Where(c => !_runningChannels.ContainsKey(c)))
+            {
+                var cts = new CancellationTokenSource();
+                _runningChannels[channel] = cts;
+                toStart.Add((channel, cts));
+            }
+        }
+
+        foreach (var (channel, cts) in toStop)
+            _ = StopChannelAsync(channel, cts);
+
+        foreach (var (channel, cts) in toStart)
+        {
+            var token = cts.Token;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    logger.LogInformation("Starting messaging channel {ChannelId}", channel.Id);
+                    await channel.StartAsync(tendrilApi, token);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Messaging channel {ChannelId} failed to start", channel.Id);
+                }
+            }, CancellationToken.None);
+        }
+    }
+
+    private async Task StopChannelAsync(ITendrilMessagingChannel channel, CancellationTokenSource cts)
+    {
+        try
+        {
+            logger.LogInformation("Stopping messaging channel {ChannelId}", channel.Id);
+            await cts.CancelAsync();
+            using var stopTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await channel.StopAsync(stopTimeout.Token);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Messaging channel {ChannelId} failed to stop cleanly", channel.Id);
+        }
+        finally
+        {
+            cts.Dispose();
+        }
+    }
+
+    private void OnNotificationReady(JobNotification notification)
+    {
+        List<ITendrilMessagingChannel> channels;
+        lock (_lock)
+            channels = _runningChannels.Keys.ToList();
+
+        if (channels.Count == 0) return;
+
+        var tendrilNotification = new TendrilNotification(notification.Title, notification.Message, notification.IsSuccess);
+        foreach (var channel in channels)
+        {
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    using var sendTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                    await channel.SendNotificationAsync(tendrilNotification, sendTimeout.Token);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Messaging channel {ChannelId} failed to send notification", channel.Id);
+                }
+            });
+        }
+    }
+
+    public void Dispose()
+    {
+        jobService.NotificationReady -= OnNotificationReady;
+        pluginManager.PluginActivated -= OnPluginStateChanged;
+        pluginManager.PluginDeactivated -= OnPluginStateChanged;
+        pluginManager.PluginUnloaded -= OnPluginStateChanged;
+        pluginManager.PluginReloaded -= OnPluginStateChanged;
+        if (configFactory != null)
+            configFactory.ConfigSaved -= OnPluginStateChanged;
+
+        List<(ITendrilMessagingChannel Channel, CancellationTokenSource Cts)> running;
+        lock (_lock)
+        {
+            running = _runningChannels.Select(kv => (kv.Key, kv.Value)).ToList();
+            _runningChannels.Clear();
+        }
+        foreach (var (channel, cts) in running)
+            StopChannelAsync(channel, cts).GetAwaiter().GetResult();
+    }
+}

--- a/src/Ivy.Tendril/Plugins/TendrilApi.cs
+++ b/src/Ivy.Tendril/Plugins/TendrilApi.cs
@@ -1,0 +1,64 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Jobs;
+
+namespace Ivy.Tendril.Plugins;
+
+internal class TendrilApi(IJobService jobService, IConfigService configService) : ITendrilApi
+{
+    public string StartCreatePlan(string description, string? project = null)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            throw new ArgumentException("Description is required", nameof(description));
+        return jobService.StartJob(new CreatePlanArgs(description, project ?? "Auto"));
+    }
+
+    public string StartExecutePlan(string planId, string? note = null)
+    {
+        var folderPath = PlanCommandHelpers.ResolvePlanFolder(planId);
+        return jobService.StartJob(new ExecutePlanArgs(folderPath, note));
+    }
+
+    public TendrilJobStatus? GetJob(string jobId)
+    {
+        var job = jobService.GetJob(jobId);
+        return job == null
+            ? null
+            : new TendrilJobStatus(job.Id, job.Type, job.Status.ToString(), job.StatusMessage, job.PlanFile);
+    }
+
+    public IReadOnlyList<TendrilPlanSummary> ListPlans(string? state = null, string? project = null, int limit = 20)
+    {
+        var results = new List<TendrilPlanSummary>();
+        var plansDir = PlanCommandHelpers.GetPlansDirectory();
+        if (!Directory.Exists(plansDir))
+            return results;
+
+        foreach (var dir in Directory.GetDirectories(plansDir).OrderByDescending(Path.GetFileName))
+        {
+            var folderName = Path.GetFileName(dir);
+            var dash = folderName.IndexOf('-');
+            if (dash <= 0 || !int.TryParse(folderName[..dash], out _)) continue;
+
+            PlanYaml yaml;
+            try { yaml = PlanCommandHelpers.ReadPlan(dir); }
+            catch { continue; }
+
+            if (!string.IsNullOrEmpty(state) &&
+                !string.Equals(yaml.State, state, StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (!string.IsNullOrEmpty(project) &&
+                !string.Equals(yaml.Project, project, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            results.Add(new TendrilPlanSummary(folderName[..dash], yaml.Title, yaml.State, yaml.Project, yaml.Level));
+            if (results.Count >= limit) break;
+        }
+
+        return results;
+    }
+
+    public IReadOnlyList<string> ListProjects() =>
+        configService.Settings.Projects.Select(p => p.Name).ToList();
+}

--- a/src/Ivy.Tendril/Plugins/TendrilPluginConfigFactory.cs
+++ b/src/Ivy.Tendril/Plugins/TendrilPluginConfigFactory.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using Ivy.Plugins;
+
+namespace Ivy.Tendril.Plugins;
+
+public class TendrilPluginConfigFactory(string tendrilHome) : IIvyPluginConfigFactory
+{
+    private IPluginManager? _pluginManager;
+
+    internal string ConfigDirectory { get; } = Path.Combine(tendrilHome, "plugin-config");
+
+    public event Action<string>? ConfigSaved;
+
+    public void SetPluginManager(IPluginManager pluginManager) => _pluginManager = pluginManager;
+
+    public IIvyPluginConfig Create(string pluginId) =>
+        new TendrilPluginConfig(ConfigDirectory, pluginId, () => _pluginManager, () => ConfigSaved?.Invoke(pluginId));
+}
+
+internal class TendrilPluginConfig : IIvyPluginConfig
+{
+    private readonly string _filePath;
+    private readonly string _pluginId;
+    private readonly Func<IPluginManager?> _pluginManager;
+    private readonly Action _onSaved;
+    private readonly Lock _lock = new();
+    private Dictionary<string, string> _values;
+
+    public TendrilPluginConfig(string configDirectory, string pluginId, Func<IPluginManager?> pluginManager, Action? onSaved = null)
+    {
+        _pluginId = pluginId;
+        _pluginManager = pluginManager;
+        _onSaved = onSaved ?? (() => { });
+        _filePath = Path.Combine(configDirectory, SanitizeFileName(pluginId) + ".json");
+        _values = Load();
+    }
+
+    public string? GetValue(string key)
+    {
+        lock (_lock)
+            return _values.TryGetValue(key, out var value) ? value : null;
+    }
+
+    public void SetValue(string key, string value)
+    {
+        lock (_lock)
+            _values[key] = value;
+    }
+
+    public void RemoveValue(string key)
+    {
+        lock (_lock)
+            _values.Remove(key);
+    }
+
+    public void Save()
+    {
+        lock (_lock)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(_filePath)!);
+            var tempPath = _filePath + ".tmp";
+            File.WriteAllText(tempPath, JsonSerializer.Serialize(_values, new JsonSerializerOptions { WriteIndented = true }));
+            File.Move(tempPath, _filePath, overwrite: true);
+        }
+        _pluginManager()?.ReconfigurePlugin(_pluginId);
+        _onSaved();
+    }
+
+    private Dictionary<string, string> Load()
+    {
+        if (!File.Exists(_filePath))
+            return new Dictionary<string, string>();
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(File.ReadAllText(_filePath))
+                   ?? new Dictionary<string, string>();
+        }
+        catch (JsonException)
+        {
+            return new Dictionary<string, string>();
+        }
+    }
+
+    private static string SanitizeFileName(string pluginId)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        return new string(pluginId.Select(c => invalid.Contains(c) ? '_' : c).ToArray());
+    }
+}

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -51,6 +51,7 @@ internal static class ServiceRegistration
         server.Services.AddSingleton<VersionCheckService>();
         server.Services.AddSingleton<IVersionCheckService>(sp => sp.GetRequiredService<VersionCheckService>());
         server.Services.AddSingleton<IPromptwareRunner, PromptwareRunner>();
+        server.Services.AddSingleton<Plugins.ITendrilApi, Plugins.TendrilApi>();
 
         server.Services.AddSingleton<OnboardingSetupService>();
         server.Services.AddSingleton<IOnboardingSetupService>(sp => sp.GetRequiredService<OnboardingSetupService>());

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -30,6 +30,22 @@ public static class TendrilServer
         server.Services.AddSingleton(tendrilArgs);
         server.AddTendrilServices(configService, tendrilArgs);
 
+        if (!string.IsNullOrEmpty(configService.TendrilHome))
+        {
+            var pluginsDirectory = Path.Combine(configService.TendrilHome, "plugins");
+            Directory.CreateDirectory(pluginsDirectory);
+            Plugins.BundledPluginDeployer.Deploy(pluginsDirectory);
+            var pluginConfigFactory = new Plugins.TendrilPluginConfigFactory(configService.TendrilHome);
+            server.Services.AddSingleton(pluginConfigFactory);
+            server.Services.AddSingleton<Plugins.MessagingChannelService>();
+            server.Services.AddSingleton<IStartable>(sp => sp.GetRequiredService<Plugins.MessagingChannelService>());
+            server.UsePlugins(
+                pluginsDirectory,
+                pluginConfigFactory,
+                hostVersion: typeof(TendrilServer).Assembly.GetName().Version,
+                sharedAssemblyNames: ["Ivy.Tendril.Plugin.Abstractions"]);
+        }
+
         var logLevel = tendrilArgs.Verbose ? "Debug"
             : tendrilArgs.Quiet ? "Warning"
             : "Error";


### PR DESCRIPTION
## Summary

Makes Tendril an Ivy plugin host and ships a bundled Slack bot plugin that users can set up in a couple of clicks — no downloads, no public URL, no webhook configuration.

### Plugin hosting (new)
- `TendrilServer` now calls `Server.UsePlugins` with plugins loaded from `TENDRIL_HOME/plugins` (hot reload enabled). The framework's Plugin Manager app is auto-registered.
- Per-plugin config persists as JSON under `TENDRIL_HOME/plugin-config/` (`TendrilPluginConfigFactory`), with atomic writes and reconfigure-on-save.
- New packable project **`Ivy.Tendril.Plugin.Abstractions`**: `ITendrilApi` (create/execute plans, job status, list plans/projects) and `ITendrilMessagingChannel` — the contract for chat integrations.
- `MessagingChannelService` starts channels registered by plugins, fans out `IJobService.NotificationReady` to them, and resyncs channels on plugin lifecycle events and config saves.

### Slack plugin (new)
- **`Ivy.Tendril.Plugin.Slack`** connects via **Slack Socket Mode** (outbound websocket → works behind NAT/firewalls). The Socket Mode + Web API clients are hand-rolled on `ClientWebSocket`/`HttpClient` — zero external dependencies.
- Commands via `/tendril`, @mention, or DM: `new <description>` (`project:Name` prefix supported), `run <planId>`, `plans [state]`, `projects`, `status <jobId>`, `help`.
- Job completion notifications post to a configurable channel; optional Slack user-ID allowlist gates commands.
- **One-click install**: the plugin is embedded into `Ivy.Tendril.dll` and auto-deployed to `TENDRIL_HOME/plugins` on startup (same pattern as `PromptwareDeployer`, version-stamped). Setup is just configuration: the wizard deep-links to Slack app creation with a **pre-filled app manifest** (bot user, `/tendril` command, scopes, Socket Mode), validates both tokens via `auth.test`/`apps.connections.open`, lets the user pick the notification channel, and starts the bot immediately on save.
- Docs: `docs/slack-bot.md`.

## Testing
- 29 new unit tests (config factory persistence, channel manager fan-out/lifecycle, command parsing, manifest/deep-link, allowlist).
- Full suite: 1785 passed, 1 unrelated flaky failure (`PlanToolsTests.VerificationRemove_Removes` — passes in isolation, plan-folder state race under parallel run).
- Live smoke test: fresh `TENDRIL_HOME` boot → plugin auto-deployed, loaded by `PluginLoader`, correctly reported *unconfigured* pending tokens, `/api/ping` healthy, hot-reload watcher running.

## Notes for review
- Channels get `ITendrilApi` handed into `StartAsync` rather than resolving host services from plugin DI (per-plugin providers don't chain to host DI).
- An active→active `ReconfigurePlugin` fires no plugin-manager event, so `TendrilPluginConfigFactory` raises `ConfigSaved` and the channel manager resyncs on it — token changes apply without restart.
- Slack token rotation is not enabled in the generated manifest; tokens are stored in the plugin config JSON under `TENDRIL_HOME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)