### PR TITLE
fix: list-row highlight styling in plan sidebars and Configuration app

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
@@ -57,7 +57,7 @@ public class SettingsApp : ViewBase
             | Icons.Settings2.ToIcon()
             | Text.Literal("Configuration");
 
-        var sidebar = new HeaderLayout(sidebarHeader, new List(rows));
+        var sidebar = new HeaderLayout(sidebarHeader, Layout.Vertical(rows).Gap(1));
 
         object content = selected.Value switch
         {

--- a/src/Ivy.Tendril/Helpers/SidebarListRow.cs
+++ b/src/Ivy.Tendril/Helpers/SidebarListRow.cs
@@ -8,12 +8,12 @@ public static class SidebarListRow
             | Text.Literal(title)
             | content;
 
-        return BuildButton(row, onClick, isSelected);
+        return BuildButton(row, onClick, isSelected, BorderRadius.None);
     }
 
     public static object Build(string title, Action onClick, bool isSelected = false)
     {
-        return BuildButton(Text.Literal(title), onClick, isSelected);
+        return BuildButton(Text.Literal(title), onClick, isSelected, BorderRadius.None);
     }
 
     public static object Build(string title, Icons icon, Action onClick, bool isSelected = false)
@@ -22,12 +22,14 @@ public static class SidebarListRow
             | icon.ToIcon()
             | Text.Literal(title);
 
-        return BuildButton(row, onClick, isSelected);
+        return BuildButton(row, onClick, isSelected, BorderRadius.Rounded);
     }
 
-    private static Button BuildButton(object content, Action onClick, bool isSelected)
+    // Rows hosted in a List widget sit between its straight separator lines, so they
+    // stay square; the icon overload lives in gap-spaced menus and keeps rounding.
+    private static Button BuildButton(object content, Action onClick, bool isSelected, BorderRadius radius)
     {
-        var button = new Button().Width(Size.Full()).Content(content).OnClick(onClick);
+        var button = new Button().Width(Size.Full()).Content(content).OnClick(onClick).BorderRadius(radius);
         return isSelected ? button.Secondary() : button.Ghost();
     }
 }


### PR DESCRIPTION
## Changes

**Plan sidebars (Drafts / Review / Recommendations / Icebox / Trash):** the selected row is a filled `Secondary` button rendered between the `List` widget's straight full-width separator lines, so its rounded corners clashed with them. `SidebarListRow` now squares the corners (`BorderRadius.None`) for list-hosted rows, making the highlight sit flush against the lines.

**Configuration app:** the section list used the `List` widget, which hardcodes a `border-b` separator per item with no gap. It now uses `Layout.Vertical(rows).Gap(1)` — no lines, spacing between items — matching the main app sidebar, while the icon rows keep the default rounded selected highlight.

No framework change was needed: `Button.BorderRadius` already exists in Ivy 1.3.8.

## Verification

Ran the app locally (`--web`, port 5077) and checked both in the browser:
- Review sidebar: selected row renders with `border-radius: 0`, filled background spans the full row width between separators.
- Configuration sidebar: no separator lines, gap between rows, rounded highlight follows section clicks (Coding Agent → Plans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)