### PR TITLE
[00654] Fix Horizontal Scrollbar From Long Strings in Agent Output Sheet

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
@@ -156,6 +156,9 @@
   color: var(--aov-fg);
   font-size: 14px;
   line-height: 1.6;
+  word-break: normal;
+  overflow-wrap: break-word;
+  min-width: 0;
 }
 
 .aov-markdown p {
@@ -176,6 +179,7 @@
   padding: 1px 5px;
   font-size: 0.9em;
   font-weight: 500;
+  overflow-wrap: break-word;
 }
 
 .aov-markdown pre {
@@ -203,6 +207,7 @@
 .aov-markdown a {
   color: var(--aov-accent);
   text-decoration: underline;
+  overflow-wrap: break-word;
 }
 
 .aov-markdown h1,


### PR DESCRIPTION
Fixes #1690

# Summary

## Changes

Added CSS word-wrapping rules to the AgentViewer widget stylesheet to prevent long unbroken strings (URLs, tokens, hashes, file paths) from triggering a horizontal scrollbar in the agent output sheet. The fix applies wrapping to assistant markdown text, inline code spans, and links, matching the existing pattern used in draft-markdown.css.

## API Changes

None.

## Files Modified

**CSS:**
- `src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css` - Added `word-break`, `overflow-wrap`, and `min-width` properties to `.aov-markdown`, `.aov-markdown code`, and `.aov-markdown a` rules

**Generated (auto-rebuilt by MSBuild):**
- `src/Ivy.Tendril.Widgets/frontend/dist/ivy-tendril-widgets.css` - CSS bundle regenerated with new wrapping rules

## Manual Testing

1. Run the Tendril application
2. Navigate to the Jobs app
3. Open a job that has agent output containing a long unbroken string (e.g., a long URL, file path, or token in the assistant text or as inline code)
4. Observe that long strings now wrap within the sheet panel instead of triggering a horizontal scrollbar
5. Verify that fenced code blocks (pre/code) still have their own internal horizontal scroll when needed

---
## Commits

- f044aa13 Fix horizontal scrollbar from long strings in agent output sheet

---
Created using [Ivy Tendril](https://ivy.app).
