### PR TITLE
[00656] Allow Rerunning Completed RetryPlan Jobs From Jobs List

### DIFF
--- a/src/Ivy.Tendril.Test/JobRerunEligibilityTests.cs
+++ b/src/Ivy.Tendril.Test/JobRerunEligibilityTests.cs
@@ -1,0 +1,161 @@
+using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Models;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class JobRerunEligibilityTests
+{
+    [Theory]
+    [InlineData(JobStatus.Completed)]
+    [InlineData(JobStatus.Running)]
+    [InlineData(JobStatus.Queued)]
+    [InlineData(JobStatus.Pending)]
+    [InlineData(JobStatus.Blocked)]
+    public void CanRerun_CompletedRetryPlanArgs_ReturnsTrue(JobStatus status)
+    {
+        var job = new JobItem
+        {
+            Id = "test-id",
+            Status = status,
+            TypedArgs = new RetryPlanArgs("/plans/00001-Test", "change request")
+        };
+
+        var result = JobsApp.CanRerun(job);
+
+        if (status == JobStatus.Completed)
+            Assert.True(result);
+        else
+            Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(JobStatus.Completed)]
+    [InlineData(JobStatus.Running)]
+    [InlineData(JobStatus.Queued)]
+    [InlineData(JobStatus.Pending)]
+    [InlineData(JobStatus.Blocked)]
+    public void CanRerun_CompletedExecutePlanArgs_ReturnsTrue(JobStatus status)
+    {
+        var job = new JobItem
+        {
+            Id = "test-id",
+            Status = status,
+            TypedArgs = new ExecutePlanArgs("/plans/00001-Test")
+        };
+
+        var result = JobsApp.CanRerun(job);
+
+        if (status == JobStatus.Completed)
+            Assert.True(result);
+        else
+            Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(JobStatus.Completed)]
+    [InlineData(JobStatus.Running)]
+    [InlineData(JobStatus.Queued)]
+    [InlineData(JobStatus.Pending)]
+    [InlineData(JobStatus.Blocked)]
+    public void CanRerun_CompletedUpdatePlanArgs_ReturnsTrue(JobStatus status)
+    {
+        var job = new JobItem
+        {
+            Id = "test-id",
+            Status = status,
+            TypedArgs = new UpdatePlanArgs("/plans/00001-Test")
+        };
+
+        var result = JobsApp.CanRerun(job);
+
+        if (status == JobStatus.Completed)
+            Assert.True(result);
+        else
+            Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(JobStatus.Completed)]
+    [InlineData(JobStatus.Running)]
+    [InlineData(JobStatus.Queued)]
+    [InlineData(JobStatus.Pending)]
+    [InlineData(JobStatus.Blocked)]
+    public void CanRerun_CompletedCreatePrArgs_ReturnsFalse(JobStatus status)
+    {
+        var job = new JobItem
+        {
+            Id = "test-id",
+            Status = status,
+            TypedArgs = new CreatePrArgs("/plans/00001-Test")
+        };
+
+        var result = JobsApp.CanRerun(job);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(JobStatus.Completed)]
+    [InlineData(JobStatus.Running)]
+    [InlineData(JobStatus.Queued)]
+    [InlineData(JobStatus.Pending)]
+    [InlineData(JobStatus.Blocked)]
+    public void CanRerun_CompletedExpandPlanArgs_ReturnsFalse(JobStatus status)
+    {
+        var job = new JobItem
+        {
+            Id = "test-id",
+            Status = status,
+            TypedArgs = new ExpandPlanArgs("/plans/00001-Test")
+        };
+
+        var result = JobsApp.CanRerun(job);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(JobStatus.Failed)]
+    [InlineData(JobStatus.Timeout)]
+    [InlineData(JobStatus.Stopped)]
+    public void CanRerun_FailedStateCreatePrArgs_ReturnsTrue(JobStatus status)
+    {
+        var job = new JobItem
+        {
+            Id = "test-id",
+            Status = status,
+            TypedArgs = new CreatePrArgs("/plans/00001-Test")
+        };
+
+        var result = JobsApp.CanRerun(job);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData(JobStatus.Failed)]
+    [InlineData(JobStatus.Timeout)]
+    [InlineData(JobStatus.Stopped)]
+    public void CanRerun_FailedStateExpandPlanArgs_ReturnsTrue(JobStatus status)
+    {
+        var job = new JobItem
+        {
+            Id = "test-id",
+            Status = status,
+            TypedArgs = new ExpandPlanArgs("/plans/00001-Test")
+        };
+
+        var result = JobsApp.CanRerun(job);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void CanRerun_NullJob_ReturnsFalse()
+    {
+        var result = JobsApp.CanRerun(null);
+
+        Assert.False(result);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Apps.Drafts;
+using Ivy.Tendril.Apps.Jobs.Dialogs;
 using Ivy.Tendril.Apps.Review;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
@@ -7,6 +8,25 @@ namespace Ivy.Tendril.Apps.Jobs;
 
 public partial class JobsApp
 {
+    /// <summary>
+    /// Determines if a job can be rerun. Returns true for Failed/Timeout/Stopped
+    /// jobs (existing behavior), or for Completed jobs whose args type supports
+    /// corrective feedback (ExecutePlan/RetryPlan/UpdatePlan).
+    /// </summary>
+    internal static bool CanRerun(JobItem? job)
+    {
+        if (job == null) return false;
+
+        // Existing behavior: all failed-state jobs can be rerun regardless of type
+        if (job.Status is JobStatus.Failed or JobStatus.Timeout or JobStatus.Stopped)
+            return true;
+
+        // New: Completed jobs can be rerun only when their args support feedback
+        if (job.Status is JobStatus.Completed)
+            return RerunJobDialog.SupportsFeedback(job.TypedArgs);
+
+        return false;
+    }
     private static object BuildDataTable(
         INavigator nav,
         List<JobItemRow> rows,
@@ -187,7 +207,7 @@ public partial class JobsApp
                         .Tooltip("Stop this running job"));
                 }
 
-                if (job?.Status is JobStatus.Failed or JobStatus.Timeout or JobStatus.Stopped)
+                if (CanRerun(job))
                 {
                     actions.Add(new MenuItem("Rerun", Icon: Icons.RotateCw, Tag: "rerun-job")
                         .Tooltip("Rerun this job"));
@@ -229,7 +249,7 @@ public partial class JobsApp
                     }
                     else if (tag == "rerun-job")
                     {
-                        if (job.Status is JobStatus.Failed or JobStatus.Timeout or JobStatus.Stopped)
+                        if (CanRerun(job))
                         {
                             if (job.TypedArgs == null)
                             {


### PR DESCRIPTION
Fixes #1673

# Summary

## Changes

Added a Rerun button to the Jobs list for completed RetryPlan, ExecutePlan, and UpdatePlan jobs so users can iterate on successful plan executions. The button was previously only shown for Failed/Timeout/Stopped jobs.

## API Changes

- **JobsApp.CanRerun(JobItem? job)** — New internal static method that determines if a job is eligible for rerun based on its status and args type.

## Files Modified

**Implementation:**
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs` — Added CanRerun predicate, updated row action guards

**Tests:**
- `src/Ivy.Tendril.Test/JobRerunEligibilityTests.cs` — New test class with 32 test cases covering the CanRerun logic

## Manual Testing

1. Run the Tendril app
2. Navigate to the Jobs list
3. Find a completed job with RetryPlanArgs, ExecutePlanArgs, or UpdatePlanArgs
4. Click the row action menu (three dots)
5. Verify the "Rerun" button appears
6. Click "Rerun" and observe the rerun dialog opens
7. Optionally provide feedback and click "Rerun"
8. Verify a new job is created with the feedback

**Expected behavior:**
- Completed jobs with feedback-supporting args show the Rerun button
- Completed jobs without feedback support (CreatePr, ExpandPlan) do NOT show the button
- Failed/Timeout/Stopped jobs continue to show the Rerun button regardless of args type

---

**Commits:**
- 4de65472 Allow rerunning completed RetryPlan/ExecutePlan/UpdatePlan jobs from Jobs list

---
Created using [Ivy Tendril](https://ivy.app).
