### PR TITLE
feat: add Slackbot configuration with one-click Slack app install

### DIFF
--- a/src/Ivy.Tendril.Test/SlackbotTests.cs
+++ b/src/Ivy.Tendril.Test/SlackbotTests.cs
@@ -1,0 +1,249 @@
+using System.Text.Json.Nodes;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Slack;
+
+namespace Ivy.Tendril.Test;
+
+public class SlackTextFormatterTests
+{
+    [Fact]
+    public void StripMention_RemovesBotMention()
+    {
+        var result = SlackTextFormatter.StripMention("<@U0BOT> fix the login bug", "U0BOT");
+
+        Assert.Equal("fix the login bug", result);
+    }
+
+    [Fact]
+    public void StripMention_RemovesMidSentenceMention()
+    {
+        var result = SlackTextFormatter.StripMention("hey <@U0BOT> please fix this", "U0BOT");
+
+        Assert.Equal("hey please fix this", result);
+    }
+
+    [Fact]
+    public void StripMention_PreservesNewlines()
+    {
+        var result = SlackTextFormatter.StripMention("<@U0BOT> fix this:\nline one\nline two", "U0BOT");
+
+        Assert.Equal("fix this:\nline one\nline two", result);
+    }
+
+    [Fact]
+    public void StripMention_LeavesOtherMentionsIntact()
+    {
+        var result = SlackTextFormatter.StripMention("<@U0BOT> ask <@U123> about it", "U0BOT");
+
+        Assert.Equal("ask <@U123> about it", result);
+    }
+
+    [Fact]
+    public void StripMention_EmptyAfterMention_ReturnsEmpty()
+    {
+        var result = SlackTextFormatter.StripMention("<@U0BOT>", "U0BOT");
+
+        Assert.Equal("", result);
+    }
+
+    [Fact]
+    public void Normalize_ReplacesUserMentions()
+    {
+        var result = SlackTextFormatter.Normalize("ask <@U123> about it", _ => "alice");
+
+        Assert.Equal("ask @alice about it", result);
+    }
+
+    [Fact]
+    public void Normalize_ReplacesLabeledLinks()
+    {
+        var result = SlackTextFormatter.Normalize("see <https://example.com/a|the docs>", _ => "");
+
+        Assert.Equal("see the docs (https://example.com/a)", result);
+    }
+
+    [Fact]
+    public void Normalize_ReplacesPlainLinks()
+    {
+        var result = SlackTextFormatter.Normalize("see <https://example.com/a>", _ => "");
+
+        Assert.Equal("see https://example.com/a", result);
+    }
+
+    [Fact]
+    public void Normalize_ReplacesChannelMentions()
+    {
+        var result = SlackTextFormatter.Normalize("posted in <#C123|general>", _ => "");
+
+        Assert.Equal("posted in #general", result);
+    }
+
+    [Fact]
+    public void Normalize_DecodesHtmlEntities()
+    {
+        var result = SlackTextFormatter.Normalize("if a &lt; b &amp;&amp; b &gt; c", _ => "");
+
+        Assert.Equal("if a < b && b > c", result);
+    }
+
+    [Fact]
+    public void ExtractUserMentions_ReturnsDistinctIds()
+    {
+        var result = SlackTextFormatter.ExtractUserMentions("<@U1> and <@U2> and <@U1> again");
+
+        Assert.Equal(new[] { "U1", "U2" }, result);
+    }
+
+    [Fact]
+    public void BuildPlanDescription_IncludesInstructionRequesterAndContext()
+    {
+        var context = new List<(string Author, string Text)>
+        {
+            ("alice", "the login test fails on CI"),
+            ("bob", "only on chromium though")
+        };
+
+        var result = SlackTextFormatter.BuildPlanDescription(
+            "fix the flaky login test", "joel", "engineering", context);
+
+        Assert.StartsWith("fix the flaky login test", result);
+        Assert.Contains("Requested by @joel via Slack in #engineering.", result);
+        Assert.Contains("- @alice: the login test fails on CI", result);
+        Assert.Contains("- @bob: only on chromium though", result);
+    }
+
+    [Fact]
+    public void BuildPlanDescription_OmitsContextSectionWhenEmpty()
+    {
+        var result = SlackTextFormatter.BuildPlanDescription(
+            "fix the bug", "joel", "general", []);
+
+        Assert.DoesNotContain("conversation context", result);
+    }
+
+    [Fact]
+    public void BuildPlanDescription_FlattensMultilineContextMessages()
+    {
+        var context = new List<(string Author, string Text)> { ("alice", "line one\nline two") };
+
+        var result = SlackTextFormatter.BuildPlanDescription("task", "joel", "general", context);
+
+        Assert.Contains("- @alice: line one line two", result);
+    }
+}
+
+public class SlackAppManifestTests
+{
+    [Fact]
+    public void BuildManifestJson_IsValidJsonWithExpectedSettings()
+    {
+        var json = JsonNode.Parse(SlackAppManifest.BuildManifestJson());
+
+        Assert.NotNull(json);
+        Assert.Equal("Tendril", json!["display_information"]?["name"]?.GetValue<string>());
+        Assert.True(json["settings"]?["socket_mode_enabled"]?.GetValue<bool>());
+
+        var events = json["settings"]?["event_subscriptions"]?["bot_events"]?.AsArray()
+            .Select(e => e?.GetValue<string>()).ToList();
+        Assert.Contains("app_mention", events!);
+
+        var scopes = json["oauth_config"]?["scopes"]?["bot"]?.AsArray()
+            .Select(s => s?.GetValue<string>()).ToList();
+        Assert.Contains("app_mentions:read", scopes!);
+        Assert.Contains("channels:history", scopes!);
+        Assert.Contains("chat:write", scopes!);
+        Assert.Contains("users:read", scopes!);
+    }
+
+    [Fact]
+    public void BuildInstallUrl_PointsToSlackAppCreation()
+    {
+        var url = SlackAppManifest.BuildInstallUrl();
+
+        Assert.StartsWith("https://api.slack.com/apps?new_app=1&manifest_json=", url);
+        Assert.DoesNotContain("\"", url.Substring("https://api.slack.com/apps?new_app=1&manifest_json=".Length));
+    }
+}
+
+public class SlackbotConfigTests
+{
+    [Fact]
+    public void LoadSettings_DeserializesSlackbotSection()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "tendril-slackbot-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        File.WriteAllText(Path.Combine(tempDir, "config.yaml"), @"
+slackbot:
+  enabled: true
+  botToken: xoxb-test
+  appToken: xapp-test
+  project: Framework
+  historyLimit: 25
+");
+
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            var slackbot = service.Settings.Slackbot;
+            Assert.NotNull(slackbot);
+            Assert.True(slackbot!.Enabled);
+            Assert.Equal("xoxb-test", slackbot.BotToken);
+            Assert.Equal("xapp-test", slackbot.AppToken);
+            Assert.Equal("Framework", slackbot.Project);
+            Assert.Equal(25, slackbot.HistoryLimit);
+        }
+        finally
+        {
+            service.Dispose();
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void SaveSettings_RoundTripsSlackbotSection()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "tendril-slackbot-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        File.WriteAllText(Path.Combine(tempDir, "config.yaml"), "projects: []\n");
+
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            service.Settings.Slackbot = new SlackbotConfig
+            {
+                Enabled = true,
+                BotToken = "xoxb-abc",
+                AppToken = "xapp-def",
+                Project = "Auto"
+            };
+            service.SaveSettings();
+
+            var savedYaml = File.ReadAllText(Path.Combine(tempDir, "config.yaml"));
+            Assert.Contains("slackbot:", savedYaml);
+            Assert.Contains("xoxb-abc", savedYaml);
+
+            service.ReloadSettings();
+            Assert.True(service.Settings.Slackbot?.Enabled);
+            Assert.Equal("xoxb-abc", service.Settings.Slackbot?.BotToken);
+        }
+        finally
+        {
+            service.Dispose();
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Settings_WithoutSlackbotSection_IsNull()
+    {
+        var settings = new TendrilSettings();
+
+        Assert.Null(settings.Slackbot);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
@@ -19,6 +19,7 @@ public class SettingsApp : ViewBase
     private const string TagPromptwares = "promptwares";
     internal const string TagProjects = "projects";
     private const string TagTunnel = "tunnel";
+    private const string TagSlackbot = "slackbot";
     private const string TagAdvanced = "advanced";
 
     public override object Build()
@@ -45,6 +46,7 @@ public class SettingsApp : ViewBase
             ("Notifications", TagNotifications, Icons.Bell),
             ("Security", TagSecurity, Icons.Lock),
             ("Tunnel", TagTunnel, Icons.Globe),
+            ("Slackbot", TagSlackbot, Icons.Slack),
             ("Advanced", TagAdvanced, Icons.Cog),
         };
 
@@ -71,6 +73,7 @@ public class SettingsApp : ViewBase
             TagPromptwares => new PromptwaresSetupView(),
             TagProjects => new ProjectsSetupView(),
             TagTunnel => new TunnelSetupView(),
+            TagSlackbot => new SlackbotSetupView(),
             TagAdvanced => new AdvancedSetupView(),
             _ => new CodingAgentSetupView()
         };

--- a/src/Ivy.Tendril/Apps/Settings/SlackbotSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/SlackbotSetupView.cs
@@ -1,0 +1,142 @@
+using System.Reactive.Disposables;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Slack;
+
+namespace Ivy.Tendril.Apps.Settings;
+
+public class SlackbotSetupView : ViewBase
+{
+    public override object Build()
+    {
+        var config = UseService<IConfigService>();
+        var client = UseService<IClientProvider>();
+        var slackbot = UseService<ISlackbotService>();
+
+        var enabled = UseState(() => config.Settings.Slackbot?.Enabled ?? false);
+        var botToken = UseState(() => config.Settings.Slackbot?.BotToken ?? "");
+        var appToken = UseState(() => config.Settings.Slackbot?.AppToken ?? "");
+        var project = UseState(() =>
+        {
+            var configured = config.Settings.Slackbot?.Project;
+            return string.IsNullOrWhiteSpace(configured) ? "Auto" : configured;
+        });
+        var status = UseState(() => slackbot.Status);
+        var saving = UseState(false);
+
+        UseEffect(() =>
+        {
+            void OnStatusChanged(SlackbotStatus newStatus) => status.Set(newStatus);
+
+            slackbot.StatusChanged += OnStatusChanged;
+            status.Set(slackbot.Status);
+
+            return Disposable.Create(() => slackbot.StatusChanged -= OnStatusChanged);
+        });
+
+        var saved = config.Settings.Slackbot;
+
+        var projectOptions = new[] { "Auto" }
+            .Concat(config.Settings.Projects.Select(p => p.Name))
+            .Distinct()
+            .ToOptions();
+
+        var hasChanges = enabled.Value != (saved?.Enabled ?? false)
+                         || botToken.Value != (saved?.BotToken ?? "")
+                         || appToken.Value != (saved?.AppToken ?? "")
+                         || project.Value != (string.IsNullOrWhiteSpace(saved?.Project) ? "Auto" : saved!.Project);
+
+        var tokensMissing = string.IsNullOrWhiteSpace(botToken.Value) || string.IsNullOrWhiteSpace(appToken.Value);
+
+        var form = Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(120)))
+                   | Text.Block("Slackbot").Bold()
+                   | Text.Block(
+                       "Install a Tendril bot in your Slack workspace. Mention the bot in any channel it has been invited to and it creates a Tendril plan from your message, using the recent conversation as context, and replies in the thread when the plan is ready.")
+                       .Muted().Small();
+
+        if (enabled.Value && (saved?.Enabled ?? false))
+        {
+            if (status.Value == SlackbotStatus.Connected)
+            {
+                var connectedContent = Layout.Vertical()
+                    | Text.Block($"Connected as @{slackbot.BotName} in {slackbot.TeamName}.")
+                    | Text.Block($"Invite the bot to a channel with /invite @{slackbot.BotName}, then mention it with a task, e.g. \"@{slackbot.BotName} fix the flaky login test\".")
+                        .Muted().Small();
+                form |= new Callout(connectedContent, "Slackbot Active", CalloutVariant.Success);
+            }
+            else if (status.Value == SlackbotStatus.Connecting)
+            {
+                var connectingContent = Layout.Vertical()
+                    | Text.Block("Connecting to Slack...")
+                    | new Loading();
+                form |= Callout.Info(connectingContent, "Slackbot Connecting");
+            }
+            else if (status.Value == SlackbotStatus.Error)
+            {
+                form |= Callout.Error(slackbot.LastError ?? "Unknown error", "Slackbot Error");
+            }
+        }
+
+        form |= Text.Block("Step 1: Create the Slack app").Bold();
+        form |= Text.Block(
+                "This opens Slack with a pre-configured Tendril app manifest (bot user, permissions, and events are already filled in). Click Create, then Install to Workspace.")
+            .Muted().Small();
+        form |= new Button("Create Slack App").Icon(Icons.Slack).Outline()
+            .OnClick(() => client.OpenUrl(SlackAppManifest.BuildInstallUrl()));
+
+        form |= Text.Block("Step 2: Paste the tokens").Bold();
+        form |= Text.Block(
+                "Bot Token: on the app page under OAuth & Permissions, copy the Bot User OAuth Token (starts with xoxb-). App-Level Token: under Basic Information, App-Level Tokens, generate a token with the connections:write scope (starts with xapp-).")
+            .Muted().Small();
+        form |= botToken.ToPasswordInput("xoxb-...")
+            .WithField().Label("Bot Token");
+        form |= appToken.ToPasswordInput("xapp-...")
+            .WithField().Label("App-Level Token");
+
+        form |= Text.Block("Step 3: Enable").Bold();
+        form |= project.ToSelectInput(projectOptions)
+            .WithField().Label("Default Project")
+            .Description("Plans created from Slack go to this project. Auto lets the agent pick.");
+        form |= enabled.ToBoolInput("Enable Slackbot");
+
+        form |= new Button("Save").Primary()
+            .Disabled(!hasChanges || saving.Value || (enabled.Value && tokensMissing))
+            .Loading(saving.Value)
+            .OnClick(async () =>
+            {
+                saving.Set(true);
+                try
+                {
+                    if (enabled.Value)
+                    {
+                        try
+                        {
+                            var auth = await slackbot.TestConnectionAsync(botToken.Value.Trim(), appToken.Value.Trim());
+                            client.Toast($"Connected to {auth.Team} as @{auth.BotName}", "Slack Connection Verified");
+                        }
+                        catch (Exception ex)
+                        {
+                            client.Toast(ex.Message, "Slack Connection Failed");
+                            return;
+                        }
+                    }
+
+                    config.Settings.Slackbot = new SlackbotConfig
+                    {
+                        Enabled = enabled.Value,
+                        BotToken = botToken.Value.Trim(),
+                        AppToken = appToken.Value.Trim(),
+                        Project = project.Value,
+                        HistoryLimit = saved?.HistoryLimit ?? 15
+                    };
+                    config.SaveSettings();
+                    client.Toast(enabled.Value ? "Slackbot enabled" : "Slackbot disabled", "Saved");
+                }
+                finally
+                {
+                    saving.Set(false);
+                }
+            });
+
+        return form;
+    }
+}

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -188,5 +188,17 @@ internal static class ServiceRegistration
             sp.GetRequiredService<Services.Tunnel.CloudflaredService>());
         server.Services.AddSingleton<IStartable>(sp =>
             sp.GetRequiredService<Services.Tunnel.CloudflaredService>());
+
+        server.Services.AddSingleton<Services.Slack.SlackbotService>(sp =>
+            new Services.Slack.SlackbotService(
+                sp.GetRequiredService<IConfigService>(),
+                sp.GetRequiredService<IJobService>(),
+                sp.GetRequiredService<IHttpClientFactory>(),
+                sp.GetRequiredService<Services.Tunnel.ICloudflaredService>(),
+                sp.GetRequiredService<ILogger<Services.Slack.SlackbotService>>()));
+        server.Services.AddSingleton<Services.Slack.ISlackbotService>(sp =>
+            sp.GetRequiredService<Services.Slack.SlackbotService>());
+        server.Services.AddSingleton<IStartable>(sp =>
+            sp.GetRequiredService<Services.Slack.SlackbotService>());
     }
 }

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -176,6 +176,7 @@ public class TendrilSettings
     public Dictionary<string, PromptwareConfig> Promptwares { get; set; } = new();
     public List<AgentConfig> CodingAgents { get; set; } = new();
     public Tunnel.TunnelConfig? Tunnel { get; set; }
+    public Slack.SlackbotConfig? Slackbot { get; set; }
     public bool Telemetry { get; set; } = true;
     public bool DesktopNotifications { get; set; } = true;
     public string? DismissedUpdateVersion { get; set; }

--- a/src/Ivy.Tendril/Services/Slack/ISlackbotService.cs
+++ b/src/Ivy.Tendril/Services/Slack/ISlackbotService.cs
@@ -1,0 +1,13 @@
+namespace Ivy.Tendril.Services.Slack;
+
+public interface ISlackbotService
+{
+    SlackbotStatus Status { get; }
+    string? BotName { get; }
+    string? TeamName { get; }
+    string? LastError { get; }
+    event Action<SlackbotStatus>? StatusChanged;
+    Task<SlackAuthInfo> TestConnectionAsync(string botToken, string appToken, CancellationToken ct = default);
+    Task RestartAsync();
+    Task StopAsync();
+}

--- a/src/Ivy.Tendril/Services/Slack/SlackApiClient.cs
+++ b/src/Ivy.Tendril/Services/Slack/SlackApiClient.cs
@@ -1,0 +1,183 @@
+using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Text.Json.Nodes;
+
+namespace Ivy.Tendril.Services.Slack;
+
+public record SlackAuthInfo(string UserId, string BotName, string Team);
+
+public record SlackMessage(string? User, string? BotId, string Text, string Ts);
+
+public class SlackApiException : Exception
+{
+    private static readonly string[] UnrecoverableErrors =
+    [
+        "invalid_auth", "not_authed", "account_inactive", "token_revoked", "token_expired", "missing_scope"
+    ];
+
+    public SlackApiException(string method, string error)
+        : base($"Slack API '{method}' failed: {error}")
+    {
+        Error = error;
+    }
+
+    public string Error { get; }
+
+    public bool IsUnrecoverable => UnrecoverableErrors.Contains(Error);
+}
+
+public class SlackApiClient(IHttpClientFactory httpClientFactory, string botToken, string appToken)
+{
+    private const string BaseUrl = "https://slack.com/api/";
+    private readonly ConcurrentDictionary<string, string> _userNames = new();
+    private readonly ConcurrentDictionary<string, string> _channelNames = new();
+
+    private async Task<JsonNode> CallAsync(string method, string token,
+        Dictionary<string, string>? args = null, CancellationToken ct = default)
+    {
+        using var http = httpClientFactory.CreateClient("Slack");
+        using var request = new HttpRequestMessage(HttpMethod.Post, BaseUrl + method);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        request.Content = new FormUrlEncodedContent(args ?? new Dictionary<string, string>());
+
+        using var response = await http.SendAsync(request, ct);
+        var body = await response.Content.ReadAsStringAsync(ct);
+        var json = JsonNode.Parse(body)
+                   ?? throw new SlackApiException(method, "empty_response");
+
+        if (json["ok"]?.GetValue<bool>() != true)
+            throw new SlackApiException(method, json["error"]?.GetValue<string>() ?? "unknown_error");
+
+        return json;
+    }
+
+    public async Task<SlackAuthInfo> AuthTestAsync(CancellationToken ct = default)
+    {
+        var json = await CallAsync("auth.test", botToken, ct: ct);
+        return new SlackAuthInfo(
+            json["user_id"]?.GetValue<string>() ?? "",
+            json["user"]?.GetValue<string>() ?? "",
+            json["team"]?.GetValue<string>() ?? "");
+    }
+
+    public async Task<string> OpenSocketUrlAsync(CancellationToken ct = default)
+    {
+        var json = await CallAsync("apps.connections.open", appToken, ct: ct);
+        return json["url"]?.GetValue<string>()
+               ?? throw new SlackApiException("apps.connections.open", "missing_url");
+    }
+
+    public async Task PostMessageAsync(string channel, string text, string? threadTs = null,
+        CancellationToken ct = default)
+    {
+        var args = new Dictionary<string, string>
+        {
+            ["channel"] = channel,
+            ["text"] = text,
+            ["unfurl_links"] = "false"
+        };
+        if (threadTs != null)
+            args["thread_ts"] = threadTs;
+
+        await CallAsync("chat.postMessage", botToken, args, ct);
+    }
+
+    public async Task AddReactionAsync(string channel, string timestamp, string name,
+        CancellationToken ct = default)
+    {
+        await CallAsync("reactions.add", botToken, new Dictionary<string, string>
+        {
+            ["channel"] = channel,
+            ["timestamp"] = timestamp,
+            ["name"] = name
+        }, ct);
+    }
+
+    public async Task<List<SlackMessage>> GetThreadRepliesAsync(string channel, string threadTs, int limit,
+        CancellationToken ct = default)
+    {
+        var json = await CallAsync("conversations.replies", botToken, new Dictionary<string, string>
+        {
+            ["channel"] = channel,
+            ["ts"] = threadTs,
+            ["limit"] = limit.ToString()
+        }, ct);
+
+        return ParseMessages(json);
+    }
+
+    public async Task<List<SlackMessage>> GetChannelHistoryAsync(string channel, int limit,
+        CancellationToken ct = default)
+    {
+        var json = await CallAsync("conversations.history", botToken, new Dictionary<string, string>
+        {
+            ["channel"] = channel,
+            ["limit"] = limit.ToString()
+        }, ct);
+
+        var messages = ParseMessages(json);
+        messages.Reverse();
+        return messages;
+    }
+
+    public async Task<string> GetChannelNameAsync(string channel, CancellationToken ct = default)
+    {
+        if (_channelNames.TryGetValue(channel, out var cached))
+            return cached;
+
+        var json = await CallAsync("conversations.info", botToken, new Dictionary<string, string>
+        {
+            ["channel"] = channel
+        }, ct);
+
+        var name = json["channel"]?["name"]?.GetValue<string>() ?? channel;
+        _channelNames[channel] = name;
+        return name;
+    }
+
+    public async Task<string> GetUserNameAsync(string userId, CancellationToken ct = default)
+    {
+        if (_userNames.TryGetValue(userId, out var cached))
+            return cached;
+
+        var json = await CallAsync("users.info", botToken, new Dictionary<string, string>
+        {
+            ["user"] = userId
+        }, ct);
+
+        var profile = json["user"]?["profile"];
+        var displayName = profile?["display_name"]?.GetValue<string>();
+        var realName = profile?["real_name"]?.GetValue<string>();
+        var name = !string.IsNullOrEmpty(displayName) ? displayName
+            : !string.IsNullOrEmpty(realName) ? realName
+            : json["user"]?["name"]?.GetValue<string>() ?? userId;
+
+        _userNames[userId] = name;
+        return name;
+    }
+
+    private static List<SlackMessage> ParseMessages(JsonNode json)
+    {
+        var result = new List<SlackMessage>();
+        if (json["messages"] is not JsonArray messages)
+            return result;
+
+        foreach (var message in messages)
+        {
+            if (message is null)
+                continue;
+
+            var subtype = message["subtype"]?.GetValue<string>();
+            if (subtype is "channel_join" or "channel_leave")
+                continue;
+
+            result.Add(new SlackMessage(
+                message["user"]?.GetValue<string>(),
+                message["bot_id"]?.GetValue<string>(),
+                message["text"]?.GetValue<string>() ?? "",
+                message["ts"]?.GetValue<string>() ?? ""));
+        }
+
+        return result;
+    }
+}

--- a/src/Ivy.Tendril/Services/Slack/SlackAppManifest.cs
+++ b/src/Ivy.Tendril/Services/Slack/SlackAppManifest.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+
+namespace Ivy.Tendril.Services.Slack;
+
+public static class SlackAppManifest
+{
+    public const string AppName = "Tendril";
+
+    public static string BuildManifestJson()
+    {
+        var manifest = new
+        {
+            display_information = new
+            {
+                name = AppName,
+                description = "Create Tendril plans by mentioning @Tendril in Slack",
+                background_color = "#1f5c3d"
+            },
+            features = new
+            {
+                bot_user = new
+                {
+                    display_name = AppName,
+                    always_online = true
+                }
+            },
+            oauth_config = new
+            {
+                scopes = new
+                {
+                    bot = new[]
+                    {
+                        "app_mentions:read",
+                        "channels:history",
+                        "groups:history",
+                        "channels:read",
+                        "groups:read",
+                        "chat:write",
+                        "reactions:write",
+                        "users:read"
+                    }
+                }
+            },
+            settings = new
+            {
+                event_subscriptions = new
+                {
+                    bot_events = new[] { "app_mention" }
+                },
+                socket_mode_enabled = true,
+                org_deploy_enabled = false,
+                token_rotation_enabled = false
+            }
+        };
+
+        return JsonSerializer.Serialize(manifest);
+    }
+
+    public static string BuildInstallUrl() =>
+        "https://api.slack.com/apps?new_app=1&manifest_json=" + Uri.EscapeDataString(BuildManifestJson());
+}

--- a/src/Ivy.Tendril/Services/Slack/SlackTextFormatter.cs
+++ b/src/Ivy.Tendril/Services/Slack/SlackTextFormatter.cs
@@ -1,0 +1,68 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Ivy.Tendril.Services.Slack;
+
+public static partial class SlackTextFormatter
+{
+    [GeneratedRegex("<@([A-Z0-9]+)(?:\\|[^>]*)?>")]
+    private static partial Regex UserMentionRegex();
+
+    [GeneratedRegex("<(https?://[^|>]+)\\|([^>]+)>")]
+    private static partial Regex LabeledLinkRegex();
+
+    [GeneratedRegex("<(https?://[^>]+)>")]
+    private static partial Regex PlainLinkRegex();
+
+    [GeneratedRegex("<#[A-Z0-9]+\\|([^>]*)>")]
+    private static partial Regex ChannelMentionRegex();
+
+    public static string StripMention(string text, string botUserId)
+    {
+        var stripped = Regex.Replace(text, $"<@{Regex.Escape(botUserId)}>[ \\t]*", "");
+        return stripped.Trim();
+    }
+
+    public static IReadOnlyList<string> ExtractUserMentions(string text) =>
+        UserMentionRegex().Matches(text).Select(m => m.Groups[1].Value).Distinct().ToList();
+
+    public static string Normalize(string text, Func<string, string> resolveUserName)
+    {
+        var result = UserMentionRegex().Replace(text, m => "@" + resolveUserName(m.Groups[1].Value));
+        result = LabeledLinkRegex().Replace(result, m => $"{m.Groups[2].Value} ({m.Groups[1].Value})");
+        result = PlainLinkRegex().Replace(result, m => m.Groups[1].Value);
+        result = ChannelMentionRegex().Replace(result, m => "#" + m.Groups[1].Value);
+        result = result.Replace("&lt;", "<").Replace("&gt;", ">").Replace("&amp;", "&");
+        return result;
+    }
+
+    public static string BuildPlanDescription(
+        string instruction,
+        string requestedBy,
+        string channelName,
+        IReadOnlyList<(string Author, string Text)> context)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(instruction.Trim());
+        sb.AppendLine();
+        sb.AppendLine($"Requested by @{requestedBy} via Slack in #{channelName}.");
+
+        if (context.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Slack conversation context (oldest first):");
+            sb.AppendLine();
+            foreach (var (author, text) in context)
+            {
+                var flattened = NormalizeWhitespace(text);
+                if (flattened.Length > 0)
+                    sb.AppendLine($"- @{author}: {flattened}");
+            }
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string NormalizeWhitespace(string text) =>
+        string.Join(" ", text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+}

--- a/src/Ivy.Tendril/Services/Slack/SlackbotConfig.cs
+++ b/src/Ivy.Tendril/Services/Slack/SlackbotConfig.cs
@@ -1,0 +1,10 @@
+namespace Ivy.Tendril.Services.Slack;
+
+public record SlackbotConfig
+{
+    public bool Enabled { get; set; }
+    public string BotToken { get; set; } = "";
+    public string AppToken { get; set; } = "";
+    public string Project { get; set; } = "Auto";
+    public int HistoryLimit { get; set; } = 15;
+}

--- a/src/Ivy.Tendril/Services/Slack/SlackbotService.cs
+++ b/src/Ivy.Tendril/Services/Slack/SlackbotService.cs
@@ -1,0 +1,546 @@
+using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json.Nodes;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Tunnel;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services.Slack;
+
+public sealed class SlackbotService : ISlackbotService, IStartable, IDisposable
+{
+    private const int MaxTrackedEvents = 500;
+
+    private readonly IConfigService _config;
+    private readonly IJobService _jobService;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ICloudflaredService _tunnelService;
+    private readonly ILogger<SlackbotService> _logger;
+
+    private readonly ConcurrentDictionary<string, byte> _processedEvents = new();
+    private readonly ConcurrentQueue<string> _processedEventOrder = new();
+    private readonly ConcurrentDictionary<string, SlackJobOrigin> _pendingJobs = new();
+
+    private readonly SemaphoreSlim _restartLock = new(1, 1);
+    private CancellationTokenSource? _cts;
+    private Task? _supervisorTask;
+    private SlackApiClient? _api;
+    private SlackbotConfig? _activeConfig;
+    private string _botUserId = "";
+    private SlackbotStatus _status = SlackbotStatus.Disabled;
+
+    private record SlackJobOrigin(string Channel, string ThreadTs);
+
+    public SlackbotService(
+        IConfigService config,
+        IJobService jobService,
+        IHttpClientFactory httpClientFactory,
+        ICloudflaredService tunnelService,
+        ILogger<SlackbotService> logger)
+    {
+        _config = config;
+        _jobService = jobService;
+        _httpClientFactory = httpClientFactory;
+        _tunnelService = tunnelService;
+        _logger = logger;
+
+        _jobService.JobsStructureChanged += OnJobsStructureChanged;
+        _config.SettingsReloaded += OnSettingsReloaded;
+    }
+
+    public SlackbotStatus Status => _status;
+    public string? BotName { get; private set; }
+    public string? TeamName { get; private set; }
+    public string? LastError { get; private set; }
+
+    public event Action<SlackbotStatus>? StatusChanged;
+
+    private void SetStatus(SlackbotStatus status)
+    {
+        if (_status == status) return;
+        _status = status;
+        StatusChanged?.Invoke(status);
+    }
+
+    private static bool IsMasterInstance =>
+        Environment.GetEnvironmentVariable("TENDRIL_NOT_MASTER") != "1";
+
+    public void Start()
+    {
+        if (!IsMasterInstance)
+        {
+            _logger.LogInformation("Skipping Slackbot (TENDRIL_NOT_MASTER=1)");
+            return;
+        }
+
+        _restartLock.Wait();
+        try
+        {
+            var slackConfig = _config.Settings.Slackbot;
+            if (slackConfig is not { Enabled: true }
+                || string.IsNullOrWhiteSpace(slackConfig.BotToken)
+                || string.IsNullOrWhiteSpace(slackConfig.AppToken))
+            {
+                _logger.LogDebug("Slackbot is disabled or not configured, skipping");
+                return;
+            }
+
+            StartSupervisor(slackConfig);
+        }
+        finally
+        {
+            _restartLock.Release();
+        }
+    }
+
+    public async Task<SlackAuthInfo> TestConnectionAsync(string botToken, string appToken,
+        CancellationToken ct = default)
+    {
+        var api = new SlackApiClient(_httpClientFactory, botToken, appToken);
+        var auth = await api.AuthTestAsync(ct);
+        await api.OpenSocketUrlAsync(ct);
+        return auth;
+    }
+
+    public async Task RestartAsync()
+    {
+        if (!IsMasterInstance)
+            return;
+
+        await _restartLock.WaitAsync();
+        try
+        {
+            await StopCoreAsync();
+
+            var slackConfig = _config.Settings.Slackbot;
+            if (slackConfig is { Enabled: true }
+                && !string.IsNullOrWhiteSpace(slackConfig.BotToken)
+                && !string.IsNullOrWhiteSpace(slackConfig.AppToken))
+            {
+                StartSupervisor(slackConfig);
+            }
+            else
+            {
+                LastError = null;
+                SetStatus(SlackbotStatus.Disabled);
+            }
+        }
+        finally
+        {
+            _restartLock.Release();
+        }
+    }
+
+    public async Task StopAsync()
+    {
+        await _restartLock.WaitAsync();
+        try
+        {
+            await StopCoreAsync();
+            LastError = null;
+            SetStatus(SlackbotStatus.Disabled);
+        }
+        finally
+        {
+            _restartLock.Release();
+        }
+    }
+
+    private async Task StopCoreAsync()
+    {
+        _cts?.Cancel();
+
+        var supervisorTask = _supervisorTask;
+        if (supervisorTask is not null)
+        {
+            try { await supervisorTask.WaitAsync(TimeSpan.FromSeconds(5)); }
+            catch (TimeoutException) { }
+            catch (OperationCanceledException) { }
+        }
+
+        _cts?.Dispose();
+        _cts = null;
+        _supervisorTask = null;
+        _activeConfig = null;
+    }
+
+    private void StartSupervisor(SlackbotConfig slackConfig)
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = new CancellationTokenSource();
+        _activeConfig = slackConfig with { };
+        LastError = null;
+        SetStatus(SlackbotStatus.Connecting);
+        var token = _cts.Token;
+        _supervisorTask = Task.Run(() => SupervisorLoopAsync(slackConfig, token));
+    }
+
+    private void OnSettingsReloaded(object? sender, EventArgs e)
+    {
+        var current = _config.Settings.Slackbot;
+        var active = _activeConfig;
+
+        var shouldRun = current is { Enabled: true }
+                        && !string.IsNullOrWhiteSpace(current.BotToken)
+                        && !string.IsNullOrWhiteSpace(current.AppToken);
+        var isRunning = active is not null;
+
+        if (shouldRun == isRunning && (active is null || active == current))
+            return;
+
+        _logger.LogInformation("Slackbot configuration changed, restarting");
+        _ = Task.Run(RestartAsync);
+    }
+
+    private async Task SupervisorLoopAsync(SlackbotConfig slackConfig, CancellationToken ct)
+    {
+        var consecutiveFailures = 0;
+
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                SetStatus(SlackbotStatus.Connecting);
+                _api = new SlackApiClient(_httpClientFactory, slackConfig.BotToken, slackConfig.AppToken);
+
+                var auth = await _api.AuthTestAsync(ct);
+                _botUserId = auth.UserId;
+                BotName = auth.BotName;
+                TeamName = auth.Team;
+
+                var socketUrl = await _api.OpenSocketUrlAsync(ct);
+
+                using var socket = new ClientWebSocket();
+                await socket.ConnectAsync(new Uri(socketUrl), ct);
+                _logger.LogInformation("Slackbot connected as @{BotName} in {Team}", BotName, TeamName);
+                consecutiveFailures = 0;
+
+                await ReceiveLoopAsync(socket, slackConfig, ct);
+
+                if (ct.IsCancellationRequested) break;
+                _logger.LogInformation("Slack socket closed, reconnecting");
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (SlackApiException ex) when (ex.IsUnrecoverable)
+            {
+                LastError = ex.Message;
+                _logger.LogError(ex, "Slackbot stopped due to an unrecoverable Slack error");
+                SetStatus(SlackbotStatus.Error);
+                return;
+            }
+            catch (Exception ex)
+            {
+                consecutiveFailures++;
+                LastError = ex.Message;
+                _logger.LogWarning(ex, "Slackbot connection failed (attempt {Count})", consecutiveFailures);
+                SetStatus(SlackbotStatus.Connecting);
+            }
+
+            if (ct.IsCancellationRequested) break;
+
+            var delay = TimeSpan.FromSeconds(Math.Min(5 * Math.Pow(2, Math.Max(consecutiveFailures - 1, 0)), 60));
+            try { await Task.Delay(delay, ct); }
+            catch (OperationCanceledException) { break; }
+        }
+
+        SetStatus(SlackbotStatus.Disabled);
+    }
+
+    private async Task ReceiveLoopAsync(ClientWebSocket socket, SlackbotConfig slackConfig, CancellationToken ct)
+    {
+        var buffer = new byte[16384];
+
+        while (socket.State == WebSocketState.Open && !ct.IsCancellationRequested)
+        {
+            var message = new MemoryStream();
+            WebSocketReceiveResult result;
+            do
+            {
+                result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), ct);
+                if (result.MessageType == WebSocketMessageType.Close)
+                    return;
+                message.Write(buffer, 0, result.Count);
+            } while (!result.EndOfMessage);
+
+            var text = Encoding.UTF8.GetString(message.ToArray());
+            JsonNode? envelope;
+            try
+            {
+                envelope = JsonNode.Parse(text);
+            }
+            catch
+            {
+                _logger.LogWarning("Slackbot received unparseable frame");
+                continue;
+            }
+
+            if (envelope is null)
+                continue;
+
+            var envelopeId = envelope["envelope_id"]?.GetValue<string>();
+            if (envelopeId is not null)
+            {
+                var ack = Encoding.UTF8.GetBytes($"{{\"envelope_id\":\"{envelopeId}\"}}");
+                await socket.SendAsync(new ArraySegment<byte>(ack), WebSocketMessageType.Text, true, ct);
+            }
+
+            switch (envelope["type"]?.GetValue<string>())
+            {
+                case "hello":
+                    SetStatus(SlackbotStatus.Connected);
+                    break;
+                case "disconnect":
+                    _logger.LogInformation("Slack requested disconnect: {Reason}",
+                        envelope["reason"]?.GetValue<string>());
+                    return;
+                case "events_api":
+                    DispatchEvent(envelope, slackConfig, ct);
+                    break;
+            }
+        }
+    }
+
+    private void DispatchEvent(JsonNode envelope, SlackbotConfig slackConfig, CancellationToken ct)
+    {
+        var payload = envelope["payload"];
+        var slackEvent = payload?["event"];
+        if (slackEvent?["type"]?.GetValue<string>() != "app_mention")
+            return;
+
+        var eventId = payload?["event_id"]?.GetValue<string>() ?? slackEvent["ts"]?.GetValue<string>() ?? "";
+        if (!TryMarkEventProcessed(eventId))
+            return;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await HandleMentionAsync(slackEvent, slackConfig, ct);
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Slackbot failed to handle mention");
+            }
+        }, ct);
+    }
+
+    private bool TryMarkEventProcessed(string eventId)
+    {
+        if (string.IsNullOrEmpty(eventId) || !_processedEvents.TryAdd(eventId, 0))
+            return false;
+
+        _processedEventOrder.Enqueue(eventId);
+        while (_processedEventOrder.Count > MaxTrackedEvents && _processedEventOrder.TryDequeue(out var oldest))
+            _processedEvents.TryRemove(oldest, out _);
+
+        return true;
+    }
+
+    private async Task HandleMentionAsync(JsonNode slackEvent, SlackbotConfig slackConfig, CancellationToken ct)
+    {
+        var api = _api;
+        if (api is null)
+            return;
+
+        var channel = slackEvent["channel"]?.GetValue<string>();
+        var ts = slackEvent["ts"]?.GetValue<string>();
+        var threadTs = slackEvent["thread_ts"]?.GetValue<string>();
+        var user = slackEvent["user"]?.GetValue<string>();
+        var text = slackEvent["text"]?.GetValue<string>() ?? "";
+
+        if (channel is null || ts is null || user is null || user == _botUserId)
+            return;
+
+        var replyTs = threadTs ?? ts;
+        var instruction = SlackTextFormatter.StripMention(text, _botUserId);
+
+        if (string.IsNullOrWhiteSpace(instruction))
+        {
+            await api.PostMessageAsync(channel,
+                "Tag me with a task and I will create a Tendril plan for it. " +
+                "For example: `@" + (BotName ?? SlackAppManifest.AppName) + " fix the flaky login test`. " +
+                "I include the recent conversation in this channel or thread as context.",
+                replyTs, ct);
+            return;
+        }
+
+        try { await api.AddReactionAsync(channel, ts, "eyes", ct); }
+        catch (SlackApiException ex) { _logger.LogDebug("Could not add reaction: {Error}", ex.Error); }
+
+        var context = await GatherContextAsync(api, channel, ts, threadTs, slackConfig.HistoryLimit, ct);
+        var userName = await ResolveUserNameAsync(api, user, ct);
+        var channelName = await ResolveChannelNameAsync(api, channel, ct);
+
+        instruction = await NormalizeTextAsync(api, instruction, ct);
+
+        var description = SlackTextFormatter.BuildPlanDescription(instruction, userName, channelName, context);
+        var project = string.IsNullOrWhiteSpace(slackConfig.Project) ? "Auto" : slackConfig.Project;
+
+        string jobId;
+        try
+        {
+            jobId = _jobService.StartJob(new CreatePlanArgs(description, project));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Slackbot failed to start CreatePlan job");
+            await api.PostMessageAsync(channel,
+                $":x: I could not create a plan: {ex.Message}", replyTs, ct);
+            return;
+        }
+
+        _pendingJobs[jobId] = new SlackJobOrigin(channel, replyTs);
+
+        var reply = ":seedling: On it! I am creating a Tendril plan from this conversation.";
+        if (_tunnelService.IsConnected && _tunnelService.TunnelUrl is { } url)
+            reply += $" Follow along at {url}";
+
+        await api.PostMessageAsync(channel, reply, replyTs, ct);
+    }
+
+    private async Task<List<(string Author, string Text)>> GatherContextAsync(
+        SlackApiClient api, string channel, string mentionTs, string? threadTs, int limit, CancellationToken ct)
+    {
+        var context = new List<(string Author, string Text)>();
+        if (limit <= 0)
+            return context;
+
+        List<SlackMessage> messages;
+        try
+        {
+            messages = threadTs is not null
+                ? await api.GetThreadRepliesAsync(channel, threadTs, limit + 1, ct)
+                : await api.GetChannelHistoryAsync(channel, limit + 1, ct);
+        }
+        catch (SlackApiException ex)
+        {
+            _logger.LogWarning("Slackbot could not read conversation history: {Error}", ex.Error);
+            return context;
+        }
+
+        foreach (var message in messages)
+        {
+            if (message.Ts == mentionTs || string.IsNullOrWhiteSpace(message.Text))
+                continue;
+
+            var author = message.User is not null
+                ? await ResolveUserNameAsync(api, message.User, ct)
+                : BotName ?? "bot";
+
+            var text = await NormalizeTextAsync(api, message.Text, ct);
+
+            context.Add((author, text));
+        }
+
+        if (context.Count > limit)
+            context.RemoveRange(0, context.Count - limit);
+
+        return context;
+    }
+
+    private async Task<string> NormalizeTextAsync(SlackApiClient api, string text, CancellationToken ct)
+    {
+        var names = new Dictionary<string, string>();
+        foreach (var id in SlackTextFormatter.ExtractUserMentions(text))
+            names[id] = await ResolveUserNameAsync(api, id, ct);
+
+        return SlackTextFormatter.Normalize(text, id => names.TryGetValue(id, out var name) ? name : id);
+    }
+
+    private async Task<string> ResolveUserNameAsync(SlackApiClient api, string userId, CancellationToken ct)
+    {
+        try
+        {
+            return await api.GetUserNameAsync(userId, ct);
+        }
+        catch (SlackApiException)
+        {
+            return userId;
+        }
+    }
+
+    private async Task<string> ResolveChannelNameAsync(SlackApiClient api, string channel, CancellationToken ct)
+    {
+        try
+        {
+            return await api.GetChannelNameAsync(channel, ct);
+        }
+        catch (SlackApiException)
+        {
+            return channel;
+        }
+    }
+
+    private void OnJobsStructureChanged()
+    {
+        if (_pendingJobs.IsEmpty)
+            return;
+
+        foreach (var (jobId, origin) in _pendingJobs)
+        {
+            var job = _jobService.GetJob(jobId);
+            if (job is null)
+            {
+                _pendingJobs.TryRemove(jobId, out _);
+                continue;
+            }
+
+            if (job.Status is JobStatus.Pending or JobStatus.Queued or JobStatus.Running or JobStatus.Blocked)
+                continue;
+
+            if (!_pendingJobs.TryRemove(jobId, out _))
+                continue;
+
+            var message = BuildCompletionMessage(job);
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    if (_api is { } api)
+                        await api.PostMessageAsync(origin.Channel, message, origin.ThreadTs);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Slackbot failed to post completion message");
+                }
+            });
+        }
+    }
+
+    private string BuildCompletionMessage(JobItem job)
+    {
+        if (job.Status == JobStatus.Completed)
+        {
+            var planId = job.ResolvePlanId();
+            var title = job.ReportedPlanTitle;
+            var label = !string.IsNullOrEmpty(title) && !string.IsNullOrEmpty(planId)
+                ? $"*{title}* (plan {planId})"
+                : !string.IsNullOrEmpty(planId) ? $"plan {planId}" : "the plan";
+
+            var message = $":white_check_mark: Done! I created {label} in Tendril.";
+            if (_tunnelService.IsConnected && _tunnelService.TunnelUrl is { } url)
+                message += $" Open it at {url}";
+            return message;
+        }
+
+        return $":x: Plan creation did not finish ({job.Status}). " +
+               (string.IsNullOrEmpty(job.ReportedFailureReason) ? "" : job.ReportedFailureReason);
+    }
+
+    public void Dispose()
+    {
+        _jobService.JobsStructureChanged -= OnJobsStructureChanged;
+        _config.SettingsReloaded -= OnSettingsReloaded;
+
+        _cts?.Cancel();
+        try { _supervisorTask?.Wait(TimeSpan.FromSeconds(5)); }
+        catch (AggregateException) { }
+        _cts?.Dispose();
+    }
+}

--- a/src/Ivy.Tendril/Services/Slack/SlackbotStatus.cs
+++ b/src/Ivy.Tendril/Services/Slack/SlackbotStatus.cs
@@ -1,0 +1,16 @@
+namespace Ivy.Tendril.Services.Slack;
+
+public enum SlackbotStatus
+{
+    /// <summary>Bot is not enabled or not configured.</summary>
+    Disabled,
+
+    /// <summary>Bot is connecting (or reconnecting) to Slack.</summary>
+    Connecting,
+
+    /// <summary>Bot is connected and listening for mentions.</summary>
+    Connected,
+
+    /// <summary>Bot stopped due to an unrecoverable error (e.g. invalid tokens).</summary>
+    Error
+}

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -255,6 +255,18 @@ editor:
 
 telemetry: true
 
+# Slack bot integration (optional). Configure from the UI: Configuration > Slackbot.
+# The UI's "Create Slack App" button opens Slack with a pre-filled app manifest;
+# after installing the app to your workspace, paste the two tokens here or in the UI.
+# Mentioning the bot in a channel creates a Tendril plan from the message, using
+# the recent channel/thread history as context.
+# slackbot:
+#   enabled: true
+#   botToken: xoxb-...    # OAuth & Permissions > Bot User OAuth Token
+#   appToken: xapp-...    # Basic Information > App-Level Tokens (connections:write scope)
+#   project: Auto         # project for plans created from Slack ("Auto" = agent picks)
+#   historyLimit: 15      # number of context messages included in the plan description
+
 planTemplate: >
   # {title}
 


### PR DESCRIPTION

<img width="1512" height="982" alt="Screenshot 2026-07-17 at 11 15 31" src="https://github.com/user-attachments/assets/3f7484e7-e11a-459a-a3a8-834ea5ea3b0c" />


## What

New "Slackbot" section in Configuration (between Tunnel and Advanced) that installs a Tendril Slack bot:

- **One-click install**: "Create Slack App" opens Slack's app creation page with a pre-filled manifest (bot user, all scopes, app_mention event subscription, Socket Mode enabled). The user only clicks Create, installs to the workspace, and pastes two tokens back.
- **Tag the bot to create plans**: mentioning @Tendril in a channel or thread starts a CreatePlan job. The message text becomes the task; the recent channel/thread history (channels:history, groups:history scopes) is included as context in the plan description.
- **Posts comments**: the bot reacts with an eyes emoji, replies in the thread when the plan job starts, and posts a follow-up with the plan title/id when the job completes (or fails). Includes the tunnel URL when the Cloudflare tunnel is active.

## How

- `SlackbotConfig` on `TendrilSettings`, persisted under `slackbot:` in config.yaml, hot-reload restarts the connection via `SettingsReloaded`.
- `SlackbotService`: Socket Mode client built on `ClientWebSocket` + `apps.connections.open` (no new NuGet packages). Supervisor loop with capped exponential backoff, envelope acking, event dedup, unrecoverable auth errors stop with an Error status shown in the UI.
- `SlackApiClient`: minimal Slack Web API wrapper over `IHttpClientFactory` (auth.test, chat.postMessage, reactions.add, conversations.history/replies/info, users.info with caching).
- Registered as `IStartable` singleton following the `CloudflaredService` pattern; honors `TENDRIL_NOT_MASTER`.
- Save verifies the tokens against Slack (auth.test + apps.connections.open) before persisting.

## Tests

- 19 new unit tests (Slack text formatting, manifest JSON/URL, config YAML round-trip). Full suite: 1808 passed.
- Verified in the browser: section renders, save with invalid tokens is rejected with a toast and does not persist, save with the bot disabled persists the section to config.yaml.

Generated with Claude Code