### PR TITLE
Remove app tab bar in favor of page navigation with icon-rail sidebar

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -621,7 +621,9 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                     footer
                 ),
                 settings.Width,
-                sidebarHeaderCollapsed: new NewPlanButton(iconOnly: true),
+                sidebarHeaderCollapsed: Layout.Vertical().Gap(2).AlignContent(Align.Center)
+                    | new Image("/tendril/assets/Tendril.svg").Width(Size.Units(8)).Height(Size.Auto())
+                    | new NewPlanButton(iconOnly: true),
                 sidebarFooterCollapsed: collapsedSettingsMenu
             ).Open(sidebarOpen.Value).MainAppSidebar(),
             importIssuesDialog,

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -621,7 +621,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                     footer
                 ),
                 settings.Width,
-                sidebarHeaderCollapsed: Layout.Vertical().Gap(2).AlignContent(Align.Center)
+                sidebarHeaderCollapsed: Layout.Vertical().Gap(6).AlignContent(Align.Center)
                     | new Image("/tendril/assets/Tendril.svg").Width(Size.Units(8)).Height(Size.Auto())
                     | new NewPlanButton(iconOnly: true),
                 sidebarFooterCollapsed: collapsedSettingsMenu

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -466,6 +466,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         if (settings.Navigation == AppShellNavigation.Pages)
         {
             body = currentApp.Value;
+            if (body == null && settings.WallpaperAppId != null)
+                body = new AppHost(settings.WallpaperAppId, null, args.ConnectionId);
         }
         else
         {
@@ -572,13 +574,24 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             )
             .Variant(ButtonVariant.Ghost).Width(Size.Full());
 
+        var footerMenuItems = settings.FooterMenuItemsTransformer(settingsMenuItems, navigator).ToArray();
+
         var settingsMenu = new DropDownMenu(
                 DropDownMenu.DefaultSelectHandler(),
                 settingsTrigger)
             .Top()
-            .Items(settings.FooterMenuItemsTransformer(settingsMenuItems, navigator));
+            .Items(footerMenuItems);
 
         object? footer = settingsMenu;
+
+        var collapsedSettingsMenu = new DropDownMenu(
+                DropDownMenu.DefaultSelectHandler(),
+                new Button(null)
+                    .Icon(Icons.Settings)
+                    .Variant(ButtonVariant.Ghost)
+                    .Tooltip("Settings"))
+            .Top()
+            .Items(footerMenuItems);
 
         if (config.ParseError != null)
             return new ConfigErrorApp(config);
@@ -607,7 +620,9 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                     settings.Footer,
                     footer
                 ),
-                settings.Width
+                settings.Width,
+                sidebarHeaderCollapsed: new NewPlanButton(iconOnly: true),
+                sidebarFooterCollapsed: collapsedSettingsMenu
             ).Open(sidebarOpen.Value).MainAppSidebar(),
             importIssuesDialog,
             updateDialog

--- a/src/Ivy.Tendril/Apps/Views/NewPlanButton.cs
+++ b/src/Ivy.Tendril/Apps/Views/NewPlanButton.cs
@@ -1,13 +1,13 @@
 namespace Ivy.Tendril.Apps.Views;
 
-public class NewPlanButton : ViewBase
+public class NewPlanButton(bool iconOnly = false) : ViewBase
 {
     public override object Build()
     {
         return new CreatePlanDialogLauncher(
-            open => new Button("New Plan")
-                .Icon(Icons.Plus)
-                .Width(Size.Full())
+            open => (iconOnly
+                    ? new Button(null).Icon(Icons.Plus).Tooltip("New Plan")
+                    : new Button("New Plan").Icon(Icons.Plus).Width(Size.Full()))
                 .Variant(ButtonVariant.Primary)
                 .OnClick(open)
                 .ShortcutKey("CTRL+ALT+N"));

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -116,7 +116,7 @@ public static class TendrilServer
             )
             .WallpaperApp<WallpaperApp>()
             .HideArgsInUrl()
-            .UseTabs(true);
+            .UsePages();
 
         server.UseAppShell(() => new TendrilAppShell(appShellSettings));
 


### PR DESCRIPTION

<img width="1512" height="982" alt="Screenshot 2026-07-17 at 13 54 01" src="https://github.com/user-attachments/assets/6ab6b790-9633-42dd-9f5c-cb44f39d5630" />

## Summary
Tendril chrome redesign (companion to Ivy-Interactive/Ivy-Framework#4723):

- **No more tab bar**: `TendrilServer` switches from `.UseTabs(true)` to `.UsePages()` — apps open full-page via the existing Pages navigation in `TendrilAppShell`/`AppShellRouter`, and the customer-facing Tabs mode in the framework is untouched. Fixed Pages mode to fall back to the wallpaper app when no app is open (previously rendered an empty body).
- **Icon-rail collapsed sidebar** (rendering implemented in the framework PR): collapsing no longer hides the sidebar to the screen edge; it becomes a 48px rail showing the app icons. "Ivy Tendril", the version, and the "Apps" header disappear; the New Plan button becomes an icon button (`NewPlanButton` gains `iconOnly`, same `CTRL+ALT+N` shortcut) and the settings menu becomes an icon-only dropdown, via the new `SidebarHeaderCollapsed`/`SidebarFooterCollapsed` slots.
- **Toggle inside the sidebar**: the sidebar toggle now lives at the bottom of the sidebar (framework change; mobile keeps the floating toggle + drawer).

## Merge dependency
⚠️ CI builds with `IvySource=false` against the pinned Ivy NuGet packages, which don't yet contain the new `SidebarLayout` slots. This PR needs an Ivy release with Ivy-Interactive/Ivy-Framework#4723 plus a version bump in `Ivy.Tendril.csproj` before it can build in CI. Locally verified against framework source (`IvySource=true`).

## Testing
- Builds clean against local framework source; `Ivy.Tendril.Test` 1789 tests pass.
- Manual browser verification with a scratch `TENDRIL_HOME`: no tab bar, wallpaper on `/`, page navigation from sidebar and rail (URL/title update correctly), rail collapse/expand, tooltips, New Plan dialog from the rail icon, settings dropdown from the rail, mobile drawer.
- Playwright E2E suite not run (requires GitHub forks + live coding agents); worth a run before release since some page objects may assume tab-based navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)