### PR TITLE
feat: post-onboarding tour with anchored tooltip stepper

### DIFF
--- a/src/Ivy.Tendril.Widgets/.samples/Apps/OnboardingTourPopover/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/OnboardingTourPopover/DemoApp.cs
@@ -1,0 +1,67 @@
+using Ivy;
+using Ivy.Tendril.Widgets;
+using TourPopoverWidget = Ivy.Tendril.Widgets.OnboardingTourPopover;
+
+namespace WidgetSamples.Apps.OnboardingTourPopover;
+
+[App(title: "Tour Popover", icon: Icons.MessageCircle, group: ["OnboardingTourPopover"])]
+class DemoApp : ViewBase
+{
+    private static readonly (string Title, string Description, string Anchor, string Placement)[] Steps =
+    [
+        ("Create your first plan",
+            "Describe a change you want made and Tendril turns it into a plan an agent can execute.",
+            "[data-testid=\"demo-new-plan\"]", "right"),
+        ("Refine it in Drafts",
+            "New plans land in Drafts. Review the proposed steps, make adjustments, and start execution when it looks right.",
+            "[data-testid=\"demo-drafts\"]", "right"),
+        ("Follow along in Jobs",
+            "Jobs shows everything Tendril is working on in the background — planning, executing and creating PRs.",
+            "[data-testid=\"demo-jobs\"]", "right"),
+        ("Accept work in Review",
+            "Completed work lands in Review. Inspect the result and accept it, or send it back with change requests.",
+            "[data-testid=\"demo-review\"]", "bottom")
+    ];
+
+    public override object Build()
+    {
+        var client = UseService<IClientProvider>();
+        var step = UseState<int?>(0);
+
+        var fakeSidebar = Layout.Vertical().Gap(2).Width(Size.Units(50))
+                          | new Button("New Plan").Icon(Icons.Plus).Primary().Width(Size.Full()).TestId("demo-new-plan")
+                          | new Button("Drafts").Icon(Icons.Feather).Ghost().Width(Size.Full()).TestId("demo-drafts")
+                          | new Button("Jobs").Icon(Icons.Activity).Ghost().Width(Size.Full()).TestId("demo-jobs")
+                          | new Button("Review").Icon(Icons.ThumbsUp).Ghost().Width(Size.Full()).TestId("demo-review")
+                          | new Spacer().Height(Size.Units(8))
+                          | new Button("Restart Tour").Outline().Width(Size.Full()).OnClick(() => step.Set(0));
+
+        object? popover = null;
+        if (step.Value is { } s)
+        {
+            var def = Steps[s];
+            popover = new TourPopoverWidget(def.Anchor)
+                .Title(def.Title)
+                .Description(def.Description)
+                .Step(s, Steps.Length)
+                .Placement(def.Placement)
+                .OnNext(() =>
+                {
+                    if (s >= Steps.Length - 1)
+                    {
+                        step.Set((int?)null);
+                        client.Toast("Tour finished", "OnNext").Info();
+                    }
+                    else step.Set(s + 1);
+                })
+                .OnBack(() => step.Set(Math.Max(0, s - 1)))
+                .OnDismiss(() =>
+                {
+                    step.Set((int?)null);
+                    client.Toast("Tour dismissed", "OnDismiss").Info();
+                });
+        }
+
+        return new Fragment(fakeSidebar, popover);
+    }
+}

--- a/src/Ivy.Tendril.Widgets/OnboardingTourPopover.cs
+++ b/src/Ivy.Tendril.Widgets/OnboardingTourPopover.cs
@@ -1,0 +1,77 @@
+namespace Ivy.Tendril.Widgets;
+
+/// <summary>
+/// Floating onboarding-tour card rendered in a portal on top of the app, with a
+/// bubble pointer aimed at the element matched by <see cref="AnchorSelector"/>.
+/// The widget renders nothing inline, so it never affects the layout of the view
+/// it is placed in; the anchor is located globally via <c>document.querySelector</c>.
+/// </summary>
+[ExternalWidget(
+    "frontend/dist/ivy-tendril-widgets.js",
+    StylePath = "frontend/dist/ivy-tendril-widgets.css",
+    ExportName = "OnboardingTourPopover",
+    GlobalName = "IvyTendrilWidgets"
+)]
+public record OnboardingTourPopover : WidgetBase<OnboardingTourPopover>
+{
+    public OnboardingTourPopover(string anchorSelector)
+    {
+        AnchorSelector = anchorSelector;
+    }
+
+    internal OnboardingTourPopover() { }
+
+    /// <summary>CSS selector (searched document-wide) for the element the pointer aims at.</summary>
+    [Prop] public string AnchorSelector { get; init; } = string.Empty;
+
+    [Prop] public string Title { get; init; } = string.Empty;
+
+    [Prop] public string Description { get; init; } = string.Empty;
+
+    /// <summary>Zero-based index of the current step; shown as "{StepIndex + 1} of {StepCount}".</summary>
+    [Prop] public int StepIndex { get; init; }
+
+    [Prop] public int StepCount { get; init; } = 1;
+
+    /// <summary>Side of the anchor the card is placed on: right, left, top or bottom. Flips automatically when there is no room.</summary>
+    [Prop] public string Placement { get; init; } = "right";
+
+    /// <summary>Draw a rounded highlight ring around the anchor element.</summary>
+    [Prop] public bool HighlightAnchor { get; init; } = true;
+
+    /// <summary>Fired by the Continue button (also on the last step, where it is labelled "Done").</summary>
+    [Event] public EventHandler<Event<OnboardingTourPopover>>? OnNext { get; init; }
+
+    /// <summary>Fired by the Back button on steps after the first.</summary>
+    [Event] public EventHandler<Event<OnboardingTourPopover>>? OnBack { get; init; }
+
+    /// <summary>Fired by the close (X) button and by Skip on the first step.</summary>
+    [Event] public EventHandler<Event<OnboardingTourPopover>>? OnDismiss { get; init; }
+}
+
+public static class OnboardingTourPopoverExtensions
+{
+    public static OnboardingTourPopover Title(this OnboardingTourPopover w, string title) =>
+        w with { Title = title };
+
+    public static OnboardingTourPopover Description(this OnboardingTourPopover w, string description) =>
+        w with { Description = description };
+
+    public static OnboardingTourPopover Step(this OnboardingTourPopover w, int stepIndex, int stepCount) =>
+        w with { StepIndex = stepIndex, StepCount = stepCount };
+
+    public static OnboardingTourPopover Placement(this OnboardingTourPopover w, string placement) =>
+        w with { Placement = placement };
+
+    public static OnboardingTourPopover HighlightAnchor(this OnboardingTourPopover w, bool highlight = true) =>
+        w with { HighlightAnchor = highlight };
+
+    public static OnboardingTourPopover OnNext(this OnboardingTourPopover w, Action handler) =>
+        w with { OnNext = new(_ => { handler(); return ValueTask.CompletedTask; }) };
+
+    public static OnboardingTourPopover OnBack(this OnboardingTourPopover w, Action handler) =>
+        w with { OnBack = new(_ => { handler(); return ValueTask.CompletedTask; }) };
+
+    public static OnboardingTourPopover OnDismiss(this OnboardingTourPopover w, Action handler) =>
+        w with { OnDismiss = new(_ => { handler(); return ValueTask.CompletedTask; }) };
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/OnboardingTourPopover/OnboardingTourPopover.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/OnboardingTourPopover/OnboardingTourPopover.tsx
@@ -1,0 +1,215 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import "./onboarding-tour.css";
+
+type IvyEventHandler = (eventName: string, widgetId: string, args: unknown[]) => void;
+
+type Placement = "right" | "left" | "top" | "bottom";
+
+interface OnboardingTourPopoverProps {
+  id: string;
+  anchorSelector?: string;
+  title?: string;
+  description?: string;
+  stepIndex?: number;
+  stepCount?: number;
+  placement?: string;
+  highlightAnchor?: boolean;
+  events?: string[];
+  eventHandler?: IvyEventHandler;
+}
+
+interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+const CARD_WIDTH = 320;
+const GAP = 14; // distance between anchor and card (leaves room for the arrow)
+const MARGIN = 8; // minimum distance from the viewport edges
+const ARROW = 12; // arrow square size
+const RING_PAD = 4;
+
+function rectsDiffer(a: Rect | null, b: Rect | null): boolean {
+  if (!a || !b) return a !== b;
+  return (
+    Math.abs(a.top - b.top) > 0.5 ||
+    Math.abs(a.left - b.left) > 0.5 ||
+    Math.abs(a.width - b.width) > 0.5 ||
+    Math.abs(a.height - b.height) > 0.5
+  );
+}
+
+function resolvePlacement(anchor: Rect, preferred: Placement, cardHeight: number): Placement {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const fits: Record<Placement, boolean> = {
+    right: anchor.left + anchor.width + GAP + CARD_WIDTH + MARGIN <= vw,
+    left: anchor.left - GAP - CARD_WIDTH - MARGIN >= 0,
+    bottom: anchor.top + anchor.height + GAP + cardHeight + MARGIN <= vh,
+    top: anchor.top - GAP - cardHeight - MARGIN >= 0,
+  };
+  if (fits[preferred]) return preferred;
+  const fallbacks: Record<Placement, Placement[]> = {
+    right: ["left", "bottom", "top"],
+    left: ["right", "bottom", "top"],
+    bottom: ["top", "right", "left"],
+    top: ["bottom", "right", "left"],
+  };
+  return fallbacks[preferred].find((p) => fits[p]) ?? preferred;
+}
+
+export const OnboardingTourPopover: React.FC<OnboardingTourPopoverProps> = ({
+  id,
+  anchorSelector = "",
+  title = "",
+  description = "",
+  stepIndex = 0,
+  stepCount = 1,
+  placement = "right",
+  highlightAnchor = true,
+  eventHandler,
+}) => {
+  const [anchorRect, setAnchorRect] = useState<Rect | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [cardHeight, setCardHeight] = useState(180);
+
+  const updateAnchor = useCallback(() => {
+    const el = anchorSelector ? document.querySelector(anchorSelector) : null;
+    if (!el) {
+      setAnchorRect((prev) => (prev === null ? prev : null));
+      return;
+    }
+    const r = el.getBoundingClientRect();
+    const next: Rect = { top: r.top, left: r.left, width: r.width, height: r.height };
+    if (r.width === 0 && r.height === 0) {
+      setAnchorRect((prev) => (prev === null ? prev : null));
+      return;
+    }
+    setAnchorRect((prev) => (rectsDiffer(prev, next) ? next : prev));
+  }, [anchorSelector]);
+
+  // Track the anchor: react to scroll/resize immediately and poll at a low
+  // frequency to catch the anchor mounting, unmounting, or moving for reasons
+  // that fire no event (e.g. sidebar content changes).
+  useEffect(() => {
+    updateAnchor();
+    const interval = window.setInterval(updateAnchor, 250);
+    window.addEventListener("resize", updateAnchor);
+    document.addEventListener("scroll", updateAnchor, true);
+    return () => {
+      window.clearInterval(interval);
+      window.removeEventListener("resize", updateAnchor);
+      document.removeEventListener("scroll", updateAnchor, true);
+    };
+  }, [updateAnchor]);
+
+  useEffect(() => {
+    if (cardRef.current) setCardHeight(cardRef.current.offsetHeight);
+  }, [title, description, anchorRect === null]);
+
+  const fire = useCallback(
+    (event: "OnNext" | "OnBack" | "OnDismiss") => () => {
+      eventHandler?.(event, id, []);
+    },
+    [eventHandler, id],
+  );
+
+  const layout = useMemo(() => {
+    if (!anchorRect) return null;
+    const side = resolvePlacement(anchorRect, (placement as Placement) || "right", cardHeight);
+    const anchorCx = anchorRect.left + anchorRect.width / 2;
+    const anchorCy = anchorRect.top + anchorRect.height / 2;
+
+    let top: number;
+    let left: number;
+    if (side === "right" || side === "left") {
+      top = anchorCy - cardHeight / 2;
+      left = side === "right" ? anchorRect.left + anchorRect.width + GAP : anchorRect.left - GAP - CARD_WIDTH;
+    } else {
+      left = anchorCx - CARD_WIDTH / 2;
+      top = side === "bottom" ? anchorRect.top + anchorRect.height + GAP : anchorRect.top - GAP - cardHeight;
+    }
+    top = Math.max(MARGIN, Math.min(top, window.innerHeight - cardHeight - MARGIN));
+    left = Math.max(MARGIN, Math.min(left, window.innerWidth - CARD_WIDTH - MARGIN));
+
+    // Arrow sits on the card edge facing the anchor, aimed at the anchor center
+    // (clamped so it stays within the card's rounded corners).
+    const arrow: React.CSSProperties = {};
+    const arrowHalf = ARROW / 2;
+    if (side === "right" || side === "left") {
+      const y = Math.max(18, Math.min(anchorCy - top, cardHeight - 18));
+      arrow.top = y - arrowHalf;
+      if (side === "right") arrow.left = -arrowHalf;
+      else arrow.right = -arrowHalf;
+    } else {
+      const x = Math.max(18, Math.min(anchorCx - left, CARD_WIDTH - 18));
+      arrow.left = x - arrowHalf;
+      if (side === "bottom") arrow.top = -arrowHalf;
+      else arrow.bottom = -arrowHalf;
+    }
+
+    return { side, top, left, arrow };
+  }, [anchorRect, placement, cardHeight]);
+
+  if (!anchorRect || !layout) return null;
+
+  const isFirst = stepIndex <= 0;
+  const isLast = stepIndex >= stepCount - 1;
+
+  return createPortal(
+    <>
+      {highlightAnchor && (
+        <div
+          className="otp-ring"
+          style={{
+            top: anchorRect.top - RING_PAD,
+            left: anchorRect.left - RING_PAD,
+            width: anchorRect.width + RING_PAD * 2,
+            height: anchorRect.height + RING_PAD * 2,
+          }}
+        />
+      )}
+      <div
+        ref={cardRef}
+        className="otp-card"
+        data-side={layout.side}
+        role="dialog"
+        aria-label={title}
+        style={{ top: layout.top, left: layout.left, width: CARD_WIDTH }}
+      >
+        <div className="otp-arrow" data-side={layout.side} style={layout.arrow} />
+        <div className="otp-header">
+          <h3 className="otp-title">{title}</h3>
+          <button className="otp-close" aria-label="Close tour" onClick={fire("OnDismiss")}>
+            <X size={15} />
+          </button>
+        </div>
+        <p className="otp-description">{description}</p>
+        <div className="otp-footer">
+          <span className="otp-counter">
+            {stepIndex + 1} of {stepCount}
+          </span>
+          <div className="otp-buttons">
+            {isFirst ? (
+              <button className="otp-btn otp-btn-secondary" onClick={fire("OnDismiss")}>
+                Skip
+              </button>
+            ) : (
+              <button className="otp-btn otp-btn-secondary" onClick={fire("OnBack")}>
+                Back
+              </button>
+            )}
+            <button className="otp-btn otp-btn-primary" onClick={fire("OnNext")}>
+              {isLast ? "Done" : "Continue"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>,
+    document.body,
+  );
+};

--- a/src/Ivy.Tendril.Widgets/frontend/src/OnboardingTourPopover/index.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/OnboardingTourPopover/index.ts
@@ -1,0 +1,1 @@
+export { OnboardingTourPopover } from "./OnboardingTourPopover";

--- a/src/Ivy.Tendril.Widgets/frontend/src/OnboardingTourPopover/onboarding-tour.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/OnboardingTourPopover/onboarding-tour.css
@@ -1,0 +1,162 @@
+.otp-card {
+  position: fixed;
+  z-index: 9999;
+  box-sizing: border-box;
+  padding: 1.125rem 1.25rem 1rem;
+  border-radius: 1rem;
+  background: var(--popover, var(--card, #fff));
+  color: var(--foreground, #111827);
+  border: 1px solid var(--border, #e5e7eb);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.06),
+    0 12px 32px rgba(0, 0, 0, 0.14);
+  font-family: system-ui, -apple-system, sans-serif;
+  animation: otp-in 0.18s ease-out;
+  transition:
+    top 0.2s ease,
+    left 0.2s ease;
+}
+
+@keyframes otp-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.otp-arrow {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: var(--popover, var(--card, #fff));
+  transform: rotate(45deg);
+  border: 1px solid var(--border, #e5e7eb);
+}
+
+/* Only the two arrow sides facing away from the card get a border. */
+.otp-arrow[data-side="right"] {
+  border-top: none;
+  border-right: none;
+}
+.otp-arrow[data-side="left"] {
+  border-bottom: none;
+  border-left: none;
+}
+.otp-arrow[data-side="bottom"] {
+  border-bottom: none;
+  border-right: none;
+}
+.otp-arrow[data-side="top"] {
+  border-top: none;
+  border-left: none;
+}
+
+.otp-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.otp-title {
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.otp-close {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.625rem;
+  height: 1.625rem;
+  margin: -0.25rem -0.375rem 0 0;
+  padding: 0;
+  border: none;
+  border-radius: 9999px;
+  background: transparent;
+  color: var(--muted-foreground, #6b7280);
+  cursor: pointer;
+}
+
+.otp-close:hover {
+  background: var(--muted, #f3f4f6);
+  color: var(--foreground, #111827);
+}
+
+.otp-description {
+  margin: 0.5rem 0 0;
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: var(--muted-foreground, #6b7280);
+}
+
+.otp-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 1rem;
+}
+
+.otp-counter {
+  font-size: 0.75rem;
+  color: var(--muted-foreground, #6b7280);
+}
+
+.otp-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.otp-btn {
+  padding: 0.375rem 0.875rem;
+  border-radius: 9999px;
+  font-size: 0.8125rem;
+  font-weight: 550;
+  font-family: inherit;
+  line-height: 1.3;
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    opacity 0.12s ease;
+}
+
+.otp-btn-secondary {
+  background: var(--popover, var(--card, #fff));
+  color: var(--foreground, #111827);
+  border: 1px solid var(--border, #e5e7eb);
+}
+
+.otp-btn-secondary:hover {
+  background: var(--muted, #f3f4f6);
+}
+
+.otp-btn-primary {
+  background: var(--primary, #111827);
+  color: var(--primary-foreground, #fff);
+  border: 1px solid transparent;
+}
+
+.otp-btn-primary:hover {
+  opacity: 0.88;
+}
+
+.otp-ring {
+  position: fixed;
+  z-index: 9998;
+  border: 2px solid var(--primary, #111827);
+  border-radius: 0.625rem;
+  pointer-events: none;
+  transition:
+    top 0.2s ease,
+    left 0.2s ease,
+    width 0.2s ease,
+    height 0.2s ease;
+  animation: otp-in 0.18s ease-out;
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/index.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/index.ts
@@ -3,6 +3,7 @@ import { AgentViewer } from "./AgentViewer";
 import { DraftMarkdown } from "./DraftMarkdown";
 import { SortableVerificationList } from "./SortableVerificationList";
 import { ContentInput } from "./ContentInput/ContentInput";
+import { OnboardingTourPopover } from "./OnboardingTourPopover";
 
 if (typeof window !== "undefined") {
   (window as unknown as Record<string, unknown>).IvyTendrilWidgets = {
@@ -11,7 +12,8 @@ if (typeof window !== "undefined") {
     DraftMarkdown,
     SortableVerificationList,
     ContentInput,
+    OnboardingTourPopover,
   };
 }
 
-export { TendrilProcessViewer, AgentViewer, DraftMarkdown, SortableVerificationList, ContentInput };
+export { TendrilProcessViewer, AgentViewer, DraftMarkdown, SortableVerificationList, ContentInput, OnboardingTourPopover };

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -132,6 +132,15 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var navigate = Context.UseSignal<NavigateSignal, NavigateArgs, Unit>();
         var navigator = UseNavigation();
         var newsArticles = UseState(Array.Empty<SidebarNewsArticle>());
+        var tourService = UseService<IOnboardingTourService>();
+        var tourRefreshToken = UseRefreshToken();
+
+        UseEffect(() =>
+        {
+            void OnTourChanged() => tourRefreshToken.Refresh();
+            tourService.Changed += OnTourChanged;
+            return Disposable.Create(() => tourService.Changed -= OnTourChanged);
+        });
 
         var (importIssuesDialog, showImportIssuesDialog) = UseTrigger((isOpen) =>
         {
@@ -198,6 +207,13 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         {
             if (config.NeedsOnboarding) return;
 
+            var startTour = config.Settings.OnboardingTourPending;
+            if (startTour)
+            {
+                config.Settings.OnboardingTourPending = false;
+                config.SaveSettings();
+            }
+
             var initialAppId = args.NavigationAppId ?? settings.DefaultAppId;
             var targetAppId = initialAppId;
             if (!string.IsNullOrWhiteSpace(targetAppId))
@@ -213,6 +229,9 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             {
                 client.Redirect("/", true);
             }
+
+            if (startTour)
+                tourService.Start();
         });
 
         // Auto-default: if there's exactly one visible app, select it and close sidebar
@@ -610,7 +629,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 settings.Width
             ).Open(sidebarOpen.Value).MainAppSidebar(),
             importIssuesDialog,
-            updateDialog
+            updateDialog,
+            OnboardingTour.Build(tourService, appRepository)
         );
     }
 

--- a/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CompleteStepView.cs
@@ -11,6 +11,7 @@ public class CompleteStepView(
     public override object Build()
     {
         var setupService = UseService<IOnboardingSetupService>();
+        var config = UseService<IConfigService>();
         var client = UseService<IClientProvider>();
 
         var isFinishing = UseState(false);
@@ -25,6 +26,10 @@ public class CompleteStepView(
             {
                 await setupService.FinalizeOnboardingAsync();
                 await setupService.StartBackgroundServicesAsync();
+
+                config.Settings.OnboardingTourPending = true;
+                config.SaveSettings();
+
                 client.ReloadPage();
             }
             catch (Exception ex)

--- a/src/Ivy.Tendril/Apps/Views/NewPlanButton.cs
+++ b/src/Ivy.Tendril/Apps/Views/NewPlanButton.cs
@@ -10,6 +10,7 @@ public class NewPlanButton : ViewBase
                 .Width(Size.Full())
                 .Variant(ButtonVariant.Primary)
                 .OnClick(open)
-                .ShortcutKey("CTRL+ALT+N"));
+                .ShortcutKey("CTRL+ALT+N")
+                .TestId(OnboardingTour.NewPlanButtonTestId));
     }
 }

--- a/src/Ivy.Tendril/Apps/Views/OnboardingTour.cs
+++ b/src/Ivy.Tendril/Apps/Views/OnboardingTour.cs
@@ -1,0 +1,65 @@
+using Ivy.Core.Apps;
+using Ivy.Tendril.Apps.Drafts;
+using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Apps.Review;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Widgets;
+
+namespace Ivy.Tendril.Apps.Views;
+
+/// <summary>
+/// Post-onboarding walkthrough shown once after setup completes. Renders a single
+/// floating <see cref="OnboardingTourPopover"/> that points at the sidebar element
+/// for the current step, so it never affects the layout of the views it explains.
+/// </summary>
+public static class OnboardingTour
+{
+    public const string NewPlanButtonTestId = "new-plan-button";
+
+    private sealed record TourStep(string Title, string Description, Func<IAppRepository, string?> AnchorSelector);
+
+    private static readonly TourStep[] Steps =
+    [
+        new("Create your first plan",
+            "Describe a change you want made and Tendril turns it into a plan an agent can execute.",
+            _ => $"[data-testid=\"{NewPlanButtonTestId}\"]"),
+        new("Refine it in Drafts",
+            "New plans land in Drafts. Review the proposed steps, make adjustments, and start execution when it looks right.",
+            repo => MenuItemSelector(repo, typeof(DraftsApp))),
+        new("Follow along in Jobs",
+            "Jobs shows everything Tendril is working on in the background — planning, executing and creating PRs.",
+            repo => MenuItemSelector(repo, typeof(JobsApp))),
+        new("Accept work in Review",
+            "Completed work lands in Review. Inspect the result and accept it, or send it back with change requests.",
+            repo => MenuItemSelector(repo, typeof(ReviewApp)))
+    ];
+
+    private static string? MenuItemSelector(IAppRepository repo, Type appType) =>
+        repo.GetApp(appType)?.Id is { } id ? $"[data-menu-item=\"{id}\"]" : null;
+
+    public static object? Build(IOnboardingTourService tourService, IAppRepository appRepository)
+    {
+        if (tourService.Step is not { } step || step < 0 || step >= Steps.Length)
+            return null;
+
+        var def = Steps[step];
+        if (def.AnchorSelector(appRepository) is not { } anchor)
+            return null;
+
+        return new OnboardingTourPopover(anchor)
+            .Title(def.Title)
+            .Description(def.Description)
+            .Step(step, Steps.Length)
+            .Placement("right")
+            .OnNext(() =>
+            {
+                if (step >= Steps.Length - 1) tourService.Dismiss();
+                else tourService.SetStep(step + 1);
+            })
+            .OnBack(() =>
+            {
+                if (step > 0) tourService.SetStep(step - 1);
+            })
+            .OnDismiss(tourService.Dismiss);
+    }
+}

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -54,6 +54,8 @@ internal static class ServiceRegistration
 
         server.Services.AddSingleton<OnboardingSetupService>();
         server.Services.AddSingleton<IOnboardingSetupService>(sp => sp.GetRequiredService<OnboardingSetupService>());
+        server.Services.AddSingleton<OnboardingTourService>();
+        server.Services.AddSingleton<IOnboardingTourService>(sp => sp.GetRequiredService<OnboardingTourService>());
         server.Services.AddSingleton<GithubService>();
         server.Services.AddSingleton<IGithubService>(sp => sp.GetRequiredService<GithubService>());
         server.Services.AddSingleton<IGitService>(sp =>

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -179,6 +179,7 @@ public class TendrilSettings
     public bool Telemetry { get; set; } = true;
     public bool DesktopNotifications { get; set; } = true;
     public string? DismissedUpdateVersion { get; set; }
+    public bool OnboardingTourPending { get; set; }
 
     public List<LevelConfig> Levels { get; set; } = new()
     {

--- a/src/Ivy.Tendril/Services/OnboardingTourService.cs
+++ b/src/Ivy.Tendril/Services/OnboardingTourService.cs
@@ -1,0 +1,35 @@
+namespace Ivy.Tendril.Services;
+
+public interface IOnboardingTourService
+{
+    /// <summary>Zero-based index of the active tour step, or null when no tour is running.</summary>
+    int? Step { get; }
+    event Action? Changed;
+    void Start();
+    void SetStep(int step);
+    void Dismiss();
+}
+
+public class OnboardingTourService : IOnboardingTourService
+{
+    public int? Step { get; private set; }
+    public event Action? Changed;
+
+    public void Start()
+    {
+        Step = 0;
+        Changed?.Invoke();
+    }
+
+    public void SetStep(int step)
+    {
+        Step = step;
+        Changed?.Invoke();
+    }
+
+    public void Dismiss()
+    {
+        Step = null;
+        Changed?.Invoke();
+    }
+}


### PR DESCRIPTION
## Summary

Reworked from the original AddProject-background-job scope: this PR is now purely a **tooltip-stepper onboarding tour**.

After onboarding completes (`OnboardingTourPending` settings flag, consumed on the next shell load), a four-step tour walks the user through the core workflow — **New Plan → Drafts → Jobs → Review** — with a floating card pointing at the actual UI element for each step.

### New `OnboardingTourPopover` widget (Ivy.Tendril.Widgets)

- Rendered through a React portal on `document.body`, positioned `fixed` on top of the app — it never participates in the layout of the view it points at (the previous framework-`Tooltip` approach shrank the Jobs data table).
- Anchors to a **global CSS selector**: `[data-menu-item="<app-id>"]` for sidebar items (ids resolved from `IAppRepository` at runtime), `[data-testid="new-plan-button"]` for the New Plan button.
- Bubble pointer arrow aimed at the anchor, plus a highlight ring around it.
- Card design: title + close ✕, muted description, "N of M" counter, pill buttons (Skip/Continue on the first step, Back/Continue in between, Back/Done at the end).
- Re-anchors on scroll/resize/DOM changes (250ms poll) and flips placement when out of viewport room; hides while the anchor is absent.
- Demo app in `.samples` (`/onboarding-tour-popover/demo`) for development and E2E.

### Tendril wiring

- `OnboardingTourService` (step state + change event) rendered as a single overlay from `TendrilAppShell` — no per-app tour code.
- `CompleteStepView` sets `OnboardingTourPending` before reloading into the main shell.

## Testing

- `dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj -p:IvySource=false` — 0 errors/warnings (samples + widgets projects too)
- `npx vitest run` in widgets frontend — 32/32 passed
- Clicked through all four steps, Back, Skip, ✕ and Done in the samples app via browser; verified right/bottom placements, arrow, ring and step counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)