### PR TITLE
fix: reject SetupProject in tendril job start with a clear error

### DIFF
--- a/src/Ivy.Tendril/Commands/JobStartCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStartCommand.cs
@@ -98,9 +98,13 @@ public class JobStartSettings : CommandSettings
         var result = CliValidation.RequireNonEmpty(JobType, "job-type");
         if (!result.Successful) return result;
 
-        if (!Constants.JobTypes.BuiltIn.Contains(JobType, StringComparer.OrdinalIgnoreCase))
+        if (string.Equals(JobType, Constants.JobTypes.SetupProject, StringComparison.OrdinalIgnoreCase))
             return Spectre.Console.ValidationResult.Error(
-                $"Unknown job type '{JobType}'. Valid types: {string.Join(", ", Constants.JobTypes.BuiltIn)}");
+                "SetupProject cannot be started from the CLI. It runs automatically during onboarding or from Settings > Add Project.");
+
+        if (!Constants.JobTypes.CliStartable.Contains(JobType, StringComparer.OrdinalIgnoreCase))
+            return Spectre.Console.ValidationResult.Error(
+                $"Unknown job type '{JobType}'. Valid types: {string.Join(", ", Constants.JobTypes.CliStartable)}");
 
         return Spectre.Console.ValidationResult.Success();
     }
@@ -212,6 +216,6 @@ public class JobStartCommand : Command<JobStartSettings>
             return new RetryPlanArgs(planFolder, settings.ChangeRequest);
         }
 
-        throw new ArgumentException($"Unknown job type: {jobType}. Valid types: {string.Join(", ", Constants.JobTypes.BuiltIn)}");
+        throw new ArgumentException($"Unknown job type: {jobType}. Valid types: {string.Join(", ", Constants.JobTypes.CliStartable)}");
     }
 }

--- a/src/Ivy.Tendril/Constants.cs
+++ b/src/Ivy.Tendril/Constants.cs
@@ -95,5 +95,10 @@ public static class Constants
         {
             CreatePlan, ExecutePlan, RetryPlan, ExpandPlan, UpdatePlan, SplitPlan, CreatePr, CreateIssue, SetupProject, SyncRepo
         };
+
+        public static readonly HashSet<string> CliStartable = new(StringComparer.OrdinalIgnoreCase)
+        {
+            CreatePlan, ExecutePlan, RetryPlan, ExpandPlan, UpdatePlan, SplitPlan, CreatePr, CreateIssue, SyncRepo
+        };
     }
 }


### PR DESCRIPTION
## Summary
- `tendril job start SetupProject <plan-id>` crashed with a confusing "Unknown job type" ArgumentException: `JobStartSettings.Validate()` accepted it (it is in `Constants.JobTypes.BuiltIn`) but `BuildJobArgs` had no branch for it.
- SetupProject is not CLI-startable by design today: it only runs in-process via `IPromptwareRunner` from onboarding / Settings > Add Project, and `SetupProjectArgs` lacks the `ProjectName` firmware wiring in `JobLauncher`/`JobService`, so a naive CLI branch would start a silently broken job.
- Validation now rejects SetupProject with a clear explanation, and a new `Constants.JobTypes.CliStartable` set (BuiltIn minus SetupProject) backs both the validation and error messages so the advertised valid types no longer include SetupProject.

## Testing
- `dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj -p:IvySource=false` — 0 errors/warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)