### PR TITLE
[00657] Remove Configuration Sidebar Title in Configuration App

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
@@ -53,11 +53,7 @@ public class SettingsApp : ViewBase
             .Append(SidebarListRow.Build("Open config.yaml", Icons.FileText,
                 () => ConfigYamlUiHelper.OpenOrNavigate(config, navigator, client, isDesktop, capturedHost)));
 
-        var sidebarHeader = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Height(Size.Px(40))
-            | Icons.Settings2.ToIcon()
-            | Text.Literal("Configuration");
-
-        var sidebar = new HeaderLayout(sidebarHeader, Layout.Vertical(rows).Gap(1));
+        var sidebar = Layout.Vertical(rows).Gap(1);
 
         object content = selected.Value switch
         {


### PR DESCRIPTION
# Summary

## Changes

Removed the redundant "Configuration" heading from the Configuration app's sidebar. The sidebar now displays the section list directly without a title bar, since the app is already clearly labeled in the shell navigation.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Settings/SettingsApp.cs` — Removed sidebar header construction and replaced `HeaderLayout` with direct list layout

## Manual Testing

1. Launch Tendril and navigate to the Configuration app (gear icon in the left nav)
2. Observe the left sidebar — it should start directly with the section list ("Coding Agent" as the first item)
3. Verify there is no "Configuration" title or settings icon above the section list
4. Verify the app's header/title still shows "Configuration" in the top navigation

---

**Commits:**
- fe1ce405 Remove Configuration sidebar title

---
Created using [Ivy Tendril](https://ivy.app).