### PR TITLE
[00060] Add Stop All Jobs Action to Jobs App

### DIFF
--- a/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
+++ b/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
@@ -111,6 +111,8 @@ public class UseStartJobTests
         {
         }
 
+        public int StopAllJobs() => 0;
+
         public void DeleteJob(string id)
         {
         }

--- a/src/Ivy.Tendril.Test/InboxControllerTests.cs
+++ b/src/Ivy.Tendril.Test/InboxControllerTests.cs
@@ -97,6 +97,8 @@ public class InboxControllerTests
         {
         }
 
+        public int StopAllJobs() => 0;
+
         public void DeleteJob(string id)
         {
         }

--- a/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
@@ -228,6 +228,7 @@ public class InboxWatcherServiceTests : IDisposable
 
         public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) { }
         public void StopJob(string id) { }
+        public int StopAllJobs() => 0;
         public void DeleteJob(string id) { }
         public void ClearCompletedJobs() { }
         public void ClearFailedJobs() { }
@@ -379,6 +380,7 @@ public class InboxWatcherServiceTests : IDisposable
 
         public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) { }
         public void StopJob(string id) { }
+        public int StopAllJobs() => 0;
         public void DeleteJob(string id) { }
         public void ClearCompletedJobs() { }
         public void ClearFailedJobs() { }
@@ -416,6 +418,7 @@ public class InboxWatcherServiceTests : IDisposable
 
         public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) { }
         public void StopJob(string id) { }
+        public int StopAllJobs() => 0;
         public void DeleteJob(string id) { }
         public void ClearCompletedJobs() { }
         public void ClearFailedJobs() { }

--- a/src/Ivy.Tendril.Test/JobServiceStopAllTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceStopAllTests.cs
@@ -1,0 +1,92 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class JobServiceStopAllTests
+{
+    [Fact]
+    public void StopAllJobs_StopsAllQueuedJobs()
+    {
+        // maxConcurrentJobs=0 means all jobs get queued
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 0);
+
+        service.StartJob(new CreatePlanArgs("Job 1", "Auto"));
+        service.StartJob(new CreatePlanArgs("Job 2", "Auto"));
+        service.StartJob(new CreatePlanArgs("Job 3", "Auto"));
+
+        var stoppedCount = service.StopAllJobs();
+
+        Assert.Equal(3, stoppedCount);
+        Assert.All(service.GetJobs(), j => Assert.Equal(JobStatus.Stopped, j.Status));
+    }
+
+    [Fact]
+    public void StopAllJobs_WithNoJobs_ReturnsZero()
+    {
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 0);
+
+        var stoppedCount = service.StopAllJobs();
+
+        Assert.Equal(0, stoppedCount);
+    }
+
+    [Fact]
+    public void StopAllJobs_StopsBlockedJobs()
+    {
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 0);
+
+        var id = service.CreateTestJob(new CreatePlanArgs("Blocked Job", "Auto"));
+        service.GetJob(id)!.Status = JobStatus.Blocked;
+
+        var stoppedCount = service.StopAllJobs();
+
+        Assert.Equal(1, stoppedCount);
+        Assert.Equal(JobStatus.Stopped, service.GetJob(id)!.Status);
+    }
+
+    [Fact]
+    public void StopAllJobs_LeavesTerminalJobsUntouched()
+    {
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 0);
+
+        var completedId = service.CreateTestJob(new CreatePlanArgs("Completed Job", "Auto"));
+        service.GetJob(completedId)!.Status = JobStatus.Completed;
+
+        service.StartJob(new CreatePlanArgs("Queued Job", "Auto"));
+
+        var stoppedCount = service.StopAllJobs();
+
+        Assert.Equal(1, stoppedCount);
+        Assert.Equal(JobStatus.Completed, service.GetJob(completedId)!.Status);
+    }
+
+    [Fact]
+    public void StopAllJobs_IsIdempotent()
+    {
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            null, 0);
+
+        service.StartJob(new CreatePlanArgs("Job 1", "Auto"));
+        service.StartJob(new CreatePlanArgs("Job 2", "Auto"));
+
+        var firstCount = service.StopAllJobs();
+        Assert.Equal(2, firstCount);
+
+        var statusesAfterFirst = service.GetJobs().Select(j => j.Status).ToList();
+
+        var secondCount = service.StopAllJobs();
+
+        Assert.Equal(0, secondCount);
+        Assert.Equal(statusesAfterFirst, service.GetJobs().Select(j => j.Status).ToList());
+    }
+}

--- a/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -231,6 +231,11 @@ public class TendrilProcessStatusServiceTests : IDisposable
             throw new NotImplementedException();
         }
 
+        public int StopAllJobs()
+        {
+            throw new NotImplementedException();
+        }
+
         public void DeleteJob(string id)
         {
             throw new NotImplementedException();

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -45,8 +45,12 @@ public partial class JobsApp
         Dictionary<string, string> projectColors,
         StackedProgress? jobsProgress,
         IState<bool> confirmDeleteOpen,
-        IState<string?> deleteJobId)
+        IState<string?> deleteJobId,
+        IState<bool> confirmStopAllOpen)
     {
+        var activeJobCount = jobs.Count(j => j.Status is JobStatus.Running or JobStatus.Queued
+                                                      or JobStatus.Pending or JobStatus.Blocked);
+
         var dataTable = rows.AsQueryable()
             .ToDataTable(t => t.Id)
             .Density(new Responsive<Density?> { Default = Density.Large, Desktop = Density.Medium })
@@ -281,26 +285,37 @@ public partial class JobsApp
 
                 return ValueTask.CompletedTask;
             })
-            .HeaderRight(_ => Layout.Horizontal()
-                              | (jobsProgress != null ? jobsProgress : null!)
-                              | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
-                                  new MenuItem("Clear Completed", Icon: Icons.Trash, Tag: "ClearCompleted")
-                                      .OnSelect(() =>
-                                      {
-                                          jobService.ClearCompletedJobs();
-                                          refreshToken.Refresh();
-                                      }),
-                                  new MenuItem("Clear Failed", Icon: Icons.Trash, Tag: "ClearFailed").OnSelect(() =>
-                                  {
-                                      jobService.ClearFailedJobs();
-                                      refreshToken.Refresh();
-                                  }),
-                                  new MenuItem("Clear All", Icon: Icons.Trash, Tag: "ClearAll").OnSelect(() =>
-                                  {
-                                      jobService.ClearAllJobs();
-                                      refreshToken.Refresh();
-                                  })
-                              ));
+            .HeaderRight(_ =>
+            {
+                var overflowItems = new List<MenuItem>();
+
+                if (activeJobCount > 0)
+                {
+                    overflowItems.Add(new MenuItem($"Stop All ({activeJobCount})", Icon: Icons.Pause, Tag: "StopAll")
+                        .OnSelect(() => confirmStopAllOpen.Set(true)));
+                }
+
+                overflowItems.Add(new MenuItem("Clear Completed", Icon: Icons.Trash, Tag: "ClearCompleted")
+                    .OnSelect(() =>
+                    {
+                        jobService.ClearCompletedJobs();
+                        refreshToken.Refresh();
+                    }));
+                overflowItems.Add(new MenuItem("Clear Failed", Icon: Icons.Trash, Tag: "ClearFailed").OnSelect(() =>
+                {
+                    jobService.ClearFailedJobs();
+                    refreshToken.Refresh();
+                }));
+                overflowItems.Add(new MenuItem("Clear All", Icon: Icons.Trash, Tag: "ClearAll").OnSelect(() =>
+                {
+                    jobService.ClearAllJobs();
+                    refreshToken.Refresh();
+                }));
+
+                return Layout.Horizontal()
+                       | (jobsProgress != null ? jobsProgress : null!)
+                       | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(overflowItems.ToArray());
+            });
 
         var confirmDialog = confirmDeleteOpen.Value ? new Dialog(
             _ => confirmDeleteOpen.Set(false),
@@ -325,6 +340,22 @@ public partial class JobsApp
             )
         ) : null;
 
-        return new Fragment(dataTable, confirmDialog);
+        var stopAllDialog = confirmStopAllOpen.Value ? new Dialog(
+            _ => confirmStopAllOpen.Set(false),
+            new DialogHeader("Stop All Jobs"),
+            new DialogBody(Text.P($"Stop all {activeJobCount} active job(s)? Running agents are killed and their plans revert to their previous state. This cannot be undone.")),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(() => confirmStopAllOpen.Set(false)),
+                new Button("Stop All").Destructive().ShortcutKey("Enter").AutoFocus().OnClick(() =>
+                {
+                    var count = jobService.StopAllJobs();
+                    confirmStopAllOpen.Set(false);
+                    client.Toast($"Stopped {count} job{(count == 1 ? "" : "s")}", "Jobs Stopped");
+                    refreshToken.Refresh();
+                })
+            )
+        ) : null;
+
+        return new Fragment(dataTable, confirmDialog, stopAllDialog);
     }
 }

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
@@ -21,6 +21,7 @@ public partial class JobsApp : ViewBase
         var openFile = UseState<string?>(null);
         var confirmDeleteOpen = UseState(false);
         var deleteJobId = UseState<string?>(null);
+        var confirmStopAllOpen = UseState(false);
 
         var (planSheet, showPlan) = UseTrigger<string>((isOpen, planPath) =>
         {
@@ -89,7 +90,7 @@ public partial class JobsApp : ViewBase
 
         var dataTable = JobsApp.BuildDataTable(nav, rows, refreshToken, updateStream, config, planService,
             jobService, client, showPlan, showOutput, showPrompt, showDebug, showRerun, jobs, projectColors, jobsProgress,
-            confirmDeleteOpen, deleteJobId);
+            confirmDeleteOpen, deleteJobId, confirmStopAllOpen);
 
         var layout = Layout.Vertical().Height(Size.Full());
 

--- a/src/Ivy.Tendril/Services/Jobs/IJobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/IJobService.cs
@@ -14,6 +14,9 @@ public interface IJobService : IDisposable
     void ForceStartJob(string id);
     void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false);
     void StopJob(string id);
+
+    /// <summary>Stops every active job (Running, Queued, Pending, Blocked). Returns the number stopped.</summary>
+    int StopAllJobs();
     void DeleteJob(string id);
     void ClearCompletedJobs();
     void ClearFailedJobs();

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -282,6 +282,36 @@ public class JobService : IJobService
             ProcessJobQueue();
     }
 
+    public int StopAllJobs()
+    {
+        var stopped = new HashSet<string>();
+
+        // Re-snapshot between passes: StopJob releases the stopped job's slot and calls
+        // ProcessJobQueue, which can promote a Queued job to Running while this sweep is
+        // in flight. Three passes is enough to drain that; the bound keeps a pathological
+        // launch/stop loop from spinning forever.
+        for (var pass = 0; pass < 3; pass++)
+        {
+            var active = _jobs.Values
+                .Where(j => j.Status is JobStatus.Running or JobStatus.Queued
+                                     or JobStatus.Pending or JobStatus.Blocked)
+                .Select(j => j.Id)
+                .Where(id => !stopped.Contains(id))
+                .ToList();
+
+            if (active.Count == 0) break;
+
+            foreach (var id in active)
+            {
+                StopJob(id);
+                if (_jobs.TryGetValue(id, out var job) && job.Status == JobStatus.Stopped)
+                    stopped.Add(id);
+            }
+        }
+
+        return stopped.Count;
+    }
+
     public void DeleteJob(string id)
     {
         if (_jobs.TryRemove(id, out var removed))


### PR DESCRIPTION
Fixes #1754

## Changes

Added a "Stop All" bulk-cancel action to the Jobs app. A new `IJobService.StopAllJobs()` sweeps
every active job (Running, Queued, Pending, Blocked) and stops each via the existing `StopJob`
path. The Jobs header overflow menu now shows "Stop All (N)" (only when jobs are active), guarded
by a confirmation dialog before invoking it.

## API Changes

- `IJobService.StopAllJobs()`: new method, returns `int` (count of jobs stopped).
- `JobService.StopAllJobs()`: new implementation.
- All 6 test-double implementations of `IJobService` gained a `StopAllJobs()` member.

## Files Modified

- `src/Ivy.Tendril/Services/Jobs/IJobService.cs` — interface member
- `src/Ivy.Tendril/Services/Jobs/JobService.cs` — `StopAllJobs` implementation
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.cs` — `confirmStopAllOpen` state
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs` — "Stop All" menu item + confirmation dialog
- `src/Ivy.Tendril.Test/JobServiceStopAllTests.cs` — new test file (5 tests)
- `src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs`, `InboxControllerTests.cs`,
  `InboxWatcherServiceTests.cs`, `PlanCountsServiceTests.cs` — stub updates for the new interface
  member

## Manual Testing

1. Run the Tendril app and start several jobs (e.g. multiple `ExecutePlan` runs) so at least one
   is Running or Queued.
2. Open the Jobs app and click the overflow (⋮) button in the header.
3. Observe "Stop All (N)" listed first, above "Clear Completed"/"Clear Failed"/"Clear All", where
   N matches the number of active (Running/Queued/Pending/Blocked) jobs.
4. Click it — a confirmation dialog appears warning that running agents are killed and plans
   revert. Click "Stop All".
5. Observe a toast reporting how many jobs were stopped, and every previously active job's status
   flips to `Stopped` in the table.
6. Re-open the overflow menu with no active jobs left — "Stop All" should no longer be present.

---

## Commits

- ddd36bac feat: add StopAllJobs to job service
- ad0c9d66 feat: add Stop All action to Jobs app header menu
- 423fbcc0 test: implement StopAllJobs on IJobService test doubles
- 5acb248e test: add JobServiceStopAllTests

---
Created using [Ivy Tendril](https://ivy.app).
