### PR TITLE
[00058] Let Agents Delete Outdated Promptware Memories

### DIFF
--- a/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
@@ -126,6 +126,44 @@ public class FirmwareCompilerTests : IDisposable
         Assert.Contains("**Tools:**", result);
     }
 
+    [Fact]
+    public void Compile_ContainsDeleteMemoryInstructions()
+    {
+        var context = new FirmwareContext(
+            "/programs/CreatePlan",
+            new Dictionary<string, string>());
+
+        var result = FirmwareCompiler.Compile(context);
+
+        Assert.Contains("tendril promptware delete-memory CreatePlan <filename>.md", result);
+    }
+
+    [Fact]
+    public void Compile_ListsMemoryFileWithFirstLineDescription()
+    {
+        var memoryDir = Path.Combine(_tempDir, "Memory");
+        Directory.CreateDirectory(memoryDir);
+        File.WriteAllText(Path.Combine(memoryDir, "some-memory.md"), "# Some Heading\n\nBody text.");
+
+        var context = new FirmwareContext(_tempDir, new Dictionary<string, string>());
+        var result = FirmwareCompiler.Compile(context);
+
+        Assert.Contains("some-memory.md", result);
+        Assert.Contains("Some Heading", result);
+    }
+
+    [Fact]
+    public void Compile_EmptyMemoryFolder_RendersEmptyLabel()
+    {
+        var context = new FirmwareContext(
+            "/programs/Test",
+            new Dictionary<string, string>());
+
+        var result = FirmwareCompiler.Compile(context);
+
+        Assert.Contains("(no memory yet)", result);
+    }
+
     // --- Projects Section ---
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Commands/PromptwareDeleteMemoryCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareDeleteMemoryCommandTests.cs
@@ -1,0 +1,96 @@
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Test;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Test.Commands;
+
+[Collection("TendrilHome")]
+public class PromptwareDeleteMemoryCommandTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("tendril-promptware-delete-test");
+    private readonly string _originalTendrilHome;
+
+    public PromptwareDeleteMemoryCommandTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+
+        var promptwareDir = Path.Combine(_tempDir.Path, "Promptwares", "TestPromptware");
+        Directory.CreateDirectory(promptwareDir);
+        File.WriteAllText(Path.Combine(promptwareDir, "Program.md"), "# Program");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+    }
+
+    private static CommandApp BuildApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("promptware", promptware =>
+            {
+                promptware.AddCommand<PromptwareDeleteMemoryCommand>("delete-memory");
+            });
+        });
+        return app;
+    }
+
+    [Fact]
+    public void DeleteMemory_RemovesExistingFile()
+    {
+        var memoryDir = Path.Combine(_tempDir.Path, "Promptwares", "TestPromptware", "Memory");
+        Directory.CreateDirectory(memoryDir);
+        var staleFile = Path.Combine(memoryDir, "stale.md");
+        File.WriteAllText(staleFile, "This is no longer true");
+
+        var app = BuildApp();
+        var exit = app.Run(["promptware", "delete-memory", "TestPromptware", "stale.md"]);
+
+        Assert.Equal(0, exit);
+        Assert.False(File.Exists(staleFile));
+    }
+
+    [Fact]
+    public void DeleteMemory_MissingFile_SucceedsIdempotently()
+    {
+        var app = BuildApp();
+
+        var exit = app.Run(["promptware", "delete-memory", "TestPromptware", "does-not-exist.md"]);
+
+        Assert.Equal(0, exit);
+    }
+
+    [Fact]
+    public void DeleteMemory_IgnoresPathTraversal()
+    {
+        var promptwareDir = Path.Combine(_tempDir.Path, "Promptwares", "TestPromptware");
+        var programFile = Path.Combine(promptwareDir, "Program.md");
+        Assert.True(File.Exists(programFile));
+
+        var app = BuildApp();
+        var exit = app.Run(["promptware", "delete-memory", "TestPromptware", "../../Program.md"]);
+
+        Assert.Equal(0, exit);
+        Assert.True(File.Exists(programFile));
+    }
+
+    [Fact]
+    public void DeleteMemory_RejectsDotfile()
+    {
+        var memoryDir = Path.Combine(_tempDir.Path, "Promptwares", "TestPromptware", "Memory");
+        Directory.CreateDirectory(memoryDir);
+        var dotfile = Path.Combine(memoryDir, ".gitkeep");
+        File.WriteAllText(dotfile, "");
+
+        var app = BuildApp();
+        var exit = app.Run(["promptware", "delete-memory", "TestPromptware", ".gitkeep"]);
+
+        Assert.NotEqual(0, exit);
+        Assert.True(File.Exists(dotfile));
+    }
+}

--- a/src/Ivy.Tendril/Commands/PromptwareDeleteMemoryCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareDeleteMemoryCommand.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel;
+using Ivy.Tendril.Helpers;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class PromptwareDeleteMemorySettings : CommandSettings
+{
+    [Description("Promptware name (e.g., SetupProject)")]
+    [CommandArgument(0, "<name>")]
+    public string Name { get; set; } = "";
+
+    [Description("Filename to delete (e.g., cli-quirks.md)")]
+    [CommandArgument(1, "<filename>")]
+    public string Filename { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(Name, "name"),
+            CliValidation.RequireNonEmpty(Filename, "filename")
+        );
+    }
+}
+
+public class PromptwareDeleteMemoryCommand : Command<PromptwareDeleteMemorySettings>
+{
+    protected override int Execute(CommandContext context, PromptwareDeleteMemorySettings settings, CancellationToken cancellationToken)
+    {
+        var filename = Path.GetFileName(settings.Filename);
+
+        if (filename.StartsWith('.'))
+        {
+            Console.Error.WriteLine($"Refusing to delete dotfile: {filename}");
+            return 1;
+        }
+
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        var programFolder = PromptwareHelper.ResolvePromptwareFolder(settings.Name, tendrilHome);
+
+        var memoryDir = Path.Combine(programFolder, "Memory");
+        var filePath = Path.Combine(memoryDir, filename);
+
+        if (!File.Exists(filePath))
+        {
+            Console.Write($"Memory file not found (nothing to delete): {filename}");
+            return 0;
+        }
+
+        File.Delete(filePath);
+        Console.Write(filePath);
+        return 0;
+    }
+}

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -492,6 +492,8 @@ public class Program
                     .WithDescription("Read a promptware memory file to STDOUT");
                 pw.AddCommand<PromptwareWriteMemoryCommand>("write-memory")
                     .WithDescription("Write a promptware memory file from STDIN");
+                pw.AddCommand<PromptwareDeleteMemoryCommand>("delete-memory")
+                    .WithDescription("Delete a promptware memory file that is no longer true");
                 pw.AddCommand<PromptwareWriteToolCommand>("write-tool")
                     .WithDescription("Write a promptware tool file from STDIN");
             });

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -210,6 +210,7 @@ These commands are for internal use by other promptwares (e.g., a verification s
 | `tendril promptware run <name>` | Run a promptware directly (bypasses job service) |
 | `tendril promptware read-memory <name> <file>` | Read promptware memory |
 | `tendril promptware write-memory <name> <file>` | Write promptware memory (--file/--stdin) |
+| `tendril promptware delete-memory <name> <file>` | Delete an outdated promptware memory |
 | `tendril promptware write-tool <name> <file>` | Write promptware tool (--file/--stdin) |
 
 ### Project Commands

--- a/src/Ivy.Tendril/Services/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/FirmwareCompiler.cs
@@ -66,8 +66,18 @@ public static class FirmwareCompiler
         '@ | tendril promptware write-memory {PROMPTWARE_NAME} <filename>.md
         ```
 
-        - Note that learnings might be falsified over time. Pruning memory is just as important as storing new memory.
-        - Many sessions don't have any new learnings. Only store memory when you need it.
+        To delete a memory file that is no longer true:
+        ```bash
+        tendril promptware delete-memory {PROMPTWARE_NAME} <filename>.md
+        ```
+
+        **Memory hygiene (do this before writing any new memory):**
+        - Read the listed memories that overlap what you touched this session. A memory you did not verify is a memory you cannot trust.
+        - If this session proved a memory wrong (a command it calls broken now works, a workaround it prescribes is no longer needed, a path or flag it names no longer exists), delete it with `delete-memory`. Do not keep it for history.
+        - Never write a memory saying that something is fixed or works now. Such a memory is only meaningful against the memory that said it was broken, so delete that one instead of adding a second file.
+        - If a memory is only partly stale, rewrite the whole file with `write-memory` under the same filename (it overwrites) instead of adding a near duplicate.
+        - Learnings get falsified over time. Pruning memory is as important as storing it.
+        - Many sessions have no new learnings. Only store memory when you need it.
         """;
 
     public static string Compile(FirmwareContext context)
@@ -82,7 +92,7 @@ public static class FirmwareCompiler
             .Select(kv => $"{kv.Key}: {NormalizeHeaderValue(kv.Key, kv.Value)}"));
 
         var toolsListing = ListDirectoryFiles(Path.Combine(context.ProgramFolder, "Tools"), "(no tools yet)");
-        var memoryListing = ListDirectoryFiles(Path.Combine(context.ProgramFolder, "Memory"), "(no memory yet)");
+        var memoryListing = ListMemoryFiles(Path.Combine(context.ProgramFolder, "Memory"));
 
         var promptwareName = Path.GetFileName(context.ProgramFolder);
 
@@ -199,6 +209,45 @@ public static class FirmwareCompiler
             .ToList();
 
         return files.Count == 0 ? emptyLabel : string.Join(", ", files);
+    }
+
+    private static string ListMemoryFiles(string directory, string emptyLabel = "(no memory yet)")
+    {
+        if (!Directory.Exists(directory))
+            return emptyLabel;
+
+        var files = Directory.GetFiles(directory)
+            .Select(Path.GetFileName)
+            .Where(f => f != null && !f.StartsWith('.'))
+            .OrderBy(f => f)
+            .ToList();
+
+        if (files.Count == 0)
+            return emptyLabel;
+
+        var lines = files.Select(f => $"- {f} - {DescribeMemoryFile(Path.Combine(directory, f!))}");
+        return "\n" + string.Join("\n", lines);
+    }
+
+    private static string DescribeMemoryFile(string filePath)
+    {
+        var filename = Path.GetFileName(filePath);
+
+        try
+        {
+            var firstLine = File.ReadLines(filePath)
+                .Select(l => l.TrimStart('#', ' ').Trim())
+                .FirstOrDefault(l => !string.IsNullOrWhiteSpace(l));
+
+            if (string.IsNullOrWhiteSpace(firstLine))
+                return filename;
+
+            return firstLine.Length > 100 ? firstLine[..100] : firstLine;
+        }
+        catch (IOException)
+        {
+            return filename;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1748

# Summary

## Changes

Added a `tendril promptware delete-memory <name> <file>` CLI command so promptware agents can
remove a memory file once it's proven stale, instead of only ever appending new ones. The firmware
template's Reflection section now teaches agents when to use it via a memory hygiene checklist, and
the `{MEMORY}` listing shown to agents now includes each file's first-line description so an agent
can judge relevance without opening every file.

## API Changes

- New CLI command: `tendril promptware delete-memory <name> <filename>` - deletes
  `<programFolder>/Memory/<filename>`. Idempotent (exit 0, "nothing to delete" message) if the file
  doesn't exist. Rejects dotfile filenames with a non-zero exit to protect folder markers.
- `FirmwareCompiler`: the `{MEMORY}` section of compiled firmware now lists each memory file as
  `- <filename> - <first line description>` instead of a comma-separated filename list. The
  `{TOOLS}` section is unchanged.
- `FirmwareCompiler.Compile` output now includes a `delete-memory` bash snippet and a "Memory
  hygiene" rules list in the Reflection section.

## Files Modified

- `src/Ivy.Tendril/Commands/PromptwareDeleteMemoryCommand.cs` (new) - the command itself
- `src/Ivy.Tendril/Program.cs` - registers `delete-memory` in the `promptware` branch
- `src/Ivy.Tendril/Services/FirmwareCompiler.cs` - new `ListMemoryFiles`/`DescribeMemoryFile`
  helpers, updated `FirmwareTemplate` Reflection section
- `src/Ivy.Tendril/Prompts/AgentPrompt.md` - documents the new command
- `src/Ivy.Tendril.Test/Commands/PromptwareDeleteMemoryCommandTests.cs` (new)
- `src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs` - three new cases

## Manual Testing

1. Run `tendril promptware write-memory SomePromptware stale.md <<< "old info"` to seed a memory
   file, then `tendril promptware delete-memory SomePromptware stale.md` and confirm it prints the
   deleted path and the file is gone from `<TENDRIL_HOME>/Promptwares/SomePromptware/Memory/`.
2. Run `tendril promptware delete-memory SomePromptware already-gone.md` against a nonexistent
   file and confirm it exits 0 with a "nothing to delete" message rather than an error.
3. Run `tendril promptware delete-memory SomePromptware .gitkeep` and confirm it exits non-zero and
   the file is untouched.
4. Start any job (e.g. `CreatePlan`) and inspect its compiled firmware header: the `**Memory:**`
   section should list each memory file with a one-line description pulled from that file's first
   line, and the Reflection section should show the new `delete-memory` command and the memory
   hygiene checklist.


---
- 6e6a831d test: cover promptware delete-memory and memory listing (Plan 00058)
- 99ae8a17 docs: document promptware delete-memory command (Plan 00058)
- d42398e1 feat: teach firmware to prune outdated memory (Plan 00058)
- 517c51ab feat: add promptware delete-memory command (Plan 00058)

---
Created using [Ivy Tendril](https://ivy.app).