### PR TITLE
[00062] Add Claude Opus 5 Model Support

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudeModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudeModelCatalogTests.cs
@@ -1,0 +1,69 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Claude;
+
+namespace Ivy.Tendril.Agents.Test.Claude;
+
+public class ClaudeModelCatalogTests
+{
+    private readonly ClaudeModelCatalog _catalog = new();
+
+    [Fact]
+    public void AgentId_IsClaude()
+    {
+        Assert.Equal("claude", _catalog.AgentId);
+    }
+
+    [Fact]
+    public void GetStaticModels_HasExactlyOneDefault()
+    {
+        var models = _catalog.GetStaticModels();
+        Assert.Single(models, m => m.IsDefault);
+    }
+
+    [Fact]
+    public void GetStaticModels_IdsAreUnique()
+    {
+        var ids = _catalog.GetStaticModels().Select(m => m.Id).ToList();
+        Assert.Equal(ids.Count, ids.Distinct().Count());
+    }
+
+    [Fact]
+    public void GetStaticModels_AllHavePricing()
+    {
+        var models = _catalog.GetStaticModels();
+        foreach (var model in models)
+        {
+            Assert.True(model.InputPerMillion > 0, $"{model.Id} missing InputPerMillion");
+            Assert.True(model.OutputPerMillion > 0, $"{model.Id} missing OutputPerMillion");
+        }
+    }
+
+    [Fact]
+    public void GetStaticModels_AllHaveProvider()
+    {
+        var models = _catalog.GetStaticModels();
+        Assert.All(models, m => Assert.False(string.IsNullOrEmpty(m.Provider)));
+    }
+
+    [Fact]
+    public void GetStaticModels_ContainsOpus5()
+    {
+        var models = _catalog.GetStaticModels();
+        var opus5 = Assert.Single(models, m => m.Id == "claude-opus-5");
+
+        Assert.Equal(1_000_000, opus5.ContextWindow);
+        Assert.Equal(128_000, opus5.MaxOutputTokens);
+        Assert.Equal(5.00m, opus5.InputPerMillion);
+        Assert.Equal(25.00m, opus5.OutputPerMillion);
+    }
+
+    [Fact]
+    public async Task GetModelsAsync_ReturnsModels()
+    {
+        var result = await _catalog.GetModelsAsync();
+
+        Assert.NotNull(result);
+        Assert.Equal("claude", result.AgentId);
+        Assert.NotEmpty(result.Models);
+    }
+}

--- a/src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs
@@ -24,8 +24,8 @@ public class ModelPricingProviderTests
         var pricing = _provider.GetPricing("sonnet");
 
         Assert.NotNull(pricing);
-        Assert.Equal(3m, pricing.InputPerMillion);
-        Assert.Equal(15m, pricing.OutputPerMillion);
+        Assert.Equal(2m, pricing.InputPerMillion);
+        Assert.Equal(10m, pricing.OutputPerMillion);
     }
 
     [Fact]
@@ -34,8 +34,8 @@ public class ModelPricingProviderTests
         var pricing = _provider.GetPricing("claude-sonnet-4");
 
         Assert.NotNull(pricing);
-        Assert.Equal(3m, pricing.InputPerMillion);
-        Assert.Equal(15m, pricing.OutputPerMillion);
+        Assert.Equal(2m, pricing.InputPerMillion);
+        Assert.Equal(10m, pricing.OutputPerMillion);
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public class ModelPricingProviderTests
             inputTokens: 1000,
             outputTokens: 500);
 
-        var expected = (1000m * 3m / 1_000_000m) + (500m * 15m / 1_000_000m);
+        var expected = (1000m * 2m / 1_000_000m) + (500m * 10m / 1_000_000m);
         Assert.Equal(expected, cost);
     }
 

--- a/src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs
@@ -14,8 +14,8 @@ public class ModelPricingProviderTests
 
         Assert.NotNull(pricing);
         Assert.Equal("opus", pricing.Model);
-        Assert.Equal(10m, pricing.InputPerMillion);
-        Assert.Equal(50m, pricing.OutputPerMillion);
+        Assert.Equal(5m, pricing.InputPerMillion);
+        Assert.Equal(25m, pricing.OutputPerMillion);
     }
 
     [Fact]
@@ -81,7 +81,7 @@ public class ModelPricingProviderTests
             inputTokens: 1_000_000,
             outputTokens: 1_000_000);
 
-        Assert.Equal(10m + 50m, cost);
+        Assert.Equal(5m + 25m, cost);
     }
 
     [Fact]
@@ -94,7 +94,7 @@ public class ModelPricingProviderTests
             cacheReadTokens: 1_000_000,
             cacheWriteTokens: 1_000_000);
 
-        Assert.Equal(1.00m + 12.50m, cost);
+        Assert.Equal(0.50m + 6.25m, cost);
     }
 
     [Fact]
@@ -164,8 +164,8 @@ public class ModelPricingProviderTests
     {
         var pricing = _provider.GetPricing("opus")!;
 
-        Assert.Equal(12.50m, pricing.CacheWritePerMillion);
-        Assert.Equal(1.00m, pricing.CacheReadPerMillion);
+        Assert.Equal(6.25m, pricing.CacheWritePerMillion);
+        Assert.Equal(0.50m, pricing.CacheReadPerMillion);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
@@ -58,18 +58,19 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         },
         new()
         {
+            // Introductory pricing ($2 / $10) applies through 2026-08-31; standard pricing is $3 / $15 after.
             Id = "sonnet", DisplayName = "Claude Sonnet",
             Capabilities = MidCaps,
-            ContextWindow = 200_000, MaxOutputTokens = 16_000,
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
-            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
-            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
+            InputPerMillion = 2.00m, OutputPerMillion = 10.00m,
+            CacheWritePerMillion = 2.50m, CacheReadPerMillion = 0.20m,
         },
         new()
         {
             Id = "haiku", DisplayName = "Claude Haiku",
             Capabilities = LiteCaps,
-            ContextWindow = 200_000, MaxOutputTokens = 8_192,
+            ContextWindow = 200_000, MaxOutputTokens = 64_000,
             Provider = "anthropic",
             InputPerMillion = 1.00m, OutputPerMillion = 5.00m,
             CacheWritePerMillion = 1.25m, CacheReadPerMillion = 0.10m,

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
@@ -40,12 +40,21 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         },
         new()
         {
+            Id = "claude-opus-5", DisplayName = "Claude Opus 5",
+            Capabilities = FullCaps,
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
+            Provider = "anthropic",
+            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
+            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
+        },
+        new()
+        {
             Id = "opus", DisplayName = "Claude Opus",
             Capabilities = FullCaps,
-            ContextWindow = 200_000, MaxOutputTokens = 32_000,
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic", IsDefault = true,
-            InputPerMillion = 10.00m, OutputPerMillion = 50.00m,
-            CacheWritePerMillion = 12.50m, CacheReadPerMillion = 1.00m,
+            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
+            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
         },
         new()
         {

--- a/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/01_ClaudeCode.md
+++ b/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/01_ClaudeCode.md
@@ -50,7 +50,9 @@ The profile is selected automatically based on the plan's complexity level, or c
 | Claude Fable | `claude-fable-5` | 1M | $10.00 / $50.00 |
 | Claude Opus 5 | `claude-opus-5` | 1M | $5.00 / $25.00 |
 | Claude Opus | `opus` | 1M | $5.00 / $25.00 |
-| Claude Sonnet | `sonnet` | 200k | $3.00 / $15.00 |
+| Claude Sonnet | `sonnet` | 1M | $2.00 / $10.00 |
 | Claude Haiku | `haiku` | 200k | $1.00 / $5.00 |
 
 `opus`, `sonnet`, and `haiku` are Claude Code aliases that track Anthropic's current model for that tier, while `claude-opus-5` and `claude-fable-5` are pinned IDs.
+
+Claude Sonnet's introductory pricing of $2.00 / $10.00 applies through 2026-08-31; standard pricing of $3.00 / $15.00 applies after.

--- a/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/01_ClaudeCode.md
+++ b/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/01_ClaudeCode.md
@@ -42,3 +42,15 @@ Tendril maps effort levels to Claude models:
 | `quick` | haiku | Simple fixes, formatting, small edits |
 
 The profile is selected automatically based on the plan's complexity level, or can be configured per promptware in `config.yaml`.
+
+## Available models
+
+| Model | ID | Context Window | Pricing (input / output per MTok) |
+|-------|----|-----------------|------------------------------------|
+| Claude Fable | `claude-fable-5` | 1M | $10.00 / $50.00 |
+| Claude Opus 5 | `claude-opus-5` | 1M | $5.00 / $25.00 |
+| Claude Opus | `opus` | 1M | $5.00 / $25.00 |
+| Claude Sonnet | `sonnet` | 200k | $3.00 / $15.00 |
+| Claude Haiku | `haiku` | 200k | $1.00 / $5.00 |
+
+`opus`, `sonnet`, and `haiku` are Claude Code aliases that track Anthropic's current model for that tier, while `claude-opus-5` and `claude-fable-5` are pinned IDs.


### PR DESCRIPTION
Fixes #1761

# Summary

## Changes

Added a pinned `claude-opus-5` catalog entry and refreshed the `opus` alias to Opus 5 specs
(1M context, 128k max output, $5/$25 per MTok) so users can select the exact model and cost
telemetry no longer bills opus-tagged jobs at stale, roughly-2x Opus 4 rates. Added a
`ClaudeModelCatalogTests` class (the only Claude/Anthropic-agent catalog previously untested)
and documented the available Claude models in the Claude Code docs page.

## API Changes

- `ClaudeModelCatalog.GetStaticModels()` now returns a new entry with `Id = "claude-opus-5"`
  (`DisplayName = "Claude Opus 5"`, 1M context, 128k max output, $5.00/$25.00 per MTok,
  $6.25/$0.50 cache write/read).
- The existing `opus` entry's `ContextWindow`, `MaxOutputTokens`, `InputPerMillion`,
  `OutputPerMillion`, `CacheWritePerMillion`, and `CacheReadPerMillion` changed from
  200k/32k/$10.00/$50.00/$12.50/$1.00 to 1M/128k/$5.00/$25.00/$6.25/$0.50. `Id`, `DisplayName`,
  and `IsDefault` are unchanged.
- No other public API surface changed.

## Files Modified

**Source:**
- `src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs` - new `claude-opus-5` entry, refreshed `opus` pricing/specs

**Tests:**
- `src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs` - updated assertions to match new `opus` pricing
- `src/Ivy.Tendril.Agents.Test/Claude/ClaudeModelCatalogTests.cs` - new test class covering the Claude catalog

**Docs:**
- `src/Ivy.Tendril.Docs/Docs/06_CodingAgents/01_ClaudeCode.md` - new "Available models" table

## Manual Testing

1. Open **Settings > Coding Agent** in Tendril with Claude Code selected as the agent.
2. Open the model picker - "Claude Opus 5" should now appear as a selectable pinned model,
   alongside "Claude Opus" (alias), "Claude Fable", "Claude Sonnet", and "Claude Haiku".
3. Run `tendril models` (or the equivalent `ModelsCommand`) and confirm `claude-opus-5` is listed
   with 1,000,000 context window / 128,000 max output tokens.
4. Run a job with the `deep` profile (which resolves to the `opus` alias) and check the Jobs/Costs
   table - the reported cost should now reflect $5/$25 per MTok instead of the previous $10/$50.

## Fix: Refresh sonnet and haiku alias metadata

Per reviewer feedback, the `sonnet` and `haiku` alias entries in `ClaudeModelCatalog` carried stale specs (the same issue the `opus` alias had before this plan). Refreshed `sonnet` to Sonnet 5 specs (1M context, 128k max output, $2.00/$10.00 per MTok introductory pricing through 2026-08-31, standard $3.00/$15.00 after) and `haiku` to Haiku 4.5's 64k max output (was 8,192; context window and pricing were already correct). Updated the corresponding `ModelPricingProviderTests` assertions and the "Available models" docs table to match.

### Files Modified

- `src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs` - refreshed `sonnet` and `haiku` specs/pricing
- `src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs` - updated assertions for new `sonnet` pricing
- `src/Ivy.Tendril.Docs/Docs/06_CodingAgents/01_ClaudeCode.md` - updated "Available models" table for `sonnet`, added introductory-pricing note

**Note:** No manual testing changes needed - this only affects the reported context window, max output, and per-MTok pricing shown for `sonnet`/`haiku`, which the existing manual testing steps for `opus`/`claude-opus-5` already exercise via the same model picker and cost telemetry surfaces.

---
Commits:
- 981e85bf Add claude-opus-5 pinned model and refresh opus alias pricing
- cf65519e Update ModelPricingProviderTests for new opus alias pricing
- abe580e5 Add ClaudeModelCatalogTests
- f45e74d2 Document available Claude models in Claude Code docs
- 31ea9c30 Refresh sonnet and haiku alias metadata (plan 00062)

---
Created using [Ivy Tendril](https://ivy.app).
