### PR TITLE
[00063] Add Bulk Stop for Queued Jobs and Readable Prompt Titles

### DIFF
--- a/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
+++ b/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
@@ -127,6 +127,11 @@ public class UseStartJobTests
         {
         }
 
+        public int StopQueuedJobs()
+        {
+            return 0;
+        }
+
         public JobItem? GetJob(string id)
         {
             return null;

--- a/src/Ivy.Tendril.Test/InboxControllerTests.cs
+++ b/src/Ivy.Tendril.Test/InboxControllerTests.cs
@@ -113,6 +113,11 @@ public class InboxControllerTests
         {
         }
 
+        public int StopQueuedJobs()
+        {
+            return 0;
+        }
+
         public List<JobItem> GetJobs()
         {
             return new List<JobItem>();

--- a/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
@@ -232,6 +232,7 @@ public class InboxWatcherServiceTests : IDisposable
         public void ClearCompletedJobs() { }
         public void ClearFailedJobs() { }
         public void ClearAllJobs() { }
+        public int StopQueuedJobs() => 0;
         public List<JobItem> GetJobs() => new();
         public List<JobItem> GetJobsForPlan(string planFile) => new();
         public JobItem? GetJob(string id) => null;
@@ -383,6 +384,7 @@ public class InboxWatcherServiceTests : IDisposable
         public void ClearCompletedJobs() { }
         public void ClearFailedJobs() { }
         public void ClearAllJobs() { }
+        public int StopQueuedJobs() => 0;
         public List<JobItem> GetJobs() => new();
         public List<JobItem> GetJobsForPlan(string planFile) => new();
         public JobItem? GetJob(string id) => null;
@@ -420,6 +422,7 @@ public class InboxWatcherServiceTests : IDisposable
         public void ClearCompletedJobs() { }
         public void ClearFailedJobs() { }
         public void ClearAllJobs() { }
+        public int StopQueuedJobs() => 0;
         public List<JobItem> GetJobs() => new();
         public List<JobItem> GetJobsForPlan(string planFile) => new();
         public JobItem? GetJob(string id) => null;

--- a/src/Ivy.Tendril.Test/JobServiceStopQueuedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceStopQueuedTests.cs
@@ -1,0 +1,93 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class JobServiceStopQueuedTests
+{
+    private static JobService CreateService()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+        return new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+    }
+
+    private static void AddJobDirectly(JobService service, JobItem job)
+    {
+        var field = typeof(JobService).GetField("_jobs",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        var jobs = (ConcurrentDictionary<string, JobItem>)field!.GetValue(service)!;
+        jobs[job.Id] = job;
+    }
+
+    [Fact]
+    public void StopQueuedJobs_StopsOnlyQueuedJobs()
+    {
+        var service = CreateService();
+        AddJobDirectly(service, new JobItem { Id = "queued-1", Status = JobStatus.Queued });
+        AddJobDirectly(service, new JobItem { Id = "queued-2", Status = JobStatus.Queued });
+        AddJobDirectly(service, new JobItem { Id = "queued-3", Status = JobStatus.Queued });
+        AddJobDirectly(service, new JobItem { Id = "running-1", Status = JobStatus.Running });
+        AddJobDirectly(service, new JobItem { Id = "completed-1", Status = JobStatus.Completed });
+
+        var stoppedCount = service.StopQueuedJobs();
+
+        Assert.Equal(3, stoppedCount);
+        Assert.Equal(JobStatus.Stopped, service.GetJob("queued-1")!.Status);
+        Assert.Equal(JobStatus.Stopped, service.GetJob("queued-2")!.Status);
+        Assert.Equal(JobStatus.Stopped, service.GetJob("queued-3")!.Status);
+        Assert.Equal(JobStatus.Running, service.GetJob("running-1")!.Status);
+        Assert.Equal(JobStatus.Completed, service.GetJob("completed-1")!.Status);
+    }
+
+    [Fact]
+    public void StopQueuedJobs_NoQueuedJobs_ReturnsZeroAndRaisesNoEvent()
+    {
+        var service = CreateService();
+        AddJobDirectly(service, new JobItem { Id = "running-1", Status = JobStatus.Running });
+        AddJobDirectly(service, new JobItem { Id = "completed-1", Status = JobStatus.Completed });
+
+        var structureChangedCount = 0;
+        service.JobsStructureChanged += () => structureChangedCount++;
+
+        var stoppedCount = service.StopQueuedJobs();
+
+        Assert.Equal(0, stoppedCount);
+        Assert.Equal(0, structureChangedCount);
+    }
+
+    [Fact]
+    public void StopQueuedJobs_RaisesStructureChangedExactlyOnce()
+    {
+        var service = CreateService();
+        AddJobDirectly(service, new JobItem { Id = "queued-1", Status = JobStatus.Queued });
+        AddJobDirectly(service, new JobItem { Id = "queued-2", Status = JobStatus.Queued });
+        AddJobDirectly(service, new JobItem { Id = "queued-3", Status = JobStatus.Queued });
+
+        var structureChangedCount = 0;
+        service.JobsStructureChanged += () => structureChangedCount++;
+
+        service.StopQueuedJobs();
+
+        Assert.Equal(1, structureChangedCount);
+    }
+
+    [Fact]
+    public void StopQueuedJobs_LeavesJobsVisibleUntilCleared()
+    {
+        var service = CreateService();
+        AddJobDirectly(service, new JobItem { Id = "queued-1", Status = JobStatus.Queued });
+        AddJobDirectly(service, new JobItem { Id = "queued-2", Status = JobStatus.Queued });
+
+        service.StopQueuedJobs();
+
+        Assert.NotNull(service.GetJob("queued-1"));
+        Assert.NotNull(service.GetJob("queued-2"));
+
+        service.ClearAllJobs();
+
+        Assert.Null(service.GetJob("queued-1"));
+        Assert.Null(service.GetJob("queued-2"));
+    }
+}

--- a/src/Ivy.Tendril.Test/JobsAppPromptDisplayTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppPromptDisplayTests.cs
@@ -1,0 +1,213 @@
+using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Test;
+
+public class JobsAppPromptDisplayTests
+{
+    [Fact]
+    public void FlattenMarkdownLinks_ReplacesLinkWithText()
+    {
+        var result = JobsApp.FlattenMarkdownLinks("[GitHub Issue #925](https://github.com/o/r/issues/925)");
+
+        Assert.Equal("GitHub Issue #925", result);
+    }
+
+    [Fact]
+    public void FlattenMarkdownLinks_HandlesMultipleLinksAndPlainText()
+    {
+        var result = JobsApp.FlattenMarkdownLinks(
+            "See [Issue #1](https://example.com/1) and also [Issue #2](https://example.com/2) for details.");
+
+        Assert.Equal("See Issue #1 and also Issue #2 for details.", result);
+    }
+
+    [Fact]
+    public void FlattenMarkdownLinks_LeavesUnmatchedBracketsAlone()
+    {
+        Assert.Equal("[not a link", JobsApp.FlattenMarkdownLinks("[not a link"));
+        Assert.Equal("array[0] value", JobsApp.FlattenMarkdownLinks("array[0] value"));
+    }
+
+    [Fact]
+    public void GetPromptDisplay_CreatePlanArgs_FlattensLink()
+    {
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = Constants.JobTypes.CreatePlan,
+            PlanFile = "",
+            TypedArgs = new CreatePlanArgs(
+                "[GitHub Issue #925](https://github.com/o/r/issues/925)", "Ivy-Tendril")
+        };
+
+        var display = JobsApp.GetPromptDisplay(job, new FakePlanReaderService());
+
+        Assert.Equal("GitHub Issue #925", display);
+    }
+
+    [Fact]
+    public void GetFullPrompt_PreservesRawMarkdown()
+    {
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = Constants.JobTypes.CreatePlan,
+            TypedArgs = new CreatePlanArgs(
+                "[GitHub Issue #925](https://github.com/o/r/issues/925)", "Ivy-Tendril")
+        };
+
+        var fullPrompt = JobsApp.GetFullPrompt(job);
+
+        Assert.Equal("[GitHub Issue #925](https://github.com/o/r/issues/925)", fullPrompt);
+    }
+
+    private class FakePlanReaderService : IPlanReaderService
+    {
+        public string PlansDirectory => "/tmp";
+        public bool IsDatabaseReady => true;
+#pragma warning disable CS0067
+        public event Action? CountsInvalidated;
+#pragma warning restore CS0067
+
+        public void MigratePlans()
+        {
+        }
+
+        public void RecoverStuckPlans()
+        {
+        }
+
+        public List<PlanFile> GetPlans(PlanStatus? statusFilter = null)
+        {
+            return [];
+        }
+
+        public PlanFile? GetPlanByFolder(string folderPath)
+        {
+            return null;
+        }
+
+        public List<PlanFile> GetIceboxPlans()
+        {
+            return [];
+        }
+
+        public void TransitionState(string folderName, PlanStatus newState)
+        {
+        }
+
+        public void ResetToDraft(string folderName)
+        {
+        }
+
+        public void ResetVerificationsForRetry(string folderName)
+        {
+        }
+
+        public void SetVerificationStatus(string folderName, string name, VerificationStatus status)
+        {
+        }
+
+        public void RevertRevision(string folderName)
+        {
+        }
+
+        public void SaveRevision(string folderName, string content)
+        {
+        }
+
+        public string ReadLatestRevision(string folderName)
+        {
+            return "";
+        }
+
+        public List<(int Number, string Content, DateTime Modified)> GetRevisions(string folderName)
+        {
+            return [];
+        }
+
+        public void DeletePlan(string folderName)
+        {
+        }
+
+        public string ReadRawPlan(string folderName)
+        {
+            return "";
+        }
+
+        public void SavePlan(string folderName, string fullContent)
+        {
+        }
+
+        public void UpdateLatestRevision(string folderName, string content)
+        {
+        }
+
+        public DashboardModels GetDashboardData(string? projectFilter)
+        {
+            return new DashboardModels(0, 0, 0, 0, 0, 0, 0, [], []);
+        }
+
+        public decimal GetPlanTotalCost(string folderPath)
+        {
+            return 0;
+        }
+
+        public int GetPlanTotalTokens(string folderPath)
+        {
+            return 0;
+        }
+
+        public List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7, string? projectFilter = null)
+        {
+            return [];
+        }
+
+        public List<Recommendation> GetRecommendations()
+        {
+            return [];
+        }
+
+        public int GetPendingRecommendationsCount()
+        {
+            return 0;
+        }
+
+        public PlanReaderService.PlanCountSnapshot ComputePlanCounts()
+        {
+            return new PlanReaderService.PlanCountSnapshot(0, 0, 0, 0, 0, 0);
+        }
+
+        public void UpdateRecommendationState(string planFolderName, string recommendationTitle, string newState,
+            string? declineReason = null)
+        {
+        }
+
+        public void SyncPlanArtifacts(string planFolder)
+        {
+        }
+
+        public void InvalidateCaches()
+        {
+        }
+
+        public Task FlushPendingWritesAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public List<RecommendationYaml> GetRecommendationsForPlan(string folderName)
+        {
+            return [];
+        }
+
+        public void AcceptRecommendationAndRetry(string folderName, string recommendationTitle)
+        {
+        }
+
+        public void AcceptRecommendationsAndRetry(string folderName, IReadOnlyCollection<string> titles)
+        {
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -251,6 +251,11 @@ public class TendrilProcessStatusServiceTests : IDisposable
             throw new NotImplementedException();
         }
 
+        public int StopQueuedJobs()
+        {
+            throw new NotImplementedException();
+        }
+
         public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null)
         {
             throw new NotImplementedException();

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -45,8 +45,10 @@ public partial class JobsApp
         Dictionary<string, string> projectColors,
         StackedProgress? jobsProgress,
         IState<bool> confirmDeleteOpen,
-        IState<string?> deleteJobId)
+        IState<string?> deleteJobId,
+        IState<bool> confirmStopQueuedOpen)
     {
+        var queuedCount = jobs.Count(j => j.Status == JobStatus.Queued);
         var dataTable = rows.AsQueryable()
             .ToDataTable(t => t.Id)
             .Density(new Responsive<Density?> { Default = Density.Large, Desktop = Density.Medium })
@@ -284,23 +286,8 @@ public partial class JobsApp
             .HeaderRight(_ => Layout.Horizontal()
                               | (jobsProgress != null ? jobsProgress : null!)
                               | new Button().Icon(Icons.EllipsisVertical).Ghost().WithDropDown(
-                                  new MenuItem("Clear Completed", Icon: Icons.Trash, Tag: "ClearCompleted")
-                                      .OnSelect(() =>
-                                      {
-                                          jobService.ClearCompletedJobs();
-                                          refreshToken.Refresh();
-                                      }),
-                                  new MenuItem("Clear Failed", Icon: Icons.Trash, Tag: "ClearFailed").OnSelect(() =>
-                                  {
-                                      jobService.ClearFailedJobs();
-                                      refreshToken.Refresh();
-                                  }),
-                                  new MenuItem("Clear All", Icon: Icons.Trash, Tag: "ClearAll").OnSelect(() =>
-                                  {
-                                      jobService.ClearAllJobs();
-                                      refreshToken.Refresh();
-                                  })
-                              ));
+                                  BuildHeaderMenuItems(queuedCount, jobService, refreshToken,
+                                      confirmStopQueuedOpen)));
 
         var confirmDialog = confirmDeleteOpen.Value ? new Dialog(
             _ => confirmDeleteOpen.Set(false),
@@ -325,6 +312,56 @@ public partial class JobsApp
             )
         ) : null;
 
-        return new Fragment(dataTable, confirmDialog);
+        var confirmStopQueuedDialog = confirmStopQueuedOpen.Value ? new Dialog(
+            _ => confirmStopQueuedOpen.Set(false),
+            new DialogHeader("Stop Queued Jobs"),
+            new DialogBody(Text.P($"Stop all {queuedCount} queued jobs? Running jobs are not affected.")),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(() => confirmStopQueuedOpen.Set(false)),
+                new Button("Stop All").Destructive().ShortcutKey("Enter").AutoFocus().OnClick(() =>
+                {
+                    var count = jobService.StopQueuedJobs();
+                    confirmStopQueuedOpen.Set(false);
+                    client.Toast($"Stopped {count} queued job(s).", "Jobs");
+                    refreshToken.Refresh();
+                })
+            )
+        ) : null;
+
+        return new Fragment(dataTable, confirmDialog, confirmStopQueuedDialog);
+    }
+
+    private static MenuItem[] BuildHeaderMenuItems(
+        int queuedCount,
+        IJobService jobService,
+        RefreshToken refreshToken,
+        IState<bool> confirmStopQueuedOpen)
+    {
+        var items = new List<MenuItem>();
+
+        if (queuedCount > 0)
+        {
+            items.Add(new MenuItem($"Stop All Queued ({queuedCount})", Icon: Icons.Pause, Tag: "StopAllQueued")
+                .OnSelect(() => confirmStopQueuedOpen.Set(true)));
+        }
+
+        items.Add(new MenuItem("Clear Completed", Icon: Icons.Trash, Tag: "ClearCompleted")
+            .OnSelect(() =>
+            {
+                jobService.ClearCompletedJobs();
+                refreshToken.Refresh();
+            }));
+        items.Add(new MenuItem("Clear Failed", Icon: Icons.Trash, Tag: "ClearFailed").OnSelect(() =>
+        {
+            jobService.ClearFailedJobs();
+            refreshToken.Refresh();
+        }));
+        items.Add(new MenuItem("Clear All Finished", Icon: Icons.Trash, Tag: "ClearAll").OnSelect(() =>
+        {
+            jobService.ClearAllJobs();
+            refreshToken.Refresh();
+        }));
+
+        return items.ToArray();
     }
 }

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs
@@ -97,7 +97,13 @@ public partial class JobsApp
         return collapsed.Trim();
     }
 
-    private static string GetPromptDisplay(JobItem j, IPlanReaderService planService)
+    private static readonly Regex MarkdownLinkRegex =
+        new(@"\[([^\]]+)\]\((?:[^)]*)\)", RegexOptions.Compiled);
+
+    internal static string FlattenMarkdownLinks(string text)
+        => string.IsNullOrEmpty(text) ? text : MarkdownLinkRegex.Replace(text, "$1");
+
+    internal static string GetPromptDisplay(JobItem j, IPlanReaderService planService)
     {
         // Try loading plan title from service
         if (TryGetPlanTitle(j.PlanFile, planService, out var planTitle))
@@ -136,9 +142,9 @@ public partial class JobsApp
         return false;
     }
 
-    private static string TruncatePrompt(string? text)
+    internal static string TruncatePrompt(string? text)
     {
-        var cleaned = CleanPromptText(text ?? string.Empty);
+        var cleaned = FlattenMarkdownLinks(CleanPromptText(text ?? string.Empty));
         return cleaned.Length > PromptDisplayMaxLength
             ? cleaned[..PromptDisplayMaxLength] + "..."
             : cleaned;

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
@@ -21,6 +21,7 @@ public partial class JobsApp : ViewBase
         var openFile = UseState<string?>(null);
         var confirmDeleteOpen = UseState(false);
         var deleteJobId = UseState<string?>(null);
+        var confirmStopQueuedOpen = UseState(false);
 
         var (planSheet, showPlan) = UseTrigger<string>((isOpen, planPath) =>
         {
@@ -89,7 +90,7 @@ public partial class JobsApp : ViewBase
 
         var dataTable = JobsApp.BuildDataTable(nav, rows, refreshToken, updateStream, config, planService,
             jobService, client, showPlan, showOutput, showPrompt, showDebug, showRerun, jobs, projectColors, jobsProgress,
-            confirmDeleteOpen, deleteJobId);
+            confirmDeleteOpen, deleteJobId, confirmStopQueuedOpen);
 
         var layout = Layout.Vertical().Height(Size.Full());
 

--- a/src/Ivy.Tendril/Services/Jobs/IJobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/IJobService.cs
@@ -18,6 +18,9 @@ public interface IJobService : IDisposable
     void ClearCompletedJobs();
     void ClearFailedJobs();
     void ClearAllJobs();
+
+    /// <summary>Stops every Queued job. Returns the number stopped.</summary>
+    int StopQueuedJobs();
     List<JobItem> GetJobs();
     List<JobItem> GetJobsForPlan(string planFile);
     JobItem? GetJob(string id);

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -20,6 +20,7 @@ public class JobService : IJobService
     private TimeSpan _jobTimeout;
     private readonly ConcurrentDictionary<string, JobItem> _jobs = new();
     private int _maxConcurrentJobs;
+    private int _structureChangedSuppressed;
     private readonly ModelPricingService? _modelPricingService;
     private readonly IPlanReaderService? _planReaderService;
     private readonly IPlanWatcherService? _planWatcherService;
@@ -465,6 +466,26 @@ public class JobService : IJobService
     public void ClearAllJobs()
         => ClearJobsByStatus(j => j.Status is not JobStatus.Running and not JobStatus.Queued);
 
+    public int StopQueuedJobs()
+    {
+        var ids = _jobs.Values.Where(j => j.Status == JobStatus.Queued).Select(j => j.Id).ToList();
+        if (ids.Count == 0) return 0;
+
+        Interlocked.Increment(ref _structureChangedSuppressed);
+        try
+        {
+            foreach (var id in ids)
+                StopJob(id);
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _structureChangedSuppressed);
+        }
+
+        RaiseJobsStructureChanged();
+        return ids.Count;
+    }
+
     private void ClearJobsByStatus(Func<JobItem, bool> predicate)
     {
         var ids = _jobs.Values.Where(predicate).Select(j => j.Id).ToList();
@@ -595,6 +616,7 @@ public class JobService : IJobService
 
     private void RaiseJobsStructureChanged()
     {
+        if (Volatile.Read(ref _structureChangedSuppressed) > 0) return;
         if (_syncContext != null)
             _syncContext.Post(_ =>
             {


### PR DESCRIPTION
Fixes #1755

# Summary: Add Bulk Stop for Queued Jobs and Readable Prompt Titles

## Changes

1. **Bulk-stop queued jobs.** Added `IJobService.StopQueuedJobs()`, implemented in `JobService` by reusing `StopJob` per queued job under an event-suppression counter, so a batch stop of N jobs fires `JobsStructureChanged` exactly once instead of N times.
2. **Header menu.** The Jobs table header menu now shows `Stop All Queued (N)` (only when N > 0), guarded by a confirm dialog ("Stop all N queued jobs? Running jobs are not affected."). `Clear All` was renamed to `Clear All Finished` to accurately describe its unchanged behavior (it never touched Running/Queued jobs).
3. **Readable prompt titles.** Added `FlattenMarkdownLinks`, which strips `[text](url)` markdown link syntax down to `text`. Wired into `TruncatePrompt` (used by the Jobs table's Prompt/Title column) so rows read e.g. `GitHub Issue #925` instead of `[GitHub Issue #925](https://github.co...`. `GetFullPrompt` (used by the full-prompt sheet) is untouched and still shows the raw markdown/URL.
4. **Test doubles.** Updated the six existing `IJobService` fakes (`TrackedStubJobService`, `DeleteBeforeRenameJobService`, `TimestampedJobService`, `TestJobService`, `StubJobService`, `FakeJobService`) to implement the new interface member.

## API Changes

- `IJobService.StopQueuedJobs(): int` — new member. Stops every job currently in `JobStatus.Queued`, returns the count stopped. Idempotent no-op (returns 0, raises no event) when there are no queued jobs.

## Files Modified

- `src/Ivy.Tendril/Services/Jobs/IJobService.cs`
- `src/Ivy.Tendril/Services/Jobs/JobService.cs`
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.cs`
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs`
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs`
- `src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs`
- `src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs`
- `src/Ivy.Tendril.Test/InboxControllerTests.cs`
- `src/Ivy.Tendril.Test/PlanCountsServiceTests.cs`
- `src/Ivy.Tendril.Test/JobServiceStopQueuedTests.cs` (new)
- `src/Ivy.Tendril.Test/JobsAppPromptDisplayTests.cs` (new)

## Manual Testing

No live UI walkthrough was performed in this sandbox (no running app instance / browser available in this execution environment). Verification relied on:

- `dotnet build` of the main and test projects (0 errors).
- `dotnet test` against the plan's specified scope — 107/107 passing, including the 9 new tests covering bulk-stop scoping, event-suppression correctness, the zero-queued no-op path, and markdown-link flattening (including the "leave `GetFullPrompt` raw" guarantee).
- `dotnet format --verify-no-changes` — clean, no reformatting needed.
- Manual code review cross-checking every UI/dialog/menu change against the plan's Solution section line-by-line.

Recommend a human do a quick visual pass in a running instance to confirm the dialog copy and button placement read well, since that layer wasn't rendered in this session.

---
## Commits

- 7f38cc80 feat: add IJobService.StopQueuedJobs for bulk-stopping queued jobs
- 27e3bbb1 feat: add Stop All Queued header menu item and rename Clear All
- 8f479336 feat: flatten markdown links in Jobs table prompt/title column
- b4c22779 test: update IJobService test doubles for StopQueuedJobs
- 9c814cb7 test: add coverage for StopQueuedJobs and prompt title flattening

---
Created using [Ivy Tendril](https://ivy.app).
