### PR TITLE
[00077] Show Currency Indicator on Dashboard Cost Chart Series

### DIFF
--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -158,7 +158,8 @@ public class DashboardApp : ViewBase
                 .ToList();
         }
 
-        const string costMeasureName = "Cost ($)";
+        const string costMeasureName = "Cost";
+        const string costSeriesLabel = "Cost ($)";
         const string tokensMeasureName = "Tokens";
 
         var combinedChart = hourlyBurn.ToBarChart(
@@ -168,7 +169,7 @@ public class DashboardApp : ViewBase
                     Tooltip = new ChartTooltip().Animated(true),
                     Bars =
                     [
-                        new Bar(costMeasureName).Radius(0).YAxisIndex(0),
+                        new Bar(costMeasureName).Name(costSeriesLabel).Radius(0).YAxisIndex(0),
                         new Bar(tokensMeasureName).Radius(0).YAxisIndex(1)
                     ],
                     XAxis =


### PR DESCRIPTION
Fixes #1739

# Show Currency Indicator on Dashboard Cost Chart Series

## Summary

The Dashboard's hourly burn chart tooltip showed `Cost: 1.212` with no currency indicator, because the `"($)"` suffix lived inside the chart's measure name, which is sanitised to a plain identifier before it reaches the frontend as the series' data key. `src/Ivy.Tendril/Apps/DashboardApp.cs` was updated to split the punctuation-free data key (`"Cost"`) from an explicit display label (`"Cost ($)"`) set via `Bar.Name(...)`, so the tooltip now renders `Cost ($): 1.212` without changing any aggregation, value, or precision logic.

### Files Modified

- `src/Ivy.Tendril/Apps/DashboardApp.cs`

## Fix: Completed the delivery left unfinished by the initial execution

**Why there was no solution to review:** the initial ExecutePlan run had already made the correct code edit (verified byte-for-byte identical to this plan's Solution section) but stopped before doing anything else — the change was never `git commit`ed, no verifications (`DotnetFormat`, `DotnetBuild`, `CheckResult`) were run, no `Artifacts/summary.md` or `Logs/` existed, and `plan.yaml` had an empty `commits` list. From the reviewer's perspective this looked exactly like "no solution" was produced, even though the correct fix was sitting uncommitted in the worktree. Likely cause: the prior run was interrupted (timeout/crash) between editing the file and its commit step.

This retry did not need to change the implementation — it matched the plan exactly. It completed the missing delivery steps:
- Committed the existing edit (`85b76bd4` — "feat: label Cost bar series with currency indicator").
- Ran and passed `DotnetFormat` (no reformatting needed) and `DotnetBuild` (0 errors) — using the plan's fallback of building `Ivy.Tendril.csproj` directly, since `Ivy.Tendril.slnx` doesn't restore in a worktree that lacks a sibling `Ivy-Framework` checkout.
- Ran `CheckResult`, confirming the diff is a 1:1 match with the plan's Problem/Solution.
- Wrote this `Artifacts/summary.md`, which the initial run had also never created.

### Files Modified

None beyond the single file already listed above — this retry only added the missing commit, verification reports, and this summary.

**Note:** Manual check still recommended: open the Dashboard, hover a bar in the hourly burn chart, and confirm the tooltip reads `Cost ($): <value>` alongside `Tokens: <value>`.

---
## Commits
- 85b76bd4 feat: label Cost bar series with currency indicator

---
Created using [Ivy Tendril](https://ivy.app).