### PR TITLE
[00061] Redirect Stale .NET Tool Invocations to the Installed Tendril CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ dotnet tool install -g Ivy.Tendril
 
 > **Tip:** PowerShell 7, Git and gh CLI need to be present on your machine if you install using the `dotnet tool` command.
 
+> **Note:** The `dotnet tool` install and the Quick Install above are separate installs that can both end up on `PATH`. If you move from the .NET tool to the installer, run `dotnet tool uninstall --global Ivy.Tendril` so `tendril` on `PATH` cannot resolve to the older, frozen tool copy. Run `tendril doctor` to check for a conflicting install.
+
 ### Run
 
 ```bash

--- a/src/Ivy.Tendril.Test/DoctorChecksTests.cs
+++ b/src/Ivy.Tendril.Test/DoctorChecksTests.cs
@@ -67,6 +67,52 @@ public class DoctorChecksTests : IDisposable
     }
 
     [Fact]
+    public async Task InstallationCheck_LegacyDotnetToolPresent_ReportsError()
+    {
+        var original = TendrilInstallHelper.UserProfileOverride;
+        TendrilInstallHelper.UserProfileOverride = _tempDir.Path;
+
+        try
+        {
+            var storeDir = Path.Combine(_tempDir.Path, ".dotnet", "tools", ".store", "ivy.tendril", "1.0.0");
+            Directory.CreateDirectory(storeDir);
+
+            var check = new InstallationCheck();
+            var result = await check.RunAsync();
+
+            var legacyStatus = result.Statuses.FirstOrDefault(s => s.Label == "Legacy .NET tool");
+            Assert.NotNull(legacyStatus);
+            Assert.Equal(StatusKind.Error, legacyStatus.Kind);
+            Assert.True(result.HasErrors);
+        }
+        finally
+        {
+            TendrilInstallHelper.UserProfileOverride = original;
+        }
+    }
+
+    [Fact]
+    public async Task InstallationCheck_NoLegacyDotnetTool_ReportsOk()
+    {
+        var original = TendrilInstallHelper.UserProfileOverride;
+        TendrilInstallHelper.UserProfileOverride = _tempDir.Path;
+
+        try
+        {
+            var check = new InstallationCheck();
+            var result = await check.RunAsync();
+
+            var legacyStatus = result.Statuses.FirstOrDefault(s => s.Label == "Legacy .NET tool");
+            Assert.NotNull(legacyStatus);
+            Assert.Equal(StatusKind.Ok, legacyStatus.Kind);
+        }
+        finally
+        {
+            TendrilInstallHelper.UserProfileOverride = original;
+        }
+    }
+
+    [Fact]
     public void PrintStatus_WithBracketCharacters_DoesNotThrow()
     {
         var exception = Record.Exception(() =>

--- a/src/Ivy.Tendril.Test/Helpers/PathHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/PathHelperTests.cs
@@ -124,4 +124,41 @@ public class PathHelperTests
             Environment.SetEnvironmentVariable("PATH", originalPath);
         }
     }
+
+    [Fact]
+    public void AugmentPath_PlacesDotnetToolsAfterLocalBin()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var dotnetTools = Path.Combine(home, ".dotnet", "tools");
+        var localBin = Path.Combine(home, ".local", "bin");
+
+        // Only meaningful when both directories exist on this machine; otherwise AugmentPath
+        // never adds the missing one and the ordering assertion below would be vacuous.
+        if (!Directory.Exists(dotnetTools) || !Directory.Exists(localBin)) return;
+
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", string.Empty);
+
+            PathHelper.AugmentPath(forceShellPath: false);
+
+            var path = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+            var dirs = path.Split(':', StringSplitOptions.RemoveEmptyEntries);
+
+            var localBinIndex = Array.IndexOf(dirs, localBin);
+            var dotnetToolsIndex = Array.IndexOf(dirs, dotnetTools);
+
+            Assert.True(localBinIndex >= 0, "~/.local/bin should be present in PATH");
+            Assert.True(dotnetToolsIndex >= 0, "~/.dotnet/tools should be present in PATH");
+            Assert.True(localBinIndex < dotnetToolsIndex, "~/.local/bin should come before ~/.dotnet/tools");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+    }
 }

--- a/src/Ivy.Tendril.Test/Helpers/TendrilInstallHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/TendrilInstallHelperTests.cs
@@ -1,0 +1,152 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test.Helpers;
+
+[Collection("TendrilHome")]
+public class TendrilInstallHelperTests
+{
+    [Fact]
+    public void IsLegacyToolInstalled_TogglesWithStoreDirectory()
+    {
+        using var fixture = new TempDirectoryFixture("ivy-legacy-test");
+        var original = TendrilInstallHelper.UserProfileOverride;
+        TendrilInstallHelper.UserProfileOverride = fixture.Path;
+
+        try
+        {
+            Assert.False(TendrilInstallHelper.IsLegacyToolInstalled());
+
+            var storeDir = Path.Combine(fixture.Path, ".dotnet", "tools", ".store", "ivy.tendril", "1.1.0");
+            Directory.CreateDirectory(storeDir);
+
+            Assert.True(TendrilInstallHelper.IsLegacyToolInstalled());
+        }
+        finally
+        {
+            TendrilInstallHelper.UserProfileOverride = original;
+        }
+    }
+
+    [Fact]
+    public void GetLegacyToolVersion_MultipleVersions_ReturnsNewest()
+    {
+        using var fixture = new TempDirectoryFixture("ivy-legacy-version-test");
+        var original = TendrilInstallHelper.UserProfileOverride;
+        TendrilInstallHelper.UserProfileOverride = fixture.Path;
+
+        try
+        {
+            var storeRoot = Path.Combine(fixture.Path, ".dotnet", "tools", ".store", "ivy.tendril");
+            Directory.CreateDirectory(Path.Combine(storeRoot, "1.0.0"));
+            Directory.CreateDirectory(Path.Combine(storeRoot, "1.2.0"));
+            Directory.CreateDirectory(Path.Combine(storeRoot, "1.1.5"));
+
+            var result = TendrilInstallHelper.GetLegacyToolVersion();
+
+            Assert.Equal("1.2.0", result);
+        }
+        finally
+        {
+            TendrilInstallHelper.UserProfileOverride = original;
+        }
+    }
+
+    [Fact]
+    public void FindInstalledCli_NoCandidatesExist_ReturnsNullThenFindsLocalBinFile()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        using var fixture = new TempDirectoryFixture("ivy-install-test");
+        var original = TendrilInstallHelper.UserProfileOverride;
+        TendrilInstallHelper.UserProfileOverride = fixture.Path;
+
+        try
+        {
+            var before = TendrilInstallHelper.FindInstalledCli();
+            if (before != null)
+            {
+                // A fixed OS-standard candidate (e.g. /Applications/Ivy Tendril.app or
+                // /usr/local/bin/tendril) already resolves on this machine. Those absolute
+                // paths are not affected by UserProfileOverride, so the isolated assertion
+                // below does not apply here.
+                return;
+            }
+
+            var localBinDir = Path.Combine(fixture.Path, ".local", "bin");
+            Directory.CreateDirectory(localBinDir);
+            var tendrilPath = Path.Combine(localBinDir, "tendril");
+            File.WriteAllText(tendrilPath, "#!/bin/sh\n");
+
+            var after = TendrilInstallHelper.FindInstalledCli();
+
+            Assert.Equal(tendrilPath, after);
+        }
+        finally
+        {
+            TendrilInstallHelper.UserProfileOverride = original;
+        }
+    }
+
+    [Fact]
+    public void FindInstalledCli_SymlinkTargetsLegacyTool_ReturnsNull()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        using var fixture = new TempDirectoryFixture("ivy-install-symlink-test");
+        var original = TendrilInstallHelper.UserProfileOverride;
+        TendrilInstallHelper.UserProfileOverride = fixture.Path;
+
+        try
+        {
+            var before = TendrilInstallHelper.FindInstalledCli();
+            if (before != null)
+            {
+                // A fixed OS-standard candidate already resolves on this machine; see above.
+                return;
+            }
+
+            var legacyToolsDir = Path.Combine(fixture.Path, ".dotnet", "tools");
+            Directory.CreateDirectory(legacyToolsDir);
+            var legacyExe = Path.Combine(legacyToolsDir, "tendril");
+            File.WriteAllText(legacyExe, "#!/bin/sh\n");
+
+            var localBinDir = Path.Combine(fixture.Path, ".local", "bin");
+            Directory.CreateDirectory(localBinDir);
+            var symlinkPath = Path.Combine(localBinDir, "tendril");
+            File.CreateSymbolicLink(symlinkPath, legacyExe);
+
+            var result = TendrilInstallHelper.FindInstalledCli();
+
+            Assert.Null(result);
+        }
+        finally
+        {
+            TendrilInstallHelper.UserProfileOverride = original;
+        }
+    }
+
+    [Fact]
+    public void ResolveOnPath_FindsExecutableInPath()
+    {
+        using var fixture = new TempDirectoryFixture("ivy-resolve-path-test");
+        var exeName = OperatingSystem.IsWindows() ? "fake-tendril-tool.exe" : "fake-tendril-tool";
+        var exePath = Path.Combine(fixture.Path, exeName);
+        File.WriteAllText(exePath, "#!/bin/sh\n");
+
+        var originalPath = Environment.GetEnvironmentVariable("PATH");
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+
+        try
+        {
+            Environment.SetEnvironmentVariable("PATH", fixture.Path + separator + originalPath);
+
+            var result = TendrilInstallHelper.ResolveOnPath("fake-tendril-tool");
+
+            Assert.Equal(exePath, result);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+    }
+}

--- a/src/Ivy.Tendril/Commands/DoctorChecks/InstallationCheck.cs
+++ b/src/Ivy.Tendril/Commands/DoctorChecks/InstallationCheck.cs
@@ -1,0 +1,51 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Commands.DoctorChecks;
+
+internal class InstallationCheck : IDoctorCheck
+{
+    public string Name => "Installation";
+
+    public async Task<CheckResult> RunAsync()
+    {
+        var statuses = new List<CheckStatus>();
+        var hasErrors = false;
+
+        var version = typeof(Program).Assembly.GetName().Version?.ToString(3);
+        statuses.Add(new CheckStatus("Version", version ?? "Unknown", StatusKind.Ok));
+
+        var executable = Environment.ProcessPath;
+        statuses.Add(new CheckStatus("Executable", executable ?? "Unknown", StatusKind.Ok));
+
+        var onPath = TendrilInstallHelper.ResolveOnPath("tendril");
+        if (onPath == null)
+        {
+            statuses.Add(new CheckStatus("tendril on PATH", "Not found on PATH", StatusKind.Warn));
+        }
+        else
+        {
+            var installedCli = TendrilInstallHelper.FindInstalledCli();
+            var resolvesToKnownGoodCli =
+                (executable != null && string.Equals(onPath, executable, StringComparison.OrdinalIgnoreCase)) ||
+                (installedCli != null && string.Equals(onPath, installedCli, StringComparison.OrdinalIgnoreCase));
+            statuses.Add(new CheckStatus("tendril on PATH", onPath, resolvesToKnownGoodCli ? StatusKind.Ok : StatusKind.Warn));
+        }
+
+        if (TendrilInstallHelper.IsLegacyToolInstalled())
+        {
+            var legacyVersion = TendrilInstallHelper.GetLegacyToolVersion();
+            var legacyPath = TendrilInstallHelper.FindLegacyToolInstallPath();
+            statuses.Add(new CheckStatus(
+                "Legacy .NET tool",
+                $"Conflicting global tool v{legacyVersion ?? "unknown"} at {legacyPath}. Run: dotnet tool uninstall --global Ivy.Tendril",
+                StatusKind.Error));
+            hasErrors = true;
+        }
+        else
+        {
+            statuses.Add(new CheckStatus("Legacy .NET tool", "Not installed", StatusKind.Ok));
+        }
+
+        return await Task.FromResult(new CheckResult(hasErrors, statuses));
+    }
+}

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -41,6 +41,7 @@ public static class DoctorCommand
 
         var checks = new IDoctorCheck[]
         {
+            new InstallationCheck(),
             new EnvironmentCheck(),
             new SoftwareCheck(configService, agentRunner),
             new DatabaseCheck(),

--- a/src/Ivy.Tendril/Helpers/PathHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PathHelper.cs
@@ -199,9 +199,11 @@ public static class PathHelper
                 "/opt/homebrew/sbin",
                 "/usr/local/bin",
                 "/usr/local/sbin",
-                Path.Combine(home, ".dotnet", "tools"),
                 Path.Combine(home, ".npm-global", "bin"),
-                Path.Combine(home, ".local", "bin")
+                Path.Combine(home, ".local", "bin"),
+                // Legacy `dotnet tool install -g` shim directory. Kept last so the installer's
+                // CLI symlink locations above always win over a stale .NET tool copy of tendril.
+                Path.Combine(home, ".dotnet", "tools")
             };
 
             if (forceShellPath)

--- a/src/Ivy.Tendril/Helpers/TendrilInstallHelper.cs
+++ b/src/Ivy.Tendril/Helpers/TendrilInstallHelper.cs
@@ -1,0 +1,131 @@
+namespace Ivy.Tendril.Helpers;
+
+public static class TendrilInstallHelper
+{
+    /// <summary>
+    /// Overrides the user profile root used by all path builders below, for tests. Mirrors
+    /// <see cref="PathHelper.DefaultTendrilHomeOverride"/>.
+    /// </summary>
+    internal static string? UserProfileOverride { get; set; }
+
+    private static string UserProfile =>
+        UserProfileOverride ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+    private static StringComparison PathComparison =>
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    private static string LegacyToolsDir => Path.Combine(UserProfile, ".dotnet", "tools");
+
+    private static string LegacyStoreDir => Path.Combine(LegacyToolsDir, ".store", "ivy.tendril");
+
+    private static string LegacyToolExe => Path.Combine(LegacyToolsDir, OperatingSystem.IsWindows() ? "tendril.exe" : "tendril");
+
+    public static bool IsLegacyDotnetToolProcess()
+    {
+        var baseDir = Path.TrimEndingDirectorySeparator(System.AppContext.BaseDirectory);
+        var toolsDir = Path.TrimEndingDirectorySeparator(LegacyToolsDir);
+        return baseDir.Equals(toolsDir, PathComparison) ||
+               baseDir.StartsWith(toolsDir + Path.DirectorySeparatorChar, PathComparison);
+    }
+
+    public static string? GetLegacyToolVersion()
+    {
+        if (!Directory.Exists(LegacyStoreDir)) return null;
+
+        try
+        {
+            return Directory.GetDirectories(LegacyStoreDir)
+                .Select(Path.GetFileName)
+                .OfType<string>()
+                .OrderByDescending(name => Version.TryParse(name, out var v) ? v : new Version(0, 0, 0, 0))
+                .FirstOrDefault();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static bool IsLegacyToolInstalled() => FindLegacyToolInstallPath() != null;
+
+    internal static string? FindLegacyToolInstallPath()
+    {
+        if (Directory.Exists(LegacyStoreDir)) return LegacyStoreDir;
+        if (File.Exists(LegacyToolExe)) return LegacyToolExe;
+        return null;
+    }
+
+    public static string? FindInstalledCli()
+    {
+        var candidates = new List<string>();
+
+        if (OperatingSystem.IsWindows())
+        {
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            candidates.Add(Path.Combine(localAppData, "IvyTendril", "current", "Ivy.Tendril.exe"));
+            candidates.Add(Path.Combine(localAppData, "IvyTendril", "Ivy.Tendril.exe"));
+        }
+        else
+        {
+            if (OperatingSystem.IsMacOS())
+            {
+                candidates.Add("/Applications/Ivy Tendril.app/Contents/MacOS/Ivy.Tendril");
+                candidates.Add(Path.Combine(UserProfile, "Applications", "Ivy Tendril.app", "Contents", "MacOS", "Ivy.Tendril"));
+            }
+
+            candidates.Add("/usr/local/bin/tendril");
+            candidates.Add(Path.Combine(UserProfile, ".local", "bin", "tendril"));
+        }
+
+        var legacyToolsDir = Path.TrimEndingDirectorySeparator(LegacyToolsDir);
+
+        foreach (var candidate in candidates)
+        {
+            if (!File.Exists(candidate)) continue;
+
+            var resolvedTarget = candidate;
+            try
+            {
+                var target = File.ResolveLinkTarget(candidate, returnFinalTarget: true);
+                if (target != null) resolvedTarget = target.FullName;
+            }
+            catch
+            {
+                // Not a symlink, or link resolution failed; treat the candidate path as-is.
+            }
+
+            if (resolvedTarget.Equals(legacyToolsDir, PathComparison) ||
+                resolvedTarget.StartsWith(legacyToolsDir + Path.DirectorySeparatorChar, PathComparison))
+            {
+                continue;
+            }
+
+            return candidate;
+        }
+
+        return null;
+    }
+
+    public static string? ResolveOnPath(string command)
+    {
+        var pathVar = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        var dirs = pathVar.Split(separator, StringSplitOptions.RemoveEmptyEntries);
+
+        var names = OperatingSystem.IsWindows()
+            ? new[] { command + ".exe", command + ".cmd", command }
+            : new[] { command };
+
+        foreach (var dir in dirs)
+        {
+            foreach (var name in names)
+            {
+                var candidate = Path.Combine(dir, name);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -57,6 +57,11 @@ public class Program
             catch { }
         }
         PathHelper.AugmentPath(forceShellPath: false);
+
+        var legacyRedirectExitCode = TryRedirectLegacyToolInvocation(args);
+        if (legacyRedirectExitCode.HasValue)
+            return legacyRedirectExitCode.Value;
+
         PathHelper.EnsureCliSymlink();
 
         if (OperatingSystem.IsWindows())
@@ -387,6 +392,59 @@ public class Program
         var argv0 = Environment.GetCommandLineArgs().FirstOrDefault() ?? string.Empty;
         var argv0Name = Path.GetFileNameWithoutExtension(argv0);
         return argv0Name.Equals("tendril", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// When this process is the stale `dotnet tool install` copy of tendril and a newer
+    /// installer-managed CLI is present, forwards the invocation to that CLI and returns its
+    /// exit code. Returns null when the run should proceed normally in this process.
+    /// </summary>
+    private static int? TryRedirectLegacyToolInvocation(string[] args)
+    {
+        if (Environment.GetEnvironmentVariable("TENDRIL_NO_LEGACY_REDIRECT") == "1")
+            return null;
+        if (args.Contains(DetachedLaunchMarker))
+            return null;
+
+        try
+        {
+            if (!TendrilInstallHelper.IsLegacyDotnetToolProcess())
+                return null;
+
+            var installedCli = TendrilInstallHelper.FindInstalledCli();
+            if (installedCli == null)
+                return null;
+
+            if (Environment.GetEnvironmentVariable("TENDRIL_QUIET") != "1")
+            {
+                var version = TendrilInstallHelper.GetLegacyToolVersion();
+                Console.Error.WriteLine(
+                    $"Warning: you are running the outdated Ivy.Tendril .NET tool (v{version ?? "unknown"}). " +
+                    $"Forwarding to the installed version at {installedCli}. " +
+                    "Remove the stale tool with: dotnet tool uninstall --global Ivy.Tendril");
+            }
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = installedCli,
+                UseShellExecute = false
+            };
+            foreach (var arg in args)
+                psi.ArgumentList.Add(arg);
+            psi.Environment["TENDRIL_NO_LEGACY_REDIRECT"] = "1";
+
+            using var process = Process.Start(psi);
+            if (process == null)
+                return null;
+
+            process.WaitForExit();
+            return process.ExitCode;
+        }
+        catch (Exception ex)
+        {
+            CrashLog.Write($"[Program] TryRedirectLegacyToolInvocation failed: {ex}");
+            return null;
+        }
     }
 
     private static int RelaunchDesktopDetached(string[] filteredArgs)


### PR DESCRIPTION
Fixes #1745

# Summary: Redirect Stale .NET Tool Invocations to the Installed Tendril CLI

Implements the fix for [Issue #1745](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/1745):
when Tendril was installed both via `dotnet tool install -g Ivy.Tendril` and later via the
standalone installer, PATH resolution could favor the stale .NET tool copy, silently running an
outdated CLI with no diagnostic to explain why.

## Changes

1. **`src/Ivy.Tendril/Helpers/TendrilInstallHelper.cs`** (new) — detects whether the running
   process is the legacy .NET tool (`IsLegacyDotnetToolProcess`), reads its installed version
   (`GetLegacyToolVersion`), checks whether it's installed at all (`IsLegacyToolInstalled`),
   locates an installer-managed CLI binary across Windows/macOS/Linux install locations while
   rejecting symlinks that resolve back into the legacy tool tree (`FindInstalledCli`), and scans
   `PATH` for a named executable (`ResolveOnPath`). All path builders honor an injectable
   `UserProfileOverride` for test isolation.
2. **`src/Ivy.Tendril/Program.cs`** — added `TryRedirectLegacyToolInvocation`, called right after
   `AugmentPath` and before `EnsureCliSymlink`. When the running process is the legacy tool and an
   installer-managed CLI is found, it prints a warning, forwards the original arguments to the
   installed binary with a recursion guard (`TENDRIL_NO_LEGACY_REDIRECT=1`), and returns its exit
   code. Any failure falls through to normal execution so the redirect can never break the CLI.
3. **`src/Ivy.Tendril/Helpers/PathHelper.cs`** — reordered `AugmentPath`'s `commonDirs` so
   `~/.local/bin` (where the installer's CLI symlink lives) is added before `~/.dotnet/tools`,
   so the installer's binary wins PATH resolution when both are present.
4. **`src/Ivy.Tendril/Commands/DoctorChecks/InstallationCheck.cs`** (new) — a new `tendril doctor`
   check, registered first (before `EnvironmentCheck`), that reports the running version,
   executable path, PATH resolution status, and flags a conflicting legacy .NET tool install with
   the exact uninstall command to run.
5. **`README.md`** — added a note under `### .NET Tool` explaining that the .NET tool and
   installer are separate installs and that switching from tool to installer requires
   `dotnet tool uninstall --global Ivy.Tendril`.

## Tests

Added 8 new test cases (5 in `TendrilInstallHelperTests.cs`, 1 in `PathHelperTests.cs`, 2 in
`DoctorChecksTests.cs`) covering legacy-tool detection, version resolution, installed-CLI lookup
(including the symlink-rejection case), PATH scanning, PATH ordering, and the new doctor check's
error/ok states. Machine-dependent assertions include defensive skip guards for directories or
fixed OS-standard install paths that may already exist on the running machine.

## Verification

| Verification | Result |
|---|---|
| DotnetFormat | Pass |
| DotnetBuild | Pass |
| DotnetTest | Pass (1797 passed, 1 pre-existing unrelated skip) |
| VitePlusTest | Skipped (no frontend files changed) |
| CheckResult | Pass |

The top-level `Ivy.Tendril.slnx` could not restore in this isolated worktree because it
conditionally references a sibling `Ivy-Framework` checkout not present here; format/build were
run against the two owning `.csproj` files directly instead, per each verification's own documented
fallback.

## Commits

- `5644b68d` Redirect stale .NET tool invocations to the installed Tendril CLI
- `81269f31` Add doctor check for conflicting legacy .NET tool install
- `c0e0c96d` Add tests for legacy .NET tool detection and PATH ordering
- `b303212f` Document the .NET tool / installer conflict in README


---
Created using [Ivy Tendril](https://ivy.app).