### PR TITLE
[00073] Resolve Memory References Instead of Failing in Read Memory CLI

### DIFF
--- a/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs
@@ -126,6 +126,18 @@ public class FirmwareCompilerTests : IDisposable
         Assert.Contains("**Tools:**", result);
     }
 
+    [Fact]
+    public void Compile_IncludesListMemoryHintWithPromptwareName()
+    {
+        var context = new FirmwareContext(
+            "/programs/Test",
+            new Dictionary<string, string>());
+
+        var result = FirmwareCompiler.Compile(context);
+
+        Assert.Contains("list-memory Test", result);
+    }
+
     // --- Projects Section ---
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Commands/PromptwareMemoryLookupTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareMemoryLookupTests.cs
@@ -1,0 +1,239 @@
+using Ivy.Tendril.Commands;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Test.Commands;
+
+[Collection("TendrilHome")]
+public class PromptwareMemoryLookupTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("tendril-promptware-memory-test");
+    private readonly string _originalTendrilHome;
+    private readonly string _memoryDir;
+
+    public PromptwareMemoryLookupTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+
+        var promptwareDir = Path.Combine(_tempDir.Path, "Promptwares", "TestPromptware");
+        Directory.CreateDirectory(promptwareDir);
+        File.WriteAllText(Path.Combine(promptwareDir, "Program.md"), "# Program");
+
+        _memoryDir = Path.Combine(promptwareDir, "Memory");
+        Directory.CreateDirectory(_memoryDir);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+    }
+
+    private static CommandApp BuildApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("promptware", promptware =>
+            {
+                promptware.AddCommand<PromptwareReadMemoryCommand>("read-memory");
+                promptware.AddCommand<PromptwareListMemoryCommand>("list-memory");
+            });
+        });
+        return app;
+    }
+
+    // --- read-memory ---
+
+    [Fact]
+    public void ReadMemory_ExactName_ReturnsContent()
+    {
+        File.WriteAllText(Path.Combine(_memoryDir, "pattern.md"), "Memory content");
+        var app = BuildApp();
+
+        var output = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(output);
+        int exit;
+        try
+        {
+            exit = app.Run(["promptware", "read-memory", "TestPromptware", "pattern.md"]);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        Assert.Equal(0, exit);
+        Assert.Equal("Memory content", output.ToString());
+    }
+
+    [Fact]
+    public void ReadMemory_NameWithoutExtension_ResolvesMdFile()
+    {
+        File.WriteAllText(Path.Combine(_memoryDir, "coalmininggame-pnpm.md"), "pnpm notes");
+        var app = BuildApp();
+
+        var output = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(output);
+        int exit;
+        try
+        {
+            exit = app.Run(["promptware", "read-memory", "TestPromptware", "coalmininggame-pnpm"]);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        Assert.Equal(0, exit);
+        Assert.Equal("pnpm notes", output.ToString());
+    }
+
+    [Fact]
+    public void ReadMemory_WikiLinkReference_ResolvesMdFile()
+    {
+        File.WriteAllText(Path.Combine(_memoryDir, "coalmininggame-pnpm.md"), "pnpm notes");
+        var app = BuildApp();
+
+        var output = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(output);
+        int exit;
+        try
+        {
+            exit = app.Run(["promptware", "read-memory", "TestPromptware", "[[coalmininggame-pnpm]]"]);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        Assert.Equal(0, exit);
+        Assert.Equal("pnpm notes", output.ToString());
+    }
+
+    [Fact]
+    public void ReadMemory_DifferentCase_ResolvesFile()
+    {
+        File.WriteAllText(Path.Combine(_memoryDir, "coalmininggame-pnpm.md"), "pnpm notes");
+        var app = BuildApp();
+
+        var output = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(output);
+        int exit;
+        try
+        {
+            exit = app.Run(["promptware", "read-memory", "TestPromptware", "CoalMiningGame-PNPM.md"]);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        Assert.Equal(0, exit);
+        Assert.Equal("pnpm notes", output.ToString());
+    }
+
+    [Fact]
+    public void ReadMemory_Missing_ListsAvailableAndSuggests()
+    {
+        File.WriteAllText(Path.Combine(_memoryDir, "vite-plus-check-workflow.md"), "workflow notes");
+        var app = BuildApp();
+
+        var ex = Assert.Throws<FileNotFoundException>(() =>
+            app.Run(["promptware", "read-memory", "TestPromptware", "voidzero-vite-plus-stack"]));
+
+        Assert.Contains("Available memories: vite-plus-check-workflow.md", ex.Message);
+        Assert.Contains("Did you mean: vite-plus-check-workflow.md?", ex.Message);
+        Assert.Contains("may have been pruned", ex.Message);
+    }
+
+    [Fact]
+    public void ReadMemory_Missing_EmptyFolder_ReportsNone()
+    {
+        var app = BuildApp();
+
+        var ex = Assert.Throws<FileNotFoundException>(() =>
+            app.Run(["promptware", "read-memory", "TestPromptware", "anything.md"]));
+
+        Assert.Contains("Available memories: (none)", ex.Message);
+        Assert.DoesNotContain("Did you mean", ex.Message);
+    }
+
+    [Fact]
+    public void ReadMemory_UnknownPromptware_ReportsPromptwareNotFound()
+    {
+        var app = BuildApp();
+
+        var ex = Assert.Throws<FileNotFoundException>(() =>
+            app.Run(["promptware", "read-memory", "NoSuchPromptware", "anything.md"]));
+
+        Assert.Contains("Promptware not found: NoSuchPromptware", ex.Message);
+        Assert.DoesNotContain("Memory file not found", ex.Message);
+    }
+
+    [Fact]
+    public void ReadMemory_PathTraversal_DoesNotEscapeMemoryFolder()
+    {
+        var app = BuildApp();
+
+        var ex = Assert.Throws<FileNotFoundException>(() =>
+            app.Run(["promptware", "read-memory", "TestPromptware", "../Program.md"]));
+
+        Assert.Contains("Memory file not found: Program.md", ex.Message);
+    }
+
+    // --- list-memory ---
+
+    [Fact]
+    public void ListMemory_PrintsOneFilePerLine_ExcludingDotfiles()
+    {
+        File.WriteAllText(Path.Combine(_memoryDir, "b-memory.md"), "b");
+        File.WriteAllText(Path.Combine(_memoryDir, "a-memory.md"), "a");
+        File.WriteAllText(Path.Combine(_memoryDir, ".hidden.md"), "hidden");
+        var app = BuildApp();
+
+        var output = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(output);
+        int exit;
+        try
+        {
+            exit = app.Run(["promptware", "list-memory", "TestPromptware"]);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        Assert.Equal(0, exit);
+        var lines = output.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(["a-memory.md", "b-memory.md"], lines);
+    }
+
+    [Fact]
+    public void ListMemory_EmptyFolder_ExitsZeroWithNoOutput()
+    {
+        var app = BuildApp();
+
+        var output = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(output);
+        int exit;
+        try
+        {
+            exit = app.Run(["promptware", "list-memory", "TestPromptware"]);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        Assert.Equal(0, exit);
+        Assert.Equal("", output.ToString());
+    }
+}

--- a/src/Ivy.Tendril/Commands/PromptwareListMemoryCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareListMemoryCommand.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel;
+using Ivy.Tendril.Helpers;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class PromptwareListMemorySettings : CommandSettings
+{
+    [Description("Promptware name (e.g., SetupProject)")]
+    [CommandArgument(0, "<name>")]
+    public string Name { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(Name, "name");
+    }
+}
+
+public class PromptwareListMemoryCommand : Command<PromptwareListMemorySettings>
+{
+    protected override int Execute(CommandContext context, PromptwareListMemorySettings settings, CancellationToken cancellationToken)
+    {
+        var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        var programFolder = PromptwareHelper.ResolvePromptwareFolder(settings.Name, tendrilHome);
+        PromptwareHelper.RequireProgramFolder(programFolder, settings.Name, tendrilHome);
+
+        var memoryDir = Path.Combine(programFolder, "Memory");
+        if (!Directory.Exists(memoryDir))
+            return 0;
+
+        foreach (var name in Directory.EnumerateFiles(memoryDir)
+                     .Select(Path.GetFileName)
+                     .Where(f => !string.IsNullOrEmpty(f) && !f!.StartsWith('.'))
+                     .OrderBy(f => f, StringComparer.Ordinal))
+        {
+            Console.WriteLine(name);
+        }
+
+        return 0;
+    }
+}

--- a/src/Ivy.Tendril/Commands/PromptwareReadMemoryCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareReadMemoryCommand.cs
@@ -29,15 +29,35 @@ public class PromptwareReadMemoryCommand : Command<PromptwareReadMemorySettings>
     {
         var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
         var programFolder = PromptwareHelper.ResolvePromptwareFolder(settings.Name, tendrilHome);
+        PromptwareHelper.RequireProgramFolder(programFolder, settings.Name, tendrilHome);
 
         var memoryDir = Path.Combine(programFolder, "Memory");
-        var filename = Path.GetFileName(settings.Filename);
-        var filePath = Path.Combine(memoryDir, filename);
+        var resolvedPath = PromptwareMemoryResolver.Resolve(memoryDir, settings.Filename);
 
-        if (!File.Exists(filePath))
-            throw new FileNotFoundException($"Memory file not found: {filename}", filePath);
+        if (resolvedPath is null)
+        {
+            var normalized = PromptwareMemoryResolver.NormalizeName(settings.Filename);
 
-        Console.Write(File.ReadAllText(filePath));
+            var available = Directory.Exists(memoryDir)
+                ? string.Join(", ", Directory.EnumerateFiles(memoryDir)
+                    .Select(Path.GetFileName)
+                    .Where(f => !string.IsNullOrEmpty(f) && !f!.StartsWith('.'))
+                    .OrderBy(f => f, StringComparer.Ordinal))
+                : "";
+            if (string.IsNullOrEmpty(available))
+                available = "(none)";
+
+            var suggestions = PromptwareMemoryResolver.Suggest(memoryDir, settings.Filename);
+            var didYouMean = suggestions.Count > 0 ? $"\nDid you mean: {suggestions[0]}?" : "";
+
+            var message = $"Memory file not found: {normalized} (promptware: {settings.Name})\n" +
+                          $"Available memories: {available}{didYouMean}\n" +
+                          $"This memory may have been pruned. Run `tendril promptware list-memory {settings.Name}` for the current list, and do not re-reference a memory that no longer exists.";
+
+            throw new FileNotFoundException(message, Path.Combine(memoryDir, normalized));
+        }
+
+        Console.Write(File.ReadAllText(resolvedPath));
         return 0;
     }
 }

--- a/src/Ivy.Tendril/Helpers/PromptwareHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PromptwareHelper.cs
@@ -52,4 +52,24 @@ public static class PromptwareHelper
 
         return sourceRoot;
     }
+
+    public static void RequireProgramFolder(string programFolder, string promptwareName, string? tendrilHome)
+    {
+        if (File.Exists(Path.Combine(programFolder, "Program.md")))
+            return;
+
+        var promptsRoot = ResolvePromptsRoot(tendrilHome);
+        var available = Directory.Exists(promptsRoot)
+            ? string.Join(", ", Directory.EnumerateDirectories(promptsRoot)
+                .Where(d => File.Exists(Path.Combine(d, "Program.md")))
+                .Select(Path.GetFileName)
+                .OrderBy(n => n, StringComparer.Ordinal))
+            : "";
+        if (string.IsNullOrEmpty(available))
+            available = "(none)";
+
+        throw new FileNotFoundException(
+            $"Promptware not found: {promptwareName}. Available promptwares: {available}",
+            programFolder);
+    }
 }

--- a/src/Ivy.Tendril/Helpers/PromptwareMemoryResolver.cs
+++ b/src/Ivy.Tendril/Helpers/PromptwareMemoryResolver.cs
@@ -1,0 +1,102 @@
+namespace Ivy.Tendril.Helpers;
+
+public static class PromptwareMemoryResolver
+{
+    public static string NormalizeName(string filename)
+    {
+        var trimmed = filename.Trim();
+
+        if (trimmed.StartsWith("[[") && trimmed.EndsWith("]]") && trimmed.Length >= 4)
+            trimmed = trimmed[2..^2].Trim();
+
+        var name = Path.GetFileName(trimmed);
+
+        if (string.IsNullOrEmpty(Path.GetExtension(name)))
+            name += ".md";
+
+        return name;
+    }
+
+    public static string? Resolve(string memoryDir, string filename)
+    {
+        var normalized = NormalizeName(filename);
+        var raw = Path.GetFileName(filename);
+
+        var normalizedPath = Path.Combine(memoryDir, normalized);
+        if (File.Exists(normalizedPath))
+            return normalizedPath;
+
+        if (!string.IsNullOrEmpty(raw) && raw != normalized)
+        {
+            var rawPath = Path.Combine(memoryDir, raw);
+            if (File.Exists(rawPath))
+                return rawPath;
+        }
+
+        if (!Directory.Exists(memoryDir))
+            return null;
+
+        foreach (var file in Directory.EnumerateFiles(memoryDir))
+        {
+            var candidateName = Path.GetFileName(file);
+            if (string.Equals(candidateName, normalized, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(candidateName, raw, StringComparison.OrdinalIgnoreCase))
+                return file;
+        }
+
+        return null;
+    }
+
+    public static IReadOnlyList<string> Suggest(string memoryDir, string filename, int max = 3)
+    {
+        if (!Directory.Exists(memoryDir))
+            return [];
+
+        List<string> files;
+        try
+        {
+            files = Directory.EnumerateFiles(memoryDir)
+                .Select(Path.GetFileName)
+                .Where(f => !string.IsNullOrEmpty(f) && !f!.StartsWith('.'))
+                .Select(f => f!)
+                .ToList();
+        }
+        catch (IOException)
+        {
+            return [];
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return [];
+        }
+
+        var stem = Path.GetFileNameWithoutExtension(NormalizeName(filename));
+        if (string.IsNullOrEmpty(stem))
+            return [];
+
+        return files
+            .Select(f => (Name: f, Score: ScoreMatch(f, stem)))
+            .Where(x => x.Score > 0)
+            .OrderByDescending(x => x.Score)
+            .ThenBy(x => x.Name.Length)
+            .ThenBy(x => x.Name, StringComparer.Ordinal)
+            .Take(max)
+            .Select(x => x.Name)
+            .ToList();
+    }
+
+    private static int ScoreMatch(string candidateFileName, string stem)
+    {
+        var candidateStem = Path.GetFileNameWithoutExtension(candidateFileName);
+        if (string.IsNullOrEmpty(candidateStem))
+            return 0;
+
+        if (candidateStem.Contains(stem, StringComparison.OrdinalIgnoreCase) ||
+            stem.Contains(candidateStem, StringComparison.OrdinalIgnoreCase))
+            return 1000 - Math.Abs(candidateStem.Length - stem.Length);
+
+        var stemTokens = stem.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        var candidateTokens = candidateStem.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        return stemTokens.Count(t => candidateTokens.Contains(t, StringComparer.OrdinalIgnoreCase));
+    }
+}

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -490,6 +490,8 @@ public class Program
                     .WithDescription("Run a promptware directly");
                 pw.AddCommand<PromptwareReadMemoryCommand>("read-memory")
                     .WithDescription("Read a promptware memory file to STDOUT");
+                pw.AddCommand<PromptwareListMemoryCommand>("list-memory")
+                    .WithDescription("List a promptware's memory files");
                 pw.AddCommand<PromptwareWriteMemoryCommand>("write-memory")
                     .WithDescription("Write a promptware memory file from STDIN");
                 pw.AddCommand<PromptwareWriteToolCommand>("write-tool")

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -208,6 +208,7 @@ These commands are for internal use by other promptwares (e.g., a verification s
 | Command | Description |
 |---------|-------------|
 | `tendril promptware run <name>` | Run a promptware directly (bypasses job service) |
+| `tendril promptware list-memory <name>` | List a promptware's memory files |
 | `tendril promptware read-memory <name> <file>` | Read promptware memory |
 | `tendril promptware write-memory <name> <file>` | Write promptware memory (--file/--stdin) |
 | `tendril promptware write-tool <name> <file>` | Write promptware tool (--file/--stdin) |

--- a/src/Ivy.Tendril/Services/FirmwareCompiler.cs
+++ b/src/Ivy.Tendril/Services/FirmwareCompiler.cs
@@ -46,6 +46,8 @@ public static class FirmwareCompiler
         tendril promptware read-memory {PROMPTWARE_NAME} <filename>.md
         ```
 
+        A `[[name]]` cross-reference inside a memory means the file `name.md`. If a read fails, the memory was likely pruned: run `tendril promptware list-memory {PROMPTWARE_NAME}` for the current list instead of guessing filenames.
+
         Complete your task and present the user with a summary.
 
         ## Reflection


### PR DESCRIPTION
Fixes #1746

# Summary

## Changes

`tendril promptware read-memory <name> <file>` no longer fails outright on any near miss. It now:

- Resolves extension-less bare names (`voidzero-vite-plus-stack` -> `voidzero-vite-plus-stack.md`).
- Resolves wiki-link syntax (`[[coalmininggame-pnpm]]` -> `coalmininggame-pnpm.md`).
- Resolves case-insensitive matches via a directory scan fallback.
- Distinguishes an unknown promptware name from a missing memory file, reporting "Promptware not found" with a list of available promptwares.
- On a genuine miss, reports the list of available memory files in that promptware plus a best-guess "Did you mean" suggestion (substring match first, then shared-token scoring) and a hint to run `list-memory` instead of guessing filenames.

Added `tendril promptware list-memory <name>` so agents can enumerate a promptware's current memory files (one per line, dotfiles excluded) rather than relying on stale wiki-links.

Updated the firmware template (`FirmwareCompiler.cs`) and `AgentPrompt.md` so agents are told about `[[name]]` resolution semantics and the new discovery command.

Left [Plan 00058](plan://00058) (`LetAgentsDeleteOutdatedPromptwareMemories`) untouched: no changes to the Reflection section or the `{MEMORY}` listing enrichment it owns.

## API Changes

- New public surface: `PromptwareMemoryResolver.Resolve`, `PromptwareMemoryResolver.Suggest`, `PromptwareMemoryResolver.NormalizeName` (`src/Ivy.Tendril/Helpers/PromptwareMemoryResolver.cs`).
- New public surface: `PromptwareHelper.RequireProgramFolder` (`src/Ivy.Tendril/Helpers/PromptwareHelper.cs`), shared by `PromptwareReadMemoryCommand` and the new `PromptwareListMemoryCommand`.
- New CLI command: `tendril promptware list-memory <name>` (`PromptwareListMemoryCommand.cs`, registered in `Program.cs`).
- Behavior change (not a signature change): `PromptwareReadMemoryCommand.Execute` throws `FileNotFoundException` with a differently-shaped message on both the "promptware not found" and "memory not found" paths; callers relying on message text (none found in this repo) would need updating, but the exception type is unchanged.

## Files Modified

- `src/Ivy.Tendril/Commands/PromptwareReadMemoryCommand.cs`
- `src/Ivy.Tendril/Commands/PromptwareListMemoryCommand.cs` (new)
- `src/Ivy.Tendril/Helpers/PromptwareHelper.cs`
- `src/Ivy.Tendril/Helpers/PromptwareMemoryResolver.cs` (new)
- `src/Ivy.Tendril/Program.cs`
- `src/Ivy.Tendril/Services/FirmwareCompiler.cs`
- `src/Ivy.Tendril/Prompts/AgentPrompt.md`
- `src/Ivy.Tendril.Test/Commands/PromptwareMemoryLookupTests.cs` (new)
- `src/Ivy.Tendril.Test/Agents/FirmwareCompilerTests.cs`

## Manual Testing

Not manually exercised against a live `TENDRIL_HOME` beyond the automated test suite, since this is a non-interactive execution. Verified via:

- `dotnet test` filtered to the affected test classes: 41/41 passed.
- Full `Ivy.Tendril.Test` suite: 1800/1801 passed, 1 pre-existing unrelated skip (`TelemetryServicePosthogTests.SendTestEvent_IngestsSuccessfully`).
- `dotnet format --verify-no-changes` on both affected csproj files: no diffs.
- `dotnet build -c Debug` on both affected csproj files: 0 errors, 2 pre-existing unrelated `NU1504` warnings.

---
## Commits
- 9bf7ec9f feat: resolve memory references instead of failing in read-memory CLI
- 30ab37c5 docs: document list-memory and reference resolution in firmware and CLI docs
- 69041ea9 test: cover memory reference resolution and list-memory

---
Created using [Ivy Tendril](https://ivy.app).