### PR TITLE
[00080] Fix Duplicate Ivy.Analyser PackageReference NU1504 Warning

### DIFF
--- a/src/.releases/UpdateIvyPackages.ps1
+++ b/src/.releases/UpdateIvyPackages.ps1
@@ -1,5 +1,12 @@
 # UpdateIvyPackages.ps1
 # Script to update all Ivy.* packages to their latest versions on NuGet
+#
+# NOTE: this script edits the Version attribute on existing <PackageReference> nodes directly
+# instead of shelling out to `dotnet add <csproj> package <pkg>`. `dotnet add package` does not
+# know how to update a PackageReference that lives inside a conditioned <ItemGroup> (e.g. the
+# IvySource-guarded groups in Ivy.Tendril.csproj) - it inserts a brand-new item into an
+# unconditioned group instead, producing a duplicate PackageReference (NU1504 warning) rather
+# than bumping the version.
 
 # Find repo root by looking for Directory.Build.props using .NET path APIs
 $current = $PSScriptRoot
@@ -44,40 +51,121 @@ if ($modifiedContent -eq $originalContent) {
     Set-Content -Path $propsFile -Value $modifiedContent -NoNewline
 }
 
+# Cache of resolved latest-stable versions, keyed by package id, so each package is queried once
+# even if it appears in multiple csproj files or multiple ItemGroups within one file.
+$versionCache = @{}
+
+function Get-LatestStableVersion {
+    param([string]$PackageId)
+
+    if ($versionCache.ContainsKey($PackageId)) {
+        return $versionCache[$PackageId]
+    }
+
+    $url = "https://api.nuget.org/v3-flatcontainer/$($PackageId.ToLowerInvariant())/index.json"
+    try {
+        $response = Invoke-RestMethod -Uri $url -ErrorAction Stop
+        $stableVersions = $response.versions | Where-Object { $_ -notmatch '-' }
+        if (-not $stableVersions -or $stableVersions.Count -eq 0) {
+            Write-Warning "No stable versions found for package '$PackageId'; leaving its version untouched."
+            $versionCache[$PackageId] = $null
+            return $null
+        }
+        $latest = $stableVersions | ForEach-Object { [System.Management.Automation.SemanticVersion]$_ } | Sort-Object | Select-Object -Last 1
+        $latestString = $latest.ToString()
+        $versionCache[$PackageId] = $latestString
+        return $latestString
+    } catch {
+        Write-Warning "Failed to resolve latest version for package '$PackageId' from NuGet: $_. Leaving its version untouched."
+        $versionCache[$PackageId] = $null
+        return $null
+    }
+}
+
 try {
     # 2. Find all csproj files
     $csprojFiles = Get-ChildItem -Path (Join-Path $RepoRoot "src") -Filter *.csproj -Recurse | Where-Object { $_.Name -ne "Ivy.Tendril.Docs.csproj" }
-    
+
     foreach ($file in $csprojFiles) {
         $csprojPath = $file.FullName
-        
+
         # Load XML
         [xml]$xml = Get-Content $csprojPath
         $packageRefs = $xml.SelectNodes("//PackageReference[starts-with(@Include, 'Ivy.') or @Include='Ivy']")
-        
+
         if ($packageRefs -and $packageRefs.Count -gt 0) {
-            $packagesToUpdate = @()
+            $changed = $false
+
             foreach ($ref in $packageRefs) {
-                $packagesToUpdate += $ref.Include
-            }
-            
-            # Remove duplicates
-            $packagesToUpdate = $packagesToUpdate | Select-Object -Unique
-            
-            foreach ($pkg in $packagesToUpdate) {
+                $pkg = $ref.Include
+
                 if ($pkg -eq "Ivy.Docs.Helpers") {
                     Write-Host "Skipping local-only package '$pkg'..."
                     continue
                 }
-                Write-Host "Updating package '$pkg' in '$($file.Name)'..."
-                # Run dotnet add
-                dotnet add $csprojPath package $pkg
+
+                $latestVersion = Get-LatestStableVersion -PackageId $pkg
+                if (-not $latestVersion) {
+                    continue
+                }
+
+                if ($ref.Version -ne $latestVersion) {
+                    Write-Host "Updating package '$pkg' in '$($file.Name)' to version $latestVersion..."
+                    $ref.Version = $latestVersion
+                    $changed = $true
+                }
+            }
+
+            if ($changed) {
+                $xml.Save($csprojPath)
             }
         }
     }
+
+    # 3. Duplicate guard: catch a package declared twice under conditions that could both be
+    # active at once. This is exactly the class of bug this rewrite replaces - `dotnet add
+    # package` used to leave a stray duplicate PackageReference (NU1504) instead of bumping the
+    # version in its conditioned ItemGroup. Fail loudly here instead of shipping a build warning.
+    $duplicatesFound = $false
+
+    foreach ($file in $csprojFiles) {
+        [xml]$xml = Get-Content $file.FullName
+        $packageRefs = $xml.SelectNodes("//PackageReference[@Version]")
+
+        $groups = @{}
+        foreach ($ref in $packageRefs) {
+            $include = $ref.Include
+            $itemGroup = $ref.ParentNode
+            $condition = $itemGroup.GetAttribute("Condition")
+            if (-not $groups.ContainsKey($include)) {
+                $groups[$include] = @()
+            }
+            $groups[$include] += $condition
+        }
+
+        foreach ($include in $groups.Keys) {
+            $conditions = $groups[$include]
+            if ($conditions.Count -le 1) { continue }
+
+            # Two or more unconditioned groups, or an unconditioned group plus any conditioned
+            # group, can both be active simultaneously -> duplicate. Two groups conditioned on
+            # mutually exclusive values (e.g. == 'true' and != 'true') are fine.
+            $unconditionedCount = ($conditions | Where-Object { -not $_ }).Count
+            $isConflict = $unconditionedCount -ge 2 -or ($unconditionedCount -eq 1 -and $conditions.Count -gt 1)
+
+            if ($isConflict) {
+                Write-Error "Duplicate PackageReference '$include' found in '$($file.FullName)' under conditions that can both be active: $($conditions -join ', ')"
+                $duplicatesFound = $true
+            }
+        }
+    }
+
+    if ($duplicatesFound) {
+        exit 1
+    }
 }
 finally {
-    # 3. Restore original Directory.Build.props
+    # 4. Restore original Directory.Build.props
     if ($originalContent -ne $null -and (Get-Content $propsFile -Raw) -ne $originalContent) {
         Write-Host "Restoring Directory.Build.props..."
         Set-Content -Path $propsFile -Value $originalContent -NoNewline

--- a/src/Ivy.Tendril/Ivy.Tendril.csproj
+++ b/src/Ivy.Tendril/Ivy.Tendril.csproj
@@ -38,10 +38,6 @@
 
   <!-- PackageReferences -->
   <ItemGroup>
-    <PackageReference Include="Ivy.Analyser" Version="1.3.12">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Ivy.StackAnalyzer" Version="1.0.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.4.1" />


### PR DESCRIPTION
# Summary

## Changes

Removed the duplicate unconditional `Ivy.Analyser` `PackageReference` (`1.3.12`) from
`Ivy.Tendril.csproj`, which was clashing with the correct `IvySource`-conditioned declaration
(`1.3.8`) and causing an NU1504 warning on every build. Rewrote `UpdateIvyPackages.ps1` to edit
`Version` attributes on existing `PackageReference` nodes in place (resolving the latest stable
version from the NuGet API) instead of shelling out to `dotnet add package`, which cannot update
references inside conditioned `ItemGroup`s and was the root cause of the duplicate. Added a
duplicate guard to the script that fails loudly if this class of bug recurs.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Ivy.Tendril.csproj` — removed the duplicate unconditional `Ivy.Analyser` PackageReference.
- `src/.releases/UpdateIvyPackages.ps1` — replaced `dotnet add package` loop with in-place XML version edits + duplicate guard.

## Manual Testing

N/A — internal build-plumbing fix with no user-facing behavior. Verified via
`dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj /p:IvySource=false`, which now reports 0 warnings
(previously emitted NU1504 for the duplicate `Ivy.Analyser` reference).

---
## Commits
- eea98070 fix: remove duplicate Ivy.Analyser PackageReference (NU1504)
- 46c0ea6b fix: rewrite UpdateIvyPackages.ps1 to edit versions in place

---
Created using [Ivy Tendril](https://ivy.app).
