### PR TITLE
[00066] Fix Misleading 404 Error From Tendril Job Status Reporting

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/02_REST.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/02_REST.md
@@ -219,6 +219,12 @@ Content-Type: application/json
 
 Updates progress for a running job. Used by promptware agents via the `tendril job status` CLI command.
 
+Returns `404 { "error": "Job not found" }` if the job id is unknown to the server (for example, the
+server restarted since the job started, or the job was deleted). The `tendril job status` CLI treats
+that response as a warning printed to stderr rather than a command failure, since a dropped progress
+report should not make an otherwise-successful agent script look broken. The same applies to
+`tendril job fail` against `PUT /api/jobs/{jobId}/fail`.
+
 ### Health Check
 
 ```

--- a/src/Ivy.Tendril.Test/Commands/JobFailCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/JobFailCommandTests.cs
@@ -1,9 +1,63 @@
 using Ivy.Tendril.Commands;
+using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Test.Commands;
 
-public class JobFailCommandTests
+[Collection("TendrilHome")]
+public class JobFailCommandTests : IDisposable
 {
+    private readonly TempDirectoryFixture _tempDir = new("tendril-job-fail-test");
+    private readonly string _originalTendrilHome;
+
+    public JobFailCommandTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+    }
+
+    private static CommandApp BuildApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddCommand<JobFailCommand>("fail");
+        });
+        return app;
+    }
+
+    [Fact]
+    public void Execute_NoMasterFileRunning_ReturnsZeroAndWarnsOnStderr()
+    {
+        // No .master file exists under TENDRIL_HOME, so Discover() throws. Recording the
+        // failure reason is best effort; the caller's own non-zero exit is what actually
+        // marks the job failed, so a dropped report must not fail this command too.
+        var app = BuildApp();
+        var originalError = Console.Error;
+        var errorWriter = new StringWriter();
+        Console.SetError(errorWriter);
+
+        int exit;
+        try
+        {
+            exit = app.Run(["fail", "00432", "--message", "Worktree creation failed"]);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Warning:", errorWriter.ToString());
+        Assert.Contains("00432", errorWriter.ToString());
+    }
+
     [Fact]
     public void Validate_MissingMessage_Fails()
     {

--- a/src/Ivy.Tendril.Test/Commands/JobStatusCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/JobStatusCommandTests.cs
@@ -1,0 +1,59 @@
+using Ivy.Tendril.Commands;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Test.Commands;
+
+[Collection("TendrilHome")]
+public class JobStatusCommandTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("tendril-job-status-test");
+    private readonly string _originalTendrilHome;
+
+    public JobStatusCommandTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+    }
+
+    private static CommandApp BuildApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddCommand<JobStatusCommand>("status");
+        });
+        return app;
+    }
+
+    [Fact]
+    public void Execute_NoMasterFileRunning_ReturnsZeroAndWarnsOnStderr()
+    {
+        // No .master file exists under TENDRIL_HOME, so Discover() throws. The command must
+        // treat this as best-effort telemetry rather than failing the caller's script.
+        var app = BuildApp();
+        var originalError = Console.Error;
+        var errorWriter = new StringWriter();
+        Console.SetError(errorWriter);
+
+        int exit;
+        try
+        {
+            exit = app.Run(["status", "00432", "--message", "Running verifications..."]);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Warning:", errorWriter.ToString());
+        Assert.Contains("00432", errorWriter.ToString());
+    }
+}

--- a/src/Ivy.Tendril.Test/Helpers/MasterClientErrorTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/MasterClientErrorTests.cs
@@ -1,0 +1,40 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test.Helpers;
+
+public class MasterClientErrorTests
+{
+    [Fact]
+    public void DescribeFailure_NotFound_NamesEndpointAndMentionsRestartOrDeletion()
+    {
+        var message = MasterClient.DescribeFailure(404, "api/jobs/00432/status", "");
+
+        Assert.Contains("api/jobs/00432/status", message);
+        Assert.Contains("restarted", message);
+        Assert.Contains("deleted", message);
+    }
+
+    [Fact]
+    public void DescribeFailure_Unauthorized_ReturnsAuthenticationFailedMessage()
+    {
+        var message = MasterClient.DescribeFailure(401, "api/jobs", "");
+
+        Assert.Equal("Authentication failed. Check Api.ApiKey in config.yaml.", message);
+    }
+
+    [Fact]
+    public void DescribeFailure_JsonErrorBody_SurfacesErrorProperty()
+    {
+        var message = MasterClient.DescribeFailure(400, "api/jobs", "{\"error\":\"Job not found\"}");
+
+        Assert.Equal("Job not found", message);
+    }
+
+    [Fact]
+    public void DescribeFailure_NonJsonBody_FallsBackToRawStatusAndBody()
+    {
+        var message = MasterClient.DescribeFailure(500, "api/jobs/00001/status", "Internal Server Error");
+
+        Assert.Equal("Server returned 500 for api/jobs/00001/status: Internal Server Error", message);
+    }
+}

--- a/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
@@ -147,6 +147,73 @@ public class JobServiceStartupTests
         }
     }
 
+    [Fact]
+    public void UpdateJobStatus_JobOnlyInDatabase_RehydratesAndSucceeds()
+    {
+        // Simulates a master restart: the job is gone from the in-memory dictionary
+        // (fresh JobService, no StartJob call) but was persisted to the database while running.
+        var db = new FakeDatabaseService
+        {
+            Jobs = { new JobItem { Id = "job-restarted", Status = JobStatus.Running } }
+        };
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), database: db);
+
+        var ok = service.UpdateJobStatus("job-restarted", "Running verifications...", "01234", "My Plan");
+
+        Assert.True(ok);
+        var job = service.GetJobs().Single(j => j.Id == "job-restarted");
+        Assert.Equal("Running verifications...", job.StatusMessage);
+        Assert.Equal("01234", job.ReportedPlanId);
+        Assert.Equal("My Plan", job.ReportedPlanTitle);
+    }
+
+    [Fact]
+    public void ReportJobFailure_JobOnlyInDatabase_RehydratesAndSucceeds()
+    {
+        var db = new FakeDatabaseService
+        {
+            Jobs = { new JobItem { Id = "job-restarted", Status = JobStatus.Running } }
+        };
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), database: db);
+
+        var ok = service.ReportJobFailure("job-restarted", "Worktree creation failed");
+
+        Assert.True(ok);
+        var job = service.GetJobs().Single(j => j.Id == "job-restarted");
+        Assert.Equal("Worktree creation failed", job.ReportedFailureReason);
+    }
+
+    [Fact]
+    public void UpdateJobStatus_UnknownToBothMemoryAndDatabase_ReturnsFalse()
+    {
+        var db = new FakeDatabaseService();
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), database: db);
+
+        Assert.False(service.UpdateJobStatus("nonexistent", "message"));
+    }
+
+    [Fact]
+    public void StartJob_PersistsJobToDatabaseWhileStillRunning()
+    {
+        var db = new FakeDatabaseService();
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), database: db);
+
+        // StartJob persists the job as soon as it is registered in StartJobInternal, not just
+        // on completion, so the row shows up even though the process launch below will fail
+        // in this test environment (no real coding agent available).
+        string id;
+        try
+        {
+            id = service.StartJob(new CreatePlanArgs("Test Job", "Auto"));
+        }
+        catch
+        {
+            id = service.GetJobs().Single().Id;
+        }
+
+        Assert.NotNull(db.GetJobById(id));
+    }
+
     private class FakeConfigService : IConfigService
     {
         public FakeConfigService(string tendrilHome)
@@ -323,6 +390,8 @@ public class JobServiceStartupTests
 
         public void UpsertJob(JobItem job)
         {
+            Jobs.RemoveAll(j => j.Id == job.Id);
+            Jobs.Add(job);
         }
 
         public List<string> PurgeOldJobs(int keepCount = 500)

--- a/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -858,6 +858,40 @@ public class PlanDatabaseServiceTests : IDisposable
     }
 
     [Fact]
+    public void GetRecentJobs_IncludesRunningJobDespiteLimit()
+    {
+        // Seed more completed jobs than the default limit (100), all with a CompletedAt
+        // timestamp. A plain "ORDER BY CompletedAt DESC" sorts NULL last in SQLite, so a
+        // running job (CompletedAt IS NULL) would otherwise be the first row LIMIT discards.
+        for (var i = 0; i < 110; i++)
+            _db.UpsertJob(new JobItem
+            {
+                Id = $"completed-{i:D4}",
+                Type = "ExecutePlan",
+                PlanFile = $"plan-{i}",
+                Project = "Tendril",
+                Status = JobStatus.Completed,
+                Provider = "claude",
+                CompletedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMinutes(i)
+            });
+
+        _db.UpsertJob(new JobItem
+        {
+            Id = "running-job",
+            Type = "ExecutePlan",
+            PlanFile = "plan-running",
+            Project = "Tendril",
+            Status = JobStatus.Running,
+            Provider = "claude",
+            CompletedAt = null
+        });
+
+        var jobs = _db.GetRecentJobs();
+
+        Assert.Contains(jobs, j => j.Id == "running-job");
+    }
+
+    [Fact]
     public void UpsertJob_UpdatesExistingJob()
     {
         var job = new JobItem

--- a/src/Ivy.Tendril/Commands/JobFailCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobFailCommand.cs
@@ -27,11 +27,25 @@ public class JobFailCommand : Command<JobFailSettings>
 {
     protected override int Execute(CommandContext context, JobFailSettings settings, CancellationToken cancellationToken)
     {
-        MasterClient.PutJson($"api/jobs/{settings.JobId}/fail", new { message = settings.Message }, cancellationToken);
+        try
+        {
+            MasterClient.PutJson(
+                $"api/jobs/{settings.JobId}/fail",
+                new { message = settings.Message },
+                notFoundMessage: $"Job '{settings.JobId}' is not known to the running Tendril server (it may have restarted, or the job was deleted).",
+                cancellationToken: cancellationToken);
 
-        // This only records the failure reason. The promptware is still responsible
-        // for exiting non-zero (e.g. `exit 1`) to actually fail the job.
-        Console.WriteLine($"Failure reported for job {settings.JobId}");
+            // This only records the failure reason. The promptware is still responsible
+            // for exiting non-zero (e.g. `exit 1`) to actually fail the job.
+            Console.WriteLine($"Failure reported for job {settings.JobId}");
+        }
+        catch (Exception ex)
+        {
+            // Recording the failure reason is best effort. The agent's own non-zero exit
+            // is what actually marks the job failed, so a dropped report loses no information.
+            Console.Error.WriteLine($"Warning: could not report failure for job {settings.JobId}: {ex.Message}");
+        }
+
         return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/JobStatusCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStatusCommand.cs
@@ -32,12 +32,23 @@ public class JobStatusCommand : Command<JobStatusSettings>
 {
     protected override int Execute(CommandContext context, JobStatusSettings settings, CancellationToken cancellationToken)
     {
-        MasterClient.PutJson(
-            $"api/jobs/{settings.JobId}/status",
-            new { message = settings.Message, planId = settings.PlanId, planTitle = settings.PlanTitle },
-            cancellationToken);
+        try
+        {
+            MasterClient.PutJson(
+                $"api/jobs/{settings.JobId}/status",
+                new { message = settings.Message, planId = settings.PlanId, planTitle = settings.PlanTitle },
+                notFoundMessage: $"Job '{settings.JobId}' is not known to the running Tendril server (it may have restarted, or the job was deleted).",
+                cancellationToken: cancellationToken);
 
-        Console.WriteLine($"Status updated for job {settings.JobId}");
+            Console.WriteLine($"Status updated for job {settings.JobId}");
+        }
+        catch (Exception ex)
+        {
+            // Status reporting is telemetry for the Jobs UI. A failed report must not fail
+            // the agent's script, which is what actually determines job success/failure.
+            Console.Error.WriteLine($"Warning: could not report status for job {settings.JobId}: {ex.Message}");
+        }
+
         return 0;
     }
 }

--- a/src/Ivy.Tendril/Helpers/MasterClient.cs
+++ b/src/Ivy.Tendril/Helpers/MasterClient.cs
@@ -46,7 +46,10 @@ public static class MasterClient
     /// (e.g. "api/jobs/00001/status"), throwing on a non-success status. Shared by the CLI
     /// commands that report job state so the discover/serialize/PUT convention lives in one place.
     /// </summary>
-    public static void PutJson(string relativePath, object payload, CancellationToken cancellationToken = default)
+    /// <param name="notFoundMessage">
+    /// Overrides the default 404 message with caller-supplied text (e.g. naming the job id).
+    /// </param>
+    public static void PutJson(string relativePath, object payload, string? notFoundMessage = null, CancellationToken cancellationToken = default)
     {
         var discovery = Discover();
         using var client = CreateHttpClient(discovery);
@@ -54,9 +57,54 @@ public static class MasterClient
         var json = JsonSerializer.Serialize(payload, JsonOptions);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-        var response = client.PutAsync($"{discovery.BaseUrl}/{relativePath.TrimStart('/')}", content, cancellationToken)
-            .GetAwaiter().GetResult();
-        response.EnsureSuccessStatusCode();
+        HttpResponseMessage response;
+        try
+        {
+            response = client.PutAsync($"{discovery.BaseUrl}/{relativePath.TrimStart('/')}", content, cancellationToken)
+                .GetAwaiter().GetResult();
+        }
+        catch (TaskCanceledException)
+        {
+            throw new InvalidOperationException($"Server did not respond in time (5s timeout) for {relativePath}.");
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new InvalidOperationException($"Failed to connect to Tendril server for {relativePath}: {ex.Message}");
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var responseBody = response.Content.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult();
+
+            if ((int)response.StatusCode == 404 && notFoundMessage != null)
+                throw new InvalidOperationException(notFoundMessage);
+
+            throw new InvalidOperationException(DescribeFailure((int)response.StatusCode, relativePath, responseBody));
+        }
+    }
+
+    /// <summary>
+    /// Turns a failed HTTP response into a message naming the endpoint and, when the body
+    /// carries an <c>{"error": ...}</c> property, the server's own explanation. Shared by
+    /// <see cref="PutJson"/> and <see cref="SubmitJob"/> so both agree on wording.
+    /// </summary>
+    internal static string DescribeFailure(int statusCode, string relativePath, string responseBody)
+    {
+        if (statusCode == 401)
+            return "Authentication failed. Check Api.ApiKey in config.yaml.";
+
+        if (statusCode == 404)
+            return $"Server does not know '{relativePath}' (404). The Tendril server may have restarted since the job started, or the job was deleted.";
+
+        try
+        {
+            var errorDoc = JsonDocument.Parse(responseBody);
+            if (errorDoc.RootElement.TryGetProperty("error", out var errorProp))
+                return errorProp.GetString() ?? "Unknown server error";
+        }
+        catch (JsonException) { }
+
+        return $"Server returned {statusCode} for {relativePath}: {responseBody}";
     }
 
     public static DiscoveryResult Discover(string? tendrilHome = null)
@@ -122,20 +170,7 @@ public static class MasterClient
         var responseJson = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
         if (!response.IsSuccessStatusCode)
-        {
-            if ((int)response.StatusCode == 401)
-                throw new InvalidOperationException("Authentication failed. Check Api.ApiKey in config.yaml.");
-
-            try
-            {
-                var errorDoc = JsonDocument.Parse(responseJson);
-                if (errorDoc.RootElement.TryGetProperty("error", out var errorProp))
-                    throw new InvalidOperationException(errorProp.GetString() ?? "Unknown server error");
-            }
-            catch (JsonException) { }
-
-            throw new InvalidOperationException($"Server returned {(int)response.StatusCode}: {responseJson}");
-        }
+            throw new InvalidOperationException(DescribeFailure((int)response.StatusCode, "api/jobs", responseJson));
 
         var result = JsonSerializer.Deserialize<JobStartResponse>(responseJson, JsonOptions);
         return result ?? throw new InvalidOperationException("Empty response from server");

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -502,7 +502,7 @@ public class JobService : IJobService
 
     public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null)
     {
-        if (!_jobs.TryGetValue(id, out var job))
+        if (!TryGetOrRehydrateJob(id, out var job))
             return false;
 
         job.StatusMessage = message;
@@ -511,20 +511,42 @@ public class JobService : IJobService
         if (!string.IsNullOrEmpty(planTitle))
             job.ReportedPlanTitle = planTitle;
 
+        PersistJob(job);
         RaiseJobsPropertyChanged();
         return true;
     }
 
     public bool ReportJobFailure(string id, string message)
     {
-        if (!_jobs.TryGetValue(id, out var job))
+        if (!TryGetOrRehydrateJob(id, out var job))
             return false;
 
         // Record the reason only; the job process is still running and the terminal
         // state transition still happens later in CompleteJob/SetCompletionStatus.
         job.ReportedFailureReason = message;
 
+        PersistJob(job);
         RaiseJobsPropertyChanged();
+        return true;
+    }
+
+    /// <summary>
+    ///     Looks up a job in memory, falling back to the database if the master process
+    ///     restarted since the job started (in-memory <see cref="_jobs"/> is empty on
+    ///     restart, but the job is persisted via <see cref="PersistJob"/> as soon as it
+    ///     starts). Rehydrated jobs are re-added to <see cref="_jobs"/> so subsequent
+    ///     lookups don't need to hit the database again.
+    /// </summary>
+    private bool TryGetOrRehydrateJob(string id, out JobItem job)
+    {
+        if (_jobs.TryGetValue(id, out job!))
+            return true;
+
+        var dbJob = _database?.GetJobById(id);
+        if (dbJob == null)
+            return false;
+
+        job = _jobs.GetOrAdd(id, dbJob);
         return true;
     }
 
@@ -677,6 +699,11 @@ public class JobService : IJobService
             return id;
 
         _jobs[id] = job;
+
+        // Persist immediately so a status report or a UI refresh can find this job even if
+        // the master process restarts while it's still running (only PersistJob was previously
+        // called on completion, so an in-flight job existed only in memory).
+        PersistJob(job);
 
         if (TryBlockForDependencies(job, skipDependencyCheck))
             return id;

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -707,7 +707,10 @@ public class PlanDatabaseService : IPlanDatabaseService
     {
         using (new ReadLockHandle(_lock))
         {
-            return ReadList("SELECT * FROM Jobs WHERE Cleared = 0 ORDER BY CompletedAt DESC LIMIT @limit",
+            // CompletedAt IS NULL DESC sorts running jobs (CompletedAt IS NULL) first, so
+            // they aren't the first rows discarded by LIMIT (SQLite otherwise sorts NULL
+            // last in a plain "CompletedAt DESC").
+            return ReadList("SELECT * FROM Jobs WHERE Cleared = 0 ORDER BY CompletedAt IS NULL DESC, CompletedAt DESC LIMIT @limit",
                 MapJobRow,
                 new SqliteParameter("@limit", limit));
         }


### PR DESCRIPTION
Fixes #1749

# Summary

Fixed the misleading `404 (Not Found)` error surfaced by `tendril job status` (issue #1749) and its root cause, a job-persistence gap that made in-flight jobs invisible to the server after a restart (issue #1759).

## Changes

1. **`MasterClient.PutJson` now throws a diagnosable error.** Extracted a shared `DescribeFailure` helper (also used by `SubmitJob`) that names the endpoint, surfaces the server's `{"error": ...}` body when present, and gives specific text for 401/404. `PutJson` also catches `TaskCanceledException`/`HttpRequestException` and takes an optional `notFoundMessage` override.
2. **`tendril job status` and `tendril job fail` are now best-effort.** A delivery failure prints a `Warning:` to stderr instead of failing the command (exit 0), since dropped telemetry shouldn't break an otherwise-successful agent script.
3. **Fixed the #1759 persistence gap.** `JobService` now persists a job to SQLite as soon as it starts, not just on completion, and `UpdateJobStatus`/`ReportJobFailure` fall back to the database (rehydrating into memory) when a job isn't in the in-memory dictionary. Also fixed `PlanDatabaseService.GetRecentJobs`'s `ORDER BY CompletedAt DESC`, which sorted running jobs (`CompletedAt IS NULL`) last in SQLite and could silently drop them once the 100-row limit filled with completed jobs.
4. **Documented the 404 semantics** in `02_REST.md` under "Update Job Status".

## Tests

Added `MasterClientErrorTests.cs`, `JobStatusCommandTests.cs`, and extended `JobFailCommandTests.cs`, `JobServiceStartupTests.cs`, `PlanDatabaseServiceTests.cs` per the plan's Tests section. Full `Ivy.Tendril.Test` suite: 1800 passed, 1 pre-existing skip, 0 failed.

## Verifications

DotnetFormat: Pass. DotnetBuild: Pass. DotnetTest: Pass. VitePlusTest: Skipped (no frontend changes). CheckResult: Pass.

## Commits

- `6828169e` fix: make MasterClient.PutJson throw a diagnosable error
- `b5dfe9d2` fix: make tendril job status and job fail best-effort
- `043a7b33` fix: persist running jobs and stop dropping them from recent-jobs (#1759)
- `a00e957e` docs: document 404 semantics for job status/fail endpoints

---
Created using [Ivy Tendril](https://ivy.app).
