### PR TITLE
[00069] Persist In Flight Jobs So Status Updates Survive Master Restart

### DIFF
--- a/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
+++ b/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
@@ -460,6 +460,59 @@ public class DatabaseMigratorTests : IDisposable
         Assert.DoesNotContain("Risk", columns);
     }
 
+    [Fact]
+    public void Migration_017_JobsInFlightFields_AddsColumns()
+    {
+        new Migration_001_InitialSchema().Apply(_connection);
+        new Migration_002_Fts5Search().Apply(_connection);
+        new Migration_003_JobsTable().Apply(_connection);
+        new Migration_004_SourceUrl().Apply(_connection);
+        new Migration_005_CostsLogTimestampIndex().Apply(_connection);
+        new Migration_006_CostsCompositeIndex().Apply(_connection);
+        new Migration_007_FtsSourceUrl().Apply(_connection);
+        new Migration_008_PrStatusTable().Apply(_connection);
+        new Migration_009_JobsArgs().Apply(_connection);
+        new Migration_010_RecommendationImpactRisk().Apply(_connection);
+        new Migration_011_JobsTypedArgs().Apply(_connection);
+        new Migration_012_JobsPlanFileIndex().Apply(_connection);
+        new Migration_013_JobsWorkingDirAndCliCommand().Apply(_connection);
+        new Migration_014_JobsCleared().Apply(_connection);
+        new Migration_015_RenamePlanStates().Apply(_connection);
+        new Migration_016_DropRecommendationRisk().Apply(_connection);
+
+        Assert.Equal(16, GetUserVersion());
+
+        new Migration_017_JobsInFlightFields().Apply(_connection);
+
+        Assert.Equal(17, GetUserVersion());
+
+        var columns = new List<string>();
+        using (var pragmaCmd = _connection.CreateCommand())
+        {
+            pragmaCmd.CommandText = "PRAGMA table_info(Jobs);";
+            using var reader = pragmaCmd.ExecuteReader();
+            while (reader.Read())
+                columns.Add(reader.GetString(reader.GetOrdinal("name")));
+        }
+
+        Assert.Contains("ProcessId", columns);
+        Assert.Contains("ReportedPlanId", columns);
+        Assert.Contains("ReportedPlanTitle", columns);
+        Assert.Contains("ReportedFailureReason", columns);
+
+        using var insertCmd = _connection.CreateCommand();
+        insertCmd.CommandText = """
+                                INSERT INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, ProcessId, ReportedPlanId, ReportedPlanTitle, ReportedFailureReason)
+                                VALUES ('job-1', 'ExecutePlan', 'Plan', 'Proj', 'Running', 'claude', 4242, '00069', 'Persist Jobs', 'boom')
+                                """;
+        insertCmd.ExecuteNonQuery();
+
+        using var selectCmd = _connection.CreateCommand();
+        selectCmd.CommandText =
+            "SELECT ProcessId || '|' || ReportedPlanId || '|' || ReportedPlanTitle || '|' || ReportedFailureReason FROM Jobs WHERE Id = 'job-1';";
+        Assert.Equal("4242|00069|Persist Jobs|boom", selectCmd.ExecuteScalar()?.ToString());
+    }
+
     private class FakeMigration : IMigration
     {
         private readonly List<int>? _tracker;

--- a/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
@@ -147,6 +147,192 @@ public class JobServiceStartupTests
         }
     }
 
+    [Fact]
+    public void UpdateJobStatus_JobOnlyInDatabase_RehydratesAndReturnsTrue()
+    {
+        var db = new FakeDatabaseService();
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), database: db);
+
+        // Seeded after construction so the row is only reachable through GetJobById — this is the
+        // master-restart shape: the agent outlived the server process that started it.
+        db.Jobs.Add(new JobItem
+        {
+            Id = "job-detached",
+            Type = "ExecutePlan",
+            Status = JobStatus.Running,
+            StartedAt = DateTime.UtcNow.AddMinutes(-1)
+        });
+
+        Assert.True(service.UpdateJobStatus("job-detached", "Verifying: DotnetBuild"));
+
+        var job = service.GetJob("job-detached");
+        Assert.NotNull(job);
+        Assert.Equal("Verifying: DotnetBuild", job!.StatusMessage);
+        Assert.Contains("job-detached", db.UpsertedJobIds);
+
+        // Re-registered in memory: the Jobs app shows it, and later reports don't need the fallback.
+        Assert.Contains(service.GetJobs(), j => j.Id == "job-detached");
+    }
+
+    [Fact]
+    public void UpdateJobStatus_JobInNeitherMemoryNorDatabase_ReturnsFalse()
+    {
+        var db = new FakeDatabaseService();
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), database: db);
+
+        Assert.False(service.UpdateJobStatus("no-such-job", "hello"));
+    }
+
+    [Fact]
+    public void UpdateJobStatus_DetachedJob_RefreshesStaleOutputHeartbeat()
+    {
+        var db = new FakeDatabaseService();
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), database: db);
+        db.Jobs.Add(new JobItem
+        {
+            Id = "job-heartbeat",
+            Type = "ExecutePlan",
+            Status = JobStatus.Running,
+            StartedAt = DateTime.UtcNow.AddHours(-3),
+            LastOutputAt = DateTime.UtcNow.AddHours(-3)
+        });
+
+        var before = DateTime.UtcNow;
+        Assert.True(service.UpdateJobStatus("job-heartbeat", "still working"));
+
+        var job = service.GetJob("job-heartbeat");
+        Assert.NotNull(job);
+        Assert.True(job!.LastOutputAt >= before);
+    }
+
+    [Fact]
+    public void ReportJobFailure_JobOnlyInDatabase_RehydratesAndReturnsTrue()
+    {
+        var db = new FakeDatabaseService();
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), database: db);
+        db.Jobs.Add(new JobItem
+        {
+            Id = "job-failing",
+            Type = "ExecutePlan",
+            Status = JobStatus.Running,
+            StartedAt = DateTime.UtcNow.AddMinutes(-1)
+        });
+
+        Assert.True(service.ReportJobFailure("job-failing", "Worktree creation failed"));
+
+        var job = service.GetJob("job-failing");
+        Assert.NotNull(job);
+        Assert.Equal("Worktree creation failed", job!.ReportedFailureReason);
+        Assert.Contains("job-failing", db.UpsertedJobIds);
+    }
+
+    [Fact]
+    public void UpdateJobStatus_ReportedPlanId_PersistedAndRestored()
+    {
+        var db = new FakeDatabaseService();
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), database: db);
+        var row = new JobItem
+        {
+            Id = "job-plan",
+            Type = "ExecutePlan",
+            Status = JobStatus.Running,
+            StartedAt = DateTime.UtcNow.AddMinutes(-1)
+        };
+        db.Jobs.Add(row);
+
+        Assert.True(service.UpdateJobStatus("job-plan", "Implementing...", "01500", "Test Plan"));
+
+        // The fake stores the same instance the service mutated, so a fresh service over the same
+        // database sees exactly what a real reload would read back from the persisted row.
+        var reloaded = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), database: db)
+            .GetJob("job-plan");
+        Assert.NotNull(reloaded);
+        Assert.Equal("01500", reloaded!.ReportedPlanId);
+        Assert.Equal("Test Plan", reloaded.ReportedPlanTitle);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(int.MaxValue)] // no process can hold this id
+    public void LoadHistoricalJobs_RunningJobWithDeadProcessId_MarkedFailed(int? processId)
+    {
+        var db = new FakeDatabaseService
+        {
+            Jobs =
+            {
+                new JobItem
+                {
+                    Id = "job-ghost", Type = "ExecutePlan", Status = JobStatus.Running,
+                    StartedAt = DateTime.UtcNow.AddMinutes(-30), ProcessId = processId
+                }
+            }
+        };
+
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), database: db);
+
+        var job = service.GetJob("job-ghost");
+        Assert.NotNull(job);
+        Assert.Equal(JobStatus.Failed, job!.Status);
+        Assert.Equal("Interrupted by Tendril master restart", job.StatusMessage);
+        Assert.NotNull(job.CompletedAt);
+        Assert.False(job.Detached);
+        Assert.Contains("job-ghost", db.UpsertedJobIds);
+    }
+
+    [Fact]
+    public void LoadHistoricalJobs_RunningJobWithLiveProcessId_StaysRunningAndDetached()
+    {
+        // The test host is a guaranteed-live process. StartedAt is old enough that the stale-output
+        // check (1 min timeout + 2 min reap grace) would fire off the original anchor.
+        var db = new FakeDatabaseService
+        {
+            Jobs =
+            {
+                new JobItem
+                {
+                    Id = "job-alive", Type = "ExecutePlan", Status = JobStatus.Running,
+                    StartedAt = DateTime.UtcNow.AddMinutes(-4), ProcessId = Environment.ProcessId
+                }
+            }
+        };
+
+        var service = new JobService(TimeSpan.FromHours(6), TimeSpan.FromMinutes(1), database: db);
+
+        var job = service.GetJob("job-alive");
+        Assert.NotNull(job);
+        Assert.Equal(JobStatus.Running, job!.Status);
+        Assert.True(job.Detached);
+        Assert.NotNull(job.LastOutputAt);
+
+        // The reload restarted the stale-output clock, so the very next timer tick must not reap it.
+        service.RunStuckJobCheck();
+        Assert.Equal(JobStatus.Running, service.GetJob("job-alive")!.Status);
+    }
+
+    [Fact]
+    public void LoadHistoricalJobs_BlockedJob_LeftUntouched()
+    {
+        var db = new FakeDatabaseService
+        {
+            Jobs =
+            {
+                new JobItem
+                {
+                    Id = "job-blocked", Type = "ExecutePlan", Status = JobStatus.Blocked,
+                    StatusMessage = "Waiting for 01499-Dependency"
+                }
+            }
+        };
+
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), database: db);
+
+        var job = service.GetJob("job-blocked");
+        Assert.NotNull(job);
+        Assert.Equal(JobStatus.Blocked, job!.Status);
+        Assert.Equal("Waiting for 01499-Dependency", job.StatusMessage);
+        Assert.False(job.Detached);
+    }
+
     private class FakeConfigService : IConfigService
     {
         public FakeConfigService(string tendrilHome)
@@ -193,6 +379,10 @@ public class JobServiceStartupTests
     private class FakeDatabaseService : IPlanDatabaseService
     {
         public List<JobItem> Jobs { get; } = new();
+
+        /// <summary>Ids passed to <see cref="UpsertJob" />, in call order.</summary>
+        public List<string> UpsertedJobIds { get; } = new();
+
         public bool ThrowOnGetRecentJobs { get; init; }
 
         public List<JobItem> GetRecentJobs(int limit = 100)
@@ -323,6 +513,7 @@ public class JobServiceStartupTests
 
         public void UpsertJob(JobItem job)
         {
+            UpsertedJobIds.Add(job.Id);
         }
 
         public List<string> PurgeOldJobs(int keepCount = 500)

--- a/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs
@@ -858,6 +858,91 @@ public class PlanDatabaseServiceTests : IDisposable
     }
 
     [Fact]
+    public void UpsertJob_RoundTripsInFlightFields()
+    {
+        _db.UpsertJob(new JobItem
+        {
+            Id = "job-inflight",
+            Type = "ExecutePlan",
+            PlanFile = "01500-TestPlan",
+            Project = "Tendril",
+            Status = JobStatus.Running,
+            Provider = "claude",
+            StartedAt = new DateTime(2026, 4, 7, 10, 0, 0, DateTimeKind.Utc),
+            ProcessId = 31337,
+            ReportedPlanId = "01500",
+            ReportedPlanTitle = "Test Plan Title",
+            ReportedFailureReason = "verification failed"
+        });
+
+        var result = _db.GetJobById("job-inflight");
+
+        Assert.NotNull(result);
+        Assert.Equal(31337, result!.ProcessId);
+        Assert.Equal("01500", result.ReportedPlanId);
+        Assert.Equal("Test Plan Title", result.ReportedPlanTitle);
+        Assert.Equal("verification failed", result.ReportedFailureReason);
+    }
+
+    [Fact]
+    public void UpsertJob_NullInFlightFields_RoundTripAsNull()
+    {
+        _db.UpsertJob(new JobItem
+        {
+            Id = "job-bare",
+            Type = "ExecutePlan",
+            PlanFile = "01500-TestPlan",
+            Project = "Tendril",
+            Status = JobStatus.Pending,
+            Provider = "claude"
+        });
+
+        var result = _db.GetJobById("job-bare");
+
+        Assert.NotNull(result);
+        Assert.Null(result!.ProcessId);
+        Assert.Null(result.ReportedPlanId);
+        Assert.Null(result.ReportedPlanTitle);
+        Assert.Null(result.ReportedFailureReason);
+    }
+
+    [Fact]
+    public void GetRecentJobs_InFlightJobIsNotDroppedByLimit()
+    {
+        // SQLite sorts NULLs last under DESC, so an in-flight row (NULL CompletedAt) would be the
+        // first casualty of LIMIT once enough completed jobs exist.
+        _db.UpsertJob(new JobItem
+        {
+            Id = "job-running",
+            Type = "ExecutePlan",
+            PlanFile = "01500-TestPlan",
+            Project = "Tendril",
+            Status = JobStatus.Running,
+            Provider = "claude",
+            StartedAt = new DateTime(2026, 4, 7, 9, 0, 0, DateTimeKind.Utc)
+        });
+
+        for (var i = 0; i < 5; i++)
+            _db.UpsertJob(new JobItem
+            {
+                Id = $"job-done-{i}",
+                Type = "ExecutePlan",
+                PlanFile = "01500-TestPlan",
+                Project = "Tendril",
+                Status = JobStatus.Completed,
+                Provider = "claude",
+                CompletedAt = new DateTime(2026, 4, 7, 10, 0, 0, DateTimeKind.Utc).AddMinutes(i)
+            });
+
+        var jobs = _db.GetRecentJobs(3);
+
+        Assert.Equal(3, jobs.Count);
+        Assert.Equal("job-running", jobs[0].Id);
+        Assert.Contains(jobs, j => j.Id == "job-done-4"); // completed rows still sort newest-first
+        Assert.Contains(jobs, j => j.Id == "job-done-3");
+    }
+
+    [Fact]
     public void UpsertJob_UpdatesExistingJob()
     {
         var job = new JobItem

--- a/src/Ivy.Tendril/Commands/JobFailCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobFailCommand.cs
@@ -27,7 +27,16 @@ public class JobFailCommand : Command<JobFailSettings>
 {
     protected override int Execute(CommandContext context, JobFailSettings settings, CancellationToken cancellationToken)
     {
-        MasterClient.PutJson($"api/jobs/{settings.JobId}/fail", new { message = settings.Message }, cancellationToken);
+        // Best-effort: an agent that is already failing must not be derailed by a second failure
+        // from the reporting call itself.
+        var (ok, error) = MasterClient.TryPutJson(
+            $"api/jobs/{settings.JobId}/fail", new { message = settings.Message }, cancellationToken);
+
+        if (!ok)
+        {
+            Console.Error.WriteLine($"Warning: could not report failure for job {settings.JobId}: {error}");
+            return 0;
+        }
 
         // This only records the failure reason. The promptware is still responsible
         // for exiting non-zero (e.g. `exit 1`) to actually fail the job.

--- a/src/Ivy.Tendril/Commands/JobStatusCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStatusCommand.cs
@@ -32,10 +32,17 @@ public class JobStatusCommand : Command<JobStatusSettings>
 {
     protected override int Execute(CommandContext context, JobStatusSettings settings, CancellationToken cancellationToken)
     {
-        MasterClient.PutJson(
+        // Progress telemetry must never fail an agent run: warn and still exit 0.
+        var (ok, error) = MasterClient.TryPutJson(
             $"api/jobs/{settings.JobId}/status",
             new { message = settings.Message, planId = settings.PlanId, planTitle = settings.PlanTitle },
             cancellationToken);
+
+        if (!ok)
+        {
+            Console.Error.WriteLine($"Warning: could not report status for job {settings.JobId}: {error}");
+            return 0;
+        }
 
         Console.WriteLine($"Status updated for job {settings.JobId}");
         return 0;

--- a/src/Ivy.Tendril/Database/Migrations/Migration_017_JobsInFlightFields.cs
+++ b/src/Ivy.Tendril/Database/Migrations/Migration_017_JobsInFlightFields.cs
@@ -1,0 +1,23 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Database.Migrations;
+
+public class Migration_017_JobsInFlightFields : IMigration
+{
+    public int Version => 17;
+    public string Description => "Persist in-flight job fields (process id, reported plan and failure reason)";
+
+    public void Apply(SqliteConnection connection, ILogger? logger = null)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            ALTER TABLE Jobs ADD COLUMN ProcessId INTEGER;
+            ALTER TABLE Jobs ADD COLUMN ReportedPlanId TEXT;
+            ALTER TABLE Jobs ADD COLUMN ReportedPlanTitle TEXT;
+            ALTER TABLE Jobs ADD COLUMN ReportedFailureReason TEXT;
+            PRAGMA user_version = 17;
+            """;
+        cmd.ExecuteNonQuery();
+    }
+}

--- a/src/Ivy.Tendril/Helpers/MasterClient.cs
+++ b/src/Ivy.Tendril/Helpers/MasterClient.cs
@@ -59,6 +59,44 @@ public static class MasterClient
         response.EnsureSuccessStatusCode();
     }
 
+    /// <summary>
+    /// Best-effort variant of <see cref="PutJson" /> for progress telemetry: returns the failure
+    /// reason instead of throwing, so a transient server-side problem (or a master restart that lost
+    /// the job) can't turn a status report into a non-zero exit for a running agent.
+    /// </summary>
+    public static (bool Ok, string? Error) TryPutJson(string relativePath, object payload,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var discovery = Discover();
+            using var client = CreateHttpClient(discovery);
+
+            var json = JsonSerializer.Serialize(payload, JsonOptions);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            var response = client
+                .PutAsync($"{discovery.BaseUrl}/{relativePath.TrimStart('/')}", content, cancellationToken)
+                .GetAwaiter().GetResult();
+
+            return response.IsSuccessStatusCode
+                ? (true, null)
+                : (false, $"server returned {(int)response.StatusCode} {response.ReasonPhrase}");
+        }
+        catch (TaskCanceledException)
+        {
+            return (false, $"server did not respond in time ({DefaultTimeout.TotalSeconds:0}s timeout)");
+        }
+        catch (HttpRequestException ex)
+        {
+            return (false, $"failed to connect to the Tendril server: {ex.Message}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return (false, ex.Message);
+        }
+    }
+
     public static DiscoveryResult Discover(string? tendrilHome = null)
     {
         tendrilHome ??= Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -99,6 +99,13 @@ public record JobItem
     /// once this job's output has been hydrated (or confirmed to have none).
     /// </summary>
     [JsonIgnore] public bool OutputHydrated { get; set; }
+
+    /// <summary>
+    /// True for a job restored from the database after a master restart: its agent process is
+    /// still alive but this process holds no Process handle or output stream for it.
+    /// </summary>
+    [JsonIgnore] public bool Detached { get; set; }
+
     public DateTime? LastOutputAt { get; set; }
     public CancellationTokenSource? TimeoutCts { get; set; }
     private volatile bool _staleOutputDetected;

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -500,9 +500,29 @@ public class JobService : IJobService
         return job;
     }
 
+    /// <summary>
+    ///     Resolves a job for an agent-initiated report. Falls back to the database when the job is
+    ///     not in memory — after a master restart the agent process outlives the server that started
+    ///     it, and its next report must not 404. A rehydrated job is re-registered in
+    ///     <c>_jobs</c> so subsequent reports hit memory and the Jobs app shows it again.
+    /// </summary>
+    private JobItem? ResolveJobForReport(string id)
+    {
+        if (_jobs.TryGetValue(id, out var job))
+            return job;
+
+        var stored = _database?.GetJobById(id);
+        if (stored == null)
+            return null;
+
+        // TryAdd, not indexer assignment: a concurrent report may have won the race.
+        return _jobs.TryAdd(id, stored) ? stored : _jobs.GetValueOrDefault(id) ?? stored;
+    }
+
     public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null)
     {
-        if (!_jobs.TryGetValue(id, out var job))
+        var job = ResolveJobForReport(id);
+        if (job == null)
             return false;
 
         job.StatusMessage = message;
@@ -511,19 +531,29 @@ public class JobService : IJobService
         if (!string.IsNullOrEmpty(planTitle))
             job.ReportedPlanTitle = planTitle;
 
+        // A detached agent (no Process handle here, e.g. after a master restart) produces no output
+        // stream for this process to observe, so its status calls are the only liveness signal we
+        // get. Treat them as a heartbeat so RunStuckJobCheck doesn't reap a job that is demonstrably
+        // still working. Jobs we do own are anchored by their real output instead.
+        if (job.Process == null)
+            job.LastOutputAt = DateTime.UtcNow;
+
+        PersistJob(job);
         RaiseJobsPropertyChanged();
         return true;
     }
 
     public bool ReportJobFailure(string id, string message)
     {
-        if (!_jobs.TryGetValue(id, out var job))
+        var job = ResolveJobForReport(id);
+        if (job == null)
             return false;
 
         // Record the reason only; the job process is still running and the terminal
         // state transition still happens later in CompleteJob/SetCompletionStatus.
         job.ReportedFailureReason = message;
 
+        PersistJob(job);
         RaiseJobsPropertyChanged();
         return true;
     }
@@ -564,11 +594,81 @@ public class JobService : IJobService
         try
         {
             var historicalJobs = _database.GetRecentJobs();
-            foreach (var job in historicalJobs) _jobs.TryAdd(job.Id, job);
+            foreach (var job in historicalJobs)
+                if (_jobs.TryAdd(job.Id, job))
+                    ReconcileRestoredJob(job);
         }
         catch
         {
             /* Best-effort — don't block startup */
+        }
+    }
+
+    /// <summary>
+    ///     Decides what to do with a non-terminal job restored from the database after a master
+    ///     restart. If its agent process is still alive the job keeps running detached (this process
+    ///     holds no Process handle for it); otherwise it is marked Failed so it doesn't linger as a
+    ///     ghost. Blocked jobs are left alone — the 60s blocked-job timer and ForceStartJob own them.
+    /// </summary>
+    private void ReconcileRestoredJob(JobItem job)
+    {
+        if (job.Status is not (JobStatus.Pending or JobStatus.Queued or JobStatus.Running))
+            return;
+
+        if (IsAgentProcessAlive(job))
+        {
+            job.Detached = true;
+            // Restart the stale-output clock from the reload: the original StartedAt may already be
+            // older than the stale-output timeout, which would make the next timer tick reap a
+            // healthy job before it ever gets a chance to report in.
+            job.LastOutputAt = DateTime.UtcNow;
+            _logger.LogInformation(
+                "Job {JobId}: Restored as detached (agent process {Pid} still alive)", job.Id, job.ProcessId);
+            return;
+        }
+
+        job.Status = JobStatus.Failed;
+        job.StatusMessage = "Interrupted by Tendril master restart";
+        job.CompletedAt = DateTime.UtcNow;
+        PersistJob(job);
+        _logger.LogWarning("Job {JobId}: Marked Failed — interrupted by a Tendril master restart", job.Id);
+    }
+
+    // Grace on the PID-reuse guard: the agent process starts shortly after the job does, so its
+    // StartTime should never be meaningfully later than the job's StartedAt. A much later start
+    // means the OS handed the same PID to an unrelated process.
+    private static readonly TimeSpan PidReuseGrace = TimeSpan.FromMinutes(5);
+
+    private static bool IsAgentProcessAlive(JobItem job)
+    {
+        if (job.ProcessId is not { } pid) return false;
+
+        try
+        {
+            using var process = System.Diagnostics.Process.GetProcessById(pid);
+            if (process.HasExited) return false;
+
+            // Best-effort PID-reuse guard; StartTime is not readable for every process.
+            try
+            {
+                if (job.StartedAt.HasValue
+                    && process.StartTime.ToUniversalTime() > job.StartedAt.Value + PidReuseGrace)
+                    return false;
+            }
+            catch
+            {
+                /* StartTime unavailable — fall back to "alive" */
+            }
+
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false; // No process with that id
+        }
+        catch (InvalidOperationException)
+        {
+            return false; // Process has exited and its handle is gone
         }
     }
 
@@ -678,11 +778,21 @@ public class JobService : IJobService
 
         _jobs[id] = job;
 
+        // Persist while in flight, not just on completion: the agent reports status over HTTP and
+        // must still be resolvable if the master restarts mid-job (#1759).
+        PersistJob(job);
+
         if (TryBlockForDependencies(job, skipDependencyCheck))
+        {
+            PersistJob(job);
             return id;
+        }
 
         if (!skipWaitForCheck && TryBlockForWaitForJobs(job))
+        {
+            PersistJob(job);
             return id;
+        }
 
         if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or ExpandPlanArgs or UpdatePlanArgs or SplitPlanArgs)
             _planReaderService?.FlushPendingWritesAsync().GetAwaiter().GetResult();
@@ -697,6 +807,7 @@ public class JobService : IJobService
             job.Status = JobStatus.Queued;
             job.StatusMessage = $"Waiting (max {_maxConcurrentJobs} concurrent jobs)";
             lock (_queueLock) { _jobQueue.Enqueue(id, -job.Priority); }
+            PersistJob(job);
             RaiseJobsStructureChanged();
             return id;
         }
@@ -1005,6 +1116,10 @@ public class JobService : IJobService
             (when, type, folder, project, j) => RunHooks(when, type, folder, project, j),
             (id, exitCode, timedOut, staleOutput) => CompleteJob(id, exitCode, timedOut, staleOutput),
             RaiseJobsStructureChanged);
+
+        // Capture the launch details (Running, StartedAt, SessionId, ProcessId, WorkingDirectory,
+        // CliCommand) so a master restart can find — and reconcile — this job by its process id.
+        PersistJob(job);
     }
 
     internal void RunHooks(string when, string jobType, string planFolder, string project, JobItem job)

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -674,8 +674,8 @@ public class PlanDatabaseService : IPlanDatabaseService
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
-                              INSERT OR REPLACE INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, SessionId, StartedAt, CompletedAt, DurationSeconds, Cost, Tokens, StatusMessage, Args, TypedArgs, WorkingDirectory, CliCommand, Cleared)
-                              VALUES (@id, @type, @planFile, @project, @status, @provider, @sessionId, @startedAt, @completedAt, @durationSeconds, @cost, @tokens, @statusMessage, @args, @typedArgs, @workingDirectory, @cliCommand, @cleared)
+                              INSERT OR REPLACE INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, SessionId, StartedAt, CompletedAt, DurationSeconds, Cost, Tokens, StatusMessage, Args, TypedArgs, WorkingDirectory, CliCommand, Cleared, ProcessId, ReportedPlanId, ReportedPlanTitle, ReportedFailureReason)
+                              VALUES (@id, @type, @planFile, @project, @status, @provider, @sessionId, @startedAt, @completedAt, @durationSeconds, @cost, @tokens, @statusMessage, @args, @typedArgs, @workingDirectory, @cliCommand, @cleared, @processId, @reportedPlanId, @reportedPlanTitle, @reportedFailureReason)
                               """;
             cmd.Parameters.AddWithValue("@id", job.Id);
             cmd.Parameters.AddWithValue("@type", job.Type);
@@ -699,6 +699,11 @@ public class PlanDatabaseService : IPlanDatabaseService
             cmd.Parameters.AddWithValue("@workingDirectory", (object?)job.WorkingDirectory ?? DBNull.Value);
             cmd.Parameters.AddWithValue("@cliCommand", (object?)job.CliCommand ?? DBNull.Value);
             cmd.Parameters.AddWithValue("@cleared", job.Cleared ? 1 : 0);
+            cmd.Parameters.AddWithValue("@processId", (object?)job.ProcessId ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@reportedPlanId", (object?)job.ReportedPlanId ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@reportedPlanTitle", (object?)job.ReportedPlanTitle ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@reportedFailureReason",
+                (object?)job.ReportedFailureReason ?? DBNull.Value);
             cmd.ExecuteNonQuery();
         }
     }
@@ -707,7 +712,15 @@ public class PlanDatabaseService : IPlanDatabaseService
     {
         using (new ReadLockHandle(_lock))
         {
-            return ReadList("SELECT * FROM Jobs WHERE Cleared = 0 ORDER BY CompletedAt DESC LIMIT @limit",
+            // In-flight rows (NULL CompletedAt) sort first: SQLite puts NULLs last under DESC, so
+            // without the CASE they would be the first rows dropped by LIMIT once enough completed
+            // jobs accumulate — exactly the jobs LoadHistoricalJobs needs in order to restore them.
+            return ReadList(
+                """
+                SELECT * FROM Jobs WHERE Cleared = 0
+                ORDER BY CASE WHEN CompletedAt IS NULL THEN 0 ELSE 1 END, CompletedAt DESC
+                LIMIT @limit
+                """,
                 MapJobRow,
                 new SqliteParameter("@limit", limit));
         }
@@ -774,7 +787,19 @@ public class PlanDatabaseService : IPlanDatabaseService
             CliCommand = reader.IsDBNull(reader.GetOrdinal("CliCommand"))
                 ? null
                 : reader.GetString(reader.GetOrdinal("CliCommand")),
-            Cleared = reader.GetInt32(reader.GetOrdinal("Cleared")) != 0
+            Cleared = reader.GetInt32(reader.GetOrdinal("Cleared")) != 0,
+            ProcessId = reader.IsDBNull(reader.GetOrdinal("ProcessId"))
+                ? null
+                : reader.GetInt32(reader.GetOrdinal("ProcessId")),
+            ReportedPlanId = reader.IsDBNull(reader.GetOrdinal("ReportedPlanId"))
+                ? null
+                : reader.GetString(reader.GetOrdinal("ReportedPlanId")),
+            ReportedPlanTitle = reader.IsDBNull(reader.GetOrdinal("ReportedPlanTitle"))
+                ? null
+                : reader.GetString(reader.GetOrdinal("ReportedPlanTitle")),
+            ReportedFailureReason = reader.IsDBNull(reader.GetOrdinal("ReportedFailureReason"))
+                ? null
+                : reader.GetString(reader.GetOrdinal("ReportedFailureReason"))
         };
     }
 


### PR DESCRIPTION
Fixes #1759

# Summary

`tendril job status <id>` returned HTTP 404 and exit 1 whenever the Tendril master process
restarted mid-job, because `JobService` kept active jobs only in its in-memory `_jobs` dictionary.
The agent's next status report hit a server that had never heard of the job, the non-zero exit
aborted the promptware, and the job was lost. In-flight jobs are now persisted, reports fall back
to the database, and the CLI no longer treats a failed report as fatal.

## Changes

- **Migration 017** adds `ProcessId`, `ReportedPlanId`, `ReportedPlanTitle` and
  `ReportedFailureReason` to the `Jobs` table. It is picked up by `DatabaseMigrator`'s reflection
  scan, so no registration list needed updating.
- **Jobs are persisted while in flight**, not just on completion: at Pending (registration),
  Blocked, Queued, and again in `LaunchJob` once the process is up, so `Running` /`StartedAt` /
  `SessionId` / `ProcessId` / `WorkingDirectory` / `CliCommand` all reach disk.
- **`GetRecentJobs` no longer drops in-flight rows.** SQLite sorts NULLs last under
  `ORDER BY CompletedAt DESC`, so rows with a NULL `CompletedAt` — exactly the running jobs —
  were the first casualties of `LIMIT 100`. Ordering now puts them first.
- **`UpdateJobStatus` and `ReportJobFailure` fall back to the database** through a new
  `ResolveJobForReport` helper, mirroring what `GetJob` already did. A found row is re-registered
  in `_jobs` (via `TryAdd`, so a concurrent report can't create a second instance), mutated,
  persisted, and pushed to the UI. Genuinely unknown ids still return `false` → 404.
- **Startup reconciliation.** `LoadHistoricalJobs` now inspects each restored Pending/Queued/
  Running row: if its `ProcessId` is still alive the job stays Running and is flagged `Detached`;
  otherwise it becomes `Failed` with `"Interrupted by Tendril master restart"` so it stops
  showing as Running forever. `Blocked` rows are left to the existing blocked-job timer.
- **Detached jobs don't get reaped.** A restored job has no `Process` handle and no output stream
  in this process, so `RunStuckJobCheck` would see stale output and kill it. The reconcile resets
  `LastOutputAt`, and each subsequent `UpdateJobStatus` for a handle-less job refreshes it — the
  agent's own status reports act as the heartbeat.
- **The CLI is best-effort.** New `MasterClient.TryPutJson` returns `(bool Ok, string? Error)`
  instead of throwing; `job status` and `job fail` warn on stderr and exit 0. `PutJson` is
  untouched for the commands that must fail loudly.

## API Changes

- `MasterClient.TryPutJson(string relativePath, object payload, CancellationToken)` — new;
  non-throwing sibling of `PutJson`, which is unchanged.
- `JobItem.Detached` — new transient `[JsonIgnore]` bool. Not a database column, not serialised.
- `Jobs` table gains four nullable columns (migration 017). Existing databases upgrade in place;
  older Tendril builds cannot open a v17 database, which is the normal migration contract.
- `tendril job status` / `tendril job fail` now exit 0 when the master is unreachable or returns
  an error, printing a warning to stderr. Scripts that relied on a non-zero exit to detect an
  unreachable master will no longer see one.

## Files Modified

| File | Change |
| --- | --- |
| `src/Ivy.Tendril/Database/Migrations/Migration_017_JobsInFlightFields.cs` | New — four columns, `user_version = 17` |
| `src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs` | Write/read the new columns; in-flight-first `GetRecentJobs` ordering |
| `src/Ivy.Tendril/Services/Jobs/JobService.cs` | `ResolveJobForReport`, in-flight `PersistJob` calls, `ReconcileRestoredJob`, `IsAgentProcessAlive`, detached heartbeat |
| `src/Ivy.Tendril/Models/JobModels.cs` | `JobItem.Detached` |
| `src/Ivy.Tendril/Helpers/MasterClient.cs` | `TryPutJson` |
| `src/Ivy.Tendril/Commands/JobStatusCommand.cs` | Best-effort report, warn + exit 0 |
| `src/Ivy.Tendril/Commands/JobFailCommand.cs` | Best-effort report, warn + exit 0 |
| `src/Ivy.Tendril.Test/JobServiceStartupTests.cs` | 8 new tests (DB fallback, heartbeat, reconcile alive/dead/blocked) |
| `src/Ivy.Tendril.Test/PlanDatabaseServiceTests.cs` | 3 new tests (round-trip, NULLs, LIMIT) |
| `src/Ivy.Tendril.Test/DatabaseMigratorTests.cs` | Migration 017 column + insert/read test |

10 files, +562 / −9, in four commits:

- `cf38b87a` feat: persist in-flight job fields and keep them out of LIMIT's way
- `bfd5cc7d` fix: resolve agent job reports from the database after a master restart
- `7535a287` fix: make tendril job status/fail best-effort instead of fatal
- `8f150167` test: cover in-flight job persistence and restart reconciliation

## Manual Testing

Automated coverage is the primary evidence: 1802 passed / 1 skipped / 0 failed in
`Ivy.Tendril.Test`, 951 passed in `Ivy.Tendril.Agents.Test`, `dotnet format --verify-no-changes`
clean. The reconcile tests exercise a real live PID (`Environment.ProcessId`) and a real dead one
(`int.MaxValue`), and the LIMIT test seeds 1 running + 5 completed rows against real SQLite.

To confirm end to end on a live install:

1. Start the Tendril master and launch any plan job; note its id.
2. Kill the master process (leaving the agent running) and start it again.
3. From the agent's worktree run `tendril job status <id> --message="after restart"` — it should
   print `Status updated for job <id>` and exit 0, and the Jobs view should show the job still
   Running with the new message.
4. Stop the master, kill the agent process too, then start the master: the job should now appear
   as Failed with "Interrupted by Tendril master restart".
5. With the master stopped, run `tendril job status <id> --message="x"` — expect a
   `Warning: could not report status …` line on stderr and exit code 0.

## Notes

`Ivy.Tendril.slnx` references `../../../Ivy-Framework/src/Ivy/Ivy.csproj`, which does not exist on
this machine and cannot resolve from inside a worktree, so `dotnet build` on the solution fails
with MSB3202 before compiling anything. Builds were run per-project instead (the DotnetBuild
verification's documented fallback). Raised as a recommendation.


---
## Commits
- `8f150167` test: cover in-flight job persistence and restart reconciliation (plan 00069)
- `7535a287` fix: make tendril job status/fail best-effort instead of fatal (plan 00069)
- `bfd5cc7d` fix: resolve agent job reports from the database after a master restart (plan 00069)
- `cf38b87a` feat: persist in-flight job fields and keep them out of LIMITs way (plan 00069)

---
Created using [Ivy Tendril](https://ivy.app).
