### PR TITLE
[00057] Fetch More Than 100 Issues in Import Issues Dialog

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/07_Integrations/01_Github.md
+++ b/src/Ivy.Tendril.Docs/Docs/07_Integrations/01_Github.md
@@ -33,6 +33,8 @@ Use the **Import Issues** dialog to fetch GitHub issues and convert them into Te
 
 Each imported issue retains a link back to the original GitHub issue for traceability.
 
+A single fetch returns up to 1000 open issues (GitHub's search ceiling); use the search, label, or assignee filters to narrow larger backlogs.
+
 ## Automatic PR Creation
 
 When a plan reaches the **Completed** state, the **CreatePr** promptware automatically:

--- a/src/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -187,6 +187,55 @@ public class GithubServiceTests
     }
 
     [Fact]
+    public void BuildIssueListArgs_Uses_Default_Limit_When_Not_Specified()
+    {
+        var args = GithubService.BuildIssueListArgs(new IssueSearchRequest("o", "r"));
+
+        Assert.Contains("--limit 1000", args);
+        Assert.Contains("--repo o/r --state open", args);
+        Assert.DoesNotContain("--search", args);
+        Assert.DoesNotContain("--assignee", args);
+        Assert.DoesNotContain("--label", args);
+    }
+
+    [Fact]
+    public void BuildIssueListArgs_Uses_Requested_Limit()
+    {
+        var args = GithubService.BuildIssueListArgs(new IssueSearchRequest("o", "r", Limit: 250));
+
+        Assert.Contains("--limit 250", args);
+    }
+
+    [Fact]
+    public void BuildIssueListArgs_Clamps_Limit_Above_Maximum()
+    {
+        var args = GithubService.BuildIssueListArgs(new IssueSearchRequest("o", "r", Limit: 5000));
+
+        Assert.Contains("--limit 1000", args);
+    }
+
+    [Fact]
+    public void BuildIssueListArgs_Falls_Back_To_Default_For_Nonpositive_Limit()
+    {
+        var zeroArgs = GithubService.BuildIssueListArgs(new IssueSearchRequest("o", "r", Limit: 0));
+        var negativeArgs = GithubService.BuildIssueListArgs(new IssueSearchRequest("o", "r", Limit: -1));
+
+        Assert.Contains("--limit 1000", zeroArgs);
+        Assert.Contains("--limit 1000", negativeArgs);
+    }
+
+    [Fact]
+    public void BuildIssueListArgs_Includes_Query_Assignee_And_Labels()
+    {
+        var args = GithubService.BuildIssueListArgs(new IssueSearchRequest(
+            "o", "r", Query: "bug", Assignee: "octocat", Labels: ["a", "b"]));
+
+        Assert.Contains("--search \"bug\"", args);
+        Assert.Contains("--assignee octocat", args);
+        Assert.Contains("--label \"a,b\"", args);
+    }
+
+    [Fact]
     public async Task GetAssigneesAsync_Returns_Error_When_Command_Fails()
     {
         var configService = new ConfigService(new TendrilSettings());

--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -275,7 +275,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         if (isFetching.Value)
         {
             issuesPanel = Layout.Vertical().Gap(2).AlignContent(Align.Center)
-                .Height(Size.Rem(16)).Width(Size.Full())
+                .Height(Size.Rem(18)).Width(Size.Full())
                 | new Loading()
                 | Text.Muted("Fetching issues from GitHub...");
         }
@@ -284,13 +284,13 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             if (groups.All(g => g.Issues.Count == 0))
             {
                 issuesPanel = Layout.Vertical().AlignContent(Align.Center)
-                    .Height(Size.Rem(10)).Width(Size.Full())
+                    .Height(Size.Rem(12)).Width(Size.Full())
                     | Text.Muted("No issues found matching the filters.");
             }
             else
             {
                 var repo = repos.FirstOrDefault(r => r.DisplayName == selectedRepo.Value);
-                var scrollContent = Layout.Vertical().Gap(4).Width(Size.Full());
+                var groupPanels = Layout.Vertical().Gap(4).Width(Size.Full());
 
                 foreach (var group in groups)
                 {
@@ -310,29 +310,33 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                             () => { if (issueUrl != null) client.OpenUrl(issueUrl); });
                     }).ToArray();
 
-                    scrollContent |= Layout.Vertical().Gap(2).Width(Size.Full())
-                        | Layout.Horizontal().Gap(2).AlignContent(Align.SpaceBetween).Width(Size.Full())
-                            | Text.Label(FormatGroupHeader(group, groupSelectedCount))
-                            | (Layout.Horizontal().Gap(1)
-                                | new Button("All").Ghost().Small()
-                                    .Disabled(groupSelectedCount == groupIssues.Count || groupIssues.Count == 0)
-                                    .OnClick(() => SelectAllInGroup(groupIssues))
-                                | new Button("None").Ghost().Small()
-                                    .Disabled(groupSelectedCount == 0)
-                                    .OnClick(() => SelectNoneInGroup(groupIssues)))
-                        | (groupIssues.Count > 0
-                            ? (Layout.Vertical().Gap(0).Width(Size.Full()) | issueRows)
-                            : Text.Muted("No issues for this assignee."));
+                    var groupHeader = Layout.Horizontal().Gap(2).AlignContent(Align.SpaceBetween).Width(Size.Full())
+                        | Text.Label(FormatGroupHeader(group, groupSelectedCount))
+                        | (Layout.Horizontal().Gap(1)
+                            | new Button("All").Ghost().Small()
+                                .Disabled(groupSelectedCount == groupIssues.Count || groupIssues.Count == 0)
+                                .OnClick(() => SelectAllInGroup(groupIssues))
+                            | new Button("None").Ghost().Small()
+                                .Disabled(groupSelectedCount == 0)
+                                .OnClick(() => SelectNoneInGroup(groupIssues)));
+
+                    var groupContent = groupIssues.Count > 0
+                        ? (object)(Layout.Vertical().Gap(0).Width(Size.Full()) | issueRows)
+                        : Text.Muted("No issues for this assignee.");
+
+                    // HeaderLayout keeps the All/None header pinned above its own ScrollArea,
+                    // so it stays visible while the issue rows beneath it scroll.
+                    groupPanels |= Layout.Vertical().Height(Size.Rem(26)).Width(Size.Full())
+                        | new HeaderLayout(groupHeader, groupContent);
                 }
 
-                issuesPanel = Layout.Vertical().Scroll(Scroll.Auto).Height(Size.Rem(22)).Width(Size.Full())
-                    | scrollContent;
+                issuesPanel = groupPanels;
             }
         }
         else
         {
             issuesPanel = Layout.Vertical().AlignContent(Align.Center)
-                .Height(Size.Rem(10)).Width(Size.Full())
+                .Height(Size.Rem(12)).Width(Size.Full())
                 | Text.Muted("Choose a repository, set filters, and click Fetch Issues.");
         }
 

--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -25,6 +25,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
         var fetchedIssueGroups = UseState<IReadOnlyList<FetchedIssueGroup>?>(null);
         var selectedIssueNumbers = UseState<HashSet<int>>([]);
         var errorMessage = UseState<string?>(null);
+        var resultsTruncated = UseState(false);
         var isFetching = UseState(false);
         var isImporting = UseState(false);
         var assigneesError = UseState<string?>(null);
@@ -81,6 +82,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
             fetchedIssueGroups.Set(null);
             selectedIssueNumbers.Set([]);
             errorMessage.Set(null);
+            resultsTruncated.Set(false);
             selectedAssignees.Set(Array.Empty<string>());
             selectedLabels.Set(Array.Empty<string>());
             assigneesError.Set(null);
@@ -150,6 +152,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
 
             isFetching.Set(true);
             errorMessage.Set(null);
+            resultsTruncated.Set(false);
             fetchedIssueGroups.Set(null);
             selectedIssueNumbers.Set([]);
             try
@@ -190,6 +193,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                 }
 
                 fetchedIssueGroups.Set(groups);
+                resultsTruncated.Set(groups.Any(g => g.Issues.Count >= GithubService.MaxIssueLimit));
                 var allIssueNumbers = groups
                     .SelectMany(g => g.Issues)
                     .Select(i => i.Number)
@@ -362,6 +366,9 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                     .OnClick(async () => await FetchIssues())
                 | (errorMessage.Value is { } error
                     ? Text.Danger(error).Small()
+                    : null)
+                | (resultsTruncated.Value
+                    ? Text.Muted($"Showing the first {GithubService.MaxIssueLimit} issues. Narrow the search, labels, or assignees to see the rest.").Small()
                     : null)
                 | issuesPanel
             ),

--- a/src/Ivy.Tendril/Services/Git/GithubService.cs
+++ b/src/Ivy.Tendril/Services/Git/GithubService.cs
@@ -10,6 +10,9 @@ namespace Ivy.Tendril.Services.Git;
 
 public class GithubService(IConfigService config, ILogger<GithubService> logger) : IGithubService
 {
+    public const int DefaultIssueLimit = 1000;
+    public const int MaxIssueLimit = 1000;
+
     // ConcurrentDictionary required: multiple UseQuery calls from different views/dialogs
     // can fetch different repos simultaneously, causing concurrent writes to different keys.
     private readonly ConcurrentDictionary<string, List<string>> _assigneeCache = new();
@@ -61,14 +64,7 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
     {
         try
         {
-            var args =
-                $"issue list --repo {request.Owner}/{request.Repo} --state open --limit 100 --json number,title,body,labels,assignees";
-            if (!string.IsNullOrWhiteSpace(request.Query))
-                args += $" --search \"{request.Query}\"";
-            if (!string.IsNullOrWhiteSpace(request.Assignee))
-                args += $" --assignee {request.Assignee}";
-            if (request.Labels is { Length: > 0 })
-                args += $" --label \"{string.Join(",", request.Labels)}\"";
+            var args = BuildIssueListArgs(request);
 
             var psi = new ProcessStartInfo("gh", args)
             {
@@ -110,6 +106,20 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
             _logger.LogWarning(ex, "Failed to search issues for {Owner}/{Repo}", request.Owner, request.Repo);
             return ([], $"Failed to fetch issues: {ex.Message}");
         }
+    }
+
+    internal static string BuildIssueListArgs(IssueSearchRequest request)
+    {
+        var limit = request.Limit <= 0 ? DefaultIssueLimit : Math.Min(request.Limit, MaxIssueLimit);
+        var args =
+            $"issue list --repo {request.Owner}/{request.Repo} --state open --limit {limit} --json number,title,body,labels,assignees";
+        if (!string.IsNullOrWhiteSpace(request.Query))
+            args += $" --search \"{request.Query}\"";
+        if (!string.IsNullOrWhiteSpace(request.Assignee))
+            args += $" --assignee {request.Assignee}";
+        if (request.Labels is { Length: > 0 })
+            args += $" --label \"{string.Join(",", request.Labels)}\"";
+        return args;
     }
 
     internal static List<GitHubIssue> ParseIssuesFromJson(string json)
@@ -342,8 +352,9 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
     private async Task<(List<string> labels, string? error)> FetchLabelsFromGhCliAsync(string owner, string repo)
     {
         var (labels, error) = await ExecuteGhCliAsync(
-            $"api repos/{owner}/{repo}/labels --jq \".[].name\"",
+            $"api repos/{owner}/{repo}/labels --paginate --jq \".[].name\"",
             output => output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                            .Distinct()
                             .OrderBy(x => x)
                             .ToList(),
             new List<string>());
@@ -370,8 +381,9 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
     private async Task<(List<string> assignees, string? error)> FetchAssigneesFromGhCliAsync(string owner, string repo)
     {
         var (assignees, error) = await ExecuteGhCliAsync(
-            $"api repos/{owner}/{repo}/assignees --jq \".[].login\"",
+            $"api repos/{owner}/{repo}/assignees --paginate --jq \".[].login\"",
             output => output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                            .Distinct()
                             .OrderBy(x => x)
                             .ToList(),
             new List<string>());
@@ -388,4 +400,5 @@ public record IssueSearchRequest(
     string Repo,
     string? Query = null,
     string? Assignee = null,
-    string[]? Labels = null);
+    string[]? Labels = null,
+    int Limit = GithubService.DefaultIssueLimit);


### PR DESCRIPTION
Fixes #1751

# Summary

## Changes

Raised the Import Issues dialog's hard-coded 100-issue cap to 1000 (GitHub's search API ceiling) by making the limit a configurable, clamped parameter on `GithubService.SearchIssuesAsync`. Also paginated the labels/assignees filter dropdowns (previously capped at GitHub's default 30-per-page), and added a visible hint in the dialog when a fetch hits the cap so truncation is no longer silent.

## API Changes

- `GithubService.DefaultIssueLimit` and `GithubService.MaxIssueLimit` (`public const int`, both `1000`) added.
- `IssueSearchRequest` record gained a new optional parameter: `int Limit = GithubService.DefaultIssueLimit`.
- `GithubService.BuildIssueListArgs(IssueSearchRequest request)` (`internal static`) added, extracted from the inline argument-building logic in `SearchIssuesAsync`.
- `FetchLabelsFromGhCliAsync` and `FetchAssigneesFromGhCliAsync` now pass `--paginate` to `gh api` and de-duplicate results with `.Distinct()`.

## Files Modified

- `src/Ivy.Tendril/Services/Git/GithubService.cs` - limit constants, `IssueSearchRequest.Limit`, `BuildIssueListArgs` extraction, `--paginate` + `.Distinct()` on labels/assignees fetches.
- `src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs` - `resultsTruncated` state, reset logic, and a muted hint shown when a fetch returns at the cap.
- `src/Ivy.Tendril.Test/GithubServiceTests.cs` - 5 new tests covering `BuildIssueListArgs`'s default/custom/clamped/nonpositive limits and its query/assignee/label appenders.
- `src/Ivy.Tendril.Docs/Docs/07_Integrations/01_Github.md` - one sentence documenting the 1000-issue ceiling under "Importing Issues".

## Manual Testing

1. Open the **Drafts** app and select **Import Issues** from the menu.
2. Choose a repository with more than 100 open issues (no search/label/assignee filters) and click **Fetch Issues**.
3. Observe that more than 100 issues are now returned (up to 1000), and a muted hint reading "Showing the first 1000 issues. Narrow the search, labels, or assignees to see the rest." appears above the issue list when the cap is hit.
4. Change the selected repository or re-fetch with a narrower filter (e.g. add a label) and confirm the hint disappears once the result set is under the cap.
5. Open a repository with more than 30 labels or assignees and confirm the Labels/Assignees dropdowns list all of them, not just the first 30.

## Fix: Sticky group All/None header and taller default dialog height

A reviewer follow-up on the fetch-limit fix above (now surfacing up to 1000 issues per group) noted that the All/None selection header for each assignee group scrolled out of view once a group's issue list grew long, and asked for the dialog to be slightly taller by default. Each issue group's header row is now wrapped in Ivy's `HeaderLayout` widget so the "Found N issues · All/None" row stays pinned above its own scroll area instead of scrolling away with the issue rows, and the panel/placeholder heights were bumped (22→26rem for the group content, 16→18rem for the fetching spinner, 10→12rem for the empty/initial states) so the dialog renders taller by default within its existing 85vh cap.

### Files Modified

- `src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs` - wrapped each group's header/issue-list in a `HeaderLayout` for a sticky All/None header, increased placeholder and panel heights.

**Note:** Update the manual testing section if this fix affects user-facing behavior.


---
## Commits

- e475f2e0 Make group All/None header sticky and grow default dialog height
- ad18a2d0 Document the 1000-issue import ceiling
- 3744cab6 Add tests for BuildIssueListArgs
- a3647004 Raise Import Issues limit from 100 to 1000 and surface truncation


---
Created using [Ivy Tendril](https://ivy.app).