### PR TITLE
[00076] Reject Invalid Project Names Instead of Crashing Agentic Setup

### DIFF
--- a/src/Ivy.Tendril.Test/Commands/ProjectCommandValidationTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/ProjectCommandValidationTests.cs
@@ -1,0 +1,52 @@
+using Ivy.Tendril.Commands;
+
+namespace Ivy.Tendril.Test.Commands;
+
+public class ProjectCommandValidationTests
+{
+    [Fact]
+    public void ProjectAddSettings_Validate_SlashedName_Fails()
+    {
+        var settings = new ProjectAddSettings { Name = "foo/bar" };
+
+        var result = settings.Validate();
+
+        Assert.False(result.Successful);
+        Assert.Contains("letters, digits, dots, dashes and underscores", result.Message);
+    }
+
+    [Fact]
+    public void ProjectAddSettings_Validate_ValidName_Succeeds()
+    {
+        var settings = new ProjectAddSettings { Name = "Ivy-Tendril" };
+
+        var result = settings.Validate();
+
+        Assert.True(result.Successful);
+    }
+
+    [Fact]
+    public void ProjectSetSettings_Validate_NameFieldWithSlash_Fails()
+    {
+        var settings = new ProjectSetSettings { Name = "p", Field = "name", Value = "foo/bar" };
+
+        var result = settings.Validate();
+
+        Assert.False(result.Successful);
+    }
+
+    [Fact]
+    public void ProjectSetSettings_Validate_StackHashFieldWithSlashes_Succeeds()
+    {
+        var settings = new ProjectSetSettings
+        {
+            Name = "p",
+            Field = "stackHash",
+            Value = "fe.ts:react+next/be.py:fastapi/db:postgres"
+        };
+
+        var result = settings.Validate();
+
+        Assert.True(result.Successful);
+    }
+}

--- a/src/Ivy.Tendril.Test/Helpers/InputSanitizerTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/InputSanitizerTests.cs
@@ -40,4 +40,36 @@ public class InputSanitizerTests
     {
         Assert.Equal(expected, InputSanitizer.IsValidEmail(input));
     }
+
+    [Theory]
+    [InlineData("foo/bar", false)]
+    [InlineData("foo\\bar", false)]
+    [InlineData("my project", false)]
+    [InlineData(".", false)]
+    [InlineData("..", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    [InlineData("MyProject", true)]
+    [InlineData("my-project_v2.0", true)]
+    [InlineData("Ivy-Tendril", true)]
+    public void IsValidProjectName_ReturnsExpected(string? input, bool expected)
+    {
+        Assert.Equal(expected, InputSanitizer.IsValidProjectName(input));
+    }
+
+    [Fact]
+    public void DescribeProjectNameError_InvalidName_ReturnsMessageWithNameAndSuggestion()
+    {
+        var error = InputSanitizer.DescribeProjectNameError("foo/bar");
+
+        Assert.NotNull(error);
+        Assert.Contains("foo/bar", error);
+        Assert.Contains("foobar", error);
+    }
+
+    [Fact]
+    public void DescribeProjectNameError_ValidName_ReturnsNull()
+    {
+        Assert.Null(InputSanitizer.DescribeProjectNameError("Ivy-Tendril"));
+    }
 }

--- a/src/Ivy.Tendril.Test/ProjectNameValidationTests.cs
+++ b/src/Ivy.Tendril.Test/ProjectNameValidationTests.cs
@@ -1,0 +1,88 @@
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Test;
+
+public class ProjectNameValidationTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public ProjectNameValidationTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"project-name-validation-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, true);
+    }
+
+    [Fact]
+    public void ValidateProjectNames_Logs_Error_For_Slashed_Name()
+    {
+        var yaml = @"
+projects:
+  - name: foo/bar
+    repos: []
+";
+
+        var configDir = Path.Combine(_tempDir, "config");
+        Directory.CreateDirectory(configDir);
+        File.WriteAllText(Path.Combine(configDir, "config.yaml"), yaml);
+
+        var testLogger = new TestLogger<ConfigService>();
+        // Use the in-memory-settings ctor (not the public one) so construction doesn't read/write
+        // the shared default TENDRIL_HOME — that's a parallel-test race. SetTendrilHome below loads
+        // the real config from the isolated temp dir.
+        var service = new ConfigService(new TendrilSettings(), logger: testLogger);
+        service.SetTendrilHome(configDir);
+
+        service.ValidateProjectNames();
+
+        var output = testLogger.GetOutput();
+        Assert.Contains("CRITICAL", output);
+        Assert.Contains("foo/bar", output);
+    }
+
+    [Fact]
+    public void ValidateProjectNames_NoError_For_Valid_Name()
+    {
+        var yaml = @"
+projects:
+  - name: Ivy-Tendril
+    repos: []
+";
+
+        var configDir = Path.Combine(_tempDir, "config");
+        Directory.CreateDirectory(configDir);
+        File.WriteAllText(Path.Combine(configDir, "config.yaml"), yaml);
+
+        var testLogger = new TestLogger<ConfigService>();
+        var service = new ConfigService(new TendrilSettings(), logger: testLogger);
+        service.SetTendrilHome(configDir);
+
+        service.ValidateProjectNames();
+
+        var output = testLogger.GetOutput();
+        Assert.DoesNotContain("CRITICAL", output);
+    }
+
+    private class TestLogger<T> : ILogger<T>
+    {
+        private readonly List<string> _messages = [];
+
+        public string GetOutput() => string.Join(Environment.NewLine, _messages);
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            _messages.Add(formatter(state, exception));
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+    }
+}

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -54,7 +54,19 @@ public class ProjectAgentStepView(
 
             try
             {
-                var name = InputSanitizer.SanitizeProjectName(projectName.Value);
+                var nameError = InputSanitizer.DescribeProjectNameError(projectName.Value);
+                if (nameError != null)
+                {
+                    await progressCts.CancelAsync();
+                    progressValue.Set(null);
+                    progressMessage.Set(null);
+                    error.Set(nameError);
+                    isCloning.Set(false);
+                    isStepLoading.Set(false);
+                    return;
+                }
+
+                var name = projectName.Value;
                 var existingProject = config.Settings.Projects
                     .FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
 

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs
@@ -139,12 +139,14 @@ public class EditProjectDialog(
 
         var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
         var hasInvalidRepos = RepoPathValidator.HasInvalidLocalRepos(editRepos.Value, tendrilHome);
+        var nameError = InputSanitizer.DescribeProjectNameError(editName.Value);
 
         var saveButton = new Button(isNew ? "Add" : "Save").Primary()
-            .Disabled(hasInvalidRepos)
+            .Disabled(hasInvalidRepos || nameError != null)
             .OnClick(async () =>
             {
                 if (string.IsNullOrWhiteSpace(editName.Value)) return;
+                if (nameError != null) return;
 
                 // Perform base branch validation
                 foreach (var repo in editRepos.Value)
@@ -210,7 +212,7 @@ public class EditProjectDialog(
                     new Tab("Basic",
                         Layout.Vertical().Gap(4)
                         | Text.Block("Configure the project's name, color, and AI context.").Muted()
-                        | editName.ToTextInput("Project name...").WithField().Label("Name")
+                        | editName.ToTextInput("Project name...").Invalid(nameError).WithField().Label("Name")
                         | editColor.ToColorInput().Variant(ColorInputVariant.SwatchPicker).Nullable().WithField().Label("Color")
                         | editContext.ToTextareaInput("Project context or prompt for AI agents (optional)...").Rows(4)
                             .WithField().Label("Context / Prompt (Optional)")

--- a/src/Ivy.Tendril/Commands/ProjectCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectCommand.cs
@@ -26,7 +26,10 @@ public class ProjectAddSettings : CommandSettings
 
     public override Spectre.Console.ValidationResult Validate()
     {
-        return CliValidation.RequireNonEmpty(Name, "name");
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(Name, "name"),
+            CliValidation.ValidateProjectName(Name)
+        );
     }
 }
 
@@ -74,7 +77,10 @@ public class ProjectSetSettings : CommandSettings
     {
         return CliValidation.Combine(
             CliValidation.RequireNonEmpty(Name, "name"),
-            CliValidation.ValidateField(Field, ValidFields)
+            CliValidation.ValidateField(Field, ValidFields),
+            string.Equals(Field, "name", StringComparison.OrdinalIgnoreCase)
+                ? CliValidation.ValidateProjectName(Value)
+                : Spectre.Console.ValidationResult.Success()
         );
     }
 }
@@ -425,6 +431,9 @@ public class ProjectSetCommand : Command<ProjectSetSettings>
         switch (settings.Field.ToLower())
         {
             case "name":
+                var nameError = InputSanitizer.DescribeProjectNameError(settings.Value);
+                if (nameError != null)
+                    throw new InvalidOperationException(nameError);
                 match.Name = settings.Value;
                 break;
             case "color":

--- a/src/Ivy.Tendril/Helpers/CliValidation.cs
+++ b/src/Ivy.Tendril/Helpers/CliValidation.cs
@@ -58,6 +58,12 @@ public static class CliValidation
         return SpectreValidation.Success();
     }
 
+    public static SpectreValidation ValidateProjectName(string? name)
+    {
+        var error = InputSanitizer.DescribeProjectNameError(name);
+        return error is null ? SpectreValidation.Success() : SpectreValidation.Error(error);
+    }
+
     public static SpectreValidation ValidateField(string? value, string[] validFields)
     {
         if (string.IsNullOrWhiteSpace(value))

--- a/src/Ivy.Tendril/Helpers/InputSanitizer.cs
+++ b/src/Ivy.Tendril/Helpers/InputSanitizer.cs
@@ -13,6 +13,26 @@ public static class InputSanitizer
         return Regex.Replace(input, @"[^A-Za-z0-9._-]", "");
     }
 
+    private static readonly Regex ProjectNamePattern =
+        new(@"^[A-Za-z0-9._-]+$", RegexOptions.Compiled);
+
+    public static bool IsValidProjectName(string? name)
+    {
+        var trimmed = name?.Trim();
+        if (string.IsNullOrEmpty(trimmed)) return false;
+        if (trimmed is "." or "..") return false;
+        return ProjectNamePattern.IsMatch(trimmed);
+    }
+
+    public static string? DescribeProjectNameError(string? name)
+    {
+        if (IsValidProjectName(name)) return null;
+
+        var suggestion = SanitizeProjectName(name ?? "");
+        var suggestionClause = string.IsNullOrEmpty(suggestion) ? "" : $" Suggested: '{suggestion}'.";
+        return $"Invalid project name '{name}'. Use only letters, digits, dots, dashes and underscores (no slashes or spaces).{suggestionClause}";
+    }
+
     public static bool IsValidEmail(string emailAddress) =>
         !string.IsNullOrWhiteSpace(emailAddress) && EmailPattern.IsMatch(emailAddress);
 }

--- a/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
@@ -23,6 +23,9 @@ Project and verification configuration is available via `tendril project list` a
 
 ## Available CLI Commands
 
+**Note:** Always pass `<project-name>` quoted (e.g. `"$ProjectName"`). A legacy project name
+containing unusual characters (spaces, shell metacharacters) can otherwise mangle the command line.
+
 ### Stack analysis
 ```bash
 tendril project-analyzer <repo-path>   # prints a trimmed YAML stack report (supports . and relative paths)

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -339,6 +339,7 @@ public class ConfigService : IConfigService, IDisposable
         ExpandSettingsVariables();
         ExpandRepoPaths();
         ValidateRepoPathsAreNotWorktrees();
+        ValidateProjectNames();
         CreateRequiredDirectories();
         SyncAuthFromEnvironmentAndPersistIfNeeded();
     }
@@ -662,6 +663,22 @@ public class ConfigService : IConfigService, IDisposable
                     "This will cause nested worktrees during plan execution. " +
                     "Update config.yaml to point to the main repo, not a worktree.",
                     item.Name, item.Repo.Path);
+            }
+        }
+    }
+
+    internal void ValidateProjectNames()
+    {
+        if (Settings?.Projects == null) return;
+
+        foreach (var project in Settings.Projects)
+        {
+            if (!InputSanitizer.IsValidProjectName(project.Name))
+            {
+                _logger.LogError(
+                    "CRITICAL: Project name '{ProjectName}' contains characters that are not allowed " +
+                    "(letters, digits, dots, dashes and underscores only). Rename it in config.yaml before " +
+                    "running plans or project setup.", project.Name);
             }
         }
     }


### PR DESCRIPTION
Fixes #1740

# Summary

Fixes GitHub Issue #1740: project names containing `/` (e.g. a mistyped repo slug like
`org/repo`) crashed the Spectre CLI during agentic setup instead of producing a clear,
actionable error. Validation is now centralized and enforced at every place a project name can
be entered or loaded.

## Changes

- Added `InputSanitizer.IsValidProjectName(string?)` and
  `InputSanitizer.DescribeProjectNameError(string?)`: names may only contain letters, digits,
  dots, dashes and underscores, must not be empty/`.`/`..`, and an invalid name yields a
  human-readable error message that includes a sanitized suggestion.
- Added `CliValidation.ValidateProjectName(string?)`, wrapping the above as a
  `Spectre.Console.ValidationResult` for use in Spectre CLI `Validate()` overrides.
- `ProjectCommand`:
  - `project add`: `ProjectAddSettings.Validate()` now rejects invalid names before the command
    executes.
  - `project set name <value>`: `ProjectSetSettings.Validate()` rejects invalid names, and
    `ProjectSetCommand.Execute` double-checks and throws `InvalidOperationException` with the
    same message as defense-in-depth.
- `EditProjectDialog` (Settings UI): shows an inline `.Invalid(...)` field error under the Name
  input and disables the Save button while the name is invalid.
- `ProjectAgentStepView` (onboarding wizard): validates the entered project name before starting
  the agentic clone/setup flow; on failure, cancels in-flight progress and surfaces the error
  message instead of crashing.
- `ConfigService.FinalizeConfiguration()`: added `ValidateProjectNames()`, which logs a
  `CRITICAL` error for any project already in `config.yaml` with an invalid name (defense in
  depth for configs written before this fix, or edited by hand).
- `SetupProject/Program.md`: added a note to always quote `"$ProjectName"` on the command line,
  since a legacy/invalid name could otherwise mangle command invocation.

## API Changes

- New public API: `InputSanitizer.IsValidProjectName(string?)`,
  `InputSanitizer.DescribeProjectNameError(string?)`, `CliValidation.ValidateProjectName(string?)`.
- New internal API: `ConfigService.ValidateProjectNames()`.
- No breaking changes; all existing valid project names continue to work unchanged.

## Files Modified

- `src/Ivy.Tendril/Helpers/InputSanitizer.cs`
- `src/Ivy.Tendril/Helpers/CliValidation.cs`
- `src/Ivy.Tendril/Commands/ProjectCommand.cs`
- `src/Ivy.Tendril/Apps/Settings/Dialogs/EditProjectDialog.cs`
- `src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs`
- `src/Ivy.Tendril/Services/ConfigService.cs`
- `src/Ivy.Tendril/Promptwares/SetupProject/Program.md`
- `src/Ivy.Tendril.Test/Helpers/InputSanitizerTests.cs`
- `src/Ivy.Tendril.Test/Commands/ProjectCommandValidationTests.cs` (new)
- `src/Ivy.Tendril.Test/ProjectNameValidationTests.cs` (new)

## Manual Testing

Automated testing only (no interactive UI session was run in this autonomous execution):

- `dotnet test` on the scoped test filter (`InputSanitizerTests`, `ProjectCommandValidationTests`,
  `ProjectNameValidationTests`, `WorktreeValidationTests`): 44/44 passed.
- Full `Ivy.Tendril.Test` suite: 1819 passed, 1 pre-existing unrelated skip, 0 failed.
- `dotnet build` on both `Ivy.Tendril.csproj` and `Ivy.Tendril.Test.csproj`: 0 errors, no new
  warnings.
- `dotnet format --verify-no-changes` on all changed files: no formatting issues.

---
## Commits

- 09cc1514 Add project name validation helpers
- f078e9ac Validate project name in CLI add/set commands
- da1ee11f Reject invalid project names in Settings dialog and onboarding
- 67eda12c Log invalid project names on config load, quote SetupProject args
- 1661194a Add tests for project name validation

---
Created using [Ivy Tendril](https://ivy.app).
