### PR TITLE
[00071] Pause Job Queue and Auto Retry on Provider Rate Limits

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Abstractions/RateLimitClassifierTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Abstractions/RateLimitClassifierTests.cs
@@ -1,0 +1,78 @@
+using Ivy.Tendril.Agents.Abstractions;
+
+namespace Ivy.Tendril.Agents.Test.Abstractions;
+
+public class RateLimitClassifierTests
+{
+    [Fact]
+    public void Classify_BedrockDailyTokenLimit_ReturnsDailyQuota()
+    {
+        // The exact message from issue #1756. It also contains "429", so the daily-quota
+        // patterns have to win: the cooldown for a per-day quota is much longer.
+        const string message =
+            "API Error: Request rejected (429) - Too many tokens per day, please wait before trying again.";
+
+        Assert.Equal(RateLimitScope.DailyQuota, RateLimitClassifier.Classify(message));
+    }
+
+    [Theory]
+    [InlineData("daily token limit exceeded")]
+    [InlineData("Your per-day token quota has been exceeded")]
+    [InlineData("quota exceeded for this account")]
+    public void Classify_DailyQuotaWording_ReturnsDailyQuota(string message)
+    {
+        Assert.Equal(RateLimitScope.DailyQuota, RateLimitClassifier.Classify(message));
+    }
+
+    [Theory]
+    [InlineData("rate limit exceeded")]
+    [InlineData("Error 429: too many requests")]
+    [InlineData("""{"type":"error","error":{"type":"overloaded_error"}}""")]
+    [InlineData("You have hit your session limit, resets 4pm (Europe/Stockholm)")]
+    [InlineData("Claude usage limit reached")]
+    public void Classify_ShortTermWording_ReturnsShortTerm(string message)
+    {
+        Assert.Equal(RateLimitScope.ShortTerm, RateLimitClassifier.Classify(message));
+    }
+
+    [Theory]
+    [InlineData("fatal: could not read from remote repository")]
+    [InlineData("Build failed with 2 errors")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Classify_UnrelatedFailures_ReturnsNone(string? message)
+    {
+        Assert.Equal(RateLimitScope.None, RateLimitClassifier.Classify(message));
+    }
+
+    [Fact]
+    public void Classify_Lines_ReturnsStrongestScope()
+    {
+        string[] lines =
+        [
+            "Starting run",
+            "rate limit exceeded, retrying",
+            "API Error: Request rejected (429) - Too many tokens per day, please wait before trying again."
+        ];
+
+        Assert.Equal(RateLimitScope.DailyQuota, RateLimitClassifier.Classify(lines));
+    }
+
+    [Fact]
+    public void Classify_Lines_WhenOnlyShortTermMatches_ReturnsShortTerm()
+    {
+        string[] lines = ["Starting run", "Error 429: too many requests", "Build failed with 2 errors"];
+
+        Assert.Equal(RateLimitScope.ShortTerm, RateLimitClassifier.Classify(lines));
+    }
+
+    [Fact]
+    public void Classify_Lines_WhenNothingMatches_ReturnsNone()
+    {
+        string[] lines = ["Starting run", "fatal: could not read from remote repository"];
+
+        Assert.Equal(RateLimitScope.None, RateLimitClassifier.Classify(lines));
+        Assert.Equal(RateLimitScope.None, RateLimitClassifier.Classify([]));
+    }
+}

--- a/src/Ivy.Tendril.Agents/Abstractions/RateLimitClassifier.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/RateLimitClassifier.cs
@@ -1,0 +1,80 @@
+using System.Text.RegularExpressions;
+
+namespace Ivy.Tendril.Agents.Abstractions;
+
+/// <summary>
+/// How long a provider-side rate limit is expected to last. A per-minute burst limit clears in
+/// minutes; an exhausted daily token quota does not, so the two need very different wait times.
+/// </summary>
+public enum RateLimitScope
+{
+    /// <summary>The text does not look like a rate limit at all.</summary>
+    None,
+
+    /// <summary>A burst/session limit: HTTP 429, "rate limit", "overloaded", "usage limit".</summary>
+    ShortTerm,
+
+    /// <summary>A per-day token or request quota has been exhausted.</summary>
+    DailyQuota
+}
+
+/// <summary>
+/// Recognizes provider rate-limit and quota-exhaustion wording in agent output. Shared by the
+/// per-provider <see cref="IFailureAnalyzer" /> implementations and by the job scheduler, so the
+/// scheduler's cooldown decision uses exactly the same classification the user sees reported.
+/// </summary>
+public static class RateLimitClassifier
+{
+    // Checked before the short-term patterns: the Bedrock daily-quota message
+    // ("Request rejected (429) - Too many tokens per day") contains both.
+    private static readonly Regex[] DailyQuotaPatterns =
+    [
+        new(@"tokens?\s+per\s+day", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"per[-\s]?day\s+(token\s+)?(limit|quota)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"daily\s+(token\s+|request\s+)?(limit|quota)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"quota\s+(has\s+been\s+)?exceed(ed)?", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    private static readonly Regex[] ShortTermPatterns =
+    [
+        new(@"\b429\b", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"rate[_\s-]?limit", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"too\s+many\s+requests", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"overloaded_error", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"(session|usage)\s+limit", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+        new(@"limit\s+reached", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+    ];
+
+    /// <summary>
+    /// Classifies a single block of text. Returns <see cref="RateLimitScope.None" /> for null,
+    /// empty, or unrelated text.
+    /// </summary>
+    public static RateLimitScope Classify(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return RateLimitScope.None;
+
+        if (DailyQuotaPatterns.Any(p => p.IsMatch(text)))
+            return RateLimitScope.DailyQuota;
+
+        if (ShortTermPatterns.Any(p => p.IsMatch(text)))
+            return RateLimitScope.ShortTerm;
+
+        return RateLimitScope.None;
+    }
+
+    /// <summary>
+    /// Classifies several lines at once. The strongest scope found wins, so a daily-quota line
+    /// anywhere in the output is not masked by an unrelated 429 on another line.
+    /// </summary>
+    public static RateLimitScope Classify(IEnumerable<string> lines)
+    {
+        var strongest = RateLimitScope.None;
+        foreach (var line in lines)
+        {
+            var scope = Classify(line);
+            if (scope == RateLimitScope.DailyQuota) return RateLimitScope.DailyQuota;
+            if (scope > strongest) strongest = scope;
+        }
+        return strongest;
+    }
+}

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeFailureAnalyzer.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeFailureAnalyzer.cs
@@ -22,16 +22,21 @@ public sealed class ClaudeFailureAnalyzer : IFailureAnalyzer
         var stderr = string.Join("\n", context.StderrLines);
         var lastResultResponse = context.Events.OfType<ResultEvent>().LastOrDefault()?.Response ?? "";
 
-        if (ContainsAny(stderr, "rate limit", "429", "too many requests", "session limit", "usage limit")
-            || ContainsAny(lastResultResponse, "rate limit", "session limit", "usage limit"))
+        // Shared with the job scheduler (which parks and auto-retries rate-limited jobs), so the
+        // cooldown it applies always matches the reason reported here.
+        var rateLimitScope = RateLimitClassifier.Classify([stderr, lastResultResponse]);
+        if (rateLimitScope != RateLimitScope.None)
         {
+            var isDailyQuota = rateLimitScope == RateLimitScope.DailyQuota;
             return new FailureAnalysis
             {
                 Kind = FailureKind.RateLimit,
-                Reason = "Rate limited by the API",
+                Reason = isDailyQuota ? "Daily token quota exhausted" : "Rate limited by the API",
                 ContextLines = context.StderrLines,
                 IsRetryable = true,
-                Suggestion = "Wait before retrying or switch to a different model",
+                Suggestion = isDailyQuota
+                    ? "Waiting for the quota window to reset before retrying"
+                    : "Wait before retrying or switch to a different model",
             };
         }
 

--- a/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
+++ b/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
@@ -460,6 +460,57 @@ public class DatabaseMigratorTests : IDisposable
         Assert.DoesNotContain("Risk", columns);
     }
 
+    [Fact]
+    public void Migration_017_JobsRateLimit_AddsColumnsAndRoundTripsValues()
+    {
+        new Migration_001_InitialSchema().Apply(_connection);
+        new Migration_002_Fts5Search().Apply(_connection);
+        new Migration_003_JobsTable().Apply(_connection);
+        new Migration_004_SourceUrl().Apply(_connection);
+        new Migration_005_CostsLogTimestampIndex().Apply(_connection);
+        new Migration_006_CostsCompositeIndex().Apply(_connection);
+        new Migration_007_FtsSourceUrl().Apply(_connection);
+        new Migration_008_PrStatusTable().Apply(_connection);
+        new Migration_009_JobsArgs().Apply(_connection);
+        new Migration_010_RecommendationImpactRisk().Apply(_connection);
+        new Migration_011_JobsTypedArgs().Apply(_connection);
+        new Migration_012_JobsPlanFileIndex().Apply(_connection);
+        new Migration_013_JobsWorkingDirAndCliCommand().Apply(_connection);
+        new Migration_014_JobsCleared().Apply(_connection);
+        new Migration_015_RenamePlanStates().Apply(_connection);
+        new Migration_016_DropRecommendationRisk().Apply(_connection);
+        new Migration_017_JobsRateLimit().Apply(_connection);
+
+        Assert.Equal(17, GetUserVersion());
+
+        var columns = new List<string>();
+        using var pragmaCmd = _connection.CreateCommand();
+        pragmaCmd.CommandText = "PRAGMA table_info(Jobs);";
+        using (var reader = pragmaCmd.ExecuteReader())
+        {
+            while (reader.Read())
+                columns.Add(reader.GetString(reader.GetOrdinal("name")));
+        }
+
+        Assert.Contains("RateLimitedUntil", columns);
+        Assert.Contains("RateLimitRetries", columns);
+
+        // The cooldown has to survive a restart, so both columns must persist as written.
+        using var insertCmd = _connection.CreateCommand();
+        insertCmd.CommandText = """
+                                INSERT INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, RateLimitedUntil, RateLimitRetries)
+                                VALUES ('job-rl', 'ExecutePlan', 'Plan', 'Proj', 'Blocked', 'claude', '2026-01-01T12:00:00.0000000Z', 2)
+                                """;
+        insertCmd.ExecuteNonQuery();
+
+        using var selectCmd = _connection.CreateCommand();
+        selectCmd.CommandText = "SELECT RateLimitedUntil, RateLimitRetries FROM Jobs WHERE Id = 'job-rl';";
+        using var row = selectCmd.ExecuteReader();
+        Assert.True(row.Read());
+        Assert.Equal("2026-01-01T12:00:00.0000000Z", row.GetString(0));
+        Assert.Equal(2, row.GetInt32(1));
+    }
+
     private class FakeMigration : IMigration
     {
         private readonly List<int>? _tracker;

--- a/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
@@ -197,7 +197,10 @@ public class JobServiceFailureReasonTests : IDisposable
         // Regression: a pre-set StatusMessage that happens to contain the phrase "exit code"
         // must not be mistaken for the generic fallback and replaced by the agent-level analyzer,
         // even when the analyzer would otherwise recognize the stderr content (e.g. rate limit).
-        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), agentRunner: TestAgentRunner.Create());
+        // rateLimitMaxRetries: 0 so the rate-limit stderr does not park the job (that behavior has
+        // its own coverage in JobServiceRateLimitTests).
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            agentRunner: TestAgentRunner.Create(), rateLimitMaxRetries: 0);
         var planFolder = CreateValidPlanFolder();
         // CreateTestJob, not StartJob: this ctor has no IConfigService, so a real launch would fail the
         // job before CompleteJob ever ran ("No agent program found").
@@ -332,7 +335,10 @@ public class JobServiceFailureReasonTests : IDisposable
         // Even though the text-based scan can already extract a specific stderr line here (so it
         // wouldn't hit the generic fallback), the provider-specific analyzer understands what that
         // line actually means (a retryable rate limit) and should still be consulted first.
-        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10), agentRunner: TestAgentRunner.Create());
+        // rateLimitMaxRetries: 0 keeps this test about the analyzer text beating the raw stderr scan:
+        // with auto-retry enabled the job is parked as Blocked instead (JobServiceRateLimitTests).
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            agentRunner: TestAgentRunner.Create(), rateLimitMaxRetries: 0);
         var id = service.CreateTestJob(new ExecutePlanArgs(Path.GetTempPath()));
         var job = service.GetJob(id)!;
         job.OutputLines.Enqueue("[stderr] rate limit exceeded");
@@ -379,7 +385,10 @@ public class JobServiceFailureReasonTests : IDisposable
     {
         // Regression for CreatePlan job 00292, which failed with the raw serialized
         // ResultEvent JSON blob shown as the job's failure reason instead of Claude's message.
-        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        // rateLimitMaxRetries: 0 keeps this test about the message: with auto-retry enabled a
+        // session limit parks the job as Blocked instead (JobServiceRateLimitTests).
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            rateLimitMaxRetries: 0);
         var id = service.CreateTestJob(new ExecutePlanArgs(Path.GetTempPath()));
         var job = service.GetJob(id)!;
         job.OutputLines.Enqueue(
@@ -396,7 +405,9 @@ public class JobServiceFailureReasonTests : IDisposable
     [Fact]
     public void CompleteJob_ZeroExitCode_FailedSessionLimitResult_MarksFailedWithCleanMessage()
     {
-        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        // See above: auto-retry is disabled so the assertion stays on the cleaned-up message.
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            rateLimitMaxRetries: 0);
         var id = service.CreateTestJob(new ExecutePlanArgs(Path.GetTempPath()));
         var job = service.GetJob(id)!;
         job.OutputLines.Enqueue(

--- a/src/Ivy.Tendril.Test/JobServiceRateLimitTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRateLimitTests.cs
@@ -1,0 +1,235 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Test.Helpers;
+
+namespace Ivy.Tendril.Test;
+
+/// <summary>
+///     Covers the rate-limit cooldown: a job the provider rejected for a rate limit or an exhausted
+///     daily quota is parked as Blocked, the queue is held back for the cooldown, and the job is
+///     auto-restarted once the cooldown expires (issue #1756).
+/// </summary>
+public class JobServiceRateLimitTests : IDisposable
+{
+    private const string DailyQuotaStderr =
+        "[stderr] API Error: Request rejected (429) - Too many tokens per day, please wait before trying again.";
+
+    private const string ShortTermStderr = "[stderr] rate limit exceeded";
+
+    private readonly TempDirectoryFixture _tempDir = new();
+
+    public void Dispose()
+    {
+        _tempDir.Dispose();
+    }
+
+    private string CreatePlanFolder(string name)
+    {
+        var dir = Path.Combine(_tempDir.Path, $"{name}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var repoDir = Path.Combine(dir, "repo");
+        Directory.CreateDirectory(repoDir);
+        File.WriteAllText(Path.Combine(dir, "plan.yaml"),
+            $"state: Executing\nproject: TestProject\nlevel: NiceToHave\ntitle: {name}\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\nrepos:\n- {repoDir}\nprs: []\ncommits: []\nverifications: []\nrelatedPlans: []\ndependsOn: []\n");
+        return dir;
+    }
+
+    private static JobService CreateService(
+        TimeSpan? cooldown = null,
+        TimeSpan? dailyCooldown = null,
+        int maxRetries = 3)
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+        return new JobService(
+            TimeSpan.FromMinutes(30),
+            TimeSpan.FromMinutes(10),
+            agentRunner: TestAgentRunner.Create(),
+            rateLimitCooldown: cooldown ?? TimeSpan.FromMinutes(5),
+            rateLimitDailyCooldown: dailyCooldown ?? TimeSpan.FromMinutes(60),
+            rateLimitMaxRetries: maxRetries);
+    }
+
+    /// <summary>Runs a job to a rate-limit failure and returns its id.</summary>
+    private static string FailWithRateLimit(JobService service, string planFolder, string stderrLine)
+    {
+        var id = service.CreateTestJob(new ExecutePlanArgs(planFolder));
+        service.GetJob(id)!.OutputLines.Enqueue(stderrLine);
+        service.CompleteJob(id, 1);
+        return id;
+    }
+
+    [Fact]
+    public void CompleteJob_DailyQuotaFailure_ParksJobWithCooldownInsteadOfFailing()
+    {
+        var planFolder = CreatePlanFolder("plan-quota");
+        var service = CreateService(dailyCooldown: TimeSpan.FromMinutes(60));
+
+        var notifications = new List<JobNotification>();
+        service.NotificationReady += n => notifications.Add(n);
+
+        var before = DateTime.UtcNow;
+        var id = FailWithRateLimit(service, planFolder, DailyQuotaStderr);
+
+        var job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Blocked, job.Status);
+        Assert.NotNull(job.RateLimitedUntil);
+        Assert.True(job.RateLimitedUntil > before.AddMinutes(59), "daily quota should use the long cooldown");
+        Assert.Contains("auto-retry after", job.StatusMessage);
+        Assert.Contains("attempt 1/3", job.StatusMessage);
+        Assert.Equal(0, job.RateLimitRetries);
+
+        // The plan must not go back to Draft: it is still ours, it just has to wait.
+        var planState = JobService.ReadPlanYaml(planFolder)!.State;
+        Assert.Equal(nameof(PlanStatus.Blocked), planState);
+
+        Assert.Contains(notifications, n => n.Title == "ExecutePlan Rate Limited");
+    }
+
+    [Fact]
+    public void StartJob_WhileRateLimitPaused_QueuesInsteadOfRunning()
+    {
+        var parkedPlan = CreatePlanFolder("plan-parked");
+        var nextPlan = CreatePlanFolder("plan-next");
+        var service = CreateService(cooldown: TimeSpan.FromMinutes(5));
+
+        FailWithRateLimit(service, parkedPlan, ShortTermStderr);
+
+        var queuedId = service.StartJob(new ExecutePlanArgs(nextPlan));
+
+        var queued = service.GetJob(queuedId)!;
+        Assert.Equal(JobStatus.Queued, queued.Status);
+        Assert.StartsWith("Paused: provider rate limited until", queued.StatusMessage);
+
+        // Draining the queue must not release it while the cooldown is still active.
+        service.RunBlockedJobCheck();
+        Assert.Equal(JobStatus.Queued, service.GetJob(queuedId)!.Status);
+    }
+
+    [Fact]
+    public void RunBlockedJobCheck_AfterCooldownElapsed_RestartsParkedJobAndDrainsQueue()
+    {
+        var parkedPlan = CreatePlanFolder("plan-parked");
+        var nextPlan = CreatePlanFolder("plan-next");
+        // A short cooldown keeps the test fast while still exercising a genuinely active pause.
+        var service = CreateService(cooldown: TimeSpan.FromMilliseconds(750));
+
+        var parkedId = FailWithRateLimit(service, parkedPlan, ShortTermStderr);
+        var parked = service.GetJob(parkedId)!;
+        Assert.Equal(JobStatus.Blocked, parked.Status);
+
+        var queuedId = service.StartJob(new ExecutePlanArgs(nextPlan));
+        Assert.Equal(JobStatus.Queued, service.GetJob(queuedId)!.Status);
+
+        Assert.True(
+            RetryHelper.WaitUntil(() => DateTime.UtcNow > parked.RateLimitedUntil!.Value, TimeSpan.FromSeconds(10)),
+            "cooldown did not elapse");
+
+        service.RunBlockedJobCheck();
+
+        // The parked job is replaced by a fresh attempt that carries the retry count forward.
+        Assert.Null(service.GetJob(parkedId));
+        var replacement = service.GetJobs()
+            .FirstOrDefault(j => j.Id != parkedId && j.TypedArgs?.PlanFolder == parkedPlan);
+        Assert.NotNull(replacement);
+        Assert.Equal(1, replacement.RateLimitRetries);
+        Assert.NotEqual(JobStatus.Blocked, replacement.Status);
+
+        Assert.True(
+            RetryHelper.WaitUntil(() => service.GetJob(queuedId)!.Status != JobStatus.Queued),
+            "queued job was not drained after the cooldown");
+    }
+
+    [Fact]
+    public void CompleteJob_WhenRetriesExhausted_LeavesJobFailed()
+    {
+        var planFolder = CreatePlanFolder("plan-exhausted");
+        var service = CreateService(maxRetries: 3);
+
+        var id = service.CreateTestJob(new ExecutePlanArgs(planFolder));
+        var job = service.GetJob(id)!;
+        job.RateLimitRetries = 3;
+        job.OutputLines.Enqueue(ShortTermStderr);
+
+        service.CompleteJob(id, 1);
+
+        job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.Null(job.RateLimitedUntil);
+        Assert.Contains("gave up after 3 rate-limit retries", job.StatusMessage);
+
+        // No replacement attempt: the cap is the end of the line.
+        Assert.Single(service.GetJobs(), j => j.TypedArgs?.PlanFolder == planFolder);
+    }
+
+    [Fact]
+    public void CompleteJob_WhenMaxRetriesIsZero_FailsImmediately()
+    {
+        var planFolder = CreatePlanFolder("plan-disabled");
+        var service = CreateService(maxRetries: 0);
+
+        var id = FailWithRateLimit(service, planFolder, DailyQuotaStderr);
+
+        var job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.Null(job.RateLimitedUntil);
+        Assert.DoesNotContain("auto-retry", job.StatusMessage);
+
+        // Auto-retry off means the pause is off too: the next job runs right away.
+        var nextId = service.StartJob(new ExecutePlanArgs(CreatePlanFolder("plan-next")));
+        Assert.NotEqual(JobStatus.Queued, service.GetJob(nextId)!.Status);
+    }
+
+    [Fact]
+    public void ForceStartJob_OnRateLimitParkedJob_StartsDespiteThePause()
+    {
+        var planFolder = CreatePlanFolder("plan-forced");
+        var service = CreateService(cooldown: TimeSpan.FromMinutes(5));
+
+        var parkedId = FailWithRateLimit(service, planFolder, ShortTermStderr);
+        Assert.Equal(JobStatus.Blocked, service.GetJob(parkedId)!.Status);
+
+        service.ForceStartJob(parkedId);
+
+        Assert.Null(service.GetJob(parkedId));
+        var forced = service.GetJobs().FirstOrDefault(j => j.TypedArgs?.PlanFolder == planFolder);
+        Assert.NotNull(forced);
+        Assert.NotEqual(JobStatus.Blocked, forced.Status);
+        Assert.NotEqual(JobStatus.Queued, forced.Status);
+    }
+
+    [Fact]
+    public void RunBlockedJobCheck_DependencyBlockedJob_IsStillAutoRestarted()
+    {
+        // Regression guard for the RetryBlockedJobs skip: it must only skip rate-limit-parked jobs
+        // (RateLimitedUntil set), leaving ordinary dependency-blocked jobs to be retried as before.
+        var parkedPlan = CreatePlanFolder("plan-parked");
+        var dependencyPlan = CreatePlanFolder("plan-dependency");
+        var service = CreateService(cooldown: TimeSpan.FromMinutes(5));
+
+        var parkedId = FailWithRateLimit(service, parkedPlan, ShortTermStderr);
+        var parkedUntil = service.GetJob(parkedId)!.RateLimitedUntil;
+
+        var blockedId = service.CreateTestJob(new ExecutePlanArgs(dependencyPlan));
+        var blockedJob = service.GetJob(blockedId)!;
+        blockedJob.Status = JobStatus.Blocked;
+        blockedJob.StatusMessage = "Dependency '01100-DepPlan' is 'Executing', not Completed";
+
+        var notifications = new List<JobNotification>();
+        service.NotificationReady += n => notifications.Add(n);
+
+        service.RunBlockedJobCheck();
+
+        // The dependency-blocked job was restarted...
+        Assert.Null(service.GetJob(blockedId));
+        var restarted = service.GetJobs()
+            .FirstOrDefault(j => j.Id != blockedId && j.TypedArgs?.PlanFolder == dependencyPlan);
+        Assert.NotNull(restarted);
+        Assert.Contains(notifications, n => n.Title == "Job Unblocked");
+
+        // ...while the rate-limited job stayed parked, waiting out its cooldown.
+        var stillParked = service.GetJob(parkedId);
+        Assert.NotNull(stillParked);
+        Assert.Equal(JobStatus.Blocked, stillParked.Status);
+        Assert.Equal(parkedUntil, stillParked.RateLimitedUntil);
+    }
+}

--- a/src/Ivy.Tendril.Test/Services/JobFailureAnalyzerTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobFailureAnalyzerTests.cs
@@ -66,4 +66,35 @@ public class JobFailureAnalyzerTests
         Assert.DoesNotContain("Claude API", reason);
         Assert.Contains("Could not resolve host", reason);
     }
+
+    // A failed result event reporting an exhausted per-day quota is prefixed differently from a
+    // short-term limit, so the message tells the user this is a much longer wait (issue #1756).
+    [Fact]
+    public void FailedResultEvent_DailyTokenQuota_PrefixedAsQuotaExhausted()
+    {
+        var output = new List<string>
+        {
+            """{"kind":"result","response":"API Error: Request rejected (429) - Too many tokens per day, please wait before trying again.","is_success":false,"duration_ms":812}"""
+        };
+
+        var reason = JobFailureAnalyzer.ExtractFailureReason(output, "ExecutePlan");
+
+        Assert.StartsWith("Daily token quota exhausted:", reason);
+        Assert.Contains("Too many tokens per day", reason);
+        Assert.DoesNotContain("is_success", reason);
+    }
+
+    // A short-term limit in the same shape keeps the existing usage-limit wording.
+    [Fact]
+    public void FailedResultEvent_SessionLimit_PrefixedAsUsageLimit()
+    {
+        var output = new List<string>
+        {
+            """{"kind":"result","response":"You have hit your session limit, resets 4pm (Europe/Stockholm)","is_success":false}"""
+        };
+
+        var reason = JobFailureAnalyzer.ExtractFailureReason(output, "ExecutePlan");
+
+        Assert.StartsWith("Claude usage limit reached:", reason);
+    }
 }

--- a/src/Ivy.Tendril/Apps/Settings/AdvancedSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AdvancedSetupView.cs
@@ -13,12 +13,18 @@ public class AdvancedSetupView : ViewBase
         var jobTimeout = UseState(config.Settings.JobTimeout);
         var staleOutputTimeout = UseState(config.Settings.StaleOutputTimeout);
         var maxConcurrentJobs = UseState(config.Settings.MaxConcurrentJobs);
+        var rateLimitCooldown = UseState(config.Settings.RateLimitCooldown);
+        var rateLimitDailyCooldown = UseState(config.Settings.RateLimitDailyCooldown);
+        var rateLimitMaxRetries = UseState(config.Settings.RateLimitMaxRetries);
         var editorCommand = UseState(config.Settings.Editor.Command);
         var editorLabel = UseState(config.Settings.Editor.Label);
 
         var hasChanges = jobTimeout.Value != config.Settings.JobTimeout
                          || staleOutputTimeout.Value != config.Settings.StaleOutputTimeout
                          || maxConcurrentJobs.Value != config.Settings.MaxConcurrentJobs
+                         || rateLimitCooldown.Value != config.Settings.RateLimitCooldown
+                         || rateLimitDailyCooldown.Value != config.Settings.RateLimitDailyCooldown
+                         || rateLimitMaxRetries.Value != config.Settings.RateLimitMaxRetries
                          || editorCommand.Value != config.Settings.Editor.Command
                          || editorLabel.Value != config.Settings.Editor.Label;
 
@@ -32,6 +38,16 @@ public class AdvancedSetupView : ViewBase
                        .WithField().Label("Stale Output Timeout")
                    | maxConcurrentJobs.ToNumberInput().Min(1).Max(100)
                        .WithField().Label("Max Concurrent Jobs")
+                   | Text.Block("Rate Limits").Bold()
+                   | rateLimitCooldown.ToNumberInput().Min(1).Max(1440).Suffix("min")
+                       .WithField().Label("Rate Limit Cooldown")
+                       .Description("How long the job queue pauses after the provider rate limits a job.")
+                   | rateLimitDailyCooldown.ToNumberInput().Min(1).Max(1440).Suffix("min")
+                       .WithField().Label("Daily Quota Cooldown")
+                       .Description("How long the job queue pauses after a daily token quota is exhausted.")
+                   | rateLimitMaxRetries.ToNumberInput().Min(0).Max(10)
+                       .WithField().Label("Rate Limit Max Retries")
+                       .Description("Automatic retries per job. 0 fails rate-limited jobs immediately.")
                    | Text.Block("Editor").Bold()
                    | editorCommand.ToTextInput("e.g. code, vim")
                        .WithField().Label("Command")
@@ -47,6 +63,9 @@ public class AdvancedSetupView : ViewBase
                            config.Settings.JobTimeout = jobTimeout.Value;
                            config.Settings.StaleOutputTimeout = staleOutputTimeout.Value;
                            config.Settings.MaxConcurrentJobs = maxConcurrentJobs.Value;
+                           config.Settings.RateLimitCooldown = rateLimitCooldown.Value;
+                           config.Settings.RateLimitDailyCooldown = rateLimitDailyCooldown.Value;
+                           config.Settings.RateLimitMaxRetries = rateLimitMaxRetries.Value;
                            config.Settings.Editor.Command = editorCommand.Value;
                            config.Settings.Editor.Label = editorLabel.Value;
                            config.SaveSettings();

--- a/src/Ivy.Tendril/Database/Migrations/Migration_017_JobsRateLimit.cs
+++ b/src/Ivy.Tendril/Database/Migrations/Migration_017_JobsRateLimit.cs
@@ -1,0 +1,23 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Database.Migrations;
+
+public class Migration_017_JobsRateLimit : IMigration
+{
+    public int Version => 17;
+
+    public string Description =>
+        "Add RateLimitedUntil and RateLimitRetries columns to Jobs so a rate-limit cooldown survives a restart";
+
+    public void Apply(SqliteConnection connection, ILogger? logger = null)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            ALTER TABLE Jobs ADD COLUMN RateLimitedUntil TEXT;
+            ALTER TABLE Jobs ADD COLUMN RateLimitRetries INTEGER NOT NULL DEFAULT 0;
+            PRAGMA user_version = 17;
+            """;
+        cmd.ExecuteNonQuery();
+    }
+}

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -84,6 +84,20 @@ public record JobItem
     // Soft-cleared from the Jobs app; still shown in plan Details history
     public bool Cleared { get; set; }
 
+    /// <summary>
+    /// UTC instant at which a rate-limit-parked job becomes eligible to run again. Non-null is
+    /// also the marker that distinguishes a rate-limited <see cref="JobStatus.Blocked" /> job from
+    /// a dependency-blocked one: rate-limited jobs are restarted only by the job service's
+    /// cooldown resume pass, never by the dependency re-check.
+    /// </summary>
+    public DateTime? RateLimitedUntil { get; set; }
+
+    /// <summary>
+    /// How many times this work item has already been re-queued because of a provider rate limit.
+    /// Threaded through each restart so the retry cap terminates.
+    /// </summary>
+    public int RateLimitRetries { get; set; }
+
     [JsonIgnore]
     public IEventParser? EventParser { get; set; }
     private IEventSerializer? _eventSerializer;

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -166,6 +166,15 @@ public class TendrilSettings
     public int GitTimeout { get; set; } = 10;
     public int MaxConcurrentJobs { get; set; } = 5;
 
+    /// <summary>Minutes the job queue stays paused after a short-term provider rate limit.</summary>
+    public int RateLimitCooldown { get; set; } = 5;
+
+    /// <summary>Minutes the job queue stays paused after a daily token quota is exhausted.</summary>
+    public int RateLimitDailyCooldown { get; set; } = 60;
+
+    /// <summary>Automatic retries per job for provider rate limits. 0 disables auto-retry.</summary>
+    public int RateLimitMaxRetries { get; set; } = 3;
+
     public List<ProjectConfig> Projects { get; set; } = new();
     public List<VerificationConfig> Verifications { get; set; } = new();
     public string PlanTemplate { get; set; } = "";
@@ -459,6 +468,30 @@ public class ConfigService : IConfigService, IDisposable
             _logger.LogWarning("MaxConcurrentJobs {Value} is out of bounds (1-100). Using default 5.",
                 Settings.MaxConcurrentJobs);
             Settings.MaxConcurrentJobs = 5;
+        }
+
+        // RateLimitCooldown: 1-1440 minutes (24 hours max)
+        if (Settings.RateLimitCooldown < 1 || Settings.RateLimitCooldown > 1440)
+        {
+            _logger.LogWarning("RateLimitCooldown {Value} is out of bounds (1-1440 minutes). Using default 5.",
+                Settings.RateLimitCooldown);
+            Settings.RateLimitCooldown = 5;
+        }
+
+        // RateLimitDailyCooldown: 1-1440 minutes (24 hours max)
+        if (Settings.RateLimitDailyCooldown < 1 || Settings.RateLimitDailyCooldown > 1440)
+        {
+            _logger.LogWarning("RateLimitDailyCooldown {Value} is out of bounds (1-1440 minutes). Using default 60.",
+                Settings.RateLimitDailyCooldown);
+            Settings.RateLimitDailyCooldown = 60;
+        }
+
+        // RateLimitMaxRetries: 0-10 (0 disables auto-retry)
+        if (Settings.RateLimitMaxRetries < 0 || Settings.RateLimitMaxRetries > 10)
+        {
+            _logger.LogWarning("RateLimitMaxRetries {Value} is out of bounds (0-10). Using default 3.",
+                Settings.RateLimitMaxRetries);
+            Settings.RateLimitMaxRetries = 3;
         }
     }
 

--- a/src/Ivy.Tendril/Services/Jobs/JobFailureAnalyzer.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobFailureAnalyzer.cs
@@ -194,10 +194,6 @@ internal static class JobFailureAnalyzer
         return null;
     }
 
-    private static readonly Regex UsageLimitPattern = new(
-        @"hit your (?:session|usage) limit|usage limit reached|limit reached",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
     private static string FormatFailedResultMessage(string response)
     {
         var firstLine = response
@@ -209,9 +205,14 @@ internal static class JobFailureAnalyzer
         if (sanitized.Length > 300)
             sanitized = sanitized[..300];
 
-        return UsageLimitPattern.IsMatch(sanitized)
-            ? $"Claude usage limit reached: {sanitized}"
-            : sanitized;
+        // A per-day quota is labelled distinctly from a per-minute burst limit: the two need
+        // very different waits, and the scheduler picks its cooldown off the same classifier.
+        return RateLimitClassifier.Classify(sanitized) switch
+        {
+            RateLimitScope.DailyQuota => $"Daily token quota exhausted: {sanitized}",
+            RateLimitScope.ShortTerm => $"Claude usage limit reached: {sanitized}",
+            _ => sanitized
+        };
     }
 
     internal static string? TryReadFailureArtifact(List<string> outputLines)

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -547,7 +547,7 @@ public class JobService : IJobService
         }
         catch
         {
-            // Best-effort — don't crash on timer callback
+            // Best-effort: don't crash on timer callback
         }
 
         try

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -31,6 +31,15 @@ public class JobService : IJobService
     private readonly JobCompletionHandler _completionHandler;
     private readonly IAgentRunner? _agentRunner;
     private Timer? _blockedJobCheckTimer;
+
+    // While set (and in the future), the whole queue is held back: the provider rate limited us and
+    // feeding it more jobs would just burn the same exhausted quota, ~3 minutes per job (issue #1756).
+    // Read and written under _queueLock.
+    private DateTime? _rateLimitPausedUntil;
+    private TimeSpan _rateLimitCooldown;
+    private TimeSpan _rateLimitDailyCooldown;
+    private int _rateLimitMaxRetries;
+
     public JobService(
         IConfigService configService,
         ILogger<JobService>? logger = null,
@@ -53,6 +62,9 @@ public class JobService : IJobService
         _jobTimeout = TimeSpan.FromMinutes(configService.Settings.JobTimeout);
         _staleOutputTimeout = TimeSpan.FromMinutes(configService.Settings.StaleOutputTimeout);
         _maxConcurrentJobs = configService.Settings.MaxConcurrentJobs;
+        _rateLimitCooldown = TimeSpan.FromMinutes(configService.Settings.RateLimitCooldown);
+        _rateLimitDailyCooldown = TimeSpan.FromMinutes(configService.Settings.RateLimitDailyCooldown);
+        _rateLimitMaxRetries = configService.Settings.RateLimitMaxRetries;
         _jobSlotSemaphore = _maxConcurrentJobs > 0
             ? new SemaphoreSlim(_maxConcurrentJobs, _maxConcurrentJobs)
             : new SemaphoreSlim(0, 1);
@@ -77,13 +89,19 @@ public class JobService : IJobService
         ITelemetryService? telemetryService = null,
         IPlanDatabaseService? database = null,
         ILogger<JobService>? logger = null,
-        IAgentRunner? agentRunner = null)
+        IAgentRunner? agentRunner = null,
+        TimeSpan? rateLimitCooldown = null,
+        TimeSpan? rateLimitDailyCooldown = null,
+        int rateLimitMaxRetries = 3)
     {
         _syncContext = SynchronizationContext.Current;
         _logger = logger ?? NullLogger<JobService>.Instance;
         _jobTimeout = jobTimeout;
         _staleOutputTimeout = staleOutputTimeout;
         _maxConcurrentJobs = maxConcurrentJobs;
+        _rateLimitCooldown = rateLimitCooldown ?? TimeSpan.FromMinutes(5);
+        _rateLimitDailyCooldown = rateLimitDailyCooldown ?? TimeSpan.FromMinutes(60);
+        _rateLimitMaxRetries = rateLimitMaxRetries;
         _jobSlotSemaphore = maxConcurrentJobs > 0
             ? new SemaphoreSlim(maxConcurrentJobs, maxConcurrentJobs)
             : new SemaphoreSlim(0, 1);
@@ -136,8 +154,15 @@ public class JobService : IJobService
         // the completion summary, permission denials and hook output. Those must reach the eventwire file,
         // so its appender stays open until DisposeResources below.
         job.CloseRawLog();
-        _completionHandler.HandleCompletion(
-            job, _jobs, PersistJob, RaiseNotification, RaiseJobsPropertyChanged, StartJobSkipDepCheck);
+
+        // A provider rate limit is not this job's fault and not terminal: park it as Blocked and
+        // pause the queue instead of running the full completion path, which would revert the plan
+        // to Draft and leave the user to re-execute it by hand.
+        if (job.Status == JobStatus.Failed && TryDeferForRateLimit(job))
+            HandleRateLimitDeferral(job);
+        else
+            _completionHandler.HandleCompletion(
+                job, _jobs, PersistJob, RaiseNotification, RaiseJobsPropertyChanged, StartJobSkipDepCheck);
 
         if (job.Status == JobStatus.Completed)
             job.StatusMessage = null;
@@ -218,6 +243,143 @@ public class JobService : IJobService
         job.CompletedAt = DateTime.UtcNow;
         if (job.StartedAt.HasValue)
             job.DurationSeconds = (int)(job.CompletedAt.Value - job.StartedAt.Value).TotalSeconds;
+    }
+
+    /// <summary>
+    ///     Decides whether a failed job was rejected by the provider for a rate limit or an
+    ///     exhausted quota and, if so, parks it as <see cref="JobStatus.Blocked" /> with a
+    ///     cooldown and pauses the whole queue for that long. Returns false (leaving the job
+    ///     Failed) when the failure is unrelated, auto-retry is disabled, or this work item has
+    ///     already used up its rate-limit retries.
+    /// </summary>
+    private bool TryDeferForRateLimit(JobItem job)
+    {
+        if (_rateLimitMaxRetries <= 0) return false;
+
+        // The analyzer-derived StatusMessage covers the common case; the output tail catches
+        // limits the agent only reported in its event stream.
+        var candidates = new List<string>();
+        if (!string.IsNullOrWhiteSpace(job.StatusMessage))
+            candidates.Add(job.StatusMessage);
+        candidates.AddRange(job.OutputLines.TakeLast(50));
+
+        var scope = RateLimitClassifier.Classify(candidates);
+        if (scope == RateLimitScope.None) return false;
+
+        if (job.RateLimitRetries >= _rateLimitMaxRetries)
+        {
+            job.StatusMessage =
+                $"{job.StatusMessage} (gave up after {job.RateLimitRetries} rate-limit retries)".TrimStart();
+            return false;
+        }
+
+        var isDailyQuota = scope == RateLimitScope.DailyQuota;
+        var reason = string.IsNullOrWhiteSpace(job.StatusMessage)
+            ? isDailyQuota ? "Daily token quota exhausted" : "Rate limited by the provider"
+            : job.StatusMessage!;
+
+        var until = DateTime.UtcNow + (isDailyQuota ? _rateLimitDailyCooldown : _rateLimitCooldown);
+        job.Status = JobStatus.Blocked;
+        job.RateLimitedUntil = until;
+        job.StatusMessage =
+            $"{reason} - auto-retry after {until.ToLocalTime():HH:mm} " +
+            $"(attempt {job.RateLimitRetries + 1}/{_rateLimitMaxRetries})";
+
+        lock (_queueLock)
+        {
+            var basis = _rateLimitPausedUntil ?? DateTime.UtcNow;
+            _rateLimitPausedUntil = basis > until ? basis : until;
+        }
+
+        _logger.LogWarning(
+            "Job {JobId}: provider rate limited ({Scope}), parked until {Until:O}", job.Id, scope, until);
+        return true;
+    }
+
+    /// <summary>
+    ///     Completion handling for a job parked by <see cref="TryDeferForRateLimit" />. Deliberately
+    ///     narrower than <see cref="JobCompletionHandler.HandleCompletion" />: no after-hooks, no
+    ///     artifact sync, no plan-state advancement and no inbox cleanup, because the job has not
+    ///     finished, it is going to run again once the cooldown expires.
+    /// </summary>
+    private void HandleRateLimitDeferral(JobItem job)
+    {
+        // Keeps the plan out of Draft, so it is not hand-restarted into the same exhausted quota.
+        ResetPlanStateToBlocked(job);
+        _completionHandler.WriteJobLog(job);
+        _telemetryService?.TrackJobCompleted(job.Type, job.Status, job.DurationSeconds, job.Provider);
+        RaiseNotification(new JobNotification(
+            $"{job.Type} Rate Limited", $"{job.PlanFile}: {job.StatusMessage}", false));
+    }
+
+    /// <summary>
+    ///     Restarts every job whose rate-limit cooldown has elapsed, oldest first, threading the
+    ///     retry count through so the cap terminates. Rate-limited jobs are owned exclusively by
+    ///     this pass; <see cref="Plans.DependencyChecker.RetryBlockedJobs" /> skips them.
+    /// </summary>
+    private void ResumeRateLimitedJobs()
+    {
+        var now = DateTime.UtcNow;
+        var due = _jobs.Values
+            .Where(j => j.Status == JobStatus.Blocked && j.RateLimitedUntil <= now && j.TypedArgs != null)
+            .OrderBy(j => j.CompletedAt ?? j.StartedAt ?? DateTime.MaxValue)
+            .ToList();
+
+        foreach (var job in due)
+        {
+            var planFolder = job.TypedArgs!.PlanFolder;
+            if (!string.IsNullOrEmpty(planFolder) && HasActiveJobForPlan(planFolder)) continue;
+            if (!_jobs.TryRemove(job.Id, out _)) continue;
+
+            // InboxFile is passed through so CreatePlan inbox cleanup still finds its file.
+            StartJobInternal(job.TypedArgs, job.InboxFile, rateLimitRetries: job.RateLimitRetries + 1);
+
+            RaiseNotification(new JobNotification(
+                $"{job.Type} Retrying",
+                $"{job.PlanFile}: rate-limit cooldown elapsed, auto-restarting",
+                true));
+        }
+    }
+
+    private bool HasActiveJobForPlan(string planFolder)
+        => _jobs.Values.Any(j =>
+            j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
+            !string.IsNullOrEmpty(j.TypedArgs?.PlanFolder) &&
+            j.TypedArgs!.PlanFolder!.Equals(planFolder, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    ///     True while the queue is held back by a provider rate limit. Queued jobs stay Queued and
+    ///     are drained by the blocked-job timer once the cooldown expires.
+    /// </summary>
+    private bool IsRateLimitPaused(out DateTime pausedUntil)
+    {
+        lock (_queueLock)
+        {
+            if (_rateLimitPausedUntil is { } until && until > DateTime.UtcNow)
+            {
+                pausedUntil = until;
+                return true;
+            }
+        }
+        pausedUntil = default;
+        return false;
+    }
+
+    private static string FormatRateLimitPausedMessage(DateTime pausedUntil)
+        => $"Paused: provider rate limited until {pausedUntil.ToLocalTime():HH:mm}";
+
+    private void MarkQueuedJobsPaused(DateTime pausedUntil)
+    {
+        var message = FormatRateLimitPausedMessage(pausedUntil);
+        var changed = false;
+        foreach (var job in _jobs.Values.Where(j => j.Status == JobStatus.Queued))
+        {
+            if (job.StatusMessage == message) continue;
+            job.StatusMessage = message;
+            changed = true;
+        }
+        if (changed)
+            RaiseJobsPropertyChanged();
     }
 
     public void StopJob(string id)
@@ -368,6 +530,26 @@ public class JobService : IJobService
 
     private void OnBlockedJobCheckTimer(object? state)
     {
+        try
+        {
+            bool cooldownElapsed;
+            lock (_queueLock)
+            {
+                cooldownElapsed = _rateLimitPausedUntil is { } until && until <= DateTime.UtcNow;
+                if (cooldownElapsed) _rateLimitPausedUntil = null;
+            }
+
+            if (cooldownElapsed)
+            {
+                ResumeRateLimitedJobs();
+                ProcessJobQueue();
+            }
+        }
+        catch
+        {
+            // Best-effort — don't crash on timer callback
+        }
+
         try
         {
             var hasBlocked = _jobs.Values.Any(j => j.Status == JobStatus.Blocked);
@@ -565,6 +747,15 @@ public class JobService : IJobService
         {
             var historicalJobs = _database.GetRecentJobs();
             foreach (var job in historicalJobs) _jobs.TryAdd(job.Id, job);
+
+            // Re-arm the queue pause from any job parked mid-cooldown, so restarting the app does
+            // not immediately re-burn the quota. Already-expired values are resumed by the first
+            // blocked-job timer tick.
+            var latestCooldown = _jobs.Values
+                .Where(j => j.Status == JobStatus.Blocked && j.RateLimitedUntil.HasValue)
+                .Max(j => j.RateLimitedUntil);
+            if (latestCooldown.HasValue)
+                lock (_queueLock) { _rateLimitPausedUntil = latestCooldown; }
         }
         catch
         {
@@ -654,12 +845,16 @@ public class JobService : IJobService
 
         if (!_jobs.TryRemove(id, out _)) return;
 
-        // Plan transition is handled centrally by StartJobInternal.
-        StartJobInternal(typedArgs, inboxFilePath: null, skipDependencyCheck: true, skipWaitForCheck: true);
+        // Plan transition is handled centrally by StartJobInternal. Force Start is also the manual
+        // override for a rate-limit cooldown: it bypasses the pause for this one job and leaves the
+        // pause itself in place for everything else.
+        StartJobInternal(typedArgs, inboxFilePath: null, skipDependencyCheck: true, skipWaitForCheck: true,
+            bypassRateLimitPause: true);
         RaiseJobsStructureChanged();
     }
 
-    private string StartJobInternal(JobArgsBase args, string? inboxFilePath, bool skipDependencyCheck = false, bool skipWaitForCheck = false)
+    private string StartJobInternal(JobArgsBase args, string? inboxFilePath, bool skipDependencyCheck = false,
+        bool skipWaitForCheck = false, bool bypassRateLimitPause = false, int rateLimitRetries = 0)
     {
         if (args is SyncRepoArgs syncRepoArgs)
         {
@@ -671,7 +866,7 @@ public class JobService : IJobService
         var id = _configService != null
             ? JobIdAllocator.AllocateJobId(_configService.TendrilHome)
             : Guid.NewGuid().ToString("N")[..5];
-        var job = BuildJobItem(id, args, inboxFilePath);
+        var job = BuildJobItem(id, args, inboxFilePath, rateLimitRetries);
 
         if (TryRejectConflictingJob(job))
             return id;
@@ -691,6 +886,17 @@ public class JobService : IJobService
         // place (only once the job is actually starting, not while blocked) so
         // Stop/Delete/Failed can revert the plan to where it came from.
         CaptureAndTransitionPlanStateForStart(job);
+
+        // Pressing Execute during a cooldown queues the job instead of burning another few minutes
+        // against the exhausted quota. Force Start is the deliberate override.
+        if (!bypassRateLimitPause && IsRateLimitPaused(out var pausedUntil))
+        {
+            job.Status = JobStatus.Queued;
+            job.StatusMessage = FormatRateLimitPausedMessage(pausedUntil);
+            lock (_queueLock) { _jobQueue.Enqueue(id, -job.Priority); }
+            RaiseJobsStructureChanged();
+            return id;
+        }
 
         if (!_jobSlotSemaphore.Wait(0))
         {
@@ -743,7 +949,7 @@ public class JobService : IJobService
         _planReaderService.TransitionState(folderName, target.Value);
     }
 
-    private JobItem BuildJobItem(string id, JobArgsBase args, string? inboxFilePath)
+    private JobItem BuildJobItem(string id, JobArgsBase args, string? inboxFilePath, int rateLimitRetries = 0)
     {
         var (planFile, project, priority) = ExtractJobMetadata(args);
 
@@ -757,7 +963,8 @@ public class JobService : IJobService
             TypedArgs = args,
             Provider = _configService?.Settings.CodingAgent ?? "claude",
             Priority = priority,
-            WaitForJobIds = args.WaitForJobs
+            WaitForJobIds = args.WaitForJobs,
+            RateLimitRetries = rateLimitRetries
         };
 
         if (args is CreatePlanArgs)
@@ -972,6 +1179,9 @@ public class JobService : IJobService
         if (_configService == null) return;
         _jobTimeout = TimeSpan.FromMinutes(_configService.Settings.JobTimeout);
         _staleOutputTimeout = TimeSpan.FromMinutes(_configService.Settings.StaleOutputTimeout);
+        _rateLimitCooldown = TimeSpan.FromMinutes(_configService.Settings.RateLimitCooldown);
+        _rateLimitDailyCooldown = TimeSpan.FromMinutes(_configService.Settings.RateLimitDailyCooldown);
+        _rateLimitMaxRetries = _configService.Settings.RateLimitMaxRetries;
 
         var newMaxConcurrent = _configService.Settings.MaxConcurrentJobs;
         if (newMaxConcurrent != _maxConcurrentJobs)
@@ -1016,6 +1226,15 @@ public class JobService : IJobService
 
     private void ProcessJobQueue()
     {
+        // While the provider has rate limited us, dequeuing the next job just burns the same
+        // exhausted quota. Jobs stay Queued and the blocked-job timer drains them after the
+        // cooldown; the message explains the stall in the UI.
+        if (IsRateLimitPaused(out var pausedUntil))
+        {
+            MarkQueuedJobsPaused(pausedUntil);
+            return;
+        }
+
         while (true)
         {
             if (!_jobSlotSemaphore.Wait(0))

--- a/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
+++ b/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
@@ -100,6 +100,11 @@ internal class DependencyChecker
             var planFolder = blockedJob.TypedArgs?.PlanFolder ?? "";
             if (string.IsNullOrEmpty(planFolder)) continue;
 
+            // A job parked for a provider rate limit is Blocked with its plan dependencies already
+            // satisfied, so without this guard it would be restarted the instant it was parked.
+            // Those jobs are owned by JobService.ResumeRateLimitedJobs, which waits out the cooldown.
+            if (blockedJob.RateLimitedUntil != null) continue;
+
             // A job blocked on sibling jobs (WaitForJobs) is retried by
             // JobCompletionHandler.HandleWaitForJobsDependents when those jobs finish — not here.
             // Restarting it while its WaitForJobs are still pending would immediately re-block it,

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -674,8 +674,8 @@ public class PlanDatabaseService : IPlanDatabaseService
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
-                              INSERT OR REPLACE INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, SessionId, StartedAt, CompletedAt, DurationSeconds, Cost, Tokens, StatusMessage, Args, TypedArgs, WorkingDirectory, CliCommand, Cleared)
-                              VALUES (@id, @type, @planFile, @project, @status, @provider, @sessionId, @startedAt, @completedAt, @durationSeconds, @cost, @tokens, @statusMessage, @args, @typedArgs, @workingDirectory, @cliCommand, @cleared)
+                              INSERT OR REPLACE INTO Jobs (Id, Type, PlanFile, Project, Status, Provider, SessionId, StartedAt, CompletedAt, DurationSeconds, Cost, Tokens, StatusMessage, Args, TypedArgs, WorkingDirectory, CliCommand, Cleared, RateLimitedUntil, RateLimitRetries)
+                              VALUES (@id, @type, @planFile, @project, @status, @provider, @sessionId, @startedAt, @completedAt, @durationSeconds, @cost, @tokens, @statusMessage, @args, @typedArgs, @workingDirectory, @cliCommand, @cleared, @rateLimitedUntil, @rateLimitRetries)
                               """;
             cmd.Parameters.AddWithValue("@id", job.Id);
             cmd.Parameters.AddWithValue("@type", job.Type);
@@ -699,6 +699,9 @@ public class PlanDatabaseService : IPlanDatabaseService
             cmd.Parameters.AddWithValue("@workingDirectory", (object?)job.WorkingDirectory ?? DBNull.Value);
             cmd.Parameters.AddWithValue("@cliCommand", (object?)job.CliCommand ?? DBNull.Value);
             cmd.Parameters.AddWithValue("@cleared", job.Cleared ? 1 : 0);
+            cmd.Parameters.AddWithValue("@rateLimitedUntil",
+                job.RateLimitedUntil?.ToString("O", CultureInfo.InvariantCulture) ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@rateLimitRetries", job.RateLimitRetries);
             cmd.ExecuteNonQuery();
         }
     }
@@ -774,7 +777,12 @@ public class PlanDatabaseService : IPlanDatabaseService
             CliCommand = reader.IsDBNull(reader.GetOrdinal("CliCommand"))
                 ? null
                 : reader.GetString(reader.GetOrdinal("CliCommand")),
-            Cleared = reader.GetInt32(reader.GetOrdinal("Cleared")) != 0
+            Cleared = reader.GetInt32(reader.GetOrdinal("Cleared")) != 0,
+            RateLimitedUntil = reader.IsDBNull(reader.GetOrdinal("RateLimitedUntil"))
+                ? null
+                : DateTime.Parse(reader.GetString(reader.GetOrdinal("RateLimitedUntil")),
+                    CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
+            RateLimitRetries = reader.GetInt32(reader.GetOrdinal("RateLimitRetries"))
         };
     }
 


### PR DESCRIPTION
Fixes #1756

# Summary

Plan 00071, "Pause Job Queue and Auto Retry on Provider Rate Limits" (issue #1756), implemented in
full on branch `tendril/00071-PauseJobQueueAndAutoRetryOnProviderRateLimits` off `origin/development`
(base `6b42adc0`).

## What changed

A job the provider rejects for a rate limit is no longer a terminal failure. It is parked as
`Blocked` with a cooldown, the whole job queue is held back for that cooldown, and the existing
60-second blocked-job timer restarts the job when the cooldown expires. Instead of ~20 plans failing
against the same exhausted daily budget and each needing a manual re-execute, they wait and resume.

| Area | Change |
| --- | --- |
| `Ivy.Tendril.Agents/Abstractions/RateLimitClassifier.cs` (new) | Shared classifier: `None` / `ShortTerm` / `DailyQuota`, daily patterns checked first so the Bedrock message (which also says `429`) is not mistaken for a burst limit |
| `Providers/Claude/ClaudeFailureAnalyzer.cs` | Classifies stderr plus the last result response through the classifier; distinct wording for an exhausted daily quota |
| `Services/Jobs/JobFailureAnalyzer.cs` | `UsageLimitPattern` replaced by the classifier; `"Daily token quota exhausted: "` prefix added, `"Claude usage limit reached: "` kept |
| `Models/JobModels.cs` | `RateLimitedUntil` (also the marker distinguishing a parked job from a dependency-blocked one) and `RateLimitRetries` |
| `Database/Migrations/Migration_017_JobsRateLimit.cs` (new), `Services/Plans/PlanDatabaseService.cs` | Both fields persisted so a cooldown survives a restart |
| `Services/Jobs/JobService.cs` | `TryDeferForRateLimit`, `HandleRateLimitDeferral`, `ResumeRateLimitedJobs`, the `_rateLimitPausedUntil` queue gate, `bypassRateLimitPause` on `StartJobInternal`, `ForceStartJob` override, pause re-seeding in `LoadHistoricalJobs`, settings refresh on reload |
| `Services/Plans/DependencyChecker.cs` | `RetryBlockedJobs` skips rate-limit-parked jobs, which it would otherwise restart the instant they were parked |
| `Services/ConfigService.cs`, `Apps/Settings/AdvancedSetupView.cs` | `RateLimitCooldown` (5 min), `RateLimitDailyCooldown` (60 min), `RateLimitMaxRetries` (3), clamped and editable under a "Rate Limits" section |

Behavior for the user: the failing job stays visible as `Blocked` with
`"... - auto-retry after 14:32 (attempt 1/3)"`, its plan is left `Blocked` rather than reverted to
`Draft`, jobs started during the cooldown sit in `Queued` with
`"Paused: provider rate limited until 14:32"`, and "Force Start" is the manual override that
bypasses the pause for one job. Setting `RateLimitMaxRetries` to 0 restores the old behavior
exactly.

## Commits

| SHA | Message |
| --- | --- |
| `66cb67fe` | feat(00071): share rate-limit classification between analyzers |
| `0dc0e0d6` | feat(00071): persist rate-limit cooldown on jobs |
| `4d86a293` | feat(00071): pause the job queue and auto-retry on provider rate limits |
| `38f7ce57` | feat(00071): expose rate-limit cooldown settings in Advanced setup |
| `5737e8c9` | style(00071): avoid em dash in new comment per AGENTS.md |

## Verification

| Verification | Result |
| --- | --- |
| DotnetFormat | Pass (no files reformatted) |
| DotnetBuild | Pass (0 errors, 0 new warnings) |
| DotnetTest | Pass (1799 + 968 tests) |
| VitePlusTest | Skipped (project default) |
| CheckResult | Pass |

## Deviations from the plan, worth a reviewer's attention

1. **Migration 017 was necessary and is not in the plan.** The plan states the two new `JobItem`
   properties will "round-trip through `PersistJob`" because they are public. They do not:
   `PlanDatabaseService.UpsertJob` writes an explicit column list, so both values would have been
   dropped on persist and the plan's own restart-seeding step (section 5) would never have seen a
   cooldown. Added `Migration_017_JobsRateLimit` (`RateLimitedUntil TEXT`,
   `RateLimitRetries INTEGER NOT NULL DEFAULT 0`, `PRAGMA user_version = 17`), the matching
   `UpsertJob` / `MapJobRow` handling, and a migrator test.
2. **Three more existing tests needed `rateLimitMaxRetries: 0`,** beyond the one the plan named. They
   fed session-limit or rate-limit output into `CompleteJob` and asserted `Failed`; those jobs are now
   parked, which is the point of the plan. Each was constructed with auto-retry off so it keeps
   asserting the failure *message* it was written for, and the parking behavior is covered directly by
   `JobServiceRateLimitTests`.
3. **The `.slnx` cannot be built in this environment** (it lists the sibling Ivy-Framework repo
   unconditionally and that repo is not checked out here), so the per-project entry points were built
   instead, as the DotnetBuild verification allows. No project reference paths were touched.
   `Ivy.Tendril.Docs` cannot restore for the same underlying reason (`Ivy.Docs.Helpers` is not on
   nuget.org); that is pre-existing and untouched by this plan.

---
Created using [Ivy Tendril](https://ivy.app).
