### PR TITLE
[00078] Never Start the Tendril Server for Help or Unknown CLI Arguments

### DIFF
--- a/src/Ivy.Tendril.Test/Commands/CliDispatcherTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/CliDispatcherTests.cs
@@ -1,0 +1,149 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Commands;
+using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console.Testing;
+
+namespace Ivy.Tendril.Test.Commands;
+
+public class CliDispatcherTests
+{
+    [Theory]
+    [InlineData("--help")]
+    [InlineData("-h")]
+    [InlineData("-?")]
+    [InlineData("/?")]
+    [InlineData("help")]
+    public void Classify_BareHelpToken_ReturnsHelp(string token)
+    {
+        Assert.Equal(CliInvocationKind.Help, CliDispatcher.Classify([token]));
+    }
+
+    [Theory]
+    [InlineData("job", "--help")]
+    [InlineData("project", "add", "--help")]
+    [InlineData("add", "project", "--help")]
+    public void Classify_HelpTokenAnywhereInArgs_ReturnsHelp(params string[] args)
+    {
+        Assert.Equal(CliInvocationKind.Help, CliDispatcher.Classify(args));
+    }
+
+    [Theory]
+    [InlineData("agent-instructions")]
+    [InlineData("job")]
+    [InlineData("plan")]
+    [InlineData("project")]
+    [InlineData("config")]
+    [InlineData("verification")]
+    [InlineData("trash")]
+    [InlineData("models")]
+    [InlineData("doctor")]
+    [InlineData("run")]
+    [InlineData("version")]
+    [InlineData("report-bug")]
+    public void Classify_RegisteredTopLevelCommand_ReturnsCliCommand(string command)
+    {
+        Assert.Equal(CliInvocationKind.CliCommand, CliDispatcher.Classify([command]));
+    }
+
+    [Fact]
+    public void Classify_VersionFlag_ReturnsVersion()
+    {
+        Assert.Equal(CliInvocationKind.Version, CliDispatcher.Classify(["--version"]));
+    }
+
+    [Theory]
+    [InlineData("mcp")]
+    [InlineData("hash-password")]
+    public void Classify_LegacyCommand_ReturnsLegacyCliCommand(string command)
+    {
+        Assert.Equal(CliInvocationKind.LegacyCliCommand, CliDispatcher.Classify([command]));
+    }
+
+    [Fact]
+    public void Classify_LegacyCommandWithArgs_ReturnsLegacyCliCommand()
+    {
+        Assert.Equal(CliInvocationKind.LegacyCliCommand, CliDispatcher.Classify(["hash-password", "pw"]));
+    }
+
+    [Fact]
+    public void Classify_EmptyArgs_ReturnsServerLaunch()
+    {
+        Assert.Equal(CliInvocationKind.ServerLaunch, CliDispatcher.Classify([]));
+    }
+
+    [Fact]
+    public void Classify_PortFlag_ReturnsServerLaunch()
+    {
+        Assert.Equal(CliInvocationKind.ServerLaunch, CliDispatcher.Classify(["--port", "5011"]));
+    }
+
+    [Fact]
+    public void Classify_FindAvailablePortFlag_ReturnsServerLaunch()
+    {
+        Assert.Equal(CliInvocationKind.ServerLaunch, CliDispatcher.Classify(["--find-available-port"]));
+    }
+
+    [Theory]
+    [InlineData("add", "project")]
+    [InlineData("--hepl")]
+    [InlineData("nonsense")]
+    public void Classify_UnrecognizedArgs_ReturnsUnknown(params string[] args)
+    {
+        var kind = CliDispatcher.Classify(args);
+        Assert.Equal(CliInvocationKind.Unknown, kind);
+        Assert.NotEqual(CliInvocationKind.ServerLaunch, kind);
+    }
+
+    [Fact]
+    public void TopLevelCommands_MatchesEveryCommandListedByHelp()
+    {
+        var console = new TestConsole();
+        var app = Program.ConfigureCliCommands(new ServiceCollection(), console);
+        app.Run(["--help"]);
+
+        var output = console.Output;
+        var commandsSectionStart = output.IndexOf("COMMANDS:", StringComparison.Ordinal);
+        Assert.True(commandsSectionStart >= 0, "Expected a COMMANDS: section in --help output.");
+
+        var commandsSection = output[commandsSectionStart..];
+        var commandNames = Regex.Matches(commandsSection, @"^\s{4}(\S+)", RegexOptions.Multiline)
+            .Select(m => m.Groups[1].Value)
+            .Distinct()
+            .ToList();
+
+        Assert.NotEmpty(commandNames);
+        foreach (var name in commandNames)
+        {
+            Assert.Contains(name, CliDispatcher.TopLevelCommands);
+        }
+    }
+
+    [Fact]
+    public void IsPortInUse_ReturnsTrue_WhenOnlyIPv6LoopbackIsBound()
+    {
+        var listener = new TcpListener(IPAddress.IPv6Loopback, 0);
+        listener.Start();
+        try
+        {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Assert.True(Program.IsPortInUse(port));
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public void IsPortInUse_ReturnsFalse_WhenPortIsFree()
+    {
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+
+        Assert.False(Program.IsPortInUse(port));
+    }
+}

--- a/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
+++ b/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Spectre.Console.Testing" Version="0.55.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />

--- a/src/Ivy.Tendril/Commands/CliDispatcher.cs
+++ b/src/Ivy.Tendril/Commands/CliDispatcher.cs
@@ -1,0 +1,82 @@
+namespace Ivy.Tendril.Commands;
+
+internal enum CliInvocationKind
+{
+    Help,
+    Version,
+    CliCommand,
+    LegacyCliCommand,
+    ServerLaunch,
+    Unknown
+}
+
+internal static class CliDispatcher
+{
+    // Every top-level Spectre command/branch registered in Program.ConfigureCliCommands.
+    // Single source of truth for dispatch — the drift-guard test in CliDispatcherTests asserts
+    // every command Spectre's own --help output lists is present here, so a command registered
+    // without a matching entry fails the build instead of silently falling through to ServerLaunch.
+    internal static readonly string[] TopLevelCommands =
+    [
+        "doctor", "project-analyzer", "generate-certs", "run",
+        "db-version", "db-migrate", "db-reset", "reset",
+        "update-promptwares", "promptware", "version", "update", "report-bug",
+        "job", "plan", "verification", "models", "agent-instructions",
+        "trash", "project", "config"
+    ];
+
+    // Legacy handlers not yet migrated to Spectre.Console.Cli (HashPasswordCommand, McpCommand).
+    internal static readonly string[] LegacyCliCommands = ["mcp", "hash-password"];
+
+    private static readonly string[] HelpTokens = ["--help", "-h", "-?", "/?"];
+
+    // Flags Ivy 1.3.8's Server.Args accepts on a bare server launch — kebab-case of the
+    // Port/FindAvailablePort/IKillForThisPort/PathBase/EnableDevTools/DescribeConnection/
+    // TestConnection backing fields, confirmed via `strings` against the installed Ivy.dll 1.3.8
+    // during plan 00078's execution (no literal "--xxx" constants exist in the assembly; the
+    // parser derives flag names from these property names at runtime).
+    private static readonly string[] ServerFlags =
+    [
+        "--port", "--find-available-port", "--i-kill-for-this-port", "--path-base",
+        "--enable-dev-tools", "--describe-connection", "--test-connection"
+    ];
+
+    // Server flags above that consume the following token as their value.
+    private static readonly string[] ServerFlagsWithValue = ["--port", "--path-base"];
+
+    public static CliInvocationKind Classify(string[] filteredArgs)
+    {
+        if (filteredArgs.Length == 0)
+            return CliInvocationKind.ServerLaunch;
+
+        if (filteredArgs[0] == "help" || filteredArgs.Any(HelpTokens.Contains))
+            return CliInvocationKind.Help;
+
+        if (filteredArgs[0] == "--version")
+            return CliInvocationKind.Version;
+
+        if (TopLevelCommands.Contains(filteredArgs[0]))
+            return CliInvocationKind.CliCommand;
+
+        if (LegacyCliCommands.Contains(filteredArgs[0]))
+            return CliInvocationKind.LegacyCliCommand;
+
+        if (IsServerFlagArgList(filteredArgs))
+            return CliInvocationKind.ServerLaunch;
+
+        return CliInvocationKind.Unknown;
+    }
+
+    private static bool IsServerFlagArgList(string[] args)
+    {
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (!ServerFlags.Contains(args[i]))
+                return false;
+
+            if (ServerFlagsWithValue.Contains(args[i]))
+                i++; // skip the value token that follows this flag
+        }
+        return true;
+    }
+}

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -91,10 +91,47 @@ public class Program
 
         bool isDetachedChild = args.Contains(DetachedLaunchMarker);
 
+        var invocationKind = CliDispatcher.Classify(filteredArgs);
+
+        if (invocationKind == CliInvocationKind.Help)
+        {
+            var helpApp = ConfigureCliCommands(new ServiceCollection());
+            try
+            {
+                return helpApp.Run(filteredArgs.Length == 0 ? new[] { "--help" } : filteredArgs);
+            }
+            catch (CommandParseException)
+            {
+                // First token wasn't a registered command (e.g. "add project --help") but a
+                // help token is present somewhere in the args — fall back to top-level help
+                // rather than letting Spectre's parse failure escape as an "unknown command" error.
+                return helpApp.Run(new[] { "--help" });
+            }
+        }
+
+        if (invocationKind == CliInvocationKind.Unknown)
+        {
+            AnsiConsole.MarkupLine($"[red]Unknown command '{filteredArgs[0].EscapeMarkup()}'.[/] Run [green]tendril --help[/] to see available commands.");
+            ConfigureCliCommands(new ServiceCollection()).Run(new[] { "--help" });
+            return 1;
+        }
+
+        if (invocationKind == CliInvocationKind.LegacyCliCommand)
+        {
+            var hashExitCode = HashPasswordCommand.Handle(filteredArgs);
+            if (hashExitCode >= 0)
+                return hashExitCode;
+
+            var mcpExitCode = McpCommand.Handle(filteredArgs);
+            if (mcpExitCode >= 0)
+                return mcpExitCode;
+        }
+
         // Check if we are launching the web server/desktop UI (not executing a CLI subcommand)
-        bool isServerLaunch = filteredArgs.Length == 0 || !ShouldHandleAsCliCommand(filteredArgs[0]);
+        bool isServerLaunch = invocationKind == CliInvocationKind.ServerLaunch;
         if (isServerLaunch && !isDetachedChild)
         {
+            CrashLog.Write($"[{DateTime.UtcNow:O}] Server launch (kind={invocationKind}) | raw args: {string.Join(" ", Environment.GetCommandLineArgs())}");
             var checkArgs = new Services.TendrilArgs { Beta = beta, Verbose = verbose, Quiet = quiet };
             var checkServer = TendrilServer.Create(filteredArgs, checkArgs);
             if (useDesktop)
@@ -130,7 +167,7 @@ public class Program
         }
 
         // Handle CLI commands using Spectre.Console.Cli
-        if (filteredArgs.Length > 0)
+        if (invocationKind == CliInvocationKind.CliCommand || invocationKind == CliInvocationKind.Version)
         {
             var cliServices = new ServiceCollection();
             var cliLogLevel = verbose ? LogLevel.Debug : quiet ? LogLevel.Warning : LogLevel.Information;
@@ -151,56 +188,43 @@ public class Program
             cliServices.AddSingleton<IGithubService>(sp => sp.GetRequiredService<GithubService>());
 
             var app = ConfigureCliCommands(cliServices);
-            var firstArg = filteredArgs[0];
 
             // Handle --version flag by converting it to "version" command
-            if (firstArg == "--version")
+            if (invocationKind == CliInvocationKind.Version)
                 filteredArgs = new[] { "version" };
 
-            if (ShouldHandleAsCliCommand(firstArg))
+            try
             {
-                try
+                var cliLog = Environment.GetEnvironmentVariable("TENDRIL_CLI_LOG");
+                if (!string.IsNullOrEmpty(cliLog))
                 {
-                    var cliLog = Environment.GetEnvironmentVariable("TENDRIL_CLI_LOG");
-                    if (!string.IsNullOrEmpty(cliLog))
-                    {
-                        var commandLine = string.Join(" ", filteredArgs);
-                        var sw = Stopwatch.StartNew();
-                        var exitCode = app.Run(filteredArgs);
-                        sw.Stop();
-                        CliInvocationLog.Append(cliLog, commandLine, exitCode, sw.Elapsed.TotalMilliseconds);
-                        return exitCode;
-                    }
-                    return app.Run(filteredArgs);
+                    var commandLine = string.Join(" ", filteredArgs);
+                    var sw = Stopwatch.StartNew();
+                    var exitCode = app.Run(filteredArgs);
+                    sw.Stop();
+                    CliInvocationLog.Append(cliLog, commandLine, exitCode, sw.Elapsed.TotalMilliseconds);
+                    return exitCode;
                 }
-                catch (CommandParseException ex)
-                {
-                    AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message.EscapeMarkup()}");
-                    return 1;
-                }
-                catch (CommandRuntimeException ex)
-                {
-                    AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message.EscapeMarkup()}");
-                    return 1;
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine($"Error: {ex.Message}");
-                    if (verbose)
-                        Console.Error.WriteLine(ex.ToString());
-                    return 1;
-                }
+                return app.Run(filteredArgs);
+            }
+            catch (CommandParseException ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message.EscapeMarkup()}");
+                return 1;
+            }
+            catch (CommandRuntimeException ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error:[/] {ex.Message.EscapeMarkup()}");
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error: {ex.Message}");
+                if (verbose)
+                    Console.Error.WriteLine(ex.ToString());
+                return 1;
             }
         }
-
-        // Legacy handlers for commands not yet migrated to Spectre.Console.Cli
-        var hashExitCode = HashPasswordCommand.Handle(filteredArgs);
-        if (hashExitCode >= 0)
-            return hashExitCode;
-
-        var mcpExitCode = McpCommand.Handle(filteredArgs);
-        if (mcpExitCode >= 0)
-            return mcpExitCode;
 
         CrashLog.Write($"[{DateTime.UtcNow:O}] Tendril starting (PID {Environment.ProcessId}) | {GetMemoryStats()}");
 
@@ -342,19 +366,6 @@ public class Program
         return (verbose, quiet, forceDesktop, forceWeb, beta, filtered);
     }
 
-    private static bool ShouldHandleAsCliCommand(string firstArg)
-    {
-        string[] cliCommands = new[]
-        {
-            "doctor", "db-version", "db-migrate", "db-reset",
-            "update-promptwares", "job", "plan", "promptware",
-            "trash", "verification", "project", "project-analyzer", "models", "config",
-            "version", "--version", "report-bug", "reset", "update",
-            "--help", "-h", "run", "generate-certs"
-        };
-        return cliCommands.Contains(firstArg);
-    }
-
     private static bool IsPackagedApp()
     {
         return Velopack.Locators.VelopackLocator.Current?.CurrentlyInstalledVersion != null;
@@ -445,13 +456,15 @@ public class Program
         }
     }
 
-    private static CommandApp ConfigureCliCommands(ServiceCollection cliServices)
+    internal static CommandApp ConfigureCliCommands(ServiceCollection cliServices, IAnsiConsole? console = null)
     {
         var registrar = new TypeRegistrar(cliServices);
         var app = new CommandApp(registrar);
         app.Configure(config =>
         {
             config.PropagateExceptions();
+            if (console != null)
+                config.Settings.Console = console;
 
             // Doctor command
             config.AddCommand<DoctorCliCommand>("doctor")
@@ -756,11 +769,19 @@ public class Program
             window.ClearBadge();
     }
 
-    private static bool IsPortInUse(int port)
+    internal static bool IsPortInUse(int port)
+    {
+        // Kestrel can bind the IPv6 loopback only, leaving the IPv4 probe below to report
+        // "free" even though the port is taken — so a bind failure on either family counts.
+        return IsPortBoundOn(System.Net.IPAddress.Loopback, port)
+            || IsPortBoundOn(System.Net.IPAddress.IPv6Loopback, port);
+    }
+
+    private static bool IsPortBoundOn(System.Net.IPAddress address, int port)
     {
         try
         {
-            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, port);
+            var listener = new System.Net.Sockets.TcpListener(address, port);
             listener.Start();
             listener.Stop();
             return false;


### PR DESCRIPTION
Fixes #1744

# Summary — Never Start the Tendril Server for Help or Unknown CLI Arguments

## Problem

`tendril --help`, `tendril agent-instructions` (a registered command missing from the old
dispatch list), and any unrecognized/typo'd command all fell through to booting a full Tendril
server, because dispatch was decided by a fail-open rule: "if the first argument isn't in this
hardcoded list, start the server." On a machine where Tendril was already running, this
produced Ivy's raw "port already in use" error (or an `Application Error` dialog in desktop
mode) instead of printing help — see [issue #1744](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/1744).

## What changed

1. **`src/Ivy.Tendril/Commands/CliDispatcher.cs` (new)** — a `CliInvocationKind` enum
   (`Help`, `Version`, `CliCommand`, `LegacyCliCommand`, `ServerLaunch`, `Unknown`) and a
   `Classify(string[] filteredArgs)` method that fails **closed**: only a recognized help
   token, `--version`, a registered top-level command, a legacy command (`mcp`,
   `hash-password`), an empty arg list, or a known server flag is ever treated as something
   other than `Unknown`. `TopLevelCommands` (21 entries, now including `agent-instructions`)
   is the single source of truth for what Spectre has registered.

2. **`src/Ivy.Tendril/Program.cs`** — `Main` now classifies `filteredArgs` once, immediately
   after `ParseGlobalFlags`, before anything can construct a server:
   - `Help` → runs the Spectre app against the real args (so `tendril job --help` still shows
     branch-specific help), falling back to top-level `--help` if the first token isn't a
     registered command (e.g. `tendril add project --help`).
   - `Unknown` → prints a usage error and returns 1 — no server is built.
   - `LegacyCliCommand` → `mcp`/`hash-password` now run *before* the port pre-check, so they
     work while Tendril is already running.
   - `CliCommand`/`Version` → unchanged Spectre execution path.
   - `ServerLaunch` → unchanged server-boot path, plus a `CrashLog.Write` of the raw command
     line and resolved classification right before `TendrilServer.Create`, so a future
     "help started a server" report shows exactly what arguments arrived.
   - Deleted the old fail-open `isServerLaunch`/`ShouldHandleAsCliCommand`.
   - `IsPortInUse` now probes both `IPAddress.Loopback` and `IPAddress.IPv6Loopback` (Kestrel
     can bind only the IPv6 loopback, which the old IPv4-only probe reported as free).
   - `ConfigureCliCommands` is now `internal static` with an optional `IAnsiConsole? console`
     parameter, wired to `config.Settings.Console`, so tests can capture its `--help` output.

3. **`src/Ivy.Tendril.Test/Commands/CliDispatcherTests.cs` (new)** — 33 tests covering every
   `CliInvocationKind` branch, a drift guard that runs the real `--help` output through a
   `Spectre.Console.Testing.TestConsole` and asserts every listed command is present in
   `CliDispatcher.TopLevelCommands` (so a future command registered without a matching entry
   fails the build instead of silently becoming a server launch), and a regression test for
   `IsPortInUse` against an IPv6-only loopback listener.

## Verification

| Verification | Result |
|---|---|
| DotnetFormat | Pass — scoped to the 3 changed `.cs` files |
| DotnetBuild | Pass — 0 errors on `Ivy.Tendril.csproj` and `Ivy.Tendril.Test.csproj` |
| DotnetTest | Pass — 1822 passed, 1 pre-existing skip, 0 failed (incl. the 33 new tests) |
| VitePlusTest | Skipped — no frontend source files changed |
| CheckResult | Pass — implementation matches the plan's Problem/Solution/Tests sections |

Manually verified end-to-end: `tendril --help`, `tendril -h`, `tendril help`, `tendril job --help`,
`tendril add project --help`, `tendril agent-instructions --help`, `tendril nonsense`,
`tendril add project`, `tendril --hepl`, `tendril --version`, `tendril mcp --help` all behave as
designed with exit codes 0/1 as appropriate and no server bound.

## Commits

- `23eb2ee5` — fix: never boot the Tendril server for help or unknown CLI args
- `a1b57d02` — test: cover CliDispatcher classification, drift guard, and IPv6 port check

---
Commits:
- 23eb2ee5
- a1b57d02

---
Created using [Ivy Tendril](https://ivy.app).