### PR TITLE
[00072] Stop Constant DataTable Refreshes Over Tunnel Connections

### DIFF
--- a/src/Ivy.Tendril.Test/Hooks/RefreshCoalescerTests.cs
+++ b/src/Ivy.Tendril.Test/Hooks/RefreshCoalescerTests.cs
@@ -1,0 +1,68 @@
+using System.Reactive.Linq;
+using Ivy.Core.Hooks;
+using Ivy.Tendril.Hooks;
+using Microsoft.Reactive.Testing;
+
+namespace Ivy.Tendril.Test.Hooks;
+
+public class RefreshCoalescerTests
+{
+    // RefreshToken wraps an IState<(Guid, object?, bool)> and has no test-friendly constructor,
+    // so we back it with a real State<T> and count emissions after the initial replayed value.
+    private static (RefreshToken Token, Func<int> RefreshCount) CreateRefreshToken()
+    {
+        var state = new State<(Guid, object?, bool)>((Guid.NewGuid(), null, false));
+        var count = 0;
+        state.Skip(1).Subscribe(_ => count++);
+        return (new RefreshToken(state), () => count);
+    }
+
+    [Fact]
+    public void FiveRequestsInOneWindow_ProduceExactlyOneRefresh()
+    {
+        var scheduler = new TestScheduler();
+        var (token, refreshCount) = CreateRefreshToken();
+        using var coalescer = new RefreshCoalescer(token, TimeSpan.FromMilliseconds(400), scheduler);
+
+        for (var i = 0; i < 5; i++)
+        {
+            coalescer.Request();
+            scheduler.AdvanceBy(TimeSpan.FromMilliseconds(50).Ticks);
+        }
+
+        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(400).Ticks);
+
+        Assert.Equal(1, refreshCount());
+    }
+
+    [Fact]
+    public void RequestsInSuccessiveWindows_ProduceOneRefreshEach()
+    {
+        var scheduler = new TestScheduler();
+        var (token, refreshCount) = CreateRefreshToken();
+        using var coalescer = new RefreshCoalescer(token, TimeSpan.FromMilliseconds(400), scheduler);
+
+        coalescer.Request();
+        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(400).Ticks);
+        Assert.Equal(1, refreshCount());
+
+        coalescer.Request();
+        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(400).Ticks);
+        Assert.Equal(2, refreshCount());
+    }
+
+    [Fact]
+    public void DisposeBeforeWindowElapses_ProducesNoRefresh()
+    {
+        var scheduler = new TestScheduler();
+        var (token, refreshCount) = CreateRefreshToken();
+        var coalescer = new RefreshCoalescer(token, TimeSpan.FromMilliseconds(400), scheduler);
+
+        coalescer.Request();
+        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(100).Ticks);
+        coalescer.Dispose();
+        scheduler.AdvanceBy(TimeSpan.FromMilliseconds(400).Ticks);
+
+        Assert.Equal(0, refreshCount());
+    }
+}

--- a/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
+++ b/src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
     <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.0.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
@@ -1,0 +1,156 @@
+using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test;
+
+public class JobsAppRefreshGatingTests
+{
+    private static JobItem MakeJob(string id, JobStatus status, DateTime? completedAt = null) => new()
+    {
+        Id = id,
+        Type = "ExecutePlan",
+        PlanFile = $"{id}-Plan",
+        Project = "Test",
+        Status = status,
+        CompletedAt = completedAt
+    };
+
+    [Fact]
+    public void ComputeStructuralSignature_StableWhenCostTokensOrStartedAtChangeOnRunningJob()
+    {
+        var job = MakeJob("job-1", JobStatus.Running);
+        var jobs = new List<JobItem> { job };
+        var before = JobsApp.ComputeStructuralSignature(jobs);
+
+        job.Cost = 1.23m;
+        job.Tokens = 500;
+        job.StartedAt = DateTime.UtcNow;
+        var after = JobsApp.ComputeStructuralSignature(jobs);
+
+        Assert.Equal(before, after);
+    }
+
+    [Fact]
+    public void ComputeStructuralSignature_ChangesWhenJobAdded()
+    {
+        var jobs = new List<JobItem> { MakeJob("job-1", JobStatus.Running) };
+        var before = JobsApp.ComputeStructuralSignature(jobs);
+
+        jobs.Add(MakeJob("job-2", JobStatus.Running));
+        var after = JobsApp.ComputeStructuralSignature(jobs);
+
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void ComputeStructuralSignature_ChangesWhenJobRemoved()
+    {
+        var jobs = new List<JobItem> { MakeJob("job-1", JobStatus.Running), MakeJob("job-2", JobStatus.Running) };
+        var before = JobsApp.ComputeStructuralSignature(jobs);
+
+        jobs.RemoveAt(1);
+        var after = JobsApp.ComputeStructuralSignature(jobs);
+
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void ComputeStructuralSignature_ChangesWhenStatusTransitionsRunningToCompleted()
+    {
+        var job = MakeJob("job-1", JobStatus.Running);
+        var jobs = new List<JobItem> { job };
+        var before = JobsApp.ComputeStructuralSignature(jobs);
+
+        job.Status = JobStatus.Completed;
+        var after = JobsApp.ComputeStructuralSignature(jobs);
+
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void BuildDataTableUpdates_FirstCall_ReturnsAllSixCells()
+    {
+        var jobService = new FakeJobService();
+        jobService.Jobs.Add(MakeJob("job-1", JobStatus.Running));
+        var cache = new Dictionary<string, string>();
+
+        var updates = JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
+
+        Assert.Equal(6, updates.Count);
+    }
+
+    [Fact]
+    public void BuildDataTableUpdates_SecondCallWithUnchangedState_ReturnsEmpty()
+    {
+        var jobService = new FakeJobService();
+        jobService.Jobs.Add(MakeJob("job-1", JobStatus.Running));
+        var cache = new Dictionary<string, string>();
+
+        JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
+        var second = JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
+
+        Assert.Empty(second);
+    }
+
+    [Fact]
+    public void BuildDataTableUpdates_OnlyChangedCellReturned_AfterCostUpdated()
+    {
+        var jobService = new FakeJobService();
+        var job = MakeJob("job-1", JobStatus.Running);
+        jobService.Jobs.Add(job);
+        var cache = new Dictionary<string, string>();
+        JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
+
+        job.Cost = 4.56m;
+        var updates = JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
+
+        var update = Assert.Single(updates);
+        Assert.Equal(nameof(JobItemRow.Cost), update.ColumnName);
+    }
+
+    [Fact]
+    public void BuildDataTableUpdates_PrunesCacheKeysForJobsNoLongerReturned()
+    {
+        var jobService = new FakeJobService();
+        jobService.Jobs.Add(MakeJob("job-1", JobStatus.Running));
+        var cache = new Dictionary<string, string>();
+        JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
+        Assert.NotEmpty(cache);
+
+        jobService.Jobs.Clear();
+        JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
+
+        Assert.Empty(cache);
+    }
+
+    private class FakeJobService : IJobService
+    {
+        public List<JobItem> Jobs { get; } = new();
+
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null) => throw new NotSupportedException();
+        public void ForceStartJob(string id) => throw new NotSupportedException();
+        public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) => throw new NotSupportedException();
+        public void StopJob(string id) => throw new NotSupportedException();
+        public void DeleteJob(string id) => throw new NotSupportedException();
+        public void ClearCompletedJobs() => throw new NotSupportedException();
+        public void ClearFailedJobs() => throw new NotSupportedException();
+        public void ClearAllJobs() => throw new NotSupportedException();
+        public List<JobItem> GetJobs() => Jobs;
+        public List<JobItem> GetJobsForPlan(string planFile) => throw new NotSupportedException();
+        public JobItem? GetJob(string id) => Jobs.FirstOrDefault(j => j.Id == id);
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => throw new NotSupportedException();
+        public bool ReportJobFailure(string id, string message) => throw new NotSupportedException();
+        public bool IsInboxFileTracked(string filePath) => false;
+        public void Dispose()
+        {
+        }
+
+#pragma warning disable CS0067
+        public event Action? JobsChanged;
+        public event Action? JobsStructureChanged;
+        public event Action? JobPropertyChanged;
+        public event Action<JobNotification>? NotificationReady;
+#pragma warning restore CS0067
+    }
+}

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
@@ -71,10 +71,21 @@ public partial class JobsApp
         return new StackedProgress(statusSegments).ShowLabels();
     }
 
-    private static IEnumerable<DataTableCellUpdate> BuildDataTableUpdates(IJobService jobService)
+    /// <summary>
+    /// Builds the candidate cell set exactly as before, then keeps only cells whose value actually
+    /// changed since the previous tick, per <paramref name="lastSent"/> (keyed by "{jobId} {columnName}",
+    /// owned by the caller so it survives across ticks). Keys for jobs no longer returned by the
+    /// service are pruned so the cache cannot grow without bound as jobs are evicted.
+    /// </summary>
+    internal static IEnumerable<DataTableCellUpdate> BuildDataTableUpdates(
+        IJobService jobService, Dictionary<string, string> lastSent)
     {
         var currentJobs = jobService.GetJobs();
-        return currentJobs
+        var currentJobIds = currentJobs.Select(j => j.Id).ToHashSet(StringComparer.Ordinal);
+        foreach (var staleKey in lastSent.Keys.Where(k => !currentJobIds.Contains(k.Split(' ')[0])).ToList())
+            lastSent.Remove(staleKey);
+
+        var candidates = currentJobs
             .Where(j => j.Status == JobStatus.Running ||
                         ((j.Status is JobStatus.Stopped or JobStatus.Failed or JobStatus.Timeout or JobStatus.Completed)
                          && j.CompletedAt.HasValue
@@ -88,5 +99,14 @@ public partial class JobsApp
                 new DataTableCellUpdate(j.Id, nameof(JobItemRow.Status), JobsApp.FormatStatusBadge(j.Status)),
                 new DataTableCellUpdate(j.Id, nameof(JobItemRow.StatusMessage), JobsApp.GetStatusMessage(j))
             });
+
+        foreach (var update in candidates)
+        {
+            var key = $"{update.RowId} {update.ColumnName}";
+            var value = update.Value as string ?? update.Value?.ToString() ?? "";
+            if (lastSent.TryGetValue(key, out var previous) && previous == value) continue;
+            lastSent[key] = value;
+            yield return update;
+        }
     }
 }

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Hooks.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Hooks.cs
@@ -21,16 +21,14 @@ public partial class JobsApp
         });
     }
 
-    private static void AutoRefreshCheck(IJobService jobService, RefreshToken refreshToken)
-    {
-        var hasActiveOrRecentJobs = jobService.GetJobs().Any(j =>
-            j.Status == JobStatus.Running ||
-            (j.Status is JobStatus.Stopped or JobStatus.Failed or JobStatus.Timeout or JobStatus.Completed
-             && j.CompletedAt.HasValue
-             && DateTime.UtcNow - j.CompletedAt.Value < TimeSpan.FromSeconds(5)));
-
-        if (hasActiveOrRecentJobs)
-            refreshToken.Refresh();
-    }
+    /// <summary>
+    /// Signature over the parts of a job row not already covered by <see cref="BuildDataTableUpdates"/>'s
+    /// cell update stream (Timer, Cost, Tokens, AgentOutput, Status, StatusMessage). Status is
+    /// included here too because it also drives <see cref="CanRerun"/> and the header's
+    /// StackedProgress, not just the badge cell.
+    /// </summary>
+    internal static string ComputeStructuralSignature(IReadOnlyList<JobItem> jobs) =>
+        string.Join("|", jobs.Select(j =>
+            $"{j.Id};{j.Status};{j.PlanFile};{j.ReportedPlanId};{j.Type};{j.Project}"));
 }
 

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
@@ -75,14 +75,22 @@ public partial class JobsApp : ViewBase
             return new RerunJobDialog(isOpen, job, jobService, () => refreshToken.Refresh());
         });
 
-        UseEffect(() => JobsApp.JobChangeHookDisposable(jobService, refreshToken));
-        UseInterval(() => JobsApp.AutoRefreshCheck(jobService, refreshToken), TimeSpan.FromSeconds(5));
+        var renderedSignature = UseRef("");
 
+        UseEffect(() => JobsApp.JobChangeHookDisposable(jobService, refreshToken));
+        UseInterval(() =>
+        {
+            if (JobsApp.ComputeStructuralSignature(jobService.GetJobs()) == renderedSignature.Value) return;
+            refreshToken.Refresh();
+        }, TimeSpan.FromSeconds(5));
+
+        var sentCells = UseRef(new Dictionary<string, string>(StringComparer.Ordinal));
         var updateStream = UseDataTableUpdates(
             Observable.Interval(TimeSpan.FromSeconds(1))
-                .SelectMany(_ => JobsApp.BuildDataTableUpdates(jobService)));
+                .SelectMany(_ => JobsApp.BuildDataTableUpdates(jobService, sentCells.Value)));
 
         var jobs = jobService.GetJobs();
+        renderedSignature.Value = JobsApp.ComputeStructuralSignature(jobs);
         var projectColors = BuildProjectColorMapping(config);
         var rows = BuildJobRows(jobs, planService);
         var jobsProgress = jobs.Count > 0 ? BuildStatusProgress(jobs, config) : null;

--- a/src/Ivy.Tendril/Hooks/RefreshCoalescer.cs
+++ b/src/Ivy.Tendril/Hooks/RefreshCoalescer.cs
@@ -1,0 +1,34 @@
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace Ivy.Tendril.Hooks;
+
+/// <summary>
+/// Collapses a burst of <see cref="Request"/> calls into at most one <see cref="RefreshToken.Refresh"/>
+/// per <paramref name="window"/>. Uses <c>Sample</c> rather than <c>Throttle</c> so a refresh still
+/// fires roughly every window under a sustained stream of requests, instead of being starved forever.
+/// </summary>
+internal sealed class RefreshCoalescer : IDisposable
+{
+    // Fully-qualified: the enclosing "Ivy" namespace also declares a "Unit" type, which shadows
+    // System.Reactive.Unit for an unqualified name lookup here.
+    private readonly Subject<System.Reactive.Unit> _requests = new();
+    private readonly IDisposable _subscription;
+
+    public RefreshCoalescer(RefreshToken refreshToken, TimeSpan window, IScheduler? scheduler = null)
+    {
+        _subscription = _requests
+            .Sample(window, scheduler ?? Scheduler.Default)
+            .Subscribe(_ => refreshToken.Refresh());
+    }
+
+    public void Request() => _requests.OnNext(System.Reactive.Unit.Default);
+
+    public void Dispose()
+    {
+        _subscription.Dispose();
+        _requests.OnCompleted();
+        _requests.Dispose();
+    }
+}

--- a/src/Ivy.Tendril/Hooks/UseInboxAutoRefresh.cs
+++ b/src/Ivy.Tendril/Hooks/UseInboxAutoRefresh.cs
@@ -19,12 +19,16 @@ public static class UseInboxAutoRefreshExtensions
 
         context.UseEffect(() =>
         {
+            // Coalesce the two signals below (both fed by the same file/job events, ~300ms apart)
+            // into a single refresh so a burst doesn't queue overlapping full re-renders.
+            var coalescer = new RefreshCoalescer(refreshToken, TimeSpan.FromMilliseconds(400));
+
             // Skip(1): the BehaviorSubject replays the current value on subscribe.
-            var subscription = statusService.Status.Skip(1).Subscribe(_ => refreshToken.Refresh());
+            var subscription = statusService.Status.Skip(1).Subscribe(_ => coalescer.Request());
 
             void OnChanged(string? _)
             {
-                refreshToken.Refresh();
+                coalescer.Request();
             }
 
             planWatcher.PlansChanged += OnChanged;
@@ -32,6 +36,7 @@ public static class UseInboxAutoRefreshExtensions
             {
                 subscription.Dispose();
                 planWatcher.PlansChanged -= OnChanged;
+                coalescer.Dispose();
             });
         });
     }


### PR DESCRIPTION
Fixes #1757

# Summary: Stop Constant DataTable Refreshes Over Tunnel Connections

Resolves [Issue #1757](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/1757).

## Changes

Three independent, unconditional push sources in the Jobs app were making every refresh
change-driven instead of time-driven, so DataTable churn (visible reloads, lost scroll/selection)
that was invisible on localhost stopped compounding on high-latency tunnel links:

1. **5-second full-table refresh → structural-signature gated.** The old `AutoRefreshCheck` fired
   `refreshToken.Refresh()` whenever any job was running or had completed within the last 5
   seconds, with no check that the rendered rows had actually changed. Replaced with
   `ComputeStructuralSignature` (a string over `Id;Status;PlanFile;ReportedPlanId;Type;Project`),
   compared each tick against the signature captured at the last render (held in a `UseRef`). A
   running job whose only change is elapsed time no longer triggers a full refresh; an added,
   removed, or status-changed job still does.

2. **6 cell updates/sec/job → diffed cell updates.** `BuildDataTableUpdates` emitted `Timer`,
   `Cost`, `Tokens`, `AgentOutput`, `Status` and `StatusMessage` every second regardless of whether
   the formatted value changed. It now takes a caller-owned `Dictionary<string, string>` cache
   (held in a `UseRef` so it survives re-renders), keyed by `"{jobId} {columnName}"`, and only
   yields cells whose value differs from what was last sent — pruning entries for jobs no longer
   returned by the service. A running job drops from 6 updates/sec to about 2 (`Timer`,
   `AgentOutput`); a recently completed job drops to zero.

3. **Double refresh per inbox change → coalesced.** `UseInboxAutoRefresh` subscribed to two
   independently-debounced sources (`ITendrilProcessStatusService.Status`,
   `IPlanWatcherService.PlansChanged`) fed by the same underlying events, firing two overlapping
   refreshes ~300ms apart. Added `RefreshCoalescer`, a small `Subject<Unit>` + `.Sample(window)`
   wrapper, and rewired both call sites to go through it (400ms window) instead of calling
   `refreshToken.Refresh()` directly — collapsing bursts to at most one refresh per window.

## API Changes

- `JobsApp.BuildDataTableUpdates` changed from `private static IEnumerable<DataTableCellUpdate>
  BuildDataTableUpdates(IJobService)` to `internal static IEnumerable<DataTableCellUpdate>
  BuildDataTableUpdates(IJobService, Dictionary<string, string> lastSent)` — widened visibility
  (to `internal`, via the existing `InternalsVisibleTo` to `Ivy.Tendril.Test`) and added the
  caller-owned diff cache parameter.
- `JobsApp.AutoRefreshCheck` (private) removed; replaced by `JobsApp.ComputeStructuralSignature`
  (`internal static`).
- New type: `Ivy.Tendril.Hooks.RefreshCoalescer` (`internal sealed class`, `IDisposable`).

No public API surface changed.

## Files Modified

- `src/Ivy.Tendril/Apps/Jobs/JobsApp.cs`
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.Hooks.cs`
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs`
- `src/Ivy.Tendril/Hooks/UseInboxAutoRefresh.cs`
- `src/Ivy.Tendril/Hooks/RefreshCoalescer.cs` (new)
- `src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs` (new)
- `src/Ivy.Tendril.Test/Hooks/RefreshCoalescerTests.cs` (new)
- `src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj` (added `Microsoft.Reactive.Testing` package
  reference)

## Manual Testing

Not performed — this is a backend-only C# change to a server-side refresh cadence, with no changed
frontend/widget code to exercise in a browser (`VitePlusTest` verification is Skipped, per the
plan). Verified instead via:

- `dotnet format --verify-no-changes` on all 7 changed `.cs` files (Pass, no changes needed).
- `dotnet build` of the test project (which transitively builds the main library) — 0 errors, 2
  pre-existing unrelated warnings (Pass).
- `dotnet test` with the plan's specified filter — 49/49 passed — and the full
  `Ivy.Tendril.Test` suite — 1800 passed, 1 pre-existing unrelated skip, 0 failed (Pass).
- Manual code-level trace of the Problem → Solution mapping against the actual diff (Pass); see
  `Verification/CheckResult.md` for the full comparison.

---
- bb6816bd fix: gate JobsApp refresh/cell updates on actual data changes
- c171b2e0 fix: coalesce bursty inbox auto-refresh requests
- 3cb7b6a2 test: cover refresh-gating, cell-diffing and RefreshCoalescer

---
Created using [Ivy Tendril](https://ivy.app).
