### PR TITLE
feat: add configurable URL option for local Ollama agents (#1735)

### DIFF
--- a/src/Ivy.Tendril.Agents/Helpers/HealthCheckRunner.cs
+++ b/src/Ivy.Tendril.Agents/Helpers/HealthCheckRunner.cs
@@ -13,7 +13,8 @@ public static class HealthCheckRunner
         string fileName,
         IReadOnlyList<string> arguments,
         TimeSpan? timeout = null,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        IReadOnlyDictionary<string, string>? environment = null)
     {
         timeout ??= TimeSpan.FromSeconds(30);
 
@@ -36,6 +37,12 @@ public static class HealthCheckRunner
 
         psi.Environment["CI"] = "true";
         psi.Environment["TERM"] = "dumb";
+
+        if (environment is not null)
+        {
+            foreach (var (key, value) in environment)
+                psi.Environment[key] = value;
+        }
 
         if (ct.IsCancellationRequested)
             return (-1, string.Empty, "Cancelled");

--- a/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/04_OpenCode.md
+++ b/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/04_OpenCode.md
@@ -43,3 +43,16 @@ Tendril maps effort levels to OpenCode models:
 OpenCode supports multiple backend providers (Anthropic, OpenAI, Google, etc.) and manages model selection internally. Use `tendril models` to see discovered models.
 
 The profile is selected automatically based on the plan's complexity level, or can be configured per promptware in `config.yaml`.
+
+## Local Ollama Setup
+
+When running OpenCode with local Ollama models, you can configure a custom server URL in **Settings > Coding Agent** under **Ollama Host / Base URL**. Alternatively, specify the server URL directly in `config.yaml`:
+
+```yaml
+codingAgents:
+- name: opencode
+  environmentVariables:
+    OLLAMA_HOST: "http://localhost:11434"
+    OLLAMA_BASE_URL: "http://localhost:11434"
+```
+

--- a/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
@@ -508,4 +508,32 @@ public class AgentProviderFactoryTests
 
         Assert.Equal(6, resolution.AllowedTools.Count);
     }
+
+    [Fact]
+    public void Resolve_OpenCode_ResolvesOllamaEnvironmentVariables()
+    {
+        var runner = CreateRunner();
+        var settings = CreateSettings(
+            "opencode",
+            codingAgents: new List<AgentConfig>
+            {
+                new()
+                {
+                    Name = "opencode",
+                    EnvironmentVariables = new Dictionary<string, string>
+                    {
+                        ["OLLAMA_HOST"] = "http://localhost:11434",
+                        ["OLLAMA_BASE_URL"] = "http://localhost:11434"
+                    }
+                }
+            });
+
+        var resolution = AgentProviderFactory.Resolve(runner, settings, "ExecutePlan");
+
+        Assert.Equal("opencode", resolution.AgentId);
+        Assert.True(resolution.EnvironmentVariables.TryGetValue("OLLAMA_HOST", out var host));
+        Assert.Equal("http://localhost:11434", host);
+        Assert.True(resolution.EnvironmentVariables.TryGetValue("OLLAMA_BASE_URL", out var baseUrl));
+        Assert.Equal("http://localhost:11434", baseUrl);
+    }
 }

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -43,6 +43,7 @@ public class CodingAgentSetupView : ViewBase
         var showTestDialog = UseState(false);
         var ivyApiKey = UseState(GetIvyApiKeyFromConfig(config));
         var ivyBaseUrl = UseState(GetIvyBaseUrlFromConfig(config));
+        var ollamaUrl = UseState(GetOllamaUrlFromConfig(config, selectedAgent.Value));
 
         var modelsQuery = UseQuery<ModelInfo[], string>(
             selectedAgent.Value,
@@ -84,6 +85,7 @@ public class CodingAgentSetupView : ViewBase
             deepModel.Set(GetProfileModel(config, selectedAgent.Value, "deep"));
             balancedModel.Set(GetProfileModel(config, selectedAgent.Value, "balanced"));
             quickModel.Set(GetProfileModel(config, selectedAgent.Value, "quick"));
+            ollamaUrl.Set(GetOllamaUrlFromConfig(config, selectedAgent.Value));
             lastAgent.Set(selectedAgent.Value);
         }
 
@@ -101,8 +103,9 @@ public class CodingAgentSetupView : ViewBase
         
         var hasApiKeyChanges = selectedAgent.Value == "ivy" && ivyApiKey.Value != GetIvyApiKeyFromConfig(config);
         var hasBaseUrlChanges = selectedAgent.Value == "ivy" && ivyBaseUrl.Value != GetIvyBaseUrlFromConfig(config);
+        var hasOllamaUrlChanges = selectedAgent.Value == "opencode" && ollamaUrl.Value != GetOllamaUrlFromConfig(config, selectedAgent.Value);
 
-        var hasChanges = selectedAgent.Value != config.Settings.CodingAgent || hasProfileChanges || hasApiKeyChanges || hasBaseUrlChanges;
+        var hasChanges = selectedAgent.Value != config.Settings.CodingAgent || hasProfileChanges || hasApiKeyChanges || hasBaseUrlChanges || hasOllamaUrlChanges;
 
         var registeredAgents = runner.RegisteredAgents;
         var visibleAgents = Agents.Where(a => registeredAgents.Contains(a.Key)).ToArray();
@@ -188,6 +191,14 @@ public class CodingAgentSetupView : ViewBase
                            .Label("Ivy Proxy Base URL (Optional)")
                            .Description("Optional. Overrides the default base URL for the Ivy API proxy."))
                    : null!)
+               | (selectedAgent.Value == "opencode"
+                   ? (object)(Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                       | new Spacer().Height(Size.Units(2))
+                       | ollamaUrl.ToTextInput("http://localhost:11434")
+                           .WithField()
+                           .Label("Ollama Host / Base URL (Optional)")
+                           .Description("Optional. Overrides the default Ollama server URL (sets OLLAMA_HOST and OLLAMA_BASE_URL environment variables)."))
+                   : null!)
                | new Spacer().Height(Size.Units(4))
                | (Layout.Horizontal().Gap(2)
                    | new Button("Test Agent").Outline()
@@ -201,6 +212,7 @@ public class CodingAgentSetupView : ViewBase
                            SaveProfiles(config, selectedAgent.Value, deepModel.Value, balancedModel.Value, quickModel.Value);
                            SaveIvyApiKey(config, ivyApiKey.Value);
                            SaveIvyBaseUrl(config, ivyBaseUrl.Value);
+                           SaveOllamaUrl(config, selectedAgent.Value, ollamaUrl.Value);
                            config.SaveSettings();
                            client.Toast("Coding agent settings saved", "Saved");
                        }))
@@ -333,6 +345,45 @@ public class CodingAgentSetupView : ViewBase
             ac.EnvironmentVariables["ANTHROPIC_BASE_URL"] = url;
         }
     }
+
+    private static string GetOllamaUrlFromConfig(IConfigService config, string agentId)
+    {
+        var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
+        if (ac != null)
+        {
+            if (ac.EnvironmentVariables.TryGetValue("OLLAMA_HOST", out var host) && !string.IsNullOrEmpty(host))
+                return host;
+            if (ac.EnvironmentVariables.TryGetValue("OLLAMA_BASE_URL", out var baseUrl) && !string.IsNullOrEmpty(baseUrl))
+                return baseUrl;
+        }
+        return "";
+    }
+
+    private static void SaveOllamaUrl(IConfigService config, string agentId, string url)
+    {
+        var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
+
+        if (ac == null)
+        {
+            if (string.IsNullOrEmpty(url)) return;
+            ac = new AgentConfig { Name = agentId };
+            config.Settings.CodingAgents.Add(ac);
+        }
+
+        if (string.IsNullOrEmpty(url))
+        {
+            ac.EnvironmentVariables.Remove("OLLAMA_HOST");
+            ac.EnvironmentVariables.Remove("OLLAMA_BASE_URL");
+        }
+        else
+        {
+            ac.EnvironmentVariables["OLLAMA_HOST"] = url;
+            ac.EnvironmentVariables["OLLAMA_BASE_URL"] = url;
+        }
+    }
+
 
     private static async Task<bool> InstallIvyAgentAsync(IClientProvider client)
     {


### PR DESCRIPTION
Add a configurable URL option in Coding Agent settings for local Ollama agent configurations (such as OpenCode running local Ollama models), persisting OLLAMA_HOST and OLLAMA_BASE_URL environment variables in AgentConfig.

Closes #1735.