### PR TITLE
feat(antigravity): add Gemini 3.6 Flash support

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityModelCatalogTests.cs
@@ -40,4 +40,22 @@ public class AntigravityModelCatalogTests
         var ids = _catalog.GetStaticModels().Select(m => m.Id).ToList();
         Assert.Equal(ids.Count, ids.Distinct().Count());
     }
+
+    [Theory]
+    [InlineData("gemini-3.6-flash-high")]
+    [InlineData("gemini-3.6-flash-medium")]
+    [InlineData("gemini-3.6-flash-low")]
+    [InlineData("gemini-3.6-flash")]
+    public void GetStaticModels_ContainsGemini36FlashModels(string expectedId)
+    {
+        var models = _catalog.GetStaticModels();
+        Assert.Contains(models, m => m.Id == expectedId);
+    }
+
+    [Fact]
+    public void GetStaticModels_DefaultIsGemini36FlashHigh()
+    {
+        var defaultModel = _catalog.GetStaticModels().Single(m => m.IsDefault);
+        Assert.Equal("gemini-3.6-flash-high", defaultModel.Id);
+    }
 }

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs
@@ -28,10 +28,38 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
     [
         new()
         {
-            Id = "gemini-3.5-flash-high", DisplayName = "Gemini 3.5 Flash (High)",
+            Id = "gemini-3.6-flash-high", DisplayName = "Gemini 3.6 Flash (High)",
             Capabilities = MidCaps,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google", IsDefault = true,
+        },
+        new()
+        {
+            Id = "gemini-3.6-flash-medium", DisplayName = "Gemini 3.6 Flash (Medium)",
+            Capabilities = MidCaps,
+            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
+            Provider = "google",
+        },
+        new()
+        {
+            Id = "gemini-3.6-flash-low", DisplayName = "Gemini 3.6 Flash (Low)",
+            Capabilities = MidCaps,
+            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
+            Provider = "google",
+        },
+        new()
+        {
+            Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash",
+            Capabilities = MidCaps,
+            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
+            Provider = "google",
+        },
+        new()
+        {
+            Id = "gemini-3.5-flash-high", DisplayName = "Gemini 3.5 Flash (High)",
+            Capabilities = MidCaps,
+            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
+            Provider = "google",
         },
         new()
         {


### PR DESCRIPTION
Add support for Gemini 3.6 Flash models (high, medium, low, standard) in AntigravityModelCatalog, set gemini-3.6-flash-high as the default model, and add unit tests.