### PR TITLE
fix: automatic Windows User PATH registration and tendril.cmd wrapper setup

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/05_ReleaseNotes/01_ReleaseNotes.md
+++ b/src/Ivy.Tendril.Docs/Docs/05_ReleaseNotes/01_ReleaseNotes.md
@@ -25,6 +25,7 @@ Version history, new features, improvements, and bug fixes for each Tendril rele
 - **Configurable Ollama Agent URL** - Added configurable base URL option (`--url`) for local Ollama agent endpoints.
 - **Import Issues Capacity** - Expanded the Import Issues dialog limit from 100 to 1,000 issues with truncation warnings when reaching ceilings.
 - **In-Flight Job State Persistence** - Persisted active in-flight jobs in SQLite database so job status updates survive master process restarts.
+- **Windows Automatic CLI PATH Setup** - Automatically create `tendril.cmd` wrappers and register the application directory in the Windows User PATH on app launch and Velopack installer hooks.
 
 ### Improvements
 

--- a/src/Ivy.Tendril.Test/Helpers/PathHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/PathHelperTests.cs
@@ -161,4 +161,11 @@ public class PathHelperTests
             Environment.SetEnvironmentVariable("PATH", originalPath);
         }
     }
+
+    [Fact]
+    public void EnsureWindowsCliSetup_DoesNotThrow()
+    {
+        PathHelper.EnsureWindowsCliSetup();
+        PathHelper.EnsureCliSymlink();
+    }
 }

--- a/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
@@ -132,6 +132,8 @@ public class JobsAppRefreshGatingTests
         public void ForceStartJob(string id) => throw new NotSupportedException();
         public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) => throw new NotSupportedException();
         public void StopJob(string id) => throw new NotSupportedException();
+        public void StopAllJobs() => throw new NotSupportedException();
+        public void StopQueuedJobs() => throw new NotSupportedException();
         public void DeleteJob(string id) => throw new NotSupportedException();
         public void ClearCompletedJobs() => throw new NotSupportedException();
         public void ClearFailedJobs() => throw new NotSupportedException();

--- a/src/Ivy.Tendril/Helpers/PathHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PathHelper.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Ivy.Tendril.Helpers;
@@ -260,7 +262,11 @@ public static class PathHelper
 
     public static void EnsureCliSymlink()
     {
-        if (OperatingSystem.IsWindows()) return;
+        if (OperatingSystem.IsWindows())
+        {
+            EnsureWindowsCliSetup();
+            return;
+        }
 
         try
         {
@@ -325,6 +331,88 @@ public static class PathHelper
         catch (Exception ex)
         {
             Ivy.Helpers.CrashLog.Write($"[PathHelper] EnsureCliSymlink failed: {ex}");
+        }
+    }
+
+    public static void EnsureWindowsCliSetup()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        try
+        {
+            var exePath = Environment.ProcessPath;
+            if (string.IsNullOrEmpty(exePath) || !File.Exists(exePath)) return;
+
+            var exeName = Path.GetFileName(exePath);
+            if (!string.Equals(exeName, "Ivy.Tendril.exe", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(exeName, "Ivy.Tendril", StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(exeName, "tendril.exe", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            var appDir = Path.GetDirectoryName(exePath);
+            if (string.IsNullOrEmpty(appDir) || !Directory.Exists(appDir)) return;
+
+            // 1. Create tendril.cmd in the app directory alongside Ivy.Tendril.exe
+            var cmdInAppDir = Path.Combine(appDir, "tendril.cmd");
+            var cmdContent = $"@echo off\r\n\"%~dp0{exeName}\" %*\r\n";
+            try
+            {
+                if (!File.Exists(cmdInAppDir) || File.ReadAllText(cmdInAppDir) != cmdContent)
+                {
+                    File.WriteAllText(cmdInAppDir, cmdContent, Encoding.ASCII);
+                    Ivy.Helpers.CrashLog.Write($"[PathHelper] Created tendril.cmd at {cmdInAppDir}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Ivy.Helpers.CrashLog.Write($"[PathHelper] Failed to create tendril.cmd in {appDir}: {ex.Message}");
+            }
+
+            // 2. Create tendril.cmd in %USERPROFILE%\.local\bin for global command access
+            try
+            {
+                var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                var localBinDir = Path.Combine(userProfile, ".local", "bin");
+                if (!Directory.Exists(localBinDir))
+                {
+                    Directory.CreateDirectory(localBinDir);
+                }
+
+                var localBinCmd = Path.Combine(localBinDir, "tendril.cmd");
+                var localBinCmdContent = $"@echo off\r\n\"{exePath}\" %*\r\n";
+                if (!File.Exists(localBinCmd) || File.ReadAllText(localBinCmd) != localBinCmdContent)
+                {
+                    File.WriteAllText(localBinCmd, localBinCmdContent, Encoding.ASCII);
+                    Ivy.Helpers.CrashLog.Write($"[PathHelper] Created tendril.cmd at {localBinCmd}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Ivy.Helpers.CrashLog.Write($"[PathHelper] Failed to create tendril.cmd in .local/bin: {ex.Message}");
+            }
+
+            // 3. Ensure appDir is present in User PATH environment variable
+            try
+            {
+                var userPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User) ?? "";
+                var pathDirs = userPath.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (!pathDirs.Any(d => string.Equals(d, appDir, StringComparison.OrdinalIgnoreCase)))
+                {
+                    var newPath = string.IsNullOrEmpty(userPath) ? appDir : $"{userPath}{Path.PathSeparator}{appDir}";
+                    Environment.SetEnvironmentVariable("PATH", newPath, EnvironmentVariableTarget.User);
+                    Ivy.Helpers.CrashLog.Write($"[PathHelper] Added {appDir} to Windows User PATH.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Ivy.Helpers.CrashLog.Write($"[PathHelper] Failed to update User PATH: {ex.Message}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Ivy.Helpers.CrashLog.Write($"[PathHelper] EnsureWindowsCliSetup failed: {ex}");
         }
     }
 

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -53,7 +53,11 @@ public class Program
     {
         try
         {
-            VelopackApp.Build().Run();
+            VelopackApp.Build()
+                .WithFirstRun(_ => PathHelper.EnsureCliSymlink())
+                .WithAfterInstallFastCallback(_ => PathHelper.EnsureCliSymlink())
+                .WithAfterUpdateFastCallback(_ => PathHelper.EnsureCliSymlink())
+                .Run();
         }
         catch { }
 


### PR DESCRIPTION
This PR implements automatic Windows CLI setup so that fresh installs of Ivy Tendril automatically configure the `tendril` CLI command in the user's PATH environment without requiring manual setup.

### What Changed

1. **`PathHelper.EnsureWindowsCliSetup()`**:
   - Added Windows-specific CLI environment setup in `PathHelper.cs`.
   - Creates `tendril.cmd` in the application installation directory alongside `Ivy.Tendril.exe`.
   - Creates `tendril.cmd` in `%USERPROFILE%\.local\bin` for global user command access.
   - Automatically registers the application installation directory in the user's `PATH` environment variable (`EnvironmentVariableTarget.User`) if not already present.

2. **App Launch & Installer Setup**:
   - Ensures `EnsureCliSymlink()` / `EnsureWindowsCliSetup()` executes on application startup and installer setup.

3. **Test Suite Coverage & Release Notes**:
   - Added unit test `EnsureWindowsCliSetup_DoesNotThrow` in `PathHelperTests.cs`.
   - Updated `FakeJobService` in `JobsAppRefreshGatingTests.cs` to satisfy test interface contracts.
   - Updated release notes documentation in `01_ReleaseNotes.md`.
