### PR TITLE
[00012] Suggest Closest Command On Unknown CLI Command

### DIFF
--- a/src/Ivy.Tendril.Test/Commands/CliDispatcherTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/CliDispatcherTests.cs
@@ -120,6 +120,64 @@ public class CliDispatcherTests
         }
     }
 
+    [Theory]
+    [InlineData("plna", "plan")]
+    [InlineData("jbo", "job")]
+    [InlineData("doctro", "doctor")]
+    [InlineData("verison", "version")]
+    [InlineData("db-rest", "db-reset")]
+    [InlineData("mpc", "mcp")]
+    public void SuggestCommand_SingleCharacterTypo_ReturnsCommand(string token, string expected)
+    {
+        Assert.Equal(expected, CliDispatcher.SuggestCommand(token));
+    }
+
+    [Fact]
+    public void SuggestCommand_IsCaseInsensitive()
+    {
+        Assert.Equal("plan", CliDispatcher.SuggestCommand("PLAN"));
+    }
+
+    [Theory]
+    [InlineData("--hepl", "--help")]
+    [InlineData("--prot", "--port")]
+    [InlineData("--verison", "--version")]
+    public void SuggestCommand_FlagTypo_ReturnsFlag(string token, string expected)
+    {
+        Assert.Equal(expected, CliDispatcher.SuggestCommand(token));
+    }
+
+    [Fact]
+    public void SuggestCommand_ExactCommand_ReturnsSameCommand()
+    {
+        Assert.Equal("plan", CliDispatcher.SuggestCommand("plan"));
+    }
+
+    [Theory]
+    [InlineData("nonsense")]
+    [InlineData("add")]
+    [InlineData("")]
+    [InlineData("zzzzzzzzzz")]
+    public void SuggestCommand_UnrelatedToken_ReturnsNull(string token)
+    {
+        Assert.Null(CliDispatcher.SuggestCommand(token));
+    }
+
+    [Fact]
+    public void SuggestCommand_BareWord_DoesNotSuggestFlag()
+    {
+        Assert.NotEqual("--help", CliDispatcher.SuggestCommand("hepl"));
+    }
+
+    [Fact]
+    public void SuggestCommand_EveryKnownCommand_SuggestsItself()
+    {
+        foreach (var command in CliDispatcher.TopLevelCommands.Concat(CliDispatcher.LegacyCliCommands))
+        {
+            Assert.Equal(command, CliDispatcher.SuggestCommand(command));
+        }
+    }
+
     [Fact]
     public void IsPortInUse_ReturnsTrue_WhenOnlyIPv6LoopbackIsBound()
     {

--- a/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
@@ -132,8 +132,8 @@ public class JobsAppRefreshGatingTests
         public void ForceStartJob(string id) => throw new NotSupportedException();
         public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) => throw new NotSupportedException();
         public void StopJob(string id) => throw new NotSupportedException();
-        public void StopAllJobs() => throw new NotSupportedException();
-        public void StopQueuedJobs() => throw new NotSupportedException();
+        public int StopAllJobs() => throw new NotSupportedException();
+        public int StopQueuedJobs() => throw new NotSupportedException();
         public void DeleteJob(string id) => throw new NotSupportedException();
         public void ClearCompletedJobs() => throw new NotSupportedException();
         public void ClearFailedJobs() => throw new NotSupportedException();

--- a/src/Ivy.Tendril/Commands/CliDispatcher.cs
+++ b/src/Ivy.Tendril/Commands/CliDispatcher.cs
@@ -79,4 +79,70 @@ internal static class CliDispatcher
         }
         return true;
     }
+
+    // Suggests the closest known command/flag for an unrecognized token, e.g. "plna" -> "plan".
+    public static string? SuggestCommand(string token)
+    {
+        token = token.Trim();
+        if (token.Length == 0)
+            return null;
+
+        var candidates = token.StartsWith('-')
+            ? ServerFlags.Concat(["--help", "--version"])
+            : TopLevelCommands.Concat(LegacyCliCommands);
+
+        var lowerToken = token.ToLowerInvariant();
+        var maxDistance = token.Length <= 4 ? 1 : 2;
+
+        string? best = null;
+        var bestDistance = int.MaxValue;
+
+        foreach (var candidate in candidates)
+        {
+            var distance = OptimalStringAlignmentDistance(lowerToken, candidate.ToLowerInvariant());
+            if (distance > maxDistance)
+                continue;
+
+            if (best is null
+                || distance < bestDistance
+                || (distance == bestDistance && candidate.Length < best.Length)
+                || (distance == bestDistance && candidate.Length == best.Length && string.CompareOrdinal(candidate, best) < 0))
+            {
+                best = candidate;
+                bestDistance = distance;
+            }
+        }
+
+        return best;
+    }
+
+    // Optimal string alignment distance: Levenshtein plus adjacent-transposition swaps costing 1,
+    // so a single-character swap like "plna" -> "plan" scores 1 instead of 2.
+    private static int OptimalStringAlignmentDistance(string a, string b)
+    {
+        var lenA = a.Length;
+        var lenB = b.Length;
+        var d = new int[lenA + 1, lenB + 1];
+
+        for (var i = 0; i <= lenA; i++)
+            d[i, 0] = i;
+        for (var j = 0; j <= lenB; j++)
+            d[0, j] = j;
+
+        for (var i = 1; i <= lenA; i++)
+        {
+            for (var j = 1; j <= lenB; j++)
+            {
+                var cost = a[i - 1] == b[j - 1] ? 0 : 1;
+                d[i, j] = Math.Min(
+                    Math.Min(d[i - 1, j] + 1, d[i, j - 1] + 1),
+                    d[i - 1, j - 1] + cost);
+
+                if (i > 1 && j > 1 && a[i - 1] == b[j - 2] && a[i - 2] == b[j - 1])
+                    d[i, j] = Math.Min(d[i, j], d[i - 2, j - 2] + 1);
+            }
+        }
+
+        return d[lenA, lenB];
+    }
 }

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -164,8 +164,16 @@ public class Program
 
         if (invocationKind == CliInvocationKind.Unknown)
         {
-            AnsiConsole.MarkupLine($"[red]Unknown command '{filteredArgs[0].EscapeMarkup()}'.[/] Run [green]tendril --help[/] to see available commands.");
-            ConfigureCliCommands(new ServiceCollection()).Run(new[] { "--help" });
+            var suggestion = CliDispatcher.SuggestCommand(filteredArgs[0]);
+            if (suggestion is not null)
+            {
+                AnsiConsole.MarkupLine($"[red]Unknown command '{filteredArgs[0].EscapeMarkup()}'.[/] Did you mean '[green]{suggestion.EscapeMarkup()}[/]'? Run [green]tendril --help[/] to see available commands.");
+            }
+            else
+            {
+                AnsiConsole.MarkupLine($"[red]Unknown command '{filteredArgs[0].EscapeMarkup()}'.[/] Run [green]tendril --help[/] to see available commands.");
+                ConfigureCliCommands(new ServiceCollection()).Run(new[] { "--help" });
+            }
             return 1;
         }
 


### PR DESCRIPTION
Fixes [ENG-2](https://linear.app/ivy-interactive/issue/ENG-2/add-very-small-feature-to-tendril)

## Changes

Added a "did you mean" suggestion for unrecognized top-level `tendril` CLI commands and flags. When
the CLI is given an unknown token, it now uses an edit-distance matcher against the known command
and flag lists; if a close match is found it prints the suggestion and skips the full help dump,
otherwise it falls back to today's exact behavior (error line plus the full `--help` table).

## API Changes

- New `internal static string? CliDispatcher.SuggestCommand(string token)` in
  `Ivy.Tendril.Commands.CliDispatcher` — returns the closest known command/flag by optimal string
  alignment distance (threshold 1 for tokens of length <= 4, 2 otherwise), or `null` if nothing is
  close enough. Candidate set is the flag list (`ServerFlags` + `--help`/`--version`) when the token
  starts with `-`, otherwise `TopLevelCommands` + `LegacyCliCommands`.
- New private `CliDispatcher.OptimalStringAlignmentDistance(string, string)` helper (Damerau-Levenshtein
  restricted to adjacent transpositions).
- No public/external API changes - both are `internal` to `Ivy.Tendril`.

## Files Modified

- `src/Ivy.Tendril/Commands/CliDispatcher.cs` - added `SuggestCommand` and the distance helper.
- `src/Ivy.Tendril/Program.cs` - the `CliInvocationKind.Unknown` branch now calls `SuggestCommand`
  and prints a "Did you mean" message (skipping the help dump) when a suggestion is found.
- `src/Ivy.Tendril.Test/Commands/CliDispatcherTests.cs` - 7 new test methods covering typos,
  transpositions, case-insensitivity, flag vs. bare-word candidate separation, unrelated tokens, and
  a self-suggestion guard over every known command.
- `src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs` - unrelated pre-existing fix: `FakeJobService.StopAllJobs()`/`StopQueuedJobs()` changed from `void` to `int` to match `IJobService`, which was blocking the entire test project from compiling on `origin/development`.

## Manual Testing

1. Build: `dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj` (or run via `dotnet run --project src/Ivy.Tendril -- <args>` for a quick check without installing).
2. Run `tendril plna list` (or `dotnet run --project src/Ivy.Tendril -- plna`) - expect
   `Unknown command 'plna'. Did you mean 'plan'? Run tendril --help to see available commands.`
   with no help table printed below it.
3. Run `tendril --hepl` - expect a suggestion of `--help`.
4. Run `tendril nonsense` - expect the error line followed by the full help table, unchanged from
   today.
5. Run `tendril plan list` and a bare `tendril` - expect both to behave exactly as before (real
   command dispatch and server launch are untouched).

---
## Commits

- bcaaa8bd Suggest closest command on unknown CLI command (plan 00012)
- 4f236dc6 Fix FakeJobService signature mismatch blocking test build (plan 00012)

---
Created using [Ivy Tendril](https://ivy.app).
