### PR TITLE
[00015] Add Plugin Loading Troubleshooting Note for Missing Dependency DLLs

### DIFF
--- a/docs/plugin-loading-troubleshooting.md
+++ b/docs/plugin-loading-troubleshooting.md
@@ -1,0 +1,26 @@
+# Plugin Loading Troubleshooting
+
+## Source-referenced plugin fails to load: missing dependency DLLs
+
+If you reference your plugin project as a path in `<TENDRIL_HOME>/plugins/plugin-references.yaml`
+(see "Option A: Plugin References File" in the plugin developer guide), the plugin can fail to load
+when a NuGet dependency it needs is not copied next to the built plugin assembly.
+
+**Symptom:** Tendril logs a `Could not load file or assembly` error from `PluginLoader`:
+
+```text
+Could not load file or assembly 'SomeDependency, Version=1.0.0.0, ...'
+```
+
+**Cause:** Your plugin's `AssemblyLoadContext` resolves dependencies from the plugin's own output
+folder. Only the shared host assemblies (`Ivy`, `Ivy.Plugin.Abstractions`,
+`Ivy.Tendril.Plugin.Abstractions`, `Ivy.Tendril.Plugin.Extended.Abstractions`) are provided by the
+host. Every other assembly your plugin references must ship alongside the plugin DLL.
+
+**How to fix:**
+
+- Confirm the dependency DLL is present in the plugin project's `bin/<Configuration>/net10.0/`
+  output directory, next to the plugin assembly.
+- If it is missing, make sure the `PackageReference` is a direct reference of the plugin project,
+  and that its assets are not marked `PrivateAssets="all"` or `ExcludeAssets="runtime"`.
+- Rebuild the plugin project and let Tendril reload it.


### PR DESCRIPTION
Fixes [ENG-2](https://linear.app/ivy-interactive/issue/ENG-2/add-very-small-feature-to-tendril)

# Summary

## Changes

Added a new standalone documentation file, `docs/plugin-loading-troubleshooting.md`, describing why a source-referenced plugin (via `plugin-references.yaml`) can fail to load when a NuGet dependency DLL is missing from the plugin's output folder. It documents the `Could not load file or assembly` symptom logged by `PluginLoader`, explains the `AssemblyLoadContext` resolution behavior, and lists steps to fix the missing dependency.

## API Changes

None.

## Files Modified

- `docs/plugin-loading-troubleshooting.md` (new file)

## Manual Testing

N/A - internal change with no user-facing behavior. This is a documentation-only addition; there is no runtime code path to exercise. A reviewer can simply open `docs/plugin-loading-troubleshooting.md` and confirm it reads clearly and matches the plugin developer guide's tone.

---
## Commits

- a8bcf0cc Add plugin loading troubleshooting note for missing dependency DLLs

---
Created using [Ivy Tendril](https://ivy.app).
