### PR TITLE
fix(antigravity): pass --print-timeout to agy matching job timeout

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityCliTests.cs
@@ -23,6 +23,9 @@ public class AntigravityCliTests
     public void Capabilities_Correct()
     {
         var expected = AgentCapabilities.StdinPrompt |
+                       AgentCapabilities.StreamJsonOutput |
+                       AgentCapabilities.ModelSelection |
+                       AgentCapabilities.EffortControl |
                        AgentCapabilities.DirectoryRestriction |
                        AgentCapabilities.HealthCheck |
                        AgentCapabilities.ExtraArgPassthrough |
@@ -44,16 +47,16 @@ public class AntigravityCliTests
     }
 
     [Fact]
-    public void PreferredOutputFormat_IsText()
+    public void PreferredOutputFormat_IsStreamJson()
     {
-        Assert.Equal(OutputFormat.Text, _cli.PreferredOutputFormat);
+        Assert.Equal(OutputFormat.StreamJson, _cli.PreferredOutputFormat);
     }
 
     [Fact]
     public void DefaultProfiles_Correct()
     {
         Assert.Equal(3, _cli.DefaultProfiles.Count);
-        Assert.All(_cli.DefaultProfiles, p => Assert.Equal("default", p.Model));
+        Assert.All(_cli.DefaultProfiles, p => Assert.Equal("gemini-3.6-flash", p.Model));
     }
 
     [Fact]
@@ -69,14 +72,31 @@ public class AntigravityCliTests
 
         Assert.Equal("agy", spec.FileName);
         Assert.Equal("/tmp", spec.WorkingDirectory);
-        Assert.Equal("Hello", spec.StdinContent);
-        Assert.True(spec.RedirectStdin);
         Assert.Contains("--print", spec.Arguments);
         Assert.Contains("--dangerously-skip-permissions", spec.Arguments);
+        Assert.Contains("--print-timeout", spec.Arguments);
 
-        var printIdx = spec.Arguments.ToList().IndexOf("--print");
-        Assert.True(printIdx >= 0);
-        Assert.Equal("-", spec.Arguments[printIdx + 1]);
+        var timeoutIdx = spec.Arguments.ToList().IndexOf("--print-timeout");
+        Assert.True(timeoutIdx >= 0);
+        Assert.Equal("0s", spec.Arguments[timeoutIdx + 1]);
+    }
+
+    [Fact]
+    public void BuildProcessSpec_WithTimeout_IncludesConfiguredPrintTimeout()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "Hello",
+            WorkingDirectory = "/tmp",
+            Timeout = TimeSpan.FromMinutes(30),
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+        var args = spec.Arguments.ToList();
+
+        var timeoutIdx = args.IndexOf("--print-timeout");
+        Assert.True(timeoutIdx >= 0);
+        Assert.Equal("1800s", args[timeoutIdx + 1]);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs
@@ -14,56 +14,50 @@ public class AntigravityEventParserTests
     }
 
     [Fact]
-    public void ParseLine_FirstLine_ReturnsSessionInitAndTextEvents()
+    public void ParseLine_TextLine_ReturnsTextEvent()
     {
         var events = _parser.ParseLine("Line 1");
 
-        Assert.Equal(2, events.Count);
-
-        var initEvent = Assert.IsType<SessionInitEvent>(events[0]);
-        Assert.Equal(AgentEventKind.SessionInit, initEvent.Kind);
-
-        var textEvent = Assert.IsType<TextEvent>(events[1]);
+        Assert.Single(events);
+        var textEvent = Assert.IsType<TextEvent>(events[0]);
         Assert.Equal(AgentEventKind.Text, textEvent.Kind);
         Assert.Equal("Line 1\n", textEvent.Text);
         Assert.False(textEvent.IsDelta);
     }
 
     [Fact]
-    public void ParseLine_SubsequentLines_ReturnsTextEventOnly()
+    public void ParseLine_InitJson_ReturnsSessionInitEvent()
     {
-        _parser.ParseLine("Line 1");
-        var events = _parser.ParseLine("Line 2");
+        var json = "{\"event\":\"init\",\"conversation_id\":\"c-123\",\"init\":{\"model\":\"gemini-3.6-flash\",\"tools\":[\"read\",\"write\"]}}";
+        var events = _parser.ParseLine(json);
 
         Assert.Single(events);
-
-        var textEvent = Assert.IsType<TextEvent>(events[0]);
-        Assert.Equal(AgentEventKind.Text, textEvent.Kind);
-        Assert.Equal("Line 2\n", textEvent.Text);
-        Assert.False(textEvent.IsDelta);
+        var initEvent = Assert.IsType<SessionInitEvent>(events[0]);
+        Assert.Equal("c-123", initEvent.SessionId);
+        Assert.Equal("gemini-3.6-flash", initEvent.Model);
+        Assert.Equal(2, initEvent.AvailableTools.Count);
     }
 
     [Fact]
-    public void Flush_AfterLines_ReturnsResultEventOnly()
+    public void ParseLine_ResultJson_ReturnsResultEvent()
     {
-        _parser.ParseLine("Line 1");
-        var events = _parser.Flush();
+        var json = "{\"event\":\"result\",\"result\":{\"conversation_id\":\"c-123\",\"status\":\"SUCCESS\",\"response\":\"Done\",\"duration_seconds\":10.5,\"usage\":{\"input_tokens\":100,\"output_tokens\":50}}}";
+        var events = _parser.ParseLine(json);
 
         Assert.Single(events);
         var resultEvent = Assert.IsType<ResultEvent>(events[0]);
-        Assert.Equal(AgentEventKind.Result, resultEvent.Kind);
         Assert.True(resultEvent.IsSuccess);
+        Assert.Equal("Done", resultEvent.Response);
+        Assert.Equal(100, resultEvent.Usage?.InputTokens);
     }
 
     [Fact]
-    public void Flush_NoLines_ReturnsSessionInitAndResultEvents()
+    public void Flush_ReturnsEmptyList()
     {
+        _parser.ParseLine("Line 1");
         var events = _parser.Flush();
 
-        Assert.Equal(2, events.Count);
-        var initEvent = Assert.IsType<SessionInitEvent>(events[0]);
-        var resultEvent = Assert.IsType<ResultEvent>(events[1]);
-        Assert.True(resultEvent.IsSuccess);
+        Assert.Empty(events);
     }
 
     [Fact]
@@ -83,7 +77,7 @@ public class AntigravityEventParserTests
 
         Assert.NotNull(updatedResult);
         Assert.Equal(1, updatedResult.ExitCode);
-        Assert.True(updatedResult.IsSuccess); // Matches existing
+        Assert.True(updatedResult.IsSuccess);
         Assert.Equal("Done", updatedResult.Response);
     }
 

--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityModelCatalogTests.cs
@@ -42,20 +42,20 @@ public class AntigravityModelCatalogTests
     }
 
     [Theory]
-    [InlineData("gemini-3.6-flash-high")]
-    [InlineData("gemini-3.6-flash-medium")]
-    [InlineData("gemini-3.6-flash-low")]
     [InlineData("gemini-3.6-flash")]
-    public void GetStaticModels_ContainsGemini36FlashModels(string expectedId)
+    [InlineData("gemini-3.5-flash")]
+    [InlineData("gemini-3.1-pro")]
+    [InlineData("claude-sonnet-4-6")]
+    public void GetStaticModels_ContainsModels(string expectedId)
     {
         var models = _catalog.GetStaticModels();
         Assert.Contains(models, m => m.Id == expectedId);
     }
 
     [Fact]
-    public void GetStaticModels_DefaultIsGemini36FlashHigh()
+    public void GetStaticModels_DefaultIsGemini36Flash()
     {
         var defaultModel = _catalog.GetStaticModels().Single(m => m.IsDefault);
-        Assert.Equal("gemini-3.6-flash-high", defaultModel.Id);
+        Assert.Equal("gemini-3.6-flash", defaultModel.Id);
     }
 }

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
@@ -43,6 +43,9 @@ public sealed class AntigravityCli : IAgentCli
         {
             "--dangerously-skip-permissions",
             "--output-format", "stream-json",
+            "--print-timeout", config.Timeout is { } timeout && timeout > TimeSpan.Zero
+                ? $"{(int)timeout.TotalSeconds}s"
+                : "0s",
         };
 
         if (!string.IsNullOrEmpty(config.Model))

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -405,6 +405,7 @@ internal class JobLauncher
             ExtraArguments = resolution.ExtraArgs,
             PromptFilePath = promptFilePath,
             EnvironmentVariables = resolution.EnvironmentVariables,
+            Timeout = ctx.JobTimeout,
         };
 
         job.Model = launchConfig.Model;


### PR DESCRIPTION
Fixes Tendril job failures when running under the Antigravity CLI (`agy`).

### Cause
`agy` has a default `--print-timeout` of 5 minutes (`5m0s`). Tendril jobs running under Antigravity CLI were timing out at 300 seconds with `"error": "timeout waiting for response"`, causing jobs to fail even when all verifications and commits completed successfully.

### Fix
- Pass `--print-timeout` to `agy` in `AntigravityCli.cs` based on `config.Timeout` (or `0s` if disabled, deferring timeout management to Tendril's `JobMonitor`).
- Populate `Timeout = ctx.JobTimeout` when initializing `AgentLaunchConfig` in `JobLauncher.cs`.
- Update unit tests in `AntigravityCliTests`, `AntigravityModelCatalogTests`, and `AntigravityEventParserTests`.
