### PR TITLE
fix(review-actions): sanitize leading slashes in Test-Path conditions

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
@@ -153,7 +153,7 @@ Inspect each repo to determine how to run the application. For website projects,
 
 For each review action:
 - **name**: Short descriptive name (e.g. "App", "Docs", "Frontend", "API")
-- **condition**: A `Test-Path` expression that checks if the worktree path exists (e.g. `Test-Path "Worktrees/<RepoName>/src/<Project>"`)
+- **condition**: A `Test-Path` expression that checks if the worktree path exists (e.g. `Test-Path "Worktrees/<RepoName>/src/<Project>"`). **Do NOT use a leading slash or backslash** (e.g. use `Test-Path "Worktrees/..."`, NOT `Test-Path "\Worktrees/..."`), as leading slashes cause PowerShell to resolve relative to the drive root instead of the plan working directory.
 - **command**: The command to launch the application
 
 ```bash

--- a/src/Ivy.Tendril.Test/PlatformHelperTests.cs
+++ b/src/Ivy.Tendril.Test/PlatformHelperTests.cs
@@ -9,11 +9,17 @@ public class PlatformHelperTests
     [InlineData(@"Test-Path \Worktrees\Ivy-Tendril\src\Ivy.Tendril\", @"Test-Path Worktrees\Ivy-Tendril\src\Ivy.Tendril\")]
     [InlineData(@"Test-Path ""\Worktrees\Ivy-Tendril\""", @"Test-Path ""Worktrees\Ivy-Tendril\""")]
     [InlineData(@"Test-Path '/Worktrees/Ivy-Tendril/'", @"Test-Path 'Worktrees/Ivy-Tendril/'")]
+    [InlineData(@"Test-Path \artifacts\sample\", @"Test-Path artifacts\sample\")]
+    [InlineData(@"Test-Path '/artifacts/sample/'", @"Test-Path 'artifacts/sample/'")]
     [InlineData(@"Test-Path Worktrees\Ivy-Tendril\", @"Test-Path Worktrees\Ivy-Tendril\")]
     [InlineData(@"Test-Path C:\Worktrees\Ivy-Tendril\", @"Test-Path C:\Worktrees\Ivy-Tendril\")]
+    [InlineData(@"Test-Path /Users/pavel/git/ivy/Worktrees/Ivy-Tendril", @"Test-Path /Users/pavel/git/ivy/Worktrees/Ivy-Tendril")]
+    [InlineData(@"Test-Path ""/Users/pavel/.tendril/Plans/00001/Worktrees/foo""", @"Test-Path ""/Users/pavel/.tendril/Plans/00001/Worktrees/foo""")]
+    [InlineData(@"Test-Path /home/user/Worktrees/Ivy-Tendril", @"Test-Path /home/user/Worktrees/Ivy-Tendril")]
+    [InlineData(@"Test-Path ~/Worktrees/Ivy-Tendril", @"Test-Path ~/Worktrees/Ivy-Tendril")]
     [InlineData(null, null)]
     [InlineData("", "")]
-    public void SanitizeConditionPath_StripsLeadingSlashesFromRelativePaths(string? input, string? expected)
+    public void SanitizeConditionPath_StripsLeadingSlashesFromRelativeWorktreePaths_PreservesAbsolutePaths(string? input, string? expected)
     {
         var actual = PlatformHelper.SanitizeConditionPath(input!);
         Assert.Equal(expected, actual);

--- a/src/Ivy.Tendril.Test/PlatformHelperTests.cs
+++ b/src/Ivy.Tendril.Test/PlatformHelperTests.cs
@@ -1,0 +1,41 @@
+using Ivy.Tendril.Helpers;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class PlatformHelperTests
+{
+    [Theory]
+    [InlineData(@"Test-Path \Worktrees\Ivy-Tendril\src\Ivy.Tendril\", @"Test-Path Worktrees\Ivy-Tendril\src\Ivy.Tendril\")]
+    [InlineData(@"Test-Path ""\Worktrees\Ivy-Tendril\""", @"Test-Path ""Worktrees\Ivy-Tendril\""")]
+    [InlineData(@"Test-Path '/Worktrees/Ivy-Tendril/'", @"Test-Path 'Worktrees/Ivy-Tendril/'")]
+    [InlineData(@"Test-Path Worktrees\Ivy-Tendril\", @"Test-Path Worktrees\Ivy-Tendril\")]
+    [InlineData(@"Test-Path C:\Worktrees\Ivy-Tendril\", @"Test-Path C:\Worktrees\Ivy-Tendril\")]
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    public void SanitizeConditionPath_StripsLeadingSlashesFromRelativePaths(string? input, string? expected)
+    {
+        var actual = PlatformHelper.SanitizeConditionPath(input!);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void EvaluatePowerShellCondition_WithLeadingSlashInCondition_EvaluatesRelativeToWorkingDirectory()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilPlatformHelperTest_" + Guid.NewGuid().ToString("N"));
+        var subDir = Path.Combine(tempDir, "Worktrees", "TestProject");
+        Directory.CreateDirectory(subDir);
+
+        try
+        {
+            var condition = @"Test-Path \Worktrees\TestProject";
+            var result = PlatformHelper.EvaluatePowerShellCondition(condition, tempDir);
+            Assert.True(result);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}

--- a/src/Ivy.Tendril/Helpers/PlatformHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlatformHelper.cs
@@ -15,10 +15,11 @@ public static class PlatformHelper
     {
         try
         {
+            var sanitizedCondition = SanitizeConditionPath(condition);
             var psi = new ProcessStartInfo
             {
                 FileName = PathHelper.GetPwshPath(),
-                Arguments = $"-NoProfile -Command \"if ({condition}) {{ exit 0 }} else {{ exit 1 }}\"",
+                Arguments = $"-NoProfile -Command \"if ({sanitizedCondition}) {{ exit 0 }} else {{ exit 1 }}\"",
                 WorkingDirectory = workingDirectory,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
@@ -39,6 +40,20 @@ public static class PlatformHelper
             logger?.LogWarning(ex, "Failed to evaluate PowerShell condition");
             return false;
         }
+    }
+
+    /// <summary>
+    /// Strips leading slashes or backslashes from relative paths inside Test-Path condition expressions
+    /// so PowerShell evaluates them relative to the working directory instead of the drive root.
+    /// </summary>
+    public static string SanitizeConditionPath(string condition)
+    {
+        if (string.IsNullOrWhiteSpace(condition)) return condition;
+
+        return System.Text.RegularExpressions.Regex.Replace(
+            condition,
+            @"(?i)(Test-Path\s+[""']?)[\\/]+(?![a-zA-Z]:)",
+            "$1");
     }
 
     /// <summary>

--- a/src/Ivy.Tendril/Helpers/PlatformHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlatformHelper.cs
@@ -43,8 +43,9 @@ public static class PlatformHelper
     }
 
     /// <summary>
-    /// Strips leading slashes or backslashes from relative paths inside Test-Path condition expressions
+    /// Strips leading slashes or backslashes from relative worktree/artifact paths inside Test-Path condition expressions
     /// so PowerShell evaluates them relative to the working directory instead of the drive root.
+    /// Preserves genuine absolute paths (e.g. /Users/..., /home/..., C:\...).
     /// </summary>
     public static string SanitizeConditionPath(string condition)
     {
@@ -52,7 +53,7 @@ public static class PlatformHelper
 
         return System.Text.RegularExpressions.Regex.Replace(
             condition,
-            @"(?i)(Test-Path\s+[""']?)[\\/]+(?![a-zA-Z]:)",
+            @"(?i)(Test-Path\s+[""']?)[\\/]+(?=(Worktrees|artifacts)[\\/])",
             "$1");
     }
 

--- a/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
@@ -156,7 +156,7 @@ Inspect each repo to determine how to run the application. For website projects,
 
 For each review action:
 - **name**: Short descriptive name (e.g. "App", "Docs", "Frontend", "API")
-- **condition**: A `Test-Path` expression that checks if the worktree path exists (e.g. `Test-Path "Worktrees/<RepoName>/src/<Project>"`)
+- **condition**: A `Test-Path` expression that checks if the worktree path exists (e.g. `Test-Path "Worktrees/<RepoName>/src/<Project>"`). **Do NOT use a leading slash or backslash** (e.g. use `Test-Path "Worktrees/..."`, NOT `Test-Path "\Worktrees/..."`), as leading slashes cause PowerShell to resolve relative to the drive root instead of the plan working directory.
 - **command**: The command to launch the application
 
 ```bash


### PR DESCRIPTION
Fixes #1820.

### Cause
Review action conditions generated by AI setup agents (`SetupProject`) or added manually often contain leading backslashes or slashes in `Test-Path` expressions (e.g., `Test-Path \Worktrees\Ivy-Tendril\src\Ivy.Tendril\`).

When evaluated in PowerShell with `workingDirectory = folderPath`, PowerShell interprets leading slashes/backslashes as drive-root relative (`D:\Worktrees`), which fails (`$false`) and disables the review action button.

### Fix
1. **PlatformHelper Sanitization**: Added `SanitizeConditionPath` in `PlatformHelper.cs` to strip leading slashes/backslashes from relative `Test-Path` arguments before passing them to `pwsh`.
2. **SetupProject Promptware Guidance**: Added explicit instruction in `SetupProject/Program.md` (both in `Ivy.Tendril` and `TeamIvyConfig`) directing agents **never** to output leading slashes in `Test-Path` conditions.
3. **Unit Tests**: Added `PlatformHelperTests.cs` verifying path sanitization and condition evaluation.
