### PR TITLE
[00011] Fix Create New Plan Layout and Spacing Issues

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/content-input.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ContentInput/content-input.css
@@ -81,7 +81,7 @@
   background: var(--civ-bg);
   border: none;
   border-radius: var(--radius-fields);
-  padding: 0 8px;
+  padding: 10px 12px;
   box-shadow: var(--civ-card-shadow);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -113,9 +113,8 @@
   color: var(--civ-text);
   padding: 2px 12px 2px 0;
   min-height: 80px;
-  max-height: 200px;
-  width: calc(100% + 12px);
-  margin-right: -12px;
+  max-height: 280px;
+  width: 100%;
 }
 
 .civ-textarea::placeholder {

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -136,28 +136,28 @@ public class CreatePlanDialog(
         }
 
         var projectPicker = new BadgeSelect
-            {
-                Options = projectOptions.ToArray(),
-                Value = selectedProjects.Value,
-                Placeholder = "Select project(s)",
-                Icon = selectedProjects.Value.Contains("Auto") || selectedProjects.Value.Length == 0
+        {
+            Options = projectOptions.ToArray(),
+            Value = selectedProjects.Value,
+            Placeholder = "Select project(s)",
+            Icon = selectedProjects.Value.Contains("Auto") || selectedProjects.Value.Length == 0
                     ? "WandSparkles"
                     : "Folder",
-                Multiple = true,
-                Tooltip = "Select project(s)",
-            }
+            Multiple = true,
+            Tooltip = "Select project(s)",
+        }
             .WithOnChange(SetProjects)
             .Width(Size.Grow());
 
         var priorityPicker = new BadgeSelect
-            {
-                Options = PriorityOptions.Select(p => new BadgeSelectOption(p, p)).ToArray(),
-                Value = [selectedPriority.Value],
-                Placeholder = "Priority",
-                Icon = "Flag",
-                Multiple = false,
-                Tooltip = "Priority",
-            }
+        {
+            Options = PriorityOptions.Select(p => new BadgeSelectOption(p, p)).ToArray(),
+            Value = [selectedPriority.Value],
+            Placeholder = "Priority",
+            Icon = "Flag",
+            Multiple = false,
+            Tooltip = "Priority",
+        }
             .WithOnChange(values => selectedPriority.Set(values.FirstOrDefault() ?? "Normal"))
             .Width(Size.Auto());
 

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -147,7 +147,7 @@ public class CreatePlanDialog(
                 Tooltip = "Select project(s)",
             }
             .WithOnChange(SetProjects)
-            .Width(Size.Percent(66));
+            .Width(Size.Grow());
 
         var priorityPicker = new BadgeSelect
             {
@@ -159,7 +159,7 @@ public class CreatePlanDialog(
                 Tooltip = "Priority",
             }
             .WithOnChange(values => selectedPriority.Set(values.FirstOrDefault() ?? "Normal"))
-            .Width(Size.Percent(33));
+            .Width(Size.Auto());
 
         var newProjectButton = new Button()
             .Icon(Icons.Plus)
@@ -168,7 +168,7 @@ public class CreatePlanDialog(
             .OnClick(() => isAddProjectOpen.Set(true));
 
         var bodyContent =
-                Layout.Vertical().Margin(0,2,0,0)
+                Layout.Vertical().Gap(2)
                 | (Layout.Horizontal().Gap(1).AlignContent(Align.Left).Width(Size.Full())
                     | (Layout.Horizontal().Gap(1).Width(Size.Grow())
                         | projectPicker


### PR DESCRIPTION
# Summary

## Changes

Fixed layout and spacing issues in the CreateNewPlan dialog by replacing asymmetric margins with consistent gaps, updating card padding for better edge spacing, adjusting picker widths to prevent overflow, removing the negative margin scrollbar trick, and increasing textarea max-height for better vertical space utilization.

## API Changes

None.

## Files Modified

**Backend:**
- `src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs` - Changed layout margin to gap, adjusted picker widths, applied formatting

**Frontend:**
- `src/Ivy.Tendril.Widgets/frontend/src/ContentInput/content-input.css` - Updated card padding, removed negative margin hack, increased textarea max-height

## Manual Testing

1. Run the Tendril application
2. Navigate to the Plans view
3. Click "Create New Plan" or use the keyboard shortcut
4. Observe the dialog layout:
   - Card should have consistent padding around all edges (10px top/bottom, 12px left/right)
   - Project picker and priority picker should fit within the container without overflow
   - Text area should utilize more vertical space (max 280px instead of 200px)
   - Scrollbar should appear naturally inside the card boundary without visual breaks
   - Overall spacing should feel balanced with consistent gaps between elements

---

## Commits

8fbb995e Fix formatting in CreatePlanDialog
16ce3d1c Fix CreateNewPlan dialog layout and spacing issues

---
Created using [Ivy Tendril](https://ivy.app).
