### PR TITLE
[00008] Fix Tendril Doctor Process Stdin Hang on Antigravity Health Check

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Helpers/HealthCheckRunnerTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Helpers/HealthCheckRunnerTests.cs
@@ -7,8 +7,15 @@ public class HealthCheckRunnerTests
     [Fact]
     public async Task RunAsync_SuccessfulCommand_ReturnsZeroExitCode()
     {
+        var cmd = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+            System.Runtime.InteropServices.OSPlatform.Windows) ? "cmd" : "echo";
+        var args = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+            System.Runtime.InteropServices.OSPlatform.Windows)
+            ? new[] { "/c", "echo hello" }
+            : new[] { "hello" };
+
         var (exitCode, stdout, stderr) = await HealthCheckRunner.RunAsync(
-            "echo", ["hello"], TimeSpan.FromSeconds(5));
+            cmd, args, TimeSpan.FromSeconds(5));
 
         Assert.Equal(0, exitCode);
         Assert.Contains("hello", stdout);
@@ -76,10 +83,34 @@ public class HealthCheckRunnerTests
     [Fact]
     public async Task RunAsync_DefaultTimeout_IsThirtySeconds()
     {
+        var cmd = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+            System.Runtime.InteropServices.OSPlatform.Windows) ? "cmd" : "echo";
+        var args = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+            System.Runtime.InteropServices.OSPlatform.Windows)
+            ? new[] { "/c", "echo default timeout" }
+            : new[] { "default timeout" };
+
         var (exitCode, stdout, _) = await HealthCheckRunner.RunAsync(
-            "echo", ["default timeout"]);
+            cmd, args);
 
         Assert.Equal(0, exitCode);
         Assert.Contains("default timeout", stdout);
+    }
+
+    [Fact]
+    public async Task RunAsync_ClosesStandardInput_PreventsStdinHang()
+    {
+        var cmd = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+            System.Runtime.InteropServices.OSPlatform.Windows) ? "cmd" : "sh";
+        var args = System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(
+            System.Runtime.InteropServices.OSPlatform.Windows)
+            ? new[] { "/c", "sort" }
+            : new[] { "-c", "cat" };
+
+        var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
+            cmd, args, TimeSpan.FromSeconds(5));
+
+        Assert.Equal(0, exitCode);
+        Assert.NotEqual("Timed out", stderr);
     }
 }

--- a/src/Ivy.Tendril.Agents/Helpers/HealthCheckRunner.cs
+++ b/src/Ivy.Tendril.Agents/Helpers/HealthCheckRunner.cs
@@ -58,6 +58,7 @@ public static class HealthCheckRunner
         try
         {
             process.Start();
+            process.StandardInput.Close();
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
         }


### PR DESCRIPTION
Fixes #1816

# Summary

## Changes

Fixed a process hang in `tendril doctor` health checks by closing standard input immediately after spawning CLI processes. Added `process.StandardInput.Close()` call in `HealthCheckRunner.RunAsync` to send EOF signal to child processes, preventing interactive CLI tools from waiting indefinitely for user input during non-interactive health checks.

## API Changes

None.

## Files Modified

**Core Logic:**
- `src/Ivy.Tendril.Agents/Helpers/HealthCheckRunner.cs` - Added stdin close after process start

**Tests:**
- `src/Ivy.Tendril.Agents.Test/Helpers/HealthCheckRunnerTests.cs` - Added `RunAsync_ClosesStandardInput_PreventsStdinHang` test and fixed existing tests for cross-platform compatibility

## Manual Testing

1. Run `tendril doctor`
2. Observe the AgentModelsCheck step (which runs health checks on configured coding agents like Antigravity)
3. Verify the command completes promptly without hanging (previously would hang for 30 seconds until timeout)
4. Check that all health checks complete successfully

---

**Commits:**
- 22bf8c04 Fix tendril doctor process stdin hang on health check (00008)

---
Created using [Ivy Tendril](https://ivy.app).
