### PR TITLE
[00012] Increase Default Max Concurrent Jobs Limit to 20

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
@@ -6,10 +6,10 @@ namespace Ivy.Tendril.Test;
 public class JobServiceConcurrencyTests
 {
     [Fact]
-    public void MaxConcurrentJobs_DefaultsToFive()
+    public void MaxConcurrentJobs_DefaultsToTwenty()
     {
         var settings = new TendrilSettings();
-        Assert.Equal(5, settings.MaxConcurrentJobs);
+        Assert.Equal(20, settings.MaxConcurrentJobs);
     }
 
     [Fact]
@@ -200,7 +200,7 @@ public class JobServiceConcurrencyTests
 
     private class TestConfigService : IConfigService
     {
-        public int MaxConcurrentJobs { get; set; } = 5;
+        public int MaxConcurrentJobs { get; set; } = 20;
 
         public TendrilSettings Settings => new()
         {

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -164,7 +164,7 @@ public class TendrilSettings
     public int JobTimeout { get; set; } = 30;
     public int StaleOutputTimeout { get; set; } = 10;
     public int GitTimeout { get; set; } = 10;
-    public int MaxConcurrentJobs { get; set; } = 5;
+    public int MaxConcurrentJobs { get; set; } = 20;
 
     public List<ProjectConfig> Projects { get; set; } = new();
     public List<VerificationConfig> Verifications { get; set; } = new();
@@ -457,9 +457,9 @@ public class ConfigService : IConfigService, IDisposable
         // MaxConcurrentJobs: 1-100
         if (Settings.MaxConcurrentJobs < 1 || Settings.MaxConcurrentJobs > 100)
         {
-            _logger.LogWarning("MaxConcurrentJobs {Value} is out of bounds (1-100). Using default 5.",
+            _logger.LogWarning("MaxConcurrentJobs {Value} is out of bounds (1-100). Using default 20.",
                 Settings.MaxConcurrentJobs);
-            Settings.MaxConcurrentJobs = 5;
+            Settings.MaxConcurrentJobs = 20;
         }
     }
 

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -73,7 +73,7 @@ public class JobService : IJobService
         TimeSpan jobTimeout,
         TimeSpan staleOutputTimeout,
         string? inboxPath = null,
-        int maxConcurrentJobs = 5,
+        int maxConcurrentJobs = 20,
         IPlanReaderService? planReaderService = null,
         ITelemetryService? telemetryService = null,
         IPlanDatabaseService? database = null,

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -5,7 +5,7 @@ codingAgent: claude
 jobTimeout: 30
 staleOutputTimeout: 10
 gitTimeout: 10  # Timeout in seconds for git operations (default: 10)
-maxConcurrentJobs: 5  # Maximum number of jobs to run concurrently (default: 5)
+maxConcurrentJobs: 20  # Maximum number of jobs to run concurrently (default: 20)
 
 # Variable Expansion Support:
 # - %TENDRIL_HOME% - Expands to TENDRIL_HOME env var (useful in hooks, verification prompts, and allowedTools paths)


### PR DESCRIPTION
# Summary

## Changes

Increased the default maximum concurrent jobs limit from 5 to 20 across all relevant code locations to support workflows requiring higher job parallelism.

## API Changes

- `TendrilSettings.MaxConcurrentJobs` property default changed from 5 to 20
- `JobService` secondary constructor parameter `maxConcurrentJobs` default changed from 5 to 20
- `ConfigService.ValidateSettings()` fallback value for out-of-bounds MaxConcurrentJobs changed from 5 to 20

## Files Modified

**Configuration and Services:**
- `src/Ivy.Tendril/Services/ConfigService.cs` — Updated TendrilSettings default, validation fallback value and log message
- `src/Ivy.Tendril/Services/Jobs/JobService.cs` — Updated constructor parameter default
- `src/Ivy.Tendril/example.config.yaml` — Updated example configuration value and comment

**Tests:**
- `src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs` — Updated test method name, assertions, and test helper default

## Manual Testing

N/A — internal configuration change with no user-facing UI behavior. The change affects job scheduling capacity which can be verified by monitoring the Jobs view when multiple plans are executed concurrently. With the new default, users should be able to run up to 20 jobs simultaneously instead of 5.

---

## Commits
- 8afdc4bb

---
Created using [Ivy Tendril](https://ivy.app).
