### PR TITLE
[00006] Normalize Path Separators to Forward Slashes on Windows

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -464,20 +464,14 @@ levels:
     public void ExpandVariables_NormalizesMixedPathSeparators()
     {
         var result = VariableExpansion.ExpandVariables(@"D:/Repos/Mixed\Path", "");
-        if (Path.DirectorySeparatorChar == '\\')
-            Assert.Equal(@"D:\Repos\Mixed\Path", result);
-        else
-            Assert.Equal("D:/Repos/Mixed/Path", result);
+        Assert.Equal("D:/Repos/Mixed/Path", result);
     }
 
     [Fact]
     public void ExpandVariables_NormalizesForwardSlashesOnWindows()
     {
         var result = VariableExpansion.ExpandVariables("D:/Repos/ForwardSlash", "");
-        if (Path.DirectorySeparatorChar == '\\')
-            Assert.Equal(@"D:\Repos\ForwardSlash", result);
-        else
-            Assert.Equal("D:/Repos/ForwardSlash", result);
+        Assert.Equal("D:/Repos/ForwardSlash", result);
     }
 
     [Fact]
@@ -536,6 +530,20 @@ levels:
         };
 
         var result = project.GetRepoRef(@"d:\repos\foo");
+        Assert.NotNull(result);
+        Assert.Equal("yolo", result.PrRule);
+    }
+
+    [Fact]
+    public void GetRepoRef_NormalizesMixedPathSeparators()
+    {
+        var project = new ProjectConfig
+        {
+            Name = "Test",
+            Repos = [new RepoRef { Path = @"D:\Repos\Foo", PrRule = "yolo" }]
+        };
+
+        var result = project.GetRepoRef("D:/Repos/Foo");
         Assert.NotNull(result);
         Assert.Equal("yolo", result.PrRule);
     }

--- a/src/Ivy.Tendril.Test/Helpers/VariableExpansionTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/VariableExpansionTests.cs
@@ -62,7 +62,7 @@ public class VariableExpansionTests
     public void ExpandVariables_ExpandsTendrilHome()
     {
         // Arrange
-        var testPath = Path.Combine("test", "path");
+        var testPath = Path.Combine("test", "path").Replace('\\', '/');
 
         // Act
         var result = VariableExpansion.ExpandVariables("%TENDRIL_HOME%", testPath);

--- a/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
@@ -132,8 +132,8 @@ public class JobsAppRefreshGatingTests
         public void ForceStartJob(string id) => throw new NotSupportedException();
         public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) => throw new NotSupportedException();
         public void StopJob(string id) => throw new NotSupportedException();
-        public void StopAllJobs() => throw new NotSupportedException();
-        public void StopQueuedJobs() => throw new NotSupportedException();
+        public int StopAllJobs() => throw new NotSupportedException();
+        public int StopQueuedJobs() => throw new NotSupportedException();
         public void DeleteJob(string id) => throw new NotSupportedException();
         public void ClearCompletedJobs() => throw new NotSupportedException();
         public void ClearFailedJobs() => throw new NotSupportedException();

--- a/src/Ivy.Tendril.Test/ProjectCommandTests.cs
+++ b/src/Ivy.Tendril.Test/ProjectCommandTests.cs
@@ -163,7 +163,7 @@ verifications: []
 
         var reloaded = CreateConfig();
         Assert.Single(reloaded.Settings.Projects[0].Repos);
-        Assert.Equal(repoPath, reloaded.Settings.Projects[0].Repos[0].Path);
+        Assert.Equal(repoPath.Replace('\\', '/'), reloaded.Settings.Projects[0].Repos[0].Path);
     }
 
     [Fact]
@@ -190,7 +190,7 @@ verifications: []
 
         var reloaded = CreateConfig();
         Assert.Single(reloaded.Settings.Projects[0].Repos);
-        Assert.Equal(keepPath, reloaded.Settings.Projects[0].Repos[0].Path);
+        Assert.Equal(keepPath.Replace('\\', '/'), reloaded.Settings.Projects[0].Repos[0].Path);
     }
 
     // --- Add/Remove Verification ---
@@ -486,7 +486,7 @@ verifications: []
         var ex = Assert.Throws<InvalidOperationException>(
             () => app.Run(["project", "remove-repo", "Test", Path.Combine(_tempDir.Path, "OtherRepo")]));
 
-        Assert.Contains($"Available: {seededPath}", ex.Message);
+        Assert.Contains($"Available: {seededPath.Replace('\\', '/')}", ex.Message);
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Helpers/VariableExpansion.cs
+++ b/src/Ivy.Tendril/Helpers/VariableExpansion.cs
@@ -77,7 +77,7 @@ public static class VariableExpansion
         // This handles %REPOS_HOME% and any other env vars
         value = Environment.ExpandEnvironmentVariables(value);
 
-        // Normalize path separators: convert forward slashes to backslashes on Windows,
+        // Normalize path separators: convert backslashes to forward slashes,
         // and remove any double slashes that might have been created during expansion
         if (normalizePaths)
             value = NormalizePath(value);
@@ -96,18 +96,12 @@ public static class VariableExpansion
         // (contains both path separators or environment variable markers)
         if (!value.Contains('/') && !value.Contains('\\')) return value;
 
-        // On Windows, standardize to backslashes
-        if (Path.DirectorySeparatorChar == '\\')
-            value = value.Replace('/', '\\');
-        // On Unix, standardize to forward slashes
-        else
-            value = value.Replace('\\', '/');
+        // Standardize all path separators to forward slashes on all platforms
+        value = value.Replace('\\', '/');
 
-        // Remove double separators (e.g., \\ or //) — but skip URI scheme separators (e.g., https://)
-        var sep = Path.DirectorySeparatorChar.ToString();
-        var doubleSep = sep + sep;
-        if (value.Contains(doubleSep))
-            value = Regex.Replace(value, "(?<!:)(" + Regex.Escape(doubleSep) + ")", sep);
+        // Remove double separators (e.g., //) — but skip URI scheme separators (e.g., https://)
+        if (value.Contains("//"))
+            value = Regex.Replace(value, "(?<!:)(//)", "/");
 
         return value;
     }

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -61,14 +61,14 @@ public record ProjectConfig
 
         try
         {
-            // Get full path and remove trailing directory separators
-            var normalized = Path.GetFullPath(path);
-            return normalized.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            // Get full path and remove trailing directory separators, standardizing to forward slashes
+            var normalized = Path.GetFullPath(path).Replace('\\', '/');
+            return normalized.TrimEnd('/');
         }
         catch
         {
             // If Path.GetFullPath fails (e.g., invalid path), return original with trimmed separators
-            return path.TrimEnd('/', '\\');
+            return path.Replace('\\', '/').TrimEnd('/');
         }
     }
 }


### PR DESCRIPTION
Fixes #1807

## Problem

The Tendril CLI currently normalizes forward slashes (`/`) to backslashes (`\`) on Windows systems when storing paths in variables, configuration, and data files. This behavior causes path strings in stored prompts, configuration files, xUnit/NUnit path specs, Vite/pnpm paths, and git pathspecs to be mangled with backslashes on Windows instead of consistently using forward slashes (`/`) across all platforms.

![1785359326-181839-image.png](https://stivytelemetry.blob.core.windows.net/dumpsterbot/39abdceb-722c-40d6-a432-6620e5459509/1785359326-181839-image.png)

## Solution

1. Updated `NormalizePath` in `VariableExpansion.cs` to standardize all path separators to forward slashes (`/`) on all platforms, including Windows
2. Updated `NormalizePath` in `ConfigService.cs` to return paths with forward slashes (`/`) on all platforms
3. Updated existing unit tests in `ConfigServiceTests.cs` to assert forward slashes on all platforms

---

**Commits:**
- 3f16e43f - Normalize path separators to forward slashes on Windows (Plan 00006)

---
Created using [Ivy Tendril](https://ivy.app).
