### PR TITLE
[00010] Fix Chat Session Renaming UI Reactivity

### DIFF
--- a/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
@@ -84,4 +84,35 @@ public class ChatHistoryServiceTests
                 Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void RenameSession_UpdatesTitleAndFiresEvent()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "sonnet", "Old Title");
+            var eventFired = false;
+            service.SessionsChanged += (sender, args) => eventFired = true;
+
+            service.RenameSession(session.Id, "New Title");
+
+            var updatedSession = service.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            Assert.Equal("New Title", updatedSession.Title);
+            Assert.True(eventFired);
+
+            // Verify persistence by reloading service from same temp directory
+            var newConfigService = new ConfigService(new TendrilSettings(), tempDir);
+            var reloadedService = new ChatHistoryService(newConfigService);
+            var reloadedSession = reloadedService.GetSession(session.Id);
+            Assert.NotNull(reloadedSession);
+            Assert.Equal("New Title", reloadedSession.Title);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -205,12 +205,29 @@ export function ChatWidget({
   const [sidebarEditingText, setSidebarEditingText] = useState("");
   const [attachments, setAttachments] = useState<ChatAttachmentDto[]>([]);
   const [queuedMessages, setQueuedMessages] = useState<QueuedItem[]>([]);
+  const [pendingRenames, setPendingRenames] = useState<Record<string, string>>({});
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const activeSession = sessions.find((s) => s.id === activeSessionId);
+
+  // Clear pending renames once they appear in props
+  useEffect(() => {
+    const updatedPending = { ...pendingRenames };
+    let changed = false;
+    for (const [sessionId, expectedTitle] of Object.entries(pendingRenames)) {
+      const session = sessions.find((s) => s.id === sessionId);
+      if (session && session.title === expectedTitle) {
+        delete updatedPending[sessionId];
+        changed = true;
+      }
+    }
+    if (changed) {
+      setPendingRenames(updatedPending);
+    }
+  }, [sessions, pendingRenames]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -259,7 +276,9 @@ export function ChatWidget({
 
   const saveHeaderTitleEdit = () => {
     if (activeSession && editingTitleText.trim() && editingTitleText.trim() !== activeSession.title) {
-      emit("OnRenameSession", activeSession.id, editingTitleText.trim());
+      const newTitle = editingTitleText.trim();
+      setPendingRenames((prev) => ({ ...prev, [activeSession.id]: newTitle }));
+      emit("OnRenameSession", activeSession.id, newTitle);
     }
     setIsEditingTitle(false);
   };
@@ -272,7 +291,9 @@ export function ChatWidget({
 
   const saveSidebarTitleEdit = (sessionId: string) => {
     if (sidebarEditingText.trim()) {
-      emit("OnRenameSession", sessionId, sidebarEditingText.trim());
+      const newTitle = sidebarEditingText.trim();
+      setPendingRenames((prev) => ({ ...prev, [sessionId]: newTitle }));
+      emit("OnRenameSession", sessionId, newTitle);
     }
     setEditingSessionId(null);
   };
@@ -462,7 +483,9 @@ export function ChatWidget({
                         autoFocus
                       />
                     ) : (
-                      <span className="chat-session-title">{sess.title || "Untitled Chat"}</span>
+                      <span className="chat-session-title">
+                        {pendingRenames[sess.id] || sess.title || "Untitled Chat"}
+                      </span>
                     )}
                     <div className="chat-session-meta">
                       {status === "generating" ? (
@@ -530,7 +553,9 @@ export function ChatWidget({
               />
             ) : (
               <div className="chat-header-title-row" onClick={startHeaderTitleEdit} title="Click to rename chat">
-                <h1 className="chat-main-title">{activeSession?.title || "New Chat"}</h1>
+                <h1 className="chat-main-title">
+                  {(activeSession && pendingRenames[activeSession.id]) || activeSession?.title || "New Chat"}
+                </h1>
                 <Pencil size={13} className="chat-title-pencil" />
               </div>
             )}

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -50,7 +50,8 @@ public class ChatApp : ViewBase
             return Disposable.Create(() => chatService.SessionsChanged -= OnSessionsChanged);
         });
 
-        // Map sessions to DTOs
+        // Map sessions to DTOs - force re-evaluation when sessionVersion changes
+        var _ = sessionVersion.Value; // Read to establish reactive dependency
         var sessions = chatService.GetSessions();
         if (activeSessionId.Value == null && sessions.Count > 0 && !initialHandled.Value && string.IsNullOrEmpty(args?.Prompt))
         {

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -51,7 +51,7 @@ public class ChatApp : ViewBase
         });
 
         // Map sessions to DTOs - force re-evaluation when sessionVersion changes
-        var _ = sessionVersion.Value; // Read to establish reactive dependency
+        var currentVersion = sessionVersion.Value; // Read to establish reactive dependency
         var sessions = chatService.GetSessions();
         if (activeSessionId.Value == null && sessions.Count > 0 && !initialHandled.Value && string.IsNullOrEmpty(args?.Prompt))
         {

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Reactive.Disposables;
 using Ivy.Core;
 using Ivy.Core.Hooks;
 using Ivy.Tendril.Agents.Abstractions;
@@ -29,6 +30,7 @@ public class ChatApp : ViewBase
         var serializer = UseService<IEventSerializer>();
 
         var activeSessionId = UseState<string?>(args?.SessionId);
+        var sessionVersion = UseState(0);
         var selectedAgent = UseState(() => configService.Settings.CodingAgent ?? "claude");
         var selectedModel = UseState("claude-opus-5");
         var lastSyncedSessionId = UseRef<string?>(null);
@@ -40,6 +42,13 @@ public class ChatApp : ViewBase
         var runningSessionIds = UseState(new HashSet<string>());
         var messageQueue = UseRef(new ConcurrentQueue<ChatSendMessageDto>());
         var initialHandled = UseRef(false);
+
+        UseEffect(() =>
+        {
+            void OnSessionsChanged(object? sender, EventArgs e) => sessionVersion.Set(v => v + 1);
+            chatService.SessionsChanged += OnSessionsChanged;
+            return Disposable.Create(() => chatService.SessionsChanged -= OnSessionsChanged);
+        });
 
         // Map sessions to DTOs
         var sessions = chatService.GetSessions();
@@ -368,6 +377,7 @@ public class ChatApp : ViewBase
             OnDeleteSession = e =>
             {
                 chatService.DeleteSession(e.Value);
+                sessionVersion.Set(v => v + 1);
                 if (activeSessionId.Value == e.Value)
                 {
                     var remaining = chatService.GetSessions();
@@ -380,6 +390,7 @@ public class ChatApp : ViewBase
                 if (e.Value != null && e.Value.Length >= 2)
                 {
                     chatService.RenameSession(e.Value[0], e.Value[1]);
+                    sessionVersion.Set(v => v + 1);
                 }
                 return ValueTask.CompletedTask;
             },

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -13,6 +13,8 @@ public class ChatHistoryService : IChatHistoryService
     private readonly ConcurrentDictionary<string, ChatSessionModel> _sessions = new(StringComparer.OrdinalIgnoreCase);
     private readonly object _lock = new();
 
+    public event EventHandler? SessionsChanged;
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
@@ -96,6 +98,7 @@ public class ChatHistoryService : IChatHistoryService
 
         _sessions[id] = session;
         PersistSessionToDisk(session);
+        SessionsChanged?.Invoke(this, EventArgs.Empty);
         return session;
     }
 
@@ -104,6 +107,7 @@ public class ChatHistoryService : IChatHistoryService
         if (session == null || string.IsNullOrEmpty(session.Id)) return;
         _sessions[session.Id] = session;
         PersistSessionToDisk(session);
+        SessionsChanged?.Invoke(this, EventArgs.Empty);
     }
 
     public void DeleteSession(string id)
@@ -123,6 +127,7 @@ public class ChatHistoryService : IChatHistoryService
         {
             // Best effort file deletion
         }
+        SessionsChanged?.Invoke(this, EventArgs.Empty);
     }
 
     public void RenameSession(string id, string newTitle)
@@ -139,6 +144,7 @@ public class ChatHistoryService : IChatHistoryService
             };
             _sessions[id] = updated;
             PersistSessionToDisk(updated);
+            SessionsChanged?.Invoke(this, EventArgs.Empty);
         }
     }
 
@@ -163,7 +169,7 @@ public class ChatHistoryService : IChatHistoryService
             );
 
             var updatedMessages = new List<ChatMessageModel>(session.Messages) { msg };
-            
+
             // Auto update title from first user message if title is "New Chat"
             var title = session.Title;
             if ((title == "New Chat" || string.IsNullOrWhiteSpace(title)) && role == "user" && !string.IsNullOrWhiteSpace(content))
@@ -182,6 +188,7 @@ public class ChatHistoryService : IChatHistoryService
 
             _sessions[session.Id] = updatedSession;
             PersistSessionToDisk(updatedSession);
+            SessionsChanged?.Invoke(this, EventArgs.Empty);
             return msg;
         }
     }

--- a/src/Ivy.Tendril/Services/IChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/IChatHistoryService.cs
@@ -25,6 +25,7 @@ public record ChatSessionModel(
 
 public interface IChatHistoryService
 {
+    event EventHandler? SessionsChanged;
     IReadOnlyList<ChatSessionModel> GetSessions();
     ChatSessionModel? GetSession(string id);
     ChatSessionModel CreateSession(string agentId, string modelId, string? title = null);


### PR DESCRIPTION
Fixes #1818

# Summary

## Changes

Added a `SessionsChanged` event to `IChatHistoryService` and implemented event dispatches across `ChatHistoryService` session operations (`CreateSession`, `SaveSession`, `DeleteSession`, `RenameSession`, `AddMessage`). Wired `ChatApp` to subscribe to session change events using `UseEffect` and update a reactive `sessionVersion` state on session modifications to trigger immediate UI re-rendering upon session renaming or deletion. Added unit test coverage for session renaming and event firing.

## API Changes

- `IChatHistoryService.SessionsChanged`: `event EventHandler? SessionsChanged` added to interface and concrete implementation `ChatHistoryService`.

## Files Modified

- `src/Ivy.Tendril/Services/IChatHistoryService.cs` - Added `SessionsChanged` event declaration to interface.
- `src/Ivy.Tendril/Services/ChatHistoryService.cs` - Implemented and raised `SessionsChanged` event across session modification methods.
- `src/Ivy.Tendril/Apps/Chat/ChatApp.cs` - Added reactive `sessionVersion` state, `UseEffect` subscription to `SessionsChanged`, and state updates in `OnRenameSession` and `OnDeleteSession`.
- `src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs` - Added `RenameSession_UpdatesTitleAndFiresEvent` unit test.

## Manual Testing

1. Launch the application and navigate to the Chat view.
2. Create or select a chat session.
3. Rename the chat session in the UI.
4. Observe that the chat session title in the sidebar and header updates reactively without requiring a page refresh or navigation.

## Fix: Establish Reactive Dependency for Session Version

The initial implementation updated the `sessionVersion` state when sessions changed, but never read the state value. This prevented the reactive framework from establishing a dependency, so the component wouldn't re-render when `sessionVersion` changed. Fixed by explicitly reading `sessionVersion.Value` before fetching sessions, ensuring the component re-renders whenever sessions are modified. Also fixed variable naming conflict where `_` shadowed the discard pattern used elsewhere for fire-and-forget tasks.

### Files Modified

- `src/Ivy.Tendril/Apps/Chat/ChatApp.cs` - Added explicit read of `sessionVersion.Value` to establish reactive dependency (commits 507a2d2d, 07f5850f)

## Fix: Prevent Title Revert During Rename

The frontend React component was immediately exiting edit mode and reverting to the old title from props before the backend completed the update. This caused the renamed title to briefly flash back to its original value, creating the perception that the rename "didn't work." Fixed by tracking pending renames in local state (`pendingRenames`) and displaying the new title until it appears in props, ensuring smooth visual feedback during the rename operation.

### Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx` - Added `pendingRenames` state tracking and display logic for both sidebar and header titles (commit c2a7977e)

---

## Commits

- c2a7977e Fix chat session rename UI flickering with pending state tracking
- 07f5850f Fix variable name conflict with discard pattern
- 507a2d2d Fix session rename reactivity by reading sessionVersion state
- 70ae8b15 Fix chat session renaming UI reactivity (00010)

---
Created using [Ivy Tendril](https://ivy.app).
