### PR TITLE
fix: prevent application directory locks during Velopack updates

### DIFF
--- a/src/Ivy.Tendril/Helpers/GitHelper.cs
+++ b/src/Ivy.Tendril/Helpers/GitHelper.cs
@@ -118,13 +118,12 @@ public static class GitHelper
         {
             var psi = new ProcessStartInfo("git", args)
             {
+                WorkingDirectory = !string.IsNullOrEmpty(workingDir) ? workingDir : Path.GetTempPath(),
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true
             };
-            if (!string.IsNullOrEmpty(workingDir))
-                psi.WorkingDirectory = workingDir;
 
             using var process = Process.Start(psi);
             if (process == null) return null;

--- a/src/Ivy.Tendril/Helpers/ProcessCheckHelper.cs
+++ b/src/Ivy.Tendril/Helpers/ProcessCheckHelper.cs
@@ -13,7 +13,8 @@ public static class ProcessCheckHelper
         RedirectStandardOutput = true,
         RedirectStandardError = true,
         UseShellExecute = false,
-        CreateNoWindow = true
+        CreateNoWindow = true,
+        WorkingDirectory = Path.GetTempPath()
     };
 
     public static async Task<bool> CheckCommand(string fileName, string arguments, int timeoutMs = 10_000)

--- a/src/Ivy.Tendril/Helpers/UpdateHelper.cs
+++ b/src/Ivy.Tendril/Helpers/UpdateHelper.cs
@@ -99,9 +99,32 @@ public static class UpdateHelper
 
     public static void LaunchInstaller(string tempFilePath)
     {
+        var tempDir = Path.GetDirectoryName(tempFilePath) ?? Path.GetTempPath();
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Process.Start(new ProcessStartInfo(tempFilePath) { UseShellExecute = true });
+            try
+            {
+                var currentPid = Environment.ProcessId;
+                foreach (var p in Process.GetProcessesByName("Ivy.Tendril"))
+                {
+                    if (p.Id != currentPid)
+                    {
+                        try { p.Kill(true); } catch { }
+                    }
+                }
+            }
+            catch
+            {
+                // Best effort cleanup
+            }
+
+            var psi = new ProcessStartInfo(tempFilePath)
+            {
+                UseShellExecute = true,
+                WorkingDirectory = tempDir
+            };
+            Process.Start(psi);
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
@@ -113,6 +136,7 @@ public static class UpdateHelper
             {
                 var chmod = new ProcessStartInfo("chmod", $"+x \"{tempFilePath}\"")
                 {
+                    WorkingDirectory = tempDir,
                     UseShellExecute = false,
                     CreateNoWindow = true
                 };
@@ -122,7 +146,12 @@ public static class UpdateHelper
             {
                 // Ignore
             }
-            Process.Start(new ProcessStartInfo(tempFilePath) { UseShellExecute = true });
+            var psi = new ProcessStartInfo(tempFilePath)
+            {
+                UseShellExecute = true,
+                WorkingDirectory = tempDir
+            };
+            Process.Start(psi);
         }
     }
 }

--- a/src/Ivy.Tendril/Services/Git/GithubService.cs
+++ b/src/Ivy.Tendril/Services/Git/GithubService.cs
@@ -68,6 +68,7 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
 
             var psi = new ProcessStartInfo("gh", args)
             {
+                WorkingDirectory = Path.GetTempPath(),
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
@@ -273,6 +274,7 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
         {
             var psi = new ProcessStartInfo("gh", args)
             {
+                WorkingDirectory = Path.GetTempPath(),
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,


### PR DESCRIPTION
## Summary
- Ensures all global helper process invocations (ProcessCheckHelper, GithubService, GitHelper, UpdateHelper) explicitly set WorkingDirectory = Path.GetTempPath() rather than defaulting to empty (which inherited the app install directory %LocalAppData%\IvyTendril\current).
- Updated UpdateHelper.LaunchInstaller to set WorkingDirectory to the installer directory and kill any lingering Ivy.Tendril processes on Windows before launching the installer, preventing file lock collisions during directory swap.
