### PR TITLE
Fix false rebase detection from stale .git/REBASE_HEAD

### DIFF
--- a/src/Ivy.Tendril.Test/Services/GitServiceDirtyStateTests.cs
+++ b/src/Ivy.Tendril.Test/Services/GitServiceDirtyStateTests.cs
@@ -314,6 +314,24 @@ public class GitServiceDirtyStateTests : IDisposable
         Directory.Delete(gitDir, true);
     }
 
+    [Fact]
+    public void StaleRebaseHead_WithoutRebaseStateDir_IsNotDirty()
+    {
+        // Git leaves REBASE_HEAD behind after a rebase completes or is aborted, so its
+        // presence alone must not be reported as a rebase in progress.
+        var rebaseHead = Path.Combine(_testRepoPath, ".git", "REBASE_HEAD");
+        File.WriteAllText(rebaseHead, "0123456789abcdef0123456789abcdef01234567\n");
+        var service = CreateService();
+
+        var result = service.GetRepoDirtyState(_testRepoPath, "master");
+
+        Assert.True(result.IsSuccess);
+        Assert.DoesNotContain(result.Value!.Reasons, r => r.Reason == DirtyReason.InProgressOperation);
+        Assert.False(result.Value!.IsDirty);
+
+        File.Delete(rebaseHead);
+    }
+
     // --- No remote ---
 
     [Fact]

--- a/src/Ivy.Tendril/Services/Git/GitService.cs
+++ b/src/Ivy.Tendril/Services/Git/GitService.cs
@@ -227,8 +227,8 @@ public class GitService : IGitService
         var markers = new (string Path, bool IsDir, string Operation)[]
         {
             ("MERGE_HEAD", false, "merge"),
-            ("REBASE_HEAD", false, "rebase"),
             ("CHERRY_PICK_HEAD", false, "cherry-pick"),
+            ("REVERT_HEAD", false, "revert"),
             ("BISECT_LOG", false, "bisect"),
             ("rebase-merge", true, "rebase"),
             ("rebase-apply", true, "rebase"),


### PR DESCRIPTION
Git writes `.git/REBASE_HEAD` during a rebase but does not remove it when the rebase completes or is aborted, so a leftover file caused `GetRepoDirtyState` to report a rebase in progress indefinitely. Removed it as a marker — the `rebase-merge`/`rebase-apply` state directories are the authoritative signal and were already checked.

Also added `REVERT_HEAD`, so conflicted reverts are detected.

Fixes #1812