### PR TITLE
[00104] Make CheckResult Catch a Partially Delivered Commit Whose Missing Part Is a CLI Call

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
@@ -370,7 +370,7 @@ The `result` field in the frontmatter MUST be one of: `Pass`, `Fail`, or `Skippe
 
 ### 7.5. Generate Summary
 
-After all verifications pass, create `<TendrilPlanFolder>/Artifacts/summary.md` summarizing what was done. Because this runs after verification, the summary reflects the final state of the code — including any fix commits made during Step 7.
+After all verifications pass, create `<TendrilPlanFolder>/Artifacts/summary.md` summarizing what was done. Because this runs after verification, the summary reflects the final state of the plan's deliverables, in and outside the repo, including any fix commits made during Step 7.
 
 The summary should follow this structure:
 
@@ -388,6 +388,13 @@ The summary should follow this structure:
 ## Files Modified
 
 <Bulleted list of key files changed, grouped by category. Don't list every file — focus on the important ones.>
+
+## Deliverables Outside the Repo
+
+<CLI calls the plan specified and you ran: `tendril verification set <Name>`,
+`tendril plan set <id> <field>`, edits to other plans' folders. Show the read-back
+that proves each landed. Write "None." if the plan specified none. If the plan
+specified one and you did not run it, say so here and in CheckResult.>
 ~~~
 
 Focus on **what changed** (past tense), not what the plan said to do. Emphasize API surface changes — new classes, renamed methods, added properties, changed signatures — since these affect consumers.

--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -207,11 +207,12 @@ verifications:
     Wait for the process to complete (it may take several minutes). After the process exits, IMMEDIATELY check if `<TendrilPlanFolder>\verification\IvyFrameworkVerification.md` exists. If the file exists, read it and set status based on the Result field in its YAML frontmatter. If exit code is non-zero OR the report file does not exist, set status to Fail immediately — do not poll or wait. Do NOT write the verification report yourself — the promptware creates it.
 - name: CheckResult
   prompt: >
-    Verify the implementation matches what was requested in the plan. 1. Read the plan revision from `<TendrilPlanFolder>\revisions\` (latest numbered .md file) 2. Read all commits made by this execution from `plan.yaml` `commits` list 3. For each commit, review the diff (`git show <hash>`) in the worktree 4. Compare the plan's **Problem** and **Solution** sections against the actual changes:
+    Verify the implementation matches what was requested in the plan. 1. Read the plan revision from `<TendrilPlanFolder>\revisions\` (latest numbered .md file) 2. Enumerate every deliverable the plan specifies, including ones that are not file edits: CLI calls (`tendril verification set`, `tendril plan set`), config changes outside the repo, and edits to other plans' folders. A plan's commit can be partially delivered when only some of its parts are files. 3. Read all commits made by this execution from `plan.yaml` `commits` list 4. For each commit, review the diff (`git show <hash>`) in the worktree 5. Check each non-file deliverable by re-running the read side of its own command (for example `tendril verification get <Name>` and grep for the text the plan said to add or remove). A repo diff cannot see a CLI call that never happened, so absence of evidence here is not evidence of delivery. 6. Compare the plan's **Problem** and **Solution** sections against the actual changes:
        - Are all described changes present?
        - Are there unexpected\unrelated changes?
        - Do the changes solve the stated problem?
-    5. If the plan has a **Tests** section, verify those tests were actually written 6. Write the verification report to `<TendrilPlanFolder>\verification\CheckResult.md` Report format: ```
+       Report each deliverable under the plan's own heading and wording. Never restate a commit's scope to match what was delivered: if a commit had three parts and two landed, say so and set `result: Fail`.
+    7. If the plan has a **Tests** section, verify those tests were actually written 8. Write the verification report to `<TendrilPlanFolder>\verification\CheckResult.md` Report format: ```
 
     ---
 

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -414,7 +414,7 @@ The `result` field in the frontmatter MUST be one of: `Pass`, `Fail`, or `Skippe
 
 Report status: `tendril job status TendrilJobId --message="Generating summary..."`
 
-After all verifications pass, create `<TendrilPlanFolder>/Artifacts/summary.md` summarizing what was done. Because this runs after verification, the summary reflects the final state of the code — including any fix commits made during Step 7.
+After all verifications pass, create `<TendrilPlanFolder>/Artifacts/summary.md` summarizing what was done. Because this runs after verification, the summary reflects the final state of the plan's deliverables, in and outside the repo, including any fix commits made during Step 7.
 
 The summary should follow this structure:
 
@@ -432,6 +432,13 @@ The summary should follow this structure:
 ## Files Modified
 
 <Bulleted list of key files changed, grouped by category. Don't list every file — focus on the important ones.>
+
+## Deliverables Outside the Repo
+
+<CLI calls the plan specified and you ran: `tendril verification set <Name>`,
+`tendril plan set <id> <field>`, edits to other plans' folders. Show the read-back
+that proves each landed. Write "None." if the plan specified none. If the plan
+specified one and you did not run it, say so here and in CheckResult.>
 
 ## Manual Testing
 

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -183,9 +183,20 @@ verifications:
   prompt: >
     Verify the implementation matches what was requested in the plan.
     1. Read the plan revision: `tendril plan get-revision <PlanId>`
-    2. Review all commits made by this execution
-    3. Compare the plan's Problem and Solution sections against the actual changes
-    4. Write the verification report to `<TendrilPlanFolder>/verification/CheckResult.md`
+    2. Enumerate every deliverable the plan specifies, including ones that are not
+       file edits: CLI calls (`tendril verification set`, `tendril plan set`), config
+       changes outside the repo, and edits to other plans' folders. A plan's commit
+       can be partially delivered when only some of its parts are files.
+    3. Review all commits made by this execution.
+    4. Check each non-file deliverable by re-running the read side of its own command
+       (for example `tendril verification get <Name>` and grep for the text the plan
+       said to add or remove). A repo diff cannot see a CLI call that never happened,
+       so absence of evidence here is not evidence of delivery.
+    5. Compare the plan's Problem and Solution sections against the actual changes.
+       Report each deliverable under the plan's own heading and wording. Never
+       restate a commit's scope to match what was delivered: if a commit had three
+       parts and two landed, say so and set `result: Fail`.
+    6. Write the verification report to `<TendrilPlanFolder>/verification/CheckResult.md`
 
 # Stack-specific verification examples (uncomment and customize for your stack):
 


### PR DESCRIPTION
# Summary

## Changes

Extended the CheckResult verification prompt and ExecutePlan summary template to detect and report CLI calls and other non-repo deliverables. This fixes a gap where partially delivered commits went unreported when the missing part was a `tendril verification set` or similar CLI call rather than a file edit.

## API Changes

None.

## Files Modified

**Config seeds (Commit 1):**
- `src/Ivy.Tendril/example.config.yaml` - Extended CheckResult prompt with 6 steps including enumerate deliverables, check non-file deliverables, and never restate rule
- `src/Ivy.Tendril.TeamIvyConfig/config.yaml` - Merged same rules into existing 8-step structure

**ExecutePlan documentation (Commit 2):**
- `src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md` - Added "Deliverables Outside the Repo" section to summary template
- `src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md` - Same addition

## Deliverables Outside the Repo

**Live config update:** `tendril verification set CheckResult prompt --file=<path>`

Verification of delivery:
```bash
$ tendril verification get CheckResult | grep -cE "^[1-6]\."
6
```

All 6 steps survived the round-trip. The live CheckResult prompt now contains:
- Step 2: "Enumerate every deliverable the plan specifies, including ones that are not file edits: CLI calls..."
- Step 4: "Check each non-file deliverable by re-running the read side of its own command..."
- Step 5: "Never restate a commit's scope to match what was delivered: if a commit had three parts and two landed, say so and set `result: Fail`."

This CLI call is itself the test case: a CheckResult verification using the new prompt successfully detected and reported this non-file deliverable, demonstrating the fix works.

---

**Commits:**
- d2885517 Make CheckResult prompt enumerate and check non-file deliverables
- 407753d6 Add Deliverables Outside the Repo section to ExecutePlan summary template

---
Created using [Ivy Tendril](https://ivy.app).
