### PR TITLE
[00108] Gate the CreatePr Merge on CI Checks and Stop Passing Admin Unconditionally

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md
@@ -127,7 +127,29 @@ If no custom options or `comment` is empty, skip this step.
 **!STOP — MERGE GATE. The single deciding factor is the `PrMerge` firmware header value. Nothing else.**
 
 - **If `PrMerge` is `false`: do NOT merge.** Do **not** run `gh pr merge` under any circumstances. The PR stays open for manual review. Skip directly to step 5. (Do not look for any other rule or signal — there is none.)
-- **If `PrMerge` is `true` (or the flag is absent):** merge the PR using the flags below — always `--merge --admin`, plus `--delete-branch` only when `PrDeleteBranch` is `true` (default `true`).
+- **If `PrMerge` is `true` (or the flag is absent):** merge the PR using the flags below — always `--merge`, plus `--delete-branch` only when `PrDeleteBranch` is `true` (default `true`). Do **not** pass `--admin` on the first attempt; only retry with `--admin` if the merge fails due to branch protection (at that point, the check gate below has already passed).
+
+**Wait for CI checks before merging:**
+
+Before merging, wait for checks to finish and verify they pass. This prevents merging a PR while checks are still running or have failed.
+
+```bash
+# Wait for checks to finish (no-op in ~3s if the repo has no CI; --watch cannot be combined with --json)
+gh pr checks <pr-number> --repo <owner/repo> --watch --fail-fast >/dev/null 2>&1 || true
+
+# Read the outcome. Exit code cannot distinguish "failed" from "no checks", so read buckets.
+BUCKETS=$(gh pr checks <pr-number> --repo <owner/repo> --json bucket --jq '.[].bucket' 2>/dev/null)
+if [ -z "$BUCKETS" ]; then
+  echo "No checks reported; proceeding (repo has no PR CI)."
+elif echo "$BUCKETS" | grep -qE '^(fail|cancel)$'; then
+  echo "CI is red; refusing to merge."
+  tendril job status TendrilJobId --message="PR CI checks failed, refusing to merge: <pr-url>"
+  # Skip the merge step, but continue to step 5 to record the PR URL
+  # This is a legitimate non-merged outcome, not a skipped step
+fi
+```
+
+If any check fails or is cancelled, do **not** merge. Leave the PR open and continue to step 5 so the PR URL is still recorded. A red gate is a legitimate outcome.
 
 **Merge conflict handling (applies only when merging):**
 
@@ -191,7 +213,7 @@ When the PR status is `CONFLICTING`, resolve the conflict locally before retryin
 
 **Merge command** (build `--delete-branch` from `PrDeleteBranch`):
 ```bash
-gh pr merge <pr-number> --repo <owner/repo> --merge [--delete-branch] --admin
+gh pr merge <pr-number> --repo <owner/repo> --merge [--delete-branch]
 cd <original-repo-path>
 # Only pull if the local repo is clean (no uncommitted changes, on the default branch)
 if [ -z "$(git status --porcelain)" ] && [ "$(git symbolic-ref --short HEAD)" = "<default-branch>" ]; then

--- a/src/Ivy.Tendril.Test/PromptwareDeployerTests.cs
+++ b/src/Ivy.Tendril.Test/PromptwareDeployerTests.cs
@@ -194,4 +194,41 @@ public class PromptwareDeployerTests : IDisposable
         Assert.DoesNotContain("> \"$TMPDIR/pr-body.md\"", content);
         Assert.DoesNotContain("--body-file \"$TMPDIR/pr-body.md\"", content);
     }
+
+    // Regression guard for plan 00108: CreatePr was unconditionally passing --admin and
+    // merging immediately, bypassing branch protection and racing the CI checks. The fix
+    // adds a "gh pr checks" gate that waits for and validates CI results before merging,
+    // and removes the unconditional --admin (it may only be used as a retry after the
+    // check gate has passed). Enforces this rule across both copies of Program.md.
+    [Fact]
+    public void CreatePrProgram_GatesMergeOnChecksAndDoesNotAlwaysPassAdmin()
+    {
+        var sourcePromptwarePath = Path.GetFullPath(
+            Path.Combine(System.AppContext.BaseDirectory, "..", "..", "..", "..", "Ivy.Tendril", "Promptwares"));
+        var programFile1 = Path.Combine(sourcePromptwarePath, "CreatePr", "Program.md");
+
+        var sourceTeamIvyPath = Path.GetFullPath(
+            Path.Combine(System.AppContext.BaseDirectory, "..", "..", "..", "..", "Ivy.Tendril.TeamIvyConfig", "Promptwares"));
+        var programFile2 = Path.Combine(sourceTeamIvyPath, "CreatePr", "Program.md");
+
+        Assert.True(File.Exists(programFile1), $"Expected to find {programFile1}");
+        Assert.True(File.Exists(programFile2), $"Expected to find {programFile2}");
+
+        var content1 = File.ReadAllText(programFile1);
+        var content2 = File.ReadAllText(programFile2);
+
+        // Verify the check gate is present and reads buckets
+        Assert.Contains("gh pr checks", content1);
+        Assert.Contains("--json bucket", content1);
+        Assert.Contains("gh pr checks", content2);
+        Assert.Contains("--json bucket", content2);
+
+        // Verify the unconditional --admin instructions are removed
+        Assert.DoesNotContain("Always pass `--merge --admin`", content1);
+        Assert.DoesNotContain("always `--merge --admin`", content2);
+
+        // Verify --required is not used (measured vacuous on unprotected repos)
+        Assert.DoesNotContain("--required", content1);
+        Assert.DoesNotContain("--required", content2);
+    }
 }

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -282,12 +282,35 @@ Report status: `tendril job status TendrilJobId --message="Applying merge option
 
 **Note:** Merge conflict resolution is handled in step 3.7 if `PrSolveMergeConflicts` was `true`. By this step, the PR should already be conflict-free (if step 3.7 ran successfully).
 
-When merging, build the command from the flags:
-- Always pass `--merge --admin`.
-- Add `--delete-branch` **only if `PrDeleteBranch` is `true`** (default `true`).
+**Wait for CI checks before merging:**
+
+Before merging, wait for checks to finish and verify they pass. This prevents merging a PR while checks are still running or have failed.
 
 ```bash
-gh pr merge <pr-number> --repo <owner/repo> --merge [--delete-branch] --admin
+# Wait for checks to finish (no-op in ~3s if the repo has no CI; --watch cannot be combined with --json)
+gh pr checks <pr-number> --repo <owner/repo> --watch --fail-fast >/dev/null 2>&1 || true
+
+# Read the outcome. Exit code cannot distinguish "failed" from "no checks", so read buckets.
+BUCKETS=$(gh pr checks <pr-number> --repo <owner/repo> --json bucket --jq '.[].bucket' 2>/dev/null)
+if [ -z "$BUCKETS" ]; then
+  echo "No checks reported; proceeding (repo has no PR CI)."
+elif echo "$BUCKETS" | grep -qE '^(fail|cancel)$'; then
+  echo "CI is red; refusing to merge."
+  tendril job status TendrilJobId --message="PR CI checks failed, refusing to merge: <pr-url>"
+  # Skip the merge step, but continue to step 5 to record the PR URL
+  # This is a legitimate non-merged outcome, not a skipped step
+fi
+```
+
+If any check fails or is cancelled, do **not** merge. Leave the PR open and continue to step 5 so the PR URL is still recorded. A red gate is a legitimate outcome.
+
+When merging, build the command from the flags:
+- Always pass `--merge`.
+- Add `--delete-branch` **only if `PrDeleteBranch` is `true`** (default `true`).
+- Do **not** pass `--admin` on the first attempt. Only if the merge fails because the branch is protected (GitHub returns a requirements error, not a conflict or transient error) may `--admin` be used as a retry. At that point, the check gate above has already passed, so `--admin` bypasses only non-CI requirements.
+
+```bash
+gh pr merge <pr-number> --repo <owner/repo> --merge [--delete-branch]
 cd <original-repo-path>
 # Only pull if the local repo is clean (no uncommitted changes, on the default branch)
 if [ -z "$(git status --porcelain)" ] && [ "$(git symbolic-ref --short HEAD)" = "<default-branch>" ]; then


### PR DESCRIPTION
# Summary

## Changes

Added a CI check gate to CreatePr that waits for and validates PR check status before merging, and removed the unconditional `--admin` flag that bypassed branch protection. Applied changes to both copies of CreatePr/Program.md and added a regression test.

## API Changes

None. This change modifies promptware documentation (Program.md files), not runtime code.

## Files Modified

- `src/Ivy.Tendril/Promptwares/CreatePr/Program.md` - Added check gate and made --admin conditional
- `src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md` - Added check gate and made --admin conditional  
- `src/Ivy.Tendril.Test/PromptwareDeployerTests.cs` - Added regression test `CreatePrProgram_GatesMergeOnChecksAndDoesNotAlwaysPassAdmin`

## Manual Testing

1. Deploy Tendril with these changes: `tendril deploy` or restart the app
2. Create a plan and execute it via ExecutePlan
3. Use CreatePr to create a PR for that plan in a repo that has CI checks
4. Observe in the CreatePr job log that it waits for checks to finish before merging
5. Verify the merge command shown in logs does NOT include `--admin` flag
6. Confirm the PR is only merged after all checks pass (or left open if checks fail)

---

## Commits

- da75d011 Gate CreatePr merge on CI checks and make --admin conditional

---
Created using [Ivy Tendril](https://ivy.app).
