### PR TITLE
[00130] Make ExecutePlan Reconcile Dependencies Instead of Skipping the Install

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
@@ -227,7 +227,7 @@ This ensures ExecutePlan fails immediately if worktree creation is incomplete, r
 
 Worktrees start with a clean checkout and may be missing build artifacts (e.g. `dist/`, `node_modules/`, generated files) that exist in the original repo. Determine whether the plan modifies these areas:
 
-#### Default Path (No Changes to Build-Dependent Code)
+#### Default Path (No Changes to Build-Dependent Code): Reuse Artifacts, Still Install
 
 If the plan does **NOT** modify code in directories with build artifacts:
 
@@ -243,15 +243,25 @@ for artifact_dir in $(find "<original-repo-path>" -name "dist" -type d -not -pat
 done
 ```
 
-2. **Skip dependency installation** — the copied artifacts are sufficient for build and tests.
+2. **Still install dependencies for any verification you will run.** A copied artifact directory is a build *output*, not a dependency tree - it never removes the need for an install. A fresh worktree has no `node_modules` at all, so the package manager must run before any lint, typecheck, build or test step, whether or not the plan touched that code. Never treat a populated dependency directory as evidence of a current one: install unconditionally, using the lockfile-respecting form (`pnpm install --frozen-lockfile`, `npm ci`, `yarn install --immutable`). It costs seconds when the tree is already correct, and a skipped install means exercising whatever version happens to be on disk. If the lockfile-respecting form fails because the plan edited a manifest without regenerating the lockfile, that is a real finding: re-run the plain install and commit the updated lockfile.
 
-#### Exception Path (Build-Dependent Code Changes)
+#### Exception Path (Build-Dependent Code Changes): Install and Rebuild
 
 If the plan **modifies** build-dependent code, you MUST rebuild:
 
 1. **Install dependencies** using the project's package manager
 2. **Run the build** to regenerate artifacts
 3. If dependency installation fails after 2 attempts, document the failure and fail the plan
+
+#### Which dependency trees to install
+
+Install the trees the plan's **verifications** will actually enter, not every lockfile in the repo. Some repos carry a dozen independent lockfiles (one per widget package), and a blanket sweep is slow and mostly useless; others keep theirs deeper than a shallow search would look.
+
+1. List the run-set: `tendril plan verification list <plan-id> --json` (the same set step 7 runs).
+2. For each `Pending` entry, read its prompt (`tendril verification get <Name>`) and note the directory it starts with (`cd <dir>`) and the package manager it names.
+3. Install once per distinct directory, before step 4. If two verifications share a directory, install once. If no `Pending` verification enters a package directory, install nothing.
+
+Each verification prompt is still the authority on its own directory and flags. This step exists so the install has already happened by the time step 7 runs, not to override the prompt.
 
 ### 3. Handle Cross-Repo References
 

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -262,7 +262,7 @@ If this step applies, report status: `tendril job status TendrilJobId --message=
 
 Worktrees start with a clean checkout and may be missing build artifacts (e.g. `dist/`, `node_modules/`, generated files) that exist in the original repo. Determine whether the plan modifies these areas:
 
-#### Default Path (No Changes to Build-Dependent Code)
+#### Default Path (No Changes to Build-Dependent Code): Reuse Artifacts, Still Install
 
 If the plan does **NOT** modify code in directories with build artifacts:
 
@@ -278,15 +278,25 @@ for artifact_dir in $(find "<original-repo-path>" -name "dist" -type d -not -pat
 done
 ```
 
-2. **Skip dependency installation** — the copied artifacts are sufficient for build and tests.
+2. **Still install dependencies for any verification you will run.** A copied artifact directory is a build *output*, not a dependency tree - it never removes the need for an install. A fresh worktree has no `node_modules` at all, so the package manager must run before any lint, typecheck, build or test step, whether or not the plan touched that code. Never treat a populated dependency directory as evidence of a current one: install unconditionally, using the lockfile-respecting form (`pnpm install --frozen-lockfile`, `npm ci`, `yarn install --immutable`). It costs seconds when the tree is already correct, and a skipped install means exercising whatever version happens to be on disk. If the lockfile-respecting form fails because the plan edited a manifest without regenerating the lockfile, that is a real finding: re-run the plain install and commit the updated lockfile.
 
-#### Exception Path (Build-Dependent Code Changes)
+#### Exception Path (Build-Dependent Code Changes): Install and Rebuild
 
 If the plan **modifies** build-dependent code, you MUST rebuild:
 
 1. **Install dependencies** using the project's package manager
 2. **Run the build** to regenerate artifacts
 3. If dependency installation fails after 2 attempts, document the failure and fail the plan
+
+#### Which dependency trees to install
+
+Install the trees the plan's **verifications** will actually enter, not every lockfile in the repo. Some repos carry a dozen independent lockfiles (one per widget package), and a blanket sweep is slow and mostly useless; others keep theirs deeper than a shallow search would look.
+
+1. List the run-set: `tendril plan verification list <plan-id> --json` (the same set step 7 runs).
+2. For each `Pending` entry, read its prompt (`tendril verification get <Name>`) and note the directory it starts with (`cd <dir>`) and the package manager it names.
+3. Install once per distinct directory, before step 4. If two verifications share a directory, install once. If no `Pending` verification enters a package directory, install nothing.
+
+Each verification prompt is still the authority on its own directory and flags. This step exists so the install has already happened by the time step 7 runs, not to override the prompt.
 
 ### 3. Handle Cross-Repo References
 


### PR DESCRIPTION
# Summary

## Changes

Rewrote ExecutePlan's step 2.5 to require unconditional dependency installation before running verifications, replacing the "skip dependency installation" instruction that let agents treat copied dist/ directories as evidence of a current dependency tree. Added a new subsection to scope installs to the verification run-set rather than sweeping all lockfiles.

## API Changes

None. This changes markdown instructions only, not code or CLI commands.

## Files Modified

- `src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md` - Updated step 2.5 Default Path and added "Which dependency trees to install" subsection
- `src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md` - Applied identical changes to the TeamIvyConfig copy

## Manual Testing

N/A - internal change to promptware instructions with no user-facing behavior. The change affects how ExecutePlan agents interpret their firmware, not the UI or CLI. Correctness is verified by the existing `PromptwareDryRunTests.ExecutePlan_CompilesFirmware` test (which passed in DotnetTest verification).

---

**Commits:**
- 499bdba4 Replace ExecutePlan step 2.5 skip-on-populated instruction with unconditional install

---
Created using [Ivy Tendril](https://ivy.app).
