### PR TITLE
[00101] Make CheckResult Require Documented Runtime Behavior Be Exercised, Not Just Committed

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -207,41 +207,29 @@ verifications:
     Wait for the process to complete (it may take several minutes). After the process exits, IMMEDIATELY check if `<TendrilPlanFolder>\verification\IvyFrameworkVerification.md` exists. If the file exists, read it and set status based on the Result field in its YAML frontmatter. If exit code is non-zero OR the report file does not exist, set status to Fail immediately — do not poll or wait. Do NOT write the verification report yourself — the promptware creates it.
 - name: CheckResult
   prompt: >
-    Verify the implementation matches what was requested in the plan. 1. Read the plan revision from `<TendrilPlanFolder>\revisions\` (latest numbered .md file) 2. Read all commits made by this execution from `plan.yaml` `commits` list 3. For each commit, review the diff (`git show <hash>`) in the worktree 4. Compare the plan's **Problem** and **Solution** sections against the actual changes:
-       - Are all described changes present?
-       - Are there unexpected\unrelated changes?
-       - Do the changes solve the stated problem?
-    5. If the plan has a **Tests** section, verify those tests were actually written 6. Write the verification report to `<TendrilPlanFolder>\verification\CheckResult.md` Report format: ```
-
-    ---
-
-    result: Pass
-
-    date: <CurrentTime>
-
-    attempts: 1
-
-    ---
-
-    # CheckResult
-
-    ## Requested vs Delivered | Requirement | Status | Notes | |-------------|--------|-------| | <from plan> | Done \ Missing \ Partial | <details> |
-
-    ## Unexpected Changes
-
-    <list any changes not described in the plan, or "None">
-
-    ## Output
-
-    <summary assessment>
-
-    ## Fixes Applied
-
-    None
-
-    ## Issues Found
-
-    <any gaps between plan and implementation, or "None"> ```
+    Verify the implementation matches what was requested in the plan.
+    1. Read the plan revision: `tendril plan get-revision <PlanId>`
+    2. Enumerate every deliverable the plan specifies, including ones that are not
+       file edits: CLI calls (`tendril verification set`, `tendril plan set`), config
+       changes outside the repo, and edits to other plans' folders. A plan's commit
+       can be partially delivered when only some of its parts are files.
+    3. Review all commits made by this execution.
+    4. Check each non-file deliverable by re-running the read side of its own command
+       (for example `tendril verification get <Name>` and grep for the text the plan
+       said to add or remove). A repo diff cannot see a CLI call that never happened,
+       so absence of evidence here is not evidence of delivery.
+    5. Compare the plan's Problem and Solution sections against the actual changes.
+       Report each deliverable under the plan's own heading and wording. Never
+       restate a commit's scope to match what was delivered: if a commit had three
+       parts and two landed, say so and set `result: Fail`.
+    6. If the plan's Solution documents the runtime behavior of a script, hook, command
+       or workflow, anything not reachable from the project's build and test gates,
+       exercise the documented behavior once and paste the command with its exit code
+       into the report. Neither the prose nor the diff that added it is evidence that
+       the behavior exists. If it could not be exercised (a blocked write, a missing
+       tool), the result is `Fail`, naming the unexercised claim: documenting behavior
+       the code does not have is a defect, not a partial delivery.
+    7. Write the verification report to `<TendrilPlanFolder>/verification/CheckResult.md`
 - name: CodeReview
   prompt: >-
     Perform a code review of all changes made by this plan's commits, using Claude Code's built-in `\code-review` skill. Always fix major findings; log minor concerns as plan recommendations.

--- a/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
@@ -50,4 +50,72 @@ public class OnboardingSetupServiceTests : IDisposable
         Assert.Equal("TestProject", savedSettings.Projects[0].Name);
         Assert.Equal("/tmp/test-repo", savedSettings.Projects[0].Repos[0].Path);
     }
+
+    [Fact]
+    public async Task FinalizeOnboardingAsync_Should_Seed_CheckResult_Prompt_With_Runtime_Behavior_Step()
+    {
+        // Arrange: create a bootstrapped config.yaml
+        var tendrilHome = Path.Combine(_tempDir.Path, "tendril-home");
+        Directory.CreateDirectory(tendrilHome);
+        var configPath = Path.Combine(tendrilHome, "config.yaml");
+        File.WriteAllText(configPath, "codingAgent: claude\nprojects: []\n");
+
+        var configService = new ConfigService(new TendrilSettings());
+        configService.SetPendingTendrilHome(tendrilHome);
+        configService.SetPendingProject(new ProjectConfig
+        {
+            Name = "TestProject",
+            Repos = new List<RepoRef> { new() { Path = "/tmp/test-repo" } }
+        });
+
+        var onboardingService = new OnboardingSetupService(
+            configService,
+            null!,
+            null!,
+            NullLogger<OnboardingSetupService>.Instance);
+
+        // Act
+        await onboardingService.FinalizeOnboardingAsync();
+
+        // Assert: read the seeded config and find CheckResult verification
+        var savedYaml = File.ReadAllText(configPath);
+        var savedSettings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(savedYaml);
+
+        Assert.NotNull(savedSettings);
+        var checkResult = savedSettings.Verifications.FirstOrDefault(v => v.Name == "CheckResult");
+        Assert.NotNull(checkResult);
+
+        // Assert the prompt contains the runtime behavior exercise step
+        Assert.Contains("exercise the documented behavior", checkResult.Prompt);
+
+        // Assert numbered steps are contiguous from 1 and report step is last
+        var lines = checkResult.Prompt.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var stepNumbers = new List<int>();
+        foreach (var line in lines)
+        {
+            var trimmed = line.TrimStart();
+            if (trimmed.Length > 0 && char.IsDigit(trimmed[0]) && trimmed.Contains('.'))
+            {
+                var numStr = new string(trimmed.TakeWhile(char.IsDigit).ToArray());
+                if (int.TryParse(numStr, out var num))
+                {
+                    stepNumbers.Add(num);
+                }
+            }
+        }
+
+        // Steps should be contiguous starting from 1
+        Assert.NotEmpty(stepNumbers);
+        Assert.Equal(1, stepNumbers.First());
+        for (int i = 0; i < stepNumbers.Count - 1; i++)
+        {
+            Assert.Equal(stepNumbers[i] + 1, stepNumbers[i + 1]);
+        }
+
+        // Last step should be the report-writing step
+        var lastStepIndex = checkResult.Prompt.LastIndexOf($"{stepNumbers.Last()}.");
+        Assert.NotEqual(-1, lastStepIndex);
+        var textAfterLastStep = checkResult.Prompt.Substring(lastStepIndex);
+        Assert.Contains("Write the verification report", textAfterLastStep);
+    }
 }

--- a/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
@@ -79,38 +79,16 @@ public class OnboardingSetupServiceTests : IDisposable
         Assert.Contains("exercise the documented behavior", checkResult.Prompt);
 
         // Assert numbered steps are contiguous from 1 and report step is last
-        // YAML > folding joins lines with spaces, so steps like "1. Foo" become "... 1. Foo ..."
-        // We need to find patterns like " N. " or line-start "N. " where N is a digit
-        var stepNumbers = new List<int>();
-        var prompt = checkResult.Prompt;
-
-        // Find all occurrences of " <digit>. " or "^<digit>. " patterns
-        for (int i = 0; i < prompt.Length - 2; i++)
-        {
-            // Check if we're at start of line or after a space, followed by digit(s) and a period
-            bool atLineStart = i == 0 || prompt[i - 1] == '\n';
-            bool afterSpace = i > 0 && prompt[i - 1] == ' ' && (i == 1 || prompt[i - 2] == '\n' || prompt[i - 2] == ' ');
-
-            if ((atLineStart || afterSpace) && char.IsDigit(prompt[i]) && prompt[i + 1] == '.')
-            {
-                // Extract the full number
-                int j = i;
-                while (j < prompt.Length && char.IsDigit(prompt[j]))
-                    j++;
-
-                if (j > i && j < prompt.Length && prompt[j] == '.')
-                {
-                    var numStr = prompt.Substring(i, j - i);
-                    if (int.TryParse(numStr, out var num) && num >= 1 && num <= 10)
-                    {
-                        stepNumbers.Add(num);
-                    }
-                }
-            }
-        }
-
-        // Remove duplicates and sort
-        stepNumbers = stepNumbers.Distinct().OrderBy(n => n).ToList();
+        // Use regex to find all step number patterns like "N. " where N is 1-9
+        var stepPattern = new System.Text.RegularExpressions.Regex(@"(?:^|\s)(\d+)\.\s");
+        var matches = stepPattern.Matches(checkResult.Prompt);
+        var stepNumbers = matches
+            .Cast<System.Text.RegularExpressions.Match>()
+            .Select(m => int.Parse(m.Groups[1].Value))
+            .Where(n => n >= 1 && n <= 10)
+            .Distinct()
+            .OrderBy(n => n)
+            .ToList();
 
         // Steps should be contiguous starting from 1
         Assert.NotEmpty(stepNumbers);
@@ -122,9 +100,9 @@ public class OnboardingSetupServiceTests : IDisposable
 
         // Last step should be the report-writing step
         var lastStepNum = stepNumbers.Last();
-        var lastStepPattern = $" {lastStepNum}. ";
+        var lastStepPattern = $"{lastStepNum}. ";
         var lastStepIndex = checkResult.Prompt.LastIndexOf(lastStepPattern);
-        Assert.NotEqual(-1, lastStepIndex);
+        Assert.True(lastStepIndex >= 0, $"Could not find step {lastStepNum} in prompt");
         var textAfterLastStep = checkResult.Prompt.Substring(lastStepIndex);
         Assert.Contains("Write the verification report", textAfterLastStep);
     }

--- a/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
@@ -52,37 +52,27 @@ public class OnboardingSetupServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task FinalizeOnboardingAsync_Should_Seed_CheckResult_Prompt_With_Runtime_Behavior_Step()
+    public void ExampleConfig_Should_Seed_CheckResult_Prompt_With_Runtime_Behavior_Step()
     {
-        // Arrange: create a bootstrapped config.yaml
-        var tendrilHome = Path.Combine(_tempDir.Path, "tendril-home");
-        Directory.CreateDirectory(tendrilHome);
-        var configPath = Path.Combine(tendrilHome, "config.yaml");
-        File.WriteAllText(configPath, "codingAgent: claude\nprojects: []\n");
+        // Arrange: locate example.config.yaml in the project
+        var projectDir = Path.GetDirectoryName(System.AppContext.BaseDirectory);
+        while (projectDir != null && !File.Exists(Path.Combine(projectDir, "example.config.yaml")))
+            projectDir = Path.GetDirectoryName(projectDir);
 
-        var configService = new ConfigService(new TendrilSettings());
-        configService.SetPendingTendrilHome(tendrilHome);
-        configService.SetPendingProject(new ProjectConfig
-        {
-            Name = "TestProject",
-            Repos = new List<RepoRef> { new() { Path = "/tmp/test-repo" } }
-        });
+        var exampleConfigPath = projectDir != null
+            ? Path.Combine(projectDir, "example.config.yaml")
+            : PathHelper.GetResourcePath("example.config.yaml");
 
-        var onboardingService = new OnboardingSetupService(
-            configService,
-            null!,
-            null!,
-            NullLogger<OnboardingSetupService>.Instance);
+        Assert.True(File.Exists(exampleConfigPath), $"example.config.yaml not found at {exampleConfigPath}");
 
-        // Act
-        await onboardingService.FinalizeOnboardingAsync();
+        // Act: read and parse example.config.yaml
+        var configYaml = File.ReadAllText(exampleConfigPath);
+        var settings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(configYaml);
 
-        // Assert: read the seeded config and find CheckResult verification
-        var savedYaml = File.ReadAllText(configPath);
-        var savedSettings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(savedYaml);
-
-        Assert.NotNull(savedSettings);
-        var checkResult = savedSettings.Verifications.FirstOrDefault(v => v.Name == "CheckResult");
+        // Assert: find CheckResult verification
+        Assert.NotNull(settings);
+        Assert.NotNull(settings.Verifications);
+        var checkResult = settings.Verifications.FirstOrDefault(v => v.Name == "CheckResult");
         Assert.NotNull(checkResult);
 
         // Assert the prompt contains the runtime behavior exercise step

--- a/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
@@ -79,20 +79,38 @@ public class OnboardingSetupServiceTests : IDisposable
         Assert.Contains("exercise the documented behavior", checkResult.Prompt);
 
         // Assert numbered steps are contiguous from 1 and report step is last
-        var lines = checkResult.Prompt.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        // YAML > folding joins lines with spaces, so steps like "1. Foo" become "... 1. Foo ..."
+        // We need to find patterns like " N. " or line-start "N. " where N is a digit
         var stepNumbers = new List<int>();
-        foreach (var line in lines)
+        var prompt = checkResult.Prompt;
+
+        // Find all occurrences of " <digit>. " or "^<digit>. " patterns
+        for (int i = 0; i < prompt.Length - 2; i++)
         {
-            var trimmed = line.TrimStart();
-            if (trimmed.Length > 0 && char.IsDigit(trimmed[0]) && trimmed.Contains('.'))
+            // Check if we're at start of line or after a space, followed by digit(s) and a period
+            bool atLineStart = i == 0 || prompt[i - 1] == '\n';
+            bool afterSpace = i > 0 && prompt[i - 1] == ' ' && (i == 1 || prompt[i - 2] == '\n' || prompt[i - 2] == ' ');
+
+            if ((atLineStart || afterSpace) && char.IsDigit(prompt[i]) && prompt[i + 1] == '.')
             {
-                var numStr = new string(trimmed.TakeWhile(char.IsDigit).ToArray());
-                if (int.TryParse(numStr, out var num))
+                // Extract the full number
+                int j = i;
+                while (j < prompt.Length && char.IsDigit(prompt[j]))
+                    j++;
+
+                if (j > i && j < prompt.Length && prompt[j] == '.')
                 {
-                    stepNumbers.Add(num);
+                    var numStr = prompt.Substring(i, j - i);
+                    if (int.TryParse(numStr, out var num) && num >= 1 && num <= 10)
+                    {
+                        stepNumbers.Add(num);
+                    }
                 }
             }
         }
+
+        // Remove duplicates and sort
+        stepNumbers = stepNumbers.Distinct().OrderBy(n => n).ToList();
 
         // Steps should be contiguous starting from 1
         Assert.NotEmpty(stepNumbers);
@@ -103,7 +121,9 @@ public class OnboardingSetupServiceTests : IDisposable
         }
 
         // Last step should be the report-writing step
-        var lastStepIndex = checkResult.Prompt.LastIndexOf($"{stepNumbers.Last()}.");
+        var lastStepNum = stepNumbers.Last();
+        var lastStepPattern = $" {lastStepNum}. ";
+        var lastStepIndex = checkResult.Prompt.LastIndexOf(lastStepPattern);
         Assert.NotEqual(-1, lastStepIndex);
         var textAfterLastStep = checkResult.Prompt.Substring(lastStepIndex);
         Assert.Contains("Write the verification report", textAfterLastStep);

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -183,9 +183,27 @@ verifications:
   prompt: >
     Verify the implementation matches what was requested in the plan.
     1. Read the plan revision: `tendril plan get-revision <PlanId>`
-    2. Review all commits made by this execution
-    3. Compare the plan's Problem and Solution sections against the actual changes
-    4. Write the verification report to `<TendrilPlanFolder>/verification/CheckResult.md`
+    2. Enumerate every deliverable the plan specifies, including ones that are not
+       file edits: CLI calls (`tendril verification set`, `tendril plan set`), config
+       changes outside the repo, and edits to other plans' folders. A plan's commit
+       can be partially delivered when only some of its parts are files.
+    3. Review all commits made by this execution.
+    4. Check each non-file deliverable by re-running the read side of its own command
+       (for example `tendril verification get <Name>` and grep for the text the plan
+       said to add or remove). A repo diff cannot see a CLI call that never happened,
+       so absence of evidence here is not evidence of delivery.
+    5. Compare the plan's Problem and Solution sections against the actual changes.
+       Report each deliverable under the plan's own heading and wording. Never
+       restate a commit's scope to match what was delivered: if a commit had three
+       parts and two landed, say so and set `result: Fail`.
+    6. If the plan's Solution documents the runtime behavior of a script, hook, command
+       or workflow, anything not reachable from the project's build and test gates,
+       exercise the documented behavior once and paste the command with its exit code
+       into the report. Neither the prose nor the diff that added it is evidence that
+       the behavior exists. If it could not be exercised (a blocked write, a missing
+       tool), the result is `Fail`, naming the unexercised claim: documenting behavior
+       the code does not have is a defect, not a partial delivery.
+    7. Write the verification report to `<TendrilPlanFolder>/verification/CheckResult.md`
 
 # Stack-specific verification examples (uncomment and customize for your stack):
 


### PR DESCRIPTION
# Summary

## Changes

Added a new step to the CheckResult verification prompt requiring that if a plan documents runtime behavior of a script, hook, command or workflow (anything not reachable from build/test gates), the documented behavior must be exercised once with command and exit code pasted into the report. Documenting behavior the code does not have is now a verification failure, not a partial delivery. Changes were made in three places: example.config.yaml (seed for fresh installs), TeamIvyConfig (team config), and the live system via CLI.

## API Changes

None. This plan modifies only verification prompt text in configuration files.

## Files Modified

**Configuration:**
- src/Ivy.Tendril/example.config.yaml - Updated CheckResult prompt from 4 to 7 steps
- src/Ivy.Tendril.TeamIvyConfig/config.yaml - Updated CheckResult prompt to 7 steps (was old 6-step pre-00104 format)

**Tests:**
- src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs - Added test verifying seeded config contains runtime behavior step with contiguous numbering

**Live system:**
- Updated via `tendril verification set CheckResult prompt` CLI (not a file change)

## Manual Testing

N/A - internal change with no user-facing behavior. The CheckResult verification prompt is used by ExecutePlan agents during plan execution. The change is verified by:

1. Checking the live prompt contains the new step: `tendril verification get CheckResult | grep "exercise the documented behavior"`
2. Running the test: `dotnet test --filter "ExampleConfig_Should_Seed_CheckResult_Prompt_With_Runtime_Behavior_Step"`
3. Confirming both seed files contain the new step: `grep -c "exercise the documented behavior" src/Ivy.Tendril/example.config.yaml src/Ivy.Tendril.TeamIvyConfig/config.yaml`

The non-vacuous proof in the CheckResult report demonstrates that applying the new step to historical commit 8b8795f (plan 00065) would have returned Fail, as the documented hook behavior (blocks on partially staged files) does not match the measured behavior (exit=0, unstaged code committed).

---

## Commits

- a306cd2f Use regex for step number extraction
- 064bf49c Improve step numbering detection to handle YAML folding
- 30291255 Fix test to read example.config.yaml directly
- a7f26227 Add test for CheckResult runtime behavior step in seeded config
- 785a79e9 Add CheckResult step to require exercising documented runtime behavior

---
Created using [Ivy Tendril](https://ivy.app).
