### PR TITLE
[00097] Compute Duplicate Candidates at Plan Creation Instead of Job Start

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
@@ -53,7 +53,15 @@ Do NOT read or modify `.counter` directly. Plan IDs are allocated by the `tendri
 
 ### 3. Research
 
-- **Check for duplicate plans** first — **unless `Force: true` is set in the firmware header**, in which case skip duplicate detection entirely. However, if you discover related existing plans during research (e.g., from grep results or memory), still link them via `--related-plan` on `tendril plan create`. `Force` means "create the plan regardless" — not "ignore prior work." Check the `DuplicateCandidates` firmware value. If present, it contains pre-computed matches (format: `folderName|title|state` per line). For each match, perform **state-aware duplicate detection** on those specific plans only. If `DuplicateCandidates` is absent, no potential duplicates were found — skip duplicate detection. When matches are found, decide as follows:
+- **Check for duplicate plans** first, **unless `Force: true` is set in the firmware header**, in which case skip duplicate detection entirely. However, if you discover related existing plans during research (e.g., from grep results or memory), still link them via `--related-plan` on `tendril plan create`. `Force` means "create the plan regardless", not "ignore prior work." Check the `DuplicateCandidates` firmware value. If present, it contains pre-computed matches (format: `folderName|title|state` per line). For each match, perform **state-aware duplicate detection** on those specific plans only.
+
+  An **absent** `DuplicateCandidates` header means no pre-computed match was supplied, **not** that none exists. Plans are created in concurrent batches (26 CreatePlan jobs were in flight in the batch that produced four plans for one deliverable), so a sibling covering your task may land while you research. **Always search yourself before writing the revision**, for two or three key terms from the task:
+
+  ```bash
+  tendril plan list --search "<key term>" --project="<project>"
+  ```
+
+  `tendril plan create` and `tendril plan write-revision` also print a `DuplicateCandidates:` block of their own when they find candidates (see Step 4.2). Treat every entry from any of these three sources the same way. When matches are found, decide as follows:
 
   #### Step 1: Read existing plan state
   
@@ -192,6 +200,13 @@ Verifications:
 
 Parse `PlanId` and `Directory` from the output — use these for all subsequent operations.
 
+If plans in the same project have overlapping titles, a fourth block follows the three above:
+```
+DuplicateCandidates:
+<folderName>|<title>|<state>
+```
+This is advisory and never changes the exit code. Apply the Step 3 state table to each entry before you finalize the plan (see Section 4.2 for what to do once the plan folder exists).
+
 Include optional flags as needed (always use the `--option=value` form):
 - `--source-url="<url>"` — if a source URL was extracted in Step 1
 - `--related-plan="<folder-name>"` — for each plan referenced via `[number]` syntax in the task description
@@ -215,6 +230,22 @@ EOF
 ```
 
 This reads from STDIN and auto-creates `Revisions/001.md` (or the next sequential number) in the plan folder. Do NOT use the Write or Edit tools to create revision files directly in `Revisions/`.
+
+**Duplicate candidates at finalization.** `write-revision` prints this to **stderr** when it finds overlapping plans, while still writing the revision and exiting 0:
+
+```
+warning: 3 possible duplicate plan(s) found. Review before this plan is executed:
+DuplicateCandidates:
+<folderName>|<title>|<state>
+```
+
+This is the last check that runs after your research, so it is the one that catches a sibling created while you were working. **Do not ignore it.** For each entry, apply the Step 3 state table. Your plan already exists at this point, so trashing is unavailable: the correct outcomes are
+
+- a `## Concurrent plans` section in the revision naming which plan owns which scope (rewrite the revision with a second `write-revision` call if you already wrote it),
+- `tendril plan add-related-plan <PlanId> "<folder-name>"`, and
+- retitling onto the surviving unowned scope (`tendril plan set <PlanId> title "<new title>"`) when a sibling already owns what you planned, or `tendril plan set <PlanId> state Skipped` when nothing is left unowned.
+
+Under `Force: true`, still print and read the block: `Force` skips the *decision* to create the plan, not the linking. Record every candidate via `--related-plan`.
 
 After creating the plan, report the plan ID and title to the Jobs UI so it can display progress:
 

--- a/src/Ivy.Tendril.Test/Commands/PlanCreateDuplicateCandidatesTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PlanCreateDuplicateCandidatesTests.cs
@@ -1,0 +1,276 @@
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Infrastructure;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
+using Ivy.Tendril.Services.Plans;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Test.Commands;
+
+/// <summary>
+///     The two CLI surfaces that surface <c>DuplicateCandidates</c>: <c>plan create</c> (stdout,
+///     after the existing blocks) and <c>plan write-revision</c> (stderr, exit code unchanged).
+/// </summary>
+[Collection("TendrilHome")]
+public class PlanCreateDuplicateCandidatesTests : IDisposable
+{
+    private const string Project = "Rusty-Framework";
+    private const string Title00063 = "Add the Missing Cargo Fmt Pre-Commit Guard From Plan 00042";
+    private const string Title00065 = "Deliver the Blocked Cargo Fmt Pre-Commit Hook and Correct Plan 00042's Motivation";
+
+    private readonly TempDirectoryFixture _tempDir = new("tendril-create-duplicates");
+    private readonly string _originalTendrilHome;
+    private readonly string? _originalTendrilPlans;
+    private readonly string _plansDir;
+
+    public PlanCreateDuplicateCandidatesTests()
+    {
+        _plansDir = Path.Combine(_tempDir.Path, "Plans");
+        Directory.CreateDirectory(_plansDir);
+
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        _originalTendrilPlans = Environment.GetEnvironmentVariable("TENDRIL_PLANS");
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", null);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", _originalTendrilPlans);
+        _tempDir.Dispose();
+    }
+
+    private CommandApp BuildApp()
+    {
+        var repoDir = Path.Combine(_tempDir.Path, "repos", Project);
+        Directory.CreateDirectory(repoDir);
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IPlanWatcherService, NullPlanWatcherService>();
+        var configService = new TestPlanConfigService(repoDir, Project);
+        services.AddSingleton<IConfigService>(configService);
+        services.AddSingleton<IGithubService>(new GithubService(configService, NullLogger<GithubService>.Instance));
+
+        var app = new CommandApp(new TypeRegistrar(services));
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("plan", plan =>
+            {
+                plan.AddCommand<PlanCreateCommand>("create");
+                plan.AddCommand<PlanWriteRevisionCommand>("write-revision");
+            });
+        });
+        return app;
+    }
+
+    private string SeedPlan(string folderName, string title, string project = Project, string state = "Completed")
+    {
+        var planDir = Path.Combine(_plansDir, folderName);
+        Directory.CreateDirectory(planDir);
+
+        var plan = new PlanYaml
+        {
+            State = state,
+            Project = project,
+            Title = title,
+            Level = "Bug",
+            Created = new DateTime(2026, 8, 1, 20, 0, 0, DateTimeKind.Utc),
+            Updated = new DateTime(2026, 8, 1, 20, 0, 0, DateTimeKind.Utc)
+        };
+
+        File.WriteAllText(Path.Combine(planDir, "plan.yaml"), YamlHelper.Serializer.Serialize(plan));
+        return planDir;
+    }
+
+    private static string CaptureStdout(Action action)
+    {
+        var original = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        return writer.ToString();
+    }
+
+    private static string CaptureStderr(Action action)
+    {
+        var original = Console.Error;
+        using var writer = new StringWriter();
+        Console.SetError(writer);
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Console.SetError(original);
+        }
+
+        return writer.ToString();
+    }
+
+    [Fact]
+    public void PlanCreate_MatchingSibling_PrintsBlockAfterVerifications()
+    {
+        SeedPlan("00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042", Title00063);
+        var app = BuildApp();
+
+        var exit = 0;
+        var stdout = CaptureStdout(() => exit = app.Run(["plan", "create", Title00065, Project]));
+
+        Assert.Equal(0, exit);
+        var lines = stdout.Split('\n').Select(l => l.TrimEnd('\r')).Where(l => l.Length > 0).ToArray();
+
+        var headerIndex = Array.IndexOf(lines, "DuplicateCandidates:");
+        var verificationsIndex = Array.IndexOf(lines, "Verifications:");
+        Assert.True(headerIndex > verificationsIndex, "the block must come after the Verifications block");
+        Assert.Equal(
+            $"00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042|{Title00063}|Completed",
+            lines[headerIndex + 1]);
+    }
+
+    [Fact]
+    public void PlanCreate_NoCandidates_OmitsTheHeaderEntirely()
+    {
+        SeedPlan("00200-SomethingElseCompletely", "Something Else Completely");
+        var app = BuildApp();
+
+        var stdout = CaptureStdout(() => app.Run(["plan", "create", Title00065, Project]));
+
+        Assert.DoesNotContain("DuplicateCandidates", stdout);
+    }
+
+    [Fact]
+    public void PlanCreate_ExistingBlocks_AreUnchangedByTheAddition()
+    {
+        SeedPlan("00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042", Title00063);
+        var app = BuildApp();
+
+        var stdout = CaptureStdout(() => app.Run(["plan", "create", Title00065, Project]));
+
+        var lines = stdout.Split('\n').Select(l => l.TrimEnd('\r')).ToArray();
+        var planFolder = Directory.GetDirectories(_plansDir, "*-Deliver*").Single();
+        var planId = PathHelper.GetFileNameCrossPlatform(planFolder).Split('-')[0];
+
+        // The three blocks every agent parses, in the same order and shape as before.
+        Assert.Equal($"PlanId: {planId}", lines[0]);
+        Assert.Equal($"Directory: {planFolder}", lines[1]);
+        Assert.Equal("Verifications:", lines[2]);
+    }
+
+    [Fact]
+    public void PlanCreate_NoDuplicateCheck_SuppressesTheBlock()
+    {
+        SeedPlan("00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042", Title00063);
+        var app = BuildApp();
+
+        var exit = 0;
+        var stdout = CaptureStdout(() =>
+            exit = app.Run(["plan", "create", Title00065, Project, "--no-duplicate-check"]));
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("DuplicateCandidates", stdout);
+    }
+
+    [Fact]
+    public void PlanCreate_OtherProjectSibling_IsNotReported()
+    {
+        SeedPlan("00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042", Title00063, "Ivy-Tendril");
+        var app = BuildApp();
+
+        var stdout = CaptureStdout(() => app.Run(["plan", "create", Title00065, Project]));
+
+        Assert.DoesNotContain("DuplicateCandidates", stdout);
+    }
+
+    [Fact]
+    public void PlanWriteRevision_WithCandidates_WarnsOnStderrAndStillWritesTheRevision()
+    {
+        SeedPlan("00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042", Title00063);
+        var ownFolder = SeedPlan("00065-DeliverTheBlockedCargoFmtPreCommitHook", Title00065, Project, "Draft");
+        var app = BuildApp();
+
+        var exit = 0;
+        var stderr = CaptureStderr(() => CaptureStdout(() =>
+            exit = app.Run(["plan", "write-revision", "00065", "--file", WriteRevisionFile()])));
+
+        // The revision must be written regardless: a false positive must not block plan creation.
+        Assert.Equal(0, exit);
+        var revision = Directory.GetFiles(Path.Combine(ownFolder, "Revisions")).Single();
+        Assert.Contains("# Revision body", File.ReadAllText(revision));
+
+        Assert.Contains("warning: 1 possible duplicate plan(s) found", stderr);
+        Assert.Contains("DuplicateCandidates:", stderr);
+        Assert.Contains($"00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042|{Title00063}|Completed", stderr);
+
+        // The plan must never match itself.
+        Assert.DoesNotContain("00065-DeliverTheBlockedCargoFmtPreCommitHook", stderr);
+    }
+
+    [Fact]
+    public void PlanWriteRevision_NoCandidates_WritesNoWarning()
+    {
+        SeedPlan("00200-SomethingElseCompletely", "Something Else Completely");
+        SeedPlan("00065-DeliverTheBlockedCargoFmtPreCommitHook", Title00065, Project, "Draft");
+        var app = BuildApp();
+
+        var exit = 0;
+        var stderr = CaptureStderr(() => CaptureStdout(() =>
+            exit = app.Run(["plan", "write-revision", "00065", "--file", WriteRevisionFile()])));
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("DuplicateCandidates", stderr);
+        Assert.DoesNotContain("warning:", stderr);
+    }
+
+    [Fact]
+    public void PlanWriteRevision_NoDuplicateCheck_SuppressesTheWarning()
+    {
+        SeedPlan("00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042", Title00063);
+        SeedPlan("00065-DeliverTheBlockedCargoFmtPreCommitHook", Title00065, Project, "Draft");
+        var app = BuildApp();
+
+        var exit = 0;
+        var stderr = CaptureStderr(() => CaptureStdout(() => exit = app.Run(
+            ["plan", "write-revision", "00065", "--file", WriteRevisionFile(), "--no-duplicate-check"])));
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("DuplicateCandidates", stderr);
+    }
+
+    [Fact]
+    public void PlanWriteRevision_StdoutIsStillOnlyTheRevisionPath()
+    {
+        SeedPlan("00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042", Title00063);
+        var ownFolder = SeedPlan("00065-DeliverTheBlockedCargoFmtPreCommitHook", Title00065, Project, "Draft");
+        var app = BuildApp();
+
+        string stdout = "";
+        CaptureStderr(() => stdout = CaptureStdout(() =>
+            app.Run(["plan", "write-revision", "00065", "--file", WriteRevisionFile()])));
+
+        // Agents parse this stdout as a path. The warning goes to stderr and must not pollute it.
+        var expected = Path.Combine(ownFolder, "Revisions", "001.md");
+        Assert.Equal(expected, stdout);
+    }
+
+    private string WriteRevisionFile()
+    {
+        var file = Path.Combine(_tempDir.Path, $"revision-{Guid.NewGuid():N}.md");
+        File.WriteAllText(file, "# Revision body");
+        return file;
+    }
+}

--- a/src/Ivy.Tendril.Test/Services/DuplicateCandidateFinderTests.cs
+++ b/src/Ivy.Tendril.Test/Services/DuplicateCandidateFinderTests.cs
@@ -1,0 +1,221 @@
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Plans;
+
+namespace Ivy.Tendril.Test.Services;
+
+[Collection("TendrilHome")]
+public class DuplicateCandidateFinderTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("tendril-duplicate-candidates");
+    private readonly string _plansDir;
+
+    public DuplicateCandidateFinderTests()
+    {
+        _plansDir = Path.Combine(_tempDir.Path, "Plans");
+        Directory.CreateDirectory(_plansDir);
+    }
+
+    public void Dispose() => _tempDir.Dispose();
+
+    private string SeedPlan(string folderName, string title, string project, string state = "Draft")
+    {
+        var planDir = Path.Combine(_plansDir, folderName);
+        Directory.CreateDirectory(planDir);
+
+        var plan = new PlanYaml
+        {
+            State = state,
+            Project = project,
+            Title = title,
+            Level = "Bug",
+            Created = new DateTime(2026, 8, 1, 20, 0, 0, DateTimeKind.Utc),
+            Updated = new DateTime(2026, 8, 1, 20, 0, 0, DateTimeKind.Utc)
+        };
+
+        File.WriteAllText(Path.Combine(planDir, "plan.yaml"), YamlHelper.Serializer.Serialize(plan));
+        return planDir;
+    }
+
+    // The real titles of the four plans that collapsed onto one deliverable within 17 minutes.
+    private const string Title00042 = "Remove Dead Dotnet Format Staged Glob and Enforce Cargo Fmt on Pre-Commit";
+    private const string Title00061 = "Deliver the Cargo Fmt Pre-Commit Hook That Plan 00042 Could Not Write";
+    private const string Title00063 = "Add the Missing Cargo Fmt Pre-Commit Guard From Plan 00042";
+    private const string Title00064 = "Cover the Pre-Commit Hook With a CI Harness and Land the Missing Rustfmt Block";
+    private const string Title00065 = "Deliver the Blocked Cargo Fmt Pre-Commit Hook and Correct Plan 00042's Motivation";
+
+    private void SeedTheFourSiblings()
+    {
+        SeedPlan("00042-RemoveDeadDotnetFormatStagedGlobAndEnforceCargoFmtOnPreCommi", Title00042, "Rusty-Framework", "Completed");
+        SeedPlan("00061-MakeTheCIFormatCheckGreenByRemovingTheDuplicateBlankLineInWi", Title00061, "Rusty-Framework", "Completed");
+        SeedPlan("00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042", Title00063, "Rusty-Framework", "Completed");
+        SeedPlan("00064-CoverThePreCommitHookWithACIHarnessAndLandTheMissingRustfmtB", Title00064, "Rusty-Framework", "Completed");
+    }
+
+    /// <summary>
+    ///     The regression this plan exists for: querying with 00065's title must surface all four
+    ///     plans already on disk when 00065 was finalized.
+    /// </summary>
+    [Fact]
+    public void Find_TheFourRealSiblings_ReturnsAllOfThem()
+    {
+        SeedTheFourSiblings();
+
+        var candidates = DuplicateCandidateFinder.Find(_plansDir, Title00065, "Rusty-Framework");
+
+        Assert.Equal(4, candidates.Count);
+        var folders = candidates.Select(c => c.FolderName.Split('-')[0]).OrderBy(x => x).ToArray();
+        Assert.Equal(["00042", "00061", "00063", "00064"], folders);
+    }
+
+    /// <summary>
+    ///     The mechanism this replaces must be shown not to work, otherwise the finder's green run
+    ///     proves nothing. <c>plan list --search</c> is a whole-title substring match, and the four
+    ///     sibling titles share no common substring: searching for any one of them finds only itself.
+    /// </summary>
+    [Fact]
+    public void ScanPlansSubstringSearch_TheFourRealSiblings_FindsNoneOfThem()
+    {
+        SeedTheFourSiblings();
+
+        var bySubstring = PlanListCommand.ScanPlans(
+            _plansDir,
+            new PlanListSettings { Project = "Rusty-Framework", Search = Title00065 });
+
+        Assert.Empty(bySubstring);
+    }
+
+    [Fact]
+    public void Find_DifferentProject_IsExcludedEvenOnAnIdenticalTitle()
+    {
+        SeedPlan("00100-SameTitle", Title00065, "Ivy-Tendril", "Completed");
+
+        var sameProject = DuplicateCandidateFinder.Find(_plansDir, Title00065, "Ivy-Tendril");
+        var otherProject = DuplicateCandidateFinder.Find(_plansDir, Title00065, "Rusty-Framework");
+
+        Assert.Single(sameProject);
+        Assert.Empty(otherProject);
+    }
+
+    [Fact]
+    public void Find_ExcludeFolderName_RemovesThePlansOwnFolder()
+    {
+        SeedPlan("00065-DeliverTheBlockedCargoFmtPreCommitHook", Title00065, "Rusty-Framework", "Draft");
+        SeedPlan("00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042", Title00063, "Rusty-Framework", "Completed");
+
+        var withoutExclude = DuplicateCandidateFinder.Find(_plansDir, Title00065, "Rusty-Framework");
+        var withExclude = DuplicateCandidateFinder.Find(
+            _plansDir, Title00065, "Rusty-Framework", "00065-DeliverTheBlockedCargoFmtPreCommitHook");
+
+        Assert.Equal(2, withoutExclude.Count);
+        Assert.Single(withExclude);
+        Assert.StartsWith("00063", withExclude[0].FolderName);
+    }
+
+    [Fact]
+    public void Find_OnlyStopwordsAndShortTokensShared_DoesNotMatch()
+    {
+        SeedPlan("00200-AddAThingToTheDocs", "Add a Thing to the Docs", "Ivy-Tendril");
+
+        var candidates = DuplicateCandidateFinder.Find(_plansDir, "Fix the Thing in the App", "Ivy-Tendril");
+
+        Assert.Empty(candidates);
+    }
+
+    [Fact]
+    public void Find_SinglePlanIdTokenShared_MatchesOnItsOwn()
+    {
+        SeedPlan("00300-SomethingEntirelyUnrelatedAboutPlan00042", "Something Entirely Unrelated About Plan 00042", "Ivy-Tendril");
+
+        var candidates = DuplicateCandidateFinder.Find(_plansDir, "Revisit Plan 00042 Whenever Possible", "Ivy-Tendril");
+
+        Assert.Single(candidates);
+        Assert.StartsWith("00300", candidates[0].FolderName);
+    }
+
+    [Fact]
+    public void Find_MalformedEmptyAndNonPlanDirectories_AreSkippedWithoutThrowing()
+    {
+        // Malformed YAML.
+        var malformed = Path.Combine(_plansDir, "00400-Malformed");
+        Directory.CreateDirectory(malformed);
+        File.WriteAllText(Path.Combine(malformed, "plan.yaml"), "state: [unclosed\n\ttitle: \"Cargo Fmt Pre-Commit Hook\"");
+
+        // Empty plan.yaml.
+        var empty = Path.Combine(_plansDir, "00401-Empty");
+        Directory.CreateDirectory(empty);
+        File.WriteAllText(Path.Combine(empty, "plan.yaml"), "");
+
+        // A directory with no plan.yaml at all.
+        Directory.CreateDirectory(Path.Combine(_plansDir, "00402-NoYaml"));
+
+        // A directory whose name has no numeric plan-id prefix.
+        var nonPlan = Path.Combine(_plansDir, "NotAPlanFolder");
+        Directory.CreateDirectory(nonPlan);
+        File.WriteAllText(Path.Combine(nonPlan, "plan.yaml"), "state: Draft\nproject: Rusty-Framework\ntitle: Cargo Fmt Pre-Commit Hook\n");
+
+        // One good plan, to prove the scan kept going past all of the above.
+        SeedPlan("00403-Good", Title00063, "Rusty-Framework", "Completed");
+
+        var candidates = DuplicateCandidateFinder.Find(_plansDir, Title00065, "Rusty-Framework");
+
+        Assert.Single(candidates);
+        Assert.StartsWith("00403", candidates[0].FolderName);
+    }
+
+    [Fact]
+    public void Find_MissingPlansDirectory_ReturnsEmptyWithoutThrowing()
+    {
+        var candidates = DuplicateCandidateFinder.Find(
+            Path.Combine(_tempDir.Path, "does-not-exist"), Title00065, "Rusty-Framework");
+
+        Assert.Empty(candidates);
+    }
+
+    [Fact]
+    public void Find_ReturnsStateVerbatimForEveryState()
+    {
+        SeedPlan("00500-Completed", Title00063, "Rusty-Framework", "Completed");
+        SeedPlan("00501-Failed", Title00063, "Rusty-Framework", "Failed");
+        SeedPlan("00502-Skipped", Title00063, "Rusty-Framework", "Skipped");
+        SeedPlan("00503-Icebox", Title00063, "Rusty-Framework", "Icebox");
+
+        var candidates = DuplicateCandidateFinder.Find(_plansDir, Title00065, "Rusty-Framework");
+
+        var states = candidates.Select(c => c.State).OrderBy(s => s).ToArray();
+        Assert.Equal(["Completed", "Failed", "Icebox", "Skipped"], states);
+    }
+
+    [Fact]
+    public void Find_EmptyOrStopwordOnlyTitle_ReturnsEmpty()
+    {
+        SeedPlan("00600-Something", Title00063, "Rusty-Framework", "Completed");
+
+        Assert.Empty(DuplicateCandidateFinder.Find(_plansDir, "", "Rusty-Framework"));
+        Assert.Empty(DuplicateCandidateFinder.Find(_plansDir, "   ", "Rusty-Framework"));
+        Assert.Empty(DuplicateCandidateFinder.Find(_plansDir, "the and of to", "Rusty-Framework"));
+    }
+
+    [Fact]
+    public void FormatBlock_EmptyList_ReturnsEmptyString()
+    {
+        Assert.Equal("", DuplicateCandidateFinder.FormatBlock([]));
+    }
+
+    [Fact]
+    public void FormatBlock_Candidates_UsesFolderNamePipeTitlePipeState()
+    {
+        var block = DuplicateCandidateFinder.FormatBlock(
+        [
+            new DuplicateCandidate("00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042", Title00063, "Completed"),
+            new DuplicateCandidate("00064-CoverThePreCommitHookWithACIHarnessAndLandTheMissingRustfmtB", Title00064, "Failed")
+        ]);
+
+        var lines = block.Split(Environment.NewLine);
+        Assert.Equal("DuplicateCandidates:", lines[0]);
+        Assert.Equal($"00063-AddTheMissingCargoFmtPreCommitGuardFromPlan00042|{Title00063}|Completed", lines[1]);
+        Assert.Equal($"00064-CoverThePreCommitHookWithACIHarnessAndLandTheMissingRustfmtB|{Title00064}|Failed", lines[2]);
+        Assert.Equal(3, lines.Length);
+    }
+}

--- a/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCreateCommand.cs
@@ -55,6 +55,10 @@ public class PlanCreateSettings : CommandSettings
     [CommandOption("--plans-dir")]
     public string? PlansDir { get; set; }
 
+    [Description("Suppress the DuplicateCandidates block (for scripted and test use)")]
+    [CommandOption("--no-duplicate-check")]
+    public bool NoDuplicateCheck { get; set; }
+
     public override Spectre.Console.ValidationResult Validate()
     {
         return CliValidation.Combine(
@@ -94,6 +98,11 @@ public class PlanCreateCommand : Command<PlanCreateSettings>
         }
 
         var plansDir = PlanCommandHelpers.GetPlansDirectory(settings.PlansDir);
+
+        // Computed before the new plan folder exists, so it cannot match itself.
+        var duplicateCandidates = settings.NoDuplicateCheck
+            ? []
+            : DuplicateCandidateFinder.Find(plansDir, settings.Title, resolvedProject.Name);
 
         var planId = PlanYamlHelper.AllocatePlanId(plansDir);
         var safeTitle = PlanYamlHelper.ToSafeTitle(settings.Title);
@@ -159,6 +168,14 @@ public class PlanCreateCommand : Command<PlanCreateSettings>
         Console.WriteLine("Verifications:");
         foreach (var v in plan.Verifications)
             Console.WriteLine($"{v.Name}:{v.Status}");
+
+        // Last, so the three blocks above stay byte-identical for every agent that parses them.
+        // The header is emitted only when there is something to report: the CreatePlan firmware
+        // branches on its presence.
+        var block = DuplicateCandidateFinder.FormatBlock(duplicateCandidates);
+        if (block.Length > 0)
+            Console.WriteLine(block);
+
         return 0;
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -18,6 +19,10 @@ public class PlanWriteRevisionSettings : CommandSettings
     [CommandOption("--stdin")]
     [Description("Read content from standard input")]
     public bool Stdin { get; set; }
+
+    [Description("Suppress the duplicate-candidate warning (for scripted and test use)")]
+    [CommandOption("--no-duplicate-check")]
+    public bool NoDuplicateCheck { get; set; }
 
     public int SourceCount => CliValidation.CountSources(Stdin, FilePath, "");
 
@@ -43,6 +48,57 @@ public class PlanWriteRevisionCommand : Command<PlanWriteRevisionSettings>
 
         var filePath = RevisionWriter.WriteNext(planFolder, content, new ConfigService());
         Console.Write(filePath);
+
+        if (!settings.NoDuplicateCheck)
+            WarnAboutDuplicateCandidates(planFolder);
+
         return 0;
+    }
+
+    /// <summary>
+    ///     Prints a duplicate-candidate warning to stderr after the revision has been written.
+    ///     <para>
+    ///         This is the only point in the CreatePlan lifecycle that runs after research, so it is
+    ///         the one that catches a sibling plan created while this plan was being written: of the
+    ///         four plans that collapsed onto one deliverable, 00065 was finalized with all three
+    ///         already on disk and 00064 with two, while a check at creation time alone still misses
+    ///         00063 (created 24 seconds before 00064).
+    ///     </para>
+    ///     <para>
+    ///         stderr, and the exit code stays 0: the revision must still be written. A false
+    ///         positive that blocks plan creation is worse than the duplicate it prevents.
+    ///     </para>
+    /// </summary>
+    private static void WarnAboutDuplicateCandidates(string planFolder)
+    {
+        try
+        {
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            if (string.IsNullOrWhiteSpace(plan.Title) || string.IsNullOrWhiteSpace(plan.Project))
+                return;
+
+            var plansDir = Path.GetDirectoryName(planFolder);
+            if (string.IsNullOrEmpty(plansDir))
+                return;
+
+            var candidates = DuplicateCandidateFinder.Find(
+                plansDir,
+                plan.Title,
+                plan.Project,
+                PathHelper.GetFileNameCrossPlatform(planFolder));
+
+            if (candidates.Count == 0)
+                return;
+
+            Console.Error.WriteLine();
+            Console.Error.WriteLine(
+                $"warning: {candidates.Count} possible duplicate plan(s) found. Review before this plan is executed:");
+            Console.Error.WriteLine(DuplicateCandidateFinder.FormatBlock(candidates));
+        }
+        catch
+        {
+            // Advisory only. A plan.yaml that cannot be read must not fail a revision that is
+            // already on disk.
+        }
     }
 }

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -90,7 +90,15 @@ Do NOT read or modify `.counter` directly. Plan IDs are allocated by the `tendri
 
 Report status: `tendril job status TendrilJobId --message="Researching codebase..."`
 
-- **Check for duplicate plans** first — **unless `Force: true` is set in the firmware header**, in which case skip duplicate detection entirely. However, if you discover related existing plans during research (e.g., from grep results or memory), still link them via `--related-plan` on `tendril plan create`. `Force` means "create the plan regardless" — not "ignore prior work." Check the `DuplicateCandidates` firmware value. If present, it contains pre-computed matches (format: `folderName|title|state` per line). For each match, perform **state-aware duplicate detection** on those specific plans only. If `DuplicateCandidates` is absent, no potential duplicates were found — skip duplicate detection. When matches are found, decide as follows:
+- **Check for duplicate plans** first, **unless `Force: true` is set in the firmware header**, in which case skip duplicate detection entirely. However, if you discover related existing plans during research (e.g., from grep results or memory), still link them via `--related-plan` on `tendril plan create`. `Force` means "create the plan regardless", not "ignore prior work." Check the `DuplicateCandidates` firmware value. If present, it contains pre-computed matches (format: `folderName|title|state` per line). For each match, perform **state-aware duplicate detection** on those specific plans only.
+
+  An **absent** `DuplicateCandidates` header means no pre-computed match was supplied, **not** that none exists. Plans are created in concurrent batches (26 CreatePlan jobs were in flight in the batch that produced four plans for one deliverable), so a sibling covering your task may land while you research. **Always search yourself before writing the revision**, for two or three key terms from the task:
+
+  ```bash
+  tendril plan list --search "<key term>" --project="<project>"
+  ```
+
+  `tendril plan create` and `tendril plan write-revision` also print a `DuplicateCandidates:` block of their own when they find candidates (see Step 4.2). Treat every entry from any of these three sources the same way. When matches are found, decide as follows:
 
   #### Step 1: Read existing plan state
   
@@ -240,6 +248,13 @@ Verifications:
 
 Parse `PlanId` and `Directory` from the output — use these for all subsequent operations.
 
+If plans in the same project have overlapping titles, a fourth block follows the three above:
+```
+DuplicateCandidates:
+<folderName>|<title>|<state>
+```
+This is advisory and never changes the exit code. Apply the Step 3 state table to each entry before you finalize the plan (see Section 4.2 for what to do once the plan folder exists).
+
 Include optional flags as needed (always use the `--option=value` form):
 - `--source-url="<url>"` — if a source URL was extracted in Step 1
 - `--related-plan="<folder-name>"` — for each plan referenced via `[number]` syntax in the task description
@@ -265,6 +280,22 @@ EOF
 **The revision's first line is the `# {title}` H1 heading — it MUST be the exact same string you passed as `<Title>` to `tendril plan create` above** (human-readable Title Case, not the PascalCase folder form). The `plan.yaml` title and the spec H1 must always match.
 
 This reads from STDIN and auto-creates `Revisions/001.md` (or the next sequential number) in the plan folder. Do NOT use the Write or Edit tools to create revision files directly in `Revisions/`.
+
+**Duplicate candidates at finalization.** `write-revision` prints this to **stderr** when it finds overlapping plans, while still writing the revision and exiting 0:
+
+```
+warning: 3 possible duplicate plan(s) found. Review before this plan is executed:
+DuplicateCandidates:
+<folderName>|<title>|<state>
+```
+
+This is the last check that runs after your research, so it is the one that catches a sibling created while you were working. **Do not ignore it.** For each entry, apply the Step 3 state table. Your plan already exists at this point, so trashing is unavailable: the correct outcomes are
+
+- a `## Concurrent plans` section in the revision naming which plan owns which scope (rewrite the revision with a second `write-revision` call if you already wrote it),
+- `tendril plan add-related-plan <PlanId> "<folder-name>"`, and
+- retitling onto the surviving unowned scope (`tendril plan set <PlanId> title "<new title>"`) when a sibling already owns what you planned, or `tendril plan set <PlanId> state Skipped` when nothing is left unowned.
+
+Under `Force: true`, still print and read the block: `Force` skips the *decision* to create the plan, not the linking. Record every candidate via `--related-plan`.
 
 After creating the plan, report the plan ID and title to the Jobs UI so it can display progress:
 

--- a/src/Ivy.Tendril/Services/Plans/DuplicateCandidateFinder.cs
+++ b/src/Ivy.Tendril/Services/Plans/DuplicateCandidateFinder.cs
@@ -1,0 +1,185 @@
+using Ivy.Tendril.Commands;
+
+namespace Ivy.Tendril.Services.Plans;
+
+/// <summary>
+///     A plan that may already cover the work an incoming plan describes. <c>State</c> is returned
+///     verbatim (never filtered) so the caller can apply CreatePlan's state-aware duplicate table,
+///     which has a distinct row for every state including <c>Skipped</c> and <c>Icebox</c>.
+/// </summary>
+public sealed record DuplicateCandidate(string FolderName, string Title, string State);
+
+/// <summary>
+///     Finds existing plans whose titles overlap a candidate title, so duplicate detection can run
+///     at plan creation and at revision write instead of only at job start.
+///     <para>
+///         Plans are created in concurrent batches: four plans delivering one pre-commit hook block
+///         landed within 17 minutes, because each CreatePlan job had already started (and so could
+///         not see its siblings) before the others existed. Running this finder at the two CLI
+///         surfaces that execute *after* research (<c>plan create</c> and <c>plan write-revision</c>)
+///         is what catches the same-batch case.
+///     </para>
+///     <para>
+///         Matching is significant-word overlap, not the whole-title substring that
+///         <c>plan list --search</c> uses: the four sibling titles share no common substring, so a
+///         substring test finds none of them.
+///     </para>
+/// </summary>
+public static class DuplicateCandidateFinder
+{
+    /// <summary>
+    ///     Words carrying no topical signal. Shared stopwords never contribute to a match.
+    /// </summary>
+    private static readonly HashSet<string> Stopwords = new(StringComparer.Ordinal)
+    {
+        "the", "a", "an", "and", "or", "of", "to", "in", "for", "with",
+        "on", "at", "is", "by", "from", "that", "this", "it", "as", "be"
+    };
+
+    /// <summary>
+    ///     Shortest token length that counts toward the two-token overlap threshold. Shorter tokens
+    ///     ("fmt", "pre", "ci") are too common to discriminate on their own.
+    /// </summary>
+    private const int MinimumTokenLength = 4;
+
+    /// <summary>
+    ///     Finds plans in <paramref name="plansDirectory" /> that may duplicate
+    ///     <paramref name="title" />, restricted to <paramref name="project" />.
+    ///     <para>
+    ///         Never throws. A missing plans directory, an unreadable or malformed <c>plan.yaml</c>,
+    ///         and a non-plan directory are all skipped: candidate discovery is advisory, and must
+    ///         not be able to fail plan creation.
+    ///     </para>
+    /// </summary>
+    /// <param name="plansDirectory">Directory holding the plan folders.</param>
+    /// <param name="title">Title of the incoming plan to match against.</param>
+    /// <param name="project">
+    ///     Project to restrict the search to. A Rusty-Framework title must not match an
+    ///     Ivy-Tendril plan, however similar the words.
+    /// </param>
+    /// <param name="excludeFolderName">
+    ///     Folder name to omit, so a plan never matches itself when the finder runs after the plan
+    ///     has been written to disk.
+    /// </param>
+    public static IReadOnlyList<DuplicateCandidate> Find(
+        string plansDirectory,
+        string title,
+        string project,
+        string? excludeFolderName = null)
+    {
+        var queryTokens = Tokenize(title);
+        if (queryTokens.Count == 0)
+            return [];
+
+        List<PlanListCommand.PlanListEntry> plans;
+        try
+        {
+            // Reuse the CLI's own scan rather than forking YAML parsing. It already applies the
+            // project filter and swallows per-directory read errors.
+            plans = PlanListCommand.ScanPlans(plansDirectory, new PlanListSettings { Project = project });
+        }
+        catch
+        {
+            return [];
+        }
+
+        var candidates = new List<DuplicateCandidate>();
+
+        foreach (var plan in plans)
+        {
+            if (!string.IsNullOrEmpty(excludeFolderName) &&
+                plan.FolderName.Equals(excludeFolderName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (string.IsNullOrWhiteSpace(plan.Title))
+                continue;
+
+            if (!IsMatch(queryTokens, Tokenize(plan.Title)))
+                continue;
+
+            candidates.Add(new DuplicateCandidate(plan.FolderName, plan.Title, plan.State));
+        }
+
+        return candidates;
+    }
+
+    /// <summary>
+    ///     Renders candidates in the <c>DuplicateCandidates:</c> block format the CreatePlan
+    ///     firmware documents: a header line, then one <c>folderName|title|state</c> line each.
+    ///     Returns an empty string for an empty list, since the firmware branches on the header's
+    ///     absence.
+    /// </summary>
+    public static string FormatBlock(IReadOnlyList<DuplicateCandidate> candidates)
+    {
+        if (candidates.Count == 0)
+            return "";
+
+        var lines = new List<string> { "DuplicateCandidates:" };
+        lines.AddRange(candidates.Select(c => $"{c.FolderName}|{c.Title}|{c.State}"));
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    /// <summary>
+    ///     Two titles match when they share at least two significant tokens of
+    ///     <see cref="MinimumTokenLength" /> characters or more, or a single plan id token such as
+    ///     <c>00042</c> (a title naming another plan's id is almost always about that plan).
+    /// </summary>
+    private static bool IsMatch(HashSet<string> queryTokens, HashSet<string> otherTokens)
+    {
+        var significantOverlap = 0;
+
+        foreach (var token in queryTokens)
+        {
+            if (!otherTokens.Contains(token))
+                continue;
+
+            if (IsPlanId(token))
+                return true;
+
+            if (token.Length >= MinimumTokenLength && ++significantOverlap >= 2)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     True for an all-digit token long enough to be a plan id reference (<c>00042</c>), as
+    ///     opposed to an incidental small number.
+    /// </summary>
+    private static bool IsPlanId(string token) =>
+        token.Length >= 4 && token.All(char.IsAsciiDigit);
+
+    /// <summary>
+    ///     Lowercases, splits on every non-alphanumeric character, and drops stopwords.
+    /// </summary>
+    private static HashSet<string> Tokenize(string? title)
+    {
+        var tokens = new HashSet<string>(StringComparer.Ordinal);
+        if (string.IsNullOrWhiteSpace(title))
+            return tokens;
+
+        var lowered = title.ToLowerInvariant();
+        var start = -1;
+
+        for (var i = 0; i <= lowered.Length; i++)
+        {
+            var isWordChar = i < lowered.Length && char.IsLetterOrDigit(lowered[i]);
+
+            if (isWordChar)
+            {
+                if (start < 0) start = i;
+                continue;
+            }
+
+            if (start < 0) continue;
+
+            var token = lowered[start..i];
+            start = -1;
+            if (!Stopwords.Contains(token))
+                tokens.Add(token);
+        }
+
+        return tokens;
+    }
+}


### PR DESCRIPTION
# Summary

## Changes

`DuplicateCandidates` was documented in the CreatePlan firmware but never computed by anything, and
the firmware told every agent that its absence proved no duplicates existed, so duplicate detection
had never run in any job. This adds a real candidate finder, prints its results at `tendril plan
create` (stdout) and `tendril plan write-revision` (stderr, exit code unchanged), and corrects the
firmware sentence in both `CreatePlan/Program.md` copies. `write-revision` is the surface that
matters: it is the only point in the CreatePlan lifecycle that runs after research, so it catches a
sibling plan that landed while the agent was working.

## API Changes

New:

- `Ivy.Tendril.Services.Plans.DuplicateCandidate` (`public sealed record`) with `FolderName`,
  `Title`, `State`.
- `Ivy.Tendril.Services.Plans.DuplicateCandidateFinder.Find(string plansDirectory, string title,
  string project, string? excludeFolderName = null)` returning
  `IReadOnlyList<DuplicateCandidate>`. Never throws.
- `DuplicateCandidateFinder.FormatBlock(IReadOnlyList<DuplicateCandidate>)` returning the
  `DuplicateCandidates:` block, or `""` for an empty list.
- `--no-duplicate-check` on `tendril plan create` and `tendril plan write-revision`
  (`PlanCreateSettings.NoDuplicateCheck`, `PlanWriteRevisionSettings.NoDuplicateCheck`).

Changed output, both additive:

- `tendril plan create` may append a fourth block after `Verifications:`. The existing
  `PlanId:` / `Directory:` / `Verifications:` blocks are byte-identical, asserted by a test.
- `tendril plan write-revision` may write a warning to **stderr**. Its stdout is still only the
  revision path, and its exit code is still 0.

No existing signature changed and nothing was removed.

## Files Modified

New:

- `src/Ivy.Tendril/Services/Plans/DuplicateCandidateFinder.cs`
- `src/Ivy.Tendril.Test/Services/DuplicateCandidateFinderTests.cs` (12 tests)
- `src/Ivy.Tendril.Test/Commands/PlanCreateDuplicateCandidatesTests.cs` (9 tests)

Changed:

- `src/Ivy.Tendril/Commands/PlanCreateCommand.cs`, `PlanWriteRevisionCommand.cs`
- `src/Ivy.Tendril/Promptwares/CreatePlan/Program.md` and the
  `src/Ivy.Tendril.TeamIvyConfig/` copy

## Manual Testing

The `Program.md` change only takes effect for agents once the promptware is redeployed:
`PromptwareDeployer.NeedsUpdate` compares a version file against the assembly version, so the
deployed copy at `<TendrilHome>/Promptwares/CreatePlan/Program.md` still contains the old sentence
until a version bump ships. To confirm the source is correct now:
`grep -c "no potential duplicates were found" src/Ivy.Tendril/Promptwares/CreatePlan/Program.md`
returns 0.

To see the CLI behavior:

1. Make a scratch plans directory with one plan whose title overlaps what you are about to create,
   e.g. `<tmp>/Plans/00063-Something/plan.yaml` containing `state: Completed`, `project:
   Ivy-Tendril`, and `title: Add the Missing Cargo Fmt Pre-Commit Guard From Plan 00042`.
2. `tendril plan create "Deliver the Blocked Cargo Fmt Pre-Commit Hook and Correct Plan 00042
   Motivation" "Ivy-Tendril" --plans-dir="<tmp>/Plans"`.
   Observe a `DuplicateCandidates:` block **after** the `Verifications:` list, one
   `folderName|title|state` line per match. Re-run with `--no-duplicate-check` and observe it is
   gone while the first three blocks are unchanged.
3. `TENDRIL_PLANS="<tmp>/Plans" tendril plan write-revision <the new id> --file some.md`.
   Observe on **stderr**: `warning: 1 possible duplicate plan(s) found. Review before this plan is
   executed:` followed by the same block. Confirm the exit code is 0, stdout is just the revision
   path, and `Revisions/001.md` exists: the warning must never block the write. The new plan must
   not list itself.

## Where I diverged from the plan, and why

- **Test scope widened.** The plan's filter named only the two new test classes. It omits
  `PlanCliCommandTests`, the existing suite that drives both commands I changed, so passing it would
  not have shown the additive output left the existing three blocks intact. I ran the plan's filter
  as written (61 passed) and then the whole unit project (1975 passed, 1 skipped, 0 failed).
- **One extra test, beyond the plan.** `ScanPlansSubstringSearch_TheFourRealSiblings_FindsNoneOfThem`
  asserts the *old* mechanism (`plan list --search`) finds zero of the four siblings on the same
  fixture data the new finder matches all four of. Without it, the regression test passes for two
  indistinguishable reasons.
- **The plan predicted 3 siblings; the finder returns 4.** The fourth is a real match, so the test
  asserts 4. Worth a reviewer's attention since the plan's prose says three.
- **Two pre-existing em dashes replaced on an edited line.** `AGENTS.md:17` forbids U+2014. Editing
  the middle of one long bullet made the whole line an added line, carrying two em dashes that were
  already there; both became commas. The surrounding files still contain 45 and 37 on untouched
  lines, deliberately left alone to keep the diff reviewable.

## Reflection

Three new ExecutePlan memories, each verified against this worktree rather than written from
recollection: `slnx-escapes-the-worktree` (`Ivy.Tendril.slnx` references
`../../../Ivy-Framework/src/Ivy/Ivy.csproj`, which resolves outside a plan worktree and makes
`dotnet format` fail with an undiagnosable "Restore operation failed"; reproduced MSB3202 verbatim
and confirmed the per-csproj form exits 0), `added-lines-carry-old-em-dashes`, and
`measure-heuristics-on-the-real-corpus`. No existing memory was contradicted, so none was deleted;
seven were used and re-confirmed.

Re-running the corpus measurement during reflection caught a stale number: the figures in the "rank
duplicate candidates" recommendation moved because plan **00146** ("Cover the Pre-Commit Hook's
Frontend Branch in the Real Checkout") was created at 22:54 UTC today, mid-execution. It is a sixth
member of the same pre-commit cluster this plan exists because of, which is direct evidence for the
premise: a check that runs at job start cannot see a sibling that does not exist yet. The
recommendation now cites `Artifacts/measure-rate.py` instead of hard-coded constants.

---

## Commits

- 37cd9fed feat(plans): add DuplicateCandidateFinder for significant-word plan title overlap
- b041d08a feat(cli): surface DuplicateCandidates at plan create and plan write-revision
- d47feac8 fix(promptware): stop telling CreatePlan that an absent DuplicateCandidates proves no duplicates

---
Created using [Ivy Tendril](https://ivy.app).
