### PR TITLE
[00103] Route a Failed PreExecution to Failed Instead of Laundering It Into Completed

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
@@ -118,7 +118,16 @@ After reading the plan revision, scan it for code validation markers to detect s
 3. **Decision logic:**
    - **If no validation blocks found** → Skip validation, proceed to worktree creation (backward compatible)
    - **If all validation blocks pass** → Proceed to worktree creation
-   - **If any validation fails** → Fail the plan immediately with a detailed report
+   - **If any validation fails** → Stop here and fail the job. "Fail the plan" is a concrete
+     three-step contract, not a state change:
+     1. Write `<TendrilPlanFolder>/Verification/PreExecution.md` with `result: Fail` and the detailed
+        per-block report below.
+     2. Call `tendril job fail TendrilJobId --message="PreExecution failed: <reason>"`.
+     3. `exit 1`.
+
+     The server reads that report and routes the plan to `Failed` on its own, so do **not** set the
+     state yourself (see step 9). Do not proceed to worktree creation, do not run verifications, and
+     do not commit anything: there is nothing to verify on an unmodified base branch.
 
 4. **Write validation report** — Create `<TendrilPlanFolder>/Verification/PreExecution.md`:
 
@@ -151,7 +160,17 @@ date: <CurrentTime>
    - A `<details><summary>Still relevant?</summary>` block whose body starts with `No.`
    - Phrases like *"Already applied"*, *"This plan is redundant"*, *"This plan is superseded"*, or *"previously attempted … was merged to main via PR #NNNN"* in the `## Problem` or `## Solution` sections.
 
-   If any marker is found, verify the claim: run `gh pr view <cited PR> --json state,mergeCommit` (must be `MERGED`), confirm the cited commit is in `git log origin/<default-branch>`, and byte-compare the plan's proposed code against the current file contents. If all three checks pass, write `Verification/PreExecution.md` with `Result: Fail`, write `Artifacts/summary.md` documenting the no-op, set every verification to `Skipped` via `tendril plan set-verification <plan-id> <name> Skipped`, and fail the plan **without creating a worktree** — running verifications on unchanged code wastes the time budget and produces a 0-commit PR that CreatePr cannot process.
+   If any marker is found, verify the claim: run `gh pr view <cited PR> --json state,mergeCommit` (must be `MERGED`), confirm the cited commit is in `git log origin/<default-branch>`, and byte-compare the plan's proposed code against the current file contents. If all three checks pass, fail **without creating a worktree** (running verifications on unchanged code wastes the time budget and produces a 0-commit PR that CreatePr cannot process):
+
+   1. Write `Verification/PreExecution.md` with `result: Fail` and the evidence for each of the three checks.
+   2. Write `Artifacts/summary.md` documenting the no-op.
+   3. Call `tendril job fail TendrilJobId --message="PreExecution failed: <reason>"` and `exit 1`.
+
+   **Do not set the verifications to `Skipped`.** An earlier revision of this document told you to, and
+   that is exactly how a never-executed plan reached `Review`: the server's state decision keys on
+   verification rows, so blanket `Skipped` makes every row look complete and routes the plan to
+   `Review`, where one click marks it `Completed` with zero commits. Leave the rows `Pending` and let
+   the `PreExecution: Fail` report and the non-zero exit do the work.
 
 ### 2. Create Worktrees
 
@@ -449,6 +468,8 @@ Cleanup is handled elsewhere — by CreatePr after PRs are created/merged, and b
 ### 9. Plan State
 
 **🚫 FORBIDDEN:** Do NOT call `tendril plan set <plan-id> state <anything>`. The Tendril server handles all state transitions automatically based on your exit code and verification statuses. Setting state manually causes the plan to appear in Review prematurely while your job is still running.
+
+A failed pre-execution (step 1.7) is signalled by `Verification/PreExecution.md` with `result: Fail`, plus `tendril job fail` and a non-zero exit, never by writing `state`. The server reads that report and routes the plan to `Failed`.
 
 ### Ambiguity Handling
 

--- a/src/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
+++ b/src/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
@@ -401,4 +401,39 @@ public class DoctorCommandPlansTests : IDisposable
         Assert.Contains("project: Auto", repaired);
         Assert.Contains("title: My Plan", repaired);
     }
+
+    [Fact]
+    public void Doctor_ListsCompletedPlansWithFailedPreExecution()
+    {
+        // Plans laundered into Completed before the guards from plan 00103 landed are still on disk,
+        // so doctor sweeps for them.
+        var laundered = CreatePlan("00050-Phantom", ValidYaml);
+        WritePreExecutionReport(laundered, "Fail");
+
+        // Config-only plan: Completed with no commits, but pre-execution passed. Not laundered.
+        var configOnly = CreatePlan("00051-ConfigOnly", ValidYaml);
+        WritePreExecutionReport(configOnly, "Pass");
+
+        // Failed pre-execution, but already retired by hand: not Completed, so not listed.
+        var retired = CreatePlan("00052-Retired", ValidYaml.Replace("state: Completed", "state: Skipped"));
+        WritePreExecutionReport(retired, "Fail");
+
+        // Completed with no report at all: the common case, must stay quiet.
+        CreatePlan("00053-NoReport", ValidYaml);
+
+        var allResults = DoctorCommand.ScanPlans(_plansDir);
+        var found = DoctorCommand.FindLaunderedCompletedPlans(allResults);
+
+        Assert.Single(found);
+        Assert.Equal("00050", found[0].Result.Id);
+        Assert.Equal(Path.Combine(laundered, "Verification", "PreExecution.md"), found[0].ReportPath);
+    }
+
+    private static void WritePreExecutionReport(string planDir, string result)
+    {
+        var verificationDir = Path.Combine(planDir, "Verification");
+        Directory.CreateDirectory(verificationDir);
+        File.WriteAllText(Path.Combine(verificationDir, "PreExecution.md"),
+            $"---\nresult: {result}\ndate: 2026-08-01T20:13:49Z\n---\n# PreExecution\n");
+    }
 }

--- a/src/Ivy.Tendril.Test/Services/PlanValidationServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PlanValidationServiceTests.cs
@@ -102,6 +102,21 @@ public class PlanValidationServiceTests : IDisposable
     }
 
     [Fact]
+    public void PlanValidate_CompletedWithNoCommitsOrPrs_StaysValid()
+    {
+        // Config-only plans (00048, 00050, 00053) legitimately reach Completed with no commits and no
+        // PRs: they edit verification prompts in config.yaml and touch no repo files. Validate runs on
+        // every plan.yaml write, so a rule rejecting this shape would make those plans unwritable.
+        // Plan 00103 therefore guards the two state-decision points instead. See PreExecutionFailureStateTests.
+        var plan = CreateValidPlan();
+        plan.State = nameof(PlanStatus.Completed);
+
+        var exception = Record.Exception(() => PlanValidationService.Validate(plan));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
     public void Validate_AcceptsAllValidStates()
     {
         var validStates = new[] { "Draft", "Creating", "Updating", "Executing", "Review", "Failed", "Completed", "Skipped", "Blocked", "Icebox" };

--- a/src/Ivy.Tendril.Test/Services/PreExecutionFailureStateTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PreExecutionFailureStateTests.cs
@@ -1,0 +1,283 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Test.TestHelpers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test.Services;
+
+/// <summary>
+///     Covers the pre-execution failure routing added by plan 00103. A plan whose
+///     <c>Verification/PreExecution.md</c> reads <c>result: Fail</c> had its premise checked and
+///     rejected, so nothing was implemented: it must land in Failed, not Review, from where one click
+///     marks it Completed and it reads as a delivered plan for work that never happened (plan 00041).
+///     The negative controls matter as much as the guard: an absent report, a Pass, a Skipped, and
+///     config-only plans that legitimately have no commits and no PRs must all be left alone.
+/// </summary>
+public class PreExecutionFailureStateTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("tendril-preexec-test");
+    private readonly string _repoDir;
+
+    public PreExecutionFailureStateTests()
+    {
+        _repoDir = Path.Combine(_tempDir.Path, "SomeRepo");
+        Directory.CreateDirectory(_repoDir);
+    }
+
+    public void Dispose() => _tempDir.Dispose();
+
+    // ---- fixture helpers -----------------------------------------------------------------
+
+    private string CreatePlanFolder(
+        string folderName,
+        string state,
+        (string Name, VerificationStatus Status)[] verifications,
+        string[]? commits = null,
+        string[]? prs = null)
+    {
+        var planFolder = Path.Combine(_tempDir.Path, folderName);
+        Directory.CreateDirectory(planFolder);
+
+        var plan = new PlanYaml
+        {
+            State = state,
+            Project = "TestProject",
+            Title = "Test Plan",
+        };
+        plan.Repos.Add(_repoDir);
+        foreach (var (name, status) in verifications)
+            plan.Verifications.Add(new PlanVerificationEntry { Name = name, Status = status });
+        if (commits != null) plan.Commits.AddRange(commits);
+        if (prs != null) plan.Prs.AddRange(prs);
+
+        PlanCommandHelpers.WritePlan(planFolder, plan);
+        return planFolder;
+    }
+
+    /// <summary>Writes a PreExecution report in the frontmatter form step 1.7 emits.</summary>
+    private static void WritePreExecutionReport(string planFolder, string result)
+    {
+        var verificationDir = Path.Combine(planFolder, "Verification");
+        Directory.CreateDirectory(verificationDir);
+        File.WriteAllText(Path.Combine(verificationDir, "PreExecution.md"),
+            $"---\nresult: {result}\ndate: 2026-08-01T20:13:49Z\n---\n# PreExecution\n\n**Blocks Found:** 6\n");
+    }
+
+    private PlanReaderService CreateReaderService() =>
+        new(new TempDirConfigService(_tempDir.Path), NullLogger<PlanReaderService>.Instance);
+
+    /// <summary>
+    ///     Drives the real job-completion decision point against a real plan reader and returns the
+    ///     state it left on disk.
+    /// </summary>
+    private async Task<string> RunEnsurePlanStateTransitioned(string planFolder)
+    {
+        var reader = CreateReaderService();
+        var handler = new JobCompletionHandler(
+            configService: null,
+            logger: NullLogger.Instance,
+            modelPricingService: null,
+            planReaderService: reader,
+            telemetryService: null,
+            planWatcherService: null,
+            promptsRoot: _tempDir.Path);
+
+        handler.EnsurePlanStateTransitioned(new JobItem
+        {
+            Id = "00001",
+            TypedArgs = new ExecutePlanArgs(planFolder),
+        });
+
+        await reader.FlushPendingWritesAsync();
+        return PlanCommandHelpers.ReadPlan(planFolder).State;
+    }
+
+    // ---- EnsurePlanStateTransitioned -----------------------------------------------------
+
+    [Fact]
+    public async Task EnsurePlanStateTransitioned_PreExecutionFail_AllVerificationsSkipped_SetsFailed()
+    {
+        // Plan 00041's real shape: pre-execution rejected the plan, and the agent then followed the
+        // firmware's old instruction to set every verification to Skipped, which made every row look
+        // complete. Before this guard that routed to Review.
+        var planFolder = CreatePlanFolder("00041-Stale", nameof(PlanStatus.Executing),
+        [
+            ("DotnetFormat", VerificationStatus.Skipped),
+            ("DotnetBuild", VerificationStatus.Skipped),
+            ("DotnetTest", VerificationStatus.Skipped),
+            ("WidgetsFrontendCheck", VerificationStatus.Skipped),
+            ("WidgetsFrontendTest", VerificationStatus.Skipped),
+            ("CheckResult", VerificationStatus.Skipped),
+        ]);
+        WritePreExecutionReport(planFolder, "Fail");
+
+        Assert.Equal(nameof(PlanStatus.Failed), await RunEnsurePlanStateTransitioned(planFolder));
+    }
+
+    [Fact]
+    public async Task EnsurePlanStateTransitioned_PreExecutionFail_VerificationsPending_SetsFailed()
+    {
+        // Plan 00043's shape: gates left Pending, which already routed to Failed. Pins that the new
+        // condition does not disturb it.
+        var planFolder = CreatePlanFolder("00043-Stale", nameof(PlanStatus.Executing),
+        [
+            ("DotnetBuild", VerificationStatus.Pending),
+            ("CheckResult", VerificationStatus.Pending),
+        ]);
+        WritePreExecutionReport(planFolder, "Fail");
+
+        Assert.Equal(nameof(PlanStatus.Failed), await RunEnsurePlanStateTransitioned(planFolder));
+    }
+
+    [Fact]
+    public async Task EnsurePlanStateTransitioned_PreExecutionPass_AllVerificationsPass_SetsReview()
+    {
+        var planFolder = CreatePlanFolder("00044-Clean", nameof(PlanStatus.Executing),
+        [
+            ("DotnetBuild", VerificationStatus.Pass),
+            ("DotnetTest", VerificationStatus.Pass),
+        ], commits: ["abc1234"]);
+        WritePreExecutionReport(planFolder, "Pass");
+
+        Assert.Equal(nameof(PlanStatus.Review), await RunEnsurePlanStateTransitioned(planFolder));
+    }
+
+    [Fact]
+    public async Task EnsurePlanStateTransitioned_NoPreExecutionReport_BehavesAsBefore()
+    {
+        // Step 1.7 skips validation entirely for a revision with no code blocks, so a missing report
+        // is normal. It must fall through to the verification-only decision, both ways.
+        var passing = CreatePlanFolder("00045-NoReportPassing", nameof(PlanStatus.Executing),
+        [
+            ("DotnetBuild", VerificationStatus.Pass),
+        ], commits: ["abc1234"]);
+        var pending = CreatePlanFolder("00046-NoReportPending", nameof(PlanStatus.Executing),
+        [
+            ("DotnetBuild", VerificationStatus.Pending),
+        ]);
+
+        Assert.Equal(nameof(PlanStatus.Review), await RunEnsurePlanStateTransitioned(passing));
+        Assert.Equal(nameof(PlanStatus.Failed), await RunEnsurePlanStateTransitioned(pending));
+    }
+
+    [Fact]
+    public async Task EnsurePlanStateTransitioned_PreExecutionSkipped_DoesNotForceFailed()
+    {
+        // Only Fail is a positive statement that the premise was checked and rejected.
+        var planFolder = CreatePlanFolder("00047-SkippedReport", nameof(PlanStatus.Executing),
+        [
+            ("DotnetBuild", VerificationStatus.Pass),
+        ], commits: ["abc1234"]);
+        WritePreExecutionReport(planFolder, "Skipped");
+
+        Assert.Equal(nameof(PlanStatus.Review), await RunEnsurePlanStateTransitioned(planFolder));
+    }
+
+    // ---- ReadPreExecutionResult ----------------------------------------------------------
+
+    [Fact]
+    public void ReadPreExecutionResult_ParsesFrontmatterAndLegacyResultLine()
+    {
+        // Frontmatter form, as written by the ExecutePlan firmware today.
+        var frontmatter = CreatePlanFolder("00060-Frontmatter", nameof(PlanStatus.Executing), []);
+        WritePreExecutionReport(frontmatter, "Fail");
+
+        // Legacy markdown body form, still on disk for older plans.
+        var legacy = CreatePlanFolder("00061-Legacy", nameof(PlanStatus.Executing), []);
+        var legacyDir = Path.Combine(legacy, "Verification");
+        Directory.CreateDirectory(legacyDir);
+        File.WriteAllText(Path.Combine(legacyDir, "PreExecution.md"),
+            "# PreExecution\n\n- **Result:** Fail\n- **Date:** 2026-08-01T20:13:47Z\n");
+
+        var missing = CreatePlanFolder("00062-Missing", nameof(PlanStatus.Executing), []);
+
+        Assert.Equal(VerificationStatus.Fail, PlanYamlHelper.ReadPreExecutionResult(frontmatter));
+        Assert.Equal(VerificationStatus.Fail, PlanYamlHelper.ReadPreExecutionResult(legacy));
+        Assert.Null(PlanYamlHelper.ReadPreExecutionResult(missing));
+        Assert.Null(PlanYamlHelper.ReadPreExecutionResult(""));
+    }
+
+    // ---- TransitionState guard -----------------------------------------------------------
+
+    [Fact]
+    public void TransitionState_ToCompleted_PreExecutionFail_NoCommitsNoPrs_IsBlocked()
+    {
+        var planFolder = CreatePlanFolder("00070-Laundered", nameof(PlanStatus.Review),
+        [
+            ("DotnetBuild", VerificationStatus.Skipped),
+        ]);
+        WritePreExecutionReport(planFolder, "Fail");
+        var service = CreateReaderService();
+
+        var ex = Assert.Throws<PlanTransitionBlockedException>(
+            () => service.TransitionState("00070-Laundered", PlanStatus.Completed));
+
+        Assert.Equal("00070-Laundered", ex.FolderName);
+        Assert.Equal(PlanStatus.Completed, ex.RequestedState);
+        Assert.Contains("PreExecution.md", ex.Message); // points at the diagnosis
+        Assert.Contains(nameof(PlanStatus.Skipped), ex.Message); // names the escape hatch
+        // The refused transition leaves plan.yaml alone.
+        Assert.Equal(nameof(PlanStatus.Review), PlanCommandHelpers.ReadPlan(planFolder).State);
+    }
+
+    [Fact]
+    public async Task TransitionState_ToCompleted_PreExecutionFail_WithCommits_IsAllowed()
+    {
+        // A stale or retried report must not block a plan that did real work.
+        var planFolder = CreatePlanFolder("00071-DidWork", nameof(PlanStatus.Review),
+        [
+            ("DotnetBuild", VerificationStatus.Pass),
+        ], commits: ["abc1234"]);
+        WritePreExecutionReport(planFolder, "Fail");
+        var service = CreateReaderService();
+
+        service.TransitionState("00071-DidWork", PlanStatus.Completed);
+        await service.FlushPendingWritesAsync();
+
+        Assert.Equal(nameof(PlanStatus.Completed), PlanCommandHelpers.ReadPlan(planFolder).State);
+    }
+
+    [Fact]
+    public async Task TransitionState_ToCompleted_ConfigOnlyPlan_PreExecutionPass_NoCommitsNoPrs_IsAllowed()
+    {
+        // The false-positive control, modelled on plans 00048/00050/00053: config-only plans edit
+        // verification prompts in config.yaml, touch no repo files, and are correctly commit-free and
+        // PR-free with PreExecution Pass. This is the case a bare "Completed with empty commits and
+        // empty prs is invalid" rule would have wrongly flagged.
+        var planFolder = CreatePlanFolder("00072-ConfigOnly", nameof(PlanStatus.Review),
+        [
+            ("DotnetBuild", VerificationStatus.Skipped),
+            ("CheckResult", VerificationStatus.Pass),
+        ]);
+        WritePreExecutionReport(planFolder, "Pass");
+        var service = CreateReaderService();
+
+        service.TransitionState("00072-ConfigOnly", PlanStatus.Completed);
+        await service.FlushPendingWritesAsync();
+
+        Assert.Equal(nameof(PlanStatus.Completed), PlanCommandHelpers.ReadPlan(planFolder).State);
+    }
+
+    [Fact]
+    public async Task TransitionState_ToSkipped_PreExecutionFail_IsAllowed()
+    {
+        // The escape hatch the block message points at has to actually work.
+        var planFolder = CreatePlanFolder("00073-Retire", nameof(PlanStatus.Review),
+        [
+            ("DotnetBuild", VerificationStatus.Skipped),
+        ]);
+        WritePreExecutionReport(planFolder, "Fail");
+        var service = CreateReaderService();
+
+        service.TransitionState("00073-Retire", PlanStatus.Skipped);
+        await service.FlushPendingWritesAsync();
+
+        Assert.Equal(nameof(PlanStatus.Skipped), PlanCommandHelpers.ReadPlan(planFolder).State);
+    }
+
+    private class TempDirConfigService(string planFolder) : StubConfigService, IConfigService
+    {
+        string IConfigService.PlanFolder => planFolder;
+    }
+}

--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -99,7 +99,16 @@ public class ActionBarView(
             new MenuItem("Mark as Completed", Icon: Icons.CircleCheck, Tag: "MarkCompleted")
                 .OnSelect(() =>
                 {
-                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+                    try
+                    {
+                        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+                    }
+                    catch (PlanTransitionBlockedException ex)
+                    {
+                        client.Toast(ex.Message, "Cannot Complete Plan", variant: ToastVariant.Destructive);
+                        return;
+                    }
+
                     refreshPlans();
                 }),
             new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -376,8 +376,19 @@ public class ContentView(
             {
                 var completePlanBtn = new Button("Complete Plan").Icon(Icons.CircleCheck).OnClick(() =>
                 {
-                    // Optimistic UI - update state and refresh immediately
-                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+                    try
+                    {
+                        // Optimistic UI - update state and refresh immediately
+                        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+                    }
+                    catch (PlanTransitionBlockedException ex)
+                    {
+                        // This handler is fire-and-forget, so an uncaught throw would look like a
+                        // silent no-op. Surface the reason and leave the plan where it is.
+                        client.Toast(ex.Message, "Cannot Complete Plan", variant: ToastVariant.Destructive);
+                        return;
+                    }
+
                     refreshPlans();
 
                     // Fire and forget - clean up worktrees in the background
@@ -427,7 +438,16 @@ public class ContentView(
             new MenuItem("Create PR", Icon: Icons.GitPullRequest, Tag: "CreatePR").OnSelect(showCreatePrDialog),
             new MenuItem("Set Completed", Icon: Icons.CircleCheck, Tag: "SetCompleted").OnSelect(() =>
             {
-                planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+                try
+                {
+                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+                }
+                catch (PlanTransitionBlockedException ex)
+                {
+                    client.Toast(ex.Message, "Cannot Complete Plan", variant: ToastVariant.Destructive);
+                    return;
+                }
+
                 refreshPlans();
             }),
             new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -162,6 +162,7 @@ public static class DoctorCommand
         var results = FilterResults(allResults, showAll, stateFilter, worktreesOnly);
 
         PrintPlansTable(results);
+        PrintLaunderedCompletedPlans(allResults);
         PrintPlansSummary(allResults);
 
         return allResults.Any(r => !r.IsHealthy) ? 1 : 0;
@@ -573,6 +574,56 @@ public static class DoctorCommand
 
     private static bool NeedsYamlEscaping(string value) =>
         value.Contains(':') || value.Contains('#') || value.Contains('\'');
+
+    /// <summary>
+    ///     Finds plans that read as delivered but never executed: <c>state: Completed</c> with a
+    ///     <c>Verification/PreExecution.md</c> reporting <c>result: Fail</c>. Pre-execution rejected the
+    ///     plan's premise, so there is nothing to have completed. Report only, never auto-mutate: these
+    ///     are historical records and retiring one is the user's call. See plan 00103.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately does not key on empty commits and PRs alone. Config-only plans (which edit
+    ///     verification prompts in config.yaml and touch no repo files) are correctly commit-free and
+    ///     PR-free, and flagging them would train readers to ignore the warning. The pre-execution
+    ///     result is what separates the two groups.
+    /// </remarks>
+    internal static List<(string Dir, PlanHealthResult Result, string ReportPath)> FindLaunderedCompletedPlans(
+        List<PlanHealthResult> allResults)
+    {
+        var laundered = new List<(string Dir, PlanHealthResult Result, string ReportPath)>();
+
+        foreach (var result in allResults)
+        {
+            if (result.FolderPath == null) continue;
+            if (!result.State.Equals(nameof(PlanStatus.Completed), StringComparison.OrdinalIgnoreCase)) continue;
+            if (PlanYamlHelper.ReadPreExecutionResult(result.FolderPath) != VerificationStatus.Fail) continue;
+
+            laundered.Add((result.FolderPath, result,
+                Path.Combine(result.FolderPath, "Verification", "PreExecution.md")));
+        }
+
+        return laundered;
+    }
+
+    private static void PrintLaunderedCompletedPlans(List<PlanHealthResult> allResults)
+    {
+        var laundered = FindLaunderedCompletedPlans(allResults);
+        if (laundered.Count == 0) return;
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine(
+            $"[yellow]{laundered.Count} {(laundered.Count == 1 ? "plan is" : "plans are")} Completed but failed pre-execution (nothing was implemented):[/]");
+        AnsiConsole.WriteLine();
+
+        foreach (var (_, result, reportPath) in laundered)
+        {
+            AnsiConsole.MarkupLine($"[grey]  {result.Id}-{result.Title.EscapeMarkup()}[/]");
+            AnsiConsole.MarkupLine($"[grey]    report: {reportPath.EscapeMarkup()}[/]");
+            AnsiConsole.MarkupLine($"[grey]    retire: tendril plan set {result.Id} state Skipped[/]");
+        }
+
+        AnsiConsole.WriteLine();
+    }
 
     internal static List<(string Dir, PlanHealthResult Result, string Reason)> FindPruneCandidates(
         string plansDir, List<PlanHealthResult> allResults)

--- a/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
@@ -241,6 +241,30 @@ internal static class PlanYamlHelper
             : null;
     }
 
+    /// <summary>
+    ///     Reads <c>Verification/PreExecution.md</c> for a plan folder. Returns null when the report is
+    ///     absent (plans that predate the check, or that never reached ExecutePlan step 1.7) or when it
+    ///     is unparseable. PreExecution is not a configured verification, so it has no plan.yaml row
+    ///     (<see cref="Services.Plans.PlanArtifactSyncer" /> deliberately skips it): it is read straight
+    ///     from disk instead. See plan 00103.
+    /// </summary>
+    internal static VerificationStatus? ReadPreExecutionResult(string planFolder)
+    {
+        if (string.IsNullOrEmpty(planFolder)) return null;
+
+        var reportPath = Path.Combine(planFolder, "Verification", "PreExecution.md");
+        if (!File.Exists(reportPath)) return null;
+
+        try
+        {
+            return ParseVerificationResultFromReport(FileHelper.ReadAllText(reportPath));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     internal static string? ExtractPlanIdFromFolder(string planFolder)
     {
         var folderName = PathHelper.GetFileNameCrossPlatform(planFolder);

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -111,7 +111,16 @@ After reading the plan revision, scan it for code validation markers to detect s
 3. **Decision logic:**
    - **If no validation blocks found** → Skip validation, proceed to worktree creation (backward compatible)
    - **If all validation blocks pass** → Proceed to worktree creation
-   - **If any validation fails** → Fail the plan immediately with a detailed report
+   - **If any validation fails** → Stop here and fail the job. "Fail the plan" is a concrete
+     three-step contract, not a state change:
+     1. Write `<TendrilPlanFolder>/Verification/PreExecution.md` with `result: Fail` and the detailed
+        per-block report below.
+     2. Call `tendril job fail TendrilJobId --message="PreExecution failed: <reason>"`.
+     3. `exit 1`.
+
+     The server reads that report and routes the plan to `Failed` on its own, so do **not** set the
+     state yourself (see step 9). Do not proceed to worktree creation, do not run verifications, and
+     do not commit anything: there is nothing to verify on an unmodified base branch.
 
 4. **Write validation report** — Create `<TendrilPlanFolder>/Verification/PreExecution.md`:
 
@@ -144,7 +153,17 @@ date: <CurrentTime>
    - A `<details><summary>Still relevant?</summary>` block whose body starts with `No.`
    - Phrases like *"Already applied"*, *"This plan is redundant"*, *"This plan is superseded"*, or *"previously attempted … was merged to main via PR #NNNN"* in the `## Problem` or `## Solution` sections.
 
-   If any marker is found, verify the claim: run `gh pr view <cited PR> --json state,mergeCommit` (must be `MERGED`), confirm the cited commit is in `git log origin/<default-branch>`, and byte-compare the plan's proposed code against the current file contents. If all three checks pass, write `Verification/PreExecution.md` with `Result: Fail`, write `Artifacts/summary.md` documenting the no-op, set every verification to `Skipped` via `tendril plan set-verification <plan-id> <name> Skipped`, and fail the plan **without creating a worktree** — running verifications on unchanged code wastes the time budget and produces a 0-commit PR that CreatePr cannot process.
+   If any marker is found, verify the claim: run `gh pr view <cited PR> --json state,mergeCommit` (must be `MERGED`), confirm the cited commit is in `git log origin/<default-branch>`, and byte-compare the plan's proposed code against the current file contents. If all three checks pass, fail **without creating a worktree** (running verifications on unchanged code wastes the time budget and produces a 0-commit PR that CreatePr cannot process):
+
+   1. Write `Verification/PreExecution.md` with `result: Fail` and the evidence for each of the three checks.
+   2. Write `Artifacts/summary.md` documenting the no-op.
+   3. Call `tendril job fail TendrilJobId --message="PreExecution failed: <reason>"` and `exit 1`.
+
+   **Do not set the verifications to `Skipped`.** An earlier revision of this document told you to, and
+   that is exactly how a never-executed plan reached `Review`: the server's state decision keys on
+   verification rows, so blanket `Skipped` makes every row look complete and routes the plan to
+   `Review`, where one click marks it `Completed` with zero commits. Leave the rows `Pending` and let
+   the `PreExecution: Fail` report and the non-zero exit do the work.
 
 ### 2. Create Worktrees
 
@@ -506,6 +525,8 @@ Cleanup is handled elsewhere — by CreatePr after PRs are created/merged, and b
 ### 9. Plan State
 
 **🚫 FORBIDDEN:** Do NOT call `tendril plan set <plan-id> state <anything>`. The Tendril server handles all state transitions automatically based on your exit code and verification statuses. Setting state manually causes the plan to appear in Review prematurely while your job is still running.
+
+A failed pre-execution (step 1.7) is signalled by `Verification/PreExecution.md` with `result: Fail`, plus `tendril job fail` and a non-zero exit, never by writing `state`. The server reads that report and routes the plan to `Failed`.
 
 ### Ambiguity Handling
 

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -503,9 +503,18 @@ internal class JobCompletionHandler
             var planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
             if (planYaml == null) return;
 
+            // A failed pre-execution means the plan's premise was checked and rejected, so nothing
+            // was implemented. That is decisive regardless of the verification rows: the agent may
+            // have left them Pending (which hasIncomplete already catches) or set them all Skipped
+            // for a plan it never executed, which would otherwise route to Review and from there be
+            // one click from Completed with zero commits. Absent or unparseable report, Pass and
+            // Skipped all fall through to the verification-only decision. See plan 00103.
+            var preExecution = PlanYamlHelper.ReadPreExecutionResult(planFolder);
             var hasIncomplete = planYaml.Verifications?
                 .Any(v => v.Status is VerificationStatus.Pending or VerificationStatus.Fail) ?? false;
-            var targetState = hasIncomplete ? PlanStatus.Failed : PlanStatus.Review;
+            var targetState = preExecution == VerificationStatus.Fail || hasIncomplete
+                ? PlanStatus.Failed
+                : PlanStatus.Review;
 
             var folderName = Path.GetFileName(planFolder);
             if (_planReaderService != null)

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -495,7 +495,7 @@ internal class JobCompletionHandler
         return Convert.ToBase64String(bytes);
     }
 
-    private void EnsurePlanStateTransitioned(JobItem job)
+    internal void EnsurePlanStateTransitioned(JobItem job)
     {
         try
         {

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -143,8 +143,16 @@ public class PlanReaderService(
     /// </summary>
     /// <param name="folderName">Name of the plan folder (e.g. <c>01105-TestPlan</c>).</param>
     /// <param name="newState">The target state to transition to.</param>
+    /// <exception cref="PlanTransitionBlockedException">
+    ///     The transition would record work that never happened (see
+    ///     <see cref="GetCompletionBlockReason" />).
+    /// </exception>
     public void TransitionState(string folderName, PlanStatus newState)
     {
+        if (newState == PlanStatus.Completed &&
+            GetCompletionBlockReason(Path.Combine(PlansDirectory, folderName)) is { } blockReason)
+            throw new PlanTransitionBlockedException(folderName, newState, blockReason);
+
         var planId = ExtractPlanId(folderName);
 
         // Track state transition in telemetry before making the change.
@@ -182,6 +190,28 @@ public class PlanReaderService(
             planYaml.Updated = DateTime.UtcNow;
             FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
         }, Path.Combine(PlansDirectory, folderName));
+    }
+
+    /// <summary>
+    ///     Returns the reason a plan must not be marked Completed, or null when the transition is fine.
+    ///     Blocks a plan whose <c>Verification/PreExecution.md</c> reads <c>result: Fail</c> and which has
+    ///     no commits and no PRs: pre-execution rejected the plan's premise and nothing was delivered, so
+    ///     Completed would record a phantom owner for work that never happened. The no-commits-and-no-PRs
+    ///     conjunct keeps config-only plans (which legitimately have neither, and pass pre-execution) and
+    ///     any plan that did real work out of the block. See plan 00103.
+    /// </summary>
+    internal static string? GetCompletionBlockReason(string planFolder)
+    {
+        if (PlanYamlHelper.ReadPreExecutionResult(planFolder) != VerificationStatus.Fail) return null;
+
+        var planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
+        if (planYaml == null) return null;
+        if (planYaml.Commits?.Count > 0 || planYaml.Prs?.Count > 0) return null;
+
+        var reportPath = Path.Combine(planFolder, "Verification", "PreExecution.md");
+        return "Pre-execution validation failed and this plan has no commits and no PRs, so there is "
+               + $"nothing to complete. See {reportPath} for the diagnosis. To retire it, set the state "
+               + "to Skipped instead; to complete it anyway, record its commits or PRs first.";
     }
 
     /// <summary>

--- a/src/Ivy.Tendril/Services/Plans/PlanTransitionBlockedException.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanTransitionBlockedException.cs
@@ -1,0 +1,17 @@
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Services.Plans;
+
+/// <summary>
+///     Thrown by <see cref="PlanReaderService.TransitionState" /> when a requested transition would
+///     record work that never happened, e.g. marking a plan Completed after its pre-execution check
+///     rejected the plan's premise and it produced no commits and no PRs. Callers are UI actions, so
+///     they must catch this and surface <see cref="Message" /> to the user rather than letting the
+///     throw disappear into a fire-and-forget handler. See plan 00103.
+/// </summary>
+public class PlanTransitionBlockedException(string folderName, PlanStatus requestedState, string reason)
+    : Exception(reason)
+{
+    public string FolderName { get; } = folderName;
+    public PlanStatus RequestedState { get; } = requestedState;
+}


### PR DESCRIPTION
# Summary: Route a Failed PreExecution to Failed Instead of Laundering It Into Completed

Plan 00103, project Ivy-Tendril, base branch `development`, job 01301.

## What was wrong

An agent that fails ExecutePlan step 1.7 writes `Verification/PreExecution.md` with `result: Fail` and stops.
Nothing in the server ever read that file: `grep -rIn PreExecution src/ --include=*.cs` returned exactly one
hit, the `continue` at `PlanArtifactSyncer.cs:66` that deliberately skips it. So the sole state decision,
`JobCompletionHandler.EnsurePlanStateTransitioned`, keyed only on `plan.yaml` verification rows.

Plan 00041 hit the worst path. The firmware told it to "set every verification to `Skipped`", which made
`hasIncomplete` false and routed a plan that implemented nothing to `Review`. From there the Review app,
seeing zero commits, offers a bare "Complete Plan" button, so one click made it read as a delivered plan.
That is how the `widget_harness.rs:409` fmt diff later got misattributed to 00043's scope. Plan 00043 escaped
only by accident: it left its rows `Pending`, so it landed in `Failed`.

## What changed

Four commits, 12 files, +545/-10.

### `79fc7f26` fix(plans): route a failed PreExecution to Failed instead of Review

- `PlanYamlHelper.ReadPreExecutionResult` reads the report straight from disk, reusing the existing
  `ParseVerificationResultFromReport` so both the current `---\nresult: Fail\n---` frontmatter and the legacy
  `- **Result:** Fail` body parse. Returns null for absent or unparseable, which falls through to today's
  behaviour.
- `EnsurePlanStateTransitioned` now routes to `Failed` when the report reads `Fail`, regardless of the
  verification rows. `Failed` rather than `Skipped`: it keeps the plan in the human Review queue, retains the
  worktree for inspection, and does not hide the diagnosis the agent just wrote.
- `PlanReaderService.TransitionState` refuses `Completed` when the report reads `Fail` **and** the plan has no
  commits and no PRs, throwing the new `PlanTransitionBlockedException`. The commits-and-PRs conjunct is what
  keeps config-only plans and any plan that did real work out of the block.
- The three fire-and-forget UI call sites (two in `Review/ContentView.cs`, one in `Drafts/ActionBarView.cs`)
  catch it, toast the reason, and return before `refreshPlans()`. Without that the throw would vanish into the
  handler and read as a silent no-op.
- `PlanArtifactSyncer.cs:66` was left exactly as it was: `PreExecution` still must not be synced into a
  `plan.yaml` row.

### `fa5cf106` docs(execute-plan): make the "fail the plan" instruction executable

The firmware said "fail the plan" while step 9 forbade the only verb that would do it, so the instruction had
no mechanism. Both in-repo copies of `ExecutePlan/Program.md` now spell out the contract: write the report with
`result: Fail`, call `tendril job fail`, `exit 1`. The instruction to blanket-`Skipped` the verifications is
deleted and replaced with a bolded paragraph explaining that it is precisely what routed 00041 to `Review`.
Step 9's prohibition is untouched, with one sentence added saying a failed pre-execution is signalled by
`job fail` plus a non-zero exit, never by writing `state`.

### `7f94e177` feat(doctor): surface Completed plans that failed pre-execution

`DoctorCommand.FindLaunderedCompletedPlans` lists every `Completed` plan whose `PreExecution.md` reads `Fail`,
printing the report path and a `tendril plan set <id> state Skipped` suggestion. Report only, never
auto-mutate, and the exit code is unchanged: these are historical records and retiring them is the user's call.

### `59bd0386` test(plans): cover pre-execution failure routing and the Completed block

Eleven tests. Ten in the new `PreExecutionFailureStateTests.cs` (the 00041 regression, the 00043 shape, and
negative controls for absent/Pass/Skipped reports; plus the four `TransitionState` cases including the
config-only false-positive control and the Skipped escape hatch), one pinning that `PlanValidationService`
still accepts `Completed` with empty commits and prs, one for the doctor sweep. Tests 1 through 5 drive the
real handler against a real `PlanReaderService`, not a reimplementation of the decision.

## Why the task's proposed alternative was not implemented

The task offered a fallback: have `tendril plan validate` flag `Completed` with empty `commits` and empty `prs`
as invalid. Measured on the real plans directory, 00048, 00050 and 00053 all have exactly that shape and are
healthy config-only plans (they edit verification prompts via `tendril verification set`, touch no repo files,
and all have `PreExecution: Pass`). The rule would call three good plans invalid, and since `Validate` runs
from `WritePlan` on every plan write it would make them unwritable, not merely flagged. The discriminator that
separates the groups cleanly is the execution record: `PreExecution: Fail` on both phantoms, `Pass` on all
three innocents. Test 10 exists so nobody re-adds the rejected rule.

## Verification

| Verification | Result | Notes |
| --- | --- | --- |
| PreExecution | Pass | Zero validation blocks in the revision, so step 1.7 skipped validation. Premise claims independently confirmed |
| DotnetFormat | Pass | `--verify-no-changes` on both csprojs, exit 0, nothing rewritten |
| DotnetBuild | Pass | `Ivy.Tendril` and `Ivy.Tendril.Test`, both `0 Warning(s) 0 Error(s)` under `-warnaserror` |
| DotnetTest | Pass | Plan scope 115/115; full `Ivy.Tendril.Test` 1966 passed, 1 self-skip, 0 failed |
| CheckResult | Pass | Every deliverable checked, including the doctor CLI exercised once with output and exit code |
| WidgetsFrontendCheck | Skipped | Pre-set in plan.yaml, no frontend changes |
| WidgetsFrontendTest | Skipped | Same |

The plan required proving the guard is load-bearing. With the `preExecution == VerificationStatus.Fail` term
removed, `EnsurePlanStateTransitioned_PreExecutionFail_AllVerificationsSkipped_SetsFailed` fails with
`Expected: "Failed" / Actual: "Review"`, the literal 00041 bug, while the Pending test still passes. The term
was restored and all 10 tests pass.

## Where I diverged from the plan, and why

**The two `ExecutePlan/Program.md` copies are not the same file.** The plan asserts they have the "same
content" at listed line numbers, and that the `src/Ivy.Tendril` copy is byte-identical to the deployed
`<TendrilHome>` one. `diff` disproves it: the `Ivy.Tendril.TeamIvyConfig` copy has a "Time Budget Awareness"
section the src copy lacks, lacks the src copy's status-report lines, and still describes the older manual
worktree flow. All the plan's cited line numbers are therefore wrong for at least one copy.

I made all three edits to both copies by matching on content rather than line number, then confirmed each with
the greps the plan prescribed. Same deliverable, different navigation. Anyone editing these files later should
not trust cross-copy line numbers.

**Test count and grouping.** The plan listed 11 tests; I wrote 12. The extra one,
`TransitionState_ToSkipped_PreExecutionFail_IsAllowed`, exercises the retire path the block message tells the
user to take. A block whose stated escape hatch is untested is a block that can strand a plan. The plan also
placed `Doctor_ListsCompletedPlansWithFailedPreExecution` in the new file; it went into
`DoctorCommandPlansTests.cs` instead, next to the `FindPruneCandidates` tests whose fixture helpers it reuses,
matching the plan's own instruction to "Follow DoctorCommandPlansTests.cs". The tests were committed as a
fourth commit rather than folded into the three, so the guard change and its proof are separable in history.

**`EnsurePlanStateTransitioned` visibility.** Changed from `private` to `internal` so the tests drive the real
decision point. `Ivy.Tendril.csproj` already has `InternalsVisibleTo Include="Ivy.Tendril.Test"`, and the class
itself is `internal`, so nothing new is exposed outside the assembly.

## Known issues I did not fix

Two failures inherited from `development`, both outside this plan's scope and both reproduced on a clean
checkout of the base branch:

- `Ivy.Tendril.Agents.Test` fails to build under `-warnaserror`: `AntigravityEventParserTests.cs(38,25):
  error CS8602`. Builds clean without the flag.
- Two of its tests fail on `development`: `AntigravityCliTests.BuildProcessSpec_BasicInvocation_...` and
  `OpenCodeModelCatalogTests.GetStaticModels_ReturnsDefault` (asserts `Single()` against a catalog that now has
  8 models).

This plan changed no file in that project (`git diff --stat development...HEAD -- src/Ivy.Tendril.Agents.Test/`
is empty). Both are filed as recommendations rather than fixed here, to keep this diff to the state-routing fix.

## Plan 00090 interaction

Plan 00090 guards the same `TransitionState` chokepoint for a different condition (a verification row in
`Fail`). It has not landed: neither its `PlanTransitionBlockedException` nor its `GetFailedVerifications` was
present on `development`, so this plan introduced the exception. Whoever lands second must rebase and
**compose** the two conditions rather than replacing one; the exception's docstring says so. The two are
genuinely complementary: 00041 has no `Fail` row at all, so 00090's check would pass it straight through.

---

## Commits

- 79fc7f26 fix(plans): route a failed PreExecution to Failed instead of Review
- fa5cf106 docs(execute-plan): make the "fail the plan" instruction executable
- 7f94e177 feat(doctor): surface Completed plans that failed pre-execution
- 59bd0386 test(plans): cover pre-execution failure routing and the Completed block

---
Created using [Ivy Tendril](https://ivy.app).
