### PR TITLE
[00090] Block Review to Completed When a Verification Failed and Surface Partial Delivery to Duplicate Detection

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/00_Overview.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/00_Overview.md
@@ -92,6 +92,16 @@ Every command supports `--help` for detailed usage. For example: `tendril plan c
 
 Validates your Tendril installation — checks `TENDRIL_HOME`, `config.yaml`, required tools (`gh`, `git`), `pwsh`, database schema, and agent model availability. Always a good first step when something isn't working.
 
+#### plan doctor
+
+```terminal
+>tendril plan doctor
+>tendril plan doctor --all
+>tendril plan doctor --fix
+```
+
+Scans every plan folder and reports health: missing or malformed `plan.yaml`, stale worktrees, and plans left `Completed` over a failed verification. See [Plan](01_Plan.md) for the full option and health-code reference.
+
 #### run
 
 ```terminal

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
@@ -248,3 +248,13 @@ With `--fix`: creates scaffold YAML for missing files, fills in missing fields, 
 >tendril plan doctor --fix
 >tendril plan doctor --prune
 ```
+
+### Partial delivery backfill
+
+The report also lists plans sitting at `Completed` with a verification in the `Fail` state and no `partialDelivery` flag. These predate the completion guard, so duplicate detection reads them as fully delivered even though the deliverable may be missing.
+
+Nothing is mutated: these are historical records, and whether a given plan really was a partial delivery is the user's call. Review each one, then flag the genuinely partial ones:
+
+```terminal
+>tendril plan set <id> state Completed --allow-failed-verifications
+```

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
@@ -81,7 +81,7 @@ Lists plans with optional filters.
 
 Prints the full YAML, or a single field value when `[field]` is provided.
 
-**Scalar fields:** `state`, `project`, `level`, `title`, `created`, `updated`, `executionProfile`, `initialPrompt`, `sourceUrl`, `priority`
+**Scalar fields:** `state`, `project`, `level`, `title`, `created`, `updated`, `executionProfile`, `initialPrompt`, `sourceUrl`, `priority`, `partialDelivery`
 
 **List fields:** `repos`, `prs`, `commits`, `verifications`, `dependsOn`, `relatedPlans`, `recommendations` (each item on its own line)
 
@@ -89,9 +89,12 @@ Prints the full YAML, or a single field value when `[field]` is provided.
 
 ```terminal
 >tendril plan set <plan-id> <field> <value>
+>tendril plan set <plan-id> state Completed --allow-failed-verifications
 ```
 
 Updates a single field and bumps the `updated` timestamp automatically.
+
+Setting `state` to `Completed` is refused while any verification is in the `Fail` state: a plan that reads as done while a gate rejected the work hides a missing deliverable from duplicate detection. Re-run the verification, or set it to `Skipped` with an explicit reason. `--allow-failed-verifications` records the transition anyway and sets `partialDelivery: true`, which marks the plan's deliverable as possibly missing.
 
 #### plan update
 

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/02_REST.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/02_REST.md
@@ -67,6 +67,8 @@ Content-Type: application/json
 
 Supported fields: `state`, `project`, `level`, `title`, `executionProfile`, `initialPrompt`, `sourceUrl`, `priority`.
 
+Setting `state` to `Completed` returns `400` while any of the plan's verifications is in the `Fail` state. Add `"allowFailedVerifications": true` to record it anyway; the plan is then flagged with `partialDelivery: true`, which marks its deliverable as possibly missing.
+
 ### Add Repository
 
 ```

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/03_MCP.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/03_MCP.md
@@ -38,7 +38,7 @@ All tools are prefixed with `tendril_` and provide the same capabilities as the 
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `tendril_get_plan` | `planId`, `field` (optional) | Get plan details. Returns full plan summary or single field value when `field` is specified. Supported fields: `state`, `project`, `level`, `title`, `created`, `updated`, `executionProfile`, `initialPrompt`, `sourceUrl`, `priority`, `repos`, `prs`, `commits`, `verifications`, `dependsOn`, `relatedPlans`, `recommendations` |
+| `tendril_get_plan` | `planId`, `field` (optional) | Get plan details. Returns full plan summary or single field value when `field` is specified. Supported fields: `state`, `project`, `level`, `title`, `created`, `updated`, `executionProfile`, `initialPrompt`, `sourceUrl`, `priority`, `partialDelivery`, `repos`, `prs`, `commits`, `verifications`, `dependsOn`, `relatedPlans`, `recommendations` |
 | `tendril_list_plans` | `state` (optional), `project` (optional), `since` (optional ISO date) | List plans with optional filters. Returns up to 50 plans. |
 | `tendril_inbox` | `title`, `project` (optional), `level` (optional), `prompt` (optional) | Submit a new plan to the inbox. Creates a markdown file in `TENDRIL_HOME/Inbox` for the InboxWatcher to process. |
 
@@ -46,7 +46,7 @@ All tools are prefixed with `tendril_` and provide the same capabilities as the 
 
 | Tool | Parameters | Description |
 |------|------------|-------------|
-| `tendril_plan_set` | `planId`, `field`, `value` | Update a scalar field. Supported fields: `state`, `project`, `level`, `title`, `executionProfile`, `initialPrompt`, `sourceUrl`, `priority` |
+| `tendril_plan_set` | `planId`, `field`, `value`, `allowFailedVerifications` (optional) | Update a scalar field. Supported fields: `state`, `project`, `level`, `title`, `executionProfile`, `initialPrompt`, `sourceUrl`, `priority`. Setting `state` to `Completed` is refused while any verification is `Fail`; `allowFailedVerifications: true` records it anyway and flags the plan `partialDelivery: true` |
 | `tendril_plan_add_repo` | `planId`, `repoPath` | Add a repository path to a plan |
 | `tendril_plan_remove_repo` | `planId`, `repoPath` | Remove a repository from a plan |
 | `tendril_plan_add_pr` | `planId`, `prUrl` | Add a PR URL to a plan |

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePlan/Program.md
@@ -57,12 +57,14 @@ Do NOT read or modify `.counter` directly. Plan IDs are allocated by the `tendri
 
   #### Step 1: Read existing plan state
   
-  Read the matching plan's `plan.yaml` and check its `state`, `commits`, and `prs` fields.
+  Read the matching plan's `plan.yaml` and check its `state`, `commits`, `prs`, `verifications` and
+  `partialDelivery` fields.
 
   #### Step 2: Decide based on state
 
   | Existing plan state | Action |
   |---|---|
+  | `Completed` with `partialDelivery: true` or any verification `Fail` | **Do NOT trash.** The deliverable may be missing. Verify the specific thing the incoming request asks for is present in the code, and create the plan if it is not. |
   | `Completed` (with merged PR) | Check for regression (Step 4), otherwise trash |
   | `Completed` (no PR, but commits exist) | Check for regression (Step 4), trash with note "no PR found" |
   | `Draft` / `Creating` / `Executing` | Trash, but note "plan in progress (state: X)" |
@@ -70,7 +72,21 @@ Do NOT read or modify `.counter` directly. Plan IDs are allocated by the `tendri
   | `Failed` | **Do NOT trash** — create the plan (the previous attempt failed) |
   | `Icebox` / `Skipped` | Trash with note "existing plan state: X" (issue is already covered) |
 
+  A `Completed` plan is not proof of delivery: a plan can be completed while a gate rejected the
+  work, in which case its title asserts a feature that was never written. The first row catches that,
+  and it takes precedence over the rows below it.
+
   #### Step 3: Stricter checks for critical issues
+
+  Run these two checks on **every** `Completed` candidate, before anything else:
+
+  ```bash
+  tendril plan get <id> verifications | grep -i "=Fail"   # any Fail: treat as possibly undelivered
+  tendril plan get <id> partialDelivery                    # true: completed over a failed gate
+  ```
+
+  Either signal means the plan's deliverable may be missing, so do NOT trash on state alone: verify
+  in the code that the specific thing this request asks for is present.
 
   When the incoming request describes a critical/blocking issue (errors, failures, crashes), apply **additional checks** before trashing:
 

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md
@@ -219,13 +219,21 @@ If cleanup fails, log a warning but do not fail the overall CreatePr execution.
 
 Use the CLI to update the plan — **never edit plan.yaml directly**.
 
-Add each PR URL:
+Add each PR URL. **This is unconditional:** recording the PR is always correct, whatever the plan's
+verifications say.
 
 ```bash
 tendril plan add-pr <plan-id> <pr-url>
 ```
 
-**Update state to Completed:** If `PrMerge` is `true` and ALL PRs were successfully merged, update the state:
+**Then check the verifications before setting the state:**
+
+```bash
+tendril plan get <plan-id> verifications   # output is Name=Status
+```
+
+**Update state to Completed:** If `PrMerge` is `true`, ALL PRs were successfully merged, and no
+verification is `Fail`, update the state:
 
 ```bash
 tendril plan set <plan-id> state Completed
@@ -233,11 +241,21 @@ tendril plan set <plan-id> state Completed
 
 If `PrMerge` is `false`, do NOT update the state — the plan remains open for manual review and potential revisions.
 
+**If any verification is `Fail`, do NOT set `Completed`** even on a successful merge. Leave the plan
+in `Failed`: the PR exists but a gate rejected the work, so the plan is not done. The CLI will refuse
+the transition anyway. Report it with `tendril job status <job-id> --message "PR recorded, plan left
+in Failed: <VerificationName> failed"`. This is a legitimate closeout, not a skipped step: a failed
+gate usually means the deliverable is missing, and marking the plan `Completed` hides that from every
+later plan. Only use `tendril plan set <plan-id> state Completed --allow-failed-verifications` if a
+human explicitly asked for a partial delivery to be recorded; it flags the plan as
+`partialDelivery: true`.
+
 ### Edge Case: Direct-to-Main (No PR Needed)
 
 Some plans create new repos and push directly to main (e.g., repo scaffolding). These have `repos: []`, no worktrees, and commits already on `origin/main`. When detected:
 1. Verify the commit(s) exist on the remote default branch
-2. Mark state as Completed: `tendril plan set <plan-id> state Completed`
+2. Mark state as Completed: `tendril plan set <plan-id> state Completed` (same verification rule as
+   above: if any verification is `Fail`, leave the plan in `Failed` and report it instead)
 3. Log outcome as "No PR Required — Direct-to-Main"
 4. Skip steps 2–5 entirely
 

--- a/src/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
+++ b/src/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
@@ -401,4 +401,73 @@ public class DoctorCommandPlansTests : IDisposable
         Assert.Contains("project: Auto", repaired);
         Assert.Contains("title: My Plan", repaired);
     }
+
+    // Plan 00090: the backfill report for plans that reached Completed over a failed verification
+    // before the guard existed. 00042 is the shape it exists to surface.
+    private static string CompletedWithVerifications(string checkResult, bool partialDelivery = false) =>
+        $"""
+         state: Completed
+         project: Rusty
+         title: Test Plan
+         repos:
+         - /dummy/repo
+         commits: []
+         prs:
+           - https://github.com/org/repo/pull/31
+         verifications:
+           - name: RustFmt
+             status: Skipped
+           - name: RustyFrontendTest
+             status: Pass
+           - name: CheckResult
+             status: {checkResult}
+         {(partialDelivery ? "partialDelivery: true" : "")}
+         """;
+
+    [Fact]
+    public void FindPartialDeliveryCandidates_CompletedWithFailedVerification_IsReported()
+    {
+        CreatePlan("00042-RemoveDeadGlob", CompletedWithVerifications("Fail"));
+
+        var candidates = DoctorCommand.FindPartialDeliveryCandidates(DoctorCommand.ScanPlans(_plansDir));
+
+        var candidate = Assert.Single(candidates);
+        Assert.Equal("00042", candidate.Id);
+        Assert.Equal(["CheckResult"], candidate.FailedVerifications);
+    }
+
+    [Fact]
+    public void FindPartialDeliveryCandidates_AlreadyFlagged_IsNotReported()
+    {
+        CreatePlan("00043-AlreadyFlagged", CompletedWithVerifications("Fail", partialDelivery: true));
+
+        var candidates = DoctorCommand.FindPartialDeliveryCandidates(DoctorCommand.ScanPlans(_plansDir));
+
+        Assert.Empty(candidates);
+    }
+
+    [Fact]
+    public void FindPartialDeliveryCandidates_PassingOrUncompletedPlans_AreNotReported()
+    {
+        CreatePlan("00044-AllPassed", CompletedWithVerifications("Pass"));
+        CreatePlan("00045-SkippedGate", CompletedWithVerifications("Skipped"));
+        CreatePlan("00046-StillInReview", CompletedWithVerifications("Fail").Replace(
+            "state: Completed", "state: Review"));
+
+        var candidates = DoctorCommand.FindPartialDeliveryCandidates(DoctorCommand.ScanPlans(_plansDir));
+
+        Assert.Empty(candidates);
+    }
+
+    [Fact]
+    public void FindPartialDeliveryCandidates_DoesNotMutatePlanYaml()
+    {
+        var planDir = CreatePlan("00047-HistoricalRecord", CompletedWithVerifications("Fail"));
+        var yamlPath = Path.Combine(planDir, "plan.yaml");
+        var before = File.ReadAllText(yamlPath);
+
+        DoctorCommand.FindPartialDeliveryCandidates(DoctorCommand.ScanPlans(_plansDir));
+
+        Assert.Equal(before, File.ReadAllText(yamlPath));
+    }
 }

--- a/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceCompletionGuardTests.cs
@@ -399,6 +399,9 @@ public class JobServiceCompletionGuardTests : IDisposable
             Transitions.Add((folderName, newState));
         }
 
+        public IReadOnlyList<string> GetFailedVerifications(string folderName) => [];
+        public void CompleteWithPartialDelivery(string folderName) { }
+
         public void ResetToDraft(string folderName)
         {
             ResetToDraftCalls.Add(folderName);

--- a/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
@@ -341,6 +341,9 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         {
         }
 
+        public IReadOnlyList<string> GetFailedVerifications(string folderName) => [];
+        public void CompleteWithPartialDelivery(string folderName) { }
+
         public void ResetToDraft(string folderName)
         {
         }

--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -586,6 +586,9 @@ public class JobServiceRetryBlockedTests : IDisposable
         {
         }
 
+        public IReadOnlyList<string> GetFailedVerifications(string folderName) => [];
+        public void CompleteWithPartialDelivery(string folderName) { }
+
         public void ResetToDraft(string folderName)
         {
         }

--- a/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceSplitPlanCompletionTests.cs
@@ -66,6 +66,9 @@ public class JobServiceSplitPlanCompletionTests
             Transitions.Add((folderName, newState));
         }
 
+        public IReadOnlyList<string> GetFailedVerifications(string folderName) => [];
+        public void CompleteWithPartialDelivery(string folderName) { }
+
         public void ResetToDraft(string folderName) { }
         public void ResetVerificationsForRetry(string folderName) { }
         public void SetVerificationStatus(string folderName, string name, VerificationStatus status) { }

--- a/src/Ivy.Tendril.Test/JobsAppPromptDisplayTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppPromptDisplayTests.cs
@@ -97,6 +97,9 @@ public class JobsAppPromptDisplayTests
         {
         }
 
+        public IReadOnlyList<string> GetFailedVerifications(string folderName) => [];
+        public void CompleteWithPartialDelivery(string folderName) { }
+
         public void ResetToDraft(string folderName)
         {
         }

--- a/src/Ivy.Tendril.Test/PlanCompletionVerificationGuardTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCompletionVerificationGuardTests.cs
@@ -1,0 +1,234 @@
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Infrastructure;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Spectre.Console.Cli;
+using Spectre.Console.Testing;
+
+namespace Ivy.Tendril.Test;
+
+/// <summary>
+///     Plan 00090: a plan may not reach Completed while one of its verifications is in the Fail state.
+///     The fixtures use plan 00042's real verification list, because 00042 is the incident these tests
+///     exist for: it reached Completed with a merged PR while its own CheckResult said the deliverable
+///     was missing, and four later plans re-derived the same work because it read as done.
+/// </summary>
+[Collection("TendrilHome")]
+public class PlanCompletionVerificationGuardTests : IDisposable
+{
+    private const string FolderName = "00042-RemoveDeadDotnetFormatStagedGlob";
+
+    private readonly TempDirectoryFixture _tempDir = new();
+    private readonly string _plansDir;
+    private readonly string _originalTendrilHome;
+    private readonly string? _originalTendrilPlans;
+
+    public PlanCompletionVerificationGuardTests()
+    {
+        _plansDir = Path.Combine(_tempDir.Path, "Plans");
+        Directory.CreateDirectory(_plansDir);
+
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        _originalTendrilPlans = Environment.GetEnvironmentVariable("TENDRIL_PLANS");
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", null);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", _originalTendrilPlans);
+        _tempDir.Dispose();
+    }
+
+    // Plan 00042's verifications exactly as recorded: four Skipped, three Pass, and the CheckResult
+    // that rejected the work. Keeping the Skipped entries matters, since Skipped must not block.
+    private static List<PlanVerificationEntry> Plan00042Verifications(
+        VerificationStatus checkResult = VerificationStatus.Fail) =>
+    [
+        new() { Name = "RustFmt", Status = VerificationStatus.Skipped },
+        new() { Name = "RustClippy", Status = VerificationStatus.Skipped },
+        new() { Name = "RustyFrontendLint", Status = VerificationStatus.Pass },
+        new() { Name = "RustBuild", Status = VerificationStatus.Skipped },
+        new() { Name = "RustyFrontendBuild", Status = VerificationStatus.Pass },
+        new() { Name = "RustTest", Status = VerificationStatus.Skipped },
+        new() { Name = "RustyFrontendTest", Status = VerificationStatus.Pass },
+        new() { Name = "CheckResult", Status = checkResult }
+    ];
+
+    private string SeedPlan(List<PlanVerificationEntry> verifications, string state = "Review")
+    {
+        var planFolder = Path.Combine(_plansDir, FolderName);
+        Directory.CreateDirectory(planFolder);
+
+        var plan = new PlanYaml
+        {
+            State = state,
+            Project = "Rusty",
+            Title = "Remove Dead Dotnet Format Staged Glob",
+            Repos = [_tempDir.Path],
+            Prs = ["https://github.com/org/repo/pull/31"],
+            Verifications = verifications,
+            Created = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+            Updated = new DateTime(2026, 1, 15, 10, 0, 0, DateTimeKind.Utc)
+        };
+
+        File.WriteAllText(Path.Combine(planFolder, "plan.yaml"), YamlHelper.Serializer.Serialize(plan));
+        return planFolder;
+    }
+
+    private PlanYaml ReadSeededPlan() =>
+        PlanCommandHelpers.ReadPlan(Path.Combine(_plansDir, FolderName));
+
+    private PlanReaderService CreateReaderService() =>
+        new(
+            new TestPlanConfigService(_tempDir.Path, "Rusty", tendrilHome: _tempDir.Path),
+            new NullLogger<PlanReaderService>());
+
+    // Builds a real `plan set` app the way Program.cs registers it, minus PropagateExceptions so that
+    // a blocked transition surfaces as the non-zero exit code the CLI actually returns rather than as
+    // an exception. The TestConsole keeps Spectre's error rendering out of the test output.
+    private static CommandApp BuildPlanSetApp(out TestConsole console)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IPlanWatcherService, NullPlanWatcherService>();
+
+        var testConsole = new TestConsole();
+        console = testConsole;
+
+        var app = new CommandApp(new TypeRegistrar(services));
+        app.Configure(config =>
+        {
+            config.Settings.Console = testConsole;
+            config.AddBranch("plan", plan => plan.AddCommand<PlanSetCommand>("set"));
+        });
+        return app;
+    }
+
+    // 1. The incident itself: 00042's own verification list must not be allowed to reach Completed.
+    [Fact]
+    public async Task TransitionState_ToCompleted_WithFailedVerification_Throws()
+    {
+        SeedPlan(Plan00042Verifications());
+        var service = CreateReaderService();
+
+        var ex = Assert.Throws<PlanTransitionBlockedException>(
+            () => service.TransitionState(FolderName, PlanStatus.Completed));
+
+        Assert.Equal(["CheckResult"], ex.FailedVerifications);
+        Assert.Contains("--allow-failed-verifications", ex.Message);
+
+        // The block must happen before anything is written, not after.
+        await service.FlushPendingWritesAsync();
+        var onDisk = ReadSeededPlan();
+        Assert.Equal("Review", onDisk.State);
+        Assert.False(onDisk.PartialDelivery);
+    }
+
+    // 2. Negative control, including Skipped: only Fail blocks.
+    [Fact]
+    public async Task TransitionState_ToCompleted_WithAllPassOrSkipped_Succeeds()
+    {
+        SeedPlan(Plan00042Verifications(VerificationStatus.Pass));
+        var service = CreateReaderService();
+
+        service.TransitionState(FolderName, PlanStatus.Completed);
+        await service.FlushPendingWritesAsync();
+
+        var onDisk = ReadSeededPlan();
+        Assert.Equal("Completed", onDisk.State);
+        Assert.False(onDisk.PartialDelivery);
+    }
+
+    // 3. Pending must not block here: JobCompletionHandler.EnsurePlanStateTransitioned already routes
+    //    a plan with Pending gates to Failed, so blocking again would just break manual completion.
+    [Fact]
+    public async Task TransitionState_ToCompleted_WithPendingOnly_Succeeds()
+    {
+        SeedPlan(Plan00042Verifications(VerificationStatus.Pending));
+        var service = CreateReaderService();
+
+        service.TransitionState(FolderName, PlanStatus.Completed);
+        await service.FlushPendingWritesAsync();
+
+        Assert.Equal("Completed", ReadSeededPlan().State);
+    }
+
+    // 4. Only Completed is guarded: every other transition stays available for a failed plan.
+    [Theory]
+    [InlineData(PlanStatus.Failed)]
+    [InlineData(PlanStatus.Review)]
+    [InlineData(PlanStatus.Draft)]
+    [InlineData(PlanStatus.Skipped)]
+    public async Task TransitionState_ToNonCompletedState_WithFailedVerification_Succeeds(PlanStatus target)
+    {
+        SeedPlan(Plan00042Verifications(), state: "Executing");
+        var service = CreateReaderService();
+
+        service.TransitionState(FolderName, target);
+        await service.FlushPendingWritesAsync();
+
+        Assert.Equal(target.ToString(), ReadSeededPlan().State);
+    }
+
+    // 5. The path 00042 actually took: `tendril plan set 00042 state Completed`.
+    [Fact]
+    public void PlanSet_StateCompleted_WithFailedVerification_ReturnsNonZero()
+    {
+        SeedPlan(Plan00042Verifications());
+
+        var exit = BuildPlanSetApp(out var console).Run(["plan", "set", "00042", "state", "Completed"]);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("CheckResult", console.Output);
+        var onDisk = ReadSeededPlan();
+        Assert.Equal("Review", onDisk.State);
+        Assert.False(onDisk.PartialDelivery);
+    }
+
+    // 6. The escape hatch records the partial delivery rather than bypassing the gate silently.
+    [Fact]
+    public void PlanSet_StateCompleted_WithAllowFailedVerifications_SucceedsAndSetsPartialDelivery()
+    {
+        SeedPlan(Plan00042Verifications());
+
+        var exit = BuildPlanSetApp(out _).Run(
+            ["plan", "set", "00042", "state", "Completed", "--allow-failed-verifications"]);
+
+        Assert.Equal(0, exit);
+        var onDisk = ReadSeededPlan();
+        Assert.Equal("Completed", onDisk.State);
+        Assert.True(onDisk.PartialDelivery);
+    }
+
+    // 7. partialDelivery is additive: absent means false, and a plan that never set it must not gain
+    //    the field on the next write. That is what keeps this off the schema-migration path.
+    [Fact]
+    public void PlanYaml_PartialDeliveryAbsent_DeserializesFalse_AndRoundTripsWithoutEmittingField()
+    {
+        var legacyYaml = """
+                         state: Completed
+                         project: Rusty
+                         title: Legacy Plan
+                         repos:
+                         - /dummy/repo
+                         commits: []
+                         prs: []
+                         verifications: []
+                         """;
+
+        var parsed = YamlHelper.Deserializer.Deserialize<PlanYaml>(legacyYaml);
+
+        Assert.False(parsed.PartialDelivery);
+
+        var reserialized = YamlHelper.Serializer.Serialize(parsed);
+        Assert.DoesNotContain("partialDelivery", reserialized);
+
+        parsed.PartialDelivery = true;
+        Assert.Contains("partialDelivery: true", YamlHelper.Serializer.Serialize(parsed));
+    }
+}

--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -99,7 +99,14 @@ public class ActionBarView(
             new MenuItem("Mark as Completed", Icon: Icons.CircleCheck, Tag: "MarkCompleted")
                 .OnSelect(() =>
                 {
-                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+                    // Blocked when a verification failed (plan 00090). Toast the gate names instead of
+                    // throwing out of this fire-and-forget handler, which would look like a no-op.
+                    var blocked = PlanCompletionAction.TryComplete(planService, selectedPlan);
+                    if (blocked != null)
+                    {
+                        PlanCompletionAction.ToastBlocked(client, selectedPlan, blocked);
+                        return;
+                    }
                     refreshPlans();
                 }),
             new MenuItem("Open plan.yaml", Icon: Icons.FileText, Tag: "OpenPlanYaml").OnSelect(() =>

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -106,6 +106,16 @@ public class ContentView(
                 resetToDraftLogger);
         });
 
+        // The override for a failed-verification block (plan 00090). Offered here rather than as a
+        // bare toast, because recording a partial delivery is a deliberate choice, not a retry.
+        var (partialDeliveryDialog, showPartialDeliveryDialog) =
+            UseTrigger<IReadOnlyList<string>>((isOpen, failed) =>
+            {
+                if (!isOpen.Value) return null;
+                return new PartialDeliveryDialog(isOpen, selectedPlanState.Value!, failed, planService,
+                    refreshPlans);
+            });
+
         var (debugSheet, showDebugJob) = UseTrigger<string>((isOpen, jobId) =>
         {
             if (!isOpen.Value) return null;
@@ -238,11 +248,12 @@ public class ContentView(
             selectedPlanState.Value!, selectedRecTitles, client,
             planContentQuery.Mutator.Revalidate);
 
-        var header = BuildHeader(selectedPlanState.Value, allPlans, currentIndex, client, showCreatePrDialog, nav,
-            args, selectedRecTitles, ImplementRecommendations);
+        var header = BuildHeader(selectedPlanState.Value, allPlans, currentIndex, client, showCreatePrDialog,
+            showPartialDeliveryDialog, nav, args, selectedRecTitles, ImplementRecommendations);
         var actionBar = BuildActionBar(
             selectedPlanState.Value, showResetToDraftDialog, showSuggestChangesDialog, showDiscardDialog,
-            showCreatePrDialog, copyToClipboard, client, logger, nav, args, agentRunner);
+            showCreatePrDialog, showPartialDeliveryDialog, copyToClipboard, client, logger, nav, args,
+            agentRunner);
         var content = BuildContent(
             selectedPlanState.Value, planData, planContentQuery, selectedTab, openVerification,
             openCommit, openFile, openArtifact, artifactContentQuery, assigneesQuery,
@@ -257,7 +268,8 @@ public class ContentView(
             ).Scroll(Scroll.None).Size(Size.Full())
         ).Scroll(Scroll.None).Size(Size.Full()).Key(selectedPlanState.Value.Id);
 
-        return new Fragment(mainLayout, discardDialog, suggestChangesDialog, createPrDialog, resetToDraftDialog, debugSheet);
+        return new Fragment(mainLayout, discardDialog, suggestChangesDialog, createPrDialog, resetToDraftDialog,
+            partialDeliveryDialog, debugSheet);
     }
 
     private object BuildHeader(
@@ -266,6 +278,7 @@ public class ContentView(
         int currentIndex,
         IClientProvider client,
         Action showCreatePrDialog,
+        Action<IReadOnlyList<string>> showPartialDeliveryDialog,
         INavigator nav,
         ReviewAppArgs? args,
         IState<HashSet<string>> selectedRecTitles,
@@ -376,8 +389,17 @@ public class ContentView(
             {
                 var completePlanBtn = new Button("Complete Plan").Icon(Icons.CircleCheck).OnClick(() =>
                 {
+                    // A failed verification blocks the transition (plan 00090). On a block nothing
+                    // changed, so skip the optimistic refresh and the worktree cleanup too, and offer
+                    // the partial-delivery override instead of failing silently.
+                    var blocked = PlanCompletionAction.TryComplete(planService, selectedPlan);
+                    if (blocked != null)
+                    {
+                        showPartialDeliveryDialog(blocked);
+                        return;
+                    }
+
                     // Optimistic UI - update state and refresh immediately
-                    planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
                     refreshPlans();
 
                     // Fire and forget - clean up worktrees in the background
@@ -409,6 +431,7 @@ public class ContentView(
         Action showSuggestChangesDialog,
         Action showDiscardDialog,
         Action showCreatePrDialog,
+        Action<IReadOnlyList<string>> showPartialDeliveryDialog,
         Action<string> copyToClipboard,
         IClientProvider client,
         ILogger<ContentView> logger,
@@ -427,7 +450,12 @@ public class ContentView(
             new MenuItem("Create PR", Icon: Icons.GitPullRequest, Tag: "CreatePR").OnSelect(showCreatePrDialog),
             new MenuItem("Set Completed", Icon: Icons.CircleCheck, Tag: "SetCompleted").OnSelect(() =>
             {
-                planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+                var blocked = PlanCompletionAction.TryComplete(planService, selectedPlan);
+                if (blocked != null)
+                {
+                    showPartialDeliveryDialog(blocked);
+                    return;
+                }
                 refreshPlans();
             }),
             new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -291,9 +291,16 @@ public class ContentView(
 
             var hasSourceUrl = !string.IsNullOrEmpty(selectedPlan.SourceUrl);
 
+            // The title is what readers trust, so a plan completed over a failed gate says so right
+            // next to it rather than only in plan.yaml (plan 00090).
+            object PartialDeliveryBadge() => new Badge("Partial Delivery").Variant(BadgeVariant.Warning);
+
             var desktopTitleLayout = Layout.Horizontal().Gap(2).AlignContent(Align.Left).Width(Size.Full().Min(Size.Px(0)))
                 | Text.Block($"#{selectedPlan.Id} {selectedPlan.Title}").Bold().NoWrap().Overflow(Overflow.Ellipsis)
                     .Width(Size.Shrink().Min(Size.Px(0)));
+
+            if (selectedPlan.PartialDelivery)
+                desktopTitleLayout |= PartialDeliveryBadge();
 
             if (hasSourceUrl)
                 desktopTitleLayout |= SourceButton();
@@ -310,6 +317,9 @@ public class ContentView(
                         p => p.FolderName == selectedPlan.FolderName,
                         p => selectedPlanState.Set(p))
                     .Width(Size.Grow().Min(Size.Px(0)));
+
+            if (selectedPlan.PartialDelivery)
+                mobileTitleLayout |= PartialDeliveryBadge();
 
             if (hasSourceUrl)
                 mobileTitleLayout |= SourceButton();

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/PartialDeliveryDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/PartialDeliveryDialog.cs
@@ -1,0 +1,48 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Plans;
+
+namespace Ivy.Tendril.Apps.Review.Dialogs;
+
+/// <summary>
+///     Shown when completing a plan is blocked by a failed verification (see plan 00090). Offers the
+///     one sanctioned way past the block: record the plan as a deliberate partial delivery, which
+///     stamps <see cref="PlanYaml.PartialDelivery" /> so the possibly-missing deliverable stays
+///     visible to duplicate detection instead of reading as done.
+/// </summary>
+public class PartialDeliveryDialog(
+    IState<bool> dialogOpen,
+    PlanFile selectedPlan,
+    IReadOnlyList<string> failedVerifications,
+    IPlanReaderService planService,
+    Action refreshPlans) : ViewBase
+{
+    public override object? Build()
+    {
+        if (!dialogOpen.Value) return null;
+
+        var names = string.Join(", ", failedVerifications);
+
+        return new Dialog(
+            _ => dialogOpen.Set(false),
+            new DialogHeader("Verification Failed"),
+            new DialogBody(
+                Layout.Vertical().Gap(3)
+                | Text.P($"{names} failed for plan #{selectedPlan.Id}, so it cannot be completed.")
+                | Text.Muted("Re-run the verification, or set it to Skipped with a reason, if the work is " +
+                             "actually done. Only override if you are deliberately shipping this plan " +
+                             "incomplete.")
+                | Text.Muted("Overriding marks the plan as a partial delivery so future plans are not " +
+                             "discarded as duplicates of work that never landed.")
+            ),
+            new DialogFooter(
+                new Button("Cancel").Outline().OnClick(() => dialogOpen.Set(false)),
+                new Button("Complete as Partial Delivery").Destructive().OnClick(() =>
+                {
+                    planService.CompleteWithPartialDelivery(selectedPlan.FolderName);
+                    refreshPlans();
+                    dialogOpen.Set(false);
+                })
+            )
+        );
+    }
+}

--- a/src/Ivy.Tendril/Apps/Review/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/SidebarView.cs
@@ -72,6 +72,10 @@ public class SidebarView(
                     .WithProjectColor(config, plan.Project)
                 | (!verificationsPassed
                     ? new Badge("Unverified").Variant(BadgeVariant.Warning).Small()
+                    : null)
+                // Completed over a failed gate: the deliverable may be missing (plan 00090).
+                | (plan.PartialDelivery
+                    ? new Badge("Partial").Variant(BadgeVariant.Warning).Small()
                     : null);
 
             return SidebarListRow.Build($"#{plan.Id} {plan.Title}", badges, () => selectedPlanState.Set(clickablePlan),

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -2,6 +2,7 @@ using Ivy.Tendril.Agents;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
 using Ivy.Tendril.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console;
@@ -162,6 +163,7 @@ public static class DoctorCommand
         var results = FilterResults(allResults, showAll, stateFilter, worktreesOnly);
 
         PrintPlansTable(results);
+        PrintPartialDeliveryCandidates(FindPartialDeliveryCandidates(allResults));
         PrintPlansSummary(allResults);
 
         return allResults.Any(r => !r.IsHealthy) ? 1 : 0;
@@ -630,4 +632,57 @@ public static class DoctorCommand
     private static bool HasSignificantWork(bool hasPrs, bool hasCommits, bool hasRevisions) =>
         hasPrs || hasCommits || hasRevisions;
 
+    internal record PartialDeliveryCandidate(string Id, string Title, IReadOnlyList<string> FailedVerifications);
+
+    /// <summary>
+    ///     Plans that already sit at <see cref="PlanStatus.Completed" /> with a verification in the Fail
+    ///     state and no <c>partialDelivery</c> flag. They predate the guard added by plan 00090, so they
+    ///     read as fully delivered to CreatePlan's duplicate detection even though the deliverable may
+    ///     be missing. Reported, never mutated: these are historical records and the call is the user's.
+    /// </summary>
+    internal static List<PartialDeliveryCandidate> FindPartialDeliveryCandidates(
+        List<PlanHealthResult> allResults)
+    {
+        var candidates = new List<PartialDeliveryCandidate>();
+
+        foreach (var result in allResults)
+        {
+            if (result.FolderPath == null) continue;
+            if (!result.State.Equals(nameof(PlanStatus.Completed), StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var plan = PlanYamlHelper.ReadPlanYaml(result.FolderPath);
+            if (plan == null || plan.PartialDelivery) continue;
+
+            var failed = PlanCompletionGuard.FailedVerificationNames(plan);
+            if (failed.Count > 0)
+                candidates.Add(new PartialDeliveryCandidate(result.Id, result.Title, failed));
+        }
+
+        return candidates;
+    }
+
+    internal static void PrintPartialDeliveryCandidates(List<PartialDeliveryCandidate> candidates)
+    {
+        if (candidates.Count == 0) return;
+
+        var plural = candidates.Count == 1 ? "plan is" : "plans are";
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine(
+            $"[yellow]{candidates.Count} completed {plural} missing a partialDelivery flag despite a failed verification:[/]");
+        AnsiConsole.WriteLine();
+
+        foreach (var candidate in candidates)
+        {
+            var failed = string.Join(", ", candidate.FailedVerifications);
+            AnsiConsole.MarkupLine(
+                $"[grey]  {candidate.Id}-{candidate.Title.EscapeMarkup()}  (failed: {failed.EscapeMarkup()})[/]");
+        }
+
+        AnsiConsole.WriteLine();
+        AnsiConsole.WriteLine("Their deliverables may be missing, and duplicate detection reads them as done.");
+        AnsiConsole.WriteLine("Review each one, then flag the ones that really were partial:");
+        AnsiConsole.WriteLine();
+        AnsiConsole.WriteLine("  tendril plan set <id> state Completed --allow-failed-verifications");
+    }
 }

--- a/src/Ivy.Tendril/Commands/PlanGetCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanGetCommand.cs
@@ -10,13 +10,13 @@ public class PlanGetSettings : CommandSettings
 {
     internal static readonly string[] ValidFields =
         ["state", "project", "level", "title", "created", "updated", "executionprofile", "initialprompt", "sourceurl", "priority",
-         "repos", "prs", "commits", "verifications", "dependson", "relatedplans", "recommendations"];
+         "partialdelivery", "repos", "prs", "commits", "verifications", "dependson", "relatedplans", "recommendations"];
 
     [Description("Plan ID (e.g., 03430)")]
     [CommandArgument(0, "<plan-id>")]
     public string PlanId { get; set; } = "";
 
-    [Description("Optional field name to read (state, project, level, title, created, updated, executionProfile, initialPrompt, sourceUrl, priority, repos, prs, commits, verifications, dependsOn, relatedPlans, recommendations)")]
+    [Description("Optional field name to read (state, project, level, title, created, updated, executionProfile, initialPrompt, sourceUrl, priority, partialDelivery, repos, prs, commits, verifications, dependsOn, relatedPlans, recommendations)")]
     [CommandArgument(1, "[field]")]
     public string? Field { get; set; }
 
@@ -29,7 +29,7 @@ public class PlanGetSettings : CommandSettings
         {
             if (!ValidFields.Contains(Field.ToLower(), StringComparer.OrdinalIgnoreCase))
                 return Spectre.Console.ValidationResult.Error(
-                    $"Unknown field '{Field}'. Valid fields: state, project, level, title, created, updated, executionProfile, initialPrompt, sourceUrl, priority, repos, prs, commits, verifications, dependsOn, relatedPlans, recommendations");
+                    $"Unknown field '{Field}'. Valid fields: state, project, level, title, created, updated, executionProfile, initialPrompt, sourceUrl, priority, partialDelivery, repos, prs, commits, verifications, dependsOn, relatedPlans, recommendations");
         }
 
         return Spectre.Console.ValidationResult.Success();
@@ -90,7 +90,8 @@ public class PlanGetCommand : Command<PlanGetSettings>
                 "initialprompt" => plan.InitialPrompt ?? "",
                 "sourceurl" => plan.SourceUrl ?? "",
                 "priority" => plan.Priority.ToString(),
-                _ => throw new ArgumentException($"Unknown field '{settings.Field}'. Valid fields: state, project, level, title, created, updated, executionProfile, initialPrompt, sourceUrl, priority, repos, prs, commits, verifications, dependsOn, relatedPlans, recommendations")
+                "partialdelivery" => plan.PartialDelivery.ToString().ToLowerInvariant(),
+                _ => throw new ArgumentException($"Unknown field '{settings.Field}'. Valid fields: state, project, level, title, created, updated, executionProfile, initialPrompt, sourceUrl, priority, partialDelivery, repos, prs, commits, verifications, dependsOn, relatedPlans, recommendations")
             };
 
             Console.WriteLine(value);

--- a/src/Ivy.Tendril/Commands/PlanSetCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetCommand.cs
@@ -122,24 +122,10 @@ public class PlanSetCommand : Command<PlanSetSettings>
     /// </exception>
     private static void ApplyState(PlanYaml plan, PlanSetSettings settings)
     {
-        var isCompleting = settings.Value.Equals(nameof(PlanStatus.Completed), StringComparison.OrdinalIgnoreCase);
-        if (isCompleting)
-        {
-            var failed = PlanCompletionGuard.FailedVerificationNames(plan);
-            if (failed.Count > 0)
-            {
-                if (!settings.AllowFailedVerifications)
-                    throw new PlanTransitionBlockedException(settings.PlanId, failed);
+        var warning = PlanCompletionGuard.ApplyState(
+            plan, settings.Value, settings.AllowFailedVerifications, settings.PlanId);
 
-                // Deliberate partial delivery: record it so CreatePlan's duplicate detection can see
-                // that the deliverable may be missing, instead of the plan simply reading as done.
-                plan.PartialDelivery = true;
-                Console.WriteLine(
-                    $"Warning: completing over failed verification(s) {string.Join(", ", failed)}. " +
-                    "Marked partialDelivery: true.");
-            }
-        }
-
-        plan.State = settings.Value;
+        if (warning != null)
+            Console.WriteLine(warning);
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanSetCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanSetCommand.cs
@@ -1,6 +1,7 @@
 using Ivy.Tendril.Models;
 using System.ComponentModel;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
 using Ivy.Tendril.Helpers;
 using Spectre.Console.Cli;
 
@@ -22,6 +23,10 @@ public class PlanSetSettings : CommandSettings
     [Description("Field value")]
     [CommandArgument(2, "<value>")]
     public string Value { get; set; } = "";
+
+    [Description("Record Completed despite a failed verification (partial delivery)")]
+    [CommandOption("--allow-failed-verifications")]
+    public bool AllowFailedVerifications { get; init; }
 
     public override Spectre.Console.ValidationResult Validate()
     {
@@ -60,7 +65,7 @@ public class PlanSetCommand : Command<PlanSetSettings>
         switch (settings.Field.ToLower())
         {
             case "state":
-                plan.State = settings.Value;
+                ApplyState(plan, settings);
                 break;
             case "project":
                 plan.Project = settings.Value;
@@ -102,5 +107,39 @@ public class PlanSetCommand : Command<PlanSetSettings>
 
         Console.WriteLine($"Set {settings.Field} = {settings.Value}");
         return 0;
+    }
+
+    /// <summary>
+    ///     Applies a state change, enforcing the same rule as
+    ///     <see cref="Services.Plans.PlanReaderService.TransitionState" />: Completed is refused while a
+    ///     verification is in the Fail state (see plan 00090). This command writes plan.yaml directly
+    ///     rather than going through the service, so the shared
+    ///     <see cref="Services.Plans.PlanCompletionGuard" /> is applied here explicitly.
+    /// </summary>
+    /// <exception cref="PlanTransitionBlockedException">
+    ///     Thrown for a blocked Completed without <c>--allow-failed-verifications</c>. Surfaces as a
+    ///     non-zero exit with the exception's message, which names the escape hatch.
+    /// </exception>
+    private static void ApplyState(PlanYaml plan, PlanSetSettings settings)
+    {
+        var isCompleting = settings.Value.Equals(nameof(PlanStatus.Completed), StringComparison.OrdinalIgnoreCase);
+        if (isCompleting)
+        {
+            var failed = PlanCompletionGuard.FailedVerificationNames(plan);
+            if (failed.Count > 0)
+            {
+                if (!settings.AllowFailedVerifications)
+                    throw new PlanTransitionBlockedException(settings.PlanId, failed);
+
+                // Deliberate partial delivery: record it so CreatePlan's duplicate detection can see
+                // that the deliverable may be missing, instead of the plan simply reading as done.
+                plan.PartialDelivery = true;
+                Console.WriteLine(
+                    $"Warning: completing over failed verification(s) {string.Join(", ", failed)}. " +
+                    "Marked partialDelivery: true.");
+            }
+        }
+
+        plan.State = settings.Value;
     }
 }

--- a/src/Ivy.Tendril/Controllers/PlanController.cs
+++ b/src/Ivy.Tendril/Controllers/PlanController.cs
@@ -21,12 +21,13 @@ internal static class PlanFieldAccessors
         ["executionprofile"] = p => p.ExecutionProfile,
         ["initialprompt"] = p => p.InitialPrompt,
         ["sourceurl"] = p => p.SourceUrl,
-        ["priority"] = p => p.Priority.ToString()
+        ["priority"] = p => p.Priority.ToString(),
+        ["partialdelivery"] = p => p.PartialDelivery.ToString().ToLowerInvariant()
     };
 
     private static readonly Dictionary<string, Action<PlanYaml, string>> Setters = new()
     {
-        ["state"] = (p, v) => p.State = v,
+        // "state" is handled by TrySetField itself, which routes through PlanCompletionGuard.
         ["project"] = (p, v) => p.Project = v,
         ["level"] = (p, v) => p.Level = v,
         ["title"] = (p, v) => p.Title = v,
@@ -41,8 +42,34 @@ internal static class PlanFieldAccessors
             ? getter(plan)
             : null;
 
-    public static bool TrySetField(PlanYaml plan, string field, string value, out string? error)
+    /// <param name="allowFailedVerifications">
+    ///     Records Completed despite a failed verification, flagging the plan as a partial delivery.
+    ///     Only meaningful for the <c>state</c> field (see plan 00090).
+    /// </param>
+    public static bool TrySetField(
+        PlanYaml plan,
+        string field,
+        string value,
+        out string? error,
+        bool allowFailedVerifications = false)
     {
+        // State goes through the shared guard: this endpoint writes plan.yaml directly rather than
+        // through PlanReaderService.TransitionState, so it would otherwise bypass the Completed check.
+        if (field.Equals("state", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                PlanCompletionGuard.ApplyState(plan, value, allowFailedVerifications, plan.Title);
+                error = null;
+                return true;
+            }
+            catch (PlanTransitionBlockedException ex)
+            {
+                error = ex.Message;
+                return false;
+            }
+        }
+
         if (!Setters.TryGetValue(field.ToLower(), out var setter))
         {
             error = $"Unknown field: {field}";
@@ -185,7 +212,8 @@ public class PlanController : ControllerBase
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
 
-            if (!PlanFieldAccessors.TrySetField(plan, request.Field, request.Value, out var error))
+            if (!PlanFieldAccessors.TrySetField(plan, request.Field, request.Value, out var error,
+                    request.AllowFailedVerifications))
                 return BadRequest(new { error });
 
             if (request.Field.ToLower() != "updated")
@@ -655,7 +683,7 @@ public class PlanController : ControllerBase
 }
 
 // Request DTOs
-public record SetFieldRequest(string Field, string Value);
+public record SetFieldRequest(string Field, string Value, bool AllowFailedVerifications = false);
 public record AddRepoRequest(string RepoPath);
 public record RemoveRepoRequest(string RepoPath);
 public record AddPrRequest(string PrUrl);

--- a/src/Ivy.Tendril/Helpers/PlanCompletionAction.cs
+++ b/src/Ivy.Tendril/Helpers/PlanCompletionAction.cs
@@ -1,0 +1,42 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Plans;
+
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+///     Shared "move this plan to Completed" action for the UI buttons and menu items. Swallows
+///     <see cref="PlanTransitionBlockedException" /> (see plan 00090) and hands the failed gate names
+///     back to the caller, because these all run in fire-and-forget event handlers where an unhandled
+///     throw would surface as a silent no-op.
+/// </summary>
+public static class PlanCompletionAction
+{
+    /// <summary>
+    ///     Attempts the transition to Completed. Returns <c>null</c> on success, or the names of the
+    ///     verifications that blocked it, in which case nothing changed and the caller must skip its
+    ///     follow-up work (refresh, worktree cleanup) rather than pretend the plan is done.
+    /// </summary>
+    public static IReadOnlyList<string>? TryComplete(IPlanReaderService planService, PlanFile plan)
+    {
+        try
+        {
+            planService.TransitionState(plan.FolderName, PlanStatus.Completed);
+            return null;
+        }
+        catch (PlanTransitionBlockedException ex)
+        {
+            return ex.FailedVerifications;
+        }
+    }
+
+    /// <summary>
+    ///     Reports a blocked transition where there is no override affordance (i.e. everywhere except
+    ///     the Review app, which offers a partial-delivery confirmation dialog instead).
+    /// </summary>
+    public static void ToastBlocked(IClientProvider client, PlanFile plan, IReadOnlyList<string> failed) =>
+        client.Toast(
+            $"{string.Join(", ", failed)} failed for plan #{plan.Id}. Re-run the verification, or set it " +
+            "to Skipped with a reason, before completing the plan.",
+            "Verification Failed",
+            variant: ToastVariant.Destructive);
+}

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -139,16 +139,31 @@ public sealed class PlanTools : AuthenticatedToolBase
     public string SetField(
         [Description("Plan ID (e.g., '03228') or full folder path")] string planId,
         [Description("Field name (state, project, level, title, executionProfile, initialPrompt, sourceUrl, priority)")] string field,
-        [Description("New value")] string value)
+        [Description("New value")] string value,
+        [Description("Record Completed despite a failed verification (partial delivery)")] bool allowFailedVerifications = false)
     {
         return ExecuteAuthenticated(() =>
         {
             var planFolder = PlanCommandHelpers.ResolvePlanFolder(planId);
             var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            string? warning = null;
 
             switch (field.ToLower())
             {
-                case "state": plan.State = value; break;
+                case "state":
+                    // Writes plan.yaml directly rather than going through
+                    // PlanReaderService.TransitionState, so the Completed check is applied here
+                    // explicitly (see plan 00090).
+                    try
+                    {
+                        warning = PlanCompletionGuard.ApplyState(
+                            plan, value, allowFailedVerifications, planId);
+                    }
+                    catch (PlanTransitionBlockedException ex)
+                    {
+                        return $"Error: {ex.Message}";
+                    }
+                    break;
                 case "project": plan.Project = value; break;
                 case "level": plan.Level = value; break;
                 case "title": plan.Title = value; break;
@@ -168,7 +183,9 @@ public sealed class PlanTools : AuthenticatedToolBase
                 plan.Updated = DateTime.UtcNow;
 
             PlanCommandHelpers.WritePlan(planFolder, plan);
-            return $"Updated {field} to '{value}'";
+            return warning != null
+                ? $"Updated {field} to '{value}'. {warning}"
+                : $"Updated {field} to '{value}'";
         });
     }
 
@@ -660,6 +677,7 @@ public sealed class PlanTools : AuthenticatedToolBase
         ["initialprompt"] = (p, _) => p.InitialPrompt ?? "",
         ["sourceurl"] = (p, _) => p.SourceUrl ?? "",
         ["priority"] = (p, _) => p.Priority.ToString(),
+        ["partialdelivery"] = (p, _) => p.PartialDelivery.ToString().ToLowerInvariant(),
         ["repos"] = (p, _) => string.Join("\n", p.Repos),
         ["prs"] = (p, _) => string.Join("\n", p.Prs),
         ["commits"] = (p, _) => string.Join("\n", p.Commits),

--- a/src/Ivy.Tendril/Models/PlanModels.cs
+++ b/src/Ivy.Tendril/Models/PlanModels.cs
@@ -178,6 +178,15 @@ public class PlanYaml
     public List<string> DependsOn { get; set; } = new();
     [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
     public int Priority { get; set; }
+
+    /// <summary>
+    ///     Set when a plan was moved to Completed while a verification was in Fail state. Signals to
+    ///     CreatePlan's duplicate detection that the plan's deliverable may be missing (see plan 00090).
+    ///     Additive and absent-means-false, so it needs no <see cref="CurrentSchemaVersion" /> bump.
+    /// </summary>
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+    public bool PartialDelivery { get; set; }
+
     public string? ExecutionProfile { get; set; }
     public string? InitialPrompt { get; set; }
     public string? SourceUrl { get; set; }

--- a/src/Ivy.Tendril/Models/PlanModels.cs
+++ b/src/Ivy.Tendril/Models/PlanModels.cs
@@ -34,7 +34,8 @@ public record PlanMetadata(
     DateTime Created,
     DateTime Updated,
     string? InitialPrompt,
-    string? SourceUrl);
+    string? SourceUrl,
+    bool PartialDelivery = false);
 
 public record PlanFile(
     PlanMetadata Metadata,
@@ -59,6 +60,12 @@ public record PlanFile(
     public DateTime Updated => Metadata.Updated;
     public string? InitialPrompt => Metadata.InitialPrompt;
     public string? SourceUrl => Metadata.SourceUrl;
+
+    /// <summary>
+    ///     True when the plan reached Completed over a failed verification. See
+    ///     <see cref="PlanYaml.PartialDelivery" />.
+    /// </summary>
+    public bool PartialDelivery => Metadata.PartialDelivery;
 
     /// <summary>True when the plan's source is a GitHub pull request (vs. an issue or none).</summary>
     public bool IsPullRequestSource => SourceUrl?.Contains("/pull/") == true;

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -81,6 +81,9 @@ tendril plan get <plan-id> recommendations    # Format: Title=State
 ```bash
 # Set scalar fields
 tendril plan set <plan-id> state <value>
+# `state Completed` is refused while any verification is Fail. Re-run the verification, or set it to
+# Skipped with a reason. Add --allow-failed-verifications only to record a deliberate partial
+# delivery; it also sets partialDelivery: true.
 tendril plan set <plan-id> project <value>
 tendril plan set <plan-id> title <value>
 tendril plan set <plan-id> level <value>

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -65,6 +65,8 @@ tendril plan get <plan-id> updated
 tendril plan get <plan-id> executionProfile
 tendril plan get <plan-id> initialPrompt
 tendril plan get <plan-id> sourceUrl
+tendril plan get <plan-id> partialDelivery    # true: Completed over a failed verification, so the
+                                              # deliverable may be missing
 
 # List fields (one item per line)
 tendril plan get <plan-id> repos

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -94,12 +94,14 @@ Report status: `tendril job status TendrilJobId --message="Researching codebase.
 
   #### Step 1: Read existing plan state
   
-  Read the matching plan's `plan.yaml` and check its `state`, `commits`, and `prs` fields.
+  Read the matching plan's `plan.yaml` and check its `state`, `commits`, `prs`, `verifications` and
+  `partialDelivery` fields.
 
   #### Step 2: Decide based on state
 
   | Existing plan state | Action |
   |---|---|
+  | `Completed` with `partialDelivery: true` or any verification `Fail` | **Do NOT trash.** The deliverable may be missing. Verify the specific thing the incoming request asks for is present in the code, and create the plan if it is not. |
   | `Completed` (with merged PR) | Check for regression (Step 4), otherwise trash |
   | `Completed` (no PR, but commits exist) | Check for regression (Step 4), trash with note "no PR found" |
   | `Draft` / `Creating` / `Executing` | Trash, but note "plan in progress (state: X)" |
@@ -107,7 +109,21 @@ Report status: `tendril job status TendrilJobId --message="Researching codebase.
   | `Failed` | **Do NOT trash** — create the plan (the previous attempt failed) |
   | `Icebox` / `Skipped` | Trash with note "existing plan state: X" (issue is already covered) |
 
+  A `Completed` plan is not proof of delivery: a plan can be completed while a gate rejected the
+  work, in which case its title asserts a feature that was never written. The first row catches that,
+  and it takes precedence over the rows below it.
+
   #### Step 3: Stricter checks for critical issues
+
+  Run these two checks on **every** `Completed` candidate, before anything else:
+
+  ```bash
+  tendril plan get <id> verifications | grep -i "=Fail"   # any Fail: treat as possibly undelivered
+  tendril plan get <id> partialDelivery                    # true: completed over a failed gate
+  ```
+
+  Either signal means the plan's deliverable may be missing, so do NOT trash on state alone: verify
+  in the code that the specific thing this request asks for is present.
 
   When the incoming request describes a critical/blocking issue (errors, failures, crashes), apply **additional checks** before trashing:
 

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -317,12 +317,13 @@ If cleanup fails, log a warning but do not fail the overall CreatePr execution.
 
 **!STOP — YOU ARE NOT DONE until this step is complete.** Creating the PR is not the finish line.
 Whether or not earlier steps were messy, retried, or partially failed, you MUST finish by:
-(1) recording every created/updated PR URL, and (2) setting the plan state to `Completed`. A run
+(1) recording every created/updated PR URL, and (2) recording the plan's final state. A run
 that stops before this leaves the PR invisible in Tendril and the plan stuck in Drafts.
 
 Use the CLI to update the plan — **never edit plan.yaml directly**.
 
-Add each PR URL:
+Add each PR URL. **This is unconditional:** recording the PR is always correct, whatever the plan's
+verifications say.
 
 ```bash
 tendril plan add-pr <plan-id> <pr-url>
@@ -332,19 +333,39 @@ tendril plan add-pr <plan-id> <pr-url>
 > equal `SourceUrl`). Read `plan.yaml` first and only run `add-pr` if the URL is not already present —
 > do not add a duplicate.
 
-**Set state to Completed:** Once a PR exists (created **or** updated) for the plan, set the state to
-`Completed` — **regardless of `PrMerge`**. A plan that has a PR is done; merge status is tracked
-separately as PR status and does not affect plan state.
+**Then check the verifications before setting the state:**
+
+```bash
+tendril plan get <plan-id> verifications   # output is Name=Status
+```
+
+**If no verification is `Fail`, set state to Completed.** Once a PR exists (created **or** updated)
+for the plan, set the state to `Completed` — **regardless of `PrMerge`**. A plan that has a PR is
+done; merge status is tracked separately as PR status and does not affect plan state.
 
 ```bash
 tendril plan set <plan-id> state Completed
 ```
 
+**If any verification is `Fail`, do NOT set `Completed`.** Leave the plan in `Failed`: the PR exists
+but a gate rejected the work, so the plan is not done. The CLI will refuse the transition anyway.
+Report it and stop:
+
+```bash
+tendril job status <job-id> --message "PR recorded, plan left in Failed: <VerificationName> failed"
+```
+
+This is a **legitimate closeout**, not a skipped step. A failed gate usually means the plan's
+deliverable is missing, and marking it `Completed` hides that from every later plan. Only use
+`tendril plan set <plan-id> state Completed --allow-failed-verifications` if a human explicitly asked
+for a partial delivery to be recorded; it flags the plan as `partialDelivery: true`.
+
 ### Edge Case: Direct-to-Main (No PR Needed)
 
 Some plans create new repos and push directly to main (e.g., repo scaffolding). These have `repos: []`, no worktrees, and commits already on `origin/main`. When detected:
 1. Verify the commit(s) exist on the remote default branch
-2. Mark state as Completed: `tendril plan set <plan-id> state Completed`
+2. Mark state as Completed: `tendril plan set <plan-id> state Completed` (same verification rule as
+   above: if any verification is `Fail`, leave the plan in `Failed` and report it instead)
 3. Log outcome as "No PR Required — Direct-to-Main"
 4. Skip steps 2–5 entirely
 
@@ -352,10 +373,12 @@ Some plans create new repos and push directly to main (e.g., repo scaffolding). 
 
 - **ALL 7 steps are mandatory** (including 2.5) — do not stop after creating the PR. In
   particular, **step 6 is a required closeout**: record every PR URL via `tendril plan add-pr` and
-  set the plan state to `Completed`. A run that creates a PR but skips step 6 is a **failed** run.
+  record the plan's final state. A run that creates a PR but skips step 6 is a **failed** run.
+  Leaving the plan in `Failed` because a verification failed is a *completed* step 6, not a skipped
+  one; skipping the state check entirely is not.
 - **Final summary must be verifiable:** end by echoing each recorded PR URL and the final plan
   state (e.g. `Recorded PR: <url> — plan 00015 state: Completed`) so an incomplete closeout is
-  self-evident.
+  self-evident. When a gate failed, name it (e.g. `plan 00015 state: Failed (CheckResult failed)`).
 - One PR per repo worktree that has commits
 - Skip worktrees with no commits ahead of the base branch
 - Use `gh` CLI for all GitHub operations

--- a/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
@@ -13,6 +13,19 @@ public interface IPlanReaderService
     PlanFile? GetPlanByFolder(string folderPath);
     List<PlanFile> GetIceboxPlans();
     void TransitionState(string folderName, PlanStatus newState);
+
+    /// <summary>
+    ///     Names of verifications in a Fail state, read from plan.yaml. Empty when the plan is clean.
+    ///     A plan must not reach Completed while this is non-empty (see plan 00090).
+    /// </summary>
+    IReadOnlyList<string> GetFailedVerifications(string folderName);
+
+    /// <summary>
+    ///     Overrides the failed-verification block: completes the plan and records
+    ///     <see cref="PlanYaml.PartialDelivery" /> so the missing deliverable stays visible downstream.
+    /// </summary>
+    void CompleteWithPartialDelivery(string folderName);
+
     void ResetToDraft(string folderName);
     void ResetVerificationsForRetry(string folderName);
     void SetVerificationStatus(string folderName, string name, VerificationStatus status);

--- a/src/Ivy.Tendril/Services/Plans/PlanCompletionGuard.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanCompletionGuard.cs
@@ -1,0 +1,21 @@
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Services.Plans;
+
+/// <summary>
+///     The single rule deciding whether a plan may reach <see cref="PlanStatus.Completed" />: no
+///     verification may be in the Fail state. Shared by <see cref="PlanReaderService" /> (the UI and
+///     service paths) and the <c>plan set</c> CLI command so both agree on the answer.
+/// </summary>
+public static class PlanCompletionGuard
+{
+    /// <summary>
+    ///     Names of the plan's verifications that are in the Fail state, in plan.yaml order. Empty for
+    ///     a null plan, so an unreadable plan.yaml never blocks a transition on a guess.
+    /// </summary>
+    public static IReadOnlyList<string> FailedVerificationNames(PlanYaml? plan) =>
+        plan?.Verifications?
+            .Where(v => v.Status == VerificationStatus.Fail)
+            .Select(v => v.Name)
+            .ToList() ?? [];
+}

--- a/src/Ivy.Tendril/Services/Plans/PlanCompletionGuard.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanCompletionGuard.cs
@@ -18,4 +18,49 @@ public static class PlanCompletionGuard
             .Where(v => v.Status == VerificationStatus.Fail)
             .Select(v => v.Name)
             .ToList() ?? [];
+
+    /// <summary>
+    ///     Applies a state change to an in-memory <see cref="PlanYaml" />, enforcing the rule above.
+    ///     For the write paths that edit plan.yaml directly instead of going through
+    ///     <see cref="PlanReaderService.TransitionState" />: the <c>plan set</c> CLI command, the REST
+    ///     PUT endpoint and the MCP tool. Caller writes the plan afterwards.
+    /// </summary>
+    /// <param name="plan">The plan to mutate.</param>
+    /// <param name="newState">Target state. Only Completed is guarded.</param>
+    /// <param name="allowFailedVerifications">
+    ///     When true, a blocked transition proceeds and <see cref="PlanYaml.PartialDelivery" /> is set,
+    ///     so an override records the partial delivery instead of silently bypassing the gate.
+    /// </param>
+    /// <param name="planIdForMessage">Plan ID or folder name, used only in the exception message.</param>
+    /// <returns>
+    ///     A warning to show the caller when an override was applied, otherwise <c>null</c>.
+    /// </returns>
+    /// <exception cref="PlanTransitionBlockedException">
+    ///     Thrown for a blocked Completed when <paramref name="allowFailedVerifications" /> is false.
+    /// </exception>
+    public static string? ApplyState(
+        PlanYaml plan,
+        string newState,
+        bool allowFailedVerifications,
+        string planIdForMessage)
+    {
+        string? warning = null;
+
+        if (newState.Equals(nameof(PlanStatus.Completed), StringComparison.OrdinalIgnoreCase))
+        {
+            var failed = FailedVerificationNames(plan);
+            if (failed.Count > 0)
+            {
+                if (!allowFailedVerifications)
+                    throw new PlanTransitionBlockedException(planIdForMessage, failed);
+
+                plan.PartialDelivery = true;
+                warning = $"Warning: completing over failed verification(s) {string.Join(", ", failed)}. " +
+                          "Marked partialDelivery: true.";
+            }
+        }
+
+        plan.State = newState;
+        return warning;
+    }
 }

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Ivy.Tendril.Apps.Jobs;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Database;
 using Microsoft.Data.Sqlite;
@@ -1169,8 +1170,13 @@ public class PlanDatabaseService : IPlanDatabaseService
         var created = DateTime.Parse(createdStr, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
         var updated = DateTime.Parse(updatedStr, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
 
+        // partialDelivery comes from the mirrored YAML rather than a dedicated column: it is an
+        // additive flag on a rare path, so it does not warrant a schema migration.
+        var partialDelivery = PlanYamlHelper.ParsePlanYaml(yamlRaw)?.PartialDelivery ?? false;
+
         var metadata = new PlanMetadata(planId, project, level, title, status,
-            repos, commits, prs, verifications, relatedPlans, dependsOn, created, updated, initialPrompt, sourceUrl);
+            repos, commits, prs, verifications, relatedPlans, dependsOn, created, updated, initialPrompt, sourceUrl,
+            partialDelivery);
 
         return new PlanFile(metadata, latestContent, folderPath, yamlRaw, revisionCount);
     }

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -139,11 +139,59 @@ public class PlanReaderService(
     }
 
     /// <summary>
+    ///     Names of verifications in a Fail state, read from <c>plan.yaml</c> on disk (not from the
+    ///     database) so a stale cache cannot green-light a blocked transition. Empty when the plan is
+    ///     clean, missing, or unreadable.
+    /// </summary>
+    /// <remarks>
+    ///     Pending is deliberately excluded: a user may legitimately skip gates, and
+    ///     JobCompletionHandler.EnsurePlanStateTransitioned already routes Pending to Failed. Only Fail
+    ///     is a positive statement that a gate ran and rejected the work.
+    /// </remarks>
+    /// <param name="folderName">Name of the plan folder (e.g. <c>01105-TestPlan</c>).</param>
+    public IReadOnlyList<string> GetFailedVerifications(string folderName)
+    {
+        var planYaml = PlanYamlHelper.ReadPlanYaml(Path.Combine(PlansDirectory, folderName));
+        return PlanCompletionGuard.FailedVerificationNames(planYaml);
+    }
+
+    /// <summary>
     ///     Transitions a plan to a new state by updating its <c>plan.yaml</c> file.
     /// </summary>
     /// <param name="folderName">Name of the plan folder (e.g. <c>01105-TestPlan</c>).</param>
     /// <param name="newState">The target state to transition to.</param>
+    /// <exception cref="PlanTransitionBlockedException">
+    ///     Thrown when <paramref name="newState" /> is Completed and a verification is in the Fail state.
+    ///     Every UI and CLI path to Completed funnels through here, so this one check covers them all.
+    /// </exception>
     public void TransitionState(string folderName, PlanStatus newState)
+    {
+        if (newState == PlanStatus.Completed)
+        {
+            var failed = GetFailedVerifications(folderName);
+            if (failed.Count > 0)
+                throw new PlanTransitionBlockedException(folderName, failed);
+        }
+
+        WriteStateTransition(folderName, newState, markPartialDelivery: false);
+    }
+
+    /// <summary>
+    ///     The sanctioned override for <see cref="TransitionState" />'s failed-verification block: moves
+    ///     the plan to Completed and stamps <see cref="PlanYaml.PartialDelivery" /> so duplicate detection
+    ///     can tell that the deliverable may be missing (see plan 00090).
+    /// </summary>
+    /// <remarks>
+    ///     This is for a human deliberately recording a partial delivery. It is not a way to silence the
+    ///     guard: the flag it writes is what keeps the plan visible to CreatePlan.
+    /// </remarks>
+    /// <param name="folderName">Name of the plan folder (e.g. <c>01105-TestPlan</c>).</param>
+    public void CompleteWithPartialDelivery(string folderName)
+    {
+        WriteStateTransition(folderName, PlanStatus.Completed, markPartialDelivery: true);
+    }
+
+    private void WriteStateTransition(string folderName, PlanStatus newState, bool markPartialDelivery)
     {
         var planId = ExtractPlanId(folderName);
 
@@ -180,6 +228,7 @@ public class PlanReaderService(
             var planYaml = YamlHelper.Deserializer.Deserialize<PlanYaml>(yaml) ?? new PlanYaml();
             planYaml.State = newState.ToString();
             planYaml.Updated = DateTime.UtcNow;
+            if (markPartialDelivery) planYaml.PartialDelivery = true;
             FileHelper.WriteAllText(planYamlPath, YamlHelper.SerializerCompact.Serialize(planYaml));
         }, Path.Combine(PlansDirectory, folderName));
     }

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -1010,7 +1010,8 @@ public class PlanReaderService(
                 planYaml.Created,
                 planYaml.Updated,
                 planYaml.InitialPrompt,
-                planYaml.SourceUrl
+                planYaml.SourceUrl,
+                planYaml.PartialDelivery
             );
 
             var latestContent = ReadLatestRevisionFromFileSystem(folderName);

--- a/src/Ivy.Tendril/Services/Plans/PlanTransitionBlockedException.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanTransitionBlockedException.cs
@@ -1,0 +1,19 @@
+namespace Ivy.Tendril.Services.Plans;
+
+/// <summary>
+///     Thrown when a plan is asked to move to <see cref="Models.PlanStatus.Completed" /> while one or
+///     more of its verifications are in the Fail state. See plan 00090: a plan that reaches Completed
+///     over a failed gate becomes invisible to duplicate detection, so the work it never delivered is
+///     silently trashed the next time someone asks for it.
+/// </summary>
+public class PlanTransitionBlockedException(string folderName, IReadOnlyList<string> failedVerifications)
+    : Exception(BuildMessage(folderName, failedVerifications))
+{
+    public string FolderName { get; } = folderName;
+    public IReadOnlyList<string> FailedVerifications { get; } = failedVerifications;
+
+    private static string BuildMessage(string folderName, IReadOnlyList<string> failedVerifications) =>
+        $"Plan {folderName} cannot be Completed: verification(s) {string.Join(", ", failedVerifications)} failed. " +
+        "Re-run them, set them to Skipped with an explicit reason, or use --allow-failed-verifications " +
+        "to record deliberate partial delivery.";
+}


### PR DESCRIPTION
# Plan 00090 Execution Summary

Block Review to Completed when a verification failed, and surface partial delivery to duplicate
detection.

## Changes

Plan 00042 sits at `state: Completed` with a merged PR while its own `CheckResult` verification
records `Fail` and says the primary deliverable is missing. Four later plans re-derived the same
missing work because 00042 read as done. This plan fixes both halves of that defect in four commits.

**Commit 1 (`60e3c8d2`) blocks the transition at a single chokepoint.** `PlanReaderService.TransitionState`
now throws `PlanTransitionBlockedException` when asked for `Completed` while any verification is
`Fail`. Because the CLI, both Review app buttons and the Drafts menu item all funnel through it, one
check covers them all. The failed names are read from plan.yaml on disk rather than the database, so a
stale cache cannot green-light a blocked transition. `Pending` is deliberately not included:
`JobCompletionHandler.EnsurePlanStateTransitioned` already routes Pending to `Failed`, and only `Fail`
is a positive statement that a gate ran and rejected the work.

The three UI call sites run in fire-and-forget event handlers, where an unhandled throw is a silent
no-op, so they go through `PlanCompletionAction.TryComplete`. The Review app's optimistic path skips
its `refreshPlans()` and its background worktree cleanup on a block rather than pretending the plan is
done. Review offers `PartialDeliveryDialog` as an override; the Drafts menu, which has no override
affordance, toasts the failed gate names.

**Commit 2 (`27ee2f33`) adds the escape hatch and makes CreatePr verification-aware.** A hard block
with no way out is worse than the bug, so `tendril plan set <id> state Completed` gained
`--allow-failed-verifications`, and the exception message names it. CreatePr step 6 now reads the
verifications before setting state: `add-pr` stays unconditional because recording a PR is always
correct, but a `Fail` leaves the plan in `Failed` and reports the gate. The step's MANDATORY-CLOSEOUT
framing is preserved; a failed gate is now a legitimate non-`Completed` outcome, not a skipped step.

**Commit 3 (`fcb31e1c`) makes partial delivery visible.** Blocking only protects plans completed from
now on; 00042 is already `Completed` on disk and the duplicate-detection table keys on `state` alone.
`PlanYaml.PartialDelivery` is set whenever an override is used, surfaced in the Review UI next to the
title (which is what readers trust), and readable via `tendril plan get <id> partialDelivery`. The
CreatePlan state table gained a row that overrides the "otherwise trash" verdict for these plans, plus
two mechanical greps so it is not a judgement call.

Beyond the plan's four listed sites, the REST `PUT /api/plans/{planId}` endpoint and the MCP
`tendril_plan_set` tool were found to write `plan.State` directly, bypassing the guard exactly as
`plan set` did. The rule was centralized in `PlanCompletionGuard.ApplyState`, which all three direct
writers now share, each with its own explicit opt-out.

**Commit 4 (`a4bb734b`) backfills.** `tendril plan doctor` now lists every plan at `Completed` with a
`Fail` verification and no `partialDelivery` flag, and prints the command to flag them. Report only,
never mutate: these are historical records and the call is the user's. Already-flagged plans drop off
the list, so it shrinks as the user works through it.

### Notable decisions

- **No schema migration.** `PartialDelivery` is additive and absent-means-false, so
  `CurrentSchemaVersion` stays at 3. A bump would force a one-time re-sweep of every non-terminal
  plan, which is not worth it for an additive bool. The SQLite mirror derives the flag from the
  existing `YamlRaw` column rather than gaining a dedicated column, for the same reason.
- **"Any verification Fail", not "CheckResult is Fail".** The task names `CheckResult` because that is
  where 00042's failure landed, but `CheckResult` is a per-project convention and the same hole exists
  for any required gate.
- **00042 itself was left untouched.** The plan asks for a report, not an auto-fix. It is the first
  thing `tendril plan doctor` will now surface.

## API Changes

**`IPlanReaderService`** gained two members:

```csharp
IReadOnlyList<string> GetFailedVerifications(string folderName);
void CompleteWithPartialDelivery(string folderName);
```

`TransitionState(folderName, PlanStatus.Completed)` now throws `PlanTransitionBlockedException` when a
verification is `Fail`. Existing callers that pass any other state are unaffected. Five test stubs
were updated for the two new members.

**New public types** in `Ivy.Tendril.Services.Plans`: `PlanCompletionGuard` (with
`FailedVerificationNames` and `ApplyState`) and `PlanTransitionBlockedException` (carrying
`FolderName` and `FailedVerifications`). New public helper `Ivy.Tendril.Helpers.PlanCompletionAction`.

**CLI:**

```bash
tendril plan set <id> state Completed --allow-failed-verifications   # new flag
tendril plan get <id> partialDelivery                                # new readable field
tendril plan doctor                                                  # new backfill section
```

`plan set <id> state Completed` is now a breaking change for scripts that complete a plan over a
failed gate: it exits non-zero unless the new flag is passed.

**REST:** `PUT /api/plans/{planId}` returns `400` for `state: Completed` with a failed verification.
`SetFieldRequest` gained an optional `allowFailedVerifications` (defaults to `false`, so existing
request bodies still bind). `?field=partialDelivery` is readable.

**MCP:** `tendril_plan_set` gained an optional `allowFailedVerifications` parameter and returns
`Error: ...` for a blocked completion. `tendril_get_plan` accepts `field: partialDelivery`.

**plan.yaml:** new optional `partialDelivery: true` key, omitted when false. No schema version change,
and existing files are not rewritten.

## Files Modified

32 files, 896 insertions, 39 deletions.

**New (6):**

| File | Purpose |
|---|---|
| `src/Ivy.Tendril/Services/Plans/PlanCompletionGuard.cs` | the shared rule, used by all three direct plan.yaml writers |
| `src/Ivy.Tendril/Services/Plans/PlanTransitionBlockedException.cs` | carries the failed gate names; message states the escape hatch |
| `src/Ivy.Tendril/Helpers/PlanCompletionAction.cs` | shared complete-plan action for the fire-and-forget UI handlers |
| `src/Ivy.Tendril/Apps/Review/Dialogs/PartialDeliveryDialog.cs` | the override affordance |
| `src/Ivy.Tendril.Test/PlanCompletionVerificationGuardTests.cs` | 10 tests built on 00042's real verification list |
| (no new docs files; existing pages extended) | |

**Enforcement and state (5):** `Services/Plans/PlanReaderService.cs`,
`Services/Plans/IPlanReaderService.cs`, `Models/PlanModels.cs`,
`Services/Plans/PlanDatabaseService.cs`, `Commands/PlanSetCommand.cs`

**Other write and read paths (4):** `Controllers/PlanController.cs`, `Mcp/Tools/PlanTools.cs`,
`Commands/PlanGetCommand.cs`, `Commands/DoctorCommand.cs`

**UI (3):** `Apps/Review/ContentView.cs`, `Apps/Review/SidebarView.cs`, `Apps/Drafts/ActionBarView.cs`

**Promptware and prompts (5):** `Promptwares/CreatePr/Program.md` and
`Promptwares/CreatePlan/Program.md` in both `Ivy.Tendril` and `Ivy.Tendril.TeamIvyConfig`, plus
`Prompts/Plans.md`

**Docs (4):** `09_Advanced/01_CLI/00_Overview.md`, `01_CLI/01_Plan.md`, `02_REST.md`, `03_MCP.md`

**Tests (7):** `PlanCompletionVerificationGuardTests.cs` (new), `DoctorCommandPlansTests.cs`
(+4 tests), and five `IPlanReaderService` stub updates (`JobServiceCompletionGuardTests.cs`,
`JobServiceDependencyAutoRetryTests.cs`, `JobServiceRetryBlockedTests.cs`,
`JobServiceSplitPlanCompletionTests.cs`, `JobsAppPromptDisplayTests.cs`)

## Manual Testing

Automated coverage is 83/83 in the plan's declared scope across three consecutive runs, and the guard
test was proven to fail when the `TransitionState` check is reverted. Beyond that, the CLI behaviors
the plan documents were exercised against a throwaway `TENDRIL_HOME` seeded with a 00042-shaped plan
(`CheckResult: Fail`, `state: Review`), using the worktree's own build. Full transcripts with exit
codes are in `Verification/CheckResult.md`. Fixture directories were deleted afterwards.

| Check | Result |
|---|---|
| `plan set 00042 state Completed` | exit 1, message names `CheckResult` and the escape hatch |
| plan.yaml after the block | still `state: Review`, no `partialDelivery` line: the block happens before any write |
| `plan set 00042 state Completed --allow-failed-verifications` | exit 0, warning printed, `state: Completed` and `partialDelivery: true` on disk |
| `plan get 00042 partialDelivery` | `true` |
| `plan get 00042 verifications` | `Name=Status` format confirmed, so the `grep -i "=Fail"` CreatePlan now instructs works |
| `plan doctor --all` over 3 plans | surfaces only the unflagged partial; skips the already-flagged and the fully-verified |
| plan.yaml after `plan doctor` | unchanged for both non-reported plans: report-only confirmed |

Both prose greps the plan mandated were run: all six remaining `state Completed` occurrences across
the two CreatePr copies are verification-aware, and the new CreatePlan table row is present in both
copies (main `:104`, team `:67`), ordered before the pre-existing `Completed (with merged PR)` row so
the narrower case matches first.

**Not manually exercised:** the Review app UI paths (the "Complete Plan" button, the "Set Completed"
menu item, `PartialDeliveryDialog`, and the Partial Delivery badges) and the Drafts "Mark as
Completed" toast. These need a running desktop app and were verified by reading the call sites plus
the shared `PlanCompletionAction` they delegate to, whose blocked path is covered by the guard tests.
The REST and MCP opt-outs were likewise verified by inspection rather than by driving a live server.

**Whole-project test run:** two pre-existing flaky tests surface under full parallel load
(`PromptwareReadMemoryCommandTests` is missing `[Collection("TendrilHome")]`, and `PlanFileLock.Acquire`
retries only on `IOException` while Windows raises `UnauthorizedAccessException` for a delete-pending
handle). Both were reproduced with this plan's test class excluded entirely, and both involve code
byte-identical to the base branch. Analysis is in `Verification/DotnetTest.md`; both are filed as
recommendations.

---

## Commits

- 60e3c8d25115a42a17d93d36d0a0804f02db8c00 fix(plans): block Review to Completed when a verification failed
- 27ee2f3364b6e3817a03e93ed35b62204c825b62 feat(cli): add --allow-failed-verifications and make CreatePr verification-aware
- fcb31e1cc674d6013bfdb68dfcb8304b71c86790 feat(plans): surface partial delivery to duplicate detection
- a4bb734bd823095cf00abcc44753099359bdefa5 feat(doctor): report plans completed over a failed verification (plan 00090)

---
Created using [Ivy Tendril](https://ivy.app).
