### PR TITLE
[00121] Serialize Config Writes So a Concurrent Verification Set Cannot Silently Drop a Sibling Prompt

### DIFF
--- a/src/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
+++ b/src/Ivy.Tendril.Test/BackgroundServiceActivatorTests.cs
@@ -275,6 +275,11 @@ public class BackgroundServiceActivatorTests : IAsyncLifetime
         {
         }
 
+        public void MutateAndSave(Action<TendrilSettings> mutate)
+        {
+            mutate(Settings);
+        }
+
         public void ReloadSettings()
         {
         }

--- a/src/Ivy.Tendril.Test/ConfigFileLockTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigFileLockTests.cs
@@ -21,7 +21,10 @@ public class ConfigFileLockTests : IDisposable
         Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
 
         var yaml = @"
-projects: []
+projects:
+  - name: PathProject
+    repos:
+      - path: D:\Repos\Test
 verifications:
   - name: Alpha
     prompt: SEED-ALPHA
@@ -149,6 +152,26 @@ verifications:
         var reloaded = new ConfigService();
         Assert.Equal("OUT-OF-BAND", PromptOf(reloaded.Settings, "Alpha"));
         Assert.Equal("LATER-BETA", PromptOf(reloaded.Settings, "Beta"));
+    }
+
+    /// <summary>
+    ///     MutateAndSave reloads inside the lock, and ReloadSettings used to skip the ExpandRepoPaths
+    ///     that the constructor's load path applies. The callback therefore saw raw backslashed repo
+    ///     paths and the write persisted them in that form, which broke ProjectConfig.GetRepoRef for
+    ///     `project remove-repo` and friends. Both reads must agree.
+    /// </summary>
+    [Fact]
+    public void MutateAndSave_KeepsRepoPathsNormalized()
+    {
+        var config = new ConfigService();
+        var asLoaded = config.Settings.Projects.Single().Repos.Single().Path;
+        Assert.DoesNotContain('\\', asLoaded);
+
+        string? observed = null;
+        config.MutateAndSave(s => observed = s.Projects.Single().Repos.Single().Path);
+
+        Assert.Equal(asLoaded, observed);
+        Assert.Equal(asLoaded, new ConfigService().Settings.Projects.Single().Repos.Single().Path);
     }
 
     /// <summary>The lock file must not be mistaken for config, and must not survive the lock.</summary>

--- a/src/Ivy.Tendril.Test/ConfigFileLockTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigFileLockTests.cs
@@ -116,6 +116,29 @@ verifications:
         Assert.Contains(ConfigPath + ".lock", captured!.Message);
     }
 
+    /// <summary>
+    ///     Acquire_TimesOutLoudly exercises the in-process semaphore, which is not the branch a real
+    ///     race takes. Here the lock file is held by a foreign handle, so the FileStream keeps throwing
+    ///     IOException until the budget runs out. That must surface as the same TimeoutException naming
+    ///     the lock path, not as a raw "cannot access the file" sharing violation.
+    /// </summary>
+    [Fact]
+    public void Acquire_ForeignHolder_TimesOutWithLockPath()
+    {
+        var lockPath = ConfigPath + ".lock";
+        using var foreign = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite,
+            FileShare.None, bufferSize: 1, FileOptions.DeleteOnClose);
+
+        var ex = Assert.Throws<TimeoutException>(() => ConfigFileLock.Acquire(ConfigPath, 3, 10));
+
+        Assert.Contains(lockPath, ex.Message);
+        Assert.IsType<IOException>(ex.InnerException);
+
+        // The semaphore must have been released, or every later caller in this process would hang.
+        using var after = ConfigFileLock.Acquire(ConfigPath + ".other");
+        Assert.NotNull(after);
+    }
+
     [Fact]
     public void Acquire_EmptyConfigPath_ReturnsNoOp()
     {

--- a/src/Ivy.Tendril.Test/ConfigFileLockTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigFileLockTests.cs
@@ -1,0 +1,167 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+/// <summary>
+///     Covers ConfigFileLock and ConfigService.MutateAndSave. Every config.yaml mutator serializes the
+///     whole settings graph, so two unsynchronized writers used to drop one another's change while both
+///     reported success.
+/// </summary>
+[Collection("TendrilHome")]
+public class ConfigFileLockTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("tendril-config-lock-test");
+    private readonly string _originalTendrilHome;
+
+    public ConfigFileLockTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+
+        var yaml = @"
+projects: []
+verifications:
+  - name: Alpha
+    prompt: SEED-ALPHA
+  - name: Beta
+    prompt: SEED-BETA
+";
+        File.WriteAllText(Path.Combine(_tempDir.Path, "config.yaml"), yaml);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+    }
+
+    private string ConfigPath => Path.Combine(_tempDir.Path, "config.yaml");
+
+    private static string PromptOf(TendrilSettings settings, string name) =>
+        settings.Verifications.First(v => v.Name == name).Prompt;
+
+    /// <summary>
+    ///     The regression test. Before MutateAndSave existed, each writer loaded the file in its
+    ///     ConfigService constructor, mutated one verification, and serialized the whole graph back, so
+    ///     the later write reverted the earlier one to its seed value.
+    /// </summary>
+    [Fact]
+    public void ConcurrentMutations_BothSurvive()
+    {
+        using var barrier = new Barrier(2);
+
+        void Mutate(string name, string prompt)
+        {
+            var config = new ConfigService();
+            barrier.SignalAndWait();
+            config.MutateAndSave(s => s.Verifications.First(v => v.Name == name).Prompt = prompt);
+        }
+
+        var a = new Thread(() => Mutate("Alpha", "RACE-ALPHA"));
+        var b = new Thread(() => Mutate("Beta", "RACE-BETA"));
+        a.Start();
+        b.Start();
+        Assert.True(a.Join(TimeSpan.FromSeconds(30)));
+        Assert.True(b.Join(TimeSpan.FromSeconds(30)));
+
+        var reloaded = new ConfigService();
+        Assert.Equal("RACE-ALPHA", PromptOf(reloaded.Settings, "Alpha"));
+        Assert.Equal("RACE-BETA", PromptOf(reloaded.Settings, "Beta"));
+    }
+
+    [Fact]
+    public void Acquire_SecondCallerBlocksThenSucceeds()
+    {
+        var acquired = new ManualResetEventSlim(false);
+        var held = ConfigFileLock.Acquire(ConfigPath);
+
+        var waiter = new Thread(() =>
+        {
+            using var _ = ConfigFileLock.Acquire(ConfigPath);
+            acquired.Set();
+        });
+        waiter.Start();
+
+        Assert.False(acquired.Wait(TimeSpan.FromMilliseconds(500)), "second Acquire completed while the lock was held");
+
+        held.Dispose();
+
+        Assert.True(acquired.Wait(TimeSpan.FromSeconds(10)), "second Acquire did not complete after release");
+        Assert.True(waiter.Join(TimeSpan.FromSeconds(10)));
+    }
+
+    /// <summary>
+    ///     The "fails loudly" half of the fix: the loser of a race throws instead of exiting 0 having
+    ///     silently discarded the winner's write. Program.cs maps this to "Error: ..." and exit 1.
+    /// </summary>
+    [Fact]
+    public void Acquire_TimesOutLoudly()
+    {
+        using var held = ConfigFileLock.Acquire(ConfigPath);
+
+        TimeoutException? captured = null;
+        var waiter = new Thread(() =>
+        {
+            captured = Assert.Throws<TimeoutException>(() => ConfigFileLock.Acquire(ConfigPath, 3, 10));
+        });
+        waiter.Start();
+        Assert.True(waiter.Join(TimeSpan.FromSeconds(10)), "the timing-out Acquire never returned");
+
+        Assert.NotNull(captured);
+        Assert.Contains(ConfigPath + ".lock", captured!.Message);
+    }
+
+    [Fact]
+    public void Acquire_EmptyConfigPath_ReturnsNoOp()
+    {
+        using var first = ConfigFileLock.Acquire("");
+        // A no-op handle must not block a second acquisition, since the fresh-install path has no file to guard.
+        using var second = ConfigFileLock.Acquire("");
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+    }
+
+    /// <summary>
+    ///     Proves the reload happens inside the lock: the callback sees a write committed after this
+    ///     ConfigService was constructed, rather than mutating the stale graph it loaded at construction.
+    /// </summary>
+    [Fact]
+    public void MutateAndSave_MutationSeesConcurrentWrite()
+    {
+        var config = new ConfigService();
+        Assert.Equal("SEED-ALPHA", PromptOf(config.Settings, "Alpha"));
+
+        // Out-of-band writer, as a separate service instance, lands between construction and mutation.
+        var other = new ConfigService();
+        other.MutateAndSave(s => s.Verifications.First(v => v.Name == "Alpha").Prompt = "OUT-OF-BAND");
+
+        string? observed = null;
+        config.MutateAndSave(s =>
+        {
+            observed = PromptOf(s, "Alpha");
+            s.Verifications.First(v => v.Name == "Beta").Prompt = "LATER-BETA";
+        });
+
+        Assert.Equal("OUT-OF-BAND", observed);
+
+        var reloaded = new ConfigService();
+        Assert.Equal("OUT-OF-BAND", PromptOf(reloaded.Settings, "Alpha"));
+        Assert.Equal("LATER-BETA", PromptOf(reloaded.Settings, "Beta"));
+    }
+
+    /// <summary>The lock file must not be mistaken for config, and must not survive the lock.</summary>
+    [Fact]
+    public void Acquire_LockFileIsDeletedOnRelease()
+    {
+        var lockPath = ConfigPath + ".lock";
+
+        using (ConfigFileLock.Acquire(ConfigPath))
+        {
+            Assert.True(File.Exists(lockPath));
+        }
+
+        Assert.False(File.Exists(lockPath));
+    }
+}

--- a/src/Ivy.Tendril.Test/GitServiceTests.cs
+++ b/src/Ivy.Tendril.Test/GitServiceTests.cs
@@ -43,6 +43,7 @@ public class GitServiceTests
         public Colors? GetLevelColor(string level) => null;
         public Colors? GetProjectColor(string projectName) => null;
         public void SaveSettings() { }
+        public void MutateAndSave(Action<TendrilSettings> mutate) => mutate(Settings);
         public void ReloadSettings() { }
         public void SetPendingTendrilHome(string path) { }
         public string? GetPendingTendrilHome() => null;

--- a/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceConcurrencyTests.cs
@@ -234,6 +234,7 @@ public class JobServiceConcurrencyTests
         public Colors? GetLevelColor(string level) => null;
         public Colors? GetProjectColor(string projectName) => null;
         public void SaveSettings() { }
+        public void MutateAndSave(Action<TendrilSettings> mutate) => mutate(Settings);
         public void ReloadSettings() { }
         public void SetPendingTendrilHome(string path) { }
         public string? GetPendingTendrilHome() => null;

--- a/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
@@ -117,7 +117,9 @@ public class JobServiceDeletionTests
 
             var job = new JobItem
             {
-                Id = "job-with-output", Type = "ExecutePlan", Status = JobStatus.Completed
+                Id = "job-with-output",
+                Type = "ExecutePlan",
+                Status = JobStatus.Completed
             };
             JobLogPaths.EnsureJobsDir(tendrilHome);
             job.LogFilePath = JobLogPaths.Log(tendrilHome, job);
@@ -161,6 +163,7 @@ public class JobServiceDeletionTests
         public Colors? GetLevelColor(string level) => null;
         public Colors? GetProjectColor(string projectName) => null;
         public void SaveSettings() { }
+        public void MutateAndSave(Action<TendrilSettings> mutate) => mutate(Settings);
         public void ReloadSettings() { }
         public bool TryAutoHeal() => false;
         public void ResetToDefaults() { }

--- a/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
@@ -377,6 +377,7 @@ public class JobServiceStartupTests
         public Colors? GetLevelColor(string level) => null;
         public Colors? GetProjectColor(string projectName) => null;
         public void SaveSettings() { }
+        public void MutateAndSave(Action<TendrilSettings> mutate) => mutate(Settings);
         public void ReloadSettings() { }
         public bool TryAutoHeal() => false;
         public void ResetToDefaults() { }

--- a/src/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs
+++ b/src/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs
@@ -34,6 +34,11 @@ public class StubConfigService : IConfigService
     {
     }
 
+    public void MutateAndSave(Action<TendrilSettings> mutate)
+    {
+        mutate(Settings);
+    }
+
     public void ReloadSettings()
     {
     }

--- a/src/Ivy.Tendril.Test/TestPlanConfigService.cs
+++ b/src/Ivy.Tendril.Test/TestPlanConfigService.cs
@@ -44,6 +44,7 @@ internal class TestPlanConfigService : IConfigService
     public Colors? GetLevelColor(string level) => null;
     public Colors? GetProjectColor(string projectName) => null;
     public void SaveSettings() { }
+    public void MutateAndSave(Action<TendrilSettings> mutate) => mutate(Settings);
     public void ReloadSettings() { }
     public void SetPendingTendrilHome(string path) { }
     public string? GetPendingTendrilHome() => null;

--- a/src/Ivy.Tendril.Test/VerificationCommandTests.cs
+++ b/src/Ivy.Tendril.Test/VerificationCommandTests.cs
@@ -304,4 +304,42 @@ verifications: []
         var reloaded = CreateConfig();
         Assert.Empty(reloaded.Settings.Verifications);
     }
+
+    // --- Concurrent writers (config.yaml is a whole-file read-modify-write) ---
+
+    private static CommandApp BuildVerificationSetApp()
+    {
+        var app = new CommandApp();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch("verification", verification => verification.AddCommand<VerificationSetCommand>("set"));
+        });
+        return app;
+    }
+
+    /// <summary>
+    ///     Covers the command-level wiring, not just ConfigFileLock: `verification set` must not revert a
+    ///     sibling definition that a separate ConfigService added after the command's own service loaded
+    ///     the file. See ConfigFileLockTests for the helper-level coverage.
+    /// </summary>
+    [Fact]
+    public void VerificationSet_PreservesSiblingAddedByAnotherWriter()
+    {
+        var seed = CreateConfig();
+        seed.Settings.Verifications.Add(new VerificationConfig { Name = "Target", Prompt = "SEED-TARGET" });
+        seed.SaveSettings();
+
+        // Lands after the command's ConfigService would have loaded, before its write.
+        var other = CreateConfig();
+        other.MutateAndSave(s => s.Verifications.Add(new VerificationConfig { Name = "Sibling", Prompt = "SIBLING" }));
+
+        var exit = BuildVerificationSetApp().Run(["verification", "set", "Target", "prompt", "UPDATED-TARGET"]);
+        Assert.Equal(0, exit);
+
+        var reloaded = CreateConfig();
+        Assert.Equal(2, reloaded.Settings.Verifications.Count);
+        Assert.Equal("UPDATED-TARGET", reloaded.Settings.Verifications.Single(v => v.Name == "Target").Prompt);
+        Assert.Equal("SIBLING", reloaded.Settings.Verifications.Single(v => v.Name == "Sibling").Prompt);
+    }
 }

--- a/src/Ivy.Tendril/Commands/ConfigCommand.cs
+++ b/src/Ivy.Tendril/Commands/ConfigCommand.cs
@@ -85,12 +85,12 @@ public class ConfigSetCommand(IAgentRunner runner) : Command<ConfigSetSettings>
 {
     protected override int Execute(CommandContext context, ConfigSetSettings settings, CancellationToken cancellationToken)
     {
+        // Read stdin before taking the config lock: ResolveInput can block on a pipe for its timeout.
         var value = ConsoleHelper.ResolveInput(settings.Stdin, settings.FilePath, settings.Value);
 
         var config = new ConfigService();
         // throws on bad int / out-of-range / unknown coding agent, before any write
-        ApplyField(config.Settings, settings.Key, value, runner.RegisteredAgents);
-        config.SaveSettings();
+        config.MutateAndSave(s => ApplyField(s, settings.Key, value, runner.RegisteredAgents));
 
         // Report the value actually stored (e.g. the canonical coding-agent id), not the raw input.
         var stored = ConfigGetCommand.ReadField(config.Settings, settings.Key);

--- a/src/Ivy.Tendril/Commands/ProjectCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectCommand.cs
@@ -377,17 +377,19 @@ public class ProjectAddCommand : Command<ProjectAddSettings>
     {
         var config = new ConfigService();
 
-        if (config.Settings.Projects.Any(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
-            throw new InvalidOperationException($"Project already exists: {settings.Name}");
-
-        config.Settings.Projects.Add(new ProjectConfig
+        config.MutateAndSave(s =>
         {
-            Name = settings.Name,
-            Color = settings.Color ?? "",
-            Context = settings.Context ?? ""
+            if (s.Projects.Any(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
+                throw new InvalidOperationException($"Project already exists: {settings.Name}");
+
+            s.Projects.Add(new ProjectConfig
+            {
+                Name = settings.Name,
+                Color = settings.Color ?? "",
+                Context = settings.Context ?? ""
+            });
         });
 
-        config.SaveSettings();
         Console.WriteLine($"Added project: {settings.Name}");
         return 0;
     }
@@ -398,14 +400,18 @@ public class ProjectRemoveCommand : Command<ProjectRemoveSettings>
     protected override int Execute(CommandContext context, ProjectRemoveSettings settings, CancellationToken cancellationToken)
     {
         var config = new ConfigService();
-        var match = config.Settings.Projects
-            .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-        if (match == null)
-            CliValidation.ThrowProjectNotFound(settings.Name, config.Settings.Projects.Select(p => p.Name));
+        config.MutateAndSave(s =>
+        {
+            var match = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-        config.Settings.Projects.Remove(match);
-        config.SaveSettings();
+            if (match == null)
+                CliValidation.ThrowProjectNotFound(settings.Name, s.Projects.Select(p => p.Name));
+
+            s.Projects.Remove(match);
+        });
+
         Console.WriteLine($"Removed project: {settings.Name}");
         return 0;
     }
@@ -416,34 +422,37 @@ public class ProjectSetCommand : Command<ProjectSetSettings>
     protected override int Execute(CommandContext context, ProjectSetSettings settings, CancellationToken cancellationToken)
     {
         var config = new ConfigService();
-        var match = config.Settings.Projects
-            .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-        if (match == null)
-            CliValidation.ThrowProjectNotFound(settings.Name, config.Settings.Projects.Select(p => p.Name));
-
-        switch (settings.Field.ToLower())
+        config.MutateAndSave(s =>
         {
-            case "name":
-                var nameError = InputSanitizer.DescribeProjectNameError(settings.Value);
-                if (nameError != null)
-                    throw new InvalidOperationException(nameError);
-                match.Name = settings.Value;
-                break;
-            case "color":
-                match.Color = settings.Value;
-                break;
-            case "context":
-                match.Context = settings.Value;
-                break;
-            case "stackhash":
-                match.StackHash = settings.Value;
-                break;
-            default:
-                throw new ArgumentException($"Unknown field: {settings.Field}. Valid fields: name, color, context, stackHash");
-        }
+            var match = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-        config.SaveSettings();
+            if (match == null)
+                CliValidation.ThrowProjectNotFound(settings.Name, s.Projects.Select(p => p.Name));
+
+            switch (settings.Field.ToLower())
+            {
+                case "name":
+                    var nameError = InputSanitizer.DescribeProjectNameError(settings.Value);
+                    if (nameError != null)
+                        throw new InvalidOperationException(nameError);
+                    match.Name = settings.Value;
+                    break;
+                case "color":
+                    match.Color = settings.Value;
+                    break;
+                case "context":
+                    match.Context = settings.Value;
+                    break;
+                case "stackhash":
+                    match.StackHash = settings.Value;
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown field: {settings.Field}. Valid fields: name, color, context, stackHash");
+            }
+        });
+
         Console.WriteLine($"Updated project {settings.Field} to '{settings.Value}'");
         return 0;
     }
@@ -454,15 +463,13 @@ public class ProjectAddRepoCommand : Command<ProjectAddRepoSettings>
     protected override int Execute(CommandContext context, ProjectAddRepoSettings settings, CancellationToken cancellationToken)
     {
         var config = new ConfigService();
-        var project = config.Settings.Projects
-            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        if (project == null)
+        // Fail fast on an unknown project before shelling out to git below. The authoritative
+        // lookup happens inside MutateAndSave, against the settings graph that gets written.
+        if (!config.Settings.Projects.Any(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase)))
             CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
 
-        if (project.GetRepoRef(settings.RepoPath) != null)
-            throw new InvalidOperationException($"Repository already exists in project: {settings.RepoPath}");
-
+        // Resolve the branch before taking the config lock: these spawn git and can be slow.
         string? baseBranch = settings.BaseBranch;
         if (!string.IsNullOrWhiteSpace(baseBranch))
         {
@@ -472,18 +479,29 @@ public class ProjectAddRepoCommand : Command<ProjectAddRepoSettings>
         }
         else
         {
-            // No branch supplied — detect and persist the repo's real default branch.
+            // No branch supplied, so detect and persist the repo's real default branch.
             baseBranch = Ivy.Tendril.Helpers.GitHelper.ResolveDefaultBranch(settings.RepoPath, config.TendrilHome);
         }
 
-        project.Repos.Add(new RepoRef
+        config.MutateAndSave(s =>
         {
-            Path = settings.RepoPath,
-            PrRule = settings.PrRule ?? "default",
-            BaseBranch = baseBranch
+            var project = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+                CliValidation.ThrowProjectNotFound(settings.ProjectName, s.Projects.Select(p => p.Name));
+
+            if (project.GetRepoRef(settings.RepoPath) != null)
+                throw new InvalidOperationException($"Repository already exists in project: {settings.RepoPath}");
+
+            project.Repos.Add(new RepoRef
+            {
+                Path = settings.RepoPath,
+                PrRule = settings.PrRule ?? "default",
+                BaseBranch = baseBranch
+            });
         });
 
-        config.SaveSettings();
         Console.WriteLine($"Added repository: {settings.RepoPath}");
         return 0;
     }
@@ -494,18 +512,22 @@ public class ProjectRemoveRepoCommand : Command<ProjectRemoveRepoSettings>
     protected override int Execute(CommandContext context, ProjectRemoveRepoSettings settings, CancellationToken cancellationToken)
     {
         var config = new ConfigService();
-        var project = config.Settings.Projects
-            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        if (project == null)
-            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
+        config.MutateAndSave(s =>
+        {
+            var project = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        var match = project.GetRepoRef(settings.RepoPath);
-        if (match == null)
-            CliValidation.ThrowRepoNotFound(settings.RepoPath, project.Repos.Select(r => r.Path));
+            if (project == null)
+                CliValidation.ThrowProjectNotFound(settings.ProjectName, s.Projects.Select(p => p.Name));
 
-        project.Repos.Remove(match);
-        config.SaveSettings();
+            var match = project.GetRepoRef(settings.RepoPath);
+            if (match == null)
+                CliValidation.ThrowRepoNotFound(settings.RepoPath, project.Repos.Select(r => r.Path));
+
+            project.Repos.Remove(match);
+        });
+
         Console.WriteLine($"Removed repository: {settings.RepoPath}");
         return 0;
     }
@@ -516,35 +538,38 @@ public class ProjectAddVerificationCommand : Command<ProjectAddVerificationSetti
     protected override int Execute(CommandContext context, ProjectAddVerificationSettings settings, CancellationToken cancellationToken)
     {
         var config = new ConfigService();
-        var project = config.Settings.Projects
-            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        if (project == null)
-            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
-
-        if (project.Verifications.Any(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase)))
-            throw new InvalidOperationException($"Verification already exists in project: {settings.VerificationName}");
-
-        var newRef = new ProjectVerificationRef
+        config.MutateAndSave(s =>
         {
-            Name = settings.VerificationName,
-            Required = settings.Required
-        };
+            var project = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        if (!string.IsNullOrEmpty(settings.After))
-        {
-            var afterIndex = project.Verifications
-                .FindIndex(v => v.Name.Equals(settings.After, StringComparison.OrdinalIgnoreCase));
-            if (afterIndex < 0)
-                CliValidation.ThrowVerificationNotFound(settings.After, project.Verifications.Select(v => v.Name));
-            project.Verifications.Insert(afterIndex + 1, newRef);
-        }
-        else
-        {
-            project.Verifications.Add(newRef);
-        }
+            if (project == null)
+                CliValidation.ThrowProjectNotFound(settings.ProjectName, s.Projects.Select(p => p.Name));
 
-        config.SaveSettings();
+            if (project.Verifications.Any(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase)))
+                throw new InvalidOperationException($"Verification already exists in project: {settings.VerificationName}");
+
+            var newRef = new ProjectVerificationRef
+            {
+                Name = settings.VerificationName,
+                Required = settings.Required
+            };
+
+            if (!string.IsNullOrEmpty(settings.After))
+            {
+                var afterIndex = project.Verifications
+                    .FindIndex(v => v.Name.Equals(settings.After, StringComparison.OrdinalIgnoreCase));
+                if (afterIndex < 0)
+                    CliValidation.ThrowVerificationNotFound(settings.After, project.Verifications.Select(v => v.Name));
+                project.Verifications.Insert(afterIndex + 1, newRef);
+            }
+            else
+            {
+                project.Verifications.Add(newRef);
+            }
+        });
+
         Console.WriteLine($"Added verification: {settings.VerificationName}");
         return 0;
     }
@@ -555,20 +580,24 @@ public class ProjectRemoveVerificationCommand : Command<ProjectRemoveVerificatio
     protected override int Execute(CommandContext context, ProjectRemoveVerificationSettings settings, CancellationToken cancellationToken)
     {
         var config = new ConfigService();
-        var project = config.Settings.Projects
-            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        if (project == null)
-            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
+        config.MutateAndSave(s =>
+        {
+            var project = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        var match = project.Verifications
-            .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
+            if (project == null)
+                CliValidation.ThrowProjectNotFound(settings.ProjectName, s.Projects.Select(p => p.Name));
 
-        if (match == null)
-            CliValidation.ThrowVerificationNotFound(settings.VerificationName, project.Verifications.Select(v => v.Name));
+            var match = project.Verifications
+                .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
 
-        project.Verifications.Remove(match);
-        config.SaveSettings();
+            if (match == null)
+                CliValidation.ThrowVerificationNotFound(settings.VerificationName, project.Verifications.Select(v => v.Name));
+
+            project.Verifications.Remove(match);
+        });
+
         Console.WriteLine($"Removed verification: {settings.VerificationName}");
         return 0;
     }
@@ -583,50 +612,54 @@ public class ProjectMoveVerificationCommand : Command<ProjectMoveVerificationSet
             throw new ArgumentException("Specify exactly one of --before, --after, or --position");
 
         var config = new ConfigService();
-        var project = config.Settings.Projects
-            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+        var insertIndex = 0;
 
-        if (project == null)
-            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
-
-        var item = project.Verifications
-            .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
-
-        if (item == null)
-            CliValidation.ThrowVerificationNotFound(settings.VerificationName, project.Verifications.Select(v => v.Name));
-
-        project.Verifications.Remove(item);
-
-        int insertIndex;
-        if (settings.Before != null)
+        config.MutateAndSave(s =>
         {
-            var targetIndex = project.Verifications
-                .FindIndex(v => v.Name.Equals(settings.Before, StringComparison.OrdinalIgnoreCase));
-            if (targetIndex < 0)
+            var project = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+                CliValidation.ThrowProjectNotFound(settings.ProjectName, s.Projects.Select(p => p.Name));
+
+            var item = project.Verifications
+                .FirstOrDefault(v => v.Name.Equals(settings.VerificationName, StringComparison.OrdinalIgnoreCase));
+
+            if (item == null)
+                CliValidation.ThrowVerificationNotFound(settings.VerificationName, project.Verifications.Select(v => v.Name));
+
+            project.Verifications.Remove(item);
+
+            if (settings.Before != null)
             {
-                project.Verifications.Add(item);
-                CliValidation.ThrowVerificationTargetNotFound("before", settings.Before, project.Verifications.Select(v => v.Name));
+                var targetIndex = project.Verifications
+                    .FindIndex(v => v.Name.Equals(settings.Before, StringComparison.OrdinalIgnoreCase));
+                if (targetIndex < 0)
+                {
+                    project.Verifications.Add(item);
+                    CliValidation.ThrowVerificationTargetNotFound("before", settings.Before, project.Verifications.Select(v => v.Name));
+                }
+                insertIndex = targetIndex;
             }
-            insertIndex = targetIndex;
-        }
-        else if (settings.After != null)
-        {
-            var targetIndex = project.Verifications
-                .FindIndex(v => v.Name.Equals(settings.After, StringComparison.OrdinalIgnoreCase));
-            if (targetIndex < 0)
+            else if (settings.After != null)
             {
-                project.Verifications.Add(item);
-                CliValidation.ThrowVerificationTargetNotFound("after", settings.After, project.Verifications.Select(v => v.Name));
+                var targetIndex = project.Verifications
+                    .FindIndex(v => v.Name.Equals(settings.After, StringComparison.OrdinalIgnoreCase));
+                if (targetIndex < 0)
+                {
+                    project.Verifications.Add(item);
+                    CliValidation.ThrowVerificationTargetNotFound("after", settings.After, project.Verifications.Select(v => v.Name));
+                }
+                insertIndex = targetIndex + 1;
             }
-            insertIndex = targetIndex + 1;
-        }
-        else
-        {
-            insertIndex = Math.Clamp(settings.Position!.Value, 0, project.Verifications.Count);
-        }
+            else
+            {
+                insertIndex = Math.Clamp(settings.Position!.Value, 0, project.Verifications.Count);
+            }
 
-        project.Verifications.Insert(insertIndex, item);
-        config.SaveSettings();
+            project.Verifications.Insert(insertIndex, item);
+        });
+
         Console.WriteLine($"Moved verification '{settings.VerificationName}' to position {insertIndex}");
         return 0;
     }
@@ -637,17 +670,21 @@ public class ProjectAddBuildDepCommand : Command<ProjectAddBuildDepSettings>
     protected override int Execute(CommandContext context, ProjectAddBuildDepSettings settings, CancellationToken cancellationToken)
     {
         var config = new ConfigService();
-        var project = config.Settings.Projects
-            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        if (project == null)
-            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
+        config.MutateAndSave(s =>
+        {
+            var project = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        if (project.BuildDependencies.Contains(settings.Dependency, StringComparer.OrdinalIgnoreCase))
-            throw new InvalidOperationException($"Build dependency already exists: {settings.Dependency}");
+            if (project == null)
+                CliValidation.ThrowProjectNotFound(settings.ProjectName, s.Projects.Select(p => p.Name));
 
-        project.BuildDependencies.Add(settings.Dependency);
-        config.SaveSettings();
+            if (project.BuildDependencies.Contains(settings.Dependency, StringComparer.OrdinalIgnoreCase))
+                throw new InvalidOperationException($"Build dependency already exists: {settings.Dependency}");
+
+            project.BuildDependencies.Add(settings.Dependency);
+        });
+
         Console.WriteLine($"Added build dependency: {settings.Dependency}");
         return 0;
     }
@@ -658,17 +695,20 @@ public class ProjectRemoveBuildDepCommand : Command<ProjectRemoveBuildDepSetting
     protected override int Execute(CommandContext context, ProjectRemoveBuildDepSettings settings, CancellationToken cancellationToken)
     {
         var config = new ConfigService();
-        var project = config.Settings.Projects
-            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        if (project == null)
-            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
+        config.MutateAndSave(s =>
+        {
+            var project = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        var removed = project.BuildDependencies.RemoveAll(d => d.Equals(settings.Dependency, StringComparison.OrdinalIgnoreCase));
-        if (removed == 0)
-            CliValidation.ThrowBuildDependencyNotFound(settings.Dependency, project.BuildDependencies);
+            if (project == null)
+                CliValidation.ThrowProjectNotFound(settings.ProjectName, s.Projects.Select(p => p.Name));
 
-        config.SaveSettings();
+            var removed = project.BuildDependencies.RemoveAll(d => d.Equals(settings.Dependency, StringComparison.OrdinalIgnoreCase));
+            if (removed == 0)
+                CliValidation.ThrowBuildDependencyNotFound(settings.Dependency, project.BuildDependencies);
+        });
+
         Console.WriteLine($"Removed build dependency: {settings.Dependency}");
         return 0;
     }
@@ -679,23 +719,26 @@ public class ProjectAddReviewActionCommand : Command<ProjectAddReviewActionSetti
     protected override int Execute(CommandContext context, ProjectAddReviewActionSettings settings, CancellationToken cancellationToken)
     {
         var config = new ConfigService();
-        var project = config.Settings.Projects
-            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        if (project == null)
-            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
-
-        if (project.ReviewActions.Any(r => r.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
-            throw new InvalidOperationException($"Review action already exists: {settings.Name}");
-
-        project.ReviewActions.Add(new ReviewActionConfig
+        config.MutateAndSave(s =>
         {
-            Name = settings.Name,
-            Command = settings.Command ?? "",
-            Condition = settings.Condition ?? ""
+            var project = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
+
+            if (project == null)
+                CliValidation.ThrowProjectNotFound(settings.ProjectName, s.Projects.Select(p => p.Name));
+
+            if (project.ReviewActions.Any(r => r.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
+                throw new InvalidOperationException($"Review action already exists: {settings.Name}");
+
+            project.ReviewActions.Add(new ReviewActionConfig
+            {
+                Name = settings.Name,
+                Command = settings.Command ?? "",
+                Condition = settings.Condition ?? ""
+            });
         });
 
-        config.SaveSettings();
         Console.WriteLine($"Added review action: {settings.Name}");
         return 0;
     }
@@ -706,20 +749,24 @@ public class ProjectRemoveReviewActionCommand : Command<ProjectRemoveReviewActio
     protected override int Execute(CommandContext context, ProjectRemoveReviewActionSettings settings, CancellationToken cancellationToken)
     {
         var config = new ConfigService();
-        var project = config.Settings.Projects
-            .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        if (project == null)
-            CliValidation.ThrowProjectNotFound(settings.ProjectName, config.Settings.Projects.Select(p => p.Name));
+        config.MutateAndSave(s =>
+        {
+            var project = s.Projects
+                .FirstOrDefault(p => p.Name.Equals(settings.ProjectName, StringComparison.OrdinalIgnoreCase));
 
-        var match = project.ReviewActions
-            .FirstOrDefault(r => r.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
+            if (project == null)
+                CliValidation.ThrowProjectNotFound(settings.ProjectName, s.Projects.Select(p => p.Name));
 
-        if (match == null)
-            CliValidation.ThrowReviewActionNotFound(settings.Name, project.ReviewActions.Select(r => r.Name));
+            var match = project.ReviewActions
+                .FirstOrDefault(r => r.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-        project.ReviewActions.Remove(match);
-        config.SaveSettings();
+            if (match == null)
+                CliValidation.ThrowReviewActionNotFound(settings.Name, project.ReviewActions.Select(r => r.Name));
+
+            project.ReviewActions.Remove(match);
+        });
+
         Console.WriteLine($"Removed review action: {settings.Name}");
         return 0;
     }

--- a/src/Ivy.Tendril/Commands/VerificationCommand.cs
+++ b/src/Ivy.Tendril/Commands/VerificationCommand.cs
@@ -166,20 +166,23 @@ public class VerificationAddCommand : Command<VerificationAddSettings>
     {
         var config = new ConfigService();
 
-        if (config.Settings.Verifications.Any(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
-            throw new InvalidOperationException($"Verification already exists: {settings.Name}");
-
+        // Read stdin before taking the config lock: ResolveInput can block on a pipe for its timeout.
         var prompt = ConsoleHelper.ResolveInput(settings.Stdin, settings.FilePath, settings.Prompt);
         if (string.IsNullOrWhiteSpace(prompt))
             throw new ArgumentException("Provide --prompt, --file, or --stdin");
 
-        config.Settings.Verifications.Add(new VerificationConfig
+        config.MutateAndSave(s =>
         {
-            Name = settings.Name,
-            Prompt = prompt
+            if (s.Verifications.Any(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase)))
+                throw new InvalidOperationException($"Verification already exists: {settings.Name}");
+
+            s.Verifications.Add(new VerificationConfig
+            {
+                Name = settings.Name,
+                Prompt = prompt
+            });
         });
 
-        config.SaveSettings();
         Console.WriteLine($"Added verification definition: {settings.Name}");
         return 0;
     }
@@ -190,14 +193,18 @@ public class VerificationRemoveCommand : Command<VerificationRemoveSettings>
     protected override int Execute(CommandContext context, VerificationRemoveSettings settings, CancellationToken cancellationToken)
     {
         var config = new ConfigService();
-        var match = config.Settings.Verifications
-            .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-        if (match == null)
-            CliValidation.ThrowVerificationNotFound(settings.Name, config.Settings.Verifications.Select(v => v.Name));
+        config.MutateAndSave(s =>
+        {
+            var match = s.Verifications
+                .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-        config.Settings.Verifications.Remove(match);
-        config.SaveSettings();
+            if (match == null)
+                CliValidation.ThrowVerificationNotFound(settings.Name, s.Verifications.Select(v => v.Name));
+
+            s.Verifications.Remove(match);
+        });
+
         Console.WriteLine($"Removed verification definition: {settings.Name}");
         return 0;
     }
@@ -208,30 +215,34 @@ public class VerificationSetCommand : Command<VerificationSetSettings>
     protected override int Execute(CommandContext context, VerificationSetSettings settings, CancellationToken cancellationToken)
     {
         var config = new ConfigService();
-        var match = config.Settings.Verifications
-            .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-        if (match == null)
-            CliValidation.ThrowVerificationNotFound(settings.Name, config.Settings.Verifications.Select(v => v.Name));
-
+        // Read stdin before taking the config lock: ResolveInput can block on a pipe for its timeout.
         var value = ConsoleHelper.ResolveInput(settings.Stdin, settings.FilePath, settings.Value);
 
         if (string.IsNullOrEmpty(value))
             throw new ArgumentException("value is required (use an inline <value>, --file, or --stdin)");
 
-        switch (settings.Field.ToLower())
+        config.MutateAndSave(s =>
         {
-            case "name":
-                match.Name = value;
-                break;
-            case "prompt":
-                match.Prompt = value;
-                break;
-            default:
-                throw new ArgumentException($"Unknown field: {settings.Field}. Valid fields: name, prompt");
-        }
+            var match = s.Verifications
+                .FirstOrDefault(v => v.Name.Equals(settings.Name, StringComparison.OrdinalIgnoreCase));
 
-        config.SaveSettings();
+            if (match == null)
+                CliValidation.ThrowVerificationNotFound(settings.Name, s.Verifications.Select(v => v.Name));
+
+            switch (settings.Field.ToLower())
+            {
+                case "name":
+                    match.Name = value;
+                    break;
+                case "prompt":
+                    match.Prompt = value;
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown field: {settings.Field}. Valid fields: name, prompt");
+            }
+        });
+
         var summary = value.Length <= 60 && !value.Contains('\n') ? $"to '{value}'" : $"({value.Length} chars)";
         Console.WriteLine($"Updated verification {settings.Field} {summary}");
         return 0;

--- a/src/Ivy.Tendril/Helpers/ConfigFileLock.cs
+++ b/src/Ivy.Tendril/Helpers/ConfigFileLock.cs
@@ -1,0 +1,90 @@
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+///     Cross-process file lock for config.yaml read-modify-write cycles.
+///     CLI/MCP commands each load the whole file, mutate one field, and serialize the whole
+///     graph back, so two unsynchronized writers silently drop one another's change.
+///     <see cref="Services.ConfigService.MutateAndSave"/> is the single acquisition site: acquiring
+///     again while the lock is held (for example from a nested WriteSettingsToDisk) would deadlock.
+/// </summary>
+public static class ConfigFileLock
+{
+    private const int MaxRetries = 50;
+    private const int DelayMs = 100;
+
+    /// <summary>
+    ///     FileShare.None does not exclude two handles opened by the same process, and the TUI has
+    ///     many in-process SaveSettings() sites plus a FileSystemWatcher reload, so the file lock
+    ///     alone is not enough. Same belt-and-braces pairing as PlanYamlHelper.AllocatePlanId, but a
+    ///     semaphore rather than a monitor because the handle may be disposed on another thread.
+    /// </summary>
+    private static readonly SemaphoreSlim InProcessLock = new(1, 1);
+
+    /// <summary>
+    ///     Blocks until exclusive access to <paramref name="configPath"/> is held, then returns a
+    ///     handle that releases it on dispose. Throws <see cref="TimeoutException"/> after the retry
+    ///     budget expires, which the CLI surfaces as "Error: ..." and exit 1: the loser of a race
+    ///     fails loudly instead of silently dropping the winner's write.
+    ///     An empty <paramref name="configPath"/> (the fresh-install path where TendrilHome is unset)
+    ///     yields a no-op handle rather than throwing.
+    /// </summary>
+    public static IDisposable Acquire(string configPath) =>
+        Acquire(configPath, MaxRetries, DelayMs);
+
+    /// <summary>Overload with an explicit retry budget so tests can assert the timeout without waiting for it.</summary>
+    internal static IDisposable Acquire(string configPath, int maxRetries, int delayMs)
+    {
+        if (string.IsNullOrEmpty(configPath))
+            return new NoOpLock();
+
+        var lockPath = configPath + ".lock";
+        var budgetMs = maxRetries * delayMs;
+
+        if (!InProcessLock.Wait(budgetMs))
+            throw new TimeoutException(
+                $"Could not acquire config lock at {lockPath} after {budgetMs}ms (held by this process)");
+
+        try
+        {
+            for (var i = 0; i < maxRetries; i++)
+                try
+                {
+                    var stream = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite,
+                        FileShare.None, bufferSize: 1, FileOptions.DeleteOnClose);
+                    return new FileLockHandle(stream);
+                }
+                catch (IOException) when (i < maxRetries - 1)
+                {
+                    Thread.Sleep(delayMs);
+                }
+
+            throw new TimeoutException($"Could not acquire config lock at {lockPath} after {budgetMs}ms");
+        }
+        catch
+        {
+            InProcessLock.Release();
+            throw;
+        }
+    }
+
+    /// <summary>Releases the file handle first, then the in-process semaphore, mirroring acquisition order.</summary>
+    private sealed class FileLockHandle(FileStream stream) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            stream.Dispose();
+            InProcessLock.Release();
+        }
+    }
+
+    private sealed class NoOpLock : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Ivy.Tendril/Helpers/ConfigFileLock.cs
+++ b/src/Ivy.Tendril/Helpers/ConfigFileLock.cs
@@ -57,6 +57,15 @@ public static class ConfigFileLock
                 {
                     Thread.Sleep(delayMs);
                 }
+                catch (IOException ex)
+                {
+                    // Budget exhausted. Translate rather than letting the raw sharing violation out:
+                    // "cannot access the file" does not say that we waited, and callers should see the
+                    // same exception whichever holder (this process or another) won.
+                    // PlanFileLock leaves its equivalent throw unreachable for this reason.
+                    throw new TimeoutException(
+                        $"Could not acquire config lock at {lockPath} after {budgetMs}ms", ex);
+                }
 
             throw new TimeoutException($"Could not acquire config lock at {lockPath} after {budgetMs}ms");
         }

--- a/src/Ivy.Tendril/Mcp/Tools/ConfigTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/ConfigTools.cs
@@ -34,8 +34,7 @@ public sealed class ConfigTools : AuthenticatedToolBase
         return ExecuteAuthenticated(() =>
         {
             // ApplyField throws on unknown key / bad int / out-of-range / unknown coding agent, before any write.
-            ConfigSetCommand.ApplyField(_configService.Settings, key, value, _runner.RegisteredAgents);
-            _configService.SaveSettings();
+            _configService.MutateAndSave(s => ConfigSetCommand.ApplyField(s, key, value, _runner.RegisteredAgents));
 
             // Report the value actually stored (e.g. the canonical coding-agent id), not the raw input.
             var stored = ConfigGetCommand.ReadField(_configService.Settings, key);

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -510,13 +510,42 @@ public class ConfigService : IConfigService, IDisposable
 
     public event EventHandler? SettingsReloaded;
 
+    /// <summary>
+    ///     Writes the current in-memory <see cref="Settings"/> over config.yaml, then reloads.
+    ///     Deliberately unlocked: the in-process TUI and the onboarding path build
+    ///     <see cref="Settings"/> from pending values that a reload would clobber. Out-of-process
+    ///     mutators (CLI, MCP) must use <see cref="MutateAndSave"/> instead, or a concurrent writer's
+    ///     change is silently lost, since this serializes the whole settings graph, not one field.
+    /// </summary>
     public void SaveSettings()
     {
         WriteSettingsToDisk();
         ReloadSettings();
     }
 
-    /// <summary>Serializes current <see cref="Settings"/> and writes <see cref="ConfigPath"/> (with backup). Does not reload.</summary>
+    /// <summary>
+    ///     Re-reads config.yaml under the cross-process lock, applies <paramref name="mutate"/> to the
+    ///     fresh settings, and writes them back before releasing. Use this for every out-of-process
+    ///     mutation so a concurrent writer cannot lose the change.
+    ///     The callback must do its own lookups against the <see cref="TendrilSettings"/> argument:
+    ///     anything resolved from <see cref="Settings"/> beforehand refers to a graph the reload has
+    ///     already replaced. Do not read stdin inside the callback, which would hold the lock for the
+    ///     duration of a blocking pipe read.
+    /// </summary>
+    public void MutateAndSave(Action<TendrilSettings> mutate)
+    {
+        using var _ = ConfigFileLock.Acquire(ConfigPath);
+        // Pick up whatever a competing writer committed between this service's construction and now.
+        ReloadSettings();
+        mutate(Settings);
+        WriteSettingsToDisk();
+    }
+
+    /// <summary>
+    ///     Serializes current <see cref="Settings"/> and writes <see cref="ConfigPath"/> (with backup). Does not reload.
+    ///     Never acquires <see cref="ConfigFileLock"/>: <see cref="MutateAndSave"/> already holds it, and
+    ///     <see cref="SyncAuthFromEnvironmentAndPersistIfNeeded"/> reaches here from inside that lock.
+    /// </summary>
     private void WriteSettingsToDisk()
     {
         _levelNamesCache = null;

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -585,6 +585,10 @@ public class ConfigService : IConfigService, IDisposable
             _levelNamesCache = null;
             VariableExpansion.InitializeUserSecrets(_logger);
             ExpandSettingsVariables();
+            // Same expansion the constructor applies via FinalizeConfiguration. Callers treat
+            // repo.Path as expanded and forward-slashed, so a reload that skipped this would hand
+            // out raw backslashed paths and MutateAndSave would then persist them in that form.
+            ExpandRepoPaths();
 
             SyncAuthFromEnvironmentAndPersistIfNeeded();
             SettingsReloaded?.Invoke(this, EventArgs.Empty);

--- a/src/Ivy.Tendril/Services/IConfigService.cs
+++ b/src/Ivy.Tendril/Services/IConfigService.cs
@@ -20,6 +20,10 @@ public interface IConfigService : IDisposable
     Colors? GetLevelColor(string level);
     Colors? GetProjectColor(string projectName);
     void SaveSettings();
+
+    /// <summary>Reloads, mutates and saves config.yaml under a cross-process lock. Use from CLI/MCP instead of <see cref="SaveSettings"/>.</summary>
+    void MutateAndSave(Action<TendrilSettings> mutate);
+
     void ReloadSettings();
     event EventHandler? SettingsReloaded;
     void SetPendingTendrilHome(string path);


### PR DESCRIPTION
# Plan 00121: Serialize Config Writes So a Concurrent Verification Set Cannot Silently Drop a Sibling Prompt

**Job:** 01318. **Branch:** `tendril/00121-SerializeConfigWritesSoAConcurrentVerificationSetCannotSilen`
(worktree, base `8d1ec1c3` on `development`). **All 4 in-scope verifications Pass**, 2 Skipped
(frontend, nothing touched).

## What was wrong

`tendril verification set` and every other `config.yaml` mutator was a read-modify-write with no
concurrency control. `ConfigService` loads the whole file in its constructor, the command mutates one
field, and `SaveSettings()` serializes the **entire** settings graph back. Two processes writing
different keys in the same window therefore produced a file where one write never happened, and
**both processes printed success and exited 0**. The plan measured 7 lost writes in 7 paired
iterations (job 01280). Nothing detected it, so the only mitigation was remembering to re-read every
sibling key afterwards.

## What was built

An advisory lock, per the plan's chosen option, modelled on the `PlanFileLock` the repo already uses
for the identical `plan.yaml` hazard.

| Commit | Contents |
| --- | --- |
| `0bad94a4` | `Helpers/ConfigFileLock.cs`, `ConfigService.MutateAndSave`, `IConfigService` member, 8 test doubles |
| `2cb2271d` | The 17 out-of-process `SaveSettings()` sites converted to `MutateAndSave` |
| `3b037cf0` | `ConfigFileLockTests.cs` and the `VerificationCommandTests` sibling-survival case |
| `efabd89f` | Fix: `ReloadSettings` must run `ExpandRepoPaths` (regression found by DotnetTest) |
| `5106242b` | Fix: foreign lock holder must yield `TimeoutException`, not raw `IOException` (found by CheckResult) |

`ConfigFileLock` is `configPath + ".lock"` opened `FileShare.None` + `DeleteOnClose`, retried 50 x
100ms, then a `TimeoutException` naming the path, which the CLI surfaces as `Error: ...` and exit 1.
That is the "fails loudly" property the plan wanted in place of compare-and-swap. It also holds an
in-process `SemaphoreSlim`, because `FileShare.None` does not exclude two handles in the same process
and the TUI has 21 in-process writers plus a `FileSystemWatcher` reload.

`MutateAndSave` acquires the lock, reloads, applies the callback, writes, releases. Acquisition
happens at exactly **one** site, which matters: `ReloadSettings` reaches `WriteSettingsToDisk` through
`SyncAuthFromEnvironmentAndPersistIfNeeded`, so a second acquisition inside the write would deadlock.

The 21 `Apps/` sites deliberately stay on `SaveSettings()`; converting them would let a reload stomp
unsaved dialog state, and the in-process guard is what protects them from a concurrent CLI. Both
methods now carry doc comments saying which to use, so the split reads as intentional.

## Proof it works

Against a published build in an isolated `TENDRIL_HOME`, re-running the plan's own reproduction:

```
before (plan's measurement):  7 of 7 iterations lost a write
after:                        0 of 7
```

The cross-command case the plan calls out (`project add-repo` racing `verification set`) also keeps
both writes. With the lock held by a foreign process, a write exits 1 after the full 5s budget with
`Error: Could not acquire config lock at ...config.yaml.lock after 5000ms` and leaves the config
untouched.

182/182 tests pass in the plan's filter. The regression test was proven non-vacuous, and each half of
the fix proven load-bearing, by mutation: swapping `MutateAndSave` back for load+mutate+`SaveSettings`
fails 3/3 with `Expected: "RACE-BETA" / Actual: "SEED-BETA"` (the losing write reverting to its seed,
exactly the reported bug); removing the reload fails 2; removing the lock fails 1. Every probe was
reverted and `grep -rn "MUTATION PROBE"` returns nothing.

## Where I diverged from the plan, and why

**1. Eight `IConfigService` test doubles, not four.** The plan names
`FreshInstallConfigService`, `TestConfigService` (GitServiceTests), `StubConfigService` and
`TestPlanConfigService`. There are also `TestConfigService` in `JobServiceConcurrencyTests`,
`FakeConfigService` in `JobServiceDeletionTests`, and `FakeConfigService` in `JobServiceStartupTests`.
All 8 were updated; an interface member is not optional, so the build would fail otherwise. Flagged in
`Verification/PreExecution.md` before implementation.

**2. `SemaphoreSlim` instead of the sketched `private static readonly object InProcessLock = new()`.**
The plan's snippet implies `Monitor`, which is thread-affine. The returned `IDisposable` can be
disposed on a different thread than acquired it, which would throw
`SynchronizationLockException`. Same intent and same reference (`AllocatePlanId`), correct primitive.

**3. Three tests beyond the plan's five.** `Acquire_LockFileIsDeletedOnRelease` turns the plan's step 4
prose into an assertion; the other two are regression tests for the defects below.

**4. Two defects found during verification, fixed here rather than deferred.**

- `ReloadSettings` skipped the `ExpandRepoPaths` that the constructor's `FinalizeConfiguration`
  applies. Latent before this plan, because nothing reloaded mid-command; but `MutateAndSave` reloads
  inside the lock by design, so the callback started seeing raw backslashed repo paths and would have
  persisted them, breaking `ProjectConfig.GetRepoRef`. Caught by
  `ProjectCommandTests.RemoveRepo_NotFound_ListsAvailable`, which was only in scope because the plan
  said to add `ProjectCommandTests` to the filter if the class existed.
- The cross-process lock path threw a raw `IOException`. The retry loop's `when (i < maxRetries - 1)`
  filter stops catching on the last attempt, so the trailing `throw new TimeoutException` was
  unreachable for a foreign holder. Only the in-process branch produced a `TimeoutException`, and the
  plan's `Acquire_TimesOutLoudly` goes through exactly that branch, so the suite could not catch it.
  Found only by exercising the CLI end to end, as CheckResult step 6 requires. `PlanFileLock` has the
  same unreachable throw (filed as a recommendation, not changed here).

## Not done, deliberately

- `Ivy.Tendril.Agents.Test` does not satisfy `-warnaserror` on `development` (pre-existing CS8602 at
  `AntigravityEventParserTests.cs:38`). Proven pre-existing rather than assumed: last touched by
  `45874d50`, an ancestor of `development`; the file is byte-identical to `development`; this plan
  changes no file in that project; and `Ivy.Tendril.Agents` has no ProjectReference to `Ivy.Tendril`,
  so it cannot see any of these changes. Left alone per the DotnetBuild prompt's "warnings introduced
  by the plan", filed as a recommendation.
- `ConfigService.SetTendrilHome` is a third load path that also skips `ExpandRepoPaths`. It is
  `internal` and test-only, not on the `MutateAndSave` path. Filed as a recommendation.
- No PR was opened and the plan state was not changed, per the ExecutePlan rules. The worktree is
  clean and left in place.

## Artifacts

- `Verification/PreExecution.md`, `DotnetFormat.md`, `DotnetBuild.md`, `DotnetTest.md`, `CheckResult.md`
- `Artifacts/recommendations.md`

---

## Commits
- 5106242b Throw TimeoutException when a foreign holder owns the config lock (plan 00121)
- efabd89f Expand repo paths on reload so MutateAndSave keeps them normalized (plan 00121)
- 3b037cf0 Add ConfigFileLock and concurrent-writer tests (plan 00121)
- 2cb2271d Convert the 17 out-of-process config mutators to MutateAndSave (plan 00121)
- 0bad94a4 Add ConfigFileLock and ConfigService.MutateAndSave (plan 00121)

---
Created using [Ivy Tendril](https://ivy.app).
