### PR TITLE
Fix secondary instance job duplication and master check

### DIFF
--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -412,6 +412,7 @@ public class Program
         bool forceDesktop = args.Contains("--desktop");
         bool forceWeb = args.Contains("--web");
         bool beta = args.Contains("--beta");
+        bool notMaster = args.Contains("--not-master") || args.Contains("--slave");
 
         if (verbose)
             Environment.SetEnvironmentVariable("TENDRIL_VERBOSE", "1");
@@ -419,12 +420,15 @@ public class Program
             Environment.SetEnvironmentVariable("TENDRIL_QUIET", "1");
         if (beta)
             Environment.SetEnvironmentVariable("TENDRIL_BETA", "1");
+        if (notMaster)
+            Environment.SetEnvironmentVariable("TENDRIL_NOT_MASTER", "1");
 
         var filtered = args.Where(a =>
             a != "--desktop" && a != "--web" &&
             a != "--verbose" && a != "-v" &&
             a != "--quiet" && a != "-q" &&
             a != "--beta" &&
+            a != "--not-master" && a != "--slave" &&
             a != DetachedLaunchMarker).ToArray();
 
         return (verbose, quiet, forceDesktop, forceWeb, beta, filtered);

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -672,6 +672,9 @@ public class JobService : IJobService
     /// </summary>
     private void ReconcileRestoredJob(JobItem job)
     {
+        if (Environment.GetEnvironmentVariable("TENDRIL_NOT_MASTER") == "1" || IsOtherMasterRunning())
+            return;
+
         if (job.Status is not (JobStatus.Pending or JobStatus.Queued or JobStatus.Running))
             return;
 
@@ -687,11 +690,58 @@ public class JobService : IJobService
             return;
         }
 
-        job.Status = JobStatus.Failed;
-        job.StatusMessage = "Interrupted by Tendril master restart";
-        job.CompletedAt = DateTime.UtcNow;
-        PersistJob(job);
-        _logger.LogWarning("Job {JobId}: Marked Failed — interrupted by a Tendril master restart", job.Id);
+        // Only mark RUNNING jobs as failed when their process is dead.
+        // Pending and Queued jobs do not have a process yet and must not be marked failed.
+        if (job.Status == JobStatus.Running)
+        {
+            job.Status = JobStatus.Failed;
+            job.StatusMessage = "Interrupted by Tendril master restart";
+            job.CompletedAt = DateTime.UtcNow;
+            PersistJob(job);
+            _logger.LogWarning("Job {JobId}: Marked Failed — interrupted by a Tendril master restart", job.Id);
+        }
+    }
+
+    private bool IsOtherMasterRunning()
+    {
+        if (_configService == null || string.IsNullOrEmpty(_configService.TendrilHome))
+            return false;
+
+        var masterFilePath = Path.Combine(_configService.TendrilHome, ".master");
+        if (!File.Exists(masterFilePath)) return false;
+
+        try
+        {
+            var json = File.ReadAllText(masterFilePath);
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("pid", out var pidElem) && pidElem.TryGetInt32(out var pid))
+            {
+                if (pid == Environment.ProcessId) return false;
+                try
+                {
+                    using var proc = System.Diagnostics.Process.GetProcessById(pid);
+                    if (!proc.HasExited)
+                    {
+                        if (root.TryGetProperty("heartbeat", out var hbElem) && hbElem.TryGetDateTime(out var hb))
+                        {
+                            if (DateTime.UtcNow - hb.ToUniversalTime() <= TimeSpan.FromSeconds(90))
+                                return true;
+                        }
+                    }
+                }
+                catch
+                {
+                    // Process not found or access denied
+                }
+            }
+        }
+        catch
+        {
+            // Ignore errors reading master file
+        }
+
+        return false;
     }
 
     // Grace on the PID-reuse guard: the agent process starts shortly after the job does, so its


### PR DESCRIPTION
Prevents secondary or non-master Tendril instances from marking restored jobs as failed and triggering duplicate job loops.