### PR TITLE
[00144] Make add-worktree Verify the Directory Is Gone Instead of Trusting git worktree remove's Exit Code

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md
@@ -264,6 +264,8 @@ done
 
 2. **Still install dependencies for any verification you will run.** A copied artifact directory is a build *output*, not a dependency tree - it never removes the need for an install. A fresh worktree has no `node_modules` at all, so the package manager must run before any lint, typecheck, build or test step, whether or not the plan touched that code. Never treat a populated dependency directory as evidence of a current one: install unconditionally, using the lockfile-respecting form (`pnpm install --frozen-lockfile`, `npm ci`, `yarn install --immutable`). It costs seconds when the tree is already correct, and a skipped install means exercising whatever version happens to be on disk. If the lockfile-respecting form fails because the plan edited a manifest without regenerating the lockfile, that is a real finding: re-run the plain install and commit the updated lockfile.
 
+A fresh worktree has no dependency tree, so this first install is a full one: measured at about 50 seconds for a mid-size pnpm frontend, not the 1 to 2 seconds a no-op install takes. Budget for it, and report status before starting so the run does not look stalled. Note also that the install may execute the project's `prepare` script (husky), which in a worktree sets that worktree's `core.hooksPath`. That is expected and does not need undoing.
+
 #### Exception Path (Build-Dependent Code Changes): Install and Rebuild
 
 If the plan **modifies** build-dependent code, you MUST rebuild:

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -1660,6 +1660,125 @@ public class PlanCliCommandTests : IDisposable
         Assert.Contains("git worktree add failed", output);
     }
 
+    /// <summary>
+    /// Creates the residue that makes `git worktree remove --force` exit 0 while leaving the
+    /// directory behind: a junction (Windows) or symlink (elsewhere) under a pnpm-shaped
+    /// node_modules tree, which is what a real `pnpm install` builds. Returns false if the link
+    /// could not be created, in which case the caller should skip.
+    /// </summary>
+    private static bool CreateJunctionResidue(string worktreePath)
+    {
+        var target = Path.Combine(worktreePath, "node_modules", ".pnpm", "real", "node_modules", "pkg");
+        Directory.CreateDirectory(target);
+        File.WriteAllText(Path.Combine(target, "index.js"), "module.exports = {};");
+
+        var linkParent = Path.Combine(worktreePath, "node_modules", ".pnpm", "node_modules");
+        Directory.CreateDirectory(linkParent);
+        var link = Path.Combine(linkParent, "j1");
+
+        if (OperatingSystem.IsWindows())
+        {
+            // A junction, not a symlink: symlink creation needs elevation or developer mode,
+            // while `mklink /J` works unprivileged, and pnpm uses junctions on Windows anyway.
+            using var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("cmd.exe")
+            {
+                ArgumentList = { "/c", "mklink", "/J", link, target },
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            });
+            p?.WaitForExit(15000);
+        }
+        else
+        {
+            try
+            {
+                Directory.CreateSymbolicLink(link, target);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                return false;
+            }
+        }
+
+        return Directory.Exists(link);
+    }
+
+    [Fact]
+    public void PlanAddWorktreeCommand_SucceedsWhenGitLeavesJunctionResidue()
+    {
+        var repo = SetUpRemoteAndWorkRepo();
+        if (repo == null) return; // git unavailable, skip
+
+        CreatePlanFolder("21006", "AddWorktreeJunctionResidue");
+        var app = BuildPlanAddWorktreeApp();
+
+        Assert.Equal(0, app.Run(["plan", "add-worktree", "21006", repo]));
+
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder("21006");
+        var worktreePath = Path.Combine(planFolder, "Worktrees", Path.GetFileName(repo));
+        if (!CreateJunctionResidue(worktreePath)) return; // links unavailable, skip
+
+        // `git worktree remove --force` exits 0 here but leaves the directory skeleton, so the
+        // second add must clear it itself rather than trusting git's exit code.
+        var secondExit = app.Run(["plan", "add-worktree", "21006", repo]);
+
+        Assert.Equal(0, secondExit);
+        Assert.True(Directory.Exists(worktreePath));
+        Assert.True(File.Exists(Path.Combine(worktreePath, ".git")));
+    }
+
+    [Fact]
+    public void PlanAddWorktreeCommand_FailsWhenResidueCannotBeDeleted()
+    {
+        if (!OperatingSystem.IsWindows()) return; // Only Windows blocks deletion of an open file
+
+        var repo = SetUpRemoteAndWorkRepo();
+        if (repo == null) return; // git unavailable, skip
+
+        CreatePlanFolder("21007", "AddWorktreeResidueLocked");
+        var app = BuildPlanAddWorktreeApp();
+
+        Assert.Equal(0, app.Run(["plan", "add-worktree", "21007", repo]));
+
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder("21007");
+        var worktreePath = Path.Combine(planFolder, "Worktrees", Path.GetFileName(repo));
+        if (!CreateJunctionResidue(worktreePath)) return; // links unavailable, skip
+
+        var lockedFile = Path.Combine(
+            worktreePath, "node_modules", ".pnpm", "real", "node_modules", "pkg", "index.js");
+        var stream = new FileStream(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None);
+        string output;
+        try
+        {
+            output = CaptureAnsiConsoleOutput(() =>
+            {
+                var exit = app.Run(["plan", "add-worktree", "21007", repo]);
+                Assert.NotEqual(0, exit);
+            });
+        }
+        finally
+        {
+            stream.Dispose();
+        }
+
+        // The failure must be reported at the removal step, naming the directory, not deferred to
+        // a confusing `fatal: ... already exists` from `git worktree add`. AnsiConsole hard-wraps
+        // long paths, so compare with whitespace stripped.
+        Assert.Contains("Failed to remove existing worktree", output);
+        Assert.Contains(
+            string.Concat(worktreePath.Where(c => !char.IsWhiteSpace(c))),
+            string.Concat(output.Where(c => !char.IsWhiteSpace(c))));
+        Assert.DoesNotContain("git worktree add failed", output);
+
+        // Both attempts must be accounted for: a locked file makes git's own removal exit non-zero,
+        // so reporting only that (as the pre-fix code did) hides whether the force-delete fallback
+        // ran at all. The message names git's stderr and the force-delete outcome separately.
+        Assert.Contains("git worktree remove reported:", output);
+        Assert.Contains("Force delete failed:", output);
+    }
+
     // ==================== PlanWriteRevision (--file / --stdin) ====================
 
     private static CommandApp BuildPlanWriteRevisionApp()

--- a/src/Ivy.Tendril/Commands/PlanAddWorktreeCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddWorktreeCommand.cs
@@ -52,12 +52,46 @@ public class PlanAddWorktreeCommand : Command<PlanAddWorktreeSettings>
 
         if (Directory.Exists(worktreePath))
         {
-            var (removeExitCode, _, removeStdErr) = GitHelper.RunGit($"worktree remove --force \"{worktreePath}\"", settings.Repo);
-            if (removeExitCode != 0)
+            // `git worktree remove --force` exits 0 even when it leaves the directory skeleton
+            // behind: measured on git 2.54 against a real pnpm tree, 1,132 directories survived a
+            // successful removal because the tree contains symlinks and NTFS junctions. Git's own
+            // metadata does go, so `worktree list` and `worktree prune` both consider the worktree
+            // gone, and only the leftover directory remains to make `worktree add` fail later with
+            // a misleading `fatal: ... already exists`. So the exit code is not the answer here:
+            // whether the directory is gone is. A 650 MB tree took 41 s to remove, close enough to
+            // RunGit's 60 s default to warrant an explicit longer timeout.
+            var (_, _, removeStdErr) = GitHelper.RunGit($"worktree remove --force \"{worktreePath}\"", settings.Repo, 180000);
+
+            if (Directory.Exists(worktreePath))
             {
-                AnsiConsole.MarkupLine($"[red]Failed to remove existing worktree at {worktreePath.EscapeMarkup()}:[/]");
-                AnsiConsole.MarkupLine(removeStdErr.EscapeMarkup());
-                return 1;
+                var forceDeleteError = "";
+                try
+                {
+                    WorktreeCleanupService.ForceDeleteDirectory(worktreePath, _logger);
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    forceDeleteError = ex.Message;
+                }
+
+                if (Directory.Exists(worktreePath))
+                {
+                    AnsiConsole.MarkupLine($"[red]Failed to remove existing worktree at {worktreePath.EscapeMarkup()}:[/]");
+                    AnsiConsole.MarkupLine(string.IsNullOrWhiteSpace(removeStdErr)
+                        ? "git worktree remove produced no stderr."
+                        : $"git worktree remove reported: {removeStdErr.Trim().EscapeMarkup()}");
+                    AnsiConsole.MarkupLine(string.IsNullOrWhiteSpace(forceDeleteError)
+                        ? "The force delete completed without error but the directory is still present."
+                        : $"Force delete failed: {forceDeleteError.EscapeMarkup()}");
+                    return 1;
+                }
+
+                // Deleting the directory ourselves bypasses git, so if the removal above did not
+                // finish (a timeout kills it mid-delete, which is the other reason its exit code is
+                // ignored) the worktree stays registered under .git/worktrees and `add` then fails
+                // with `is a missing but already registered worktree`. Prune clears that; it is a
+                // no-op when the removal did complete.
+                GitHelper.RunGit("worktree prune", settings.Repo, 30000);
             }
 
             // Re-executing a plan is a normal occurrence (ExecutePlan re-runs after review

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -299,6 +299,8 @@ done
 
 2. **Still install dependencies for any verification you will run.** A copied artifact directory is a build *output*, not a dependency tree - it never removes the need for an install. A fresh worktree has no `node_modules` at all, so the package manager must run before any lint, typecheck, build or test step, whether or not the plan touched that code. Never treat a populated dependency directory as evidence of a current one: install unconditionally, using the lockfile-respecting form (`pnpm install --frozen-lockfile`, `npm ci`, `yarn install --immutable`). It costs seconds when the tree is already correct, and a skipped install means exercising whatever version happens to be on disk. If the lockfile-respecting form fails because the plan edited a manifest without regenerating the lockfile, that is a real finding: re-run the plain install and commit the updated lockfile.
 
+A fresh worktree has no dependency tree, so this first install is a full one: measured at about 50 seconds for a mid-size pnpm frontend, not the 1 to 2 seconds a no-op install takes. Budget for it, and report status before starting so the run does not look stalled. Note also that the install may execute the project's `prepare` script (husky), which in a worktree sets that worktree's `core.hooksPath`. That is expected and does not need undoing.
+
 #### Exception Path (Build-Dependent Code Changes): Install and Rebuild
 
 If the plan **modifies** build-dependent code, you MUST rebuild:


### PR DESCRIPTION
# Summary

## Changes

`tendril plan add-worktree` no longer trusts `git worktree remove --force`'s exit code when clearing a
stale worktree. Git exits 0 while leaving the directory skeleton behind whenever the tree contains
symlinks or NTFS junctions (which is what a real pnpm `node_modules` is built from), and the residue
then surfaces later as a misleading `fatal: ... already exists` from `worktree add`, unrecoverable by
re-running. The command now checks whether the directory is actually gone and force-deletes it if not.
ExecutePlan's step 2.5 also gained a paragraph recording what a fresh-worktree dependency install
really costs.

## API Changes

None. No public signature changed. `PlanAddWorktreeCommand` gained an internal dependency on
`WorktreeCleanupService.ForceDeleteDirectory`, which was already `internal` in the same assembly.

Behavioral change to the `tendril plan add-worktree` CLI command: it now succeeds on a stale worktree
directory that git's own removal left behind, and when removal is genuinely impossible it fails at the
removal step with a message naming both git's stderr and the force-delete outcome, instead of failing
later and blaming `worktree add`.

## Files Modified

**Fix**
- `src/Ivy.Tendril/Commands/PlanAddWorktreeCommand.cs` - the removal block now verifies its own result,
  falls back to `WorktreeCleanupService.ForceDeleteDirectory`, prunes git's worktree registration after
  a force delete, and passes an explicit 180 s timeout to the removal.

**Tests**
- `src/Ivy.Tendril.Test/PlanCliCommandTests.cs` - two tests plus a `CreateJunctionResidue` helper.

**Firmware prose**
- `src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md`
- `src/Ivy.Tendril.TeamIvyConfig/Promptwares/ExecutePlan/Program.md`

## Where I Diverged From the Plan, and Why

**Added one line the plan did not specify.** The plan's design leans on the force-delete fallback to
recover from a removal *timeout*. Probing showed it does not: deleting the directory outside git leaves
the worktree registered under `.git/worktrees`, and the next add fails with `is a missing but already
registered worktree` (exit 128). A `git worktree prune` after a successful force delete closes that gap
and is a no-op otherwise. Exercised end to end with the real binary; see `Verification/CheckResult.md`.

**Strengthened the second test.** The plan's `FailsWhenResidueCannotBeDeleted` as specified (assert
non-zero exit, message mentions the directory) **passed at the base commit**, so it proved nothing: a
locked file already makes git's own removal exit non-zero (`exit=255`, `error: failed to delete ...:
Invalid argument`). The assertions now also require the message to account for git's stderr and the
force-delete outcome separately, which is what the fix actually changed. It fails at base with that
assertion. The plan's instruction not to weaken it to accept the pre-fix `already exists` text was
honored.

**Skipped one command in the plan's Verify block.** `dotnet build src/Ivy.Tendril/Ivy.Tendril.slnx`
cannot run from a plan worktree: the solution references `../../../Ivy-Framework/src/Ivy/Ivy.csproj`,
which resolves to a path that does not exist beside a worktree. Built the individual csproj files
instead, per the `DotnetBuild` verification's own instruction. Both clean at 0 warnings, 0 errors.

**Resolved the plan's 00130 conditional.** Plan 00130 merged before this ran (PR #1857, `799da1d8`), so
the paragraph was appended to its new text and its rewrite was not repeated, exactly as the plan
instructed for that case.

## Notes on Evidence

Both tests were watched failing at the base commit `27a7ccca` with the fix reverted in place; the fix
was restored and both pass. The full unit suite has 3 pre-existing failures in the Promptware memory
suites, confirmed identical at the base commit (base 3F/1994P/1998T, branch 3F/1996P/2000T, delta is
exactly the +2 new tests).

The bug also reproduced live during this session, outside any test: removing this session's own baseline
worktree exited 0 and left 1,861 directories with 0 files and 1,240 junctions behind.

## Manual Testing

The change is in a CLI command that ExecutePlan itself calls, so it is verifiable directly:

1. Pick any repo and create a worktree for a scratch plan:
   `tendril plan add-worktree <plan-id> <repo-path>`
2. Inside the resulting worktree, build a pnpm-shaped tree with a junction. On Windows:
   ```
   mkdir <wt>\node_modules\.pnpm\real\node_modules\pkg
   mkdir <wt>\node_modules\.pnpm\node_modules
   mklink /J <wt>\node_modules\.pnpm\node_modules\j1 <wt>\node_modules\.pnpm\real\node_modules\pkg
   ```
   (Or simply run a real `pnpm install` in the worktree's frontend directory.)
3. Run `tendril plan add-worktree <plan-id> <repo-path>` again.
4. Observe: it exits 0, prints `Worktree created:`, and the worktree has a valid `.git` file. Before this
   change the same command printed `git worktree add failed: fatal: ... already exists` and exited 1, and
   re-running did not help because the residue was still there.

To see the failure path, hold a file inside the residue open (any editor with a lock, or a PowerShell
`[System.IO.File]::Open($path,'Open','Read','None')`) and re-run: the command should now report
`Failed to remove existing worktree at <path>`, followed by git's stderr and the force-delete outcome on
separate lines, rather than a `worktree add` error.

---

## Commits
- c262b38e Record the fresh-worktree install cost in ExecutePlan step 2.5
- 9d0b8a7e Make add-worktree verify the stale worktree directory is gone

---
Created using [Ivy Tendril](https://ivy.app).
