### PR TITLE
[00155] Fix False Not Authenticated Reports for OpenCode and Gemini Health Checks

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs
@@ -35,7 +35,7 @@ public class AntigravityEventParserTests
         var initEvent = Assert.IsType<SessionInitEvent>(events[0]);
         Assert.Equal("c-123", initEvent.SessionId);
         Assert.Equal("gemini-3.6-flash", initEvent.Model);
-        Assert.Equal(2, initEvent.AvailableTools.Count);
+        Assert.Equal(2, initEvent.AvailableTools?.Count ?? 0);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Gemini/GeminiHealthCheckTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Gemini/GeminiHealthCheckTests.cs
@@ -1,0 +1,60 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Gemini;
+
+namespace Ivy.Tendril.Agents.Test.Gemini;
+
+public class GeminiHealthCheckTests
+{
+    private readonly GeminiHealthCheck _healthCheck = new();
+
+    [Fact]
+    public async Task CheckAuth_WithApiKeyEnvVar_ReturnsAuthenticated()
+    {
+        try
+        {
+            Environment.SetEnvironmentVariable("GEMINI_API_KEY", "test-key");
+
+            var result = await _healthCheck.CheckAuthAsync();
+
+            Assert.Equal(AuthStatus.Authenticated, result.Status);
+            Assert.Equal("api-key", result.AuthMethod);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GEMINI_API_KEY", null);
+        }
+    }
+
+    [Fact]
+    public void GetCredentialCandidates_ProbesMigratedConfigDirectory()
+    {
+        const string home = "/home/testuser";
+
+        var candidates = GeminiHealthCheck.GetCredentialCandidates(home);
+
+        Assert.Contains("/home/testuser/.gemini/oauth_creds.json", candidates);
+        Assert.Contains("/home/testuser/.gemini/config/oauth_creds.json", candidates);
+        Assert.Contains("/home/testuser/.gemini/google_accounts.json", candidates);
+        Assert.Contains("/home/testuser/.gemini/config/google_accounts.json", candidates);
+        Assert.Contains("/home/testuser/.gemini/settings.json", candidates);
+        Assert.Contains("/home/testuser/.gemini/config/settings.json", candidates);
+        Assert.Contains("/home/testuser/.gemini/config/config.json", candidates);
+    }
+
+    [Fact]
+    public void AgentId_IsGemini()
+    {
+        Assert.Equal(AgentId.Gemini, _healthCheck.AgentId);
+    }
+
+    [Fact]
+    public void GetOnboardingInfo_ReturnsCompleteInfo()
+    {
+        var info = _healthCheck.GetOnboardingInfo();
+
+        Assert.Equal("Gemini", info.DisplayName);
+        Assert.NotEmpty(info.InstallCommand);
+        Assert.NotNull(info.AuthCommand);
+        Assert.NotNull(info.DocsUrl);
+    }
+}

--- a/src/Ivy.Tendril.Agents.Test/Gemini/GeminiHealthCheckTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Gemini/GeminiHealthCheckTests.cs
@@ -32,13 +32,13 @@ public class GeminiHealthCheckTests
 
         var candidates = GeminiHealthCheck.GetCredentialCandidates(home);
 
-        Assert.Contains("/home/testuser/.gemini/oauth_creds.json", candidates);
-        Assert.Contains("/home/testuser/.gemini/config/oauth_creds.json", candidates);
-        Assert.Contains("/home/testuser/.gemini/google_accounts.json", candidates);
-        Assert.Contains("/home/testuser/.gemini/config/google_accounts.json", candidates);
-        Assert.Contains("/home/testuser/.gemini/settings.json", candidates);
-        Assert.Contains("/home/testuser/.gemini/config/settings.json", candidates);
-        Assert.Contains("/home/testuser/.gemini/config/config.json", candidates);
+        Assert.Contains(Path.Combine(home, ".gemini", "oauth_creds.json"), candidates);
+        Assert.Contains(Path.Combine(home, ".gemini", "config", "oauth_creds.json"), candidates);
+        Assert.Contains(Path.Combine(home, ".gemini", "google_accounts.json"), candidates);
+        Assert.Contains(Path.Combine(home, ".gemini", "config", "google_accounts.json"), candidates);
+        Assert.Contains(Path.Combine(home, ".gemini", "settings.json"), candidates);
+        Assert.Contains(Path.Combine(home, ".gemini", "config", "settings.json"), candidates);
+        Assert.Contains(Path.Combine(home, ".gemini", "config", "config.json"), candidates);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeHealthCheckTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeHealthCheckTests.cs
@@ -1,0 +1,81 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.OpenCode;
+
+namespace Ivy.Tendril.Agents.Test.OpenCode;
+
+public class OpenCodeHealthCheckTests
+{
+    private readonly OpenCodeHealthCheck _healthCheck = new();
+
+    [Fact]
+    public void ParseAuthList_WithEnvironmentCredential_ReturnsAuthenticated()
+    {
+        const string output = @"
+Credentials ~/.local/share/opencode/auth.json
+  0 credentials
+Environment
+  Amazon Bedrock  AWS_BEARER_TOKEN_BEDROCK
+  1 environment variable
+";
+
+        var result = OpenCodeHealthCheck.ParseAuthList(output);
+
+        Assert.Equal(AuthStatus.Authenticated, result.Status);
+        Assert.Equal("environment", result.AuthMethod);
+    }
+
+    [Fact]
+    public void ParseAuthList_WithNoCredentials_ReturnsNotAuthenticated()
+    {
+        const string output = @"
+Credentials ~/.local/share/opencode/auth.json
+  0 credentials
+";
+
+        var result = OpenCodeHealthCheck.ParseAuthList(output);
+
+        Assert.Equal(AuthStatus.NotAuthenticated, result.Status);
+    }
+
+    [Fact]
+    public void ParseAuthList_WithFileCredentials_ReturnsAuthenticated()
+    {
+        const string output = @"
+Credentials ~/.local/share/opencode/auth.json
+  2 credentials
+";
+
+        var result = OpenCodeHealthCheck.ParseAuthList(output);
+
+        Assert.Equal(AuthStatus.Authenticated, result.Status);
+        Assert.Equal("auth-file", result.AuthMethod);
+    }
+
+    [Fact]
+    public void ParseAuthList_WithAnsiEscapes_StripsAndParses()
+    {
+        const string output = "\x1b[90mCredentials\x1b[0m ~/.local/share/opencode/auth.json\n  0 credentials\n\x1b[90mEnvironment\x1b[0m\n  Amazon Bedrock  AWS_BEARER_TOKEN_BEDROCK\n  1 environment variable\n";
+
+        var result = OpenCodeHealthCheck.ParseAuthList(output);
+
+        Assert.Equal(AuthStatus.Authenticated, result.Status);
+        Assert.Equal("environment", result.AuthMethod);
+    }
+
+    [Fact]
+    public void AgentId_IsOpenCode()
+    {
+        Assert.Equal(AgentId.OpenCode, _healthCheck.AgentId);
+    }
+
+    [Fact]
+    public void GetOnboardingInfo_ReturnsCompleteInfo()
+    {
+        var info = _healthCheck.GetOnboardingInfo();
+
+        Assert.Equal("OpenCode", info.DisplayName);
+        Assert.NotEmpty(info.InstallCommand);
+        Assert.NotNull(info.AuthCommand);
+        Assert.NotNull(info.DocsUrl);
+    }
+}

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiHealthCheck.cs
@@ -32,43 +32,59 @@ public sealed class GeminiHealthCheck : IAgentHealthCheck
         }
 
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var credPath = Path.Combine(home, ".gemini", "oauth_creds.json");
-        var accountsPath = Path.Combine(home, ".gemini", "google_accounts.json");
-        var settingsPath = Path.Combine(home, ".gemini", "settings.json");
+        var candidates = GetCredentialCandidates(home);
 
-        if (File.Exists(credPath))
+        foreach (var path in candidates)
         {
-            var info = new FileInfo(credPath);
-            if (info.Length > 0)
+            if (!File.Exists(path))
+                continue;
+
+            var info = new FileInfo(path);
+            if (info.Length == 0)
+                continue;
+
+            var fileName = Path.GetFileName(path);
+            if (fileName == "oauth_creds.json")
+            {
                 return new AgentAuthResult
                 {
                     Status = AuthStatus.Authenticated,
                     AuthMethod = "oauth",
                 };
-        }
+            }
 
-        if (IsActiveAccountAuthenticated(accountsPath))
-        {
-            return new AgentAuthResult
+            if (fileName == "google_accounts.json" && IsActiveAccountAuthenticated(path))
             {
-                Status = AuthStatus.Authenticated,
-                AuthMethod = "oauth",
-            };
-        }
+                return new AgentAuthResult
+                {
+                    Status = AuthStatus.Authenticated,
+                    AuthMethod = "oauth",
+                };
+            }
 
-        var isTestRunner = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IVY_TEST_RUNNER"));
-        if (!isTestRunner && IsApiKeyConfiguredInSettings(settingsPath))
-        {
-            return new AgentAuthResult
+            var isTestRunner = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IVY_TEST_RUNNER"));
+            if (!isTestRunner && fileName == "settings.json" && IsApiKeyConfiguredInSettings(path))
             {
-                Status = AuthStatus.Authenticated,
-                AuthMethod = "api-key",
-            };
+                return new AgentAuthResult
+                {
+                    Status = AuthStatus.Authenticated,
+                    AuthMethod = "api-key",
+                };
+            }
+
+            if (fileName == "config.json" && IsConfigFileValid(path))
+            {
+                return new AgentAuthResult
+                {
+                    Status = AuthStatus.Authenticated,
+                    AuthMethod = "oauth",
+                };
+            }
         }
 
-        // Run a fast process check as final fallback
-        var (exitCode, _, _) = await HealthCheckRunner.RunAsync(
-            "gemini", ["-p", "ping"], TimeSpan.FromSeconds(5), ct);
+        // Run a process check as final fallback with proper timeout
+        var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
+            "gemini", ["-p", "ping"], TimeSpan.FromSeconds(30), ct);
 
         if (exitCode == 0)
         {
@@ -79,12 +95,51 @@ public sealed class GeminiHealthCheck : IAgentHealthCheck
             };
         }
 
+        if (exitCode == -1 && stderr.Contains("Timed out", StringComparison.OrdinalIgnoreCase))
+        {
+            return new AgentAuthResult
+            {
+                Status = AuthStatus.Unknown,
+                Error = "Gemini auth check timed out",
+            };
+        }
+
         return new AgentAuthResult
         {
             Status = AuthStatus.NotAuthenticated,
             Error = "OAuth credentials not found and no API key set",
             SignInHint = "Run 'gemini auth' or set GEMINI_API_KEY",
         };
+    }
+
+    internal static List<string> GetCredentialCandidates(string home)
+    {
+        var candidates = new List<string>();
+
+        var files = new[] { "oauth_creds.json", "google_accounts.json", "settings.json" };
+        foreach (var file in files)
+        {
+            candidates.Add(Path.Combine(home, ".gemini", file));
+            candidates.Add(Path.Combine(home, ".gemini", "config", file));
+        }
+
+        candidates.Add(Path.Combine(home, ".gemini", "config", "config.json"));
+
+        return candidates;
+    }
+
+    private static bool IsConfigFileValid(string filePath)
+    {
+        try
+        {
+            if (!File.Exists(filePath)) return false;
+            var content = File.ReadAllText(filePath);
+            return content.Length > 2 && content.Contains("{", StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     private static bool IsApiKeyConfiguredInSettings(string filePath)

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeHealthCheck.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Helpers;
 
@@ -18,7 +19,7 @@ public sealed class OpenCodeHealthCheck : IAgentHealthCheck
         return new AgentInstallStatus { IsInstalled = true, Version = version, BinaryPath = path };
     }
 
-    public Task<AgentAuthResult> CheckAuthAsync(CancellationToken ct = default)
+    public async Task<AgentAuthResult> CheckAuthAsync(CancellationToken ct = default)
     {
         var authPath = GetAuthFilePath();
 
@@ -27,16 +28,74 @@ public sealed class OpenCodeHealthCheck : IAgentHealthCheck
             var info = new FileInfo(authPath);
             if (info.Length >= 2)
             {
-                return Task.FromResult(new AgentAuthResult { Status = AuthStatus.Authenticated });
+                return new AgentAuthResult
+                {
+                    Status = AuthStatus.Authenticated,
+                    AuthMethod = "auth-file",
+                };
             }
         }
 
-        return Task.FromResult(new AgentAuthResult
+        // Auth file not found or empty - check environment variables via CLI
+        var binaryPath = OpenCodeBinaryResolver.Resolve();
+        var (exitCode, stdout, stderr) = await HealthCheckRunner.RunAsync(
+            binaryPath, ["auth", "list"], TimeSpan.FromSeconds(15), ct);
+
+        if (exitCode != 0)
+        {
+            return new AgentAuthResult
+            {
+                Status = AuthStatus.Unknown,
+                Error = $"Failed to check OpenCode credentials: {stderr}",
+                SignInHint = "Run 'opencode providers login' to authenticate",
+            };
+        }
+
+        var authResult = ParseAuthList(stdout);
+        if (authResult.Status == AuthStatus.NotAuthenticated)
+        {
+            authResult = authResult with
+            {
+                Error = "No OpenCode credentials configured (auth.json empty and no provider environment variables)",
+                SignInHint = "Run 'opencode providers login' to authenticate",
+            };
+        }
+
+        return authResult;
+    }
+
+    internal static AgentAuthResult ParseAuthList(string stdout)
+    {
+        var cleaned = Regex.Replace(stdout, @"\x1b\[[0-9;]*m", "");
+
+        var fileCredsMatch = Regex.Match(cleaned, @"(\d+)\s+credentials?", RegexOptions.IgnoreCase);
+        var envCredsMatch = Regex.Match(cleaned, @"(\d+)\s+environment\s+variables?", RegexOptions.IgnoreCase);
+
+        var fileCount = fileCredsMatch.Success ? int.Parse(fileCredsMatch.Groups[1].Value) : 0;
+        var envCount = envCredsMatch.Success ? int.Parse(envCredsMatch.Groups[1].Value) : 0;
+
+        if (envCount > 0)
+        {
+            return new AgentAuthResult
+            {
+                Status = AuthStatus.Authenticated,
+                AuthMethod = "environment",
+            };
+        }
+
+        if (fileCount > 0)
+        {
+            return new AgentAuthResult
+            {
+                Status = AuthStatus.Authenticated,
+                AuthMethod = "auth-file",
+            };
+        }
+
+        return new AgentAuthResult
         {
             Status = AuthStatus.NotAuthenticated,
-            Error = $"Auth file not found or empty at {authPath}",
-            SignInHint = "Run 'opencode providers login' to authenticate",
-        });
+        };
     }
 
     public async Task<string?> GetVersionAsync(CancellationToken ct = default)

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -288,9 +288,6 @@ public class CodingAgentStepView(
             },
             async () =>
             {
-                if (agentKey == "opencode")
-                    return HealthCheckStatus.Authenticated;
-
                 var result = await healthCheck.CheckAuthAsync();
                 return result.Status == AuthStatus.Authenticated
                     ? HealthCheckStatus.Authenticated

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -177,7 +177,7 @@ public class ProjectAgentStepView(
                         }
                     }
 
-                    if (agentKey != "opencode" && agentKey != "ivy")
+                    if (agentKey != "ivy")
                     {
                         progressMessage.Set($"Verifying {info.DisplayName} authentication...");
                         var authStatus = await healthCheck.CheckAuthAsync();

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/AgentTestDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/AgentTestDialog.cs
@@ -92,9 +92,7 @@ public class AgentTestDialog(
                 results[1] = results[1] with { Status = TestStatus.Running };
                 testResults.Set([.. results]);
 
-                var authResult = agentId == "opencode"
-                    ? new AgentAuthResult { Status = AuthStatus.Authenticated }
-                    : await healthCheck.CheckAuthAsync(ct);
+                var authResult = await healthCheck.CheckAuthAsync(ct);
                 var providerLabel = authResult.Provider != null ? $" ({authResult.Provider})" : "";
                 results[1] = authResult.Status switch
                 {


### PR DESCRIPTION
Fixes #1409

# Summary

## Changes

Fixed false "Not authenticated" reports for OpenCode and Gemini health checks. OpenCode now detects environment-variable credentials via `opencode auth list`, and Gemini now probes both legacy (`~/.gemini/`) and migrated (`~/.gemini/config/`) credential directories. Removed three hard-coded authentication bypasses that were masking the underlying check bugs.

## API Changes

**OpenCodeHealthCheck:**
- `CheckAuthAsync()` changed from synchronous to async
- Added `ParseAuthList(string stdout)` internal static helper

**GeminiHealthCheck:**
- Added `GetCredentialCandidates(string home)` internal static helper

**AgentAuthResult:**
- No changes to public contract, but `AuthMethod` now populated with "environment", "auth-file", "api-key", or "oauth"

## Files Modified

**Health Check Implementation:**
- `src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeHealthCheck.cs` - Added CLI probe and parser for environment credentials
- `src/Ivy.Tendril.Agents/Providers/Gemini/GeminiHealthCheck.cs` - Added migrated config directory probing, raised timeout from 5s to 30s

**UI Bypass Removals:**
- `src/Ivy.Tendril/Apps/Settings/Dialogs/AgentTestDialog.cs` - Removed OpenCode hard-coded bypass
- `src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs` - Removed OpenCode early return
- `src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs` - Narrowed exclusion to just "ivy"

**Tests:**
- `src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeHealthCheckTests.cs` (new) - 6 tests covering auth list parsing
- `src/Ivy.Tendril.Agents.Test/Gemini/GeminiHealthCheckTests.cs` (new) - 4 tests covering credential probing

**Fixes for Pre-Existing Issues:**
- `src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs` - Fixed nullable reference warning

## Manual Testing

1. **OpenCode with environment credentials:**
   - Set an OpenCode provider environment variable (e.g., `AWS_BEARER_TOKEN_BEDROCK`)
   - Delete or move `~/.local/share/opencode/auth.json` if it exists
   - Run `tendril doctor` - OpenCode should show "OK ... Ready" (not "Installed but not authenticated")

2. **OpenCode without credentials:**
   - Unset all provider environment variables
   - Ensure `auth.json` does not exist
   - Run `tendril doctor` - OpenCode should show "Installed but not authenticated"

3. **Gemini with migrated config:**
   - Ensure Gemini CLI is installed and authenticated
   - Verify credentials exist under `~/.gemini/config/`
   - Run `tendril doctor` - Gemini should show "OK ... Ready"

4. **Settings Agent Test Dialog:**
   - Open Tendril Settings > Agents
   - Click "Test" for OpenCode or Gemini
   - Authentication check should show correct status (not hard-coded to "Ok")

---
## Commits

- 4b147743 Fix path separator in GeminiHealthCheckTests
- 10f28cb1 Fix nullable reference warning in AntigravityEventParserTests
- 52c6ebc9 Remove hard-coded OpenCode authentication bypasses
- cbcb0e8d Fix Gemini auth check to probe migrated config directory
- 593e62ec Fix OpenCode auth check to detect environment credentials

---
Created using [Ivy Tendril](https://ivy.app).