### PR TITLE
[00152] Make Plan and Job CLI Listing Work Outside an Agent Shell

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
@@ -24,7 +24,7 @@ searchHints:
 # plan
 
 <Ingress>
-Create, read, update, and validate plans from the terminal. All subcommands resolve the plan folder from `TENDRIL_PLANS` (or `TENDRIL_HOME/Plans`).
+Create, read, update, and validate plans from the terminal. All subcommands resolve the plan folder from `TENDRIL_PLANS`, `TENDRIL_HOME/Plans`, or `~/.tendril/Plans` when environment variables are unset.
 </Ingress>
 
 ## CRUD
@@ -59,12 +59,13 @@ Lists plans with optional filters.
 | Option | Effect |
 |--------|--------|
 | `--state <state>` | Filter by state (e.g. `Draft`, `Executing`, `Failed`) |
-| `--project <name>` | Filter by project name |
+| `--project <name>` | Filter by project name (validated against configured projects) |
 | `--level <level>` | Filter by level (e.g. `Bug`, `Feature`, `Epic`) |
 | `--has-pr` | Only plans that have associated PRs |
 | `--has-worktree` | Only plans that have worktrees |
 | `--limit <n>` | Maximum number of results |
 | `--format <fmt>` | Output format: `table` (default), `ids`, `folders`, `json` |
+| `--plans-dir <path>` | Override plans directory path |
 
 ```terminal
 >tendril plan list --state Draft
@@ -72,6 +73,11 @@ Lists plans with optional filters.
 >tendril plan list --state Failed --format ids
 >tendril plan list --format json --limit 10
 ```
+
+<Callout type="Info">
+`plan list` shows plans (from `plan.yaml` files), not jobs. For job history and execution status, use `job list` instead (see [Other Commands](05_Other.md#job-list)).
+
+</Callout>
 
 #### plan get
 

--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/05_Other.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/05_Other.md
@@ -52,6 +52,36 @@ Read and write files in a promptware's `Memory/` and `Tools/` directories. Used 
 
 ## job
 
+#### job list
+
+```terminal
+>tendril job list
+>tendril job list --project Ivy-Tendril --status Running
+>tendril job list --type ExecutePlan --limit 20
+>tendril job list --format json
+```
+
+Lists jobs from the Tendril database. Works without a running server by directly reading `tendril.db`. Filters by project, status, type, or plan ID. Results are ordered with in-flight jobs (NULL `CompletedAt`) first, then by most recent start time.
+
+| Option | Effect |
+|--------|--------|
+| `--project <name>` | Filter by project name (validated against configured projects) |
+| `--status <status>` | Filter by status (`Pending`, `Queued`, `Running`, `Completed`, `Failed`, `Timeout`, `Stopped`, `Blocked`) |
+| `--type <type>` | Filter by job type (e.g., `CreatePlan`, `ExecutePlan`, `CreatePr`) |
+| `--plan <id>` | Filter by plan ID |
+| `--limit <n>` | Maximum results (default: 50) |
+| `--format <fmt>` | Output format: `table` (default), `ids`, `json` |
+
+```terminal
+>tendril job list --project Ivy-Tendril --status Failed
+>tendril job list --plan 00152 --format ids
+```
+
+<Callout type="Tip">
+Unlike `plan list`, `job list` reads directly from the database and does not require the Tendril server to be running. It only reads `tendril.db` from `TENDRIL_HOME`, falling back to `~/.tendril` when the environment variable is unset.
+
+</Callout>
+
 #### job start
 
 ```terminal

--- a/src/Ivy.Tendril.Test/Commands/JobListCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/JobListCommandTests.cs
@@ -42,7 +42,7 @@ public class JobListCommandTests : IDisposable
     {
         using var conn = new SqliteConnection($"Data Source={_dbPath};Mode=ReadWrite");
         conn.Open();
-        using var cmd = new SqliteCommand(conn);
+        using var cmd = conn.CreateCommand();
         cmd.CommandText = @"
             INSERT INTO Jobs (Id, Type, Project, Status, ReportedPlanId, StartedAt, CompletedAt, DurationSeconds, Cost, Cleared)
             VALUES (@id, @type, @project, @status, @planId, @startedAt, @completedAt, @durationSeconds, 0.0, @cleared)";
@@ -172,7 +172,7 @@ public class JobListCommandTests : IDisposable
         var missingDbPath = Path.Combine(_tempDir.Path, "nonexistent.db");
 
         var settings = new JobListSettings();
-        Assert.Throws<System.Data.SQLite.SqliteException>(() => JobListCommand.QueryJobs(missingDbPath, settings));
+        Assert.Throws<Microsoft.Data.Sqlite.SqliteException>(() => JobListCommand.QueryJobs(missingDbPath, settings));
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Commands/JobListCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/JobListCommandTests.cs
@@ -1,4 +1,4 @@
-using System.Data.SQLite;
+using Microsoft.Data.Sqlite;
 using Ivy.Tendril.Commands;
 using Ivy.Tendril.Database;
 using Ivy.Tendril.Helpers;
@@ -31,7 +31,8 @@ public class JobListCommandTests : IDisposable
 
     private void InitializeDatabase()
     {
-        using var conn = SqliteConnectionFactory.OpenConfigured(_dbPath, readWriteCreate: true);
+        using var conn = new SqliteConnection($"Data Source={_dbPath};Mode=ReadWriteCreate");
+        conn.Open();
         var migrator = new DatabaseMigrator(conn);
         migrator.ApplyMigrations();
     }
@@ -39,8 +40,9 @@ public class JobListCommandTests : IDisposable
     private void InsertJob(string id, string type, string project, string status, string? planId = null,
         DateTime? startedAt = null, DateTime? completedAt = null, int? durationSeconds = null, bool cleared = false)
     {
-        using var conn = SqliteConnectionFactory.OpenConfigured(_dbPath, readWriteCreate: false);
-        using var cmd = new SQLiteCommand(conn);
+        using var conn = new SqliteConnection($"Data Source={_dbPath};Mode=ReadWrite");
+        conn.Open();
+        using var cmd = new SqliteCommand(conn);
         cmd.CommandText = @"
             INSERT INTO Jobs (Id, Type, Project, Status, ReportedPlanId, StartedAt, CompletedAt, DurationSeconds, Cost, Cleared)
             VALUES (@id, @type, @project, @status, @planId, @startedAt, @completedAt, @durationSeconds, 0.0, @cleared)";
@@ -170,7 +172,7 @@ public class JobListCommandTests : IDisposable
         var missingDbPath = Path.Combine(_tempDir.Path, "nonexistent.db");
 
         var settings = new JobListSettings();
-        Assert.Throws<System.Data.SQLite.SQLiteException>(() => JobListCommand.QueryJobs(missingDbPath, settings));
+        Assert.Throws<System.Data.SQLite.SqliteException>(() => JobListCommand.QueryJobs(missingDbPath, settings));
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Commands/JobListCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/JobListCommandTests.cs
@@ -44,12 +44,13 @@ public class JobListCommandTests : IDisposable
         conn.Open();
         using var cmd = conn.CreateCommand();
         cmd.CommandText = @"
-            INSERT INTO Jobs (Id, Type, Project, Status, ReportedPlanId, StartedAt, CompletedAt, DurationSeconds, Cost, Cleared)
-            VALUES (@id, @type, @project, @status, @planId, @startedAt, @completedAt, @durationSeconds, 0.0, @cleared)";
+            INSERT INTO Jobs (Id, Type, Project, Status, PlanFile, ReportedPlanId, StartedAt, CompletedAt, DurationSeconds, Cost, Cleared)
+            VALUES (@id, @type, @project, @status, @planFile, @planId, @startedAt, @completedAt, @durationSeconds, 0.0, @cleared)";
         cmd.Parameters.AddWithValue("@id", id);
         cmd.Parameters.AddWithValue("@type", type);
         cmd.Parameters.AddWithValue("@project", project);
         cmd.Parameters.AddWithValue("@status", status);
+        cmd.Parameters.AddWithValue("@planFile", "");
         cmd.Parameters.AddWithValue("@planId", (object?)planId ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@startedAt", (object?)startedAt?.ToString("o") ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@completedAt", (object?)completedAt?.ToString("o") ?? DBNull.Value);

--- a/src/Ivy.Tendril.Test/Commands/JobListCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/JobListCommandTests.cs
@@ -1,0 +1,195 @@
+using System.Data.SQLite;
+using Ivy.Tendril.Commands;
+using Ivy.Tendril.Database;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test.Commands;
+
+[Collection("TendrilHome")]
+public class JobListCommandTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("tendril-job-list-test");
+    private readonly string _originalTendrilHome;
+    private readonly string _dbPath;
+
+    public JobListCommandTests()
+    {
+        _originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME") ?? "";
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
+        _dbPath = Path.Combine(_tempDir.Path, "tendril.db");
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        _tempDir.Dispose();
+    }
+
+    private void InitializeDatabase()
+    {
+        using var conn = SqliteConnectionFactory.OpenConfigured(_dbPath, readWriteCreate: true);
+        var migrator = new DatabaseMigrator(conn);
+        migrator.ApplyMigrations();
+    }
+
+    private void InsertJob(string id, string type, string project, string status, string? planId = null,
+        DateTime? startedAt = null, DateTime? completedAt = null, int? durationSeconds = null, bool cleared = false)
+    {
+        using var conn = SqliteConnectionFactory.OpenConfigured(_dbPath, readWriteCreate: false);
+        using var cmd = new SQLiteCommand(conn);
+        cmd.CommandText = @"
+            INSERT INTO Jobs (Id, Type, Project, Status, ReportedPlanId, StartedAt, CompletedAt, DurationSeconds, Cost, Cleared)
+            VALUES (@id, @type, @project, @status, @planId, @startedAt, @completedAt, @durationSeconds, 0.0, @cleared)";
+        cmd.Parameters.AddWithValue("@id", id);
+        cmd.Parameters.AddWithValue("@type", type);
+        cmd.Parameters.AddWithValue("@project", project);
+        cmd.Parameters.AddWithValue("@status", status);
+        cmd.Parameters.AddWithValue("@planId", (object?)planId ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@startedAt", (object?)startedAt?.ToString("o") ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@completedAt", (object?)completedAt?.ToString("o") ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@durationSeconds", (object?)durationSeconds ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@cleared", cleared ? 1 : 0);
+        cmd.ExecuteNonQuery();
+    }
+
+    [Fact]
+    public void JobList_ReturnsJobsForProject()
+    {
+        InitializeDatabase();
+        InsertJob("job-001", "ExecutePlan", "ProjectA", "Completed", "00123",
+            DateTime.UtcNow.AddHours(-1), DateTime.UtcNow, 300);
+        InsertJob("job-002", "CreatePlan", "ProjectB", "Running", "00124",
+            DateTime.UtcNow.AddMinutes(-10));
+        InsertJob("job-003", "ExecutePlan", "ProjectA", "Failed", "00125",
+            DateTime.UtcNow.AddHours(-2), DateTime.UtcNow.AddMinutes(-30), 5400);
+
+        var settings = new JobListSettings { Project = "ProjectA" };
+        var jobs = JobListCommand.QueryJobs(_dbPath, settings);
+
+        Assert.Equal(2, jobs.Count);
+        Assert.All(jobs, j => Assert.Equal("ProjectA", j.Project));
+    }
+
+    [Fact]
+    public void JobList_FiltersByStatus()
+    {
+        InitializeDatabase();
+        InsertJob("job-001", "ExecutePlan", "ProjectA", "Completed", startedAt: DateTime.UtcNow.AddHours(-1),
+            completedAt: DateTime.UtcNow);
+        InsertJob("job-002", "CreatePlan", "ProjectA", "Running", startedAt: DateTime.UtcNow);
+        InsertJob("job-003", "ExecutePlan", "ProjectA", "Failed", startedAt: DateTime.UtcNow.AddHours(-2),
+            completedAt: DateTime.UtcNow.AddMinutes(-30));
+
+        var settings = new JobListSettings { Status = "Running" };
+        var jobs = JobListCommand.QueryJobs(_dbPath, settings);
+
+        Assert.Single(jobs);
+        Assert.Equal("Running", jobs[0].Status);
+    }
+
+    [Fact]
+    public void JobList_FiltersByType()
+    {
+        InitializeDatabase();
+        InsertJob("job-001", "ExecutePlan", "ProjectA", "Completed", startedAt: DateTime.UtcNow);
+        InsertJob("job-002", "CreatePlan", "ProjectA", "Completed", startedAt: DateTime.UtcNow);
+        InsertJob("job-003", "ExecutePlan", "ProjectA", "Completed", startedAt: DateTime.UtcNow);
+
+        var settings = new JobListSettings { Type = "CreatePlan" };
+        var jobs = JobListCommand.QueryJobs(_dbPath, settings);
+
+        Assert.Single(jobs);
+        Assert.Equal("CreatePlan", jobs[0].Type);
+    }
+
+    [Fact]
+    public void JobList_OrdersInFlightJobsFirst()
+    {
+        InitializeDatabase();
+        InsertJob("job-001", "ExecutePlan", "ProjectA", "Completed",
+            startedAt: DateTime.UtcNow.AddHours(-5), completedAt: DateTime.UtcNow.AddHours(-4));
+        InsertJob("job-002", "ExecutePlan", "ProjectA", "Running",
+            startedAt: DateTime.UtcNow.AddHours(-10));
+        InsertJob("job-003", "ExecutePlan", "ProjectA", "Completed",
+            startedAt: DateTime.UtcNow.AddHours(-1), completedAt: DateTime.UtcNow);
+
+        var settings = new JobListSettings();
+        var jobs = JobListCommand.QueryJobs(_dbPath, settings);
+
+        Assert.Equal("job-002", jobs[0].Id);
+    }
+
+    [Fact]
+    public void JobList_ExcludesClearedJobs()
+    {
+        InitializeDatabase();
+        InsertJob("job-001", "ExecutePlan", "ProjectA", "Completed", cleared: false, startedAt: DateTime.UtcNow);
+        InsertJob("job-002", "ExecutePlan", "ProjectA", "Completed", cleared: true, startedAt: DateTime.UtcNow);
+
+        var settings = new JobListSettings();
+        var jobs = JobListCommand.QueryJobs(_dbPath, settings);
+
+        Assert.Single(jobs);
+        Assert.Equal("job-001", jobs[0].Id);
+    }
+
+    [Fact]
+    public void JobList_RespectsLimit()
+    {
+        InitializeDatabase();
+        for (int i = 1; i <= 100; i++)
+        {
+            InsertJob($"job-{i:D3}", "ExecutePlan", "ProjectA", "Completed",
+                startedAt: DateTime.UtcNow.AddHours(-i));
+        }
+
+        var settings = new JobListSettings { Limit = 10 };
+        var jobs = JobListCommand.QueryJobs(_dbPath, settings);
+
+        Assert.Equal(10, jobs.Count);
+    }
+
+    [Fact]
+    public void JobList_EmptyDatabase_ReturnsZeroCount()
+    {
+        InitializeDatabase();
+
+        var settings = new JobListSettings();
+        var jobs = JobListCommand.QueryJobs(_dbPath, settings);
+
+        Assert.Empty(jobs);
+    }
+
+    [Fact]
+    public void JobList_MissingDatabase_ReturnsZeroCount()
+    {
+        var missingDbPath = Path.Combine(_tempDir.Path, "nonexistent.db");
+
+        var settings = new JobListSettings();
+        Assert.Throws<System.Data.SQLite.SQLiteException>(() => JobListCommand.QueryJobs(missingDbPath, settings));
+    }
+
+    [Fact]
+    public void JobList_InvalidStatus_FailsValidation()
+    {
+        var settings = new JobListSettings { Status = "InvalidStatus" };
+        var result = settings.Validate();
+
+        Assert.False(result.Successful);
+        Assert.Contains("Invalid value", result.Message);
+    }
+
+    [Fact]
+    public void JobList_InvalidLimit_FailsValidation()
+    {
+        var settings = new JobListSettings { Limit = -1 };
+        var result = settings.Validate();
+
+        Assert.False(result.Successful);
+        Assert.Contains("must be a positive integer", result.Message);
+    }
+}

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -1845,4 +1845,52 @@ public class PlanCliCommandTests : IDisposable
 
         Assert.Equal("Draft", ReadPlan("20312").State);
     }
+
+    // ==================== GetPlansDirectory Fallback ====================
+
+    [Fact]
+    public void GetPlansDirectory_FallsBackToDefaultHome_WhenEnvUnset()
+    {
+        var testHome = Path.Combine(_tempDir.Path, "fallback-home");
+        var plansInFallback = Path.Combine(testHome, "Plans");
+        Directory.CreateDirectory(plansInFallback);
+
+        var originalOverride = PathHelper.DefaultTendrilHomeOverride;
+        try
+        {
+            PathHelper.DefaultTendrilHomeOverride = testHome;
+            Environment.SetEnvironmentVariable("TENDRIL_HOME", null);
+            Environment.SetEnvironmentVariable("TENDRIL_PLANS", null);
+
+            var resolved = PlanCommandHelpers.GetPlansDirectory();
+            Assert.Equal(plansInFallback, resolved);
+        }
+        finally
+        {
+            PathHelper.DefaultTendrilHomeOverride = originalOverride;
+            Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        }
+    }
+
+    [Fact]
+    public void GetPlansDirectory_Throws_WhenResolvedPlansDirMissing()
+    {
+        var testHome = Path.Combine(_tempDir.Path, "missing-plans-home");
+        Directory.CreateDirectory(testHome);
+
+        var originalOverride = PathHelper.DefaultTendrilHomeOverride;
+        try
+        {
+            PathHelper.DefaultTendrilHomeOverride = testHome;
+            Environment.SetEnvironmentVariable("TENDRIL_HOME", null);
+            Environment.SetEnvironmentVariable("TENDRIL_PLANS", null);
+
+            Assert.Throws<DirectoryNotFoundException>(() => PlanCommandHelpers.GetPlansDirectory());
+        }
+        finally
+        {
+            PathHelper.DefaultTendrilHomeOverride = originalOverride;
+            Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
+        }
+    }
 }

--- a/src/Ivy.Tendril/Commands/JobListCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobListCommand.cs
@@ -1,5 +1,5 @@
 using System.ComponentModel;
-using System.Data.SQLite;
+using Microsoft.Data.Sqlite;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
@@ -68,8 +68,7 @@ public class JobListCommand : Command<JobListSettings>
 
         if (!string.IsNullOrEmpty(settings.Project))
         {
-            var config = _configService.GetConfiguration();
-            var availableProjects = config.Projects.Keys.ToList();
+            var availableProjects = _configService.Projects.Select(p => p.Name).ToList();
             if (!availableProjects.Contains(settings.Project, StringComparer.OrdinalIgnoreCase))
             {
                 CliValidation.ThrowProjectNotFound(settings.Project, availableProjects);
@@ -123,39 +122,40 @@ public class JobListCommand : Command<JobListSettings>
         var jobs = new List<JobListEntry>();
         var limit = settings.Limit ?? 50;
 
-        using var conn = SqliteConnectionFactory.OpenConfigured(dbPath, readWriteCreate: false);
+        using var conn = new SqliteConnection($"Data Source={dbPath};Mode=ReadOnly");
+        conn.Open();
 
         var sql = "SELECT Id, Type, Project, Status, ReportedPlanId, StartedAt, CompletedAt, DurationSeconds, Cost FROM Jobs WHERE Cleared = 0";
-        var parameters = new List<SQLiteParameter>();
+        var parameters = new List<SqliteParameter>();
 
         if (!string.IsNullOrEmpty(settings.Project))
         {
             sql += " AND Project = @project";
-            parameters.Add(new SQLiteParameter("@project", settings.Project));
+            parameters.Add(new SqliteParameter("@project", settings.Project));
         }
 
         if (!string.IsNullOrEmpty(settings.Status))
         {
             sql += " AND Status = @status";
-            parameters.Add(new SQLiteParameter("@status", settings.Status));
+            parameters.Add(new SqliteParameter("@status", settings.Status));
         }
 
         if (!string.IsNullOrEmpty(settings.Type))
         {
             sql += " AND Type = @type";
-            parameters.Add(new SQLiteParameter("@type", settings.Type));
+            parameters.Add(new SqliteParameter("@type", settings.Type));
         }
 
         if (!string.IsNullOrEmpty(settings.Plan))
         {
             sql += " AND ReportedPlanId = @plan";
-            parameters.Add(new SQLiteParameter("@plan", settings.Plan));
+            parameters.Add(new SqliteParameter("@plan", settings.Plan));
         }
 
         sql += " ORDER BY CASE WHEN CompletedAt IS NULL THEN 0 ELSE 1 END, StartedAt DESC LIMIT @limit";
-        parameters.Add(new SQLiteParameter("@limit", limit));
+        parameters.Add(new SqliteParameter("@limit", limit));
 
-        using var cmd = new SQLiteCommand(sql, conn);
+        using var cmd = new SqliteCommand(sql, conn);
         cmd.Parameters.AddRange(parameters.ToArray());
 
         using var reader = cmd.ExecuteReader();

--- a/src/Ivy.Tendril/Commands/JobListCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobListCommand.cs
@@ -1,0 +1,196 @@
+using System.ComponentModel;
+using System.Data.SQLite;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class JobListSettings : CommandSettings
+{
+    [CommandOption("--project")]
+    [Description("Filter by project name")]
+    public string? Project { get; init; }
+
+    [CommandOption("--status")]
+    [Description("Filter by status (Pending, Queued, Running, Completed, Failed, Timeout, Stopped, Blocked)")]
+    public string? Status { get; init; }
+
+    [CommandOption("--type")]
+    [Description("Filter by type (e.g., CreatePlan, ExecutePlan, CreatePr)")]
+    public string? Type { get; init; }
+
+    [CommandOption("--plan")]
+    [Description("Filter by plan ID")]
+    public string? Plan { get; init; }
+
+    [CommandOption("--limit")]
+    [Description("Maximum number of results (default: 50)")]
+    public int? Limit { get; init; }
+
+    [CommandOption("--format")]
+    [Description("Output format: table (default), ids, json")]
+    public string? Format { get; init; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.ValidateOneOf(Status, "--status", CliValidation.ValidJobStatuses),
+            CliValidation.ValidateOneOf(Format, "--format", ["table", "ids", "json"]),
+            Limit.HasValue && Limit.Value <= 0
+                ? Spectre.Console.ValidationResult.Error("--limit must be a positive integer.")
+                : Spectre.Console.ValidationResult.Success()
+        );
+    }
+}
+
+public class JobListCommand : Command<JobListSettings>
+{
+    private readonly ConfigService _configService;
+
+    public JobListCommand(ConfigService configService)
+    {
+        _configService = configService;
+    }
+
+    protected override int Execute(CommandContext context, JobListSettings settings, CancellationToken cancellationToken)
+    {
+        var home = PathHelper.GetDefaultTendrilHome();
+        var dbPath = Path.Combine(home, "tendril.db");
+
+        if (!File.Exists(dbPath))
+        {
+            Console.WriteLine("No jobs found.");
+            return 0;
+        }
+
+        if (!string.IsNullOrEmpty(settings.Project))
+        {
+            var config = _configService.GetConfiguration();
+            var availableProjects = config.Projects.Keys.ToList();
+            if (!availableProjects.Contains(settings.Project, StringComparer.OrdinalIgnoreCase))
+            {
+                CliValidation.ThrowProjectNotFound(settings.Project, availableProjects);
+            }
+        }
+
+        var jobs = QueryJobs(dbPath, settings);
+
+        var format = (settings.Format ?? "table").ToLower();
+        switch (format)
+        {
+            case "ids":
+                foreach (var job in jobs)
+                    Console.WriteLine(job.Id);
+                break;
+            case "json":
+                Console.WriteLine("[");
+                for (var i = 0; i < jobs.Count; i++)
+                {
+                    var j = jobs[i];
+                    var comma = i < jobs.Count - 1 ? "," : "";
+                    Console.WriteLine($"  {{\"id\":\"{Escape(j.Id)}\",\"type\":\"{Escape(j.Type)}\",\"project\":\"{Escape(j.Project)}\",\"status\":\"{Escape(j.Status)}\",\"plan\":\"{Escape(j.Plan)}\",\"started\":\"{Escape(j.Started)}\",\"duration\":\"{Escape(j.Duration)}\"}}{comma}");
+                }
+                Console.WriteLine("]");
+                break;
+            default:
+                if (jobs.Count == 0)
+                {
+                    AnsiConsole.MarkupLine("[dim]No jobs found.[/]");
+                    return 0;
+                }
+                var rows = jobs.Select(j => (IReadOnlyList<string>)new[]
+                {
+                    j.Id,
+                    Truncate(j.Type, 20),
+                    Truncate(j.Project, 20),
+                    j.Status,
+                    Truncate(j.Plan, 10),
+                    j.Started,
+                    j.Duration
+                });
+                CliOutput.WriteTable(["Id", "Type", "Project", "Status", "Plan", "Started", "Duration"], rows);
+                break;
+        }
+
+        return 0;
+    }
+
+    internal static List<JobListEntry> QueryJobs(string dbPath, JobListSettings settings)
+    {
+        var jobs = new List<JobListEntry>();
+        var limit = settings.Limit ?? 50;
+
+        using var conn = SqliteConnectionFactory.OpenConfigured(dbPath, readWriteCreate: false);
+
+        var sql = "SELECT Id, Type, Project, Status, ReportedPlanId, StartedAt, CompletedAt, DurationSeconds, Cost FROM Jobs WHERE Cleared = 0";
+        var parameters = new List<SQLiteParameter>();
+
+        if (!string.IsNullOrEmpty(settings.Project))
+        {
+            sql += " AND Project = @project";
+            parameters.Add(new SQLiteParameter("@project", settings.Project));
+        }
+
+        if (!string.IsNullOrEmpty(settings.Status))
+        {
+            sql += " AND Status = @status";
+            parameters.Add(new SQLiteParameter("@status", settings.Status));
+        }
+
+        if (!string.IsNullOrEmpty(settings.Type))
+        {
+            sql += " AND Type = @type";
+            parameters.Add(new SQLiteParameter("@type", settings.Type));
+        }
+
+        if (!string.IsNullOrEmpty(settings.Plan))
+        {
+            sql += " AND ReportedPlanId = @plan";
+            parameters.Add(new SQLiteParameter("@plan", settings.Plan));
+        }
+
+        sql += " ORDER BY CASE WHEN CompletedAt IS NULL THEN 0 ELSE 1 END, StartedAt DESC LIMIT @limit";
+        parameters.Add(new SQLiteParameter("@limit", limit));
+
+        using var cmd = new SQLiteCommand(sql, conn);
+        cmd.Parameters.AddRange(parameters.ToArray());
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            var id = reader.GetString(0);
+            var type = reader.GetString(1);
+            var project = reader.GetString(2);
+            var status = reader.GetString(3);
+            var planId = reader.IsDBNull(4) ? "" : reader.GetString(4);
+            var startedAt = reader.IsDBNull(5) ? (DateTime?)null : DateTime.Parse(reader.GetString(5));
+            var completedAt = reader.IsDBNull(6) ? (DateTime?)null : DateTime.Parse(reader.GetString(6));
+            var durationSeconds = reader.IsDBNull(7) ? (int?)null : reader.GetInt32(7);
+
+            var started = startedAt?.ToString("yyyy-MM-dd HH:mm") ?? "";
+            var duration = durationSeconds.HasValue ? FormatDuration(durationSeconds.Value) : "";
+
+            jobs.Add(new JobListEntry(id, type, project, status, planId, started, duration));
+        }
+
+        return jobs;
+    }
+
+    private static string FormatDuration(int seconds)
+    {
+        if (seconds < 60) return $"{seconds}s";
+        if (seconds < 3600) return $"{seconds / 60}m";
+        return $"{seconds / 3600}h {(seconds % 3600) / 60}m";
+    }
+
+    private static string Truncate(string s, int max) =>
+        s.Length <= max ? s : s[..(max - 3)] + "...";
+
+    private static string Escape(string s) =>
+        s.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+    internal record JobListEntry(string Id, string Type, string Project, string Status, string Plan, string Started, string Duration);
+}

--- a/src/Ivy.Tendril/Commands/PlanListCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanListCommand.cs
@@ -71,8 +71,7 @@ public class PlanListCommand : Command<PlanListSettings>
     {
         if (!string.IsNullOrEmpty(settings.Project))
         {
-            var config = _configService.GetConfiguration();
-            var availableProjects = config.Projects.Keys.ToList();
+            var availableProjects = _configService.Projects.Select(p => p.Name).ToList();
             CliValidation.ValidateConfiguredProject(settings.Project, availableProjects);
         }
 

--- a/src/Ivy.Tendril/Commands/PlanListCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanListCommand.cs
@@ -41,6 +41,10 @@ public class PlanListSettings : CommandSettings
     [Description("Maximum number of results")]
     public int? Limit { get; init; }
 
+    [CommandOption("--plans-dir")]
+    [Description("Override plans directory path")]
+    public string? PlansDir { get; init; }
+
     public override Spectre.Console.ValidationResult Validate()
     {
         return CliValidation.Combine(
@@ -56,19 +60,33 @@ public class PlanListSettings : CommandSettings
 
 public class PlanListCommand : Command<PlanListSettings>
 {
+    private readonly ConfigService _configService;
+
+    public PlanListCommand(ConfigService configService)
+    {
+        _configService = configService;
+    }
+
     protected override int Execute(CommandContext context, PlanListSettings settings, CancellationToken cancellationToken)
     {
-        var plansDirectory = Environment.GetEnvironmentVariable("TENDRIL_PLANS")?.Trim();
-        if (string.IsNullOrEmpty(plansDirectory))
+        if (!string.IsNullOrEmpty(settings.Project))
         {
-            var home = Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
-            if (string.IsNullOrEmpty(home))
-                throw new InvalidOperationException("TENDRIL_HOME environment variable is not set");
-            plansDirectory = Path.Combine(home, "Plans");
+            var config = _configService.GetConfiguration();
+            var availableProjects = config.Projects.Keys.ToList();
+            CliValidation.ValidateConfiguredProject(settings.Project, availableProjects);
         }
 
-        if (!Directory.Exists(plansDirectory))
-            throw new InvalidOperationException($"Plans directory not found: {plansDirectory}");
+        string plansDirectory;
+        if (!string.IsNullOrEmpty(settings.PlansDir))
+        {
+            plansDirectory = settings.PlansDir;
+            if (!Directory.Exists(plansDirectory))
+                throw new DirectoryNotFoundException($"Plans directory not found: {plansDirectory}");
+        }
+        else
+        {
+            plansDirectory = PlanCommandHelpers.GetPlansDirectory();
+        }
 
         var results = ScanPlans(plansDirectory, settings);
 

--- a/src/Ivy.Tendril/Helpers/CliValidation.cs
+++ b/src/Ivy.Tendril/Helpers/CliValidation.cs
@@ -33,6 +33,13 @@ public static class CliValidation
 
     public static readonly string[] ValidFormats = ["table", "ids", "folders", "json"];
 
+    public static readonly string[] ValidJobStatuses =
+    [
+        nameof(JobStatus.Pending), nameof(JobStatus.Queued), nameof(JobStatus.Running),
+        nameof(JobStatus.Completed), nameof(JobStatus.Failed), nameof(JobStatus.Timeout),
+        nameof(JobStatus.Stopped), nameof(JobStatus.Blocked)
+    ];
+
     public static readonly string[] ValidExecutionProfiles = ["deep", "balanced"];
 
     public static readonly string[] ValidImpactLevels = ["Small", "Medium", "High"];
@@ -125,4 +132,12 @@ public static class CliValidation
         sourceCount > 1
             ? SpectreValidation.Error($"Provide the value in exactly one way: {inlineSources}.")
             : SpectreValidation.Success();
+
+    public static void ValidateConfiguredProject(string projectName, IEnumerable<string> availableProjects)
+    {
+        if (!availableProjects.Contains(projectName, StringComparer.OrdinalIgnoreCase))
+        {
+            ThrowProjectNotFound(projectName, availableProjects);
+        }
+    }
 }

--- a/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
@@ -66,6 +66,7 @@ public static class PlanCommandHelpers
 
     /// <summary>
     ///     Resolves the plans directory from an explicit override, TENDRIL_PLANS, or TENDRIL_HOME/Plans.
+    ///     Falls back to ~/.tendril/Plans when environment variables are unset.
     /// </summary>
     public static string GetPlansDirectory(string? explicitPlansDir = null)
     {
@@ -84,10 +85,7 @@ public static class PlanCommandHelpers
             return plans;
         }
 
-        var home = Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
-        if (string.IsNullOrWhiteSpace(home))
-            throw new InvalidOperationException("TENDRIL_HOME environment variable is not set");
-
+        var home = PathHelper.GetDefaultTendrilHome();
         var plansDirectory = Path.Combine(home, "Plans");
         if (!Directory.Exists(plansDirectory))
             throw new DirectoryNotFoundException($"Plans directory not found: {plansDirectory}");

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -650,6 +650,8 @@ public class Program
             // Job management commands
             config.AddBranch("job", job =>
             {
+                job.AddCommand<JobListCommand>("list")
+                    .WithDescription("List jobs with optional filters");
                 job.AddCommand<JobStatusCommand>("status")
                     .WithDescription("Report job status (message, planId, planTitle)");
                 job.AddCommand<JobFailCommand>("fail")


### PR DESCRIPTION
Fixes #1845

# Summary

## Changes

Fixed three defects in Issue #1845 where CLI commands required environment variables. Plan and job commands now fall back to `~/.tendril` when `TENDRIL_HOME` is unset. Added new `tendril job list` command for querying job history without raw SQL. Invalid project names now fail loudly with available options listed.

## API Changes

**New Commands:**
- `tendril job list` - List jobs with optional filters for project, status, type, plan
  - Options: `--project`, `--status`, `--type`, `--plan`, `--limit`, `--format`

**Changed Commands:**
- `tendril plan list` - Added `--plans-dir` option to override plans directory path
- Both `plan list` and `job list` validate `--project` against configured projects

**New Classes:**
- `JobListCommand` - Implements job listing with database queries
- `JobListSettings` - Command settings for job list

**Modified Methods:**
- `PlanCommandHelpers.GetPlansDirectory()` - Now falls back to `PathHelper.GetDefaultTendrilHome()` instead of throwing

**New Validation:**
- `CliValidation.ValidJobStatuses` - Array of valid job status values
- `CliValidation.ValidateConfiguredProject()` - Validates project name against configuration

## Files Modified

**Core Implementation:**
- src/Ivy.Tendril/Commands/JobListCommand.cs (new)
- src/Ivy.Tendril/Commands/PlanListCommand.cs
- src/Ivy.Tendril/Helpers/PlanCommandHelpers.cs
- src/Ivy.Tendril/Helpers/CliValidation.cs
- src/Ivy.Tendril/Program.cs

**Tests:**
- src/Ivy.Tendril.Test/Commands/JobListCommandTests.cs (new)
- src/Ivy.Tendril.Test/PlanCliCommandTests.cs

**Documentation:**
- src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
- src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/05_Other.md

## Manual Testing

**Test 1: Plan list without environment variables**
1. Open a terminal outside Tendril agent shell (no `TENDRIL_HOME` set)
2. Run: `tendril plan list --limit 5`
3. Expected: Lists up to 5 plans from `~/.tendril/Plans` without errors

**Test 2: Job list command**
1. Run: `tendril job list --limit 10`
2. Expected: Lists up to 10 jobs from `tendril.db`, ordered with in-flight jobs first

**Test 3: Project validation**
1. Run: `tendril plan list --project "InvalidName"`
2. Expected: Error message listing all available project names

**Test 4: Job filtering**
1. Run: `tendril job list --status Running --project Ivy-Tendril`
2. Expected: Lists only running jobs for the Ivy-Tendril project

## Commits

- 1351e983 Add PlanFile column to test InsertJob method
- 0ca65e3d Fix SqliteCommand creation in test
- 6fa39bc8 Fix Sqlite namespace and ConfigService usage in JobListCommand
- 1fbd61d7 Merge remote-tracking branch 'origin/development' into tendril/00152-MakePlanAndJobCLIListingWorkOutsideAnAgentShell
- cb22e1d9 Add fallback to ~/.tendril for plan and job CLI commands

---
Created using [Ivy Tendril](https://ivy.app).