### PR TITLE
[00148] Resolve Plan Folder to an Absolute Path When Rerunning a Job

### DIFF
--- a/src/Ivy.Tendril.Test/RerunJobDialogTests.cs
+++ b/src/Ivy.Tendril.Test/RerunJobDialogTests.cs
@@ -1,11 +1,25 @@
 using Ivy.Tendril.Apps.Jobs.Dialogs;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Plans;
 using Xunit;
 
 namespace Ivy.Tendril.Test;
 
 public class RerunJobDialogTests
 {
+    private sealed class MockPlanReaderService(string plansDirectory) : IPlanReaderService
+    {
+        public string PlansDirectory => plansDirectory;
+        public bool IsDatabaseReady => false;
+        public void MigratePlans() { }
+        public void RecoverStuckPlans() { }
+        public List<PlanFile> GetPlans(PlanStatus? statusFilter = null) => [];
+        public PlanFile? GetPlanByFolder(string folderPath) => null;
+        public List<PlanFile> GetIceboxPlans() => [];
+        public void TransitionState(string folderName, PlanStatus newState) { }
+        public HashSet<string> GetFailedVerificationNames(string folderName) => [];
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
@@ -131,5 +145,65 @@ public class RerunJobDialogTests
         };
 
         Assert.True(RerunJobDialog.SupportsFeedback(job, null));
+    }
+
+    [Fact]
+    public void ResolvePlanFolder_PlanIdMatchesFolder_ReturnsAbsolutePath()
+    {
+        using var tempDir = new TempDirectoryFixture("rerun-job-dialog-test");
+        var planFolder = Path.Combine(tempDir.Path, "00038-FixRustyDocsGeneratorOutputAndAddWidgetSampleAppsWithAligned");
+        Directory.CreateDirectory(planFolder);
+
+        var job = new JobItem
+        {
+            Id = "00001",
+            Type = "ExecutePlan",
+            ReportedPlanId = "00038",
+            PlanFile = "00038-FixRustyDocsGeneratorOutputAndAddWidgetSampleAppsWithAligned"
+        };
+        var planService = new MockPlanReaderService(tempDir.Path);
+
+        var result = RerunJobDialog.ResolvePlanFolder(job, planService);
+
+        Assert.NotNull(result);
+        Assert.True(Path.IsPathRooted(result), $"Expected rooted path but got: {result}");
+        Assert.Equal(planFolder, result);
+    }
+
+    [Fact]
+    public void ResolvePlanFolder_PlanFileWithoutExistingDirectory_ReturnsAbsolutePath()
+    {
+        using var tempDir = new TempDirectoryFixture("rerun-job-dialog-test");
+
+        var job = new JobItem
+        {
+            Id = "00001",
+            Type = "ExecutePlan",
+            ReportedPlanId = "00099",
+            PlanFile = "00099-Missing"
+        };
+        var planService = new MockPlanReaderService(tempDir.Path);
+
+        var result = RerunJobDialog.ResolvePlanFolder(job, planService);
+
+        Assert.NotNull(result);
+        Assert.True(Path.IsPathRooted(result), $"Expected rooted path but got: {result}");
+        Assert.StartsWith(tempDir.Path, result);
+    }
+
+    [Fact]
+    public void BuildRerunArgs_CreatePlanWithAbsolutePlanFolder_PassesPathThrough()
+    {
+        using var tempDir = new TempDirectoryFixture("rerun-job-dialog-test");
+        var planFolder = Path.Combine(tempDir.Path, "00042-LoginFeature");
+        Directory.CreateDirectory(planFolder);
+
+        var original = new CreatePlanArgs("Create a login feature", "MyProject");
+
+        var result = RerunJobDialog.BuildRerunArgs(original, "", planFolder);
+
+        var execute = Assert.IsType<ExecutePlanArgs>(result);
+        Assert.True(Path.IsPathRooted(execute.FolderPath), $"Expected rooted path but got: {execute.FolderPath}");
+        Assert.Equal(planFolder, execute.FolderPath);
     }
 }

--- a/src/Ivy.Tendril.Test/RerunJobDialogTests.cs
+++ b/src/Ivy.Tendril.Test/RerunJobDialogTests.cs
@@ -17,7 +17,34 @@ public class RerunJobDialogTests
         public PlanFile? GetPlanByFolder(string folderPath) => null;
         public List<PlanFile> GetIceboxPlans() => [];
         public void TransitionState(string folderName, PlanStatus newState) { }
-        public HashSet<string> GetFailedVerificationNames(string folderName) => [];
+        public IReadOnlyList<string> GetFailedVerifications(string folderName) => [];
+        public void CompleteWithPartialDelivery(string folderName) { }
+        public void ResetToDraft(string folderName) { }
+        public void ResetVerificationsForRetry(string folderName) { }
+        public void SetVerificationStatus(string folderName, string name, VerificationStatus status) { }
+        public void SaveRevision(string folderName, string content) { }
+        public void RevertRevision(string folderName) { }
+        public string ReadLatestRevision(string folderName) => "";
+        public List<(int Number, string Content, DateTime Modified)> GetRevisions(string folderName) => [];
+        public void DeletePlan(string folderName) { }
+        public string ReadRawPlan(string folderName) => "";
+        public void SavePlan(string folderName, string fullContent) { }
+        public void UpdateLatestRevision(string folderName, string content) { }
+        public DashboardModels GetDashboardData(string? projectFilter) => new(0, 0, 0, 0, 0, 0, 0m, [], []);
+        public decimal GetPlanTotalCost(string folderPath) => 0;
+        public int GetPlanTotalTokens(string folderPath) => 0;
+        public List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7, string? projectFilter = null) => [];
+        public List<Recommendation> GetRecommendations() => [];
+        public int GetPendingRecommendationsCount() => 0;
+        public PlanReaderService.PlanCountSnapshot ComputePlanCounts() => new(0, 0, 0, 0, 0, 0);
+        public void UpdateRecommendationState(string planFolderName, string recommendationTitle, string newState, string? declineReason = null) { }
+        public List<RecommendationYaml> GetRecommendationsForPlan(string folderName) => [];
+        public void AcceptRecommendationAndRetry(string folderName, string recommendationTitle) { }
+        public void AcceptRecommendationsAndRetry(string folderName, IReadOnlyCollection<string> titles) { }
+        public void SyncPlanArtifacts(string planFolder) { }
+        public void InvalidateCaches() { }
+        public Task FlushPendingWritesAsync() => Task.CompletedTask;
+        public event Action? CountsInvalidated { add { } remove { } }
     }
 
     [Theory]

--- a/src/Ivy.Tendril/Apps/Jobs/Dialogs/RerunJobDialog.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Dialogs/RerunJobDialog.cs
@@ -123,8 +123,12 @@ public class RerunJobDialog(
                 if (Directory.Exists(fullPath)) return fullPath;
             }
 
-            if (!string.IsNullOrEmpty(planId) && plansDir != null)
-                return Path.Combine(plansDir, job.PlanFile);
+            if (!string.IsNullOrEmpty(planId))
+            {
+                if (plansDir != null)
+                    return Path.Combine(plansDir, job.PlanFile);
+                return job.PlanFile;
+            }
         }
 
         return null;

--- a/src/Ivy.Tendril/Apps/Jobs/Dialogs/RerunJobDialog.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Dialogs/RerunJobDialog.cs
@@ -109,7 +109,7 @@ public class RerunJobDialog(
         if (!string.IsNullOrEmpty(planId) && plansDir != null && Directory.Exists(plansDir))
         {
             var folder = PlanYamlHelper.FindPlanFolderById(plansDir, planId);
-            if (folder != null) return folder;
+            if (folder != null) return Path.Combine(plansDir, folder);
         }
 
         if (!string.IsNullOrEmpty(job.PlanFile))
@@ -123,8 +123,8 @@ public class RerunJobDialog(
                 if (Directory.Exists(fullPath)) return fullPath;
             }
 
-            if (!string.IsNullOrEmpty(planId))
-                return job.PlanFile;
+            if (!string.IsNullOrEmpty(planId) && plansDir != null)
+                return Path.Combine(plansDir, job.PlanFile);
         }
 
         return null;

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -616,6 +616,12 @@ internal class JobLauncher
 
     private void EnsurePlanFolderWritable(string planFolder)
     {
+        if (!Directory.Exists(planFolder))
+        {
+            _logger.LogWarning("Plan folder does not exist, skipping write check: {PlanFolder}", planFolder);
+            return;
+        }
+
         var testFile = Path.Combine(planFolder, $".write-test-{Guid.NewGuid():N}");
         try
         {
@@ -626,6 +632,10 @@ internal class JobLauncher
         {
             _logger.LogWarning("Plan folder is not writable, attempting repair: {PlanFolder}", planFolder);
             TryRepairFolderAccess(planFolder);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            _logger.LogWarning("Plan folder directory not found: {PlanFolder}", planFolder);
         }
         finally
         {


### PR DESCRIPTION
Fixes #1848

# Summary

## Changes

Fixed a defect where rerunning a job from the Jobs app failed with `DirectoryNotFoundException`. The root cause was `ResolvePlanFolder` returning a bare folder name instead of an absolute path, which `Path.Combine` then resolved against the process working directory (the Tendril install folder) instead of the plans directory. Updated `ResolvePlanFolder` to always return absolute paths when the plans directory is available, and hardened `EnsurePlanFolderWritable` to handle non-existent folders gracefully.

## API Changes

**Modified:**
- `RerunJobDialog.ResolvePlanFolder(JobItem, IPlanReaderService?)` - Now returns absolute paths when `plansDir` is available. When `plansDir` is null (backward compatibility), still returns bare folder names.

## Files Modified

**Core fixes:**
- `src/Ivy.Tendril/Apps/Jobs/Dialogs/RerunJobDialog.cs` - Return absolute paths from `ResolvePlanFolder`
- `src/Ivy.Tendril/Services/Jobs/JobLauncher.cs` - Add early guard and `DirectoryNotFoundException` catch in `EnsurePlanFolderWritable`

**Tests:**
- `src/Ivy.Tendril.Test/RerunJobDialogTests.cs` - Added three regression tests for absolute path behavior

## Manual Testing

1. **Setup:** Identify a completed plan in the Plans app with a folder name longer than ~50 characters (e.g., `00038-FixRustyDocsGeneratorOutputAndAddWidgetSampleAppsWithAligned`).

2. **Reproduce original issue (pre-fix):**
   - Open the Jobs app
   - Find a completed ExecutePlan job for that plan
   - Click the "Rerun" button
   - **Expected (before fix):** Job immediately fails with `DirectoryNotFoundException` mentioning a path under `AppData\Local\IvyTendril\current\<plan-folder>\.write-test-...`

3. **Verify fix:**
   - With this PR merged, repeat steps above
   - **Expected (after fix):** Job executes normally. The plan folder path is correctly resolved to the plans directory (e.g., `C:\Users\pavel\.tendril\Plans\00038-...`) instead of the install directory.

4. **Verify launcher hardening:**
   - The error log should no longer show unhandled `DirectoryNotFoundException` when a relative path is passed to `EnsurePlanFolderWritable`. Instead, it logs a warning and continues gracefully.

---

## Commits

- e72f8ac8 Fix ResolvePlanFolder fallback when planService is null
- 550e0717 Update MockPlanReaderService to match current IPlanReaderService interface
- a928a33a Return absolute paths from ResolvePlanFolder when rerunning jobs
- 8cecc6f9 Fix broken baseline: remove leftover merge conflict markers
- d3ac71fd Return absolute paths from ResolvePlanFolder when rerunning jobs

---
Created using [Ivy Tendril](https://ivy.app).
