### PR TITLE
[00169] Fix the Diff View Right Shift When a File Has No Deleted Lines

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.test.tsx
@@ -171,3 +171,79 @@ describe("PlanDiffView", () => {
     expect(listItems.length).toBe(2);
   });
 });
+
+describe("PlanDiffView unified column collapse", () => {
+  const insertOnlyDiff = `diff --git a/file.txt b/file.txt
+index abc1234..def5678 100644
+--- a/file.txt
++++ b/file.txt
+@@ -1,0 +1,2 @@
++line 1
++line 2`;
+
+  const deleteOnlyDiff = `diff --git a/file.txt b/file.txt
+index abc1234..def5678 100644
+--- a/file.txt
++++ b/file.txt
+@@ -1,2 +1,0 @@
+-line 1
+-line 2`;
+
+  const mixedDiff = `diff --git a/file.txt b/file.txt
+index abc1234..def5678 100644
+--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,3 @@
+ context
+-old line
++new line`;
+
+  const emptyDiff = `diff --git a/file.txt b/file.txt
+old mode 100644
+new mode 100755`;
+
+  it("renders insert-only diff with diff-no-deletions class", () => {
+    const { container } = render(<PlanDiffView id="test-1" diff={insertOnlyDiff} viewType="Unified" />);
+    const table = container.querySelector(".diff");
+    expect(table).toHaveClass("diff-unified-view");
+    expect(table).toHaveClass("diff-no-deletions");
+    expect(table).not.toHaveClass("diff-no-additions");
+  });
+
+  it("renders delete-only diff with diff-no-additions class", () => {
+    const { container } = render(<PlanDiffView id="test-2" diff={deleteOnlyDiff} viewType="Unified" />);
+    const table = container.querySelector(".diff");
+    expect(table).toHaveClass("diff-unified-view");
+    expect(table).toHaveClass("diff-no-additions");
+    expect(table).not.toHaveClass("diff-no-deletions");
+  });
+
+  it("renders mixed diff with neither marker class", () => {
+    const { container } = render(<PlanDiffView id="test-3" diff={mixedDiff} viewType="Unified" />);
+    const table = container.querySelector(".diff");
+    expect(table).toHaveClass("diff-unified-view");
+    expect(table).not.toHaveClass("diff-no-deletions");
+    expect(table).not.toHaveClass("diff-no-additions");
+  });
+
+  it("renders zero-change diff with neither marker class", () => {
+    const { container } = render(<PlanDiffView id="test-4" diff={emptyDiff} viewType="Unified" />);
+    const table = container.querySelector(".diff");
+    expect(table).toHaveClass("diff-unified-view");
+    expect(table).not.toHaveClass("diff-no-deletions");
+    expect(table).not.toHaveClass("diff-no-additions");
+  });
+
+  it("emits a three-col colgroup and diff-line rows with three td children", () => {
+    const { container } = render(<PlanDiffView id="test-5" diff={insertOnlyDiff} viewType="Unified" />);
+    const colgroup = container.querySelector(".diff colgroup");
+    expect(colgroup).toBeTruthy();
+    const cols = colgroup?.querySelectorAll("col");
+    expect(cols?.length).toBe(3);
+
+    const diffLine = container.querySelector(".diff-line");
+    expect(diffLine).toBeTruthy();
+    const cells = diffLine?.querySelectorAll("td");
+    expect(cells?.length).toBe(3);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
@@ -668,7 +668,7 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
             {!isCollapsed && (
               <div className="overflow-x-auto">
                 <Diff
-                  className={`${effectiveViewType === "unified" ? "diff-unified-view" : "diff-split-view"} ${deletions === 0 ? "diff-no-deletions" : ""} ${additions === 0 ? "diff-no-additions" : ""}`}
+                  className={`${effectiveViewType === "unified" ? "diff-unified-view" : "diff-split-view"} ${deletions === 0 && additions > 0 ? "diff-no-deletions" : ""} ${additions === 0 && deletions > 0 ? "diff-no-additions" : ""}`}
                   viewType={effectiveViewType}
                   diffType={file.type}
                   hunks={file.hunks}

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/plan-diff.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/plan-diff.css
@@ -171,19 +171,14 @@ td.diff-gutter-empty::after {
   content: none !important;
 }
 
-/* Hide empty line number columns in unified view when no deletions or additions exist */
-.diff-unified-view.diff-no-deletions colgroup col:nth-child(1) {
-  display: none;
-}
-.diff-unified-view.diff-no-deletions .diff-row td:nth-child(1) {
-  display: none;
-}
-
+/* Collapse the unused line-number column in unified view.
+   `display` and `visibility` do not work on <col>; `width` does, and with
+   `table-layout: fixed` a zero-width col removes the column entirely.
+   Do NOT also hide the <td>: with a fixed layout that collapses the code
+   column too (measured: code column drops to 47px). */
+.diff-unified-view.diff-no-deletions colgroup col:first-child,
 .diff-unified-view.diff-no-additions colgroup col:nth-child(2) {
-  display: none;
-}
-.diff-unified-view.diff-no-additions .diff-row td:nth-child(2) {
-  display: none;
+  width: 0;
 }
 
 /* Outer layout and widget padding adjustments */


### PR DESCRIPTION
Fixes #1837

# Summary

## Changes

Fixed the diff view right shift bug where files with only added lines (no deletions) caused the code display to be pushed far to the right. The fix replaced ineffective `display: none` rules with `width: 0` on `<col>` elements to properly collapse unused line number columns, and guarded the marker classes to prevent both columns from collapsing on zero-change diffs (mode-only or pure renames).

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/plan-diff.css** - Replaced CSS block (lines 174-187) with correct column collapse rules using `width: 0` on col elements
- **src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx** - Added guards (`additions > 0` and `deletions > 0`) to the className logic at line 671
- **src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.test.tsx** - Added 5 new tests for column collapse behavior

## Manual Testing

1. Open the Tendril app and navigate to the Plans view
2. Select a completed plan that modified files (e.g., a recent plan from the Plans list)
3. Open the Changes tab to view the diff
4. Find a file in the diff that has only additions (green lines) and no deletions (no red lines)
   - If the current plan doesn't have such a file, you can create a test by adding new lines to any file in a scratch branch
5. Observe that the code starts immediately after the single line-number column (around 50-100px from the left edge)
6. The code should NOT be shifted far to the right (past the halfway point of the container)
7. The line numbers should be visible and the `+` hover badge for adding comments should still work on the gutter

**Expected result:** Code aligns normally with one visible line-number column. No excessive white space or green band pushing the code to the right.

---

## Commits
- 3fb264d2 Fix diff view right shift when file has no deleted lines

---
Created using [Ivy Tendril](https://ivy.app).
