### PR TITLE
[00158] Make the Diff Header Comment Icon a Working Comment Toggle

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/CommentToggle.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/CommentToggle.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { PlanDiffView } from "./PlanDiffView";
+
+const DIFF_FIXTURE = `diff --git a/index.html b/index.html
+index 0000001..1111111 100644
+--- a/index.html
++++ b/index.html
+@@ -1,2 +1,2 @@
+-  <main id="app">
++  <div id="login">
+ </body>`;
+
+const COMMENT_FIXTURE = {
+  filePath: "index.html",
+  changeKey: "I1",
+  content: "please fix",
+  lineNumber: 1,
+};
+
+describe("PlanDiffView comment toggle", () => {
+  it("is disabled with no comments", () => {
+    const { getByLabelText } = render(
+      <PlanDiffView
+        id="test-widget"
+        diff={DIFF_FIXTURE}
+        filePath="index.html"
+        comments={[]}
+      />
+    );
+
+    const button = getByLabelText("Hide comments") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.title).toBe("No comments on this file");
+  });
+
+  it("shows the count", () => {
+    const { getByLabelText } = render(
+      <PlanDiffView
+        id="test-widget"
+        diff={DIFF_FIXTURE}
+        filePath="index.html"
+        comments={[COMMENT_FIXTURE]}
+      />
+    );
+
+    const button = getByLabelText("Hide comments") as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+    // Check the button contains a count span
+    const countSpan = button.querySelector("span.font-mono.text-\\[10px\\]");
+    expect(countSpan).toBeTruthy();
+    expect(countSpan?.textContent).toBe("1");
+  });
+
+  it("toggles visibility both ways", () => {
+    const { getByLabelText, getByText, queryByText } = render(
+      <PlanDiffView
+        id="test-widget"
+        diff={DIFF_FIXTURE}
+        filePath="index.html"
+        comments={[COMMENT_FIXTURE]}
+      />
+    );
+
+    // Initially visible
+    expect(getByText("please fix")).toBeTruthy();
+
+    // Click to hide
+    const hideButton = getByLabelText("Hide comments");
+    fireEvent.click(hideButton);
+
+    // Comment should be hidden
+    expect(queryByText("please fix")).toBeNull();
+
+    // Click to show
+    const showButton = getByLabelText("Show comments");
+    fireEvent.click(showButton);
+
+    // Comment should be visible again
+    expect(getByText("please fix")).toBeTruthy();
+  });
+
+  it("does not collapse the file and does not dispatch", () => {
+    const eventHandler = vi.fn();
+    const { getByLabelText, container } = render(
+      <PlanDiffView
+        id="test-widget"
+        diff={DIFF_FIXTURE}
+        filePath="index.html"
+        comments={[COMMENT_FIXTURE]}
+        eventHandler={eventHandler}
+      />
+    );
+
+    // Click the toggle
+    const button = getByLabelText("Hide comments");
+    fireEvent.click(button);
+
+    // Diff rows should still be present (file not collapsed)
+    const diffCells = container.querySelectorAll("td.diff-code");
+    expect(diffCells.length).toBeGreaterThan(0);
+
+    // No events should be dispatched
+    expect(eventHandler).not.toHaveBeenCalled();
+  });
+
+  it("an open compose form survives the toggle", () => {
+    const { getByLabelText, container } = render(
+      <PlanDiffView
+        id="test-widget"
+        diff={DIFF_FIXTURE}
+        filePath="index.html"
+        comments={[COMMENT_FIXTURE]}
+      />
+    );
+
+    // Click a gutter cell to open the form
+    const gutterCell = container.querySelector("td.diff-gutter");
+    if (gutterCell) {
+      fireEvent.click(gutterCell);
+    }
+
+    // Wait for the form to appear
+    const textarea = container.querySelector("textarea");
+    expect(textarea).toBeTruthy();
+
+    // Type some text
+    if (textarea) {
+      fireEvent.change(textarea, { target: { value: "test comment" } });
+    }
+
+    // Click the toggle
+    const button = getByLabelText("Hide comments");
+    fireEvent.click(button);
+
+    // The textarea should still be present with its text
+    const textareaAfter = container.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textareaAfter).toBeTruthy();
+    expect(textareaAfter?.value).toBe("test comment");
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
@@ -279,6 +279,7 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
   const [activeFormKeys, setActiveFormKeys] = useState<Record<string, boolean>>({});
   const [editingCommentKeys, setEditingCommentKeys] = useState<Record<string, string>>({});
   const [activeDropdownIndex, setActiveDropdownIndex] = useState<number | null>(null);
+  const [commentsHidden, setCommentsHidden] = useState<Record<number, boolean>>({});
 
   useEffect(() => {
     if (activeDropdownIndex === null) return;
@@ -335,7 +336,7 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
     }
   };
 
-  const getWidgets = (hunks: HunkData[]) => {
+  const getWidgets = (hunks: HunkData[], hideComments = false) => {
     const allChanges = hunks.reduce<ChangeData[]>((result, hunk) => [...result, ...hunk.changes], []);
     const widgets: Record<string, React.ReactNode> = {};
 
@@ -350,11 +351,12 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
         ? rawLine.slice(1)
         : rawLine;
 
-      if (lineComments.length > 0 || showForm || isEditing) {
+      const visibleComments = hideComments ? [] : lineComments;
+      if (visibleComments.length > 0 || showForm || isEditing) {
         widgets[changeKey] = (
           <CommentWidgetContainer
             changeKey={changeKey}
-            comments={lineComments}
+            comments={visibleComments}
             isEditing={isEditing}
             editingText={editingCommentKeys[changeKey]}
             originalLineText={originalLineText}
@@ -608,8 +610,37 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
                     Viewed
                   </label>
 
-                  {/* Message bubble icon */}
-                  <MessageSquare className="w-3.5 h-3.5 text-[var(--muted-foreground)]" />
+                  {/* Comment count / visibility toggle */}
+                  {(() => {
+                    const fileCommentCount = comments.length;
+                    const hidden = commentsHidden[fileIndex] ?? false;
+                    return (
+                      <button
+                        type="button"
+                        aria-label={hidden ? "Show comments" : "Hide comments"}
+                        aria-pressed={!hidden}
+                        disabled={fileCommentCount === 0}
+                        title={
+                          fileCommentCount === 0
+                            ? "No comments on this file"
+                            : hidden
+                              ? `Show ${fileCommentCount} comment(s)`
+                              : `Hide ${fileCommentCount} comment(s)`
+                        }
+                        className="flex items-center gap-1 p-1 rounded hover:bg-[var(--muted)] text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors cursor-pointer disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-[var(--muted-foreground)]"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (fileCommentCount === 0) return;
+                          setCommentsHidden((prev) => ({ ...prev, [fileIndex]: !hidden }));
+                        }}
+                      >
+                        <MessageSquare className="w-3.5 h-3.5" />
+                        {fileCommentCount > 0 && (
+                          <span className="font-mono text-[10px]">{fileCommentCount}</span>
+                        )}
+                      </button>
+                    );
+                  })()}
 
                   {/* More actions button & dropdown */}
                   <div className="diff-more-actions-container relative">
@@ -672,7 +703,7 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
                   viewType={effectiveViewType}
                   diffType={file.type}
                   hunks={file.hunks}
-                  widgets={getWidgets(file.hunks)}
+                  widgets={getWidgets(file.hunks, commentsHidden[fileIndex] ?? false)}
                   gutterEvents={{
                     onClick: ({ change }) => {
                       if (change) {


### PR DESCRIPTION
Fixes #1838

# Summary

## Changes

Converted the decorative comment bubble icon in the PlanDiffView diff header into a working toggle button. The button shows the file comment count, allows hiding/showing all comments in that file with a click, and is disabled when no comments exist. The toggle is client-side only and preserves open compose/edit forms.

## API Changes

None. The change is entirely internal to `PlanDiffView.tsx` - no new props, events, or exported functions.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx` - Added comment toggle button and visibility state
- `src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/CommentToggle.test.tsx` - New test suite with 5 tests

## Manual Testing

1. Launch the Tendril Review app
2. Navigate to the Changes tab for any plan with draft comments on file diffs
3. Observe the comment bubble icon in each file's diff header now shows a count badge (e.g., "2") next to it
4. Click the icon - all comments in that file should hide
5. Click again - comments reappear
6. With comments hidden, click a gutter cell to open the compose form - verify the textarea appears and remains visible even though comments are hidden
7. Type some text in the compose form, then click the toggle - verify the textarea stays open with your text
8. On a file with no comments, verify the button is disabled (grayed out) with tooltip "No comments on this file"

---

## Commits

- 630e8dd2 Make diff header comment icon a working toggle

---
Created using [Ivy Tendril](https://ivy.app).
