### PR TITLE
fix(Onboarding): Persist and resolve custom Tendril Home location across fresh sessions

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/OnboardingApp.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/OnboardingApp.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Apps.Onboarding.Models;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps.Onboarding;
@@ -74,9 +75,7 @@ public class OnboardingApp : ViewBase
         var commonChecksPassed = UseState(false);
         var homeBootstrapped = UseState(false);
         var completedAgentKey = UseState<string?>();
-        var tendrilHomePath = UseState(() =>
-            Environment.GetEnvironmentVariable("TENDRIL_HOME")
-            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril"));
+        var tendrilHomePath = UseState(() => PathHelper.GetDefaultTendrilHome());
         var selectedRepos = UseState(() => new List<RepoRef>());
         var projectName = UseState("");
         var isStepLoading = UseState(false);

--- a/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/TendrilHomeStepView.cs
@@ -17,9 +17,7 @@ public class TendrilHomeStepView(
         var error = UseState<string?>(null);
         var isBootstrapping = UseState(false);
 
-        var defaultHome = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".tendril");
+        var defaultHome = PathHelper.GetDefaultTendrilHome();
 
         return Layout.Vertical().Margin(0, 0, 0, 2)
                | Text.H3("Where should we store your data?")

--- a/src/Ivy.Tendril/Helpers/PathHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PathHelper.cs
@@ -35,6 +35,40 @@ public static class PathHelper
             return envHome;
         }
 
+        if (OperatingSystem.IsWindows())
+        {
+            try
+            {
+                var userEnvHome = Environment.GetEnvironmentVariable("TENDRIL_HOME", EnvironmentVariableTarget.User)?.Trim();
+                if (!string.IsNullOrEmpty(userEnvHome))
+                {
+                    if (userEnvHome.StartsWith("\"") && userEnvHome.EndsWith("\""))
+                        userEnvHome = userEnvHome[1..^1];
+                    if (File.Exists(Path.Combine(userEnvHome, "config.yaml")))
+                    {
+                        Environment.SetEnvironmentVariable("TENDRIL_HOME", userEnvHome);
+                        return userEnvHome;
+                    }
+                }
+            }
+            catch { }
+        }
+
+        try
+        {
+            var pointerFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril_location");
+            if (File.Exists(pointerFile))
+            {
+                var location = File.ReadAllText(pointerFile).Trim();
+                if (!string.IsNullOrEmpty(location) && File.Exists(Path.Combine(location, "config.yaml")))
+                {
+                    Environment.SetEnvironmentVariable("TENDRIL_HOME", location);
+                    return location;
+                }
+            }
+        }
+        catch { }
+
         return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril");
     }
 

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -103,7 +103,7 @@ internal static class ServiceRegistration
         {
             var config = sp.GetRequiredService<IConfigService>();
             var home = string.IsNullOrEmpty(config.TendrilHome)
-                ? System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile), ".tendril")
+                ? Helpers.PathHelper.GetDefaultTendrilHome()
                 : config.TendrilHome;
             return new WorktreeLifecycleLogger(home);
         });

--- a/src/Ivy.Tendril/Services/OnboardingSetupService.cs
+++ b/src/Ivy.Tendril/Services/OnboardingSetupService.cs
@@ -66,6 +66,16 @@ public class OnboardingSetupService(IConfigService config, IAgentRunner agentRun
 
         try
         {
+            var pointerFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril_location");
+            await FileHelper.WriteAllTextAsync(pointerFile, tendrilHome);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to write .tendril_location pointer file");
+        }
+
+        try
+        {
             if (OperatingSystem.IsWindows())
             {
                 Environment.SetEnvironmentVariable("TENDRIL_HOME", tendrilHome, EnvironmentVariableTarget.User);


### PR DESCRIPTION
Ensures Tendril Home location is correctly remembered on fresh app launches when set to a custom directory (e.g. D:/.tendril).