### PR TITLE
fix(PathHelper): Prefer valid Tendril Home target with config.yaml over stale process env

### DIFF
--- a/src/Ivy.Tendril/Helpers/PathHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PathHelper.cs
@@ -32,7 +32,9 @@ public static class PathHelper
         {
             if (envHome.StartsWith("\"") && envHome.EndsWith("\""))
                 envHome = envHome[1..^1];
-            return envHome;
+
+            if (File.Exists(Path.Combine(envHome, "config.yaml")))
+                return envHome;
         }
 
         if (OperatingSystem.IsWindows())
@@ -68,6 +70,9 @@ public static class PathHelper
             }
         }
         catch { }
+
+        if (!string.IsNullOrEmpty(envHome))
+            return envHome;
 
         return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril");
     }


### PR DESCRIPTION
Ensures that if process environment variable points to a directory without config.yaml (e.g. inherited ~/.tendril), PathHelper checks User registry and .tendril_location pointer file for the valid config.