### PR TITLE
fix(Project): Ensure Bg job button renders for all beta flag sources

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -1,5 +1,7 @@
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Jobs;
+using Ivy.Tendril.Models;
 using Ivy.Tendril.Apps.Views;
 
 namespace Ivy.Tendril.Apps.Onboarding;
@@ -22,7 +24,13 @@ public class ProjectInputStepView(
     {
         var config = UseService<IConfigService>();
         var tendrilArgs = UseService<TendrilArgs>();
-        var isBeta = tendrilArgs?.Beta == true;
+        var jobService = UseService<IJobService>();
+        var client = UseService<IClientProvider>();
+
+        var isBeta = (tendrilArgs?.Beta ?? false) ||
+                     (config?.Settings?.Beta ?? false) ||
+                     Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" ||
+                     Environment.GetEnvironmentVariable("IVY_BETA") == "1";
 
         UseEffect(() =>
         {
@@ -49,12 +57,29 @@ public class ProjectInputStepView(
                           && !string.IsNullOrWhiteSpace(projectName.Value)
                           && !nameExists;
 
+        Action handleBgJob = onBgJob ?? (() =>
+        {
+            if (!canContinue) return;
+            var newProj = new ProjectConfig
+            {
+                Name = projectName.Value.Trim(),
+                Repos = new List<RepoRef>(selectedRepos.Value)
+            };
+            config.Settings.Projects.Add(newProj);
+            try { config.SaveSettings(); } catch { }
+
+            jobService?.StartJob(new AddProjectArgs(newProj.Name, newProj.Repos));
+            if (client != null)
+                client.Toast($"Created background job for project '{newProj.Name}'", "Job Started");
+            onNext();
+        });
+
         var buttonArea = Layout.Horizontal().Width(Size.Full()).Gap(2)
             | (onSkip != null ? (object)new Button(skipButtonText).Ghost().Large().Disabled(disableSkipWhenCannotContinue && !canContinue).OnClick(() => onSkip()) : new Spacer())
             | new Spacer()
             | (onBack != null ? (object)new Button("Back").Outline().Large().Icon(Icons.ArrowLeft).OnClick(onBack) : null!)
-            | (isBeta && onBgJob != null
-                ? (object)new Button("Bg job").Outline().Large().Disabled(!canContinue).OnClick(onBgJob)
+            | (isBeta
+                ? (object)new Button("Bg job").Outline().Large().Disabled(!canContinue).OnClick(handleBgJob)
                 : null!)
             | new Button(nextButtonText).Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
                 .Disabled(!canContinue)

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -178,6 +178,7 @@ public class TendrilSettings
     public Tunnel.TunnelConfig? Tunnel { get; set; }
     public bool Telemetry { get; set; } = true;
     public bool DesktopNotifications { get; set; } = true;
+    public bool Beta { get; set; } = false;
     public string? DismissedUpdateVersion { get; set; }
 
     public List<LevelConfig> Levels { get; set; } = new()

--- a/src/Ivy.Tendril/Services/TendrilArgs.cs
+++ b/src/Ivy.Tendril/Services/TendrilArgs.cs
@@ -2,7 +2,12 @@ namespace Ivy.Tendril.Services;
 
 public class TendrilArgs
 {
-    public bool Beta { get; init; } = Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1";
+    private readonly bool? _beta;
+    public bool Beta
+    {
+        get => _beta ?? (Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" || Environment.GetEnvironmentVariable("IVY_BETA") == "1");
+        init => _beta = value;
+    }
     public bool Verbose { get; init; } = Environment.GetEnvironmentVariable("TENDRIL_VERBOSE") == "1";
     public bool Quiet { get; init; } = Environment.GetEnvironmentVariable("TENDRIL_QUIET") == "1";
 }


### PR DESCRIPTION
Ensures the 'Bg job' button renders to the left of Create Project whenever beta mode is enabled via --beta, TENDRIL_BETA=1, IVY_BETA=1, or config.yaml Beta: true setting.