### PR TITLE
fix(TendrilArgs): Clean up Beta property backing field evaluation

### DIFF
--- a/src/Ivy.Tendril/Services/TendrilArgs.cs
+++ b/src/Ivy.Tendril/Services/TendrilArgs.cs
@@ -5,7 +5,7 @@ public class TendrilArgs
     private readonly bool? _beta;
     public bool Beta
     {
-        get => _beta ?? (Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" || Environment.GetEnvironmentVariable("IVY_BETA") == "1");
+        get => _beta == true || Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" || Environment.GetEnvironmentVariable("IVY_BETA") == "1";
         init => _beta = value;
     }
     public bool Verbose { get; init; } = Environment.GetEnvironmentVariable("TENDRIL_VERBOSE") == "1";


### PR DESCRIPTION
Cleans up TendrilArgs.Beta property getter so that _beta == true or TENDRIL_BETA / IVY_BETA env vars evaluate consistently.