### PR TITLE
fix(AgentViewer): Prevent tool calls count label from wrapping onto multiple lines

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
@@ -318,6 +318,8 @@
   user-select: none;
   font-size: 14px;
   outline: none;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .aov-tool-chevron {
@@ -360,6 +362,8 @@
 .aov-tool-name {
   color: var(--aov-accent);
   font-weight: 600;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .aov-tool-preview {
@@ -412,6 +416,8 @@
   user-select: none;
   font-size: 14px;
   outline: none;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .aov-tool-group-body {


### PR DESCRIPTION
Ensures .aov-tool-name and header elements use white-space: nowrap and flex-shrink: 0 so tool call group titles (e.g. '11 tool calls') remain on a single line.