### PR TITLE
fix(AgentViewer): Reduce expanded tool group padding and update Chat Agent project setup rules

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
@@ -376,7 +376,7 @@
 }
 
 .aov-tool-body {
-  padding: 4px 0 4px 37px;
+  padding: 4px 0 4px 18px;
   animation: aov-tool-expand 0.2s ease-out both;
 }
 
@@ -421,7 +421,7 @@
 }
 
 .aov-tool-group-body {
-  padding: 4px 0 4px 37px;
+  padding: 4px 0 4px 18px;
   animation: aov-tool-expand 0.2s ease-out both;
 }
 

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -194,12 +194,15 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 | `CreatePr` | `<plan-id>` | `--no-merge`, `--no-delete-branch`, `--no-artifacts`, `--assignee`, `--comment`, `--draft` |
 | `RetryPlan` | `<plan-id>`, `--change-request` | — |
 | `CreatePlan` | `--description`, `--project` | `--priority`, `--force`, `--source-path` |
+| `SetupProject` | `<project-name>` | — |
+| `AddProject` | `<project-name>` | — |
 
 Examples:
 ```bash
 tendril job start ExecutePlan 00042
 tendril job start RetryPlan 00042 --change-request="Fix the failing tests"
 tendril job start CreatePlan --description="Add dark mode" --project=MyProject
+tendril job start AddProject "MyProject"
 ```
 
 ### Promptware Commands
@@ -239,6 +242,17 @@ These commands are for internal use by other promptwares (e.g., a verification s
 | `tendril config set <key> <value>` | Set a top-level config value (use `--file`/`--stdin` for multiline values) |
 
 Valid keys: `codingAgent`, `jobTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate`. Example: `tendril config get planTemplate` prints the configured Plan Template.
+
+## Adding & Configuring Projects
+
+When the user asks you to add or configure a project (e.g. "add https://github.com/... as a project"):
+
+1. **DO NOT MANUALLY CONFIGURE**: Do NOT manually add verifications, review actions, or stack hashes using low-level CLI commands.
+2. **USE PROMPTWARE JOBS**: Always trigger the `AddProject` or `SetupProject` promptware job so that the automated setup engine runs:
+   ```bash
+   tendril job start AddProject "<ProjectName>"
+   ```
+3. **CLONE REMOTE REPOS TO DISK**: Always ensure remote Git repository URLs are cloned/pulled into `{TENDRIL_HOME}/Repos/<RepoName>` so local repository files exist on disk before inspecting or running project setup.
 
 ## Finding Projects & Repositories
 


### PR DESCRIPTION
Reduces left padding in expanded tool call groups from 37px to 18px for consistent layout, and updates Prompts/AgentPrompt.md to instruct Chat Agents to run AddProject background jobs and clone remote repos to disk.