### PR TITLE
fix(AppShell): Separate Chat App and Agent App sidebar badges

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -105,7 +105,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             ["trash"] = status.TrashCount,
             ["chat"] = status.GeneratingChatSessionsCount,
             ["chat-app"] = status.GeneratingChatSessionsCount,
-            ["agent"] = status.GeneratingChatSessionsCount
+            ["agent"] = runner.ActiveSessions.Count
         };
         var agentId = config.Settings.CodingAgent;
         return repo.GetMenuItems()


### PR DESCRIPTION
Disambiguates sidebar badges so Chat App badge reflects generating chat sessions, while Agent App badge reflects active agent runner sessions.