### PR TITLE
fix(ChatApp): Prevent duplicate Chat tabs

### DIFF
--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -18,7 +18,7 @@ using Ivy.Tendril.Widgets;
 
 namespace Ivy.Tendril.Apps.Chat;
 
-[App(title: "Chat", icon: Icons.MessageSquare, group: ["Apps"], order: Constants.Chat, isVisible: false, allowDuplicateTabs: true)]
+[App(title: "Chat", icon: Icons.MessageSquare, group: ["Apps"], order: Constants.Chat, isVisible: false, allowDuplicateTabs: false)]
 public class ChatApp : ViewBase
 {
     public override object Build()


### PR DESCRIPTION
Sets allowDuplicateTabs to false on ChatApp to prevent opening duplicate Chat tabs when navigating or selecting Chat in the sidebar.