### PR TITLE
feat(CLI): Add tendril job cancel command and POST api/jobs/{id}/cancel endpoint

### DIFF
--- a/src/Ivy.Tendril/Commands/JobCancelCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobCancelCommand.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel;
+using Ivy.Tendril.Helpers;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class JobCancelSettings : CommandSettings
+{
+    [Description("Job ID (e.g., 00011 or job-0011)")]
+    [CommandArgument(0, "<job-id>")]
+    public string JobId { get; set; } = "";
+
+    [Description("Reason for cancellation")]
+    [CommandOption("--message|-m")]
+    public string? Message { get; set; }
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.RequireNonEmpty(JobId, "job-id");
+    }
+}
+
+public class JobCancelCommand : Command<JobCancelSettings>
+{
+    protected override int Execute(CommandContext context, JobCancelSettings settings, CancellationToken cancellationToken)
+    {
+        var (ok, error) = MasterClient.TryPostJson(
+            $"api/jobs/{settings.JobId}/cancel",
+            new { message = settings.Message ?? "Cancelled by user" },
+            cancellationToken);
+
+        if (!ok)
+        {
+            Console.Error.WriteLine($"Error: could not cancel job {settings.JobId}: {error}");
+            return 1;
+        }
+
+        Console.WriteLine($"Cancelled job {settings.JobId}");
+        return 0;
+    }
+}

--- a/src/Ivy.Tendril/Controllers/JobController.cs
+++ b/src/Ivy.Tendril/Controllers/JobController.cs
@@ -49,10 +49,33 @@ public class JobController(IJobService jobService, IConfigService configService)
     [HttpPut("{jobId}/fail")]
     public IActionResult ReportJobFailure(string jobId, [FromBody] ReportJobFailureRequest request)
     {
-        if (!jobService.ReportJobFailure(NormalizeJobId(jobId), request.Message))
+        var id = NormalizeJobId(jobId);
+        if (!jobService.ReportJobFailure(id, request.Message))
             return NotFound(new { error = "Job not found" });
 
+        if (request.Stop)
+        {
+            jobService.StopJob(id);
+        }
+
         return Ok(new { status = "Failure reported" });
+    }
+
+    [HttpPost("{jobId}/cancel")]
+    public IActionResult CancelJob(string jobId, [FromBody] CancelJobRequest? request)
+    {
+        var id = NormalizeJobId(jobId);
+        var job = jobService.GetJob(id);
+        if (job == null)
+            return NotFound(new { error = "Job not found" });
+
+        if (!string.IsNullOrWhiteSpace(request?.Message))
+        {
+            jobService.ReportJobFailure(id, request.Message);
+        }
+
+        jobService.StopJob(id);
+        return Ok(new { status = "Cancelled" });
     }
 
     /// <summary>Appends an <c>## Agent Log</c> section to the job's log in <c>&lt;TendrilHome&gt;/Jobs/</c>.</summary>
@@ -81,6 +104,8 @@ public class JobController(IJobService jobService, IConfigService configService)
 
 public record UpdateJobStatusRequest(string Message, string? PlanId = null, string? PlanTitle = null);
 
-public record ReportJobFailureRequest(string Message);
+public record ReportJobFailureRequest(string Message, bool Stop = false);
+
+public record CancelJobRequest(string? Message = null);
 
 public record AddLogRequest(string Action, string? Summary = null);

--- a/src/Ivy.Tendril/Helpers/MasterClient.cs
+++ b/src/Ivy.Tendril/Helpers/MasterClient.cs
@@ -145,6 +145,39 @@ public static class MasterClient
         }
     }
 
+    public static (bool Ok, string? Error) TryPostJson(string relativePath, object payload,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var discovery = Discover();
+            using var client = CreateHttpClient(discovery);
+
+            var json = JsonSerializer.Serialize(payload, JsonOptions);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            var response = client
+                .PostAsync($"{discovery.BaseUrl}/{relativePath.TrimStart('/')}", content, cancellationToken)
+                .GetAwaiter().GetResult();
+
+            return response.IsSuccessStatusCode
+                ? (true, null)
+                : (false, $"server returned {(int)response.StatusCode} {response.ReasonPhrase}");
+        }
+        catch (TaskCanceledException)
+        {
+            return (false, $"server did not respond in time ({DefaultTimeout.TotalSeconds:0}s timeout)");
+        }
+        catch (HttpRequestException ex)
+        {
+            return (false, $"failed to connect to the Tendril server: {ex.Message}");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return (false, ex.Message);
+        }
+    }
+
     public static DiscoveryResult Discover(string? tendrilHome = null)
     {
         tendrilHome ??= Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -694,6 +694,8 @@ public class Program
                     .WithDescription("Report job status (message, planId, planTitle)");
                 job.AddCommand<JobFailCommand>("fail")
                     .WithDescription("Report a job failure with a descriptive message");
+                job.AddCommand<JobCancelCommand>("cancel")
+                    .WithDescription("Cancel a running or queued job, terminate its process, and revert plan state");
                 job.AddCommand<JobStartCommand>("start")
                     .WithDescription("Start a job via the running Tendril server");
                 job.AddCommand<JobAddLogCommand>("add-log")

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -180,6 +180,7 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 |---------|-------------|
 | `tendril job start <Type> <plan-id> [options]` | Start a job on the running Tendril server |
 | `tendril job status <job-id> -m <message>` | Report job status to the server |
+| `tendril job cancel <job-id> [-m <message>]` | Cancel a running or queued job, terminate its process, and revert plan state |
 | `tendril job add-log <job-id> <action> [--summary=<text>]` | Append a narrative log entry to this job's log |
 
 **Job types and options for `tendril job start`:**


### PR DESCRIPTION
Enables canceling running or queued jobs via tendril job cancel <job-id> [-m message], which stops the process, reverts plan state, and updates job status.