### PR TITLE
fix(Program): Set CreateNoWindow to true on process launch

### DIFF
--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -546,7 +546,8 @@ public class Program
             var psi = new ProcessStartInfo
             {
                 FileName = installedCli,
-                UseShellExecute = false
+                UseShellExecute = false,
+                CreateNoWindow = true
             };
             foreach (var arg in args)
                 psi.ArgumentList.Add(arg);


### PR DESCRIPTION
Ensures CreateNoWindow is set to true on process redirect start to prevent console pop-ups on Windows.