### PR TITLE
fix(InboxWatcherService): Non-blocking startup for existing inbox files and background services

### DIFF
--- a/src/Ivy.Tendril/Services/InboxWatcherService.cs
+++ b/src/Ivy.Tendril/Services/InboxWatcherService.cs
@@ -28,8 +28,6 @@ public class InboxWatcherService : IInboxWatcherService
         // Recover crashed CreatePlan jobs: rename .processing files back to .md
         RecoverProcessingFiles();
 
-        ProcessExistingFiles();
-
         _watcher = new FileSystemWatcher(_inboxPath, "*.md")
         {
             InternalBufferSize = 65536,
@@ -42,6 +40,8 @@ public class InboxWatcherService : IInboxWatcherService
             CrashLog.Write($"[{DateTime.UtcNow:O}] InboxWatcher FSW error: {e.GetException()}");
 
         _pollTimer = new Timer(OnPollTimer, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+
+        _ = Task.Run(ProcessExistingFilesAsync);
     }
 
     public void Dispose()
@@ -66,7 +66,7 @@ public class InboxWatcherService : IInboxWatcherService
     {
         try
         {
-            ProcessExistingFiles();
+            _ = ProcessExistingFilesAsync();
         }
         catch (Exception ex)
         {
@@ -95,14 +95,23 @@ public class InboxWatcherService : IInboxWatcherService
             }
     }
 
-    internal void ProcessExistingFiles()
+    internal async Task ProcessExistingFilesAsync()
     {
         if (!Directory.Exists(_inboxPath))
             return;
 
-        var files = Directory.GetFiles(_inboxPath, "*.md")
-            .OrderBy(f => File.GetCreationTimeUtc(f))
-            .ToList();
+        List<string> files;
+        try
+        {
+            files = Directory.GetFiles(_inboxPath, "*.md")
+                .OrderBy(f => File.GetCreationTimeUtc(f))
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to list inbox files for processing");
+            return;
+        }
 
         for (int i = 0; i < files.Count; i++)
         {
@@ -110,7 +119,7 @@ public class InboxWatcherService : IInboxWatcherService
 
             // Stagger startup to avoid thundering herd
             if (i < files.Count - 1)
-                Thread.Sleep(2000);
+                await Task.Delay(2000);
         }
     }
 

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -65,7 +65,7 @@ public static class TendrilServer
                     PromptwareDeployer.Deploy(promptwaresDir);
                 }
 
-                BackgroundServiceActivator.Start(app.Services);
+                _ = BackgroundServiceActivator.StartAsync(app.Services, app.Services.GetRequiredService<ILogger<Server>>());
             }
 
             var telemetryService = app.Services.GetRequiredService<TelemetryService>();


### PR DESCRIPTION
Converts InboxWatcherService.ProcessExistingFiles into an async task and activates background services asynchronously in TendrilServer, allowing Tendril and Kestrel HTTP server to launch immediately without waiting for queued startup jobs.