### PR TITLE
feat(agents): refactor Ivy Agent and introduce OpenAI Proxy provider

### DIFF
--- a/src/Ivy.Tendril.Agents/Abstractions/AgentTypes.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/AgentTypes.cs
@@ -9,6 +9,7 @@ public static class AgentId
     public const string Gemini = "gemini";
     public const string OpenCode = "opencode";
     public const string Ivy = "ivy";
+    public const string OpenAiProxy = "openaiproxy";
 }
 
 public static class CanonicalTools

--- a/src/Ivy.Tendril.Agents/AgentServiceCollectionExtensions.cs
+++ b/src/Ivy.Tendril.Agents/AgentServiceCollectionExtensions.cs
@@ -22,6 +22,9 @@ public sealed class AgentInfrastructureOptions
     public Func<IServiceProvider, Func<string?>>? IvyApiKeyProviderFactory { get; set; }
     public Func<IServiceProvider, Func<string?>>? IvyTokenProviderFactory { get; set; }
     public Func<IServiceProvider, Func<CancellationToken, Task<string?>>>? IvyEmailProviderFactory { get; set; }
+
+    public Func<IServiceProvider, Func<string?>>? OpenAiProxyApiKeyProviderFactory { get; set; }
+    public Func<IServiceProvider, Func<string?>>? OpenAiProxyBaseUrlProviderFactory { get; set; }
 }
 
 public static class AgentServiceCollectionExtensions
@@ -110,6 +113,18 @@ public static class AgentServiceCollectionExtensions
                     new Providers.Ivy.IvySessionCostParser(),
                     new Providers.Ivy.IvyPty(apiKeyProvider),
                     new Providers.Ivy.IvyModelCatalog());
+
+                Func<string?> openAiProxyApiKeyProvider = options.OpenAiProxyApiKeyProviderFactory?.Invoke(sp) ?? (() => null);
+                Func<string?> openAiProxyBaseUrlProvider = options.OpenAiProxyBaseUrlProviderFactory?.Invoke(sp) ?? (() => null);
+
+                runner.Register(
+                    new Providers.OpenAiProxy.OpenAiProxyCli(openAiProxyApiKeyProvider, openAiProxyBaseUrlProvider),
+                    new Providers.OpenAiProxy.OpenAiProxyEventParser(),
+                    new Providers.OpenAiProxy.OpenAiProxyHealthCheck(openAiProxyApiKeyProvider, openAiProxyBaseUrlProvider),
+                    new Providers.OpenAiProxy.OpenAiProxyFailureAnalyzer(),
+                    new Providers.OpenAiProxy.OpenAiProxySessionCostParser(),
+                    new Providers.OpenAiProxy.OpenAiProxyPty(openAiProxyApiKeyProvider, openAiProxyBaseUrlProvider),
+                    new Providers.OpenAiProxy.OpenAiProxyModelCatalog());
             }
 
             return runner;

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
@@ -1,21 +1,23 @@
-using System.Collections.Frozen;
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Ivy;
 using Ivy.Tendril.Agents.Providers.OpenCode;
 
-namespace Ivy.Tendril.Agents.Providers.Ivy;
+namespace Ivy.Tendril.Agents.Providers.OpenAiProxy;
 
-public sealed class IvyCli : IAgentCli
+public sealed class OpenAiProxyCli : IAgentCli
 {
-    private readonly Func<string?> _apiKeyProvider;
     private readonly OpenCodeCli _inner = new();
+    private readonly Func<string?> _apiKeyProvider;
+    private readonly Func<string?> _baseUrlProvider;
 
-    public IvyCli(Func<string?>? apiKeyProvider = null)
+    public OpenAiProxyCli(Func<string?>? apiKeyProvider = null, Func<string?>? baseUrlProvider = null)
     {
         _apiKeyProvider = apiKeyProvider ?? (() => null);
+        _baseUrlProvider = baseUrlProvider ?? (() => null);
     }
 
-    public string Id => Abstractions.AgentId.Ivy;
-    public string DisplayName => "Ivy Agent";
+    public string Id => Abstractions.AgentId.OpenAiProxy;
+    public string DisplayName => "OpenAI Proxy";
 
     public AgentCapabilities Capabilities => _inner.Capabilities;
     public TransportKind SupportedTransports => _inner.SupportedTransports;
@@ -32,7 +34,12 @@ public sealed class IvyCli : IAgentCli
         var spec = _inner.BuildProcessSpec(config);
 
         var env = new Dictionary<string, string>(spec.Environment);
-        env["ANTHROPIC_BASE_URL"] = "https://llmproxy.ivy.app";
+
+        var baseUrl = _baseUrlProvider();
+        if (!string.IsNullOrEmpty(baseUrl))
+        {
+            env["ANTHROPIC_BASE_URL"] = baseUrl;
+        }
 
         var apiKey = _apiKeyProvider();
         if (!string.IsNullOrEmpty(apiKey))
@@ -58,7 +65,11 @@ public sealed class IvyCli : IAgentCli
     public IReadOnlyDictionary<string, string> GetDefaultEnvironment()
     {
         var env = new Dictionary<string, string>(_inner.GetDefaultEnvironment());
-        env["ANTHROPIC_BASE_URL"] = "https://llmproxy.ivy.app";
+        var baseUrl = _baseUrlProvider();
+        if (!string.IsNullOrEmpty(baseUrl))
+        {
+            env["ANTHROPIC_BASE_URL"] = baseUrl;
+        }
         return env;
     }
 }

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyEventParser.cs
@@ -1,0 +1,23 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.OpenCode;
+
+namespace Ivy.Tendril.Agents.Providers.OpenAiProxy;
+
+public sealed class OpenAiProxyEventParser : IEventParser
+{
+    private readonly OpenCodeEventParser _inner = new();
+
+    public string AgentId => Abstractions.AgentId.OpenAiProxy;
+
+    public IReadOnlyList<AgentEvent> ParseLine(string rawLine)
+        => _inner.ParseLine(rawLine);
+
+    public IReadOnlyList<AgentEvent> Flush()
+        => _inner.Flush();
+
+    public ResultEvent? BuildResult(IReadOnlyList<AgentEvent> events, int exitCode)
+        => _inner.BuildResult(events, exitCode);
+
+    public IEventParser CreateFresh()
+        => new OpenAiProxyEventParser();
+}

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyFailureAnalyzer.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyFailureAnalyzer.cs
@@ -1,0 +1,42 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.OpenCode;
+
+namespace Ivy.Tendril.Agents.Providers.OpenAiProxy;
+
+public sealed class OpenAiProxyFailureAnalyzer : IFailureAnalyzer
+{
+    private readonly OpenCodeFailureAnalyzer _inner = new();
+
+    public FailureAnalysis Analyze(FailureContext context)
+    {
+        var originalContext = new FailureContext
+        {
+            Events = context.Events,
+            StderrLines = context.StderrLines,
+            ExitCode = context.ExitCode,
+            TimedOut = context.TimedOut,
+            IdleTimeout = context.IdleTimeout,
+            AgentId = AgentId.OpenCode,
+        };
+
+        var result = _inner.Analyze(originalContext);
+
+        var reason = result.Reason
+            .Replace("OpenCode", "OpenAI Proxy")
+            .Replace("opencode", "openaiproxy");
+
+        var suggestion = result.Suggestion?
+            .Replace("OpenCode", "OpenAI Proxy")
+            .Replace("opencode", "openaiproxy")
+            .Replace("Run 'ivy providers login' to authenticate", "Ensure you have entered a valid Base URL and API Key in Settings -> Coding Agent.");
+
+        return new FailureAnalysis
+        {
+            Kind = result.Kind,
+            Reason = reason,
+            ContextLines = result.ContextLines,
+            IsRetryable = result.IsRetryable,
+            Suggestion = suggestion
+        };
+    }
+}

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyHealthCheck.cs
@@ -1,0 +1,138 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Helpers;
+using Ivy.Tendril.Agents.Providers.Ivy;
+
+namespace Ivy.Tendril.Agents.Providers.OpenAiProxy;
+
+public sealed class OpenAiProxyHealthCheck : IAgentHealthCheck
+{
+    private readonly Func<string?> _apiKeyProvider;
+    private readonly Func<string?> _baseUrlProvider;
+
+    public OpenAiProxyHealthCheck(
+        Func<string?>? apiKeyProvider = null,
+        Func<string?>? baseUrlProvider = null)
+    {
+        _apiKeyProvider = apiKeyProvider ?? (() => null);
+        _baseUrlProvider = baseUrlProvider ?? (() => null);
+    }
+
+    public string AgentId => Abstractions.AgentId.OpenAiProxy;
+
+    public async Task<AgentInstallStatus> CheckInstallAsync(CancellationToken ct = default)
+    {
+        var path = IvyBinaryResolver.Resolve();
+        if (!File.Exists(path))
+            return new AgentInstallStatus { IsInstalled = false, Error = "ivy-agent not found" };
+
+        var version = await GetVersionAsync(ct);
+        return new AgentInstallStatus { IsInstalled = true, Version = version, BinaryPath = path };
+    }
+
+    public Task<AgentAuthResult> CheckAuthAsync(CancellationToken ct = default)
+    {
+        var baseUrl = _baseUrlProvider();
+        var apiKey = _apiKeyProvider();
+
+        if (string.IsNullOrEmpty(baseUrl))
+        {
+            return Task.FromResult(new AgentAuthResult
+            {
+                Status = AuthStatus.NotAuthenticated,
+                Error = "Base URL is not configured.",
+                SignInHint = "Specify the API Base URL under Settings -> Coding Agent."
+            });
+        }
+
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            return Task.FromResult(new AgentAuthResult
+            {
+                Status = AuthStatus.NotAuthenticated,
+                Error = "API Key is not configured.",
+                SignInHint = "Specify an API Key under Settings -> Coding Agent."
+            });
+        }
+
+        return Task.FromResult(new AgentAuthResult
+        {
+            Status = AuthStatus.Authenticated,
+            Provider = "Configured Endpoint"
+        });
+    }
+
+    public async Task<string?> GetVersionAsync(CancellationToken ct = default)
+    {
+        var binaryPath = IvyBinaryResolver.Resolve();
+        var (exitCode, stdout, _) = await HealthCheckRunner.RunAsync(
+            binaryPath, ["--version"], TimeSpan.FromSeconds(10), ct);
+
+        if (exitCode != 0) return null;
+        return stdout.Trim();
+    }
+
+    public async Task<ModelValidationResult> ValidateModelAsync(string model, CancellationToken ct = default)
+    {
+        if (!string.IsNullOrEmpty(model) && !string.Equals(model, "default", StringComparison.OrdinalIgnoreCase))
+            return new ModelValidationResult
+            {
+                Status = ModelValidationStatus.Unknown,
+                Model = model,
+                ErrorMessage = "OpenAI Proxy does not support model validation for non-default models",
+            };
+
+        var baseUrl = _baseUrlProvider();
+        var apiKey = _apiKeyProvider();
+
+        if (string.IsNullOrEmpty(baseUrl) || string.IsNullOrEmpty(apiKey))
+        {
+            return new ModelValidationResult
+            {
+                Status = ModelValidationStatus.AuthError,
+                Model = model,
+                ErrorMessage = "Base URL or API key not configured.",
+            };
+        }
+
+        var binaryPath = IvyBinaryResolver.Resolve();
+        var originalEnv = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
+        var originalUrl = Environment.GetEnvironmentVariable("ANTHROPIC_BASE_URL");
+        try
+        {
+            Environment.SetEnvironmentVariable("ANTHROPIC_BASE_URL", baseUrl);
+            Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", apiKey);
+
+            var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
+                binaryPath, ["run", "ping"],
+                TimeSpan.FromSeconds(30), ct);
+
+            if (exitCode == 0)
+                return new ModelValidationResult { Status = ModelValidationStatus.Ok, Model = model };
+
+            return new ModelValidationResult
+            {
+                Status = ModelValidationStatus.Unknown,
+                Model = model,
+                ErrorMessage = stderr,
+            };
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", originalEnv);
+            Environment.SetEnvironmentVariable("ANTHROPIC_BASE_URL", originalUrl);
+        }
+    }
+
+    public Task<bool> RunAuthFlowAsync(AuthFlowCallbacks callbacks, CancellationToken ct = default)
+        => Task.FromResult(false);
+
+    public AgentOnboardingInfo GetOnboardingInfo() => new()
+    {
+        DisplayName = "OpenAI Proxy",
+        InstallCommand = "curl -fsSL https://raw.githubusercontent.com/Ivy-Interactive/ivy-agent-cli/main/install.sh | bash",
+        InstallUrl = "https://github.com/Ivy-Interactive/ivy-agent-cli",
+        AuthCommand = "",
+        SignInHint = "Enter your Base URL and API Key in settings",
+        DocsUrl = "https://github.com/Ivy-Interactive/ivy-agent-cli",
+    };
+}

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
@@ -1,0 +1,53 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.OpenCode;
+
+namespace Ivy.Tendril.Agents.Providers.OpenAiProxy;
+
+public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
+{
+    private readonly OpenCodeModelCatalog _inner = new();
+
+    public string AgentId => Abstractions.AgentId.OpenAiProxy;
+
+    public IReadOnlyList<ModelInfo> GetStaticModels()
+    {
+        return _inner.GetStaticModels().Select(m => new ModelInfo
+        {
+            Id = m.Id,
+            DisplayName = m.DisplayName.Replace("OpenCode", "OpenAI Proxy"),
+            Capabilities = m.Capabilities,
+            Provider = "openaiproxy",
+            IsDefault = m.IsDefault,
+            ContextWindow = m.ContextWindow,
+            InputPerMillion = m.InputPerMillion,
+            OutputPerMillion = m.OutputPerMillion,
+            CacheReadPerMillion = m.CacheReadPerMillion,
+            CacheWritePerMillion = m.CacheWritePerMillion,
+        }).ToList();
+    }
+
+    public async Task<ModelCatalogResult> GetModelsAsync(CancellationToken ct = default)
+    {
+        var result = await _inner.GetModelsAsync(ct);
+        return new ModelCatalogResult
+        {
+            AgentId = AgentId,
+            Models = result.Models.Select(m => new ModelInfo
+            {
+                Id = m.Id,
+                DisplayName = m.DisplayName.Replace("OpenCode", "OpenAI Proxy"),
+                Capabilities = m.Capabilities,
+                Provider = "openaiproxy",
+                IsDefault = m.IsDefault,
+                ContextWindow = m.ContextWindow,
+                InputPerMillion = m.InputPerMillion,
+                OutputPerMillion = m.OutputPerMillion,
+                CacheReadPerMillion = m.CacheReadPerMillion,
+                CacheWritePerMillion = m.CacheWritePerMillion,
+            }).ToList(),
+            Source = result.Source,
+            RetrievedAt = result.RetrievedAt,
+            ExpiresAt = result.ExpiresAt,
+        };
+    }
+}

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
@@ -1,38 +1,43 @@
-using System.Collections.Frozen;
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Ivy;
 using Ivy.Tendril.Agents.Providers.OpenCode;
 
-namespace Ivy.Tendril.Agents.Providers.Ivy;
+namespace Ivy.Tendril.Agents.Providers.OpenAiProxy;
 
-public sealed class IvyCli : IAgentCli
+public sealed class OpenAiProxyPty : IAgentPty
 {
     private readonly Func<string?> _apiKeyProvider;
-    private readonly OpenCodeCli _inner = new();
+    private readonly Func<string?> _baseUrlProvider;
+    private readonly OpenCodePty _inner = new();
 
-    public IvyCli(Func<string?>? apiKeyProvider = null)
+    public OpenAiProxyPty(Func<string?>? apiKeyProvider = null, Func<string?>? baseUrlProvider = null)
     {
         _apiKeyProvider = apiKeyProvider ?? (() => null);
+        _baseUrlProvider = baseUrlProvider ?? (() => null);
     }
 
-    public string Id => Abstractions.AgentId.Ivy;
-    public string DisplayName => "Ivy Agent";
+    public string Id => Abstractions.AgentId.OpenAiProxy;
+    public string DisplayName => "OpenAI Proxy";
 
     public AgentCapabilities Capabilities => _inner.Capabilities;
     public TransportKind SupportedTransports => _inner.SupportedTransports;
-    public PromptTransport PromptTransport => _inner.PromptTransport;
-    public OutputFormat PreferredOutputFormat => _inner.PreferredOutputFormat;
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles => _inner.DefaultProfiles;
+    public string? ContextFileName => _inner.ContextFileName;
 
     public string? TranslateToolName(string canonicalTool) => _inner.TranslateToolName(canonicalTool);
     public string? ReverseTranslateToolName(string nativeTool) => _inner.ReverseTranslateToolName(nativeTool);
     public IReadOnlyList<string> ExtractWritableDirectories(IReadOnlyList<string> allowedTools) => _inner.ExtractWritableDirectories(allowedTools);
 
-    public AgentProcessSpec BuildProcessSpec(AgentLaunchConfig config)
+    public AgentPtySpec BuildPtySpec(AgentPtyConfig config)
     {
-        var spec = _inner.BuildProcessSpec(config);
+        var spec = _inner.BuildPtySpec(config);
 
         var env = new Dictionary<string, string>(spec.Environment);
-        env["ANTHROPIC_BASE_URL"] = "https://llmproxy.ivy.app";
+        var baseUrl = _baseUrlProvider();
+        if (!string.IsNullOrEmpty(baseUrl))
+        {
+            env["ANTHROPIC_BASE_URL"] = baseUrl;
+        }
 
         var apiKey = _apiKeyProvider();
         if (!string.IsNullOrEmpty(apiKey))
@@ -40,25 +45,30 @@ public sealed class IvyCli : IAgentCli
             env["ANTHROPIC_API_KEY"] = apiKey;
         }
 
-        return new AgentProcessSpec
+        var args = new List<string>(spec.CommandLine);
+        if (args.Count > 0 && args[0] == "opencode")
         {
-            FileName = IvyBinaryResolver.Resolve(),
-            Arguments = spec.Arguments,
+            args[0] = IvyBinaryResolver.Resolve();
+        }
+
+        return new AgentPtySpec
+        {
+            CommandLine = args,
             WorkingDirectory = spec.WorkingDirectory,
             Environment = env,
-            StdinContent = spec.StdinContent,
-            RedirectStdin = spec.RedirectStdin,
-            RedirectStdout = spec.RedirectStdout,
-            RedirectStderr = spec.RedirectStderr,
-            CreateNoWindow = spec.CreateNoWindow,
-            UseShellExecute = spec.UseShellExecute,
         };
     }
 
     public IReadOnlyDictionary<string, string> GetDefaultEnvironment()
     {
         var env = new Dictionary<string, string>(_inner.GetDefaultEnvironment());
-        env["ANTHROPIC_BASE_URL"] = "https://llmproxy.ivy.app";
+        var baseUrl = _baseUrlProvider();
+        if (!string.IsNullOrEmpty(baseUrl))
+        {
+            env["ANTHROPIC_BASE_URL"] = baseUrl;
+        }
         return env;
     }
+
+    public AgentActivityPatterns? GetActivityPatterns() => _inner.GetActivityPatterns();
 }

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxySessionCostParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxySessionCostParser.cs
@@ -1,0 +1,32 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.OpenCode;
+
+namespace Ivy.Tendril.Agents.Providers.OpenAiProxy;
+
+public sealed class OpenAiProxySessionCostParser : ISessionCostParser
+{
+    private readonly OpenCodeSessionCostParser _inner = new();
+
+    public string AgentId => Abstractions.AgentId.OpenAiProxy;
+
+    public SessionCostResult Parse(string filePath, IModelPricingProvider pricing)
+    {
+        var result = _inner.Parse(filePath, pricing);
+        return new SessionCostResult
+        {
+            SessionId = result.SessionId,
+            AgentId = AgentId,
+            Model = result.Model,
+            InputTokens = result.InputTokens,
+            OutputTokens = result.OutputTokens,
+            CacheReadTokens = result.CacheReadTokens,
+            CacheWriteTokens = result.CacheWriteTokens,
+            TotalCostUsd = result.TotalCostUsd,
+            StartedAt = result.StartedAt,
+            CompletedAt = result.CompletedAt,
+        };
+    }
+
+    public IReadOnlyList<string> DiscoverSessionFiles(string? projectPath = null)
+        => _inner.DiscoverSessionFiles(projectPath);
+}

--- a/src/Ivy.Tendril.Agents/Runtime/AgentValidator.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/AgentValidator.cs
@@ -48,6 +48,7 @@ public sealed class AgentValidator
             AgentId.Copilot => Providers.Copilot.CopilotBinaryResolver.Resolve().FileName,
             AgentId.OpenCode => Providers.OpenCode.OpenCodeBinaryResolver.Resolve(),
             AgentId.Ivy => Providers.Ivy.IvyBinaryResolver.Resolve(),
+            AgentId.OpenAiProxy => Providers.Ivy.IvyBinaryResolver.Resolve(),
             _ => cli.Id
         };
         if (!BinaryResolver.IsInstalled(binaryName))

--- a/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
@@ -1,0 +1,62 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Ivy;
+using Ivy.Tendril.Agents.Providers.OpenAiProxy;
+
+namespace Ivy.Tendril.Test.Agents;
+
+public class OpenAiProxyTests
+{
+    [Fact]
+    public void OpenAiProxyCli_BuildProcessSpec_SetsCustomBaseUrlAndApiKey()
+    {
+        var cli = new OpenAiProxyCli(
+            apiKeyProvider: () => "test-sk-key",
+            baseUrlProvider: () => "https://custom.openai.proxy/v1");
+
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "Hello test",
+            WorkingDirectory = Path.GetTempPath(),
+        };
+
+        var spec = cli.BuildProcessSpec(config);
+
+        Assert.Equal("openaiproxy", cli.Id);
+        Assert.Equal("OpenAI Proxy", cli.DisplayName);
+        Assert.Equal("https://custom.openai.proxy/v1", spec.Environment["ANTHROPIC_BASE_URL"]);
+        Assert.Equal("test-sk-key", spec.Environment["ANTHROPIC_API_KEY"]);
+    }
+
+    [Fact]
+    public async Task OpenAiProxyHealthCheck_CheckAuthAsync_RequiresBaseUrlAndApiKey()
+    {
+        var noBaseUrl = new OpenAiProxyHealthCheck(apiKeyProvider: () => "key", baseUrlProvider: () => null);
+        var noKey = new OpenAiProxyHealthCheck(apiKeyProvider: () => null, baseUrlProvider: () => "https://api.openai.com");
+        var valid = new OpenAiProxyHealthCheck(apiKeyProvider: () => "key", baseUrlProvider: () => "https://api.openai.com");
+
+        var authResultNoUrl = await noBaseUrl.CheckAuthAsync();
+        var authResultNoKey = await noKey.CheckAuthAsync();
+        var authResultValid = await valid.CheckAuthAsync();
+
+        Assert.Equal(AuthStatus.NotAuthenticated, authResultNoUrl.Status);
+        Assert.Equal(AuthStatus.NotAuthenticated, authResultNoKey.Status);
+        Assert.Equal(AuthStatus.Authenticated, authResultValid.Status);
+    }
+
+    [Fact]
+    public void IvyCli_BuildProcessSpec_HardcodesIvyProxyUrl()
+    {
+        var ivyCli = new IvyCli(apiKeyProvider: () => "ivy-key");
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "Hello test",
+            WorkingDirectory = Path.GetTempPath(),
+        };
+
+        var spec = ivyCli.BuildProcessSpec(config);
+
+        Assert.Equal("ivy", ivyCli.Id);
+        Assert.Equal("https://llmproxy.ivy.app", spec.Environment["ANTHROPIC_BASE_URL"]);
+        Assert.Equal("ivy-key", spec.Environment["ANTHROPIC_API_KEY"]);
+    }
+}

--- a/src/Ivy.Tendril.Test/TestAgentRunner.cs
+++ b/src/Ivy.Tendril.Test/TestAgentRunner.cs
@@ -4,6 +4,8 @@ using Ivy.Tendril.Agents.Providers.Codex;
 using Ivy.Tendril.Agents.Providers.Copilot;
 using Ivy.Tendril.Agents.Providers.Antigravity;
 using Ivy.Tendril.Agents.Providers.OpenCode;
+using Ivy.Tendril.Agents.Providers.Ivy;
+using Ivy.Tendril.Agents.Providers.OpenAiProxy;
 using Ivy.Tendril.Agents.Runtime;
 
 namespace Ivy.Tendril.Test;
@@ -28,6 +30,12 @@ internal static class TestAgentRunner
         runner.Register(
             new OpenCodeCli(), new OpenCodeEventParser(), new OpenCodeHealthCheck(),
             new OpenCodeFailureAnalyzer(), new OpenCodeSessionCostParser(), new OpenCodePty());
+        runner.Register(
+            new IvyCli(), new IvyEventParser(), new IvyHealthCheck(),
+            new IvyFailureAnalyzer(), new IvySessionCostParser(), new IvyPty());
+        runner.Register(
+            new OpenAiProxyCli(), new OpenAiProxyEventParser(), new OpenAiProxyHealthCheck(),
+            new OpenAiProxyFailureAnalyzer(), new OpenAiProxySessionCostParser(), new OpenAiProxyPty());
         return runner;
     }
 }

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -22,7 +22,8 @@ public class CodingAgentSetupView : ViewBase
         new("gemini", "Gemini", AgentBranding.IconFor("gemini")),
         new("antigravity", "Antigravity", AgentBranding.IconFor("antigravity")),
         new("opencode", "OpenCode", AgentBranding.IconFor("opencode")),
-        new("ivy", "Ivy Agent", AgentBranding.IconFor("ivy"))
+        new("ivy", "Ivy Agent", AgentBranding.IconFor("ivy")),
+        new("openaiproxy", "OpenAI Proxy", AgentBranding.IconFor("openaiproxy"))
     ];
 
     public override object Build()
@@ -42,7 +43,8 @@ public class CodingAgentSetupView : ViewBase
         var lastAgent = UseState(selectedAgent.Value);
         var showTestDialog = UseState(false);
         var ivyApiKey = UseState(GetIvyApiKeyFromConfig(config));
-        var ivyBaseUrl = UseState(GetIvyBaseUrlFromConfig(config));
+        var openAiProxyApiKey = UseState(GetOpenAiProxyApiKeyFromConfig(config));
+        var openAiProxyBaseUrl = UseState(GetOpenAiProxyBaseUrlFromConfig(config));
         var ollamaUrl = UseState(GetOllamaUrlFromConfig(config, selectedAgent.Value));
 
         var modelsQuery = UseQuery<ModelInfo[], string>(
@@ -63,7 +65,7 @@ public class CodingAgentSetupView : ViewBase
 
         var checkIvyInstall = async () =>
         {
-            var hc = runner.GetHealthCheck("ivy");
+            var hc = runner.GetHealthCheck("ivy") ?? runner.GetHealthCheck("openaiproxy");
             if (hc != null)
             {
                 var status = await hc.CheckInstallAsync();
@@ -102,10 +104,11 @@ public class CodingAgentSetupView : ViewBase
             quickModel.Value != GetProfileModel(config, selectedAgent.Value, "quick");
         
         var hasApiKeyChanges = selectedAgent.Value == "ivy" && ivyApiKey.Value != GetIvyApiKeyFromConfig(config);
-        var hasBaseUrlChanges = selectedAgent.Value == "ivy" && ivyBaseUrl.Value != GetIvyBaseUrlFromConfig(config);
+        var hasOpenAiProxyApiKeyChanges = selectedAgent.Value == "openaiproxy" && openAiProxyApiKey.Value != GetOpenAiProxyApiKeyFromConfig(config);
+        var hasOpenAiProxyBaseUrlChanges = selectedAgent.Value == "openaiproxy" && openAiProxyBaseUrl.Value != GetOpenAiProxyBaseUrlFromConfig(config);
         var hasOllamaUrlChanges = selectedAgent.Value == "opencode" && ollamaUrl.Value != GetOllamaUrlFromConfig(config, selectedAgent.Value);
 
-        var hasChanges = selectedAgent.Value != config.Settings.CodingAgent || hasProfileChanges || hasApiKeyChanges || hasBaseUrlChanges || hasOllamaUrlChanges;
+        var hasChanges = selectedAgent.Value != config.Settings.CodingAgent || hasProfileChanges || hasApiKeyChanges || hasOpenAiProxyApiKeyChanges || hasOpenAiProxyBaseUrlChanges || hasOllamaUrlChanges;
 
         var registeredAgents = runner.RegisteredAgents;
         var visibleAgents = Agents.Where(a => registeredAgents.Contains(a.Key)).ToArray();
@@ -125,6 +128,52 @@ public class CodingAgentSetupView : ViewBase
                 selectedAgent.Set(a.Key);
             }));
 
+        object BuildIvyInstallBox()
+        {
+            return new Box()
+                .BorderColor(Colors.Warning)
+                .Padding(4)
+                .BorderRadius(BorderRadius.Rounded)
+                .Content(
+                    Layout.Vertical().Gap(2)
+                    | Text.Block("Ivy Agent Tooling").Bold().Color(Colors.Warning)
+                    | Text.Rich()
+                        .Run("Ivy Agent / OpenAI Proxy requires the local ivy-agent CLI tooling. Download and installation is available from the ")
+                        .Link("GitHub repository", "https://github.com/Ivy-Interactive/ivy-agent-cli")
+                        .Run(".")
+                        .OnLinkClick(url => client.OpenUrl(url))
+                    | new Spacer().Height(Size.Units(1))
+                    | (isIvyInstalled.Value
+                        ? Text.Block("✓ Tooling is installed locally.").Color(Colors.Success).Small()
+                        : (object)(Layout.Vertical().Gap(1)
+                            | new Button(isInstalling.Value ? "Downloading & Installing..." : "One-Click Download & Install")
+                                .Primary()
+                                .Disabled(isInstalling.Value)
+                                .OnClick(async () =>
+                                {
+                                    isInstalling.Set(true);
+                                    installError.Set(null);
+                                    try
+                                    {
+                                        await InstallIvyAgentAsync(client);
+                                        await checkIvyInstall();
+                                        client.Toast("Tooling downloaded and installed successfully!", "Success");
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        installError.Set(ex.Message);
+                                    }
+                                    finally
+                                    {
+                                        isInstalling.Set(false);
+                                    }
+                                })
+                            | (installError.Value != null ? Text.Block(installError.Value).Color(Colors.Destructive).Small() : null!)
+                          )
+                      )
+                );
+        }
+
         return Layout.Vertical().Padding(4)
                | Text.Block("Coding Agent").Bold()
                | (Layout.Vertical().Padding(0)
@@ -138,58 +187,26 @@ public class CodingAgentSetupView : ViewBase
                    | quickModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Quick"))
                | (selectedAgent.Value == "ivy"
                    ? (object)(Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
-                       | new Box()
-                           .BorderColor(Colors.Warning)
-                           .Padding(4)
-                           .BorderRadius(BorderRadius.Rounded)
-                           .Content(
-                               Layout.Vertical().Gap(2)
-                               | Text.Block("Ivy Agent Invite-Only Beta").Bold().Color(Colors.Warning)
-                               | Text.Rich()
-                                   .Run("Ivy Agent is currently in early beta with invite-only access. You can find the installation guide and download the tooling from the ")
-                                   .Link("private GitHub repository", "https://github.com/Ivy-Interactive/ivy-agent-cli")
-                                   .Run(".")
-                                   .OnLinkClick(url => client.OpenUrl(url))
-                               | new Spacer().Height(Size.Units(1))
-                               | (isIvyInstalled.Value
-                                   ? Text.Block("✓ Ivy Agent is installed locally.").Color(Colors.Success).Small()
-                                   : (object)(Layout.Vertical().Gap(1)
-                                       | new Button(isInstalling.Value ? "Downloading & Installing..." : "One-Click Download & Install")
-                                           .Primary()
-                                           .Disabled(isInstalling.Value)
-                                           .OnClick(async () =>
-                                           {
-                                               isInstalling.Set(true);
-                                               installError.Set(null);
-                                               try
-                                               {
-                                                   await InstallIvyAgentAsync(client);
-                                                   await checkIvyInstall();
-                                                   client.Toast("Ivy Agent downloaded and installed successfully!", "Success");
-                                               }
-                                               catch (Exception ex)
-                                               {
-                                                   installError.Set(ex.Message);
-                                               }
-                                               finally
-                                               {
-                                                   isInstalling.Set(false);
-                                               }
-                                           })
-                                       | (installError.Value != null ? Text.Block(installError.Value).Color(Colors.Destructive).Small() : null!)
-                                     )
-                                 )
-                           )
+                       | BuildIvyInstallBox()
                        | new Spacer().Height(Size.Units(2))
                        | ivyApiKey.ToPasswordInput("sk-...")
                            .WithField()
                            .Label("Ivy Proxy API Key (Optional)")
-                           .Description("Optional. If not set, Tendril will use the token from your @ivy.app account login.")
+                           .Description("Optional. Hardcoded to https://llmproxy.ivy.app. If not set, Tendril will use the token from your @ivy.app account login."))
+                   : null!)
+               | (selectedAgent.Value == "openaiproxy"
+                   ? (object)(Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                       | BuildIvyInstallBox()
                        | new Spacer().Height(Size.Units(2))
-                       | ivyBaseUrl.ToTextInput("https://llmproxy.ivy.app")
+                       | openAiProxyBaseUrl.ToTextInput("https://api.openai.com")
                            .WithField()
-                           .Label("Ivy Proxy Base URL (Optional)")
-                           .Description("Optional. Overrides the default base URL for the Ivy API proxy."))
+                           .Label("API Base URL (Required)")
+                           .Description("Required. Endpoint URL for your OpenAI-compatible API proxy (sets ANTHROPIC_BASE_URL for ivy-agent).")
+                       | new Spacer().Height(Size.Units(2))
+                       | openAiProxyApiKey.ToPasswordInput("sk-...")
+                           .WithField()
+                           .Label("API Key (Required)")
+                           .Description("Required. API Key for authenticating with your OpenAI-compatible endpoint (sets ANTHROPIC_API_KEY for ivy-agent)."))
                    : null!)
                | (selectedAgent.Value == "opencode"
                    ? (object)(Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
@@ -211,7 +228,8 @@ public class CodingAgentSetupView : ViewBase
                            config.Settings.CodingAgent = selectedAgent.Value;
                            SaveProfiles(config, selectedAgent.Value, deepModel.Value, balancedModel.Value, quickModel.Value);
                            SaveIvyApiKey(config, ivyApiKey.Value);
-                           SaveIvyBaseUrl(config, ivyBaseUrl.Value);
+                           SaveOpenAiProxyApiKey(config, openAiProxyApiKey.Value);
+                           SaveOpenAiProxyBaseUrl(config, openAiProxyBaseUrl.Value);
                            SaveOllamaUrl(config, selectedAgent.Value, ollamaUrl.Value);
                            config.SaveSettings();
                            client.Toast("Coding agent settings saved", "Saved");
@@ -511,4 +529,63 @@ public class CodingAgentSetupView : ViewBase
         }
     }
 
+    private static string GetOpenAiProxyApiKeyFromConfig(IConfigService config)
+    {
+        var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals("openaiproxy", StringComparison.OrdinalIgnoreCase));
+        if (ac != null && ac.EnvironmentVariables.TryGetValue("ANTHROPIC_API_KEY", out var key))
+            return key;
+        return "";
+    }
+
+    private static void SaveOpenAiProxyApiKey(IConfigService config, string apiKey)
+    {
+        var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals("openaiproxy", StringComparison.OrdinalIgnoreCase));
+
+        if (ac == null)
+        {
+            ac = new AgentConfig { Name = "openaiproxy" };
+            config.Settings.CodingAgents.Add(ac);
+        }
+
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            ac.EnvironmentVariables.Remove("ANTHROPIC_API_KEY");
+        }
+        else
+        {
+            ac.EnvironmentVariables["ANTHROPIC_API_KEY"] = apiKey;
+        }
+    }
+
+    private static string GetOpenAiProxyBaseUrlFromConfig(IConfigService config)
+    {
+        var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals("openaiproxy", StringComparison.OrdinalIgnoreCase));
+        if (ac != null && ac.EnvironmentVariables.TryGetValue("ANTHROPIC_BASE_URL", out var url))
+            return url;
+        return "";
+    }
+
+    private static void SaveOpenAiProxyBaseUrl(IConfigService config, string url)
+    {
+        var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals("openaiproxy", StringComparison.OrdinalIgnoreCase));
+
+        if (ac == null)
+        {
+            ac = new AgentConfig { Name = "openaiproxy" };
+            config.Settings.CodingAgents.Add(ac);
+        }
+
+        if (string.IsNullOrEmpty(url))
+        {
+            ac.EnvironmentVariables.Remove("ANTHROPIC_BASE_URL");
+        }
+        else
+        {
+            ac.EnvironmentVariables["ANTHROPIC_BASE_URL"] = url;
+        }
+    }
 }

--- a/src/Ivy.Tendril/Helpers/AgentBranding.cs
+++ b/src/Ivy.Tendril/Helpers/AgentBranding.cs
@@ -32,6 +32,7 @@ public static class AgentBranding
             AgentId.Antigravity => Icons.Antigravity,
             AgentId.OpenCode => Icons.OpenCode,
             AgentId.Ivy => Icons.IvyCorner,
+            AgentId.OpenAiProxy => Icons.OpenAI,
             _ => DefaultIcon,
         };
     }

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -72,6 +72,42 @@ internal static class ServiceRegistration
                     return userInfo?.Email;
                 };
             };
+
+            opts.OpenAiProxyApiKeyProviderFactory = sp =>
+            {
+                var config = sp.GetService<IConfigService>();
+                return () =>
+                {
+                    if (config?.Settings != null)
+                    {
+                        var openAiProxyAgent = config.Settings.CodingAgents.FirstOrDefault(a =>
+                            a.Name.Equals("openaiproxy", StringComparison.OrdinalIgnoreCase));
+                        if (openAiProxyAgent != null && openAiProxyAgent.EnvironmentVariables.TryGetValue("ANTHROPIC_API_KEY", out var key) && !string.IsNullOrEmpty(key))
+                        {
+                            return key;
+                        }
+                    }
+                    return null;
+                };
+            };
+
+            opts.OpenAiProxyBaseUrlProviderFactory = sp =>
+            {
+                var config = sp.GetService<IConfigService>();
+                return () =>
+                {
+                    if (config?.Settings != null)
+                    {
+                        var openAiProxyAgent = config.Settings.CodingAgents.FirstOrDefault(a =>
+                            a.Name.Equals("openaiproxy", StringComparison.OrdinalIgnoreCase));
+                        if (openAiProxyAgent != null && openAiProxyAgent.EnvironmentVariables.TryGetValue("ANTHROPIC_BASE_URL", out var url) && !string.IsNullOrEmpty(url))
+                        {
+                            return url;
+                        }
+                    }
+                    return null;
+                };
+            };
         });
 
         server.Services.AddSingleton<ModelPricingService>();


### PR DESCRIPTION
Separates hardcoded Ivy Agent proxy endpoint (https://llmproxy.ivy.app) from general OpenAI Proxy endpoints. Adds OpenAiProxy provider suite, updates settings UI, and adds unit tests.