### PR TITLE
feat(app): hide Memory app behind beta flag

### DIFF
--- a/src/Ivy.Tendril/Apps/Memory/MemoryApp.cs
+++ b/src/Ivy.Tendril/Apps/Memory/MemoryApp.cs
@@ -17,7 +17,7 @@ public enum MemoryViewMode
     NodeBased
 }
 
-[App(title: "Memory", icon: Icons.Brain, group: ["Apps"], order: Constants.Memory)]
+[App(title: "Memory", icon: Icons.Brain, group: ["Apps"], order: Constants.Memory, isVisible: false)]
 public class MemoryApp : ViewBase
 {
     public override object Build()

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -95,7 +95,7 @@ public static class TendrilServer
 
         var assembly = typeof(TendrilServer).Assembly;
         server.AppRepository.AddFactory(() => AppHelpers.GetApps(assembly)
-            .Select(app => app.Type == typeof(Ivy.Tendril.Apps.Chat.ChatApp) ? new AppDescriptor
+            .Select(app => (app.Type == typeof(Ivy.Tendril.Apps.Chat.ChatApp) || app.Type == typeof(Ivy.Tendril.Apps.Memory.MemoryApp)) ? new AppDescriptor
             {
                 Id = app.Id,
                 Title = app.Title,


### PR DESCRIPTION
Hides the Memory app in the sidebar navigation behind the beta flag (IsVisible = isBeta).