### PR TITLE
[00026] Support Math Expressions in Markdown

### DIFF
--- a/src/Ivy.Tendril.Test/MarkdownMathTests.cs
+++ b/src/Ivy.Tendril.Test/MarkdownMathTests.cs
@@ -1,0 +1,113 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test;
+
+/// <summary>
+///     Math expressions are rendered client-side by KaTeX in the markdown widgets, so the C#
+///     side's only job is to carry TeX through to the renderer untouched. These tests pin that
+///     down: the markdown pipeline (link polishing plus broken-link annotation) must not mangle
+///     TeX delimiters, backslash commands, or braces, and must not mistake a `$$...$$` block for
+///     a link or a bare plan number.
+/// </summary>
+public class MarkdownMathTests : IDisposable
+{
+    private const string InlineMath = "The relation $$E = mc^2$$ holds.";
+
+    private const string BlockMath = """
+        $$
+        \sum_{i=1}^{n} i = \frac{n(n+1)}{2}
+        $$
+        """;
+
+    private readonly string _plansDir;
+    private readonly TempDirectoryFixture _tempDir = new();
+
+    public MarkdownMathTests()
+    {
+        _plansDir = Path.Combine(_tempDir.Path, "Plans");
+        Directory.CreateDirectory(_plansDir);
+    }
+
+    public void Dispose()
+    {
+        _tempDir.Dispose();
+    }
+
+    [Theory]
+    [InlineData(InlineMath)]
+    [InlineData(BlockMath)]
+    [InlineData(@"$$\varphi = \frac{1 + \sqrt{5}}{2}$$")]
+    [InlineData(@"$$A = \begin{pmatrix} a & b \\ c & d \end{pmatrix}$$")]
+    public void PolishLinks_PreservesMathExpressions(string markdown)
+    {
+        var result = new MarkdownLinkPolisher().PolishLinks(markdown, _plansDir);
+
+        Assert.Equal(markdown, result);
+    }
+
+    [Theory]
+    [InlineData(InlineMath)]
+    [InlineData(BlockMath)]
+    public void AnnotateAllBrokenLinks_PreservesMathExpressions(string markdown)
+    {
+        var result = MarkdownHelper.AnnotateAllBrokenLinks(markdown, _plansDir);
+
+        Assert.Equal(markdown, result);
+        Assert.DoesNotContain("⚠️", result);
+    }
+
+    [Fact]
+    public void PolishLinks_PreservesProseDollarSigns()
+    {
+        // Single dollars are not math (the renderer has singleDollarTextMath disabled), and the
+        // C# pipeline must not rewrite them either.
+        var markdown = "bash expands any $ (e.g. $env:PORT, or vars like $IsMacOS) so $ survives, costs $5";
+
+        var result = new MarkdownLinkPolisher().PolishLinks(markdown, _plansDir);
+
+        Assert.Equal(markdown, result);
+    }
+
+    [Fact]
+    public void PolishLinks_PreservesMathAlongsideLinkPolishing()
+    {
+        // A verbose file link on the same line as math: the link is simplified as usual while
+        // the TeX passes through byte for byte.
+        var markdown = "See [file:///C:/repo/Foo.cs:42](file:///C:/repo/Foo.cs:42) for $$x^2 + y^2 = z^2$$.";
+
+        var result = new MarkdownLinkPolisher().PolishLinks(markdown, _plansDir);
+
+        Assert.Contains("$$x^2 + y^2 = z^2$$", result);
+        Assert.Contains("[Foo.cs:42](file:///C:/repo/Foo.cs)", result);
+    }
+
+    [Fact]
+    public void PolishLinks_DoesNotTreatFiveDigitExponentAsPlanNumber()
+    {
+        // Bare five-digit numbers become plan links only after the word "Plan"/"Plans", so a
+        // five-digit literal inside math is left alone.
+        Directory.CreateDirectory(Path.Combine(_plansDir, "12345-SomePlan"));
+        var markdown = @"$$n = 12345$$";
+
+        var result = new MarkdownLinkPolisher().PolishLinks(markdown, _plansDir);
+
+        Assert.Equal(markdown, result);
+        Assert.DoesNotContain("plan://", result);
+    }
+
+    [Fact]
+    public void RevisionWriter_WritesMathExpressionsUnchanged()
+    {
+        // Revisions are the main math-bearing content, and they are polished on the way to disk.
+        var planFolder = Path.Combine(_plansDir, "00026-SupportMathExpressionsInMarkdown");
+        Directory.CreateDirectory(planFolder);
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        var content = $"# Plan\n\n{InlineMath}\n\n{BlockMath}\n";
+
+        var path = RevisionWriter.WriteNext(planFolder, content, config);
+
+        var written = File.ReadAllText(path);
+        Assert.Contains("$$E = mc^2$$", written);
+        Assert.Contains(@"\sum_{i=1}^{n} i = \frac{n(n+1)}{2}", written);
+    }
+}

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/MathApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/MathApp.cs
@@ -1,0 +1,64 @@
+using Ivy;
+using Ivy.Tendril.Widgets;
+using DraftMarkdownWidget = Ivy.Tendril.Widgets.DraftMarkdown;
+
+namespace WidgetSamples.Apps.DraftMarkdown;
+
+[App(title: "Math", icon: Icons.Sigma, group: ["DraftMarkdown"])]
+class MathApp : ViewBase
+{
+    public override object Build()
+    {
+        var markdown = """
+            # Math Expressions
+
+            ## Inline Math
+            Math written as `$$...$$` inside a paragraph renders inline: the relation
+            $$E = mc^2$$ holds for any rest mass, and the golden ratio
+            $$\varphi = \frac{1 + \sqrt{5}}{2}$$ appears throughout geometry.
+
+            ## Display Math
+            A `$$...$$` block on its own lines renders centered:
+
+            $$
+            \sum_{i=1}^{n} i = \frac{n(n+1)}{2}
+            $$
+
+            $$
+            \int_{-\infty}^{\infty} e^{-x^2} \, dx = \sqrt{\pi}
+            $$
+
+            ## Matrices and Alignment
+
+            $$
+            A = \begin{pmatrix}
+            a & b \\
+            c & d
+            \end{pmatrix}
+            \qquad
+            \det(A) = ad - bc
+            $$
+
+            ## Prose Dollar Signs
+            Single dollar signs are never treated as math, so shell variables and prices
+            survive verbatim: bash expands any $ (e.g. $env:PORT, or vars like $IsMacOS)
+            so $ survives, and this widget costs $0.
+
+            Dollars inside code are untouched too: `$env:PORT`, and
+
+            ```bash
+            echo $PATH
+            export PORT=$PORT
+            ```
+
+            A lone $x^2$ with single dollars stays literal text rather than becoming math.
+
+            ## Malformed Math
+            Unparseable TeX renders as a red inline error instead of breaking the page:
+
+            $$\frac{a}{$$
+            """;
+
+        return new DraftMarkdownWidget(markdown).Article();
+    }
+}

--- a/src/Ivy.Tendril.Widgets/frontend/package.json
+++ b/src/Ivy.Tendril.Widgets/frontend/package.json
@@ -20,7 +20,9 @@
     "react-diff-view": "^3.3.3",
     "react-markdown": "9.1.0",
     "react-syntax-highlighter": "16.1.1",
+    "rehype-katex": "7.0.1",
     "remark-gfm": "4.0.1",
+    "remark-math": "6.0.0",
     "unidiff": "^1.0.4"
   },
   "devDependencies": {
@@ -44,6 +46,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
+  "packageManager": "pnpm@10.33.0",
   "pnpm": {
     "overrides": {
       "lodash": "4.18.1",
@@ -55,6 +58,5 @@
       "ws": "8.21.0",
       "@vitest/browser": "4.1.10"
     }
-  },
-  "packageManager": "pnpm@10.33.0"
+  }
 }

--- a/src/Ivy.Tendril.Widgets/frontend/pnpm-lock.yaml
+++ b/src/Ivy.Tendril.Widgets/frontend/pnpm-lock.yaml
@@ -57,9 +57,15 @@ importers:
       react-syntax-highlighter:
         specifier: 16.1.1
         version: 16.1.1(react@19.2.3)
+      rehype-katex:
+        specifier: 7.0.1
+        version: 7.0.1
       remark-gfm:
         specifier: 4.0.1
         version: 4.0.1
+      remark-math:
+        specifier: 6.0.0
+        version: 6.0.0
       unidiff:
         specifier: ^1.0.4
         version: 1.0.4
@@ -781,6 +787,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -1358,6 +1367,10 @@ packages:
   electron-to-chromium@1.5.363:
     resolution: {integrity: sha512-VjUKPyWzGnT1fujlkEGC/BvN70Hh70KXtAqcmniXviYlJC/ivcT+BWGPyxWVbJZLfvtKR6dqg1L7T7pgAMBtWA==}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
@@ -1449,11 +1462,29 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-dom@5.0.1:
+    resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
+
+  hast-util-from-html-isomorphic@2.0.0:
+    resolution: {integrity: sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==}
+
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
 
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
@@ -1708,6 +1739,9 @@ packages:
   mdast-util-gfm@3.1.0:
     resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
+  mdast-util-math@3.0.0:
+    resolution: {integrity: sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==}
+
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
 
@@ -1762,6 +1796,9 @@ packages:
 
   micromark-extension-gfm@3.0.0:
     resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -1900,6 +1937,9 @@ packages:
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -2054,8 +2094,14 @@ packages:
   refractor@5.0.0:
     resolution: {integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==}
 
+  rehype-katex@7.0.1:
+    resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-math@6.0.0:
+    resolution: {integrity: sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -2243,11 +2289,17 @@ packages:
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-remove-position@5.0.0:
+    resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
@@ -2270,6 +2322,9 @@ packages:
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -2337,6 +2392,9 @@ packages:
 
   warning@4.0.3:
     resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
@@ -2890,6 +2948,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/katex@0.16.8': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -3408,6 +3468,8 @@ snapshots:
 
   electron-to-chromium@1.5.363: {}
 
+  entities@6.0.1: {}
+
   entities@8.0.0: {}
 
   es-errors@1.3.0: {}
@@ -3479,6 +3541,43 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-dom@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hastscript: 9.0.1
+      web-namespaces: 2.0.1
+
+  hast-util-from-html-isomorphic@2.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-dom: 5.0.1
+      hast-util-from-html: 2.0.3
+      unist-util-remove-position: 5.0.0
+
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-parse-selector@4.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -3502,6 +3601,13 @@ snapshots:
       vfile-message: 4.0.3
     transitivePeerDependencies:
       - supports-color
+
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
 
   hast-util-whitespace@3.0.0:
     dependencies:
@@ -3777,6 +3883,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-math@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      longest-streak: 3.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      unist-util-remove-position: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -3952,6 +4070,16 @@ snapshots:
       micromark-extension-gfm-tagfilter: 2.0.0
       micromark-extension-gfm-task-list-item: 2.1.0
       micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.8
+      devlop: 1.1.0
+      katex: 0.16.47
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -4167,6 +4295,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -4318,6 +4450,16 @@ snapshots:
       hastscript: 9.0.1
       parse-entities: 4.0.2
 
+  rehype-katex@7.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/katex': 0.16.8
+      hast-util-from-html-isomorphic: 2.0.0
+      hast-util-to-text: 4.0.2
+      katex: 0.16.47
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -4325,6 +4467,15 @@ snapshots:
       micromark-extension-gfm: 3.0.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-math@6.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-math: 3.0.0
+      micromark-extension-math: 3.1.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
@@ -4538,6 +4689,11 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -4545,6 +4701,11 @@ snapshots:
   unist-util-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
+
+  unist-util-remove-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-visit: 5.1.0
 
   unist-util-stringify-position@4.0.0:
     dependencies:
@@ -4570,6 +4731,11 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@14.0.0: {}
+
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
 
   vfile-message@4.0.3:
     dependencies:
@@ -4677,6 +4843,8 @@ snapshots:
   warning@4.0.3:
     dependencies:
       loose-envify: 1.4.0
+
+  web-namespaces@2.0.1: {}
 
   webidl-conversions@8.0.1: {}
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import "./agent-output.css";
 import type { EventHandler, PresentationEvent } from "./types";
 import { getHeight, getWidth } from "../styles";
@@ -13,6 +12,7 @@ import { ToolUseCard } from "./tool-use-card";
 import { ResultSummary } from "./result-summary";
 import { groupToolUseEvents } from "./group-events";
 import { ToolUseGroup } from "./tool-use-group";
+import { getMarkdownPlugins } from "../math";
 
 function buildSuppressIndices(events: PresentationEvent[]): Set<number> {
   const indices = new Set<number>();
@@ -188,7 +188,7 @@ export const AgentViewer: React.FC<AgentViewerProps> = ({
             case "assistant-text":
               return (
                 <div key={idx} className="aov-markdown aov-assistant">
-                  <Markdown remarkPlugins={[remarkGfm]} components={{ code: CodeBlock }}>
+                  <Markdown {...getMarkdownPlugins(event.text)} components={{ code: CodeBlock }}>
                     {event.text}
                   </Markdown>
                 </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import type { ResultWire } from "./types";
 import { CodeBlock } from "../CodeBlock";
+import { getMarkdownPlugins } from "../math";
 
 interface ResultSummaryProps {
   wire: ResultWire;
@@ -38,6 +38,8 @@ export const ResultSummary: React.FC<ResultSummaryProps> = ({ wire }) => {
 
   const hasResponse = Boolean(wire.response && wire.response.trim().length > 0);
 
+  const plugins = getMarkdownPlugins(wire.response ?? "");
+
   // Return null if there is nothing to render, preventing empty container boxes
   if (!isError && !hasResponse && statsList.length === 0) {
     return null;
@@ -52,7 +54,11 @@ export const ResultSummary: React.FC<ResultSummaryProps> = ({ wire }) => {
       )}
       {hasResponse && (
         <div className="aov-markdown aov-result-body">
-          <Markdown remarkPlugins={[remarkGfm]} components={{ code: CodeBlock }}>
+          <Markdown
+            remarkPlugins={plugins.remarkPlugins}
+            rehypePlugins={plugins.rehypePlugins}
+            components={{ code: CodeBlock }}
+          >
             {wire.response}
           </Markdown>
         </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -660,7 +660,9 @@ export function ChatWidget({
                   ) : (
                     msg.content && (
                       <div className="chat-markdown-body">
-                        <ReactMarkdown {...getMarkdownPlugins(msg.content)}>{msg.content}</ReactMarkdown>
+                        <ReactMarkdown {...getMarkdownPlugins(msg.content)}>
+                          {msg.content}
+                        </ReactMarkdown>
                       </div>
                     )
                   )}

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -2,8 +2,8 @@ import React, { useState, useRef, useEffect, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
 import { Plus, Trash2, Mic, Bot, Cpu, Search, MessageSquare, ChevronDown, Check, Pencil, Paperclip, X, Square, Clock, Loader2 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { AgentViewer } from "../AgentViewer";
+import { getMarkdownPlugins } from "../math";
 import "./chat-widget.css";
 
 export interface ChatMessageDto {
@@ -660,7 +660,7 @@ export function ChatWidget({
                   ) : (
                     msg.content && (
                       <div className="chat-markdown-body">
-                        <ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown>
+                        <ReactMarkdown {...getMarkdownPlugins(msg.content)}>{msg.content}</ReactMarkdown>
                       </div>
                     )
                   )}

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.math.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.math.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { DraftMarkdown } from "./DraftMarkdown";
+
+const renderContent = (content: string) => {
+  const { container } = render(<DraftMarkdown id="w1" content={content} />);
+  return container;
+};
+
+describe("DraftMarkdown math", () => {
+  it("renders block math as a KaTeX display block", () => {
+    const container = renderContent("$$\n\\sum_{i=1}^n i\n$$");
+    expect(container.querySelector(".katex-display")).not.toBeNull();
+    expect(container.querySelector(".katex-error")).toBeNull();
+  });
+
+  it("renders math inside a paragraph inline", () => {
+    const container = renderContent("the relation $$E = mc^2$$ holds");
+    expect(container.querySelector(".katex")).not.toBeNull();
+    expect(container.querySelector(".katex-display")).toBeNull();
+    expect(container.textContent).toContain("holds");
+  });
+
+  it("keeps prose dollar signs as literal text", () => {
+    const container = renderContent("bash expands $env:PORT so $ survives, costs $5");
+    expect(container.querySelector(".katex")).toBeNull();
+    expect(container.textContent).toContain("$env:PORT");
+    expect(container.textContent).toContain("$5");
+  });
+
+  it("still renders ordinary markdown alongside math", () => {
+    const container = renderContent("# Heading\n\n$$x^2$$");
+    expect(container.querySelector("h1")?.textContent).toBe("Heading");
+    expect(container.querySelector(".katex")).not.toBeNull();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Markdown, { defaultUrlTransform } from "react-markdown";
-import remarkGfm from "remark-gfm";
 import "./draft-markdown.css";
 import { getHeight, getWidth } from "../styles";
 import { CodeBlock } from "../CodeBlock";
@@ -10,6 +9,7 @@ import { AddAnnotationPopover, EditAnnotationPopover, SelectionToolbar } from ".
 import { AlertBlockquote } from "./AlertBlockquote";
 import { ImageRenderer } from "./ImageRenderer";
 import { isLocalFileUrl, transformLocalFileUrl } from "./localFiles";
+import { getMarkdownPlugins } from "../math";
 
 type IvyEventHandler = (eventName: string, widgetId: string, args: unknown[]) => void;
 
@@ -258,6 +258,10 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
     [dangerouslyAllowLocalFiles],
   );
 
+  // Math plugins are added only when the content actually contains math
+  // delimiters, so plain plan markdown skips the extra KaTeX pass entirely.
+  const plugins = useMemo(() => getMarkdownPlugins(content), [content]);
+
   const fixed = slots?.StickyContent;
   const hasFixed = !!fixed && React.Children.count(fixed) > 0;
 
@@ -271,7 +275,8 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
       <div className="pmv-body">
         <div ref={contentRef} className={article ? "pmv-markdown pmv-article" : "pmv-markdown"}>
           <Markdown
-            remarkPlugins={[remarkGfm]}
+            remarkPlugins={plugins.remarkPlugins}
+            rehypePlugins={plugins.rehypePlugins}
             urlTransform={urlTransform}
             components={{ a: anchor, code: CodeBlock, blockquote: AlertBlockquote, img: ImageRenderer }}
           >

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
@@ -3,9 +3,9 @@ import { parseDiff, Diff, Hunk, getChangeKey, type ChangeData, type HunkData } f
 import "react-diff-view/style/index.css";
 import "./plan-diff.css";
 import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 type IvyEventHandler = (eventName: string, widgetId: string, args: any[]) => void;
 import { getWidth, getHeight } from "../styles";
+import { getMarkdownPlugins } from "../math";
 import { Eye, Pencil, Trash2, MoreHorizontal, MessageSquare } from "lucide-react";
 
 /** Container width (px) below which the diff is too cramped for a side-by-side (split) view. */
@@ -150,7 +150,7 @@ const CommentWidgetContainer: React.FC<CommentWidgetContainerProps> = ({
                 </div>
               </div>
               <div className="diff-comment-markdown leading-relaxed text-[11px] text-[var(--foreground)] mt-1">
-                <Markdown remarkPlugins={[remarkGfm]}>{comment.content}</Markdown>
+                <Markdown {...getMarkdownPlugins(comment.content)}>{comment.content}</Markdown>
               </div>
             </div>
           ))}
@@ -205,7 +205,9 @@ const CommentWidgetContainer: React.FC<CommentWidgetContainerProps> = ({
             ) : (
               <div className="diff-comment-markdown w-full min-h-[80px] p-2 text-[11px] bg-[var(--muted)] border border-[var(--border)] rounded overflow-auto">
                 {(isEditing ? editingText : inputText)?.trim() ? (
-                  <Markdown remarkPlugins={[remarkGfm]}>{isEditing ? editingText : inputText}</Markdown>
+                  <Markdown {...getMarkdownPlugins((isEditing ? editingText : inputText) ?? "")}>
+                    {isEditing ? editingText : inputText}
+                  </Markdown>
                 ) : (
                   <span className="text-[var(--muted-foreground)] italic">Nothing to preview</span>
                 )}

--- a/src/Ivy.Tendril.Widgets/frontend/src/math.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/math.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import Markdown from "react-markdown";
+import { getMarkdownPlugins, hasMath } from "./math";
+
+const render = (content: string) =>
+  renderToStaticMarkup(<Markdown {...getMarkdownPlugins(content)}>{content}</Markdown>);
+
+describe("hasMath", () => {
+  it("detects $$ delimiters", () => {
+    expect(hasMath("$$E = mc^2$$")).toBe(true);
+    expect(hasMath("the relation $$E = mc^2$$ holds")).toBe(true);
+  });
+
+  it("does not treat single dollar signs as math", () => {
+    expect(hasMath("costs $5")).toBe(false);
+    expect(hasMath("$env:PORT and $IsMacOS")).toBe(false);
+    expect(hasMath("inline $x^2$ here")).toBe(false);
+  });
+});
+
+describe("getMarkdownPlugins", () => {
+  it("always includes a remark plugin for GFM", () => {
+    expect(getMarkdownPlugins("plain text").remarkPlugins).toHaveLength(1);
+  });
+
+  it("adds no rehype plugins when the content has no math", () => {
+    expect(getMarkdownPlugins("plain text").rehypePlugins).toHaveLength(0);
+  });
+
+  it("adds the math plugins when the content has math", () => {
+    const plugins = getMarkdownPlugins("$$x^2$$");
+    expect(plugins.remarkPlugins).toHaveLength(2);
+    expect(plugins.rehypePlugins).toHaveLength(1);
+  });
+});
+
+describe("math rendering", () => {
+  it("renders $$...$$ standing alone as a KaTeX display block", () => {
+    const html = render("$$\n\\sum_{i=1}^n i = \\frac{n(n+1)}{2}\n$$");
+    expect(html).toContain("katex-display");
+    expect(html).not.toContain("katex-error");
+    // The MathML annotation carries the original TeX source.
+    expect(html).toContain("\\frac{n(n+1)}{2}");
+  });
+
+  it("renders $$...$$ inside a paragraph inline, not as a display block", () => {
+    const html = render("the relation $$E = mc^2$$ holds");
+    expect(html).toContain("katex");
+    expect(html).not.toContain("katex-display");
+    expect(html).toContain("holds");
+  });
+
+  it("renders \\frac as math", () => {
+    const html = render("$$\\frac{a}{b}$$");
+    expect(html).toContain("katex");
+    expect(html).not.toContain("katex-error");
+  });
+
+  it("leaves prose dollar signs as literal text", () => {
+    const prose = "bash expands any $ (e.g. $env:PORT, vars like $IsMacOS) so $ survives, costs $5";
+    const html = render(prose);
+    expect(html).not.toContain("katex");
+    expect(html).toContain("$env:PORT");
+    expect(html).toContain("$5");
+  });
+
+  it("leaves single-dollar spans as literal text rather than rendering them as math", () => {
+    const html = render("inline $x^2$ here");
+    expect(html).not.toContain("katex");
+    expect(html).toContain("$x^2$");
+  });
+
+  it("leaves dollar signs inside code untouched", () => {
+    const fenced = render("```bash\necho $PATH\n```");
+    expect(fenced).not.toContain("katex");
+    expect(fenced).toContain("$PATH");
+
+    const inline = render("use `$env:PORT` here");
+    expect(inline).not.toContain("katex");
+    expect(inline).toContain("<code>$env:PORT</code>");
+  });
+
+  it("renders malformed TeX as a visible KaTeX error instead of throwing", () => {
+    const html = render("$$\\frac{a}{$$");
+    expect(html).toContain("katex-error");
+  });
+
+  it("still renders GFM features when math is present", () => {
+    const html = render("- [x] done\n\n$$x^2$$");
+    expect(html).toContain("katex");
+    expect(html).toContain('type="checkbox"');
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/math.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/math.ts
@@ -1,0 +1,45 @@
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
+import type { Options } from "react-markdown";
+
+type MarkdownPlugins = Required<Pick<Options, "remarkPlugins" | "rehypePlugins">>;
+
+/**
+ * The only delimiter that marks math in Tendril markdown: `$$...$$`.
+ *
+ * Single-dollar text math is deliberately not recognised (see
+ * `singleDollarTextMath` below), so a lone `$` is not a math signal.
+ */
+const MATH_DELIMITER = /\$\$/;
+
+/** True when the content contains a `$$` math delimiter. */
+export const hasMath = (content: string): boolean => MATH_DELIMITER.test(content);
+
+/**
+ * The remark/rehype plugin lists for rendering markdown: GFM always, plus
+ * remark-math and rehype-katex when the content actually contains math. Gating
+ * on the content keeps the KaTeX pass off the render path for the overwhelming
+ * majority of plan markdown, notes and agent output, which has no math at all.
+ *
+ * `singleDollarTextMath: false` is required, not a preference: Tendril markdown
+ * is full of prose dollar signs (`$env:PORT`, `$IsMacOS`, prices), and with
+ * single-dollar math enabled remark-math pairs them up and renders the text
+ * between two unrelated dollars as math. Inline math therefore also uses
+ * `$$...$$`, which remark-math renders inline when it sits inside a paragraph
+ * and as a centered display block when it stands on its own line. This matches
+ * the Ivy framework's own Markdown widget, so math behaves the same in
+ * `Text.Markdown` and in the Tendril widgets.
+ *
+ * KaTeX's stylesheet and web fonts are deliberately not bundled here: the Ivy
+ * host page already loads them eagerly (its `vendor-markdown-*.css` carries the
+ * `.katex` rules and all `KaTeX_*` `@font-face` declarations), so the widget
+ * bundle inherits them and only needs the plugins.
+ */
+export const getMarkdownPlugins = (content: string): MarkdownPlugins =>
+  hasMath(content)
+    ? {
+        remarkPlugins: [remarkGfm, [remarkMath, { singleDollarTextMath: false }]],
+        rehypePlugins: [rehypeKatex],
+      }
+    : { remarkPlugins: [remarkGfm], rehypePlugins: [] };


### PR DESCRIPTION
Fixes #1915

# Support Math Expressions in Markdown

Tendril's markdown views now render TeX/LaTeX math. Closes [#1915](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/1915).

## Changes

**Math rendering in the Tendril widget bundle.** `remark-math` 6.0.0 and `rehype-katex` 7.0.1 (the same versions the Ivy framework uses) are added to `Ivy.Tendril.Widgets`, wired through a new shared helper `src/Ivy.Tendril.Widgets/frontend/src/math.ts`. All five react-markdown instances in the bundle now route their plugin lists through it, so math renders in plans, notes, summaries, PR comments, agent output and chat messages.

The Ivy framework's own `Markdown` widget (used by the Icebox, PlanSheet, Recommendations and Review views) already had math as of Ivy 1.3.17, so it needed no change. This work closes the gap in Tendril's own widgets.

**Delimiter: `$$...$$` only, for both display and inline.** A `$$...$$` block on its own lines renders centred; `$$...$$` inside a paragraph renders inline. Single-dollar `$...$` is deliberately **not** treated as math (`singleDollarTextMath: false`).

That choice is forced. remark-math pairs any two dollar signs in a paragraph, so enabling `$...$` turns ordinary prose into garbled TeX: "This widget costs $0 and that one costs $5 today." renders `0 and that one costs` as a math expression, and `Set $env:PORT and then read $PATH` renders `env:PORT and then read` as one. Tendril markdown is full of prose dollars (shell variables in plans, prices, `$env:PORT` in docs), so prose safety was treated as the binding requirement. This also matches what the Ivy framework chose for the same trade-off, keeping both widgets consistent inside one app. The measured comparison is in `Verification/CheckResult.md`; the trade-off is filed as a recommendation.

**Math plugins load only when needed.** `getMarkdownPlugins(content)` checks for a `$$` delimiter first and returns just `remarkGfm` when there is none, so ordinary markdown never pays for the KaTeX pass.

**No KaTeX CSS or fonts are bundled.** The Ivy host page already links `vendor-markdown-*.css` eagerly, which carries the `.katex-display` rules and all 59 KaTeX web fonts. Verified: `grep -c katex dist/ivy-tendril-widgets.css` is 0, and the bundle grew only 12 KB.

**Malformed TeX degrades safely.** `$$\frac{a}{$$` renders as a red `katex-error` span rather than throwing, so one bad expression cannot break a page.

---

- e98f35d30e4a051ba6460db551e60737245c39e4 Render math expressions in Tendril markdown widgets (plan 00026)
- 81d75a3b7eeb562ee80d74a574cfa13ca83d0ef7 Add tests for markdown math rendering (plan 00026)
- 61e0bd2d690b7feba2bc1bd26f10c69419a94a45 Add DraftMarkdown math sample app (plan 00026)
- fce222f31e6bc150afb4929a78beeca340672314 Wrap ChatWidget markdown children to match the formatter (plan 00026)
- a2f0910b58323ea5cb8de9bcc5d596da2c3c55c4 Render math in AgentViewer assistant text too (plan 00026)

---
Created using [Ivy Tendril](https://ivy.app).
