### PR TITLE
[00024] Hide Revert Button for Revision One

### DIFF
--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyModelCatalog.cs
@@ -44,7 +44,7 @@ public sealed class IvyModelCatalog : IModelCatalogProvider
             var result = await _inner.GetModelsAsync(ct);
             var ivyModels = result.Models
                 .Where(m => m.Id.StartsWith("ivy", StringComparison.OrdinalIgnoreCase) ||
-                            m.Provider.Equals("ivy", StringComparison.OrdinalIgnoreCase))
+                            "ivy".Equals(m.Provider, StringComparison.OrdinalIgnoreCase))
                 .Select(m => new ModelInfo
                 {
                     Id = m.Id,

--- a/src/Ivy.Tendril.Test/Apps/Views/Tabs/DetailsTabViewRevisionCellTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Views/Tabs/DetailsTabViewRevisionCellTests.cs
@@ -1,0 +1,67 @@
+using Ivy.Core;
+using Ivy.Tendril.Apps.Views.Tabs;
+
+namespace Ivy.Tendril.Test.Apps.Views.Tabs;
+
+public class DetailsTabViewRevisionCellTests
+{
+    private static object[] BuildChildren(int count, Action onRevert)
+    {
+        var layout = DetailsTabView.BuildRevisionCell(count, onRevert);
+        return ((IWidget)layout.Build()!).Children;
+    }
+
+    [Fact]
+    public void BuildRevisionCell_AtRevisionOne_OmitsRevertButton()
+    {
+        var children = BuildChildren(1, () => { });
+
+        Assert.Empty(children.OfType<Button>());
+    }
+
+    [Fact]
+    public void BuildRevisionCell_AtRevisionZero_OmitsRevertButton()
+    {
+        // Defensive: a plan with no revisions on disk reports 0 and still has nothing to revert to.
+        var children = BuildChildren(0, () => { });
+
+        Assert.Empty(children.OfType<Button>());
+    }
+
+    [Fact]
+    public void BuildRevisionCell_AtRevisionTwo_ShowsEnabledRevertButton()
+    {
+        var children = BuildChildren(2, () => { });
+
+        var button = Assert.Single(children.OfType<Button>());
+        Assert.False(button.Disabled);
+        Assert.Equal("Revert to previous revision", button.Tooltip);
+        Assert.Equal(Icons.Undo, button.Icon);
+    }
+
+    [Fact]
+    public void BuildRevisionCell_AlwaysShowsRevisionNumber()
+    {
+        Assert.Equal("1", RenderedText(1));
+        Assert.Equal("7", RenderedText(7));
+    }
+
+    [Fact]
+    public async Task BuildRevisionCell_ButtonClick_InvokesRevertCallback()
+    {
+        var reverted = false;
+        var children = BuildChildren(3, () => reverted = true);
+
+        var button = Assert.Single(children.OfType<Button>());
+        await ((IWidget)button).InvokeEventAsync(nameof(Button.OnClick), []);
+
+        Assert.True(reverted);
+    }
+
+    private static string RenderedText(int count)
+    {
+        var children = BuildChildren(count, () => { });
+        var text = Assert.Single(children.OfType<TextBuilder>());
+        return Assert.IsType<TextBlock>(text.Build()).Content;
+    }
+}

--- a/src/Ivy.Tendril.Test/Helpers/GitHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/GitHelperTests.cs
@@ -248,6 +248,8 @@ public class GitHelperTests : IDisposable
         }
     }
 
+    // Only ever reached from the Windows-guarded fsmonitor test; GetCommandLine is WMI-based.
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
     private static int CountFsmonitorDaemons()
     {
         try

--- a/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs
@@ -42,19 +42,13 @@ public class DetailsTabView(
             .Builder(x => x.PlanId, f => f.CopyToClipboard())
             .Builder(x => x.Folder, f => f.CopyToClipboard())
             .Multiline(x => x.InitialPrompt)
-            .Builder(x => x.Revision, f => f.Func((int count) =>
-                Layout.Horizontal().Gap(2).AlignContent(Align.Center)
-                | Text.Block(count.ToString())
-                | new Button().Icon(Icons.Undo).Outline().Small()
-                    .Tooltip("Revert to previous revision")
-                    .Disabled(count <= 1)
-                    .OnClick(() =>
-                    {
-                        planService.RevertRevision(plan.FolderName);
-                        var updated = planService.GetPlanByFolder(plan.FolderPath);
-                        if (updated != null) selectedPlanState.Set(updated);
-                        refreshPlans();
-                    })))
+            .Builder(x => x.Revision, f => f.Func((int count) => BuildRevisionCell(count, () =>
+                {
+                    planService.RevertRevision(plan.FolderName);
+                    var updated = planService.GetPlanByFolder(plan.FolderPath);
+                    if (updated != null) selectedPlanState.Set(updated);
+                    refreshPlans();
+                })))
             .Builder(x => x.RelatedPlans, f => f.Func((List<Link> links) =>
                 new LinkListView(links, href =>
                 {
@@ -77,6 +71,25 @@ public class DetailsTabView(
                       | Text.H4("Jobs")
                       | new PlanJobsDataTableView(jobs, showDebug))
                    : null);
+    }
+
+    /// <summary>
+    /// Renders the Revision row: the revision number, plus a revert button only when there is an
+    /// earlier revision to go back to. At revision 1 the button is omitted entirely rather than
+    /// rendered disabled, since there is nothing to revert to.
+    /// </summary>
+    internal static LayoutView BuildRevisionCell(int count, Action onRevert)
+    {
+        var layout = Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                     | Text.Block(count.ToString());
+
+        if (count <= 1)
+            return layout;
+
+        return layout
+               | new Button().Icon(Icons.Undo).Outline().Small()
+                   .Tooltip("Revert to previous revision")
+                   .OnClick(onRevert);
     }
 
     // Execution profiles are stored lowercase (e.g. "balanced"); present them title-cased.


### PR DESCRIPTION
Fixes #1841

# Summary

## Changes

The "Revert to previous revision" button in a plan's Details tab is no longer
rendered at revision 1, where there is nothing to revert to. Previously it was
rendered disabled, so it still appeared in the UI. The Revision cell was
extracted into a testable static method that omits the button entirely when the
revision count is 1 or lower.

## API Changes

- Added `internal static LayoutView DetailsTabView.BuildRevisionCell(int count, Action onRevert)`.
  Builds the Details tab's Revision cell; includes the revert button only when
  `count > 1`. Internal, and `Ivy.Tendril.Test` already has `InternalsVisibleTo`.
- Removed the `.Disabled(count <= 1)` call from the revert button, now redundant
  because the button is only constructed when it would be enabled.

## Files Modified

Feature:
- `src/Ivy.Tendril/Apps/Views/Tabs/DetailsTabView.cs` — extracted `BuildRevisionCell`,
  gated the revert button on `count > 1`.

Tests:
- `src/Ivy.Tendril.Test/Apps/Views/Tabs/DetailsTabViewRevisionCellTests.cs` — new,
  5 tests over the built widget tree.

Verification fixes (pre-existing `--warnaserror` failures, not plan scope):
- `src/Ivy.Tendril.Agents/Providers/Ivy/IvyModelCatalog.cs` — CS8602 null-deref on
  the nullable `ModelInfo.Provider`.
- `src/Ivy.Tendril.Test/Helpers/GitHelperTests.cs` — CA1416 missing
  `[SupportedOSPlatform("windows")]` on a WMI-based helper.

## Manual Testing

1. Run Tendril and open the Plans app.
2. Select a plan that has only one revision (a freshly created plan, or check
   that the Details tab shows `Revision 1`).
3. Open the **Details** tab. Confirm the Revision row shows just the number `1`
   with **no** undo/revert icon button next to it. Before this change an
   greyed-out undo button was visible there.
4. Select a plan with two or more revisions (any plan that has been through
   ExpandPlan or UpdatePlan, so Revision is 2+).
5. Open its **Details** tab. Confirm the undo icon button **is** shown next to the
   number, is clickable rather than greyed out, and shows the tooltip
   "Revert to previous revision" on hover.
6. Click it. Confirm the plan reverts to the previous revision and the Revision
   number decrements. If that takes the plan down to revision 1, confirm the
   button disappears.


---
- 82d77853 Hide revert button at revision one (plan 00024)
- 17f051a8 Fix warnaserror failures from DotnetBuild (plan 00024)

---
Created using [Ivy Tendril](https://ivy.app).