### PR TITLE
[00122] Remove Cancel Button From Update Plan Dialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/UpdatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/UpdatePlanDialog.cs
@@ -145,9 +145,6 @@ public class UpdatePlanDialog(
                     .Bind(updateText)
                     .SubmitLabel("Update")
                     .Placeholder("Enter update instructions...")
-            ),
-            new DialogFooter(
-                new Button("Cancel").Outline().OnClick(() => HandleClose())
             )
         ).Width(Size.Rem(30));
     }


### PR DESCRIPTION
# Summary

## Changes

Removed the redundant `Cancel` button from the footer of the Update Plan dialog (`UpdatePlanDialog.cs`). The dialog already closes via the header X button and Escape (both routed through `HandleClose()`), so the footer-only Cancel button wasted vertical space and duplicated an existing affordance.

## API Changes

None. Internal view rendering change only.

## Files Modified

- `src/Ivy.Tendril/Apps/Drafts/Dialogs/UpdatePlanDialog.cs` — removed the `DialogFooter`/`Cancel` button, switched to the 3-argument `Dialog(onClose, header, body)` overload (matching the sibling `CreatePlanDialog`).

## Manual Testing

1. Run the Tendril app and open the Drafts app.
2. Select a draft plan and press `U` (or use the equivalent action) to open the Update Plan dialog.
3. Confirm no `Cancel` button is rendered in the dialog footer.
4. Confirm the dialog still closes via the header X button and via Escape.

---
Commits:
- d411e50a [00122] Remove Cancel button from Update Plan dialog

---
Created using [Ivy Tendril](https://ivy.app).
