### PR TITLE
[00121] Center the Plus Glyph in the Diff Gutter Add Comment Button

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/plan-diff.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/plan-diff.css
@@ -133,7 +133,7 @@ td.diff-gutter-delete:hover {
 td.diff-gutter-normal::after,
 td.diff-gutter-insert::after,
 td.diff-gutter-delete::after {
-  content: "+";
+  content: "";
   position: absolute;
   left: 50%;
   top: 50%;
@@ -141,14 +141,15 @@ td.diff-gutter-delete::after {
   width: 18px;
   height: 18px;
   background-color: var(--primary);
-  color: var(--primary-foreground, #ffffff);
+  /* Two bars instead of a "+" text glyph: text ink is positioned by font
+     metrics, not by the box, so the glyph rendered 1.5px low (#1941). */
+  background-image:
+    linear-gradient(var(--primary-foreground, #ffffff), var(--primary-foreground, #ffffff)),
+    linear-gradient(var(--primary-foreground, #ffffff), var(--primary-foreground, #ffffff));
+  background-size: 8px 2px, 2px 8px;
+  background-position: center center;
+  background-repeat: no-repeat;
   border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 13px;
-  line-height: 1;
-  font-weight: 600;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.1s ease, transform 0.1s ease;

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/plan-diff.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/plan-diff.css.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const cssPath = join(dirname(fileURLToPath(import.meta.url)), "plan-diff.css");
+const css = readFileSync(cssPath, "utf-8");
+
+function gutterAfterBlock(source: string): string {
+  const start = source.indexOf("td.diff-gutter-normal::after,");
+  const end = source.indexOf("}", start);
+  return source.slice(start, end + 1);
+}
+
+describe("plan-diff.css gutter add-comment button", () => {
+  const block = gutterAfterBlock(css);
+
+  it("does not draw the plus with a text glyph", () => {
+    expect(block).not.toContain('content: "+"');
+  });
+
+  it("draws the plus geometrically with centered background bars", () => {
+    expect(block).toMatch(/background-size:\s*8px 2px,\s*2px 8px/);
+    expect(block).toMatch(/background-position:\s*center center/);
+  });
+});


### PR DESCRIPTION
Fixes #1941

# Summary

## Changes

Fixed [issue #1941](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/1941): the "add comment"
plus button in the Review app's `PlanDiffView` diff gutter rendered its "+" glyph ~1.5px below the
disc's vertical center with unequal arm widths, because it was drawn as a text character centered
by flexbox (which centers the line box, not the ink). The pseudo-element now draws the plus
geometrically with two centered `background-image` gradient bars instead of a text glyph, so it
lands on integer pixels regardless of font metrics.

## API Changes

None. This is a CSS-only fix with no public API surface.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/plan-diff.css` — replaced the text-glyph `"+"`
  in the gutter `::after` pseudo-element with two centered background bars.
- `src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/plan-diff.css.test.ts` (new) — vitest guard
  asserting the gutter rule no longer uses `content: "+"` and declares the centered background bars.

## Manual Testing

1. Run the Review app and open a plan's Changes tab (`PlanDiffView`).
2. Hover a non-empty line in the diff gutter to reveal the round "add comment" button.
3. Visually confirm the white plus is centered in the disc with equal-length horizontal and
   vertical arms (previously the plus sat ~1.5px low with unequal arms). Check both light and dark
   themes, since the fix relies on the `--primary-foreground` custom property with a `#ffffff`
   fallback.

---
## Commits
- 7ceb4686 Draw the diff gutter plus geometrically instead of as a text glyph

---
Created using [Ivy Tendril](https://ivy.app).
