### PR TITLE
[00119] Align Diff View Font Sizes With the App Type Scale

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/CommentToggle.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/CommentToggle.test.tsx
@@ -48,7 +48,7 @@ describe("PlanDiffView comment toggle", () => {
     expect(button.disabled).toBe(false);
     expect(button.getAttribute("aria-pressed")).toBe("true");
     // Check the button contains a count span
-    const countSpan = button.querySelector("span.font-mono.text-\\[10px\\]");
+    const countSpan = button.querySelector("span.font-mono.text-xs");
     expect(countSpan).toBeTruthy();
     expect(countSpan?.textContent).toBe("1");
   });

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.test.tsx
@@ -170,6 +170,26 @@ describe("PlanDiffView", () => {
     const listItems = document.querySelectorAll(".diff-comment-markdown ul li");
     expect(listItems.length).toBe(2);
   });
+
+  it("does not render any off-scale text size classes", () => {
+    render(
+      <PlanDiffView
+        id="pdv-1"
+        onIvyEvent={vi.fn()}
+        diff={diff}
+        comments={[
+          {
+            filePath: "a.txt",
+            changeKey: changeKey,
+            content: "a comment",
+            lineNumber: 1,
+          },
+        ]}
+      />
+    );
+
+    expect(document.querySelectorAll('[class*="text-[10px]"], [class*="text-[11px]"]').length).toBe(0);
+  });
 });
 
 describe("PlanDiffView unified column collapse", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
@@ -129,7 +129,7 @@ const CommentWidgetContainer: React.FC<CommentWidgetContainerProps> = ({
         <div className="flex flex-col gap-2">
           {comments.map((comment, idx) => (
             <div key={idx} className="flex flex-col gap-1 border-b border-[var(--border)] pb-2 last:border-0 last:pb-0">
-              <div className="flex items-center justify-between text-[10px] text-[var(--muted-foreground)]">
+              <div className="flex items-center justify-between text-xs text-[var(--muted-foreground)]">
                 <span className="font-medium text-[var(--foreground)]">Agent Instruction (Draft)</span>
                 <div className="flex items-center gap-1">
                   <button
@@ -149,7 +149,7 @@ const CommentWidgetContainer: React.FC<CommentWidgetContainerProps> = ({
                   </button>
                 </div>
               </div>
-              <div className="diff-comment-markdown leading-relaxed text-[11px] text-[var(--foreground)] mt-1">
+              <div className="diff-comment-markdown leading-relaxed text-sm text-[var(--foreground)] mt-1">
                 <Markdown {...getMarkdownPlugins(comment.content)}>{comment.content}</Markdown>
               </div>
             </div>
@@ -162,7 +162,7 @@ const CommentWidgetContainer: React.FC<CommentWidgetContainerProps> = ({
               <div className="flex gap-2">
                 <button
                   type="button"
-                  className={`pb-1 px-1 border-b-2 text-[11px] font-medium transition-all cursor-pointer ${
+                  className={`pb-1 px-1 border-b-2 text-xs font-medium transition-all cursor-pointer ${
                     activeTab === "write"
                       ? "border-[var(--primary)] text-[var(--foreground)]"
                       : "border-transparent text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
@@ -173,7 +173,7 @@ const CommentWidgetContainer: React.FC<CommentWidgetContainerProps> = ({
                 </button>
                 <button
                   type="button"
-                  className={`pb-1 px-1 border-b-2 text-[11px] font-medium transition-all cursor-pointer ${
+                  className={`pb-1 px-1 border-b-2 text-xs font-medium transition-all cursor-pointer ${
                     activeTab === "preview"
                       ? "border-[var(--primary)] text-[var(--foreground)]"
                       : "border-transparent text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
@@ -183,14 +183,14 @@ const CommentWidgetContainer: React.FC<CommentWidgetContainerProps> = ({
                   Preview
                 </button>
               </div>
-              <span className="text-[10px] text-[var(--muted-foreground)]">
+              <span className="text-xs text-[var(--muted-foreground)]">
                 Markdown instruction for the agent
               </span>
             </div>
 
             {activeTab === "write" ? (
               <textarea
-                className="w-full min-h-[80px] p-2 text-[11px] bg-[var(--background)] border border-[var(--border)] rounded focus:outline-none focus:ring-1 focus:ring-[var(--primary)] resize-y"
+                className="w-full min-h-[80px] p-2 text-sm bg-[var(--background)] border border-[var(--border)] rounded focus:outline-none focus:ring-1 focus:ring-[var(--primary)] resize-y"
                 placeholder="Enter instruction for the agent at this line..."
                 value={isEditing ? (editingText ?? "") : inputText}
                 onChange={(e) => {
@@ -203,7 +203,7 @@ const CommentWidgetContainer: React.FC<CommentWidgetContainerProps> = ({
                 autoFocus
               />
             ) : (
-              <div className="diff-comment-markdown w-full min-h-[80px] p-2 text-[11px] bg-[var(--muted)] border border-[var(--border)] rounded overflow-auto">
+              <div className="diff-comment-markdown w-full min-h-[80px] p-2 text-sm bg-[var(--muted)] border border-[var(--border)] rounded overflow-auto">
                 {(isEditing ? editingText : inputText)?.trim() ? (
                   <Markdown {...getMarkdownPlugins((isEditing ? editingText : inputText) ?? "")}>
                     {isEditing ? editingText : inputText}
@@ -217,7 +217,7 @@ const CommentWidgetContainer: React.FC<CommentWidgetContainerProps> = ({
             <div className="flex items-center justify-end gap-2 mt-1">
               <button
                 type="button"
-                className="px-3 py-1 text-[10px] font-medium border border-[var(--border)] rounded hover:bg-[var(--muted)] transition-colors cursor-pointer"
+                className="px-3 py-1 text-xs font-medium border border-[var(--border)] rounded hover:bg-[var(--muted)] transition-colors cursor-pointer"
                 onClick={() => {
                   if (isEditing) {
                     onCancelEdit();
@@ -230,7 +230,7 @@ const CommentWidgetContainer: React.FC<CommentWidgetContainerProps> = ({
               </button>
               <button
                 type="button"
-                className="px-3 py-1 text-[10px] font-medium bg-[var(--primary)] text-[var(--primary-foreground)] rounded hover:opacity-90 transition-colors disabled:opacity-50 cursor-pointer"
+                className="px-3 py-1 text-xs font-medium bg-[var(--primary)] text-[var(--primary-foreground)] rounded hover:opacity-90 transition-colors disabled:opacity-50 cursor-pointer"
                 disabled={isEditing ? !editingText?.trim() : !inputText.trim()}
                 onClick={() => {
                   if (isEditing) {
@@ -456,18 +456,18 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
   }
 
   return (
-    <div ref={containerRef} style={style} className={`ivy-diff-view text-xs${effectiveWordWrap ? " diff-wrap" : ""}`}>
+    <div ref={containerRef} style={style} className={`ivy-diff-view text-sm${effectiveWordWrap ? " diff-wrap" : ""}`}>
       {showFileDropdown && (
         <div
           className="sticky top-0 z-20 flex items-center gap-2 px-3 py-1.5 bg-[var(--muted)] border-b border-[var(--border)]"
           style={{ fontFamily: 'var(--font-sans, sans-serif)' }}
         >
-          <span className="text-[11px] text-[var(--muted-foreground)] shrink-0">
+          <span className="text-xs text-[var(--muted-foreground)] shrink-0">
             {fileMeta.length} files
           </span>
           <select
             aria-label="Jump to file"
-            className="flex-1 min-w-0 text-[11px] px-2 py-1 rounded bg-[var(--background)] text-[var(--foreground)] border border-[var(--border)]"
+            className="flex-1 min-w-0 text-xs px-2 py-1 rounded bg-[var(--background)] text-[var(--foreground)] border border-[var(--border)]"
             style={{ fontFamily: 'var(--font-sans, sans-serif)' }}
             defaultValue=""
             onChange={(e) => {
@@ -543,7 +543,7 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
           >
             {hasHeader && (
               <div
-                className="flex items-center justify-between px-3 py-1.5 text-[11px] bg-[var(--muted)] text-[var(--muted-foreground)] border-b border-[var(--border)] sticky top-0 z-10 font-sans"
+                className="flex items-center justify-between px-3 py-1.5 text-sm bg-[var(--muted)] text-[var(--muted-foreground)] border-b border-[var(--border)] sticky top-0 z-10 font-sans"
                 style={{
                   top: showFileDropdown ? "2rem" : 0,
                 }}
@@ -578,14 +578,14 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
 
                 <div className="flex items-center gap-4 shrink-0 pl-2">
                   {/* Additions / Deletions count */}
-                  <span className="flex items-center gap-1 font-mono text-[11px]">
+                  <span className="flex items-center gap-1 font-mono text-xs">
                     {additions > 0 && <span className="text-[var(--success)]">+{additions}</span>}
                     {deletions > 0 && <span className="text-[var(--destructive)]">-{deletions}</span>}
                     {renderDiffSquares(additions, deletions)}
                   </span>
 
                   {/* Viewed / Collapsed Checkbox */}
-                  <label className="flex items-center gap-1.5 text-[11px] text-[var(--muted-foreground)] cursor-pointer select-none font-medium">
+                  <label className="flex items-center gap-1.5 text-xs text-[var(--muted-foreground)] cursor-pointer select-none font-medium">
                     <button
                       type="button"
                       role="checkbox"
@@ -638,7 +638,7 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
                       >
                         <MessageSquare className="w-3.5 h-3.5" />
                         {fileCommentCount > 0 && (
-                          <span className="font-mono text-[10px]">{fileCommentCount}</span>
+                          <span className="font-mono text-xs">{fileCommentCount}</span>
                         )}
                       </button>
                     );


### PR DESCRIPTION
Fixes #1938

# Summary

## Changes

The Review app's Changes tab diff widget (`PlanDiffView`) used ad-hoc `text-[10px]`/`text-[11px]` classes that sat below the rest of the app's 14px/12px type scale, inverting the visual hierarchy (the filename header rendered smaller than the code beneath it). Replaced every off-scale class with Tailwind's existing `text-sm` (14px, matching every other code surface in Tendril) or `text-xs` (12px, secondary metadata) — no config or token changes were needed.

## API Changes

None. This is a CSS class-only change within `PlanDiffView.tsx`; no props, exports, or public surface changed.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx` — replaced 16 `text-[10px]`/`text-[11px]` class occurrences with `text-sm` or `text-xs` per the app's type scale.
- `src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.test.tsx` — added a regression test asserting no rendered element carries an off-scale text size class.
- `src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/CommentToggle.test.tsx` — updated a test selector that hard-coded the old `text-[10px]` class on the comment-count badge.

## Manual Testing

1. Run the Tendril app and open the Review app's Plans view.
2. Open a plan with commits and go to its **Changes** tab.
3. Confirm the diff code and line-number gutter render at the same size as code blocks elsewhere in the app (e.g. artifact viewers, markdown code fences), and that the filename header above each file's diff is no longer smaller than the code below it.
4. Click a line to open the comment widget; the comment text, Write/Preview tabs, textarea, and Cancel/Save buttons should read at a consistent, slightly larger size than before but not be so large that layout breaks in a narrow panel.

---

## Commits
- 47b6f7a3 [00119] Align diff view font sizes with the app type scale

---
Created using [Ivy Tendril](https://ivy.app).
