### PR TITLE
[00117] Remove View File Option From Diff File Context Menu

### DIFF
--- a/src/Ivy.Tendril.Widgets/PlanDiffView.cs
+++ b/src/Ivy.Tendril.Widgets/PlanDiffView.cs
@@ -68,8 +68,6 @@ public record PlanDiffView : WidgetBase<PlanDiffView>
 
     [Event] public Func<Event<PlanDiffView, DirectEditArgs>, ValueTask>? OnDirectEdit { get; init; }
 
-    [Event] public Func<Event<PlanDiffView, string>, ValueTask>? OnViewFile { get; init; }
-
     [Event] public Func<Event<PlanDiffView, string>, ValueTask>? OnEditFile { get; init; }
 
     [Event] public Func<Event<PlanDiffView, string>, ValueTask>? OnDeleteFile { get; init; }

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
@@ -6,7 +6,7 @@ import Markdown from "react-markdown";
 type IvyEventHandler = (eventName: string, widgetId: string, args: any[]) => void;
 import { getWidth, getHeight } from "../styles";
 import { getMarkdownPlugins } from "../math";
-import { Eye, Pencil, Trash2, MoreHorizontal, MessageSquare } from "lucide-react";
+import { Pencil, Trash2, MoreHorizontal, MessageSquare } from "lucide-react";
 
 /** Container width (px) below which the diff is too cramped for a side-by-side (split) view. */
 export const NARROW_BREAKPOINT = 768;
@@ -659,17 +659,6 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
                     </button>
                     {activeDropdownIndex === fileIndex && (
                       <div className="absolute right-0 mt-1 z-50 w-36 bg-[var(--background)] border border-[var(--border)] rounded-md shadow-lg py-1 text-xs">
-                        <button
-                          type="button"
-                          className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-[var(--muted)] text-[var(--foreground)] text-left cursor-pointer"
-                          onClick={() => {
-                            setActiveDropdownIndex(null);
-                            dispatchEvent?.("OnViewFile", id, [filePath]);
-                          }}
-                        >
-                          <Eye className="w-3.5 h-3.5" />
-                          View file
-                        </button>
                         <button
                           type="button"
                           className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-[var(--muted)] text-[var(--foreground)] text-left cursor-pointer"

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -615,7 +615,6 @@ public class ContentView(
                 refreshPlans,
                 planData.CommitRows,
                 hash => openCommit.Set(hash),
-                openFile,
                 selectedPlan.Project);
 
             var tabNamesList = new List<string> { "summary", "plan", "details" };

--- a/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
@@ -22,7 +22,6 @@ public class ChangesTabView(
     Action refreshPlans,
     List<PlanContentHelpers.CommitRow> commitRows,
     Action<string> setOpenCommit,
-    IState<string?> openFile,
     string? projectName = null) : ViewBase
 {
     public int FileCount => changesData?.Files.Count ?? 0;
@@ -140,20 +139,6 @@ public class ChangesTabView(
                 OnDirectEdit = async e =>
                 {
                     await HandleDirectEdit(e.Value);
-                },
-                OnViewFile = e =>
-                {
-                    var repoPath = changesData?.SourceRepoPath;
-                    if (string.IsNullOrEmpty(repoPath))
-                    {
-                        repoPath = selectedPlan.GetEffectiveRepoPaths(config).FirstOrDefault();
-                    }
-                    if (!string.IsNullOrEmpty(repoPath))
-                    {
-                        var absolutePath = Path.Combine(repoPath, e.Value).Replace('\\', '/');
-                        openFile.Set(absolutePath);
-                    }
-                    return ValueTask.CompletedTask;
                 },
                 OnEditFile = e =>
                 {


### PR DESCRIPTION
Fixes #1939

# Summary

## Changes

Removed the "View file" item from the per-file kebab menu in the `PlanDiffView` widget, leaving
only Edit file and Delete file. Deleted the now-unreachable `OnViewFile` event plumbing and the
`openFile` parameter it required in `ChangesTabView`, without touching the unrelated `openFile`
state still used elsewhere in `ContentView`.

## API Changes

- Removed event: `PlanDiffView.OnViewFile` (C# widget record, `Ivy.Tendril.Widgets`)
- Removed dispatch: `"OnViewFile"` event dispatch from the `PlanDiffView` React component
- `ChangesTabView` constructor: removed the `IState<string?> openFile` parameter

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx` — deleted the "View file" button and the unused `Eye` icon import
- `src/Ivy.Tendril.Widgets/PlanDiffView.cs` — deleted the `OnViewFile` event property
- `src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs` — deleted the `OnViewFile` handler and its `openFile` constructor parameter
- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — dropped the `openFile` argument from the `ChangesTabView` construction call

## Manual Testing

1. Run the Tendril app and open the Review app for any plan with file changes.
2. Open the Plan tab's file diff view and click the kebab (`⋯`) menu on any file's header.
3. Confirm the menu shows only **Edit file** and **Delete file** — no **View file** entry.
4. Confirm **Edit file** and **Delete file** still work as before (unchanged behavior).


---
**Commits:**
- bda3d0a5 [00117] Remove View file option from diff file context menu


---
Created using [Ivy Tendril](https://ivy.app).