### PR TITLE
[00113] Make RetryPlan Resume Prior Work Instead of Re-Implementing the Plan

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/RetryPlan/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/RetryPlan/Program.md
@@ -2,7 +2,9 @@
 
 **Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined as verifications in the project configuration. Examples in this document use multiple tech stacks for illustration.
 
-Implement improvements on an already-executed plan, incorporating reviewer feedback. Works in the **existing worktree** created by ExecutePlan — does NOT create or destroy worktrees.
+Implement improvements on an already-executed plan, incorporating reviewer feedback. Works in the **existing worktree** created by ExecutePlan, resuming from where that run left off rather than starting over.
+
+**Resume, do not redo.** The worktree already contains the previous run's implementation and commits. The `ChangeRequest` is a **delta** on top of that work, not a fresh start. Never re-implement a part of the plan that is already in the code, never revert, amend, squash or force-push existing commits, and never delete the worktree branch. Verify what exists first (Step 2.5), then change only what is missing or wrong.
 
 ## Context
 
@@ -31,45 +33,66 @@ Read the ChangeRequest carefully before starting implementation. The original pl
 - Extract the plan ID from the folder name (e.g. `00012` from `00012-AddNewsletterSignupToHelpApp`)
 - Report plan context to Jobs UI: `tendril job status TendrilJobId --message="Retrying plan..." --plan-id=<plan-id> --plan-title="<title>"`
 
-### 2. Enter Existing Worktrees
+### 2. Enter or Recover Worktrees
 
 The worktrees were created by the prior ExecutePlan run and already contain branches with previous commits. A project may consist of multiple repos — each has its own worktree under `<TendrilPlanFolder>/Worktrees/`.
 
-For each repo in `plan.yaml` `repos` (or the project's repos from the **Projects** section if empty):
+For each repo in `plan.yaml` `repos` (or the project's repos from the **Projects** section if empty), resolve the worktree in this order:
 
-1. **Locate the worktree** at `<TendrilPlanFolder>/Worktrees/<repo-folder-name>`.
+1. **Worktree directory exists and is valid.** `<TendrilPlanFolder>/Worktrees/<repo-folder-name>` exists and contains a `.git` file: use it as-is. Confirm it is actually attached rather than a stale leftover: `git -C <main-repo> worktree list` must list this path. Running `git status` inside a stale directory silently reports the main repo's state instead of failing, which can look healthy when it is not.
 
-2. **Verify it exists:**
+2. **Directory missing, but the branch still exists.** Check the main repo for the plan's own branch, and for the head branch of any PR listed in plan.yaml `prs` or `SourceUrl` when the plan updates an existing PR:
 
 ```bash
-if [ ! -d "<TendrilPlanFolder>/Worktrees/<repo-folder-name>" ]; then
-    echo "ERROR: Worktree not found at <TendrilPlanFolder>/Worktrees/<repo-folder-name>"
-    echo "RetryPlan requires an existing worktree from a prior ExecutePlan run."
-    echo "Re-run ExecutePlan first, or check that worktrees were not cleaned up prematurely."
-    exit 1
-fi
+git -C <main-repo> branch --list "tendril/<planFolderName>"
 ```
 
-3. **Verify it's a valid git worktree** (has a `.git` file):
+   If a branch is found, re-attach the worktree without touching its history:
+
+```bash
+git -C <main-repo> worktree add "<TendrilPlanFolder>/Worktrees/<repo-folder-name>" "<existing-branch>"
+```
+
+   Do not use `tendril plan add-worktree` here: it always creates a new branch from the base branch, which would fail or cut a fresh branch over the prior work instead of reusing it.
+
+3. **Neither the directory nor a branch exists.** The prior run died before creating anything to resume. Create a fresh worktree, report via `tendril job status` that no prior work was recoverable, and implement the revision in full:
+
+```bash
+tendril plan add-worktree <plan-id> <repo-path> [--base <baseBranch from RepoConfigs>]
+```
+
+   Note this in the Step 4.5 summary update: this run implemented the plan from scratch.
+
+After cases 2 and 3, verify `<TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git` exists:
 
 ```bash
 if [ ! -f "<TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git" ]; then
-    echo "ERROR: Directory exists but is not a valid git worktree (.git file missing)"
+    echo "ERROR: Worktree recovery failed - .git file missing"
     exit 1
 fi
 ```
 
-4. **Switch to the worktree directory** — all subsequent work happens here.
+4. **Switch to the worktree directory.** All subsequent work happens here.
 
+### 2.5. Assess Prior Work
+
+Before changing anything, gather what the previous run already did:
+
+- `tendril plan get <plan-id> commits`: the commits the prior run recorded.
+- In each worktree: `git log --oneline -n 30`, `git status --short`, and `git diff --stat "origin/<baseBranch>"...HEAD` for the full set of changes already made.
+- `<TendrilPlanFolder>/Artifacts/summary.md`, if present: the prior run's own account of what it did.
+- Every `<TendrilPlanFolder>/Verification/*.md`: the `result` in the frontmatter, plus its "Fixes Applied" and "Issues Found" sections. The server resets every non-Skipped verification in plan.yaml back to `Pending` before this job starts, so these report files are the only surviving record of what previously passed and what was already fixed.
+
+From this, build a short mental ledger with three buckets: **already delivered** (present in the code and committed), **still missing** from the revision's Solution, and **to change** per the ChangeRequest. Confirm each "already delivered" item against the actual files, not against the plan text or the summary; a summary can describe work that a later crash left unfinished.
 
 ### 3. Implement Changes
 
-Work exclusively in the worktree directories. Address the **ChangeRequest** feedback:
+Work exclusively in the worktree directories, using the ledger from Step 2.5:
 
-1. **ChangeRequest** — Address the reviewer's feedback. This is why this re-execution was triggered.
-2. **Problem** — Understand what needs to be done (from the plan revision) for context
-3. **Solution** — Implement the changes in the worktree, incorporating the ChangeRequest modifications
-4. **Tests** — Write and run any tests specified
+1. Apply the **ChangeRequest** items. This is why this re-execution was triggered.
+2. Apply only the **Solution** items the ledger marks as still missing.
+3. Skip anything the ledger marks as already delivered. If a file, function, or test already exists, edit it rather than recreating it, and never duplicate an existing test.
+4. Add new commits on top of the existing history. When the ChangeRequest asks for something to be undone, do that as a new commit, not by rewriting history.
 
 ### 4. Commit
 
@@ -89,7 +112,7 @@ After all commits, verify no uncommitted files remain:
 git status
 ```
 
-If there are uncommitted changes, either commit them or discard them with a clear reason. The worktree must be clean.
+Inspect any uncommitted changes before deciding what to do with them: after a crashed or stopped run they are usually unfinished implementation, so finish and commit them. Discard only files that are clearly build, dependency, or test debris, and state what was discarded and why in the status message. The worktree must be clean.
 
 ### 4.5. Update Summary
 
@@ -129,6 +152,8 @@ Create a `Verification/` directory in the plan folder if it doesn't exist.
 Get the run-set via `tendril plan verification list <plan-id> --json` — it emits a JSON array of `{ name, status }` **in run order**. Run the entries whose `status` is `Pending`, in array order. Skip entries whose `status` is `Skipped`.
 
 **Delegated verifications:** Some verifications are implemented as separate promptwares. The **Projects** section marks delegated verifications. Delegated verifications MUST be run via `tendril promptware run <Name>` — you are FORBIDDEN from writing their report files or setting their status to Pass yourself.
+
+Before running a verification, read its previous report at `<TendrilPlanFolder>/Verification/<VerificationName>.md` if one exists. If it recorded a fix, confirm the fix is still committed rather than redoing it. If it left issues open, start the fix loop from those issues instead of from scratch.
 
 For each `Pending` verification (in listed order):
 
@@ -211,7 +236,7 @@ The launcher script handles state transitions (Completed/Failed) based on exit c
 ## Prohibited Actions
 
 - **NEVER kill `dotnet.exe` or `Ivy.Tendril.exe` processes.** Tendril (your orchestrator) is a .NET application hosted by `dotnet.exe`. Killing it will terminate Tendril itself, losing all job state.
-- **NEVER create or destroy worktrees.** RetryPlan works in the existing worktree. If the worktree is missing, fail immediately.
+- **NEVER destroy or reset an existing worktree, its branch, or its commits.** Create a worktree only when both the directory and its branch are missing (Step 2, case 3).
 - Do NOT commit artifact files (screenshots, images) to the repo. Test artifacts belong in `<TendrilPlanFolder>/Artifacts/` only.
 - Do NOT create filesystem aliases or shortcuts (symlinks, drive mappings) to worktree paths.
 

--- a/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
@@ -2,7 +2,9 @@
 
 **Note:** This promptware is stack-agnostic. Stack-specific operations (build, format, test) are defined as verifications in the project configuration. Examples in this document use multiple tech stacks for illustration.
 
-Implement improvements on an already-executed plan, incorporating reviewer feedback. Works in the **existing worktree** created by ExecutePlan — does NOT create or destroy worktrees.
+Implement improvements on an already-executed plan, incorporating reviewer feedback. Works in the **existing worktree** created by ExecutePlan, resuming from where that run left off rather than starting over.
+
+**Resume, do not redo.** The worktree already contains the previous run's implementation and commits. The `ChangeRequest` is a **delta** on top of that work, not a fresh start. Never re-implement a part of the plan that is already in the code, never revert, amend, squash or force-push existing commits, and never delete the worktree branch. Verify what exists first (Step 2.5), then change only what is missing or wrong.
 
 ## Context
 
@@ -32,49 +34,72 @@ Read the ChangeRequest carefully before starting implementation. The original pl
 - Extract the plan ID from the folder name (e.g. `00012` from `00012-AddNewsletterSignupToHelpApp`)
 - Report plan context to Jobs UI: `tendril job status TendrilJobId --message="Retrying plan..." --plan-id=<plan-id> --plan-title="<title>"`
 
-### 2. Enter Existing Worktrees
+### 2. Enter or Recover Worktrees
 
 Report status: `tendril job status TendrilJobId --message="Entering worktrees..."`
 
 The worktrees were created by the prior ExecutePlan run and already contain branches with previous commits. A project may consist of multiple repos — each has its own worktree under `<TendrilPlanFolder>/Worktrees/`.
 
-For each repo in `plan.yaml` `repos` (or the project's repos from the **Projects** section if empty):
+For each repo in `plan.yaml` `repos` (or the project's repos from the **Projects** section if empty), resolve the worktree in this order:
 
-1. **Locate the worktree** at `<TendrilPlanFolder>/Worktrees/<repo-folder-name>`.
+1. **Worktree directory exists and is valid.** `<TendrilPlanFolder>/Worktrees/<repo-folder-name>` exists and contains a `.git` file: use it as-is. Confirm it is actually attached rather than a stale leftover: `git -C <main-repo> worktree list` must list this path. Running `git status` inside a stale directory silently reports the main repo's state instead of failing, which can look healthy when it is not.
 
-2. **Verify it exists:**
+2. **Directory missing, but the branch still exists.** Check the main repo for the plan's own branch, and for the head branch of any PR listed in plan.yaml `prs` or `SourceUrl` when the plan updates an existing PR:
 
 ```bash
-if [ ! -d "<TendrilPlanFolder>/Worktrees/<repo-folder-name>" ]; then
-    echo "ERROR: Worktree not found at <TendrilPlanFolder>/Worktrees/<repo-folder-name>"
-    echo "RetryPlan requires an existing worktree from a prior ExecutePlan run."
-    echo "Re-run ExecutePlan first, or check that worktrees were not cleaned up prematurely."
-    exit 1
-fi
+git -C <main-repo> branch --list "tendril/<planFolderName>"
 ```
 
-3. **Verify it's a valid git worktree** (has a `.git` file):
+   If a branch is found, re-attach the worktree without touching its history:
+
+```bash
+git -C <main-repo> worktree add "<TendrilPlanFolder>/Worktrees/<repo-folder-name>" "<existing-branch>"
+```
+
+   Do not use `tendril plan add-worktree` here: it always creates a new branch from the base branch, which would fail or cut a fresh branch over the prior work instead of reusing it.
+
+3. **Neither the directory nor a branch exists.** The prior run died before creating anything to resume. Create a fresh worktree, report via `tendril job status` that no prior work was recoverable, and implement the revision in full:
+
+```bash
+tendril plan add-worktree <plan-id> <repo-path> [--base <baseBranch from RepoConfigs>]
+```
+
+   Note this in the Step 4.5 summary update: this run implemented the plan from scratch.
+
+After cases 2 and 3, verify `<TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git` exists:
 
 ```bash
 if [ ! -f "<TendrilPlanFolder>/Worktrees/<repo-folder-name>/.git" ]; then
-    echo "ERROR: Directory exists but is not a valid git worktree (.git file missing)"
+    echo "ERROR: Worktree recovery failed - .git file missing"
     exit 1
 fi
 ```
 
-4. **Switch to the worktree directory** — all subsequent work happens here.
+4. **Switch to the worktree directory.** All subsequent work happens here.
 
+### 2.5. Assess Prior Work
+
+Report status: `tendril job status TendrilJobId --message="Assessing prior work..."`
+
+Before changing anything, gather what the previous run already did:
+
+- `tendril plan get <plan-id> commits`: the commits the prior run recorded.
+- In each worktree: `git log --oneline -n 30`, `git status --short`, and `git diff --stat "origin/<baseBranch>"...HEAD` for the full set of changes already made.
+- `<TendrilPlanFolder>/Artifacts/summary.md`, if present: the prior run's own account of what it did.
+- Every `<TendrilPlanFolder>/Verification/*.md`: the `result` in the frontmatter, plus its "Fixes Applied" and "Issues Found" sections. The server resets every non-Skipped verification in plan.yaml back to `Pending` before this job starts, so these report files are the only surviving record of what previously passed and what was already fixed.
+
+From this, build a short mental ledger with three buckets: **already delivered** (present in the code and committed), **still missing** from the revision's Solution, and **to change** per the ChangeRequest. Confirm each "already delivered" item against the actual files, not against the plan text or the summary; a summary can describe work that a later crash left unfinished.
 
 ### 3. Implement Changes
 
 Report status: `tendril job status TendrilJobId --message="Implementing changes..."`
 
-Work exclusively in the worktree directories. Address the **ChangeRequest** feedback:
+Work exclusively in the worktree directories, using the ledger from Step 2.5:
 
-1. **ChangeRequest** — Address the reviewer's feedback. This is why this re-execution was triggered.
-2. **Problem** — Understand what needs to be done (from the plan revision) for context
-3. **Solution** — Implement the changes in the worktree, incorporating the ChangeRequest modifications
-4. **Tests** — Write and run any tests specified
+1. Apply the **ChangeRequest** items. This is why this re-execution was triggered.
+2. Apply only the **Solution** items the ledger marks as still missing.
+3. Skip anything the ledger marks as already delivered. If a file, function, or test already exists, edit it rather than recreating it, and never duplicate an existing test.
+4. Add new commits on top of the existing history. When the ChangeRequest asks for something to be undone, do that as a new commit, not by rewriting history.
 
 ### 4. Commit
 
@@ -96,7 +121,7 @@ After all commits, verify no uncommitted files remain:
 git status
 ```
 
-If there are uncommitted changes, either commit them or discard them with a clear reason. The worktree must be clean.
+Inspect any uncommitted changes before deciding what to do with them: after a crashed or stopped run they are usually unfinished implementation, so finish and commit them. Discard only files that are clearly build, dependency, or test debris, and state what was discarded and why in the status message. The worktree must be clean.
 
 ### 4.5. Update Summary
 
@@ -138,6 +163,8 @@ Create a `Verification/` directory in the plan folder if it doesn't exist.
 Get the run-set via `tendril plan verification list <plan-id> --json` — it emits a JSON array of `{ name, status }` **in run order**. Run the entries whose `status` is `Pending`, in array order. Skip entries whose `status` is `Skipped`.
 
 **Delegated verifications:** Some verifications are implemented as separate promptwares. The **Projects** section marks delegated verifications. Delegated verifications MUST be run via `tendril promptware run <Name>` — you are FORBIDDEN from writing their report files or setting their status to Pass yourself.
+
+Before running a verification, read its previous report at `<TendrilPlanFolder>/Verification/<VerificationName>.md` if one exists. If it recorded a fix, confirm the fix is still committed rather than redoing it. If it left issues open, start the fix loop from those issues instead of from scratch.
 
 For each `Pending` verification (in listed order):
 
@@ -191,7 +218,7 @@ The launcher script handles state transitions (Completed/Failed) based on exit c
 ## Prohibited Actions
 
 - **NEVER kill `dotnet.exe` or `Ivy.Tendril.exe` processes.** Tendril (your orchestrator) is a .NET application hosted by `dotnet.exe`. Killing it will terminate Tendril itself, losing all job state.
-- **NEVER create or destroy worktrees.** RetryPlan works in the existing worktree. If the worktree is missing, fail immediately.
+- **NEVER destroy or reset an existing worktree, its branch, or its commits.** Create a worktree only when both the directory and its branch are missing (Step 2, case 3).
 - Do NOT commit artifact files (screenshots, images) to the repo. Test artifacts belong in `<TendrilPlanFolder>/Artifacts/` only.
 - Do NOT create filesystem aliases or shortcuts (symlinks, drive mappings) to worktree paths.
 


### PR DESCRIPTION
Fixes #1946

# Summary

## Changes

Rewrote the RetryPlan promptware's `Program.md` (both the shipped copy and the team config copy) so it treats a retry as a delta on top of the prior ExecutePlan run instead of re-implementing the whole plan revision from scratch. It now recovers a missing worktree from its surviving branch when possible, assesses what was already delivered before touching anything, and reuses prior verification reports rather than redoing passed work.

## API Changes

None. This is a documentation-only change to two `Program.md` promptware files; no code, CLI, or config surface changed.

## Files Modified

- `src/Ivy.Tendril/Promptwares/RetryPlan/Program.md` — added the resume doctrine, three-way worktree recovery in Step 2, new Step 2.5 "Assess Prior Work", delta-based Step 3, partial-work handling in Step 4, verification-report reuse in Step 6, and an updated Prohibited Actions bullet.
- `src/Ivy.Tendril.TeamIvyConfig/Promptwares/RetryPlan/Program.md` — the same set of edits, with the team copy's pre-existing differences (no `tendril job status` report lines, extra Step 6.5 "Generate Recommendations") preserved as-is.

## Manual Testing

N/A — this changes agent-facing promptware instructions, not application behavior directly observable in the UI. The plan's own manual verification step is: put a plan in `Review` with commits and passing verification reports, use "Request Changes" with a small request (for example "rename one method"), and confirm the resulting RetryPlan job reports an "Assessing prior work" status, then commits only the requested change while leaving the earlier commits intact.

---
## Commits

- 3cca44c2 Make RetryPlan resume prior work instead of re-implementing the plan

---
Created using [Ivy Tendril](https://ivy.app).
