### PR TITLE
[00111] Fix Browse Button Background Not Reaching Field Edge in Add a Project Dialog

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
@@ -81,24 +81,25 @@ public class ProjectRepoPickerView(
         }
 
         object pickerControls;
+        var repoInput = inputValue.ToTextInput("Repository URL or Local Path")
+                            .Width(Size.Grow())
+                            .OnSubmit(() => { _ = AddAsync(); });
+
         if (isDesktop)
         {
-            pickerControls = inputValue.ToTextInput("Repository URL or Local Path")
-                                 .Width(Size.Grow())
-                                 .OnSubmit(() => { _ = AddAsync(); })
-                                 .Suffix(new Button("Browse").Icon(Icons.FolderOpen).Ghost()
-                                     .OnClick(() =>
-                                     {
-                                         var picked = desktop!.ShowSelectFolderDialog("Select repository folder");
-                                         if (picked is { Length: > 0 } && !string.IsNullOrEmpty(picked[0]))
-                                             inputValue.Set(picked[0]);
-                                     }));
+            pickerControls = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.Center).Gap(2)
+                             | repoInput
+                             | new Button("Browse").Icon(Icons.FolderOpen).Outline()
+                                 .OnClick(() =>
+                                 {
+                                     var picked = desktop!.ShowSelectFolderDialog("Select repository folder");
+                                     if (picked is { Length: > 0 } && !string.IsNullOrEmpty(picked[0]))
+                                         inputValue.Set(picked[0]);
+                                 });
         }
         else
         {
-            pickerControls = inputValue.ToTextInput("Repository URL or Local Path")
-                                 .Width(Size.Grow())
-                                 .OnSubmit(() => { _ = AddAsync(); });
+            pickerControls = repoInput;
         }
 
         var addButton = new Button("Add Repository").Icon(Icons.Plus)


### PR DESCRIPTION
Fixes #1948

# Summary

## Changes

Fixed issue #1948: the Browse button in the "Repository URL or Local Path" field (Add a project / Edit project / onboarding dialogs) left a visible white sliver at the field's right edge because its embedded affix-suffix chrome is inset from the field's rounded corner by the Ivy-Framework. `ProjectRepoPickerView` now renders Browse as a sibling `.Outline()` button in a horizontal layout next to the field instead of as an affix suffix, eliminating the inset chrome entirely.

## API Changes

None. `ProjectRepoPickerView.Build()` still returns the same `object` shape consumed by its call sites (`AddProjectDialog`, `EditProjectDialog`, onboarding's `ProjectInputStepView`); no public members changed.

## Files Modified

- `src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs` — Browse button moved from an affix `.Suffix()` on the text input to a sibling button in a `Layout.Horizontal()`, using `.Outline()` instead of `.Ghost()`.

## Manual Testing

1. Run the Tendril desktop app and open Settings, then "Add a project" (or trigger onboarding / Edit an existing project with repos).
2. In the "Repository URL or Local Path" field, observe the Browse button: it now has its own visible border and sits beside the field rather than appearing inset inside it.
3. Hover over Browse and confirm the hover-highlight fill covers the entire button with no white sliver or clipped-corner artifact at the field's right edge.
4. Click Browse to confirm the folder picker still opens and populates the field as before (unchanged callback behavior).

Note: Browse only renders when a `DesktopWindow` service is present, so this cannot be exercised in a browser build — a desktop build/run is required to see the fix.


---
## Commits

- 7866580e Render Browse as a sibling button instead of an affix suffix


---
Created using [Ivy Tendril](https://ivy.app).