### PR TITLE
[00125] Support Selecting Multiple Reviewers When Creating a PR

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/05_Other.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/05_Other.md
@@ -97,7 +97,7 @@ Starts a job on the running Tendril server. Requires Tendril to be running (comm
 | `SplitPlan` | `<plan-id>` | — |
 | `ExpandPlan` | `<plan-id>` | — |
 | `CreateIssue` | `<plan-id>`, `--repo` | `--assignee`, `--comment`, `--labels` |
-| `CreatePr` | `<plan-id>` | `--no-merge`, `--no-delete-branch`, `--no-artifacts`, `--assignee`, `--comment`, `--draft` |
+| `CreatePr` | `<plan-id>` | `--no-merge`, `--no-delete-branch`, `--no-artifacts`, `--assignee`, `--reviewer`, `--comment`, `--draft` |
 | `RetryPlan` | `<plan-id>`, `--change-request` | — |
 | `CreatePlan` | `--description`, `--project` | `--priority`, `--force`, `--source-path` |
 

--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md
@@ -31,7 +31,7 @@ Before processing, read `plan.yaml` and check the `state` field. After reading, 
   - `PrMerge` — `true`/`false` (default: `true`) — **whether to merge the PR after creating it**
   - `PrDeleteBranch` — `true`/`false` (default: `true`)
   - `PrIncludeArtifacts` — `true`/`false` (default: `true`)
-  - `PrReviewer` — GitHub username to request as reviewer (default: none)
+  - `PrReviewer` — comma-separated GitHub usernames to request as reviewers (default: none)
   - `PrComment` — Review comment text (default: none)
   - `PrDraft` — `true`/`false` (default: `false`)
 
@@ -109,7 +109,7 @@ EOF
   body="${issueLink}${summaryContent}\n\n---\n${commitsList}${artifactMarkdown}"
   ```
 - **Draft (custom options):** If custom options exist and `draft` is `true`, add `--draft` to the `gh pr create` command to create the PR in draft mode. If no custom options or `draft` is `false`, create as ready for review (default behavior).
-- **Reviewer (custom options):** If custom options exist and `reviewer` is non-empty, add `--reviewer <reviewer>` to the `gh pr create` command.
+- **Reviewer (custom options):** If custom options exist and `reviewer` is non-empty, split `PrReviewer` on commas and add one `--reviewer <username>` flag per name to the `gh pr create` command. **Never pass a bare `--reviewer` with no value** (that fails with `flag needs an argument: --reviewer`). Omit the flag entirely when `PrReviewer` is empty.
 - **Assignee:** Always pass `--assignee @me` so the PR is assigned to the current (gh-authenticated) user. If assignment fails (e.g. the account cannot self-assign on a given repo), this is non-fatal — log a warning and continue; do not fail PR creation.
 
 ### 3.5. Add PR Comment (custom options)

--- a/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
@@ -92,9 +92,10 @@ projects:
         return values;
     }
 
-    // The PR dialog's "Reviewer" field flows into CreatePrArgs.Reviewer and must reach the
-    // CreatePr promptware as the PrReviewer firmware value (issue #1311). It used to be the
-    // PrAssignee value, which emitted a GitHub assignee instead of a requested reviewer.
+    // The PR dialog's "Reviewer" field flows into CreatePrArgs.Reviewers and must reach the
+    // CreatePr promptware as the PrReviewer firmware value (issue #1311, extended for #1765 to
+    // support multiple reviewers). It used to be the PrAssignee value, which emitted a GitHub
+    // assignee instead of a requested reviewer.
     [Fact]
     public void AddCreatePrOptions_EmitsPrReviewer_WhenReviewerSet()
     {
@@ -102,7 +103,7 @@ projects:
         {
             Id = "pr-1",
             Type = "CreatePr",
-            TypedArgs = new CreatePrArgs(@"D:\Plans\01234-TestPlan", Reviewer: "octocat"),
+            TypedArgs = new CreatePrArgs(@"D:\Plans\01234-TestPlan", Reviewers: ["octocat"]),
             Project = "TestProject"
         };
 
@@ -126,6 +127,44 @@ projects:
         var values = InvokeAddCreatePrOptions(job);
 
         Assert.False(values.ContainsKey("PrReviewer"));
+    }
+
+    [Fact]
+    public void AddCreatePrOptions_JoinsPrReviewers_WhenMultipleSet()
+    {
+        var job = new JobItem
+        {
+            Id = "pr-3",
+            Type = "CreatePr",
+            TypedArgs = new CreatePrArgs(@"D:\Plans\01234-TestPlan", Reviewers: ["octocat", "hubot"]),
+            Project = "TestProject"
+        };
+
+        var values = InvokeAddCreatePrOptions(job);
+
+        Assert.Equal("octocat,hubot", values["PrReviewer"]);
+    }
+
+    [Fact]
+    public void AddCreatePrOptions_OmitsPrReviewer_WhenReviewersEmptyOrBlank()
+    {
+        var emptyJob = new JobItem
+        {
+            Id = "pr-4",
+            Type = "CreatePr",
+            TypedArgs = new CreatePrArgs(@"D:\Plans\01234-TestPlan", Reviewers: []),
+            Project = "TestProject"
+        };
+        var blankJob = new JobItem
+        {
+            Id = "pr-5",
+            Type = "CreatePr",
+            TypedArgs = new CreatePrArgs(@"D:\Plans\01234-TestPlan", Reviewers: ["", "  "]),
+            Project = "TestProject"
+        };
+
+        Assert.False(InvokeAddCreatePrOptions(emptyJob).ContainsKey("PrReviewer"));
+        Assert.False(InvokeAddCreatePrOptions(blankJob).ContainsKey("PrReviewer"));
     }
 
     public void Dispose()

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs
@@ -20,7 +20,7 @@ public class CreatePrDialog(
         var createPrDeleteBranch = UseState(true);
         var createPrIncludeArtifacts = UseState(false);
         var createPrDraft = UseState(false);
-        var createPrReviewer = UseState<string?>(null);
+        var createPrReviewers = UseState(Array.Empty<string>());
         var createPrComment = UseState("");
         
         UseEffect(() =>
@@ -47,8 +47,9 @@ public class CreatePrDialog(
                     .Disabled(!createPrMerge.Value)
                 | createPrIncludeArtifacts.ToBoolInput("Include Artifacts")
                 | createPrDraft.ToBoolInput("Create as Draft")
-                | createPrReviewer.ToSelectInput((assigneesQuery.Value ?? Array.Empty<string>()).ToOptions())
-                    .Nullable().WithField().Label("Reviewer")
+                | createPrReviewers.ToSelectInput((assigneesQuery.Value ?? Array.Empty<string>()).ToOptions())
+                    .Placeholder("Select reviewers...")
+                    .WithField().Label("Reviewers")
                 | (assigneesError.Value is { } err
                     ? Text.Danger(err).Small()
                     : null)
@@ -67,7 +68,7 @@ public class CreatePrDialog(
                             Merge: createPrMerge.Value,
                             DeleteBranch: createPrDeleteBranch.Value && createPrMerge.Value,
                             IncludeArtifacts: createPrIncludeArtifacts.Value,
-                            Reviewer: createPrReviewer.Value,
+                            Reviewers: createPrReviewers.Value,
                             Comment: string.IsNullOrEmpty(createPrComment.Value) ? null : createPrComment.Value,
                             Draft: createPrDraft.Value));
                         // Plan transition (and pre-state snapshot) handled by JobService.StartJob.

--- a/src/Ivy.Tendril/Commands/JobStartCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStartCommand.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Linq;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Microsoft.Extensions.Logging;
@@ -32,6 +33,10 @@ public class JobStartSettings : CommandSettings
     [Description("Assignee")]
     [CommandOption("--assignee")]
     public string? Assignee { get; set; }
+
+    [Description("Reviewer(s) for CreatePr. Repeatable, or comma-separated.")]
+    [CommandOption("--reviewer")]
+    public string[]? Reviewers { get; set; }
 
     [Description("Comment")]
     [CommandOption("--comment")]
@@ -196,14 +201,19 @@ public class JobStartCommand : Command<JobStartSettings>
         }
 
         if (string.Equals(jobType, Constants.JobTypes.CreatePr, StringComparison.OrdinalIgnoreCase))
+        {
+            var reviewers = settings.Reviewers is { Length: > 0 }
+                ? settings.Reviewers.SelectMany(r => r.Split(',')).ToArray()
+                : settings.Assignee is null ? null : [settings.Assignee];
             return new CreatePrArgs(
                 planFolder,
                 Merge: !settings.NoMerge,
                 DeleteBranch: !settings.NoDeleteBranch,
                 IncludeArtifacts: !settings.NoArtifacts,
-                Reviewer: settings.Assignee,
+                Reviewers: reviewers,
                 Comment: settings.Comment,
                 Draft: settings.Draft);
+        }
 
         if (string.Equals(jobType, Constants.JobTypes.RetryPlan, StringComparison.OrdinalIgnoreCase))
         {

--- a/src/Ivy.Tendril/Models/JobArgs.cs
+++ b/src/Ivy.Tendril/Models/JobArgs.cs
@@ -79,7 +79,7 @@ public record CreatePrArgs(
     bool Merge = true,
     bool DeleteBranch = true,
     bool IncludeArtifacts = true,
-    string? Reviewer = null,
+    string[]? Reviewers = null,
     string? Comment = null,
     bool Draft = false) : JobArgsBase
 {

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -193,7 +193,7 @@ Plan IDs accept: full path, folder name, zero-padded ID (e.g., `00015`), or bare
 | `SplitPlan` | `<plan-id>` | — |
 | `ExpandPlan` | `<plan-id>` | — |
 | `CreateIssue` | `<plan-id>`, `--repo` | `--assignee`, `--comment`, `--labels` |
-| `CreatePr` | `<plan-id>` | `--no-merge`, `--no-delete-branch`, `--no-artifacts`, `--assignee`, `--comment`, `--draft` |
+| `CreatePr` | `<plan-id>` | `--no-merge`, `--no-delete-branch`, `--no-artifacts`, `--assignee`, `--reviewer`, `--comment`, `--draft` |
 | `RetryPlan` | `<plan-id>`, `--change-request` | — |
 | `CreatePlan` | `--description`, `--project` | `--priority`, `--force`, `--source-path` |
 | `SetupProject` | `<project-name>` | — |

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -45,7 +45,7 @@ Before processing, read `plan.yaml` and check the `state` field. After reading, 
   - `PrMerge` — `true`/`false` (default: `true`) — **whether to merge the PR after creating it**
   - `PrDeleteBranch` — `true`/`false` (default: `true`)
   - `PrIncludeArtifacts` — `true`/`false` (default: `true`)
-  - `PrReviewer` — GitHub username to request as reviewer (default: none)
+  - `PrReviewer` — comma-separated GitHub usernames to request as reviewers (default: none)
   - `PrComment` — Review comment text (default: none)
   - `PrDraft` — `true`/`false` (default: `false`)
 
@@ -190,7 +190,7 @@ rm -f "$body_file"
   body="${issueLink}${summaryContent}\n\n---\n${commitsList}${artifactMarkdown}\n\n---\nCreated using [Ivy Tendril](https://ivy.app)."
   ```
 - **Draft (custom options):** If custom options exist and `draft` is `true`, add `--draft` to the `gh pr create` command to create the PR in draft mode. If no custom options or `draft` is `false`, create as ready for review (default behavior).
-- **Reviewer (custom options):** If custom options exist and `reviewer` is non-empty, add `--reviewer <reviewer>` to the `gh pr create` command. **Never pass a bare `--reviewer` with no value** — that fails with `flag needs an argument: --reviewer`. Omit the flag entirely when `PrReviewer` is empty.
+- **Reviewer (custom options):** If custom options exist and `reviewer` is non-empty, split `PrReviewer` on commas and add one `--reviewer <username>` flag per name to the `gh pr create` command. **Never pass a bare `--reviewer` with no value** — that fails with `flag needs an argument: --reviewer`. Omit the flag entirely when `PrReviewer` is empty.
 - **Assignee:** Always pass `--assignee @me` so the PR is assigned to the current (gh-authenticated) user. If assignment fails (e.g. the account cannot self-assign on a given repo), this is non-fatal — log a warning and continue; do not fail PR creation.
 
 ### 3.5. Add PR Comment (custom options)

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Linq;
 using Ivy.Helpers;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Helpers;
@@ -559,8 +560,12 @@ internal class JobLauncher
         values["PrDeleteBranch"] = pr.DeleteBranch.ToString().ToLowerInvariant();
         values["PrIncludeArtifacts"] = pr.IncludeArtifacts.ToString().ToLowerInvariant();
         values["PrDraft"] = pr.Draft.ToString().ToLowerInvariant();
-        if (!string.IsNullOrEmpty(pr.Reviewer))
-            values["PrReviewer"] = pr.Reviewer;
+        var reviewers = (pr.Reviewers ?? [])
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .Select(r => r.Trim())
+            .ToArray();
+        if (reviewers.Length > 0)
+            values["PrReviewer"] = string.Join(",", reviewers);
         if (!string.IsNullOrEmpty(pr.Comment))
             values["PrComment"] = pr.Comment;
     }


### PR DESCRIPTION
Fixes #1765

# Summary

## Changes

The Create PR dialog's single-select "Reviewer" field is now a multi-select "Reviewers" field.
The change flows through `CreatePrArgs`, the job launcher's firmware value join, the CLI's
`--reviewer` option, and the `CreatePr` promptware's `gh pr create` invocation, so any number of
reviewers can be requested end-to-end.

## API Changes

- `CreatePrArgs.Reviewer` (`string?`) renamed to `CreatePrArgs.Reviewers` (`string[]?`) in
  `Ivy.Tendril.Models.JobArgs`.
- New CLI option: `--reviewer` (repeatable, or comma-separated) on `tendril job start CreatePr`.
  Falls back to `--assignee` when `--reviewer` is not given, so existing scripted callers keep
  working.
- `PrReviewer` firmware header value is now documented as comma-separated GitHub usernames
  (previously a single username); the `CreatePr` promptware now emits one `--reviewer <username>`
  flag per name to `gh pr create` instead of a single flag.

## Files Modified

- `src/Ivy.Tendril/Models/JobArgs.cs` — `CreatePrArgs.Reviewer` to `Reviewers`
- `src/Ivy.Tendril/Services/Jobs/JobLauncher.cs` — joins reviewers into `PrReviewer`
- `src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs` — multi-select reviewers field
- `src/Ivy.Tendril/Commands/JobStartCommand.cs` — `--reviewer` CLI option
- `src/Ivy.Tendril/Promptwares/CreatePr/Program.md`, `src/Ivy.Tendril.TeamIvyConfig/Promptwares/CreatePr/Program.md` — comma-separated `PrReviewer` docs, one `--reviewer` flag per name
- `src/Ivy.Tendril/Prompts/AgentPrompt.md`, `src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/05_Other.md` — added `--reviewer` to the `CreatePr` option row
- `src/Ivy.Tendril.Test/Services/JobLauncherTests.cs` — updated and added reviewer join tests

## Manual Testing

1. Open a plan in Review with `Create PR`.
2. Click "Create PR" to open the dialog and select two or more reviewers in the "Reviewers"
   field (chips should render without overflowing the dialog).
3. Submit and confirm the resulting PR requests all selected users as reviewers on GitHub.
4. From the CLI, run `tendril job start CreatePr <plan-id> --reviewer alice --reviewer bob` (or
   `--reviewer alice,bob`) and confirm both are requested as reviewers.

This was not verified visually in this sandbox (no display server available); it was verified via
a clean build and unit tests covering the `Reviewers` -> `PrReviewer` join logic, plus a code-level
comparison against the existing `ImportIssuesDialog` multi-select pattern.

---
- 50407fa4 Support selecting multiple reviewers when creating a PR
- 0cb69f28 Add tests for multi-reviewer CreatePrArgs joining
- a96d11eb Document multi-reviewer support in CreatePr promptwares and docs

---
Created using [Ivy Tendril](https://ivy.app).
