### PR TITLE
[00108] Align Viewed Checkbox and Diff Stat Columns in File Diff Headers

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/CommentToggle.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/CommentToggle.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, within } from "@testing-library/react";
 import { PlanDiffView } from "./PlanDiffView";
 
 const DIFF_FIXTURE = `diff --git a/index.html b/index.html
@@ -51,6 +51,42 @@ describe("PlanDiffView comment toggle", () => {
     const countSpan = button.querySelector("span.font-mono.text-\\[10px\\]");
     expect(countSpan).toBeTruthy();
     expect(countSpan?.textContent).toBe("1");
+  });
+
+  it("reserves the comment count column with no comments", () => {
+    const empty = render(
+      <PlanDiffView
+        id="test-widget-empty"
+        diff={DIFF_FIXTURE}
+        filePath="index.html"
+        comments={[]}
+      />
+    );
+    const withComment = render(
+      <PlanDiffView
+        id="test-widget-with-comment"
+        diff={DIFF_FIXTURE}
+        filePath="index.html"
+        comments={[COMMENT_FIXTURE]}
+      />
+    );
+
+    const emptyButton = within(empty.container).getByLabelText("Hide comments") as HTMLButtonElement;
+    const withCommentButton = within(withComment.container).getByLabelText("Hide comments") as HTMLButtonElement;
+
+    expect(emptyButton.children.length).toBe(withCommentButton.children.length);
+
+    const emptyCountSpan = emptyButton.querySelector("span.font-mono.text-\\[10px\\]");
+    const withCommentCountSpan = withCommentButton.querySelector("span.font-mono.text-\\[10px\\]");
+    expect(emptyCountSpan).toBeTruthy();
+    expect(withCommentCountSpan).toBeTruthy();
+    expect(emptyCountSpan?.textContent).toBe("");
+    expect(withCommentCountSpan?.textContent).toBe("1");
+
+    // Stat wrapper reserves width for the +N / -N spans
+    const statWrapper = withComment.container.querySelector(".min-w-\\[4\\.5rem\\]");
+    expect(statWrapper).toBeTruthy();
+    expect(statWrapper?.textContent).toContain("+");
   });
 
   it("toggles visibility both ways", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
@@ -578,9 +578,11 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
 
                 <div className="flex items-center gap-4 shrink-0 pl-2">
                   {/* Additions / Deletions count */}
-                  <span className="flex items-center gap-1 font-mono text-[11px]">
-                    {additions > 0 && <span className="text-[var(--success)]">+{additions}</span>}
-                    {deletions > 0 && <span className="text-[var(--destructive)]">-{deletions}</span>}
+                  <span className="flex items-center gap-1 font-mono text-[11px] tabular-nums">
+                    <span className="flex items-center justify-end gap-1 min-w-[4.5rem]">
+                      {additions > 0 && <span className="text-[var(--success)]">+{additions}</span>}
+                      {deletions > 0 && <span className="text-[var(--destructive)]">-{deletions}</span>}
+                    </span>
                     {renderDiffSquares(additions, deletions)}
                   </span>
 
@@ -637,9 +639,9 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
                         }}
                       >
                         <MessageSquare className="w-3.5 h-3.5" />
-                        {fileCommentCount > 0 && (
-                          <span className="font-mono text-[10px]">{fileCommentCount}</span>
-                        )}
+                        <span className="font-mono text-[10px] tabular-nums min-w-3 text-left">
+                          {fileCommentCount > 0 ? fileCommentCount : ""}
+                        </span>
                       </button>
                     );
                   })()}


### PR DESCRIPTION
Fixes #1940

# Summary

## Changes

Fixed the file diff header misalignment reported in issue #1940 by making the two
data-dependent width columns in `PlanDiffView`'s header (the additions/deletions
stat and the comment count) width-deterministic. The `+N`/`-N` stat spans now sit
in a `min-w-[4.5rem]` right-aligned box, and the comment count span always renders
(empty when zero) instead of being conditionally mounted, so the "Viewed" checkbox
and everything after it now lines up across every file row.

## API Changes

None. All changes are internal to the `PlanDiffView` React component's markup/classes.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx` — wrapped stat
  spans in a reserved-width box; comment count span now always renders.
- `src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/CommentToggle.test.tsx` — added a
  test asserting the comment-count column and stat-width invariants that keep the
  header aligned.

## Manual Testing

1. Open the Agent Review / Changes tab for a plan with multiple changed files, where
   at least one file has comments and another does not, and where files have varying
   additions/deletions counts (e.g. one file with `+9`, another with `+123 -45`).
2. Observe the right-hand header group of each file's diff card: the stat squares,
   "Viewed" checkbox, comment icon, and "..." menu should now start at the same
   horizontal offset across all file rows, regardless of comment count or stat digit
   count.
3. Click the comment toggle on a file with zero comments — it should remain disabled
   with `opacity-40`, with no visible layout shift from the reserved (empty) count span.

---
Commits:
- eb0c615c Reserve fixed-width columns for stat numbers and comment count

---
Created using [Ivy Tendril](https://ivy.app).
