### PR TITLE
[00110] Restore the Missing Git Tab in the Drafts App

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/04_Apps/02_Review.md
+++ b/src/Ivy.Tendril.Docs/Docs/04_Apps/02_Review.md
@@ -23,6 +23,7 @@ Queue of finished work: **Review** or **Failed** plans. Nothing merges without y
 - **Diff** — Changes vs. your tracked branch.
 - **Verification output** — Logs from hooks (`DotnetBuild`, `NpmTest`, …).
 - **Plan text** — Latest `revisions/*.md` (what the agent was implementing).
+- **Git tab**: Worktrees, recorded commits and PRs for the plan, with a button to synchronize a worktree with its remote.
 
 ## Actions
 

--- a/src/Ivy.Tendril.Docs/Docs/04_Apps/03_Drafts.md
+++ b/src/Ivy.Tendril.Docs/Docs/04_Apps/03_Drafts.md
@@ -23,6 +23,7 @@ New plans start here. Refine the plan with the UI and promptwares before heavy c
 - **Sidebar** — Filtered draft list; main pane shows the selected plan.
 - **Content** — Latest revision markdown (problem, approach, tests).
 - **Project** — Settings from `config.yaml` for that repo.
+- **Git tab** — Appears for drafts that already have worktrees, commits or PRs (for example after a Revise from Review).
 
 ## Actions
 

--- a/src/Ivy.Tendril.Test/GitTabDataBuilderTests.cs
+++ b/src/Ivy.Tendril.Test/GitTabDataBuilderTests.cs
@@ -1,0 +1,51 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Test;
+
+public class GitTabDataBuilderTests
+{
+    private static PlanFile CreatePlan(string folderPath, List<string> commits, List<string> prs)
+    {
+        var metadata = new PlanMetadata(
+            1, "Test", "Bug", "Test Plan", PlanStatus.Draft,
+            [], commits, prs, [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
+        return new PlanFile(metadata, "", folderPath, "");
+    }
+
+    private static GitTabDataBuilder.WorktreeSection CreateWorktreeSection() =>
+        new("Ivy-Tendril", "/tmp/worktree", "tendril/00001", "abc1234", false, []);
+
+    [Fact]
+    public void CountGitItems_WithNoWorktreesCommitsOrPrs_ReturnsZero()
+    {
+        var plan = CreatePlan("/tmp/plan", [], []);
+        var data = new GitTabDataBuilder.GitTabData([], []);
+
+        var count = GitTabDataBuilder.CountGitItems(data, plan);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void CountGitItems_WithCommitsOnly_CountsCommits()
+    {
+        var plan = CreatePlan("/tmp/plan", ["abc1234", "def5678"], []);
+        var data = new GitTabDataBuilder.GitTabData([], []);
+
+        var count = GitTabDataBuilder.CountGitItems(data, plan);
+
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public void CountGitItems_SumsWorktreesCommitsAndPrs()
+    {
+        var plan = CreatePlan("/tmp/plan", ["abc1234", "def5678"], ["https://github.com/owner/repo/pull/1"]);
+        var data = new GitTabDataBuilder.GitTabData([CreateWorktreeSection()], []);
+
+        var count = GitTabDataBuilder.CountGitItems(data, plan);
+
+        Assert.Equal(4, count);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -232,7 +232,25 @@ public class ContentView(
         }
         else
         {
-            var tabs = Layout.Tabs(
+            var planData = planContentQuery.Value;
+            var gitData = GitTabDataBuilder.BuildGitTabData(planData.CommitRows, selectedPlan!, config, gitService);
+            var gitItemCount = GitTabDataBuilder.CountGitItems(gitData, selectedPlan!);
+
+            var gitTabView = new GitTabView(
+                gitData,
+                selectedPlan!,
+                hash => openCommit.Set(hash),
+                path =>
+                {
+                    copyToClipboard(path);
+                    client.Toast("Copied path to clipboard", "Path Copied");
+                    return null!;
+                },
+                null,
+                null);
+
+            var tabList = new List<Tab>
+            {
                 // DraftMarkdown owns its own scroll and the pinned StickyContent slot,
                 // so it is not wrapped in Cap() (whose outer scroll would also scroll the
                 // pinned element). The widget reproduces Cap()'s left inset + max-width.
@@ -240,8 +258,14 @@ public class ContentView(
                 new Tab("Details", Cap(new DetailsTabView(selectedPlan!,
                     jobService.GetJobsForPlan(selectedPlan!.FolderName),
                     showDebugJob, planService, selectedPlanState, refreshPlans,
-                    folderPath => selectedPlanState.Set(planService.GetPlanByFolder(folderPath)))))
-            ).OnSelect(v => selectedTab.Set(v)).SelectedIndex(selectedTab.Value).Variant(TabsVariant.Content).RemoveParentPadding();
+                    folderPath => selectedPlanState.Set(planService.GetPlanByFolder(folderPath))))),
+            };
+
+            if (gitItemCount > 0)
+                tabList.Add(new Tab("Git", Cap(gitTabView)).Badge(gitItemCount.ToString()));
+
+            var tabs = Layout.Tabs(tabList.ToArray())
+                .OnSelect(v => selectedTab.Set(v)).SelectedIndex(selectedTab.Value).Variant(TabsVariant.Content).RemoveParentPadding();
 
             content |= (Layout.Vertical().Padding(2).Height(Size.Full()) | tabs);
         }

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -598,6 +598,21 @@ public class ContentView(
         }
         else
         {
+            var gitData = GitTabDataBuilder.BuildGitTabData(planData.CommitRows, selectedPlan!, config, gitService);
+            var gitTabView = new GitTabView(
+                gitData,
+                selectedPlan!,
+                hash => openCommit.Set(hash),
+                path =>
+                {
+                    copyToClipboard(path);
+                    client.Toast("Copied path to clipboard", "Path Copied");
+                    return null!;
+                },
+                syncingWorktrees.Value,
+                worktreePath => SynchronizeWorktreeAsync(worktreePath, syncingWorktrees, planContentQuery, client, planService, selectedPlanState, logger)
+            );
+
             var totalArtifacts = (planData.Artifacts.GetValueOrDefault("screenshots")?.Count ?? 0)
                                  + (planData.Artifacts.ContainsKey("sample") ? 1 : 0);
 
@@ -618,7 +633,7 @@ public class ContentView(
                 openFile,
                 selectedPlan.Project);
 
-            var tabNamesList = new List<string> { "summary", "plan", "details" };
+            var tabNamesList = new List<string> { "summary", "plan", "details", "git" };
             var tabList = new List<Tab>
             {
                 // Summary is rendered via DraftMarkdown with a pinned Verifications sidebar, so it is
@@ -633,6 +648,7 @@ public class ContentView(
                     jobService.GetJobsForPlan(selectedPlan.FolderName),
                     showDebugJob, planService, selectedPlanState, refreshPlans,
                     folderPath => selectedPlanState.Set(planService.GetPlanByFolder(folderPath))))),
+                new Tab("Git", Cap(gitTabView)).Badge(GitTabDataBuilder.CountGitItems(gitData, selectedPlan).ToString()),
             };
 
             // Only surface the Changes tab once there are actual file changes — no point showing

--- a/src/Ivy.Tendril/Helpers/GitTabDataBuilder.cs
+++ b/src/Ivy.Tendril/Helpers/GitTabDataBuilder.cs
@@ -40,6 +40,13 @@ public static class GitTabDataBuilder
         return BuildGitTabDataInternal(plan, config, gitService, precomputedCommitRows);
     }
 
+    /// <summary>
+    /// Number of git items behind the Git tab: worktrees, recorded commits and PRs.
+    /// Zero means there is nothing to show and the tab is hidden.
+    /// </summary>
+    public static int CountGitItems(GitTabData data, PlanFile plan) =>
+        data.WorktreeSections.Count + plan.Commits.Count + plan.Prs.Count;
+
     private static GitTabData BuildGitTabDataInternal(
         PlanFile plan,
         IConfigService config,


### PR DESCRIPTION
Fixes #1935

# Summary

## Changes

Restored the missing Git tab in the Drafts app (issue #1935) by reusing the existing
`GitTabDataBuilder`/`GitTabView` helpers that already power the Review app's git UI. The tab
appears only for drafts that already carry worktrees, commits, or PRs - the common case being a
plan sent back to Draft via Revise, or a Blocked plan - so a freshly created draft still shows
just Plan/Details.

## API Changes

- New public static method `GitTabDataBuilder.CountGitItems(GitTabData data, PlanFile plan)` in
  `src/Ivy.Tendril/Helpers/GitTabDataBuilder.cs` - returns the count of worktrees + commits + PRs
  behind the Git tab (0 means hide the tab).

## Files Modified

- `src/Ivy.Tendril/Helpers/GitTabDataBuilder.cs` - added `CountGitItems`.
- `src/Ivy.Tendril/Apps/Drafts/ContentView.cs` - builds `GitTabData` from the already-computed
  `planContentQuery.Value.CommitRows`, and conditionally adds a badged `Git` tab.
- `src/Ivy.Tendril.Test/GitTabDataBuilderTests.cs` (new) - unit tests for `CountGitItems`.
- `src/Ivy.Tendril.Docs/Docs/04_Apps/03_Drafts.md` - documents the new Git tab.

**Note:** The plan also asked to update Review's `ContentView.cs` to share the badge-count
expression via the new helper. That step was skipped: an unrelated commit (`0775dbc3`, 2026-08-02)
removed Review's entire Git tab after this plan was drafted, so there is nothing left there to
refactor. See the filed recommendation below.

## Fix: Restore the Git tab in the Review app

The reviewer confirmed the Git tab (worktrees, commits, PRs) was also missing from the **Review**
app itself, not just Drafts. It was accidentally dropped by commit `ff0ad88f` ("port interactive
Plan Diff viewer and Submit Review flow") when the new Changes-tab diff viewer landed - that
commit deleted the `GitTabView` construction and the unconditional `Git` tab entry from
`ContentView.cs` as an unrelated side effect, and no later commit brought it back (the earlier
note in this summary blaming `0775dbc3` was a red herring from an unrelated merge-conflict
cleanup). Restored the tab exactly where it was, reusing `GitTabDataBuilder.CountGitItems` for
the badge count as originally intended.

### Files Modified

- `src/Ivy.Tendril/Apps/Review/ContentView.cs` - re-added `GitTabData`/`GitTabView` construction
  and the unconditional `Git` tab (with worktree-synchronize support), badged via
  `GitTabDataBuilder.CountGitItems`.
- `src/Ivy.Tendril.Docs/Docs/04_Apps/02_Review.md` - documents the Git tab.

## Manual Testing

1. Run the Tendril server and open the **Drafts** app.
2. Select a plan that has never been executed (no worktree/commits/PRs) - only **Plan** and
   **Details** tabs should show; no empty **Git** tab.
3. Send a plan back to Draft from Review via **Needs work (Revise)** (or find a **Blocked**
   draft that already has a worktree/commits from a prior run).
4. Select that plan in Drafts - a **Git** tab should now appear with a badge counting its
   worktrees/commits/PRs, showing the same worktree/commit/PR details the Review app's Git tab
   shows. Clicking a commit should open the `CommitDetailSheet`.
5. Open the **Review** app and select any plan awaiting review - a **Git** tab should appear
   (unconditionally, unlike Drafts) between **Details** and **Changes**, showing worktrees,
   commits and PRs with a working **Synchronize** action and a badge matching the total count.
   Clicking a commit should open the `CommitDetailSheet`.

---
Commits:
- ac4000d8 Restore Git tab in Review app (plan 00110)
- 5e84dc25 Document the Drafts Git tab (plan 00110)
- d43d79ac Add tests for GitTabDataBuilder.CountGitItems (plan 00110)
- a8436053 Restore Git tab in Drafts app (plan 00110)

---
Created using [Ivy Tendril](https://ivy.app).
