### PR TITLE
[00107] Add Bottom and Left Spacing to the Review Changes Tab

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
@@ -249,11 +249,14 @@ public class ChangesTabView(
             | totalsText
             | submitBtn;
 
-        var toolbar = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.SpaceBetween).Height(Size.Auto())
+        var toolbar = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.SpaceBetween).Height(Size.Auto()).Padding(2, 0, 0, 0)
             | leftSide
             | rightSide;
 
-        var mainLayout = Layout.Horizontal().Height(Size.Full().Min(Size.Px(0)))
+        // Padding order is (left, top, right, bottom). Left 2 aligns the tree/diff content with
+        // the toolbar above; bottom 4 matches Cap()'s bottom inset so content doesn't run into
+        // the action bar separator below.
+        var mainLayout = Layout.Horizontal().Height(Size.Full().Min(Size.Px(0))).Padding(2, 0, 2, 4)
             | treePanel
             | diffsLayout;
 


### PR DESCRIPTION
Fixes #1944

# Add Bottom and Left Spacing to the Review Changes Tab

## What Changed

The Review app's **Changes** tab file tree/diff content had a smaller left inset than the
action bar below it and almost no bottom gap before the footer separator (GitHub issue #1944).
The plan's original line-level instructions targeted `ChangesTabView.cs` as it existed before
two upstream commits (`ff0ad88f`, `4e7cba84`) restructured the `toolbar` and `mainLayout`
layouts, so the described `.Padding(1)` / `.Padding(0, 0, 2, 2)` calls no longer existed in the
file. The fix was re-derived against the current structure:

- `toolbar`: added `.Padding(2, 0, 0, 0)` so the "Hide formatting changes" switch's left edge
  lines up with the content below.
- `mainLayout`: added `.Padding(2, 0, 2, 4)` (left 2, top 0, right 2, bottom 4) so the file tree
  card aligns with the action bar and no longer runs into the footer separator. The bottom
  value matches `Cap()`'s bottom inset used by every other tab in `ContentView.cs`.
- Added a short comment recording the `Padding(left, top, right, bottom)` argument order, since
  two earlier commits in this file had written values into the wrong slot.

### Files Modified

- `src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs`

## Manual Testing

Run Tendril, open the Review app on a plan that has commits, select the **Changes** tab, and
confirm the file tree card's left edge lines up with the "Previous" button in the action bar and
there is a clear gap between the bottom of the tree/diff area and the action bar separator.

---
Commits:
- 5a7f90a3 Add left and bottom spacing to Review Changes tab (plan 00107)

---
Created using [Ivy Tendril](https://ivy.app).
