### PR TITLE
[00105] Regression-Test and Document the Agent Instructions CLI Command

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/05_Other.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/05_Other.md
@@ -10,6 +10,9 @@ searchHints:
   - hash
   - password
   - update
+  - agent-instructions
+  - instructions
+  - prompt
 ---
 
 # Other Commands
@@ -149,4 +152,12 @@ server to be running. Agents pass the `TendrilJobId` firmware header value as `<
 ```
 
 Writes a file to `$TENDRIL_HOME/Trash/` from `--file` or `--stdin`. Used by agents to soft-delete content (e.g. duplicate plan files) instead of permanently removing it. Prints the written file path to stdout.
+
+## agent-instructions
+
+```terminal
+>tendril agent-instructions
+```
+
+Prints the compiled agent system prompt — the same instructions the Agent app gives the interactive assistant — to stdout, with `{TENDRIL_HOME}` and `{PLAN_FOLDER}` substituted from `config.yaml`. Exits 1 if the embedded prompt resource is missing. Useful for piping into another agent or diffing prompt changes.
 

--- a/src/Ivy.Tendril.Test/Commands/AgentInstructionsCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/AgentInstructionsCommandTests.cs
@@ -1,0 +1,79 @@
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console.Testing;
+
+namespace Ivy.Tendril.Test.Commands;
+
+public class AgentInstructionsCommandTests
+{
+    // Mirrors CliOutputTests.CaptureConsoleOut: the command writes via Console.Write, not
+    // AnsiConsole, so we must swap Console.Out rather than the Spectre console.
+    private static string CaptureConsoleOut(Action action)
+    {
+        var original = Console.Out;
+        var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        return writer.ToString();
+    }
+
+    private static (Spectre.Console.Cli.CommandApp App, string TendrilHome) BuildApp()
+    {
+        var tendrilHome = Path.Combine(Path.GetTempPath(), $"agent-instructions-test-{Guid.NewGuid():N}");
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfigService>(new TestPlanConfigService(
+            repoDir: Path.GetTempPath(),
+            tendrilHome: tendrilHome));
+
+        var app = Program.ConfigureCliCommands(services, new TestConsole());
+        return (app, tendrilHome);
+    }
+
+    [Fact]
+    public void AgentInstructions_WritesCompiledPromptToStdout_AndReturnsZero()
+    {
+        var (app, _) = BuildApp();
+        int exitCode = 0;
+
+        var output = CaptureConsoleOut(() => exitCode = app.Run(["agent-instructions"]));
+
+        Assert.Equal(0, exitCode);
+        Assert.StartsWith("# Tendril", output);
+        Assert.NotEmpty(output);
+    }
+
+    [Fact]
+    public void AgentInstructions_SubstitutesTendrilHomeAndPlanFolder()
+    {
+        var (app, tendrilHome) = BuildApp();
+        var expectedHome = tendrilHome.Replace('\\', '/').TrimEnd('/');
+        var expectedPlanFolder = Path.Combine(tendrilHome, "Plans").Replace('\\', '/').TrimEnd('/');
+
+        var output = CaptureConsoleOut(() => app.Run(["agent-instructions"]));
+
+        Assert.Contains(expectedHome, output);
+        Assert.Contains(expectedPlanFolder, output);
+        Assert.DoesNotContain("{TENDRIL_HOME}", output);
+        Assert.DoesNotContain("{PLAN_FOLDER}", output);
+    }
+
+    [Fact]
+    public void Compile_ReturnsPrompt_WhenEmbeddedResourceIsPresent()
+    {
+        var config = new TestPlanConfigService(
+            repoDir: Path.GetTempPath(),
+            tendrilHome: Path.Combine(Path.GetTempPath(), $"agent-instructions-test-{Guid.NewGuid():N}"));
+
+        var prompt = AgentPromptCompiler.Compile(config);
+
+        Assert.NotNull(prompt);
+    }
+}


### PR DESCRIPTION
Fixes #1953

# Summary

## Changes

Added end-to-end regression tests for the `tendril agent-instructions` CLI command, which had no
test coverage beyond a `Classify()` drift-guard assertion, and documented the command in the CLI
reference. No production code changed — the dispatch bug this issue reported was already fixed by
a prior plan (PR #1780); this plan closes the test and documentation gaps that let it look
unverified.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Test/Commands/AgentInstructionsCommandTests.cs` (new) — three tests exercising
  the real Spectre app: stdout output + exit code, `{TENDRIL_HOME}`/`{PLAN_FOLDER}` substitution,
  and `AgentPromptCompiler.Compile` returning a non-null prompt.
- `src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/05_Other.md` — added an `## agent-instructions`
  section and matching `searchHints` entries.

## Manual Testing

N/A — internal test/documentation change with no user-facing behavior beyond what the CLI already
does. To sanity-check manually: run `tendril agent-instructions` from a built Tendril binary and
confirm it prints the compiled prompt starting with `# Tendril` and exits 0; the new docs page can
be viewed under Advanced → CLI → Other in the docs site.

---
## Commits
- bfe8f5e3 Document the agent-instructions CLI command
- 10dbf58d Add end-to-end tests for the agent-instructions CLI command

---
Created using [Ivy Tendril](https://ivy.app).
