### PR TITLE
[00099] Move Add Project Into the Project Picker Dropdown

### DIFF
--- a/src/Ivy.Tendril.Test/CreatePlanDialogTests.cs
+++ b/src/Ivy.Tendril.Test/CreatePlanDialogTests.cs
@@ -42,4 +42,36 @@ public class CreatePlanDialogTests
         Assert.Contains("description: \"Make a md5 tool\"", prompt);
         Assert.DoesNotContain("md5 tool \"", prompt);
     }
+
+    [Fact]
+    public void BuildProjectPickerOptions_MultipleProjects_ReturnsAutoFirstThenEachProject()
+    {
+        var (options, _) = CreatePlanDialog.BuildProjectPickerOptions(["Tendril-Services", "lots-of-dev-tools"]);
+
+        Assert.Equal(3, options.Length);
+        Assert.Equal("Auto", options[0].Value);
+        Assert.False(options[0].Removable);
+        Assert.Equal("Tendril-Services", options[1].Value);
+        Assert.Equal("lots-of-dev-tools", options[2].Value);
+    }
+
+    [Fact]
+    public void BuildProjectPickerOptions_SingleProject_OmitsAuto()
+    {
+        var (options, _) = CreatePlanDialog.BuildProjectPickerOptions(["Tendril-Services"]);
+
+        Assert.Single(options);
+        Assert.Equal("Tendril-Services", options[0].Value);
+    }
+
+    [Fact]
+    public void BuildProjectPickerOptions_ReturnsExactlyOneAddProjectAction()
+    {
+        var (options, actions) = CreatePlanDialog.BuildProjectPickerOptions(["Tendril-Services", "lots-of-dev-tools"]);
+
+        Assert.Single(actions);
+        Assert.Equal(CreatePlanDialog.AddProjectActionValue, actions[0].Value);
+        Assert.Equal("Add Project", actions[0].Label);
+        Assert.DoesNotContain(options, o => o.Value == CreatePlanDialog.AddProjectActionValue);
+    }
 }

--- a/src/Ivy.Tendril.Widgets/BadgeSelect.cs
+++ b/src/Ivy.Tendril.Widgets/BadgeSelect.cs
@@ -21,8 +21,10 @@ public record BadgeSelect : WidgetBase<BadgeSelect>
     [Prop] public string? Icon { get; init; }
     [Prop] public bool Multiple { get; init; } = true;
     [Prop] public string? Tooltip { get; init; }
+    [Prop] public BadgeSelectOption[] Actions { get; init; } = [];
 
     [Event] public Func<Event<BadgeSelect, string[]>, ValueTask>? OnChange { get; init; }
+    [Event] public Func<Event<BadgeSelect, string>, ValueTask>? OnAction { get; init; }
 }
 
 public static class BadgeSelectExtensions
@@ -47,6 +49,24 @@ public static class BadgeSelectExtensions
 
     public static BadgeSelect Tooltip(this BadgeSelect w, string? tooltip) =>
         w with { Tooltip = tooltip };
+
+    public static BadgeSelect Actions(this BadgeSelect w, params BadgeSelectOption[] actions) =>
+        w with { Actions = actions };
+
+    public static BadgeSelect WithOnAction(
+        this BadgeSelect w,
+        Func<Event<BadgeSelect, string>, ValueTask> handler
+    ) => w with { OnAction = handler };
+
+    public static BadgeSelect WithOnAction(this BadgeSelect w, Action<string> handler) =>
+        w with
+        {
+            OnAction = e =>
+            {
+                handler(e.Value);
+                return ValueTask.CompletedTask;
+            }
+        };
 
     public static BadgeSelect WithOnChange(
         this BadgeSelect w,

--- a/src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/BadgeSelect.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/BadgeSelect.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { BadgeSelect, type BadgeSelectOption } from "./BadgeSelect";
+
+const projectOptions: BadgeSelectOption[] = [
+  { value: "Tendril-Services", label: "Tendril-Services" },
+  { value: "lots-of-dev-tools", label: "lots-of-dev-tools" },
+];
+
+const addProjectAction: BadgeSelectOption[] = [
+  { value: "__tendril_add_project__", label: "Add Project", icon: "Plus" },
+];
+
+describe("BadgeSelect actions", () => {
+  it("renders the action row label below the options when the trigger is opened", () => {
+    render(<BadgeSelect id="bs-1" options={projectOptions} actions={addProjectAction} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /select/i }));
+
+    const optionLabels = screen.getAllByRole("option").map((el) => el.textContent);
+    const actionButton = screen.getByText("Add Project");
+
+    expect(optionLabels).toEqual(["Tendril-Services", "lots-of-dev-tools"]);
+    expect(actionButton).toBeInTheDocument();
+    expect(actionButton).not.toHaveAttribute("role", "option");
+  });
+
+  it("emits OnAction with the action value and not OnChange when the action row is clicked", () => {
+    const eventHandler = vi.fn();
+    render(
+      <BadgeSelect
+        id="bs-1"
+        options={projectOptions}
+        actions={addProjectAction}
+        events={["OnChange", "OnAction"]}
+        eventHandler={eventHandler}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /select/i }));
+    fireEvent.click(screen.getByText("Add Project"));
+
+    expect(eventHandler).toHaveBeenCalledWith("OnAction", "bs-1", ["__tendril_add_project__"]);
+    expect(eventHandler).not.toHaveBeenCalledWith("OnChange", "bs-1", expect.anything());
+  });
+
+  it("closes the menu when the action row is clicked", () => {
+    render(
+      <BadgeSelect
+        id="bs-1"
+        options={projectOptions}
+        actions={addProjectAction}
+        events={["OnAction"]}
+        eventHandler={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /select/i });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByText("Add Project"));
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("still emits OnChange for a normal option and never includes the action value", () => {
+    const eventHandler = vi.fn();
+    render(
+      <BadgeSelect
+        id="bs-1"
+        options={projectOptions}
+        actions={addProjectAction}
+        multiple
+        events={["OnChange", "OnAction"]}
+        eventHandler={eventHandler}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /select/i }));
+    fireEvent.click(screen.getByText("Tendril-Services"));
+
+    expect(eventHandler).toHaveBeenCalledWith("OnChange", "bs-1", [["Tendril-Services"]]);
+    const [, , args] = eventHandler.mock.calls[0];
+    expect((args as string[][])[0]).not.toContain("__tendril_add_project__");
+  });
+
+  it("renders no separator and no extra row when actions is omitted", () => {
+    render(<BadgeSelect id="bs-1" options={projectOptions} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /select/i }));
+
+    expect(document.querySelector(".bselect-separator")).toBeNull();
+    expect(document.querySelectorAll(".bselect-action").length).toBe(0);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/BadgeSelect.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/BadgeSelect.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { ChevronDown, Flag, Folder, WandSparkles, X, type LucideIcon } from "lucide-react";
+import { ChevronDown, Flag, Folder, Plus, WandSparkles, X, type LucideIcon } from "lucide-react";
 import "./badge-select.css";
 
 type IvyEventHandler = (eventName: string, widgetId: string, args: unknown[]) => void;
@@ -21,11 +21,13 @@ interface BadgeSelectProps {
   multiple?: boolean;
   tooltip?: string;
   width?: string;
+  actions?: BadgeSelectOption[];
   events?: string[];
   eventHandler?: IvyEventHandler;
 }
 
 const EMPTY_OPTIONS: BadgeSelectOption[] = [];
+const EMPTY_ACTIONS: BadgeSelectOption[] = [];
 const EMPTY_VALUE: string[] = [];
 const EMPTY_EVENTS: string[] = [];
 const MENU_GAP = 4;
@@ -35,6 +37,7 @@ const ICONS: Record<string, LucideIcon> = {
   ChevronDown,
   Flag,
   Folder,
+  Plus,
   WandSparkles,
   X,
 };
@@ -95,6 +98,7 @@ export function BadgeSelect({
   multiple = true,
   tooltip,
   width,
+  actions = EMPTY_ACTIONS,
   events = EMPTY_EVENTS,
   eventHandler,
 }: BadgeSelectProps) {
@@ -132,7 +136,7 @@ export function BadgeSelect({
   useLayoutEffect(() => {
     if (!open) return;
     updateMenuPosition();
-  }, [open, options.length, selected.length]);
+  }, [open, options.length, selected.length, actions.length]);
 
   useEffect(() => {
     const el = rootRef.current;
@@ -206,6 +210,13 @@ export function BadgeSelect({
     }
   };
 
+  const runAction = (actionValue: string) => {
+    if (eventHandler && events.includes("OnAction")) {
+      eventHandler("OnAction", id, [actionValue]);
+    }
+    setOpen(false);
+  };
+
   const toggle = (optionValue: string) => {
     if (multiple) {
       if (selected.includes(optionValue)) {
@@ -263,6 +274,22 @@ export function BadgeSelect({
             </button>
           );
         })}
+        {actions.length > 0 && (
+          <>
+            <div className="bselect-separator" role="separator" />
+            {actions.map((action) => (
+              <button
+                key={action.value}
+                type="button"
+                className="bselect-item bselect-action"
+                onClick={() => runAction(action.value)}
+              >
+                <NamedIcon name={action.icon} />
+                <span className="bselect-item-label">{action.label}</span>
+              </button>
+            ))}
+          </>
+        )}
       </div>,
       document.body,
     );

--- a/src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/badge-select.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/badge-select.css
@@ -164,3 +164,17 @@
   flex-shrink: 0;
   color: var(--muted-foreground);
 }
+
+.bselect-separator {
+  height: 1px;
+  margin: 4px 0;
+  background: var(--border);
+}
+
+.bselect-action {
+  color: var(--muted-foreground);
+}
+
+.bselect-action:hover {
+  color: var(--foreground);
+}

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -24,6 +24,20 @@ public class CreatePlanDialog(
 
     internal static readonly List<string> PriorityOptions = ["Normal", "High", "Urgent"];
 
+    internal const string AddProjectActionValue = "__tendril_add_project__";
+
+    internal static (BadgeSelectOption[] Options, BadgeSelectOption[] Actions) BuildProjectPickerOptions(
+        IReadOnlyList<string> projectNames)
+    {
+        var options = new List<BadgeSelectOption>();
+        if (projectNames.Count > 1)
+            options.Add(new BadgeSelectOption("Auto", "Auto", "WandSparkles", Removable: false));
+        options.AddRange(projectNames.Select(p => new BadgeSelectOption(p, p)));
+
+        var actions = new[] { new BadgeSelectOption(AddProjectActionValue, "Add Project", "Plus") };
+        return (options.ToArray(), actions);
+    }
+
     internal static int ParsePriority(string option) => option.ToLowerInvariant() switch
     {
         "normal" => 0,
@@ -94,8 +108,9 @@ public class CreatePlanDialog(
         var hasAutoOption = currentProjectNames.Count > 1;
 
         // "Auto" is exclusive: picking it clears real projects, picking a real project clears "Auto".
-        void SetProjects(string[] newValue)
+        void SetProjects(string[] rawValue)
         {
+            var newValue = rawValue.Where(p => p != AddProjectActionValue).ToArray();
             var current = selectedProjects.Value;
             string[] next;
             if (newValue.Contains("Auto") && !current.Contains("Auto"))
@@ -109,10 +124,7 @@ public class CreatePlanDialog(
             selectedProjects.Set(next);
         }
 
-        var projectOptions = new List<BadgeSelectOption>();
-        if (hasAutoOption)
-            projectOptions.Add(new BadgeSelectOption("Auto", "Auto", "WandSparkles", Removable: false));
-        projectOptions.AddRange(currentProjectNames.Select(p => new BadgeSelectOption(p, p)));
+        var (projectOptions, projectActions) = BuildProjectPickerOptions(currentProjectNames);
 
         var planWasCreated = false;
         void HandleClose()
@@ -137,7 +149,7 @@ public class CreatePlanDialog(
 
         var projectPicker = new BadgeSelect
         {
-            Options = projectOptions.ToArray(),
+            Options = projectOptions,
             Value = selectedProjects.Value,
             Placeholder = "Select project(s)",
             Icon = selectedProjects.Value.Contains("Auto") || selectedProjects.Value.Length == 0
@@ -145,8 +157,13 @@ public class CreatePlanDialog(
                     : "Folder",
             Multiple = true,
             Tooltip = "Select project(s)",
+            Actions = projectActions,
         }
             .WithOnChange(SetProjects)
+            .WithOnAction(value =>
+            {
+                if (value == AddProjectActionValue) isAddProjectOpen.Set(true);
+            })
             .Width(Size.Grow());
 
         var priorityPicker = new BadgeSelect
@@ -161,19 +178,11 @@ public class CreatePlanDialog(
             .WithOnChange(values => selectedPriority.Set(values.FirstOrDefault() ?? "Normal"))
             .Width(Size.Auto());
 
-        var newProjectButton = new Button()
-            .Icon(Icons.Plus)
-            .Small().Ghost()
-            .Tooltip("New Project")
-            .OnClick(() => isAddProjectOpen.Set(true));
-
         var bodyContent =
                 Layout.Vertical().Gap(2)
                 | (Layout.Horizontal().Gap(1).AlignContent(Align.Left).Width(Size.Full())
-                    | (Layout.Horizontal().Gap(1).Width(Size.Grow())
-                        | projectPicker
-                        | priorityPicker)
-                    | newProjectButton)
+                    | projectPicker
+                    | priorityPicker)
                 | new Ivy.Tendril.Widgets.ContentInput
                 {
                     UploadUrl = uploadContext.Value.UploadUrl,


### PR DESCRIPTION
Fixes #1927

# Summary

## Changes

Removed the standalone "+" (New Project) button from the create-plan dialog and replaced it with
an "Add Project" action row inside the project picker's own dropdown menu. This required adding a
generic "actions" concept to the `BadgeSelect` widget so it can render non-selectable command rows
below its options, separate from the selection-driven `OnChange` event.

## API Changes

- `BadgeSelect` (C#, `Ivy.Tendril.Widgets`): new `Actions` prop (`BadgeSelectOption[]`, default
  `[]`) and new `OnAction` event (`Func<Event<BadgeSelect, string>, ValueTask>?`). New extension
  methods `Actions(params BadgeSelectOption[])`, `WithOnAction(Func<Event<BadgeSelect, string>,
  ValueTask>)`, and `WithOnAction(Action<string>)`.
- `BadgeSelect` (React, frontend): new `actions?: BadgeSelectOption[]` prop. Emits a new
  `"OnAction"` event (via the existing `eventHandler`/`events` mechanism) with the clicked action's
  `value` when an action row is clicked.
- `CreatePlanDialog`: new `internal const string AddProjectActionValue` and new `internal static
  (BadgeSelectOption[] Options, BadgeSelectOption[] Actions) BuildProjectPickerOptions(IReadOnlyList<string>)`
  helper, both usable from tests.

## Files Modified

- `src/Ivy.Tendril.Widgets/BadgeSelect.cs` — `Actions`/`OnAction` widget API
- `src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/BadgeSelect.tsx` — action-row rendering, `Plus` icon, `runAction` handler
- `src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/badge-select.css` — `.bselect-separator` / `.bselect-action` styles
- `src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/BadgeSelect.test.tsx` — new test file (5 tests)
- `src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs` — removed the "+" button, wired the project picker's action row to open `AddProjectDialog`
- `src/Ivy.Tendril.Test/CreatePlanDialogTests.cs` — 3 new tests for `BuildProjectPickerOptions`

## Manual Testing

1. Run the Tendril app and open the "Create New Plan" dialog (from the Plans view).
2. Confirm the standalone "+" ghost button next to the project/priority pickers is gone.
3. Click the project picker to open its dropdown. Below the project options, confirm an "Add
   Project" row appears with a `+` icon, separated from the options by a thin divider.
4. Click "Add Project" — the dropdown should close and the "Add Project" dialog should open (same
   dialog that used to open from the standalone button).
5. Click a normal project option instead — it should toggle selection as before ("Add Project" is
   never selectable and never appears as a badge in the trigger).
6. Open the priority picker's dropdown — it should look unchanged, with no separator or extra row
   (it has no `actions`).

---
## Commits
- e4d1a238 Add action rows to BadgeSelect widget
- 8e041a69 Add tests for BadgeSelect action rows
- e7b12c96 Move Add Project into the project picker dropdown

---
Created using [Ivy Tendril](https://ivy.app).
