### PR TITLE
[00098] Remove Clear All Finished From Jobs Overflow Menu

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -314,11 +314,6 @@ public partial class JobsApp
                     jobService.ClearFailedJobs();
                     refreshToken.Refresh();
                 }));
-                overflowItems.Add(new MenuItem("Clear All Finished", Icon: Icons.Trash, Tag: "ClearAll").OnSelect(() =>
-                {
-                    jobService.ClearAllJobs();
-                    refreshToken.Refresh();
-                }));
 
                 return Layout.Horizontal()
                        | (jobsProgress != null ? jobsProgress : null!)


### PR DESCRIPTION
Fixes #1930

# Summary

## Changes

Removed the "Clear All Finished" item from the Jobs app overflow menu (GitHub #1930), leaving
"Clear Completed" and "Clear Failed" as the only clear actions there. The underlying
`IJobService.ClearAllJobs` service method and its test coverage were intentionally left in place.

## API Changes

None. `IJobService.ClearAllJobs` and `JobService.ClearAllJobs` are unchanged and remain callable —
only their UI entry point in the overflow menu was removed.

## Files Modified

- `src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs` — deleted the `MenuItem("Clear All Finished", ...)` block from the Jobs app's header overflow menu.

## Manual Testing

1. Run the Ivy Tendril app and open the Jobs app.
2. Click the overflow (⋮) menu in the Jobs table header.
3. Confirm only "Clear Completed" and "Clear Failed" appear (plus any "Stop All..." items if
   there are queued/active jobs) — "Clear All Finished" should no longer be present.
4. Confirm "Clear Completed" and "Clear Failed" still work as before.

---
## Commits
- 688f3e18 Remove Clear All Finished from Jobs overflow menu

---
Created using [Ivy Tendril](https://ivy.app).
