### PR TITLE
Fix scroll issues in Add Project dialogue

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -189,7 +189,7 @@ public class ProjectAgentStepView(
                       )
                         .Width(Size.Full())
                         .Height(Size.Units(100).Max(Size.Fraction(0.6f)))
-                        .Padding(4, 4, 0, 4)
+                        .Padding(4, 4, 2, 4)
                    : null!)
                | buttonArea
                | new Spacer().Height(Size.Units(4));


### PR DESCRIPTION
## Summary

- Adjust bottom padding in `ProjectAgentStepView` from `0` to `2` to fix scroll issues in the Add Project dialogue

## Test plan

- [ ] Open the Add Project dialogue
- [ ] Verify scrolling works correctly without layout issues

Made with [Cursor](https://cursor.com)