### PR TITLE
fix(config): prevent test runs from polluting live TENDRIL_HOME config

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1589,6 +1589,7 @@ maxConcurrentJobs: 10
         var prevHashSecret = Environment.GetEnvironmentVariable("TENDRIL_AUTH_HASH_SECRET");
         try
         {
+            PathHelper.DefaultTendrilHomeOverride = emptyDir;
             Environment.SetEnvironmentVariable("TENDRIL_HOME", emptyDir);
             Environment.SetEnvironmentVariable("TENDRIL_AUTH_PASSWORD", "mysecretpassword");
             Environment.SetEnvironmentVariable("TENDRIL_AUTH_HASH_SECRET",
@@ -1602,6 +1603,7 @@ maxConcurrentJobs: 10
         }
         finally
         {
+            PathHelper.DefaultTendrilHomeOverride = null;
             Environment.SetEnvironmentVariable("TENDRIL_HOME", prevHome);
             Environment.SetEnvironmentVariable("TENDRIL_AUTH_PASSWORD", prevPassword);
             Environment.SetEnvironmentVariable("TENDRIL_AUTH_HASH_SECRET", prevHashSecret);

--- a/src/Ivy.Tendril/Helpers/PathHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PathHelper.cs
@@ -33,8 +33,7 @@ public static class PathHelper
             if (envHome.StartsWith("\"") && envHome.EndsWith("\""))
                 envHome = envHome[1..^1];
 
-            if (File.Exists(Path.Combine(envHome, "config.yaml")))
-                return envHome;
+            return envHome;
         }
 
         if (OperatingSystem.IsWindows())


### PR DESCRIPTION
This PR fixes PathHelper.GetDefaultTendrilHome() so that an explicitly specified TENDRIL_HOME environment variable is respected directly instead of falling back to user-level tendril home when config.yaml is not yet present, preventing test runs from overwriting live config.yaml files.