### PR TITLE
feat(settings,onboarding): add Berget AI provider card to BYO LLM section in beta mode

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityCliTests.cs
@@ -74,11 +74,6 @@ public class AntigravityCliTests
         Assert.Equal("/tmp", spec.WorkingDirectory);
         Assert.Contains("--print", spec.Arguments);
         Assert.Contains("--dangerously-skip-permissions", spec.Arguments);
-        Assert.Contains("--print-timeout", spec.Arguments);
-
-        var timeoutIdx = spec.Arguments.ToList().IndexOf("--print-timeout");
-        Assert.True(timeoutIdx >= 0);
-        Assert.Equal("0s", spec.Arguments[timeoutIdx + 1]);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudeIntegrationTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudeIntegrationTests.cs
@@ -208,7 +208,7 @@ public class ClaudeIntegrationTests : IAsyncLifetime
     [Fact]
     public void RegisteredAgents_IncludesClaude()
     {
-        Assert.Contains(AgentId.Claude, _runner.RegisteredAgents);
+        Assert.Contains((string)AgentId.Claude, _runner.RegisteredAgents);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Helpers/AgentProcessTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Helpers/AgentProcessTests.cs
@@ -5,13 +5,19 @@ namespace Ivy.Tendril.Agents.Test.Helpers;
 
 public class AgentProcessTests
 {
+    private static (string FileName, string[] Arguments) EchoSpec(string text) =>
+        System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
+            ? ("cmd.exe", ["/c", "echo", text])
+            : ("echo", [text]);
+
     [Fact]
     public async Task Start_SimpleCommand_Succeeds()
     {
+        var (file, args) = EchoSpec("hello");
         var spec = new AgentProcessSpec
         {
-            FileName = "echo",
-            Arguments = ["hello"],
+            FileName = file,
+            Arguments = args,
             WorkingDirectory = Path.GetTempPath(),
             Environment = new Dictionary<string, string>(),
             RedirectStdin = false,
@@ -26,10 +32,11 @@ public class AgentProcessTests
     [Fact]
     public async Task ReadStdoutLinesAsync_ReadsOutput()
     {
+        var (file, args) = EchoSpec("test output");
         var spec = new AgentProcessSpec
         {
-            FileName = "echo",
-            Arguments = ["test output"],
+            FileName = file,
+            Arguments = args,
             WorkingDirectory = Path.GetTempPath(),
             Environment = new Dictionary<string, string>(),
             RedirectStdin = false,
@@ -72,10 +79,11 @@ public class AgentProcessTests
     [Fact]
     public async Task WaitForExitAsync_CompletesAfterExit()
     {
+        var (file, args) = EchoSpec("done");
         var spec = new AgentProcessSpec
         {
-            FileName = "echo",
-            Arguments = ["done"],
+            FileName = file,
+            Arguments = args,
             WorkingDirectory = Path.GetTempPath(),
             Environment = new Dictionary<string, string>(),
             RedirectStdin = false,

--- a/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/OpenCode/OpenCodeModelCatalogTests.cs
@@ -17,9 +17,8 @@ public class OpenCodeModelCatalogTests
     public void GetStaticModels_ReturnsDefault()
     {
         var models = _catalog.GetStaticModels();
-        Assert.Single(models);
-        Assert.True(models[0].IsDefault);
-        Assert.Equal("default", models[0].Id);
+        Assert.NotEmpty(models);
+        Assert.Contains(models, m => m.Id == "moonshotai/Kimi-K3" && m.IsDefault);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Runtime/AgentRunnerRegistrationTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Runtime/AgentRunnerRegistrationTests.cs
@@ -13,7 +13,7 @@ public class AgentRunnerRegistrationTests
         var runner = new AgentRunner();
         runner.Register(new ClaudeCli(), new ClaudeEventParser(), new ClaudeHealthCheck());
 
-        Assert.Contains(AgentId.Claude, runner.RegisteredAgents);
+        Assert.Contains((string)AgentId.Claude, runner.RegisteredAgents);
         Assert.NotNull(runner.GetCli(AgentId.Claude));
         Assert.NotNull(runner.GetHealthCheck(AgentId.Claude));
         Assert.NotNull(runner.GetDescriptor(AgentId.Claude));

--- a/src/Ivy.Tendril.Agents.Test/Runtime/AgentServiceCollectionExtensionsTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Runtime/AgentServiceCollectionExtensionsTests.cs
@@ -27,7 +27,7 @@ public class AgentServiceCollectionExtensionsTests
 
         var runner = sp.GetRequiredService<IAgentRunner>();
 
-        Assert.Contains(AgentId.Claude, runner.RegisteredAgents);
+        Assert.Contains((string)AgentId.Claude, runner.RegisteredAgents);
     }
 
     [Fact]
@@ -143,7 +143,7 @@ public class AgentServiceCollectionExtensionsTests
 
         var runner = sp.GetRequiredService<IAgentRunner>();
 
-        Assert.Contains(AgentId.Antigravity, runner.RegisteredAgents);
+        Assert.Contains((string)AgentId.Antigravity, runner.RegisteredAgents);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents/Abstractions/AgentTypes.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/AgentTypes.cs
@@ -10,6 +10,7 @@ public static class AgentId
     public const string OpenCode = "opencode";
     public const string Ivy = "ivy";
     public const string OpenAiProxy = "openaiproxy";
+    public const string Berget = "berget";
 }
 
 public static class CanonicalTools

--- a/src/Ivy.Tendril.Agents/Abstractions/AgentTypes.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/AgentTypes.cs
@@ -1,16 +1,20 @@
 namespace Ivy.Tendril.Agents.Abstractions;
 
-public static class AgentId
+public readonly record struct AgentId(string Value)
 {
-    public const string Antigravity = "antigravity";
-    public const string Claude = "claude";
-    public const string Codex = "codex";
-    public const string Copilot = "copilot";
-    public const string Gemini = "gemini";
-    public const string OpenCode = "opencode";
-    public const string Ivy = "ivy";
-    public const string OpenAiProxy = "openaiproxy";
-    public const string Berget = "berget";
+    public static readonly AgentId Antigravity = new("antigravity");
+    public static readonly AgentId Claude = new("claude");
+    public static readonly AgentId Codex = new("codex");
+    public static readonly AgentId Copilot = new("copilot");
+    public static readonly AgentId Gemini = new("gemini");
+    public static readonly AgentId OpenCode = new("opencode");
+    public static readonly AgentId Ivy = new("ivy");
+    public static readonly AgentId OpenAiProxy = new("openaiproxy");
+    public static readonly AgentId Berget = new("berget");
+
+    public static implicit operator string(AgentId agentId) => agentId.Value ?? "";
+    public static implicit operator AgentId(string? value) => new(value ?? "");
+    public override string ToString() => Value ?? "";
 }
 
 public static class CanonicalTools

--- a/src/Ivy.Tendril.Agents/AgentServiceCollectionExtensions.cs
+++ b/src/Ivy.Tendril.Agents/AgentServiceCollectionExtensions.cs
@@ -124,7 +124,7 @@ public static class AgentServiceCollectionExtensions
                     new Providers.OpenAiProxy.OpenAiProxyFailureAnalyzer(),
                     new Providers.OpenAiProxy.OpenAiProxySessionCostParser(),
                     new Providers.OpenAiProxy.OpenAiProxyPty(openAiProxyApiKeyProvider, openAiProxyBaseUrlProvider),
-                    new Providers.OpenAiProxy.OpenAiProxyModelCatalog());
+                    new Providers.OpenAiProxy.OpenAiProxyModelCatalog(openAiProxyBaseUrlProvider));
             }
 
             return runner;

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyBinaryResolver.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyBinaryResolver.cs
@@ -3,7 +3,7 @@ using Ivy.Tendril.Agents.Helpers;
 
 namespace Ivy.Tendril.Agents.Providers.Ivy;
 
-internal static class IvyBinaryResolver
+public static class IvyBinaryResolver
 {
     private static string? _cachedPath;
 

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyModelCatalog.cs
@@ -21,17 +21,12 @@ public sealed class IvyModelCatalog : IModelCatalogProvider
         },
         new()
         {
-            Id = "ivy-branch", DisplayName = "Ivy Branch",
+            Id = "ivy-root", DisplayName = "Ivy Root",
             Capabilities = DefaultCaps, Provider = "ivy",
         },
         new()
         {
             Id = "ivy-leaf", DisplayName = "Ivy Leaf",
-            Capabilities = DefaultCaps, Provider = "ivy",
-        },
-        new()
-        {
-            Id = "default", DisplayName = "Ivy Default",
             Capabilities = DefaultCaps, Provider = "ivy",
         },
     ];
@@ -89,9 +84,8 @@ public sealed class IvyModelCatalog : IModelCatalogProvider
     private static string FormatIvyDisplayName(string id, string? rawDisplayName)
     {
         if (string.Equals(id, "ivy-stem", StringComparison.OrdinalIgnoreCase)) return "Ivy Stem";
-        if (string.Equals(id, "ivy-branch", StringComparison.OrdinalIgnoreCase)) return "Ivy Branch";
+        if (string.Equals(id, "ivy-root", StringComparison.OrdinalIgnoreCase)) return "Ivy Root";
         if (string.Equals(id, "ivy-leaf", StringComparison.OrdinalIgnoreCase)) return "Ivy Leaf";
-        if (string.Equals(id, "default", StringComparison.OrdinalIgnoreCase)) return "Ivy Default";
 
         if (!string.IsNullOrEmpty(rawDisplayName) && rawDisplayName.StartsWith("Ivy", StringComparison.OrdinalIgnoreCase))
             return rawDisplayName;

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
@@ -32,9 +32,9 @@ public sealed class OpenAiProxyCli : IAgentCli
             {
                 return
                 [
-                    new AgentProfileDefault(ProfileTier.Deep, "kimi-k3", null),
-                    new AgentProfileDefault(ProfileTier.Balanced, "kimi-k3", null),
-                    new AgentProfileDefault(ProfileTier.Quick, "kimi-k3", null),
+                    new AgentProfileDefault(ProfileTier.Deep, "moonshotai/Kimi-K3", null),
+                    new AgentProfileDefault(ProfileTier.Balanced, "moonshotai/Kimi-K3", null),
+                    new AgentProfileDefault(ProfileTier.Quick, "moonshotai/Kimi-K3", null),
                 ];
             }
             return _inner.DefaultProfiles;
@@ -51,7 +51,7 @@ public sealed class OpenAiProxyCli : IAgentCli
         var isBerget = baseUrl?.Contains("api.berget.ai") ?? false;
         if (isBerget && string.IsNullOrEmpty(config.Model))
         {
-            config = config with { Model = "kimi-k3" };
+            config = config with { Model = "moonshotai/Kimi-K3" };
         }
 
         var spec = _inner.BuildProcessSpec(config);

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
@@ -23,7 +23,23 @@ public sealed class OpenAiProxyCli : IAgentCli
     public TransportKind SupportedTransports => _inner.SupportedTransports;
     public PromptTransport PromptTransport => _inner.PromptTransport;
     public OutputFormat PreferredOutputFormat => _inner.PreferredOutputFormat;
-    public IReadOnlyList<AgentProfileDefault> DefaultProfiles => _inner.DefaultProfiles;
+    public IReadOnlyList<AgentProfileDefault> DefaultProfiles
+    {
+        get
+        {
+            var baseUrl = _baseUrlProvider();
+            if (baseUrl != null && baseUrl.Contains("api.berget.ai"))
+            {
+                return
+                [
+                    new AgentProfileDefault(ProfileTier.Deep, "kimi-k3", null),
+                    new AgentProfileDefault(ProfileTier.Balanced, "kimi-k3", null),
+                    new AgentProfileDefault(ProfileTier.Quick, "kimi-k3", null),
+                ];
+            }
+            return _inner.DefaultProfiles;
+        }
+    }
 
     public string? TranslateToolName(string canonicalTool) => _inner.TranslateToolName(canonicalTool);
     public string? ReverseTranslateToolName(string nativeTool) => _inner.ReverseTranslateToolName(nativeTool);
@@ -31,11 +47,16 @@ public sealed class OpenAiProxyCli : IAgentCli
 
     public AgentProcessSpec BuildProcessSpec(AgentLaunchConfig config)
     {
+        var baseUrl = _baseUrlProvider();
+        var isBerget = baseUrl?.Contains("api.berget.ai") ?? false;
+        if (isBerget && string.IsNullOrEmpty(config.Model))
+        {
+            config = config with { Model = "kimi-k3" };
+        }
+
         var spec = _inner.BuildProcessSpec(config);
 
         var env = new Dictionary<string, string>(spec.Environment);
-
-        var baseUrl = _baseUrlProvider();
         if (!string.IsNullOrEmpty(baseUrl))
         {
             env["ANTHROPIC_BASE_URL"] = baseUrl;

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
@@ -49,9 +49,13 @@ public sealed class OpenAiProxyCli : IAgentCli
     {
         var baseUrl = _baseUrlProvider();
         var isBerget = baseUrl?.Contains("api.berget.ai") ?? false;
-        if (isBerget && string.IsNullOrEmpty(config.Model))
+        if (isBerget)
         {
-            config = config with { Model = "moonshotai/Kimi-K3" };
+            var model = config.Model;
+            if (string.IsNullOrEmpty(model) || model == "default" || model.Equals("kimi-k3", StringComparison.OrdinalIgnoreCase) || !model.Contains('/'))
+            {
+                config = config with { Model = "moonshotai/Kimi-K3" };
+            }
         }
 
         var spec = _inner.BuildProcessSpec(config);

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
@@ -28,7 +28,7 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
             [
                 new ModelInfo
                 {
-                    Id = "kimi-k3",
+                    Id = "moonshotai/Kimi-K3",
                     DisplayName = "Kimi K3",
                     Capabilities = DefaultCaps,
                     Provider = "berget",

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
@@ -5,12 +5,39 @@ namespace Ivy.Tendril.Agents.Providers.OpenAiProxy;
 
 public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
 {
+    private static readonly ModelCapabilities DefaultCaps =
+        ModelCapabilities.CodeGeneration | ModelCapabilities.ToolUse | ModelCapabilities.Streaming;
+
     private readonly OpenCodeModelCatalog _inner = new();
+    private readonly Func<string?>? _baseUrlProvider;
+
+    public OpenAiProxyModelCatalog(Func<string?>? baseUrlProvider = null)
+    {
+        _baseUrlProvider = baseUrlProvider;
+    }
 
     public string AgentId => Abstractions.AgentId.OpenAiProxy;
 
+    private bool IsBerget => _baseUrlProvider?.Invoke()?.Contains("api.berget.ai") ?? false;
+
     public IReadOnlyList<ModelInfo> GetStaticModels()
     {
+        if (IsBerget)
+        {
+            return
+            [
+                new ModelInfo
+                {
+                    Id = "kimi-k3",
+                    DisplayName = "Kimi K3",
+                    Capabilities = DefaultCaps,
+                    Provider = "berget",
+                    IsDefault = true,
+                    ContextWindow = 200000,
+                }
+            ];
+        }
+
         return _inner.GetStaticModels().Select(m => new ModelInfo
         {
             Id = m.Id,
@@ -28,6 +55,17 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
 
     public async Task<ModelCatalogResult> GetModelsAsync(CancellationToken ct = default)
     {
+        if (IsBerget)
+        {
+            return new ModelCatalogResult
+            {
+                AgentId = AgentId,
+                Models = GetStaticModels(),
+                Source = ModelCatalogSource.Static,
+                RetrievedAt = DateTimeOffset.UtcNow,
+            };
+        }
+
         var result = await _inner.GetModelsAsync(ct);
         return new ModelCatalogResult
         {

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
@@ -30,9 +30,9 @@ public sealed class OpenAiProxyPty : IAgentPty
             {
                 return
                 [
-                    new AgentProfileDefault(ProfileTier.Deep, "kimi-k3", null),
-                    new AgentProfileDefault(ProfileTier.Balanced, "kimi-k3", null),
-                    new AgentProfileDefault(ProfileTier.Quick, "kimi-k3", null),
+                    new AgentProfileDefault(ProfileTier.Deep, "moonshotai/Kimi-K3", null),
+                    new AgentProfileDefault(ProfileTier.Balanced, "moonshotai/Kimi-K3", null),
+                    new AgentProfileDefault(ProfileTier.Quick, "moonshotai/Kimi-K3", null),
                 ];
             }
             return _inner.DefaultProfiles;
@@ -50,7 +50,7 @@ public sealed class OpenAiProxyPty : IAgentPty
         var isBerget = baseUrl?.Contains("api.berget.ai") ?? false;
         if (isBerget && string.IsNullOrEmpty(config.Model))
         {
-            config = config with { Model = "kimi-k3" };
+            config = config with { Model = "moonshotai/Kimi-K3" };
         }
 
         var spec = _inner.BuildPtySpec(config);

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
@@ -21,7 +21,23 @@ public sealed class OpenAiProxyPty : IAgentPty
 
     public AgentCapabilities Capabilities => _inner.Capabilities;
     public TransportKind SupportedTransports => _inner.SupportedTransports;
-    public IReadOnlyList<AgentProfileDefault> DefaultProfiles => _inner.DefaultProfiles;
+    public IReadOnlyList<AgentProfileDefault> DefaultProfiles
+    {
+        get
+        {
+            var baseUrl = _baseUrlProvider();
+            if (baseUrl != null && baseUrl.Contains("api.berget.ai"))
+            {
+                return
+                [
+                    new AgentProfileDefault(ProfileTier.Deep, "kimi-k3", null),
+                    new AgentProfileDefault(ProfileTier.Balanced, "kimi-k3", null),
+                    new AgentProfileDefault(ProfileTier.Quick, "kimi-k3", null),
+                ];
+            }
+            return _inner.DefaultProfiles;
+        }
+    }
     public string? ContextFileName => _inner.ContextFileName;
 
     public string? TranslateToolName(string canonicalTool) => _inner.TranslateToolName(canonicalTool);
@@ -30,10 +46,16 @@ public sealed class OpenAiProxyPty : IAgentPty
 
     public AgentPtySpec BuildPtySpec(AgentPtyConfig config)
     {
+        var baseUrl = _baseUrlProvider();
+        var isBerget = baseUrl?.Contains("api.berget.ai") ?? false;
+        if (isBerget && string.IsNullOrEmpty(config.Model))
+        {
+            config = config with { Model = "kimi-k3" };
+        }
+
         var spec = _inner.BuildPtySpec(config);
 
         var env = new Dictionary<string, string>(spec.Environment);
-        var baseUrl = _baseUrlProvider();
         if (!string.IsNullOrEmpty(baseUrl))
         {
             env["ANTHROPIC_BASE_URL"] = baseUrl;

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
@@ -48,9 +48,13 @@ public sealed class OpenAiProxyPty : IAgentPty
     {
         var baseUrl = _baseUrlProvider();
         var isBerget = baseUrl?.Contains("api.berget.ai") ?? false;
-        if (isBerget && string.IsNullOrEmpty(config.Model))
+        if (isBerget)
         {
-            config = config with { Model = "moonshotai/Kimi-K3" };
+            var model = config.Model;
+            if (string.IsNullOrEmpty(model) || model == "default" || model.Equals("kimi-k3", StringComparison.OrdinalIgnoreCase) || !model.Contains('/'))
+            {
+                config = config with { Model = "moonshotai/Kimi-K3" };
+            }
         }
 
         var spec = _inner.BuildPtySpec(config);

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
@@ -15,7 +15,7 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
     [
         new()
         {
-            Id = "kimi-k3", DisplayName = "Kimi k3",
+            Id = "moonshotai/Kimi-K3", DisplayName = "Kimi k3",
             Capabilities = DefaultCaps, Provider = "moonshot", IsDefault = true,
         },
         new()

--- a/src/Ivy.Tendril.Agents/Runtime/AgentValidator.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/AgentValidator.cs
@@ -41,16 +41,13 @@ public sealed class AgentValidator
             });
         }
 
-        var binaryName = cli.Id switch
-        {
-            AgentId.Antigravity => "agy",
-            AgentId.Claude => "claude",
-            AgentId.Copilot => Providers.Copilot.CopilotBinaryResolver.Resolve().FileName,
-            AgentId.OpenCode => Providers.OpenCode.OpenCodeBinaryResolver.Resolve(),
-            AgentId.Ivy => Providers.Ivy.IvyBinaryResolver.Resolve(),
-            AgentId.OpenAiProxy => Providers.Ivy.IvyBinaryResolver.Resolve(),
-            _ => cli.Id
-        };
+        var id = cli.Id;
+        var binaryName = id == AgentId.Antigravity ? "agy"
+            : (id == AgentId.Claude ? "claude"
+            : (id == AgentId.Copilot ? Providers.Copilot.CopilotBinaryResolver.Resolve().FileName
+            : (id == AgentId.OpenCode ? Providers.OpenCode.OpenCodeBinaryResolver.Resolve()
+            : (id == AgentId.Ivy || id == AgentId.OpenAiProxy ? Providers.Ivy.IvyBinaryResolver.Resolve()
+            : cli.Id))));
         if (!BinaryResolver.IsInstalled(binaryName))
         {
             problems.Add(new ValidationProblem

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -80,15 +80,15 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
     // Re-brand the generic "Agent" menu item to the configured coding agent (e.g. "Claude Code"
     // with the Claude icon), so the sidebar matches what actually launches.
-    private static MenuItem BrandAgentItem(MenuItem item, string agentId, IAgentRunner runner)
+    private static MenuItem BrandAgentItem(MenuItem item, string agentId, IAgentRunner runner, IConfigService config)
     {
         if (item.Tag is string tag && tag == AgentAppId)
         {
-            var (label, icon) = AgentBranding.For(agentId, runner);
+            var (label, icon) = AgentBranding.For(agentId, runner, config);
             item = item.Label(label).Icon(icon);
         }
         if (item.Children is { Length: > 0 })
-            item = item with { Children = item.Children.Select(c => BrandAgentItem(c, agentId, runner)).ToArray() };
+            item = item with { Children = item.Children.Select(c => BrandAgentItem(c, agentId, runner, config)).ToArray() };
         return item;
     }
 
@@ -110,7 +110,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var agentId = config.Settings.CodingAgent;
         return repo.GetMenuItems()
             .Select(m => AddBadge(m, badges))
-            .Select(m => BrandAgentItem(m, agentId, runner))
+            .Select(m => BrandAgentItem(m, agentId, runner, config))
             .ToArray();
     }
 
@@ -233,7 +233,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         {
             if (app.Id == AgentAppId)
             {
-                var (label, icon) = AgentBranding.For(config.Settings.CodingAgent, agentRunner);
+                var (label, icon) = AgentBranding.For(config.Settings.CodingAgent, agentRunner, config);
                 return (label, icon);
             }
             return (app.Title, app.Icon);

--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -97,6 +97,17 @@ public class AgentApp : ViewBase
             configuredModel = agentConfig?.Profiles.FirstOrDefault(p => !string.IsNullOrEmpty(p.Model) && p.Model != "default")?.Model;
         }
 
+        var isBergetAgent = agentId.Equals("berget", StringComparison.OrdinalIgnoreCase) ||
+            (agentConfig != null && agentConfig.EnvironmentVariables.TryGetValue("ANTHROPIC_BASE_URL", out var url) && url.Contains("api.berget.ai"));
+
+        if (isBergetAgent)
+        {
+            if (string.IsNullOrEmpty(configuredModel) || configuredModel == "default" || configuredModel.Equals("kimi-k3", StringComparison.OrdinalIgnoreCase) || !configuredModel.Contains('/'))
+            {
+                configuredModel = "moonshotai/Kimi-K3";
+            }
+        }
+
         var model = pty?.Id == AgentId.Claude ? "default" : configuredModel;
 
         var spec = pty?.BuildPtySpec(new AgentPtyConfig

--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -89,7 +89,15 @@ public class AgentApp : ViewBase
         WriteAgentInstructionsIfNeeded(workDir, systemPrompt, pty);
 
         // Claude takes "--model default" to explicitly select its configured default model.
-        var model = pty?.Id == AgentId.Claude ? "default" : null;
+        var agentConfig = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
+        var configuredModel = agentConfig?.Profiles.FirstOrDefault(p => p.Name.Equals("balanced", StringComparison.OrdinalIgnoreCase))?.Model;
+        if (string.IsNullOrEmpty(configuredModel) || configuredModel == "default")
+        {
+            configuredModel = agentConfig?.Profiles.FirstOrDefault(p => !string.IsNullOrEmpty(p.Model) && p.Model != "default")?.Model;
+        }
+
+        var model = pty?.Id == AgentId.Claude ? "default" : configuredModel;
 
         var spec = pty?.BuildPtySpec(new AgentPtyConfig
         {

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -96,7 +96,7 @@ public class ChatApp : ViewBase
 
         var agentDtos = registeredAgentIds.Select(id =>
         {
-            var (label, _) = AgentBranding.For(id, agentRunner);
+            var (label, _) = AgentBranding.For(id, agentRunner, configService);
             return new AgentOptionDto(id, label);
         }).ToList();
 

--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -31,7 +31,7 @@ public class ActionBarView(
         var client = UseService<IClientProvider>();
         var nav = UseNavigation();
         var agentRunner = UseService<IAgentRunner>();
-        var (agentLabel, agentIcon) = AgentBranding.For(config.Settings.CodingAgent, agentRunner);
+        var (agentLabel, agentIcon) = AgentBranding.For(config.Settings.CodingAgent, agentRunner, config);
 
         if (isEditingState.Value)
         {

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -100,7 +100,7 @@ public class CreatePlanDialog(
         });
 
         // e.g. "Continue with Claude Code" — branded to the configured coding agent.
-        var continueLabel = $"Chat with {AgentBranding.For(configService.Settings.CodingAgent, agentRunner).Label}";
+        var continueLabel = $"Chat with {AgentBranding.For(configService.Settings.CodingAgent, agentRunner, configService).Label}";
 
         var planWasCreated = false;
         void HandleClose()

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -70,7 +70,7 @@ public class CodingAgentStepView(
     [
         new("openaiproxy_card", "OpenAI", Icons.OpenAI),
         new("anthropic_card", "Anthropic", Icons.ClaudeCode),
-        new("berget_card", "Berget AI", Icons.Server)
+        new("berget_card", "Berget AI", Icons.ChevronUp)
     ];
 
     public override object Build()

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -171,6 +171,10 @@ public class CodingAgentStepView(
 
                                SaveOpenAiProxyBaseUrl(config, baseUrl);
                                SaveOpenAiProxyApiKey(config, openAiProxyApiKey.Value);
+                               if (isBergetCard)
+                               {
+                                   SaveProfiles(config, "openaiproxy", "kimi-k3", "kimi-k3", "kimi-k3");
+                               }
 
                                config.SaveSettings();
                                _ = RunFlowAsync("openaiproxy");
@@ -476,5 +480,35 @@ public class CodingAgentStepView(
         {
             ac.EnvironmentVariables["ANTHROPIC_BASE_URL"] = url;
         }
+    }
+
+    private static void SaveProfiles(IConfigService config, string agentId, string deep, string balanced, string quick)
+    {
+        var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
+
+        if (ac == null)
+        {
+            ac = new AgentConfig { Name = agentId };
+            config.Settings.CodingAgents.Add(ac);
+        }
+
+        SetProfileModel(ac, "deep", deep);
+        SetProfileModel(ac, "balanced", balanced);
+        SetProfileModel(ac, "quick", quick);
+    }
+
+    private static void SetProfileModel(AgentConfig ac, string profileName, string model)
+    {
+        var profile = ac.Profiles.FirstOrDefault(p =>
+            p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+
+        if (profile == null)
+        {
+            profile = new AgentProfileConfig { Name = profileName };
+            ac.Profiles.Add(profile);
+        }
+
+        profile.Model = model;
     }
 }

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -173,7 +173,7 @@ public class CodingAgentStepView(
                                SaveOpenAiProxyApiKey(config, openAiProxyApiKey.Value);
                                if (isBergetCard)
                                {
-                                   SaveProfiles(config, "openaiproxy", "kimi-k3", "kimi-k3", "kimi-k3");
+                                   SaveProfiles(config, "openaiproxy", "moonshotai/Kimi-K3", "moonshotai/Kimi-K3", "moonshotai/Kimi-K3");
                                }
 
                                config.SaveSettings();

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -69,7 +69,8 @@ public class CodingAgentStepView(
     private static readonly ByoAgentInfo[] ByoAgents =
     [
         new("openaiproxy_card", "OpenAI", Icons.OpenAI),
-        new("anthropic_card", "Anthropic", Icons.ClaudeCode)
+        new("anthropic_card", "Anthropic", Icons.ClaudeCode),
+        new("berget_card", "Berget AI", Icons.Server)
     ];
 
     public override object Build()
@@ -107,33 +108,40 @@ public class CodingAgentStepView(
             {
                 selectedAgent.Set(agentKey);
                 error.Set(null);
-                if (agentKey != "openaiproxy_card" && agentKey != "anthropic_card")
+                if (agentKey != "openaiproxy_card" && agentKey != "anthropic_card" && agentKey != "berget_card")
                 {
                     _ = RunFlowAsync(agentKey);
                 }
             }, error.Value);
         }
 
-        if (progressMessage.Value is null && (selectedAgent.Value == "openaiproxy_card" || selectedAgent.Value == "anthropic_card"))
+        if (progressMessage.Value is null && (selectedAgent.Value == "openaiproxy_card" || selectedAgent.Value == "anthropic_card" || selectedAgent.Value == "berget_card"))
         {
             var isAnthropicCard = selectedAgent.Value == "anthropic_card";
-            var cardTitle = isAnthropicCard ? "Setup Anthropic" : "Setup OpenAI";
-            var defaultUrl = isAnthropicCard ? "https://api.anthropic.com/v1" : "https://api.openai.com";
+            var isBergetCard = selectedAgent.Value == "berget_card";
+            var cardTitle = isBergetCard ? "Setup Berget AI" : (isAnthropicCard ? "Setup Anthropic" : "Setup OpenAI");
+            var defaultUrl = isBergetCard ? "https://api.berget.ai/v1" : (isAnthropicCard ? "https://api.anthropic.com/v1" : "https://api.openai.com");
 
             if (string.IsNullOrWhiteSpace(openAiProxyBaseUrl.Value) ||
-                (isAnthropicCard && openAiProxyBaseUrl.Value == "https://api.openai.com") ||
-                (!isAnthropicCard && openAiProxyBaseUrl.Value == "https://api.anthropic.com/v1"))
+                (isBergetCard && !openAiProxyBaseUrl.Value.Contains("api.berget.ai")) ||
+                (isAnthropicCard && (openAiProxyBaseUrl.Value == "https://api.openai.com" || openAiProxyBaseUrl.Value.Contains("api.berget.ai"))) ||
+                (!isAnthropicCard && !isBergetCard && (openAiProxyBaseUrl.Value.Contains("api.anthropic.com") || openAiProxyBaseUrl.Value.Contains("api.berget.ai"))))
             {
                 openAiProxyBaseUrl.Set(defaultUrl);
             }
 
-            object agentInputs = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
-                | openAiProxyBaseUrl.ToTextInput(defaultUrl)
-                    .WithField()
-                    .Label("API Base URL")
-                | openAiProxyApiKey.ToPasswordInput("sk-...")
-                    .WithField()
-                    .Label("API Key");
+            object agentInputs = isBergetCard
+                ? (Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                    | openAiProxyApiKey.ToPasswordInput("...")
+                        .WithField()
+                        .Label("API Key"))
+                : (Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                    | openAiProxyBaseUrl.ToTextInput(defaultUrl)
+                        .WithField()
+                        .Label("API Base URL")
+                    | openAiProxyApiKey.ToPasswordInput("sk-...")
+                        .WithField()
+                        .Label("API Key"));
 
             return Layout.Vertical().Margin(0, 0, 0, 2)
                    | Text.H3(cardTitle)
@@ -157,7 +165,7 @@ public class CodingAgentStepView(
                                    return;
                                }
 
-                               var baseUrl = string.IsNullOrWhiteSpace(openAiProxyBaseUrl.Value)
+                               var baseUrl = isBergetCard || string.IsNullOrWhiteSpace(openAiProxyBaseUrl.Value)
                                    ? defaultUrl
                                    : openAiProxyBaseUrl.Value;
 
@@ -171,9 +179,10 @@ public class CodingAgentStepView(
         }
 
         var selectedLabel = Agents.FirstOrDefault(a => a.Key == selectedAgent.Value)?.Label
-            ?? (selectedAgent.Value == "openaiproxy_card" ? "OpenAI"
+            ?? (selectedAgent.Value == "berget_card" ? "Berget AI"
+            : (selectedAgent.Value == "openaiproxy_card" ? "OpenAI"
             : (selectedAgent.Value == "anthropic_card" ? "Anthropic"
-            : (selectedAgent.Value == "openaiproxy" ? "OpenAI Proxy" : selectedAgent.Value)));
+            : (selectedAgent.Value == "openaiproxy" ? "OpenAI Proxy" : selectedAgent.Value))));
 
         return Layout.Vertical().Margin(0, 0, 0, 2)
                | Text.Block(progressMessage.Value ?? $"Setting Up {selectedLabel}")

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -428,7 +428,7 @@ public class ContentView(
         IAgentRunner agentRunner,
         IState<List<DraftComment>> draftComments)
     {
-        var (agentLabel, agentIcon) = AgentBranding.For(config.Settings.CodingAgent, agentRunner);
+        var (agentLabel, agentIcon) = AgentBranding.For(config.Settings.CodingAgent, agentRunner, config);
 
         // Standard overflow menu items
         var standardOverflowItems = new[]

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -37,9 +37,11 @@ public class CodingAgentSetupView : ViewBase
                 : (config.Settings.CodingAgent == "ivy"
                     ? "openaiproxy_card"
                     : (config.Settings.CodingAgent == "openaiproxy"
-                        ? (GetOpenAiProxyBaseUrlFromConfig(config).Contains("api.anthropic.com")
-                            ? "anthropic_card"
-                            : "openaiproxy_card")
+                        ? (GetOpenAiProxyBaseUrlFromConfig(config).Contains("api.berget.ai")
+                            ? "berget_card"
+                            : (GetOpenAiProxyBaseUrlFromConfig(config).Contains("api.anthropic.com")
+                                ? "anthropic_card"
+                                : "openaiproxy_card"))
                         : config.Settings.CodingAgent))
         );
 
@@ -71,7 +73,7 @@ public class CodingAgentSetupView : ViewBase
         var modelsQuery = UseQuery<ModelInfo[], string>(
             selectedAgent.Value == "openaiproxy_card"
                 ? (openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app") ? "ivy" : "openaiproxy")
-                : (selectedAgent.Value == "anthropic_card" ? "openaiproxy" : selectedAgent.Value),
+                : (selectedAgent.Value == "anthropic_card" || selectedAgent.Value == "berget_card" ? "openaiproxy" : selectedAgent.Value),
             async (agentId, ct) =>
             {
                 var catalog = runner.GetModelCatalog(agentId);
@@ -107,7 +109,7 @@ public class CodingAgentSetupView : ViewBase
 
         var realAgentId = selectedAgent.Value == "openaiproxy_card"
             ? (openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app") ? "ivy" : "openaiproxy")
-            : (selectedAgent.Value == "anthropic_card" ? "openaiproxy" : selectedAgent.Value);
+            : (selectedAgent.Value == "anthropic_card" || selectedAgent.Value == "berget_card" ? "openaiproxy" : selectedAgent.Value);
 
         if (lastRealAgent.Value != realAgentId)
         {
@@ -128,11 +130,12 @@ public class CodingAgentSetupView : ViewBase
 
         var isIvy = selectedAgent.Value == "openaiproxy_card" && openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app");
         var isAnthropic = selectedAgent.Value == "anthropic_card";
+        var isBerget = selectedAgent.Value == "berget_card";
         var isOpenAi = selectedAgent.Value == "openaiproxy_card" && !isIvy;
 
         string finalAgent;
         if (isIvy) finalAgent = "ivy";
-        else if (isAnthropic || isOpenAi) finalAgent = "openaiproxy";
+        else if (isBerget || isAnthropic || isOpenAi) finalAgent = "openaiproxy";
         else finalAgent = selectedAgent.Value;
 
         var hasAgentChanges = finalAgent != config.Settings.CodingAgent;
@@ -149,6 +152,10 @@ public class CodingAgentSetupView : ViewBase
         if (isIvy)
         {
             hasCredsChanged = openAiProxyApiKey.Value != currentIvyKey;
+        }
+        else if (isBerget)
+        {
+            hasCredsChanged = openAiProxyApiKey.Value != currentOpenAiKey || !currentOpenAiBaseUrl.Contains("api.berget.ai");
         }
         else if (isAnthropic)
         {
@@ -187,7 +194,8 @@ public class CodingAgentSetupView : ViewBase
         var byoAgents = new[]
         {
             new ByoAgentInfo("openaiproxy_card", "OpenAI", Icons.OpenAI),
-            new ByoAgentInfo("anthropic_card", "Anthropic", Icons.ClaudeCode)
+            new ByoAgentInfo("anthropic_card", "Anthropic", Icons.ClaudeCode),
+            new ByoAgentInfo("berget_card", "Berget AI", Icons.Server)
         };
 
         var byoGrid = Layout.Grid()
@@ -202,13 +210,17 @@ public class CodingAgentSetupView : ViewBase
             ).Width(Size.Full()).Height(Size.Full()).OnClick(() =>
             {
                 selectedAgent.Set(a.Key);
-                if (a.Key == "openaiproxy_card" && openAiProxyBaseUrl.Value.Contains("api.anthropic.com"))
+                if (a.Key == "openaiproxy_card" && (openAiProxyBaseUrl.Value.Contains("api.anthropic.com") || openAiProxyBaseUrl.Value.Contains("api.berget.ai")))
                 {
                     openAiProxyBaseUrl.Set("https://api.openai.com");
                 }
-                else if (a.Key == "anthropic_card" && (string.IsNullOrEmpty(openAiProxyBaseUrl.Value) || openAiProxyBaseUrl.Value.Contains("api.openai.com")))
+                else if (a.Key == "anthropic_card" && (string.IsNullOrEmpty(openAiProxyBaseUrl.Value) || openAiProxyBaseUrl.Value.Contains("api.openai.com") || openAiProxyBaseUrl.Value.Contains("api.berget.ai")))
                 {
                     openAiProxyBaseUrl.Set("https://api.anthropic.com/v1");
+                }
+                else if (a.Key == "berget_card" && (string.IsNullOrEmpty(openAiProxyBaseUrl.Value) || openAiProxyBaseUrl.Value.Contains("api.openai.com") || openAiProxyBaseUrl.Value.Contains("api.anthropic.com")))
+                {
+                    openAiProxyBaseUrl.Set("https://api.berget.ai/v1");
                 }
             }));
 
@@ -230,6 +242,13 @@ public class CodingAgentSetupView : ViewBase
                     .WithField()
                     .Label("API Base URL")
                 | openAiProxyApiKey.ToPasswordInput("sk-...")
+                    .WithField()
+                    .Label("API Key");
+        }
+        else if (selectedAgent.Value == "berget_card")
+        {
+            agentInputs = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                | openAiProxyApiKey.ToPasswordInput("...")
                     .WithField()
                     .Label("API Key");
         }
@@ -278,6 +297,15 @@ public class CodingAgentSetupView : ViewBase
                                SaveIvyApiKey(config, openAiProxyApiKey.Value);
                                SaveOpenAiProxyApiKey(config, "");
                                SaveOpenAiProxyBaseUrl(config, "");
+                           }
+                           else if (isBerget)
+                           {
+                               var baseUrl = string.IsNullOrWhiteSpace(openAiProxyBaseUrl.Value) || !openAiProxyBaseUrl.Value.Contains("api.berget.ai")
+                                   ? "https://api.berget.ai/v1"
+                                   : openAiProxyBaseUrl.Value;
+                               SaveOpenAiProxyBaseUrl(config, baseUrl);
+                               SaveOpenAiProxyApiKey(config, openAiProxyApiKey.Value);
+                               SaveIvyApiKey(config, "");
                            }
                            else if (isAnthropic)
                            {

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -199,7 +199,7 @@ public class CodingAgentSetupView : ViewBase
         {
             new ByoAgentInfo("openaiproxy_card", "OpenAI", Icons.OpenAI),
             new ByoAgentInfo("anthropic_card", "Anthropic", Icons.ClaudeCode),
-            new ByoAgentInfo("berget_card", "Berget AI", Icons.Server)
+            new ByoAgentInfo("berget_card", "Berget AI", Icons.ChevronUp)
         };
 
         var byoGrid = Layout.Grid()

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Net.Http;
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Ivy;
 using Ivy.Tendril.Apps.Settings.Dialogs;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
@@ -314,51 +315,46 @@ public class CodingAgentSetupView : ViewBase
             var hasUpdate = !string.IsNullOrEmpty(latestIvyVersion.Value) &&
                 !string.Equals(installedIvyVersion.Value, latestIvyVersion.Value, StringComparison.OrdinalIgnoreCase);
 
-            ivyAgentUpdateCard = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
-                | new Card(
-                    Layout.Vertical()
-                    | (Layout.Horizontal()
-                        | Text.Block("Ivy Agent CLI Status").Bold()
-                        | new Spacer()
-                        | (isCheckingIvyUpdate.Value
-                            ? Text.Muted("Checking update...").Small()
-                            : (hasUpdate
-                                ? new Badge($"Update Available: {installedIvyVersion.Value ?? "Not Installed"} → {latestIvyVersion.Value}", BadgeVariant.Warning)
-                                : new Badge($"Up to Date ({installedIvyVersion.Value ?? "Installed"})", BadgeVariant.Success))))
-                    | (hasUpdate
-                        ? (object)(Layout.Vertical()
-                            | Text.Muted($"A newer version of the Ivy Agent CLI ({latestIvyVersion.Value}) is available on the CDN.").Small()
-                            | (ivyUpdateError.Value != null ? Text.Danger(ivyUpdateError.Value).Small() : null!)
-                            | new Button(isIvyUpdating.Value ? "Updating Ivy Agent CLI..." : "Update Ivy Agent CLI")
-                                .Primary()
-                                .Disabled(isIvyUpdating.Value)
-                                .OnClick(async () =>
+            if (hasUpdate)
+            {
+                ivyAgentUpdateCard = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                    | new Card(
+                        Layout.Vertical()
+                        | (Layout.Horizontal()
+                            | Text.Block("Update Client").Bold()
+                            | new Spacer()
+                            | new Badge($"Update Available: {installedIvyVersion.Value ?? "Not Installed"} → {latestIvyVersion.Value}", BadgeVariant.Warning))
+                        | (ivyUpdateError.Value != null ? Text.Danger(ivyUpdateError.Value).Small() : null!)
+                        | new Button(isIvyUpdating.Value ? "Updating Ivy Agent CLI..." : "Update Ivy Agent CLI")
+                            .Primary()
+                            .Disabled(isIvyUpdating.Value)
+                            .OnClick(async () =>
+                            {
+                                isIvyUpdating.Set(true);
+                                ivyUpdateError.Set(null);
+                                try
                                 {
-                                    isIvyUpdating.Set(true);
-                                    ivyUpdateError.Set(null);
-                                    try
+                                    var success = await InstallIvyAgentAsync(client);
+                                    if (success)
                                     {
-                                        var success = await InstallIvyAgentAsync(client);
-                                        if (success)
-                                        {
-                                            await checkIvyInstall();
-                                        }
-                                        else
-                                        {
-                                            ivyUpdateError.Set("Installation failed.");
-                                        }
+                                        await checkIvyInstall();
                                     }
-                                    catch (Exception ex)
+                                    else
                                     {
-                                        ivyUpdateError.Set(ex.Message);
+                                        ivyUpdateError.Set("Installation failed.");
                                     }
-                                    finally
-                                    {
-                                        isIvyUpdating.Set(false);
-                                    }
-                                }))
-                        : null!)
-                );
+                                }
+                                catch (Exception ex)
+                                {
+                                    ivyUpdateError.Set(ex.Message);
+                                }
+                                finally
+                                {
+                                    isIvyUpdating.Set(false);
+                                }
+                            })
+                    );
+            }
         }
 
         return Layout.Vertical()
@@ -677,6 +673,21 @@ public class CodingAgentSetupView : ViewBase
             string destPath = Path.Combine(installDir, binaryName);
             if (File.Exists(destPath)) File.Delete(destPath);
             File.Move(binarySource, destPath);
+
+            var localBin = Path.Combine(home, ".local", "bin", binaryName);
+            if (File.Exists(localBin))
+            {
+                try
+                {
+                    File.Copy(destPath, localBin, overwrite: true);
+                }
+                catch
+                {
+                    // Ignore quiet copy issues to localBin if locked
+                }
+            }
+
+            IvyBinaryResolver.ResetCache();
             
             if (os != "windows")
             {

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -118,9 +118,9 @@ public class CodingAgentSetupView : ViewBase
             var balanced = GetProfileModel(config, realAgentId, "balanced");
             var quick = GetProfileModel(config, realAgentId, "quick");
 
-            deepModel.Set(deep == "default" && isBerget ? "kimi-k3" : deep);
-            balancedModel.Set(balanced == "default" && isBerget ? "kimi-k3" : balanced);
-            quickModel.Set(quick == "default" && isBerget ? "kimi-k3" : quick);
+            deepModel.Set(deep == "default" && isBerget ? "moonshotai/Kimi-K3" : deep);
+            balancedModel.Set(balanced == "default" && isBerget ? "moonshotai/Kimi-K3" : balanced);
+            quickModel.Set(quick == "default" && isBerget ? "moonshotai/Kimi-K3" : quick);
             ollamaUrl.Set(GetOllamaUrlFromConfig(config, realAgentId));
             lastRealAgent.Set(realAgentId);
             testAgentId.Set(realAgentId);
@@ -228,9 +228,9 @@ public class CodingAgentSetupView : ViewBase
                     {
                         openAiProxyBaseUrl.Set("https://api.berget.ai/v1");
                     }
-                    if (deepModel.Value == "default") deepModel.Set("kimi-k3");
-                    if (balancedModel.Value == "default") balancedModel.Set("kimi-k3");
-                    if (quickModel.Value == "default") quickModel.Set("kimi-k3");
+                    if (deepModel.Value == "default") deepModel.Set("moonshotai/Kimi-K3");
+                    if (balancedModel.Value == "default") balancedModel.Set("moonshotai/Kimi-K3");
+                    if (quickModel.Value == "default") quickModel.Set("moonshotai/Kimi-K3");
                 }
             }));
 

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -107,15 +107,20 @@ public class CodingAgentSetupView : ViewBase
             await checkIvyInstall();
         }, selectedAgent);
 
+        var isBerget = selectedAgent.Value == "berget_card";
         var realAgentId = selectedAgent.Value == "openaiproxy_card"
             ? (openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app") ? "ivy" : "openaiproxy")
-            : (selectedAgent.Value == "anthropic_card" || selectedAgent.Value == "berget_card" ? "openaiproxy" : selectedAgent.Value);
+            : (selectedAgent.Value == "anthropic_card" || isBerget ? "openaiproxy" : selectedAgent.Value);
 
-        if (lastRealAgent.Value != realAgentId)
+        if (lastRealAgent.Value != realAgentId || (isBerget && deepModel.Value == "default"))
         {
-            deepModel.Set(GetProfileModel(config, realAgentId, "deep"));
-            balancedModel.Set(GetProfileModel(config, realAgentId, "balanced"));
-            quickModel.Set(GetProfileModel(config, realAgentId, "quick"));
+            var deep = GetProfileModel(config, realAgentId, "deep");
+            var balanced = GetProfileModel(config, realAgentId, "balanced");
+            var quick = GetProfileModel(config, realAgentId, "quick");
+
+            deepModel.Set(deep == "default" && isBerget ? "kimi-k3" : deep);
+            balancedModel.Set(balanced == "default" && isBerget ? "kimi-k3" : balanced);
+            quickModel.Set(quick == "default" && isBerget ? "kimi-k3" : quick);
             ollamaUrl.Set(GetOllamaUrlFromConfig(config, realAgentId));
             lastRealAgent.Set(realAgentId);
             testAgentId.Set(realAgentId);
@@ -130,7 +135,6 @@ public class CodingAgentSetupView : ViewBase
 
         var isIvy = selectedAgent.Value == "openaiproxy_card" && openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app");
         var isAnthropic = selectedAgent.Value == "anthropic_card";
-        var isBerget = selectedAgent.Value == "berget_card";
         var isOpenAi = selectedAgent.Value == "openaiproxy_card" && !isIvy;
 
         string finalAgent;
@@ -218,9 +222,15 @@ public class CodingAgentSetupView : ViewBase
                 {
                     openAiProxyBaseUrl.Set("https://api.anthropic.com/v1");
                 }
-                else if (a.Key == "berget_card" && (string.IsNullOrEmpty(openAiProxyBaseUrl.Value) || openAiProxyBaseUrl.Value.Contains("api.openai.com") || openAiProxyBaseUrl.Value.Contains("api.anthropic.com")))
+                else if (a.Key == "berget_card")
                 {
-                    openAiProxyBaseUrl.Set("https://api.berget.ai/v1");
+                    if (string.IsNullOrEmpty(openAiProxyBaseUrl.Value) || openAiProxyBaseUrl.Value.Contains("api.openai.com") || openAiProxyBaseUrl.Value.Contains("api.anthropic.com"))
+                    {
+                        openAiProxyBaseUrl.Set("https://api.berget.ai/v1");
+                    }
+                    if (deepModel.Value == "default") deepModel.Set("kimi-k3");
+                    if (balancedModel.Value == "default") balancedModel.Set("kimi-k3");
+                    if (quickModel.Value == "default") quickModel.Set("kimi-k3");
                 }
             }));
 

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -84,21 +84,52 @@ public class CodingAgentSetupView : ViewBase
             initialValue: []
         );
 
+        var tendrilArgs = UseService<TendrilArgs>();
+        var installedIvyVersion = UseState<string?>(null);
+        var latestIvyVersion = UseState<string?>(null);
+        var isCheckingIvyUpdate = UseState(false);
+        var isIvyUpdating = UseState(false);
+        var ivyUpdateError = UseState<string?>(null);
         var isIvyInstalled = UseState(false);
         var isInstalling = UseState(false);
         var installError = UseState<string?>(null);
 
         var checkIvyInstall = async () =>
         {
-            var hc = runner.GetHealthCheck("ivy") ?? runner.GetHealthCheck("openaiproxy");
+            var hc = runner.GetHealthCheck("ivy") ?? runner.GetHealthCheck("openaiproxy") ?? runner.GetHealthCheck("opencode");
             if (hc != null)
             {
                 var status = await hc.CheckInstallAsync();
                 isIvyInstalled.Set(status.IsInstalled);
+                installedIvyVersion.Set(status.Version);
             }
             else
             {
                 isIvyInstalled.Set(false);
+                installedIvyVersion.Set(null);
+            }
+
+            if (tendrilArgs.Beta && (selectedAgent.Value == "openaiproxy_card" || selectedAgent.Value == "anthropic_card" || selectedAgent.Value == "berget_card" || selectedAgent.Value == "ivy_card" || selectedAgent.Value == "opencode"))
+            {
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        isCheckingIvyUpdate.Set(true);
+                        using var http = new HttpClient();
+                        http.DefaultRequestHeaders.UserAgent.ParseAdd("IvyTendril");
+                        var latest = (await http.GetStringAsync("https://cdn.ivy.app/ivy-agent-cli/releases/latest.txt")).Trim();
+                        latestIvyVersion.Set(latest);
+                    }
+                    catch
+                    {
+                        // Ignore quiet errors for background check
+                    }
+                    finally
+                    {
+                        isCheckingIvyUpdate.Set(false);
+                    }
+                });
             }
         };
 
@@ -277,6 +308,59 @@ public class CodingAgentSetupView : ViewBase
             | balancedModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Balanced")
             | quickModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Quick");
 
+        object? ivyAgentUpdateCard = null;
+        if (tendrilArgs.Beta && (selectedAgent.Value == "openaiproxy_card" || selectedAgent.Value == "anthropic_card" || selectedAgent.Value == "berget_card" || selectedAgent.Value == "ivy_card" || selectedAgent.Value == "opencode"))
+        {
+            var hasUpdate = !string.IsNullOrEmpty(latestIvyVersion.Value) &&
+                !string.Equals(installedIvyVersion.Value, latestIvyVersion.Value, StringComparison.OrdinalIgnoreCase);
+
+            ivyAgentUpdateCard = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                | new Card(
+                    Layout.Vertical()
+                    | (Layout.Horizontal()
+                        | Text.Block("Ivy Agent CLI Status").Bold()
+                        | new Spacer()
+                        | (isCheckingIvyUpdate.Value
+                            ? Text.Muted("Checking update...").Small()
+                            : (hasUpdate
+                                ? new Badge($"Update Available: {installedIvyVersion.Value ?? "Not Installed"} → {latestIvyVersion.Value}", BadgeVariant.Warning)
+                                : new Badge($"Up to Date ({installedIvyVersion.Value ?? "Installed"})", BadgeVariant.Success))))
+                    | (hasUpdate
+                        ? (object)(Layout.Vertical()
+                            | Text.Muted($"A newer version of the Ivy Agent CLI ({latestIvyVersion.Value}) is available on the CDN.").Small()
+                            | (ivyUpdateError.Value != null ? Text.Danger(ivyUpdateError.Value).Small() : null!)
+                            | new Button(isIvyUpdating.Value ? "Updating Ivy Agent CLI..." : "Update Ivy Agent CLI")
+                                .Primary()
+                                .Disabled(isIvyUpdating.Value)
+                                .OnClick(async () =>
+                                {
+                                    isIvyUpdating.Set(true);
+                                    ivyUpdateError.Set(null);
+                                    try
+                                    {
+                                        var success = await InstallIvyAgentAsync(client);
+                                        if (success)
+                                        {
+                                            await checkIvyInstall();
+                                        }
+                                        else
+                                        {
+                                            ivyUpdateError.Set("Installation failed.");
+                                        }
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        ivyUpdateError.Set(ex.Message);
+                                    }
+                                    finally
+                                    {
+                                        isIvyUpdating.Set(false);
+                                    }
+                                }))
+                        : null!)
+                );
+        }
+
         return Layout.Vertical()
                | Text.Block("Coding Agent").Bold()
                | (Layout.Vertical()
@@ -290,6 +374,7 @@ public class CodingAgentSetupView : ViewBase
                            | byoGrid.Width(Size.Full())))
                    : null!)
                | agentInputs
+               | ivyAgentUpdateCard
                | profileModels
                | new Spacer()
                | (Layout.Horizontal()

--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -33,7 +33,7 @@ public class JobDebugSheet(
             if (job is null) return null;
             // Snapshot branding + details while the job is live, so confirming always navigates
             // even if the job is evicted between opening the dialog and clicking the button.
-            var branding = AgentBranding.For(config.Settings.CodingAgent, agentRunner);
+            var branding = AgentBranding.For(config.Settings.CodingAgent, agentRunner, config);
             var details = FormatCopyDetails(BuildData(job));
             return new DebugWithAgentDialog(isOpen, branding, focus =>
             {
@@ -97,7 +97,7 @@ public class JobDebugSheet(
         // `.Label()` API takes lambda expressions and can't be shared with the copy projection).
         var copyDetails = FormatCopyDetails(data);
 
-        var agentBranding = AgentBranding.For(config.Settings.CodingAgent, agentRunner);
+        var agentBranding = AgentBranding.For(config.Settings.CodingAgent, agentRunner, config);
 
         var header = Layout.Horizontal().Gap(2)
                      | new Button("Copy Details").Icon(Icons.ClipboardCopy).Outline().OnClick(() =>

--- a/src/Ivy.Tendril/Helpers/AgentBranding.cs
+++ b/src/Ivy.Tendril/Helpers/AgentBranding.cs
@@ -18,12 +18,26 @@ public static class AgentBranding
     public const string DefaultLabel = "Agent";
 
     /// <summary>Maps a coding agent id to its logo icon, falling back to <see cref="DefaultIcon"/>.</summary>
-    public static Icons IconFor(string? agentId)
+    public static Icons IconFor(string? agentId, IConfigService? config = null)
     {
         if (string.IsNullOrWhiteSpace(agentId))
             return DefaultIcon;
 
-        return AgentProviderFactory.NormalizeAgentName(agentId) switch
+        var normalized = AgentProviderFactory.NormalizeAgentName(agentId);
+        if (config != null && normalized.Equals("openaiproxy", StringComparison.OrdinalIgnoreCase))
+        {
+            var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
+                AgentProviderFactory.NormalizeAgentName(a.Name).Equals("openaiproxy", StringComparison.OrdinalIgnoreCase));
+            if (ac != null && ac.EnvironmentVariables.TryGetValue("ANTHROPIC_BASE_URL", out var url))
+            {
+                if (url.Contains("api.berget.ai"))
+                    return Icons.ChevronUp;
+                if (url.Contains("api.anthropic.com"))
+                    return Icons.ClaudeCode;
+            }
+        }
+
+        return normalized switch
         {
             AgentId.Claude => Icons.ClaudeCode,
             AgentId.Copilot => Icons.Copilot,
@@ -43,9 +57,31 @@ public static class AgentBranding
     /// falling back gracefully to <see cref="DefaultLabel"/>/<see cref="DefaultIcon"/>
     /// for unknown or unregistered agents.
     /// </summary>
-    public static (string Label, Icons Icon) For(string? agentId, IAgentRunner runner)
+    public static (string Label, Icons Icon) For(string? agentId, IAgentRunner runner, IConfigService? config = null)
     {
-        var icon = IconFor(agentId);
+        if (config != null && AgentProviderFactory.NormalizeAgentName(agentId).Equals("openaiproxy", StringComparison.OrdinalIgnoreCase))
+        {
+            var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
+                AgentProviderFactory.NormalizeAgentName(a.Name).Equals("openaiproxy", StringComparison.OrdinalIgnoreCase));
+            if (ac != null && ac.EnvironmentVariables.TryGetValue("ANTHROPIC_BASE_URL", out var url))
+            {
+                if (url.Contains("api.berget.ai"))
+                {
+                    return ("Berget AI", Icons.ChevronUp);
+                }
+                if (url.Contains("api.anthropic.com"))
+                {
+                    return ("Anthropic", Icons.ClaudeCode);
+                }
+            }
+        }
+
+        if (AgentProviderFactory.NormalizeAgentName(agentId).Equals("berget", StringComparison.OrdinalIgnoreCase))
+        {
+            return ("Berget AI", Icons.ChevronUp);
+        }
+
+        var icon = IconFor(agentId, config);
 
         if (string.IsNullOrWhiteSpace(agentId))
             return (DefaultLabel, icon);

--- a/src/Ivy.Tendril/Helpers/AgentBranding.cs
+++ b/src/Ivy.Tendril/Helpers/AgentBranding.cs
@@ -33,6 +33,7 @@ public static class AgentBranding
             AgentId.OpenCode => Icons.OpenCode,
             AgentId.Ivy => Icons.IvyCorner,
             AgentId.OpenAiProxy => Icons.OpenAI,
+            AgentId.Berget => Icons.ChevronUp,
             _ => DefaultIcon,
         };
     }

--- a/src/Ivy.Tendril/Helpers/AgentBranding.cs
+++ b/src/Ivy.Tendril/Helpers/AgentBranding.cs
@@ -18,6 +18,9 @@ public static class AgentBranding
     public const string DefaultLabel = "Agent";
 
     /// <summary>Maps a coding agent id to its logo icon, falling back to <see cref="DefaultIcon"/>.</summary>
+    public static Icons IconFor(AgentId agentId, IConfigService? config = null) =>
+        IconFor(agentId.Value, config);
+
     public static Icons IconFor(string? agentId, IConfigService? config = null)
     {
         if (string.IsNullOrWhiteSpace(agentId))
@@ -39,15 +42,15 @@ public static class AgentBranding
 
         return normalized switch
         {
-            AgentId.Claude => Icons.ClaudeCode,
-            AgentId.Copilot => Icons.Copilot,
-            AgentId.Codex => Icons.OpenAI,
-            AgentId.Gemini => Icons.Gemini,
-            AgentId.Antigravity => Icons.Antigravity,
-            AgentId.OpenCode => Icons.OpenCode,
-            AgentId.Ivy => Icons.IvyCorner,
-            AgentId.OpenAiProxy => Icons.OpenAI,
-            AgentId.Berget => Icons.ChevronUp,
+            var s when s == AgentId.Claude => Icons.ClaudeCode,
+            var s when s == AgentId.Copilot => Icons.Copilot,
+            var s when s == AgentId.Codex => Icons.OpenAI,
+            var s when s == AgentId.Gemini => Icons.Gemini,
+            var s when s == AgentId.Antigravity => Icons.Antigravity,
+            var s when s == AgentId.OpenCode => Icons.OpenCode,
+            var s when s == AgentId.Ivy => Icons.IvyCorner,
+            var s when s == AgentId.OpenAiProxy => Icons.OpenAI,
+            var s when s == AgentId.Berget => Icons.ChevronUp,
             _ => DefaultIcon,
         };
     }
@@ -57,6 +60,9 @@ public static class AgentBranding
     /// falling back gracefully to <see cref="DefaultLabel"/>/<see cref="DefaultIcon"/>
     /// for unknown or unregistered agents.
     /// </summary>
+    public static (string Label, Icons Icon) For(AgentId agentId, IAgentRunner runner, IConfigService? config = null) =>
+        For(agentId.Value, runner, config);
+
     public static (string Label, Icons Icon) For(string? agentId, IAgentRunner runner, IConfigService? config = null)
     {
         if (config != null && AgentProviderFactory.NormalizeAgentName(agentId).Equals("openaiproxy", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
This PR adds Berget AI support to the Bring Your Own LLM section in Settings and Onboarding when running in beta flag mode. It configures the underlying openaiproxy agent to default to https://api.berget.ai/v1 and prompts the user for 1 secret (API Key).