### PR TITLE
[00073] Render Questions Code Fences as a Blue Callout in DraftMarkdown

### DIFF
--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/AnnotationsApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/AnnotationsApp.cs
@@ -64,6 +64,11 @@ class AnnotationsApp : ViewBase
 
             > **Note:** This spec is subject to review by the platform team
             > before implementation begins.
+
+            ```questions
+            Should the retry budget be per-request or per-session?
+            What is the retention policy for read notifications?
+            ```
             """;
 
         object sidePanel;

--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/annotations.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/annotations.spec.ts
@@ -272,4 +272,26 @@ test.describe("DraftMarkdown Annotations", () => {
     await expect(highlights).toHaveCount(2);
     await stepScreenshot("both-annotations-visible");
   });
+
+  test("renders a questions callout in the sample app", async ({ page, stepScreenshot }) => {
+    const callout = page.locator(".pmv-questions");
+    await expect(callout).toBeVisible();
+    await expect(callout).toContainText("Should the retry budget be per-request or per-session?");
+    await stepScreenshot("questions-callout-visible");
+  });
+
+  test("selecting text inside a questions callout does not show the selection toolbar", async ({ page, stepScreenshot }) => {
+    const calloutContent = page.locator(".pmv-questions-content");
+    const box = await calloutContent.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.mouse.move(box!.x + 5, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width - 5, box!.y + box!.height / 2);
+    await page.mouse.up();
+
+    const toolbar = page.locator(".pmv-selection-toolbar");
+    await expect(toolbar).not.toBeVisible();
+    await stepScreenshot("no-toolbar-for-questions-selection");
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
@@ -3,7 +3,7 @@ import Markdown from "react-markdown";
 import "./agent-output.css";
 import type { EventHandler, PresentationEvent } from "./types";
 import { getHeight, getWidth } from "../styles";
-import { CodeBlock } from "../CodeBlock";
+import { BlockHandler } from "../BlockHandler";
 import { useAutoScroll } from "./use-auto-scroll";
 import { parseEventWireStream } from "./parse-events";
 import { deriveStatus } from "./status";
@@ -188,7 +188,7 @@ export const AgentViewer: React.FC<AgentViewerProps> = ({
             case "assistant-text":
               return (
                 <div key={idx} className="aov-markdown aov-assistant">
-                  <Markdown {...getMarkdownPlugins(event.text)} components={{ code: CodeBlock }}>
+                  <Markdown {...getMarkdownPlugins(event.text)} components={{ code: BlockHandler }}>
                     {event.text}
                   </Markdown>
                 </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Markdown from "react-markdown";
 import type { ResultWire } from "./types";
-import { CodeBlock } from "../CodeBlock";
+import { BlockHandler } from "../BlockHandler";
 import { getMarkdownPlugins } from "../math";
 
 interface ResultSummaryProps {
@@ -57,7 +57,7 @@ export const ResultSummary: React.FC<ResultSummaryProps> = ({ wire }) => {
           <Markdown
             remarkPlugins={plugins.remarkPlugins}
             rehypePlugins={plugins.rehypePlugins}
-            components={{ code: CodeBlock }}
+            components={{ code: BlockHandler }}
           >
             {wire.response}
           </Markdown>

--- a/src/Ivy.Tendril.Widgets/frontend/src/BlockHandler.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/BlockHandler.tsx
@@ -30,7 +30,7 @@ const codeBlockPreStyle: React.CSSProperties = {
   overflowWrap: "break-word",
 };
 
-export const CodeBlock: React.FC<React.HTMLAttributes<HTMLElement>> = ({ className, children, style: _style, ...rest }) => {
+export const BlockHandler: React.FC<React.HTMLAttributes<HTMLElement>> = ({ className, children, style: _style, ...rest }) => {
   const match = /language-(\w+)/.exec(String(className || ""));
   const content = String(children).replace(/\n$/, "");
   const [copied, setCopied] = useState(false);

--- a/src/Ivy.Tendril.Widgets/frontend/src/CodeBlock.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/CodeBlock.tsx
@@ -1,6 +1,7 @@
 import React, { lazy, Suspense, useCallback, useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { prismTheme } from "./prismTheme";
+import { QuestionsCallout } from "./DraftMarkdown/QuestionsCallout";
 
 const MermaidRenderer = lazy(() => import("./DraftMarkdown/MermaidRenderer").then((m) => ({ default: m.MermaidRenderer })));
 const GraphvizRenderer = lazy(() => import("./DraftMarkdown/GraphvizRenderer").then((m) => ({ default: m.GraphvizRenderer })));
@@ -58,6 +59,10 @@ export const CodeBlock: React.FC<React.HTMLAttributes<HTMLElement>> = ({ classNa
           <GraphvizRenderer content={content} />
         </Suspense>
       );
+    }
+
+    if (lang === "questions") {
+      return <QuestionsCallout content={content} />;
     }
 
     const normalizedLang = lang === "xml" || lang === "html" || lang === "svg" ? "markup" : lang;

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.questions.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { DraftMarkdown } from "./DraftMarkdown";
+
+const renderContent = (content: string) => {
+  const { container } = render(<DraftMarkdown id="w1" content={content} />);
+  return container;
+};
+
+describe("DraftMarkdown questions callout", () => {
+  it("renders a questions fence as a callout containing the fence text", () => {
+    const content = "```questions\nShould the retry budget be per-request or per-session?\n```";
+    const container = renderContent(content);
+
+    const callout = container.querySelector(".pmv-questions");
+    expect(callout).not.toBeNull();
+    expect(callout?.textContent).toContain("Should the retry budget be per-request or per-session?");
+  });
+
+  it("renders no code block or Prism tokens, proving it bypassed Prism", () => {
+    const content = "```questions\nWhat is the retention policy for read notifications?\n```";
+    const container = renderContent(content);
+
+    expect(container.querySelector(".pmv-code-block")).toBeNull();
+    expect(container.querySelectorAll(".token").length).toBe(0);
+  });
+
+  it("still renders a regular js fence as a code block, so the dispatch does not regress", () => {
+    const content = "```questions\nWhat about retries?\n```\n\n```js\nconst x = 1;\n```";
+    const container = renderContent(content);
+
+    expect(container.querySelector(".pmv-questions")).not.toBeNull();
+    expect(container.querySelector(".pmv-code-block")).not.toBeNull();
+  });
+
+  it("keeps line breaks for multi-line fence content", () => {
+    const content = "```questions\nFirst question?\nSecond question?\n```";
+    const container = renderContent(content);
+
+    const content_ = container.querySelector(".pmv-questions-content");
+    expect(content_).not.toBeNull();
+    expect(content_?.textContent).toBe("First question?\nSecond question?");
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
@@ -4,7 +4,7 @@ import "./draft-markdown.css";
 import { getHeight, getWidth } from "../styles";
 import { CodeBlock } from "../CodeBlock";
 import type { MarkdownAnnotation } from "./annotationUtils";
-import { applyAnnotationHighlights, getPlainTextOffset } from "./annotationUtils";
+import { applyAnnotationHighlights, getPlainTextOffset, rangeTouchesQuestions } from "./annotationUtils";
 import { AddAnnotationPopover, EditAnnotationPopover, SelectionToolbar } from "./AnnotationPopover";
 import { AlertBlockquote } from "./AlertBlockquote";
 import { ImageRenderer } from "./ImageRenderer";
@@ -92,6 +92,10 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
 
       const range = selection.getRangeAt(0);
       if (!container.contains(range.commonAncestorContainer)) {
+        return;
+      }
+
+      if (rangeTouchesQuestions(container, range)) {
         return;
       }
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import Markdown, { defaultUrlTransform } from "react-markdown";
 import "./draft-markdown.css";
 import { getHeight, getWidth } from "../styles";
-import { CodeBlock } from "../CodeBlock";
+import { BlockHandler } from "../BlockHandler";
 import type { MarkdownAnnotation } from "./annotationUtils";
 import { applyAnnotationHighlights, getPlainTextOffset, rangeTouchesQuestions } from "./annotationUtils";
 import { AddAnnotationPopover, EditAnnotationPopover, SelectionToolbar } from "./AnnotationPopover";
@@ -282,7 +282,7 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
             remarkPlugins={plugins.remarkPlugins}
             rehypePlugins={plugins.rehypePlugins}
             urlTransform={urlTransform}
-            components={{ a: anchor, code: CodeBlock, blockquote: AlertBlockquote, img: ImageRenderer }}
+            components={{ a: anchor, code: BlockHandler, blockquote: AlertBlockquote, img: ImageRenderer }}
           >
             {content}
           </Markdown>

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/QuestionsCallout.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/QuestionsCallout.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+const HelpCircleIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+    <path d="M12 17h.01" />
+  </svg>
+);
+
+export const QuestionsCallout: React.FC<{ content: string }> = ({ content }) => (
+  <div className="pmv-questions" role="note">
+    <div className="pmv-questions-header">
+      <HelpCircleIcon />
+      <span className="pmv-questions-title">Questions</span>
+    </div>
+    <div className="pmv-questions-content">{content}</div>
+  </div>
+);

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/annotationUtils.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/annotationUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { getPlainTextOffset, getPlainText } from "./annotationUtils";
+import { getPlainTextOffset, getPlainText, rangeTouchesQuestions, applyAnnotationHighlights } from "./annotationUtils";
+import type { MarkdownAnnotation } from "./annotationUtils";
 
 describe("getPlainTextOffset", () => {
   let container: HTMLDivElement;
@@ -52,5 +53,102 @@ describe("getPlainText", () => {
 
   it("returns empty string for empty container", () => {
     expect(getPlainText(container)).toBe("");
+  });
+});
+
+describe("rangeTouchesQuestions", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    container.innerHTML =
+      '<p>Some prose before.</p><div class="pmv-questions"><div class="pmv-questions-content">A question?</div></div><p>Some prose after.</p>';
+  });
+
+  it("returns true for a range fully inside a questions block", () => {
+    const questionsText = container.querySelector(".pmv-questions-content")!.firstChild!;
+    const range = document.createRange();
+    range.setStart(questionsText, 0);
+    range.setEnd(questionsText, 3);
+    expect(rangeTouchesQuestions(container, range)).toBe(true);
+  });
+
+  it("returns true for a range that starts in prose and drags into a questions block", () => {
+    const proseText = container.querySelector("p")!.firstChild!;
+    const questionsText = container.querySelector(".pmv-questions-content")!.firstChild!;
+    const range = document.createRange();
+    range.setStart(proseText, 0);
+    range.setEnd(questionsText, 3);
+    expect(rangeTouchesQuestions(container, range)).toBe(true);
+  });
+
+  it("returns false for a prose-only range", () => {
+    const firstP = container.querySelectorAll("p")[0].firstChild!;
+    const secondP = container.querySelectorAll("p")[1].firstChild!;
+    const range = document.createRange();
+    range.setStart(firstP, 0);
+    range.setEnd(firstP, 4);
+    expect(rangeTouchesQuestions(container, range)).toBe(false);
+
+    const rangeAfter = document.createRange();
+    rangeAfter.setStart(secondP, 0);
+    rangeAfter.setEnd(secondP, 4);
+    expect(rangeTouchesQuestions(container, rangeAfter)).toBe(false);
+  });
+});
+
+describe("applyAnnotationHighlights with questions blocks", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  it("creates no mark inside a .pmv-questions element", () => {
+    container.innerHTML =
+      '<p>Before text.</p><div class="pmv-questions"><div class="pmv-questions-content">A question here?</div></div>';
+    const fullText = getPlainText(container);
+    const annotation: MarkdownAnnotation = {
+      id: "a1",
+      startOffset: 0,
+      endOffset: fullText.length,
+      selectedText: fullText,
+      comment: "spans everything",
+    };
+
+    applyAnnotationHighlights(container, [annotation]);
+
+    const questionsBlock = container.querySelector(".pmv-questions")!;
+    expect(questionsBlock.querySelector("mark[data-annotation-id]")).toBeNull();
+  });
+
+  it("keeps offsets stable for prose that follows a questions block", () => {
+    // Without the guard, callout text would be skipped from highlighting but still
+    // counted for offsets by getPlainTextOffset — this is the exact scenario that
+    // regression (b) protects: an annotation on the trailing prose must land on the
+    // same characters whether or not a questions block precedes it.
+    container.innerHTML =
+      '<p>Intro.</p><div class="pmv-questions"><div class="pmv-questions-content">A question?</div></div><p>Trailing prose to highlight.</p>';
+
+    const fullText = getPlainText(container);
+    const target = "Trailing prose";
+    const startOffset = fullText.indexOf(target);
+    const endOffset = startOffset + target.length;
+
+    const annotation: MarkdownAnnotation = {
+      id: "a2",
+      startOffset,
+      endOffset,
+      selectedText: target,
+      comment: "trailing",
+    };
+
+    applyAnnotationHighlights(container, [annotation]);
+
+    const mark = container.querySelector("mark[data-annotation-id]");
+    expect(mark).not.toBeNull();
+    expect(mark?.textContent).toBe(target);
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/annotationUtils.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/annotationUtils.ts
@@ -6,6 +6,15 @@ export interface MarkdownAnnotation {
   comment: string;
 }
 
+export const QUESTIONS_SELECTOR = ".pmv-questions";
+
+export function rangeTouchesQuestions(container: HTMLElement, range: Range): boolean {
+  for (const block of container.querySelectorAll(QUESTIONS_SELECTOR)) {
+    if (range.intersectsNode(block)) return true;
+  }
+  return false;
+}
+
 export function getPlainTextOffset(
   container: Node,
   targetNode: Node,
@@ -58,7 +67,13 @@ function getTextNodesInRange(
     const nodeStart = offset;
     const nodeEnd = offset + nodeLen;
 
-    if (nodeEnd > startOffset && nodeStart < endOffset) {
+    // Callout text is excluded from highlighting, but the offset counter below
+    // must still advance over it — getPlainTextOffset walks every text node in
+    // the container, so skipping the offset here would shift every annotation
+    // that appears after a questions block.
+    const inQuestions = !!(node as Text).parentElement?.closest(QUESTIONS_SELECTOR);
+
+    if (!inQuestions && nodeEnd > startOffset && nodeStart < endOffset) {
       const sliceStart = Math.max(0, startOffset - nodeStart);
       const sliceEnd = Math.min(nodeLen, endOffset - nodeStart);
       const slice = node.textContent?.slice(sliceStart, sliceEnd) ?? "";

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -676,7 +676,7 @@
 }
 
 /* ─── Questions callout ─────────────────────────────────────────────────
-   Rendered by CodeBlock for ```questions fences, wrapped in a <pre> by
+   Rendered by BlockHandler for ```questions fences, wrapped in a <pre> by
    react-markdown (only the `code` element is overridden). Reset the UA
    `pre` styles (monospace font, white-space: pre) that would otherwise
    inherit in and stop the question text from wrapping like prose. */

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -675,6 +675,45 @@
   color: hsl(0 84% 60%);
 }
 
+/* ─── Questions callout ─────────────────────────────────────────────────
+   Rendered by CodeBlock for ```questions fences, wrapped in a <pre> by
+   react-markdown (only the `code` element is overridden). Reset the UA
+   `pre` styles (monospace font, white-space: pre) that would otherwise
+   inherit in and stop the question text from wrapping like prose. */
+.pmv-questions {
+  border-radius: 0.375rem;
+  border: 1px solid;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  font-family: inherit;
+  white-space: normal;
+  border-color: hsl(199 89% 48% / 0.3);
+  background: hsl(199 89% 48% / 0.08);
+}
+
+.pmv-questions-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  white-space: normal;
+  color: hsl(199 89% 48%);
+}
+
+.pmv-questions-header svg {
+  flex-shrink: 0;
+}
+
+.pmv-questions-title {
+  font-size: 0.875rem;
+}
+
+.pmv-questions-content {
+  margin-top: 0.25rem;
+  white-space: pre-wrap;
+}
+
 /* Image viewer */
 .pmv-img-clickable {
   cursor: pointer;


### PR DESCRIPTION
# Summary

## Changes

Added a `` ```questions `` fenced-code-block handler to the DraftMarkdown widget: instead of falling through to Prism as an unknown language, it now renders as a blue callout box (matching the existing GitHub-style alert palette) showing the question text. Text selections that touch a questions callout no longer trigger the "Add Comment" selection toolbar (or its `Cmd/Ctrl+Alt+M` shortcut), and existing annotations can never be highlighted inside one.

## API Changes

- New exported React component `QuestionsCallout` (`src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/QuestionsCallout.tsx`), taking a `content: string` prop.
- New exports from `annotationUtils.ts`: `QUESTIONS_SELECTOR` (`".pmv-questions"`) and `rangeTouchesQuestions(container, range): boolean`.
- New CSS classes: `.pmv-questions`, `.pmv-questions-header`, `.pmv-questions-title`, `.pmv-questions-content`.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/QuestionsCallout.tsx` (new) — the callout component
- `src/Ivy.Tendril.Widgets/frontend/src/CodeBlock.tsx` — dispatches `lang === "questions"` to `QuestionsCallout`
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css` — `.pmv-questions*` styles
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/annotationUtils.ts` — `QUESTIONS_SELECTOR`, `rangeTouchesQuestions`, and a guard in `getTextNodesInRange`
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx` — calls `rangeTouchesQuestions` in `handleMouseUp` to suppress the selection toolbar
- `src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/AnnotationsApp.cs` — sample markdown now ends with a questions fence
- Tests: `DraftMarkdown.questions.test.tsx` (new), `annotationUtils.test.ts`, `.tests/widgets/draft-markdown/annotations.spec.ts`

## Manual Testing

1. Run the Widgets sample app and open the DraftMarkdown "Annotations" sample.
2. Scroll to the bottom of the markdown — a blue callout box titled "Questions" should appear below the "Note" blockquote, containing "Should the retry budget be per-request or per-session?" and "What is the retention policy for read notifications?" on separate lines.
3. Try to select text inside that callout by click-dragging — no floating "Add Comment" toolbar should appear (compare with selecting text in a normal paragraph, where the toolbar does appear).
4. Select text that starts in a paragraph just above the callout and drags into it — the toolbar should still not appear.

## Fix: Rename `CodeBlock.tsx` to `BlockHandler`

Per reviewer feedback, renamed the component and its file from `CodeBlock`/`CodeBlock.tsx` to `BlockHandler`/`BlockHandler.tsx`, since it dispatches fenced blocks to several language-specific renderers (Prism, Mermaid, Graphviz, and now the questions callout) rather than only rendering plain code. All three importers were updated to match; no behavioral change.

### Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/CodeBlock.tsx` → renamed to `src/Ivy.Tendril.Widgets/frontend/src/BlockHandler.tsx`; exported symbol `CodeBlock` renamed to `BlockHandler`
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx` — updated import and `code:` component mapping
- `src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx` — updated import and `code:` component mapping
- `src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx` — updated import and `code:` component mapping
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css` — updated a comment referencing the old component name

**Note:** No user-facing behavior changed; the manual testing steps above still apply unmodified.

---
## Commits

- c64242c9 Plan 00073: render questions code fences as a blue callout
- 046072f7 Plan 00073: block annotations on questions callouts
- 70d685c7 Plan 00073: add a questions fence to the annotations sample app
- ee1d6958 Plan 00073: add tests for the questions callout
- 333c1187 Plan 00073: rename CodeBlock.tsx to BlockHandler

---
Created using [Ivy Tendril](https://ivy.app).
