### PR TITLE
[00074] Open Review Actions in a PTY Terminal Tab

### DIFF
--- a/src/Ivy.Tendril.Test/AppShell/TabTitleResolverTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/TabTitleResolverTests.cs
@@ -1,0 +1,51 @@
+using Ivy.Tendril.Apps.Agent;
+using Ivy.Tendril.Apps.ReviewAction;
+using static Ivy.Tendril.AppShell.TendrilAppShell;
+
+namespace Ivy.Tendril.Test.AppShell;
+
+public class TabTitleResolverTests
+{
+    [Fact]
+    public void ResolveArgsTabTitle_ReviewActionArgs_FormatsPlanIdAndActionName()
+    {
+        var title = ResolveArgsTabTitle(
+            new ReviewActionAppArgs("00074-OpenReviewActionsInAPTYTerminalTab", "Tendril"));
+
+        Assert.Equal("#74 Tendril", title);
+    }
+
+    [Fact]
+    public void ResolveArgsTabTitle_NoNumericPrefix_FallsBackToRawFolderName()
+    {
+        var title = ResolveArgsTabTitle(new ReviewActionAppArgs("NoNumericPrefix", "Tendril"));
+
+        Assert.Equal("#NoNumericPrefix Tendril", title);
+    }
+
+    [Theory]
+    [InlineData(null, "Tendril")]
+    [InlineData("00074-OpenReviewActionsInAPTYTerminalTab", null)]
+    [InlineData("", "Tendril")]
+    [InlineData("00074-OpenReviewActionsInAPTYTerminalTab", "")]
+    public void ResolveArgsTabTitle_MissingPlanIdOrActionName_ReturnsNull(string? planId, string? actionName)
+    {
+        var title = ResolveArgsTabTitle(new ReviewActionAppArgs(planId, actionName));
+
+        Assert.Null(title);
+    }
+
+    [Fact]
+    public void ResolveArgsTabTitle_NonReviewActionArgs_ReturnsNull()
+    {
+        var title = ResolveArgsTabTitle(new AgentAppArgs("Do something"));
+
+        Assert.Null(title);
+    }
+
+    [Fact]
+    public void ResolveArgsTabTitle_NullArgs_ReturnsNull()
+    {
+        Assert.Null(ResolveArgsTabTitle(null));
+    }
+}

--- a/src/Ivy.Tendril.Test/Apps/ReviewActionAppTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/ReviewActionAppTests.cs
@@ -1,0 +1,63 @@
+using Ivy.Tendril.Apps.ReviewAction;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Test.TestHelpers;
+
+namespace Ivy.Tendril.Test.Apps;
+
+public class ReviewActionAppTests
+{
+    private static StubConfigService BuildConfig() => new([
+        new ProjectConfig
+        {
+            Name = "Tendril",
+            ReviewActions =
+            [
+                new ReviewActionConfig { Name = "Run App", Condition = "$true", Command = "dotnet run" },
+                new ReviewActionConfig { Name = "No Command", Condition = "$true", Command = "" }
+            ]
+        }
+    ]);
+
+    [Fact]
+    public void ResolveAction_KnownActionWithCommand_ReturnsAction()
+    {
+        var action = ReviewActionApp.ResolveAction(BuildConfig(), "Tendril", "Run App");
+
+        Assert.NotNull(action);
+        Assert.Equal("dotnet run", action.Command);
+    }
+
+    [Fact]
+    public void ResolveAction_UnknownActionName_ReturnsNull()
+    {
+        var action = ReviewActionApp.ResolveAction(BuildConfig(), "Tendril", "Does Not Exist");
+
+        Assert.Null(action);
+    }
+
+    [Fact]
+    public void ResolveAction_ActionWithEmptyCommand_ReturnsNull()
+    {
+        var action = ReviewActionApp.ResolveAction(BuildConfig(), "Tendril", "No Command");
+
+        Assert.Null(action);
+    }
+
+    [Fact]
+    public void ResolveAction_UnknownProject_ReturnsNull()
+    {
+        var action = ReviewActionApp.ResolveAction(BuildConfig(), "NoSuchProject", "Run App");
+
+        Assert.Null(action);
+    }
+
+    [Theory]
+    [InlineData(null, "Run App")]
+    [InlineData("Tendril", null)]
+    public void ResolveAction_MissingProjectOrActionName_ReturnsNull(string? project, string? actionName)
+    {
+        var action = ReviewActionApp.ResolveAction(BuildConfig(), project, actionName);
+
+        Assert.Null(action);
+    }
+}

--- a/src/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs
+++ b/src/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs
@@ -2,13 +2,13 @@ using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test.TestHelpers;
 
-public class StubConfigService : IConfigService
+public class StubConfigService(List<ProjectConfig>? projects = null) : IConfigService
 {
     public TendrilSettings Settings => new();
     public string TendrilHome => "";
     public string ConfigPath => "";
     public string PlanFolder => "";
-    public List<ProjectConfig> Projects => [];
+    public List<ProjectConfig> Projects => projects ?? [];
     public List<LevelConfig> Levels => [];
     public string[] LevelNames => [];
     public EditorConfig Editor => new() { Command = "code", Label = "VS Code" };
@@ -17,7 +17,7 @@ public class StubConfigService : IConfigService
 
     public ProjectConfig? GetProject(string name)
     {
-        return null;
+        return Projects.FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
     }
 
     public Colors? GetLevelColor(string level)

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -7,6 +7,7 @@ using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.AppShell.Dialogs;
 using Ivy.Tendril.Apps;
 using Ivy.Tendril.Apps.Onboarding;
+using Ivy.Tendril.Apps.ReviewAction;
 using Ivy.Tendril.Apps.Settings;
 using Ivy.Tendril.Apps.Trash;
 using Ivy.Tendril.Apps.Views;
@@ -27,6 +28,26 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
     private static readonly HttpClient NewsHttp = new();
     private static readonly HashSet<string> OnboardingAppIds =
         new(StringComparer.OrdinalIgnoreCase) { "onboarding", "OnboardingApp", "onboarding-app" };
+
+    /// <summary>
+    ///     Overrides the default app-descriptor tab title for apps whose title depends on the
+    ///     navigation args rather than being fixed. Currently only <see cref="ReviewActionApp"/>,
+    ///     which is titled "#&lt;PlanId&gt; &lt;ReviewActionName&gt;". Returns null (use the
+    ///     descriptor title) for every other arg shape.
+    /// </summary>
+    internal static string? ResolveArgsTabTitle(object? appArgs) => appArgs switch
+    {
+        ReviewActionAppArgs { PlanId: { Length: > 0 } planId, ActionName: { Length: > 0 } name }
+            => $"#{FormatPlanId(planId)} {name}",
+        _ => null
+    };
+
+    // "00074-OpenReviewActions..." -> "74". Falls back to the raw folder name when the numeric
+    // prefix is missing, so a malformed arg never throws inside OpenApp (which swallows exceptions).
+    private static string FormatPlanId(string planFolderName) =>
+        int.TryParse(PlanYamlHelper.ExtractPlanIdFromFolder(planFolderName), out var id)
+            ? id.ToString()
+            : planFolderName;
 
     private static async Task<SidebarNewsArticle[]> FetchNewsAsync()
     {
@@ -367,6 +388,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             var appHost = navigateArgs.ToAppHost(args.ConnectionId);
             var app = appRepository.GetAppOrDefault(effectiveAppId);
             var (tabTitle, tabIcon) = BrandedAppDisplay(app);
+            tabTitle = ResolveArgsTabTitle(navigateArgs.AppArgs) ?? tabTitle;
 
             var newTabs = tabs.Value.Add(new TabState(tabId, app.Id, tabTitle, appHost,
                 tabIcon, Guid.NewGuid().ToString()));

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -634,7 +634,7 @@ public class ContentView(
             var totalArtifacts = (planData.Artifacts.GetValueOrDefault("screenshots")?.Count ?? 0)
                                  + (planData.Artifacts.ContainsKey("sample") ? 1 : 0);
 
-            content |= new ReviewActionsBarView(selectedPlan, planData.ReviewActionStates, config, logger);
+            content |= new ReviewActionsBarView(selectedPlan, planData.ReviewActionStates, config);
 
             var recommendationsTab = new RecommendationsTabView(pendingRecs, selectedRecTitles, config);
 

--- a/src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs
@@ -1,25 +1,25 @@
-using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Apps.ReviewAction;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
-using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Apps.Review;
 
 /// <summary>
 ///     The project-configured review-actions bar shown above the tabs: one button per
 ///     <see cref="ReviewActionConfig"/>, disabled when its precomputed condition isn't met,
-///     otherwise running the action's PowerShell command in the plan folder. Renders nothing
-///     (returns null) when the project defines no review actions, so callers can compose it
-///     unconditionally.
+///     otherwise opening a <see cref="ReviewActionApp"/> tab that runs the action's PowerShell
+///     command in a PTY. Renders nothing (returns null) when the project defines no review
+///     actions, so callers can compose it unconditionally.
 /// </summary>
 public class ReviewActionsBarView(
     PlanFile selectedPlan,
     IReadOnlyList<(string Name, bool ConditionMet)> reviewActionStates,
-    IConfigService config,
-    ILogger logger) : ViewBase
+    IConfigService config) : ViewBase
 {
     public override object? Build()
     {
+        var nav = UseNavigation();
+
         var projectConfig = config.GetProject(selectedPlan.Project);
         var reviewActions = projectConfig?.ReviewActions ?? [];
         if (reviewActions.Count == 0)
@@ -39,13 +39,8 @@ public class ReviewActionsBarView(
             else
             {
                 var actionCapture = action;
-                btn = btn.OnClick(() =>
-                {
-                    if (!PlatformHelper.RunPowerShellAction(actionCapture.Command, selectedPlan.FolderPath, logger))
-                    {
-                        logger.LogWarning("Failed to run review action {ActionName}: pwsh not found", actionCapture.Name);
-                    }
-                });
+                btn = btn.OnClick(() => nav.Navigate<ReviewActionApp>(
+                    new ReviewActionAppArgs(selectedPlan.FolderName, actionCapture.Name)));
             }
 
             actionsBar |= btn;

--- a/src/Ivy.Tendril/Apps/ReviewAction/ReviewActionApp.cs
+++ b/src/Ivy.Tendril/Apps/ReviewAction/ReviewActionApp.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics;
+using System.Reactive.Disposables;
+using Ivy.Hooks.Pty;
+using Ivy.Tendril.Agents.Helpers;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Widgets.Xterm;
+using Xterm = Ivy.Widgets.Xterm;
+
+namespace Ivy.Tendril.Apps.ReviewAction;
+
+/// <summary>
+///     Hosts a review action's PowerShell command in a PTY terminal, opened as its own tab
+///     (see <see cref="AppShell.TendrilAppShell.ResolveArgsTabTitle"/> for the tab title).
+///     Modelled on <see cref="Agent.AgentApp"/>, but without trust-prompt handling or agent
+///     config: the command is re-resolved server-side from the plan's project config so it
+///     never travels through navigation args.
+/// </summary>
+[App(title: "Review Action", icon: Icons.Play, isVisible: false, order: Constants.ReviewAction, allowDuplicateTabs: true)]
+public class ReviewActionApp : ViewBase
+{
+    public override object Build()
+    {
+        var configService = UseService<IConfigService>();
+        var planService = UseService<IPlanReaderService>();
+        var args = UseArgs<ReviewActionAppArgs>();
+
+        // Ivy hooks must come first (IVYHOOK005), so the plan/action lookup that determines the
+        // command line and working directory happens inside GetCommandLine/GetWorkDir (called as
+        // direct arguments, like AgentApp does), not as statements preceding UsePty. When nothing
+        // resolves, GetCommandLine returns an empty array, which makes UsePty's StartPtyAsync a
+        // no-op, so nothing is spawned.
+        var ptyHandle = Context.UsePty(
+            GetCommandLine(configService, planService, args),
+            GetWorkDir(planService, args));
+
+        // Windows job-object teardown (which UsePty relies on to kill the whole process tree on
+        // disposal) does not reliably reach every grandchild - verified by spawning a pwsh -> a
+        // long-running grandchild and observing the grandchild survive a plain pty.Kill(). So this
+        // app also kills the process tree by pid explicitly when the tab closes, as a backstop.
+        UseEffect(() => Disposable.Create(() =>
+        {
+            if (ptyHandle.GetProcessId?.Invoke() is not { } pid) return;
+            try
+            {
+                ProcessRunner.KillProcessTree(Process.GetProcessById(pid));
+            }
+            catch (ArgumentException)
+            {
+                // Process already exited.
+            }
+        }), EffectTrigger.OnMount());
+
+        var plan = ResolvePlan(planService, args?.PlanId);
+        if (plan is null)
+        {
+            return Text.Muted("Plan not found.");
+        }
+
+        var action = ResolveAction(configService, plan.Project, args?.ActionName);
+        if (action is null)
+        {
+            return Text.Muted($"Review action \"{args?.ActionName}\" is not configured for project \"{plan.Project}\".");
+        }
+
+        return new Xterm.Terminal()
+            .Stream(ptyHandle.Stream)
+            .OnInput(ptyHandle.HandleInput)
+            .OnResize(ptyHandle.HandleResize)
+            .Closed(ptyHandle.Closed)
+            .AllowClipboard()
+            .Loading($"Starting {action.Name}...")
+            .WithLayout()
+            .Full()
+            .RemoveParentPadding();
+    }
+
+    private static string[] GetCommandLine(IConfigService configService, IPlanReaderService planService, ReviewActionAppArgs? args)
+    {
+        var plan = ResolvePlan(planService, args?.PlanId);
+        var action = plan is not null ? ResolveAction(configService, plan.Project, args?.ActionName) : null;
+        return action is not null
+            ? [PathHelper.GetPwshPath(), "-NoExit", "-NoProfile", "-Command", action.Command]
+            : [];
+    }
+
+    private static string? GetWorkDir(IPlanReaderService planService, ReviewActionAppArgs? args) =>
+        ResolvePlan(planService, args?.PlanId)?.FolderPath;
+
+    private static PlanFile? ResolvePlan(IPlanReaderService planService, string? planId)
+    {
+        if (string.IsNullOrEmpty(planId)) return null;
+        var folder = Path.Combine(planService.PlansDirectory, planId);
+        return planService.GetPlanByFolder(folder);
+    }
+
+    /// <summary>
+    ///     Resolves a review action's command by name from the project config. Returns null
+    ///     (so the caller renders an explanation instead of spawning <c>pwsh</c>) when the
+    ///     project, action, or its command is missing.
+    /// </summary>
+    internal static ReviewActionConfig? ResolveAction(IConfigService config, string? project, string? actionName)
+    {
+        if (string.IsNullOrEmpty(project) || string.IsNullOrEmpty(actionName)) return null;
+        var action = config.GetProject(project)?.ReviewActions.FirstOrDefault(a => a.Name == actionName);
+        return string.IsNullOrEmpty(action?.Command) ? null : action;
+    }
+}

--- a/src/Ivy.Tendril/Apps/ReviewAction/ReviewActionApp.cs
+++ b/src/Ivy.Tendril/Apps/ReviewAction/ReviewActionApp.cs
@@ -53,22 +53,30 @@ public class ReviewActionApp : ViewBase
             }
         }), EffectTrigger.OnMount());
 
-        // The plan/action lookup that determines the command line and working directory happens
-        // inside GetCommandLine/GetWorkDir (called as direct arguments, like AgentApp does), not
-        // as statements preceding UsePty. When nothing resolves, GetCommandLine returns an empty
-        // array, which makes UsePty's StartPtyAsync a no-op, so nothing is spawned.
+        // The plan/action lookup happens once via UseMemo (itself a hook, so this still satisfies
+        // IVYHOOK005's "hooks must come first" rule - it can't be a plain statement preceding
+        // UsePty). GetCommandLine then derives its argv from the already-resolved tuple instead
+        // of re-running ResolvePlan/ResolveAction. When nothing resolves, GetCommandLine returns
+        // an empty array, which makes UsePty's StartPtyAsync a no-op, so nothing is spawned.
+        var (plan, action) = UseMemo(() =>
+        {
+            var resolvedPlan = ResolvePlan(planService, args?.PlanId);
+            var resolvedAction = resolvedPlan is not null
+                ? ResolveAction(configService, resolvedPlan.Project, args?.ActionName)
+                : null;
+            return (resolvedPlan, resolvedAction);
+        });
+
         var ptyHandle = Context.UsePty(
-            GetCommandLine(configService, planService, args),
-            GetWorkDir(planService, args));
+            GetCommandLine(plan, action),
+            plan?.FolderPath);
         ptyHandleRef.Value = ptyHandle;
 
-        var plan = ResolvePlan(planService, args?.PlanId);
         if (plan is null)
         {
             return Text.Muted("Plan not found.");
         }
 
-        var action = ResolveAction(configService, plan.Project, args?.ActionName);
         if (action is null)
         {
             return Text.Muted($"Review action \"{args?.ActionName}\" is not configured for project \"{plan.Project}\".");
@@ -86,17 +94,10 @@ public class ReviewActionApp : ViewBase
             .RemoveParentPadding();
     }
 
-    private static string[] GetCommandLine(IConfigService configService, IPlanReaderService planService, ReviewActionAppArgs? args)
-    {
-        var plan = ResolvePlan(planService, args?.PlanId);
-        var action = plan is not null ? ResolveAction(configService, plan.Project, args?.ActionName) : null;
-        return action is not null
+    private static string[] GetCommandLine(PlanFile? plan, ReviewActionConfig? action) =>
+        plan is not null && action is not null
             ? [PathHelper.GetPwshPath(), "-NoExit", "-NoProfile", "-Command", action.Command]
             : [];
-    }
-
-    private static string? GetWorkDir(IPlanReaderService planService, ReviewActionAppArgs? args) =>
-        ResolvePlan(planService, args?.PlanId)?.FolderPath;
 
     private static PlanFile? ResolvePlan(IPlanReaderService planService, string? planId)
     {

--- a/src/Ivy.Tendril/Apps/ReviewAction/ReviewActionApp.cs
+++ b/src/Ivy.Tendril/Apps/ReviewAction/ReviewActionApp.cs
@@ -25,23 +25,24 @@ public class ReviewActionApp : ViewBase
         var configService = UseService<IConfigService>();
         var planService = UseService<IPlanReaderService>();
         var args = UseArgs<ReviewActionAppArgs>();
-
-        // Ivy hooks must come first (IVYHOOK005), so the plan/action lookup that determines the
-        // command line and working directory happens inside GetCommandLine/GetWorkDir (called as
-        // direct arguments, like AgentApp does), not as statements preceding UsePty. When nothing
-        // resolves, GetCommandLine returns an empty array, which makes UsePty's StartPtyAsync a
-        // no-op, so nothing is spawned.
-        var ptyHandle = Context.UsePty(
-            GetCommandLine(configService, planService, args),
-            GetWorkDir(planService, args));
+        var ptyHandleRef = UseRef<PtyHandle?>();
 
         // Windows job-object teardown (which UsePty relies on to kill the whole process tree on
         // disposal) does not reliably reach every grandchild - verified by spawning a pwsh -> a
         // long-running grandchild and observing the grandchild survive a plain pty.Kill(). So this
         // app also kills the process tree by pid explicitly when the tab closes, as a backstop.
+        //
+        // This effect is registered BEFORE Context.UsePty() below so its cleanup runs first when
+        // the tab closes (effect cleanups run in registration order): by the time UsePty's own
+        // cleanup calls pty.Kill()/Dispose(), the tree is already gone, instead of the reverse -
+        // where UsePty kills the parent first and Process.GetProcessById(pid) below would throw
+        // because the pid no longer exists, silently skipping the grandchild kill entirely.
+        // ptyHandleRef bridges the value across, since the handle itself doesn't exist yet at
+        // this point in Build() (Ivy hooks must come first, IVYHOOK005, so it can't be resolved
+        // via a preceding non-hook statement either).
         UseEffect(() => Disposable.Create(() =>
         {
-            if (ptyHandle.GetProcessId?.Invoke() is not { } pid) return;
+            if (ptyHandleRef.Value?.GetProcessId?.Invoke() is not { } pid) return;
             try
             {
                 ProcessRunner.KillProcessTree(Process.GetProcessById(pid));
@@ -51,6 +52,15 @@ public class ReviewActionApp : ViewBase
                 // Process already exited.
             }
         }), EffectTrigger.OnMount());
+
+        // The plan/action lookup that determines the command line and working directory happens
+        // inside GetCommandLine/GetWorkDir (called as direct arguments, like AgentApp does), not
+        // as statements preceding UsePty. When nothing resolves, GetCommandLine returns an empty
+        // array, which makes UsePty's StartPtyAsync a no-op, so nothing is spawned.
+        var ptyHandle = Context.UsePty(
+            GetCommandLine(configService, planService, args),
+            GetWorkDir(planService, args));
+        ptyHandleRef.Value = ptyHandle;
 
         var plan = ResolvePlan(planService, args?.PlanId);
         if (plan is null)

--- a/src/Ivy.Tendril/Apps/ReviewAction/ReviewActionAppArgs.cs
+++ b/src/Ivy.Tendril/Apps/ReviewAction/ReviewActionAppArgs.cs
@@ -1,0 +1,3 @@
+namespace Ivy.Tendril.Apps.ReviewAction;
+
+public record ReviewActionAppArgs(string? PlanId = null, string? ActionName = null);

--- a/src/Ivy.Tendril/Constants.cs
+++ b/src/Ivy.Tendril/Constants.cs
@@ -17,6 +17,7 @@ public static class Constants
     public const int Icebox = 70;
     public const int Chat = 75;
     public const int Agent = 80;
+    public const int ReviewAction = 85;
     public const int Trash = 90;
     public const int Help = 100;
     public const int Onboarding = 110;

--- a/src/Ivy.Tendril/Helpers/PlatformHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlatformHelper.cs
@@ -57,65 +57,6 @@ public static class PlatformHelper
             "$1");
     }
 
-    /// <summary>
-    /// Launches a PowerShell action. Returns false if pwsh is not found or the launch fails.
-    /// </summary>
-    public static bool RunPowerShellAction(string action, string workingDirectory, ILogger? logger = null)
-    {
-        try
-        {
-            var pwshPath = PathHelper.GetPwshPath();
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                // On macOS, create a temporary .command script and open it in Terminal.app
-                // This ensures the terminal window is visible and interactive
-                var scriptPath = Path.Combine(Path.GetTempPath(), $"tendril-action-{Guid.NewGuid():N}.command");
-                var scriptContent = $"#!/bin/bash\ncd \"{workingDirectory}\"\n\"{pwshPath}\" -NoExit -NoProfile -Command \"{action.Replace("\"", "\\\"")}\"\nrm \"{scriptPath}\"\n";
-                File.WriteAllText(scriptPath, scriptContent);
-
-                // Make the script executable
-                var chmodPsi = new ProcessStartInfo("chmod", $"+x \"{scriptPath}\"")
-                {
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-                using (var chmodProc = Process.Start(chmodPsi))
-                {
-                    chmodProc?.WaitForExit();
-                }
-
-                // Open the script in Terminal.app
-                Process.Start(new ProcessStartInfo
-                {
-                    FileName = "open",
-                    Arguments = $"-a Terminal \"{scriptPath}\"",
-                    UseShellExecute = false
-                });
-                return true;
-            }
-
-            // Windows and Linux: run pwsh directly
-            Process.Start(new ProcessStartInfo
-            {
-                FileName = pwshPath,
-                Arguments = $"-NoExit -NoProfile -Command \"{action}\"",
-                WorkingDirectory = workingDirectory,
-                UseShellExecute = true
-            });
-            return true;
-        }
-        catch (Win32Exception ex)
-        {
-            logger?.LogWarning(ex, "Failed to run PowerShell action");
-            return false;
-        }
-        catch (FileNotFoundException ex)
-        {
-            logger?.LogWarning(ex, "Failed to run PowerShell action");
-            return false;
-        }
-    }
-
     public static bool OpenInTerminal(string workingDirectory, ILogger? logger = null)
     {
         try


### PR DESCRIPTION
# Summary

## Changes

Review actions now run in an in-app PTY terminal tab instead of an external OS terminal window.
Clicking a review action navigates to a new `ReviewActionApp` tab (titled `#<PlanId>
<ReviewActionName>`) that runs the action's PowerShell command in a PTY, matching how `AgentApp`
already hosts coding-agent sessions. Closing the tab reliably kills the whole process tree,
including any grandchild processes (e.g. `dotnet run`), which was verified empirically and
required an explicit fix beyond relying on the PTY's own job-object teardown.

## API Changes

- New: `Ivy.Tendril.Apps.ReviewAction.ReviewActionAppArgs(string? PlanId, string? ActionName)`
- New: `Ivy.Tendril.Apps.ReviewAction.ReviewActionApp` (`[App]`, `isVisible: false`,
  `allowDuplicateTabs: true`), including `internal static ReviewActionConfig? ResolveAction(IConfigService, string? project, string? actionName)`
- New: `Ivy.Tendril.Constants.ReviewAction = 85`
- New (internal): `Ivy.Tendril.AppShell.TendrilAppShell.ResolveArgsTabTitle(object? appArgs)`
- Changed: `Ivy.Tendril.Apps.Review.ReviewActionsBarView` constructor no longer takes `ILogger logger`
- Removed: `Ivy.Tendril.Helpers.PlatformHelper.RunPowerShellAction(...)` (no remaining callers)
- Changed (Ivy-Framework, companion PR): `Ivy.Hooks.Pty.PtyHandle` gained an additive trailing field
  `Func<int?>? GetProcessId = null` - a live accessor to the spawned process's OS pid, for
  callers that need to back up `UsePty`'s own cleanup with an explicit process-tree kill.
- Test helper: `Ivy.Tendril.Test.TestHelpers.StubConfigService` gained an optional
  `List<ProjectConfig>?` constructor parameter (parameterless default behavior unchanged).

## Files Modified

- `src/Ivy.Tendril/Apps/ReviewAction/ReviewActionApp.cs` (new), `ReviewActionAppArgs.cs` (new)
- `src/Ivy.Tendril/Apps/Review/ReviewActionsBarView.cs` - navigates to `ReviewActionApp` instead of calling `PlatformHelper.RunPowerShellAction`
- `src/Ivy.Tendril/Apps/Review/ContentView.cs` - updated `ReviewActionsBarView` call site
- `src/Ivy.Tendril/Helpers/PlatformHelper.cs` - deleted `RunPowerShellAction` (incl. its macOS Terminal.app branch)
- `src/Ivy.Tendril/AppShell/TendrilAppShell.cs` - `ResolveArgsTabTitle`/`FormatPlanId`, wired into `HandleCreateNewTab`
- `src/Ivy.Tendril/Constants.cs` - `ReviewAction = 85`
- `src/Ivy.Tendril.Test/AppShell/TabTitleResolverTests.cs` (new), `Apps/ReviewActionAppTests.cs` (new)
- `src/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs` - optional project list for `GetProject`

This PR depends on the companion Ivy-Framework PR (`Ivy.Hooks.Pty.PtyHandle.GetProcessId`) from
the same plan.

## Manual Testing

1. Run Tendril, open a plan's Review tab for a project with `reviewActions` configured
   (e.g. the `Tendril` project's own `Tendril` action).
2. Click the action button. A new tab opens titled `#<PlanId> <ActionName>` running the
   command in an interactive terminal (not a separate OS window).
3. If the action spawns a long-running child (e.g. `dotnet run`), note its PID
   (`Get-CimInstance Win32_Process | Where-Object Name -match 'pwsh|dotnet'`).
4. Close the tab. Both the `pwsh` process and the child/grandchild process should disappear
   within a couple seconds.
5. Click the action again (or a different action) - a new tab opens each time rather than
   reusing the previous one (matching `AgentApp`'s behavior; tab reuse is out of scope, see
   Plan 00054).

## Fix: Deduplicate plan/action resolution in ReviewActionApp.Build()

Per the code review recommendation, `Build()` previously resolved the plan/action pair up to
three times per render (once each inside `GetCommandLine` and `GetWorkDir`, then again directly
in `Build()` for the not-found branches). Replaced this with a single `UseMemo` call that
resolves `(plan, action)` once; `GetCommandLine` now takes the already-resolved tuple instead of
re-running `ResolvePlan`/`ResolveAction`, and `GetWorkDir` was removed since its one remaining
call site (`plan?.FolderPath`) is now inline.

**Note:** No user-facing behavior change; this is an internal readability/efficiency cleanup.

---
## Commits

- 2f434650 Plan 00074: Add ReviewActionApp to host review actions in a PTY tab
- 4c33bfdf Plan 00074: Open review actions in a PTY tab instead of an external terminal
- bcb4375a Plan 00074: Title review action tabs with the plan id and action name
- 4c0c4a0f Plan 00074: Add tests for tab title resolution and review action lookup
- 6a778ed1 code-review: fix cleanup ordering so process-tree kill isn't skipped
- 28062c55 Plan 00074: Deduplicate plan/action resolution in ReviewActionApp.Build()

---
Created using [Ivy Tendril](https://ivy.app).
