### PR TITLE
[00080] Render Recommendation Descriptions as Markdown With Working File Links

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -321,8 +321,10 @@ verifications:
 
     - For each minor concern, add a plan recommendation:
       `tendril plan rec add "<plan-id>" "<short imperative title>"`
-    - Then attach detail (file:line + what to change) via:
+    - Then attach detail as markdown via:
       `tendril plan rec set "<plan-id>" "<short imperative title>" description "<detail>"`
+      Write `<detail>` as a markdown link to the file (`[file.cs:42](file:///absolute/path/to/file.cs)`,
+      line number in the link text only, never in the URL) followed by what to change.
     - Use the plan id derived in Step 1 (the plan folder name works as the id).
 
     - Do not edit code for minor concerns — they are left for the human to accept or decline.

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -41,7 +41,7 @@ public class ContentView(
                 plan?.Title ?? folderName
             ).Width(UxHelper.SheetWidth).Resizable();
 
-            return new Fragment(sheet, new FileSheet(openFile, config));
+            return sheet;
         });
         var (notesDialog, showNotesDialog) = UseTrigger((isOpen) =>
         {
@@ -129,7 +129,16 @@ public class ContentView(
 
         // Description
         scrollableContent |= new Separator();
-        scrollableContent |= new Markdown(MarkdownHelper.PrepareForDisplay(selectedRecommendation.Description, config));
+        scrollableContent |= new Markdown(MarkdownHelper.PrepareForDisplay(selectedRecommendation.Description, config))
+            .DangerouslyAllowLocalFiles()
+            .Article()
+            .OnLinkClick(FileSheet.CreateLinkClickHandler(openFile, planId =>
+            {
+                var planFolder = Directory.GetDirectories(planService.PlansDirectory, $"{planId:D5}-*")
+                    .FirstOrDefault();
+                if (planFolder != null)
+                    showPlan(planFolder);
+            }));
 
         // Standard overflow menu items
         var standardOverflowItems = new[]
@@ -223,7 +232,7 @@ public class ContentView(
             ).Size(Size.Full())
         ).Scroll(Scroll.None).Size(Size.Full());
 
-        return new Fragment(mainLayout, planSheet, notesDialog);
+        return new Fragment(mainLayout, planSheet, notesDialog, new FileSheet(openFile, config));
     }
 
     private void GoToNext()

--- a/src/Ivy.Tendril/Apps/Recommendations/Dialogs/AcceptWithNotesDialog.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/Dialogs/AcceptWithNotesDialog.cs
@@ -25,7 +25,10 @@ public class AcceptWithNotesDialog(
             new DialogBody(
                 Layout.Vertical().Gap(2)
                 | Text.Block("Add notes to include with this recommendation:").Muted()
-                | new Markdown(MarkdownHelper.PrepareForDisplay(_recommendation.Description, config))
+                // Deliberately no .DangerouslyAllowLocalFiles() / OnLinkClick() here: a Sheet
+                // stacked on top of this open Dialog isn't a pattern this codebase uses, and an
+                // inert link is a smaller failure than a live-looking one that does nothing.
+                | new Markdown(MarkdownHelper.PrepareForDisplay(_recommendation.Description, config)).Article()
                 | notesText.ToTextareaInput("Enter your notes...").Rows(6).AutoFocus()
             ),
             new DialogFooter(

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -587,7 +587,7 @@ public class ContentView(
 
             content |= new ReviewActionsBarView(selectedPlan, planData.ReviewActionStates, config);
 
-            var recommendationsTab = new RecommendationsTabView(pendingRecs, selectedRecTitles, config, onImplementRecommendations);
+            var recommendationsTab = new RecommendationsTabView(pendingRecs, selectedRecTitles, config, onImplementRecommendations, onLinkClick);
 
             var changesTabView = new ChangesTabView(
                 planData.AllChanges,

--- a/src/Ivy.Tendril/Apps/Review/Tabs/RecommendationsTabView.cs
+++ b/src/Ivy.Tendril/Apps/Review/Tabs/RecommendationsTabView.cs
@@ -14,7 +14,8 @@ public class RecommendationsTabView(
     List<RecommendationYaml> pendingRecs,
     IState<HashSet<string>> selectedRecTitles,
     IConfigService config,
-    Action onImplement) : ViewBase
+    Action onImplement,
+    Action<string> onLinkClick) : ViewBase
 {
     public override object Build()
     {
@@ -37,7 +38,7 @@ public class RecommendationsTabView(
 
         for (var i = 0; i < pendingRecs.Count; i++)
         {
-            layout |= new RecommendationRowView(pendingRecs[i], selectedRecTitles, config)
+            layout |= new RecommendationRowView(pendingRecs[i], selectedRecTitles, config, onLinkClick)
                 .Key(pendingRecs[i].Title);
             if (i < pendingRecs.Count - 1)
                 layout |= new Separator();
@@ -55,7 +56,8 @@ public class RecommendationsTabView(
 public class RecommendationRowView(
     RecommendationYaml rec,
     IState<HashSet<string>> selectedTitles,
-    IConfigService config) : ViewBase
+    IConfigService config,
+    Action<string> onLinkClick) : ViewBase
 {
     public override object Build()
     {
@@ -95,6 +97,7 @@ public class RecommendationRowView(
         return content
                | new Markdown(MarkdownHelper.PrepareForDisplay(rec.Description, config))
                    .DangerouslyAllowLocalFiles()
-                   .Article();
+                   .Article()
+                   .OnLinkClick(onLinkClick);
     }
 }

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -112,6 +112,8 @@ tendril plan add-depends-on <plan-id> <folder-name>
 
 # Recommendations
 tendril plan rec add <plan-id> <title> -d <description> [--impact=Small|Medium|High]
+# <description> is markdown, rendered in the Recommendations app and the Review tab. File links
+# follow the same file:/// rules given in the Notes section at the bottom of this document.
 tendril plan rec accept <plan-id> <title> [--notes=<text>]
 tendril plan rec decline <plan-id> <title> [--reason=<text>]
 tendril plan rec set <plan-id> <title> <field> <value>

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -483,6 +483,16 @@ tendril plan rec add <plan-id> "Short descriptive title" -d "Markdown descriptio
 
 `--impact` is optional (Small, Medium, or High) and indicates the value of implementing it.
 
+The description is rendered as markdown in the Recommendations app and the Review tab, so write it
+as displayable markdown, not a bare sentence:
+
+- Use short paragraphs, bullets, and fenced code blocks for snippets.
+- Link every file the reader needs with a markdown link whose URL is an absolute `file:///` path
+  written with forward slashes. Put the line number in the display text only, never in the URL (no
+  `:42` suffix, no `#L123`) — see the plan link rules in the Reference Documents.
+- Only link files that exist; write paths of files that do not exist yet in inline code instead.
+- Reference other plans as bare `Plan NNNNN` in prose and let the link polisher convert them.
+
 Do NOT include items that are part of the current plan's scope. Do NOT include recommendations about code formatting, linting, or style issues — those are handled by verifications.
 
 **After registering any recommendations via the CLI**, create `<TendrilPlanFolder>/Artifacts/recommendations.md`. Having zero recommendations is fine — but the file must still be created:


### PR DESCRIPTION
# Summary

## Changes

Recommendation descriptions now render with the same markdown recipe used by every other
document in Tendril (`.DangerouslyAllowLocalFiles().Article().OnLinkClick(...)`), so `file:///`
and `plan://` links in a recommendation's description are clickable in all three places they're
shown: the Recommendations app detail pane, the Review app's Recommendations tab, and (typography
only, deliberately no link handler) the accept-with-notes dialog. Agent-facing guidance
(ExecutePlan, `Plans.md`, the CodeReview verification prompt) was updated to tell agents writing
recommendations to use displayable markdown with proper file links instead of bare text.

## API Changes

- `RecommendationsTabView` constructor gained a required `Action<string> onLinkClick` parameter
  (5th positional arg).
- `RecommendationRowView` constructor gained a required `Action<string> onLinkClick` parameter
  (4th positional arg).

Both are internal Tendril app classes with a single construction site each (updated in this
plan) — no external consumers.

## Files Modified

- **Recommendations app** — `src/Ivy.Tendril/Apps/Recommendations/ContentView.cs`: single root
  `FileSheet` (was duplicated inside a trigger fragment); description markdown now uses the house
  recipe with plan-link support.
- **Recommendations app** — `src/Ivy.Tendril/Apps/Recommendations/Dialogs/AcceptWithNotesDialog.cs`:
  added `.Article()` typography; documented why link handling is intentionally omitted.
- **Review app** — `src/Ivy.Tendril/Apps/Review/Tabs/RecommendationsTabView.cs`: threaded
  `onLinkClick` through both view classes.
- **Review app** — `src/Ivy.Tendril/Apps/Review/ContentView.cs`: passes the existing `onLinkClick`
  local into `RecommendationsTabView`.
- **Agent guidance** — `src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md`,
  `src/Ivy.Tendril/Prompts/Plans.md`, `src/Ivy.Tendril.TeamIvyConfig/config.yaml`: prose updates
  telling agents to write recommendation descriptions as markdown with proper `file:///` links.

## Manual Testing

1. Run the Tendril app and open the **Recommendations** app on a recommendation whose description
   contains a `file:///` link (or accept a recommendation from a plan whose `CodeReview` step
   logged one). Click the link — the `FileSheet` should open showing the file contents.
2. Open the same plan in the **Review** app's Recommendations tab and click the same kind of link
   in a row's description — it should open the `FileSheet` the same way.
3. Open **Accept with Notes** on a recommendation — the description should render with article
   spacing (headings/paragraphs), and any `file:///`/`plan://` links in it should render as plain
   (non-clickable) text, not broken anchors.

---
## Commits

- f06957cf Plan 00080: Render recommendation description markdown with file links in Recommendations app
- 17a9172e Plan 00080: Wire OnLinkClick into Review app Recommendations tab
- 6a55ad39 Plan 00080: Instruct agents to write recommendation descriptions as markdown

---
Created using [Ivy Tendril](https://ivy.app).
