### PR TITLE
[00081] Suppress In App Job Toast When Native Desktop Notification Is Shown

### DIFF
--- a/src/Ivy.Tendril.Test/AppShell/AppShellNotificationTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/AppShellNotificationTests.cs
@@ -1,0 +1,34 @@
+using static Ivy.Tendril.AppShell.TendrilAppShell;
+
+namespace Ivy.Tendril.Test.AppShell;
+
+public class AppShellNotificationTests
+{
+    [Fact]
+    public void ShouldShowInAppToast_DesktopWithNativeNotificationsEnabled_ReturnsFalse()
+    {
+        // Native notification covers it, so the in-app toast would be a duplicate.
+        Assert.False(ShouldShowInAppToast(isDesktop: true, desktopNotificationsEnabled: true));
+    }
+
+    [Fact]
+    public void ShouldShowInAppToast_DesktopWithNativeNotificationsDisabled_ReturnsTrue()
+    {
+        // Native path is suppressed by the setting, so the toast is the only notification left.
+        Assert.True(ShouldShowInAppToast(isDesktop: true, desktopNotificationsEnabled: false));
+    }
+
+    [Fact]
+    public void ShouldShowInAppToast_WebWithNativeNotificationsEnabled_ReturnsTrue()
+    {
+        // Web mode has no native notification path, so it must always toast.
+        Assert.True(ShouldShowInAppToast(isDesktop: false, desktopNotificationsEnabled: true));
+    }
+
+    [Fact]
+    public void ShouldShowInAppToast_WebWithNativeNotificationsDisabled_ReturnsTrue()
+    {
+        // The setting only governs the native path; it must not disable the web toast.
+        Assert.True(ShouldShowInAppToast(isDesktop: false, desktopNotificationsEnabled: false));
+    }
+}

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -3,6 +3,7 @@ using System.Reactive.Disposables;
 using System.Text.Json;
 using Ivy.Core;
 using Ivy.Core.Apps;
+using Ivy.Desktop;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.AppShell.Dialogs;
 using Ivy.Tendril.Apps;
@@ -48,6 +49,15 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         int.TryParse(PlanYamlHelper.ExtractPlanIdFromFolder(planFolderName), out var id)
             ? id.ToString()
             : planFolderName;
+
+    /// <summary>
+    ///     Whether the in-app toast should be shown for a job notification. In desktop mode the
+    ///     native OS notification raised in Program.cs covers it, so the toast would be a duplicate.
+    ///     When desktop notifications are switched off the native path does not fire, so the toast
+    ///     is the only notification left and must stay.
+    /// </summary>
+    internal static bool ShouldShowInAppToast(bool isDesktop, bool desktopNotificationsEnabled)
+        => !isDesktop || !desktopNotificationsEnabled;
 
     private static async Task<SidebarNewsArticle[]> FetchNewsAsync()
     {
@@ -203,11 +213,18 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         });
 
         var jobService = UseService<IJobService>();
+        Context.TryUseService<DesktopWindow>(out var desktopWindow);
+        var isDesktop = desktopWindow != null;
 
         UseEffect(() =>
         {
             void OnNotification(JobNotification notification)
             {
+                // Read the setting at notification time: the user can toggle it in Settings while
+                // the shell is mounted, and the effect does not re-subscribe on that change.
+                if (!ShouldShowInAppToast(isDesktop, config.Settings.DesktopNotifications))
+                    return;
+
                 if (notification.IsSuccess)
                     client.Toast(notification.Message, notification.Title);
                 else


### PR DESCRIPTION
# Summary

## Changes

In desktop mode, the app shell's in-app job-completion toast is now suppressed whenever the
native OS notification (`DesktopWindow.ShowNotification` in `Program.cs`) will actually fire for
the same event, eliminating the duplicate notification. The toast still shows normally in web
mode, and in desktop mode when the user has turned the `DesktopNotifications` setting off (since
the native path is then the one that's silent).

## API Changes

- New `internal static bool TendrilAppShell.ShouldShowInAppToast(bool isDesktop, bool desktopNotificationsEnabled)` in `Ivy.Tendril.AppShell.TendrilAppShell` — pure helper encoding the suppression rule (`!isDesktop || !desktopNotificationsEnabled`). Internal, so no external consumers.

## Files Modified

- `src/Ivy.Tendril/AppShell/TendrilAppShell.cs` — added `using Ivy.Desktop;`, the `ShouldShowInAppToast` helper, a `Context.TryUseService<DesktopWindow>` resolution in `Build()`, and a gate at the top of the `JobNotification` handler.
- `src/Ivy.Tendril.Test/AppShell/AppShellNotificationTests.cs` (new) — 4 `[Fact]` cases covering the full desktop × setting truth table for `ShouldShowInAppToast`.

## Manual Testing

1. Launch Tendril in desktop mode (native window), leave the default "Desktop Notifications" setting on (Settings → Notifications).
2. Trigger a job to completion (e.g. run any promptware/plan execution).
3. Observe: only the native OS notification appears — no in-app toast in the bottom corner of the Tendril window.
4. In Settings → Notifications, turn "Desktop Notifications" off, then trigger another job completion.
5. Observe: the native OS notification no longer appears, but the in-app toast now shows instead (fallback).
6. Run Tendril in web mode (`tendril --web`) in a browser tab and trigger a job completion.
7. Observe: the in-app toast always shows, regardless of the `DesktopNotifications` setting (there is no native path in web mode).

---
## Commits
- ab3cb190 Suppress in-app toast when native desktop notification is shown

---
Created using [Ivy Tendril](https://ivy.app).
