### PR TITLE
[00078] Structured Question Blocks in Plan Markdown

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
@@ -202,6 +202,37 @@ Writes a numbered revision file to `Revisions/` (e.g. `002.md`) from stdin or `-
 
 Prints revision content to stdout — the latest revision by default, or a specific numbered revision with `--number`.
 
+## Questions
+
+A revision can carry questions for the user in fenced `questions` blocks. Promptwares run headless and cannot ask anything mid-run, so a planning agent that hits an ambiguity it cannot research away emits a block instead. The user answers in the UI, which writes the answers back into the same block, and UpdatePlan then folds them into the plan and removes the questions.
+
+````
+```questions
+questions:                    # 1-4 items
+  - title:       string       # required, the question
+    header:      string       # optional, <=12 char chip label
+    description: markdown     # optional, context shown under the question
+    multiple:    bool         # optional, default false; true = multi-select
+    other:       bool         # optional, default true; user may type a free value
+    options:                  # 2-4 items; omit entirely for a pure free-text question
+      - title:       string   # required, 1-5 words
+        description: markdown # optional
+        value:       slug     # required, ^[a-z0-9][a-z0-9-]*$, referenced by `answer`
+        recommended: bool     # optional, max one per question
+    answer:      value | [values] | string   # filled in on response
+```
+````
+
+A block may appear anywhere in the document, and a revision may contain any number of them. No `answer` key means unanswered; `answer: null` means the user deliberately skipped the question and left the decision to the agent.
+
+`write-revision` validates every block and refuses the write if any is malformed, printing each problem prefixed with the line of its opening fence. Nothing is written on rejection, so a rejected revision does not consume a revision number. A block whose body predates the schema (plain prose rather than a `questions` mapping) is reported as a warning and written unchanged.
+
+```terminal
+>tendril plan write-revision <plan-id> --file revision.md --no-question-check
+```
+
+`--no-question-check` skips the validation. It exists for scripted and test use — promptwares should not use it.
+
 ## Recommendations
 
 ```terminal

--- a/src/Ivy.Tendril.Test/QuestionBlockParserTests.cs
+++ b/src/Ivy.Tendril.Test/QuestionBlockParserTests.cs
@@ -1,0 +1,306 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Test;
+
+public class QuestionBlockParserTests
+{
+    [Fact]
+    public void Parse_ReadsSingleSelectFixedSet()
+    {
+        const string markdown = """
+            # A plan
+
+            ```questions
+            questions:
+              - title: Which auth scheme?
+                header: Auth
+                other: false
+                options:
+                  - title: JSON Web Tokens
+                    value: jwt
+                    recommended: true
+                  - title: Server sessions
+                    description: Stateful, needs a store.
+                    value: sessions
+            ```
+            """;
+
+        var blocks = QuestionBlockParser.Parse(markdown);
+
+        var question = Assert.Single(Assert.Single(blocks).Block!.Questions);
+        Assert.Equal("Which auth scheme?", question.Title);
+        Assert.Equal("Auth", question.Header);
+        Assert.False(question.Other);
+        Assert.False(question.Multiple);
+        Assert.Equal(2, question.Options!.Count);
+        Assert.Equal("jwt", question.Options[0].Value);
+        Assert.True(question.Options[0].Recommended);
+        Assert.Equal("Stateful, needs a store.", question.Options[1].Description);
+        Assert.False(question.Options[1].Recommended);
+    }
+
+    [Fact]
+    public void Parse_ReadsMultiSelectOpenSet()
+    {
+        const string markdown = """
+            ```questions
+            questions:
+              - title: Which platforms ship first?
+                multiple: true
+                options:
+                  - title: Windows
+                    value: windows
+                  - title: macOS
+                    value: macos
+                  - title: Linux
+                    value: linux
+            ```
+            """;
+
+        var question = Assert.Single(Assert.Single(QuestionBlockParser.Parse(markdown)).Block!.Questions);
+
+        Assert.True(question.Multiple);
+        Assert.True(question.Other); // default when the key is absent
+        Assert.Equal(3, question.Options!.Count);
+    }
+
+    [Fact]
+    public void Parse_ReadsPureFreeTextQuestion()
+    {
+        const string markdown = """
+            ```questions
+            questions:
+              - title: What should the feature be called?
+                description: Anything is fine as long as it is not "Manager".
+            ```
+            """;
+
+        var question = Assert.Single(Assert.Single(QuestionBlockParser.Parse(markdown)).Block!.Questions);
+
+        Assert.Null(question.Options);
+        Assert.True(question.Other);
+        Assert.Equal(AnswerState.Unanswered, question.AnswerState);
+    }
+
+    [Fact]
+    public void Parse_ReportsOneBasedLineOfOpeningFence()
+    {
+        const string markdown = """
+            # A plan
+
+            Some prose.
+
+            ```questions
+            questions:
+              - title: Really?
+            ```
+            """;
+
+        Assert.Equal(5, Assert.Single(QuestionBlockParser.Parse(markdown)).Line);
+    }
+
+    [Fact]
+    public void Parse_IgnoresQuestionsFenceNestedInLongerFence()
+    {
+        // A plan that documents the format must not fail its own validator.
+        const string markdown = """"
+            Here is how the format looks:
+
+            ````
+            ```questions
+            questions:
+              - title: An example, not a real question.
+            ```
+            ````
+            """";
+
+        Assert.Empty(QuestionBlockParser.Parse(markdown));
+    }
+
+    [Fact]
+    public void Parse_ReturnsEveryTopLevelBlockInDocumentOrder()
+    {
+        const string markdown = """
+            # A plan
+
+            ```questions
+            questions:
+              - title: First scope question?
+            ```
+
+            ## Solution
+
+            ```csharp
+            var x = 1;
+            ```
+
+            ```questions
+            questions:
+              - title: Second design question?
+            ```
+            """;
+
+        var blocks = QuestionBlockParser.Parse(markdown);
+
+        Assert.Equal(2, blocks.Count);
+        Assert.Equal("First scope question?", blocks[0].Block!.Questions[0].Title);
+        Assert.Equal("Second design question?", blocks[1].Block!.Questions[0].Title);
+        Assert.True(blocks[0].Line < blocks[1].Line);
+    }
+
+    [Fact]
+    public void Parse_TreatsProseBodyAsLegacyWithoutYamlError()
+    {
+        const string markdown = """
+            ```questions
+            Should this use JWTs or server sessions? We could not tell from the code.
+            ```
+            """;
+
+        var block = Assert.Single(QuestionBlockParser.Parse(markdown));
+
+        Assert.True(block.IsLegacy);
+        Assert.Null(block.YamlError);
+        Assert.Null(block.Block);
+    }
+
+    [Fact]
+    public void Parse_TreatsProseThatIsNotValidYamlAsLegacy()
+    {
+        // Prose with stray colons does not parse as YAML, and must still never be an error.
+        const string markdown = """
+            ```questions
+            Open: should we do this? Note: the caller decides: here or there.
+            - unbalanced [bracket
+            ```
+            """;
+
+        var block = Assert.Single(QuestionBlockParser.Parse(markdown));
+
+        Assert.True(block.IsLegacy);
+        Assert.Null(block.YamlError);
+    }
+
+    [Fact]
+    public void Parse_ReportsBrokenYamlInAStructuredBlockAsError()
+    {
+        const string markdown = """
+            ```questions
+            questions:
+              - title: Broken
+                options: [unclosed
+            ```
+            """;
+
+        var block = Assert.Single(QuestionBlockParser.Parse(markdown));
+
+        Assert.False(block.IsLegacy);
+        Assert.NotNull(block.YamlError);
+    }
+
+    [Theory]
+    [InlineData("", AnswerState.Unanswered)]
+    [InlineData("    answer:", AnswerState.Declined)]
+    [InlineData("    answer: jwt", AnswerState.Answered)]
+    public void Parse_DistinguishesAnswerStates(string answerLine, AnswerState expected)
+    {
+        var markdown = $"```questions\nquestions:\n  - title: Which one?\n{answerLine}\n```";
+
+        var question = Assert.Single(Assert.Single(QuestionBlockParser.Parse(markdown)).Block!.Questions);
+
+        Assert.Equal(expected, question.AnswerState);
+    }
+
+    [Fact]
+    public void Parse_DistinguishesScalarFromListAnswer()
+    {
+        const string markdown = """
+            ```questions
+            questions:
+              - title: Scalar?
+                answer: jwt
+              - title: List?
+                multiple: true
+                answer: [jwt, sessions]
+            ```
+            """;
+
+        var questions = Assert.Single(QuestionBlockParser.Parse(markdown)).Block!.Questions;
+
+        Assert.False(questions[0].AnswerIsList);
+        Assert.Equal(["jwt"], questions[0].AnswerValues);
+
+        Assert.True(questions[1].AnswerIsList);
+        Assert.Equal(["jwt", "sessions"], questions[1].AnswerValues);
+    }
+
+    [Fact]
+    public void Parse_ReadsFreeTextAnswerThatMatchesNoOption()
+    {
+        const string markdown = """
+            ```questions
+            questions:
+              - title: Which auth scheme?
+                options:
+                  - title: JSON Web Tokens
+                    value: jwt
+                  - title: Server sessions
+                    value: sessions
+                answer: mTLS, actually
+            ```
+            """;
+
+        var question = Assert.Single(Assert.Single(QuestionBlockParser.Parse(markdown)).Block!.Questions);
+
+        Assert.Equal(AnswerState.Answered, question.AnswerState);
+        Assert.Equal(["mTLS, actually"], question.AnswerValues);
+    }
+
+    [Fact]
+    public void Parse_HandlesUnterminatedFence()
+    {
+        const string markdown = """
+            ```questions
+            questions:
+              - title: Never closed?
+            """;
+
+        var block = Assert.Single(QuestionBlockParser.Parse(markdown));
+
+        Assert.Equal("Never closed?", block.Block!.Questions[0].Title);
+    }
+
+    [Fact]
+    public void Parse_IgnoresOtherLanguages()
+    {
+        const string markdown = """
+            ```yaml
+            questions:
+              - title: Documentation, not a question.
+            ```
+            """;
+
+        Assert.Empty(QuestionBlockParser.Parse(markdown));
+    }
+
+    [Fact]
+    public void FindFenceRanges_CoversFenceDelimiters()
+    {
+        const string markdown = """
+            # A plan
+
+            ```questions
+            questions:
+              - title: Really?
+            ```
+
+            Trailing prose.
+            """;
+
+        var range = Assert.Single(QuestionBlockParser.FindFenceRanges(markdown));
+
+        Assert.Equal(3, range.StartLine);
+        Assert.Equal(6, range.EndLine);
+    }
+}

--- a/src/Ivy.Tendril.Test/QuestionValidationServiceTests.cs
+++ b/src/Ivy.Tendril.Test/QuestionValidationServiceTests.cs
@@ -1,0 +1,456 @@
+using Ivy.Tendril.Services.Plans;
+
+namespace Ivy.Tendril.Test;
+
+public class QuestionValidationServiceTests
+{
+    private static IReadOnlyList<QuestionIssue> Validate(string body) =>
+        QuestionValidationService.Validate($"```questions\n{body}\n```");
+
+    private static string SingleError(string body)
+    {
+        var issue = Assert.Single(Validate(body));
+        Assert.Equal(QuestionIssueSeverity.Error, issue.Severity);
+        return issue.Message;
+    }
+
+    // ---------------------------------------------------------------- clean documents
+
+    [Fact]
+    public void Validate_ReturnsNothingForAValidDocument()
+    {
+        const string markdown = """
+            # A plan
+
+            ```questions
+            questions:
+              - title: Which auth scheme?
+                header: Auth
+                other: false
+                options:
+                  - title: JSON Web Tokens
+                    value: jwt
+                    recommended: true
+                  - title: Server sessions
+                    value: sessions
+                answer: jwt
+              - title: What should it be called?
+            ```
+
+            ## Solution
+
+            Prose.
+            """;
+
+        Assert.Empty(QuestionValidationService.Validate(markdown));
+    }
+
+    [Fact]
+    public void Validate_ReturnsNothingForADocumentWithNoQuestionBlocks()
+    {
+        Assert.Empty(QuestionValidationService.Validate("# A plan\n\nJust prose and a ```csharp fence.\n"));
+    }
+
+    [Fact]
+    public void Validate_IgnoresQuestionsFenceNestedInLongerFence()
+    {
+        const string markdown = """"
+            ````
+            ```questions
+            questions:
+              - title: Documentation, with five options and every rule broken.
+                options:
+                  - title: Other
+                    value: NOPE
+            ```
+            ````
+            """";
+
+        Assert.Empty(QuestionValidationService.Validate(markdown));
+    }
+
+    // ---------------------------------------------------------------- lint rules
+
+    [Fact]
+    public void Validate_RejectsMoreThanOneRecommendedOption()
+    {
+        var message = SingleError("""
+            questions:
+              - title: Which one?
+                options:
+                  - title: First
+                    value: first
+                    recommended: true
+                  - title: Second
+                    value: second
+                    recommended: true
+            """);
+
+        Assert.Equal("question 1: more than one option is recommended", message);
+    }
+
+    [Theory]
+    [InlineData("Other")]
+    [InlineData("Something else")]
+    [InlineData("Custom")]
+    public void Validate_RejectsHandAuthoredOtherOption(string title)
+    {
+        var message = SingleError($"""
+            questions:
+              - title: Which one?
+                options:
+                  - title: First
+                    value: first
+                  - title: {title}
+                    value: something-else
+            """);
+
+        Assert.Equal($"question 1: option '{title}' duplicates what other: true provides", message);
+    }
+
+    [Fact]
+    public void Validate_RejectsOtherFalseWithNoOptions()
+    {
+        var message = SingleError("""
+            questions:
+              - title: Which one?
+                other: false
+            """);
+
+        Assert.Equal("question 1: other: false with no options is unanswerable", message);
+    }
+
+    [Fact]
+    public void Validate_RejectsScalarAnswerWhenMultipleIsTrue()
+    {
+        var message = SingleError("""
+            questions:
+              - title: Which ones?
+                multiple: true
+                answer: first
+            """);
+
+        Assert.Equal("question 1: multiple: true requires a list answer", message);
+    }
+
+    [Fact]
+    public void Validate_RejectsListAnswerWhenMultipleIsFalse()
+    {
+        var message = SingleError("""
+            questions:
+              - title: Which one?
+                answer: [first, second]
+            """);
+
+        Assert.Equal("question 1: answer must be a scalar when multiple is false", message);
+    }
+
+    [Fact]
+    public void Validate_RejectsDuplicateOptionValue()
+    {
+        var message = SingleError("""
+            questions:
+              - title: Which one?
+                options:
+                  - title: First
+                    value: jwt
+                  - title: Second
+                    value: jwt
+            """);
+
+        Assert.Equal("question 1: duplicate option value 'jwt'", message);
+    }
+
+    [Fact]
+    public void Validate_RejectsUnmatchedAnswerWhenOtherIsFalse()
+    {
+        var message = SingleError("""
+            questions:
+              - title: Which one?
+                other: false
+                options:
+                  - title: First
+                    value: first
+                  - title: Second
+                    value: second
+                answer: third
+            """);
+
+        Assert.Equal("question 1: answer 'third' matches no option and other is false", message);
+    }
+
+    [Fact]
+    public void Validate_AllowsUnmatchedAnswerWhenOtherIsTrue()
+    {
+        Assert.Empty(Validate("""
+            questions:
+              - title: Which one?
+                options:
+                  - title: First
+                    value: first
+                  - title: Second
+                    value: second
+                answer: something the user typed
+            """));
+    }
+
+    // ---------------------------------------------------------------- schema bounds
+
+    [Fact]
+    public void Validate_RejectsBlockWithNoQuestions()
+    {
+        var message = SingleError("questions: []");
+
+        Assert.Equal("at least one question is required", message);
+    }
+
+    [Fact]
+    public void Validate_RejectsMoreThanFourQuestions()
+    {
+        var body = "questions:\n" + string.Join("\n",
+            Enumerable.Range(1, 5).Select(i => $"  - title: Question {i}?"));
+
+        Assert.Equal("5 questions in one block; at most 4 are allowed", SingleError(body));
+    }
+
+    [Fact]
+    public void Validate_AcceptsFourQuestions()
+    {
+        var body = "questions:\n" + string.Join("\n",
+            Enumerable.Range(1, 4).Select(i => $"  - title: Question {i}?"));
+
+        Assert.Empty(Validate(body));
+    }
+
+    [Fact]
+    public void Validate_RejectsSingleOption()
+    {
+        var message = SingleError("""
+            questions:
+              - title: Which one?
+                options:
+                  - title: Only
+                    value: only
+            """);
+
+        Assert.Equal("question 1: 1 option; at least 2 are required", message);
+    }
+
+    [Fact]
+    public void Validate_RejectsMoreThanFourOptions()
+    {
+        var body = "questions:\n  - title: Which one?\n    options:\n" + string.Join("\n",
+            Enumerable.Range(1, 5).Select(i => $"      - title: Option {i}\n        value: option-{i}"));
+
+        Assert.Equal("question 1: 5 options; at most 4 are allowed", SingleError(body));
+    }
+
+    [Fact]
+    public void Validate_RejectsHeaderLongerThanTwelveCharacters()
+    {
+        var message = SingleError("""
+            questions:
+              - title: Which one?
+                header: ThirteenChars
+            """);
+
+        Assert.Equal("question 1: header 'ThirteenChars' is 13 characters; at most 12 are allowed", message);
+    }
+
+    [Fact]
+    public void Validate_AcceptsTwelveCharacterHeader()
+    {
+        Assert.Empty(Validate("""
+            questions:
+              - title: Which one?
+                header: TwelveChars!
+            """));
+    }
+
+    [Fact]
+    public void Validate_RejectsMissingTitle()
+    {
+        var message = SingleError("""
+            questions:
+              - header: Auth
+            """);
+
+        Assert.Equal("question 1: title is required", message);
+    }
+
+    [Theory]
+    [InlineData("JWT")]
+    [InlineData("-jwt")]
+    [InlineData("json web tokens")]
+    [InlineData("json_web_tokens")]
+    public void Validate_RejectsOptionValueThatIsNotASlug(string value)
+    {
+        var message = SingleError($"""
+            questions:
+              - title: Which one?
+                options:
+                  - title: First
+                    value: {value}
+                  - title: Second
+                    value: second
+            """);
+
+        Assert.Equal($"question 1: option value '{value}' must match ^[a-z0-9][a-z0-9-]*$", message);
+    }
+
+    [Fact]
+    public void Validate_AcceptsSlugOptionValues()
+    {
+        Assert.Empty(Validate("""
+            questions:
+              - title: Which one?
+                options:
+                  - title: First
+                    value: json-web-tokens
+                  - title: Second
+                    value: 2fa
+            """));
+    }
+
+    [Fact]
+    public void Validate_RejectsUnknownKeyOnQuestion()
+    {
+        var message = SingleError("""
+            questions:
+              - title: Which one?
+                requird: true
+            """);
+
+        Assert.StartsWith("invalid questions YAML:", message);
+        Assert.Contains("requird", message);
+    }
+
+    [Fact]
+    public void Validate_RejectsUnknownKeyOnOption()
+    {
+        var message = SingleError("""
+            questions:
+              - title: Which one?
+                options:
+                  - title: First
+                    value: first
+                    reccommended: true
+                  - title: Second
+                    value: second
+            """);
+
+        Assert.StartsWith("invalid questions YAML:", message);
+        Assert.Contains("reccommended", message);
+    }
+
+    // ---------------------------------------------------------------- legacy blocks
+
+    [Fact]
+    public void Validate_WarnsOnceForALegacyProseBlock()
+    {
+        var issue = Assert.Single(Validate("Should this use JWTs or server sessions?"));
+
+        Assert.Equal(QuestionIssueSeverity.Warning, issue.Severity);
+        Assert.Contains("free-text questions block", issue.Message);
+    }
+
+    [Fact]
+    public void Validate_WarnsRatherThanErringForAMappingWithoutQuestions()
+    {
+        var issue = Assert.Single(Validate("open: should we use JWTs?"));
+
+        Assert.Equal(QuestionIssueSeverity.Warning, issue.Severity);
+    }
+
+    // ---------------------------------------------------------------- multiple blocks
+
+    [Fact]
+    public void Validate_AcceptsSeveralValidBlocksAtDifferentPoints()
+    {
+        const string markdown = """
+            # A plan
+
+            ```questions
+            questions:
+              - title: A scope question?
+            ```
+
+            ## Solution
+
+            ```questions
+            questions:
+              - title: A design question?
+            ```
+            """;
+
+        Assert.Empty(QuestionValidationService.Validate(markdown));
+    }
+
+    [Fact]
+    public void Validate_NumbersEachBlockWhenThereIsMoreThanOne()
+    {
+        const string markdown = """
+            ```questions
+            questions:
+              - title: Fine?
+              - title: Also fine?
+                other: false
+            ```
+
+            ```questions
+            questions:
+              - title: Broken?
+                header: WayTooLongHeader
+            ```
+            """;
+
+        var issues = QuestionValidationService.Validate(markdown);
+
+        Assert.Equal(2, issues.Count);
+        Assert.Equal("block 1: question 2: other: false with no options is unanswerable", issues[0].Message);
+        Assert.StartsWith("block 2: question 1: header 'WayTooLongHeader'", issues[1].Message);
+        Assert.Equal(1, issues[0].Line);
+        Assert.Equal(8, issues[1].Line);
+    }
+
+    [Fact]
+    public void Validate_OmitsBlockPrefixForASingleBlock()
+    {
+        Assert.DoesNotContain("block 1", SingleError("""
+            questions:
+              - title: Which one?
+                other: false
+            """));
+    }
+
+    [Fact]
+    public void QuestionIssue_RendersWithItsSourceLine()
+    {
+        var issue = new QuestionIssue(QuestionIssueSeverity.Error, 12, "question 2: duplicate option value 'jwt'");
+
+        Assert.Equal("line 12: question 2: duplicate option value 'jwt'", issue.ToString());
+    }
+
+    [Fact]
+    public void Validate_ReportsEveryProblemAtOnce()
+    {
+        var issues = Validate("""
+            questions:
+              - title: Which one?
+                header: FarTooLongToFit
+                options:
+                  - title: First
+                    value: jwt
+                    recommended: true
+                  - title: Second
+                    value: jwt
+                    recommended: true
+            """);
+
+        Assert.Equal(3, issues.Count);
+        Assert.All(issues, i => Assert.Equal(QuestionIssueSeverity.Error, i.Severity));
+        Assert.Contains(issues, i => i.Message.Contains("at most 12 are allowed"));
+        Assert.Contains(issues, i => i.Message.Contains("duplicate option value 'jwt'"));
+        Assert.Contains(issues, i => i.Message.Contains("more than one option is recommended"));
+    }
+}

--- a/src/Ivy.Tendril.Test/RevisionWriterTests.cs
+++ b/src/Ivy.Tendril.Test/RevisionWriterTests.cs
@@ -167,4 +167,16 @@ public class RevisionWriterTests : IDisposable
         Assert.Contains($"    description: \"{bait}\"", written);
         Assert.EndsWith(input[input.IndexOf("```questions", StringComparison.Ordinal)..], written);
     }
+
+    [Fact]
+    public void WriteNext_PreservesBlankLinesAroundQuestionBlock()
+    {
+        // Splitting the document around the fence must not lose empty segments: a document that
+        // opens with a blank line makes the first polished segment the empty string.
+        const string input = "\n\n```questions\nquestions:\n  - title: Which one?\n```\n\ntail\n";
+
+        var written = File.ReadAllText(RevisionWriter.WriteNext(_planFolder, input, _config));
+
+        Assert.Equal(input, written);
+    }
 }

--- a/src/Ivy.Tendril.Test/RevisionWriterTests.cs
+++ b/src/Ivy.Tendril.Test/RevisionWriterTests.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
 
 namespace Ivy.Tendril.Test;
 
@@ -53,5 +54,117 @@ public class RevisionWriterTests : IDisposable
         var path = RevisionWriter.WriteNext(_planFolder, clean, _config);
 
         Assert.Equal(clean, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void WriteNext_RejectsInvalidQuestionBlockAndWritesNothing()
+    {
+        const string invalid = """
+            # A plan
+
+            ```questions
+            questions:
+              - title: Which one?
+                other: false
+            ```
+            """;
+
+        var ex = Assert.Throws<QuestionValidationException>(
+            () => RevisionWriter.WriteNext(_planFolder, invalid, _config));
+
+        Assert.Equal("question 1: other: false with no options is unanswerable", Assert.Single(ex.Issues).Message);
+        Assert.Contains("line 3:", ex.Message);
+
+        // Nothing on disk, so the rejected revision did not consume a number.
+        var revisions = Path.Combine(_planFolder, "Revisions");
+        Assert.True(!Directory.Exists(revisions) || Directory.GetFiles(revisions).Length == 0);
+        Assert.EndsWith("001.md", RevisionWriter.WriteNext(_planFolder, "next", _config));
+    }
+
+    [Fact]
+    public void WriteNext_ReportsEveryErrorAtOnce()
+    {
+        const string invalid = """
+            ```questions
+            questions:
+              - title: Which one?
+                options:
+                  - title: First
+                    value: jwt
+                  - title: Other
+                    value: jwt
+            ```
+            """;
+
+        var ex = Assert.Throws<QuestionValidationException>(
+            () => RevisionWriter.WriteNext(_planFolder, invalid, _config));
+
+        Assert.Equal(2, ex.Issues.Count);
+        Assert.Contains("duplicate option value 'jwt'", ex.Message);
+        Assert.Contains("duplicates what other: true provides", ex.Message);
+    }
+
+    [Fact]
+    public void WriteNext_SkipsQuestionValidationWhenAsked()
+    {
+        const string invalid = """
+            ```questions
+            questions:
+              - title: Which one?
+                other: false
+            ```
+            """;
+
+        var path = RevisionWriter.WriteNext(_planFolder, invalid, _config, validateQuestions: false);
+
+        Assert.Equal(invalid, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void WriteNext_ReportsLegacyBlocksAsWarningsWithoutBlocking()
+    {
+        const string legacy = """
+            ```questions
+            Should this use JWTs or server sessions?
+            ```
+            """;
+
+        var path = RevisionWriter.WriteNext(_planFolder, legacy, _config, out var warnings);
+
+        Assert.Equal(legacy, File.ReadAllText(path));
+        Assert.Equal(QuestionIssueSeverity.Warning, Assert.Single(warnings).Severity);
+    }
+
+    [Fact]
+    public void WriteNext_LeavesQuestionBlockContentUnpolished()
+    {
+        // The same bait inside and outside the fence: outside it must be polished, inside it must
+        // not, because option values and answers are matched literally.
+        const string bait = "See [helpers.cs:348](file:///D:/repo/helpers.cs:348) and Plan 02369.";
+        var input = $$"""
+            {{bait}}
+
+            ```questions
+            questions:
+              - title: Which one?
+                description: "{{bait}}"
+                options:
+                  - title: First
+                    value: first
+                  - title: Second
+                    value: second
+            ```
+            """;
+
+        var written = File.ReadAllText(RevisionWriter.WriteNext(_planFolder, input, _config));
+
+        // Outside the fence: polished (the :348 suffix stripped, the plan number linked).
+        Assert.StartsWith(
+            "See [helpers.cs:348](file:///D:/repo/helpers.cs) and Plan [02369](plan://02369).",
+            written);
+
+        // Inside the fence: byte for byte what the agent wrote.
+        Assert.Contains($"    description: \"{bait}\"", written);
+        Assert.EndsWith(input[input.IndexOf("```questions", StringComparison.Ordinal)..], written);
     }
 }

--- a/src/Ivy.Tendril/AGENTS.md
+++ b/src/Ivy.Tendril/AGENTS.md
@@ -11,6 +11,12 @@ When changing the `plan.yaml` structure (adding/removing/renaming fields, changi
 
 Existing plans on disk are never recreated — they must be migrated in place. If a migration can't fix a plan it is logged and skipped, and that plan won't appear in the UI. Always test your migration against real plan files. Terminal plans (Completed/Skipped) are treated as immutable and are not migrated.
 
+## Question Blocks
+
+Fenced `questions` blocks let a planning agent ask the user something from a headless run. The normative spec is the `## Question Blocks` section of `Prompts/Plans.md` (embedded as an assembly resource and injected into every promptware firmware); the enforcement is `Services/Plans/QuestionValidationService.cs`, reached from `RevisionWriter.WriteNext` so the CLI, REST and MCP write paths are all covered. **The two must change together** — a rule the validator enforces but Plans.md does not document is a rule agents cannot follow, and vice versa.
+
+No `plan.yaml` migration is involved: questions live in the revision markdown, not in `plan.yaml`.
+
 ## Project Structure
 
 - `Services/` — ConfigService, PlanReaderService, JobService, GitService

--- a/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs
@@ -24,6 +24,10 @@ public class PlanWriteRevisionSettings : CommandSettings
     [CommandOption("--no-duplicate-check")]
     public bool NoDuplicateCheck { get; set; }
 
+    [Description("Skip validation of questions blocks (for scripted and test use)")]
+    [CommandOption("--no-question-check")]
+    public bool NoQuestionCheck { get; set; }
+
     public int SourceCount => CliValidation.CountSources(Stdin, FilePath, "");
 
     public override Spectre.Console.ValidationResult Validate()
@@ -46,13 +50,42 @@ public class PlanWriteRevisionCommand : Command<PlanWriteRevisionSettings>
         if (string.IsNullOrWhiteSpace(content))
             throw new ArgumentException("No content provided (use --file or --stdin)");
 
-        var filePath = RevisionWriter.WriteNext(planFolder, content, new ConfigService());
+        string filePath;
+        IReadOnlyList<QuestionIssue> questionWarnings;
+        try
+        {
+            filePath = RevisionWriter.WriteNext(planFolder, content, new ConfigService(),
+                out questionWarnings, !settings.NoQuestionCheck);
+        }
+        catch (QuestionValidationException ex)
+        {
+            // Nothing was written, so the agent can fix the source and retry without re-sending it.
+            Console.Error.WriteLine(ex.Message);
+            return 1;
+        }
+
         Console.Write(filePath);
+
+        WarnAboutQuestionBlocks(questionWarnings);
 
         if (!settings.NoDuplicateCheck)
             WarnAboutDuplicateCandidates(planFolder);
 
         return 0;
+    }
+
+    /// <summary>
+    ///     Prints non-blocking question-block warnings to stderr. Like the duplicate warning below,
+    ///     the exit code stays 0 — a pre-schema free-text block is legal and must not fail a write.
+    /// </summary>
+    private static void WarnAboutQuestionBlocks(IReadOnlyList<QuestionIssue> warnings)
+    {
+        if (warnings.Count == 0)
+            return;
+
+        Console.Error.WriteLine();
+        foreach (var warning in warnings)
+            Console.Error.WriteLine($"warning: {warning}");
     }
 
     /// <summary>

--- a/src/Ivy.Tendril/Helpers/MarkdownLinkPolisher.cs
+++ b/src/Ivy.Tendril/Helpers/MarkdownLinkPolisher.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Ivy.Tendril.Helpers;
@@ -33,9 +34,63 @@ public class MarkdownLinkPolisher
         if (string.IsNullOrEmpty(markdownContent))
             return markdownContent;
 
-        var result = markdownContent;
+        var questionFences = QuestionBlockParser.FindFenceRanges(markdownContent);
+        if (questionFences.Count == 0)
+            return Polish(markdownContent, plansDirectory);
 
-        result = RemoveBackticksFromFileLinkText(result);
+        // A `questions` fence is machine-read YAML — option values are slugs matched literally
+        // against answers — so polishing one would corrupt the block (a bare 5-digit value would
+        // become a plan link). Everything around it is polished as before. Lines keep their own
+        // terminators, so splitting and rejoining on '\n' is byte-preserving for CRLF too.
+        var lines = markdownContent.Split('\n');
+        var builder = new StringBuilder();
+        var pending = new List<string>();
+        var fenceIndex = 0;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var lineNumber = i + 1;
+            while (fenceIndex < questionFences.Count && questionFences[fenceIndex].EndLine < lineNumber)
+                fenceIndex++;
+
+            var insideFence = fenceIndex < questionFences.Count &&
+                              lineNumber >= questionFences[fenceIndex].StartLine &&
+                              lineNumber <= questionFences[fenceIndex].EndLine;
+
+            if (!insideFence)
+            {
+                pending.Add(lines[i]);
+                continue;
+            }
+
+            Flush();
+            Append(lines[i]);
+        }
+
+        Flush();
+        return builder.ToString();
+
+        void Flush()
+        {
+            if (pending.Count == 0)
+                return;
+
+            Append(Polish(string.Join("\n", pending), plansDirectory));
+            pending.Clear();
+        }
+
+        void Append(string text)
+        {
+            if (builder.Length > 0)
+                builder.Append('\n');
+
+            builder.Append(text);
+        }
+    }
+
+    private string Polish(string content, string plansDirectory)
+    {
+        var result = RemoveBackticksFromFileLinkText(content);
         result = PolishMarkdownLinks(result);
         result = ConvertBarePlanNumbers(result, plansDirectory);
 

--- a/src/Ivy.Tendril/Helpers/MarkdownLinkPolisher.cs
+++ b/src/Ivy.Tendril/Helpers/MarkdownLinkPolisher.cs
@@ -46,6 +46,7 @@ public class MarkdownLinkPolisher
         var builder = new StringBuilder();
         var pending = new List<string>();
         var fenceIndex = 0;
+        var wroteAny = false;
 
         for (var i = 0; i < lines.Length; i++)
         {
@@ -81,9 +82,13 @@ public class MarkdownLinkPolisher
 
         void Append(string text)
         {
-            if (builder.Length > 0)
+            // Tracked with a flag rather than `builder.Length > 0`: the first segment is the empty
+            // string whenever the document opens with a blank line, and testing the length would
+            // swallow the separator and silently drop that line.
+            if (wroteAny)
                 builder.Append('\n');
 
+            wroteAny = true;
             builder.Append(text);
         }
     }

--- a/src/Ivy.Tendril/Helpers/QuestionBlockParser.cs
+++ b/src/Ivy.Tendril/Helpers/QuestionBlockParser.cs
@@ -1,0 +1,266 @@
+using Ivy.Tendril.Models;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+///     One fenced <c>questions</c> block found in a markdown document.
+/// </summary>
+/// <param name="Line">1-based line number of the opening fence.</param>
+/// <param name="Body">Raw fence body, dedented by the opening fence's own indentation.</param>
+/// <param name="Block">The deserialized block, or null when legacy or unparseable.</param>
+/// <param name="YamlError">Parse or shape error, or null. Only set for a block that was meant to be structured.</param>
+/// <param name="IsLegacy">
+///     True when the body is not a YAML mapping with a <c>questions</c> key — the plain-text form
+///     that shipped before the schema existed. Legacy blocks warn, never error, and are never rewritten.
+/// </param>
+public record ParsedQuestionsBlock(
+    int Line,
+    string Body,
+    QuestionsBlock? Block,
+    string? YamlError,
+    bool IsLegacy);
+
+/// <summary>
+///     Extracts fenced <c>questions</c> blocks from plan revision markdown.
+///     <para>
+///         Fence tracking follows CommonMark: a fence opened with N of a delimiter is closed only by
+///         a run of N or more of the same delimiter, so a <c>questions</c> fence written inside a
+///         longer fence is documentation, not a question. Without this, a plan that documents the
+///         format fails its own validator.
+///     </para>
+/// </summary>
+public static class QuestionBlockParser
+{
+    private const string InfoWord = "questions";
+
+    /// <summary>
+    ///     Strict deserializer: the schema is <c>additionalProperties: false</c>, so unlike
+    ///     <see cref="YamlHelper.Deserializer" /> this one must NOT ignore unmatched properties —
+    ///     an unknown key is a typo the agent has to fix, not something to swallow.
+    /// </summary>
+    private static readonly IDeserializer StrictDeserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    /// <summary>
+    ///     Returns every top-level <c>questions</c> block in <paramref name="markdown" />, in
+    ///     document order. A document may contain any number of blocks, anywhere.
+    /// </summary>
+    public static IReadOnlyList<ParsedQuestionsBlock> Parse(string markdown) =>
+        Scan(markdown).Select(block => Analyze(block.StartLine, block.Body)).ToList();
+
+    /// <summary>
+    ///     1-based inclusive line ranges of every <c>questions</c> fence, delimiters included.
+    ///     Used by <see cref="MarkdownLinkPolisher" /> to leave machine-read YAML alone.
+    /// </summary>
+    public static IReadOnlyList<QuestionFenceRange> FindFenceRanges(string markdown) =>
+        Scan(markdown).Select(block => new QuestionFenceRange(block.StartLine, block.EndLine)).ToList();
+
+    private static List<RawBlock> Scan(string markdown)
+    {
+        var results = new List<RawBlock>();
+        if (string.IsNullOrEmpty(markdown))
+            return results;
+
+        var lines = markdown.Replace("\r\n", "\n").Split('\n');
+
+        var open = false;
+        var openChar = '\0';
+        var openLength = 0;
+        var openIndent = 0;
+        var isQuestions = false;
+        var startLine = 0;
+        var body = new List<string>();
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var fence = MatchFence(lines[i]);
+
+            if (!open)
+            {
+                if (fence is not { } opening)
+                    continue;
+
+                open = true;
+                openChar = opening.Delimiter;
+                openLength = opening.Length;
+                openIndent = opening.Indent;
+                isQuestions = IsQuestionsInfo(opening.Info);
+                startLine = i + 1;
+                body.Clear();
+                continue;
+            }
+
+            // Only a bare run of the same delimiter, at least as long as the opener, closes a fence.
+            if (fence is { } closing && closing.Delimiter == openChar &&
+                closing.Length >= openLength && closing.Info.Length == 0)
+            {
+                if (isQuestions)
+                    results.Add(new RawBlock(startLine, i + 1, string.Join("\n", body)));
+
+                open = false;
+                continue;
+            }
+
+            body.Add(Dedent(lines[i], openIndent));
+        }
+
+        // An unterminated fence runs to the end of the document (CommonMark).
+        if (open && isQuestions)
+            results.Add(new RawBlock(startLine, lines.Length, string.Join("\n", body)));
+
+        return results;
+    }
+
+    private static ParsedQuestionsBlock Analyze(int line, string body)
+    {
+        // Pass 1: the raw node, which is the only place that knows whether an `answer` key exists.
+        YamlMappingNode? mapping = null;
+        string? loadError = null;
+        try
+        {
+            var stream = new YamlStream();
+            stream.Load(new StringReader(body));
+            if (stream.Documents.Count > 0)
+                mapping = stream.Documents[0].RootNode as YamlMappingNode;
+        }
+        catch (YamlException ex)
+        {
+            loadError = Flatten(ex.Message);
+        }
+
+        var questionsNode = mapping is not null &&
+                            mapping.Children.TryGetValue(new YamlScalarNode(InfoWord), out var node)
+            ? node
+            : null;
+
+        if (questionsNode is null)
+        {
+            // Broken YAML that clearly meant to be structured is an error; anything else is the
+            // pre-schema plain-text form, which must never be rejected.
+            if (loadError is not null && LooksStructured(body))
+                return new ParsedQuestionsBlock(line, body, null, loadError, IsLegacy: false);
+
+            return new ParsedQuestionsBlock(line, body, null, null, IsLegacy: true);
+        }
+
+        // Pass 2: the typed fields, strictly.
+        QuestionsBlock? typed;
+        try
+        {
+            typed = StrictDeserializer.Deserialize<QuestionsBlock>(body);
+        }
+        catch (YamlException ex)
+        {
+            return new ParsedQuestionsBlock(line, body, null, Flatten(ex.Message), IsLegacy: false);
+        }
+
+        if (typed is null)
+            return new ParsedQuestionsBlock(line, body, null, "block is empty", IsLegacy: false);
+
+        return new ParsedQuestionsBlock(
+            line, body, typed with { Questions = StampAnswers(typed.Questions, questionsNode) }, null, IsLegacy: false);
+    }
+
+    /// <summary>
+    ///     Copies <c>answer</c>-key presence from the raw YAML onto the deserialized questions.
+    /// </summary>
+    private static List<PlanQuestion> StampAnswers(List<PlanQuestion> questions, YamlNode questionsNode)
+    {
+        if (questionsNode is not YamlSequenceNode sequence)
+            return questions;
+
+        var answerKey = new YamlScalarNode("answer");
+        var stamped = new List<PlanQuestion>(questions.Count);
+        for (var i = 0; i < questions.Count; i++)
+        {
+            var present = i < sequence.Children.Count &&
+                          sequence.Children[i] is YamlMappingNode item &&
+                          item.Children.ContainsKey(answerKey);
+            stamped.Add(questions[i] with { AnswerPresent = present });
+        }
+
+        return stamped;
+    }
+
+    /// <summary>The first meaningful line is a <c>questions:</c> key, so the body meant to be structured.</summary>
+    private static bool LooksStructured(string body)
+    {
+        foreach (var raw in body.Split('\n'))
+        {
+            var line = raw.Trim();
+            if (line.Length == 0 || line.StartsWith('#'))
+                continue;
+
+            return line.StartsWith(InfoWord + ":", StringComparison.Ordinal);
+        }
+
+        return false;
+    }
+
+    private static bool IsQuestionsInfo(string info)
+    {
+        if (info.Length == 0)
+            return false;
+
+        var end = info.IndexOfAny([' ', '\t']);
+        var word = end < 0 ? info : info[..end];
+
+        // Matches the renderer, which keys off the fence language verbatim.
+        return word.Equals(InfoWord, StringComparison.Ordinal);
+    }
+
+    private static string Dedent(string line, int indent)
+    {
+        var strip = 0;
+        while (strip < indent && strip < line.Length && line[strip] == ' ')
+            strip++;
+
+        return line[strip..];
+    }
+
+    private static Fence? MatchFence(string line)
+    {
+        var indent = 0;
+        while (indent < line.Length && indent < 4 && line[indent] == ' ')
+            indent++;
+
+        if (indent > 3 || indent >= line.Length)
+            return null;
+
+        var delimiter = line[indent];
+        if (delimiter is not ('`' or '~'))
+            return null;
+
+        var end = indent;
+        while (end < line.Length && line[end] == delimiter)
+            end++;
+
+        var length = end - indent;
+        if (length < 3)
+            return null;
+
+        var info = line[end..].Trim();
+
+        // A backtick fence's info string may not contain a backtick (CommonMark), which is what keeps
+        // inline code like ``a ``` b`` from being read as a fence.
+        if (delimiter == '`' && info.Contains('`'))
+            return null;
+
+        return new Fence(delimiter, length, indent, info);
+    }
+
+    private static string Flatten(string message) =>
+        message.Replace("\r\n", " ").Replace('\n', ' ').Replace('\r', ' ').Trim();
+
+    private readonly record struct Fence(char Delimiter, int Length, int Indent, string Info);
+
+    private readonly record struct RawBlock(int StartLine, int EndLine, string Body);
+}
+
+/// <summary>A <c>questions</c> fence's 1-based inclusive line range, opening and closing lines included.</summary>
+public readonly record struct QuestionFenceRange(int StartLine, int EndLine);

--- a/src/Ivy.Tendril/Helpers/RevisionWriter.cs
+++ b/src/Ivy.Tendril/Helpers/RevisionWriter.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
 
 namespace Ivy.Tendril.Helpers;
 
@@ -15,8 +16,36 @@ public static class RevisionWriter
     ///     Writes <paramref name="content" /> as the next revision under
     ///     <paramref name="planFolder" />, returning the full path written.
     /// </summary>
-    public static string WriteNext(string planFolder, string content, IConfigService config)
+    /// <param name="validateQuestions">
+    ///     Whether to reject malformed <c>questions</c> blocks. The escape hatch for scripted and
+    ///     test use — promptwares should never turn this off.
+    /// </param>
+    /// <exception cref="QuestionValidationException">A <c>questions</c> block is malformed.</exception>
+    public static string WriteNext(string planFolder, string content, IConfigService config,
+        bool validateQuestions = true) =>
+        WriteNext(planFolder, content, config, out _, validateQuestions);
+
+    /// <summary>
+    ///     As <see cref="WriteNext(string,string,IConfigService,bool)" />, additionally reporting the
+    ///     non-blocking question-block warnings (currently: pre-schema free-text blocks) so a caller
+    ///     can surface them without failing the write.
+    /// </summary>
+    public static string WriteNext(string planFolder, string content, IConfigService config,
+        out IReadOnlyList<QuestionIssue> warnings, bool validateQuestions = true)
     {
+        warnings = [];
+
+        // Validated before anything touches disk, so a rejected revision does not consume a number.
+        if (validateQuestions)
+        {
+            var issues = QuestionValidationService.Validate(content);
+            var errors = issues.Where(i => i.Severity == QuestionIssueSeverity.Error).ToList();
+            if (errors.Count > 0)
+                throw new QuestionValidationException(errors);
+
+            warnings = issues.Where(i => i.Severity == QuestionIssueSeverity.Warning).ToList();
+        }
+
         var revisionsDir = Path.Combine(planFolder, "Revisions");
         FileHelper.EnsureDirectory(revisionsDir);
 

--- a/src/Ivy.Tendril/Models/QuestionModels.cs
+++ b/src/Ivy.Tendril/Models/QuestionModels.cs
@@ -1,0 +1,134 @@
+using System.Collections;
+using System.Globalization;
+using YamlDotNet.Serialization;
+
+namespace Ivy.Tendril.Models;
+
+/// <summary>Whether a question carries an answer, and what kind.</summary>
+public enum AnswerState
+{
+    /// <summary>No <c>answer</c> key at all. Carry the question forward unchanged.</summary>
+    Unanswered,
+
+    /// <summary><c>answer: null</c> — asked and deliberately skipped. Means "you decide".</summary>
+    Declined,
+
+    /// <summary><c>answer</c> present with a value.</summary>
+    Answered
+}
+
+/// <summary>
+///     Body of a fenced <c>questions</c> block in plan revision markdown — the machine-readable
+///     way a planning agent asks the user something it cannot settle by research.
+///     <para>
+///         The normative spec lives in <c>Prompts/Plans.md</c> (<c>## Question Blocks</c>), which is
+///         injected into every promptware firmware. That document and this model must change
+///         together. Blocks are extracted by <see cref="Helpers.QuestionBlockParser" /> and checked
+///         by <c>QuestionValidationService</c>.
+///     </para>
+/// </summary>
+public record QuestionsBlock
+{
+    /// <summary>1-4 questions. Deserialized from the <c>questions</c> key.</summary>
+    public List<PlanQuestion> Questions { get; init; } = [];
+}
+
+/// <summary>A single question inside a <see cref="QuestionsBlock" />.</summary>
+public record PlanQuestion
+{
+    /// <summary>The question itself. Required.</summary>
+    public string Title { get; init; } = "";
+
+    /// <summary>Short chip label (max 12 chars). Derived from <see cref="Title" /> when absent.</summary>
+    public string? Header { get; init; }
+
+    /// <summary>Markdown context shown under the question.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>True when several options may be selected. Answers are then always a list.</summary>
+    public bool Multiple { get; init; }
+
+    /// <summary>Whether the user may type a value of their own. Defaults to true, per the schema.</summary>
+    public bool Other { get; init; } = true;
+
+    /// <summary>2-4 options, or null for a pure free-text question.</summary>
+    public List<QuestionOption>? Options { get; init; }
+
+    /// <summary>
+    ///     The raw <c>answer</c> node: a scalar, a list, or null. Heterogeneous by design, because
+    ///     <see cref="Other" /> lets an entry be either an option <see cref="QuestionOption.Value" />
+    ///     or the user's own text.
+    /// </summary>
+    [YamlMember(Alias = "answer")]
+    public object? RawAnswer { get; init; }
+
+    /// <summary>
+    ///     Whether the <c>answer</c> key was present in the source YAML. Set by the parser from the
+    ///     raw YAML node: YamlDotNet cannot distinguish an absent key from an explicit null on a
+    ///     plain property, and the two mean different things here.
+    /// </summary>
+    [YamlIgnore]
+    public bool AnswerPresent { get; init; }
+
+    /// <summary>Absent key, explicit null, or a real answer.</summary>
+    [YamlIgnore]
+    public AnswerState AnswerState =>
+        !AnswerPresent ? AnswerState.Unanswered :
+        RawAnswer is null ? AnswerState.Declined :
+        AnswerState.Answered;
+
+    /// <summary>Whether <c>answer</c> was written as a YAML sequence rather than a scalar.</summary>
+    [YamlIgnore]
+    public bool AnswerIsList => RawAnswer is IList;
+
+    /// <summary>
+    ///     The answer flattened to strings — empty when unanswered or declined. An entry that equals
+    ///     an option's <see cref="QuestionOption.Value" /> is that option; anything else is the
+    ///     user's own text.
+    /// </summary>
+    [YamlIgnore]
+    public IReadOnlyList<string> AnswerValues
+    {
+        get
+        {
+            switch (RawAnswer)
+            {
+                case null:
+                    return [];
+                case IList list:
+                    var values = new List<string>(list.Count);
+                    foreach (var item in list)
+                    {
+                        if (item is not null)
+                            values.Add(Stringify(item));
+                    }
+
+                    return values;
+                default:
+                    return [Stringify(RawAnswer)];
+            }
+        }
+    }
+
+    private static string Stringify(object value) =>
+        value as string ?? Convert.ToString(value, CultureInfo.InvariantCulture) ?? "";
+}
+
+/// <summary>One selectable option of a <see cref="PlanQuestion" />.</summary>
+public record QuestionOption
+{
+    /// <summary>1-5 words. Required.</summary>
+    public string Title { get; init; } = "";
+
+    /// <summary>Markdown body expanding on this option.</summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    ///     Stable slug referenced by <see cref="PlanQuestion.RawAnswer" />. Required, and constrained
+    ///     to <c>^[a-z0-9][a-z0-9-]*$</c> so an option value can never be mistaken for free prose.
+    /// </summary>
+    public string Value { get; init; } = "";
+
+    /// <summary>The option the asking agent would pick. At most one per question.</summary>
+    public bool Recommended { get; init; }
+}

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -271,6 +271,87 @@ The initial revision is created by CreatePlan using the `planTemplate` from `con
 
 Subsequent revisions are written by ExpandPlan, UpdatePlan, or SplitPlan agents.
 
+## Question Blocks
+
+Promptwares run headless and cannot ask the user anything mid-run. A planning agent that hits a
+genuine ambiguity instead emits one or more fenced `questions` blocks in the revision markdown. The
+user answers them in the UI, which writes the answers back into the same blocks; UpdatePlan then
+folds those answers into the plan and retires the questions.
+
+Emit a block only for an ambiguity that research cannot settle and that changes what gets built. A
+question you can answer by reading the code is not a question, it is research you skipped.
+
+A block holds 1-4 questions. There is no cap on how many blocks a revision may contain. Place each
+block wherever it makes the most sense — right after the `# {title}` H1 for a question about overall
+scope, or inline under the `## Solution` subsection it concerns for a question about one design
+decision.
+
+````
+```questions
+questions:                    # 1-4 items
+  - title:       string       # required, the question
+    header:      string       # optional, <=12 char chip label; derived from title if absent
+    description: markdown     # optional, context shown under the question
+    multiple:    bool         # optional, default false; true = multi-select
+    other:       bool         # optional, default true; user may type a free value
+    options:                  # 2-4 items; omit entirely for a pure free-text question
+      - title:       string   # required, 1-5 words
+        description: markdown # optional, the expanded body for this option
+        value:       slug     # required, stable id used by `answer`; ^[a-z0-9][a-z0-9-]*$
+        recommended: bool     # optional, max one per question
+    answer:      value | [values] | string   # filled in on response
+```
+````
+
+Three shapes fall out of `multiple` / `other` / the presence of `options`:
+
+| Shape | How |
+|---|---|
+| Single-select, fixed set | `other: false` plus options |
+| Multi-select, open set | `multiple: true` plus options |
+| Pure free text | no options at all |
+
+### Answer semantics
+
+- An entry that matches an option's `value` is that option.
+- An entry that matches nothing is the user's own text. Legal when `other` is true, or when there are
+  no options.
+- `multiple: true` means `answer` is always a list, even with one selection.
+- `answer` absent means not yet answered. Carry the block forward unchanged.
+- `answer: null` means asked and deliberately skipped. Treat it as "you decide", record the decision
+  in the plan, and retire the block.
+
+### Lint rules
+
+`tendril plan write-revision` rejects a revision whose blocks break any of these, prints every
+problem at once prefixed with the line of the opening fence, and writes nothing — so a rejected
+revision does not consume a revision number. Fix the reported lines and retry.
+
+| Rule | Message |
+|---|---|
+| At most one `recommended: true` per question | `question N: more than one option is recommended` |
+| No hand-authored option titled "Other", "Something else", "Custom" | `question N: option '<title>' duplicates what other: true provides` |
+| `other: false` with no options | `question N: other: false with no options is unanswerable` |
+| `answer` is a list iff `multiple: true` | `question N: multiple: true requires a list answer` / `question N: answer must be a scalar when multiple is false` |
+| `value` unique within a question | `question N: duplicate option value '<value>'` |
+| `other: false` and an answer entry matches no option value | `question N: answer '<entry>' matches no option and other is false` |
+
+Schema bounds are enforced too: 1-4 questions, a required `title`, a `header` of at most 12
+characters, 2-4 options when `options` is present, a required `title` and slug `value` on each
+option, and no unknown keys anywhere.
+
+Blocks are numbered by position in the document, so a revision with several of them gets a
+`block 1:` / `block 2:` prefix on top of the `question N:` prefix.
+
+A `questions` fence written inside a longer fence is documentation, not a question — this document
+is itself an example — so it is neither validated nor rendered.
+
+**Legacy blocks.** A fence whose body is not a YAML mapping with a `questions` key is the plain-text
+form that predates this schema. It produces a warning, never an error, and is never rewritten.
+
+`--no-question-check` on `write-revision` skips this validation. It is the escape hatch for scripted
+and test use; promptwares should never reach for it.
+
 ## Logs
 
 `logs/{NNN}-{Action}.md` per promptware run (Completed time, status, …).

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -438,9 +438,17 @@ Analyze the task complexity and choose an `executionProfile`. This is passed via
 
 If you cannot determine complexity (e.g., task is too vague), omit `--execution-profile` — ExecutePlan will use the configured default.
 
-### 4.6. Questions Section
+### 4.6. Questions
 
-Only include `## Questions` if you have genuine questions for the user that block the plan. Place it immediately after the title (before `## Problem`). If there are no questions, **omit the section entirely** — do not include an empty heading or placeholder text.
+When you hit a genuine ambiguity, ask the user with a fenced `questions` block. The schema, answer semantics and lint rules are in the **Question Blocks** section of **Reference Documents** — follow them exactly.
+
+- Ask only about an ambiguity that research cannot settle and that changes what gets built. A question you can answer by reading the code is not a question, it is research you skipped.
+- Emit one or more blocks of 1-4 questions each. Place each block where it is most relevant: right after the H1 for a scope-level question, or inline under the `## Solution` subsection it concerns for a narrower design question.
+- Never write an `answer` key. CreatePlan asks; it never answers.
+- Prefer options with `recommended: true` on the one you would pick, so an unanswered plan still has a defensible default.
+- The plan must remain executable if nobody answers: state the fallback in `## Solution`.
+- There is no `## Questions` section any more. Do not write one.
+- `write-revision` rejects a malformed block and writes nothing; fix the reported lines and retry.
 
 ### 4.7. Tests Section
 

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -532,6 +532,15 @@ A failed pre-execution (step 1.7) is signalled by `Verification/PreExecution.md`
 
 You are running in non-interactive mode and CANNOT ask questions. If you are unsure about requirements, encounter conflicting instructions, or cannot find referenced files — STOP and fail with a clear message explaining what needs clarification. Do NOT guess when uncertain.
 
+**Unanswered question blocks.** Before doing any work, scan the plan revision you read in step 1 for any fenced `questions` block (see the **Question Blocks** section of **Reference Documents**). If any question in it has no `answer` key, the plan is not ready:
+
+```bash
+tendril job fail TendrilJobId --message="Plan has an unanswered question; answer it and run UpdatePlan"
+exit 1
+```
+
+Guessing at an open question wastes an execution. A block that is fully answered but still present — the user executed without running UpdatePlan first — is not a failure: honor the answers as decisions and continue. ExecutePlan never writes revisions, so it never adds question blocks.
+
 ### Rules
 
 - All work happens in worktree directories, never in the original repos

--- a/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExpandPlan/Program.md
@@ -66,7 +66,7 @@ Report status: `tendril job status TendrilJobId --message="Writing expanded revi
 
 ### Rules
 
-- If the expanded revision has no questions, omit the `## Questions` section entirely
+- Expansion is research, so it retires the questions it answers. For every question in a `questions` fence that your research settles, fold the finding into the plan and delete that question from its block; drop the fence when its last question goes. Questions that need a human decision — a product or naming call — stay exactly as they are, in place. You may add blocks, but only for genuine decisions, never for anything you could have looked up, and placed next to the section they concern. The schema is in the **Question Blocks** section of **Reference Documents**; `write-revision` rejects a malformed block and writes nothing.
 - The expanded plan must be **immediately actionable** without further investigation
 - If research reveals the problem is already solved or doesn't exist, note that clearly
 - Do NOT modify the original revision — always create a new revision file

--- a/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/RetryPlan/Program.md
@@ -226,6 +226,15 @@ The launcher script handles state transitions (Completed/Failed) based on exit c
 
 You are running in non-interactive mode and CANNOT ask questions. If you are unsure about requirements, encounter conflicting instructions, or cannot find referenced files — STOP and fail with a clear message explaining what needs clarification. Do NOT guess when uncertain.
 
+**Unanswered question blocks.** Before doing any work, scan the plan revision you read for any fenced `questions` block (see the **Question Blocks** section of **Reference Documents**). If any question in it has no `answer` key, the plan is not ready:
+
+```bash
+tendril job fail TendrilJobId --message="Plan has an unanswered question; answer it and run UpdatePlan"
+exit 1
+```
+
+Guessing at an open question wastes an execution. A block that is fully answered but still present — the user retried without running UpdatePlan first — is not a failure: honor the answers as decisions and continue. RetryPlan never writes revisions, so it never adds question blocks.
+
 ## Rules
 
 - All work happens in worktree directories, never in the original repos

--- a/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SplitPlan/Program.md
@@ -68,7 +68,15 @@ EOF
 
 **The revision's first line is the `# {title}` H1 heading — it MUST be the exact same string you passed as `<Title>` to `tendril plan create` for that plan** (human-readable Title Case, not the PascalCase folder form). The `plan.yaml` title and the spec H1 must always match.
 
-The command reads from STDIN and auto-creates the next numbered revision file. Fill in Problem, Solution, Remaining Design Questions, Tests sections. Each plan must be fully self-contained. Do NOT use the Write or Edit tools to create revision files directly in `Revisions/`.
+The command reads from STDIN and auto-creates the next numbered revision file. Fill in Problem, Solution, Tests sections. Each plan must be fully self-contained. Do NOT use the Write or Edit tools to create revision files directly in `Revisions/`.
+
+#### Open Questions
+
+The parent's open questions live in fenced `questions` blocks (see the **Question Blocks** section of **Reference Documents**), and the split has to distribute them:
+
+- Each open question goes to exactly one child plan — the one whose scope it decides. Never copy the same question into two children, or the user answers it twice.
+- Answered questions are folded into whichever children they affect, and are not carried over.
+- A question that decides the split itself belongs in the parent, which means the split is premature. Say so instead of splitting.
 
 #### Project Assignment
 

--- a/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/UpdatePlan/Program.md
@@ -36,17 +36,17 @@ For each question in the instructions:
 1. Read relevant source files to find the answer
 2. Use the firmware header for project context if needed
 
-### 3.5. Resolve Answered Questions
+### 3.5. Retire Answered Questions
 
-Compare each existing question in `## Questions` against:
-- The user's instructions (user may have directly answered a question)
-- Your research findings from step 3
+This is where the user's answers land: the UI writes them back into the revision markdown, and the user then runs UpdatePlan. The schema and answer semantics are in the **Question Blocks** section of **Reference Documents**.
 
-For each question, determine if it has been answered — either explicitly by the user's instructions or implicitly by a decision made in the updated plan. If answered:
-- Wrap the question in a `<details>` block (collapsed) with the answer as the body
-- The answer should reference the user's instruction or the design decision that resolves it
-
-If all questions are resolved and no new questions arose, omit the `## Questions` section entirely.
+1. Scan the revision markdown for every `questions` fence. There may be several, anywhere in the document.
+2. For every question whose block has an `answer` key with a non-null value, treat it as a decision by the user. Fold it into whichever section it sits nearest to (or `## Problem` / `## Solution` for a scope-level question) as concrete prose or steps, and **delete that question from its block**. Never restate it as an open question, and never leave an answered question in a revision.
+3. For every question with `answer: null` (declined), make the call yourself, write one sentence near where the block sits saying which way you went and that the user deferred, then delete the question.
+4. A question the user answered in prose in `UpdateInstructions` counts as answered even though the markdown has no `answer` key. Same handling.
+5. Carry every question with no `answer` key forward verbatim — same `header`, `options`, ordering, and position in the document. Do not reword it, and do not add an `answer`.
+6. If a block's last question is retired, drop that fence entirely. If new ambiguity appeared, add new blocks, each with 4 or fewer questions, placed next to the section it concerns.
+7. The old prose `## Questions` section is gone. If a prior revision has one, convert the still-open items into `questions` block(s) and fold the rest into the plan.
 
 ### 4. Apply Changes
 
@@ -61,13 +61,7 @@ Report status: `tendril job status TendrilJobId --message="Applying changes..."`
 
   The command reads from STDIN and auto-creates the next numbered revision file. Do NOT use the Write or Edit tools to create revision files directly in `Revisions/`.
 - Incorporate the intent of each instruction into the updated plan
-- Maintain the `## Questions` section (placed after the title, before `## Problem`) using `<details>` tags: (1) Existing questions answered by the user's instructions or research should be collapsed into `<details>` blocks with the answer. (2) New questions become new `<details>` blocks with answers. (3) Unanswered questions from prior revisions remain as open items (not in `<details>`). (4) If all questions are resolved and no new ones arose, omit the section entirely. Format:
-  ```html
-  <details>
-  <summary>Question</summary>
-  Answer
-  </details>
-  ```
+- Carry the `questions` blocks forward as decided in step 3.5. `write-revision` rejects a malformed block and writes nothing; fix the reported lines and retry.
 - Preserve the plan template structure
 - The updated plan must be at least as comprehensive as the original
 

--- a/src/Ivy.Tendril/Services/Plans/QuestionValidationException.cs
+++ b/src/Ivy.Tendril/Services/Plans/QuestionValidationException.cs
@@ -1,0 +1,22 @@
+namespace Ivy.Tendril.Services.Plans;
+
+/// <summary>
+///     Thrown when a revision contains a malformed <c>questions</c> block. Carries every error at
+///     once — the caller is an agent that has to fix them all in one edit — and renders them one per
+///     line so the message can go straight to stderr or an API response.
+/// </summary>
+public class QuestionValidationException(IReadOnlyList<QuestionIssue> issues)
+    : Exception(FormatMessage(issues))
+{
+    /// <summary>Every error that blocked the write, in document order.</summary>
+    public IReadOnlyList<QuestionIssue> Issues { get; } = issues;
+
+    private static string FormatMessage(IReadOnlyList<QuestionIssue> issues)
+    {
+        var header = issues.Count == 1
+            ? "Invalid questions block:"
+            : $"Invalid questions blocks ({issues.Count} errors):";
+
+        return string.Join(Environment.NewLine, new[] { header }.Concat(issues.Select(i => i.ToString())));
+    }
+}

--- a/src/Ivy.Tendril/Services/Plans/QuestionValidationService.cs
+++ b/src/Ivy.Tendril/Services/Plans/QuestionValidationService.cs
@@ -1,0 +1,178 @@
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Services.Plans;
+
+/// <summary>How much a question-block problem matters.</summary>
+public enum QuestionIssueSeverity
+{
+    /// <summary>Reported to the caller, never blocks the write.</summary>
+    Warning,
+
+    /// <summary>Blocks the write. The agent has to fix it and retry.</summary>
+    Error
+}
+
+/// <summary>One problem found in a <c>questions</c> block, located by the line of its opening fence.</summary>
+public record QuestionIssue(QuestionIssueSeverity Severity, int Line, string Message)
+{
+    /// <summary>Renders as <c>line 12: question 2: duplicate option value 'jwt'</c>.</summary>
+    public override string ToString() => $"line {Line}: {Message}";
+}
+
+/// <summary>
+///     Validates fenced <c>questions</c> blocks in plan revision markdown against the schema and lint
+///     rules in <c>Prompts/Plans.md</c> (<c>## Question Blocks</c>).
+///     <para>
+///         Unlike <see cref="PlanValidationService" /> this reports every problem at once instead of
+///         throwing on the first, because the caller is an agent that has to fix them all in one edit.
+///     </para>
+/// </summary>
+public static class QuestionValidationService
+{
+    private static readonly Regex SlugRegex = new("^[a-z0-9][a-z0-9-]*$", RegexOptions.Compiled);
+
+    /// <summary>Titles that restate what <c>other: true</c> already provides.</summary>
+    private static readonly string[] ReservedOptionTitles = ["Other", "Something else", "Custom"];
+
+    private const int MaxQuestionsPerBlock = 4;
+    private const int MinOptions = 2;
+    private const int MaxOptions = 4;
+    private const int MaxHeaderLength = 12;
+
+    /// <summary>
+    ///     Returns every issue in every <c>questions</c> block of <paramref name="markdown" />, in
+    ///     document order. An empty result means the document is clean.
+    /// </summary>
+    public static IReadOnlyList<QuestionIssue> Validate(string markdown)
+    {
+        var blocks = QuestionBlockParser.Parse(markdown);
+        var issues = new List<QuestionIssue>();
+
+        // "block N:" is noise when there is only one block, and essential when there are several.
+        var numbered = blocks.Count > 1;
+
+        for (var b = 0; b < blocks.Count; b++)
+        {
+            var block = blocks[b];
+            var prefix = numbered ? $"block {b + 1}: " : "";
+
+            if (block.IsLegacy)
+            {
+                issues.Add(new QuestionIssue(QuestionIssueSeverity.Warning, block.Line,
+                    prefix + "free-text questions block predating the schema; rewrite it as a questions mapping (see Question Blocks in Plans.md)"));
+                continue;
+            }
+
+            if (block.YamlError is not null)
+            {
+                issues.Add(Error(block.Line, prefix + $"invalid questions YAML: {block.YamlError}"));
+                continue;
+            }
+
+            ValidateBlock(block.Block!, block.Line, prefix, issues);
+        }
+
+        return issues;
+    }
+
+    private static void ValidateBlock(QuestionsBlock block, int line, string prefix, List<QuestionIssue> issues)
+    {
+        var questions = block.Questions;
+
+        if (questions.Count == 0)
+        {
+            issues.Add(Error(line, prefix + "at least one question is required"));
+            return;
+        }
+
+        if (questions.Count > MaxQuestionsPerBlock)
+            issues.Add(Error(line, prefix + $"{questions.Count} questions in one block; at most {MaxQuestionsPerBlock} are allowed"));
+
+        for (var n = 0; n < questions.Count; n++)
+            ValidateQuestion(questions[n], line, $"{prefix}question {n + 1}: ", issues);
+    }
+
+    private static void ValidateQuestion(PlanQuestion question, int line, string prefix, List<QuestionIssue> issues)
+    {
+        if (string.IsNullOrWhiteSpace(question.Title))
+            issues.Add(Error(line, prefix + "title is required"));
+
+        if (question.Header is { } header && header.Length > MaxHeaderLength)
+            issues.Add(Error(line, prefix + $"header '{header}' is {header.Length} characters; at most {MaxHeaderLength} are allowed"));
+
+        var options = question.Options;
+        if (options is null || options.Count == 0)
+        {
+            if (!question.Other)
+                issues.Add(Error(line, prefix + "other: false with no options is unanswerable"));
+        }
+        else
+        {
+            ValidateOptions(options, line, prefix, issues);
+        }
+
+        ValidateAnswer(question, line, prefix, issues);
+    }
+
+    private static void ValidateOptions(List<QuestionOption> options, int line, string prefix, List<QuestionIssue> issues)
+    {
+        if (options.Count < MinOptions)
+            issues.Add(Error(line, prefix + $"{options.Count} option; at least {MinOptions} are required"));
+
+        if (options.Count > MaxOptions)
+            issues.Add(Error(line, prefix + $"{options.Count} options; at most {MaxOptions} are allowed"));
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var recommended = 0;
+
+        foreach (var option in options)
+        {
+            if (string.IsNullOrWhiteSpace(option.Title))
+                issues.Add(Error(line, prefix + "option title is required"));
+            else if (ReservedOptionTitles.Contains(option.Title.Trim(), StringComparer.OrdinalIgnoreCase))
+                issues.Add(Error(line, prefix + $"option '{option.Title}' duplicates what other: true provides"));
+
+            if (string.IsNullOrWhiteSpace(option.Value))
+                issues.Add(Error(line, prefix + $"option '{option.Title}' is missing a value"));
+            else if (!SlugRegex.IsMatch(option.Value))
+                issues.Add(Error(line, prefix + $"option value '{option.Value}' must match ^[a-z0-9][a-z0-9-]*$"));
+            else if (!seen.Add(option.Value))
+                issues.Add(Error(line, prefix + $"duplicate option value '{option.Value}'"));
+
+            if (option.Recommended)
+                recommended++;
+        }
+
+        if (recommended > 1)
+            issues.Add(Error(line, prefix + "more than one option is recommended"));
+    }
+
+    private static void ValidateAnswer(PlanQuestion question, int line, string prefix, List<QuestionIssue> issues)
+    {
+        if (question.AnswerState != AnswerState.Answered)
+            return;
+
+        if (question.Multiple && !question.AnswerIsList)
+        {
+            issues.Add(Error(line, prefix + "multiple: true requires a list answer"));
+        }
+        else if (!question.Multiple && question.AnswerIsList)
+        {
+            issues.Add(Error(line, prefix + "answer must be a scalar when multiple is false"));
+        }
+
+        if (question.Other || question.Options is not { Count: > 0 } options)
+            return;
+
+        foreach (var entry in question.AnswerValues)
+        {
+            if (!options.Any(o => string.Equals(o.Value, entry, StringComparison.Ordinal)))
+                issues.Add(Error(line, prefix + $"answer '{entry}' matches no option and other is false"));
+        }
+    }
+
+    private static QuestionIssue Error(int line, string message) =>
+        new(QuestionIssueSeverity.Error, line, message);
+}


### PR DESCRIPTION
# Summary

## Changes

Added structured, machine-readable question blocks to plan revision markdown: a planning agent that
hits a genuine ambiguity now emits a fenced `questions` block of YAML instead of free prose, and the
user's answers are written back into that same block. A parser and validator enforce the schema and
six lint rules at `RevisionWriter.WriteNext`, the single point every revision-write surface (CLI,
REST, MCP) funnels through, and all six plan-handling promptwares were updated to ask, retire, split
and refuse-to-guess accordingly. No UI: rendering and answer capture are a later plan.

## API Changes

New public types:

- `Ivy.Tendril.Models.QuestionsBlock` — `List<PlanQuestion> Questions`.
- `Ivy.Tendril.Models.PlanQuestion` — `Title`, `Header`, `Description`, `Multiple`, `Other`
  (defaults `true`), `Options`, `RawAnswer` (aliased to the `answer` key), `AnswerPresent`, and the
  computed `AnswerState`, `AnswerIsList`, `AnswerValues`.
- `Ivy.Tendril.Models.AnswerState` — `Unanswered` | `Declined` | `Answered`.
- `Ivy.Tendril.Models.QuestionOption` — `Title`, `Description`, `Value` (slug), `Recommended`.
- `Ivy.Tendril.Helpers.QuestionBlockParser` — `Parse(string)` returning
  `IReadOnlyList<ParsedQuestionsBlock>`, and `FindFenceRanges(string)` returning
  `IReadOnlyList<QuestionFenceRange>`.
- `Ivy.Tendril.Helpers.ParsedQuestionsBlock` / `QuestionFenceRange`.
- `Ivy.Tendril.Services.Plans.QuestionValidationService.Validate(string)` returning
  `IReadOnlyList<QuestionIssue>`.
- `Ivy.Tendril.Services.Plans.QuestionIssue` / `QuestionIssueSeverity`.
- `Ivy.Tendril.Services.Plans.QuestionValidationException`, carrying `Issues`.

Changed signatures:

- `RevisionWriter.WriteNext(planFolder, content, config, bool validateQuestions = true)` — new
  optional parameter; existing callers are source-compatible. A second overload adds
  `out IReadOnlyList<QuestionIssue> warnings`. Now throws `QuestionValidationException`.

New CLI option:

- `tendril plan write-revision --no-question-check` — skips validation; exits `1` with every error
  on stderr when a block is malformed, and writes nothing in that case.

## Files Modified

**New — parser, models, validator**

- `src/Ivy.Tendril/Models/QuestionModels.cs`
- `src/Ivy.Tendril/Helpers/QuestionBlockParser.cs`
- `src/Ivy.Tendril/Services/Plans/QuestionValidationService.cs`
- `src/Ivy.Tendril/Services/Plans/QuestionValidationException.cs`

**Enforcement**

- `src/Ivy.Tendril/Helpers/RevisionWriter.cs` — validate before polish and before disk.
- `src/Ivy.Tendril/Commands/PlanWriteRevisionCommand.cs` — `--no-question-check`, stderr, exit code.
- `src/Ivy.Tendril/Helpers/MarkdownLinkPolisher.cs` — polish only outside `questions` fences.

**Specification and docs**

- `src/Ivy.Tendril/Prompts/Plans.md` — the normative `## Question Blocks` section.
- `src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md`, `src/Ivy.Tendril/AGENTS.md`.

**Promptwares** — `CreatePlan`, `UpdatePlan`, `ExpandPlan`, `SplitPlan`, `ExecutePlan`, `RetryPlan`.

**Tests** — `QuestionBlockParserTests.cs` (15), `QuestionValidationServiceTests.cs` (30),
`RevisionWriterTests.cs` (extended).

## Manual Testing

Nothing is rendered yet, so this is exercised through the CLI. From a shell with `tendril` built
from this branch:

1. **A valid block is accepted.** Put this in `rev.md` and run
   `tendril plan write-revision <plan-id> --file rev.md`:

   ~~~
   # Some Plan

   ```questions
   questions:
     - title: Which token format should the API issue?
       header: Token
       other: false
       options:
         - title: Opaque token
           value: opaque
         - title: Signed JWT
           value: jwt
           recommended: true
   ```
   ~~~

   Expect exit `0` and a new `Revisions/NNN.md`.

2. **A malformed block is rejected with every error at once.** Give one question two
   `recommended: true` options, reuse a `value`, and add a `header` longer than 12 characters.
   Expect exit `1`, one `line N: question 1: ...` line per violation on stderr, **no** new revision
   file, and the next successful write to reuse the same revision number.

3. **`--no-question-check` bypasses it.** Re-run the malformed file with that flag: exit `0`, file
   written verbatim.

4. **Legacy prose warns but does not block.** A `questions` fence whose body is plain prose writes
   normally at exit `0` with a `warning: line N: free-text questions block predating the schema...`
   on stderr.

5. **Documenting the format does not trip the validator.** Wrap an intentionally invalid
   `questions` fence inside a four-backtick fence — it is documentation and must be accepted.

6. **The polisher leaves the fence alone.** Put
   `[helpers.cs:348](file:///D:/repo/helpers.cs:348)` both outside and inside a block. After
   writing, the outside one has lost its `:348` suffix and the one inside the fence is byte for
   byte what you wrote.

---
## Commits

- b2ffcc52 Plan 00078: keep blank lines when polishing around a questions fence
- d682abde Plan 00078: document question blocks and update the planning promptwares
- 8cd996eb Plan 00078: add questions block schema, parser and validator

---
Created using [Ivy Tendril](https://ivy.app).
