### PR TITLE
[00089] Remove Source Plan Section From Recommendation Detail View

### DIFF
--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -119,16 +119,7 @@ public class ContentView(
         // Content
         var scrollableContent = Layout.Vertical().Width(Size.Full().Max(Size.Units(200))).Padding(6, 2, 6, 2);
 
-        // Source plan info
-        var metaRow = Layout.Horizontal().Gap(2).AlignContent(Align.Left)
-                      | Text.Muted($"Plan #{selectedRecommendation.ShortPlanId}: {selectedRecommendation.PlanTitle}");
-
-        scrollableContent |= Layout.Vertical().Gap(1)
-                             | Text.Block("Source Plan").Bold()
-                             | metaRow;
-
         // Description
-        scrollableContent |= new Separator();
         scrollableContent |= new Markdown(MarkdownHelper.PrepareForDisplay(selectedRecommendation.Description, config))
             .DangerouslyAllowLocalFiles()
             .Article()


### PR DESCRIPTION
# Summary

## Changes

Removed the redundant "Source Plan" block (bold heading, muted `Plan #NN: <title>` line, and its
trailing separator) from the top of the recommendation detail pane in the Recommendations app.
The plan number and title are already visible in the detail header and every sidebar row, and the
source plan remains one click away via the "View Plan" action.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Recommendations/ContentView.cs` — deleted the "Source Plan" heading block
  and its trailing `Separator`; the description `Markdown` block is now the first thing rendered
  in the scrollable content area.

## Manual Testing

1. Run the Tendril app and open the Recommendations app.
2. Select any recommendation with a source plan.
3. Observe the detail pane now opens directly with the description markdown — no "Source Plan"
   heading, no muted "Plan #NN: ..." line, and no stray horizontal rule above the description.
4. Confirm the plan number/title is still visible in the pane's header and can still be opened via
   "View Plan".

---
## Commits

- 2bdf3773 Remove Source Plan section from Recommendation detail view

---
Created using [Ivy Tendril](https://ivy.app).
