### PR TITLE
[00087] Show the Worktree Base Branch in the Git Tab

### DIFF
--- a/src/Ivy.Tendril.Test/GitServiceTests.cs
+++ b/src/Ivy.Tendril.Test/GitServiceTests.cs
@@ -203,4 +203,35 @@ public class GitServiceTests
         Assert.NotNull(result.Value);
         Assert.Empty(result.Value);
     }
+
+    [Fact]
+    public void GetWorktreeBase_WithInvalidRepo_ReturnsInvalidRepoPathError()
+    {
+        // Arrange
+        var gitService = CreateGitService();
+        var invalidRepoPath = "D:\\NonExistent\\Repo\\Path";
+
+        // Act
+        var result = gitService.GetWorktreeBase(invalidRepoPath);
+
+        // Assert
+        Assert.False(result.IsSuccess);
+        Assert.Equal(GitError.InvalidRepoPath, result.Error);
+        Assert.Contains("Repository path does not exist", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void GetWorktreeBase_WithNoUpstream_ReturnsNullValue()
+    {
+        // Arrange
+        var gitService = CreateGitService();
+        var validRepoPath = System.IO.Path.GetTempPath(); // Use temp path as a valid directory
+
+        // Act
+        var result = gitService.GetWorktreeBase(validRepoPath);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Value);
+    }
 }

--- a/src/Ivy.Tendril.Test/GitTabDataBuilderTests.cs
+++ b/src/Ivy.Tendril.Test/GitTabDataBuilderTests.cs
@@ -1,10 +1,19 @@
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Git;
 
 namespace Ivy.Tendril.Test;
 
-public class GitTabDataBuilderTests
+public class GitTabDataBuilderTests : IDisposable
 {
+    private readonly string _tempDir = Path.Combine(Path.GetTempPath(), $"GitTabDataBuilderTests-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+
     private static PlanFile CreatePlan(string folderPath, List<string> commits, List<string> prs)
     {
         var metadata = new PlanMetadata(
@@ -47,5 +56,139 @@ public class GitTabDataBuilderTests
         var count = GitTabDataBuilder.CountGitItems(data, plan);
 
         Assert.Equal(4, count);
+    }
+
+    private const string MainWorktreeBranch = "development";
+    private const string MainWorktreeHash = "1df3f14ecommitfullhash000000000000000";
+
+    private (PlanFile Plan, string WorktreePath) CreateBaseTestPlan()
+    {
+        var planFolder = Path.Combine(_tempDir, "plan");
+        var worktreePath = Path.Combine(planFolder, "Worktrees", "Ivy-Tendril");
+        Directory.CreateDirectory(worktreePath);
+        return (CreatePlan(planFolder, [], []), worktreePath);
+    }
+
+    private static List<WorktreeInfo> WorktreesFor(string worktreePath) =>
+    [
+        new WorktreeInfo(worktreePath, "tendril/00087-Test", "abcdef1234567890"),
+        new WorktreeInfo("/tmp/main-worktree", MainWorktreeBranch, MainWorktreeHash)
+    ];
+
+    [Fact]
+    public void BuildGitTabData_WithUpstream_UsesMergeBaseAsBase()
+    {
+        var (plan, worktreePath) = CreateBaseTestPlan();
+        var gitService = new StubGitService
+        {
+            Worktrees = WorktreesFor(worktreePath),
+            WorktreeBase = new WorktreeBaseInfo("origin/epic-draft-questions", "8ba0663ff315cdbfa1894f05f0a6d8620ad2c866")
+        };
+
+        var data = GitTabDataBuilder.BuildGitTabData([], plan, null!, gitService);
+
+        var section = Assert.Single(data.WorktreeSections);
+        Assert.Equal("epic-draft-questions", section.BaseBranch);
+        Assert.Equal("8ba0663", section.BaseShortHash);
+        Assert.NotEqual(MainWorktreeBranch, section.BaseBranch);
+        Assert.NotEqual(MainWorktreeHash[..7], section.BaseShortHash);
+    }
+
+    [Fact]
+    public void BuildGitTabData_WithoutUpstream_FallsBackToMainWorktreeBranch()
+    {
+        var (plan, worktreePath) = CreateBaseTestPlan();
+        var gitService = new StubGitService
+        {
+            Worktrees = WorktreesFor(worktreePath),
+            WorktreeBase = null
+        };
+
+        var data = GitTabDataBuilder.BuildGitTabData([], plan, null!, gitService);
+
+        var section = Assert.Single(data.WorktreeSections);
+        Assert.Equal(MainWorktreeBranch, section.BaseBranch);
+        Assert.Equal(MainWorktreeHash[..7], section.BaseShortHash);
+    }
+
+    [Fact]
+    public void BuildGitTabData_WhenBaseLookupFails_FallsBackToMainWorktreeBranch()
+    {
+        var (plan, worktreePath) = CreateBaseTestPlan();
+        var gitService = new StubGitService
+        {
+            Worktrees = WorktreesFor(worktreePath),
+            WorktreeBaseFails = true
+        };
+
+        var data = GitTabDataBuilder.BuildGitTabData([], plan, null!, gitService);
+
+        var section = Assert.Single(data.WorktreeSections);
+        Assert.Equal(MainWorktreeBranch, section.BaseBranch);
+        Assert.Equal(MainWorktreeHash[..7], section.BaseShortHash);
+        Assert.Equal("/tmp/main-worktree", section.ParentRepoPath);
+    }
+
+    [Fact]
+    public void BuildGitTabData_StripsOriginPrefixFromBaseBranch()
+    {
+        var (plan, worktreePath) = CreateBaseTestPlan();
+        var gitService = new StubGitService
+        {
+            Worktrees = WorktreesFor(worktreePath),
+            WorktreeBase = new WorktreeBaseInfo("origin/development", "8ba0663ff315cdbfa1894f05f0a6d8620ad2c866")
+        };
+
+        var data = GitTabDataBuilder.BuildGitTabData([], plan, null!, gitService);
+        Assert.Equal("development", Assert.Single(data.WorktreeSections).BaseBranch);
+
+        gitService.WorktreeBase = new WorktreeBaseInfo("upstream/main", "8ba0663ff315cdbfa1894f05f0a6d8620ad2c866");
+        var data2 = GitTabDataBuilder.BuildGitTabData([], plan, null!, gitService);
+        Assert.Equal("upstream/main", Assert.Single(data2.WorktreeSections).BaseBranch);
+    }
+
+    private class StubGitService : IGitService
+    {
+        public List<WorktreeInfo> Worktrees { get; set; } = [];
+        public WorktreeBaseInfo? WorktreeBase { get; set; }
+        public bool WorktreeBaseFails { get; set; }
+
+        public GitResult<string> GetCommitTitle(string repoPath, string commitHash) =>
+            GitResult<string>.Failure(GitError.CommandFailed, "Not implemented in stub");
+
+        public GitResult<string> GetCommitDiff(string repoPath, string commitHash) =>
+            GitResult<string>.Failure(GitError.CommandFailed, "Not implemented in stub");
+
+        public GitResult<List<(string Status, string FilePath)>> GetCommitFiles(string repoPath, string commitHash) =>
+            GitResult<List<(string Status, string FilePath)>>.Failure(GitError.CommandFailed, "Not implemented in stub");
+
+        public GitResult<int> GetCommitFileCount(string repoPath, string commitHash) =>
+            GitResult<int>.Failure(GitError.CommandFailed, "Not implemented in stub");
+
+        public GitResult<string> GetCombinedDiff(string repoPath, string firstCommit, string lastCommit) =>
+            GitResult<string>.Failure(GitError.CommandFailed, "Not implemented in stub");
+
+        public GitResult<List<(string Status, string FilePath)>> GetCombinedChangedFiles(string repoPath, string firstCommit, string lastCommit) =>
+            GitResult<List<(string Status, string FilePath)>>.Failure(GitError.CommandFailed, "Not implemented in stub");
+
+        public GitResult<List<WorktreeInfo>> GetWorktrees(string repoPath) =>
+            GitResult<List<WorktreeInfo>>.Success(Worktrees);
+
+        public GitResult<Dictionary<string, (string Title, int FileCount)>> GetCommitSummaries(string repoPath, IEnumerable<string> commitHashes) =>
+            GitResult<Dictionary<string, (string Title, int FileCount)>>.Failure(GitError.CommandFailed, "Not implemented in stub");
+
+        public GitResult<bool> HasUncommittedChanges(string repoPath) =>
+            GitResult<bool>.Success(false);
+
+        public GitResult<List<string>> GetReachableCommits(string repoPath, IEnumerable<string> candidateHashes) =>
+            GitResult<List<string>>.Success([]);
+
+        public GitResult<DirtyRepoResult> GetRepoDirtyState(string repoPath, string expectedBaseBranch) =>
+            GitResult<DirtyRepoResult>.Failure(GitError.CommandFailed, "Not implemented in stub");
+
+        public GitResult<WorktreeBaseInfo?> GetWorktreeBase(string repoPath) =>
+            WorktreeBaseFails
+                ? GitResult<WorktreeBaseInfo?>.Failure(GitError.CommandFailed, "Not implemented in stub")
+                : GitResult<WorktreeBaseInfo?>.Success(WorktreeBase);
     }
 }

--- a/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
+++ b/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
@@ -480,5 +480,8 @@ public class PlanContentHelpersTests
         {
             return GitResult<DirtyRepoResult>.Success(new DirtyRepoResult());
         }
+
+        public GitResult<WorktreeBaseInfo?> GetWorktreeBase(string repoPath) =>
+            GitResult<WorktreeBaseInfo?>.Success(null);
     }
 }

--- a/src/Ivy.Tendril/Apps/Views/Tabs/GitTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/GitTabView.cs
@@ -115,9 +115,9 @@ public class GitTabView(
                 new("Repository", Text.Monospaced(section.ParentRepoPath.Replace('\\', '/')))
             ];
 
-            if (section is { ParentBranch: not null, ParentShortHash: not null })
+            if (section is { BaseBranch: not null, BaseShortHash: not null })
             {
-                detailsList.Add(new("Parent", Text.Monospaced($"{section.ParentBranch}@{section.ParentShortHash}")));
+                detailsList.Add(new("Base", Text.Monospaced($"{section.BaseBranch}@{section.BaseShortHash}")));
             }
 
             detailsList.Add(new("Worktree", Text.Monospaced(section.Path.Replace('\\', '/'))));

--- a/src/Ivy.Tendril/Helpers/GitTabDataBuilder.cs
+++ b/src/Ivy.Tendril/Helpers/GitTabDataBuilder.cs
@@ -18,8 +18,8 @@ public static class GitTabDataBuilder
         bool HasUncommittedChanges,
         List<PlanContentHelpers.CommitRow> CommitRows,
         string? ParentRepoPath = null,
-        string? ParentBranch = null,
-        string? ParentShortHash = null
+        string? BaseBranch = null,
+        string? BaseShortHash = null
     );
 
     public static GitTabData BuildGitTabData(
@@ -88,9 +88,7 @@ public static class GitTabDataBuilder
 
         if (worktree == null) return null;
 
-        var shortHash = worktree.CommitHash.Length > 7
-            ? worktree.CommitHash[..7]
-            : worktree.CommitHash;
+        var shortHash = Shorten(worktree.CommitHash);
 
         var hasUncommitted = false;
         var statusResult = gitService.HasUncommittedChanges(repoDir);
@@ -117,7 +115,7 @@ public static class GitTabDataBuilder
             }
         }
 
-        var (parentRepoPath, parentBranch, parentShortHash) = ResolveParentInfo(repoDir, worktreesResult.Value, gitService);
+        var (parentRepoPath, baseBranch, baseShortHash) = ResolveParentInfo(repoDir, worktreesResult.Value, gitService);
 
         return new WorktreeSection(
             Path.GetFileName(repoDir),
@@ -127,12 +125,27 @@ public static class GitTabDataBuilder
             hasUncommitted,
             worktreeCommits,
             parentRepoPath,
-            parentBranch,
-            parentShortHash
+            baseBranch,
+            baseShortHash
         );
     }
 
     private static (string? Path, string? Branch, string? ShortHash) ResolveParentInfo(
+        string repoDir, List<WorktreeInfo> worktrees, IGitService gitService)
+    {
+        var fallback = ResolveMainWorktreeInfo(repoDir, worktrees, gitService);
+
+        var baseResult = gitService.GetWorktreeBase(repoDir);
+        if (baseResult.IsSuccess && baseResult.Value != null)
+        {
+            var baseInfo = baseResult.Value;
+            return (fallback.Path, StripOriginPrefix(baseInfo.Branch), Shorten(baseInfo.CommitHash));
+        }
+
+        return fallback;
+    }
+
+    private static (string? Path, string? Branch, string? ShortHash) ResolveMainWorktreeInfo(
         string repoDir, List<WorktreeInfo> worktrees, IGitService gitService)
     {
         var mainWorktree = worktrees.FirstOrDefault(w =>
@@ -143,7 +156,7 @@ public static class GitTabDataBuilder
             return (
                 mainWorktree.Path,
                 mainWorktree.Branch,
-                mainWorktree.CommitHash.Length > 7 ? mainWorktree.CommitHash[..7] : mainWorktree.CommitHash
+                Shorten(mainWorktree.CommitHash)
             );
         }
 
@@ -161,7 +174,12 @@ public static class GitTabDataBuilder
         return (
             resolvedRoot,
             main.Branch,
-            main.CommitHash.Length > 7 ? main.CommitHash[..7] : main.CommitHash
+            Shorten(main.CommitHash)
         );
     }
+
+    private static string StripOriginPrefix(string branch) =>
+        branch.StartsWith("origin/", StringComparison.Ordinal) ? branch["origin/".Length..] : branch;
+
+    private static string Shorten(string hash) => hash.Length > 7 ? hash[..7] : hash;
 }

--- a/src/Ivy.Tendril/Services/Git/GitService.cs
+++ b/src/Ivy.Tendril/Services/Git/GitService.cs
@@ -283,6 +283,37 @@ public class GitService : IGitService
         }
     }
 
+    public GitResult<WorktreeBaseInfo?> GetWorktreeBase(string repoPath)
+    {
+        try
+        {
+            if (!Directory.Exists(repoPath))
+                return GitResult<WorktreeBaseInfo?>.Failure(GitError.InvalidRepoPath, $"Repository path does not exist: {repoPath}");
+
+            var (upstreamExit, upstreamOutput) = RunGitCommand(repoPath, "rev-parse --abbrev-ref @{u}");
+            var upstream = upstreamOutput.Trim();
+            if (upstreamExit != 0 || string.IsNullOrEmpty(upstream))
+                return GitResult<WorktreeBaseInfo?>.Success(null);
+
+            var (baseExit, baseOutput) = RunGitCommand(repoPath, "merge-base HEAD @{u}");
+            var forkPoint = baseOutput.Trim();
+            if (baseExit != 0 || string.IsNullOrEmpty(forkPoint))
+                return GitResult<WorktreeBaseInfo?>.Success(null);
+
+            return GitResult<WorktreeBaseInfo?>.Success(new WorktreeBaseInfo(upstream, forkPoint));
+        }
+        catch (FileNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "Git executable not found");
+            return GitResult<WorktreeBaseInfo?>.Failure(GitError.GitNotFound, "Git executable not found");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unknown error resolving worktree base");
+            return GitResult<WorktreeBaseInfo?>.Failure(GitError.UnknownError, ex.Message);
+        }
+    }
+
     // --- Infrastructure ---
 
     private GitResult<T> ExecuteGitCommand<T>(string repoPath, string args, Func<string, T> parseOutput)

--- a/src/Ivy.Tendril/Services/Git/IGitService.cs
+++ b/src/Ivy.Tendril/Services/Git/IGitService.cs
@@ -13,6 +13,9 @@ public interface IGitService
     GitResult<bool> HasUncommittedChanges(string repoPath);
     GitResult<List<string>> GetReachableCommits(string repoPath, IEnumerable<string> candidateHashes);
     GitResult<DirtyRepoResult> GetRepoDirtyState(string repoPath, string expectedBaseBranch);
+    GitResult<WorktreeBaseInfo?> GetWorktreeBase(string repoPath);
 }
 
 public record WorktreeInfo(string Path, string Branch, string CommitHash);
+
+public record WorktreeBaseInfo(string Branch, string CommitHash);


### PR DESCRIPTION
# Summary

## Changes

The Git tab's worktree "Parent" row previously showed the main worktree's currently checked-out
branch and HEAD, which is unrelated to the branch a worktree was actually created from (e.g. a
plan stacked on an epic branch showed today's `development` head instead of the epic branch it
forked from). Added `IGitService.GetWorktreeBase` to resolve a worktree's real upstream branch and
merge-base fork point via git, wired it into `GitTabDataBuilder`, and relabeled the row "Base",
falling back to the old main-worktree behavior when there is no upstream.

## API Changes

- `IGitService.GetWorktreeBase(string repoPath)` — new method returning
  `GitResult<WorktreeBaseInfo?>`.
- `WorktreeBaseInfo(string Branch, string CommitHash)` — new record in `Ivy.Tendril.Services.Git`.
- `GitTabDataBuilder.WorktreeSection`: `ParentBranch`/`ParentShortHash` renamed to
  `BaseBranch`/`BaseShortHash`. `ParentRepoPath` is unchanged.

## Files Modified

- `src/Ivy.Tendril/Services/Git/IGitService.cs` / `GitService.cs` — new `GetWorktreeBase` member and implementation.
- `src/Ivy.Tendril/Helpers/GitTabDataBuilder.cs` — `ResolveParentInfo` now prefers the worktree's real upstream/fork-point, falling back to the main worktree's branch; added `StripOriginPrefix`/`Shorten` helpers.
- `src/Ivy.Tendril/Apps/Views/Tabs/GitTabView.cs` — row label "Parent" → "Base".
- `src/Ivy.Tendril.Test/GitServiceTests.cs`, `GitTabDataBuilderTests.cs`, `PlanContentHelpersTests.cs` — new/updated tests and stub coverage.

## Manual Testing

1. Open a plan in the Tendril UI whose worktree branch was created from a non-default branch (e.g.
   an epic branch), and open its Git tab.
2. The worktree's details block should now show a "Base" row reading
   `<epic-branch>@<fork-point-short-hash>` instead of a "Parent" row reading
   `development@<today's head>`.
3. For a plan branched directly off the default branch, or a worktree with no configured upstream,
   the row still reads `development@<hash>` (unchanged fallback behavior) — just re-labeled "Base".

---
## Commits

- f0c4671a Add IGitService.GetWorktreeBase to resolve upstream fork point
- 0e279439 Show worktree base branch instead of main checkout in Git tab
- 658c12ca Add tests for worktree base branch resolution

---
Created using [Ivy Tendril](https://ivy.app).
