### PR TITLE
[00088] Keep DraftMarkdown Annotation Popovers Anchored While Scrolling

### DIFF
--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/AnnotationsApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/AnnotationsApp.cs
@@ -64,6 +64,49 @@ class AnnotationsApp : ViewBase
 
             > **Note:** This spec is subject to review by the platform team
             > before implementation begins.
+
+            ## Appendix: Rollout Plan
+
+            The rollout proceeds in four phases, each gated on the previous phase's
+            success metrics before the next one begins. This section is intentionally
+            long so the document overflows the widget's viewport and can be scrolled,
+            which end-to-end tests rely on to verify that floating annotation UI stays
+            anchored to the underlying text while scrolling.
+
+            1. **Internal dogfood** — the platform team enables notifications for its
+               own accounts and monitors delivery latency and error rates for one week.
+            2. **Limited beta** — a small, opted-in cohort of external users receives
+               notifications, with a kill switch ready in case of unexpected volume.
+            3. **Staged rollout** — the feature is enabled for an increasing percentage
+               of accounts (5%, 25%, 50%, 100%) over two weeks, with rollback criteria
+               defined for each stage.
+            4. **General availability** — notifications are enabled by default for all
+               accounts, with the settings page exposed for per-channel opt-out.
+
+            Each phase has a dedicated on-call rotation and a rollback runbook. Metrics
+            reviewed at each gate include delivery latency (p50/p95/p99), delivery
+            failure rate per channel, and unsubscribe rate. Any regression beyond the
+            agreed thresholds pauses the rollout until root-caused.
+
+            ### Risks and Mitigations
+
+            - **Provider outages**: email and push both depend on third-party
+              providers; the fan-out consumers retry with exponential backoff and
+              fall back to in-app delivery when a channel is degraded.
+            - **Notification fatigue**: batching and per-channel preferences reduce
+              the chance that users disable notifications outright.
+            - **Data consistency**: the topic is the single source of truth for
+              delivery status, so a consumer crash cannot silently drop a
+              notification — it re-reads from the last committed offset on restart.
+
+            ### Appendix Glossary
+
+            - **Fan-out**: publishing a single event to multiple independent
+              consumers, one per delivery channel.
+            - **Dead-letter queue**: where events land after exhausting their retry
+              budget, for manual inspection.
+            - **Kill switch**: an operator-controlled flag that disables a channel
+              immediately, independent of the staged rollout percentage.
             """;
 
         object sidePanel;

--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/annotations.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/annotations.spec.ts
@@ -272,4 +272,40 @@ test.describe("DraftMarkdown Annotations", () => {
     await expect(highlights).toHaveCount(2);
     await stepScreenshot("both-annotations-visible");
   });
+
+  test("selection toolbar follows the text while scrolling", async ({ page, stepScreenshot }) => {
+    const shell = page.locator(".pmv-shell");
+
+    // Sanity: the sample content must actually overflow the shell at this
+    // viewport, otherwise scrolling below would be a no-op and the position
+    // assertion would pass vacuously.
+    const isScrollable = await shell.evaluate((el) => el.scrollHeight > el.clientHeight + 50);
+    expect(isScrollable).toBe(true);
+
+    const paragraph = page.locator(".pmv-markdown p").first();
+    const box = await paragraph.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.mouse.move(box!.x + 5, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + 200, box!.y + box!.height / 2);
+    await page.mouse.up();
+
+    const toolbar = page.locator(".pmv-selection-toolbar");
+    await expect(toolbar).toBeVisible({ timeout: 5000 });
+    const before = await toolbar.boundingBox();
+    expect(before).not.toBeNull();
+    await stepScreenshot("toolbar-before-scroll");
+
+    await shell.evaluate((el) => el.scrollBy(0, 200));
+
+    // The capture-phase scroll listener repositions the toolbar
+    // asynchronously; poll until it settles at the expected offset.
+    await expect(async () => {
+      const after = await toolbar.boundingBox();
+      expect(after).not.toBeNull();
+      expect(Math.abs(before!.y - 200 - after!.y)).toBeLessThanOrEqual(2);
+    }).toPass({ timeout: 5000 });
+    await stepScreenshot("toolbar-after-scroll");
+  });
 });

--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/annotations.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/annotations.spec.ts
@@ -282,13 +282,17 @@ test.describe("DraftMarkdown Annotations", () => {
     const isScrollable = await shell.evaluate((el) => el.scrollHeight > el.clientHeight + 50);
     expect(isScrollable).toBe(true);
 
-    const paragraph = page.locator(".pmv-markdown p").first();
-    const box = await paragraph.boundingBox();
+    // Select within the (single-line) "Overview" heading rather than a
+    // wrapped paragraph: a drag whose midpoint Y lands between two wrapped
+    // lines can produce a collapsed selection, as the "text selection shows
+    // toolbar" test above avoids by using the same heading.
+    const heading = page.locator(".pmv-markdown h2").first();
+    const box = await heading.boundingBox();
     expect(box).not.toBeNull();
 
     await page.mouse.move(box!.x + 5, box!.y + box!.height / 2);
     await page.mouse.down();
-    await page.mouse.move(box!.x + 200, box!.y + box!.height / 2);
+    await page.mouse.move(box!.x + box!.width - 5, box!.y + box!.height / 2);
     await page.mouse.up();
 
     const toolbar = page.locator(".pmv-selection-toolbar");

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/AnnotationPopover.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/AnnotationPopover.tsx
@@ -8,6 +8,10 @@ interface Position {
 
 interface AddAnnotationPopoverProps {
   position: Position;
+  /** False once the anchor has scrolled out of the shell's viewport. Hides
+   * (rather than unmounts) the popover so a half-typed comment survives
+   * scrolling the anchor back into view. Defaults to true. */
+  visible?: boolean;
   selectedText: string;
   onAdd: (comment: string) => void;
   onCancel: () => void;
@@ -15,6 +19,7 @@ interface AddAnnotationPopoverProps {
 
 export const AddAnnotationPopover: React.FC<AddAnnotationPopoverProps> = ({
   position,
+  visible = true,
   selectedText,
   onAdd,
   onCancel,
@@ -49,7 +54,11 @@ export const AddAnnotationPopover: React.FC<AddAnnotationPopoverProps> = ({
   }, [comment, onAdd]);
 
   return createPortal(
-    <div ref={popoverRef} className="pmv-popover" style={{ top: position.top, left: position.left }}>
+    <div
+      ref={popoverRef}
+      className="pmv-popover"
+      style={{ top: position.top, left: position.left, visibility: visible ? "visible" : "hidden" }}
+    >
       <div className="pmv-popover-quote">
         &ldquo;{selectedText.slice(0, 50)}
         {selectedText.length > 50 ? "..." : ""}&rdquo;
@@ -72,7 +81,11 @@ export const AddAnnotationPopover: React.FC<AddAnnotationPopoverProps> = ({
         <button type="button" className="pmv-popover-btn pmv-popover-btn--ghost" onClick={onCancel}>
           Cancel
         </button>
-        <button type="button" className="pmv-popover-btn pmv-popover-btn--primary" onClick={handleSubmit}>
+        <button
+          type="button"
+          className="pmv-popover-btn pmv-popover-btn--primary"
+          onClick={handleSubmit}
+        >
           Add
         </button>
       </div>
@@ -83,6 +96,10 @@ export const AddAnnotationPopover: React.FC<AddAnnotationPopoverProps> = ({
 
 interface EditAnnotationPopoverProps {
   position: Position;
+  /** False once the anchor has scrolled out of the shell's viewport. Hides
+   * (rather than unmounts) the popover so in-progress edits survive
+   * scrolling the anchor back into view. Defaults to true. */
+  visible?: boolean;
   annotation: { selectedText: string; comment: string };
   onSave: (comment: string) => void;
   onRemove: () => void;
@@ -91,6 +108,7 @@ interface EditAnnotationPopoverProps {
 
 export const EditAnnotationPopover: React.FC<EditAnnotationPopoverProps> = ({
   position,
+  visible = true,
   annotation,
   onSave,
   onRemove,
@@ -126,7 +144,11 @@ export const EditAnnotationPopover: React.FC<EditAnnotationPopoverProps> = ({
   }, [comment, onSave]);
 
   return createPortal(
-    <div ref={popoverRef} className="pmv-popover" style={{ top: position.top, left: position.left }}>
+    <div
+      ref={popoverRef}
+      className="pmv-popover"
+      style={{ top: position.top, left: position.left, visibility: visible ? "visible" : "hidden" }}
+    >
       <div className="pmv-popover-quote">
         &ldquo;{annotation.selectedText.slice(0, 50)}
         {annotation.selectedText.length > 50 ? "..." : ""}&rdquo;
@@ -146,14 +168,26 @@ export const EditAnnotationPopover: React.FC<EditAnnotationPopoverProps> = ({
         }}
       />
       <div className="pmv-popover-actions pmv-popover-actions--between">
-        <button type="button" className="pmv-popover-btn pmv-popover-btn--danger" onClick={onRemove}>
+        <button
+          type="button"
+          className="pmv-popover-btn pmv-popover-btn--danger"
+          onClick={onRemove}
+        >
           Remove
         </button>
         <div className="pmv-popover-actions pmv-popover-actions--end">
-          <button type="button" className="pmv-popover-btn pmv-popover-btn--ghost" onClick={onCancel}>
+          <button
+            type="button"
+            className="pmv-popover-btn pmv-popover-btn--ghost"
+            onClick={onCancel}
+          >
             Cancel
           </button>
-          <button type="button" className="pmv-popover-btn pmv-popover-btn--primary" onClick={handleSave}>
+          <button
+            type="button"
+            className="pmv-popover-btn pmv-popover-btn--primary"
+            onClick={handleSave}
+          >
             Save
           </button>
         </div>
@@ -165,15 +199,25 @@ export const EditAnnotationPopover: React.FC<EditAnnotationPopoverProps> = ({
 
 interface SelectionToolbarProps {
   position: Position;
+  /** False once the anchor has scrolled out of the shell's viewport. Hides
+   * (rather than unmounts) the toolbar. Defaults to true. */
+  visible?: boolean;
   onAddComment: () => void;
 }
 
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
 const ADD_COMMENT_SHORTCUT = isMac ? "⌘⌥M" : "Ctrl+Alt+M";
 
-export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({ position, onAddComment }) => {
+export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
+  position,
+  visible = true,
+  onAddComment,
+}) => {
   return createPortal(
-    <div className="pmv-selection-toolbar" style={{ top: position.top, left: position.left }}>
+    <div
+      className="pmv-selection-toolbar"
+      style={{ top: position.top, left: position.left, visibility: visible ? "visible" : "hidden" }}
+    >
       <button
         type="button"
         className="pmv-selection-toolbar-btn"

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
@@ -10,6 +10,7 @@ import { AlertBlockquote } from "./AlertBlockquote";
 import { ImageRenderer } from "./ImageRenderer";
 import { isLocalFileUrl, transformLocalFileUrl } from "./localFiles";
 import { getMarkdownPlugins } from "../math";
+import { useAnchoredPosition } from "./useAnchoredPosition";
 
 type IvyEventHandler = (eventName: string, widgetId: string, args: unknown[]) => void;
 
@@ -28,13 +29,7 @@ interface DraftMarkdownProps {
   };
 }
 
-interface Position {
-  top: number;
-  left: number;
-}
-
 interface SelectionState {
-  position: Position;
   startOffset: number;
   endOffset: number;
   selectedText: string;
@@ -56,9 +51,17 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
   slots,
 }) => {
   const contentRef = useRef<HTMLDivElement>(null);
+  const shellRef = useRef<HTMLDivElement>(null);
   const [selectionToolbar, setSelectionToolbar] = useState<SelectionState | null>(null);
   const [addPopover, setAddPopover] = useState<SelectionState | null>(null);
-  const [editPopover, setEditPopover] = useState<{ position: Position; annotation: MarkdownAnnotation } | null>(null);
+  const [editPopover, setEditPopover] = useState<MarkdownAnnotation | null>(null);
+
+  // Re-measured on scroll/resize so the fixed-position toolbar/popovers stay
+  // lined up with the text they anchor to, instead of the one-shot rect
+  // captured at mouseup/click time.
+  const selectionAnchor = useAnchoredPosition(contentRef, shellRef, selectionToolbar);
+  const addAnchor = useAnchoredPosition(contentRef, shellRef, addPopover);
+  const editAnchor = useAnchoredPosition(contentRef, shellRef, editPopover);
 
   const annotationsEnabled = events.includes("OnAnnotationsChange");
 
@@ -101,13 +104,7 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
       const startOffset = getPlainTextOffset(container, range.startContainer, range.startOffset);
       const endOffset = getPlainTextOffset(container, range.endContainer, range.endOffset);
 
-      const rect = range.getBoundingClientRect();
-      setSelectionToolbar({
-        position: { top: rect.bottom + 4, left: rect.left },
-        startOffset,
-        endOffset,
-        selectedText,
-      });
+      setSelectionToolbar({ startOffset, endOffset, selectedText });
     };
 
     container.addEventListener("mouseup", handleMouseUp);
@@ -133,18 +130,16 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
     if (!container) return;
 
     const handleClick = (e: MouseEvent) => {
-      const mark = (e.target as HTMLElement).closest("mark[data-annotation-id]") as HTMLElement | null;
+      const mark = (e.target as HTMLElement).closest(
+        "mark[data-annotation-id]",
+      ) as HTMLElement | null;
       if (!mark) return;
 
       const annotationId = mark.dataset.annotationId;
       const annotation = annotations.find((a) => a.id === annotationId);
       if (!annotation) return;
 
-      const rect = mark.getBoundingClientRect();
-      setEditPopover({
-        position: { top: rect.bottom + 4, left: rect.left },
-        annotation,
-      });
+      setEditPopover(annotation);
     };
 
     container.addEventListener("click", handleClick);
@@ -195,7 +190,7 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
   const handleEditAnnotation = useCallback(
     (comment: string) => {
       if (!editPopover) return;
-      const updated = annotations.map((a) => (a.id === editPopover.annotation.id ? { ...a, comment } : a));
+      const updated = annotations.map((a) => (a.id === editPopover.id ? { ...a, comment } : a));
       fireAnnotationsChange(updated);
       setEditPopover(null);
     },
@@ -204,7 +199,7 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
 
   const handleRemoveAnnotation = useCallback(() => {
     if (!editPopover) return;
-    const filtered = annotations.filter((a) => a.id !== editPopover.annotation.id);
+    const filtered = annotations.filter((a) => a.id !== editPopover.id);
     fireAnnotationsChange(filtered);
     setEditPopover(null);
   }, [editPopover, annotations, fireAnnotationsChange]);
@@ -222,7 +217,8 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
     (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
       const { href, children, ...rest } = props;
       const isLocalFile =
-        !!href && (href.startsWith("file:") || (!/^[a-z]+:\/\//i.test(href) && !href.startsWith("#")));
+        !!href &&
+        (href.startsWith("file:") || (!/^[a-z]+:\/\//i.test(href) && !href.startsWith("#")));
       if (isLocalFile && !dangerouslyAllowLocalFiles) {
         return <span {...rest}>{children}</span>;
       }
@@ -271,14 +267,19 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
   };
 
   return (
-    <div className="pmv-shell" style={shellStyle}>
+    <div ref={shellRef} className="pmv-shell" style={shellStyle}>
       <div className="pmv-body">
         <div ref={contentRef} className={article ? "pmv-markdown pmv-article" : "pmv-markdown"}>
           <Markdown
             remarkPlugins={plugins.remarkPlugins}
             rehypePlugins={plugins.rehypePlugins}
             urlTransform={urlTransform}
-            components={{ a: anchor, code: CodeBlock, blockquote: AlertBlockquote, img: ImageRenderer }}
+            components={{
+              a: anchor,
+              code: CodeBlock,
+              blockquote: AlertBlockquote,
+              img: ImageRenderer,
+            }}
           >
             {content}
           </Markdown>
@@ -286,21 +287,27 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
       </div>
       {hasFixed && <div className="pmv-sticky">{fixed}</div>}
 
-      {annotationsEnabled && selectionToolbar && (
-        <SelectionToolbar position={selectionToolbar.position} onAddComment={handleAddComment} />
+      {annotationsEnabled && selectionToolbar && selectionAnchor && (
+        <SelectionToolbar
+          position={selectionAnchor.position}
+          visible={selectionAnchor.visible}
+          onAddComment={handleAddComment}
+        />
       )}
-      {annotationsEnabled && addPopover && (
+      {annotationsEnabled && addPopover && addAnchor && (
         <AddAnnotationPopover
-          position={addPopover.position}
+          position={addAnchor.position}
+          visible={addAnchor.visible}
           selectedText={addPopover.selectedText}
           onAdd={handleAddAnnotation}
           onCancel={() => setAddPopover(null)}
         />
       )}
-      {annotationsEnabled && editPopover && (
+      {annotationsEnabled && editPopover && editAnchor && (
         <EditAnnotationPopover
-          position={editPopover.position}
-          annotation={editPopover.annotation}
+          position={editAnchor.position}
+          visible={editAnchor.visible}
+          annotation={editPopover}
           onSave={handleEditAnnotation}
           onRemove={handleRemoveAnnotation}
           onCancel={() => setEditPopover(null)}

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/annotationUtils.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/annotationUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { getPlainTextOffset, getPlainText } from "./annotationUtils";
+import { getPlainTextOffset, getPlainText, createRangeFromOffsets } from "./annotationUtils";
 
 describe("getPlainTextOffset", () => {
   let container: HTMLDivElement;
@@ -30,6 +30,44 @@ describe("getPlainTextOffset", () => {
   it("handles empty container", () => {
     container.innerHTML = "";
     expect(getPlainTextOffset(container, container, 0)).toBe(0);
+  });
+});
+
+describe("createRangeFromOffsets", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  it("builds a range within a single text node", () => {
+    container.textContent = "Hello world";
+    const range = createRangeFromOffsets(container, 0, 5);
+    expect(range?.toString()).toBe("Hello");
+  });
+
+  it("builds a range spanning nested elements", () => {
+    container.innerHTML = "<p>Hello </p><p>world</p>";
+    const range = createRangeFromOffsets(container, 0, 11);
+    expect(range?.toString()).toBe("Hello world");
+  });
+
+  it("builds a range spanning inline formatting", () => {
+    container.innerHTML = "<p>Hello <strong>bold</strong> text</p>";
+    const range = createRangeFromOffsets(container, 6, 10);
+    expect(range?.toString()).toBe("bold");
+  });
+
+  it("builds a range spanning an existing annotation mark", () => {
+    container.innerHTML = 'Hello <mark data-annotation-id="a1">bold</mark> text';
+    const range = createRangeFromOffsets(container, 0, 15);
+    expect(range?.toString()).toBe("Hello bold text");
+  });
+
+  it("returns null for an empty container", () => {
+    container.innerHTML = "";
+    expect(createRangeFromOffsets(container, 0, 5)).toBeNull();
   });
 });
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/annotationUtils.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/annotationUtils.ts
@@ -79,6 +79,41 @@ function getTextNodesInRange(
   return ranges;
 }
 
+/**
+ * Builds a Range spanning the given plain-text offsets within container, from
+ * the first matching text node's start to the last matching text node's end.
+ * Returns null when the walk yields no text nodes (e.g. an empty container).
+ */
+export function createRangeFromOffsets(
+  container: HTMLElement,
+  startOffset: number,
+  endOffset: number,
+): Range | null {
+  const textNodes = getTextNodesInRange(container, startOffset, endOffset);
+  if (textNodes.length === 0) return null;
+
+  const first = textNodes[0];
+  const last = textNodes[textNodes.length - 1];
+
+  const range = document.createRange();
+  range.setStart(first.node, first.start);
+  range.setEnd(last.node, last.end);
+  return range;
+}
+
+/**
+ * Bounding rect for the plain-text offset range, kept separate from
+ * createRangeFromOffsets so the DOM walk itself stays unit-testable under
+ * jsdom, which reports every rect as zero.
+ */
+export function getOffsetRect(
+  container: HTMLElement,
+  startOffset: number,
+  endOffset: number,
+): DOMRect | null {
+  return createRangeFromOffsets(container, startOffset, endOffset)?.getBoundingClientRect() ?? null;
+}
+
 export function applyAnnotationHighlights(
   container: HTMLElement,
   annotations: MarkdownAnnotation[],

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/useAnchoredPosition.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/useAnchoredPosition.ts
@@ -1,0 +1,86 @@
+import { useEffect, useLayoutEffect, useState, type RefObject } from "react";
+import { getOffsetRect } from "./annotationUtils";
+
+export interface Position {
+  top: number;
+  left: number;
+}
+
+interface AnchorOffsets {
+  startOffset: number;
+  endOffset: number;
+}
+
+interface AnchoredPosition {
+  position: Position;
+  visible: boolean;
+}
+
+/**
+ * Tracks the viewport position of a plain-text offset range inside
+ * containerRef, re-measuring on scroll/resize so a `position: fixed` element
+ * anchored to it (a selection toolbar or annotation popover) stays lined up
+ * with the text as the scrollable shell scrolls. Mirrors the
+ * scroll(capture)/resize pattern used by BadgeSelect, ChatWidget and
+ * PlanDiffView.
+ *
+ * `visible` becomes false once the anchor scrolls outside shellRef's bounds,
+ * so callers can hide (not unmount) the element and preserve its state.
+ */
+export function useAnchoredPosition(
+  containerRef: RefObject<HTMLElement | null>,
+  shellRef: RefObject<HTMLElement | null>,
+  anchor: AnchorOffsets | null,
+): AnchoredPosition | null {
+  const [result, setResult] = useState<AnchoredPosition | null>(null);
+  const { startOffset, endOffset } = anchor ?? {};
+
+  useLayoutEffect(() => {
+    if (startOffset === undefined || endOffset === undefined) {
+      setResult(null);
+      return;
+    }
+    recompute(containerRef, shellRef, startOffset, endOffset, setResult);
+  }, [containerRef, shellRef, startOffset, endOffset]);
+
+  useEffect(() => {
+    if (startOffset === undefined || endOffset === undefined) return;
+    const onReposition = () => recompute(containerRef, shellRef, startOffset, endOffset, setResult);
+    window.addEventListener("scroll", onReposition, true);
+    window.addEventListener("resize", onReposition);
+    return () => {
+      window.removeEventListener("scroll", onReposition, true);
+      window.removeEventListener("resize", onReposition);
+    };
+  }, [containerRef, shellRef, startOffset, endOffset]);
+
+  return result;
+}
+
+function recompute(
+  containerRef: RefObject<HTMLElement | null>,
+  shellRef: RefObject<HTMLElement | null>,
+  startOffset: number,
+  endOffset: number,
+  setResult: (result: AnchoredPosition | null) => void,
+): void {
+  const container = containerRef.current;
+  if (!container) {
+    setResult(null);
+    return;
+  }
+
+  const rect = getOffsetRect(container, startOffset, endOffset);
+  if (!rect) {
+    setResult(null);
+    return;
+  }
+
+  const shellRect = shellRef.current?.getBoundingClientRect();
+  const visible = !shellRect || !(rect.bottom < shellRect.top || rect.top > shellRect.bottom);
+
+  setResult({
+    position: { top: rect.bottom + 4, left: rect.left },
+    visible,
+  });
+}


### PR DESCRIPTION
# Summary

## Changes

DraftMarkdown's selection toolbar and add/edit annotation popovers are now anchored to stable
plain-text offsets and re-measured on scroll (capture phase) and resize, instead of freezing at
the viewport coordinates captured once at `mouseup`/click time. A new `useAnchoredPosition` hook
mirrors the scroll/resize pattern already used by BadgeSelect, ChatWidget and PlanDiffView, and
each popover now hides (rather than unmounts) once its anchor scrolls outside the widget's
viewport, so an in-progress comment survives being scrolled out of view and back.

## API Changes

- `annotationUtils.ts`: new exports `createRangeFromOffsets(container, startOffset, endOffset): Range | null` and `getOffsetRect(container, startOffset, endOffset): DOMRect | null`.
- New internal hook `useAnchoredPosition(containerRef, shellRef, anchor): { position, visible } | null` in `useAnchoredPosition.ts` (not exported from the widget's public `index.ts`).
- `AddAnnotationPopover`, `EditAnnotationPopover`, `SelectionToolbar` (`AnnotationPopover.tsx`) each gained an optional `visible?: boolean` prop (default `true`); when `false`, the popover renders with `visibility: hidden` instead of unmounting.
- No changes to the public `DraftMarkdown` widget props/events (`[Prop]`/`[Event]` surface on `window.IvyTendrilWidgets` is unaffected).

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/annotationUtils.ts` — new offset-based range/rect helpers.
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/useAnchoredPosition.ts` — new hook (scroll/resize repositioning + visibility).
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx` — wires the hook into all three floating elements; state simplified to drop the one-shot `position` field.
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/AnnotationPopover.tsx` — `visible` prop plumbed through to all three exported components.
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/annotationUtils.test.ts` — new `createRangeFromOffsets` unit tests.
- `src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/annotations.spec.ts` — new Playwright test asserting the toolbar tracks a scroll delta.
- `src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/AnnotationsApp.cs` — extended sample markdown so the widget overflows (and is scrollable) at the E2E test viewport.

## Manual Testing

1. Run the widgets sample app: `cd src\Ivy.Tendril.Widgets\.samples` then `dotnet run -- --port 5100`, open the app, navigate to **DraftMarkdown → Annotations**.
2. Select some text midway down the document (e.g. in the "Architecture" section) and click "Add Comment" so the comment popover opens.
3. Scroll the document up or down using the mouse wheel inside the markdown pane. The popover should move together with the highlighted/selected text, staying pinned just below it, instead of staying fixed in place while the text scrolls away.
4. Scroll far enough that the selected text leaves the visible area — the popover should disappear (hidden, not closed); scroll back and it should reappear at the correct position with any typed comment text still intact.
5. Add an annotation, then click its highlight to reopen the edit popover, and repeat the same scroll check — it should track the highlighted text the same way.
6. Note: dragging the scrollbar itself still dismisses the toolbar/popover (pre-existing, out-of-scope defect noted in the plan).

---
Commits:
- 84ec5c5e Plan 00088: Add offset-based range/rect helpers to annotationUtils
- 575732aa Plan 00088: Add useAnchoredPosition hook to reposition on scroll/resize
- ee55cbf5 Plan 00088: Anchor selection toolbar and annotation popovers to text offsets
- b4fe98ea Plan 00088: Add E2E coverage for the selection toolbar following scroll
- c72996c7 Plan 00088: Select within the heading, not a wrapped paragraph, in the new scroll test

---
Created using [Ivy Tendril](https://ivy.app).
