### PR TITLE
feat(agents): support Gemini 3.7 Flash and Claude 5 models

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityModelCatalogTests.cs
@@ -42,9 +42,12 @@ public class AntigravityModelCatalogTests
     }
 
     [Theory]
+    [InlineData("gemini-3.7-flash")]
     [InlineData("gemini-3.6-flash")]
     [InlineData("gemini-3.5-flash")]
     [InlineData("gemini-3.1-pro")]
+    [InlineData("claude-opus-5")]
+    [InlineData("claude-sonnet-5")]
     [InlineData("claude-sonnet-4-6")]
     public void GetStaticModels_ContainsModels(string expectedId)
     {

--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudeModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudeModelCatalogTests.cs
@@ -58,6 +58,18 @@ public class ClaudeModelCatalogTests
     }
 
     [Fact]
+    public void GetStaticModels_ContainsSonnet5()
+    {
+        var models = _catalog.GetStaticModels();
+        var sonnet5 = Assert.Single(models, m => m.Id == "claude-sonnet-5");
+
+        Assert.Equal(1_000_000, sonnet5.ContextWindow);
+        Assert.Equal(128_000, sonnet5.MaxOutputTokens);
+        Assert.Equal(3.00m, sonnet5.InputPerMillion);
+        Assert.Equal(15.00m, sonnet5.OutputPerMillion);
+    }
+
+    [Fact]
     public async Task GetModelsAsync_ReturnsModels()
     {
         var result = await _catalog.GetModelsAsync();

--- a/src/Ivy.Tendril.Agents.Test/Gemini/GeminiModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Gemini/GeminiModelCatalogTests.cs
@@ -21,38 +21,50 @@ public class GeminiModelCatalogTests
     }
 
     [Fact]
-    public void GetStaticModels_ContainsGemini25Pro()
+    public void GetStaticModels_ContainsGemini37Flash()
     {
         var models = _catalog.GetStaticModels();
-        var pro = models.FirstOrDefault(m => m.Id == "gemini-2.5-pro");
+        var flash = models.FirstOrDefault(m => m.Id == "gemini-3.7-flash");
+        Assert.NotNull(flash);
+        Assert.Equal("Gemini 3.7 Flash", flash!.DisplayName);
+        Assert.Equal("google", flash.Provider);
+    }
+
+    [Fact]
+    public void GetStaticModels_ContainsGemini36Flash()
+    {
+        var models = _catalog.GetStaticModels();
+        var flash = models.FirstOrDefault(m => m.Id == "gemini-3.6-flash");
+        Assert.NotNull(flash);
+        Assert.Equal("Gemini 3.6 Flash", flash!.DisplayName);
+    }
+
+    [Fact]
+    public void GetStaticModels_ContainsGemini35Flash()
+    {
+        var models = _catalog.GetStaticModels();
+        var flash = models.FirstOrDefault(m => m.Id == "gemini-3.5-flash");
+        Assert.NotNull(flash);
+        Assert.Equal("Gemini 3.5 Flash", flash!.DisplayName);
+    }
+
+    [Fact]
+    public void GetStaticModels_ContainsGemini31Pro()
+    {
+        var models = _catalog.GetStaticModels();
+        var pro = models.FirstOrDefault(m => m.Id == "gemini-3.1-pro");
         Assert.NotNull(pro);
-        Assert.Equal("Gemini 2.5 Pro", pro!.DisplayName);
+        Assert.Equal("Gemini 3.1 Pro", pro!.DisplayName);
         Assert.Equal("google", pro.Provider);
     }
 
     [Fact]
-    public void GetStaticModels_ContainsGemini25Flash()
-    {
-        var models = _catalog.GetStaticModels();
-        var flash = models.FirstOrDefault(m => m.Id == "gemini-2.5-flash");
-        Assert.NotNull(flash);
-    }
-
-    [Fact]
-    public void GetStaticModels_ContainsGemini25FlashLite()
-    {
-        var models = _catalog.GetStaticModels();
-        var lite = models.FirstOrDefault(m => m.Id == "gemini-2.5-flash-lite");
-        Assert.NotNull(lite);
-    }
-
-    [Fact]
-    public void GetStaticModels_DefaultModelIsGemini25Pro()
+    public void GetStaticModels_DefaultModelIsGemini37Flash()
     {
         var models = _catalog.GetStaticModels();
         var defaults = models.Where(m => m.IsDefault).ToList();
         Assert.Single(defaults);
-        Assert.Equal("gemini-2.5-pro", defaults[0].Id);
+        Assert.Equal("gemini-3.7-flash", defaults[0].Id);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs
@@ -27,6 +27,13 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
     [
         new()
         {
+            Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash",
+            Capabilities = MidCaps,
+            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
+            Provider = "google",
+        },
+        new()
+        {
             Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash",
             Capabilities = MidCaps, IsDefault = true,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
@@ -45,6 +52,20 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
             Capabilities = FullCaps,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
+        },
+        new()
+        {
+            Id = "claude-opus-5", DisplayName = "Claude Opus 5",
+            Capabilities = FullCaps,
+            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
+            Provider = "anthropic",
+        },
+        new()
+        {
+            Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5",
+            Capabilities = FullCaps,
+            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
+            Provider = "anthropic",
         },
         new()
         {

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
@@ -67,6 +67,15 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         },
         new()
         {
+            Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5",
+            Capabilities = MidCaps,
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
+            Provider = "anthropic",
+            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
+            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
+        },
+        new()
+        {
             Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6",
             Capabilities = MidCaps,
             ContextWindow = 1_000_000, MaxOutputTokens = 128_000,

--- a/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotModelCatalog.cs
@@ -19,6 +19,8 @@ public sealed class CopilotModelCatalog : CachedModelCatalogProvider
         new() { Id = "gpt-5.4-mini", DisplayName = "GPT-5.4 Mini", Capabilities = DefaultCaps, Provider = "openai" },
         new() { Id = "gpt-5-mini", DisplayName = "GPT-5 Mini", Capabilities = DefaultCaps, Provider = "openai" },
         new() { Id = "gpt-4.1", DisplayName = "GPT-4.1", Capabilities = DefaultCaps, Provider = "openai" },
+        new() { Id = "claude-opus-5", DisplayName = "Claude Opus 5", Capabilities = DefaultCaps, Provider = "anthropic" },
+        new() { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5", Capabilities = DefaultCaps, Provider = "anthropic" },
         new() { Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6", Capabilities = DefaultCaps, Provider = "anthropic" },
         new() { Id = "claude-sonnet-4-5", DisplayName = "Claude Sonnet 4.5", Capabilities = DefaultCaps, Provider = "anthropic" },
         new() { Id = "claude-haiku-4-5", DisplayName = "Claude Haiku 4.5", Capabilities = DefaultCaps, Provider = "anthropic" },

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiModelCatalog.cs
@@ -23,16 +23,16 @@ public sealed class GeminiModelCatalog : CachedModelCatalogProvider
     [
         new()
         {
-            Id = "gemini-2.5-pro", DisplayName = "Gemini 2.5 Pro",
-            Capabilities = FullCaps,
+            Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash",
+            Capabilities = MidCaps,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google", IsDefault = true,
-            InputPerMillion = 1.25m, OutputPerMillion = 10.00m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.315m,
+            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
+            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.0375m,
         },
         new()
         {
-            Id = "gemini-2.5-flash", DisplayName = "Gemini 2.5 Flash",
+            Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash",
             Capabilities = MidCaps,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
@@ -41,12 +41,21 @@ public sealed class GeminiModelCatalog : CachedModelCatalogProvider
         },
         new()
         {
-            Id = "gemini-2.5-flash-lite", DisplayName = "Gemini 2.5 Flash Lite",
+            Id = "gemini-3.5-flash", DisplayName = "Gemini 3.5 Flash",
             Capabilities = MidCaps,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
-            InputPerMillion = 0.075m, OutputPerMillion = 0.30m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.01875m,
+            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
+            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.0375m,
+        },
+        new()
+        {
+            Id = "gemini-3.1-pro", DisplayName = "Gemini 3.1 Pro",
+            Capabilities = FullCaps,
+            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
+            Provider = "google",
+            InputPerMillion = 1.25m, OutputPerMillion = 10.00m,
+            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.315m,
         },
         new()
         {

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
@@ -35,6 +35,16 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
         },
         new()
         {
+            Id = "claude-opus-5", DisplayName = "Claude Opus 5",
+            Capabilities = DefaultCaps, Provider = "anthropic",
+        },
+        new()
+        {
+            Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5",
+            Capabilities = DefaultCaps, Provider = "anthropic",
+        },
+        new()
+        {
             Id = "claude-opus-4-7", DisplayName = "Claude Opus 4.7",
             Capabilities = DefaultCaps, Provider = "anthropic",
         },
@@ -137,6 +147,8 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
     private static readonly (string Pattern, KnownPricing Pricing)[] KnownPricingTable =
     [
         // Anthropic
+        ("claude-opus-5",     new(5.00m, 25.00m, 0.50m, 6.25m, 1_000_000)),
+        ("claude-sonnet-5",   new(3.00m, 15.00m, 0.30m, 3.75m, 1_000_000)),
         ("claude-opus-4-7",   new(10.00m, 50.00m, 1.00m, 12.50m, 200_000)),
         ("claude-opus-4-6",   new(5.00m, 25.00m, 0.50m, 6.25m, 200_000)),
         ("claude-opus-4-5",   new(5.00m, 25.00m, 0.50m, 6.25m, 200_000)),
@@ -167,6 +179,10 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
         ("o1-pro",        new(150.00m, 600.00m, 0m, 0m, 128_000)),
         ("o1",            new(15.00m, 60.00m, 7.50m, 18.75m, 200_000)),
         // Google
+        ("gemini-3.7-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
+        ("gemini-3.6-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
+        ("gemini-3.5-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
+        ("gemini-3.1-pro",   new(1.25m, 10.00m, 0.3125m, 1.5625m, 1_048_576)),
         ("gemini-2.5-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
         ("gemini-2.5",       new(1.25m, 10.00m, 0.3125m, 1.5625m, 1_048_576)),
         ("gemini-2.0-flash", new(0.10m, 0.40m, 0.025m, 0.125m, 1_048_576)),

--- a/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/05_Gemini.md
+++ b/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/05_Gemini.md
@@ -35,17 +35,18 @@ Tendril maps effort levels to Gemini models:
 
 | Profile | Model | Use Case |
 |---------|-------|----------|
-| `deep` | gemini-2.5-pro | Complex multi-file changes |
-| `balanced` | gemini-2.5-flash | Standard plan execution |
-| `quick` | gemini-2.5-flash-lite | Simple fixes and small edits |
+| `deep` | gemini-3.1-pro | Complex multi-file changes |
+| `balanced` | gemini-3.7-flash | Standard plan execution |
+| `quick` | gemini-3.5-flash | Simple fixes and small edits |
 
 The profile is selected automatically based on the plan's complexity level, or can be configured per promptware in `config.yaml`.
 
 ## Available Models
 
-- `gemini-2.5-pro` — Full reasoning, 1M context (default)
-- `gemini-2.5-flash` — Fast and capable, 1M context
-- `gemini-2.5-flash-lite` — Lightweight, lowest cost
+- `gemini-3.7-flash` — Next-gen fast and capable reasoning, 1M context (default)
+- `gemini-3.6-flash` — Fast and capable, 1M context
+- `gemini-3.5-flash` — Lightweight and fast, 1M context
+- `gemini-3.1-pro` — Advanced reasoning, 1M context
 - `gemini-3-pro-preview` — Next-gen reasoning (preview)
 - `gemini-3-flash-preview` — Next-gen fast (preview)
 
@@ -56,5 +57,5 @@ codingAgents:
   - name: gemini
     profiles:
       - name: deep
-        model: gemini-3-pro-preview
+        model: gemini-3.1-pro
 ```


### PR DESCRIPTION
## Summary
- **Gemini Agent**: Updated Gemini model catalog to include Gemini 3.x models (`gemini-3.7-flash`, `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.1-pro`) and removed deprecated 2.x models.
- **Claude Agent**: Added `claude-sonnet-5` to catalog alongside `claude-opus-5`.
- **Antigravity Agent**: Added `gemini-3.7-flash`, `claude-opus-5`, and `claude-sonnet-5` to static models.
- **Copilot Agent**: Added `claude-opus-5` and `claude-sonnet-5`.
- **OpenCode Agent**: Added `claude-opus-5` and `claude-sonnet-5` to static models, and updated known pricing table with Gemini 3.x (`gemini-3.7-flash`, `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.1-pro`) and Claude 5 (`claude-opus-5`, `claude-sonnet-5`).
- **Docs & Tests**: Updated Gemini documentation and model catalog unit tests across Gemini, Claude, and Antigravity.