### PR TITLE
fix(chat): initialize selected model dynamically from agent catalog instead of hardcoding

### DIFF
--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -34,7 +34,12 @@ public class ChatApp : ViewBase
         var activeSessionId = UseState<string?>(args?.SessionId);
         var sessionVersion = UseState(0);
         var selectedAgent = UseState(() => configService.Settings.CodingAgent ?? "claude");
-        var selectedModel = UseState("claude-opus-5");
+        var selectedModel = UseState(() =>
+        {
+            var agent = configService.Settings.CodingAgent ?? "claude";
+            var initialModels = GetModelsForAgent(agentRunner, agent);
+            return initialModels.Count > 0 ? initialModels[0].Id : "default";
+        });
         var lastSyncedSessionId = UseRef<string?>(null);
         var isStreaming = UseState(false);
         var streamingSessionId = UseState<string?>(null);


### PR DESCRIPTION
Initializes `selectedModel` dynamically in `ChatApp` using the configured agent's model catalog rather than a hardcoded default string.