### PR TITLE
feat(chat): Redesign Queued Messages UI with dedicated panel and inline actions

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { ChatWidget } from "./ChatWidget";
+
+describe("ChatWidget Queued Messages UI", () => {
+  beforeEach(() => {
+    window.ResizeObserver = class {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    } as any;
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("renders queued messages panel when isStreaming and user queues messages", () => {
+    const handleEvent = vi.fn();
+    render(
+      <ChatWidget
+        id="test-chat"
+        isStreaming={true}
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />
+    );
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const queueBtn = screen.getByRole("button", { name: /Queue/i });
+
+    // Queue first message
+    fireEvent.change(textarea, { target: { value: "test message 1" } });
+    fireEvent.click(queueBtn);
+
+    // Queue second message
+    fireEvent.change(textarea, { target: { value: "test message 2" } });
+    fireEvent.click(queueBtn);
+
+    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("Sends after agent finishes working")).toBeInTheDocument();
+
+    expect(screen.getByText("test message 1")).toBeInTheDocument();
+    expect(screen.getByText("test message 2")).toBeInTheDocument();
+  });
+
+  it("allows collapsing and expanding the queued messages list", () => {
+    render(<ChatWidget id="test-chat" isStreaming={true} />);
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const queueBtn = screen.getByRole("button", { name: /Queue/i });
+
+    fireEvent.change(textarea, { target: { value: "queued task" } });
+    fireEvent.click(queueBtn);
+
+    const toggleBtn = screen.getByRole("button", { name: /Collapse queued messages/i });
+    fireEvent.click(toggleBtn);
+
+    expect(screen.queryByText("queued task")).not.toBeInTheDocument();
+
+    const expandBtn = screen.getByRole("button", { name: /Expand queued messages/i });
+    fireEvent.click(expandBtn);
+
+    expect(screen.getByText("queued task")).toBeInTheDocument();
+  });
+
+  it("supports editing a queued message", () => {
+    render(<ChatWidget id="test-chat" isStreaming={true} />);
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const queueBtn = screen.getByRole("button", { name: /Queue/i });
+
+    fireEvent.change(textarea, { target: { value: "original prompt" } });
+    fireEvent.click(queueBtn);
+
+    const editBtn = screen.getByRole("button", { name: /Edit message/i });
+    fireEvent.click(editBtn);
+
+    const editInput = screen.getByDisplayValue("original prompt");
+    fireEvent.change(editInput, { target: { value: "updated prompt" } });
+
+    const saveBtn = screen.getByRole("button", { name: /Save/i });
+    fireEvent.click(saveBtn);
+
+    expect(screen.getByText("updated prompt")).toBeInTheDocument();
+    expect(screen.queryByText("original prompt")).not.toBeInTheDocument();
+  });
+
+  it("supports sending a queued message immediately and deleting a queued message", () => {
+    const handleEvent = vi.fn();
+    render(
+      <ChatWidget
+        id="test-chat"
+        isStreaming={true}
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />
+    );
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const queueBtn = screen.getByRole("button", { name: /Queue/i });
+
+    fireEvent.change(textarea, { target: { value: "message to send now" } });
+    fireEvent.click(queueBtn);
+
+    fireEvent.change(textarea, { target: { value: "message to delete" } });
+    fireEvent.click(queueBtn);
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+
+    // Delete second message
+    const deleteBtns = screen.getAllByRole("button", { name: /Delete message/i });
+    fireEvent.click(deleteBtns[1]);
+
+    expect(screen.queryByText("message to delete")).not.toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+
+    // Send first message now
+    const sendNowBtn = screen.getByRole("button", { name: /Send now/i });
+    fireEvent.click(sendNowBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnSendMessage",
+      "test-chat",
+      expect.arrayContaining([expect.objectContaining({ prompt: "message to send now" })])
+    );
+    expect(screen.queryByText("Queued Messages")).not.toBeInTheDocument();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
-import { Mic, Bot, Cpu, MessageSquare, ChevronDown, Check, Pencil, Paperclip, X, Square, Clock } from "lucide-react";
+import { Mic, Bot, Cpu, MessageSquare, ChevronDown, Check, Pencil, Paperclip, X, Square, ArrowRight, Trash2 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import { AgentViewer } from "../AgentViewer";
 import { getMarkdownPlugins } from "../math";
@@ -202,6 +202,9 @@ export function ChatWidget({
   const [editingTitleText, setEditingTitleText] = useState("");
   const [attachments, setAttachments] = useState<ChatAttachmentDto[]>([]);
   const [queuedMessages, setQueuedMessages] = useState<QueuedItem[]>([]);
+  const [collapsedQueue, setCollapsedQueue] = useState(false);
+  const [editingQueuedId, setEditingQueuedId] = useState<string | null>(null);
+  const [editingQueuedText, setEditingQueuedText] = useState("");
   const [pendingRenames, setPendingRenames] = useState<Record<string, string>>({});
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -292,6 +295,46 @@ export function ChatWidget({
   const handleCancelStream = () => {
     setQueuedMessages([]);
     emit("OnCancelStream");
+  };
+
+  const handleSendQueuedNow = (queueId: string) => {
+    const item = queuedMessages.find((q) => q.id === queueId);
+    if (!item) return;
+
+    const payload = { prompt: item.prompt, attachments: item.attachments, sessionId: activeSessionId };
+    emit("OnSendMessage", payload);
+    setQueuedMessages((prev) => prev.filter((q) => q.id !== queueId));
+  };
+
+  const handleStartEditQueued = (item: QueuedItem) => {
+    setEditingQueuedId(item.id);
+    setEditingQueuedText(item.prompt);
+  };
+
+  const handleSaveEditQueued = (queueId: string) => {
+    const trimmed = editingQueuedText.trim();
+    if (!trimmed) {
+      handleDeleteQueued(queueId);
+    } else {
+      setQueuedMessages((prev) =>
+        prev.map((q) => (q.id === queueId ? { ...q, prompt: trimmed } : q))
+      );
+    }
+    setEditingQueuedId(null);
+    setEditingQueuedText("");
+  };
+
+  const handleCancelEditQueued = () => {
+    setEditingQueuedId(null);
+    setEditingQueuedText("");
+  };
+
+  const handleDeleteQueued = (queueId: string) => {
+    setQueuedMessages((prev) => prev.filter((q) => q.id !== queueId));
+    if (editingQueuedId === queueId) {
+      setEditingQueuedId(null);
+      setEditingQueuedText("");
+    }
   };
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -556,24 +599,117 @@ export function ChatWidget({
             </div>
           )}
 
-          {/* Queued Messages */}
-          {queuedMessages.map((q) => (
-            <div key={q.id} className="chat-message-row user queued">
-              <div className="chat-message-bubble queued">
-                <div className="chat-queued-badge">
-                  <Clock size={11} />
-                  <span>Queued</span>
-                </div>
-                <div>{q.prompt}</div>
-              </div>
-            </div>
-          ))}
 
           <div ref={messagesEndRef} />
         </div>
 
         {/* Footer & Resizable Input Toolbar */}
         <div className="chat-footer">
+          {queuedMessages.length > 0 && (
+            <div className="chat-queued-panel">
+              <div className="chat-queued-header">
+                <div className="chat-queued-header-left">
+                  <span className="chat-queued-title">Queued Messages</span>
+                  <span className="chat-queued-badge">{queuedMessages.length}</span>
+                  <span className="chat-queued-subtitle">Sends after agent finishes working</span>
+                </div>
+                <div className="chat-queued-header-right">
+                  <button
+                    type="button"
+                    className="chat-queued-toggle-btn"
+                    onClick={() => setCollapsedQueue(!collapsedQueue)}
+                    title={collapsedQueue ? "Expand queued messages" : "Collapse queued messages"}
+                    aria-label={collapsedQueue ? "Expand queued messages" : "Collapse queued messages"}
+                  >
+                    <ChevronDown className={`chat-queued-chevron ${collapsedQueue ? "collapsed" : ""}`} size={16} />
+                  </button>
+                </div>
+              </div>
+
+              {!collapsedQueue && (
+                <div className="chat-queued-list">
+                  {queuedMessages.map((q) => (
+                    <div key={q.id} className="chat-queued-item">
+                      {editingQueuedId === q.id ? (
+                        <div className="chat-queued-edit-container">
+                          <input
+                            type="text"
+                            className="chat-queued-edit-input"
+                            value={editingQueuedText}
+                            onChange={(e) => setEditingQueuedText(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter") handleSaveEditQueued(q.id);
+                              if (e.key === "Escape") handleCancelEditQueued();
+                            }}
+                            autoFocus
+                          />
+                          <button
+                            type="button"
+                            className="chat-queued-item-btn save"
+                            onClick={() => handleSaveEditQueued(q.id)}
+                            title="Save"
+                            aria-label="Save"
+                          >
+                            <Check size={14} />
+                          </button>
+                          <button
+                            type="button"
+                            className="chat-queued-item-btn cancel"
+                            onClick={handleCancelEditQueued}
+                            title="Cancel"
+                            aria-label="Cancel"
+                          >
+                            <X size={14} />
+                          </button>
+                        </div>
+                      ) : (
+                        <>
+                          <div className="chat-queued-item-text">
+                            {q.prompt}
+                            {q.attachments && q.attachments.length > 0 && (
+                              <span className="chat-queued-item-att-count">
+                                <Paperclip size={11} />
+                                {q.attachments.length}
+                              </span>
+                            )}
+                          </div>
+                          <div className="chat-queued-item-actions">
+                            <button
+                              type="button"
+                              className="chat-queued-item-btn send"
+                              onClick={() => handleSendQueuedNow(q.id)}
+                              title="Send now"
+                              aria-label="Send now"
+                            >
+                              <ArrowRight size={15} />
+                            </button>
+                            <button
+                              type="button"
+                              className="chat-queued-item-btn edit"
+                              onClick={() => handleStartEditQueued(q)}
+                              title="Edit message"
+                              aria-label="Edit message"
+                            >
+                              <Pencil size={15} />
+                            </button>
+                            <button
+                              type="button"
+                              className="chat-queued-item-btn delete"
+                              onClick={() => handleDeleteQueued(q.id)}
+                              title="Delete message"
+                              aria-label="Delete message"
+                            >
+                              <Trash2 size={15} />
+                            </button>
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
           <div className="chat-input-box">
             {/* Attachment preview pills */}
             {attachments.length > 0 && (

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -844,3 +844,214 @@ button .text-muted {
   font-weight: 400 !important;
   color: var(--muted-foreground) !important;
 }
+
+/* Queued Messages Panel */
+.chat-queued-panel {
+  margin-bottom: 0.625rem;
+  background-color: var(--background);
+  border: 1px solid var(--border);
+  border-radius: var(--radius, 10px);
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  transition: all 0.2s ease;
+}
+
+.chat-queued-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background-color: var(--muted);
+  border-bottom: 1px solid var(--border);
+  user-select: none;
+}
+
+.chat-queued-header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+}
+
+.chat-queued-title {
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.chat-queued-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 6px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  border-radius: 9999px;
+  background-color: var(--accent);
+  color: var(--foreground);
+  border: 1px solid var(--border);
+}
+
+.chat-queued-subtitle {
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+  margin-left: 0.25rem;
+}
+
+.chat-queued-header-right {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.chat-queued-toggle-btn {
+  background: transparent;
+  border: none;
+  color: var(--muted-foreground);
+  padding: 0.25rem;
+  border-radius: var(--radius, 4px);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s ease;
+}
+
+.chat-queued-toggle-btn:hover {
+  color: var(--foreground);
+  background-color: var(--accent);
+}
+
+.chat-queued-chevron {
+  transition: transform 0.2s ease;
+}
+
+.chat-queued-chevron.collapsed {
+  transform: rotate(-90deg);
+}
+
+.chat-queued-list {
+  display: flex;
+  flex-direction: column;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.chat-queued-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.8125rem;
+  background-color: var(--background);
+  transition: background-color 0.15s ease;
+}
+
+.chat-queued-item:last-child {
+  border-bottom: none;
+}
+
+.chat-queued-item:hover {
+  background-color: color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
+.chat-queued-item-text {
+  flex: 1;
+  color: var(--foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.chat-queued-item-att-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-size: 0.6875rem;
+  color: var(--muted-foreground);
+  background-color: var(--muted);
+  border-radius: 4px;
+  padding: 0.0625rem 0.3125rem;
+}
+
+.chat-queued-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+.chat-queued-item-btn {
+  background: transparent;
+  border: none;
+  color: var(--muted-foreground);
+  padding: 0.25rem;
+  border-radius: var(--radius, 4px);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s ease;
+}
+
+.chat-queued-item-btn:hover {
+  color: var(--foreground);
+  background-color: var(--accent);
+}
+
+.chat-queued-item-btn.send:hover {
+  color: var(--primary);
+  background-color: color-mix(in srgb, var(--primary) 15%, transparent);
+}
+
+.chat-queued-item-btn.edit:hover {
+  color: var(--foreground);
+  background-color: var(--accent);
+}
+
+.chat-queued-item-btn.delete:hover {
+  color: var(--destructive);
+  background-color: color-mix(in srgb, var(--destructive) 15%, transparent);
+}
+
+.chat-queued-edit-container {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  width: 100%;
+}
+
+.chat-queued-edit-input {
+  flex: 1;
+  background-color: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius, 4px);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--foreground);
+  outline: none;
+}
+
+.chat-queued-edit-input:focus {
+  border-color: var(--ring);
+}
+
+.chat-queued-item-btn.save {
+  color: var(--primary);
+}
+
+.chat-queued-item-btn.save:hover {
+  background-color: color-mix(in srgb, var(--primary) 15%, transparent);
+}
+
+.chat-queued-item-btn.cancel:hover {
+  color: var(--destructive);
+  background-color: color-mix(in srgb, var(--destructive) 15%, transparent);
+}
+


### PR DESCRIPTION
Redesigned the queued messages UI in `ChatWidget` to replace raw message bubbles with a sleek, collapsible panel docked above the input toolbar.

### Key Changes
- **Dedicated Queued Panel**: Added collapsible panel with header, badge count, status label ("Sends after agent finishes working"), and expand/collapse toggle.
- **Inline Message Actions**:
  - **Send Now** (`ArrowRight`): Immediately sends queued prompt without waiting.
  - **Edit** (`Pencil`): Inline prompt editing with Save/Cancel buttons and Enter/Esc shortcuts.
  - **Delete** (`Trash2`): Removes queued message from queue.
  - **Attachment Count Badge**: Displays attachment count when files are attached.
- **Styling**: Added dark-mode friendly CSS, smooth hover effects, and rounded card styling.
- **Unit Tests**: Added automated unit tests in `ChatWidget.test.tsx` covering queue panel rendering, expansion toggling, editing, immediate sending, and deletion.