### PR TITLE
[00086] Add Project and Branch Columns to the Pull Requests App

### DIFF
--- a/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
+++ b/src/Ivy.Tendril.Test/DatabaseMigratorTests.cs
@@ -513,6 +513,45 @@ public class DatabaseMigratorTests : IDisposable
         Assert.Equal("4242|00069|Persist Jobs|boom", selectCmd.ExecuteScalar()?.ToString());
     }
 
+    [Fact]
+    public void Migration_018_PrStatusBranch_AddsColumn()
+    {
+        new Migration_001_InitialSchema().Apply(_connection);
+        new Migration_002_Fts5Search().Apply(_connection);
+        new Migration_003_JobsTable().Apply(_connection);
+        new Migration_004_SourceUrl().Apply(_connection);
+        new Migration_005_CostsLogTimestampIndex().Apply(_connection);
+        new Migration_006_CostsCompositeIndex().Apply(_connection);
+        new Migration_007_FtsSourceUrl().Apply(_connection);
+        new Migration_008_PrStatusTable().Apply(_connection);
+        new Migration_009_JobsArgs().Apply(_connection);
+        new Migration_010_RecommendationImpactRisk().Apply(_connection);
+        new Migration_011_JobsTypedArgs().Apply(_connection);
+        new Migration_012_JobsPlanFileIndex().Apply(_connection);
+        new Migration_013_JobsWorkingDirAndCliCommand().Apply(_connection);
+        new Migration_014_JobsCleared().Apply(_connection);
+        new Migration_015_RenamePlanStates().Apply(_connection);
+        new Migration_016_DropRecommendationRisk().Apply(_connection);
+        new Migration_017_JobsInFlightFields().Apply(_connection);
+
+        Assert.Equal(17, GetUserVersion());
+
+        new Migration_018_PrStatusBranch().Apply(_connection);
+
+        Assert.Equal(18, GetUserVersion());
+
+        var columns = new List<string>();
+        using (var pragmaCmd = _connection.CreateCommand())
+        {
+            pragmaCmd.CommandText = "PRAGMA table_info(PrStatuses);";
+            using var reader = pragmaCmd.ExecuteReader();
+            while (reader.Read())
+                columns.Add(reader.GetString(reader.GetOrdinal("name")));
+        }
+
+        Assert.Contains("Branch", columns);
+    }
+
     private class FakeMigration : IMigration
     {
         private readonly List<int>? _tracker;

--- a/src/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -262,6 +262,41 @@ public class GithubServiceTests
     }
 
     [Fact]
+    public void ParsePrStatuses_ParsesStatusAndBranch()
+    {
+        var json = """
+                   [
+                     {"url": "https://github.com/owner/repo/pull/1", "state": "OPEN", "headRefName": "feature/foo"},
+                     {"url": "https://github.com/owner/repo/pull/2", "state": "MERGED", "headRefName": "feature/bar"}
+                   ]
+                   """;
+
+        var statuses = GithubService.ParsePrStatuses(json);
+
+        Assert.Equal(2, statuses.Count);
+        Assert.Equal("Open", statuses["https://github.com/owner/repo/pull/1"].Status);
+        Assert.Equal("feature/foo", statuses["https://github.com/owner/repo/pull/1"].Branch);
+        Assert.Equal("Merged", statuses["https://github.com/owner/repo/pull/2"].Status);
+        Assert.Equal("feature/bar", statuses["https://github.com/owner/repo/pull/2"].Branch);
+    }
+
+    [Fact]
+    public void ParsePrStatuses_TreatsMissingHeadRefNameAsEmpty()
+    {
+        var json = """
+                   [
+                     {"url": "https://github.com/owner/repo/pull/1", "state": "OPEN"}
+                   ]
+                   """;
+
+        var statuses = GithubService.ParsePrStatuses(json);
+
+        Assert.Single(statuses);
+        Assert.Equal("Open", statuses["https://github.com/owner/repo/pull/1"].Status);
+        Assert.Equal("", statuses["https://github.com/owner/repo/pull/1"].Branch);
+    }
+
+    [Fact]
     public async Task GetLabelsAsync_Returns_Error_When_Command_Fails()
     {
         var configService = new ConfigService(new TendrilSettings());

--- a/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDeletionTests.cs
@@ -329,12 +329,12 @@ public class JobServiceDeletionTests
             return new List<string>();
         }
 
-        public Dictionary<string, string> GetAllPrStatuses()
+        public Dictionary<string, PrInfo> GetAllPrStatuses()
         {
-            return new Dictionary<string, string>();
+            return new Dictionary<string, PrInfo>();
         }
 
-        public void UpsertPrStatus(string prUrl, string owner, string repo, string status, DateTime lastChecked)
+        public void UpsertPrStatus(string prUrl, string owner, string repo, string status, string branch, DateTime lastChecked)
         {
         }
 

--- a/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
@@ -549,12 +549,12 @@ public class JobServiceStartupTests
             return new List<string>();
         }
 
-        public Dictionary<string, string> GetAllPrStatuses()
+        public Dictionary<string, PrInfo> GetAllPrStatuses()
         {
-            return new Dictionary<string, string>();
+            return new Dictionary<string, PrInfo>();
         }
 
-        public void UpsertPrStatus(string prUrl, string owner, string repo, string status, DateTime lastChecked)
+        public void UpsertPrStatus(string prUrl, string owner, string repo, string status, string branch, DateTime lastChecked)
         {
         }
 

--- a/src/Ivy.Tendril.Test/PrStatusSyncServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PrStatusSyncServiceTests.cs
@@ -31,34 +31,80 @@ public class PrStatusSyncServiceTests : IDisposable
     [Fact]
     public void UpsertPrStatus_StoresAndRetrieves()
     {
-        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Open", DateTime.UtcNow);
-        _db.UpsertPrStatus("https://github.com/owner/repo/pull/2", "owner", "repo", "Merged", DateTime.UtcNow);
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Open", "", DateTime.UtcNow);
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/2", "owner", "repo", "Merged", "", DateTime.UtcNow);
 
         var statuses = _db.GetAllPrStatuses();
         Assert.Equal(2, statuses.Count);
-        Assert.Equal("Open", statuses["https://github.com/owner/repo/pull/1"]);
-        Assert.Equal("Merged", statuses["https://github.com/owner/repo/pull/2"]);
+        Assert.Equal("Open", statuses["https://github.com/owner/repo/pull/1"].Status);
+        Assert.Equal("Merged", statuses["https://github.com/owner/repo/pull/2"].Status);
     }
 
     [Fact]
     public void UpsertPrStatus_UpdatesExistingStatus()
     {
         var now = DateTime.UtcNow;
-        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Open", now);
-        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Merged", now.AddMinutes(10));
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Open", "", now);
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Merged", "", now.AddMinutes(10));
 
         var statuses = _db.GetAllPrStatuses();
         Assert.Single(statuses);
-        Assert.Equal("Merged", statuses["https://github.com/owner/repo/pull/1"]);
+        Assert.Equal("Merged", statuses["https://github.com/owner/repo/pull/1"].Status);
+    }
+
+    [Fact]
+    public void UpsertPrStatus_StoresAndRetrievesBranch()
+    {
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Open", "feature/foo", DateTime.UtcNow);
+
+        var statuses = _db.GetAllPrStatuses();
+        Assert.Equal("feature/foo", statuses["https://github.com/owner/repo/pull/1"].Branch);
+    }
+
+    [Fact]
+    public void UpsertPrStatus_UpdatesBranchOnConflict()
+    {
+        var now = DateTime.UtcNow;
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Open", "feature/foo", now);
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Open", "feature/bar", now.AddMinutes(10));
+
+        var statuses = _db.GetAllPrStatuses();
+        Assert.Equal("feature/bar", statuses["https://github.com/owner/repo/pull/1"].Branch);
+    }
+
+    [Fact]
+    public void GetAllPrStatuses_MapsNullBranchColumnToEmptyString()
+    {
+        // Simulate a pre-migration row: insert directly (on a fresh connection to the same file,
+        // since PlanDatabaseService doesn't expose its connection), bypassing UpsertPrStatus and
+        // leaving Branch NULL.
+        using (var connection = new SqliteConnection($"Data Source={_dbPath}"))
+        {
+            connection.Open();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = """
+                              INSERT INTO PrStatuses (PrUrl, Owner, Repo, Status, LastChecked)
+                              VALUES (@url, @owner, @repo, @status, @checked)
+                              """;
+            cmd.Parameters.AddWithValue("@url", "https://github.com/owner/repo/pull/1");
+            cmd.Parameters.AddWithValue("@owner", "owner");
+            cmd.Parameters.AddWithValue("@repo", "repo");
+            cmd.Parameters.AddWithValue("@status", "Open");
+            cmd.Parameters.AddWithValue("@checked", DateTime.UtcNow.ToString("O"));
+            cmd.ExecuteNonQuery();
+        }
+
+        var statuses = _db.GetAllPrStatuses();
+        Assert.Equal("", statuses["https://github.com/owner/repo/pull/1"].Branch);
     }
 
     [Fact]
     public void GetNonMergedPrUrls_ExcludesMerged()
     {
         var now = DateTime.UtcNow;
-        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Open", now);
-        _db.UpsertPrStatus("https://github.com/owner/repo/pull/2", "owner", "repo", "Merged", now);
-        _db.UpsertPrStatus("https://github.com/owner/repo/pull/3", "owner", "repo", "Closed", now);
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/1", "owner", "repo", "Open", "", now);
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/2", "owner", "repo", "Merged", "", now);
+        _db.UpsertPrStatus("https://github.com/owner/repo/pull/3", "owner", "repo", "Closed", "", now);
 
         var nonMerged = _db.GetNonMergedPrUrls();
         Assert.Equal(2, nonMerged.Count);

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
@@ -6,13 +6,8 @@ namespace Ivy.Tendril.Apps.Jobs;
 
 public partial class JobsApp
 {
-    private Dictionary<string, string> BuildProjectColorMapping(IConfigService config)
-    {
-        return config.Projects
-            .Select(p => new { p.Name, Color = config.GetProjectColor(p.Name) })
-            .Where(x => x.Color.HasValue)
-            .ToDictionary(x => x.Name, x => x.Color!.Value.ToString());
-    }
+    private Dictionary<string, string> BuildProjectColorMapping(IConfigService config) =>
+        ProjectHelper.BuildColorMapping(config);
 
     private List<JobItemRow> BuildJobRows(List<JobItem> jobs, IPlanReaderService planService)
     {

--- a/src/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -108,7 +108,7 @@ public class PullRequestApp : ViewBase
             .RefreshToken(refreshToken)
             .Width(Size.Full())
             .Height(Size.Full())
-            .Order(e => e.Plan, e => e.Project, e => e.Status, e => e.Pr, e => e.Branch, e => e.Tokens, e => e.Cost, e => e.Repository)
+            .Order(e => e.Plan, e => e.Project, e => e.Status, e => e.Pr, e => e.Repository, e => e.Branch, e => e.Tokens, e => e.Cost)
             .Header(t => t.Project, "Project")
             .Header(t => t.Repository, "Repository")
             .Header(t => t.Status, "Status")
@@ -117,14 +117,14 @@ public class PullRequestApp : ViewBase
             .Header(t => t.Pr, "PR")
             .Header(t => t.Branch, "Branch")
             .Header(t => t.Plan, "Plan")
-            .Width(t => t.Project, Size.Px(150))
-            .Width(t => t.Repository, Size.Fraction(1 / 6f))
-            .Width(t => t.Status, Size.Px(90))
+            .Width(t => t.Plan, Size.Fraction(1 / 4f))
+            .Width(t => t.Project, Size.Px(100))
+            .Width(t => t.Status, Size.Px(100))
             .Width(t => t.Pr, Size.Fraction(1 / 4f))
+            .Width(t => t.Repository, Size.Fraction(1 / 4f))
             .Width(t => t.Branch, Size.Fraction(1 / 4f))
-            .Width(t => t.Plan, Size.Fraction(1 / 3f))
-            .Width(t => t.Cost, Size.Px(80))
             .Width(t => t.Tokens, Size.Px(80))
+            .Width(t => t.Cost, Size.Px(80))
             .Renderer(t => t.Status, new LabelsDisplayRenderer
             {
                 BadgeColorMapping = new Dictionary<string, string>

--- a/src/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -70,6 +70,7 @@ public class PullRequestApp : ViewBase
         });
 
         var prStatuses = databaseService.GetAllPrStatuses();
+        var projectColors = ProjectHelper.BuildColorMapping(config);
 
         var plans = planService.GetPlans()
             .Where(p => p.Prs.Count > 0)
@@ -132,6 +133,10 @@ public class PullRequestApp : ViewBase
                     ["Merged"] = nameof(Colors.Purple),
                     ["Closed"] = nameof(Colors.Zinc)
                 }
+            })
+            .Renderer(t => t.Project, new LabelsDisplayRenderer
+            {
+                BadgeColorMapping = projectColors
             })
             .Renderer(t => t.Pr, new LinkDisplayRenderer())
             .SortDirection(t => t.PlanId, SortDirection.Descending)

--- a/src/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -82,17 +82,23 @@ public class PullRequestApp : ViewBase
             var cost = costValue > 0 ? $"${costValue:F2}" : "";
             var tokenValue = planService.GetPlanTotalTokens(plan.FolderPath);
             var tokens = tokenValue > 0 ? FormatHelper.FormatTokens(tokenValue) : "";
-            return plan.Prs.Where(IsValidUrl).Reverse().Select((pr, i) => new PrRow
+            return plan.Prs.Where(IsValidUrl).Reverse().Select((pr, i) =>
             {
-                Id = $"{plan.Id}-{i}",
-                PlanId = $"{plan.Id:D5}",
-                Repository = ExtractRepo(pr, logger),
-                Status = prStatuses.GetValueOrDefault(pr, ""),
-                Pr = pr,
-                Plan = $"#{plan.Id:D5} {plan.Title}",
-                Cost = cost,
-                Tokens = tokens,
-                PlanFolderPath = plan.FolderPath
+                var info = prStatuses.GetValueOrDefault(pr);
+                return new PrRow
+                {
+                    Id = $"{plan.Id}-{i}",
+                    PlanId = $"{plan.Id:D5}",
+                    Project = plan.Project,
+                    Repository = ExtractRepo(pr, logger),
+                    Status = info?.Status ?? "",
+                    Pr = pr,
+                    Branch = info?.Branch ?? "",
+                    Plan = $"#{plan.Id:D5} {plan.Title}",
+                    Cost = cost,
+                    Tokens = tokens,
+                    PlanFolderPath = plan.FolderPath
+                };
             });
         }).ToList();
 
@@ -101,16 +107,20 @@ public class PullRequestApp : ViewBase
             .RefreshToken(refreshToken)
             .Width(Size.Full())
             .Height(Size.Full())
-            .Order(e => e.Plan, e => e.Status, e => e.Pr, e => e.Tokens, e => e.Cost, e => e.Repository)
+            .Order(e => e.Plan, e => e.Project, e => e.Status, e => e.Pr, e => e.Branch, e => e.Tokens, e => e.Cost, e => e.Repository)
+            .Header(t => t.Project, "Project")
             .Header(t => t.Repository, "Repository")
             .Header(t => t.Status, "Status")
             .Header(t => t.Cost, "Cost")
             .Header(t => t.Tokens, "Tokens")
             .Header(t => t.Pr, "PR")
+            .Header(t => t.Branch, "Branch")
             .Header(t => t.Plan, "Plan")
-            .Width(t => t.Repository, Size.Fraction(1 / 3f))
+            .Width(t => t.Project, Size.Px(150))
+            .Width(t => t.Repository, Size.Fraction(1 / 6f))
             .Width(t => t.Status, Size.Px(90))
-            .Width(t => t.Pr, Size.Fraction(1 / 3f))
+            .Width(t => t.Pr, Size.Fraction(1 / 4f))
+            .Width(t => t.Branch, Size.Fraction(1 / 4f))
             .Width(t => t.Plan, Size.Fraction(1 / 3f))
             .Width(t => t.Cost, Size.Px(80))
             .Width(t => t.Tokens, Size.Px(80))

--- a/src/Ivy.Tendril/Database/Migrations/Migration_018_PrStatusBranch.cs
+++ b/src/Ivy.Tendril/Database/Migrations/Migration_018_PrStatusBranch.cs
@@ -1,0 +1,20 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Database.Migrations;
+
+public class Migration_018_PrStatusBranch : IMigration
+{
+    public int Version => 18;
+    public string Description => "Add branch (head ref) to the PR status cache";
+
+    public void Apply(SqliteConnection connection, ILogger? logger = null)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            ALTER TABLE PrStatuses ADD COLUMN Branch TEXT;
+            PRAGMA user_version = 18;
+            """;
+        cmd.ExecuteNonQuery();
+    }
+}

--- a/src/Ivy.Tendril/Helpers/ProjectHelper.cs
+++ b/src/Ivy.Tendril/Helpers/ProjectHelper.cs
@@ -1,7 +1,22 @@
+using Ivy.Tendril.Services;
+
 namespace Ivy.Tendril.Helpers;
 
 public static class ProjectHelper
 {
+    /// <summary>
+    ///     Builds a project-name-to-color-name mapping (e.g. for
+    ///     <see cref="LabelsDisplayRenderer.BadgeColorMapping"/>) from the configured projects'
+    ///     colors. Projects without a configured color are omitted.
+    /// </summary>
+    public static Dictionary<string, string> BuildColorMapping(IConfigService config)
+    {
+        return config.Projects
+            .Select(p => new { p.Name, Color = config.GetProjectColor(p.Name) })
+            .Where(x => x.Color.HasValue)
+            .ToDictionary(x => x.Name, x => x.Color!.Value.ToString());
+    }
+
     public static string[] ParseProjects(string? projectValue)
     {
         if (string.IsNullOrWhiteSpace(projectValue))

--- a/src/Ivy.Tendril/Models/PullRequestModels.cs
+++ b/src/Ivy.Tendril/Models/PullRequestModels.cs
@@ -4,8 +4,10 @@ public record PrRow
 {
     public string Id { get; init; } = "";
     public string PlanId { get; init; } = "";
+    public string Project { get; init; } = "";
     public string Repository { get; init; } = "";
     public string Pr { get; init; } = "";
+    public string Branch { get; init; } = "";
     public string Plan { get; init; } = "";
     public string Cost { get; init; } = "";
     public string Status { get; init; } = "";

--- a/src/Ivy.Tendril/Services/Git/GithubService.cs
+++ b/src/Ivy.Tendril/Services/Git/GithubService.cs
@@ -56,7 +56,7 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
     public async Task<(List<string> labels, string? error)> GetLabelsAsync(string owner, string repo)
         => await GetCachedListAsync(_labelCache, owner, repo, FetchLabelsFromGhCliAsync);
 
-    public async Task<(Dictionary<string, string> statuses, string? error)> GetPrStatusesAsync(string owner, string repo)
+    public async Task<(Dictionary<string, PrInfo> statuses, string? error)> GetPrStatusesAsync(string owner, string repo)
     {
         return await FetchPrStatusesFromGhCliAsync(owner, repo);
     }
@@ -318,9 +318,9 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
         return (items, error);
     }
 
-    private Dictionary<string, string> ParsePrStatuses(string json)
+    internal static Dictionary<string, PrInfo> ParsePrStatuses(string json)
     {
-        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var result = new Dictionary<string, PrInfo>(StringComparer.OrdinalIgnoreCase);
         using var doc = JsonDocument.Parse(json);
 
         foreach (var element in doc.RootElement.EnumerateArray())
@@ -330,13 +330,20 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
 
             if (url is not null && state is not null)
             {
-                result[url] = state switch
+                var status = state switch
                 {
                     "OPEN" => "Open",
                     "CLOSED" => "Closed",
                     "MERGED" => "Merged",
                     _ => state
                 };
+
+                var branch = element.TryGetProperty("headRefName", out var headRefProp) &&
+                             headRefProp.ValueKind == JsonValueKind.String
+                    ? headRefProp.GetString() ?? ""
+                    : "";
+
+                result[url] = new PrInfo(status, branch);
             }
         }
 
@@ -359,12 +366,12 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
         return (labels, error);
     }
 
-    private async Task<(Dictionary<string, string> statuses, string? error)> FetchPrStatusesFromGhCliAsync(string owner, string repo)
+    private async Task<(Dictionary<string, PrInfo> statuses, string? error)> FetchPrStatusesFromGhCliAsync(string owner, string repo)
     {
         var (statuses, error) = await ExecuteGhCliAsync(
-            $"pr list --repo {owner}/{repo} --limit 100 --state all --json url,state",
+            $"pr list --repo {owner}/{repo} --limit 100 --state all --json url,state,headRefName",
             ParsePrStatuses,
-            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+            new Dictionary<string, PrInfo>(StringComparer.OrdinalIgnoreCase));
 
         if (error is not null)
             _logger.LogWarning("gh pr list failed for {Owner}/{Repo}", owner, repo);

--- a/src/Ivy.Tendril/Services/Git/IGithubService.cs
+++ b/src/Ivy.Tendril/Services/Git/IGithubService.cs
@@ -8,6 +8,12 @@ public record GitHubIssue(
     string[] Assignees
 );
 
+/// <summary>
+///     A PR's cached status and the branch (head ref) it was opened from. <see cref="Branch" /> is
+///     <c>""</c> when GitHub reported no head ref (or the field was absent).
+/// </summary>
+public record PrInfo(string Status, string Branch);
+
 public interface IGithubService
 {
     List<RepoConfig> GetRepos();
@@ -27,6 +33,6 @@ public interface IGithubService
     IReadOnlyList<string> GetResolvedGithubRepos(ProjectConfig project);
     Task<(List<string> assignees, string? error)> GetAssigneesAsync(string owner, string repo);
     Task<(List<string> labels, string? error)> GetLabelsAsync(string owner, string repo);
-    Task<(Dictionary<string, string> statuses, string? error)> GetPrStatusesAsync(string owner, string repo);
+    Task<(Dictionary<string, PrInfo> statuses, string? error)> GetPrStatusesAsync(string owner, string repo);
     Task<(List<GitHubIssue> issues, string? error)> SearchIssuesAsync(IssueSearchRequest request);
 }

--- a/src/Ivy.Tendril/Services/Git/PrStatusSyncService.cs
+++ b/src/Ivy.Tendril/Services/Git/PrStatusSyncService.cs
@@ -48,8 +48,8 @@ public class PrStatusSyncService : IStartable, IDisposable
 
             foreach (var url in prUrls)
             {
-                if (existingStatuses.TryGetValue(url, out var status) &&
-                    string.Equals(status, "Merged", StringComparison.OrdinalIgnoreCase))
+                if (existingStatuses.TryGetValue(url, out var info) &&
+                    string.Equals(info.Status, "Merged", StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 urlsToCheck.Add(url);
@@ -88,8 +88,10 @@ public class PrStatusSyncService : IStartable, IDisposable
 
                     foreach (var url in urls)
                     {
-                        var resolvedStatus = statuses.GetValueOrDefault(url, "Open");
-                        _database.UpsertPrStatus(url, parts[0], parts[1], resolvedStatus, now);
+                        if (statuses.TryGetValue(url, out var info))
+                            _database.UpsertPrStatus(url, parts[0], parts[1], info.Status, info.Branch, now);
+                        else
+                            _database.UpsertPrStatus(url, parts[0], parts[1], "Open", "", now);
                     }
 
                     _logger.LogDebug("Synced {Count} PR statuses for {Repo}", urls.Count, ownerRepo);

--- a/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanDatabaseService.cs
@@ -53,8 +53,8 @@ public interface IPlanDatabaseService : IDisposable
     void DeleteJob(string id);
 
     // PR statuses
-    Dictionary<string, string> GetAllPrStatuses();
-    void UpsertPrStatus(string prUrl, string owner, string repo, string status, DateTime lastChecked);
+    Dictionary<string, PrInfo> GetAllPrStatuses();
+    void UpsertPrStatus(string prUrl, string owner, string repo, string status, string branch, DateTime lastChecked);
     List<string> GetNonMergedPrUrls();
 
     // Diagnostics

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -885,36 +885,39 @@ public class PlanDatabaseService : IPlanDatabaseService
         }
     }
 
-    public Dictionary<string, string> GetAllPrStatuses()
+    public Dictionary<string, PrInfo> GetAllPrStatuses()
     {
         using (new ReadLockHandle(_lock))
         {
-            var list = ReadList("SELECT PrUrl, Status FROM PrStatuses", reader =>
-                (Url: reader.GetString(0), Status: reader.GetString(1)));
+            var list = ReadList("SELECT PrUrl, Status, Branch FROM PrStatuses", reader =>
+                (Url: reader.GetString(0), Status: reader.GetString(1),
+                    Branch: reader.IsDBNull(2) ? "" : reader.GetString(2)));
 
-            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var (url, status) in list)
-                result[url] = status;
+            var result = new Dictionary<string, PrInfo>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (url, status, branch) in list)
+                result[url] = new PrInfo(status, branch);
             return result;
         }
     }
 
-    public void UpsertPrStatus(string prUrl, string owner, string repo, string status, DateTime lastChecked)
+    public void UpsertPrStatus(string prUrl, string owner, string repo, string status, string branch, DateTime lastChecked)
     {
         using (new WriteLockHandle(_lock))
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = """
-                              INSERT INTO PrStatuses (PrUrl, Owner, Repo, Status, LastChecked)
-                              VALUES (@url, @owner, @repo, @status, @checked)
+                              INSERT INTO PrStatuses (PrUrl, Owner, Repo, Status, Branch, LastChecked)
+                              VALUES (@url, @owner, @repo, @status, @branch, @checked)
                               ON CONFLICT(PrUrl) DO UPDATE SET
                                   Status = excluded.Status,
+                                  Branch = excluded.Branch,
                                   LastChecked = excluded.LastChecked
                               """;
             cmd.Parameters.AddWithValue("@url", prUrl);
             cmd.Parameters.AddWithValue("@owner", owner);
             cmd.Parameters.AddWithValue("@repo", repo);
             cmd.Parameters.AddWithValue("@status", status);
+            cmd.Parameters.AddWithValue("@branch", branch);
             cmd.Parameters.AddWithValue("@checked", lastChecked.ToString("O", CultureInfo.InvariantCulture));
             cmd.ExecuteNonQuery();
         }


### PR DESCRIPTION
# Summary

## Changes

Added **Project** and **Branch** columns to the Pull Requests app table. Project comes from the
plan's already-in-memory `Project` field; Branch is fetched from GitHub's `headRefName` on each PR
sync, persisted in a new `PrStatuses.Branch` column, and read back through the existing `Resync`
action. PRs already `Merged` before this change ships keep a permanently blank Branch (no
backfill, by design).

## API Changes

- `IGithubService`: new `public record PrInfo(string Status, string Branch)`. `GetPrStatusesAsync`
  now returns `Task<(Dictionary<string, PrInfo> statuses, string? error)>` (was
  `Dictionary<string, string>`).
- `GithubService.ParsePrStatuses` changed from `private` to `internal static` and now returns
  `Dictionary<string, PrInfo>`.
- `IPlanDatabaseService`/`PlanDatabaseService`:
  - `GetAllPrStatuses()` now returns `Dictionary<string, PrInfo>` (was `Dictionary<string, string>`).
  - `UpsertPrStatus(...)` gains a new required `string branch` parameter (before `lastChecked`).
- New database migration `Migration_018_PrStatusBranch` — adds `PrStatuses.Branch TEXT` (nullable,
  no backfill; `user_version` → 18).
- `PrRow` (`Ivy.Tendril.Models`): new `Project` and `Branch` string properties.

## Files Modified

- **GitHub integration:** `IGithubService.cs`, `GithubService.cs`
- **Database:** `Migration_018_PrStatusBranch.cs` (new), `IPlanDatabaseService.cs`,
  `PlanDatabaseService.cs`
- **Sync:** `PrStatusSyncService.cs`
- **UI:** `PullRequestModels.cs`, `PullRequestApp.cs`
- **Tests:** `GithubServiceTests.cs`, `PrStatusSyncServiceTests.cs`, `DatabaseMigratorTests.cs`,
  `JobServiceDeletionTests.cs`, `JobServiceStartupTests.cs` (fake `IPlanDatabaseService`
  implementations updated for the new interface signatures)

## Manual Testing

1. Run Tendril and open the **Pull Requests** app.
2. Confirm a **Project** column appears (populated for every row, since it comes from the plan's
   existing `Project` field) and a **Branch** column appears (blank until the next sync).
3. Pick a plan with an open PR, use the row's **Resync** action (or wait for the periodic sync),
   and confirm the Branch cell populates with the PR's actual head branch name from GitHub.
4. For a PR that was already `Merged` before this change, confirm its Branch cell stays blank
   after a resync — this is expected (no backfill), not a bug.
5. Confirm sorting/filtering/search still work on the existing columns, and that the two new
   columns participate in the same table config (sortable, filterable, included in search).

## Fix: Color-code the Project column as pills, like JobsApp

Per reviewer feedback, the plain-text `Project` column read poorly next to `Status`'s colored
badges. Added a `LabelsDisplayRenderer` with a `BadgeColorMapping` for the `Project` column,
sourced from the same per-project color configuration `JobsApp`'s `Project` column already uses
(`config.Projects` + `IConfigService.GetProjectColor`). The mapping logic was extracted from
`JobsApp.Data.cs`'s private `BuildProjectColorMapping` into a new shared
`ProjectHelper.BuildColorMapping(IConfigService)`, which both `JobsApp` and `PullRequestApp` now
call, so the two apps can't drift out of sync on how project colors are derived.

### Files Modified

- `src/Ivy.Tendril/Helpers/ProjectHelper.cs` — new `BuildColorMapping` static method
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs` — `BuildProjectColorMapping` now delegates to the
  shared helper (no behavior change)
- `src/Ivy.Tendril/Apps/PullRequestApp.cs` — computes `projectColors` and adds a `.Renderer(t =>
  t.Project, new LabelsDisplayRenderer { BadgeColorMapping = projectColors })`

**Note:** Step 5 of Manual Testing above now also applies to color: the `Project` column should
render as a colored pill matching the color shown for the same project in the Jobs app (projects
without a configured color fall back to the renderer's default, unstyled pill).

---
## Commits

- c92721ac Plan 00086: Fetch PR branch (head ref) from GitHub
- 1627fea6 Plan 00086: Add PrStatuses.Branch column migration
- b8814602 Plan 00086: Widen PR status DB API to carry Branch
- 02752936 Plan 00086: Add Project and Branch columns to the Pull Requests app
- 30a25397 Plan 00086: Add tests for PR branch persistence and parsing
- f9effc73 Plan 00086: Color-code Project column as pills, like JobsApp
- 9cedecc3 Refactor Pull Request app column order and widths for improved layout

---
Created using [Ivy Tendril](https://ivy.app).
