### PR TITLE
[00085] Show the Plan Id in Discuss With Agent Tab Titles

### DIFF
--- a/src/Ivy.Tendril.Test/AppShell/TabTitleResolverTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/TabTitleResolverTests.cs
@@ -44,6 +44,24 @@ public class TabTitleResolverTests
     }
 
     [Fact]
+    public void ResolveArgsTabTitle_AgentArgs_ReturnsTitleVerbatim()
+    {
+        var title = ResolveArgsTabTitle(new AgentAppArgs("prompt", "#85"));
+
+        Assert.Equal("#85", title);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ResolveArgsTabTitle_AgentArgs_NullOrEmptyTitle_ReturnsNull(string? title)
+    {
+        var result = ResolveArgsTabTitle(new AgentAppArgs("prompt", title));
+
+        Assert.Null(result);
+    }
+
+    [Fact]
     public void ResolveArgsTabTitle_NullArgs_ReturnsNull()
     {
         Assert.Null(ResolveArgsTabTitle(null));

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -7,6 +7,7 @@ using Ivy.Desktop;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.AppShell.Dialogs;
 using Ivy.Tendril.Apps;
+using Ivy.Tendril.Apps.Agent;
 using Ivy.Tendril.Apps.Onboarding;
 using Ivy.Tendril.Apps.ReviewAction;
 using Ivy.Tendril.Apps.Settings;
@@ -32,20 +33,24 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
     /// <summary>
     ///     Overrides the default app-descriptor tab title for apps whose title depends on the
-    ///     navigation args rather than being fixed. Currently only <see cref="ReviewActionApp"/>,
-    ///     which is titled "#&lt;PlanId&gt; &lt;ReviewActionName&gt;". Returns null (use the
-    ///     descriptor title) for every other arg shape.
+    ///     navigation args rather than being fixed. <see cref="ReviewActionApp"/> is titled
+    ///     "#&lt;PlanId&gt; &lt;ReviewActionName&gt;", formatted here from the plan folder name.
+    ///     <see cref="AgentApp"/> is titled with the caller-supplied <see cref="AgentAppArgs.Title"/>
+    ///     verbatim (see the Draft/Review "Discuss with &lt;Agent&gt;" call sites, which build it
+    ///     with <see cref="FormatPlanId"/>). Returns null (use the descriptor title) for every other
+    ///     arg shape, including <see cref="AgentAppArgs"/> without a <see cref="AgentAppArgs.Title"/>.
     /// </summary>
     internal static string? ResolveArgsTabTitle(object? appArgs) => appArgs switch
     {
         ReviewActionAppArgs { PlanId: { Length: > 0 } planId, ActionName: { Length: > 0 } name }
             => $"#{FormatPlanId(planId)} {name}",
+        AgentAppArgs { Title: { Length: > 0 } title } => title,
         _ => null
     };
 
     // "00074-OpenReviewActions..." -> "74". Falls back to the raw folder name when the numeric
     // prefix is missing, so a malformed arg never throws inside OpenApp (which swallows exceptions).
-    private static string FormatPlanId(string planFolderName) =>
+    internal static string FormatPlanId(string planFolderName) =>
         int.TryParse(PlanYamlHelper.ExtractPlanIdFromFolder(planFolderName), out var id)
             ? id.ToString()
             : planFolderName;

--- a/src/Ivy.Tendril/Apps/Agent/AgentAppArgs.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentAppArgs.cs
@@ -1,3 +1,9 @@
 namespace Ivy.Tendril.Apps.Agent;
 
-public record AgentAppArgs(string? Prompt = null);
+/// <summary>
+///     Args for <see cref="AgentApp"/>. <paramref name="Title"/> is the fully-formatted tab title
+///     (e.g. "#85"), built by the caller; when set, the shell uses it verbatim instead of the
+///     branded agent label. See TendrilAppShell.ResolveArgsTabTitle and
+///     TendrilAppShell.FormatPlanId for the helper callers should use to build it.
+/// </summary>
+public record AgentAppArgs(string? Prompt = null, string? Title = null);

--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.AppShell;
 using Ivy.Tendril.Apps.Agent;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
@@ -60,7 +61,8 @@ public class ActionBarView(
         {
             new MenuItem($"Discuss with {agentLabel}", Icon: agentIcon, Tag: "DiscussWithAgent")
                 .OnSelect(() => nav.Navigate<AgentApp>(new AgentAppArgs(
-                    $"User wants to discuss the plan {selectedPlan.FolderPath} currently in Draft mode."))),
+                    $"User wants to discuss the plan {selectedPlan.FolderPath} currently in Draft mode.",
+                    $"#{TendrilAppShell.FormatPlanId(selectedPlan.FolderName)}"))),
             new MenuItem("Create Issue", Icon: Icons.Github, Tag: "CreateIssue").OnSelect(showCreateIssueDialog),
             new MenuItem("Open in File Manager", Icon: Icons.FolderOpen, Tag: "OpenInExplorer")
                 .OnSelect(() => { PlatformHelper.OpenInFileManager(selectedPlan.FolderPath); }),

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -3,6 +3,7 @@ using System.Reactive.Disposables;
 using System.Text;
 using Ivy.Core;
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.AppShell;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Apps.Agent;
 using Ivy.Tendril.Apps.Jobs;
@@ -392,7 +393,8 @@ public class ContentView(
         {
             new MenuItem($"Discuss with {agentLabel}", Icon: agentIcon, Tag: "DiscussWithAgent")
                 .OnSelect(() => nav.Navigate<AgentApp>(new AgentAppArgs(
-                    $"User wants to discuss the plan {selectedPlan.FolderPath} currently in Review mode."))),
+                    $"User wants to discuss the plan {selectedPlan.FolderPath} currently in Review mode.",
+                    $"#{TendrilAppShell.FormatPlanId(selectedPlan.FolderName)}"))),
             new MenuItem("Create PR", Icon: Icons.GitPullRequest, Tag: "CreatePR").OnSelect(showCreatePrDialog),
             new MenuItem("Set Completed", Icon: Icons.CircleCheck, Tag: "SetCompleted").OnSelect(() =>
             {
@@ -599,7 +601,8 @@ public class ContentView(
                 refreshPlans,
                 selectedPlan.Project,
                 onDiscussWithAgent: () => nav.Navigate<AgentApp>(new AgentAppArgs(
-                    $"User wants to discuss the plan {selectedPlan.FolderPath} currently in Review mode.")));
+                    $"User wants to discuss the plan {selectedPlan.FolderPath} currently in Review mode.",
+                    $"#{TendrilAppShell.FormatPlanId(selectedPlan.FolderName)}")));
 
             var tabNamesList = new List<string> { "summary", "plan", "details", "git" };
             var tabList = new List<Tab>


### PR DESCRIPTION
# Summary

## Changes

"Discuss with `<Agent>`" in Drafts and Review now opens the `AgentApp` tab titled `#<PlanId>`
instead of the branded agent label (e.g. "Claude Code"), so discussing multiple plans no longer
produces several indistinguishable tabs. `AgentAppArgs` gained a caller-supplied `Title` hint that
`TendrilAppShell.ResolveArgsTabTitle` uses verbatim when present, reusing the plan-id formatter
introduced for `ReviewActionApp` tabs.

## API Changes

- `AgentAppArgs` (`Ivy.Tendril.Apps.Agent`): added optional `Title` parameter —
  `public record AgentAppArgs(string? Prompt = null, string? Title = null);`. Backward-compatible;
  every existing `new AgentAppArgs(prompt)` call still compiles.
- `TendrilAppShell.FormatPlanId(string planFolderName)` (`Ivy.Tendril.AppShell`): accessibility
  widened from `private` to `internal`. No behavior change.
- `TendrilAppShell.ResolveArgsTabTitle` gained an `AgentAppArgs { Title: { Length: > 0 } title } => title`
  case (internal, not directly consumer-facing).

## Files Modified

- `src/Ivy.Tendril/AppShell/TendrilAppShell.cs` — `ResolveArgsTabTitle` gains the `AgentAppArgs`
  case; `FormatPlanId` made `internal`.
- `src/Ivy.Tendril/Apps/Agent/AgentAppArgs.cs` — added `Title` parameter.
- `src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs` — Drafts "Discuss with `<Agent>`" menu item now
  passes `$"#{TendrilAppShell.FormatPlanId(selectedPlan.FolderName)}"` as the title.
- `src/Ivy.Tendril/Apps/Review/ContentView.cs` — both Review "Discuss with `<Agent>`" call sites
  (overflow menu item and `onDiscussWithAgent` passed into `ChangesTabView`) pass the same title.
- `src/Ivy.Tendril.Test/AppShell/TabTitleResolverTests.cs` — two new tests covering the verbatim
  title case and the null/empty fallback case.

## Manual Testing

1. Run the Tendril app and open the Drafts view.
2. Select a plan, open its overflow menu, and click "Discuss with `<Agent>`".
3. Observe the new tab is titled `#<PlanId>` (e.g. `#85`) instead of the agent's branded name.
4. Repeat steps 2-3 for a different plan (or the same plan again) — the new tab gets its own
   `#<PlanId>` title, distinguishing it from the first.
5. Repeat in the Review view: both the overflow menu's "Discuss with `<Agent>`" and the changes-tab
   "Discuss with Agent" action should behave the same way.
6. Open "Discuss with `<Agent>`" from the New Plan dialog (Drafts) and from a Job Debug sheet —
   both should still show the branded agent label, since neither has a plan.

## Retry: Investigated "stuck on Loading" report — no code change

A reviewer screenshot showed a "Discuss with `<Agent>`" tab (correctly titled `#84`, confirming
this plan's own change works) stuck on the `Terminal` widget's loading overlay. Investigated
whether this plan's diff caused it before making any change:

- `git diff origin/development...HEAD` for this plan touches exactly 5 files
  (`TendrilAppShell.cs`, `AgentAppArgs.cs`, `ActionBarView.cs`, `ContentView.cs`,
  `TabTitleResolverTests.cs`) — none of them are `AgentApp.cs`, `Ivy.Hooks.Pty/UsePty.cs`, or
  `Ivy.Widgets.Xterm`'s `Terminal.tsx`, which are the files that actually own PTY startup and the
  loading overlay (`showLoading = loading && !streamDataReceived && !closed` in `Terminal.tsx`).
- `D:/Tendril/crash.log` shows the preview server for this exact plan/worktree ran from
  2026-08-13T17:10:42Z to 2026-08-13T17:13:39Z (`ProcessExit`, no exception logged) — the
  ~3-minute window the screenshot was taken in. No stack trace or error correlates with the
  incident.
- The plan's `Ivy-Framework` worktree is a few commits behind `origin/development` (missing the
  00076 UTF-8-decoder fix), but that fix only changes the backend `OnOutput` text path used for
  trust-prompt matching — the raw `stream.Write(data)` bytes the frontend renders are explicitly
  untouched by it, so it can't explain a stuck frontend overlay.

Conclusion: this is not a regression introduced by this plan's tab-title change. It's most
likely the Claude CLI process itself taking longer to print its first output than the ~3-minute
preview session lasted. No code was changed for this retry. Filed as plan recommendation
"Investigate PTY terminal getting stuck on Loading in Discuss with Agent" for separate follow-up
(possibly a visible timeout/error state in `Terminal.tsx`'s loading overlay) rather than guessing
at an unrelated fix inside this plan's scope.


---
## Commits
- 535c1267 Plan 00085: Add Title hint to AgentAppArgs and resolve it verbatim in tab titles
- dd36906d Plan 00085: Pass plan id as tab title from Discuss with Agent call sites
- 6066bf6c Plan 00085: Add tests for AgentAppArgs title resolution

---
Created using [Ivy Tendril](https://ivy.app).
