### PR TITLE
Add opt-in to beta features in Advanced Settings

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1924,4 +1924,35 @@ projects:
             PathHelper.DefaultTendrilHomeOverride = null;
         }
     }
+
+    [Fact]
+    public void Beta_Setting_PersistsAndSetsEnvironmentVariable()
+    {
+        var yaml = @"
+beta: true
+";
+        var originalEnv = Environment.GetEnvironmentVariable("TENDRIL_BETA");
+        var tempDir = CreateTempConfigFile(yaml);
+        PathHelper.DefaultTendrilHomeOverride = tempDir;
+        try
+        {
+            Environment.SetEnvironmentVariable("TENDRIL_BETA", null);
+            using var service = new ConfigService();
+            Assert.True(service.Settings.Beta);
+            Assert.Equal("1", Environment.GetEnvironmentVariable("TENDRIL_BETA"));
+
+            service.Settings.Beta = false;
+            Environment.SetEnvironmentVariable("TENDRIL_BETA", null);
+            service.SaveSettings();
+
+            var yamlOnDisk = File.ReadAllText(Path.Combine(tempDir, "config.yaml"));
+            Assert.Contains("beta: false", yamlOnDisk);
+        }
+        finally
+        {
+            PathHelper.DefaultTendrilHomeOverride = null;
+            Environment.SetEnvironmentVariable("TENDRIL_BETA", originalEnv);
+            Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril/Apps/Settings/AdvancedSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AdvancedSetupView.cs
@@ -15,14 +15,16 @@ public class AdvancedSetupView : ViewBase
         var maxConcurrentJobs = UseState(config.Settings.MaxConcurrentJobs);
         var editorCommand = UseState(config.Settings.Editor.Command);
         var editorLabel = UseState(config.Settings.Editor.Label);
+        var beta = UseState(config.Settings.Beta);
 
         var hasChanges = jobTimeout.Value != config.Settings.JobTimeout
                          || staleOutputTimeout.Value != config.Settings.StaleOutputTimeout
                          || maxConcurrentJobs.Value != config.Settings.MaxConcurrentJobs
                          || editorCommand.Value != config.Settings.Editor.Command
-                         || editorLabel.Value != config.Settings.Editor.Label;
+                         || editorLabel.Value != config.Settings.Editor.Label
+                         || beta.Value != config.Settings.Beta;
 
-        var form = Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(120)))
+        var form = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
                    | Text.Block("Advanced Settings").Bold()
                    | Text.Block("Configure timeouts, concurrency limits, and editor preferences.").Muted().Small()
                    | Text.Block("Timeouts").Bold()
@@ -40,6 +42,10 @@ public class AdvancedSetupView : ViewBase
                            : null)
                    | editorLabel.ToTextInput("e.g. VS Code, Vim")
                        .WithField().Label("Label")
+                   | Text.Block("Beta Features").Bold()
+                   | beta.ToSwitchInput()
+                       .WithField().Label("Opt-in to beta features")
+                   | Text.Muted("A Tendril restart is required for changes to take effect.").Small()
                    | new Button("Save").Primary()
                        .Disabled(!hasChanges)
                        .OnClick(() =>
@@ -49,6 +55,15 @@ public class AdvancedSetupView : ViewBase
                            config.Settings.MaxConcurrentJobs = maxConcurrentJobs.Value;
                            config.Settings.Editor.Command = editorCommand.Value;
                            config.Settings.Editor.Label = editorLabel.Value;
+                           config.Settings.Beta = beta.Value;
+                           if (beta.Value)
+                           {
+                               Environment.SetEnvironmentVariable("TENDRIL_BETA", "1");
+                           }
+                           else
+                           {
+                               Environment.SetEnvironmentVariable("TENDRIL_BETA", null);
+                           }
                            config.SaveSettings();
                            client.Toast("Settings saved and applied", "Saved");
                        });

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -262,11 +262,10 @@ public class Program
                 .AddConsole(options => options.FormatterName = "clean")
                 .AddConsoleFormatter<CleanConsoleFormatter, ConsoleFormatterOptions>());
             cliServices.AddSingleton<IPlanWatcherService, NullPlanWatcherService>();
-            cliServices.AddAgentInfrastructure(opts => opts.IncludeBetaProviders = beta);
-
             var configService = new ConfigService(Microsoft.Extensions.Logging.Abstractions.NullLogger<ConfigService>.Instance);
             cliServices.AddSingleton<IConfigService>(configService);
             cliServices.AddSingleton<ConfigService>(configService);
+            cliServices.AddAgentInfrastructure(opts => opts.IncludeBetaProviders = beta || configService.Settings.Beta || Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" || Environment.GetEnvironmentVariable("IVY_BETA") == "1");
 
             // Needed by `plan create` to validate that a source issue/PR URL belongs to the
             // chosen project (PlanSourceProjectGuard). Resolves git remotes of project repos.

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -33,6 +33,7 @@ internal static class ServiceRegistration
         server.Services.AddAgentInfrastructure(opts =>
         {
             opts.IncludeBetaProviders = (tendrilArgs?.Beta ?? false) ||
+                                        configService.Settings.Beta ||
                                         Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" ||
                                         Environment.GetEnvironmentVariable("IVY_BETA") == "1";
             

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -257,6 +257,7 @@ public class ConfigService : IConfigService, IDisposable
         ConfigPath = !string.IsNullOrEmpty(TendrilHome)
             ? Path.Combine(TendrilHome, "config.yaml")
             : PathHelper.GetResourcePath("config.yaml");
+        SyncBetaFromSettings();
     }
 
     public ConfigService(ILogger<ConfigService>? logger = null)
@@ -385,6 +386,15 @@ public class ConfigService : IConfigService, IDisposable
         ValidateProjectNames();
         CreateRequiredDirectories();
         SyncAuthFromEnvironmentAndPersistIfNeeded();
+        SyncBetaFromSettings();
+    }
+
+    private void SyncBetaFromSettings()
+    {
+        if (Settings.Beta)
+        {
+            Environment.SetEnvironmentVariable("TENDRIL_BETA", "1");
+        }
     }
 
     /// <summary>
@@ -634,6 +644,7 @@ public class ConfigService : IConfigService, IDisposable
             ExpandRepoPaths();
 
             SyncAuthFromEnvironmentAndPersistIfNeeded();
+            SyncBetaFromSettings();
             SettingsReloaded?.Invoke(this, EventArgs.Empty);
         }
         catch (Exception ex)

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -90,6 +90,7 @@ public static class TendrilServer
         });
 
         var isBeta = tendrilArgs.Beta ||
+                     configService.Settings.Beta ||
                      Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" ||
                      Environment.GetEnvironmentVariable("IVY_BETA") == "1";
 


### PR DESCRIPTION
### Summary of Changes
- Added an **Opt-in to beta features** switch under **Advanced Settings** in Tendril.
- Added a note indicating that a Tendril restart is required for changes to take effect.
- Synchronized the `Beta` configuration with the `TENDRIL_BETA` environment variable so it persists across subsequent launches.
- Added unit tests verifying `Beta` settings persistence and environment variable synchronization.