### PR TITLE
fix(agents): filter stderr and non-json output in AntigravityEventParser

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs
@@ -14,15 +14,52 @@ public class AntigravityEventParserTests
     }
 
     [Fact]
-    public void ParseLine_TextLine_ReturnsTextEvent()
+    public void ParseLine_EmptyString_ReturnsEmpty()
+    {
+        var events = _parser.ParseLine("");
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void ParseLine_Whitespace_ReturnsEmpty()
+    {
+        var events = _parser.ParseLine("   ");
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void ParseLine_NonJson_ReturnsEmpty()
     {
         var events = _parser.ParseLine("Line 1");
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void ParseLine_StderrPrefix_ReturnsEmpty()
+    {
+        var events = _parser.ParseLine("[stderr] warning: conversation \"2c358e24-748c-4bc1-8df8-37b0f2648a4f\" not found");
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public void ParseLine_MalformedJson_ReturnsUnknownEvent()
+    {
+        var events = _parser.ParseLine("{not valid json!!");
+        Assert.Single(events);
+        Assert.IsType<UnknownEvent>(events[0]);
+    }
+
+    [Fact]
+    public void ParseLine_StepUpdate_AgentResponse_ReturnsTextEvent()
+    {
+        var json = "{\"event\":\"step_update\",\"step_update\":{\"step_type\":\"agent_response\",\"text_delta\":\"Hello world\"}}";
+        var events = _parser.ParseLine(json);
 
         Assert.Single(events);
         var textEvent = Assert.IsType<TextEvent>(events[0]);
         Assert.Equal(AgentEventKind.Text, textEvent.Kind);
-        Assert.Equal("Line 1\n", textEvent.Text);
-        Assert.False(textEvent.IsDelta);
+        Assert.Equal("Hello world", textEvent.Text);
+        Assert.True(textEvent.IsDelta);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityEventParser.cs
@@ -10,15 +10,17 @@ public sealed class AntigravityEventParser : IEventParser
     public string AgentId => Abstractions.AgentId.Antigravity;
 
     private static readonly IReadOnlyList<AgentEvent> Empty = Array.Empty<AgentEvent>();
+    private const string StderrPrefix = "[stderr] ";
 
     public IReadOnlyList<AgentEvent> ParseLine(string rawLine)
     {
         if (string.IsNullOrWhiteSpace(rawLine)) return Empty;
+
+        if (rawLine.StartsWith(StderrPrefix, StringComparison.Ordinal))
+            return Empty;
+
         var trimmed = rawLine.Trim();
-        if (trimmed.Length == 0 || trimmed[0] != '{')
-        {
-            return [new TextEvent { Kind = AgentEventKind.Text, Text = rawLine + "\n", RawLine = rawLine }];
-        }
+        if (trimmed.Length == 0 || trimmed[0] != '{') return Empty;
 
         try
         {
@@ -27,7 +29,7 @@ public sealed class AntigravityEventParser : IEventParser
 
             if (!root.TryGetProperty("event", out var evtProp))
             {
-                return [new TextEvent { Kind = AgentEventKind.Text, Text = rawLine + "\n", RawLine = rawLine }];
+                return [new UnknownEvent { Kind = AgentEventKind.Unknown, Content = rawLine, RawLine = rawLine }];
             }
 
             var evtType = evtProp.GetString();
@@ -41,7 +43,7 @@ public sealed class AntigravityEventParser : IEventParser
         }
         catch (JsonException)
         {
-            return [new TextEvent { Kind = AgentEventKind.Text, Text = rawLine + "\n", RawLine = rawLine }];
+            return [new UnknownEvent { Kind = AgentEventKind.Unknown, Content = rawLine, RawLine = rawLine }];
         }
     }
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/parse-events.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/parse-events.test.ts
@@ -81,4 +81,18 @@ describe("parseEventWireStream", () => {
     expect(events).toHaveLength(1);
     expect(events[0].kind).toBe("assistant-text");
   });
+
+  it("skips text events starting with [stderr]", () => {
+    const stream = [
+      '{"kind":"text","timestamp":"T","text":"[stderr] warning: conversation not found","delta":false}',
+      '{"kind":"text","timestamp":"T","text":"Valid assistant message","delta":false}',
+    ].join("\n");
+
+    const events = parseEventWireStream(stream);
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("assistant-text");
+    if (events[0].kind === "assistant-text") {
+      expect(events[0].text).toBe("Valid assistant message");
+    }
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/parse-events.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/parse-events.ts
@@ -36,6 +36,9 @@ export function parseEventWireStream(jsonStream: string): PresentationEvent[] {
         break;
 
       case "text":
+        if (evt.text?.startsWith("[stderr]")) {
+          break;
+        }
         if (evt.delta) {
           pendingText = (pendingText ?? "") + evt.text;
         } else {


### PR DESCRIPTION
## Summary
- Prevents spurious `[stderr]` warning messages from rendering as assistant message cards in AgentViewer.
- Filters non-JSON and `[stderr] ` prefixed lines in `AntigravityEventParser.cs` (matching behavior of other agent parsers).
- Adds frontend guard in `parse-events.ts` to ignore any leaked `[stderr]` text events.
- Adds comprehensive unit tests in `AntigravityEventParserTests.cs` and `parse-events.test.ts`.