### PR TITLE
fix(chat): remove horizontal scrollbar and nested button overflow in chat sidebar

### DIFF
--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -45,7 +45,7 @@ public class ContentView(
                     sessionVersion.Set(v => v + 1);
                 });
 
-            return Layout.Vertical().Gap(3).AlignContent(Align.Center).Width(Size.Full()).Height(Size.Full()).Padding(6)
+            return Layout.Vertical().AlignContent(Align.Center).Width(Size.Full()).Height(Size.Full())
                 | Icons.MessageSquare.ToIcon().Size(Size.Px(48)).Color(Colors.Muted)
                 | Text.H3("No Chat Selected")
                 | Text.Muted("Select an existing chat session from history or start a new chat.")

--- a/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
@@ -59,11 +59,19 @@ public class SidebarView(
                 var formattedDate = sess.UpdatedAt.ToString("M/d, h:mm tt");
                 var displayTitle = string.IsNullOrWhiteSpace(sess.Title) ? "New Chat" : sess.Title;
 
-                var textStack = Layout.Vertical().Gap(1).AlignContent(Align.Left)
+                var textStack = Layout.Vertical().AlignContent(Align.Left)
                     | Text.Literal(displayTitle).Small()
                     | Text.Muted($"{formattedDate} • {sess.AgentId}").Small();
 
-                var actionButtons = Layout.Horizontal().Gap(1).AlignContent(Align.Center)
+                var sessionBtn = new Button()
+                    .Width(Size.Full())
+                    .Content(textStack)
+                    .OnClick(() => activeSessionId.Set(sess.Id))
+                    .BorderRadius(BorderRadius.None);
+
+                var sessionBtnStyled = isSelected ? sessionBtn.Secondary() : sessionBtn.Ghost();
+
+                var actionButtons = Layout.Horizontal().AlignContent(Align.Center)
                     | new Button()
                         .Icon(Icons.Pencil)
                         .Ghost()
@@ -89,20 +97,12 @@ public class SidebarView(
                             }
                         });
 
-                var rowLayout = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.SpaceBetween)
-                    | textStack
+                return Layout.Horizontal().Width(Size.Full()).AlignContent(Align.SpaceBetween)
+                    | sessionBtnStyled
                     | actionButtons;
-
-                var rowBtn = new Button()
-                    .Width(Size.Full())
-                    .Content(rowLayout)
-                    .OnClick(() => activeSessionId.Set(sess.Id))
-                    .BorderRadius(BorderRadius.None);
-
-                return isSelected ? rowBtn.Secondary() : rowBtn.Ghost();
             }));
         }
 
-        return new HeaderLayout(sidebarHeader, sidebarContent);
+        return new HeaderLayout(sidebarHeader, sidebarContent).Scroll(Scroll.None);
     }
 }


### PR DESCRIPTION
## Summary
- Eliminates horizontal scrollbar in Chat app history sidebar list.
- Replaces nested `<button>` row architecture with sibling session selection and action buttons.
- Disables nested `HeaderLayout` scroll area around the virtualized `List` via `.Scroll(Scroll.None)`.
- Cleans up explicit `.Gap()` and `.Padding()` calls in Chat views according to repository style rules.