### PR TITLE
fix(sidebar): expand collapsed settings trigger to full rail width and clean gaps

### DIFF
--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -633,6 +633,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var settingsMenuCollapsed = new DropDownMenu(
                 DropDownMenu.DefaultSelectHandler(),
                 settingsTriggerCollapsed)
+            .Width(Size.Full())
             .Top()
             .Items(settings.FooterMenuItemsTransformer(settingsMenuItems, navigator));
 
@@ -656,7 +657,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             new SidebarLayout(
                 body ?? null!,
                 sidebarMenu,
-                sidebarHeader: Layout.Vertical().Gap(2)
+                sidebarHeader: Layout.Vertical()
                     | settings.Header
                     | new NewPlanButton(collapsed: false),
                 sidebarFooter: Layout.Vertical(
@@ -665,9 +666,10 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                     footer
                 ),
                 width: settings.Width,
-                sidebarHeaderCollapsed: Layout.Vertical().Gap(2)
+                sidebarHeaderCollapsed: Layout.Vertical()
                     | new NewPlanButton(collapsed: true),
-                sidebarFooterCollapsed: settingsMenuCollapsed
+                sidebarFooterCollapsed: Layout.Vertical().Width(Size.Full())
+                    | settingsMenuCollapsed
             ).Open(sidebarOpen.Value).MainAppSidebar(),
             importIssuesDialog,
             updateDialog


### PR DESCRIPTION
## Summary
- Ensures collapsed settings dropdown trigger expands to full rail width matching other sidebar items.
- Wraps `sidebarFooterCollapsed` in `Layout.Vertical().Width(Size.Full())` and sets `.Width(Size.Full())` on `settingsMenuCollapsed`.
- Removes custom `.Gap(2)` invocations from sidebar layout headers per repository style rules.