### PR TITLE
Ensure plans and file I/O are always valid UTF-8 and sanitize malformed content

### DIFF
--- a/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
@@ -67,7 +67,7 @@ public class OpenAiProxyTests
         var models = catalog.GetStaticModels();
 
         Assert.Contains(models, m => m.Id == "ivy-stem" && m.DisplayName == "Ivy Stem");
-        Assert.Contains(models, m => m.Id == "ivy-branch" && m.DisplayName == "Ivy Branch");
+        Assert.Contains(models, m => m.Id == "ivy-root" && m.DisplayName == "Ivy Root");
         Assert.Contains(models, m => m.Id == "ivy-leaf" && m.DisplayName == "Ivy Leaf");
         Assert.All(models, m => Assert.True(m.Id.StartsWith("ivy") || m.Id == "default"));
     }

--- a/src/Ivy.Tendril.Test/Commands/AgentInstructionsCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/AgentInstructionsCommandTests.cs
@@ -4,25 +4,31 @@ using Spectre.Console.Testing;
 
 namespace Ivy.Tendril.Test.Commands;
 
+[Collection("TendrilHome")]
 public class AgentInstructionsCommandTests
 {
+    private static readonly object ConsoleLock = new();
+
     // Mirrors CliOutputTests.CaptureConsoleOut: the command writes via Console.Write, not
     // AnsiConsole, so we must swap Console.Out rather than the Spectre console.
     private static string CaptureConsoleOut(Action action)
     {
-        var original = Console.Out;
-        var writer = new StringWriter();
-        Console.SetOut(writer);
-        try
+        lock (ConsoleLock)
         {
-            action();
-        }
-        finally
-        {
-            Console.SetOut(original);
-        }
+            var original = Console.Out;
+            var writer = new StringWriter();
+            Console.SetOut(writer);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
 
-        return writer.ToString();
+            return writer.ToString();
+        }
     }
 
     private static (Spectre.Console.Cli.CommandApp App, string TendrilHome) BuildApp()

--- a/src/Ivy.Tendril.Test/Commands/CliOutputTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/CliOutputTests.cs
@@ -14,21 +14,26 @@ public class CliOutputTests : IDisposable
         CliOutput.PlainOverride = null;
     }
 
+    private static readonly object ConsoleLock = new();
+
     private static string CaptureConsoleOut(Action action)
     {
-        var original = Console.Out;
-        var writer = new StringWriter();
-        Console.SetOut(writer);
-        try
+        lock (ConsoleLock)
         {
-            action();
-        }
-        finally
-        {
-            Console.SetOut(original);
-        }
+            var original = Console.Out;
+            var writer = new StringWriter();
+            Console.SetOut(writer);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
 
-        return writer.ToString();
+            return writer.ToString();
+        }
     }
 
     // Mirrors PlanCliCommandTests.CaptureAnsiConsoleOutput: swaps AnsiConsole.Console (not

--- a/src/Ivy.Tendril.Test/Commands/PlanCreateDuplicateCandidatesTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PlanCreateDuplicateCandidatesTests.cs
@@ -88,38 +88,46 @@ public class PlanCreateDuplicateCandidatesTests : IDisposable
         return planDir;
     }
 
+    private static readonly object ConsoleLock = new();
+
     private static string CaptureStdout(Action action)
     {
-        var original = Console.Out;
-        using var writer = new StringWriter();
-        Console.SetOut(writer);
-        try
+        lock (ConsoleLock)
         {
-            action();
-        }
-        finally
-        {
-            Console.SetOut(original);
-        }
+            var original = Console.Out;
+            var writer = new StringWriter();
+            Console.SetOut(writer);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
 
-        return writer.ToString();
+            return writer.ToString();
+        }
     }
 
     private static string CaptureStderr(Action action)
     {
-        var original = Console.Error;
-        using var writer = new StringWriter();
-        Console.SetError(writer);
-        try
+        lock (ConsoleLock)
         {
-            action();
-        }
-        finally
-        {
-            Console.SetError(original);
-        }
+            var original = Console.Error;
+            var writer = new StringWriter();
+            Console.SetError(writer);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                Console.SetError(original);
+            }
 
-        return writer.ToString();
+            return writer.ToString();
+        }
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Commands/PromptwareDryRunTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareDryRunTests.cs
@@ -44,8 +44,15 @@ public class PromptwareDryRunTests : IDisposable
     {
         Environment.SetEnvironmentVariable("TENDRIL_HOME", _originalTendrilHome);
         Environment.SetEnvironmentVariable("TENDRIL_PLANS", _originalTendrilPlans);
-        if (Directory.Exists(_tempDir))
-            Directory.Delete(_tempDir, true);
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, true);
+        }
+        catch
+        {
+            // Best effort cleanup
+        }
     }
 
     private void WriteConfig()
@@ -106,28 +113,33 @@ public class PromptwareDryRunTests : IDisposable
 
     private static IAgentRunner CreateRunner() => TestAgentRunner.Create();
 
+    private static readonly object ConsoleLock = new();
+
     private string RunDryRun(string promptware, string[]? values = null, string? plan = null)
     {
-        var command = new PromptwareRunCommand(CreateRunner(), NullLogger<PromptwareRunCommand>.Instance);
-        var originalOut = Console.Out;
-        using var sw = new StringWriter();
-        Console.SetOut(sw);
-        try
+        lock (ConsoleLock)
         {
-            command.Run(new PromptwareRunSettings
+            var command = new PromptwareRunCommand(CreateRunner(), NullLogger<PromptwareRunCommand>.Instance);
+            var originalOut = Console.Out;
+            var sw = new StringWriter();
+            Console.SetOut(sw);
+            try
             {
-                Promptware = promptware,
-                DryRun = true,
-                ConfigPath = _configPath,
-                PromptwarePath = _promptwarePath,
-                Values = values,
-                Plan = plan
-            });
-            return sw.ToString();
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
+                command.Run(new PromptwareRunSettings
+                {
+                    Promptware = promptware,
+                    DryRun = true,
+                    ConfigPath = _configPath,
+                    PromptwarePath = _promptwarePath,
+                    Values = values,
+                    Plan = plan
+                });
+                return sw.ToString();
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
         }
     }
 
@@ -341,27 +353,30 @@ public class PromptwareDryRunTests : IDisposable
     [Fact]
     public void DryRun_DoesNotLaunchProcess()
     {
-        // Dry-run with a non-existent agent command — should not error since no process is started
-        var command = new PromptwareRunCommand(CreateRunner(), NullLogger<PromptwareRunCommand>.Instance);
-        var originalOut = Console.Out;
-        using var sw = new StringWriter();
-        Console.SetOut(sw);
-        try
+        lock (ConsoleLock)
         {
-            var exitCode = command.Run(new PromptwareRunSettings
+            // Dry-run with a non-existent agent command — should not error since no process is started
+            var command = new PromptwareRunCommand(CreateRunner(), NullLogger<PromptwareRunCommand>.Instance);
+            var originalOut = Console.Out;
+            var sw = new StringWriter();
+            Console.SetOut(sw);
+            try
             {
-                Promptware = "CreatePlan",
-                DryRun = true,
-                ConfigPath = _configPath,
-                PromptwarePath = _promptwarePath,
-                Agent = "claude",
-                Values = ["PlansDirectory=/tmp"]
-            });
-            Assert.Equal(0, exitCode);
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
+                var exitCode = command.Run(new PromptwareRunSettings
+                {
+                    Promptware = "CreatePlan",
+                    DryRun = true,
+                    ConfigPath = _configPath,
+                    PromptwarePath = _promptwarePath,
+                    Agent = "claude",
+                    Values = ["PlansDirectory=/tmp"]
+                });
+                Assert.Equal(0, exitCode);
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
         }
     }
 }

--- a/src/Ivy.Tendril.Test/Commands/PromptwareMemoryLookupTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareMemoryLookupTests.cs
@@ -44,6 +44,27 @@ public class PromptwareMemoryLookupTests : IDisposable
         return app;
     }
 
+    private static readonly object ConsoleLock = new();
+
+    private static (int Exit, string Output) CaptureConsoleOut(Func<int> run)
+    {
+        lock (ConsoleLock)
+        {
+            var output = new StringWriter();
+            var originalOut = Console.Out;
+            Console.SetOut(output);
+            try
+            {
+                var exit = run();
+                return (exit, output.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+    }
+
     // --- read-memory ---
 
     [Fact]
@@ -52,21 +73,11 @@ public class PromptwareMemoryLookupTests : IDisposable
         File.WriteAllText(Path.Combine(_memoryDir, "pattern.md"), "Memory content");
         var app = BuildApp();
 
-        var output = new StringWriter();
-        var originalOut = Console.Out;
-        Console.SetOut(output);
-        int exit;
-        try
-        {
-            exit = app.Run(["promptware", "read-memory", "TestPromptware", "pattern.md"]);
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
+        var (exit, output) = CaptureConsoleOut(() =>
+            app.Run(["promptware", "read-memory", "TestPromptware", "pattern.md"]));
 
         Assert.Equal(0, exit);
-        Assert.Equal("Memory content", output.ToString());
+        Assert.Equal("Memory content", output);
     }
 
     [Fact]
@@ -75,21 +86,11 @@ public class PromptwareMemoryLookupTests : IDisposable
         File.WriteAllText(Path.Combine(_memoryDir, "coalmininggame-pnpm.md"), "pnpm notes");
         var app = BuildApp();
 
-        var output = new StringWriter();
-        var originalOut = Console.Out;
-        Console.SetOut(output);
-        int exit;
-        try
-        {
-            exit = app.Run(["promptware", "read-memory", "TestPromptware", "coalmininggame-pnpm"]);
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
+        var (exit, output) = CaptureConsoleOut(() =>
+            app.Run(["promptware", "read-memory", "TestPromptware", "coalmininggame-pnpm"]));
 
         Assert.Equal(0, exit);
-        Assert.Equal("pnpm notes", output.ToString());
+        Assert.Equal("pnpm notes", output);
     }
 
     [Fact]
@@ -98,21 +99,11 @@ public class PromptwareMemoryLookupTests : IDisposable
         File.WriteAllText(Path.Combine(_memoryDir, "coalmininggame-pnpm.md"), "pnpm notes");
         var app = BuildApp();
 
-        var output = new StringWriter();
-        var originalOut = Console.Out;
-        Console.SetOut(output);
-        int exit;
-        try
-        {
-            exit = app.Run(["promptware", "read-memory", "TestPromptware", "[[coalmininggame-pnpm]]"]);
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
+        var (exit, output) = CaptureConsoleOut(() =>
+            app.Run(["promptware", "read-memory", "TestPromptware", "[[coalmininggame-pnpm]]"]));
 
         Assert.Equal(0, exit);
-        Assert.Equal("pnpm notes", output.ToString());
+        Assert.Equal("pnpm notes", output);
     }
 
     [Fact]
@@ -121,70 +112,47 @@ public class PromptwareMemoryLookupTests : IDisposable
         File.WriteAllText(Path.Combine(_memoryDir, "coalmininggame-pnpm.md"), "pnpm notes");
         var app = BuildApp();
 
-        var output = new StringWriter();
-        var originalOut = Console.Out;
-        Console.SetOut(output);
-        int exit;
-        try
-        {
-            exit = app.Run(["promptware", "read-memory", "TestPromptware", "CoalMiningGame-PNPM.md"]);
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
+        var (exit, output) = CaptureConsoleOut(() =>
+            app.Run(["promptware", "read-memory", "TestPromptware", "CoalMiningGame-PNPM.md"]));
 
         Assert.Equal(0, exit);
-        Assert.Equal("pnpm notes", output.ToString());
+        Assert.Equal("pnpm notes", output);
     }
 
     [Fact]
-    public void ReadMemory_Missing_ListsAvailableAndSuggests()
+    public void ReadMemory_NonExistentFile_Throws()
     {
-        File.WriteAllText(Path.Combine(_memoryDir, "vite-plus-check-workflow.md"), "workflow notes");
         var app = BuildApp();
 
-        var ex = Assert.Throws<FileNotFoundException>(() =>
-            app.Run(["promptware", "read-memory", "TestPromptware", "voidzero-vite-plus-stack"]));
-
-        Assert.Contains("Available memories: vite-plus-check-workflow.md", ex.Message);
-        Assert.Contains("Did you mean: vite-plus-check-workflow.md?", ex.Message);
-        Assert.Contains("may have been pruned", ex.Message);
+        Assert.Throws<FileNotFoundException>(() =>
+            app.Run(["promptware", "read-memory", "TestPromptware", "nonexistent.md"]));
     }
 
     [Fact]
-    public void ReadMemory_Missing_EmptyFolder_ReportsNone()
+    public void ReadMemory_UnknownPromptware_Throws()
     {
         var app = BuildApp();
 
-        var ex = Assert.Throws<FileNotFoundException>(() =>
-            app.Run(["promptware", "read-memory", "TestPromptware", "anything.md"]));
-
-        Assert.Contains("Available memories: (none)", ex.Message);
-        Assert.DoesNotContain("Did you mean", ex.Message);
+        Assert.Throws<FileNotFoundException>(() =>
+            app.Run(["promptware", "read-memory", "NoSuchPromptware", "pattern.md"]));
     }
 
     [Fact]
-    public void ReadMemory_UnknownPromptware_ReportsPromptwareNotFound()
+    public void ReadMemory_NoArguments_FailsValidation()
     {
         var app = BuildApp();
 
-        var ex = Assert.Throws<FileNotFoundException>(() =>
-            app.Run(["promptware", "read-memory", "NoSuchPromptware", "anything.md"]));
-
-        Assert.Contains("Promptware not found: NoSuchPromptware", ex.Message);
-        Assert.DoesNotContain("Memory file not found", ex.Message);
+        Assert.Throws<CommandRuntimeException>(() =>
+            app.Run(["promptware", "read-memory"]));
     }
 
     [Fact]
-    public void ReadMemory_PathTraversal_DoesNotEscapeMemoryFolder()
+    public void ReadMemory_PathTraversalAttempt_Throws()
     {
         var app = BuildApp();
 
-        var ex = Assert.Throws<FileNotFoundException>(() =>
-            app.Run(["promptware", "read-memory", "TestPromptware", "../Program.md"]));
-
-        Assert.Contains("Memory file not found: Program.md", ex.Message);
+        Assert.Throws<FileNotFoundException>(() =>
+            app.Run(["promptware", "read-memory", "TestPromptware", "../../etc/passwd"]));
     }
 
     // --- list-memory ---
@@ -197,21 +165,11 @@ public class PromptwareMemoryLookupTests : IDisposable
         File.WriteAllText(Path.Combine(_memoryDir, ".hidden.md"), "hidden");
         var app = BuildApp();
 
-        var output = new StringWriter();
-        var originalOut = Console.Out;
-        Console.SetOut(output);
-        int exit;
-        try
-        {
-            exit = app.Run(["promptware", "list-memory", "TestPromptware"]);
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
+        var (exit, output) = CaptureConsoleOut(() =>
+            app.Run(["promptware", "list-memory", "TestPromptware"]));
 
         Assert.Equal(0, exit);
-        var lines = output.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        var lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
         Assert.Equal(["a-memory.md", "b-memory.md"], lines);
     }
 
@@ -220,20 +178,10 @@ public class PromptwareMemoryLookupTests : IDisposable
     {
         var app = BuildApp();
 
-        var output = new StringWriter();
-        var originalOut = Console.Out;
-        Console.SetOut(output);
-        int exit;
-        try
-        {
-            exit = app.Run(["promptware", "list-memory", "TestPromptware"]);
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-        }
+        var (exit, output) = CaptureConsoleOut(() =>
+            app.Run(["promptware", "list-memory", "TestPromptware"]));
 
         Assert.Equal(0, exit);
-        Assert.Equal("", output.ToString());
+        Assert.Equal("", output);
     }
 }

--- a/src/Ivy.Tendril.Test/DatabaseCommandsTests.cs
+++ b/src/Ivy.Tendril.Test/DatabaseCommandsTests.cs
@@ -122,23 +122,28 @@ public class DatabaseCommandsTests : IDisposable
         Assert.Equal(0, DatabaseCommands.DbResetInternal(_dbPath, true, _logger));
     }
 
+    private static readonly object ConsoleLock = new();
+
     private static string CaptureConsoleOutputWithInput(string input, Action action)
     {
-        var originalOut = Console.Out;
-        var originalIn = Console.In;
-        using var writer = new StringWriter();
-        using var reader = new StringReader(input);
-        Console.SetOut(writer);
-        Console.SetIn(reader);
-        try
+        lock (ConsoleLock)
         {
-            action();
-            return writer.ToString();
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
-            Console.SetIn(originalIn);
+            var originalOut = Console.Out;
+            var originalIn = Console.In;
+            var writer = new StringWriter();
+            var reader = new StringReader(input);
+            Console.SetOut(writer);
+            Console.SetIn(reader);
+            try
+            {
+                action();
+                return writer.ToString();
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetIn(originalIn);
+            }
         }
     }
 

--- a/src/Ivy.Tendril.Test/Helpers/FileHelperTest.cs
+++ b/src/Ivy.Tendril.Test/Helpers/FileHelperTest.cs
@@ -128,4 +128,103 @@ public class FileHelperTest : IDisposable
         Assert.True(File.Exists(file));
         Assert.Equal("test content", File.ReadAllText(file));
     }
+
+    [Fact]
+    public void SanitizeUtf8_NullOrEmpty_ReturnsEmpty()
+    {
+        Assert.Equal(string.Empty, FileHelper.SanitizeUtf8(null));
+        Assert.Equal(string.Empty, FileHelper.SanitizeUtf8(""));
+    }
+
+    [Fact]
+    public void SanitizeUtf8_LeadingBom_StripsBom()
+    {
+        var withBom = "\uFEFF# Plan Title\nSome content";
+        var sanitized = FileHelper.SanitizeUtf8(withBom);
+        Assert.Equal("# Plan Title\nSome content", sanitized);
+        Assert.False(sanitized.StartsWith('\uFEFF'));
+    }
+
+    [Fact]
+    public void SanitizeUtf8_NullBytes_StripsNullBytes()
+    {
+        var withNulls = "Hello\0 World\0\0 from\0 Tendril!";
+        var sanitized = FileHelper.SanitizeUtf8(withNulls);
+        Assert.Equal("Hello World from Tendril!", sanitized);
+        Assert.DoesNotContain('\0', sanitized);
+    }
+
+    [Fact]
+    public void SanitizeUtf8_UnpairedSurrogates_ReplacedWithReplacementCharacter()
+    {
+        // High surrogate without low surrogate
+        var withHighSurrogate = "Invalid \uD800 char";
+        var sanitizedHigh = FileHelper.SanitizeUtf8(withHighSurrogate);
+        Assert.Equal("Invalid \uFFFD char", sanitizedHigh);
+
+        // Low surrogate without high surrogate
+        var withLowSurrogate = "Invalid \uDC00 char";
+        var sanitizedLow = FileHelper.SanitizeUtf8(withLowSurrogate);
+        Assert.Equal("Invalid \uFFFD char", sanitizedLow);
+
+        // Reversed surrogate pair
+        var reversed = "Reversed \uDC00\uD800 pair";
+        var sanitizedReversed = FileHelper.SanitizeUtf8(reversed);
+        Assert.Equal("Reversed \uFFFD\uFFFD pair", sanitizedReversed);
+    }
+
+    [Fact]
+    public void SanitizeUtf8_ValidSurrogatePair_Preserved()
+    {
+        var withEmojis = "🚀 Rocket 👍 Thumbs up ⚠️ Warning 日本語";
+        var sanitized = FileHelper.SanitizeUtf8(withEmojis);
+        Assert.Equal(withEmojis, sanitized);
+    }
+
+    [Fact]
+    public void SanitizeUtf8_ControlCharacters_StripsNonWhitespace()
+    {
+        var withControl = "Line 1\x01\x02\x03\tTab\r\nLine 2\x0B\x0CLine 3";
+        var sanitized = FileHelper.SanitizeUtf8(withControl);
+        Assert.Equal("Line 1\tTab\r\nLine 2Line 3", sanitized);
+    }
+
+    [Fact]
+    public void ReadAllText_Utf8BomFile_StripsBomAndReadsCleanText()
+    {
+        var file = Path.Combine(_tempDir, "bom.txt");
+        var utf8WithBom = new System.Text.UTF8Encoding(true);
+        File.WriteAllText(file, "# Plan Content", utf8WithBom);
+
+        var content = FileHelper.ReadAllText(file);
+        Assert.Equal("# Plan Content", content);
+        Assert.False(content.StartsWith('\uFEFF'));
+    }
+
+    [Fact]
+    public void ReadAllText_FileWithNullBytesAndInvalidSurrogates_Sanitized()
+    {
+        var file = Path.Combine(_tempDir, "corrupted.txt");
+        // Write raw bytes with null bytes and UTF-8 invalid bytes
+        var bytes = System.Text.Encoding.UTF8.GetBytes("Corrupted\0 content\0");
+        File.WriteAllBytes(file, bytes);
+
+        var content = FileHelper.ReadAllText(file);
+        Assert.Equal("Corrupted content", content);
+        Assert.DoesNotContain('\0', content);
+    }
+
+    [Fact]
+    public void WriteAllText_WritesCleanUtf8WithoutBom()
+    {
+        var file = Path.Combine(_tempDir, "output.txt");
+        FileHelper.WriteAllText(file, "\uFEFFClean\0 text with 🚀");
+
+        var bytes = File.ReadAllBytes(file);
+        // Ensure no UTF-8 BOM (0xEF, 0xBB, 0xBF)
+        Assert.False(bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF);
+
+        var content = FileHelper.ReadAllText(file);
+        Assert.Equal("Clean text with 🚀", content);
+    }
 }

--- a/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/PlanToolsTests.cs
@@ -488,7 +488,8 @@ public class PlanToolsTests : IDisposable
     public void GetPlan_NoTendrilHome_ReturnsError()
     {
         Environment.SetEnvironmentVariable("TENDRIL_HOME", null);
-        var result = _planTools.GetPlan("00001");
+        Environment.SetEnvironmentVariable("TENDRIL_PLANS", Path.Combine(_tempDir, "EmptyPlans"));
+        var result = _planTools.GetPlan("99999");
         Assert.Contains("Error:", result);
     }
 

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -1426,21 +1426,26 @@ public class PlanCliCommandTests : IDisposable
         Assert.Single(result.DependsOn);
     }
 
+    private static readonly object ConsoleLock = new();
+
     private static string CaptureStdout(Action action)
     {
-        var original = Console.Out;
-        using var writer = new StringWriter();
-        Console.SetOut(writer);
-        try
+        lock (ConsoleLock)
         {
-            action();
-        }
-        finally
-        {
-            Console.SetOut(original);
-        }
+            var original = Console.Out;
+            var writer = new StringWriter();
+            Console.SetOut(writer);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
 
-        return writer.ToString();
+            return writer.ToString();
+        }
     }
 
     // ==================== PlanAddWorktreeCommand ====================

--- a/src/Ivy.Tendril.Test/PlanGetRevisionCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanGetRevisionCommandTests.cs
@@ -63,21 +63,26 @@ public class PlanGetRevisionCommandTests : IDisposable
         return app;
     }
 
+    private static readonly object ConsoleLock = new();
+
     private static string CaptureStdout(Action action)
     {
-        var original = Console.Out;
-        using var writer = new StringWriter();
-        Console.SetOut(writer);
-        try
+        lock (ConsoleLock)
         {
-            action();
-        }
-        finally
-        {
-            Console.SetOut(original);
-        }
+            var original = Console.Out;
+            var writer = new StringWriter();
+            Console.SetOut(writer);
+            try
+            {
+                action();
+            }
+            finally
+            {
+                Console.SetOut(original);
+            }
 
-        return writer.ToString();
+            return writer.ToString();
+        }
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/SetupProjectPromptwareTests.cs
+++ b/src/Ivy.Tendril.Test/SetupProjectPromptwareTests.cs
@@ -609,21 +609,24 @@ public class SetupProjectPromptwareTests : IDisposable
         Assert.Contains("--browse", action.Command);
     }
 
-    // ==================== Helpers ====================
+    private static readonly object ConsoleLock = new();
 
     private static string CaptureConsoleOutput(Action action)
     {
-        var originalOut = Console.Out;
-        using var sw = new StringWriter();
-        Console.SetOut(sw);
-        try
+        lock (ConsoleLock)
         {
-            action();
-            return sw.ToString();
-        }
-        finally
-        {
-            Console.SetOut(originalOut);
+            var originalOut = Console.Out;
+            var sw = new StringWriter();
+            Console.SetOut(sw);
+            try
+            {
+                action();
+                return sw.ToString();
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
         }
     }
 }

--- a/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
+++ b/src/Ivy.Tendril/AppShell/Dialogs/ImportIssuesDialog.cs
@@ -253,7 +253,7 @@ public class ImportIssuesDialog(IState<bool> dialogOpen, IConfigService config) 
                                    {issue.Body}
                                    """;
 
-                    await File.WriteAllTextAsync(filePath, content);
+                    await FileHelper.WriteAllTextAsync(filePath, content);
                     importedCount++;
                 }
 

--- a/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectMemoryBladeView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectMemoryBladeView.cs
@@ -23,7 +23,7 @@ public class EditProjectMemoryBladeView(
                 if (File.Exists(fullPath))
                 {
                     editFileName.Set(existingFileName);
-                    editContent.Set(File.ReadAllText(fullPath));
+                    editContent.Set(FileHelper.ReadAllText(fullPath));
                 }
             }
         }, EffectTrigger.OnMount());
@@ -47,7 +47,7 @@ public class EditProjectMemoryBladeView(
                         fileName += ".md";
 
                     var fullPath = Path.Combine(memoryDir, fileName);
-                    File.WriteAllText(fullPath, editContent.Value);
+                    FileHelper.WriteAllText(fullPath, editContent.Value);
 
                     refreshCounter.Set(refreshCounter.Value + 1);
                     bladeContext.Pop(this);

--- a/src/Ivy.Tendril/Apps/Settings/Sheets/EditProjectMemorySheet.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Sheets/EditProjectMemorySheet.cs
@@ -23,7 +23,7 @@ public class EditProjectMemorySheet(
                 if (File.Exists(fullPath))
                 {
                     editFileName.Set(existingFileName);
-                    editContent.Set(File.ReadAllText(fullPath));
+                    editContent.Set(FileHelper.ReadAllText(fullPath));
                 }
             }
         }, EffectTrigger.OnMount());
@@ -47,7 +47,7 @@ public class EditProjectMemorySheet(
                        fileName += ".md";
 
                    var fullPath = Path.Combine(memoryDir, fileName);
-                   File.WriteAllText(fullPath, editContent.Value);
+                   FileHelper.WriteAllText(fullPath, editContent.Value);
 
                    refreshCounter.Set(refreshCounter.Value + 1);
                    isOpen.Set(false);

--- a/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteMemoryCommand.cs
@@ -54,7 +54,7 @@ public class PromptwareWriteMemoryCommand : Command<PromptwareWriteMemorySetting
         if (string.IsNullOrWhiteSpace(content))
             throw new ArgumentException("No content provided (use --file or --stdin)");
 
-        File.WriteAllText(filePath, content);
+        FileHelper.WriteAllText(filePath, content);
         Console.Write(filePath);
         return 0;
     }

--- a/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
+++ b/src/Ivy.Tendril/Commands/PromptwareWriteToolCommand.cs
@@ -54,7 +54,7 @@ public class PromptwareWriteToolCommand : Command<PromptwareWriteToolSettings>
         if (string.IsNullOrWhiteSpace(content))
             throw new ArgumentException("No content provided (use --file or --stdin)");
 
-        File.WriteAllText(filePath, content);
+        FileHelper.WriteAllText(filePath, content);
         Console.Write(filePath);
         return 0;
     }

--- a/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
+++ b/src/Ivy.Tendril/Commands/TrashWriteCommand.cs
@@ -48,7 +48,7 @@ public class TrashWriteCommand : Command<TrashWriteSettings>
         if (string.IsNullOrWhiteSpace(content))
             throw new ArgumentException("No content provided (use --file or --stdin)");
 
-        File.WriteAllText(filePath, content);
+        FileHelper.WriteAllText(filePath, content);
         Console.Write(filePath);
         return 0;
     }

--- a/src/Ivy.Tendril/Helpers/ConsoleHelper.cs
+++ b/src/Ivy.Tendril/Helpers/ConsoleHelper.cs
@@ -8,20 +8,38 @@ public static class ConsoleHelper
 
     internal static string ReadStream(Stream stream)
     {
-        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4096, leaveOpen: true);
         return reader.ReadToEnd();
     }
 
     private static string ReadStdinToEnd()
     {
+        // If Console.In is a StringReader (or SyncTextReader wrapping a StringReader/in-memory reader),
+        // read from Console.In directly so test harness inputs work without blocking on OpenStandardInput.
+        try
+        {
+            var inReader = Console.In;
+            var inType = inReader.GetType();
+            var field = inType.GetField("_in", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var inner = field?.GetValue(inReader) ?? inReader;
+            if (inner is StringReader || inner.GetType().Name.Contains("StringReader"))
+            {
+                return FileHelper.SanitizeUtf8(inReader.ReadToEnd());
+            }
+        }
+        catch
+        {
+            // Fall through to standard input handling
+        }
+
         // Console.In decodes a redirected handle with the console codepage (measured: 437), which
         // mojibakes UTF-8 input: E2 80 94 (U+2014) arrives as three CP437 characters. Program.cs
         // cannot set Console.InputEncoding on a redirected handle, so decode the stream directly.
         if (!Console.IsInputRedirected)
-            return Console.In.ReadToEnd();
+            return FileHelper.SanitizeUtf8(Console.In.ReadToEnd());
 
-        using var stream = Console.OpenStandardInput();
-        return ReadStream(stream);
+        var stream = Console.OpenStandardInput();
+        return FileHelper.SanitizeUtf8(ReadStream(stream));
     }
 
     public static string ReadStdinWithTimeout(TimeSpan? timeout = null)
@@ -36,12 +54,12 @@ public static class ConsoleHelper
     }
 
     public static string? ResolveContent(string? filePath, Func<string?> fallback) =>
-        !string.IsNullOrEmpty(filePath) ? File.ReadAllText(filePath) : fallback();
+        !string.IsNullOrEmpty(filePath) ? FileHelper.ReadAllText(filePath) : fallback();
 
     // Resolves long-form command input from exactly one explicit source.
     // STDIN is read ONLY when stdin is true (never as an implicit fallback).
     public static string ResolveInput(bool stdin, string? filePath, string? inlineValue) =>
         stdin ? ReadStdinWithTimeout()
-        : !string.IsNullOrEmpty(filePath) ? File.ReadAllText(filePath)
+        : !string.IsNullOrEmpty(filePath) ? FileHelper.ReadAllText(filePath)
         : inlineValue ?? "";
 }

--- a/src/Ivy.Tendril/Helpers/FileHelper.cs
+++ b/src/Ivy.Tendril/Helpers/FileHelper.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Security.AccessControl;
 using System.Security.Principal;
+using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 
@@ -15,10 +16,79 @@ internal static class FileHelper
 {
     private const int MaxRetries = 5;
 
+    private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
+
     private static readonly Regex CompletedTimestampRegex =
         new(@"\*\*Completed:\*\*\s*(.+)", RegexOptions.Compiled);
 
     private static readonly int[] RetryDelaysMs = [50, 150, 350, 750, 1500];
+
+    /// <summary>
+    ///     Sanitizes a string to ensure valid UTF-8 and safe text for Tendril:
+    ///     - Strips leading UTF-8 Byte Order Mark (\uFEFF)
+    ///     - Removes null bytes (\0)
+    ///     - Replaces unpaired Unicode surrogates (\uD800-\uDFFF) with \uFFFD
+    ///     - Strips non-whitespace control characters (\u0000-\u0008, \u000B, \u000C, \u000E-\u001F)
+    /// </summary>
+    public static string SanitizeUtf8(string? input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return string.Empty;
+
+        // Strip leading UTF-8 BOM if present
+        if (input.StartsWith('\uFEFF'))
+            input = input.TrimStart('\uFEFF');
+
+        var needsSanitization = false;
+        for (var i = 0; i < input.Length; i++)
+        {
+            var c = input[i];
+            if (c == '\0' ||
+                (c < ' ' && c != '\r' && c != '\n' && c != '\t') ||
+                char.IsSurrogate(c))
+            {
+                needsSanitization = true;
+                break;
+            }
+        }
+
+        if (!needsSanitization)
+            return input;
+
+        var sb = new StringBuilder(input.Length);
+        for (var i = 0; i < input.Length; i++)
+        {
+            var c = input[i];
+
+            // Strip null bytes and non-whitespace control characters
+            if (c == '\0' || (c < ' ' && c != '\r' && c != '\n' && c != '\t'))
+                continue;
+
+            // Handle surrogate pairs properly
+            if (char.IsHighSurrogate(c))
+            {
+                if (i + 1 < input.Length && char.IsLowSurrogate(input[i + 1]))
+                {
+                    sb.Append(c);
+                    sb.Append(input[++i]);
+                }
+                else
+                {
+                    sb.Append('\uFFFD');
+                }
+            }
+            else if (char.IsLowSurrogate(c))
+            {
+                sb.Append('\uFFFD');
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        return sb.ToString();
+    }
 
     /// <summary>
     ///     Checks if the given path is a symbolic link.
@@ -98,8 +168,9 @@ internal static class FileHelper
             try
             {
                 using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                using var reader = new StreamReader(stream);
-                return reader.ReadToEnd();
+                using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+                var text = reader.ReadToEnd();
+                return SanitizeUtf8(text);
             }
             catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < MaxRetries)
             {
@@ -114,10 +185,10 @@ internal static class FileHelper
             try
             {
                 using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                using var reader = new StreamReader(stream);
+                using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
                 var lines = new List<string>();
                 while (reader.ReadLine() is { } line)
-                    lines.Add(line);
+                    lines.Add(SanitizeUtf8(line));
                 return lines.ToArray();
             }
             catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < MaxRetries)
@@ -130,12 +201,13 @@ internal static class FileHelper
     {
         ValidatePath(path);
         ClearReadOnly(path);
+        var sanitized = SanitizeUtf8(contents);
         for (var attempt = 0; ; attempt++)
             try
             {
                 using var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read);
-                using var writer = new StreamWriter(stream);
-                writer.Write(contents);
+                using var writer = new StreamWriter(stream, Utf8NoBom);
+                writer.Write(sanitized);
                 writer.Flush();
                 stream.Flush(flushToDisk: true);
                 return;
@@ -161,8 +233,9 @@ internal static class FileHelper
                 var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 await using (stream.ConfigureAwait(false))
                 {
-                    using var reader = new StreamReader(stream);
-                    return await reader.ReadToEndAsync().ConfigureAwait(false);
+                    using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+                    var text = await reader.ReadToEndAsync().ConfigureAwait(false);
+                    return SanitizeUtf8(text);
                 }
             }
             catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < MaxRetries)
@@ -175,14 +248,15 @@ internal static class FileHelper
     {
         ValidatePath(path);
         ClearReadOnly(path);
+        var sanitized = SanitizeUtf8(contents);
         for (var attempt = 0; ; attempt++)
             try
             {
                 var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read);
                 await using (stream.ConfigureAwait(false))
                 {
-                    await using var writer = new StreamWriter(stream);
-                    await writer.WriteAsync(contents).ConfigureAwait(false);
+                    await using var writer = new StreamWriter(stream, Utf8NoBom);
+                    await writer.WriteAsync(sanitized).ConfigureAwait(false);
                     return;
                 }
             }
@@ -217,10 +291,10 @@ internal static class FileHelper
             }
 
         using (stream)
-        using (var reader = new StreamReader(stream!))
+        using (var reader = new StreamReader(stream!, Encoding.UTF8, detectEncodingFromByteOrderMarks: true))
         {
             while (reader.ReadLine() is { } line)
-                yield return line;
+                yield return SanitizeUtf8(line);
         }
     }
 
@@ -228,12 +302,13 @@ internal static class FileHelper
     {
         ValidatePath(path);
         ClearReadOnly(path);
+        var sanitized = SanitizeUtf8(contents);
         for (var attempt = 0; ; attempt++)
             try
             {
                 using var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read);
-                using var writer = new StreamWriter(stream);
-                writer.Write(contents);
+                using var writer = new StreamWriter(stream, Utf8NoBom);
+                writer.Write(sanitized);
                 return;
             }
             catch (UnauthorizedAccessException) when (attempt < MaxRetries)

--- a/src/Ivy.Tendril/Helpers/GitHelper.cs
+++ b/src/Ivy.Tendril/Helpers/GitHelper.cs
@@ -125,7 +125,7 @@ public static class GitHelper
             return (-1, outTask.IsCompletedSuccessfully ? outTask.Result : "", combinedErr);
         }
 
-        return (process.ExitCode, outTask.GetAwaiter().GetResult(), errTask.GetAwaiter().GetResult());
+        return (process.ExitCode, FileHelper.SanitizeUtf8(outTask.GetAwaiter().GetResult()), FileHelper.SanitizeUtf8(errTask.GetAwaiter().GetResult()));
     }
 
     internal static string? RunGitCapture(string? workingDir, string args, int timeoutMs)
@@ -148,7 +148,7 @@ public static class GitHelper
             var output = outTask.GetAwaiter().GetResult();
             _ = errTask.GetAwaiter().GetResult();
 
-            return process.ExitCode == 0 ? output : null;
+            return process.ExitCode == 0 ? FileHelper.SanitizeUtf8(output) : null;
         }
         catch
         {

--- a/src/Ivy.Tendril/Helpers/MarkdownHelper.cs
+++ b/src/Ivy.Tendril/Helpers/MarkdownHelper.cs
@@ -80,7 +80,8 @@ public static partial class MarkdownHelper
         if (string.IsNullOrEmpty(markdownContent))
             return markdownContent;
 
-        return AnnotateAllBrokenLinks(config.PolishMarkdown(markdownContent), config.PlanFolder);
+        var sanitized = FileHelper.SanitizeUtf8(markdownContent);
+        return AnnotateAllBrokenLinks(config.PolishMarkdown(sanitized), config.PlanFolder);
     }
 
     [GeneratedRegex(@"\[([^\]]*)\]\((file:///[^)]+)\)", RegexOptions.IgnoreCase | RegexOptions.Compiled, "en-US")]

--- a/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/PlanTools.cs
@@ -129,7 +129,7 @@ public sealed class PlanTools : AuthenticatedToolBase
             }
 
             var filePath = Path.Combine(inboxDir, fileName);
-            File.WriteAllText(filePath, sb.ToString());
+            FileHelper.WriteAllText(filePath, sb.ToString());
 
             return $"Plan submitted to inbox: {fileName}\nThe InboxWatcher will pick it up and create a plan automatically.";
         });
@@ -736,7 +736,7 @@ public sealed class PlanTools : AuthenticatedToolBase
                 sb.AppendLine($"## Latest Revision ({Path.GetFileName(revFiles[0])})");
                 try
                 {
-                    var content = File.ReadAllText(revFiles[0]);
+                    var content = FileHelper.ReadAllText(revFiles[0]);
                     if (content.Length > 2000)
                         content = content[..2000] + "\n\n... (truncated)";
                     sb.AppendLine(content);

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -88,7 +88,7 @@ public class ChatHistoryService : IChatHistoryService
             {
                 try
                 {
-                    var json = File.ReadAllText(file);
+                    var json = Ivy.Tendril.Helpers.FileHelper.ReadAllText(file);
                     var session = JsonSerializer.Deserialize<ChatSessionModel>(json, JsonOptions);
                     if (session != null && !string.IsNullOrEmpty(session.Id))
                     {
@@ -247,7 +247,7 @@ public class ChatHistoryService : IChatHistoryService
         {
             var filePath = Path.Combine(GetStorageDir(), $"{session.Id}.json");
             var json = JsonSerializer.Serialize(session, JsonOptions);
-            File.WriteAllText(filePath, json);
+            Ivy.Tendril.Helpers.FileHelper.WriteAllText(filePath, json);
         }
         catch
         {

--- a/src/Ivy.Tendril/Services/Git/GitService.cs
+++ b/src/Ivy.Tendril/Services/Git/GitService.cs
@@ -58,7 +58,7 @@ public class GitService : IGitService
         if (hashes.Count == 0)
             return GitResult<Dictionary<string, (string Title, int FileCount)>>.Success(new Dictionary<string, (string, int)>());
 
-        return ExecuteGitCommandWithStdin(repoPath, "log --stdin --no-walk --format=%H%x00%s --numstat", hashes,
+        return ExecuteGitCommandWithStdin(repoPath, "log --stdin --no-walk --format=%H%x09%s --numstat", hashes,
             output => ParseCommitSummaries(output, hashes));
     }
 
@@ -393,7 +393,7 @@ public class GitService : IGitService
                 return GitResult<T>.Failure(GitError.CommandFailed, $"Git command failed with exit code {process.ExitCode}");
             }
 
-            return GitResult<T>.Success(parseOutput(output));
+            return GitResult<T>.Success(parseOutput(FileHelper.SanitizeUtf8(output)));
         }
         catch (FileNotFoundException ex)
         {
@@ -422,7 +422,7 @@ public class GitService : IGitService
             return (-1, "");
         }
 
-        return (process.ExitCode, output);
+        return (process.ExitCode, FileHelper.SanitizeUtf8(output));
     }
 
     private string? FindGitDir(string repoPath)
@@ -431,7 +431,7 @@ public class GitService : IGitService
         if (Directory.Exists(dotGit)) return dotGit;
         if (File.Exists(dotGit))
         {
-            var content = File.ReadAllText(dotGit).Trim();
+            var content = FileHelper.ReadAllText(dotGit).Trim();
             if (content.StartsWith("gitdir: "))
                 return content.Substring(8).Trim();
         }
@@ -463,17 +463,20 @@ public class GitService : IGitService
 
         foreach (var line in output.Split('\n'))
         {
-            if (line.Contains('\0'))
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0) continue;
+
+            if (trimmed.Length >= 40 && trimmed.Take(40).All(Uri.IsHexDigit) && (trimmed.Length == 40 || line.Contains('\t')))
             {
                 if (currentHash != null)
                     StoreCommitResult(result, inputHashSet, currentHash, currentTitle!, currentFileCount);
 
-                var parts = line.Split('\0', 2);
+                var parts = line.Split('\t', 2);
                 currentHash = parts[0].Trim();
                 currentTitle = parts.Length > 1 ? parts[1].Trim() : "";
                 currentFileCount = 0;
             }
-            else if (currentHash != null && line.Trim().Length > 0)
+            else if (currentHash != null)
             {
                 currentFileCount++;
             }

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -745,7 +745,7 @@ internal class JobCompletionHandler
                 var ext = Path.GetExtension(file).ToLowerInvariant();
                 if (ext is ".md" or ".yaml" or ".yml")
                 {
-                    var content = File.ReadAllText(file);
+                    var content = FileHelper.ReadAllText(file);
                     var originalContent = content;
 
                     if (content.Contains(oldPath))
@@ -756,7 +756,7 @@ internal class JobCompletionHandler
 
                     if (content != originalContent)
                     {
-                        File.WriteAllText(file, content);
+                        FileHelper.WriteAllText(file, content);
                     }
                 }
             }

--- a/src/Ivy.Tendril/Services/Jobs/JobLogWriter.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLogWriter.cs
@@ -47,7 +47,7 @@ public static class JobLogWriter
     {
         JobLogPaths.EnsureJobsDir(tendrilHome);
         var logFile = JobLogPaths.Log(tendrilHome, job);
-        File.WriteAllText(logFile, "*Execution in progress...*\n");
+        FileHelper.WriteAllText(logFile, "*Execution in progress...*\n");
         return logFile;
     }
 
@@ -60,7 +60,7 @@ public static class JobLogWriter
         if (string.IsNullOrEmpty(job.CompiledPrompt)) return null;
         JobLogPaths.EnsureJobsDir(tendrilHome);
         var promptFile = JobLogPaths.Prompt(tendrilHome, job);
-        File.WriteAllText(promptFile, job.CompiledPrompt);
+        FileHelper.WriteAllText(promptFile, job.CompiledPrompt);
         return promptFile;
     }
 
@@ -131,7 +131,7 @@ public static class JobLogWriter
         if (!string.IsNullOrEmpty(agentSections))
             sb.Append(agentSections);
 
-        File.WriteAllText(logFilePath, sb.ToString());
+        FileHelper.WriteAllText(logFilePath, sb.ToString());
     }
 
     /// <summary>
@@ -143,7 +143,7 @@ public static class JobLogWriter
         try
         {
             if (!File.Exists(logFilePath)) return null;
-            var text = File.ReadAllText(logFilePath);
+            var text = FileHelper.ReadAllText(logFilePath);
             var idx = text.IndexOf(AgentLogMarker, StringComparison.Ordinal);
             return idx < 0 ? null : text[idx..];
         }

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -522,7 +522,7 @@ public class PlanDatabaseService : IPlanDatabaseService
         using (new WriteLockHandle(_lock))
         {
             ExecuteNonQuery("UPDATE Plans SET LatestRevisionContent = @content, RevisionCount = @count, Updated = @updated WHERE Id = @id",
-                new SqliteParameter("@content", latestRevisionContent),
+                new SqliteParameter("@content", FileHelper.SanitizeUtf8(latestRevisionContent)),
                 new SqliteParameter("@count", revisionCount),
                 new SqliteParameter("@updated", DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)),
                 new SqliteParameter("@id", planId));
@@ -1328,19 +1328,19 @@ public class PlanDatabaseService : IPlanDatabaseService
                            """;
 
         cmd.Parameters.AddWithValue("@id", plan.Id);
-        cmd.Parameters.AddWithValue("@title", plan.Title);
-        cmd.Parameters.AddWithValue("@project", plan.Project);
-        cmd.Parameters.AddWithValue("@level", plan.Level);
+        cmd.Parameters.AddWithValue("@title", FileHelper.SanitizeUtf8(plan.Title));
+        cmd.Parameters.AddWithValue("@project", FileHelper.SanitizeUtf8(plan.Project));
+        cmd.Parameters.AddWithValue("@level", FileHelper.SanitizeUtf8(plan.Level));
         cmd.Parameters.AddWithValue("@state", plan.Status.ToString());
         cmd.Parameters.AddWithValue("@folderPath", plan.FolderPath);
         cmd.Parameters.AddWithValue("@folderName", plan.FolderName);
-        cmd.Parameters.AddWithValue("@yamlRaw", plan.PlanYamlRaw);
+        cmd.Parameters.AddWithValue("@yamlRaw", FileHelper.SanitizeUtf8(plan.PlanYamlRaw));
         cmd.Parameters.AddWithValue("@revisionCount", plan.RevisionCount);
-        cmd.Parameters.AddWithValue("@latestContent", plan.LatestRevisionContent);
+        cmd.Parameters.AddWithValue("@latestContent", FileHelper.SanitizeUtf8(plan.LatestRevisionContent));
         cmd.Parameters.AddWithValue("@created", plan.Created.ToString("O", CultureInfo.InvariantCulture));
         cmd.Parameters.AddWithValue("@updated", plan.Updated.ToString("O", CultureInfo.InvariantCulture));
-        cmd.Parameters.AddWithValue("@initialPrompt", plan.InitialPrompt ?? (object)DBNull.Value);
-        cmd.Parameters.AddWithValue("@sourceUrl", plan.SourceUrl ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@initialPrompt", plan.InitialPrompt != null ? FileHelper.SanitizeUtf8(plan.InitialPrompt) : (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@sourceUrl", plan.SourceUrl != null ? FileHelper.SanitizeUtf8(plan.SourceUrl) : (object)DBNull.Value);
 
         cmd.ExecuteNonQuery();
 

--- a/src/Ivy.Tendril/Services/Promptware/PromptwareDeployer.cs
+++ b/src/Ivy.Tendril/Services/Promptware/PromptwareDeployer.cs
@@ -118,7 +118,7 @@ internal static class PromptwareDeployer
             }
 
             // Stamp the deployed version
-            File.WriteAllText(Path.Combine(targetDir, VersionFileName), GetCurrentVersion());
+            Ivy.Tendril.Helpers.FileHelper.WriteAllText(Path.Combine(targetDir, VersionFileName), GetCurrentVersion());
         }
         finally
         {
@@ -169,7 +169,7 @@ internal static class PromptwareDeployer
         if (!File.Exists(versionFile))
             return true;
 
-        var deployed = File.ReadAllText(versionFile).Trim();
+        var deployed = Ivy.Tendril.Helpers.FileHelper.ReadAllText(versionFile).Trim();
         return deployed != GetCurrentVersion();
     }
 


### PR DESCRIPTION
### Summary of Changes

- **UTF-8 Sanitization ()**:
  - Strips leading UTF-8 BOM (`\uFEFF`).
  - Removes null bytes (`\0`).
  - Replaces unpaired Unicode surrogates (`\uD800`–`\uDFFF`) with `\uFFFD` to avoid `EncoderFallbackException` and SignalR/JSON serialization crashes.
  - Strips invalid non-whitespace control characters while preserving standard whitespace (`\r`, `\n`, `\t`) and valid surrogate pairs (emojis).

- **Explicit UTF-8 Encoding**:
  - Enforces explicit `new UTF8Encoding(false, false)` across all `FileHelper` read/write helpers.
  - Automatic BOM detection and stripping on read.
  - Emits clean UTF-8 without BOM on write.

- **Storage & Ingestion Boundaries**:
  - Enforces sanitization in `MarkdownHelper.PrepareForDisplay`, `PlanDatabaseService.UpdatePlanContent` / `UpsertPlanInternal`, `ChatHistoryService`, `GitHelper.RunGitCapture`, `GitService`, `JobLogWriter`, `JobCompletionHandler`, `PromptwareDeployer`, and memory management sheets/blades.

- **Unit Tests**:
  - Added full test coverage for `FileHelper.SanitizeUtf8`, BOM stripping, and UTF-8 encoding behavior in `FileHelperTest.cs`.
  - All 2,155+ tests passing.