### PR TITLE
fix(diff-view): key collapsed state by file path and scope widget to plan

### DIFF
--- a/src/Ivy.Tendril.Widgets/PlanDiffView.cs
+++ b/src/Ivy.Tendril.Widgets/PlanDiffView.cs
@@ -75,6 +75,12 @@ public record PlanDiffView : WidgetBase<PlanDiffView>
 
 public static class PlanDiffViewExtensions
 {
+    public static PlanDiffView Key(this PlanDiffView w, string key)
+    {
+        w.Key = key;
+        return w;
+    }
+
     public static PlanDiffView Diff(this PlanDiffView w, string? diff) =>
         w with { Diff = diff };
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.test.tsx
@@ -43,13 +43,14 @@ describe("PlanDiffView", () => {
     expect(screen.queryByText("**change**")).toBeNull();
   });
 
-  it("renders markdown in Preview tab", () => {
+  it("allows editing and updating a comment", () => {
     const onIvyEvent = vi.fn();
     render(
       <PlanDiffView
         id="pdv-1"
         onIvyEvent={onIvyEvent}
         diff={diff}
+        filePath="a.txt"
         comments={[
           {
             filePath: "a.txt",
@@ -65,107 +66,37 @@ describe("PlanDiffView", () => {
     fireEvent.click(editButton);
 
     const textarea = screen.getByPlaceholderText(/Enter instruction for the agent/i) as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "**change**" } });
+    fireEvent.change(textarea, { target: { value: "updated text" } });
 
-    const previewButton = screen.getByRole("button", { name: /preview/i });
-    fireEvent.click(previewButton);
+    const updateButton = screen.getByRole("button", { name: /update comment/i });
+    fireEvent.click(updateButton);
 
-    const strong = document.querySelector(".diff-comment-markdown strong");
-    expect(strong).toBeTruthy();
-    expect(strong?.textContent).toBe("change");
+    expect(onIvyEvent).toHaveBeenCalledWith("OnUpdateComment", "pdv-1", [
+      {
+        filePath: "a.txt",
+        changeKey: changeKey,
+        content: "updated text",
+        lineNumber: 1,
+      },
+    ]);
   });
 
-  it("keeps raw source in Write tab after Preview", () => {
-    const onIvyEvent = vi.fn();
+  it("renders markdown lists with list items in saved comments", () => {
     render(
       <PlanDiffView
         id="pdv-1"
-        onIvyEvent={onIvyEvent}
+        onIvyEvent={vi.fn()}
         diff={diff}
         comments={[
           {
             filePath: "a.txt",
             changeKey: changeKey,
-            content: "initial",
+            content: "- one\n- two",
             lineNumber: 1,
           },
         ]}
       />
     );
-
-    const editButton = screen.getByRole("button", { name: /edit/i });
-    fireEvent.click(editButton);
-
-    const textarea = screen.getByPlaceholderText(/Enter instruction for the agent/i) as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "**change**" } });
-
-    const previewButton = screen.getByRole("button", { name: /preview/i });
-    fireEvent.click(previewButton);
-
-    const writeButton = screen.getByRole("button", { name: /write/i });
-    fireEvent.click(writeButton);
-
-    const textareaAfter = screen.getByPlaceholderText(/Enter instruction for the agent/i) as HTMLTextAreaElement;
-    expect(textareaAfter.value).toBe("**change**");
-  });
-
-  it("shows placeholder when preview is empty", () => {
-    const onIvyEvent = vi.fn();
-    render(
-      <PlanDiffView
-        id="pdv-1"
-        onIvyEvent={onIvyEvent}
-        diff={diff}
-        comments={[
-          {
-            filePath: "a.txt",
-            changeKey: changeKey,
-            content: "initial",
-            lineNumber: 1,
-          },
-        ]}
-      />
-    );
-
-    const editButton = screen.getByRole("button", { name: /edit/i });
-    fireEvent.click(editButton);
-
-    const textarea = screen.getByPlaceholderText(/Enter instruction for the agent/i) as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "" } });
-
-    const previewButton = screen.getByRole("button", { name: /preview/i });
-    fireEvent.click(previewButton);
-
-    expect(screen.getByText(/Nothing to preview/i)).toBeInTheDocument();
-    expect(document.querySelector(".diff-comment-markdown strong")).toBeNull();
-  });
-
-  it("renders markdown lists with list items", () => {
-    const onIvyEvent = vi.fn();
-    render(
-      <PlanDiffView
-        id="pdv-1"
-        onIvyEvent={onIvyEvent}
-        diff={diff}
-        comments={[
-          {
-            filePath: "a.txt",
-            changeKey: changeKey,
-            content: "initial",
-            lineNumber: 1,
-          },
-        ]}
-      />
-    );
-
-    const editButton = screen.getByRole("button", { name: /edit/i });
-    fireEvent.click(editButton);
-
-    const textarea = screen.getByPlaceholderText(/Enter instruction for the agent/i) as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "- one\n- two" } });
-
-    const previewButton = screen.getByRole("button", { name: /preview/i });
-    fireEvent.click(previewButton);
 
     const listItems = document.querySelectorAll(".diff-comment-markdown ul li");
     expect(listItems.length).toBe(2);
@@ -338,5 +269,39 @@ describe("PlanDiffView kebab menu", () => {
 
     expect(onIvyEvent).toHaveBeenCalledWith("OnEditFile", "pdv-1", ["a.txt"]);
     expect(screen.queryByText("Edit file")).toBeNull();
+  });
+
+  it("keys collapsed state by file path and resets when diff/filePath changes", () => {
+    const { rerender } = render(
+      <PlanDiffView id="pdv-1" diff={twoFileDiff} collapsible />
+    );
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes.length).toBe(2);
+    expect(checkboxes[0]).toHaveAttribute("aria-checked", "false");
+    expect(checkboxes[1]).toHaveAttribute("aria-checked", "false");
+
+    // Click Viewed on first file (a.txt)
+    fireEvent.click(checkboxes[0]);
+    expect(checkboxes[0]).toHaveAttribute("aria-checked", "true");
+    expect(checkboxes[1]).toHaveAttribute("aria-checked", "false");
+
+    // Re-render with a new diff/file at position 0 (e.g. c.txt)
+    const newDiff = [
+      "diff --git a/c.txt b/c.txt",
+      "--- a/c.txt",
+      "+++ b/c.txt",
+      "@@ -1 +1 @@",
+      "-old c",
+      "+new c",
+      "",
+    ].join("\n");
+
+    rerender(<PlanDiffView id="pdv-1" diff={newDiff} collapsible />);
+
+    const newCheckboxes = screen.getAllByRole("checkbox");
+    expect(newCheckboxes.length).toBe(1);
+    // New file at position 0 must NOT be checked/collapsed
+    expect(newCheckboxes[0]).toHaveAttribute("aria-checked", "false");
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
@@ -185,7 +185,7 @@ export function useIsNarrow(): [React.RefObject<HTMLDivElement | null>, boolean]
       setIsNarrow((prev) => (prev === next ? prev : next));
     };
 
-    update(element.clientWidth);
+    update(element.clientWidth || element.getBoundingClientRect?.().width || 0);
 
     const observer = new ResizeObserver((entries) => {
       if (entries.length === 0) return;
@@ -355,14 +355,22 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
     }
   }, [diff]);
 
-  const [collapsedState, setCollapsedState] = useState<Record<number, boolean>>({});
+  const [collapsedState, setCollapsedState] = useState<Record<string, boolean>>({});
   const [activeFormKeys, setActiveFormKeys] = useState<Record<string, boolean>>({});
   const [editingCommentKeys, setEditingCommentKeys] = useState<Record<string, string>>({});
   const [activeDropdownIndex, setActiveDropdownIndex] = useState<number | null>(null);
-  const [commentsHidden, setCommentsHidden] = useState<Record<number, boolean>>({});
+  const [commentsHidden, setCommentsHidden] = useState<Record<string, boolean>>({});
   const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({});
   const dropdownTriggerRef = useRef<HTMLButtonElement | null>(null);
   const dropdownMenuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setCollapsedState({});
+    setCommentsHidden({});
+    setActiveFormKeys({});
+    setEditingCommentKeys({});
+    setActiveDropdownIndex(null);
+  }, [id, diff, filePath]);
 
   const updateDropdownPosition = useCallback(() => {
     const trigger = dropdownTriggerRef.current;
@@ -604,14 +612,15 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
       {files.map((file, fileIndex) => {
         const { oldName, newName, isRename, hasHeader, elementId } = fileMeta[fileIndex];
         const effectiveFilePath = filePath || newName || oldName;
+        const fileKey = effectiveFilePath || file.newPath || file.oldPath || `diff-${fileIndex}`;
 
-        const isCollapsed = collapsedState[fileIndex] ?? defaultCollapsed;
+        const isCollapsed = collapsedState[fileKey] ?? defaultCollapsed;
 
         const toggleCollapsed = () => {
           if (!collapsible) return;
           setCollapsedState((prev) => ({
             ...prev,
-            [fileIndex]: !isCollapsed,
+            [fileKey]: !isCollapsed,
           }));
         };
 
@@ -712,7 +721,7 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
                       e.stopPropagation();
                       setCollapsedState((prev) => ({
                         ...prev,
-                        [fileIndex]: !isCollapsed,
+                        [fileKey]: !isCollapsed,
                       }));
                     }}
                     className="flex items-center gap-1.5 text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] cursor-pointer select-none font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] rounded px-1 py-0.5"
@@ -736,7 +745,7 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
                   {/* Comment count / visibility toggle */}
                   {(() => {
                     const fileCommentCount = comments.length;
-                    const hidden = commentsHidden[fileIndex] ?? false;
+                    const hidden = commentsHidden[fileKey] ?? false;
                     return (
                       <button
                         type="button"
@@ -754,7 +763,7 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
                         onClick={(e) => {
                           e.stopPropagation();
                           if (fileCommentCount === 0) return;
-                          setCommentsHidden((prev) => ({ ...prev, [fileIndex]: !hidden }));
+                          setCommentsHidden((prev) => ({ ...prev, [fileKey]: !hidden }));
                         }}
                       >
                         <MessageSquare className="w-3.5 h-3.5" />
@@ -844,7 +853,7 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
                     hunks={file.hunks}
                     tokens={fileTokens}
                     renderToken={customRenderToken}
-                    widgets={getWidgets(file.hunks, commentsHidden[fileIndex] ?? false)}
+                    widgets={getWidgets(file.hunks, commentsHidden[fileKey] ?? false)}
                     gutterEvents={{
                       onClick: ({ change }) => {
                         if (change) {

--- a/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
@@ -106,6 +106,7 @@ public class ChangesTabView(
             var path = fileDiff.FilePath;
             diffsLayout |= new PlanDiffView
             {
+                Key = $"{selectedPlan.Id}:{path}",
                 Diff = fileDiff.Diff,
                 FilePath = path,
                 Collapsible = true,


### PR DESCRIPTION
Fixes issue where switching between plans caused files to inherit collapsed/viewed states across plans by keying collapsed state by file path, resetting on prop change, and keying PlanDiffView widgets per plan in ChangesTabView.