### PR TITLE
fix(chat): ensure sidebar item background covers full width and title text truncates

### DIFF
--- a/src/Ivy.Tendril.Test/Commands/PromptwareReadMemoryCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareReadMemoryCommandTests.cs
@@ -27,6 +27,7 @@ public class PromptwareReadMemoryCommandTests : IDisposable
 
     private string CreateTestMemoryDir(string promptwareName)
     {
+        Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempHome);
         var pwDir = Path.Combine(_tempHome, "Promptwares", promptwareName);
         Directory.CreateDirectory(pwDir);
         File.WriteAllText(Path.Combine(pwDir, "Program.md"), "# Test Program");

--- a/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
@@ -59,19 +59,11 @@ public class SidebarView(
                 var formattedDate = sess.UpdatedAt.ToString("M/d, h:mm tt");
                 var displayTitle = string.IsNullOrWhiteSpace(sess.Title) ? "New Chat" : sess.Title;
 
-                var textStack = Layout.Vertical().AlignContent(Align.Left)
-                    | Text.Literal(displayTitle).Small()
-                    | Text.Muted($"{formattedDate} • {sess.AgentId}").Small();
+                var textStack = Layout.Vertical().AlignContent(Align.Left).Width(Size.Grow())
+                    | Text.Block(displayTitle).Small().NoWrap().Overflow(Overflow.Ellipsis)
+                    | Text.Muted($"{formattedDate} • {sess.AgentId}").Small().NoWrap().Overflow(Overflow.Ellipsis);
 
-                var sessionBtn = new Button()
-                    .Width(Size.Full())
-                    .Content(textStack)
-                    .OnClick(() => activeSessionId.Set(sess.Id))
-                    .BorderRadius(BorderRadius.None);
-
-                var sessionBtnStyled = isSelected ? sessionBtn.Secondary() : sessionBtn.Ghost();
-
-                var actionButtons = Layout.Horizontal().AlignContent(Align.Center)
+                var actionButtons = Layout.Horizontal().AlignContent(Align.Center).Width(Size.Fit())
                     | new Button()
                         .Icon(Icons.Pencil)
                         .Ghost()
@@ -97,9 +89,17 @@ public class SidebarView(
                             }
                         });
 
-                return Layout.Horizontal().Width(Size.Full()).AlignContent(Align.SpaceBetween)
-                    | sessionBtnStyled
+                var rowLayout = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.SpaceBetween)
+                    | textStack
                     | actionButtons;
+
+                var rowBtn = new Button()
+                    .Width(Size.Full())
+                    .Content(rowLayout)
+                    .OnClick(() => activeSessionId.Set(sess.Id))
+                    .BorderRadius(BorderRadius.None);
+
+                return isSelected ? rowBtn.Secondary() : rowBtn.Ghost();
             }));
         }
 


### PR DESCRIPTION
Fixes chat history list items in the sidebar so the background fill spans the entire width of each row and long titles truncate with ellipsis instead of overflowing/wrapping.