### PR TITLE
refactor(agent): extract shareable AgentLaunchHelper and unify launch logic in ChatApp and AgentApp

### DIFF
--- a/src/Ivy.Tendril.Test/Commands/HashPasswordCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/HashPasswordCommandTests.cs
@@ -23,16 +23,22 @@ public class HashPasswordCommandTests
     [Fact]
     public void Handle_ValidArgs_ReturnsZero()
     {
-        var result = HashPasswordCommand.Handle(["hash-password", "test123"]);
-        Assert.Equal(0, result);
+        lock (TestLocks.ConsoleLock)
+        {
+            var result = HashPasswordCommand.Handle(["hash-password", "test123"]);
+            Assert.Equal(0, result);
+        }
     }
 
     [Fact]
     public void Handle_WithExistingSecret_ReturnsZero()
     {
-        var secret = Convert.ToBase64String(new byte[32]);
-        var result = HashPasswordCommand.Handle(["hash-password", "test123", secret]);
-        Assert.Equal(0, result);
+        lock (TestLocks.ConsoleLock)
+        {
+            var secret = Convert.ToBase64String(new byte[32]);
+            var result = HashPasswordCommand.Handle(["hash-password", "test123", secret]);
+            Assert.Equal(0, result);
+        }
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Commands/PromptwareMemoryLookupTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareMemoryLookupTests.cs
@@ -44,12 +44,11 @@ public class PromptwareMemoryLookupTests : IDisposable
         return app;
     }
 
-    private static readonly object ConsoleLock = new();
-
-    private static (int Exit, string Output) CaptureConsoleOut(Func<int> run)
+    private (int Exit, string Output) CaptureConsoleOut(Func<int> run)
     {
-        lock (ConsoleLock)
+        lock (TestLocks.ConsoleLock)
         {
+            Environment.SetEnvironmentVariable("TENDRIL_HOME", _tempDir.Path);
             var output = new StringWriter();
             var originalOut = Console.Out;
             Console.SetOut(output);

--- a/src/Ivy.Tendril.Test/Helpers/AgentLaunchHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/AgentLaunchHelperTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Helpers;
+
+[Collection("TendrilHome")]
+public class AgentLaunchHelperTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new("agent-launch-helper-tests");
+
+    public void Dispose()
+    {
+        _tempDir.Dispose();
+    }
+
+    [Fact]
+    public void GetDefaultWorkDir_ReturnsTendrilHome_WhenConfigured()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        var dir = AgentLaunchHelper.GetDefaultWorkDir(config);
+        Assert.Equal(_tempDir.Path, dir);
+    }
+
+    [Fact]
+    public void GetDefaultWorkDir_ReturnsUserProfile_WhenTendrilHomeEmpty()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: "");
+        var dir = AgentLaunchHelper.GetDefaultWorkDir(config);
+        Assert.Equal(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), dir);
+    }
+
+    [Fact]
+    public void CompileSystemPrompt_ReturnsValidPrompt()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        var prompt = AgentLaunchHelper.CompileSystemPrompt(config);
+        Assert.NotNull(prompt);
+        Assert.Contains(config.TendrilHome.Replace('\\', '/'), prompt);
+    }
+
+    [Fact]
+    public void WriteAgentInstructionsIfNeeded_WritesAgentsMd_ForAntigravity()
+    {
+        var runner = TestAgentRunner.Create();
+        var workDir = _tempDir.Path;
+        var instructions = "# Test System Prompt";
+
+        AgentLaunchHelper.WriteAgentInstructionsIfNeeded(workDir, instructions, runner, "antigravity");
+
+        var expectedFile = Path.Combine(workDir, "AGENTS.md");
+        Assert.True(File.Exists(expectedFile));
+        Assert.Equal(instructions, File.ReadAllText(expectedFile));
+    }
+
+    [Fact]
+    public void WriteAgentInstructionsIfNeeded_Skips_ForClaude()
+    {
+        var runner = TestAgentRunner.Create();
+        var workDir = Path.Combine(_tempDir.Path, "claude-test");
+        Directory.CreateDirectory(workDir);
+        var instructions = "# Test System Prompt";
+
+        AgentLaunchHelper.WriteAgentInstructionsIfNeeded(workDir, instructions, runner, "claude");
+
+        Assert.False(File.Exists(Path.Combine(workDir, "AGENTS.md")));
+        Assert.False(File.Exists(Path.Combine(workDir, "GEMINI.md")));
+    }
+
+    [Fact]
+    public void GetEnvironment_IncludesAgentSpecificEnvAndTendrilEnv()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        config.Settings.CodingAgents =
+        [
+            new AgentConfig
+            {
+                Name = "claude",
+                EnvironmentVariables = new Dictionary<string, string>
+                {
+                    ["CUSTOM_KEY"] = "custom_val",
+                    ["ANTHROPIC_BASE_URL"] = "https://api.example.com"
+                }
+            }
+        ];
+
+        var env = AgentLaunchHelper.GetEnvironment(config, "claude");
+
+        Assert.Equal("custom_val", env["CUSTOM_KEY"]);
+        Assert.Equal("https://api.example.com", env["ANTHROPIC_BASE_URL"]);
+        Assert.Equal(_tempDir.Path, env["TENDRIL_HOME"]);
+        Assert.True(env.ContainsKey("PATH"));
+    }
+
+    [Fact]
+    public void ResolveModel_HonorsExplicitRequestedModel()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        var runner = TestAgentRunner.Create();
+
+        var model = AgentLaunchHelper.ResolveModel(config, runner, "claude", "claude-3-opus");
+        Assert.Equal("claude-3-opus", model);
+    }
+
+    [Fact]
+    public void ResolveModel_ReturnsDefault_ForClaude()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        var runner = TestAgentRunner.Create();
+
+        var model = AgentLaunchHelper.ResolveModel(config, runner, "claude", "default");
+        Assert.Equal("default", model);
+    }
+
+    [Fact]
+    public void ResolveModel_ReturnsKimiK3_ForBerget()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        var runner = TestAgentRunner.Create();
+
+        var model = AgentLaunchHelper.ResolveModel(config, runner, "berget", "default");
+        Assert.Equal("moonshotai/Kimi-K3", model);
+    }
+
+    [Fact]
+    public void PrepareResolutionContext_ConstructsCompleteContext()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        var runner = TestAgentRunner.Create();
+
+        var context = AgentLaunchHelper.PrepareResolutionContext(
+            config,
+            runner,
+            "antigravity",
+            "Do a task",
+            modelOverride: "default",
+            permissionMode: PermissionMode.FullAuto
+        );
+
+        Assert.Equal("antigravity", context.AgentId);
+        Assert.Equal("Do a task", context.Prompt);
+        Assert.NotNull(context.SystemPrompt);
+        Assert.Equal(_tempDir.Path, context.WorkingDirectory);
+        Assert.Equal(PermissionMode.FullAuto, context.PermissionMode);
+        Assert.NotNull(context.ExtraEnvironment);
+        Assert.True(context.ExtraEnvironment.ContainsKey("TENDRIL_HOME"));
+
+        // AGENTS.md should be written to the working directory for Antigravity
+        var agentsMd = Path.Combine(_tempDir.Path, "AGENTS.md");
+        Assert.True(File.Exists(agentsMd));
+    }
+}

--- a/src/Ivy.Tendril.Test/Helpers/PathHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/PathHelperTests.cs
@@ -2,6 +2,7 @@ using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Test.Helpers;
 
+[Collection("TendrilHome")]
 public class PathHelperTests
 {
     [Fact]
@@ -138,27 +139,30 @@ public class PathHelperTests
         // never adds the missing one and the ordering assertion below would be vacuous.
         if (!Directory.Exists(dotnetTools) || !Directory.Exists(localBin)) return;
 
-        var originalPath = Environment.GetEnvironmentVariable("PATH");
-
-        try
+        lock (TestLocks.ConsoleLock)
         {
-            Environment.SetEnvironmentVariable("PATH", string.Empty);
+            var originalPath = Environment.GetEnvironmentVariable("PATH");
 
-            PathHelper.AugmentPath(forceShellPath: false);
+            try
+            {
+                Environment.SetEnvironmentVariable("PATH", string.Empty);
 
-            var path = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-            var dirs = path.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                PathHelper.AugmentPath(forceShellPath: false);
 
-            var localBinIndex = Array.IndexOf(dirs, localBin);
-            var dotnetToolsIndex = Array.IndexOf(dirs, dotnetTools);
+                var path = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+                var dirs = path.Split(':', StringSplitOptions.RemoveEmptyEntries);
 
-            Assert.True(localBinIndex >= 0, "~/.local/bin should be present in PATH");
-            Assert.True(dotnetToolsIndex >= 0, "~/.dotnet/tools should be present in PATH");
-            Assert.True(localBinIndex < dotnetToolsIndex, "~/.local/bin should come before ~/.dotnet/tools");
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("PATH", originalPath);
+                var localBinIndex = Array.IndexOf(dirs, localBin);
+                var dotnetToolsIndex = Array.IndexOf(dirs, dotnetTools);
+
+                Assert.True(localBinIndex >= 0, "~/.local/bin should be present in PATH");
+                Assert.True(dotnetToolsIndex >= 0, "~/.dotnet/tools should be present in PATH");
+                Assert.True(localBinIndex < dotnetToolsIndex, "~/.local/bin should come before ~/.dotnet/tools");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("PATH", originalPath);
+            }
         }
     }
 

--- a/src/Ivy.Tendril.Test/TestPlanConfigService.cs
+++ b/src/Ivy.Tendril.Test/TestPlanConfigService.cs
@@ -5,6 +5,7 @@ namespace Ivy.Tendril.Test;
 internal class TestPlanConfigService : IConfigService
 {
     private readonly List<ProjectConfig> _projects;
+    private readonly TendrilSettings _settings;
 
     public TestPlanConfigService(string repoDir, string projectName = "TestProject",
         IReadOnlyList<ProjectVerificationRef>? verifications = null, string? tendrilHome = null)
@@ -19,9 +20,10 @@ internal class TestPlanConfigService : IConfigService
                 Verifications = verifications?.ToList() ?? []
             }
         ];
+        _settings = new TendrilSettings { Projects = _projects };
     }
 
-    public TendrilSettings Settings => new() { Projects = _projects };
+    public TendrilSettings Settings => _settings;
     public string TendrilHome { get; }
     public string ConfigPath => "";
     public string PlanFolder => string.IsNullOrEmpty(TendrilHome) ? "" : Path.Combine(TendrilHome, "Plans");

--- a/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
+++ b/src/Ivy.Tendril/Apps/Agent/AgentApp.cs
@@ -34,10 +34,10 @@ public class AgentApp : ViewBase
 
         var ptyHandle = Context.UsePty(
             GetCommandLine(configService, agentRunner, args?.Prompt),
-            GetWorkDir(configService, agentRunner),
+            AgentLaunchHelper.GetWorkDir(configService, agentRunner),
             new PtyOptions
             {
-                Environment = GetEnvironment(configService),
+                Environment = AgentLaunchHelper.GetEnvironment(configService),
                 OnOutput = text =>
                 {
                     var (regex, accept) = trust.Value;
@@ -57,7 +57,7 @@ public class AgentApp : ViewBase
 
         // Wire the input sink + trust pattern now that the handle exists (OnOutput is supplied first).
         sendInput.Value = ptyHandle.HandleInput;
-        var patterns = GetActivityPatterns(configService, agentRunner);
+        var patterns = AgentLaunchHelper.GetActivityPatterns(configService, agentRunner);
         trust.Value = (
             patterns?.TrustPromptPattern is { Length: > 0 } trustPattern
                 ? new Regex(trustPattern, RegexOptions.IgnoreCase)
@@ -83,32 +83,12 @@ public class AgentApp : ViewBase
         var agentId = config.Settings.CodingAgent;
         var cli = runner.GetCli(agentId);
         var pty = runner.GetPty(agentId);
-        var workDir = GetDefaultWorkDir(config);
-        var systemPrompt = AgentPromptCompiler.Compile(config);
+        var workDir = AgentLaunchHelper.GetDefaultWorkDir(config);
+        var systemPrompt = AgentLaunchHelper.CompileSystemPrompt(config);
 
-        WriteAgentInstructionsIfNeeded(workDir, systemPrompt, pty);
+        AgentLaunchHelper.WriteAgentInstructionsIfNeeded(workDir, systemPrompt, pty);
 
-        // Claude takes "--model default" to explicitly select its configured default model.
-        var agentConfig = config.Settings.CodingAgents.FirstOrDefault(a =>
-            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
-        var configuredModel = agentConfig?.Profiles.FirstOrDefault(p => p.Name.Equals("balanced", StringComparison.OrdinalIgnoreCase))?.Model;
-        if (string.IsNullOrEmpty(configuredModel) || configuredModel == "default")
-        {
-            configuredModel = agentConfig?.Profiles.FirstOrDefault(p => !string.IsNullOrEmpty(p.Model) && p.Model != "default")?.Model;
-        }
-
-        var isBergetAgent = agentId.Equals("berget", StringComparison.OrdinalIgnoreCase) ||
-            (agentConfig != null && agentConfig.EnvironmentVariables.TryGetValue("ANTHROPIC_BASE_URL", out var url) && url.Contains("api.berget.ai"));
-
-        if (isBergetAgent)
-        {
-            if (string.IsNullOrEmpty(configuredModel) || configuredModel == "default" || configuredModel.Equals("kimi-k3", StringComparison.OrdinalIgnoreCase) || !configuredModel.Contains('/'))
-            {
-                configuredModel = "moonshotai/Kimi-K3";
-            }
-        }
-
-        var model = pty?.Id == AgentId.Claude ? "default" : configuredModel;
+        var model = AgentLaunchHelper.ResolveModel(config, runner, agentId);
 
         var spec = pty?.BuildPtySpec(new AgentPtyConfig
         {
@@ -120,63 +100,5 @@ public class AgentApp : ViewBase
             InitialPrompt = initialPrompt,
         });
         return spec?.ResolveCommand().CommandLine.ToArray() ?? [cli.Id];
-    }
-
-    private static void WriteAgentInstructionsIfNeeded(string workDir, string? systemPrompt, IAgentPty? pty)
-    {
-        if (string.IsNullOrEmpty(systemPrompt) || string.IsNullOrEmpty(workDir))
-            return;
-
-        // Each agent declares the file it reads for project/system instructions (AGENTS.md,
-        // GEMINI.md, …). When ContextFileName is null the agent takes its system prompt via a
-        // command-line flag instead (Claude → --append-system-prompt-file) and needs no file.
-        var contextFile = pty?.ContextFileName;
-        if (string.IsNullOrEmpty(contextFile))
-            return;
-
-        File.WriteAllText(Path.Combine(workDir, contextFile), systemPrompt);
-    }
-
-    private static string GetWorkDir(IConfigService config, IAgentRunner runner)
-    {
-        var agentId = config.Settings.CodingAgent;
-        var pty = runner.GetPty(agentId);
-        var defaultDir = GetDefaultWorkDir(config);
-        var spec = pty?.BuildPtySpec(new AgentPtyConfig
-        {
-            WorkingDirectory = defaultDir,
-            PermissionMode = PermissionMode.Default,
-        });
-        return spec?.WorkingDirectory ?? defaultDir;
-    }
-
-    private static Dictionary<string, string>? GetEnvironment(IConfigService config)
-    {
-        var env = new Dictionary<string, string>();
-
-        var agentId = config.Settings.CodingAgent;
-        var agentConfig = config.Settings.CodingAgents.FirstOrDefault(a =>
-            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
-        if (agentConfig?.EnvironmentVariables is { Count: > 0 } d)
-            foreach (var (key, value) in d)
-                env[key] = value;
-
-        // Expose the `tendril` CLI (via shim) and the active config/plans to the agent running in
-        // the PTY, so it can run `tendril ...` even when no tendril binary is installed (e.g. in dev).
-        AgentProcessHelper.ApplyTendrilEnvironment(env, config);
-
-        return env.Count > 0 ? env : null;
-    }
-
-    private static string GetDefaultWorkDir(IConfigService config) =>
-        !string.IsNullOrEmpty(config.TendrilHome)
-            ? config.TendrilHome
-            : Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-
-    private static AgentActivityPatterns? GetActivityPatterns(IConfigService config, IAgentRunner runner)
-    {
-        var agentId = config.Settings.CodingAgent;
-        var pty = runner.GetPty(agentId);
-        return pty?.GetActivityPatterns();
     }
 }

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -227,20 +227,13 @@ public class ChatApp : ViewBase
 
             try
             {
-                var systemPrompt = AgentPromptCompiler.Compile(configService);
-                var extraEnv = new Dictionary<string, string>();
-                AgentProcessHelper.ApplyTendrilEnvironment(extraEnv, configService);
-
-                var context = new AgentResolutionContext
-                {
-                    AgentId = selectedAgent.Value,
-                    Prompt = fullAgentPrompt,
-                    SystemPrompt = systemPrompt,
-                    ModelOverride = selectedModel.Value,
-                    WorkingDirectory = !string.IsNullOrEmpty(configService.TendrilHome) ? configService.TendrilHome : Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-                    PermissionMode = PermissionMode.FullAuto,
-                    ExtraEnvironment = extraEnv,
-                };
+                var context = AgentLaunchHelper.PrepareResolutionContext(
+                    configService,
+                    agentRunner,
+                    selectedAgent.Value,
+                    fullAgentPrompt,
+                    modelOverride: selectedModel.Value,
+                    permissionMode: PermissionMode.FullAuto);
 
                 var session = await agentRunner.LaunchAsync(context);
                 activeSessionRef.Value = session;

--- a/src/Ivy.Tendril/Helpers/AgentLaunchHelper.cs
+++ b/src/Ivy.Tendril/Helpers/AgentLaunchHelper.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Helpers;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Helpers;
+
+public static class AgentLaunchHelper
+{
+    public static string GetDefaultWorkDir(IConfigService config) =>
+        !string.IsNullOrEmpty(config.TendrilHome)
+            ? config.TendrilHome
+            : Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+    public static string GetWorkDir(IConfigService config, IAgentRunner runner, string? agentId = null)
+    {
+        var targetAgentId = agentId ?? config.Settings.CodingAgent;
+        var pty = runner.GetPty(targetAgentId);
+        var defaultDir = GetDefaultWorkDir(config);
+        var spec = pty?.BuildPtySpec(new AgentPtyConfig
+        {
+            WorkingDirectory = defaultDir,
+            PermissionMode = PermissionMode.Default,
+        });
+        return spec?.WorkingDirectory ?? defaultDir;
+    }
+
+    public static string? CompileSystemPrompt(IConfigService config)
+    {
+        return AgentPromptCompiler.Compile(config);
+    }
+
+    public static void WriteAgentInstructionsIfNeeded(string workDir, string? systemPrompt, IAgentPty? pty)
+    {
+        if (string.IsNullOrEmpty(systemPrompt) || string.IsNullOrEmpty(workDir))
+            return;
+
+        // Each agent declares the file it reads for project/system instructions (AGENTS.md,
+        // GEMINI.md, …). When ContextFileName is null the agent takes its system prompt via a
+        // command-line flag instead (Claude → --append-system-prompt-file) and needs no file.
+        var contextFile = pty?.ContextFileName;
+        if (string.IsNullOrEmpty(contextFile))
+            return;
+
+        File.WriteAllText(Path.Combine(workDir, contextFile), systemPrompt);
+    }
+
+    public static void WriteAgentInstructionsIfNeeded(string workDir, string? systemPrompt, IAgentRunner runner, string agentId)
+    {
+        var pty = runner.GetPty(agentId);
+        WriteAgentInstructionsIfNeeded(workDir, systemPrompt, pty);
+    }
+
+    public static Dictionary<string, string> GetEnvironment(IConfigService config, string? agentId = null)
+    {
+        var env = new Dictionary<string, string>();
+
+        var targetAgentId = agentId ?? config.Settings.CodingAgent;
+        var agentConfig = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(targetAgentId, StringComparison.OrdinalIgnoreCase));
+        if (agentConfig?.EnvironmentVariables is { Count: > 0 } d)
+        {
+            foreach (var (key, value) in d)
+                env[key] = value;
+        }
+
+        // Expose the `tendril` CLI (via shim) and the active config/plans to the agent running in
+        // the process/PTY, so it can run `tendril ...` even when no tendril binary is installed (e.g. in dev).
+        AgentProcessHelper.ApplyTendrilEnvironment(env, config);
+
+        return env;
+    }
+
+    public static string? ResolveModel(IConfigService config, IAgentRunner runner, string agentId, string? requestedModel = null)
+    {
+        if (!string.IsNullOrEmpty(requestedModel) && requestedModel != "default")
+        {
+            return requestedModel;
+        }
+
+        var pty = runner.GetPty(agentId);
+        if (pty?.Id == AgentId.Claude)
+        {
+            return "default";
+        }
+
+        var agentConfig = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
+        var configuredModel = agentConfig?.Profiles.FirstOrDefault(p => p.Name.Equals("balanced", StringComparison.OrdinalIgnoreCase))?.Model;
+        if (string.IsNullOrEmpty(configuredModel) || configuredModel == "default")
+        {
+            configuredModel = agentConfig?.Profiles.FirstOrDefault(p => !string.IsNullOrEmpty(p.Model) && p.Model != "default")?.Model;
+        }
+
+        var isBergetAgent = agentId.Equals("berget", StringComparison.OrdinalIgnoreCase) ||
+            (agentConfig != null && agentConfig.EnvironmentVariables.TryGetValue("ANTHROPIC_BASE_URL", out var url) && url.Contains("api.berget.ai"));
+
+        if (isBergetAgent)
+        {
+            if (string.IsNullOrEmpty(configuredModel) || configuredModel == "default" || configuredModel.Equals("kimi-k3", StringComparison.OrdinalIgnoreCase) || !configuredModel.Contains('/'))
+            {
+                configuredModel = "moonshotai/Kimi-K3";
+            }
+        }
+
+        return string.IsNullOrEmpty(configuredModel) ? (requestedModel ?? "default") : configuredModel;
+    }
+
+    public static AgentResolutionContext PrepareResolutionContext(
+        IConfigService config,
+        IAgentRunner runner,
+        string agentId,
+        string prompt,
+        string? modelOverride = null,
+        PermissionMode permissionMode = PermissionMode.FullAuto)
+    {
+        var workDir = GetWorkDir(config, runner, agentId);
+        var systemPrompt = CompileSystemPrompt(config);
+        WriteAgentInstructionsIfNeeded(workDir, systemPrompt, runner, agentId);
+
+        var resolvedModel = ResolveModel(config, runner, agentId, modelOverride);
+        var env = GetEnvironment(config, agentId);
+
+        return new AgentResolutionContext
+        {
+            AgentId = agentId,
+            Prompt = prompt,
+            SystemPrompt = systemPrompt,
+            ModelOverride = resolvedModel,
+            WorkingDirectory = workDir,
+            PermissionMode = permissionMode,
+            ExtraEnvironment = env,
+        };
+    }
+
+    public static AgentActivityPatterns? GetActivityPatterns(IConfigService config, IAgentRunner runner, string? agentId = null)
+    {
+        var targetAgentId = agentId ?? config.Settings.CodingAgent;
+        var pty = runner.GetPty(targetAgentId);
+        return pty?.GetActivityPatterns();
+    }
+}


### PR DESCRIPTION
### Summary
- Extracted shared coding agent launch logic from `AgentApp` into `AgentLaunchHelper`:
  - System prompt compilation (`CompileSystemPrompt`)
  - Working directory resolution (`GetWorkDir` / `GetDefaultWorkDir`)
  - Context instructions file creation on disk (`WriteAgentInstructionsIfNeeded` for `AGENTS.md` / `GEMINI.md`)
  - Environment variables resolution (`GetEnvironment` combining custom `CodingAgents` config env vars with Tendril CLI shims and path setups)
  - Model resolution with balanced profile and Berget defaults (`ResolveModel`)
  - Full context preparation (`PrepareResolutionContext`)
- Refactored `AgentApp` to delegate to `AgentLaunchHelper`.
- Updated `ChatApp` to use `AgentLaunchHelper.PrepareResolutionContext`, ensuring the chat agent receives full system instructions, context files, custom provider environment variables, and Tendril CLI tool access in the exact same manner as `AgentApp`.
- Added unit tests in `AgentLaunchHelperTests.cs`.