### PR TITLE
fix(chat): prevent title text overlay by separating session button and action buttons in sidebar

### DIFF
--- a/src/Ivy.Tendril.Test/PromptwareHelperTests.cs
+++ b/src/Ivy.Tendril.Test/PromptwareHelperTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Ivy.Tendril.Test;
 
+[Collection("TendrilHome")]
 public class PromptwareHelperTests : IDisposable
 {
     private readonly string? _originalTendrilHome;

--- a/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
@@ -63,6 +63,13 @@ public class SidebarView(
                     | Text.Block(displayTitle).Small().NoWrap().Overflow(Overflow.Ellipsis)
                     | Text.Muted($"{formattedDate} • {sess.AgentId}").Small().NoWrap().Overflow(Overflow.Ellipsis);
 
+                var sessionBtn = new Button()
+                    .Width(Size.Grow())
+                    .Content(textStack)
+                    .OnClick(() => activeSessionId.Set(sess.Id))
+                    .BorderRadius(BorderRadius.None)
+                    .Ghost();
+
                 var actionButtons = Layout.Horizontal().AlignContent(Align.Center).Width(Size.Fit())
                     | new Button()
                         .Icon(Icons.Pencil)
@@ -90,16 +97,10 @@ public class SidebarView(
                         });
 
                 var rowLayout = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.SpaceBetween)
-                    | textStack
+                    | sessionBtn
                     | actionButtons;
 
-                var rowBtn = new Button()
-                    .Width(Size.Full())
-                    .Content(rowLayout)
-                    .OnClick(() => activeSessionId.Set(sess.Id))
-                    .BorderRadius(BorderRadius.None);
-
-                return isSelected ? rowBtn.Secondary() : rowBtn.Ghost();
+                return isSelected ? rowLayout.Background(Colors.Secondary) : rowLayout;
             }));
         }
 


### PR DESCRIPTION
Fixes chat sidebar session row layout so sessionBtn and actionButtons are sibling flex items in rowLayout with rowLayout receiving the full-width background, ensuring title text truncates before action buttons without overlapping.