### PR TITLE
feat(settings): add default main sidebar behavior option to Appearance settings

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1955,4 +1955,30 @@ beta: true
             Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void SidebarOpen_Setting_DefaultsAndPersists()
+    {
+        var yaml = @"
+sidebarOpen: false
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        PathHelper.DefaultTendrilHomeOverride = tempDir;
+        try
+        {
+            using var service = new ConfigService();
+            Assert.False(service.Settings.SidebarOpen);
+
+            service.Settings.SidebarOpen = true;
+            service.SaveSettings();
+
+            var yamlOnDisk = File.ReadAllText(Path.Combine(tempDir, "config.yaml"));
+            Assert.Contains("sidebarOpen: true", yamlOnDisk);
+        }
+        finally
+        {
+            PathHelper.DefaultTendrilHomeOverride = null;
+            Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -165,7 +165,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var agentRunner = UseService<IAgentRunner>();
         var menuItems = UseState(() => BuildMenuItems(appRepository, statusService.Current, config, agentRunner));
         var status = UseState(() => statusService.Current);
-        var sidebarOpen = UseState(settings.SidebarOpen);
+        var sidebarOpen = UseState(config.Settings.SidebarOpen);
         var args = UseService<AppContext>();
         var serverArgs = UseService<ServerArgs>();
         var navigate = Context.UseSignal<NavigateSignal, NavigateArgs, Unit>();
@@ -211,8 +211,11 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         // branded "Agent" item updates immediately without needing a reload.
         UseEffect(() =>
         {
-            void OnSettingsReloaded(object? sender, EventArgs e) =>
+            void OnSettingsReloaded(object? sender, EventArgs e)
+            {
                 menuItems.Set(BuildMenuItems(appRepository, status.Value, config, agentRunner));
+                sidebarOpen.Set(config.Settings.SidebarOpen);
+            }
             config.SettingsReloaded += OnSettingsReloaded;
             return Disposable.Create(() => config.SettingsReloaded -= OnSettingsReloaded);
         });

--- a/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
@@ -6,17 +6,41 @@ public class AppearanceSetupView : ViewBase
 {
     public override object Build()
     {
+        var config = UseService<IConfigService>();
         var client = UseService<IClientProvider>();
 
-        return Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(120)))
+        var isSidebarOpen = config.Settings.SidebarOpen;
+
+        return Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
                | Text.Block("Appearance").Bold()
                | Text.Muted("Choose how Tendril appears. System matches your OS setting.").Small()
-               | (Layout.Horizontal().Gap(2)
+               | (Layout.Horizontal()
                   | new Button("Light").Variant(ButtonVariant.Outline).Icon(Icons.Sun)
                       .OnClick(() => client.SetThemeMode(ThemeMode.Light))
                   | new Button("Dark").Variant(ButtonVariant.Outline).Icon(Icons.Moon)
                       .OnClick(() => client.SetThemeMode(ThemeMode.Dark))
                   | new Button("System").Variant(ButtonVariant.Outline).Icon(Icons.SunMoon)
-                      .OnClick(() => client.SetThemeMode(ThemeMode.System)));
+                      .OnClick(() => client.SetThemeMode(ThemeMode.System)))
+               | Text.Block("Main Sidebar").Bold()
+               | Text.Muted("Choose the default state for the main sidebar on startup.").Small()
+               | (Layout.Horizontal()
+                  | new Button("Expanded")
+                      .Variant(isSidebarOpen ? ButtonVariant.Primary : ButtonVariant.Outline)
+                      .Icon(Icons.PanelLeftOpen)
+                      .OnClick(() =>
+                      {
+                          config.Settings.SidebarOpen = true;
+                          config.SaveSettings();
+                          client.Toast("Sidebar set to expanded by default", "Saved");
+                      })
+                  | new Button("Collapsed")
+                      .Variant(!isSidebarOpen ? ButtonVariant.Primary : ButtonVariant.Outline)
+                      .Icon(Icons.PanelLeftClose)
+                      .OnClick(() =>
+                      {
+                          config.Settings.SidebarOpen = false;
+                          config.SaveSettings();
+                          client.Toast("Sidebar set to collapsed by default", "Saved");
+                      }));
     }
 }

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -220,6 +220,7 @@ public class TendrilSettings
     public Tunnel.TunnelConfig? Tunnel { get; set; }
     public bool Telemetry { get; set; } = true;
     public bool DesktopNotifications { get; set; } = true;
+    public bool SidebarOpen { get; set; } = true;
     public bool Beta { get; set; } = false;
     public string? DismissedUpdateVersion { get; set; }
 


### PR DESCRIPTION
### Summary
- Added `SidebarOpen` (`bool`, defaults to `true`) to `TendrilSettings`.
- Added option in `AppearanceSetupView` to configure the default state of the main sidebar on startup (`Expanded` vs `Collapsed`).
- Updated `TendrilAppShell` to initialize and sync its sidebar state with `config.Settings.SidebarOpen`.
- Added unit tests in `ConfigServiceTests` to verify serialization and persistence.