### PR TITLE
feat(chat): remove sidebar action buttons and add delete button in chat header

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -125,4 +125,38 @@ describe("ChatWidget Queued Messages UI", () => {
     );
     expect(screen.queryByText("Queued Messages")).not.toBeInTheDocument();
   });
+
+  it("renders delete button next to chat title and emits OnDeleteSession", () => {
+    const handleEvent = vi.fn();
+    const session = {
+      id: "sess-123",
+      title: "My Great Chat",
+      agentId: "antigravity",
+      modelId: "gemini-3.7-flash",
+      createdAt: "2026-08-15T12:00:00Z",
+      updatedAt: "2026-08-15T12:30:00Z",
+      messages: [],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-123"
+        sessions={[session]}
+        events={["OnDeleteSession"]}
+        eventHandler={handleEvent}
+      />
+    );
+
+    const deleteBtn = screen.getByRole("button", { name: /Delete chat session/i });
+    expect(deleteBtn).toBeInTheDocument();
+
+    fireEvent.click(deleteBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnDeleteSession",
+      "test-chat",
+      ["sess-123"]
+    );
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -516,11 +516,27 @@ export function ChatWidget({
                 autoFocus
               />
             ) : (
-              <div className="chat-header-title-row" onClick={startHeaderTitleEdit} title="Click to rename chat">
-                <h1 className="chat-main-title">
-                  {(activeSession && pendingRenames[activeSession.id]) || activeSession?.title || "New Chat"}
-                </h1>
-                <Pencil size={13} className="chat-title-pencil" />
+              <div className="chat-header-title-row">
+                <div className="chat-header-title-clickable" onClick={startHeaderTitleEdit} title="Click to rename chat">
+                  <h1 className="chat-main-title">
+                    {(activeSession && pendingRenames[activeSession.id]) || activeSession?.title || "New Chat"}
+                  </h1>
+                  <Pencil size={13} className="chat-title-pencil" />
+                </div>
+                {activeSession && (
+                  <button
+                    type="button"
+                    className="chat-header-delete-btn"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      emit("OnDeleteSession", activeSession.id);
+                    }}
+                    title="Delete chat session"
+                    aria-label="Delete chat session"
+                  >
+                    <Trash2 size={13} />
+                  </button>
+                )}
               </div>
             )}
           </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -256,13 +256,19 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.chat-header-title-clickable {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   cursor: pointer;
   padding: 0.125rem 0.375rem;
   border-radius: var(--radius, 4px);
   transition: background-color 0.15s ease;
 }
 
-.chat-header-title-row:hover {
+.chat-header-title-clickable:hover {
   background-color: var(--accent);
 }
 
@@ -279,9 +285,29 @@
   transition: opacity 0.15s ease, color 0.15s ease;
 }
 
-.chat-header-title-row:hover .chat-title-pencil {
+.chat-header-title-clickable:hover .chat-title-pencil {
   opacity: 1;
   color: var(--foreground);
+}
+
+.chat-header-delete-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: var(--radius, 4px);
+  color: var(--muted-foreground);
+  opacity: 0.5;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.15s ease, color 0.15s ease, background-color 0.15s ease;
+}
+
+.chat-header-delete-btn:hover {
+  opacity: 1;
+  color: var(--destructive, #ef4444);
+  background-color: var(--accent);
 }
 
 .chat-main-title-input {

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -50,8 +50,6 @@ public class ChatApp : ViewBase
         var initialHandled = UseRef(false);
 
         var searchState = UseState("");
-        var renamingSessionId = UseState<string?>(null);
-        var renameText = UseState("");
 
         UseEffect(() =>
         {
@@ -367,8 +365,6 @@ public class ChatApp : ViewBase
             sessionVersion,
             selectedAgent,
             selectedModel,
-            renamingSessionId,
-            renameText,
             searchState,
             chatService
         );
@@ -393,12 +389,7 @@ public class ChatApp : ViewBase
             SendMessage
         );
 
-        var layoutView = new SidebarLayout(content, sidebar).SidebarContentScroll(Scroll.None);
-
-        return new Fragment(
-            layoutView,
-            new RenameSessionDialog(renamingSessionId, renameText, chatService, sessionVersion)
-        );
+        return new SidebarLayout(content, sidebar).SidebarContentScroll(Scroll.None);
     }
 
     internal static List<(string Id, string DisplayName)> GetModelsForAgent(IAgentRunner runner, string agentId)

--- a/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
@@ -15,8 +15,6 @@ public class SidebarView(
     IState<int> sessionVersion,
     IState<string> selectedAgent,
     IState<string> selectedModel,
-    IState<string?> renamingSessionId,
-    IState<string> renameText,
     IState<string> searchState,
     IChatHistoryService chatService) : ViewBase
 {
@@ -59,48 +57,17 @@ public class SidebarView(
                 var formattedDate = sess.UpdatedAt.ToString("M/d, h:mm tt");
                 var displayTitle = string.IsNullOrWhiteSpace(sess.Title) ? "New Chat" : sess.Title;
 
-                var textStack = Layout.Vertical().AlignContent(Align.Left).Width(Size.Grow())
+                var textStack = Layout.Vertical().AlignContent(Align.Left).Width(Size.Full())
                     | Text.Block(displayTitle).Small().NoWrap().Overflow(Overflow.Ellipsis)
                     | Text.Muted($"{formattedDate} • {sess.AgentId}").Small().NoWrap().Overflow(Overflow.Ellipsis);
 
                 var sessionBtn = new Button()
-                    .Width(Size.Grow())
+                    .Width(Size.Full())
                     .Content(textStack)
                     .OnClick(() => activeSessionId.Set(sess.Id))
-                    .BorderRadius(BorderRadius.None)
-                    .Ghost();
+                    .BorderRadius(BorderRadius.None);
 
-                var actionButtons = Layout.Horizontal().AlignContent(Align.Center).Width(Size.Fit())
-                    | new Button()
-                        .Icon(Icons.Pencil)
-                        .Ghost()
-                        .Small()
-                        .OnClick(() =>
-                        {
-                            renamingSessionId.Set(sess.Id);
-                            var cleanTitle = sess.Title.TrimEnd('.').TrimEnd('…').Trim();
-                            renameText.Set(cleanTitle);
-                        })
-                    | new Button()
-                        .Icon(Icons.Trash2)
-                        .Ghost()
-                        .Small()
-                        .OnClick(() =>
-                        {
-                            chatService.DeleteSession(sess.Id);
-                            sessionVersion.Set(v => v + 1);
-                            if (activeSessionId.Value == sess.Id)
-                            {
-                                var remaining = chatService.GetSessions();
-                                activeSessionId.Set(remaining.FirstOrDefault()?.Id);
-                            }
-                        });
-
-                var rowLayout = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.SpaceBetween)
-                    | sessionBtn
-                    | actionButtons;
-
-                return isSelected ? rowLayout.Background(Colors.Secondary) : rowLayout;
+                return isSelected ? sessionBtn.Secondary() : sessionBtn.Ghost();
             }));
         }
 


### PR DESCRIPTION
### Summary
- Removed edit and delete action buttons from the Chat sidebar session items, giving full-width space to chat titles and subtitles.
- Added a delete button (Trash2 icon) directly next to the title and edit pencil in the open chat header.
- Added unit test in `ChatWidget.test.tsx` for the header delete button.
- Rebuilt frontend widget bundle.