### PR TITLE
feat(chat): move delete button to top right and remove agent/model header chips

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -516,34 +516,30 @@ export function ChatWidget({
                 autoFocus
               />
             ) : (
-              <div className="chat-header-title-row">
-                <div className="chat-header-title-clickable" onClick={startHeaderTitleEdit} title="Click to rename chat">
-                  <h1 className="chat-main-title">
-                    {(activeSession && pendingRenames[activeSession.id]) || activeSession?.title || "New Chat"}
-                  </h1>
-                  <Pencil size={13} className="chat-title-pencil" />
-                </div>
-                {activeSession && (
-                  <button
-                    type="button"
-                    className="chat-header-delete-btn"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      emit("OnDeleteSession", activeSession.id);
-                    }}
-                    title="Delete chat session"
-                    aria-label="Delete chat session"
-                  >
-                    <Trash2 size={13} />
-                  </button>
-                )}
+              <div className="chat-header-title-clickable" onClick={startHeaderTitleEdit} title="Click to rename chat">
+                <h1 className="chat-main-title">
+                  {(activeSession && pendingRenames[activeSession.id]) || activeSession?.title || "New Chat"}
+                </h1>
+                <Pencil size={13} className="chat-title-pencil" />
               </div>
             )}
           </div>
-          <div className="chat-header-badges">
-            <span className="chat-badge">{selectedAgent}</span>
-            <span className="chat-badge">{selectedModel}</span>
-          </div>
+          {activeSession && (
+            <div className="chat-header-actions">
+              <button
+                type="button"
+                className="chat-header-delete-btn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  emit("OnDeleteSession", activeSession.id);
+                }}
+                title="Delete chat session"
+                aria-label="Delete chat session"
+              >
+                <Trash2 size={16} />
+              </button>
+            </div>
+          )}
         </div>
 
         {/* Message List Container */}

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -252,12 +252,6 @@
   flex: 1;
 }
 
-.chat-header-title-row {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
 .chat-header-title-clickable {
   display: flex;
   align-items: center;
@@ -290,14 +284,20 @@
   color: var(--foreground);
 }
 
+.chat-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
 .chat-header-delete-btn {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0.25rem;
+  padding: 0.375rem;
   border-radius: var(--radius, 4px);
   color: var(--muted-foreground);
-  opacity: 0.5;
+  opacity: 0.6;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -321,22 +321,6 @@
   outline: none;
   width: 280px;
   font-family: inherit;
-}
-
-.chat-header-badges {
-  display: flex;
-  align-items: center;
-  gap: 0.375rem;
-}
-
-.chat-badge {
-  padding: 0.125rem 0.5rem;
-  border-radius: var(--radius, 6px);
-  font-size: 0.75rem;
-  font-weight: 500;
-  background-color: var(--muted);
-  color: var(--muted-foreground);
-  border: 1px solid var(--border);
 }
 
 .chat-messages-container {


### PR DESCRIPTION
### Summary
- Removed the agent and model chips from the top right of the Chat header.
- Placed the delete button (Trash2 icon) in the top right header actions area.
- Rebuilt frontend widget bundle and verified tests.