### PR TITLE
fix(agent-viewer): ensure theme-responsive blockquote and GitHub alert styling

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
@@ -13,6 +13,7 @@ import { ResultSummary } from "./result-summary";
 import { groupToolUseEvents } from "./group-events";
 import { ToolUseGroup } from "./tool-use-group";
 import { getMarkdownPlugins } from "../math";
+import { AlertBlockquote } from "../DraftMarkdown/AlertBlockquote";
 
 function buildSuppressIndices(events: PresentationEvent[]): Set<number> {
   const indices = new Set<number>();
@@ -188,7 +189,10 @@ export const AgentViewer: React.FC<AgentViewerProps> = ({
             case "assistant-text":
               return (
                 <div key={idx} className="aov-markdown aov-assistant">
-                  <Markdown {...getMarkdownPlugins(event.text)} components={{ code: CodeBlock }}>
+                  <Markdown
+                    {...getMarkdownPlugins(event.text)}
+                    components={{ code: CodeBlock, blockquote: AlertBlockquote }}
+                  >
                     {event.text}
                   </Markdown>
                 </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
@@ -268,8 +268,8 @@
   margin: 0.5rem 0;
   padding: 4px 12px;
   border-left: 3px solid var(--aov-border-strong);
-  color: var(--aov-fg-muted);
-  background-color: rgba(39, 39, 42, 0.4);
+  color: var(--aov-fg);
+  background-color: color-mix(in srgb, var(--muted-foreground) 8%, transparent);
   border-radius: 0 4px 4px 0;
 }
 
@@ -342,15 +342,15 @@
 }
 
 .aov-tool-status--success {
-  background: #22c55e;
+  background: var(--green, #22c55e);
 }
 
 .aov-tool-status--error {
-  background: #ef4444;
+  background: var(--destructive, #ef4444);
 }
 
 .aov-tool-status--running {
-  background: #3b82f6;
+  background: var(--primary, #3b82f6);
   animation: aov-pulse 1.5s ease-in-out infinite;
 }
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx
@@ -3,6 +3,7 @@ import Markdown from "react-markdown";
 import type { ResultWire } from "./types";
 import { CodeBlock } from "../CodeBlock";
 import { getMarkdownPlugins } from "../math";
+import { AlertBlockquote } from "../DraftMarkdown/AlertBlockquote";
 
 interface ResultSummaryProps {
   wire: ResultWire;
@@ -57,7 +58,7 @@ export const ResultSummary: React.FC<ResultSummaryProps> = ({ wire }) => {
           <Markdown
             remarkPlugins={plugins.remarkPlugins}
             rehypePlugins={plugins.rehypePlugins}
-            components={{ code: CodeBlock }}
+            components={{ code: CodeBlock, blockquote: AlertBlockquote }}
           >
             {wire.response}
           </Markdown>

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -4,6 +4,8 @@ import { Mic, Bot, Cpu, MessageSquare, ChevronDown, Check, Pencil, Paperclip, X,
 import ReactMarkdown from "react-markdown";
 import { AgentViewer } from "../AgentViewer";
 import { getMarkdownPlugins } from "../math";
+import { CodeBlock } from "../CodeBlock";
+import { AlertBlockquote } from "../DraftMarkdown/AlertBlockquote";
 import "./chat-widget.css";
 
 export interface ChatMessageDto {
@@ -571,7 +573,10 @@ export function ChatWidget({
                   ) : (
                     msg.content && (
                       <div className="chat-markdown-body">
-                        <ReactMarkdown {...getMarkdownPlugins(msg.content)}>
+                        <ReactMarkdown
+                          {...getMarkdownPlugins(msg.content)}
+                          components={{ code: CodeBlock, blockquote: AlertBlockquote }}
+                        >
                           {msg.content}
                         </ReactMarkdown>
                       </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -605,6 +605,7 @@
   border: 1px solid;
   padding: 0.75rem 1rem;
   font-size: 0.875rem;
+  color: var(--foreground);
 }
 
 .pmv-alert-header {
@@ -625,6 +626,7 @@
 
 .pmv-alert-content {
   margin-top: 0.25rem;
+  color: var(--foreground);
 }
 
 .pmv-alert-content p {
@@ -636,43 +638,43 @@
 }
 
 .pmv-alert--note {
-  border-color: hsl(199 89% 48% / 0.3);
-  background: hsl(199 89% 48% / 0.08);
+  border-color: color-mix(in srgb, var(--primary) 30%, var(--border));
+  background: color-mix(in srgb, var(--primary) 8%, transparent);
 }
 .pmv-alert--note .pmv-alert-header {
-  color: hsl(199 89% 48%);
+  color: var(--primary);
 }
 
 .pmv-alert--tip {
-  border-color: hsl(160 84% 39% / 0.3);
-  background: hsl(160 84% 39% / 0.08);
+  border-color: color-mix(in srgb, var(--green, #22c55e) 30%, var(--border));
+  background: color-mix(in srgb, var(--green, #22c55e) 8%, transparent);
 }
 .pmv-alert--tip .pmv-alert-header {
-  color: hsl(160 84% 39%);
+  color: var(--green, #22c55e);
 }
 
 .pmv-alert--important {
-  border-color: hsl(38 92% 50% / 0.3);
-  background: hsl(38 92% 50% / 0.08);
+  border-color: color-mix(in srgb, var(--amber, #f59e0b) 30%, var(--border));
+  background: color-mix(in srgb, var(--amber, #f59e0b) 8%, transparent);
 }
 .pmv-alert--important .pmv-alert-header {
-  color: hsl(38 92% 50%);
+  color: var(--amber, #f59e0b);
 }
 
 .pmv-alert--warning {
-  border-color: hsl(38 92% 50% / 0.3);
-  background: hsl(38 92% 50% / 0.08);
+  border-color: color-mix(in srgb, var(--warning, #f59e0b) 30%, var(--border));
+  background: color-mix(in srgb, var(--warning, #f59e0b) 8%, transparent);
 }
 .pmv-alert--warning .pmv-alert-header {
-  color: hsl(38 92% 50%);
+  color: var(--warning, #f59e0b);
 }
 
 .pmv-alert--caution {
-  border-color: hsl(0 84% 60% / 0.3);
-  background: hsl(0 84% 60% / 0.08);
+  border-color: color-mix(in srgb, var(--destructive, #ef4444) 30%, var(--border));
+  background: color-mix(in srgb, var(--destructive, #ef4444) 8%, transparent);
 }
 .pmv-alert--caution .pmv-alert-header {
-  color: hsl(0 84% 60%);
+  color: var(--destructive, #ef4444);
 }
 
 /* Image viewer */


### PR DESCRIPTION
### Summary
- Wired `AlertBlockquote` into `AgentViewer`, `ResultSummary`, and `ChatWidget` markdown renderers so GitHub callouts/alerts (`[!NOTE]`, etc.) render as rich themed callout cards.
- Replaced hardcoded dark background (`rgba(39, 39, 42, 0.4)`) on `.aov-markdown blockquote` with theme-responsive `color-mix` matching the light/dark mode theme.
- Updated `.pmv-alert` borders, backgrounds, and text colors to use CSS theme variables with `color-mix`.
- Replaced hardcoded tool status hex colors with theme variables.