### PR TITLE
fix(repo): support case-insensitive repository and PR URLs (Https://, HTTPS://, Git@)

### DIFF
--- a/src/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -17,6 +17,20 @@ public class GithubServiceTests
     }
 
     [Fact]
+    public void Should_Parse_MixedCase_Https_Url()
+    {
+        var repo = GithubService.ParseRepoConfigFromUrl("Https://github.com/Ivy-Interactive/Ivy-Framework.git");
+        Assert.NotNull(repo);
+        Assert.Equal("Ivy-Interactive", repo.Owner);
+        Assert.Equal("Ivy-Framework", repo.Name);
+
+        var repo2 = GithubService.ParseRepoConfigFromUrl("HTTPS://github.com/Ivy-Interactive/Ivy-Framework.GIT");
+        Assert.NotNull(repo2);
+        Assert.Equal("Ivy-Interactive", repo2.Owner);
+        Assert.Equal("Ivy-Framework", repo2.Name);
+    }
+
+    [Fact]
     public void Should_Parse_Https_Url_Without_Git_Suffix()
     {
         var repo = GithubService.ParseRepoConfigFromUrl("https://github.com/Ivy-Interactive/Ivy-Framework");

--- a/src/Ivy.Tendril.Test/Helpers/RepoPathValidatorTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/RepoPathValidatorTests.cs
@@ -9,6 +9,8 @@ public class RepoPathValidatorTests
     [InlineData("git@gitlab.com:org/repo", RepoPathKind.SshUrl)]
     [InlineData("git@bitbucket.org:team/repo.git", RepoPathKind.SshUrl)]
     [InlineData("git@custom-host.example.com:user/project.git", RepoPathKind.SshUrl)]
+    [InlineData("Git@github.com:owner/repo.git", RepoPathKind.SshUrl)]
+    [InlineData("GIT@github.com:owner/repo.git", RepoPathKind.SshUrl)]
     public void Classify_SshUrl_ReturnsCorrect(string input, RepoPathKind expected)
     {
         Assert.Equal(expected, RepoPathValidator.Classify(input));
@@ -19,6 +21,10 @@ public class RepoPathValidatorTests
     [InlineData("https://github.com/owner/repo", RepoPathKind.HttpUrl)]
     [InlineData("http://gitlab.com/org/repo", RepoPathKind.HttpUrl)]
     [InlineData("https://bitbucket.org/team/project.git", RepoPathKind.HttpUrl)]
+    [InlineData("Https://github.com/owner/repo.git", RepoPathKind.HttpUrl)]
+    [InlineData("HTTPS://github.com/owner/repo", RepoPathKind.HttpUrl)]
+    [InlineData("Http://gitlab.com/org/repo", RepoPathKind.HttpUrl)]
+    [InlineData("HTTPS://BITBUCKET.ORG/team/project.GIT", RepoPathKind.HttpUrl)]
     public void Classify_HttpUrl_ReturnsCorrect(string input, RepoPathKind expected)
     {
         Assert.Equal(expected, RepoPathValidator.Classify(input));
@@ -48,6 +54,8 @@ public class RepoPathValidatorTests
     [InlineData("git@gitlab.com:org/my-project", "my-project")]
     [InlineData("https://github.com/owner/repo.git", "repo")]
     [InlineData("https://github.com/owner/repo", "repo")]
+    [InlineData("Https://github.com/owner/repo.git", "repo")]
+    [InlineData("HTTPS://github.com/owner/repo", "repo")]
     [InlineData("http://gitlab.com/org/my-lib.git", "my-lib")]
     [InlineData("/home/user/repos/myapp", "myapp")]
     [InlineData("~/code/project", "project")]
@@ -68,6 +76,8 @@ public class RepoPathValidatorTests
     [Theory]
     [InlineData("git@github.com:owner/repo.git")]
     [InlineData("https://github.com/owner/repo")]
+    [InlineData("Https://github.com/owner/repo")]
+    [InlineData("HTTPS://github.com/owner/repo.git")]
     [InlineData("/home/user/repos/myapp")]
     [InlineData("~/code/project")]
     public void IsValid_ValidInputs_ReturnsTrue(string input)
@@ -88,6 +98,8 @@ public class RepoPathValidatorTests
     [Theory]
     [InlineData("git@github.com:owner/repo.git")]
     [InlineData("git@gitlab.com:org/repo")]
+    [InlineData("Git@github.com:owner/repo.git")]
+    [InlineData("GIT@github.com:owner/repo.git")]
     public void IsSshUrl_ValidSsh_ReturnsTrue(string input)
     {
         Assert.True(RepoPathValidator.IsSshUrl(input));
@@ -104,6 +116,9 @@ public class RepoPathValidatorTests
     [Theory]
     [InlineData("https://github.com/owner/repo.git")]
     [InlineData("http://gitlab.com/org/repo")]
+    [InlineData("Https://github.com/owner/repo.git")]
+    [InlineData("HTTPS://github.com/owner/repo")]
+    [InlineData("Http://gitlab.com/org/repo")]
     public void IsHttpUrl_ValidHttp_ReturnsTrue(string input)
     {
         Assert.True(RepoPathValidator.IsHttpUrl(input));

--- a/src/Ivy.Tendril.Test/PrStatusSyncServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PrStatusSyncServiceTests.cs
@@ -136,6 +136,8 @@ public class PrStatusSyncServiceTests : IDisposable
         Assert.True(PullRequestApp.IsValidUrl("https://github.com/owner/repo/pull/1"));
         Assert.True(PullRequestApp.IsValidUrl("https://github.com/owner/repo/pull/123"));
         Assert.True(PullRequestApp.IsValidUrl("http://github.com/owner/repo/pull/1"));
+        Assert.True(PullRequestApp.IsValidUrl("Https://github.com/owner/repo/pull/1"));
+        Assert.True(PullRequestApp.IsValidUrl("HTTPS://GITHUB.COM/owner/repo/pull/1"));
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Apps/PullRequestApp.cs
+++ b/src/Ivy.Tendril/Apps/PullRequestApp.cs
@@ -211,7 +211,7 @@ public class PullRequestApp : ViewBase
     ///     E.g. "https://github.com/owner/repo/pull/123" -> "owner/repo"
     /// </summary>
     private static readonly Regex GitHubPrPattern = new(
-        @"^https?://github\.com/[^/]+/[^/]+/pull/\d+", RegexOptions.Compiled);
+        @"^https?://github\.com/[^/]+/[^/]+/pull/\d+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     internal static bool IsValidUrl(string? value) =>
         value is not null && GitHubPrPattern.IsMatch(value);

--- a/src/Ivy.Tendril/Helpers/RepoPathValidator.cs
+++ b/src/Ivy.Tendril/Helpers/RepoPathValidator.cs
@@ -10,12 +10,12 @@ public static class RepoPathValidator
     // git@<host>:<owner>/<repo>(.git)?
     private static readonly Regex SshPattern = new(
         @"^git@[\w.\-]+:[\w.\-]+/[\w.\-]+(?:\.git)?$",
-        RegexOptions.Compiled);
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     // http(s)://<host>/<path>(.git)?
     private static readonly Regex HttpPattern = new(
         @"^https?://[\w.\-]+(:\d+)?(/[\w.\-~%]+)+(?:\.git)?$",
-        RegexOptions.Compiled);
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     public static RepoPathKind Classify(string input)
     {

--- a/src/Ivy.Tendril/Services/Git/GithubService.cs
+++ b/src/Ivy.Tendril/Services/Git/GithubService.cs
@@ -195,7 +195,7 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
 
     internal static RepoConfig? ParseRepoConfigFromUrl(string url)
     {
-        var match = Regex.Match(url, @"[/:](?<owner>[^/]+)/(?<name>[^/]+?)(?:\.git)?$");
+        var match = Regex.Match(url, @"[/:](?<owner>[^/]+)/(?<name>[^/]+?)(?:\.git)?$", RegexOptions.IgnoreCase);
         if (!match.Success) return null;
 
         return new RepoConfig


### PR DESCRIPTION
### Summary
Enables case-insensitive parsing and validation for repository URLs and PR URLs across Tendril, allowing schemes and hosts typed with mixed or upper case (such as `Https://`, `HTTPS://`, `Http://`, `Git@...`, `.GIT`) to be properly recognized and handled.

---

### Changes
1. **[RepoPathValidator.cs](file:///Users/rorychatt/git/ivy/Ivy-Tendril/src/Ivy.Tendril/Helpers/RepoPathValidator.cs)**: Added `RegexOptions.IgnoreCase` to `HttpPattern` and `SshPattern`.
2. **[GithubService.cs](file:///Users/rorychatt/git/ivy/Ivy-Tendril/src/Ivy.Tendril/Services/Git/GithubService.cs)**: Added `RegexOptions.IgnoreCase` to `ParseRepoConfigFromUrl` to handle upper/mixed-case schemes, hosts, and `.GIT` suffixes.
3. **[PullRequestApp.cs](file:///Users/rorychatt/git/ivy/Ivy-Tendril/src/Ivy.Tendril/Apps/PullRequestApp.cs)**: Added `RegexOptions.IgnoreCase` to `GitHubPrPattern`.
4. **Unit Tests**: Added test cases in `RepoPathValidatorTests.cs`, `GithubServiceTests.cs`, and `PrStatusSyncServiceTests.cs` covering `Https://`, `HTTPS://`, `Http://`, `Git@`, and `GIT@`.