### PR TITLE
fix(jobs): disable MSBuild node reuse and dotnet build servers to prevent background pipe holds

### DIFF
--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -765,6 +765,12 @@ internal class JobLauncher
         // Deliberately no TENDRIL_JOB_ID: process env does not reach the agent's nested `tendril` calls
         // (see AGENTS.md). The job id travels as the TendrilJobId firmware header and is passed as an argument.
 
+        // Disable MSBuild node reuse and dotnet CLI build servers so background worker daemons do not
+        // outlive the agent process and hold redirected stdout/stderr pipes open (#2044).
+        psi.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+        psi.Environment["DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER"] = "1";
+        psi.Environment["DOTNET_NOLOGO"] = "1";
+
         EnsureTendrilOnPath(psi);
     }
 


### PR DESCRIPTION
### Summary
Closes #2044

Sets `MSBUILDDISABLENODEREUSE=1`, `DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1`, and `DOTNET_NOLOGO=1` in `JobLauncher.SetTendrilEnvironment` so commands run by agents during jobs do not spawn long-lived background MSBuild/Roslyn daemon processes that hold inherited stdout/stderr pipes open.