### PR TITLE
Optimize Review and Drafts app performance and eliminate tab switching lag

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -81,7 +81,7 @@ public class ContentView(
             selectedPlan?.FolderPath ?? "",
             async (folderPath, ct) => await Task.Run(() => LoadPlanContent(folderPath), ct),
             initialValue: new PlanContentData(null,
-                new Dictionary<string, List<string>>(), new List<PlanContentHelpers.CommitRow>(), new Dictionary<string, bool>(), null)
+                new Dictionary<string, List<string>>(), new List<PlanContentHelpers.CommitRow>(), new Dictionary<string, bool>(), null, new GitTabDataBuilder.GitTabData([], []))
         );
 
         // Authentication effects (was UseAuthenticationEffects)
@@ -233,7 +233,7 @@ public class ContentView(
         else
         {
             var planData = planContentQuery.Value;
-            var gitData = GitTabDataBuilder.BuildGitTabData(planData.CommitRows, selectedPlan!, config, gitService);
+            var gitData = planData.GitData ?? new GitTabDataBuilder.GitTabData([], []);
             var gitItemCount = GitTabDataBuilder.CountGitItems(gitData, selectedPlan!);
 
             var gitTabView = new GitTabView(
@@ -249,20 +249,24 @@ public class ContentView(
                 null,
                 null);
 
+            var isPlanSelected = selectedTab.Value == 0;
+            var isDetailsSelected = selectedTab.Value == 1;
+            var isGitSelected = selectedTab.Value == 2;
+
             var tabList = new List<Tab>
             {
                 // DraftMarkdown owns its own scroll and the pinned StickyContent slot,
                 // so it is not wrapped in Cap() (whose outer scroll would also scroll the
                 // pinned element). The widget reproduces Cap()'s left inset + max-width.
-                new Tab("Plan", planTabContent),
-                new Tab("Details", Cap(new DetailsTabView(selectedPlan!,
+                new Tab("Plan", isPlanSelected ? planTabContent : new Empty()),
+                new Tab("Details", isDetailsSelected ? Cap(new DetailsTabView(selectedPlan!,
                     jobService.GetJobsForPlan(selectedPlan!.FolderName),
                     showDebugJob, planService, selectedPlanState, refreshPlans,
-                    folderPath => selectedPlanState.Set(planService.GetPlanByFolder(folderPath))))),
+                    folderPath => selectedPlanState.Set(planService.GetPlanByFolder(folderPath)))) : new Empty()),
             };
 
             if (gitItemCount > 0)
-                tabList.Add(new Tab("Git", Cap(gitTabView)).Badge(gitItemCount.ToString()));
+                tabList.Add(new Tab("Git", isGitSelected ? Cap(gitTabView) : new Empty()).Badge(gitItemCount.ToString()));
 
             var tabs = Layout.Tabs(tabList.ToArray())
                 .OnSelect(v => selectedTab.Set(v)).SelectedIndex(selectedTab.Value).Variant(TabsVariant.Content).RemoveParentPadding();
@@ -364,7 +368,8 @@ public class ContentView(
         if (selectedPlan is null)
             return new PlanContentData(null,
                 new Dictionary<string, List<string>>(), [],
-                new Dictionary<string, bool>(), null);
+                new Dictionary<string, bool>(), null,
+                new GitTabDataBuilder.GitTabData([], []));
 
         var summaryPath = Path.Combine(folderPath, "Artifacts", "summary.md");
         var summaryMd = File.Exists(summaryPath) ? FileHelper.ReadAllText(summaryPath) : null;
@@ -373,13 +378,15 @@ public class ContentView(
 
         var commitRows = PlanContentHelpers.BuildCommitRows(selectedPlan, config, gitService);
 
+        var gitData = GitTabDataBuilder.BuildGitTabData(commitRows, selectedPlan, config, gitService);
+
         var allChanges = PlanContentHelpers.GetAllChangesData(selectedPlan, config, gitService);
 
         var verReports = selectedPlan.Verifications.ToDictionary(
             v => v.Name,
             v => File.Exists(Path.Combine(folderPath, "Verification", $"{v.Name}.md")));
 
-        return new PlanContentData(summaryMd, artifacts, commitRows, verReports, allChanges);
+        return new PlanContentData(summaryMd, artifacts, commitRows, verReports, allChanges, gitData);
     }
 
     private PendingAnnotationsDialog? BuildAnnotationsGuardDialog(
@@ -611,5 +618,6 @@ public class ContentView(
         Dictionary<string, List<string>> Artifacts,
         List<PlanContentHelpers.CommitRow> CommitRows,
         Dictionary<string, bool> VerificationReports,
-        PlanContentHelpers.AllChangesData? AllChanges);
+        PlanContentHelpers.AllChangesData? AllChanges,
+        GitTabDataBuilder.GitTabData? GitData);
 }

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -113,7 +113,8 @@ public class ContentView(
                     if (selectedPlanState.Value is null)
                         return new PlanContentData(new List<RecommendationYaml>(), null,
                             new Dictionary<string, List<string>>(), new List<PlanContentHelpers.CommitRow>(),
-                            new Dictionary<string, bool>(), new List<(string Name, bool ConditionMet)>(), null);
+                            new Dictionary<string, bool>(), new List<(string Name, bool ConditionMet)>(), null,
+                            new GitTabDataBuilder.GitTabData([], []));
 
                     // Recommendations from database (or plan.yaml fallback)
                     List<RecommendationYaml> recs;
@@ -136,6 +137,9 @@ public class ContentView(
 
                     // Commit rows
                     var commitRows = PlanContentHelpers.BuildCommitRows(selectedPlanState.Value!, config, gitService);
+
+                    // Git tab data (computed asynchronously in background)
+                    var gitData = GitTabDataBuilder.BuildGitTabData(commitRows, selectedPlanState.Value!, config, gitService);
 
                     // All changes data
                     var allChanges = PlanContentHelpers.GetAllChangesData(selectedPlanState.Value!, config, gitService);
@@ -160,13 +164,13 @@ public class ContentView(
                         actionStates[i] = (action.Name, PlatformHelper.EvaluatePowerShellCondition(action.Condition, folderPath, logger: logger));
                     });
 
-                    return new PlanContentData(recs, summaryMd, artifacts, commitRows, verReports, actionStates.ToList(), allChanges);
+                    return new PlanContentData(recs, summaryMd, artifacts, commitRows, verReports, actionStates.ToList(), allChanges, gitData);
                 }, ct);
             },
             options: QueryScope.View,
             initialValue: new PlanContentData(new List<RecommendationYaml>(), null,
                 new Dictionary<string, List<string>>(), new List<PlanContentHelpers.CommitRow>(), new Dictionary<string, bool>(),
-                new List<(string Name, bool ConditionMet)>(), null)
+                new List<(string Name, bool ConditionMet)>(), null, new GitTabDataBuilder.GitTabData([], []))
         );
 
         var planWatcher = UseService<IPlanWatcherService>();
@@ -540,7 +544,7 @@ public class ContentView(
         }
         else
         {
-            var gitData = GitTabDataBuilder.BuildGitTabData(planData.CommitRows, selectedPlan!, config, gitService);
+            var gitData = planData.GitData ?? new GitTabDataBuilder.GitTabData([], []);
             var gitTabView = new GitTabView(
                 gitData,
                 selectedPlan!,
@@ -576,42 +580,58 @@ public class ContentView(
                     $"#{TendrilAppShell.FormatPlanId(selectedPlan.FolderName)}")));
 
             var tabNamesList = new List<string> { "summary", "plan", "details", "git" };
+            var isSummarySelected = selectedTab.Value == 0;
+            var isPlanSelected = selectedTab.Value == 1;
+            var isDetailsSelected = selectedTab.Value == 2;
+            var isGitSelected = selectedTab.Value == 3;
+
             var tabList = new List<Tab>
             {
                 // Summary is rendered via DraftMarkdown with a pinned Verifications sidebar, so it is
                 // NOT wrapped in Cap() (whose outer scroll would also scroll the sticky box). The widget
                 // reproduces Cap()'s left inset + max-width.
-                new Tab("Summary", new SummaryTabView(
+                new Tab("Summary", isSummarySelected ? new SummaryTabView(
                     config, planData.SummaryMarkdown, selectedPlan.Verifications,
                     planData.VerificationReports, v => openVerification.Set(v), onLinkClick,
-                    planContentQuery.Loading)),
-                new Tab("Plan", Cap(planTabContent)),
-                new Tab("Details", Cap(new DetailsTabView(selectedPlan,
+                    planContentQuery.Loading) : new Empty()),
+                new Tab("Plan", isPlanSelected ? Cap(planTabContent) : new Empty()),
+                new Tab("Details", isDetailsSelected ? Cap(new DetailsTabView(selectedPlan,
                     jobService.GetJobsForPlan(selectedPlan.FolderName),
                     showDebugJob, planService, selectedPlanState, refreshPlans,
-                    folderPath => selectedPlanState.Set(planService.GetPlanByFolder(folderPath))))),
-                new Tab("Git", Cap(gitTabView)).Badge(GitTabDataBuilder.CountGitItems(gitData, selectedPlan).ToString()),
+                    folderPath => selectedPlanState.Set(planService.GetPlanByFolder(folderPath)))) : new Empty()),
+                new Tab("Git", isGitSelected ? Cap(gitTabView) : new Empty())
+                    .Badge(GitTabDataBuilder.CountGitItems(gitData, selectedPlan).ToString()),
             };
 
             // Only surface the Changes tab once there are actual file changes — no point showing
             // an empty "No commits yet." tab before any work has landed.
-            if (changesTabView.FileCount > 0)
+            var changesCount = planData.AllChanges?.Files.Count ?? 0;
+            if (changesCount > 0)
             {
-                tabList.Add(new Tab("Changes",
-                        Layout.Vertical().Width(Size.Full()).Height(Size.Full().Min(Size.Px(0))) | changesTabView)
-                    .Badge(changesTabView.FileCount.ToString()));
+                var changesTabIndex = tabList.Count;
+                var isChangesSelected = selectedTab.Value == changesTabIndex;
+                tabList.Add(new Tab("Changes", isChangesSelected
+                    ? (Layout.Vertical().Width(Size.Full()).Height(Size.Full().Min(Size.Px(0))) | changesTabView)
+                    : new Empty())
+                    .Badge(changesCount.ToString()));
                 tabNamesList.Add("changes");
             }
 
             if (totalArtifacts > 0)
             {
-                tabList.Add(new Tab("Artifacts", Cap(new ArtifactsTabView(planData.Artifacts))).Badge(totalArtifacts.ToString()));
+                var artifactsTabIndex = tabList.Count;
+                var isArtifactsSelected = selectedTab.Value == artifactsTabIndex;
+                tabList.Add(new Tab("Artifacts", isArtifactsSelected ? Cap(new ArtifactsTabView(planData.Artifacts)) : new Empty())
+                    .Badge(totalArtifacts.ToString()));
                 tabNamesList.Add("Artifacts");
             }
 
             if (pendingRecs.Count > 0)
             {
-                tabList.Add(new Tab("Recommendations", Cap(recommendationsTab)).Badge(pendingRecs.Count.ToString()));
+                var recsTabIndex = tabList.Count;
+                var isRecsSelected = selectedTab.Value == recsTabIndex;
+                tabList.Add(new Tab("Recommendations", isRecsSelected ? Cap(recommendationsTab) : new Empty())
+                    .Badge(pendingRecs.Count.ToString()));
                 tabNamesList.Add("recommendations");
             }
 
@@ -819,7 +839,8 @@ public class ContentView(
         List<PlanContentHelpers.CommitRow> CommitRows,
         Dictionary<string, bool> VerificationReports,
         List<(string Name, bool ConditionMet)> ReviewActionStates,
-        PlanContentHelpers.AllChangesData? AllChanges);
+        PlanContentHelpers.AllChangesData? AllChanges,
+        GitTabDataBuilder.GitTabData? GitData);
 
     // Groups the request-scoped services and navigation state shared by BuildHeader, BuildActionBar
     // and BuildContent, so a new piece of shared infrastructure only needs to be added here instead

--- a/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/ChangesTabView.cs
@@ -73,7 +73,7 @@ public class ChangesTabView(
                 "The plan may have been created in the wrong project.", "Wrong project?");
         }
 
-        var allFileDiffs = PlanContentHelpers.SplitDiffByFile(changesData);
+        var allFileDiffs = changesData.FileDiffs ?? PlanContentHelpers.SplitDiffByFile(changesData);
 
         if (allFileDiffs.Count == 0 && changesData.Files.Count == 0)
             return Text.Muted("No file changes.");

--- a/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
@@ -346,7 +346,8 @@ public static class PlanContentHelpers
         // The repo/worktree the diff was read from, and whether that was a worktree NOT in the
         // plan's configured repos (the work landed in a repo outside the plan's project — #1340).
         string? SourceRepoPath = null,
-        bool FromUnlistedWorktree = false
+        bool FromUnlistedWorktree = false,
+        List<FileDiff>? FileDiffs = null
     );
 
     public static AllChangesData? GetAllChangesData(PlanFile plan, IConfigService config, IGitService gitService)
@@ -384,7 +385,10 @@ public static class PlanContentHelpers
             var deleted = fileList.Count(f => f.Status == "D");
             var modified = fileList.Count - added - deleted;
 
-            return new AllChangesData(diff, fileList, added, modified, deleted, repo, fromUnlistedWorktree);
+            var baseData = new AllChangesData(diff, fileList, added, modified, deleted, repo, fromUnlistedWorktree);
+            var fileDiffs = SplitDiffByFile(baseData);
+
+            return baseData with { FileDiffs = fileDiffs };
         }
 
         // Prefer the plan's / project's configured repos.


### PR DESCRIPTION
### Summary of Changes
- **Async Git Tab Computation**: Moved `GitTabDataBuilder.BuildGitTabData` into the background `planContentQuery` instead of executing synchronous git CLI processes on the UI thread during every `Build()` render.
- **Lazy Tab Content Rendering**: Tab contents (such as `ChangesTabView` with multi-file `PlanDiffView` widgets, `GitTabView`, `ArtifactsTabView`, etc.) are now rendered only when their respective tab is selected. This prevents constructing and serializing all git diffs across all tabs on every state change or plan switch.
- **Precomputed File Diffs**: Added `FileDiffs` to `AllChangesData` and pre-split the diff in the background thread when plan changes load, avoiding regex parsing on the UI thread.

### Verification
- All 2,183 unit tests in `Ivy.Tendril.Test` passed.