### PR TITLE
Prevent stale output timeout on processes that already exited

### DIFF
--- a/src/Ivy.Tendril/Services/Jobs/JobMonitor.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobMonitor.cs
@@ -150,6 +150,9 @@ internal class JobMonitor
                 if (!jobs.TryGetValue(id, out var job) || job.Status != JobStatus.Running)
                     return;
 
+                if (job.Process is { HasExited: true })
+                    return;
+
                 var currentTimeout = staleOutputTimeout();
                 if (currentTimeout <= TimeSpan.Zero)
                     continue;


### PR DESCRIPTION
## Summary
- Added check in `JobMonitor.RunStaleOutputWatchdog` to avoid triggering stale output timeout if `job.Process.HasExited` is true.
- Ensures jobs whose process has exited cleanly complete via normal exit handling.