### PR TITLE
Dynamically merge project verifications for draft plans and auto-seed on execution

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/VerificationsCardView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/VerificationsCardView.cs
@@ -24,8 +24,36 @@ public class VerificationsCardView(
         var projectVerifications = config.GetProject(selectedPlan.Project)?.Verifications
                                    ?? new List<ProjectVerificationRef>();
 
+        var storedVerifications = selectedPlan.Verifications;
+        if (editable && projectVerifications.Count > 0)
+        {
+            var existingMap = storedVerifications.ToDictionary(v => v.Name, v => v.Status, StringComparer.OrdinalIgnoreCase);
+            var merged = new List<PlanVerificationEntry>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var pv in projectVerifications)
+            {
+                var status = existingMap.TryGetValue(pv.Name, out var existingStatus)
+                    ? existingStatus
+                    : pv.Required ? VerificationStatus.Pending : VerificationStatus.Skipped;
+                merged.Add(new PlanVerificationEntry { Name = pv.Name, Status = status });
+                seen.Add(pv.Name);
+            }
+
+            foreach (var v in storedVerifications)
+            {
+                if (!seen.Contains(v.Name))
+                {
+                    merged.Add(v);
+                    seen.Add(v.Name);
+                }
+            }
+
+            storedVerifications = merged;
+        }
+
         // Always present in project-config order, regardless of plan.yaml storage order.
-        var verifications = PlanCommandHelpers.OrderByProjectConfig(selectedPlan.Verifications, projectVerifications);
+        var verifications = PlanCommandHelpers.OrderByProjectConfig(storedVerifications, projectVerifications);
 
         bool IsRequired(string name) => projectVerifications
             .Any(pv => pv.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && pv.Required);

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -201,7 +201,10 @@ internal class JobLauncher
         ctx.RunHooks("before", type, planFolderForHooks, job.Project, job);
 
         if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs && !string.IsNullOrEmpty(job.TypedArgs?.PlanFolder))
+        {
             EnsurePlanFolderWritable(job.TypedArgs!.PlanFolder!);
+            EnsurePlanVerificationsSeeded(job.TypedArgs!.PlanFolder!, job.Project);
+        }
 
         job.SessionId = Guid.NewGuid().ToString();
     }
@@ -712,6 +715,30 @@ internal class JobLauncher
         finally
         {
             try { if (File.Exists(testFile)) File.Delete(testFile); } catch { /* best-effort cleanup */ }
+        }
+    }
+
+    private void EnsurePlanVerificationsSeeded(string planFolder, string? projectName)
+    {
+        if (string.IsNullOrEmpty(projectName) || !Directory.Exists(planFolder)) return;
+
+        var project = _configService?.GetProject(projectName);
+        if (project == null || project.Verifications.Count == 0) return;
+
+        try
+        {
+            var plan = PlanCommandHelpers.ReadPlan(planFolder);
+            if (plan.Verifications == null || plan.Verifications.Count == 0)
+            {
+                PlanCommandHelpers.ApplyProjectVerifications(plan, project, new Dictionary<string, VerificationStatus>());
+                PlanCommandHelpers.WritePlan(planFolder, plan);
+                _logger.LogInformation("Seeded {Count} project verifications for plan in {Folder}",
+                    plan.Verifications.Count, Path.GetFileName(planFolder));
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to seed verifications for plan in {Folder}", Path.GetFileName(planFolder));
         }
     }
 


### PR DESCRIPTION
## Summary
- In `VerificationsCardView`, dynamically merge project configured verifications for `Draft` plans so that plans imported/created before project verifications were configured display the project's verification gates.
- In `JobLauncher`, automatically seed project verifications into `plan.yaml` when launching `ExecutePlan` if `plan.Verifications` is empty.
- Preserves existing verification statuses and custom/ad-hoc verifications.