### PR TITLE
[00672] Fix Inconsistent Padding Across Configuration Sections

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs
@@ -132,12 +132,12 @@ public class ClaudeCliTests
         Assert.Contains("--permission-mode", spec.Arguments);
         Assert.Contains("dontAsk", spec.Arguments);
         Assert.Contains("--settings", spec.Arguments);
-        
+
         var settingsIdx = spec.Arguments.ToList().IndexOf("--settings");
         Assert.True(settingsIdx >= 0);
         Assert.Contains("permissions", spec.Arguments[settingsIdx + 1]);
         Assert.Contains("allow", spec.Arguments[settingsIdx + 1]);
-        
+
         Assert.Contains("-", spec.Arguments);
         Assert.Equal("Hello", spec.StdinContent);
         Assert.Equal("/tmp", spec.WorkingDirectory);

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyBinaryResolver.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyBinaryResolver.cs
@@ -21,7 +21,7 @@ public static class IvyBinaryResolver
         // 2. Check user profile directory ~/.ivy-agent/bin/ivy-agent
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var fallbackDir = Path.Combine(home, ".ivy-agent", "bin");
-        
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             string[] extensions = [".exe", ".cmd", ".bat"];

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyHealthCheck.cs
@@ -115,7 +115,7 @@ public sealed class IvyHealthCheck : IAgentHealthCheck
             {
                 Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", key);
             }
-            
+
             var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
                 binaryPath, ["run", "ping"],
                 TimeSpan.FromSeconds(30), ct);

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeBinaryResolver.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeBinaryResolver.cs
@@ -21,7 +21,7 @@ internal static class OpenCodeBinaryResolver
         // 2. Check user profile directory ~/.opencode/bin/opencode
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var fallbackDir = Path.Combine(home, ".opencode", "bin");
-        
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             string[] extensions = [".cmd", ".exe", ".bat"];

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/WebViewer/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/WebViewer/DemoApp.cs
@@ -148,12 +148,12 @@ public class DemoApp : ViewBase
         switch (e)
         {
             case ConsoleEvent c:
-            {
-                var text = Text.Block($"{c.Level}: {c.Text}");
-                if (c.Level == "error") text = text.Color(Colors.Red);
-                else if (c.Level == "warn") text = text.Color(Colors.Amber);
-                return text;
-            }
+                {
+                    var text = Text.Block($"{c.Level}: {c.Text}");
+                    if (c.Level == "error") text = text.Color(Colors.Red);
+                    else if (c.Level == "warn") text = text.Color(Colors.Amber);
+                    return text;
+                }
             case ClickEvent c:
                 return Text.Block($"🖱 {c.Tag} {(c.Text is { Length: > 0 } ? $"“{c.Text}” " : "")}· {c.Selector}").Color(Colors.Muted);
             case CommentEvent c:

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs
@@ -52,7 +52,7 @@ public class CreatePrDialog(
             },
             initialValue: Array.Empty<string>()
         );
-        
+
         UseEffect(() =>
         {
             if (!createPrMerge.Value) createPrDeleteBranch.Set(false);

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -179,7 +179,7 @@ public class CodingAgentSetupView : ViewBase
             deepModel.Value != GetProfileModel(config, finalAgent, "deep") ||
             balancedModel.Value != GetProfileModel(config, finalAgent, "balanced") ||
             quickModel.Value != GetProfileModel(config, finalAgent, "quick");
-        
+
         var currentIvyKey = GetIvyApiKeyFromConfig(config);
         var currentOpenAiBaseUrl = GetOpenAiProxyBaseUrlFromConfig(config);
         var currentOpenAiKey = GetOpenAiProxyApiKeyFromConfig(config);
@@ -426,7 +426,7 @@ public class CodingAgentSetupView : ViewBase
                        var currentModels = new[] { deepModel.Value, balancedModel.Value, quickModel.Value };
                        var entries = new List<TestModelEntry>();
                        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
- 
+
                        foreach (var m in currentModels)
                        {
                            if (string.IsNullOrEmpty(m) || m.Equals("default", StringComparison.OrdinalIgnoreCase))
@@ -443,7 +443,7 @@ public class CodingAgentSetupView : ViewBase
                                }
                            }
                        }
- 
+
                        return entries;
                    },
                    runner);
@@ -592,20 +592,20 @@ public class CodingAgentSetupView : ViewBase
         string os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows" :
                     RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "darwin" : "linux";
         string arch = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "arm64" : "x64";
-        
+
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var installDir = Path.Combine(home, ".ivy-agent", "bin");
         Directory.CreateDirectory(installDir);
-        
+
         var tempDir = Path.Combine(Path.GetTempPath(), "ivy-agent-install");
         if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
         Directory.CreateDirectory(tempDir);
-        
+
         try
         {
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("IvyTendril");
-            
+
             // 1. Get latest version from GitHub releases / CDN
             string version;
             try
@@ -616,13 +616,13 @@ public class CodingAgentSetupView : ViewBase
             {
                 throw new Exception($"Failed to fetch latest version metadata: {ex.Message}");
             }
-            
+
             // 2. Download the archive from CDN
             string extension = os == "windows" ? ".zip" : ".tar.gz";
             string archiveName = $"ivy-agent-cli-{os}-{arch}{extension}";
             string downloadUrl = $"https://cdn.ivy.app/ivy-agent-cli/releases/download/{version}/{archiveName}";
             string archivePath = Path.Combine(tempDir, archiveName);
-            
+
             try
             {
                 using var stream = await httpClient.GetStreamAsync(downloadUrl);
@@ -633,7 +633,7 @@ public class CodingAgentSetupView : ViewBase
             {
                 throw new Exception($"Failed to download release archive from CDN: {ex.Message}");
             }
-            
+
             if (archivePath.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
             {
                 ZipFile.ExtractToDirectory(archivePath, tempDir, true);
@@ -659,16 +659,16 @@ public class CodingAgentSetupView : ViewBase
                     }
                 }
             }
-            
+
             string binaryName = os == "windows" ? "ivy-agent.exe" : "ivy-agent";
             var files = Directory.GetFiles(tempDir, binaryName, SearchOption.AllDirectories);
             var binarySource = files.FirstOrDefault();
-            
+
             if (string.IsNullOrEmpty(binarySource))
             {
                 throw new Exception($"Binary '{binaryName}' not found in the downloaded archive.");
             }
-            
+
             // Kill any running ivy-agent processes before updating
             try
             {
@@ -711,7 +711,7 @@ public class CodingAgentSetupView : ViewBase
             }
 
             IvyBinaryResolver.ResetCache();
-            
+
             if (os != "windows")
             {
                 var chmodInfo = new ProcessStartInfo
@@ -724,7 +724,7 @@ public class CodingAgentSetupView : ViewBase
                 using var chmodProc = Process.Start(chmodInfo);
                 if (chmodProc != null) await chmodProc.WaitForExitAsync();
             }
-            
+
             if (os == "darwin")
             {
                 var codesignInfo = new ProcessStartInfo
@@ -737,7 +737,7 @@ public class CodingAgentSetupView : ViewBase
                 using var codesignProc = Process.Start(codesignInfo);
                 if (codesignProc != null) await codesignProc.WaitForExitAsync();
             }
-            
+
             return true;
         }
         finally
@@ -746,7 +746,7 @@ public class CodingAgentSetupView : ViewBase
             {
                 if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
             }
-            catch {}
+            catch { }
         }
     }
 

--- a/src/Ivy.Tendril/Apps/Settings/LevelsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/LevelsSetupView.cs
@@ -67,7 +67,7 @@ public class LevelsSetupView : ViewBase
             ))
             .Width(Size.Fit());
 
-        return Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(200)))
+        return Layout.Vertical().Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Priority Levels").Bold()
                | Text.Block("Define priority levels used to categorize plans.").Muted().Small()
                | table

--- a/src/Ivy.Tendril/Apps/Settings/NotificationsSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/NotificationsSetupView.cs
@@ -14,7 +14,7 @@ public class NotificationsSetupView : ViewBase
 
         var hasChanges = desktopNotifications.Value != config.Settings.DesktopNotifications;
 
-        var form = Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(120)))
+        var form = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
                    | Text.Block("Notification Settings").Bold()
                    | Text.Block("Configure how Tendril notifies you about job completions, failures, and other events.").Muted().Small()
 

--- a/src/Ivy.Tendril/Apps/Settings/PlansSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/PlansSetupView.cs
@@ -12,7 +12,7 @@ public class PlansSetupView : ViewBase
 
         var hasChanges = planTemplate.Value != config.Settings.PlanTemplate;
 
-        return Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(120)))
+        return Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
                | Text.Block("Plans").Bold()
                | Text.Muted("Configure the default plan template used when creating new plans.").Small()
                | planTemplate.ToCodeInput("Plan template...")

--- a/src/Ivy.Tendril/Apps/Settings/PromptwaresSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/PromptwaresSetupView.cs
@@ -72,7 +72,7 @@ public class PromptwaresSetupView : ViewBase
             }))
             .Width(Size.Fit());
 
-        return Layout.Vertical().Padding(4).Width(Size.Auto().Max(Size.Units(200)))
+        return Layout.Vertical().Width(Size.Auto().Max(Size.Units(200)))
                | Text.Block("Promptware Configuration").Bold()
                | Text.Block("Configure agent profile and tool permissions for each promptware.")
                    .Muted().Small()

--- a/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
@@ -181,7 +181,7 @@ public class SettingsApp : ViewBase
 
         var contentWithMobileHeader = Layout.Vertical().Height(Size.Full()).Gap(2)
                                       | mobileHeader
-                                      | (Layout.Vertical().Height(Size.Grow()) | content)
+                                      | (Layout.Vertical().Height(Size.Grow()).Padding(4) | content)
                                       | addProjectDialog;
 
         return new SidebarLayout(contentWithMobileHeader, sidebar);

--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -25,7 +25,7 @@ public class JobDebugSheet(
         var (reportBugDialog, showReportBugDialog) = UseTrigger((isOpen) =>
             !isOpen.Value ? null : new ReportBugDialog(isOpen, jobId));
 
-        #if DEBUG
+#if DEBUG
         var (debugAgentDialog, showDebugAgentDialog) = UseTrigger((isOpen) =>
         {
             if (!isOpen.Value) return null;
@@ -46,7 +46,7 @@ public class JobDebugSheet(
                 closeSheet();
             });
         });
-        #endif
+#endif
 
         var job = jobService.GetJob(jobId);
         if (job is null)
@@ -107,17 +107,17 @@ public class JobDebugSheet(
                      })
                      | new Button("Report Bug").Icon(Icons.Bug).OnClick(() => showReportBugDialog());
 
-        #if DEBUG
+#if DEBUG
         header |= new Button($"Debug with {agentBranding.Label}").Icon(agentBranding.Icon).Outline()
             .OnClick(() => showDebugAgentDialog());
-        #endif
+#endif
 
         return new Fragment(
             new HeaderLayout(header, detailsView).Size(Size.Full()),
             reportBugDialog
-            #if DEBUG
+#if DEBUG
             , debugAgentDialog
-            #endif
+#endif
         );
     }
 

--- a/src/Ivy.Tendril/Commands/UpdateCliCommand.cs
+++ b/src/Ivy.Tendril/Commands/UpdateCliCommand.cs
@@ -104,7 +104,7 @@ public class UpdateCliCommand : AsyncCommand<UpdateCliCommand.Settings>
                 .StartAsync(async ctx =>
                 {
                     var task = ctx.AddTask("[green]Downloading installer[/]", autoStart: true, maxValue: 100);
-                    
+
                     await UpdateHelper.DownloadFileWithProgressAsync(downloadUrl, tempFilePath, (read, total) =>
                     {
                         if (total > 0)
@@ -116,7 +116,7 @@ public class UpdateCliCommand : AsyncCommand<UpdateCliCommand.Settings>
 
             AnsiConsole.MarkupLine($"[green]Download complete. Launching installer...[/]");
             UpdateHelper.LaunchInstaller(tempFilePath);
-            
+
             AnsiConsole.MarkupLine("[green]Exiting Tendril to allow installation.[/]");
             Environment.Exit(0);
             return 0;

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -36,7 +36,7 @@ internal static class ServiceRegistration
                                         configService.Settings.Beta ||
                                         Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" ||
                                         Environment.GetEnvironmentVariable("IVY_BETA") == "1";
-            
+
             opts.IvyApiKeyProviderFactory = sp =>
             {
                 var config = sp.GetService<IConfigService>();
@@ -55,13 +55,13 @@ internal static class ServiceRegistration
                     return authTokenHandler?.GetCurrentToken()?.AccessToken;
                 };
             };
-            
+
             opts.IvyTokenProviderFactory = sp =>
             {
                 var authTokenHandler = sp.GetService<Ivy.IAuthTokenHandlerService>();
                 return () => authTokenHandler?.GetCurrentToken()?.AccessToken;
             };
-            
+
             opts.IvyEmailProviderFactory = sp =>
             {
                 var authTokenHandler = sp.GetService<Ivy.IAuthTokenHandlerService>();

--- a/src/Ivy.Tendril/Services/BugReportService.cs
+++ b/src/Ivy.Tendril/Services/BugReportService.cs
@@ -309,8 +309,8 @@ public sealed class BugReportService
     private void CollectJobFiles(IReadOnlyCollection<string> jobIds, List<BugReportFile> files)
     {
         foreach (var jobId in jobIds)
-        foreach (var file in JobLogPaths.AllForJobId(_config.TendrilHome, jobId))
-            files.Add(new BugReportFile(file, Path.Combine("Jobs", Path.GetFileName(file))));
+            foreach (var file in JobLogPaths.AllForJobId(_config.TendrilHome, jobId))
+                files.Add(new BugReportFile(file, Path.Combine("Jobs", Path.GetFileName(file))));
     }
 
     private static void CollectPlanFiles(string planFolder, List<BugReportFile> files)


### PR DESCRIPTION
Fixes #2088

# Summary

## Changes

Standardized padding across all configuration sections in the Settings panel. Added padding to the content wrapper in SettingsApp and removed duplicate padding from individual section views, ensuring consistent 24px inset (8px base + 16px padding) throughout.

## API Changes

None.

## Files Modified

**Settings Infrastructure:**
- `src/Ivy.Tendril/Apps/Settings/SettingsApp.cs` - Added padding to content wrapper

**Section Views:**
- `src/Ivy.Tendril/Apps/Settings/PlansSetupView.cs` - Removed duplicate padding
- `src/Ivy.Tendril/Apps/Settings/NotificationsSetupView.cs` - Removed duplicate padding
- `src/Ivy.Tendril/Apps/Settings/LevelsSetupView.cs` - Removed duplicate padding
- `src/Ivy.Tendril/Apps/Settings/PromptwaresSetupView.cs` - Removed duplicate padding

**Formatting:**
- 11 files with pre-existing whitespace issues fixed by dotnet format

## Manual Testing

1. Launch the Tendril app
2. Open Configuration panel (Settings icon in app shell)
3. Click through each section in order: Coding Agent, Plans, Appearance, Projects, Promptwares, Levels, Notifications, Security & Tunnel, Advanced, Help
4. Observe that:
   - All section headings remain at the same horizontal position
   - All section headings remain at the same vertical position
   - There is consistent visible gap between the sidebar divider and content (24px total)
   - No visual jump or content shift when switching between sections
5. Verify the Coding Agent card grid still displays three cards per row on desktop without clipping
6. Narrow window to mobile width and verify the section picker dropdown renders without horizontal overflow

---

**Commits:**
- 7bf2d3dd Standardize padding across configuration sections
- 0ffbefd3 Apply dotnet format

---
Created using [Ivy Tendril](https://ivy.app).
