### PR TITLE
[00671] Stop Passing an Unknown Conversation Id to the Antigravity CLI

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityCliTests.cs
@@ -28,8 +28,7 @@ public class AntigravityCliTests
                        AgentCapabilities.EffortControl |
                        AgentCapabilities.DirectoryRestriction |
                        AgentCapabilities.HealthCheck |
-                       AgentCapabilities.ExtraArgPassthrough |
-                       AgentCapabilities.SessionResume;
+                       AgentCapabilities.ExtraArgPassthrough;
 
         Assert.Equal(expected, _cli.Capabilities);
     }
@@ -95,7 +94,7 @@ public class AntigravityCliTests
     }
 
     [Fact]
-    public void BuildProcessSpec_IncludesSessionId()
+    public void BuildProcessSpec_DoesNotPassConversationForNewSession()
     {
         var config = new AgentLaunchConfig
         {
@@ -107,9 +106,8 @@ public class AntigravityCliTests
         var spec = _cli.BuildProcessSpec(config);
         var args = spec.Arguments.ToList();
 
-        var idx = args.IndexOf("--conversation");
-        Assert.True(idx >= 0);
-        Assert.Equal("sess-123", args[idx + 1]);
+        Assert.DoesNotContain("--conversation", args);
+        Assert.DoesNotContain("sess-123", args);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs
@@ -132,12 +132,12 @@ public class ClaudeCliTests
         Assert.Contains("--permission-mode", spec.Arguments);
         Assert.Contains("dontAsk", spec.Arguments);
         Assert.Contains("--settings", spec.Arguments);
-        
+
         var settingsIdx = spec.Arguments.ToList().IndexOf("--settings");
         Assert.True(settingsIdx >= 0);
         Assert.Contains("permissions", spec.Arguments[settingsIdx + 1]);
         Assert.Contains("allow", spec.Arguments[settingsIdx + 1]);
-        
+
         Assert.Contains("-", spec.Arguments);
         Assert.Equal("Hello", spec.StdinContent);
         Assert.Equal("/tmp", spec.WorkingDirectory);

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
@@ -17,8 +17,7 @@ public sealed class AntigravityCli : IAgentCli
         AgentCapabilities.EffortControl |
         AgentCapabilities.DirectoryRestriction |
         AgentCapabilities.HealthCheck |
-        AgentCapabilities.ExtraArgPassthrough |
-        AgentCapabilities.SessionResume;
+        AgentCapabilities.ExtraArgPassthrough;
 
     public TransportKind SupportedTransports => TransportKind.CliSpawn;
     public PromptTransport PromptTransport => PromptTransport.Stdin;
@@ -67,11 +66,10 @@ public sealed class AntigravityCli : IAgentCli
             args.Add(effort);
         }
 
-        if (!string.IsNullOrEmpty(config.SessionId))
-        {
-            args.Add("--conversation");
-            args.Add(config.SessionId);
-        }
+        // Note: agy --conversation only accepts an existing conversation ID that agy already stored in
+        // ~/.gemini/antigravity-cli/conversations/*.pb. AgentLaunchConfig.SessionId is a per-job GUID
+        // minted by JobLauncher.PrepareJobForLaunch, so passing it would cause agy to print
+        // "warning: conversation <id> not found" on every run. See GitHub issue #2074.
 
         foreach (var dir in config.WritableDirectories)
         {

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyBinaryResolver.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyBinaryResolver.cs
@@ -21,7 +21,7 @@ public static class IvyBinaryResolver
         // 2. Check user profile directory ~/.ivy-agent/bin/ivy-agent
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var fallbackDir = Path.Combine(home, ".ivy-agent", "bin");
-        
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             string[] extensions = [".exe", ".cmd", ".bat"];

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyHealthCheck.cs
@@ -115,7 +115,7 @@ public sealed class IvyHealthCheck : IAgentHealthCheck
             {
                 Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", key);
             }
-            
+
             var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
                 binaryPath, ["run", "ping"],
                 TimeSpan.FromSeconds(30), ct);

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeBinaryResolver.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeBinaryResolver.cs
@@ -21,7 +21,7 @@ internal static class OpenCodeBinaryResolver
         // 2. Check user profile directory ~/.opencode/bin/opencode
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var fallbackDir = Path.Combine(home, ".opencode", "bin");
-        
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             string[] extensions = [".cmd", ".exe", ".bat"];


### PR DESCRIPTION
Fixes #2074

# Summary

## Changes

Removed the `--conversation` flag from Antigravity CLI invocations to eliminate stderr warnings about unknown conversation IDs. The flag was being passed with a freshly-minted GUID on every job execution, causing `agy` to warn that the conversation doesn't exist. Also removed the `SessionResume` capability from `AntigravityCli` since it no longer supports session resumption.

## API Changes

**AntigravityCli class:**
- Removed `AgentCapabilities.SessionResume` from the `Capabilities` property
- Removed `--conversation` flag handling from `BuildProcessSpec` method

**AntigravityCliTests class:**
- Renamed test: `BuildProcessSpec_IncludesSessionId` → `BuildProcessSpec_DoesNotPassConversationForNewSession`
- Updated test assertions to verify `--conversation` is NOT passed

## Files Modified

**Core Implementation:**
- `src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs` - Removed conversation flag and SessionResume capability

**Tests:**
- `src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityCliTests.cs` - Updated capability test and conversation handling test

**Formatting Fixes (pre-existing issues):**
- `src/Ivy.Tendril.Agents/Providers/Ivy/IvyBinaryResolver.cs`
- `src/Ivy.Tendril.Agents/Providers/Ivy/IvyHealthCheck.cs`
- `src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeBinaryResolver.cs`
- `src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs`

## Manual Testing

1. Run any promptware (e.g., CreatePlan, ExecutePlan) with Antigravity selected as the coding agent
2. Open the Jobs app and view the job's output panel
3. Verify that the output does NOT contain `warning: conversation "<guid>" not found`
4. Check the job's `.raw.jsonl` file in `~/.tendril/Jobs/` and verify it does NOT contain the warning (though pre-existing job logs may still show it)
5. Verify the job executes normally and the agent responds correctly

Alternative: Check the Job Debug sheet for a recent Antigravity job and confirm no stderr warnings are present.

---

## Commits
- 8b622307 Apply dotnet format to test project
- 0b60ab56 Apply dotnet format
- 9c6910b4 Stop passing unknown conversation ID to Antigravity CLI

---
Created using [Ivy Tendril](https://ivy.app).
