### PR TITLE
[00663] Remove Previous and Next Buttons From Review Action Bar

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs
@@ -132,12 +132,12 @@ public class ClaudeCliTests
         Assert.Contains("--permission-mode", spec.Arguments);
         Assert.Contains("dontAsk", spec.Arguments);
         Assert.Contains("--settings", spec.Arguments);
-        
+
         var settingsIdx = spec.Arguments.ToList().IndexOf("--settings");
         Assert.True(settingsIdx >= 0);
         Assert.Contains("permissions", spec.Arguments[settingsIdx + 1]);
         Assert.Contains("allow", spec.Arguments[settingsIdx + 1]);
-        
+
         Assert.Contains("-", spec.Arguments);
         Assert.Equal("Hello", spec.StdinContent);
         Assert.Equal("/tmp", spec.WorkingDirectory);

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyBinaryResolver.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyBinaryResolver.cs
@@ -21,7 +21,7 @@ public static class IvyBinaryResolver
         // 2. Check user profile directory ~/.ivy-agent/bin/ivy-agent
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var fallbackDir = Path.Combine(home, ".ivy-agent", "bin");
-        
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             string[] extensions = [".exe", ".cmd", ".bat"];

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyHealthCheck.cs
@@ -115,7 +115,7 @@ public sealed class IvyHealthCheck : IAgentHealthCheck
             {
                 Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", key);
             }
-            
+
             var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
                 binaryPath, ["run", "ping"],
                 TimeSpan.FromSeconds(30), ct);

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeBinaryResolver.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeBinaryResolver.cs
@@ -21,7 +21,7 @@ internal static class OpenCodeBinaryResolver
         // 2. Check user profile directory ~/.opencode/bin/opencode
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var fallbackDir = Path.Combine(home, ".opencode", "bin");
-        
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             string[] extensions = [".cmd", ".exe", ".bat"];

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/WebViewer/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/WebViewer/DemoApp.cs
@@ -148,12 +148,12 @@ public class DemoApp : ViewBase
         switch (e)
         {
             case ConsoleEvent c:
-            {
-                var text = Text.Block($"{c.Level}: {c.Text}");
-                if (c.Level == "error") text = text.Color(Colors.Red);
-                else if (c.Level == "warn") text = text.Color(Colors.Amber);
-                return text;
-            }
+                {
+                    var text = Text.Block($"{c.Level}: {c.Text}");
+                    if (c.Level == "error") text = text.Color(Colors.Red);
+                    else if (c.Level == "warn") text = text.Color(Colors.Amber);
+                    return text;
+                }
             case ClickEvent c:
                 return Text.Block($"🖱 {c.Tag} {(c.Text is { Length: > 0 } ? $"“{c.Text}” " : "")}· {c.Selector}").Color(Colors.Muted);
             case CommentEvent c:

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -360,7 +360,7 @@ public class ContentView(
         IAgentRunner agentRunner,
         IState<List<DraftComment>> draftComments)
     {
-        var (client, logger, nav, args, copyToClipboard) = context;
+        var (client, logger, nav, _, copyToClipboard) = context;
         var (agentLabel, agentIcon) = AgentBranding.For(config.Settings.CodingAgent, agentRunner, config);
 
         // Standard overflow menu items
@@ -467,14 +467,10 @@ public class ContentView(
         }
 
         // Action bar without .Wrap() - single row with progressive collapse.
-        // Full (>=1024px): Previous, Next, Reset to Draft, Request Changes, Discard inline + overflow dropdown.
-        // Compact (768-1023px): Previous, Next, Reset to Draft, Request Changes inline; Discard in dropdown.
-        // Minimal (<768px): Previous, Next inline; everything else in dropdown.
+        // Full (>=1024px): Reset to Draft, Request Changes, Discard inline + overflow dropdown.
+        // Compact (768-1023px): Reset to Draft, Request Changes inline; Discard in dropdown.
+        // Minimal (<768px): everything in dropdown.
         return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
-                | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(() => GoToPrevious(nav, args))
-                    .ShortcutKey("p").AlwaysVisible()
-                | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(() => GoToNext(nav, args))
-                    .ShortcutKey("n").AlwaysVisible()
                 | new Button("Reset to Draft").Icon(Icons.RotateCcw).Outline().ShortcutKey("r")
                     .OnClick(showResetToDraftDialog).CompactUp()
                 | requestChangesBtn
@@ -760,22 +756,6 @@ public class ContentView(
         var verificationDir = Path.GetFullPath(Path.Combine(planFolderPath, "Verification"));
         var resolvedPath = Path.GetFullPath(Path.Combine(verificationDir, $"{name}.md"));
         return resolvedPath.StartsWith(verificationDir, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private void GoToNext(INavigator nav, ReviewAppArgs? args)
-    {
-        if (allPlans.Count == 0) return;
-        var currentIndex = allPlans.FindIndex(p => p.FolderName == selectedPlanState.Value?.FolderName);
-        var nextIndex = (currentIndex + 1) % allPlans.Count;
-        selectedPlanState.Set(allPlans[nextIndex]);
-    }
-
-    private void GoToPrevious(INavigator nav, ReviewAppArgs? args)
-    {
-        if (allPlans.Count == 0) return;
-        var currentIndex = allPlans.FindIndex(p => p.FolderName == selectedPlanState.Value?.FolderName);
-        var prevIndex = (currentIndex - 1 + allPlans.Count) % allPlans.Count;
-        selectedPlanState.Set(allPlans[prevIndex]);
     }
 
     private static async void SynchronizeWorktreeAsync(

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs
@@ -52,7 +52,7 @@ public class CreatePrDialog(
             },
             initialValue: Array.Empty<string>()
         );
-        
+
         UseEffect(() =>
         {
             if (!createPrMerge.Value) createPrDeleteBranch.Set(false);

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -179,7 +179,7 @@ public class CodingAgentSetupView : ViewBase
             deepModel.Value != GetProfileModel(config, finalAgent, "deep") ||
             balancedModel.Value != GetProfileModel(config, finalAgent, "balanced") ||
             quickModel.Value != GetProfileModel(config, finalAgent, "quick");
-        
+
         var currentIvyKey = GetIvyApiKeyFromConfig(config);
         var currentOpenAiBaseUrl = GetOpenAiProxyBaseUrlFromConfig(config);
         var currentOpenAiKey = GetOpenAiProxyApiKeyFromConfig(config);
@@ -426,7 +426,7 @@ public class CodingAgentSetupView : ViewBase
                        var currentModels = new[] { deepModel.Value, balancedModel.Value, quickModel.Value };
                        var entries = new List<TestModelEntry>();
                        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
- 
+
                        foreach (var m in currentModels)
                        {
                            if (string.IsNullOrEmpty(m) || m.Equals("default", StringComparison.OrdinalIgnoreCase))
@@ -443,7 +443,7 @@ public class CodingAgentSetupView : ViewBase
                                }
                            }
                        }
- 
+
                        return entries;
                    },
                    runner);
@@ -592,20 +592,20 @@ public class CodingAgentSetupView : ViewBase
         string os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows" :
                     RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "darwin" : "linux";
         string arch = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "arm64" : "x64";
-        
+
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         var installDir = Path.Combine(home, ".ivy-agent", "bin");
         Directory.CreateDirectory(installDir);
-        
+
         var tempDir = Path.Combine(Path.GetTempPath(), "ivy-agent-install");
         if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
         Directory.CreateDirectory(tempDir);
-        
+
         try
         {
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("IvyTendril");
-            
+
             // 1. Get latest version from GitHub releases / CDN
             string version;
             try
@@ -616,13 +616,13 @@ public class CodingAgentSetupView : ViewBase
             {
                 throw new Exception($"Failed to fetch latest version metadata: {ex.Message}");
             }
-            
+
             // 2. Download the archive from CDN
             string extension = os == "windows" ? ".zip" : ".tar.gz";
             string archiveName = $"ivy-agent-cli-{os}-{arch}{extension}";
             string downloadUrl = $"https://cdn.ivy.app/ivy-agent-cli/releases/download/{version}/{archiveName}";
             string archivePath = Path.Combine(tempDir, archiveName);
-            
+
             try
             {
                 using var stream = await httpClient.GetStreamAsync(downloadUrl);
@@ -633,7 +633,7 @@ public class CodingAgentSetupView : ViewBase
             {
                 throw new Exception($"Failed to download release archive from CDN: {ex.Message}");
             }
-            
+
             if (archivePath.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
             {
                 ZipFile.ExtractToDirectory(archivePath, tempDir, true);
@@ -659,16 +659,16 @@ public class CodingAgentSetupView : ViewBase
                     }
                 }
             }
-            
+
             string binaryName = os == "windows" ? "ivy-agent.exe" : "ivy-agent";
             var files = Directory.GetFiles(tempDir, binaryName, SearchOption.AllDirectories);
             var binarySource = files.FirstOrDefault();
-            
+
             if (string.IsNullOrEmpty(binarySource))
             {
                 throw new Exception($"Binary '{binaryName}' not found in the downloaded archive.");
             }
-            
+
             // Kill any running ivy-agent processes before updating
             try
             {
@@ -711,7 +711,7 @@ public class CodingAgentSetupView : ViewBase
             }
 
             IvyBinaryResolver.ResetCache();
-            
+
             if (os != "windows")
             {
                 var chmodInfo = new ProcessStartInfo
@@ -724,7 +724,7 @@ public class CodingAgentSetupView : ViewBase
                 using var chmodProc = Process.Start(chmodInfo);
                 if (chmodProc != null) await chmodProc.WaitForExitAsync();
             }
-            
+
             if (os == "darwin")
             {
                 var codesignInfo = new ProcessStartInfo
@@ -737,7 +737,7 @@ public class CodingAgentSetupView : ViewBase
                 using var codesignProc = Process.Start(codesignInfo);
                 if (codesignProc != null) await codesignProc.WaitForExitAsync();
             }
-            
+
             return true;
         }
         finally
@@ -746,7 +746,7 @@ public class CodingAgentSetupView : ViewBase
             {
                 if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
             }
-            catch {}
+            catch { }
         }
     }
 

--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -25,7 +25,7 @@ public class JobDebugSheet(
         var (reportBugDialog, showReportBugDialog) = UseTrigger((isOpen) =>
             !isOpen.Value ? null : new ReportBugDialog(isOpen, jobId));
 
-        #if DEBUG
+#if DEBUG
         var (debugAgentDialog, showDebugAgentDialog) = UseTrigger((isOpen) =>
         {
             if (!isOpen.Value) return null;
@@ -46,7 +46,7 @@ public class JobDebugSheet(
                 closeSheet();
             });
         });
-        #endif
+#endif
 
         var job = jobService.GetJob(jobId);
         if (job is null)
@@ -107,17 +107,17 @@ public class JobDebugSheet(
                      })
                      | new Button("Report Bug").Icon(Icons.Bug).OnClick(() => showReportBugDialog());
 
-        #if DEBUG
+#if DEBUG
         header |= new Button($"Debug with {agentBranding.Label}").Icon(agentBranding.Icon).Outline()
             .OnClick(() => showDebugAgentDialog());
-        #endif
+#endif
 
         return new Fragment(
             new HeaderLayout(header, detailsView).Size(Size.Full()),
             reportBugDialog
-            #if DEBUG
+#if DEBUG
             , debugAgentDialog
-            #endif
+#endif
         );
     }
 

--- a/src/Ivy.Tendril/Commands/UpdateCliCommand.cs
+++ b/src/Ivy.Tendril/Commands/UpdateCliCommand.cs
@@ -104,7 +104,7 @@ public class UpdateCliCommand : AsyncCommand<UpdateCliCommand.Settings>
                 .StartAsync(async ctx =>
                 {
                     var task = ctx.AddTask("[green]Downloading installer[/]", autoStart: true, maxValue: 100);
-                    
+
                     await UpdateHelper.DownloadFileWithProgressAsync(downloadUrl, tempFilePath, (read, total) =>
                     {
                         if (total > 0)
@@ -116,7 +116,7 @@ public class UpdateCliCommand : AsyncCommand<UpdateCliCommand.Settings>
 
             AnsiConsole.MarkupLine($"[green]Download complete. Launching installer...[/]");
             UpdateHelper.LaunchInstaller(tempFilePath);
-            
+
             AnsiConsole.MarkupLine("[green]Exiting Tendril to allow installation.[/]");
             Environment.Exit(0);
             return 0;

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -36,7 +36,7 @@ internal static class ServiceRegistration
                                         configService.Settings.Beta ||
                                         Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" ||
                                         Environment.GetEnvironmentVariable("IVY_BETA") == "1";
-            
+
             opts.IvyApiKeyProviderFactory = sp =>
             {
                 var config = sp.GetService<IConfigService>();
@@ -55,13 +55,13 @@ internal static class ServiceRegistration
                     return authTokenHandler?.GetCurrentToken()?.AccessToken;
                 };
             };
-            
+
             opts.IvyTokenProviderFactory = sp =>
             {
                 var authTokenHandler = sp.GetService<Ivy.IAuthTokenHandlerService>();
                 return () => authTokenHandler?.GetCurrentToken()?.AccessToken;
             };
-            
+
             opts.IvyEmailProviderFactory = sp =>
             {
                 var authTokenHandler = sp.GetService<Ivy.IAuthTokenHandlerService>();

--- a/src/Ivy.Tendril/Services/BugReportService.cs
+++ b/src/Ivy.Tendril/Services/BugReportService.cs
@@ -309,8 +309,8 @@ public sealed class BugReportService
     private void CollectJobFiles(IReadOnlyCollection<string> jobIds, List<BugReportFile> files)
     {
         foreach (var jobId in jobIds)
-        foreach (var file in JobLogPaths.AllForJobId(_config.TendrilHome, jobId))
-            files.Add(new BugReportFile(file, Path.Combine("Jobs", Path.GetFileName(file))));
+            foreach (var file in JobLogPaths.AllForJobId(_config.TendrilHome, jobId))
+                files.Add(new BugReportFile(file, Path.Combine("Jobs", Path.GetFileName(file))));
     }
 
     private static void CollectPlanFiles(string planFolder, List<BugReportFile> files)


### PR DESCRIPTION
Fixes #2060

# Summary

## Changes

Removed the Previous (P) and Next (N) navigation buttons from the Review app's action bar per GitHub issue #2060. The sidebar plan list already provides direct selection, making these buttons redundant.

## API Changes

None - this is a UI-only change in the Review app. No public APIs were modified.

## Files Modified

- `src/Ivy.Tendril/Apps/Review/ContentView.cs`:
  - Removed Previous and Next buttons from BuildActionBar
  - Deleted GoToNext and GoToPrevious navigation methods
  - Updated action bar tier comments to reflect new layout
  - Changed unused args parameter to discard in context deconstruction

## Manual Testing

1. Launch Tendril and navigate to the Review app
2. Verify the bottom action bar shows: Reset to Draft, Request Changes, Discard, and the overflow menu
3. Verify there are no Previous or Next buttons visible
4. Press the `p` and `n` keys - verify they do nothing (shortcuts removed)
5. Click different plans in the sidebar - verify plan selection still works
6. Verify the header still shows the position indicator (e.g., "1/3 plans")
7. Narrow the window below 1024px and below 768px - verify the action bar collapses cleanly with no empty leading gap
---

## Commits

- 48224ee3 Remove Previous and Next buttons from Review action bar
- 005b3aaf Apply dotnet format

---
Created using [Ivy Tendril](https://ivy.app).