### PR TITLE
[00669] Make Tool Call Titles Sticky When Scrolling

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
@@ -17,6 +17,7 @@
   --aov-warn: var(--warning);
   --aov-mono: "Geist Mono", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo,
     Consolas, monospace;
+  --aov-tool-header-h: 26px;
 
   color: var(--aov-fg);
   font-size: 14px;
@@ -309,6 +310,11 @@
   background: color-mix(in srgb, var(--muted-foreground) 4%, var(--aov-bg-elev));
 }
 
+.aov-tool.open > .aov-tool-header,
+.aov-tool-group.open > .aov-tool-group-header {
+  background: color-mix(in srgb, var(--muted-foreground) 4%, var(--aov-bg-elev));
+}
+
 .aov-tool-header {
   display: flex;
   align-items: center;
@@ -320,6 +326,9 @@
   outline: none;
   white-space: nowrap;
   min-width: 0;
+  position: sticky;
+  top: 0;
+  z-index: 2;
 }
 
 .aov-tool-chevron {
@@ -418,11 +427,18 @@
   outline: none;
   white-space: nowrap;
   min-width: 0;
+  position: sticky;
+  top: 0;
+  z-index: 3;
 }
 
 .aov-tool-group-body {
   padding: 4px 0 4px 18px;
   animation: aov-tool-expand 0.2s ease-out both;
+}
+
+.aov-tool-group-body .aov-tool-header {
+  top: var(--aov-tool-header-h);
 }
 
 .aov-tool-section {


### PR DESCRIPTION
Fixes #2093\n\n# Summary

## Changes

Added CSS sticky positioning to tool call and tool group headers in the AgentViewer widget. Headers now remain visible at the top of the scroll viewport when viewing long tool outputs, preventing context loss. The implementation uses pure CSS with no JavaScript or markup changes.

## API Changes

None.

## Files Modified

- **src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css**
  - Added `--aov-tool-header-h: 26px` CSS variable for header height
  - Made `.aov-tool-header` sticky with `z-index: 2`
  - Made `.aov-tool-group-header` sticky with `z-index: 3`
  - Added opaque background to open card headers to hide scrolling content
  - Offset nested card headers below group headers using the height variable

## Manual Testing

1. Run the AgentViewer sample app:
   ```bash
   cd src/Ivy.Tendril.Widgets/.samples
   dotnet run -- --port 5100
   ```

2. Navigate to `/agent-viewer/pre-buffered`

3. Expand a tool call with long output (e.g., a tool with extensive IN/OUT blocks)

4. Scroll down through the tool output

5. Verify the tool call title row (with chevron, status dot, and tool name) remains pinned at the top of the widget's scroll container while the card is visible

6. Scroll past the end of the tool call and verify the title unpins as the next card comes into view

7. Toggle "Group Tool Calls" on, expand a group with multiple tool calls

8. Verify:
   - The group header ("N tool calls") pins at the top
   - Individual tool headers within the group pin directly below the group header
   - Content scrolls behind the pinned headers without showing through

9. Check collapsed tool calls still have transparent backgrounds and only show background on hover

---

## Commits

- 4c94ef2a Make tool call titles sticky when scrolling

---
Created using [Ivy Tendril](https://ivy.app).