### PR TITLE
[00678] Treat HTTP 409 as a Successful Newsletter Subscription

### DIFF
--- a/src/Ivy.Tendril/Apps/Views/NewsletterView.cs
+++ b/src/Ivy.Tendril/Apps/Views/NewsletterView.cs
@@ -41,13 +41,12 @@ public class NewsletterView : ViewBase
                         source = "tendril"
                     });
 
-                    if (!response.IsSuccessStatusCode)
+                    if (!response.IsSuccessStatusCode && response.StatusCode != System.Net.HttpStatusCode.Conflict)
                     {
                         subscribed.Value = false;
                         error.Value = response.StatusCode switch
                         {
                             System.Net.HttpStatusCode.TooManyRequests => "Too many attempts. Please try again later.",
-                            System.Net.HttpStatusCode.Conflict => "This email is already subscribed.",
                             _ => "Something went wrong. Please try again later."
                         };
                     }


### PR DESCRIPTION
# Summary

## Changes

Modified the newsletter subscription handler to treat HTTP 409 Conflict responses as successful subscriptions. When the API returns 409 (email already on the list), the UI now keeps the optimistic "Subscribed!" state instead of reverting to the form with an error message.

## API Changes

None. This is an internal UI behavior change only.

## Files Modified

- **src/Ivy.Tendril/Apps/Views/NewsletterView.cs** — Modified the error handling logic to exclude 409 Conflict from the revert condition and removed the "This email is already subscribed." message

## Manual Testing

1. Run the Tendril app
2. Open Settings > Help > Newsletter (or complete onboarding to reach the newsletter signup step)
3. Enter an email address that is **already subscribed** to the newsletter
4. Click Subscribe
5. Observe that the view shows "Subscribed!" and stays in that state (does not revert to showing the form with an error message)

Additionally verify:
- Submitting a **new** email address shows "Subscribed!"
- Submitting too many requests (rate limited) reverts to the form with "Too many attempts. Please try again later."
- Network failures revert to the form with "Could not connect. Please check your internet connection."

---

## Commits

- dcdc5a7d Treat HTTP 409 as successful newsletter subscription

---
Created using [Ivy Tendril](https://ivy.app).
