### PR TITLE
[00677] Remove Previous and Next Buttons From Drafts, Icebox and Recommendations

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -23,9 +23,7 @@ public class ActionBarView(
     Action refreshPlans,
     Action<string> copyToClipboard,
     bool hasActiveExpandJob,
-    bool hasActiveSplitJob,
-    Action goToNext,
-    Action goToPrevious) : ViewBase
+    bool hasActiveSplitJob) : ViewBase
 {
     public override object Build()
     {
@@ -185,14 +183,10 @@ public class ActionBarView(
         minimalDropdownItems.AddRange(standardOverflowItems);
 
         // Action bar without .Wrap() - single row layout with progressive collapse.
-        // Full tier (>=1024px): all buttons inline + overflow-only dropdown.
-        // Compact tier (768-1023px): Previous, Next, Edit, Update inline; Split/Expand/Delete in dropdown.
-        // Minimal tier (<768px): Previous, Next inline; everything else in dropdown.
+        // Full tier (>=1024px): Edit, Update, Split, Expand, Delete inline + overflow dropdown.
+        // Compact tier (768-1023px): Edit, Update inline; Split/Expand/Delete in dropdown.
+        // Minimal tier (<768px): everything in dropdown.
         return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
-               | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(goToPrevious)
-                   .ShortcutKey("p").AlwaysVisible()
-               | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(goToNext)
-                   .ShortcutKey("n").AlwaysVisible()
                | new Button("Edit").Icon(Icons.Pencil).Outline().ShortcutKey("E")
                    .OnClick(() => isEditingState.Set(true)).CompactUp()
                | new Button("Update").Icon(Icons.WandSparkles).Outline().ShortcutKey("u")

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -296,9 +296,7 @@ public class ContentView(
             refreshPlans,
             copyToClipboard,
             hasActiveExpandJob,
-            hasActiveSplitJob,
-            GoToNext,
-            GoToPrevious);
+            hasActiveSplitJob);
 
         var mainLayout = new HeaderLayout(
             header,
@@ -595,22 +593,6 @@ public class ContentView(
         }
 
         return sb.ToString().TrimEnd();
-    }
-
-    private void GoToNext()
-    {
-        if (allPlans.Count == 0) return;
-        var currentIndex = allPlans.FindIndex(p => p.FolderName == selectedPlan?.FolderName);
-        var nextIndex = (currentIndex + 1) % allPlans.Count;
-        selectedPlanState.Set(allPlans[nextIndex]);
-    }
-
-    private void GoToPrevious()
-    {
-        if (allPlans.Count == 0) return;
-        var currentIndex = allPlans.FindIndex(p => p.FolderName == selectedPlan?.FolderName);
-        var prevIndex = (currentIndex - 1 + allPlans.Count) % allPlans.Count;
-        selectedPlanState.Set(allPlans[prevIndex]);
     }
 
     private record PlanContentData(

--- a/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/ContentView.cs
@@ -84,10 +84,6 @@ public class ContentView(
 
         var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(1).Wrap()
                         | new Button("Delete").Icon(Icons.Trash).Outline().ShortcutKey("Backspace").OnClick(() => showDeleteDialog())
-                        | new Button("Previous").Icon(Icons.ChevronLeft).Outline().OnClick(() => GoToPrevious())
-                            .ShortcutKey("p")
-                        | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().OnClick(() => GoToNext())
-                            .ShortcutKey("n")
                         | new Button("Thaw").Icon(Icons.Flame).Primary().OnClick(() =>
                         {
                             planService.TransitionState(selectedPlan.FolderName, PlanStatus.Draft);
@@ -184,21 +180,5 @@ public class ContentView(
         // Plan transition (and pre-state snapshot) handled by JobService.StartJob.
         jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath) { WaitForJobs = syncJobIds });
         refreshPlans();
-    }
-
-    private void GoToNext()
-    {
-        if (allPlans.Count == 0) return;
-        var currentIndex = allPlans.FindIndex(p => p.FolderName == selectedPlan?.FolderName);
-        var nextIndex = (currentIndex + 1) % allPlans.Count;
-        selectedPlanState.Set(allPlans[nextIndex]);
-    }
-
-    private void GoToPrevious()
-    {
-        if (allPlans.Count == 0) return;
-        var currentIndex = allPlans.FindIndex(p => p.FolderName == selectedPlan?.FolderName);
-        var prevIndex = (currentIndex - 1 + allPlans.Count) % allPlans.Count;
-        selectedPlanState.Set(allPlans[prevIndex]);
     }
 }

--- a/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Recommendations/ContentView.cs
@@ -193,14 +193,10 @@ public class ContentView(
         minimalDropdownItems.AddRange(standardOverflowItems);
 
         // Action bar without .Wrap() - single row with progressive collapse.
-        // Full (>=1024px): Previous, Next, Accept with Notes, View Plan inline + overflow dropdown.
-        // Compact (768-1023px): Previous, Next, Accept with Notes inline; View Plan in dropdown.
-        // Minimal (<768px): Previous, Next inline; everything else in dropdown.
+        // Full (>=1024px): Accept with Notes, View Plan inline + overflow dropdown.
+        // Compact (768-1023px): Accept with Notes inline; View Plan in dropdown.
+        // Minimal (<768px): everything in dropdown.
         var actionBar = Layout.Horizontal().AlignContent(Align.Left).Gap(2)
-                        | new Button("Previous").Icon(Icons.ChevronLeft).Outline().ShortcutKey("p")
-                            .OnClick(GoToPrevious).AlwaysVisible()
-                        | new Button("Next").Icon(Icons.ChevronRight, Align.Right).Outline().ShortcutKey("n")
-                            .OnClick(GoToNext).AlwaysVisible()
                         | new Button("Accept with Notes").Icon(Icons.CircleCheck).Outline().ShortcutKey("w")
                             .OnClick(() => showNotesDialog()).CompactUp()
                         | new Button("View Plan").Icon(Icons.ExternalLink).Outline()
@@ -233,14 +229,5 @@ public class ContentView(
         if (currentIndex == -1) return; // Prevent navigation if not found
         var nextIndex = (currentIndex + 1) % allRecommendations.Count;
         selectedState.Set(allRecommendations[nextIndex]);
-    }
-
-    private void GoToPrevious()
-    {
-        if (allRecommendations.Count == 0) return;
-        var currentIndex = allRecommendations.FindIndex(r => r.PlanId == selectedRecommendation?.PlanId && r.Title == selectedRecommendation?.Title);
-        if (currentIndex == -1) return; // Prevent navigation if not found
-        var prevIndex = (currentIndex - 1 + allRecommendations.Count) % allRecommendations.Count;
-        selectedState.Set(allRecommendations[prevIndex]);
     }
 }

--- a/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
+++ b/src/Ivy.Tendril/Helpers/ActionBarResponsive.cs
@@ -24,15 +24,6 @@ namespace Ivy.Tendril.Helpers;
 public static class ActionBarResponsive
 {
     /// <summary>
-    /// Shows button at all breakpoints (always visible). Used for navigation
-    /// (Previous/Next) which must stay visible at every size.
-    /// </summary>
-    public static Button AlwaysVisible(this Button btn)
-    {
-        return btn;
-    }
-
-    /// <summary>
     /// Shows button only at the Full tier — a wide desktop monitor (width ≥1024px).
     /// Hidden at the Compact and Minimal tiers, where the button collapses into a dropdown.
     /// </summary>


### PR DESCRIPTION
# Summary

## Changes

Removed redundant Previous and Next navigation buttons from the Drafts, Icebox, and Recommendations apps for consistency with the Review app. The sidebar list already provides direct plan selection, making keyboard-driven sequential navigation unnecessary. This change reduces visual clutter in the action bars and simplifies the UI.

## API Changes

**Removed:**
- `ActionBarView` (Drafts) constructor parameters: `Action goToNext`, `Action goToPrevious`
- `ActionBarResponsive.AlwaysVisible()` extension method
- Private methods `GoToNext()` and `GoToPrevious()` from Drafts and Icebox apps
- Private method `GoToPrevious()` from Recommendations app (kept `GoToNext()` as it's used by Accept/Decline handlers)

## Files Modified

**UI Components:**
- `src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs` - Removed Previous/Next buttons, updated constructor, updated tier comments
- `src/Ivy.Tendril/Apps/Drafts/ContentView.cs` - Removed GoToNext/GoToPrevious implementations
- `src/Ivy.Tendril/Apps/Icebox/ContentView.cs` - Removed Previous/Next buttons and implementations
- `src/Ivy.Tendril/Apps/Recommendations/ContentView.cs` - Removed Previous/Next buttons, removed GoToPrevious, updated tier comments

**Helper:**
- `src/Ivy.Tendril/Helpers/ActionBarResponsive.cs` - Removed now-unused AlwaysVisible() method

## Manual Testing

1. **Launch Tendril** and open the Drafts app
2. **Verify Previous/Next buttons are gone** from the bottom action bar
3. **Test keyboard shortcuts** - pressing `p` or `n` should do nothing (no navigation)
4. **Select plans** using the sidebar list - selection should work normally
5. **Repeat for Icebox and Recommendations apps** - same behavior expected
6. **In Recommendations**: Accept or Decline a recommendation - should advance to the next recommendation automatically (GoToNext still works internally)
7. **Check Onboarding wizard** - Next buttons should still be present (these are different buttons and should not be affected)
8. **Resize window** to different breakpoints (mobile, tablet, desktop) - action bar should collapse gracefully without Previous/Next taking up space

---

**Commits:**
- e7f76cb5 Remove Previous and Next navigation buttons from Drafts, Icebox and Recommendations apps

---
Created using [Ivy Tendril](https://ivy.app).
