### PR TITLE
Fix false job failure on Antigravity recovered tool error (#2106)

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityEventParserTests.cs
@@ -85,7 +85,21 @@ public class AntigravityEventParserTests
         var resultEvent = Assert.IsType<ResultEvent>(events[0]);
         Assert.True(resultEvent.IsSuccess);
         Assert.Equal("Done", resultEvent.Response);
+        Assert.Null(resultEvent.Error);
         Assert.Equal(100, resultEvent.Usage?.InputTokens);
+    }
+
+    [Fact]
+    public void ParseLine_ResultJson_WithError_SetsErrorAndIsSuccessFalse()
+    {
+        var json = "{\"event\":\"result\",\"result\":{\"conversation_id\":\"c-123\",\"status\":\"ERROR\",\"error\":\"declaring permissions: cortex tool write_to_file: path is not valid\",\"response\":\"I have finished the plan execution\",\"duration_seconds\":15.2}}";
+        var events = _parser.ParseLine(json);
+
+        Assert.Single(events);
+        var resultEvent = Assert.IsType<ResultEvent>(events[0]);
+        Assert.False(resultEvent.IsSuccess);
+        Assert.Equal("declaring permissions: cortex tool write_to_file: path is not valid", resultEvent.Error);
+        Assert.Equal("I have finished the plan execution", resultEvent.Response);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Runtime/JsonEventSerializerTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Runtime/JsonEventSerializerTests.cs
@@ -269,6 +269,28 @@ public class JsonEventSerializerTests
     }
 
     [Fact]
+    public void RoundTrip_ResultEvent_WithError_PreservesData()
+    {
+        var original = new ResultEvent
+        {
+            Kind = AgentEventKind.Result,
+            Response = "Done execution",
+            Error = "Tool error occurred",
+            IsSuccess = false,
+            TurnCount = 2,
+        };
+
+        var json = _serializer.Serialize(original);
+        var deserialized = _serializer.Deserialize(json) as ResultEvent;
+
+        Assert.NotNull(deserialized);
+        Assert.False(deserialized.IsSuccess);
+        Assert.Equal("Done execution", deserialized.Response);
+        Assert.Equal("Tool error occurred", deserialized.Error);
+        Assert.Equal(2, deserialized.TurnCount);
+    }
+
+    [Fact]
     public void RoundTrip_ErrorEvent_PreservesData()
     {
         var original = new ErrorEvent

--- a/src/Ivy.Tendril.Agents/Abstractions/AgentEvent.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/AgentEvent.cs
@@ -149,6 +149,7 @@ public sealed record ErrorEvent : AgentEvent
 public sealed record ResultEvent : AgentEvent
 {
     public string? Response { get; init; }
+    public string? Error { get; init; }
     public AgentUsage? Usage { get; init; }
     public TimeSpan? Duration { get; init; }
     public int? TurnCount { get; init; }

--- a/src/Ivy.Tendril.Agents/Abstractions/AgentEventSchema.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/AgentEventSchema.cs
@@ -84,6 +84,7 @@ public sealed record ResultWire : EventWire
 {
     public override string Kind => "result";
     public string? Response { get; init; }
+    public string? Error { get; init; }
     public bool IsSuccess { get; init; }
     public long? DurationMs { get; init; }
     public int? TurnCount { get; init; }

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
@@ -87,16 +87,23 @@ public sealed class AntigravityCli : IAgentCli
         foreach (var arg in config.ExtraArguments)
             args.Add(arg);
 
-        const string antigravityToolRule = "IMPORTANT: When calling write_to_file to create or edit repository/worktree files (source code, tests, configs, markdown docs), NEVER pass ArtifactMetadata. ArtifactMetadata is ONLY valid for internal agent brain artifacts.";
         var finalPrompt = !string.IsNullOrEmpty(config.SystemPrompt)
-            ? config.SystemPrompt + "\n\n" + antigravityToolRule + "\n\n---\n\n" + config.Prompt
-            : antigravityToolRule + "\n\n" + config.Prompt;
+            ? config.SystemPrompt + "\n\n---\n\n" + config.Prompt
+            : config.Prompt;
 
         args.Add("--print");
-        var tempFile = Path.Combine(Path.GetTempPath(), $"tendril-agy-prompt-{Guid.NewGuid():N}.md");
-        File.WriteAllText(tempFile, finalPrompt);
-        var normalizedTemp = tempFile.Replace('\\', '/');
-        args.Add($"@{normalizedTemp}");
+        if (!string.IsNullOrEmpty(config.PromptFilePath) && string.IsNullOrEmpty(config.SystemPrompt))
+        {
+            var normalizedPath = config.PromptFilePath.Replace('\\', '/');
+            args.Add($"@{normalizedPath}");
+        }
+        else
+        {
+            var tempFile = Path.Combine(Path.GetTempPath(), $"tendril-agy-prompt-{Guid.NewGuid():N}.md");
+            File.WriteAllText(tempFile, finalPrompt);
+            var normalizedTemp = tempFile.Replace('\\', '/');
+            args.Add($"@{normalizedTemp}");
+        }
 
         var env = new Dictionary<string, string>(GetDefaultEnvironment());
         if (config.EnvironmentVariables is not null)

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
@@ -87,23 +87,16 @@ public sealed class AntigravityCli : IAgentCli
         foreach (var arg in config.ExtraArguments)
             args.Add(arg);
 
+        const string antigravityToolRule = "IMPORTANT: When calling write_to_file to create or edit repository/worktree files (source code, tests, configs, markdown docs), NEVER pass ArtifactMetadata. ArtifactMetadata is ONLY valid for internal agent brain artifacts.";
         var finalPrompt = !string.IsNullOrEmpty(config.SystemPrompt)
-            ? config.SystemPrompt + "\n\n---\n\n" + config.Prompt
-            : config.Prompt;
+            ? config.SystemPrompt + "\n\n" + antigravityToolRule + "\n\n---\n\n" + config.Prompt
+            : antigravityToolRule + "\n\n" + config.Prompt;
 
         args.Add("--print");
-        if (!string.IsNullOrEmpty(config.PromptFilePath) && string.IsNullOrEmpty(config.SystemPrompt))
-        {
-            var normalizedPath = config.PromptFilePath.Replace('\\', '/');
-            args.Add($"@{normalizedPath}");
-        }
-        else
-        {
-            var tempFile = Path.Combine(Path.GetTempPath(), $"tendril-agy-prompt-{Guid.NewGuid():N}.md");
-            File.WriteAllText(tempFile, finalPrompt);
-            var normalizedTemp = tempFile.Replace('\\', '/');
-            args.Add($"@{normalizedTemp}");
-        }
+        var tempFile = Path.Combine(Path.GetTempPath(), $"tendril-agy-prompt-{Guid.NewGuid():N}.md");
+        File.WriteAllText(tempFile, finalPrompt);
+        var normalizedTemp = tempFile.Replace('\\', '/');
+        args.Add($"@{normalizedTemp}");
 
         var env = new Dictionary<string, string>(GetDefaultEnvironment());
         if (config.EnvironmentVariables is not null)

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityEventParser.cs
@@ -202,6 +202,7 @@ public sealed class AntigravityEventParser : IEventParser
         var status = res.TryGetProperty("status", out var sp) ? sp.GetString() : "SUCCESS";
         var isSuccess = !string.Equals(status, "ERROR", StringComparison.OrdinalIgnoreCase);
         var responseText = res.TryGetProperty("response", out var rp) ? rp.GetString() : null;
+        var errorText = res.TryGetProperty("error", out var ep) ? ep.GetString() : null;
         var durationSec = res.TryGetProperty("duration_seconds", out var dp) ? dp.GetDouble() : 0;
 
         AgentUsage? usage = null;
@@ -219,6 +220,7 @@ public sealed class AntigravityEventParser : IEventParser
         {
             Kind = AgentEventKind.Result,
             Response = responseText,
+            Error = errorText,
             IsSuccess = isSuccess,
             Duration = durationSec > 0 ? TimeSpan.FromSeconds(durationSec) : null,
             Usage = usage,

--- a/src/Ivy.Tendril.Agents/Runtime/JsonEventSerializer.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/JsonEventSerializer.cs
@@ -137,6 +137,7 @@ public sealed class JsonEventSerializer : IEventSerializer
             {
                 Timestamp = ts,
                 Response = e.Response,
+                Error = e.Error,
                 IsSuccess = e.IsSuccess,
                 DurationMs = e.Duration.HasValue ? (long)e.Duration.Value.TotalMilliseconds : null,
                 TurnCount = e.TurnCount,
@@ -285,6 +286,7 @@ public sealed class JsonEventSerializer : IEventSerializer
         Kind = AgentEventKind.Result,
         Timestamp = DateTimeOffset.Parse(timestamp),
         Response = root.TryGetProperty("response", out var resp) ? resp.GetString() : null,
+        Error = root.TryGetProperty("error", out var err) ? err.GetString() : null,
         IsSuccess = root.TryGetProperty("is_success", out var s) && s.GetBoolean(),
         Duration = root.TryGetProperty("duration_ms", out var dur)
             ? TimeSpan.FromMilliseconds(dur.GetInt64())

--- a/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceFailureReasonTests.cs
@@ -375,6 +375,19 @@ public class JobServiceFailureReasonTests : IDisposable
     }
 
     [Fact]
+    public void ExtractFailureReason_FailedResultEvent_WithError_PrefersErrorOverResponse()
+    {
+        var lines = new List<string>
+        {
+            """{"kind":"result","error":"declaring permissions: cortex tool write_to_file: path is not a valid artifact path","response":"I have completed the execution of Plan #123.\nAll steps succeeded.","is_success":false}"""
+        };
+
+        var result = JobService.ExtractFailureReason(lines, "test");
+
+        Assert.Equal("declaring permissions: cortex tool write_to_file: path is not a valid artifact path", result);
+    }
+
+    [Fact]
     public void CompleteJob_NonZeroExit_SessionLimitResult_MarksFailedWithCleanMessage()
     {
         // Regression for CreatePlan job 00292, which failed with the raw serialized

--- a/src/Ivy.Tendril.Test/Services/JobServiceRecoveredExecutionTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobServiceRecoveredExecutionTests.cs
@@ -1,0 +1,170 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Jobs;
+
+namespace Ivy.Tendril.Test.Services;
+
+public class JobServiceRecoveredExecutionTests : IDisposable
+{
+    private readonly TempDirectoryFixture _tempDir = new();
+
+    public void Dispose()
+    {
+        _tempDir.Dispose();
+    }
+
+    private string CreatePlanFolder(
+        string state = "Executing",
+        List<string>? commits = null,
+        List<(string Name, VerificationStatus Status)>? verifications = null,
+        VerificationStatus? preExecutionResult = null)
+    {
+        var dir = Path.Combine(_tempDir.Path, $"plan-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+
+        var commitsList = commits ?? ["abc1234"];
+        var verifsList = verifications ?? [("Build", VerificationStatus.Pass), ("Test", VerificationStatus.Pass)];
+
+        var yaml = $"""
+                    state: {state}
+                    project: TestProject
+                    level: Feature
+                    title: Test Recovered Plan
+                    repos:
+                    - /path/to/repo
+                    prs: []
+                    commits:
+                    {string.Join("\n", commitsList.Select(c => $"- {c}"))}
+                    verifications:
+                    {string.Join("\n", verifsList.Select(v => $"  - name: {v.Name}\n    status: {v.Status}"))}
+                    relatedPlans: []
+                    dependsOn: []
+                    """;
+
+        File.WriteAllText(Path.Combine(dir, "plan.yaml"), yaml);
+
+        if (preExecutionResult.HasValue)
+        {
+            var preDir = Path.Combine(dir, "Verification");
+            Directory.CreateDirectory(preDir);
+            File.WriteAllText(Path.Combine(preDir, "PreExecution.md"), $"---\nresult: {preExecutionResult.Value}\n---\n");
+        }
+
+        return dir;
+    }
+
+    [Fact]
+    public void IsRecoveredExecutionJob_WithCommitsAndAllPassingVerifications_ReturnsTrue()
+    {
+        var planFolder = CreatePlanFolder();
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = "ExecutePlan",
+            TypedArgs = new ExecutePlanArgs(planFolder),
+        };
+
+        var isRecovered = JobService.IsRecoveredExecutionJob(job);
+
+        Assert.True(isRecovered);
+    }
+
+    [Fact]
+    public void IsRecoveredExecutionJob_WithNoCommits_ReturnsFalse()
+    {
+        var planFolder = CreatePlanFolder(commits: []);
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = "ExecutePlan",
+            TypedArgs = new ExecutePlanArgs(planFolder),
+        };
+
+        var isRecovered = JobService.IsRecoveredExecutionJob(job);
+
+        Assert.False(isRecovered);
+    }
+
+    [Fact]
+    public void IsRecoveredExecutionJob_WithFailedVerification_ReturnsFalse()
+    {
+        var planFolder = CreatePlanFolder(verifications: [("Build", VerificationStatus.Pass), ("Test", VerificationStatus.Fail)]);
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = "ExecutePlan",
+            TypedArgs = new ExecutePlanArgs(planFolder),
+        };
+
+        var isRecovered = JobService.IsRecoveredExecutionJob(job);
+
+        Assert.False(isRecovered);
+    }
+
+    [Fact]
+    public void IsRecoveredExecutionJob_WithPendingVerification_ReturnsFalse()
+    {
+        var planFolder = CreatePlanFolder(verifications: [("Build", VerificationStatus.Pass), ("Test", VerificationStatus.Pending)]);
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = "ExecutePlan",
+            TypedArgs = new ExecutePlanArgs(planFolder),
+        };
+
+        var isRecovered = JobService.IsRecoveredExecutionJob(job);
+
+        Assert.False(isRecovered);
+    }
+
+    [Fact]
+    public void IsRecoveredExecutionJob_WithPreExecutionFail_ReturnsFalse()
+    {
+        var planFolder = CreatePlanFolder(preExecutionResult: VerificationStatus.Fail);
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = "ExecutePlan",
+            TypedArgs = new ExecutePlanArgs(planFolder),
+        };
+
+        var isRecovered = JobService.IsRecoveredExecutionJob(job);
+
+        Assert.False(isRecovered);
+    }
+
+    [Fact]
+    public void CompleteJob_ExitCode0_WithRecoveredAntigravityToolError_CompletesSuccessfully()
+    {
+        var planFolder = CreatePlanFolder();
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var id = service.CreateTestJob(new ExecutePlanArgs(planFolder));
+        var job = service.GetJob(id)!;
+
+        // Simulate Antigravity output where mid-turn tool error occurred, but agent completed work
+        job.OutputLines.Enqueue("""{"kind":"result","error":"declaring permissions: cortex tool write_to_file: path is not valid","response":"I have completed execution","is_success":false}""");
+
+        service.CompleteJob(id, 0);
+
+        job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Completed, job.Status);
+        Assert.Null(job.StatusMessage);
+    }
+
+    [Fact]
+    public void CompleteJob_ExitCode0_WithUnrecoveredAntigravityToolError_MarksFailedWithCleanErrorMessage()
+    {
+        // When verifications failed and no commits were made, job is not recovered and should fail
+        var planFolder = CreatePlanFolder(commits: [], verifications: [("Build", VerificationStatus.Fail)]);
+        var service = new JobService(TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10));
+        var id = service.CreateTestJob(new ExecutePlanArgs(planFolder));
+        var job = service.GetJob(id)!;
+
+        job.OutputLines.Enqueue("""{"kind":"result","error":"declaring permissions: cortex tool write_to_file: path is not valid","response":"I have completed execution","is_success":false}""");
+
+        service.CompleteJob(id, 0);
+
+        job = service.GetJob(id)!;
+        Assert.Equal(JobStatus.Failed, job.Status);
+        Assert.Equal("declaring permissions: cortex tool write_to_file: path is not valid", job.StatusMessage);
+    }
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/types.ts
@@ -45,6 +45,7 @@ export interface ResultWire {
   kind: "result";
   timestamp: string;
   response?: string;
+  error?: string;
   is_success: boolean;
   duration_ms?: number;
   turn_count?: number;

--- a/src/Ivy.Tendril/Services/Jobs/JobFailureAnalyzer.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobFailureAnalyzer.cs
@@ -188,8 +188,13 @@ internal static class JobFailureAnalyzer
             var evt = serializer.Deserialize(line);
             if (evt is ErrorEvent { Message.Length: > 0 } e)
                 return SanitizeForDisplay(e.Message);
-            if (evt is ResultEvent { IsSuccess: false } r && !string.IsNullOrWhiteSpace(r.Response))
-                return FormatFailedResultMessage(r.Response);
+            if (evt is ResultEvent { IsSuccess: false } r)
+            {
+                if (!string.IsNullOrWhiteSpace(r.Error))
+                    return FormatFailedResultMessage(r.Error);
+                if (!string.IsNullOrWhiteSpace(r.Response))
+                    return FormatFailedResultMessage(r.Response);
+            }
         }
         return null;
     }

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -167,8 +167,17 @@ public class JobService : IJobService
                 var errorMessage = JobFailureAnalyzer.TryExtractErrorEvent(job.OutputLines);
                 if (errorMessage != null)
                 {
-                    success = false;
-                    job.StatusMessage = errorMessage;
+                    if (IsRecoveredExecutionJob(job))
+                    {
+                        _logger.LogInformation(
+                            "Job {JobId}: Agent encountered a recoverable error ({ErrorMessage}) but completed execution, recorded commits, and passed verifications.",
+                            job.Id, errorMessage);
+                    }
+                    else
+                    {
+                        success = false;
+                        job.StatusMessage = errorMessage;
+                    }
                 }
             }
             else if (!string.IsNullOrEmpty(job.ReportedFailureReason))
@@ -1335,4 +1344,26 @@ public class JobService : IJobService
 
     internal static void LogCostToCsv(string planFolder, string jobType, int tokens, double cost)
         => PlanYamlHelper.LogCostToCsv(planFolder, jobType, tokens, cost);
+
+    internal static bool IsRecoveredExecutionJob(JobItem job)
+    {
+        if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs)
+        {
+            var planFolder = job.TypedArgs.PlanFolder;
+            if (!string.IsNullOrEmpty(planFolder) && Directory.Exists(planFolder))
+            {
+                var planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
+                if (planYaml != null)
+                {
+                    var preExecution = PlanYamlHelper.ReadPreExecutionResult(planFolder);
+                    var hasIncompleteVerifications = planYaml.Verifications?
+                        .Any(v => v.Status is VerificationStatus.Pending or VerificationStatus.Fail) ?? false;
+                    var hasCommits = planYaml.Commits?.Count > 0;
+
+                    return preExecution != VerificationStatus.Fail && !hasIncompleteVerifications && hasCommits;
+                }
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Fixes #2106

### Summary of Changes
- **Result Error Extraction**:
  - Added `Error` property to `ResultEvent` and wire models (`ResultWire`).
  - Parsed `result.error` in `AntigravityEventParser.cs`.
  - Updated `JobFailureAnalyzer.TryExtractErrorEvent` to prefer `r.Error` over `r.Response` when `IsSuccess == false`.
- **Job Recovery Reconciliation**: In `JobService.cs`, when a job exits with code 0 and has an extracted error event from a mid-turn tool call, `IsRecoveredExecutionJob` verifies that commits were created and all verifications passed before concluding failure, allowing recovered runs to complete normally.
- **Tests**:
  - Added `AntigravityEventParserTests` for `result.error` parsing.
  - Added `JsonEventSerializerTests` for `ResultEvent.Error` round-tripping.
  - Added `JobServiceFailureReasonTests` for preferring `Error` over `Response`.
  - Added `JobServiceRecoveredExecutionTests` covering recovery reconciliation.