### PR TITLE
[00083] Interactive Question Blocks in DraftMarkdown

### DIFF
--- a/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
+++ b/src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md
@@ -209,7 +209,8 @@ A revision can carry questions for the user in fenced `questions` blocks. Prompt
 ````
 ```questions
 questions:                    # 1-4 items
-  - title:       string       # required, the question
+  - id:          string       # required, stable, unique across the whole revision
+    title:       string       # required, the question
     header:      string       # optional, <=12 char chip label
     description: markdown     # optional, context shown under the question
     multiple:    bool         # optional, default false; true = multi-select
@@ -223,7 +224,7 @@ questions:                    # 1-4 items
 ```
 ````
 
-A block may appear anywhere in the document, and a revision may contain any number of them. No `answer` key means unanswered; `answer: null` means the user deliberately skipped the question and left the decision to the agent.
+A block may appear anywhere in the document, and a revision may contain any number of them. No `answer` key means unanswered; `answer: null` means the user deliberately skipped the question and left the decision to the agent. An answer is addressed by its question's `id` alone, so an `id` has to be unique across the whole revision rather than just within its own block.
 
 `write-revision` validates every block and refuses the write if any is malformed, printing each problem prefixed with the line of its opening fence. Nothing is written on rejection, so a rejected revision does not consume a revision number. A block whose body predates the schema (plain prose rather than a `questions` mapping) is reported as a warning and written unchanged.
 

--- a/src/Ivy.Tendril.Test/QuestionBlockParserTests.cs
+++ b/src/Ivy.Tendril.Test/QuestionBlockParserTests.cs
@@ -13,7 +13,8 @@ public class QuestionBlockParserTests
 
             ```questions
             questions:
-              - title: Which auth scheme?
+              - id: auth-scheme
+                title: Which auth scheme?
                 header: Auth
                 other: false
                 options:
@@ -29,6 +30,7 @@ public class QuestionBlockParserTests
         var blocks = QuestionBlockParser.Parse(markdown);
 
         var question = Assert.Single(Assert.Single(blocks).Block!.Questions);
+        Assert.Equal("auth-scheme", question.Id);
         Assert.Equal("Which auth scheme?", question.Title);
         Assert.Equal("Auth", question.Header);
         Assert.False(question.Other);
@@ -46,7 +48,8 @@ public class QuestionBlockParserTests
         const string markdown = """
             ```questions
             questions:
-              - title: Which platforms ship first?
+              - id: q1
+                title: Which platforms ship first?
                 multiple: true
                 options:
                   - title: Windows
@@ -71,7 +74,8 @@ public class QuestionBlockParserTests
         const string markdown = """
             ```questions
             questions:
-              - title: What should the feature be called?
+              - id: q1
+                title: What should the feature be called?
                 description: Anything is fine as long as it is not "Manager".
             ```
             """;
@@ -93,7 +97,8 @@ public class QuestionBlockParserTests
 
             ```questions
             questions:
-              - title: Really?
+              - id: q1
+                title: Really?
             ```
             """;
 
@@ -110,7 +115,8 @@ public class QuestionBlockParserTests
             ````
             ```questions
             questions:
-              - title: An example, not a real question.
+              - id: q1
+                title: An example, not a real question.
             ```
             ````
             """";
@@ -126,7 +132,8 @@ public class QuestionBlockParserTests
 
             ```questions
             questions:
-              - title: First scope question?
+              - id: q1
+                title: First scope question?
             ```
 
             ## Solution
@@ -137,7 +144,8 @@ public class QuestionBlockParserTests
 
             ```questions
             questions:
-              - title: Second design question?
+              - id: q1
+                title: Second design question?
             ```
             """;
 
@@ -188,7 +196,8 @@ public class QuestionBlockParserTests
         const string markdown = """
             ```questions
             questions:
-              - title: Broken
+              - id: q1
+                title: Broken
                 options: [unclosed
             ```
             """;
@@ -218,9 +227,11 @@ public class QuestionBlockParserTests
         const string markdown = """
             ```questions
             questions:
-              - title: Scalar?
+              - id: q1
+                title: Scalar?
                 answer: jwt
-              - title: List?
+              - id: q2
+                title: List?
                 multiple: true
                 answer: [jwt, sessions]
             ```
@@ -241,7 +252,8 @@ public class QuestionBlockParserTests
         const string markdown = """
             ```questions
             questions:
-              - title: Which auth scheme?
+              - id: q1
+                title: Which auth scheme?
                 options:
                   - title: JSON Web Tokens
                     value: jwt
@@ -263,7 +275,8 @@ public class QuestionBlockParserTests
         const string markdown = """
             ```questions
             questions:
-              - title: Never closed?
+              - id: q1
+                title: Never closed?
             """;
 
         var block = Assert.Single(QuestionBlockParser.Parse(markdown));
@@ -277,7 +290,8 @@ public class QuestionBlockParserTests
         const string markdown = """
             ```yaml
             questions:
-              - title: Documentation, not a question.
+              - id: q1
+                title: Documentation, not a question.
             ```
             """;
 
@@ -292,7 +306,8 @@ public class QuestionBlockParserTests
 
             ```questions
             questions:
-              - title: Really?
+              - id: q1
+                title: Really?
             ```
 
             Trailing prose.
@@ -301,6 +316,6 @@ public class QuestionBlockParserTests
         var range = Assert.Single(QuestionBlockParser.FindFenceRanges(markdown));
 
         Assert.Equal(3, range.StartLine);
-        Assert.Equal(6, range.EndLine);
+        Assert.Equal(7, range.EndLine);
     }
 }

--- a/src/Ivy.Tendril.Test/QuestionValidationServiceTests.cs
+++ b/src/Ivy.Tendril.Test/QuestionValidationServiceTests.cs
@@ -24,7 +24,8 @@ public class QuestionValidationServiceTests
 
             ```questions
             questions:
-              - title: Which auth scheme?
+              - id: q1
+                title: Which auth scheme?
                 header: Auth
                 other: false
                 options:
@@ -34,7 +35,8 @@ public class QuestionValidationServiceTests
                   - title: Server sessions
                     value: sessions
                 answer: jwt
-              - title: What should it be called?
+              - id: q2
+                title: What should it be called?
             ```
 
             ## Solution
@@ -58,7 +60,8 @@ public class QuestionValidationServiceTests
             ````
             ```questions
             questions:
-              - title: Documentation, with five options and every rule broken.
+              - id: q1
+                title: Documentation, with five options and every rule broken.
                 options:
                   - title: Other
                     value: NOPE
@@ -76,7 +79,8 @@ public class QuestionValidationServiceTests
     {
         var message = SingleError("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 options:
                   - title: First
                     value: first
@@ -97,7 +101,8 @@ public class QuestionValidationServiceTests
     {
         var message = SingleError($"""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 options:
                   - title: First
                     value: first
@@ -113,7 +118,8 @@ public class QuestionValidationServiceTests
     {
         var message = SingleError("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 other: false
             """);
 
@@ -125,7 +131,8 @@ public class QuestionValidationServiceTests
     {
         var message = SingleError("""
             questions:
-              - title: Which ones?
+              - id: q1
+                title: Which ones?
                 multiple: true
                 answer: first
             """);
@@ -138,7 +145,8 @@ public class QuestionValidationServiceTests
     {
         var message = SingleError("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 answer: [first, second]
             """);
 
@@ -150,7 +158,8 @@ public class QuestionValidationServiceTests
     {
         var message = SingleError("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 options:
                   - title: First
                     value: jwt
@@ -166,7 +175,8 @@ public class QuestionValidationServiceTests
     {
         var message = SingleError("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 other: false
                 options:
                   - title: First
@@ -184,7 +194,8 @@ public class QuestionValidationServiceTests
     {
         Assert.Empty(Validate("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 options:
                   - title: First
                     value: first
@@ -208,7 +219,7 @@ public class QuestionValidationServiceTests
     public void Validate_RejectsMoreThanFourQuestions()
     {
         var body = "questions:\n" + string.Join("\n",
-            Enumerable.Range(1, 5).Select(i => $"  - title: Question {i}?"));
+            Enumerable.Range(1, 5).Select(i => $"  - id: q{i}\n    title: Question {i}?"));
 
         Assert.Equal("5 questions in one block; at most 4 are allowed", SingleError(body));
     }
@@ -217,7 +228,7 @@ public class QuestionValidationServiceTests
     public void Validate_AcceptsFourQuestions()
     {
         var body = "questions:\n" + string.Join("\n",
-            Enumerable.Range(1, 4).Select(i => $"  - title: Question {i}?"));
+            Enumerable.Range(1, 4).Select(i => $"  - id: q{i}\n    title: Question {i}?"));
 
         Assert.Empty(Validate(body));
     }
@@ -227,7 +238,8 @@ public class QuestionValidationServiceTests
     {
         var message = SingleError("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 options:
                   - title: Only
                     value: only
@@ -239,7 +251,7 @@ public class QuestionValidationServiceTests
     [Fact]
     public void Validate_RejectsMoreThanFourOptions()
     {
-        var body = "questions:\n  - title: Which one?\n    options:\n" + string.Join("\n",
+        var body = "questions:\n  - id: q1\n    title: Which one?\n    options:\n" + string.Join("\n",
             Enumerable.Range(1, 5).Select(i => $"      - title: Option {i}\n        value: option-{i}"));
 
         Assert.Equal("question 1: 5 options; at most 4 are allowed", SingleError(body));
@@ -250,7 +262,8 @@ public class QuestionValidationServiceTests
     {
         var message = SingleError("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 header: ThirteenChars
             """);
 
@@ -262,7 +275,8 @@ public class QuestionValidationServiceTests
     {
         Assert.Empty(Validate("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 header: TwelveChars!
             """));
     }
@@ -272,10 +286,48 @@ public class QuestionValidationServiceTests
     {
         var message = SingleError("""
             questions:
-              - header: Auth
+              - id: q1
+                header: Auth
             """);
 
         Assert.Equal("question 1: title is required", message);
+    }
+
+    [Fact]
+    public void Validate_RejectsMissingId()
+    {
+        var message = SingleError("""
+            questions:
+              - title: Which one?
+            """);
+
+        Assert.Equal("question 1: id is required", message);
+    }
+
+    [Fact]
+    public void Validate_RejectsBlankId()
+    {
+        var message = SingleError("""
+            questions:
+              - id: "   "
+                title: Which one?
+            """);
+
+        Assert.Equal("question 1: id is required", message);
+    }
+
+    [Fact]
+    public void Validate_RejectsDuplicateIdWithinOneBlock()
+    {
+        var message = SingleError("""
+            questions:
+              - id: scope
+                title: Which one?
+              - id: scope
+                title: And which one?
+            """);
+
+        Assert.Equal("question 2: duplicate question id 'scope'", message);
     }
 
     [Theory]
@@ -287,7 +339,8 @@ public class QuestionValidationServiceTests
     {
         var message = SingleError($"""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 options:
                   - title: First
                     value: {value}
@@ -303,7 +356,8 @@ public class QuestionValidationServiceTests
     {
         Assert.Empty(Validate("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 options:
                   - title: First
                     value: json-web-tokens
@@ -317,7 +371,8 @@ public class QuestionValidationServiceTests
     {
         var message = SingleError("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 requird: true
             """);
 
@@ -330,7 +385,8 @@ public class QuestionValidationServiceTests
     {
         var message = SingleError("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 options:
                   - title: First
                     value: first
@@ -372,18 +428,47 @@ public class QuestionValidationServiceTests
 
             ```questions
             questions:
-              - title: A scope question?
+              - id: q1
+                title: A scope question?
             ```
 
             ## Solution
 
             ```questions
             questions:
-              - title: A design question?
+              - id: q2
+                title: A design question?
             ```
             """;
 
         Assert.Empty(QuestionValidationService.Validate(markdown));
+    }
+
+    [Fact]
+    public void Validate_RejectsAnIdReusedByAnotherBlock()
+    {
+        // An answer travels as an id and nothing else, so the same id in two blocks would leave it
+        // ambiguous which question was answered. Only this service sees the whole document.
+        const string markdown = """
+            ```questions
+            questions:
+              - id: scope
+                title: A scope question?
+            ```
+
+            ## Solution
+
+            ```questions
+            questions:
+              - id: scope
+                title: A design question?
+            ```
+            """;
+
+        var issue = Assert.Single(QuestionValidationService.Validate(markdown));
+
+        Assert.Equal("block 2: question 1: duplicate question id 'scope'", issue.Message);
+        Assert.Equal(9, issue.Line);
     }
 
     [Fact]
@@ -392,14 +477,17 @@ public class QuestionValidationServiceTests
         const string markdown = """
             ```questions
             questions:
-              - title: Fine?
-              - title: Also fine?
+              - id: q1
+                title: Fine?
+              - id: q2
+                title: Also fine?
                 other: false
             ```
 
             ```questions
             questions:
-              - title: Broken?
+              - id: q3
+                title: Broken?
                 header: WayTooLongHeader
             ```
             """;
@@ -410,7 +498,7 @@ public class QuestionValidationServiceTests
         Assert.Equal("block 1: question 2: other: false with no options is unanswerable", issues[0].Message);
         Assert.StartsWith("block 2: question 1: header 'WayTooLongHeader'", issues[1].Message);
         Assert.Equal(1, issues[0].Line);
-        Assert.Equal(8, issues[1].Line);
+        Assert.Equal(10, issues[1].Line);
     }
 
     [Fact]
@@ -418,7 +506,8 @@ public class QuestionValidationServiceTests
     {
         Assert.DoesNotContain("block 1", SingleError("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 other: false
             """));
     }
@@ -436,7 +525,8 @@ public class QuestionValidationServiceTests
     {
         var issues = Validate("""
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 header: FarTooLongToFit
                 options:
                   - title: First

--- a/src/Ivy.Tendril.Test/RevisionWriterTests.cs
+++ b/src/Ivy.Tendril.Test/RevisionWriterTests.cs
@@ -64,7 +64,8 @@ public class RevisionWriterTests : IDisposable
 
             ```questions
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 other: false
             ```
             """;
@@ -87,7 +88,8 @@ public class RevisionWriterTests : IDisposable
         const string invalid = """
             ```questions
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 options:
                   - title: First
                     value: jwt
@@ -110,7 +112,8 @@ public class RevisionWriterTests : IDisposable
         const string invalid = """
             ```questions
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 other: false
             ```
             """;
@@ -146,7 +149,8 @@ public class RevisionWriterTests : IDisposable
 
             ```questions
             questions:
-              - title: Which one?
+              - id: q1
+                title: Which one?
                 description: "{{bait}}"
                 options:
                   - title: First
@@ -173,7 +177,7 @@ public class RevisionWriterTests : IDisposable
     {
         // Splitting the document around the fence must not lose empty segments: a document that
         // opens with a blank line makes the first polished segment the empty string.
-        const string input = "\n\n```questions\nquestions:\n  - title: Which one?\n```\n\ntail\n";
+        const string input = "\n\n```questions\nquestions:\n  - id: q1\n    title: Which one?\n```\n\ntail\n";
 
         var written = File.ReadAllText(RevisionWriter.WriteNext(_planFolder, input, _config));
 

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsAnsweredApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsAnsweredApp.cs
@@ -1,0 +1,105 @@
+using Ivy;
+using Ivy.Tendril.Widgets;
+using DraftMarkdownWidget = Ivy.Tendril.Widgets.DraftMarkdown;
+
+namespace WidgetSamples.Apps.DraftMarkdown;
+
+/// <summary>
+///     The read-only half: no <c>OnAnswersChange</c> subscriber, so every block renders as the
+///     static blue callout regardless of whether it parses as the structured schema.
+///     <para>
+///         This is the regression guard for "an answered plan still reads correctly", and for the
+///         legacy plain-text fence that shipped before the schema existed.
+///     </para>
+/// </summary>
+[App(title: "Questions (Answered)", icon: Icons.CircleCheck, group: ["DraftMarkdown"])]
+class QuestionsAnsweredApp : ViewBase
+{
+    private const string Markdown = """
+        # Notification Delivery: Decisions Taken
+
+        This plan has been through review. Nothing below is interactive — the host did not
+        subscribe to `OnAnswersChange`, which is what keeps a plan readable in contexts that
+        only display it.
+
+        ## Answered
+
+        Every question here carries an `answer`, including a multi-select whose answer is a
+        list and a free-text answer that matches no option.
+
+        ```questions
+        questions:
+          - id: retry-scope
+            title: Should the retry budget be per-request or per-session?
+            header: Retry scope
+            other: false
+            options:
+              - title: Per request
+                value: per-request
+              - title: Per session
+                value: per-session
+                recommended: true
+              - title: Per tenant
+                value: per-tenant
+            answer: per-session
+          - id: launch-channels
+            title: Which channels should ship in the first release?
+            header: Channels
+            multiple: true
+            options:
+              - title: In-app
+                value: in-app
+              - title: Email
+                value: email
+              - title: Push
+                value: push
+              - title: Webhook
+                value: webhook
+            answer:
+              - in-app
+              - email
+          - id: service-name
+            title: What should the service be called?
+            header: Name
+            answer: courier
+        ```
+
+        ## Skipped
+
+        `answer: null` is not the same as an absent `answer`. It means the question was
+        asked and deliberately handed back — "you decide".
+
+        ```questions
+        questions:
+          - id: dead-letter
+            title: How long should undeliverable messages be retained?
+            header: Dead letter
+            description: Left to the implementer.
+            options:
+              - title: 7 days
+                value: 7d
+              - title: 30 days
+                value: 30d
+            answer: null
+        ```
+
+        ## Legacy
+
+        A fence whose body is not a YAML mapping with a `questions` key is the plain-text
+        form that predates the schema. Existing revisions contain it, it is never rewritten,
+        and it renders exactly as it always has.
+
+        ```questions
+        Should we support notification templates with variables?
+        What is the retention policy for read notifications?
+        Do we need delivery confirmation for critical notifications?
+        ```
+        """;
+
+    public override object Build() =>
+        Layout.Horizontal().Height(Size.Full()).RemoveParentPadding()
+        | new DraftMarkdownWidget(Markdown)
+            .Article()
+            .Width(Size.Full())
+            .Height(Size.Full());
+}

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsApp.cs
@@ -1,0 +1,161 @@
+using System.Collections.Immutable;
+using Ivy;
+using Ivy.Tendril.Widgets;
+using DraftMarkdownWidget = Ivy.Tendril.Widgets.DraftMarkdown;
+
+namespace WidgetSamples.Apps.DraftMarkdown;
+
+/// <summary>
+///     Interactive `questions` blocks. Subscribing to <c>OnAnswersChange</c> is what turns the
+///     read-only blue callout into a picker.
+///     <para>
+///         The document is deliberately never rewritten when an answer comes in: the event reports
+///         <c>{ QuestionId, Answer }</c> and the host decides how to persist it. So the picker only
+///         changes appearance when the markdown itself changes — what you see here instead is the
+///         raw stream of records the widget emitted.
+///     </para>
+/// </summary>
+[App(title: "Questions", icon: Icons.CircleQuestionMark, group: ["DraftMarkdown"])]
+class QuestionsApp : ViewBase
+{
+    private const string InitialMarkdown = """
+        # Notification Delivery: Open Decisions
+
+        Three decisions are still open before the delivery pipeline can be built. Each is a
+        `questions` block, and each block demonstrates a different shape from the schema.
+
+        ## Retry policy
+
+        A burst of provider failures has to be absorbed somewhere. Where the budget lives
+        decides whether one bad request can starve the rest of a session.
+
+        ```questions
+        questions:
+          - id: retry-scope
+            title: Should the retry budget be per-request or per-session?
+            header: Retry scope
+            description: A **fixed** set — one of these three, no free text.
+            other: false
+            options:
+              - title: Per request
+                description: Each call gets its own budget. Simple, but a retry storm
+                  multiplies across a session.
+                value: per-request
+              - title: Per session
+                description: One budget shared by every call in the session, so a storm
+                  is capped no matter how many calls make it up.
+                value: per-session
+                recommended: true
+              - title: Per tenant
+                description: One budget for the whole tenant. Fairest under load, hardest
+                  to reason about locally.
+                value: per-tenant
+        ```
+
+        ## Launch channels
+
+        Delivery is fanned out per channel, and each channel is a separate consumer. We do
+        not have to ship them all at once.
+
+        ```questions
+        questions:
+          - id: launch-channels
+            title: Which channels should ship in the first release?
+            header: Channels
+            description: Multi-select, and you may add a channel that is not listed.
+            multiple: true
+            options:
+              - title: In-app
+                description: WebSocket with a polling fallback.
+                value: in-app
+              - title: Email
+                description: Queued via SES with rate limiting.
+                value: email
+                recommended: true
+              - title: Push
+                description: Firebase Cloud Messaging for mobile.
+                value: push
+              - title: Webhook
+                description: Outbound POST to a tenant-supplied URL.
+                value: webhook
+        ```
+
+        ## Naming and ownership
+
+        Two questions with no options at all — the pure free-text shape. Because there is
+        more than one question in this block, they render as a tab strip.
+
+        ```questions
+        questions:
+          - id: service-name
+            title: What should the service be called?
+            header: Name
+            description: Something short enough to fit in a log prefix.
+          - id: rollout-owner
+            title: Who owns the rollout?
+            header: Owner
+            description: The person paged when delivery latency regresses.
+        ```
+
+        ## Not a question
+
+        The block below is documentation, not a question — it is written inside a longer
+        fence, so it renders as an ordinary code block and never becomes a picker.
+
+        ````
+        ```questions
+        questions:
+          - id: example
+            title: This one is an example, not a live question.
+        ```
+        ````
+        """;
+
+    public override object Build()
+    {
+        var markdown = UseState(InitialMarkdown);
+        var answers = UseState(ImmutableList<QuestionAnswer>.Empty);
+
+        object panel;
+        if (answers.Value.Count > 0)
+        {
+            var items = answers.Value.Reverse().Select(answer =>
+                (object)(Layout.Vertical().Gap(1)
+                | Text.Block(answer.QuestionId).Bold()
+                | Text.Muted(Describe(answer))));
+
+            panel = Layout.Vertical().Gap(3).Width(Size.Units(80))
+                    | Text.Block($"Answers received ({answers.Value.Count})").Bold()
+                    | Text.Muted("Newest first. Each entry is one OnAnswersChange event.")
+                    | items
+                    | new Button("Reset").Outline().OnClick(() =>
+                    {
+                        markdown.Set(InitialMarkdown);
+                        answers.Set(ImmutableList<QuestionAnswer>.Empty);
+                    });
+        }
+        else
+        {
+            panel = Layout.Vertical().Gap(3).Width(Size.Units(80))
+                    | Text.Block("Answers received (0)").Bold()
+                    | Text.Muted("Pick an option, type an answer, or press Clear. Every change "
+                                 + "shows up here as a QuestionAnswer record.");
+        }
+
+        return Layout.Horizontal().Height(Size.Full()).RemoveParentPadding()
+               | new DraftMarkdownWidget(markdown.Value)
+                   .Article()
+                   .OnAnswersChange(answer => answers.Set(answers.Value.Add(answer)))
+                   .Width(Size.Full())
+                   .Height(Size.Full())
+                   .StickyContent(panel);
+    }
+
+    /// <summary>The record's tri-state <c>Answer</c>, spelled out.</summary>
+    private static string Describe(QuestionAnswer answer) => answer.Answer switch
+    {
+        null => "cleared — back to unanswered",
+        { Count: 0 } => "skipped — answer: null",
+        var entries => string.Join(", ", entries),
+    };
+}

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsApp.cs
@@ -83,7 +83,9 @@ class QuestionsApp : ViewBase
         ## Naming and ownership
 
         Two questions with no options at all — the pure free-text shape. Because there is
-        more than one question in this block, they render as a tab strip.
+        more than one question in this block, they render as a tab strip. The second one
+        carries `answer: null` — asked and deliberately skipped — which the picker says out
+        loud instead of leaving it looking untouched.
 
         ```questions
         questions:
@@ -95,6 +97,7 @@ class QuestionsApp : ViewBase
             title: Who owns the rollout?
             header: Owner
             description: The person paged when delivery latency regresses.
+            answer: null
         ```
 
         ## Not a question

--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts
@@ -35,6 +35,11 @@ test.describe("DraftMarkdown Questions", () => {
     await expect(panel.getByText("retry-scope", { exact: true })).toBeVisible({ timeout: 15_000 });
     await expect(panel.getByText("per-request", { exact: true })).toBeVisible({ timeout: 15_000 });
 
+    // A second answer appends rather than replacing, and lands at the top (newest first).
+    await callout.locator(".pmv-question-check").nth(1).click();
+    await expect(panel.getByText("Answers received (2)")).toBeVisible({ timeout: 15_000 });
+    await expect(panel.getByText("per-session", { exact: true })).toBeVisible({ timeout: 15_000 });
+
     await stepScreenshot("answer-received");
   });
 

--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "../../fixtures/widget-test.js";
+import { navigateToApp, waitForDraftMarkdown } from "../../utils/ivy.js";
+
+test.describe("DraftMarkdown Questions", () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToApp(page, "draft-markdown/questions");
+    await waitForDraftMarkdown(page);
+  });
+
+  test("renders the picker with a recommended chip", async ({ page, stepScreenshot }) => {
+    const callout = page.locator(".pmv-questions").first();
+    await expect(callout).toBeVisible();
+
+    // Option rows, not raw YAML.
+    await expect(callout.locator(".pmv-question-option").first()).toBeVisible();
+    await expect(callout.locator(".pmv-question-title")).toContainText("retry budget");
+
+    const chip = callout.locator(".pmv-question-option-recommended").first();
+    await expect(chip).toBeVisible();
+    await expect(chip).toHaveText("Recommended");
+
+    await stepScreenshot("picker-rendered");
+  });
+
+  test("selecting an option round-trips through SignalR", async ({ page, stepScreenshot }) => {
+    // Scoped to the pinned panel: the question's own title also contains these words.
+    const panel = page.locator(".pmv-sticky");
+    await expect(panel.getByText("Answers received (0)")).toBeVisible();
+
+    const callout = page.locator(".pmv-questions").first();
+    await callout.locator(".pmv-question-check").first().click();
+
+    // The server echoes the QuestionAnswer record back into the pinned panel.
+    await expect(panel.getByText("Answers received (1)")).toBeVisible({ timeout: 15_000 });
+    await expect(panel.getByText("retry-scope", { exact: true })).toBeVisible({ timeout: 15_000 });
+    await expect(panel.getByText("per-request", { exact: true })).toBeVisible({ timeout: 15_000 });
+
+    await stepScreenshot("answer-received");
+  });
+
+  test("Clear reports the cleared state", async ({ page }) => {
+    const panel = page.locator(".pmv-sticky");
+    const callout = page.locator(".pmv-questions").first();
+    await callout.locator(".pmv-question-clear").click();
+
+    await expect(panel.getByText("Answers received (1)")).toBeVisible({ timeout: 15_000 });
+    await expect(panel.getByText("cleared — back to unanswered")).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("a documentation fence stays a code block", async ({ page }) => {
+    // The `questions` fence nested inside a four-backtick fence must never become a picker.
+    await expect(page.locator(".pmv-code-block")).toBeVisible();
+    await expect(page.locator(".pmv-code-block")).toContainText("This one is an example");
+  });
+
+  test("dragging across the picker raises no selection toolbar", async ({ page, stepScreenshot }) => {
+    const callout = page.locator(".pmv-questions").first();
+    const box = await callout.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.mouse.move(box!.x + 8, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width - 8, box!.y + box!.height / 2);
+    await page.mouse.up();
+
+    await expect(page.locator(".pmv-selection-toolbar")).toHaveCount(0);
+    await stepScreenshot("no-toolbar-over-picker");
+  });
+});

--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/questions.spec.ts
@@ -58,6 +58,23 @@ test.describe("DraftMarkdown Questions", () => {
     await expect(page.locator(".pmv-code-block")).toContainText("This one is an example");
   });
 
+  test("the answered sample stays read-only", async ({ page, stepScreenshot }) => {
+    await navigateToApp(page, "draft-markdown/questions-answered");
+    await waitForDraftMarkdown(page);
+
+    // No OnAnswersChange subscriber, so every block renders as the static callout — including the
+    // ones that parse as the structured schema.
+    const callouts = page.locator(".pmv-questions");
+    await expect(callouts).toHaveCount(3);
+    await expect(page.locator(".pmv-question-option")).toHaveCount(0);
+    await expect(callouts.first().locator(".pmv-questions-content")).toBeVisible();
+
+    // The legacy plain-text fence still reads as prose.
+    await expect(callouts.nth(2)).toContainText("Should we support notification templates");
+
+    await stepScreenshot("answered-read-only");
+  });
+
   test("dragging across the picker raises no selection toolbar", async ({ page, stepScreenshot }) => {
     const callout = page.locator(".pmv-questions").first();
     const box = await callout.boundingBox();

--- a/src/Ivy.Tendril.Widgets/DraftMarkdown.cs
+++ b/src/Ivy.Tendril.Widgets/DraftMarkdown.cs
@@ -12,6 +12,21 @@ public record MarkdownAnnotation
 }
 
 /// <summary>
+/// A single question's answer, identified by the question's <c>id</c> in the <c>questions</c>
+/// YAML schema. <see cref="Answer" /> encodes all three answer states without a sentinel:
+/// <c>null</c> clears the question back to unanswered (removes the <c>answer</c> key), an empty
+/// list records an explicit skip (<c>answer: null</c>), and a non-empty list is the answer itself —
+/// one entry for a single-select or free-text question, several when the question's
+/// <c>multiple</c> is <c>true</c>.
+/// <para>
+/// Merging this back into the block's YAML is the host's job: find the question by <c>id</c> and
+/// set or delete its <c>answer</c> key. The widget's <c>setAnswer</c> in <c>questionsSource.ts</c>
+/// is the reference implementation of that merge.
+/// </para>
+/// </summary>
+public sealed record QuestionAnswer(string QuestionId, IReadOnlyList<string>? Answer);
+
+/// <summary>
 /// Renders plan markdown in its own internal scroll container, alongside a
 /// <c>StickyContent</c> slot that is pinned in place and unaffected by the
 /// markdown scroll. Use the slot for interactive elements that should stay put
@@ -50,6 +65,13 @@ public record DraftMarkdown : WidgetBase<DraftMarkdown>
 
     /// <summary>Fired when annotations are added, edited, or removed.</summary>
     [Event] public EventHandler<Event<DraftMarkdown, List<MarkdownAnnotation>>>? OnAnnotationsChange { get; init; }
+
+    /// <summary>
+    /// Fired when the user answers, skips, or clears a question in a <c>questions</c> block.
+    /// Subscribing is also what switches those blocks from a read-only callout to an interactive
+    /// picker; a host that does not subscribe renders exactly as before.
+    /// </summary>
+    [Event] public EventHandler<Event<DraftMarkdown, QuestionAnswer>>? OnAnswersChange { get; init; }
 }
 
 public static class DraftMarkdownExtensions
@@ -99,6 +121,21 @@ public static class DraftMarkdownExtensions
             OnAnnotationsChange = new(e =>
             {
                 handler(e.Value.ToImmutableList());
+                return ValueTask.CompletedTask;
+            }),
+        };
+
+    public static DraftMarkdown OnAnswersChange(
+        this DraftMarkdown w,
+        Func<Event<DraftMarkdown, QuestionAnswer>, ValueTask> handler
+    ) => w with { OnAnswersChange = new(handler) };
+
+    public static DraftMarkdown OnAnswersChange(this DraftMarkdown w, Action<QuestionAnswer> handler) =>
+        w with
+        {
+            OnAnswersChange = new(e =>
+            {
+                handler(e.Value);
                 return ValueTask.CompletedTask;
             }),
         };

--- a/src/Ivy.Tendril.Widgets/frontend/package.json
+++ b/src/Ivy.Tendril.Widgets/frontend/package.json
@@ -23,7 +23,8 @@
     "rehype-katex": "7.0.1",
     "remark-gfm": "4.0.1",
     "remark-math": "6.0.0",
-    "unidiff": "^1.0.4"
+    "unidiff": "^1.0.4",
+    "yaml": "2.9.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/src/Ivy.Tendril.Widgets/frontend/pnpm-lock.yaml
+++ b/src/Ivy.Tendril.Widgets/frontend/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       unidiff:
         specifier: ^1.0.4
         version: 1.0.4
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -90,7 +93,7 @@ importers:
         version: 15.5.13
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))
+        version: 6.0.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))
       autoprefixer:
         specifier: 10.4.23
         version: 10.4.23(postcss@8.5.18)
@@ -102,19 +105,19 @@ importers:
         version: 8.5.18
       tailwindcss:
         specifier: 3.4.19
-        version: 3.4.19
+        version: 3.4.19(yaml@2.9.0)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.2.1
-        version: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)'
+        version: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0)'
       vite-plus:
         specifier: 0.2.1
-        version: 0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)
+        version: 0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)(yaml@2.9.0)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@types/node@25.9.0)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jsdom@29.1.1)
+        version: 4.1.9(@types/node@25.9.0)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(jsdom@29.1.1)
 
 packages:
 
@@ -2426,6 +2429,11 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -2979,33 +2987,33 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@6.0.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))':
+  '@vitejs/plugin-react@6.0.1(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0)'
 
-  '@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(vitest@4.1.9)':
+  '@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(vitest@4.1.9)
-      vitest: 4.1.9(@types/node@25.9.0)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jsdom@29.1.1)
+      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(vitest@4.1.9)
+      vitest: 4.1.9(@types/node@25.9.0)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(jsdom@29.1.1)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(vitest@4.1.9)':
+  '@vitest/browser@4.1.10(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))
+      '@vitest/mocker': 4.1.10(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@25.9.0)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jsdom@29.1.1)
+      vitest: 4.1.9(@types/node@25.9.0)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(jsdom@29.1.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -3022,21 +3030,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))':
+  '@vitest/mocker@4.1.10(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0)'
 
-  '@vitest/mocker@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))':
+  '@vitest/mocker@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0)'
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -3074,7 +3082,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)':
+  '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
       '@oxc-project/runtime': 0.136.0
       '@oxc-project/types': 0.136.0
@@ -3085,6 +3093,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
       typescript: 5.9.3
+      yaml: 2.9.0
 
   '@voidzero-dev/vite-plus-darwin-arm64@0.2.1':
     optional: true
@@ -4211,7 +4220,7 @@ snapshots:
 
   obug@2.1.1: {}
 
-  oxfmt@0.55.0(vite-plus@0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)):
+  oxfmt@0.55.0(vite-plus@0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
@@ -4234,7 +4243,7 @@ snapshots:
       '@oxfmt/binding-win32-arm64-msvc': 0.55.0
       '@oxfmt/binding-win32-ia32-msvc': 0.55.0
       '@oxfmt/binding-win32-x64-msvc': 0.55.0
-      vite-plus: 0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)
+      vite-plus: 0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)(yaml@2.9.0)
 
   oxlint-tsgolint@0.23.0:
     optionalDependencies:
@@ -4245,7 +4254,7 @@ snapshots:
       '@oxlint-tsgolint/win32-arm64': 0.23.0
       '@oxlint-tsgolint/win32-x64': 0.23.0
 
-  oxlint@1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)):
+  oxlint@1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.70.0
       '@oxlint/binding-android-arm64': 1.70.0
@@ -4267,7 +4276,7 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.70.0
       '@oxlint/binding-win32-x64-msvc': 1.70.0
       oxlint-tsgolint: 0.23.0
-      vite-plus: 0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)
+      vite-plus: 0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)(yaml@2.9.0)
 
   package-manager-detector@1.6.0: {}
 
@@ -4330,12 +4339,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.18
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.18):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.18)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.18
+      yaml: 2.9.0
 
   postcss-nested@6.2.0(postcss@8.5.18):
     dependencies:
@@ -4574,7 +4584,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(yaml@2.9.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -4593,7 +4603,7 @@ snapshots:
       postcss: 8.5.18
       postcss-import: 15.1.0(postcss@8.5.18)
       postcss-js: 4.1.0(postcss@8.5.18)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.18)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.18)(yaml@2.9.0)
       postcss-nested: 6.2.0(postcss@8.5.18)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -4731,24 +4741,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plus@0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3):
+  vite-plus@0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       '@oxc-project/types': 0.136.0
       '@oxlint/plugins': 1.68.0
-      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(vitest@4.1.9)
-      '@vitest/browser-preview': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(vitest@4.1.9)
+      '@vitest/browser': 4.1.10(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser-preview': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))
+      '@vitest/mocker': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
       '@vitest/spy': 4.1.9
       '@vitest/utils': 4.1.9
-      '@voidzero-dev/vite-plus-core': 0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)
-      oxfmt: 0.55.0(vite-plus@0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3))
-      oxlint: 1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3))
+      '@voidzero-dev/vite-plus-core': 0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0)
+      oxfmt: 0.55.0(vite-plus@0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)(yaml@2.9.0))
+      oxlint: 1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.2.1(@types/node@25.9.0)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(jiti@1.21.7)(jsdom@29.1.1)(typescript@5.9.3)(yaml@2.9.0))
       oxlint-tsgolint: 0.23.0
-      vitest: 4.1.9(@types/node@25.9.0)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jsdom@29.1.1)
+      vitest: 4.1.9(@types/node@25.9.0)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(jsdom@29.1.1)
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.1
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.1
@@ -4791,10 +4801,10 @@ snapshots:
       - vite
       - yaml
 
-  vitest@4.1.9(@types/node@25.9.0)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(jsdom@29.1.1):
+  vitest@4.1.9(@types/node@25.9.0)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(jsdom@29.1.1):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))
+      '@vitest/mocker': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -4811,11 +4821,11 @@ snapshots:
       tinyexec: 1.2.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0)'
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.0
-      '@vitest/browser-preview': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3))(vitest@4.1.9)
+      '@vitest/browser-preview': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@25.9.0)(jiti@1.21.7)(typescript@5.9.3)(yaml@2.9.0))(vitest@4.1.9)
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
@@ -4852,5 +4862,7 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  yaml@2.9.0: {}
 
   zwitch@2.0.4: {}

--- a/src/Ivy.Tendril.Widgets/frontend/src/BlockHandler.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/BlockHandler.tsx
@@ -1,7 +1,11 @@
-import React, { lazy, Suspense, useCallback, useState } from "react";
+import React, { lazy, Suspense, useCallback, useContext, useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { prismTheme } from "./prismTheme";
 import { QuestionsCallout } from "./DraftMarkdown/QuestionsCallout";
+import { QuestionsAnswerContext } from "./DraftMarkdown/questionsContext";
+
+/** `questions`, or `questions_<n>` once `tagQuestionBlocks` has stamped the block's index on it. */
+const QUESTIONS_LANG = /^questions(?:_(\d+))?$/;
 
 const MermaidRenderer = lazy(() => import("./DraftMarkdown/MermaidRenderer").then((m) => ({ default: m.MermaidRenderer })));
 const GraphvizRenderer = lazy(() => import("./DraftMarkdown/GraphvizRenderer").then((m) => ({ default: m.GraphvizRenderer })));
@@ -34,6 +38,7 @@ export const BlockHandler: React.FC<React.HTMLAttributes<HTMLElement>> = ({ clas
   const match = /language-(\w+)/.exec(String(className || ""));
   const content = String(children).replace(/\n$/, "");
   const [copied, setCopied] = useState(false);
+  const onAnswer = useContext(QuestionsAnswerContext);
 
   const handleCopy = useCallback(() => {
     navigator.clipboard.writeText(content).then(() => {
@@ -61,8 +66,15 @@ export const BlockHandler: React.FC<React.HTMLAttributes<HTMLElement>> = ({ clas
       );
     }
 
-    if (lang === "questions") {
-      return <QuestionsCallout content={content} />;
+    const questions = QUESTIONS_LANG.exec(lang);
+    if (questions) {
+      return (
+        <QuestionsCallout
+          content={content}
+          blockIndex={questions[1] ? Number(questions[1]) : 0}
+          onAnswer={onAnswer}
+        />
+      );
     }
 
     const normalizedLang = lang === "xml" || lang === "html" || lang === "svg" ? "markup" : lang;

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.questions.test.tsx
@@ -200,6 +200,32 @@ describe("DraftMarkdown interactive questions", () => {
     expect(answerCalls(eventHandler)).toEqual([{ questionId: "budget", answer: null }]);
   });
 
+  it("marks an explicitly skipped question as skipped rather than unanswered", () => {
+    const skipped = fence(
+      "questions:",
+      "  - id: budget",
+      "    title: Retry budget scope?",
+      "    options:",
+      "      - title: Per request",
+      "        value: per-request",
+      "      - title: Per session",
+      "        value: per-session",
+      "    answer: null",
+    );
+
+    const { container } = renderInteractive(skipped);
+
+    expect(container.querySelector(".pmv-question-skipped")?.textContent).toBe("Skipped — you decide");
+    // Skipping selects nothing, which is what made it look identical to an untouched question.
+    expect(checks(container).some((check) => check.checked)).toBe(false);
+  });
+
+  it("does not mark an unanswered question as skipped", () => {
+    const { container } = renderInteractive(SINGLE);
+
+    expect(container.querySelector(".pmv-question-skipped")).toBeNull();
+  });
+
   it("renders no Other row when other is false", () => {
     const { container } = renderInteractive(SINGLE_NO_OTHER);
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.questions.test.tsx
@@ -148,7 +148,7 @@ describe("DraftMarkdown interactive questions", () => {
 
     expect(eventHandler).toHaveBeenCalledTimes(1);
     expect(eventHandler).toHaveBeenCalledWith("OnAnswersChange", "w1", [
-      { QuestionId: "budget", Answer: ["per-request"] },
+      { questionId: "budget", answer: ["per-request"] },
     ]);
   });
 
@@ -157,7 +157,7 @@ describe("DraftMarkdown interactive questions", () => {
 
     fireEvent.click(checks(container)[1]);
 
-    expect(answerCalls(eventHandler)).toEqual([{ QuestionId: "budget", Answer: ["per-session"] }]);
+    expect(answerCalls(eventHandler)).toEqual([{ questionId: "budget", answer: ["per-session"] }]);
   });
 
   it("accumulates values on a multi-select question", () => {
@@ -166,7 +166,7 @@ describe("DraftMarkdown interactive questions", () => {
     fireEvent.click(checks(container)[1]);
 
     expect(answerCalls(eventHandler)).toEqual([
-      { QuestionId: "channels", Answer: ["in-app", "email"] },
+      { questionId: "channels", answer: ["in-app", "email"] },
     ]);
   });
 
@@ -175,7 +175,7 @@ describe("DraftMarkdown interactive questions", () => {
 
     fireEvent.click(checks(container)[0]);
 
-    expect(answerCalls(eventHandler)).toEqual([{ QuestionId: "channels", Answer: [] }]);
+    expect(answerCalls(eventHandler)).toEqual([{ questionId: "channels", answer: [] }]);
   });
 
   it("fires the typed text when Other is chosen", () => {
@@ -189,7 +189,7 @@ describe("DraftMarkdown interactive questions", () => {
     expect(input).not.toBeNull();
     fireEvent.change(input!, { target: { value: "per-tenant" } });
 
-    expect(answerCalls(eventHandler)).toEqual([{ QuestionId: "budget", Answer: ["per-tenant"] }]);
+    expect(answerCalls(eventHandler)).toEqual([{ questionId: "budget", answer: ["per-tenant"] }]);
   });
 
   it("fires a null answer when Clear is used", () => {
@@ -197,7 +197,7 @@ describe("DraftMarkdown interactive questions", () => {
 
     fireEvent.click(container.querySelector<HTMLButtonElement>(".pmv-question-clear")!);
 
-    expect(answerCalls(eventHandler)).toEqual([{ QuestionId: "budget", Answer: null }]);
+    expect(answerCalls(eventHandler)).toEqual([{ questionId: "budget", answer: null }]);
   });
 
   it("renders no Other row when other is false", () => {
@@ -218,7 +218,7 @@ describe("DraftMarkdown interactive questions", () => {
     expect(input).not.toBeNull();
 
     fireEvent.change(input!, { target: { value: "Notifier" } });
-    expect(answerCalls(eventHandler)).toEqual([{ QuestionId: "name", Answer: ["Notifier"] }]);
+    expect(answerCalls(eventHandler)).toEqual([{ questionId: "name", answer: ["Notifier"] }]);
   });
 
   it("marks the recommended option with a chip", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.questions.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { render } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
 import { DraftMarkdown } from "./DraftMarkdown";
 
 const renderContent = (content: string) => {
@@ -40,5 +40,260 @@ describe("DraftMarkdown questions callout", () => {
     const content_ = container.querySelector(".pmv-questions-content");
     expect(content_).not.toBeNull();
     expect(content_?.textContent).toBe("First question?\nSecond question?");
+  });
+});
+
+// ─── Interactive picker ───────────────────────────────────────────────────
+
+const fence = (...body: string[]) => ["```questions", ...body, "```"].join("\n");
+
+const SINGLE = fence(
+  "questions:",
+  "  - id: budget",
+  "    title: Should the retry budget be per-request or per-session?",
+  "    options:",
+  "      - title: Per request",
+  "        value: per-request",
+  "      - title: Per session",
+  "        value: per-session",
+  "        recommended: true",
+);
+
+const SINGLE_NO_OTHER = fence(
+  "questions:",
+  "  - id: budget",
+  "    title: Retry budget scope?",
+  "    other: false",
+  "    options:",
+  "      - title: Per request",
+  "        value: per-request",
+  "      - title: Per session",
+  "        value: per-session",
+);
+
+const SINGLE_ANSWERED = fence(
+  "questions:",
+  "  - id: budget",
+  "    title: Retry budget scope?",
+  "    options:",
+  "      - title: Per request",
+  "        value: per-request",
+  "      - title: Per session",
+  "        value: per-session",
+  "    answer: per-request",
+);
+
+const MULTI_ANSWERED = fence(
+  "questions:",
+  "  - id: channels",
+  "    title: Which channels ship first?",
+  "    multiple: true",
+  "    options:",
+  "      - title: In-app",
+  "        value: in-app",
+  "      - title: Email",
+  "        value: email",
+  "      - title: Push",
+  "        value: push",
+  "    answer:",
+  "      - in-app",
+);
+
+const TWO_QUESTIONS = fence(
+  "questions:",
+  "  - id: naming",
+  "    title: What should it be called?",
+  "    header: Naming",
+  "  - id: owner",
+  "    title: Who owns the rollout?",
+  "    header: Owner",
+  "    answer: platform",
+);
+
+const renderInteractive = (content: string) => {
+  const eventHandler = vi.fn();
+  const { container } = render(
+    <DraftMarkdown id="w1" content={content} events={["OnAnswersChange"]} eventHandler={eventHandler} />,
+  );
+  return { container, eventHandler };
+};
+
+const checks = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll<HTMLInputElement>(".pmv-question-check"));
+
+const answerCalls = (eventHandler: ReturnType<typeof vi.fn>) =>
+  eventHandler.mock.calls.map((call) => call[2][0]);
+
+describe("DraftMarkdown interactive questions", () => {
+  it("renders option rows rather than raw YAML when the host subscribes", () => {
+    const { container } = renderInteractive(SINGLE);
+
+    expect(container.querySelectorAll(".pmv-question-option").length).toBeGreaterThan(0);
+    expect(container.querySelector(".pmv-questions-content")).toBeNull();
+    expect(container.textContent).not.toContain("questions:");
+    expect(container.textContent).toContain("Per request");
+  });
+
+  it("renders the static callout when the host does not subscribe", () => {
+    const container = renderContent(SINGLE);
+
+    expect(container.querySelector(".pmv-question-option")).toBeNull();
+    expect(container.querySelector(".pmv-questions-content")?.textContent).toContain("questions:");
+  });
+
+  it("fires once with the question id and a one-element list when an option is clicked", () => {
+    const { container, eventHandler } = renderInteractive(SINGLE);
+
+    fireEvent.click(checks(container)[0]);
+
+    expect(eventHandler).toHaveBeenCalledTimes(1);
+    expect(eventHandler).toHaveBeenCalledWith("OnAnswersChange", "w1", [
+      { QuestionId: "budget", Answer: ["per-request"] },
+    ]);
+  });
+
+  it("replaces the previous value on a single-select question", () => {
+    const { container, eventHandler } = renderInteractive(SINGLE_ANSWERED);
+
+    fireEvent.click(checks(container)[1]);
+
+    expect(answerCalls(eventHandler)).toEqual([{ QuestionId: "budget", Answer: ["per-session"] }]);
+  });
+
+  it("accumulates values on a multi-select question", () => {
+    const { container, eventHandler } = renderInteractive(MULTI_ANSWERED);
+
+    fireEvent.click(checks(container)[1]);
+
+    expect(answerCalls(eventHandler)).toEqual([
+      { QuestionId: "channels", Answer: ["in-app", "email"] },
+    ]);
+  });
+
+  it("removes a value when an already-selected multi-select option is clicked", () => {
+    const { container, eventHandler } = renderInteractive(MULTI_ANSWERED);
+
+    fireEvent.click(checks(container)[0]);
+
+    expect(answerCalls(eventHandler)).toEqual([{ QuestionId: "channels", Answer: [] }]);
+  });
+
+  it("fires the typed text when Other is chosen", () => {
+    const { container, eventHandler } = renderInteractive(SINGLE);
+
+    const otherRow = container.querySelector(".pmv-question-option--other");
+    expect(otherRow).not.toBeNull();
+    fireEvent.click(otherRow!.querySelector<HTMLInputElement>(".pmv-question-check")!);
+
+    const input = container.querySelector<HTMLInputElement>(".pmv-question-other-input");
+    expect(input).not.toBeNull();
+    fireEvent.change(input!, { target: { value: "per-tenant" } });
+
+    expect(answerCalls(eventHandler)).toEqual([{ QuestionId: "budget", Answer: ["per-tenant"] }]);
+  });
+
+  it("fires a null answer when Clear is used", () => {
+    const { container, eventHandler } = renderInteractive(SINGLE);
+
+    fireEvent.click(container.querySelector<HTMLButtonElement>(".pmv-question-clear")!);
+
+    expect(answerCalls(eventHandler)).toEqual([{ QuestionId: "budget", Answer: null }]);
+  });
+
+  it("renders no Other row when other is false", () => {
+    const { container } = renderInteractive(SINGLE_NO_OTHER);
+
+    expect(container.querySelector(".pmv-question-option--other")).toBeNull();
+    expect(container.querySelector(".pmv-question-other-input")).toBeNull();
+    expect(container.querySelectorAll(".pmv-question-option")).toHaveLength(2);
+  });
+
+  it("renders a free-text input and no options for a question with no options", () => {
+    const { container, eventHandler } = renderInteractive(
+      fence("questions:", "  - id: name", "    title: What should it be called?"),
+    );
+
+    expect(container.querySelector(".pmv-question-option--other")).toBeNull();
+    const input = container.querySelector<HTMLInputElement>(".pmv-question-other-input");
+    expect(input).not.toBeNull();
+
+    fireEvent.change(input!, { target: { value: "Notifier" } });
+    expect(answerCalls(eventHandler)).toEqual([{ QuestionId: "name", Answer: ["Notifier"] }]);
+  });
+
+  it("marks the recommended option with a chip", () => {
+    const { container } = renderInteractive(SINGLE);
+
+    const chips = container.querySelectorAll(".pmv-question-option-recommended");
+    expect(chips).toHaveLength(1);
+    expect(chips[0].textContent).toBe("Recommended");
+    expect(chips[0].closest(".pmv-question-option")?.textContent).toContain("Per session");
+  });
+
+  it("renders a tab per question, badged once answered", () => {
+    const { container } = renderInteractive(TWO_QUESTIONS);
+
+    const tabs = container.querySelectorAll(".pmv-questions-tab");
+    expect(tabs).toHaveLength(2);
+    expect(Array.from(tabs).map((t) => t.textContent?.trim())).toEqual(["Naming", "Owner"]);
+    expect(container.querySelectorAll(".pmv-questions-tab-badge")).toHaveLength(1);
+    expect(tabs[1].querySelector(".pmv-questions-tab-badge")).not.toBeNull();
+  });
+
+  it("switches the visible question when a tab is clicked", () => {
+    const { container } = renderInteractive(TWO_QUESTIONS);
+
+    expect(container.querySelector(".pmv-question-title")?.textContent).toBe(
+      "What should it be called?",
+    );
+
+    fireEvent.click(container.querySelectorAll(".pmv-questions-tab")[1]);
+
+    expect(container.querySelector(".pmv-question-title")?.textContent).toBe(
+      "Who owns the rollout?",
+    );
+  });
+
+  it("renders no tab strip for a single question", () => {
+    const { container } = renderInteractive(SINGLE);
+
+    expect(container.querySelector(".pmv-questions-tabs")).toBeNull();
+  });
+
+  it("keeps a legacy prose fence static next to a structured one", () => {
+    const legacy = "```questions\nWhat is the retention policy?\n```";
+    const { container } = renderInteractive(`${legacy}\n\n${SINGLE}`);
+
+    const callouts = container.querySelectorAll(".pmv-questions");
+    expect(callouts).toHaveLength(2);
+
+    expect(callouts[0].querySelector(".pmv-questions-content")?.textContent).toBe(
+      "What is the retention policy?",
+    );
+    expect(callouts[0].querySelector(".pmv-question-option")).toBeNull();
+    expect(callouts[1].querySelector(".pmv-questions-content")).toBeNull();
+    expect(callouts[1].querySelectorAll(".pmv-question-option").length).toBeGreaterThan(0);
+  });
+
+  it("gives each block its own radio group so two blocks do not interfere", () => {
+    const { container } = renderInteractive(`${SINGLE}\n\n${SINGLE_NO_OTHER}`);
+
+    const names = new Set(checks(container).map((input) => input.name));
+    expect(names.size).toBe(2);
+  });
+
+  it("does not wrap the question UI in a pre", () => {
+    const { container } = renderInteractive(SINGLE);
+
+    expect(container.querySelector(".pmv-questions")).not.toBeNull();
+    expect(container.querySelector("pre .pmv-questions")).toBeNull();
+    expect(container.querySelector("pre")).toBeNull();
+  });
+
+  it("still wraps an ordinary fence in its code block after the pre override", () => {
+    const { container } = renderInteractive("```js\nconst x = 1;\n```");
+
+    expect(container.querySelector(".pmv-code-block")).not.toBeNull();
+    expect(container.querySelector("pre")).not.toBeNull();
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
@@ -77,7 +77,9 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
       const value =
         answer === undefined ? null : answer === null ? [] : Array.isArray(answer) ? answer : [answer];
 
-      eventHandler("OnAnswersChange", id, [{ QuestionId: questionId, Answer: value }]);
+      // camelCase on the wire: the server deserializes event args with a camelCase naming policy
+      // and no case-insensitive fallback, so PascalCase keys would bind to nothing.
+      eventHandler("OnAnswersChange", id, [{ questionId, answer: value }]);
     },
     [eventHandler, id],
   );

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
@@ -10,6 +10,9 @@ import { AlertBlockquote } from "./AlertBlockquote";
 import { ImageRenderer } from "./ImageRenderer";
 import { isLocalFileUrl, transformLocalFileUrl } from "./localFiles";
 import { getMarkdownPlugins } from "../math";
+import { tagQuestionBlocks } from "./questionsSource";
+import { QuestionsAnswerContext } from "./questionsContext";
+import type { AnswerCallback } from "./questionsContext";
 
 type IvyEventHandler = (eventName: string, widgetId: string, args: unknown[]) => void;
 
@@ -61,6 +64,26 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
   const [editPopover, setEditPopover] = useState<{ position: Position; annotation: MarkdownAnnotation } | null>(null);
 
   const annotationsEnabled = events.includes("OnAnnotationsChange");
+  const questionsEnabled = events.includes("OnAnswersChange");
+
+  // Reports one changed question. `Answer` carries all three states without a sentinel: null
+  // clears the question back to unanswered, an empty list is an explicit skip, and a non-empty
+  // list is the answer itself. The document is never merged here — the host decides how and
+  // whether to persist it.
+  const handleAnswer = useCallback<AnswerCallback>(
+    (questionId, answer) => {
+      if (!eventHandler) return;
+
+      const value =
+        answer === undefined ? null : answer === null ? [] : Array.isArray(answer) ? answer : [answer];
+
+      eventHandler("OnAnswersChange", id, [{ QuestionId: questionId, Answer: value }]);
+    },
+    [eventHandler, id],
+  );
+
+  // undefined puts every callout in read-only mode, mirroring how annotations gate on their event.
+  const answerCallback = questionsEnabled ? handleAnswer : undefined;
 
   const fireAnnotationsChange = useCallback(
     (newAnnotations: MarkdownAnnotation[]) => {
@@ -262,9 +285,30 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
     [dangerouslyAllowLocalFiles],
   );
 
+  // react-markdown wraps an overridden `code` element in a `pre`. A question form is flow content
+  // and does not belong inside one — inputs there inherit the monospace stack — so the wrapper is
+  // dropped for questions blocks only.
+  const pre = useCallback((props: React.HTMLAttributes<HTMLPreElement>) => {
+    const { children, ...rest } = props;
+    const only = React.Children.count(children) === 1 ? React.Children.toArray(children)[0] : null;
+
+    if (React.isValidElement<{ className?: string }>(only)) {
+      if (/(^|\s)language-questions(_\d+)?(\s|$)/.test(String(only.props.className ?? ""))) {
+        return <>{children}</>;
+      }
+    }
+
+    return <pre {...rest}>{children}</pre>;
+  }, []);
+
   // Math plugins are added only when the content actually contains math
   // delimiters, so plain plan markdown skips the extra KaTeX pass entirely.
   const plugins = useMemo(() => getMarkdownPlugins(content), [content]);
+
+  // Each top-level `questions` fence gets its index stamped onto its info line, which is how the
+  // renderer learns which block it is dispatching. The info line is never rendered, so annotation
+  // offsets — computed over rendered text — are unaffected.
+  const tagged = useMemo(() => tagQuestionBlocks(content), [content]);
 
   const fixed = slots?.StickyContent;
   const hasFixed = !!fixed && React.Children.count(fixed) > 0;
@@ -278,14 +322,16 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
     <div className="pmv-shell" style={shellStyle}>
       <div className="pmv-body">
         <div ref={contentRef} className={article ? "pmv-markdown pmv-article" : "pmv-markdown"}>
-          <Markdown
-            remarkPlugins={plugins.remarkPlugins}
-            rehypePlugins={plugins.rehypePlugins}
-            urlTransform={urlTransform}
-            components={{ a: anchor, code: BlockHandler, blockquote: AlertBlockquote, img: ImageRenderer }}
-          >
-            {content}
-          </Markdown>
+          <QuestionsAnswerContext.Provider value={answerCallback}>
+            <Markdown
+              remarkPlugins={plugins.remarkPlugins}
+              rehypePlugins={plugins.rehypePlugins}
+              urlTransform={urlTransform}
+              components={{ a: anchor, code: BlockHandler, pre, blockquote: AlertBlockquote, img: ImageRenderer }}
+            >
+              {tagged}
+            </Markdown>
+          </QuestionsAnswerContext.Provider>
         </div>
       </div>
       {hasFixed && <div className="pmv-sticky">{fixed}</div>}

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/QuestionsCallout.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/QuestionsCallout.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from "react";
 import Markdown from "react-markdown";
-import { answerEntries, otherEntry, parseQuestions, questionLabel } from "./questionsSchema";
+import { answerEntries, isSkipped, otherEntry, parseQuestions, questionLabel } from "./questionsSchema";
 import type { PlanQuestion, QuestionOption } from "./questionsSchema";
 import type { AnswerCallback } from "./questionsContext";
 
@@ -59,7 +59,9 @@ const QuestionView: React.FC<QuestionViewProps> = ({ question, blockIndex, onAns
   const entries = answerEntries(question);
   const options = question.options ?? [];
   const hasOptions = options.length > 0;
-  const optionValues = useMemo(() => new Set(options.map((o) => o.value)), [options]);
+  // Not memoized: `options` is a fresh array whenever `question.options` is absent, so a memo keyed
+  // on it would never hit anyway, and a set of 2-4 slugs is cheaper to rebuild than to track.
+  const optionValues = new Set(options.map((o) => o.value));
   const typed = otherEntry(question);
 
   // The typed text is a draft, not answer state: the host is told only what changed and may never
@@ -141,6 +143,10 @@ const QuestionView: React.FC<QuestionViewProps> = ({ question, blockIndex, onAns
           <InlineMarkdown text={question.description} />
         </div>
       )}
+
+      {/* `answer: null` selects nothing, so without this a skipped question is indistinguishable
+          from one that was never touched. */}
+      {isSkipped(question) && <div className="pmv-question-skipped">Skipped — you decide</div>}
 
       <div className="pmv-question-options">
         {options.map((option) => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/QuestionsCallout.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/QuestionsCallout.tsx
@@ -1,4 +1,8 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
+import Markdown from "react-markdown";
+import { answerEntries, otherEntry, parseQuestions, questionLabel } from "./questionsSchema";
+import type { PlanQuestion, QuestionOption } from "./questionsSchema";
+import type { AnswerCallback } from "./questionsContext";
 
 const HelpCircleIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -8,12 +12,247 @@ const HelpCircleIcon = () => (
   </svg>
 );
 
-export const QuestionsCallout: React.FC<{ content: string }> = ({ content }) => (
+const CheckIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+/**
+ * Question and option descriptions are markdown, but only inline markdown: a paragraph collapses to
+ * its children and a code span stays a plain `code` element. Deliberately *not* routed through
+ * `BlockHandler` — a `questions` fence nested in a description is text, not another picker.
+ */
+const inlineComponents = {
+  p: ({ children }: React.HTMLAttributes<HTMLParagraphElement>) => <>{children}</>,
+  code: ({ children }: React.HTMLAttributes<HTMLElement>) => <code>{children}</code>,
+};
+
+const InlineMarkdown: React.FC<{ text: string }> = ({ text }) => (
+  <Markdown components={inlineComponents}>{text}</Markdown>
+);
+
+const Shell: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <div className="pmv-questions" role="note">
     <div className="pmv-questions-header">
       <HelpCircleIcon />
       <span className="pmv-questions-title">Questions</span>
     </div>
-    <div className="pmv-questions-content">{content}</div>
+    {children}
   </div>
 );
+
+/** The pre-schema rendering: the fence body as plain text. Unchanged since plan 00073. */
+const StaticCallout: React.FC<{ content: string }> = ({ content }) => (
+  <Shell>
+    <div className="pmv-questions-content">{content}</div>
+  </Shell>
+);
+
+interface QuestionViewProps {
+  question: PlanQuestion;
+  blockIndex: number;
+  onAnswer: AnswerCallback;
+}
+
+const QuestionView: React.FC<QuestionViewProps> = ({ question, blockIndex, onAnswer }) => {
+  const entries = answerEntries(question);
+  const options = question.options ?? [];
+  const hasOptions = options.length > 0;
+  const optionValues = useMemo(() => new Set(options.map((o) => o.value)), [options]);
+  const typed = otherEntry(question);
+
+  // The typed text is a draft, not answer state: the host is told only what changed and may never
+  // echo an updated document back, so the input has to hold what the user is typing. Selection
+  // state proper is still derived from `question` on every render.
+  const [draft, setDraft] = useState(typed ?? "");
+  const [seenTyped, setSeenTyped] = useState(typed);
+  const [otherOpen, setOtherOpen] = useState(typed !== undefined);
+  if (typed !== seenTyped) {
+    // The document changed underneath us — resync the draft to it.
+    setSeenTyped(typed);
+    setDraft(typed ?? "");
+    setOtherOpen(typed !== undefined);
+  }
+
+  const groupName = `pmv-q-${blockIndex}-${question.id}`;
+  const otherActive = typed !== undefined;
+
+  const selectOption = (option: QuestionOption) => {
+    setOtherOpen(false);
+    if (!question.multiple) {
+      onAnswer(question.id, option.value);
+      return;
+    }
+
+    const next = entries.includes(option.value)
+      ? entries.filter((entry) => entry !== option.value)
+      : [...entries, option.value];
+    onAnswer(question.id, next);
+  };
+
+  const writeOther = (value: string) => {
+    setDraft(value);
+    if (!question.multiple) {
+      onAnswer(question.id, value);
+      return;
+    }
+
+    const kept = entries.filter((entry) => optionValues.has(entry));
+    onAnswer(question.id, value ? [...kept, value] : kept);
+  };
+
+  const toggleOther = () => {
+    if (question.multiple && otherActive) {
+      setOtherOpen(false);
+      onAnswer(
+        question.id,
+        entries.filter((entry) => optionValues.has(entry)),
+      );
+      return;
+    }
+
+    setOtherOpen(true);
+    if (draft) writeOther(draft);
+  };
+
+  const clear = () => {
+    setDraft("");
+    setOtherOpen(false);
+    onAnswer(question.id, undefined);
+  };
+
+  const freeTextInput = (
+    <input
+      type="text"
+      className="pmv-question-other-input"
+      value={draft}
+      placeholder="Type your answer"
+      aria-label={`Other answer for ${question.title || question.id}`}
+      onChange={(e) => writeOther(e.target.value)}
+    />
+  );
+
+  return (
+    <div className="pmv-question">
+      <div className="pmv-question-title">{question.title}</div>
+      {question.description && (
+        <div className="pmv-question-description">
+          <InlineMarkdown text={question.description} />
+        </div>
+      )}
+
+      <div className="pmv-question-options">
+        {options.map((option) => {
+          const selected = entries.includes(option.value);
+          return (
+            <label
+              key={option.value}
+              className={`pmv-question-option${selected ? " pmv-question-option--selected" : ""}`}
+            >
+              <input
+                type={question.multiple ? "checkbox" : "radio"}
+                name={groupName}
+                className="pmv-question-check"
+                checked={selected}
+                onChange={() => selectOption(option)}
+              />
+              <span className="pmv-question-option-body">
+                <span className="pmv-question-option-title">
+                  {option.title}
+                  {option.recommended && (
+                    <span className="pmv-question-option-recommended">Recommended</span>
+                  )}
+                </span>
+                {option.description && (
+                  <span className="pmv-question-option-description">
+                    <InlineMarkdown text={option.description} />
+                  </span>
+                )}
+              </span>
+            </label>
+          );
+        })}
+
+        {hasOptions && question.other && (
+          <div
+            className={`pmv-question-option pmv-question-option--other${otherActive ? " pmv-question-option--selected" : ""}`}
+          >
+            <label className="pmv-question-other-label">
+              <input
+                type={question.multiple ? "checkbox" : "radio"}
+                name={groupName}
+                className="pmv-question-check"
+                checked={otherActive}
+                onChange={toggleOther}
+              />
+              <span className="pmv-question-option-title">Other</span>
+            </label>
+            {otherOpen && freeTextInput}
+          </div>
+        )}
+
+        {!hasOptions && freeTextInput}
+      </div>
+
+      <div className="pmv-question-actions">
+        <button type="button" className="pmv-question-clear" onClick={clear}>
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export interface QuestionsCalloutProps {
+  content: string;
+  /** Which `questions` fence this is, 0-based. Keeps radio groups distinct across blocks. */
+  blockIndex?: number;
+  /** Absent when the host did not subscribe to `OnAnswersChange`, which means read-only. */
+  onAnswer?: AnswerCallback;
+}
+
+export const QuestionsCallout: React.FC<QuestionsCalloutProps> = ({ content, blockIndex = 0, onAnswer }) => {
+  const parsed = useMemo(() => parseQuestions(content), [content]);
+  const [tab, setTab] = useState(0);
+
+  if (parsed.kind === "invalid" || parsed.questions.length === 0 || !onAnswer) {
+    return <StaticCallout content={content} />;
+  }
+
+  const questions = parsed.questions;
+  const active = Math.min(tab, questions.length - 1);
+
+  return (
+    <Shell>
+      {questions.length > 1 && (
+        <div className="pmv-questions-tabs" role="tablist">
+          {questions.map((question, index) => (
+            <button
+              key={question.id}
+              type="button"
+              role="tab"
+              aria-selected={index === active}
+              className={`pmv-questions-tab${index === active ? " pmv-questions-tab--active" : ""}`}
+              onClick={() => setTab(index)}
+            >
+              {questionLabel(question, index)}
+              {question.answerPresent && (
+                <span className="pmv-questions-tab-badge" aria-label="answered">
+                  <CheckIcon />
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <QuestionView
+        key={questions[active].id}
+        question={questions[active]}
+        blockIndex={blockIndex}
+        onAnswer={onAnswer}
+      />
+    </Shell>
+  );
+};

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -763,6 +763,13 @@
   margin-bottom: 0.5rem;
 }
 
+.pmv-question-skipped {
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  font-style: italic;
+  margin-bottom: 0.5rem;
+}
+
 .pmv-question-options {
   display: flex;
   flex-direction: column;

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -676,17 +676,14 @@
 }
 
 /* ─── Questions callout ─────────────────────────────────────────────────
-   Rendered by BlockHandler for ```questions fences, wrapped in a <pre> by
-   react-markdown (only the `code` element is overridden). Reset the UA
-   `pre` styles (monospace font, white-space: pre) that would otherwise
-   inherit in and stop the question text from wrapping like prose. */
+   Rendered by BlockHandler for ```questions fences. DraftMarkdown overrides
+   `pre` to render these bare, so there is no UA `pre` styling to reset — a
+   question form is flow content and must not sit inside a `pre` at all. */
 .pmv-questions {
   border-radius: 0.375rem;
   border: 1px solid;
   padding: 0.75rem 1rem;
   font-size: 0.875rem;
-  font-family: inherit;
-  white-space: normal;
   border-color: hsl(199 89% 48% / 0.3);
   background: hsl(199 89% 48% / 0.08);
 }
@@ -712,6 +709,171 @@
 .pmv-questions-content {
   margin-top: 0.25rem;
   white-space: pre-wrap;
+}
+
+/* ─── Interactive question picker ───────────────────────────────────────
+   Shown instead of .pmv-questions-content when the block parses as the
+   structured schema and the host subscribed to OnAnswersChange. */
+.pmv-questions-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin: 0.5rem 0 0.75rem;
+  border-bottom: 1px solid hsl(199 89% 48% / 0.25);
+}
+
+.pmv-questions-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.3rem 0.6rem;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0.25rem 0.25rem 0 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+.pmv-questions-tab:hover {
+  background: hsl(199 89% 48% / 0.08);
+}
+
+.pmv-questions-tab--active {
+  border-bottom-color: hsl(199 89% 48%);
+  color: hsl(199 89% 48%);
+  font-weight: 600;
+}
+
+.pmv-questions-tab-badge {
+  display: inline-flex;
+  align-items: center;
+  color: hsl(199 89% 48%);
+}
+
+.pmv-question-title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.pmv-question-description {
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+}
+
+.pmv-question-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.pmv-question-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid hsl(199 89% 48% / 0.25);
+  border-radius: 0.375rem;
+  background: var(--background, hsl(0 0% 100% / 0.5));
+  cursor: pointer;
+}
+
+.pmv-question-option:hover {
+  border-color: hsl(199 89% 48% / 0.5);
+}
+
+.pmv-question-option--selected {
+  border-color: hsl(199 89% 48%);
+  background: hsl(199 89% 48% / 0.12);
+}
+
+.pmv-question-check {
+  margin-top: 0.15rem;
+  flex-shrink: 0;
+  accent-color: hsl(199 89% 48%);
+}
+
+.pmv-question-option-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.pmv-question-option-title {
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.pmv-question-option-recommended {
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  background: hsl(199 89% 48% / 0.18);
+  color: hsl(199 89% 38%);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.pmv-question-option-description {
+  color: var(--text-secondary);
+  font-weight: 400;
+}
+
+.pmv-question-option--other {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+.pmv-question-other-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.pmv-question-other-input {
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid hsl(199 89% 48% / 0.35);
+  border-radius: 0.25rem;
+  background: var(--background, hsl(0 0% 100%));
+  color: inherit;
+  font: inherit;
+  font-size: 0.875rem;
+}
+
+.pmv-question-other-input:focus {
+  outline: 2px solid hsl(199 89% 48% / 0.4);
+  outline-offset: -1px;
+}
+
+.pmv-question-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+
+.pmv-question-clear {
+  padding: 0.25rem 0.5rem;
+  border: none;
+  border-radius: 0.25rem;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+.pmv-question-clear:hover {
+  background: hsl(199 89% 48% / 0.1);
+  color: hsl(199 89% 48%);
 }
 
 /* Image viewer */

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/questionsContext.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/questionsContext.ts
@@ -1,0 +1,19 @@
+import { createContext } from "react";
+
+/** Reports a single answered, skipped or cleared question. */
+export type AnswerCallback = (
+  questionId: string,
+  answer: string | string[] | null | undefined,
+) => void;
+
+/**
+ * Carries the answer callback from `DraftMarkdown` down to a `QuestionsCallout`.
+ *
+ * A context rather than a prop because `BlockHandler` sits between the two and takes only the
+ * react-markdown component signature. `undefined` means the host did not subscribe to
+ * `OnAnswersChange`, which is what puts the callout in read-only mode.
+ *
+ * It lives in its own module so that `BlockHandler` can read it without importing
+ * `DraftMarkdown.tsx`, which imports `BlockHandler` in turn.
+ */
+export const QuestionsAnswerContext = createContext<AnswerCallback | undefined>(undefined);

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/questionsSchema.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/questionsSchema.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from "vitest";
+import {
+  answerEntries,
+  isSkipped,
+  otherEntry,
+  parseQuestions,
+  questionLabel,
+} from "./questionsSchema";
+
+const body = (...lines: string[]) => lines.join("\n");
+
+const SINGLE_SELECT = body(
+  "questions:",
+  "  - id: budget",
+  "    title: Should the retry budget be per-request or per-session?",
+  "    header: Retry scope",
+  "    description: Affects how a burst of failures is absorbed.",
+  "    other: false",
+  "    options:",
+  "      - title: Per request",
+  "        description: Each call gets its **own** budget.",
+  "        value: per-request",
+  "      - title: Per session",
+  "        value: per-session",
+  "        recommended: true",
+  "      - title: Both",
+  "        value: both",
+);
+
+const MULTI_SELECT = body(
+  "questions:",
+  "  - id: channels",
+  "    title: Which channels ship first?",
+  "    multiple: true",
+  "    options:",
+  "      - title: In-app",
+  "        value: in-app",
+  "      - title: Email",
+  "        value: email",
+  "      - title: Push",
+  "        value: push",
+  "      - title: SMS",
+  "        value: sms",
+);
+
+const FREE_TEXT = body(
+  "questions:",
+  "  - id: name",
+  "    title: What should the feature be called?",
+  "  - id: owner",
+  "    title: Who owns the rollout?",
+);
+
+describe("parseQuestions shapes", () => {
+  it("reads the single-select fixed set", () => {
+    const parsed = parseQuestions(SINGLE_SELECT);
+
+    expect(parsed.kind).toBe("questions");
+    if (parsed.kind !== "questions") return;
+
+    const [question] = parsed.questions;
+    expect(question.id).toBe("budget");
+    expect(question.header).toBe("Retry scope");
+    expect(question.description).toBe("Affects how a burst of failures is absorbed.");
+    expect(question.other).toBe(false);
+    expect(question.multiple).toBe(false);
+    expect(question.options).toHaveLength(3);
+    expect(question.options?.[0].description).toBe("Each call gets its **own** budget.");
+    expect(question.options?.[1].recommended).toBe(true);
+    expect(question.options?.[0].recommended).toBe(false);
+  });
+
+  it("reads the multi-select open set", () => {
+    const parsed = parseQuestions(MULTI_SELECT);
+
+    expect(parsed.kind).toBe("questions");
+    if (parsed.kind !== "questions") return;
+
+    const [question] = parsed.questions;
+    expect(question.multiple).toBe(true);
+    expect(question.options).toHaveLength(4);
+  });
+
+  it("reads the pure free-text shape", () => {
+    const parsed = parseQuestions(FREE_TEXT);
+
+    expect(parsed.kind).toBe("questions");
+    if (parsed.kind !== "questions") return;
+
+    expect(parsed.questions).toHaveLength(2);
+    expect(parsed.questions[0].options).toBeUndefined();
+    expect(parsed.questions.map((q) => q.id)).toEqual(["name", "owner"]);
+  });
+});
+
+describe("parseQuestions defaults", () => {
+  it("treats other as true and multiple as false when absent", () => {
+    const parsed = parseQuestions(MULTI_SELECT);
+
+    expect(parsed.kind).toBe("questions");
+    if (parsed.kind !== "questions") return;
+    expect(parsed.questions[0].other).toBe(true);
+
+    const free = parseQuestions(FREE_TEXT);
+    if (free.kind !== "questions") return;
+    expect(free.questions[0].other).toBe(true);
+    expect(free.questions[0].multiple).toBe(false);
+  });
+});
+
+describe("parseQuestions answer states", () => {
+  const withAnswer = (line: string) =>
+    parseQuestions(body("questions:", "  - id: q", "    title: T", line));
+
+  it("distinguishes an absent answer from an explicit null", () => {
+    const absent = parseQuestions(body("questions:", "  - id: q", "    title: T"));
+    if (absent.kind !== "questions") throw new Error("expected questions");
+    expect(absent.questions[0].answerPresent).toBe(false);
+    expect(isSkipped(absent.questions[0])).toBe(false);
+    expect(answerEntries(absent.questions[0])).toEqual([]);
+
+    const skipped = withAnswer("    answer: null");
+    if (skipped.kind !== "questions") throw new Error("expected questions");
+    expect(skipped.questions[0].answerPresent).toBe(true);
+    expect(isSkipped(skipped.questions[0])).toBe(true);
+    expect(answerEntries(skipped.questions[0])).toEqual([]);
+  });
+
+  it("reads a scalar answer and a list answer", () => {
+    const scalar = withAnswer("    answer: per-session");
+    if (scalar.kind !== "questions") throw new Error("expected questions");
+    expect(scalar.questions[0].answerPresent).toBe(true);
+    expect(answerEntries(scalar.questions[0])).toEqual(["per-session"]);
+
+    const list = parseQuestions(
+      body("questions:", "  - id: q", "    title: T", "    answer:", "      - a", "      - b"),
+    );
+    if (list.kind !== "questions") throw new Error("expected questions");
+    expect(answerEntries(list.questions[0])).toEqual(["a", "b"]);
+  });
+
+  it("reports the entry matching no option as the user's own text", () => {
+    const parsed = parseQuestions(`${MULTI_SELECT}\n    answer:\n      - email\n      - carrier pigeon`);
+    if (parsed.kind !== "questions") throw new Error("expected questions");
+
+    expect(otherEntry(parsed.questions[0])).toBe("carrier pigeon");
+  });
+
+  it("reports no other entry when every entry is an option value", () => {
+    const parsed = parseQuestions(`${MULTI_SELECT}\n    answer:\n      - email`);
+    if (parsed.kind !== "questions") throw new Error("expected questions");
+
+    expect(otherEntry(parsed.questions[0])).toBeUndefined();
+  });
+});
+
+describe("parseQuestions tolerance", () => {
+  it("reports a prose body as invalid rather than throwing", () => {
+    expect(parseQuestions("Should the retry budget be per-request?\nAnd what about jitter?")).toEqual({
+      kind: "invalid",
+    });
+  });
+
+  it("reports valid YAML with no questions key as invalid", () => {
+    expect(parseQuestions("title: not a question block\ncount: 3")).toEqual({ kind: "invalid" });
+  });
+
+  it("reports malformed YAML as invalid rather than throwing", () => {
+    expect(parseQuestions("questions:\n  - id: [unclosed\n   bad: : :")).toEqual({ kind: "invalid" });
+  });
+
+  it("reports an empty body as invalid", () => {
+    expect(parseQuestions("")).toEqual({ kind: "invalid" });
+  });
+
+  it("reports a missing id as invalid", () => {
+    expect(parseQuestions(body("questions:", "  - title: No id here"))).toEqual({ kind: "invalid" });
+    expect(parseQuestions(body("questions:", "  - id: ''", "    title: Empty id"))).toEqual({
+      kind: "invalid",
+    });
+  });
+
+  it("reports two questions sharing an id within the block as invalid", () => {
+    const duplicate = body(
+      "questions:",
+      "  - id: same",
+      "    title: First",
+      "  - id: same",
+      "    title: Second",
+    );
+
+    expect(parseQuestions(duplicate)).toEqual({ kind: "invalid" });
+  });
+});
+
+describe("questionLabel", () => {
+  it("prefers the header", () => {
+    const parsed = parseQuestions(SINGLE_SELECT);
+    if (parsed.kind !== "questions") throw new Error("expected questions");
+
+    expect(questionLabel(parsed.questions[0], 0)).toBe("Retry scope");
+  });
+
+  it("falls back to the first few words of the title", () => {
+    const parsed = parseQuestions(FREE_TEXT);
+    if (parsed.kind !== "questions") throw new Error("expected questions");
+
+    expect(questionLabel(parsed.questions[0], 0)).toBe("What should the");
+  });
+
+  it("falls back to the position when there is no title either", () => {
+    const parsed = parseQuestions(body("questions:", "  - id: bare"));
+    if (parsed.kind !== "questions") throw new Error("expected questions");
+
+    expect(questionLabel(parsed.questions[0], 2)).toBe("Question 3");
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/questionsSchema.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/questionsSchema.ts
@@ -1,0 +1,137 @@
+import { parse } from "yaml";
+
+/**
+ * A TypeScript mirror of the `questions` block schema, plus a tolerant reader.
+ *
+ * The schema of record lives in `Prompts/Plans.md` and is enforced C#-side on the
+ * `write-revision` path. This reader is deliberately **tolerant, not a validator**: it reports
+ * `invalid` rather than throwing, because the widget's job is to display a plan, never to refuse
+ * to.
+ */
+
+export interface QuestionOption {
+  title: string;
+  description?: string;
+  value: string;
+  recommended?: boolean;
+}
+
+export interface PlanQuestion {
+  /** Stable and unique across the whole document — `OnAnswersChange` identifies a question by it. */
+  id: string;
+  title: string;
+  header?: string;
+  description?: string;
+  /** True when several options may be selected. Answers are then always a list. */
+  multiple: boolean;
+  /** Whether the user may type a value of their own. Defaults to true, per the schema. */
+  other: boolean;
+  options?: QuestionOption[];
+  /** The raw `answer` node: absent, null, a scalar or a list. */
+  answer?: unknown;
+  /** Whether the `answer` key was present at all — absent and explicit null mean different things. */
+  answerPresent: boolean;
+}
+
+export type ParsedQuestions =
+  | { kind: "questions"; questions: PlanQuestion[] }
+  /**
+   * The body is not a mapping with a `questions` key — the plain-text form that predates the
+   * schema, which existing revisions contain — or its `id`s are missing or collide within this
+   * block. Renders as the static callout.
+   */
+  | { kind: "invalid" };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readOptions(raw: unknown): QuestionOption[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+
+  return raw.filter(isRecord).map((option) => ({
+    title: typeof option.title === "string" ? option.title : "",
+    description: optionalString(option.description),
+    value: typeof option.value === "string" ? option.value : "",
+    recommended: option.recommended === true,
+  }));
+}
+
+/**
+ * Reads one fence body. Never throws: malformed YAML, prose, and a mapping without a `questions`
+ * key all come back as `kind: "invalid"`.
+ *
+ * `id` is required and must be unique **within this block**. A cross-block collision is out of
+ * reach here — this parser only ever sees one fence — and belongs in the C# validator, the one
+ * component with the whole document in view.
+ */
+export function parseQuestions(body: string): ParsedQuestions {
+  let raw: unknown;
+  try {
+    raw = parse(body);
+  } catch {
+    return { kind: "invalid" };
+  }
+
+  if (!isRecord(raw) || !Array.isArray(raw.questions)) return { kind: "invalid" };
+
+  const seen = new Set<string>();
+  const questions: PlanQuestion[] = [];
+
+  for (const entry of raw.questions) {
+    if (!isRecord(entry)) return { kind: "invalid" };
+
+    const id = entry.id;
+    if (typeof id !== "string" || id.length === 0 || seen.has(id)) return { kind: "invalid" };
+    seen.add(id);
+
+    questions.push({
+      id,
+      title: typeof entry.title === "string" ? entry.title : "",
+      header: optionalString(entry.header),
+      description: optionalString(entry.description),
+      multiple: entry.multiple === true,
+      other: entry.other !== false,
+      options: readOptions(entry.options),
+      answer: entry.answer,
+      answerPresent: Object.prototype.hasOwnProperty.call(entry, "answer"),
+    });
+  }
+
+  return { kind: "questions", questions };
+}
+
+/**
+ * The answer as a list of entries, which is what drives selection state. Empty when the question
+ * is unanswered or explicitly skipped. An entry matching an option's `value` is that option; an
+ * entry matching nothing is the user's own free text.
+ */
+export function answerEntries(question: PlanQuestion): string[] {
+  if (!question.answerPresent || question.answer === null || question.answer === undefined) return [];
+
+  const raw = Array.isArray(question.answer) ? question.answer : [question.answer];
+  return raw.filter((entry): entry is string => typeof entry === "string");
+}
+
+/** `answer: null` — asked and deliberately skipped. */
+export function isSkipped(question: PlanQuestion): boolean {
+  return question.answerPresent && question.answer === null;
+}
+
+/** The answer entry that matches no option, i.e. what the user typed into "Other". */
+export function otherEntry(question: PlanQuestion): string | undefined {
+  const values = new Set((question.options ?? []).map((option) => option.value));
+  return answerEntries(question).find((entry) => !values.has(entry));
+}
+
+/** Short chip label for a tab: `header` when given, else the first few words of `title`. */
+export function questionLabel(question: PlanQuestion, index: number): string {
+  if (question.header) return question.header;
+
+  const words = question.title.trim().split(/\s+/).filter(Boolean).slice(0, 3).join(" ");
+  return words || `Question ${index + 1}`;
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/questionsSource.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/questionsSource.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect } from "vitest";
+import { scanQuestionBlocks, setAnswer, tagQuestionBlocks } from "./questionsSource";
+import { parseQuestions } from "./questionsSchema";
+
+/** Builds a document without a trailing newline, so offsets stay easy to reason about. */
+const doc = (...lines: string[]) => lines.join("\n");
+
+const ONE_BLOCK = doc(
+  "# Title",
+  "",
+  "```questions",
+  "questions:",
+  "  - id: q1",
+  "    title: Pick one",
+  "```",
+  "",
+  "Trailing prose.",
+);
+
+const TWO_BLOCKS = doc(
+  "Intro prose.",
+  "",
+  "```questions",
+  "questions:",
+  "  - id: alpha",
+  "    title: First",
+  "```",
+  "",
+  "Middle prose.",
+  "",
+  "```questions",
+  "questions:",
+  "  - id: beta",
+  "    title: Second",
+  "  - id: gamma",
+  "    title: Third",
+  "```",
+  "",
+  "Outro prose.",
+);
+
+describe("scanQuestionBlocks", () => {
+  it("finds a single block", () => {
+    const blocks = scanQuestionBlocks(ONE_BLOCK);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].index).toBe(0);
+    expect(blocks[0].body).toBe("questions:\n  - id: q1\n    title: Pick one\n");
+  });
+
+  it("finds several blocks in document order", () => {
+    const blocks = scanQuestionBlocks(TWO_BLOCKS);
+
+    expect(blocks.map((b) => b.index)).toEqual([0, 1]);
+    expect(blocks[0].body).toContain("alpha");
+    expect(blocks[1].body).toContain("beta");
+    expect(blocks[0].bodyEnd).toBeLessThan(blocks[1].bodyStart);
+  });
+
+  it("finds none in a document without any", () => {
+    expect(scanQuestionBlocks("# Just prose\n\nAnd a paragraph.")).toEqual([]);
+    expect(scanQuestionBlocks("")).toEqual([]);
+  });
+
+  it("bounds the body exactly, excluding both fence lines", () => {
+    const [block] = scanQuestionBlocks(ONE_BLOCK);
+
+    expect(ONE_BLOCK.slice(block.bodyStart, block.bodyEnd)).toBe(block.body);
+    expect(block.body).not.toContain("```");
+    // The character just before the body is the newline ending the opening fence line.
+    expect(ONE_BLOCK.slice(0, block.bodyStart).endsWith("```questions\n")).toBe(true);
+    expect(ONE_BLOCK.slice(block.bodyEnd).startsWith("```")).toBe(true);
+  });
+
+  it("treats a questions fence inside a four-backtick fence as documentation", () => {
+    const md = doc("````", "```questions", "questions:", "  - id: nope", "```", "````");
+
+    expect(scanQuestionBlocks(md)).toEqual([]);
+  });
+
+  it("finds a tilde fence", () => {
+    const md = doc("~~~questions", "questions:", "  - id: t1", "~~~");
+    const blocks = scanQuestionBlocks(md);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].body).toBe("questions:\n  - id: t1\n");
+  });
+
+  it("ignores a questions info line inside an open tilde fence of greater run length", () => {
+    const md = doc("~~~~", "~~~questions", "questions:", "  - id: no", "~~~", "~~~~");
+
+    expect(scanQuestionBlocks(md)).toEqual([]);
+  });
+
+  it("does not let a tilde run close a backtick fence", () => {
+    const md = doc("```questions", "questions:", "  - id: q1", "~~~", "```");
+    const [block] = scanQuestionBlocks(md);
+
+    expect(block.body).toBe("questions:\n  - id: q1\n~~~\n");
+  });
+
+  it("runs an unterminated fence to the end of the document", () => {
+    const md = doc("```questions", "questions:", "  - id: q1");
+    const [block] = scanQuestionBlocks(md);
+
+    expect(block.bodyEnd).toBe(md.length);
+    expect(block.body).toBe("questions:\n  - id: q1");
+  });
+
+  it("handles an empty body", () => {
+    const [block] = scanQuestionBlocks(doc("```questions", "```"));
+
+    expect(block.body).toBe("");
+    expect(block.bodyStart).toBe(block.bodyEnd);
+  });
+
+  it("keeps offsets valid for CRLF input", () => {
+    const md = ["```questions", "questions:", "  - id: q1", "```"].join("\r\n");
+    const [block] = scanQuestionBlocks(md);
+
+    expect(md.slice(block.bodyStart, block.bodyEnd)).toBe(block.body);
+    expect(block.body).toBe("questions:\r\n  - id: q1\r\n");
+  });
+});
+
+describe("tagQuestionBlocks", () => {
+  it("stamps the index onto each top-level opening info line", () => {
+    const tagged = tagQuestionBlocks(TWO_BLOCKS);
+
+    expect(tagged).toContain("```questions_0");
+    expect(tagged).toContain("```questions_1");
+    expect(tagged).not.toMatch(/```questions\n/);
+  });
+
+  it("leaves a nested info line alone", () => {
+    const md = doc("````", "```questions", "questions:", "  - id: nope", "```", "````");
+
+    expect(tagQuestionBlocks(md)).toBe(md);
+  });
+
+  it("is a no-op on a document with no blocks", () => {
+    const md = "# Title\n\nProse only.";
+
+    expect(tagQuestionBlocks(md)).toBe(md);
+  });
+
+  it("changes nothing but the info word", () => {
+    const tagged = tagQuestionBlocks(ONE_BLOCK);
+
+    expect(tagged).toBe(ONE_BLOCK.replace("```questions", "```questions_0"));
+  });
+
+  it("preserves trailing info after the word", () => {
+    const md = doc("```questions extra", "questions:", "  - id: q1", "```");
+
+    expect(tagQuestionBlocks(md)).toContain("```questions_0 extra");
+  });
+});
+
+describe("setAnswer", () => {
+  it("writes a scalar answer", () => {
+    const out = setAnswer(ONE_BLOCK, 0, "q1", "yes");
+
+    expect(out).toContain("answer: yes");
+  });
+
+  it("writes a list answer", () => {
+    const out = setAnswer(ONE_BLOCK, 0, "q1", ["a", "b"]);
+    const [block] = scanQuestionBlocks(out);
+
+    expect(block.body).toContain("- a");
+    expect(block.body).toContain("- b");
+  });
+
+  it("writes an explicit null", () => {
+    const out = setAnswer(ONE_BLOCK, 0, "q1", null);
+
+    expect(out).toContain("answer: null");
+  });
+
+  it("removes the key when passed undefined", () => {
+    const answered = setAnswer(ONE_BLOCK, 0, "q1", "yes");
+    const cleared = setAnswer(answered, 0, "q1", undefined);
+
+    expect(cleared).not.toContain("answer");
+    expect(cleared).toBe(ONE_BLOCK);
+  });
+
+  it("addresses the question by id rather than position", () => {
+    const out = setAnswer(TWO_BLOCKS, 1, "gamma", "third");
+    const [, second] = scanQuestionBlocks(out);
+    const parsed = parseQuestions(second.body);
+
+    expect(parsed.kind).toBe("questions");
+    if (parsed.kind !== "questions") return;
+    expect(parsed.questions[0].answerPresent).toBe(false);
+    expect(parsed.questions[1].id).toBe("gamma");
+    expect(parsed.questions[1].answer).toBe("third");
+  });
+
+  it("throws when the question id matches nothing in the block", () => {
+    expect(() => setAnswer(TWO_BLOCKS, 0, "gamma", "x")).toThrow(/no question with id "gamma"/);
+  });
+
+  it("throws when the block index is out of range", () => {
+    expect(() => setAnswer(ONE_BLOCK, 4, "q1", "x")).toThrow(/no questions block at index 4/);
+  });
+
+  it("leaves the other block and all prose byte-identical", () => {
+    const out = setAnswer(TWO_BLOCKS, 1, "beta", "second");
+
+    const before = scanQuestionBlocks(TWO_BLOCKS);
+    const after = scanQuestionBlocks(out);
+    expect(after[0].body).toBe(before[0].body);
+
+    // Everything up to the second block's body is untouched, as is everything after it.
+    expect(out.slice(0, after[1].bodyStart)).toBe(TWO_BLOCKS.slice(0, before[1].bodyStart));
+    expect(out.slice(after[1].bodyEnd)).toBe(TWO_BLOCKS.slice(before[1].bodyEnd));
+    expect(out).toContain("Intro prose.");
+    expect(out).toContain("Middle prose.");
+    expect(out).toContain("Outro prose.");
+  });
+
+  it("preserves a comment and the original key order", () => {
+    const md = doc(
+      "```questions",
+      "questions:",
+      "  # why we ask this",
+      "  - id: alpha",
+      "    title: First",
+      "    other: false",
+      "```",
+    );
+
+    const out = setAnswer(md, 0, "alpha", "picked");
+
+    expect(out).toContain("# why we ask this");
+    expect(out.indexOf("title: First")).toBeLessThan(out.indexOf("other: false"));
+  });
+
+  it("round-trips: set, re-scan, parse yields the written answer", () => {
+    const out = setAnswer(ONE_BLOCK, 0, "q1", ["one", "two"]);
+    const [block] = scanQuestionBlocks(out);
+    const parsed = parseQuestions(block.body);
+
+    expect(parsed.kind).toBe("questions");
+    if (parsed.kind !== "questions") return;
+    expect(parsed.questions[0].answerPresent).toBe(true);
+    expect(parsed.questions[0].answer).toEqual(["one", "two"]);
+  });
+
+  it("does not fold a long answer onto a second line", () => {
+    const long = "a".repeat(200);
+    const out = setAnswer(ONE_BLOCK, 0, "q1", long);
+
+    expect(out).toContain(`answer: ${long}`);
+  });
+
+  it("keeps the fence's own indentation", () => {
+    const md = doc(
+      "- item:",
+      "",
+      "  ```questions",
+      "  questions:",
+      "    - id: ind",
+      "      title: Indented",
+      "  ```",
+    );
+
+    const out = setAnswer(md, 0, "ind", "yes");
+
+    expect(out).toContain("  questions:");
+    expect(out).toContain("      answer: yes");
+    expect(out).toContain("- item:");
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/questionsSource.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/questionsSource.ts
@@ -1,0 +1,282 @@
+import { parseDocument } from "yaml";
+
+/**
+ * Locating `questions` fences in markdown source, and editing them in place.
+ *
+ * Fence tracking follows CommonMark, exactly as the C# `QuestionBlockParser` does and for the same
+ * reason: a `questions` fence written inside a longer fence is documentation, not a question. A
+ * fence opened with N of a delimiter is closed only by a run of N or more of the same delimiter,
+ * and any info line seen while a longer fence is open is body text. Without this, a plan that
+ * documents the format gets its own examples turned into live pickers.
+ */
+
+const INFO_WORD = "questions";
+
+export interface QuestionBlockSource {
+  /** 0-based, document order. */
+  index: number;
+  /** Offset into the markdown of the first body character. */
+  bodyStart: number;
+  /** Offset just past the last body character. */
+  bodyEnd: number;
+  /**
+   * The body, verbatim: `markdown.slice(bodyStart, bodyEnd)`. Includes the newline that terminates
+   * the last body line, and excludes both fence lines.
+   */
+  body: string;
+}
+
+interface ScannedBlock extends QuestionBlockSource {
+  /** Indentation of the opening fence, 0-3 spaces. Body lines carry it too. */
+  indent: number;
+  /** Offset of the `questions` word on the opening fence's info line. */
+  wordStart: number;
+  /** Offset just past that word. */
+  wordEnd: number;
+}
+
+interface SourceLine {
+  /** Line content, without its terminator and without a trailing CR. */
+  text: string;
+  /** Offset of the first character. */
+  start: number;
+  /** Offset just past `text` — at the CR of a CRLF pair, or at the LF, or at end of input. */
+  textEnd: number;
+  /** Offset of the start of the next line. */
+  next: number;
+}
+
+interface Fence {
+  delimiter: string;
+  length: number;
+  indent: number;
+  info: string;
+}
+
+function splitLines(markdown: string): SourceLine[] {
+  const lines: SourceLine[] = [];
+  let pos = 0;
+
+  for (;;) {
+    const lf = markdown.indexOf("\n", pos);
+    const terminated = lf !== -1;
+    const lineEnd = terminated ? lf : markdown.length;
+    const textEnd = lineEnd > pos && markdown[lineEnd - 1] === "\r" ? lineEnd - 1 : lineEnd;
+
+    lines.push({
+      text: markdown.slice(pos, textEnd),
+      start: pos,
+      textEnd,
+      next: terminated ? lf + 1 : markdown.length,
+    });
+
+    if (!terminated) return lines;
+    pos = lf + 1;
+  }
+}
+
+function matchFence(line: string): Fence | null {
+  let indent = 0;
+  while (indent < line.length && indent < 4 && line[indent] === " ") indent++;
+  if (indent > 3 || indent >= line.length) return null;
+
+  const delimiter = line[indent];
+  if (delimiter !== "`" && delimiter !== "~") return null;
+
+  let end = indent;
+  while (end < line.length && line[end] === delimiter) end++;
+
+  const length = end - indent;
+  if (length < 3) return null;
+
+  const info = line.slice(end).trim();
+
+  // A backtick fence's info string may not contain a backtick (CommonMark), which is what keeps
+  // inline code like ``a ``` b`` from being read as a fence.
+  if (delimiter === "`" && info.includes("`")) return null;
+
+  return { delimiter, length, indent, info };
+}
+
+/** The first whitespace-delimited word of the info string, matched verbatim like the renderer. */
+function isQuestionsInfo(info: string): boolean {
+  if (info.length === 0) return false;
+  const end = info.search(/[ \t]/);
+  return (end < 0 ? info : info.slice(0, end)) === INFO_WORD;
+}
+
+/** Offsets of the info string's first word within `line`, or null when there is no info. */
+function wordSpan(line: SourceLine, fence: Fence): { wordStart: number; wordEnd: number } {
+  const afterRun = line.start + fence.indent + fence.length;
+  const raw = line.text.slice(fence.indent + fence.length);
+  const leading = raw.length - raw.trimStart().length;
+  const wordStart = afterRun + leading;
+
+  const trimmed = raw.trimStart();
+  const end = trimmed.search(/[ \t]/);
+  const wordLength = end < 0 ? trimmed.trimEnd().length : end;
+
+  return { wordStart, wordEnd: wordStart + wordLength };
+}
+
+function scan(markdown: string): ScannedBlock[] {
+  const blocks: ScannedBlock[] = [];
+  if (!markdown) return blocks;
+
+  const lines = splitLines(markdown);
+
+  let open = false;
+  let openChar = "";
+  let openLength = 0;
+  let openIndent = 0;
+  let isQuestions = false;
+  let bodyStart = 0;
+  let wordStart = 0;
+  let wordEnd = 0;
+
+  for (const line of lines) {
+    const fence = matchFence(line.text);
+
+    if (!open) {
+      if (!fence) continue;
+
+      open = true;
+      openChar = fence.delimiter;
+      openLength = fence.length;
+      openIndent = fence.indent;
+      isQuestions = isQuestionsInfo(fence.info);
+      bodyStart = line.next;
+      ({ wordStart, wordEnd } = wordSpan(line, fence));
+      continue;
+    }
+
+    // Only a bare run of the same delimiter, at least as long as the opener, closes a fence.
+    if (fence && fence.delimiter === openChar && fence.length >= openLength && fence.info.length === 0) {
+      if (isQuestions) {
+        blocks.push({
+          index: blocks.length,
+          bodyStart,
+          bodyEnd: line.start,
+          body: markdown.slice(bodyStart, line.start),
+          indent: openIndent,
+          wordStart,
+          wordEnd,
+        });
+      }
+      open = false;
+    }
+  }
+
+  // An unterminated fence runs to the end of the document (CommonMark).
+  if (open && isQuestions) {
+    blocks.push({
+      index: blocks.length,
+      bodyStart,
+      bodyEnd: markdown.length,
+      body: markdown.slice(bodyStart, markdown.length),
+      indent: openIndent,
+      wordStart,
+      wordEnd,
+    });
+  }
+
+  return blocks;
+}
+
+/** Every top-level `questions` block in `markdown`, in document order. */
+export function scanQuestionBlocks(markdown: string): QuestionBlockSource[] {
+  return scan(markdown).map(({ index, bodyStart, bodyEnd, body }) => ({ index, bodyStart, bodyEnd, body }));
+}
+
+/**
+ * Rewrites each top-level opening info line from `questions` to `questions_<index>`, so the
+ * renderer learns which block it is dispatching. `BlockHandler` derives the language from
+ * `/language-(\w+)/` and `_` is a `\w` character, so the tagged word survives react-markdown
+ * untouched. The info line is never rendered, so annotation offsets — computed over rendered
+ * text — are unaffected.
+ */
+export function tagQuestionBlocks(markdown: string): string {
+  const blocks = scan(markdown);
+  if (blocks.length === 0) return markdown;
+
+  let out = "";
+  let cursor = 0;
+  for (const block of blocks) {
+    out += markdown.slice(cursor, block.wordStart) + `${INFO_WORD}_${block.index}`;
+    cursor = block.wordEnd;
+  }
+
+  return out + markdown.slice(cursor);
+}
+
+function dedent(body: string, indent: number): string {
+  if (indent === 0) return body;
+  return body
+    .split("\n")
+    .map((line) => {
+      let strip = 0;
+      while (strip < indent && strip < line.length && line[strip] === " ") strip++;
+      return line.slice(strip);
+    })
+    .join("\n");
+}
+
+function reindent(body: string, indent: number): string {
+  if (indent === 0) return body;
+  const pad = " ".repeat(indent);
+  return body
+    .split("\n")
+    .map((line) => (line.length === 0 ? line : pad + line))
+    .join("\n");
+}
+
+/**
+ * Writes `answer` onto the question identified by `questionId` inside block `blockIndex`, and
+ * returns the whole document with only that block's body replaced.
+ *
+ * The body round-trips through `parseDocument`, so comments, key order and scalar style survive;
+ * every byte outside `[bodyStart, bodyEnd)` — including other blocks — is untouched. Passing
+ * `undefined` deletes the `answer` key (back to unanswered); passing `null` writes an explicit
+ * null (asked and deliberately skipped).
+ *
+ * Throws when `blockIndex` is out of range or `questionId` matches no question in that block —
+ * both are caller-side bugs, not the malformed-document case the renderer tolerates.
+ */
+export function setAnswer(
+  markdown: string,
+  blockIndex: number,
+  questionId: string,
+  answer: string | string[] | null | undefined,
+): string {
+  const blocks = scan(markdown);
+  const block = blocks[blockIndex];
+  if (!block) {
+    throw new Error(`setAnswer: no questions block at index ${blockIndex} (found ${blocks.length})`);
+  }
+
+  const doc = parseDocument(dedent(block.body, block.indent));
+  const js = doc.toJS() as { questions?: unknown } | null;
+  const questions = js && typeof js === "object" ? js.questions : undefined;
+  if (!Array.isArray(questions)) {
+    throw new Error(`setAnswer: block ${blockIndex} has no questions list`);
+  }
+
+  const index = questions.findIndex(
+    (q) => q !== null && typeof q === "object" && (q as { id?: unknown }).id === questionId,
+  );
+  if (index < 0) {
+    throw new Error(`setAnswer: block ${blockIndex} has no question with id "${questionId}"`);
+  }
+
+  if (answer === undefined) {
+    doc.deleteIn(["questions", index, "answer"]);
+  } else {
+    doc.setIn(["questions", index, "answer"], answer);
+  }
+
+  // lineWidth: 0 disables folding, so a long answer is never re-wrapped into a shape the author
+  // did not write.
+  const updated = reindent(doc.toString({ lineWidth: 0 }), block.indent);
+
+  return markdown.slice(0, block.bodyStart) + updated + markdown.slice(block.bodyEnd);
+}

--- a/src/Ivy.Tendril/Models/QuestionModels.cs
+++ b/src/Ivy.Tendril/Models/QuestionModels.cs
@@ -36,6 +36,14 @@ public record QuestionsBlock
 /// <summary>A single question inside a <see cref="QuestionsBlock" />.</summary>
 public record PlanQuestion
 {
+    /// <summary>
+    ///     Stable handle for this question. Required, and unique across the whole revision rather
+    ///     than just its own block: the UI reports an answer as an id and a value, with no block or
+    ///     position alongside it, so a collision anywhere in the document makes an answer ambiguous.
+    ///     Uniqueness is therefore checked by <c>QuestionValidationService</c>, which sees every block.
+    /// </summary>
+    public string Id { get; init; } = "";
+
     /// <summary>The question itself. Required.</summary>
     public string Title { get; init; } = "";
 

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -289,7 +289,8 @@ decision.
 ````
 ```questions
 questions:                    # 1-4 items
-  - title:       string       # required, the question
+  - id:          string       # required, stable, unique across the whole revision
+    title:       string       # required, the question
     header:      string       # optional, <=12 char chip label; derived from title if absent
     description: markdown     # optional, context shown under the question
     multiple:    bool         # optional, default false; true = multi-select
@@ -302,6 +303,12 @@ questions:                    # 1-4 items
     answer:      value | [values] | string   # filled in on response
 ```
 ````
+
+Every question carries an `id` — a short, stable handle such as `retry-scope`. It is how an answer is
+addressed: the UI reports an answer as that id and a value, with no block or position alongside it.
+So an `id` must be unique across the **whole revision**, not merely within its own block, and must
+keep its meaning across revisions — rewording a question is fine, renaming its `id` orphans an answer
+already given for it.
 
 Three shapes fall out of `multiple` / `other` / the presence of `options`:
 
@@ -329,6 +336,8 @@ revision does not consume a revision number. Fix the reported lines and retry.
 
 | Rule | Message |
 |---|---|
+| Every question has a non-empty `id` | `question N: id is required` |
+| `id` unique across the whole revision, blocks included | `question N: duplicate question id '<id>'` |
 | At most one `recommended: true` per question | `question N: more than one option is recommended` |
 | No hand-authored option titled "Other", "Something else", "Custom" | `question N: option '<title>' duplicates what other: true provides` |
 | `other: false` with no options | `question N: other: false with no options is unanswerable` |
@@ -336,7 +345,7 @@ revision does not consume a revision number. Fix the reported lines and retry.
 | `value` unique within a question | `question N: duplicate option value '<value>'` |
 | `other: false` and an answer entry matches no option value | `question N: answer '<entry>' matches no option and other is false` |
 
-Schema bounds are enforced too: 1-4 questions, a required `title`, a `header` of at most 12
+Schema bounds are enforced too: 1-4 questions, a required `id` and `title`, a `header` of at most 12
 characters, 2-4 options when `options` is present, a required `title` and slug `value` on each
 option, and no unknown keys anywhere.
 

--- a/src/Ivy.Tendril/Services/Plans/QuestionValidationService.cs
+++ b/src/Ivy.Tendril/Services/Plans/QuestionValidationService.cs
@@ -53,6 +53,12 @@ public static class QuestionValidationService
         // "block N:" is noise when there is only one block, and essential when there are several.
         var numbered = blocks.Count > 1;
 
+        // Question ids are addressed document-wide, not per block: an answer travels as an id and a
+        // value with no block alongside it, so two blocks reusing one id would leave it ambiguous
+        // which question was answered. This is the only component that sees every block at once, so
+        // the set spans them all instead of being reset per block.
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+
         for (var b = 0; b < blocks.Count; b++)
         {
             var block = blocks[b];
@@ -71,13 +77,13 @@ public static class QuestionValidationService
                 continue;
             }
 
-            ValidateBlock(block.Block!, block.Line, prefix, issues);
+            ValidateBlock(block.Block!, block.Line, prefix, ids, issues);
         }
 
         return issues;
     }
 
-    private static void ValidateBlock(QuestionsBlock block, int line, string prefix, List<QuestionIssue> issues)
+    private static void ValidateBlock(QuestionsBlock block, int line, string prefix, HashSet<string> ids, List<QuestionIssue> issues)
     {
         var questions = block.Questions;
 
@@ -91,11 +97,16 @@ public static class QuestionValidationService
             issues.Add(Error(line, prefix + $"{questions.Count} questions in one block; at most {MaxQuestionsPerBlock} are allowed"));
 
         for (var n = 0; n < questions.Count; n++)
-            ValidateQuestion(questions[n], line, $"{prefix}question {n + 1}: ", issues);
+            ValidateQuestion(questions[n], line, $"{prefix}question {n + 1}: ", ids, issues);
     }
 
-    private static void ValidateQuestion(PlanQuestion question, int line, string prefix, List<QuestionIssue> issues)
+    private static void ValidateQuestion(PlanQuestion question, int line, string prefix, HashSet<string> ids, List<QuestionIssue> issues)
     {
+        if (string.IsNullOrWhiteSpace(question.Id))
+            issues.Add(Error(line, prefix + "id is required"));
+        else if (!ids.Add(question.Id))
+            issues.Add(Error(line, prefix + $"duplicate question id '{question.Id}'"));
+
         if (string.IsNullOrWhiteSpace(question.Title))
             issues.Add(Error(line, prefix + "title is required"));
 


### PR DESCRIPTION
Fixes #1960

# Summary

## Changes

A `questions` fence in `DraftMarkdown` now renders as an interactive picker — option rows with
radios or checkboxes, a Recommended chip, an "Other" free-text input, a tab strip when a block holds
several questions, and a Clear action — instead of showing its raw YAML in a blue box. The widget
reports each change through a new `OnAnswersChange` event carrying a typed
`QuestionAnswer { QuestionId, Answer }`; subscribing to that event is what switches a block from
read-only to interactive, so every existing caller behaves exactly as before. All work is in
`Ivy.Tendril.Widgets`; nothing persists an answer yet, which the plan scoped out.

## API Changes

**C# — `Ivy.Tendril.Widgets`**

- `public sealed record QuestionAnswer(string QuestionId, IReadOnlyList<string>? Answer)` — new.
  `Answer` encodes three states without a sentinel: `null` clears back to unanswered, `[]` is an
  explicit skip (`answer: null`), a non-empty list is the answer.
- `DraftMarkdown.OnAnswersChange` — new `[Event] EventHandler<Event<DraftMarkdown, QuestionAnswer>>?`.
- `DraftMarkdownExtensions.OnAnswersChange(Func<Event<DraftMarkdown, QuestionAnswer>, ValueTask>)`
  and `OnAnswersChange(Action<QuestionAnswer>)` — new overloads.

**TypeScript — `frontend/src/DraftMarkdown`**

- `questionsSource.ts` (new): `scanQuestionBlocks(markdown)`, `tagQuestionBlocks(markdown)`,
  `setAnswer(markdown, blockIndex, questionId, answer)`, and the `QuestionBlockSource` interface.
- `questionsSchema.ts` (new): `parseQuestions(body)`, `answerEntries`, `isSkipped`, `otherEntry`,
  `questionLabel`, and the `QuestionOption` / `PlanQuestion` / `ParsedQuestions` types.
- `questionsContext.ts` (new): `QuestionsAnswerContext`, `AnswerCallback`.
- `QuestionsCallout` props widened from `{ content }` to `{ content, blockIndex?, onAnswer? }`.

**Dependency:** `yaml@2.9.0` added to the widgets frontend.

## Files Modified

- **Widget API** — `DraftMarkdown.cs`
- **New frontend modules** — `questionsSource.ts`, `questionsSchema.ts`, `questionsContext.ts`
- **Rendering** — `QuestionsCallout.tsx` (rewritten), `BlockHandler.tsx`, `DraftMarkdown.tsx`,
  `draft-markdown.css`
- **Samples** — `.samples/Apps/DraftMarkdown/QuestionsApp.cs`, `QuestionsAnsweredApp.cs`
- **Tests** — `questionsSource.test.ts` (26), `questionsSchema.test.ts` (19),
  `DraftMarkdown.questions.test.tsx` (22: 4 pre-existing unchanged + 18 new),
  `.tests/widgets/draft-markdown/questions.spec.ts` (6 Playwright)

## Known Limitation (resolved in this PR)

The picker originally could not be driven by an agent-written plan because plan 00078's schema of
record had no `id` field. This gap is closed below — `PlanQuestion.Id` was added and enforced as
non-empty and unique document-wide.

## Manual Testing

Run the widget samples app:

```bash
cd src/Ivy.Tendril.Widgets/.samples
dotnet run
```

1. Open **DraftMarkdown → Questions** (`/draft-markdown/questions`).
   - The first block shows three option rows with radio buttons; "Per session" carries a
     **Recommended** chip. It is a card, not monospaced text in a grey box.
   - Click an option. The pinned panel on the right goes from "Answers received (0)" to
     "Answers received (1)" and lists `retry-scope` with `per-request`. Click another — it appends,
     newest first.
   - The radio itself does **not** stay visually selected. That is by design: the widget reports the
     change and waits for the host to echo an updated document back, and this sample deliberately
     never rewrites its markdown.
   - On the second block (multi-select), tick two channels — the panel shows both values in one
     entry. Tick "Other", type a value, and it is reported verbatim.
   - The third block has two questions, so it renders a **tab strip**; switching tabs swaps the
     question.
   - Press **Clear** — the panel records "cleared — back to unanswered".
   - Scroll to "Not a question": the fence nested inside a longer fence must render as an ordinary
     code block with a copy button, never as a picker.
   - Press **Reset** to empty the panel.

2. Open **DraftMarkdown → Questions (Answered)** (`/draft-markdown/questions-answered`).
   - All three blocks render as plain blue callouts with no controls at all — this host does not
     subscribe to `OnAnswersChange`. The last one is the legacy plain-text form.

3. Open **DraftMarkdown → Annotations** and drag across the `questions` callout at the bottom: no
   comment toolbar should appear (the plan 00073 guarantee, now that the callout has controls).

4. On the third block, switch to the **Owner** tab: it is badged as answered and shows a muted
   *"Skipped — you decide"* line where before it was indistinguishable from the untouched **Name**
   tab. Picking or typing an answer replaces it; **Clear** returns the question to unanswered and the
   line does not come back, because clearing removes the `answer` key rather than nulling it.

## Fix: a required `id` on the questions schema

The picker addresses a question by `id` alone — `OnAnswersChange` carries `{ questionId, answer }`
with no block or position alongside it — but plan 00078's schema of record had no `id`, and its
deserializer is strict about unknown keys. An agent therefore could not write a revision the picker
could drive. `PlanQuestion` gains `Id`, and `QuestionValidationService` enforces it as **non-empty**
and **unique across the whole document**, not per block.

- `src/Ivy.Tendril/Models/QuestionModels.cs` — `PlanQuestion.Id`.
- `src/Ivy.Tendril/Services/Plans/QuestionValidationService.cs` — a document-wide id set threaded
  through `ValidateBlock`/`ValidateQuestion`; two new errors, `id is required` and
  `duplicate question id '<id>'`.
- `src/Ivy.Tendril/Prompts/Plans.md` — `id` in the schema fence, a paragraph on why it is
  document-wide, two lint-rule rows, and `id` added to the schema-bounds sentence.
- `src/Ivy.Tendril.Docs/Docs/09_Advanced/01_CLI/01_Plan.md` — the same field in the CLI reference.
- `src/Ivy.Tendril.Test/QuestionValidationServiceTests.cs`, `QuestionBlockParserTests.cs`,
  `RevisionWriterTests.cs` — fixtures updated, new tests for missing/blank/duplicate ids.

## Fix: render the skipped state, drop a dead memo

`isSkipped` was exported from `questionsSchema.ts` but unused in production, so a question carrying
`answer: null` (asked and deliberately skipped) looked identical to an untouched one. It now renders
a muted "Skipped — you decide" line above the options. Separately, `QuestionView`'s memo over option
values could never hit because `question.options ?? []` allocated a fresh array every render; the
set is now rebuilt inline instead.

- `QuestionsCallout.tsx` — `isSkipped` wired in; `useMemo` dropped from `optionValues`.
- `draft-markdown.css` — `.pmv-question-skipped`.
- `DraftMarkdown.questions.test.tsx` — two new tests for the skipped/unanswered label.
- `QuestionsApp.cs` — the tab-strip block's second question carries `answer: null`.

---

## Commits

- `971579e6` Plan 00083: add a YAML parser and questions source/schema modules
- `c9c53b32` Plan 00083: add OnAnswersChange to the DraftMarkdown widget
- `1d93f4e5` Plan 00083: render questions blocks as an interactive picker
- `3662283c` Plan 00083: add questions sample apps
- `f49b5ebe` Plan 00083: send answer payloads camelCase and add the questions E2E spec
- `ace51caf` Plan 00083: assert a second answer appends in the questions E2E spec
- `3eebadca` Plan 00083: assert the answered sample renders read-only
- `1587017d` Plan 00083: add a required id to the questions schema
- `e116a658` Plan 00083: show the skipped state and drop a dead memo

---
Created using [Ivy Tendril](https://ivy.app).
