### PR TITLE
Add effort level picker to Profile Models for supported agents

### DIFF
--- a/src/Ivy.Tendril.Agents/Abstractions/IAgentDescriptor.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/IAgentDescriptor.cs
@@ -12,6 +12,8 @@ public sealed record AgentProfileDefault(ProfileTier Tier, string? Model, string
     public string Name => Tier.ToString().ToLowerInvariant();
 }
 
+public sealed record EffortOption(string Id, string DisplayName);
+
 public interface IAgentDescriptor
 {
     string Id { get; }
@@ -19,6 +21,8 @@ public interface IAgentDescriptor
     AgentCapabilities Capabilities { get; }
     TransportKind SupportedTransports { get; }
     IReadOnlyList<AgentProfileDefault> DefaultProfiles { get; }
+    IReadOnlyList<EffortOption> SupportedEfforts => [];
+    IReadOnlyList<EffortOption> GetSupportedEfforts(string? model = null) => SupportedEfforts;
     string? TranslateToolName(string canonicalTool);
     string? ReverseTranslateToolName(string nativeTool);
     IReadOnlyList<string> ExtractWritableDirectories(IReadOnlyList<string> allowedTools);

--- a/src/Ivy.Tendril.Agents/Abstractions/ModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/ModelCatalog.cs
@@ -5,6 +5,7 @@ public sealed record ModelInfo
     public required string Id { get; init; }
     public required string DisplayName { get; init; }
     public ModelCapabilities Capabilities { get; init; }
+    public IReadOnlyList<EffortOption>? SupportedEfforts { get; init; }
     public int? ContextWindow { get; init; }
     public int? MaxOutputTokens { get; init; }
     public string? Provider { get; init; }
@@ -15,6 +16,23 @@ public sealed record ModelInfo
     public decimal CacheWritePerMillion { get; init; }
     public decimal CacheReadPerMillion { get; init; }
     public string? PricingSource { get; init; }
+}
+
+public static class EffortLevels
+{
+    public static readonly EffortOption None = new("none", "None");
+    public static readonly EffortOption Low = new("low", "Low");
+    public static readonly EffortOption Medium = new("medium", "Medium");
+    public static readonly EffortOption High = new("high", "High");
+    public static readonly EffortOption ExtraHigh = new("xhigh", "Extra High");
+    public static readonly EffortOption Max = new("max", "Max");
+
+    public static readonly IReadOnlyList<EffortOption> Claude = [Low, Medium, High, ExtraHigh, Max];
+    public static readonly IReadOnlyList<EffortOption> Codex = [None, Low, Medium, High, ExtraHigh];
+    public static readonly IReadOnlyList<EffortOption> Copilot = [Low, Medium, High, ExtraHigh];
+    public static readonly IReadOnlyList<EffortOption> Antigravity = [Low, Medium, High];
+    public static readonly IReadOnlyList<EffortOption> Gemini = [Low, Medium, High];
+    public static readonly IReadOnlyList<EffortOption> OpenCode = [Low, Medium, High, ExtraHigh, Max];
 }
 
 [Flags]

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
@@ -30,6 +30,13 @@ public sealed class AntigravityCli : IAgentCli
         new(ProfileTier.Quick, "gemini-3.6-flash", "medium"),
     ];
 
+    public IReadOnlyList<EffortOption> SupportedEfforts { get; } =
+    [
+        new("low", "Low"),
+        new("medium", "Medium"),
+        new("high", "High"),
+    ];
+
     public string? TranslateToolName(string canonicalTool) => null;
 
     public string? ReverseTranslateToolName(string nativeTool) => null;

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
@@ -30,12 +30,7 @@ public sealed class AntigravityCli : IAgentCli
         new(ProfileTier.Quick, "gemini-3.6-flash", "medium"),
     ];
 
-    public IReadOnlyList<EffortOption> SupportedEfforts { get; } =
-    [
-        new("low", "Low"),
-        new("medium", "Medium"),
-        new("high", "High"),
-    ];
+    public IReadOnlyList<EffortOption> SupportedEfforts => EffortLevels.Antigravity;
 
     public string? TranslateToolName(string canonicalTool) => null;
 

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs
@@ -29,6 +29,7 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
         {
             Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash",
             Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Antigravity,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
         },
@@ -36,6 +37,7 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
         {
             Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash",
             Capabilities = MidCaps, IsDefault = true,
+            SupportedEfforts = EffortLevels.Antigravity,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
         },
@@ -43,6 +45,7 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
         {
             Id = "gemini-3.5-flash", DisplayName = "Gemini 3.5 Flash",
             Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Antigravity,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
         },
@@ -50,6 +53,7 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
         {
             Id = "gemini-3.1-pro", DisplayName = "Gemini 3.1 Pro",
             Capabilities = FullCaps,
+            SupportedEfforts = EffortLevels.Antigravity,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
         },
@@ -57,6 +61,7 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
         {
             Id = "claude-opus-5", DisplayName = "Claude Opus 5",
             Capabilities = FullCaps,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "anthropic",
         },
@@ -64,6 +69,7 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
         {
             Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5",
             Capabilities = FullCaps,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "anthropic",
         },
@@ -71,6 +77,7 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
         {
             Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6",
             Capabilities = FullCaps,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "anthropic",
         },
@@ -78,6 +85,7 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
         {
             Id = "claude-opus-4-6", DisplayName = "Claude Opus 4.6",
             Capabilities = FullCaps,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "anthropic",
         },
@@ -85,6 +93,7 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
         {
             Id = "gpt-oss-120b", DisplayName = "GPT-OSS 120B",
             Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Antigravity,
             ContextWindow = 128_000, MaxOutputTokens = 32_768,
             Provider = "openai",
         },

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeCli.cs
@@ -32,14 +32,7 @@ public sealed class ClaudeCli : IAgentCli
         new(ProfileTier.Quick, "haiku", "low"),
     ];
 
-    public IReadOnlyList<EffortOption> SupportedEfforts { get; } =
-    [
-        new("low", "Low"),
-        new("medium", "Medium"),
-        new("high", "High"),
-        new("xhigh", "Extra High"),
-        new("max", "Max"),
-    ];
+    public IReadOnlyList<EffortOption> SupportedEfforts => EffortLevels.Claude;
 
     private static readonly FrozenDictionary<string, string> ToolNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeCli.cs
@@ -32,6 +32,15 @@ public sealed class ClaudeCli : IAgentCli
         new(ProfileTier.Quick, "haiku", "low"),
     ];
 
+    public IReadOnlyList<EffortOption> SupportedEfforts { get; } =
+    [
+        new("low", "Low"),
+        new("medium", "Medium"),
+        new("high", "High"),
+        new("xhigh", "Extra High"),
+        new("max", "Max"),
+    ];
+
     private static readonly FrozenDictionary<string, string> ToolNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         [CanonicalTools.Read] = "Read",
@@ -182,7 +191,7 @@ public sealed class ClaudeCli : IAgentCli
                 EffortLevel.Low => "low",
                 EffortLevel.Medium => "medium",
                 EffortLevel.High => "high",
-                EffortLevel.XHigh => "max",
+                EffortLevel.XHigh => "xhigh",
                 EffortLevel.Max => "max",
                 _ => "medium"
             });

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
@@ -33,6 +33,7 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         {
             Id = "claude-opus-5", DisplayName = "Claude Opus 5",
             Capabilities = FullCaps, IsDefault = true,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
             InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
@@ -42,6 +43,7 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         {
             Id = "claude-opus-4-8", DisplayName = "Claude Opus 4.8",
             Capabilities = FullCaps,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
             InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
@@ -51,6 +53,7 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         {
             Id = "claude-opus-4-7", DisplayName = "Claude Opus 4.7",
             Capabilities = FullCaps,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
             InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
@@ -60,6 +63,7 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         {
             Id = "opus", DisplayName = "Claude Opus (Default)",
             Capabilities = FullCaps,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
             InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
@@ -69,6 +73,7 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         {
             Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5",
             Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
             InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
@@ -78,6 +83,7 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         {
             Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6",
             Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
             InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
@@ -87,6 +93,7 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         {
             Id = "claude-3.7-sonnet", DisplayName = "Claude Sonnet 3.7",
             Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
             InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
@@ -96,6 +103,7 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         {
             Id = "sonnet", DisplayName = "Claude Sonnet",
             Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
             Provider = "anthropic",
             InputPerMillion = 2.00m, OutputPerMillion = 10.00m,
@@ -105,6 +113,7 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         {
             Id = "claude-haiku-4-5", DisplayName = "Claude Haiku 4.5",
             Capabilities = LiteCaps,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 200_000, MaxOutputTokens = 64_000,
             Provider = "anthropic",
             InputPerMillion = 1.00m, OutputPerMillion = 5.00m,
@@ -114,6 +123,7 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         {
             Id = "haiku", DisplayName = "Claude Haiku",
             Capabilities = LiteCaps,
+            SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 200_000, MaxOutputTokens = 64_000,
             Provider = "anthropic",
             InputPerMillion = 1.00m, OutputPerMillion = 5.00m,

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexModelCatalog.cs
@@ -21,6 +21,7 @@ public sealed class CodexModelCatalog : CachedModelCatalogProvider
         {
             Id = "gpt-5.6-terra", DisplayName = "GPT-5.6-Terra",
             Capabilities = DefaultCaps,
+            SupportedEfforts = EffortLevels.Codex,
             ContextWindow = 272_000, MaxOutputTokens = 16_000,
             Provider = "openai", IsDefault = true,
             InputPerMillion = 1.10m, OutputPerMillion = 4.40m,
@@ -30,6 +31,7 @@ public sealed class CodexModelCatalog : CachedModelCatalogProvider
         {
             Id = "gpt-5.6-luna", DisplayName = "GPT-5.6-Luna",
             Capabilities = DefaultCaps,
+            SupportedEfforts = EffortLevels.Codex,
             ContextWindow = 272_000, MaxOutputTokens = 16_000,
             Provider = "openai",
             InputPerMillion = 1.50m, OutputPerMillion = 6.00m,
@@ -39,6 +41,7 @@ public sealed class CodexModelCatalog : CachedModelCatalogProvider
         {
             Id = "gpt-5.5", DisplayName = "GPT-5.5",
             Capabilities = DefaultCaps,
+            SupportedEfforts = EffortLevels.Codex,
             ContextWindow = 400_000, MaxOutputTokens = 32_000,
             Provider = "openai",
             InputPerMillion = 10.00m, OutputPerMillion = 40.00m,
@@ -48,6 +51,7 @@ public sealed class CodexModelCatalog : CachedModelCatalogProvider
         {
             Id = "gpt-5.4", DisplayName = "GPT-5.4",
             Capabilities = DefaultCaps,
+            SupportedEfforts = EffortLevels.Codex,
             ContextWindow = 400_000, MaxOutputTokens = 32_000,
             Provider = "openai",
             InputPerMillion = 10.00m, OutputPerMillion = 40.00m,
@@ -57,61 +61,61 @@ public sealed class CodexModelCatalog : CachedModelCatalogProvider
         {
             Id = "gpt-5.4-mini", DisplayName = "GPT-5.4 Mini",
             Capabilities = DefaultCaps,
+            SupportedEfforts = EffortLevels.Codex,
             ContextWindow = 400_000, MaxOutputTokens = 16_000,
             Provider = "openai",
             InputPerMillion = 1.10m, OutputPerMillion = 4.40m,
             CacheReadPerMillion = 0.275m, CacheWritePerMillion = 1.375m,
-
         },
         new()
         {
             Id = "gpt-5.3-codex", DisplayName = "GPT-5.3 Codex",
             Capabilities = DefaultCaps,
+            SupportedEfforts = EffortLevels.Codex,
             ContextWindow = 400_000, MaxOutputTokens = 16_000,
             Provider = "openai",
             InputPerMillion = 1.50m, OutputPerMillion = 6.00m,
             CacheReadPerMillion = 0.375m, CacheWritePerMillion = 1.875m,
-
         },
         new()
         {
             Id = "o3", DisplayName = "O3",
             Capabilities = DefaultCaps | ModelCapabilities.ExtendedThinking,
+            SupportedEfforts = EffortLevels.Codex,
             ContextWindow = 200_000, MaxOutputTokens = 100_000,
             Provider = "openai",
             InputPerMillion = 10.00m, OutputPerMillion = 40.00m,
             CacheReadPerMillion = 2.50m, CacheWritePerMillion = 12.50m,
-
         },
         new()
         {
             Id = "o4-mini", DisplayName = "O4 Mini",
             Capabilities = DefaultCaps | ModelCapabilities.ExtendedThinking,
+            SupportedEfforts = EffortLevels.Codex,
             ContextWindow = 200_000, MaxOutputTokens = 100_000,
             Provider = "openai",
             InputPerMillion = 1.10m, OutputPerMillion = 4.40m,
             CacheReadPerMillion = 0.275m, CacheWritePerMillion = 1.375m,
-
         },
         new()
         {
             Id = "gpt-4.1", DisplayName = "GPT-4.1",
             Capabilities = DefaultCaps,
+            SupportedEfforts = EffortLevels.Codex,
             ContextWindow = 1_047_576, MaxOutputTokens = 32_000,
             Provider = "openai",
             InputPerMillion = 2.00m, OutputPerMillion = 8.00m,
             CacheReadPerMillion = 0.50m, CacheWritePerMillion = 2.50m,
-
         },
         new()
         {
             Id = "codex-mini", DisplayName = "Codex Mini",
             Capabilities = DefaultCaps,
+            SupportedEfforts = EffortLevels.Codex,
             ContextWindow = 400_000, MaxOutputTokens = 16_000,
             Provider = "openai",
             InputPerMillion = 1.50m, OutputPerMillion = 6.00m,
             CacheReadPerMillion = 0.375m, CacheWritePerMillion = 1.875m,
-
         },
     ];
 
@@ -169,6 +173,7 @@ public sealed class CodexModelCatalog : CachedModelCatalogProvider
                         Id = slug,
                         DisplayName = displayName ?? slug,
                         Capabilities = DefaultCaps,
+                        SupportedEfforts = EffortLevels.Codex,
                         Provider = "openai",
                     });
                 }

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexModelCatalog.cs
@@ -19,6 +19,16 @@ public sealed class CodexModelCatalog : CachedModelCatalogProvider
     [
         new()
         {
+            Id = "gpt-5.6-sol", DisplayName = "GPT-5.6-Sol",
+            Capabilities = DefaultCaps,
+            SupportedEfforts = EffortLevels.Codex,
+            ContextWindow = 400_000, MaxOutputTokens = 32_000,
+            Provider = "openai",
+            InputPerMillion = 10.00m, OutputPerMillion = 40.00m,
+            CacheReadPerMillion = 2.50m, CacheWritePerMillion = 12.50m,
+        },
+        new()
+        {
             Id = "gpt-5.6-terra", DisplayName = "GPT-5.6-Terra",
             Capabilities = DefaultCaps,
             SupportedEfforts = EffortLevels.Codex,

--- a/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotCli.cs
@@ -30,6 +30,14 @@ public sealed class CopilotCli : IAgentCli
         new(ProfileTier.Quick, null, "low"),
     ];
 
+    public IReadOnlyList<EffortOption> SupportedEfforts { get; } =
+    [
+        new("low", "Low"),
+        new("medium", "Medium"),
+        new("high", "High"),
+        new("xhigh", "Extra High"),
+    ];
+
     private static readonly string ShellToolName =
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "powershell" : "bash";
 

--- a/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotCli.cs
@@ -30,13 +30,7 @@ public sealed class CopilotCli : IAgentCli
         new(ProfileTier.Quick, null, "low"),
     ];
 
-    public IReadOnlyList<EffortOption> SupportedEfforts { get; } =
-    [
-        new("low", "Low"),
-        new("medium", "Medium"),
-        new("high", "High"),
-        new("xhigh", "Extra High"),
-    ];
+    public IReadOnlyList<EffortOption> SupportedEfforts => EffortLevels.Copilot;
 
     private static readonly string ShellToolName =
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "powershell" : "bash";

--- a/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Copilot/CopilotModelCatalog.cs
@@ -12,17 +12,17 @@ public sealed class CopilotModelCatalog : CachedModelCatalogProvider
 
     public override IReadOnlyList<ModelInfo> GetStaticModels() =>
     [
-        new() { Id = "gpt-5.4", DisplayName = "GPT-5.4", Capabilities = DefaultCaps, Provider = "openai", IsDefault = true },
-        new() { Id = "gpt-5.3-codex", DisplayName = "GPT-5.3 Codex", Capabilities = DefaultCaps, Provider = "openai" },
-        new() { Id = "gpt-5.2-codex", DisplayName = "GPT-5.2 Codex", Capabilities = DefaultCaps, Provider = "openai" },
-        new() { Id = "gpt-5.2", DisplayName = "GPT-5.2", Capabilities = DefaultCaps, Provider = "openai" },
-        new() { Id = "gpt-5.4-mini", DisplayName = "GPT-5.4 Mini", Capabilities = DefaultCaps, Provider = "openai" },
-        new() { Id = "gpt-5-mini", DisplayName = "GPT-5 Mini", Capabilities = DefaultCaps, Provider = "openai" },
-        new() { Id = "gpt-4.1", DisplayName = "GPT-4.1", Capabilities = DefaultCaps, Provider = "openai" },
-        new() { Id = "claude-opus-5", DisplayName = "Claude Opus 5", Capabilities = DefaultCaps, Provider = "anthropic" },
-        new() { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5", Capabilities = DefaultCaps, Provider = "anthropic" },
-        new() { Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6", Capabilities = DefaultCaps, Provider = "anthropic" },
-        new() { Id = "claude-sonnet-4-5", DisplayName = "Claude Sonnet 4.5", Capabilities = DefaultCaps, Provider = "anthropic" },
-        new() { Id = "claude-haiku-4-5", DisplayName = "Claude Haiku 4.5", Capabilities = DefaultCaps, Provider = "anthropic" },
+        new() { Id = "gpt-5.4", DisplayName = "GPT-5.4", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Copilot, Provider = "openai", IsDefault = true },
+        new() { Id = "gpt-5.3-codex", DisplayName = "GPT-5.3 Codex", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Copilot, Provider = "openai" },
+        new() { Id = "gpt-5.2-codex", DisplayName = "GPT-5.2 Codex", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Copilot, Provider = "openai" },
+        new() { Id = "gpt-5.2", DisplayName = "GPT-5.2", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Copilot, Provider = "openai" },
+        new() { Id = "gpt-5.4-mini", DisplayName = "GPT-5.4 Mini", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Copilot, Provider = "openai" },
+        new() { Id = "gpt-5-mini", DisplayName = "GPT-5 Mini", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Copilot, Provider = "openai" },
+        new() { Id = "gpt-4.1", DisplayName = "GPT-4.1", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Copilot, Provider = "openai" },
+        new() { Id = "claude-opus-5", DisplayName = "Claude Opus 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+        new() { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+        new() { Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+        new() { Id = "claude-sonnet-4-5", DisplayName = "Claude Sonnet 4.5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+        new() { Id = "claude-haiku-4-5", DisplayName = "Claude Haiku 4.5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
     ];
 }

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyCli.cs
@@ -22,6 +22,7 @@ public sealed class IvyCli : IAgentCli
     public PromptTransport PromptTransport => _inner.PromptTransport;
     public OutputFormat PreferredOutputFormat => _inner.PreferredOutputFormat;
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles => _inner.DefaultProfiles;
+    public IReadOnlyList<EffortOption> SupportedEfforts => _inner.SupportedEfforts;
 
     public string? TranslateToolName(string canonicalTool) => _inner.TranslateToolName(canonicalTool);
     public string? ReverseTranslateToolName(string nativeTool) => _inner.ReverseTranslateToolName(nativeTool);

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
@@ -41,6 +41,8 @@ public sealed class OpenAiProxyCli : IAgentCli
         }
     }
 
+    public IReadOnlyList<EffortOption> SupportedEfforts => _inner.SupportedEfforts;
+
     public string? TranslateToolName(string canonicalTool) => _inner.TranslateToolName(canonicalTool);
     public string? ReverseTranslateToolName(string nativeTool) => _inner.ReverseTranslateToolName(nativeTool);
     public IReadOnlyList<string> ExtractWritableDirectories(IReadOnlyList<string> allowedTools) => _inner.ExtractWritableDirectories(allowedTools);

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeCli.cs
@@ -29,6 +29,15 @@ public sealed class OpenCodeCli : IAgentCli
         new(ProfileTier.Quick, "default", "low"),
     ];
 
+    public IReadOnlyList<EffortOption> SupportedEfforts { get; } =
+    [
+        new("low", "Low"),
+        new("medium", "Medium"),
+        new("high", "High"),
+        new("xhigh", "Extra High"),
+        new("max", "Max"),
+    ];
+
     private static readonly FrozenDictionary<string, string> ToolMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
         [CanonicalTools.Read] = "read",

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeCli.cs
@@ -29,14 +29,7 @@ public sealed class OpenCodeCli : IAgentCli
         new(ProfileTier.Quick, "default", "low"),
     ];
 
-    public IReadOnlyList<EffortOption> SupportedEfforts { get; } =
-    [
-        new("low", "Low"),
-        new("medium", "Medium"),
-        new("high", "High"),
-        new("xhigh", "Extra High"),
-        new("max", "Max"),
-    ];
+    public IReadOnlyList<EffortOption> SupportedEfforts => EffortLevels.OpenCode;
 
     private static readonly FrozenDictionary<string, string> ToolMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
@@ -16,52 +16,52 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
         new()
         {
             Id = "moonshotai/Kimi-K3", DisplayName = "Kimi k3",
-            Capabilities = DefaultCaps, Provider = "moonshot", IsDefault = true,
+            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "moonshot", IsDefault = true,
         },
         new()
         {
             Id = "kimi-k2", DisplayName = "Kimi k2",
-            Capabilities = DefaultCaps, Provider = "moonshot",
+            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "moonshot",
         },
         new()
         {
             Id = "deepseek-v3", DisplayName = "DeepSeek V3",
-            Capabilities = DefaultCaps, Provider = "deepseek",
+            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "deepseek",
         },
         new()
         {
             Id = "deepseek-r1", DisplayName = "DeepSeek R1",
-            Capabilities = DefaultCaps, Provider = "deepseek",
+            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "deepseek",
         },
         new()
         {
             Id = "claude-opus-5", DisplayName = "Claude Opus 5",
-            Capabilities = DefaultCaps, Provider = "anthropic",
+            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
         },
         new()
         {
             Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5",
-            Capabilities = DefaultCaps, Provider = "anthropic",
+            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
         },
         new()
         {
             Id = "claude-opus-4-7", DisplayName = "Claude Opus 4.7",
-            Capabilities = DefaultCaps, Provider = "anthropic",
+            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
         },
         new()
         {
             Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6",
-            Capabilities = DefaultCaps, Provider = "anthropic",
+            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic",
         },
         new()
         {
             Id = "gpt-5.5", DisplayName = "GPT-5.5",
-            Capabilities = DefaultCaps, Provider = "openai",
+            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "openai",
         },
         new()
         {
             Id = "default", DisplayName = "OpenCode Default",
-            Capabilities = DefaultCaps, Provider = "opencode",
+            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "opencode",
         },
     ];
 
@@ -96,6 +96,9 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
                 Id = id,
                 DisplayName = id,
                 Capabilities = DefaultCaps,
+                SupportedEfforts = provider == "anthropic" || id.Contains("claude", StringComparison.OrdinalIgnoreCase)
+                    ? EffortLevels.Claude
+                    : EffortLevels.OpenCode,
                 Provider = provider,
                 IsDefault = first,
                 ContextWindow = pricing?.ContextWindow,

--- a/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/01_ClaudeCode.md
+++ b/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/01_ClaudeCode.md
@@ -35,11 +35,11 @@ For more details on `config.yaml` structure and settings, see [Setup & Settings]
 
 Tendril maps effort levels to Claude models:
 
-| Profile | Model | Use Case |
-|---------|-------|----------|
-| `deep` | opus | Complex multi-file changes, architecture work |
-| `balanced` | sonnet | Standard plan execution, most tasks |
-| `quick` | haiku | Simple fixes, formatting, small edits |
+| Profile | Model | Effort | Use Case |
+|---------|-------|--------|----------|
+| `deep` | opus | max | Complex multi-file changes, architecture work |
+| `balanced` | sonnet | high | Standard plan execution, most tasks |
+| `quick` | haiku | low | Simple fixes, formatting, small edits |
 
 The profile is selected automatically based on the plan's complexity level, or can be configured per promptware in `config.yaml`.
 

--- a/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/02_Codex.md
+++ b/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/02_Codex.md
@@ -34,10 +34,10 @@ For more details on `config.yaml` structure and settings, see [Setup & Settings]
 
 Tendril maps effort levels to Codex models:
 
-| Profile | Model | Use Case |
-|---------|-------|----------|
-| `deep` | gpt-5.5 | Complex multi-file changes |
-| `balanced` | gpt-5.6-terra | Standard plan execution |
-| `quick` | gpt-5.6-luna | Simple fixes and small edits |
+| Profile | Model | Effort | Use Case |
+|---------|-------|--------|----------|
+| `deep` | gpt-5.5 | high | Complex multi-file changes |
+| `balanced` | gpt-5.6-terra | medium | Standard plan execution |
+| `quick` | gpt-5.6-luna | low | Simple fixes and small edits |
 
 The profile is selected automatically based on the plan's complexity level, or can be configured per promptware in `config.yaml`.

--- a/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/02_Codex.md
+++ b/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/02_Codex.md
@@ -36,7 +36,7 @@ Tendril maps effort levels to Codex models:
 
 | Profile | Model | Effort | Use Case |
 |---------|-------|--------|----------|
-| `deep` | gpt-5.5 | high | Complex multi-file changes |
+| `deep` | gpt-5.6-sol | high | Complex multi-file changes |
 | `balanced` | gpt-5.6-terra | medium | Standard plan execution |
 | `quick` | gpt-5.6-luna | low | Simple fixes and small edits |
 

--- a/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/04_OpenCode.md
+++ b/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/04_OpenCode.md
@@ -34,11 +34,11 @@ For more details on `config.yaml` structure and settings, see [Setup & Settings]
 
 Tendril maps effort levels to OpenCode models:
 
-| Profile | Model | Use Case |
-|---------|-------|----------|
-| `deep` | default | Complex multi-file changes |
-| `balanced` | default | Standard plan execution |
-| `quick` | default | Simple fixes and small edits |
+| Profile | Model | Effort | Use Case |
+|---------|-------|--------|----------|
+| `deep` | default | high | Complex multi-file changes |
+| `balanced` | default | medium | Standard plan execution |
+| `quick` | default | low | Simple fixes and small edits |
 
 OpenCode supports multiple backend providers (Anthropic, OpenAI, Google, etc.) and manages model selection internally. Use `tendril models` to see discovered models.
 

--- a/src/Ivy.Tendril.Widgets/ChatWidget.cs
+++ b/src/Ivy.Tendril.Widgets/ChatWidget.cs
@@ -12,7 +12,8 @@ public record ChatMessageDto(
     string Timestamp,
     string? AgentId = null,
     string? ModelId = null,
-    string? RawStream = null
+    string? RawStream = null,
+    string? Effort = null
 );
 
 public record ChatSessionDto(
@@ -23,11 +24,13 @@ public record ChatSessionDto(
     string CreatedAt,
     string UpdatedAt,
     List<ChatMessageDto> Messages,
-    string Status = "done"
+    string Status = "done",
+    string? Effort = null
 );
 
 public record AgentOptionDto(string Id, string Label);
 public record ModelOptionDto(string Id, string DisplayName);
+public record EffortOptionDto(string Id, string DisplayName);
 
 public record ChatAttachmentDto(
     string Name,
@@ -56,8 +59,11 @@ public record ChatWidget : WidgetBase<ChatWidget>
     [Prop] public List<ChatSessionDto> Sessions { get; init; } = new();
     [Prop] public List<AgentOptionDto> Agents { get; init; } = new();
     [Prop] public List<ModelOptionDto> Models { get; init; } = new();
+    [Prop] public List<EffortOptionDto> Efforts { get; init; } = new();
     [Prop] public string SelectedAgent { get; init; } = "claude";
     [Prop] public string SelectedModel { get; init; } = "opus";
+    [Prop] public string SelectedEffort { get; init; } = "default";
+    [Prop] public bool SupportsEffort { get; init; } = true;
     [Prop] public bool IsStreaming { get; init; } = false;
     [Prop] public string? StreamingText { get; init; }
     [Prop] public IWriteStream<string>? StreamingStream { get; init; }
@@ -70,4 +76,5 @@ public record ChatWidget : WidgetBase<ChatWidget>
     [Event] public Func<Event<ChatWidget, object>, ValueTask>? OnCancelStream { get; init; }
     [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnAgentChanged { get; init; }
     [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnModelChanged { get; init; }
+    [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnEffortChanged { get; init; }
 }

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -159,4 +159,39 @@ describe("ChatWidget Queued Messages UI", () => {
       ["sess-123"]
     );
   });
+
+  it("renders effort picker and emits OnEffortChanged when changed", () => {
+    const handleEvent = vi.fn();
+    const efforts = [
+      { id: "default", displayName: "Default" },
+      { id: "low", displayName: "Low" },
+      { id: "high", displayName: "High" },
+      { id: "max", displayName: "Max" },
+    ];
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        efforts={efforts}
+        selectedEffort="high"
+        supportsEffort={true}
+        events={["OnEffortChanged"]}
+        eventHandler={handleEvent}
+      />
+    );
+
+    const effortTrigger = screen.getByTitle("Effort Level");
+    expect(effortTrigger).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+
+    fireEvent.click(effortTrigger.querySelector("button")!);
+    const maxOption = screen.getByRole("button", { name: /Max/i });
+    fireEvent.click(maxOption);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnEffortChanged",
+      "test-chat",
+      ["max"]
+    );
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
-import { Mic, Bot, Cpu, MessageSquare, ChevronDown, Check, Pencil, Paperclip, X, Square, ArrowRight, Trash2 } from "lucide-react";
+import { Mic, Bot, Cpu, Zap, MessageSquare, ChevronDown, Check, Pencil, Paperclip, X, Square, ArrowRight, Trash2 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import { AgentViewer } from "../AgentViewer";
 import { getMarkdownPlugins } from "../math";
@@ -16,6 +16,7 @@ export interface ChatMessageDto {
   agentId?: string;
   modelId?: string;
   rawStream?: string;
+  effort?: string;
 }
 
 export interface ChatSessionDto {
@@ -27,6 +28,7 @@ export interface ChatSessionDto {
   updatedAt: string;
   messages: ChatMessageDto[];
   status?: "generating" | "waiting" | "done";
+  effort?: string;
 }
 
 export interface AgentOptionDto {
@@ -35,6 +37,11 @@ export interface AgentOptionDto {
 }
 
 export interface ModelOptionDto {
+  id: string;
+  displayName: string;
+}
+
+export interface EffortOptionDto {
   id: string;
   displayName: string;
 }
@@ -56,8 +63,11 @@ export interface ChatWidgetProps {
   sessions?: ChatSessionDto[];
   agents?: AgentOptionDto[];
   models?: ModelOptionDto[];
+  efforts?: EffortOptionDto[];
   selectedAgent?: string;
   selectedModel?: string;
+  selectedEffort?: string;
+  supportsEffort?: boolean;
   isStreaming?: boolean;
   streamingText?: string;
   streamingStream?: { id: string };
@@ -189,8 +199,11 @@ export function ChatWidget({
   sessions = [],
   agents = [],
   models = [],
+  efforts = [],
   selectedAgent = "claude",
   selectedModel = "opus",
+  selectedEffort = "default",
+  supportsEffort = true,
   isStreaming = false,
   streamingText = "",
   streamingStream: _streamingStream,
@@ -437,14 +450,6 @@ export function ChatWidget({
     }
   };
 
-  const handleAgentChange = (val: string) => {
-    emit("OnAgentChanged", val);
-  };
-
-  const handleModelChange = (val: string) => {
-    emit("OnModelChanged", val);
-  };
-
   const toggleVoiceRecording = () => {
     if (!("webkitSpeechRecognition" in window || "SpeechRecognition" in window)) {
       alert("Speech recognition is not supported in this browser.");
@@ -488,6 +493,19 @@ export function ChatWidget({
 
   const agentSelectOptions = agents.map((a) => ({ value: a.id, label: a.label }));
   const modelSelectOptions = models.map((m) => ({ value: m.id, label: m.displayName }));
+  const effortSelectOptions = (efforts || []).map((e) => ({ value: e.id, label: e.displayName }));
+
+  const handleAgentChange = (agentId: string) => {
+    emit("OnAgentChanged", agentId);
+  };
+
+  const handleModelChange = (modelId: string) => {
+    emit("OnModelChanged", modelId);
+  };
+
+  const handleEffortChange = (effortId: string) => {
+    emit("OnEffortChanged", effortId);
+  };
 
   return (
     <div className="chat-widget-root">
@@ -774,6 +792,16 @@ export function ChatWidget({
                   onChange={handleModelChange}
                   title="Model"
                 />
+
+                {supportsEffort && effortSelectOptions.length > 0 && (
+                  <InlineSelect
+                    icon={<Zap size={13} />}
+                    value={selectedEffort}
+                    options={effortSelectOptions}
+                    onChange={handleEffortChange}
+                    title="Effort Level"
+                  />
+                )}
 
                 <button
                   type="button"

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -40,6 +40,7 @@ public class ChatApp : ViewBase
             var initialModels = GetModelsForAgent(agentRunner, agent);
             return initialModels.Count > 0 ? initialModels[0].Id : "default";
         });
+        var selectedEffort = UseState("default");
         var lastSyncedSessionId = UseRef<string?>(null);
         var isStreaming = UseState(false);
         var streamingSessionId = UseState<string?>(null);
@@ -93,6 +94,10 @@ public class ChatApp : ViewBase
             {
                 selectedModel.Set(activeSession.ModelId);
             }
+            if (!string.IsNullOrEmpty(activeSession.Effort))
+            {
+                selectedEffort.Set(activeSession.Effort);
+            }
         }
 
         var registeredAgentIds = agentRunner.RegisteredAgents;
@@ -118,6 +123,13 @@ public class ChatApp : ViewBase
             }
         }
 
+        var supportsEffort = DoesAgentSupportEffort(agentRunner, selectedAgent.Value);
+        var currentEffortOptions = GetEffortsForAgentAndModel(agentRunner, selectedAgent.Value, selectedModel.Value);
+        if (!currentEffortOptions.Any(e => e.Id.Equals(selectedEffort.Value, StringComparison.OrdinalIgnoreCase)))
+        {
+            selectedEffort.Set("default");
+        }
+
         var sessionDtos = sessions.Select(s =>
         {
             var isGenerating = runningSessionIds.Value.Contains(s.Id);
@@ -136,9 +148,11 @@ public class ChatApp : ViewBase
                     m.Timestamp.ToString("t"),
                     m.AgentId,
                     m.ModelId,
-                    m.RawStream
+                    m.RawStream,
+                    m.Effort
                 )).ToList(),
-                status
+                status,
+                s.Effort
             );
         }).ToList();
 
@@ -224,17 +238,19 @@ public class ChatApp : ViewBase
 
             var fullAgentPrompt = agentPromptBuilder.ToString();
 
-            chatService.AddMessage(targetSessionId, "user", promptWithAttachments, selectedAgent.Value, selectedModel.Value);
+            chatService.AddMessage(targetSessionId, "user", promptWithAttachments, selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
             isStreaming.Set(true);
 
             try
             {
+                var effortOverride = selectedEffort.Value != "default" ? AgentProviderFactory.ParseEffort(selectedEffort.Value) : null;
                 var context = AgentLaunchHelper.PrepareResolutionContext(
                     configService,
                     agentRunner,
                     selectedAgent.Value,
                     fullAgentPrompt,
                     modelOverride: selectedModel.Value,
+                    effortOverride: effortOverride,
                     permissionMode: PermissionMode.FullAuto);
 
                 var session = await agentRunner.LaunchAsync(context);
@@ -278,11 +294,11 @@ public class ChatApp : ViewBase
                 {
                     if (rawLines.Count > 0) fullRawStream = string.Join("\n", rawLines);
                 }
-                chatService.AddMessage(targetSessionId, "assistant", responseContent, selectedAgent.Value, selectedModel.Value, rawStream: fullRawStream);
+                chatService.AddMessage(targetSessionId, "assistant", responseContent, selectedAgent.Value, selectedModel.Value, rawStream: fullRawStream, effort: selectedEffort.Value);
             }
             catch (Exception ex)
             {
-                chatService.AddMessage(targetSessionId, "assistant", $"Error executing request: {ex.Message}", selectedAgent.Value, selectedModel.Value);
+                chatService.AddMessage(targetSessionId, "assistant", $"Error executing request: {ex.Message}", selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
             }
             finally
             {
@@ -333,7 +349,7 @@ public class ChatApp : ViewBase
             string targetSessionId = !string.IsNullOrEmpty(dto.SessionId) ? dto.SessionId : (activeSessionId.Value ?? "");
             if (string.IsNullOrEmpty(targetSessionId))
             {
-                var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value);
+                var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
                 targetSessionId = newSess.Id;
                 activeSessionId.Set(targetSessionId);
             }
@@ -356,7 +372,7 @@ public class ChatApp : ViewBase
             var targetId = activeSessionId.Value;
             if (string.IsNullOrEmpty(targetId))
             {
-                var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value);
+                var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
                 targetId = newSess.Id;
                 activeSessionId.Set(targetId);
             }
@@ -379,6 +395,7 @@ public class ChatApp : ViewBase
             sessionVersion,
             selectedAgent,
             selectedModel,
+            selectedEffort,
             isStreaming,
             streamingSessionId,
             runningSessionIds,
@@ -388,12 +405,66 @@ public class ChatApp : ViewBase
             sessionDtos,
             agentDtos,
             modelDtos,
+            currentEffortOptions,
+            supportsEffort,
             chatService,
             agentRunner,
             SendMessage
         );
 
         return new SidebarLayout(content, sidebar).SidebarContentScroll(Scroll.None);
+    }
+
+    internal static bool DoesAgentSupportEffort(IAgentRunner runner, string agentId)
+    {
+        var normalized = AgentProviderFactory.NormalizeAgentName(agentId);
+        try
+        {
+            var descriptor = runner.GetDescriptor(normalized);
+            return descriptor != null && descriptor.Capabilities.HasFlag(AgentCapabilities.EffortControl);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    internal static List<EffortOptionDto> GetEffortsForAgentAndModel(IAgentRunner runner, string agentId, string? modelId)
+    {
+        var normalized = AgentProviderFactory.NormalizeAgentName(agentId);
+        IAgentDescriptor? descriptor = null;
+        try { descriptor = runner.GetDescriptor(normalized); } catch { }
+
+        IReadOnlyList<EffortOption>? efforts = null;
+        if (descriptor != null)
+        {
+            var catalog = runner.GetModelCatalog(normalized);
+            if (catalog != null && !string.IsNullOrEmpty(modelId) && modelId != "default")
+            {
+                var staticModels = catalog.GetStaticModels();
+                var match = staticModels?.FirstOrDefault(m => m.Id.Equals(modelId, StringComparison.OrdinalIgnoreCase));
+                if (match?.SupportedEfforts != null && match.SupportedEfforts.Count > 0)
+                {
+                    efforts = match.SupportedEfforts;
+                }
+            }
+
+            if (efforts == null || efforts.Count == 0)
+            {
+                efforts = descriptor.GetSupportedEfforts(modelId);
+            }
+            if (efforts == null || efforts.Count == 0)
+            {
+                efforts = descriptor.SupportedEfforts;
+            }
+        }
+
+        var list = new List<EffortOptionDto> { new("default", "Default") };
+        if (efforts != null && efforts.Count > 0)
+        {
+            list.AddRange(efforts.Select(e => new EffortOptionDto(e.Id, e.DisplayName)));
+        }
+        return list;
     }
 
     internal static List<(string Id, string DisplayName)> GetModelsForAgent(IAgentRunner runner, string agentId)

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -18,6 +18,7 @@ public class ContentView(
     IState<int> sessionVersion,
     IState<string> selectedAgent,
     IState<string> selectedModel,
+    IState<string> selectedEffort,
     IState<bool> isStreaming,
     IState<string?> streamingSessionId,
     IState<HashSet<string>> runningSessionIds,
@@ -27,6 +28,8 @@ public class ContentView(
     List<ChatSessionDto> sessionDtos,
     List<AgentOptionDto> agentDtos,
     List<ModelOptionDto> modelDtos,
+    List<EffortOptionDto> effortDtos,
+    bool supportsEffort,
     IChatHistoryService chatService,
     IAgentRunner agentRunner,
     Action<ChatSendMessageDto> sendMessage) : ViewBase
@@ -40,7 +43,7 @@ public class ContentView(
                 .Primary()
                 .OnClick(() =>
                 {
-                    var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value);
+                    var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
                     activeSessionId.Set(newSess.Id);
                     sessionVersion.Set(v => v + 1);
                 });
@@ -63,8 +66,11 @@ public class ContentView(
             Sessions = sessionDtos,
             Agents = agentDtos,
             Models = modelDtos,
+            Efforts = effortDtos,
             SelectedAgent = selectedAgent.Value,
             SelectedModel = selectedModel.Value,
+            SelectedEffort = selectedEffort.Value,
+            SupportsEffort = supportsEffort,
             IsStreaming = activeSessionId.Value != null && runningSessionIds.Value.Contains(activeSessionId.Value),
             StreamingText = activeSessionLiveStream,
 
@@ -95,7 +101,7 @@ public class ContentView(
             },
             OnCreateSession = _ =>
             {
-                var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value);
+                var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
                 activeSessionId.Set(newSess.Id);
                 return ValueTask.CompletedTask;
             },
@@ -131,11 +137,18 @@ public class ContentView(
                 {
                     selectedModel.Set(newModels[0].Id);
                 }
+                selectedEffort.Set("default");
                 return ValueTask.CompletedTask;
             },
             OnModelChanged = e =>
             {
                 selectedModel.Set(e.Value);
+                selectedEffort.Set("default");
+                return ValueTask.CompletedTask;
+            },
+            OnEffortChanged = e =>
+            {
+                selectedEffort.Set(e.Value);
                 return ValueTask.CompletedTask;
             }
         }

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -142,23 +142,24 @@ public class CodingAgentSetupView : ViewBase
 
         var supportsEffort = descriptor != null && descriptor.Capabilities.HasFlag(AgentCapabilities.EffortControl);
 
-        IAnyOption[] GetEffortOptions(string? model)
+        IAnyOption[] GetEffortOptions(string? modelId)
         {
-            if (descriptor == null) return [new Option<string>("Default", "default")];
-            var efforts = descriptor.GetSupportedEfforts(model);
-            if (efforts.Count == 0)
-                efforts = descriptor.SupportedEfforts;
-            if (efforts.Count == 0)
+            var modelInfo = !string.IsNullOrEmpty(modelId)
+                ? models.FirstOrDefault(m => m.Id.Equals(modelId, StringComparison.OrdinalIgnoreCase))
+                : null;
+
+            var efforts = modelInfo?.SupportedEfforts;
+            if (efforts == null || efforts.Count == 0)
             {
-                return
-                [
-                    new Option<string>("Default", "default"),
-                    new Option<string>("Low", "low"),
-                    new Option<string>("Medium", "medium"),
-                    new Option<string>("High", "high"),
-                    new Option<string>("Extra High", "xhigh"),
-                    new Option<string>("Max", "max")
-                ];
+                efforts = descriptor?.GetSupportedEfforts(modelId);
+            }
+            if (efforts == null || efforts.Count == 0)
+            {
+                efforts = descriptor?.SupportedEfforts;
+            }
+            if (efforts == null || efforts.Count == 0)
+            {
+                efforts = EffortLevels.Claude;
             }
 
             return new[] { new Option<string>("Default", "default") }

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -67,6 +67,9 @@ public class CodingAgentSetupView : ViewBase
         var deepModel = UseState(GetProfileModel(config, config.Settings.CodingAgent, "deep"));
         var balancedModel = UseState(GetProfileModel(config, config.Settings.CodingAgent, "balanced"));
         var quickModel = UseState(GetProfileModel(config, config.Settings.CodingAgent, "quick"));
+        var deepEffort = UseState(GetProfileEffort(config, config.Settings.CodingAgent, "deep"));
+        var balancedEffort = UseState(GetProfileEffort(config, config.Settings.CodingAgent, "balanced"));
+        var quickEffort = UseState(GetProfileEffort(config, config.Settings.CodingAgent, "quick"));
         var lastRealAgent = UseState(config.Settings.CodingAgent);
         var showTestDialog = UseState(false);
         var testAgentId = UseState(config.Settings.CodingAgent);
@@ -97,10 +100,16 @@ public class CodingAgentSetupView : ViewBase
             var deep = GetProfileModel(config, realAgentId, "deep");
             var balanced = GetProfileModel(config, realAgentId, "balanced");
             var quick = GetProfileModel(config, realAgentId, "quick");
+            var deepEff = GetProfileEffort(config, realAgentId, "deep");
+            var balancedEff = GetProfileEffort(config, realAgentId, "balanced");
+            var quickEff = GetProfileEffort(config, realAgentId, "quick");
 
             deepModel.Set(deep == "default" && isBerget ? "moonshotai/Kimi-K3" : deep);
             balancedModel.Set(balanced == "default" && isBerget ? "moonshotai/Kimi-K3" : balanced);
             quickModel.Set(quick == "default" && isBerget ? "moonshotai/Kimi-K3" : quick);
+            deepEffort.Set(deepEff);
+            balancedEffort.Set(balancedEff);
+            quickEffort.Set(quickEff);
             ollamaUrl.Set(GetOllamaUrlFromConfig(config, realAgentId));
             lastRealAgent.Set(realAgentId);
             testAgentId.Set(realAgentId);
@@ -122,11 +131,36 @@ public class CodingAgentSetupView : ViewBase
         else if (isBerget || isAnthropic || isOpenAi) finalAgent = "openaiproxy";
         else finalAgent = selectedAgent.Value;
 
+        bool supportsEffort;
+        try
+        {
+            var descriptor = runner.GetDescriptor(finalAgent);
+            supportsEffort = descriptor.Capabilities.HasFlag(AgentCapabilities.EffortControl);
+        }
+        catch
+        {
+            supportsEffort = false;
+        }
+
+        var effortOptions = new IAnyOption[]
+        {
+            new Option<string>("Default", "default"),
+            new Option<string>("Low", "low"),
+            new Option<string>("Medium", "medium"),
+            new Option<string>("High", "high"),
+            new Option<string>("Max", "max")
+        };
+
         var hasAgentChanges = finalAgent != config.Settings.CodingAgent;
         var hasProfileChanges =
             deepModel.Value != GetProfileModel(config, finalAgent, "deep") ||
             balancedModel.Value != GetProfileModel(config, finalAgent, "balanced") ||
-            quickModel.Value != GetProfileModel(config, finalAgent, "quick");
+            quickModel.Value != GetProfileModel(config, finalAgent, "quick") ||
+            (supportsEffort && (
+                deepEffort.Value != GetProfileEffort(config, finalAgent, "deep") ||
+                balancedEffort.Value != GetProfileEffort(config, finalAgent, "balanced") ||
+                quickEffort.Value != GetProfileEffort(config, finalAgent, "quick")
+            ));
 
         var currentIvyKey = GetIvyApiKeyFromConfig(config);
         var currentOpenAiBaseUrl = GetOpenAiProxyBaseUrlFromConfig(config);
@@ -252,10 +286,22 @@ public class CodingAgentSetupView : ViewBase
 
         var profileModels = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
             | Text.Block("Profile Models").Bold()
-            | Text.Muted("Promptwares are configured to use different profiles depending on the complexity of the task. You can specify what model to use for each profile.").Small()
-            | deepModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Deep")
-            | balancedModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Balanced")
-            | quickModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Quick");
+            | Text.Muted("Promptwares are configured to use different profiles depending on the complexity of the task. You can specify what model and effort level to use for each profile.").Small()
+            | (supportsEffort
+                ? (object)(Layout.Vertical()
+                    | (Layout.Horizontal()
+                        | deepModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Deep").Width(Size.Fraction(0.65f))
+                        | deepEffort.ToSelectInput(effortOptions).WithField().Label("Effort").Width(Size.Fraction(0.35f)))
+                    | (Layout.Horizontal()
+                        | balancedModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Balanced").Width(Size.Fraction(0.65f))
+                        | balancedEffort.ToSelectInput(effortOptions).WithField().Label("Effort").Width(Size.Fraction(0.35f)))
+                    | (Layout.Horizontal()
+                        | quickModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Quick").Width(Size.Fraction(0.65f))
+                        | quickEffort.ToSelectInput(effortOptions).WithField().Label("Effort").Width(Size.Fraction(0.35f))))
+                : (Layout.Vertical()
+                    | deepModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Deep")
+                    | balancedModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Balanced")
+                    | quickModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Quick")));
 
         return Layout.Vertical()
                | Text.Block("Coding Agent").Bold()
@@ -281,7 +327,10 @@ public class CodingAgentSetupView : ViewBase
                        .OnClick(() =>
                        {
                            config.Settings.CodingAgent = finalAgent;
-                           SaveProfiles(config, finalAgent, deepModel.Value, balancedModel.Value, quickModel.Value);
+                           SaveProfiles(config, finalAgent,
+                               deepModel.Value, deepEffort.Value,
+                               balancedModel.Value, balancedEffort.Value,
+                               quickModel.Value, quickEffort.Value);
                            if (isIvy)
                            {
                                SaveIvyApiKey(config, openAiProxyApiKey.Value);
@@ -357,7 +406,24 @@ public class CodingAgentSetupView : ViewBase
         return string.IsNullOrEmpty(value) ? "default" : value;
     }
 
-    private static void SaveProfiles(IConfigService config, string agentId, string deep, string balanced, string quick)
+    private static string GetProfileEffort(IConfigService config, string agentId, string profileName)
+    {
+        var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
+        var profile = ac?.Profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+        var value = profile?.Effort;
+        if (string.IsNullOrWhiteSpace(value)) return "default";
+        return value.ToLowerInvariant() switch
+        {
+            "xhigh" => "max",
+            _ => value.ToLowerInvariant()
+        };
+    }
+
+    private static void SaveProfiles(IConfigService config, string agentId,
+        string deepModel, string deepEffort,
+        string balancedModel, string balancedEffort,
+        string quickModel, string quickEffort)
     {
         var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
             AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
@@ -368,12 +434,12 @@ public class CodingAgentSetupView : ViewBase
             config.Settings.CodingAgents.Add(ac);
         }
 
-        SetProfileModel(ac, "deep", deep);
-        SetProfileModel(ac, "balanced", balanced);
-        SetProfileModel(ac, "quick", quick);
+        SetProfile(ac, "deep", deepModel, deepEffort);
+        SetProfile(ac, "balanced", balancedModel, balancedEffort);
+        SetProfile(ac, "quick", quickModel, quickEffort);
     }
 
-    private static void SetProfileModel(AgentConfig ac, string profileName, string model)
+    private static void SetProfile(AgentConfig ac, string profileName, string model, string effort)
     {
         var profile = ac.Profiles.FirstOrDefault(p =>
             p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
@@ -385,6 +451,7 @@ public class CodingAgentSetupView : ViewBase
         }
 
         profile.Model = model;
+        profile.Effort = string.IsNullOrWhiteSpace(effort) || effort.Equals("default", StringComparison.OrdinalIgnoreCase) ? "" : effort;
     }
 
     private static string GetIvyApiKeyFromConfig(IConfigService config)

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -131,25 +131,40 @@ public class CodingAgentSetupView : ViewBase
         else if (isBerget || isAnthropic || isOpenAi) finalAgent = "openaiproxy";
         else finalAgent = selectedAgent.Value;
 
-        bool supportsEffort;
+        IAgentDescriptor? descriptor = null;
         try
         {
-            var descriptor = runner.GetDescriptor(finalAgent);
-            supportsEffort = descriptor.Capabilities.HasFlag(AgentCapabilities.EffortControl);
+            descriptor = runner.GetDescriptor(finalAgent);
         }
         catch
         {
-            supportsEffort = false;
         }
 
-        var effortOptions = new IAnyOption[]
+        var supportsEffort = descriptor != null && descriptor.Capabilities.HasFlag(AgentCapabilities.EffortControl);
+
+        IAnyOption[] GetEffortOptions(string? model)
         {
-            new Option<string>("Default", "default"),
-            new Option<string>("Low", "low"),
-            new Option<string>("Medium", "medium"),
-            new Option<string>("High", "high"),
-            new Option<string>("Max", "max")
-        };
+            if (descriptor == null) return [new Option<string>("Default", "default")];
+            var efforts = descriptor.GetSupportedEfforts(model);
+            if (efforts.Count == 0)
+                efforts = descriptor.SupportedEfforts;
+            if (efforts.Count == 0)
+            {
+                return
+                [
+                    new Option<string>("Default", "default"),
+                    new Option<string>("Low", "low"),
+                    new Option<string>("Medium", "medium"),
+                    new Option<string>("High", "high"),
+                    new Option<string>("Extra High", "xhigh"),
+                    new Option<string>("Max", "max")
+                ];
+            }
+
+            return new[] { new Option<string>("Default", "default") }
+                .Concat(efforts.Select(e => new Option<string>(e.DisplayName, e.Id)))
+                .ToArray<IAnyOption>();
+        }
 
         var hasAgentChanges = finalAgent != config.Settings.CodingAgent;
         var hasProfileChanges =
@@ -291,13 +306,13 @@ public class CodingAgentSetupView : ViewBase
                 ? (object)(Layout.Vertical()
                     | (Layout.Horizontal()
                         | deepModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Deep").Width(Size.Fraction(0.65f))
-                        | deepEffort.ToSelectInput(effortOptions).WithField().Label("Effort").Width(Size.Fraction(0.35f)))
+                        | deepEffort.ToSelectInput(GetEffortOptions(deepModel.Value)).WithField().Label("Effort").Width(Size.Fraction(0.35f)))
                     | (Layout.Horizontal()
                         | balancedModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Balanced").Width(Size.Fraction(0.65f))
-                        | balancedEffort.ToSelectInput(effortOptions).WithField().Label("Effort").Width(Size.Fraction(0.35f)))
+                        | balancedEffort.ToSelectInput(GetEffortOptions(balancedModel.Value)).WithField().Label("Effort").Width(Size.Fraction(0.35f)))
                     | (Layout.Horizontal()
                         | quickModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Quick").Width(Size.Fraction(0.65f))
-                        | quickEffort.ToSelectInput(effortOptions).WithField().Label("Effort").Width(Size.Fraction(0.35f))))
+                        | quickEffort.ToSelectInput(GetEffortOptions(quickModel.Value)).WithField().Label("Effort").Width(Size.Fraction(0.35f))))
                 : (Layout.Vertical()
                     | deepModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Deep")
                     | balancedModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Balanced")
@@ -412,12 +427,7 @@ public class CodingAgentSetupView : ViewBase
             AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
         var profile = ac?.Profiles.FirstOrDefault(p => p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
         var value = profile?.Effort;
-        if (string.IsNullOrWhiteSpace(value)) return "default";
-        return value.ToLowerInvariant() switch
-        {
-            "xhigh" => "max",
-            _ => value.ToLowerInvariant()
-        };
+        return string.IsNullOrWhiteSpace(value) ? "default" : value.ToLowerInvariant();
     }
 
     private static void SaveProfiles(IConfigService config, string agentId,

--- a/src/Ivy.Tendril/Helpers/AgentLaunchHelper.cs
+++ b/src/Ivy.Tendril/Helpers/AgentLaunchHelper.cs
@@ -128,6 +128,7 @@ public static class AgentLaunchHelper
         string agentId,
         string prompt,
         string? modelOverride = null,
+        EffortLevel? effortOverride = null,
         PermissionMode permissionMode = PermissionMode.FullAuto)
     {
         var workDir = GetWorkDir(config, runner, agentId);
@@ -135,7 +136,7 @@ public static class AgentLaunchHelper
         WriteAgentInstructionsIfNeeded(workDir, systemPrompt, runner, agentId);
 
         var resolvedModel = ResolveModel(config, runner, agentId, modelOverride);
-        var resolvedEffort = ResolveEffort(config, runner, agentId);
+        var resolvedEffort = effortOverride ?? ResolveEffort(config, runner, agentId);
         var env = GetEnvironment(config, agentId);
 
         return new AgentResolutionContext

--- a/src/Ivy.Tendril/Helpers/AgentLaunchHelper.cs
+++ b/src/Ivy.Tendril/Helpers/AgentLaunchHelper.cs
@@ -109,6 +109,19 @@ public static class AgentLaunchHelper
         return string.IsNullOrEmpty(configuredModel) ? (requestedModel ?? "default") : configuredModel;
     }
 
+    public static EffortLevel? ResolveEffort(IConfigService config, IAgentRunner runner, string agentId, string? profileName = "balanced")
+    {
+        var agentConfig = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
+        var configuredEffort = agentConfig?.Profiles.FirstOrDefault(p => p.Name.Equals(profileName ?? "balanced", StringComparison.OrdinalIgnoreCase))?.Effort;
+        if (string.IsNullOrEmpty(configuredEffort) || configuredEffort == "default")
+        {
+            configuredEffort = agentConfig?.Profiles.FirstOrDefault(p => !string.IsNullOrEmpty(p.Effort) && p.Effort != "default")?.Effort;
+        }
+
+        return string.IsNullOrEmpty(configuredEffort) ? null : AgentProviderFactory.ParseEffort(configuredEffort);
+    }
+
     public static AgentResolutionContext PrepareResolutionContext(
         IConfigService config,
         IAgentRunner runner,
@@ -122,6 +135,7 @@ public static class AgentLaunchHelper
         WriteAgentInstructionsIfNeeded(workDir, systemPrompt, runner, agentId);
 
         var resolvedModel = ResolveModel(config, runner, agentId, modelOverride);
+        var resolvedEffort = ResolveEffort(config, runner, agentId);
         var env = GetEnvironment(config, agentId);
 
         return new AgentResolutionContext
@@ -130,6 +144,7 @@ public static class AgentLaunchHelper
             Prompt = prompt,
             SystemPrompt = systemPrompt,
             ModelOverride = resolvedModel,
+            EffortOverride = resolvedEffort,
             WorkingDirectory = workDir,
             PermissionMode = permissionMode,
             ExtraEnvironment = env,

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -143,7 +143,7 @@ public class ChatHistoryService : IChatHistoryService
         return session;
     }
 
-    public ChatSessionModel CreateSession(string agentId, string modelId, string? title = null)
+    public ChatSessionModel CreateSession(string agentId, string modelId, string? title = null, string? effort = null)
     {
         var now = DateTimeOffset.UtcNow;
         var id = Guid.NewGuid().ToString("N");
@@ -156,7 +156,8 @@ public class ChatHistoryService : IChatHistoryService
             UpdatedAt: now,
             AgentId: agentId,
             ModelId: modelId,
-            Messages: new List<ChatMessageModel>()
+            Messages: new List<ChatMessageModel>(),
+            Effort: effort
         );
 
         _sessions[id] = session;
@@ -211,14 +212,14 @@ public class ChatHistoryService : IChatHistoryService
         }
     }
 
-    public ChatMessageModel AddMessage(string sessionId, string role, string content, string? agentId = null, string? modelId = null, string? rawStream = null)
+    public ChatMessageModel AddMessage(string sessionId, string role, string content, string? agentId = null, string? modelId = null, string? rawStream = null, string? effort = null)
     {
         lock (_lock)
         {
             var session = GetSession(sessionId);
             if (session == null)
             {
-                session = CreateSession(agentId ?? "claude", modelId ?? "opus");
+                session = CreateSession(agentId ?? "claude", modelId ?? "opus", effort: effort);
             }
 
             var msg = new ChatMessageModel(
@@ -228,7 +229,8 @@ public class ChatHistoryService : IChatHistoryService
                 Timestamp: DateTimeOffset.UtcNow,
                 AgentId: agentId ?? session.AgentId,
                 ModelId: modelId ?? session.ModelId,
-                RawStream: rawStream
+                RawStream: rawStream,
+                Effort: effort ?? session.Effort
             );
 
             var updatedMessages = new List<ChatMessageModel>(session.Messages) { msg };
@@ -248,6 +250,7 @@ public class ChatHistoryService : IChatHistoryService
                 UpdatedAt = DateTimeOffset.UtcNow,
                 AgentId = agentId ?? session.AgentId,
                 ModelId = modelId ?? session.ModelId,
+                Effort = effort ?? session.Effort,
                 Messages = updatedMessages
             };
 

--- a/src/Ivy.Tendril/Services/IChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/IChatHistoryService.cs
@@ -10,7 +10,8 @@ public record ChatMessageModel(
     DateTimeOffset Timestamp,
     string? AgentId = null,
     string? ModelId = null,
-    string? RawStream = null
+    string? RawStream = null,
+    string? Effort = null
 );
 
 public record ChatSessionModel(
@@ -20,7 +21,8 @@ public record ChatSessionModel(
     DateTimeOffset UpdatedAt,
     string AgentId,
     string ModelId,
-    List<ChatMessageModel> Messages
+    List<ChatMessageModel> Messages,
+    string? Effort = null
 );
 
 public interface IChatHistoryService
@@ -29,11 +31,11 @@ public interface IChatHistoryService
     event EventHandler? GeneratingSessionsChanged;
     IReadOnlyList<ChatSessionModel> GetSessions();
     ChatSessionModel? GetSession(string id);
-    ChatSessionModel CreateSession(string agentId, string modelId, string? title = null);
+    ChatSessionModel CreateSession(string agentId, string modelId, string? title = null, string? effort = null);
     void SaveSession(ChatSessionModel session);
     void DeleteSession(string id);
     void RenameSession(string id, string newTitle);
-    ChatMessageModel AddMessage(string sessionId, string role, string content, string? agentId = null, string? modelId = null, string? rawStream = null);
+    ChatMessageModel AddMessage(string sessionId, string role, string content, string? agentId = null, string? modelId = null, string? rawStream = null, string? effort = null);
     void SetSessionGenerating(string sessionId, bool isGenerating);
     IReadOnlySet<string> GetGeneratingSessionIds();
     IReadOnlySet<string> GetCompletedSessionIds();

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -40,7 +40,7 @@ codingAgents:
 - name: codex
   profiles:
   - name: deep
-    model: gpt-5.5
+    model: gpt-5.6-sol
     effort: high
   - name: balanced
     model: gpt-5.6-terra


### PR DESCRIPTION
### Summary
- Added effort control support and detection via `runner.GetDescriptor(agent).Capabilities.HasFlag(AgentCapabilities.EffortControl)`.
- Defined standard `EffortLevels` constants (`Claude`, `Codex`, `Copilot`, `Antigravity`, `OpenCode`) and associated them per model in `ModelInfo.SupportedEfforts`.
- Added **Effort** select pickers alongside model selection for each profile tier (**Deep**, **Balanced**, **Quick**) in **Coding Agent** settings.
- Added **Effort** level picker to the **Chat** application toolbar, dynamically resolving supported effort levels for the selected agent and model.
- Updated Codex `deep` tier default model to `gpt-5.6-sol`.
- Standardized effort resolution so that effort is configured and resolved cleanly from profiles in `config.yaml` or explicit session overrides.

---

### `config.yaml` Configuration & Schema Changes

Effort levels are configured per profile tier (`deep`, `balanced`, `quick`) under each coding agent in `config.yaml`:

```yaml
codingAgent: claude # or copilot, codex, antigravity, opencode, ivy, openaiproxy

codingAgents:
  - name: claude
    profiles:
      - name: deep
        model: opus
        effort: max       # Options: default, low, medium, high, xhigh, max
      - name: balanced
        model: sonnet
        effort: high
      - name: quick
        model: haiku
        effort: low

  - name: codex
    profiles:
      - name: deep
        model: gpt-5.6-sol
        effort: high       # Options: default, none, low, medium, high, xhigh
      - name: balanced
        model: gpt-5.6-terra
        effort: medium
      - name: quick
        model: gpt-5.6-luna
        effort: low

  - name: copilot
    profiles:
      - name: deep
        model: gpt-5.4
        effort: high       # Options: default, low, medium, high, xhigh
      - name: balanced
        model: gpt-5.4
        effort: medium
      - name: quick
        model: gpt-5.4-mini
        effort: low

  - name: antigravity
    profiles:
      - name: deep
        model: gemini-3.7-flash
        effort: high       # Options: default, low, medium, high
      - name: balanced
        model: gemini-3.6-flash
        effort: medium
      - name: quick
        model: gemini-3.5-flash
        effort: low

  - name: opencode
    profiles:
      - name: deep
        model: moonshotai/Kimi-K3
        effort: max        # Options: default, low, medium, high, xhigh, max
      - name: balanced
        model: moonshotai/Kimi-K3
        effort: high
      - name: quick
        model: moonshotai/Kimi-K3
        effort: low
```

### Supported Effort Levels by Provider

| Provider / Model | Supported Effort Values | CLI Flag Output |
| :--- | :--- | :--- |
| **Claude** | `low`, `medium`, `high`, `xhigh` (Extra High), `max` | `--effort <low\|medium\|high\|xhigh\|max>` |
| **Copilot** | `low`, `medium`, `high`, `xhigh` (Extra High) | `--effort <low\|medium\|high\|xhigh>` |
| **Antigravity** | `low`, `medium`, `high` | `--effort <low\|medium\|high>` |
| **OpenCode / Ivy / Proxy** | `low`, `medium`, `high`, `xhigh`, `max` | `--variant <low\|medium\|high\|max>` |
| **Codex** | `none`, `low`, `medium`, `high`, `xhigh` | Profile effort specification |

---

### How Effort is Resolved & Dispatched
1. **Settings / UI**: Persisted to `config.yaml` as `codingAgents[agent].profiles[tier].effort`.
2. **Chat App**: Selected via Effort dropdown in the prompt input toolbar, saved with the session in chat history, and passed as `effortOverride` when launching the session.
3. **Jobs & Promptwares**: `AgentProviderFactory.Resolve(...)` resolves the active profile name (e.g. `deep` for `CreatePlan`, `balanced` for standard execution), reads `profile.Effort`, and translates it into `AgentLaunchConfig.Effort`.
4. **Agent Launch**: `IAgentCli.BuildProcessSpec(...)` receives `config.Effort` and sets the native agent CLI effort arguments.