### PR TITLE
Always show Bring your own LLM options in onboarding and settings

### DIFF
--- a/src/Ivy.Tendril.Agents/AgentServiceCollectionExtensions.cs
+++ b/src/Ivy.Tendril.Agents/AgentServiceCollectionExtensions.cs
@@ -99,33 +99,30 @@ public static class AgentServiceCollectionExtensions
                 new OpenCodePty(),
                 new OpenCodeModelCatalog());
 
-            if (options.IncludeBetaProviders)
-            {
-                Func<string?> apiKeyProvider = options.IvyApiKeyProviderFactory?.Invoke(sp) ?? (() => null);
-                Func<string?> tokenProvider = options.IvyTokenProviderFactory?.Invoke(sp) ?? (() => null);
-                Func<CancellationToken, Task<string?>> emailProvider = options.IvyEmailProviderFactory?.Invoke(sp) ?? ((_) => Task.FromResult<string?>(null));
+            Func<string?> apiKeyProvider = options.IvyApiKeyProviderFactory?.Invoke(sp) ?? (() => null);
+            Func<string?> tokenProvider = options.IvyTokenProviderFactory?.Invoke(sp) ?? (() => null);
+            Func<CancellationToken, Task<string?>> emailProvider = options.IvyEmailProviderFactory?.Invoke(sp) ?? ((_) => Task.FromResult<string?>(null));
 
-                runner.Register(
-                    new Providers.Ivy.IvyCli(apiKeyProvider),
-                    new Providers.Ivy.IvyEventParser(),
-                    new Providers.Ivy.IvyHealthCheck(apiKeyProvider, tokenProvider, emailProvider),
-                    new Providers.Ivy.IvyFailureAnalyzer(),
-                    new Providers.Ivy.IvySessionCostParser(),
-                    new Providers.Ivy.IvyPty(apiKeyProvider),
-                    new Providers.Ivy.IvyModelCatalog());
+            runner.Register(
+                new Providers.Ivy.IvyCli(apiKeyProvider),
+                new Providers.Ivy.IvyEventParser(),
+                new Providers.Ivy.IvyHealthCheck(apiKeyProvider, tokenProvider, emailProvider),
+                new Providers.Ivy.IvyFailureAnalyzer(),
+                new Providers.Ivy.IvySessionCostParser(),
+                new Providers.Ivy.IvyPty(apiKeyProvider),
+                new Providers.Ivy.IvyModelCatalog());
 
-                Func<string?> openAiProxyApiKeyProvider = options.OpenAiProxyApiKeyProviderFactory?.Invoke(sp) ?? (() => null);
-                Func<string?> openAiProxyBaseUrlProvider = options.OpenAiProxyBaseUrlProviderFactory?.Invoke(sp) ?? (() => null);
+            Func<string?> openAiProxyApiKeyProvider = options.OpenAiProxyApiKeyProviderFactory?.Invoke(sp) ?? (() => null);
+            Func<string?> openAiProxyBaseUrlProvider = options.OpenAiProxyBaseUrlProviderFactory?.Invoke(sp) ?? (() => null);
 
-                runner.Register(
-                    new Providers.OpenAiProxy.OpenAiProxyCli(openAiProxyApiKeyProvider, openAiProxyBaseUrlProvider),
-                    new Providers.OpenAiProxy.OpenAiProxyEventParser(),
-                    new Providers.OpenAiProxy.OpenAiProxyHealthCheck(openAiProxyApiKeyProvider, openAiProxyBaseUrlProvider),
-                    new Providers.OpenAiProxy.OpenAiProxyFailureAnalyzer(),
-                    new Providers.OpenAiProxy.OpenAiProxySessionCostParser(),
-                    new Providers.OpenAiProxy.OpenAiProxyPty(openAiProxyApiKeyProvider, openAiProxyBaseUrlProvider),
-                    new Providers.OpenAiProxy.OpenAiProxyModelCatalog(openAiProxyBaseUrlProvider));
-            }
+            runner.Register(
+                new Providers.OpenAiProxy.OpenAiProxyCli(openAiProxyApiKeyProvider, openAiProxyBaseUrlProvider),
+                new Providers.OpenAiProxy.OpenAiProxyEventParser(),
+                new Providers.OpenAiProxy.OpenAiProxyHealthCheck(openAiProxyApiKeyProvider, openAiProxyBaseUrlProvider),
+                new Providers.OpenAiProxy.OpenAiProxyFailureAnalyzer(),
+                new Providers.OpenAiProxy.OpenAiProxySessionCostParser(),
+                new Providers.OpenAiProxy.OpenAiProxyPty(openAiProxyApiKeyProvider, openAiProxyBaseUrlProvider),
+                new Providers.OpenAiProxy.OpenAiProxyModelCatalog(openAiProxyBaseUrlProvider));
 
             return runner;
         });

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -100,11 +100,10 @@ public class CodingAgentStepView(
 
         var registeredAgents = agentRunner.RegisteredAgents;
         var visibleAgents = Agents.Where(a => registeredAgents.Contains(a.Key)).ToArray();
-        var hasByoSupport = registeredAgents.Contains("openaiproxy") || registeredAgents.Contains("ivy");
 
         if (selectedAgent.Value is null)
         {
-            return BuildPicker(visibleAgents, hasByoSupport, agentKey =>
+            return BuildPicker(visibleAgents, agentKey =>
             {
                 selectedAgent.Set(agentKey);
                 error.Set(null);
@@ -317,48 +316,39 @@ public class CodingAgentStepView(
 
     private static object BuildPicker(
         AgentInfo[] agents,
-        bool hasByoSupport,
         Action<string> onSelect,
         string? errorMessage)
     {
-        var grid = Layout.Grid().Columns(3).Gap(2);
+        var grid = Layout.Grid().Columns(3);
 
         grid = agents.Aggregate(grid, (current, a) =>
             current | new Card(
                 Layout.Horizontal()
-                    .Gap(2)
                     .AlignContent(Align.Center)
-                    .Padding(0)
                 | a.Logo.ToIcon().Width(Size.Px(32)).Height(Size.Px(32))
                 | Text.Block(a.Label)
             ).OnClick(() => onSelect(a.Key)));
 
-        object? byoSection = null;
-        if (hasByoSupport)
-        {
-            var byoGrid = Layout.Grid().Columns(3).Gap(2);
-            byoGrid = ByoAgents.Aggregate(byoGrid, (current, a) =>
-                current | new Card(
-                    Layout.Horizontal()
-                        .Gap(2)
-                        .AlignContent(Align.Center)
-                        .Padding(0)
-                    | a.Logo.ToIcon().Width(Size.Px(32)).Height(Size.Px(32))
-                    | Text.Block(a.Label)
-                ).OnClick(() => onSelect(a.Key)));
+        var byoGrid = Layout.Grid().Columns(3);
+        byoGrid = ByoAgents.Aggregate(byoGrid, (current, a) =>
+            current | new Card(
+                Layout.Horizontal()
+                    .AlignContent(Align.Center)
+                | a.Logo.ToIcon().Width(Size.Px(32)).Height(Size.Px(32))
+                | Text.Block(a.Label)
+            ).OnClick(() => onSelect(a.Key)));
 
-            byoSection = Layout.Vertical().Margin(2, 0, 0, 0)
-                | Text.Block("Bring your own LLM").Bold()
-                | byoGrid;
-        }
+        var byoSection = Layout.Vertical()
+            | Text.Block("Bring your own LLM").Bold()
+            | byoGrid;
 
-        return Layout.Vertical().Margin(0, 0, 0, 2)
+        return Layout.Vertical()
                | Text.H3("What is your coding agent?")
                | Text.Muted(
                    "Tendril is a coding orchestrator that runs on top of your own coding agent. Pick the agent you'd like to use:")
                | (errorMessage != null ? Text.Danger(errorMessage) : null!)
                | grid
-               | (byoSection ?? null!);
+               | byoSection;
     }
 
     private static List<SoftwareCheck> BuildChecks(IAgentRunner runner, string agentKey)

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -223,8 +223,6 @@ public class CodingAgentSetupView : ViewBase
                 selectedAgent.Set(a.Key);
             }));
 
-        var hasByoSupport = registeredAgents.Contains("openaiproxy") || registeredAgents.Contains("ivy");
-
         var byoAgents = new[]
         {
             new ByoAgentInfo("openaiproxy_card", "OpenAI", Icons.OpenAI),
@@ -324,13 +322,11 @@ public class CodingAgentSetupView : ViewBase
                | (Layout.Vertical()
                    .Width(Size.Full().At(Breakpoint.Mobile).And(Breakpoint.Desktop, Size.Units(170)))
                    | topGrid.Width(Size.Full()))
-               | (hasByoSupport
-                   ? (object)(Layout.Vertical()
-                       | Text.Block("Bring your own LLM").Bold()
-                       | (Layout.Vertical()
-                           .Width(Size.Full().At(Breakpoint.Mobile).And(Breakpoint.Desktop, Size.Units(170)))
-                           | byoGrid.Width(Size.Full())))
-                   : null!)
+               | (Layout.Vertical()
+                   | Text.Block("Bring your own LLM").Bold()
+                   | (Layout.Vertical()
+                       .Width(Size.Full().At(Breakpoint.Mobile).And(Breakpoint.Desktop, Size.Units(170)))
+                       | byoGrid.Width(Size.Full())))
                | agentInputs
                | profileModels
                | new Spacer()


### PR DESCRIPTION
### Summary
- Made **Bring your own LLM** (OpenAI, Anthropic, Berget AI / `openaiproxy`, `ivy`) always visible in both the Onboarding step (`CodingAgentStepView`) and Settings (`CodingAgentSetupView`).
- Removed the beta provider restriction in `AgentServiceCollectionExtensions` so BYO LLM / proxy providers are registered unconditionally.
- Removed custom margins/gaps/paddings in adherence to layout style rules.