### PR TITLE
feat(onboarding): model selection and provider catalogs for BYO LLM and Ivy Proxy

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Claude/ClaudeCliTests.cs
@@ -182,7 +182,7 @@ public class ClaudeCliTests
     [InlineData(EffortLevel.Low, "low")]
     [InlineData(EffortLevel.Medium, "medium")]
     [InlineData(EffortLevel.High, "high")]
-    [InlineData(EffortLevel.XHigh, "max")]
+    [InlineData(EffortLevel.XHigh, "xhigh")]
     [InlineData(EffortLevel.Max, "max")]
     public void BuildProcessSpec_AllEffortLevels_MapCorrectly(EffortLevel level, string expected)
     {

--- a/src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs
@@ -1,0 +1,99 @@
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Helpers;
+using Xunit;
+
+namespace Ivy.Tendril.Agents.Test.Helpers;
+
+public sealed class ModelProfileSelectorTests
+{
+    [Fact]
+    public void SelectDefaults_IvyProxy_PicksOpus5Deep_Gemini37Balanced_GeminiQuick()
+    {
+        var models = new List<ModelInfo>
+        {
+            new() { Id = "claude-opus-4", DisplayName = "Claude Opus 4" },
+            new() { Id = "claude-opus-5", DisplayName = "Claude Opus 5" },
+            new() { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5" },
+            new() { Id = "gemini-2.5-flash-lite", DisplayName = "Gemini 2.5 Flash Lite" },
+            new() { Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash" },
+            new() { Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash" },
+        };
+
+        var (deep, balanced, quick) = ModelProfileSelector.SelectDefaults(models, isIvy: true);
+
+        Assert.Equal("claude-opus-5", deep);
+        Assert.Equal("gemini-3.7-flash", balanced);
+        Assert.Equal("gemini-3.7-flash", quick);
+    }
+
+    [Fact]
+    public void SelectDefaults_Gemini36_WhenNo37_Picks36ForBalancedAndQuick()
+    {
+        var models = new List<ModelInfo>
+        {
+            new() { Id = "claude-opus-4", DisplayName = "Claude Opus 4" },
+            new() { Id = "claude-opus-5", DisplayName = "Claude Opus 5" },
+            new() { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5" },
+            new() { Id = "gemini-2.5-flash-lite", DisplayName = "Gemini 2.5 Flash Lite" },
+            new() { Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash" },
+        };
+
+        var (deep, balanced, quick) = ModelProfileSelector.SelectDefaults(models, isIvy: true);
+
+        Assert.Equal("claude-opus-5", deep);
+        Assert.Equal("gemini-3.6-flash", balanced);
+        Assert.Equal("gemini-3.6-flash", quick);
+    }
+
+    [Fact]
+    public void SelectDefaults_AnthropicOnly_PicksOpus5_Sonnet5_Haiku5()
+    {
+        var models = new List<ModelInfo>
+        {
+            new() { Id = "claude-3-5-haiku", DisplayName = "Claude 3.5 Haiku" },
+            new() { Id = "claude-haiku-5", DisplayName = "Claude Haiku 5" },
+            new() { Id = "claude-opus-4", DisplayName = "Claude Opus 4" },
+            new() { Id = "claude-opus-5", DisplayName = "Claude Opus 5" },
+            new() { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5" },
+        };
+
+        var (deep, balanced, quick) = ModelProfileSelector.SelectDefaults(models, isAnthropic: true);
+
+        Assert.Equal("claude-opus-5", deep);
+        Assert.Equal("claude-sonnet-5", balanced);
+        Assert.Equal("claude-haiku-5", quick);
+    }
+
+    [Fact]
+    public void SelectDefaults_OpenAiOnly_PicksSol_Terra_Luna()
+    {
+        var models = new List<ModelInfo>
+        {
+            new() { Id = "gpt-4o", DisplayName = "GPT-4o" },
+            new() { Id = "gpt-4o-mini", DisplayName = "GPT-4o mini" },
+            new() { Id = "gpt-5.6-sol", DisplayName = "GPT-5.6 Sol" },
+            new() { Id = "gpt-5.6-terra", DisplayName = "GPT-5.6 Terra" },
+            new() { Id = "gpt-5.6-luna", DisplayName = "GPT-5.6 Luna" },
+        };
+
+        var (deep, balanced, quick) = ModelProfileSelector.SelectDefaults(models, isOpenAi: true);
+
+        Assert.Equal("gpt-5.6-sol", deep);
+        Assert.Equal("gpt-5.6-terra", balanced);
+        Assert.Equal("gpt-5.6-luna", quick);
+    }
+
+    [Fact]
+    public void SelectDefaults_EmptyModels_ReturnsCardDefaults()
+    {
+        var (deepIvy, balancedIvy, quickIvy) = ModelProfileSelector.SelectDefaults(null, isIvy: true);
+        Assert.Equal("claude-opus-5", deepIvy);
+        Assert.Equal("gemini-3.7-flash", balancedIvy);
+        Assert.Equal("gemini-3.7-flash", quickIvy);
+
+        var (deepAnt, balancedAnt, quickAnt) = ModelProfileSelector.SelectDefaults(null, isAnthropic: true);
+        Assert.Equal("claude-opus-5", deepAnt);
+        Assert.Equal("claude-sonnet-5", balancedAnt);
+        Assert.Equal("claude-haiku-5", quickAnt);
+    }
+}

--- a/src/Ivy.Tendril.Agents/Abstractions/ModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Abstractions/ModelCatalog.cs
@@ -33,6 +33,7 @@ public static class EffortLevels
     public static readonly IReadOnlyList<EffortOption> Antigravity = [Low, Medium, High];
     public static readonly IReadOnlyList<EffortOption> Gemini = [Low, Medium, High];
     public static readonly IReadOnlyList<EffortOption> OpenCode = [Low, Medium, High, ExtraHigh, Max];
+    public static readonly IReadOnlyList<EffortOption> Ivy = [Low, Medium, High, ExtraHigh, Max];
 }
 
 [Flags]

--- a/src/Ivy.Tendril.Agents/Helpers/LlmEndpointTester.cs
+++ b/src/Ivy.Tendril.Agents/Helpers/LlmEndpointTester.cs
@@ -1,0 +1,215 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Ivy.Tendril.Agents.Abstractions;
+
+namespace Ivy.Tendril.Agents.Helpers;
+
+public static class LlmEndpointTester
+{
+    private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromSeconds(15) };
+
+    public static async Task<ModelValidationResult> TestModelPromptAsync(
+        string baseUrl,
+        string apiKey,
+        string model,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            return new ModelValidationResult
+            {
+                Status = ModelValidationStatus.AuthError,
+                Model = model,
+                ErrorMessage = "Base URL is not configured.",
+            };
+        }
+
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            return new ModelValidationResult
+            {
+                Status = ModelValidationStatus.AuthError,
+                Model = model,
+                ErrorMessage = "API key is not configured.",
+            };
+        }
+
+        var normalizedBaseUrl = baseUrl.TrimEnd('/');
+        var isAnthropic = normalizedBaseUrl.Contains("api.anthropic.com");
+
+        var effectiveModel = model;
+        if (string.IsNullOrWhiteSpace(effectiveModel) || effectiveModel.Equals("default", StringComparison.OrdinalIgnoreCase))
+        {
+            if (normalizedBaseUrl.Contains("llmproxy.ivy.app")) effectiveModel = "claude-opus-5";
+            else if (isAnthropic) effectiveModel = "claude-sonnet-5";
+            else if (normalizedBaseUrl.Contains("generativelanguage.googleapis.com") || normalizedBaseUrl.Contains("gemini") || normalizedBaseUrl.Contains("google")) effectiveModel = "gemini-3.7-flash";
+            else if (normalizedBaseUrl.Contains("api.berget.ai")) effectiveModel = "moonshotai/Kimi-K3";
+            else effectiveModel = "gpt-5.6-terra";
+        }
+
+        List<string> endpointsToTry = [];
+        if (isAnthropic)
+        {
+            if (normalizedBaseUrl.EndsWith("/v1", StringComparison.OrdinalIgnoreCase))
+                endpointsToTry.Add($"{normalizedBaseUrl}/messages");
+            else
+                endpointsToTry.Add($"{normalizedBaseUrl}/v1/messages");
+        }
+        else
+        {
+            if (normalizedBaseUrl.EndsWith("/v1", StringComparison.OrdinalIgnoreCase))
+            {
+                endpointsToTry.Add($"{normalizedBaseUrl}/chat/completions");
+            }
+            else
+            {
+                endpointsToTry.Add($"{normalizedBaseUrl}/v1/chat/completions");
+                endpointsToTry.Add($"{normalizedBaseUrl}/chat/completions");
+            }
+        }
+
+        string? lastError = null;
+        var lastStatus = ModelValidationStatus.Unknown;
+
+        foreach (var endpoint in endpointsToTry)
+        {
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, endpoint);
+
+                if (isAnthropic)
+                {
+                    request.Headers.Add("x-api-key", apiKey);
+                    request.Headers.Add("anthropic-version", "2023-06-01");
+
+                    var payload = new
+                    {
+                        model = effectiveModel,
+                        max_tokens = 5,
+                        messages = new[] { new { role = "user", content = "ping" } }
+                    };
+                    request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+                }
+                else
+                {
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+                    if (normalizedBaseUrl.Contains("ivy.app") || normalizedBaseUrl.Contains("llmproxy"))
+                    {
+                        request.Headers.Add("x-api-key", apiKey);
+                    }
+
+                    var payload = new
+                    {
+                        model = effectiveModel,
+                        max_tokens = 5,
+                        messages = new[] { new { role = "user", content = "ping" } }
+                    };
+                    request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+                }
+
+                using var response = await HttpClient.SendAsync(request, ct);
+                var content = await response.Content.ReadAsStringAsync(ct);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    return new ModelValidationResult
+                    {
+                        Status = ModelValidationStatus.Ok,
+                        Model = model,
+                    };
+                }
+
+                var errorMsg = ExtractErrorMessage(content, (int)response.StatusCode);
+                lastError = errorMsg;
+
+                if (response.StatusCode is System.Net.HttpStatusCode.Unauthorized or System.Net.HttpStatusCode.Forbidden ||
+                    errorMsg.Contains("API_KEY_INVALID", StringComparison.OrdinalIgnoreCase) ||
+                    errorMsg.Contains("API key not valid", StringComparison.OrdinalIgnoreCase) ||
+                    errorMsg.Contains("AuthenticationError", StringComparison.OrdinalIgnoreCase) ||
+                    errorMsg.Contains("invalid_api_key", StringComparison.OrdinalIgnoreCase) ||
+                    errorMsg.Contains("unauthorized", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new ModelValidationResult
+                    {
+                        Status = ModelValidationStatus.AuthError,
+                        Model = model,
+                        ErrorMessage = errorMsg,
+                    };
+                }
+
+                if (errorMsg.Contains("model_not_found", StringComparison.OrdinalIgnoreCase) ||
+                    errorMsg.Contains("Invalid model", StringComparison.OrdinalIgnoreCase) ||
+                    errorMsg.Contains("does not exist", StringComparison.OrdinalIgnoreCase) ||
+                    errorMsg.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
+                    errorMsg.Contains("not supported", StringComparison.OrdinalIgnoreCase) ||
+                    errorMsg.Contains("not available", StringComparison.OrdinalIgnoreCase))
+                {
+                    lastStatus = ModelValidationStatus.InvalidModel;
+                }
+                else
+                {
+                    lastStatus = ModelValidationStatus.Unknown;
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                lastError = ex.Message;
+                lastStatus = ModelValidationStatus.Unknown;
+            }
+        }
+
+        return new ModelValidationResult
+        {
+            Status = lastStatus,
+            Model = model,
+            ErrorMessage = lastError ?? "Model validation failed",
+        };
+    }
+
+    private static string ExtractErrorMessage(string jsonOrText, int statusCode)
+    {
+        if (string.IsNullOrWhiteSpace(jsonOrText))
+            return $"HTTP {statusCode}";
+
+        try
+        {
+            using var doc = JsonDocument.Parse(jsonOrText);
+            var root = doc.RootElement;
+
+            if (root.TryGetProperty("error", out var errorProp))
+            {
+                if (errorProp.ValueKind == JsonValueKind.String)
+                    return errorProp.GetString()!;
+                if (errorProp.ValueKind == JsonValueKind.Object)
+                {
+                    if (errorProp.TryGetProperty("message", out var msgProp) && msgProp.ValueKind == JsonValueKind.String)
+                        return msgProp.GetString()!;
+                    return errorProp.GetRawText();
+                }
+            }
+
+            if (root.TryGetProperty("detail", out var detailProp))
+            {
+                if (detailProp.ValueKind == JsonValueKind.String)
+                    return detailProp.GetString()!;
+                return detailProp.GetRawText();
+            }
+
+            if (root.TryGetProperty("message", out var messageProp) && messageProp.ValueKind == JsonValueKind.String)
+            {
+                return messageProp.GetString()!;
+            }
+        }
+        catch
+        {
+            // Not valid JSON, return text directly
+        }
+
+        return jsonOrText.Length > 200 ? jsonOrText[..200] + "..." : jsonOrText;
+    }
+}

--- a/src/Ivy.Tendril.Agents/Helpers/ModelProfileSelector.cs
+++ b/src/Ivy.Tendril.Agents/Helpers/ModelProfileSelector.cs
@@ -1,0 +1,114 @@
+using Ivy.Tendril.Agents.Abstractions;
+
+namespace Ivy.Tendril.Agents.Helpers;
+
+public static class ModelProfileSelector
+{
+    public static (string deep, string balanced, string quick) SelectDefaults(
+        IReadOnlyList<ModelInfo>? availableModels,
+        bool isIvy = false,
+        bool isAnthropic = false,
+        bool isBerget = false,
+        bool isGoogle = false,
+        bool isOpenAi = false)
+    {
+        if (availableModels == null || availableModels.Count == 0)
+        {
+            var fallbackDeep = isIvy || isAnthropic ? "claude-opus-5" : (isBerget ? "moonshotai/Kimi-K3" : (isGoogle ? "gemini-3.7-flash" : "gpt-5.6-sol"));
+            var fallbackBalanced = isIvy || isGoogle ? "gemini-3.7-flash" : (isAnthropic ? "claude-sonnet-5" : (isBerget ? "moonshotai/Kimi-K3" : "gpt-5.6-terra"));
+            var fallbackQuick = isIvy || isGoogle ? "gemini-3.7-flash" : (isAnthropic ? "claude-haiku-5" : (isBerget ? "moonshotai/Kimi-K3" : "gpt-5.6-luna"));
+            return (fallbackDeep, fallbackBalanced, fallbackQuick);
+        }
+
+        var modelIds = availableModels.Select(m => m.Id).ToList();
+
+        // 1. Deep Profile
+        // Prioritize Opus 5, other Opus versions, Sol / flagship reasoning models, Sonnet 5, etc.
+        var deep = FindFirstMatchingModel(modelIds,
+            // Opus 5 & variations
+            id => MatchesModel(id, "opus-5") || MatchesModel(id, "opus5"),
+            id => MatchesModel(id, "opus-4-8") || MatchesModel(id, "opus-4.8"),
+            id => MatchesModel(id, "opus-4-7") || MatchesModel(id, "opus-4.7"),
+            id => MatchesModel(id, "opus-4-6") || MatchesModel(id, "opus-4.6"),
+            id => MatchesModel(id, "opus-4-5") || MatchesModel(id, "opus-4.5"),
+            id => MatchesModel(id, "opus-4") || MatchesModel(id, "opus4"),
+            id => MatchesModel(id, "opus"),
+            // Sol / OpenAI Flagship
+            id => MatchesModel(id, "gpt-5.6-sol") || MatchesModel(id, "sol"),
+            id => MatchesModel(id, "gpt-5.6"),
+            id => MatchesModel(id, "gpt-5.5"),
+            id => MatchesModel(id, "gpt-5"),
+            id => MatchesModel(id, "o3"),
+            id => MatchesModel(id, "o1"),
+            // Sonnet 5
+            id => MatchesModel(id, "sonnet-5") || MatchesModel(id, "sonnet5"),
+            id => MatchesModel(id, "sonnet"),
+            // Moonshot Kimi K3
+            id => MatchesModel(id, "kimi-k3") || MatchesModel(id, "kimi"),
+            // Gemini Pro Flagships
+            id => MatchesModel(id, "gemini-3.7-pro") || MatchesModel(id, "gemini-3.6-pro") || MatchesModel(id, "gemini-3.1-pro"),
+            id => MatchesModel(id, "gpt-4o") && !MatchesModel(id, "mini")
+        ) ?? modelIds.FirstOrDefault() ?? "";
+
+        // 2. Balanced Profile
+        // Prioritize Gemini 3.7 (flash/pro), Gemini 3.6 (flash/pro), Sonnet 5, Terra, Gemini 3.5, etc.
+        var balanced = FindFirstMatchingModel(modelIds,
+            // Gemini 3.7
+            id => MatchesModel(id, "gemini-3.7-flash") || MatchesModel(id, "gemini-3-7-flash") || MatchesModel(id, "gemini-3.7") || MatchesModel(id, "gemini-3-7"),
+            // Gemini 3.6
+            id => MatchesModel(id, "gemini-3.6-flash") || MatchesModel(id, "gemini-3-6-flash") || MatchesModel(id, "gemini-3.6") || MatchesModel(id, "gemini-3-6"),
+            // Gemini 3.5 / 3.0 / other 3.x
+            id => (MatchesModel(id, "gemini-3") || MatchesModel(id, "gemini-3.")) && MatchesModel(id, "flash"),
+            // Sonnet 5 & variations
+            id => MatchesModel(id, "sonnet-5") || MatchesModel(id, "sonnet5"),
+            id => MatchesModel(id, "sonnet-4-5") || MatchesModel(id, "sonnet-4.5") || MatchesModel(id, "sonnet-4") || MatchesModel(id, "sonnet"),
+            // Terra
+            id => MatchesModel(id, "gpt-5.6-terra") || MatchesModel(id, "terra"),
+            id => MatchesModel(id, "gpt-5.6"),
+            // Gemini 2.5 (prefer standard Flash over Flash-Lite)
+            id => MatchesModel(id, "gemini-2.5-flash") && !MatchesModel(id, "lite"),
+            id => MatchesModel(id, "gemini-2.5"),
+            id => MatchesModel(id, "gemini-2.0") || MatchesModel(id, "gemini-2-0"),
+            id => MatchesModel(id, "gemini") && MatchesModel(id, "flash"),
+            // Moonshot Kimi
+            id => MatchesModel(id, "kimi"),
+            // GPT-4o
+            id => MatchesModel(id, "gpt-4o") && !MatchesModel(id, "mini")
+        ) ?? modelIds.ElementAtOrDefault(1) ?? modelIds.FirstOrDefault() ?? "";
+
+        // 3. Quick Profile
+        // Prioritize Gemini 3.7 / 3.6 Flash / Flash-Lite, Gemini 2.5 / 2.0 Flash, Haiku 5, Luna, Mini
+        var quick = FindFirstMatchingModel(modelIds,
+            // Gemini 3.7 / 3.6 Flash & Flash-Lite
+            id => (MatchesModel(id, "gemini-3.7") || MatchesModel(id, "gemini-3-7")) && MatchesModel(id, "flash"),
+            id => (MatchesModel(id, "gemini-3.6") || MatchesModel(id, "gemini-3-6")) && MatchesModel(id, "flash"),
+            id => MatchesModel(id, "gemini-3.7") || MatchesModel(id, "gemini-3.6"),
+            // Gemini 2.5 / 2.0 Flash & Lite
+            id => MatchesModel(id, "gemini-2.5-flash") || MatchesModel(id, "gemini-2.0-flash"),
+            id => MatchesModel(id, "gemini") && MatchesModel(id, "flash"),
+            id => MatchesModel(id, "gemini") && MatchesModel(id, "lite"),
+            // Claude Haiku 5 & variations
+            id => MatchesModel(id, "haiku-5") || MatchesModel(id, "haiku5"),
+            id => MatchesModel(id, "haiku-4-5") || MatchesModel(id, "haiku-4") || MatchesModel(id, "haiku"),
+            // OpenAI Luna & Mini
+            id => MatchesModel(id, "gpt-5.6-luna") || MatchesModel(id, "luna"),
+            id => MatchesModel(id, "gpt-4o-mini") || MatchesModel(id, "gpt-4.1-mini") || MatchesModel(id, "mini")
+        ) ?? modelIds.ElementAtOrDefault(2) ?? modelIds.ElementAtOrDefault(1) ?? modelIds.FirstOrDefault() ?? "";
+
+        return (deep, balanced, quick);
+    }
+
+    private static bool MatchesModel(string id, string pattern) =>
+        id.Contains(pattern, StringComparison.OrdinalIgnoreCase);
+
+    private static string? FindFirstMatchingModel(IEnumerable<string> models, params Func<string, bool>[] predicates)
+    {
+        foreach (var predicate in predicates)
+        {
+            var match = models.FirstOrDefault(predicate);
+            if (match != null)
+                return match;
+        }
+        return null;
+    }
+}

--- a/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Claude/ClaudeModelCatalog.cs
@@ -61,6 +61,16 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         },
         new()
         {
+            Id = "claude-opus-4-6", DisplayName = "Claude Opus 4.6",
+            Capabilities = FullCaps,
+            SupportedEfforts = EffortLevels.Claude,
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
+            Provider = "anthropic",
+            InputPerMillion = 5.00m, OutputPerMillion = 25.00m,
+            CacheWritePerMillion = 6.25m, CacheReadPerMillion = 0.50m,
+        },
+        new()
+        {
             Id = "opus", DisplayName = "Claude Opus (Default)",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Claude,
@@ -91,7 +101,27 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         },
         new()
         {
-            Id = "claude-3.7-sonnet", DisplayName = "Claude Sonnet 3.7",
+            Id = "claude-3-7-sonnet", DisplayName = "Claude Sonnet 3.7",
+            Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Claude,
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
+            Provider = "anthropic",
+            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
+            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
+        },
+        new()
+        {
+            Id = "claude-3.7-sonnet", DisplayName = "Claude Sonnet 3.7 (Alt)",
+            Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Claude,
+            ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
+            Provider = "anthropic",
+            InputPerMillion = 3.00m, OutputPerMillion = 15.00m,
+            CacheWritePerMillion = 3.75m, CacheReadPerMillion = 0.30m,
+        },
+        new()
+        {
+            Id = "claude-3-5-sonnet", DisplayName = "Claude Sonnet 3.5",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 1_000_000, MaxOutputTokens = 128_000,
@@ -111,7 +141,27 @@ public sealed class ClaudeModelCatalog : CachedModelCatalogProvider
         },
         new()
         {
+            Id = "claude-haiku-5", DisplayName = "Claude Haiku 5",
+            Capabilities = LiteCaps,
+            SupportedEfforts = EffortLevels.Claude,
+            ContextWindow = 200_000, MaxOutputTokens = 64_000,
+            Provider = "anthropic",
+            InputPerMillion = 1.00m, OutputPerMillion = 5.00m,
+            CacheWritePerMillion = 1.25m, CacheReadPerMillion = 0.10m,
+        },
+        new()
+        {
             Id = "claude-haiku-4-5", DisplayName = "Claude Haiku 4.5",
+            Capabilities = LiteCaps,
+            SupportedEfforts = EffortLevels.Claude,
+            ContextWindow = 200_000, MaxOutputTokens = 64_000,
+            Provider = "anthropic",
+            InputPerMillion = 1.00m, OutputPerMillion = 5.00m,
+            CacheWritePerMillion = 1.25m, CacheReadPerMillion = 0.10m,
+        },
+        new()
+        {
+            Id = "claude-3-5-haiku", DisplayName = "Claude Haiku 3.5",
             Capabilities = LiteCaps,
             SupportedEfforts = EffortLevels.Claude,
             ContextWindow = 200_000, MaxOutputTokens = 64_000,

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyCli.cs
@@ -21,7 +21,12 @@ public sealed class IvyCli : IAgentCli
     public TransportKind SupportedTransports => _inner.SupportedTransports;
     public PromptTransport PromptTransport => _inner.PromptTransport;
     public OutputFormat PreferredOutputFormat => _inner.PreferredOutputFormat;
-    public IReadOnlyList<AgentProfileDefault> DefaultProfiles => _inner.DefaultProfiles;
+    public IReadOnlyList<AgentProfileDefault> DefaultProfiles { get; } =
+    [
+        new(ProfileTier.Deep, "ivy-stem", "max"),
+        new(ProfileTier.Balanced, "ivy-root", "high"),
+        new(ProfileTier.Quick, "ivy-leaf", "low"),
+    ];
     public IReadOnlyList<EffortOption> SupportedEfforts => _inner.SupportedEfforts;
 
     public string? TranslateToolName(string canonicalTool) => _inner.TranslateToolName(canonicalTool);
@@ -30,6 +35,13 @@ public sealed class IvyCli : IAgentCli
 
     public AgentProcessSpec BuildProcessSpec(AgentLaunchConfig config)
     {
+        var model = config.Model;
+        if (string.IsNullOrEmpty(model) || model == "default")
+        {
+            model = "ivy-stem";
+        }
+        config = config with { Model = model };
+
         var spec = _inner.BuildProcessSpec(config);
 
         var env = new Dictionary<string, string>(spec.Environment);

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyCli.cs
@@ -23,9 +23,9 @@ public sealed class IvyCli : IAgentCli
     public OutputFormat PreferredOutputFormat => _inner.PreferredOutputFormat;
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles { get; } =
     [
-        new(ProfileTier.Deep, "ivy-stem", "max"),
-        new(ProfileTier.Balanced, "ivy-root", "high"),
-        new(ProfileTier.Quick, "ivy-leaf", "low"),
+        new(ProfileTier.Deep, "claude-opus-5", "max"),
+        new(ProfileTier.Balanced, "gemini-3.7-flash", "medium"),
+        new(ProfileTier.Quick, "gemini-3.7-flash", "low"),
     ];
     public IReadOnlyList<EffortOption> SupportedEfforts => _inner.SupportedEfforts;
 
@@ -38,7 +38,7 @@ public sealed class IvyCli : IAgentCli
         var model = config.Model;
         if (string.IsNullOrEmpty(model) || model == "default")
         {
-            model = "ivy-stem";
+            model = "claude-opus-5";
         }
         config = config with { Model = model };
 

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyCli.cs
@@ -46,11 +46,15 @@ public sealed class IvyCli : IAgentCli
 
         var env = new Dictionary<string, string>(spec.Environment);
         env["ANTHROPIC_BASE_URL"] = "https://llmproxy.ivy.app";
+        env["OPENAI_BASE_URL"] = "https://llmproxy.ivy.app/v1";
+        env["IVY_BASE_URL"] = "https://llmproxy.ivy.app";
 
         var apiKey = _apiKeyProvider();
         if (!string.IsNullOrEmpty(apiKey))
         {
             env["ANTHROPIC_API_KEY"] = apiKey;
+            env["OPENAI_API_KEY"] = apiKey;
+            env["IVY_API_KEY"] = apiKey;
         }
 
         return new AgentProcessSpec
@@ -72,6 +76,8 @@ public sealed class IvyCli : IAgentCli
     {
         var env = new Dictionary<string, string>(_inner.GetDefaultEnvironment());
         env["ANTHROPIC_BASE_URL"] = "https://llmproxy.ivy.app";
+        env["OPENAI_BASE_URL"] = "https://llmproxy.ivy.app/v1";
+        env["IVY_BASE_URL"] = "https://llmproxy.ivy.app";
         return env;
     }
 }

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyHealthCheck.cs
@@ -101,45 +101,56 @@ public sealed class IvyHealthCheck : IAgentHealthCheck
 
     public async Task<ModelValidationResult> ValidateModelAsync(string model, CancellationToken ct = default)
     {
-        if (!string.IsNullOrEmpty(model) && !string.Equals(model, "default", StringComparison.OrdinalIgnoreCase))
-            return new ModelValidationResult
-            {
-                Status = ModelValidationStatus.Unknown,
-                Model = model,
-                ErrorMessage = "Ivy Agent does not support model validation for non-default models",
-            };
-
-        var binaryPath = IvyBinaryResolver.Resolve();
-        var originalEnv = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
-        var originalUrl = Environment.GetEnvironmentVariable("ANTHROPIC_BASE_URL");
-        try
+        var key = _apiKeyProvider();
+        if (!string.IsNullOrEmpty(key))
         {
-            Environment.SetEnvironmentVariable("ANTHROPIC_BASE_URL", "https://llmproxy.ivy.app");
-            var key = _apiKeyProvider();
-            if (!string.IsNullOrEmpty(key))
+            return await LlmEndpointTester.TestModelPromptAsync("https://llmproxy.ivy.app/v1", key, model, ct);
+        }
+
+        var token = _tokenProvider();
+        if (!string.IsNullOrEmpty(token))
+        {
+            var binaryPath = IvyBinaryResolver.Resolve();
+            var originalEnv = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
+            var originalUrl = Environment.GetEnvironmentVariable("ANTHROPIC_BASE_URL");
+            try
             {
-                Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", key);
+                Environment.SetEnvironmentVariable("ANTHROPIC_BASE_URL", "https://llmproxy.ivy.app");
+
+                var args = new List<string> { "run", "ping" };
+                if (!string.IsNullOrEmpty(model) && !string.Equals(model, "default", StringComparison.OrdinalIgnoreCase))
+                {
+                    args.Add("--model");
+                    args.Add(model);
+                }
+
+                var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
+                    binaryPath, args,
+                    TimeSpan.FromSeconds(30), ct);
+
+                if (exitCode == 0)
+                    return new ModelValidationResult { Status = ModelValidationStatus.Ok, Model = model };
+
+                return new ModelValidationResult
+                {
+                    Status = ModelValidationStatus.Unknown,
+                    Model = model,
+                    ErrorMessage = stderr,
+                };
             }
-
-            var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
-                binaryPath, ["run", "ping"],
-                TimeSpan.FromSeconds(30), ct);
-
-            if (exitCode == 0)
-                return new ModelValidationResult { Status = ModelValidationStatus.Ok, Model = model };
-
-            return new ModelValidationResult
+            finally
             {
-                Status = ModelValidationStatus.Unknown,
-                Model = model,
-                ErrorMessage = stderr,
-            };
+                Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", originalEnv);
+                Environment.SetEnvironmentVariable("ANTHROPIC_BASE_URL", originalUrl);
+            }
         }
-        finally
+
+        return new ModelValidationResult
         {
-            Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", originalEnv);
-            Environment.SetEnvironmentVariable("ANTHROPIC_BASE_URL", originalUrl);
-        }
+            Status = ModelValidationStatus.AuthError,
+            Model = model,
+            ErrorMessage = "No API key or @ivy.app login configured.",
+        };
     }
 
     public Task<bool> RunAuthFlowAsync(AuthFlowCallbacks callbacks, CancellationToken ct = default)

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyModelCatalog.cs
@@ -17,17 +17,17 @@ public sealed class IvyModelCatalog : IModelCatalogProvider
         new()
         {
             Id = "ivy-stem", DisplayName = "Ivy Stem",
-            Capabilities = DefaultCaps, Provider = "ivy", IsDefault = true,
+            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy", IsDefault = true,
         },
         new()
         {
             Id = "ivy-root", DisplayName = "Ivy Root",
-            Capabilities = DefaultCaps, Provider = "ivy",
+            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy",
         },
         new()
         {
             Id = "ivy-leaf", DisplayName = "Ivy Leaf",
-            Capabilities = DefaultCaps, Provider = "ivy",
+            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy",
         },
     ];
 
@@ -45,6 +45,7 @@ public sealed class IvyModelCatalog : IModelCatalogProvider
                     Id = m.Id,
                     DisplayName = FormatIvyDisplayName(m.Id, m.DisplayName),
                     Capabilities = m.Capabilities,
+                    SupportedEfforts = EffortLevels.Ivy,
                     Provider = "ivy",
                     IsDefault = m.IsDefault,
                     ContextWindow = m.ContextWindow,

--- a/src/Ivy.Tendril.Agents/Providers/Ivy/IvyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Ivy/IvyModelCatalog.cs
@@ -1,96 +1,34 @@
 using Ivy.Tendril.Agents.Abstractions;
-using Ivy.Tendril.Agents.Providers.OpenCode;
+using Ivy.Tendril.Agents.Providers.Claude;
+using Ivy.Tendril.Agents.Providers.Codex;
+using Ivy.Tendril.Agents.Providers.Gemini;
 
 namespace Ivy.Tendril.Agents.Providers.Ivy;
 
 public sealed class IvyModelCatalog : IModelCatalogProvider
 {
-    private static readonly ModelCapabilities DefaultCaps =
-        ModelCapabilities.CodeGeneration | ModelCapabilities.ToolUse | ModelCapabilities.Streaming;
-
-    private readonly OpenCodeModelCatalog _inner = new();
+    private static readonly ClaudeModelCatalog ClaudeCatalog = new();
+    private static readonly GeminiModelCatalog GeminiCatalog = new();
+    private static readonly CodexModelCatalog CodexCatalog = new();
 
     public string AgentId => Abstractions.AgentId.Ivy;
 
     public IReadOnlyList<ModelInfo> GetStaticModels() =>
     [
-        new()
-        {
-            Id = "ivy-stem", DisplayName = "Ivy Stem",
-            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy", IsDefault = true,
-        },
-        new()
-        {
-            Id = "ivy-root", DisplayName = "Ivy Root",
-            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy",
-        },
-        new()
-        {
-            Id = "ivy-leaf", DisplayName = "Ivy Leaf",
-            Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy",
-        },
+        .. ClaudeCatalog.GetStaticModels(),
+        .. GeminiCatalog.GetStaticModels(),
+        .. CodexCatalog.GetStaticModels(),
     ];
 
-    public async Task<ModelCatalogResult> GetModelsAsync(CancellationToken ct = default)
+    public Task<ModelCatalogResult> GetModelsAsync(CancellationToken ct = default)
     {
         var staticModels = GetStaticModels();
-        try
-        {
-            var result = await _inner.GetModelsAsync(ct);
-            var ivyModels = result.Models
-                .Where(m => m.Id.StartsWith("ivy", StringComparison.OrdinalIgnoreCase) ||
-                            "ivy".Equals(m.Provider, StringComparison.OrdinalIgnoreCase))
-                .Select(m => new ModelInfo
-                {
-                    Id = m.Id,
-                    DisplayName = FormatIvyDisplayName(m.Id, m.DisplayName),
-                    Capabilities = m.Capabilities,
-                    SupportedEfforts = EffortLevels.Ivy,
-                    Provider = "ivy",
-                    IsDefault = m.IsDefault,
-                    ContextWindow = m.ContextWindow,
-                    InputPerMillion = m.InputPerMillion,
-                    OutputPerMillion = m.OutputPerMillion,
-                    CacheReadPerMillion = m.CacheReadPerMillion,
-                    CacheWritePerMillion = m.CacheWritePerMillion,
-                })
-                .ToList();
-
-            if (ivyModels.Count > 0)
-            {
-                return new ModelCatalogResult
-                {
-                    AgentId = AgentId,
-                    Models = ivyModels,
-                    Source = result.Source,
-                    RetrievedAt = result.RetrievedAt,
-                    ExpiresAt = result.ExpiresAt,
-                };
-            }
-        }
-        catch
-        {
-            // Fallback to static model list
-        }
-
-        return new ModelCatalogResult
+        return Task.FromResult(new ModelCatalogResult
         {
             AgentId = AgentId,
             Models = staticModels,
             Source = ModelCatalogSource.Static,
             RetrievedAt = DateTimeOffset.UtcNow,
-        };
-    }
-
-    private static string FormatIvyDisplayName(string id, string? rawDisplayName)
-    {
-        if (string.Equals(id, "ivy-stem", StringComparison.OrdinalIgnoreCase)) return "Ivy Stem";
-        if (string.Equals(id, "ivy-root", StringComparison.OrdinalIgnoreCase)) return "Ivy Root";
-        if (string.Equals(id, "ivy-leaf", StringComparison.OrdinalIgnoreCase)) return "Ivy Leaf";
-
-        if (!string.IsNullOrEmpty(rawDisplayName) && rawDisplayName.StartsWith("Ivy", StringComparison.OrdinalIgnoreCase))
-            return rawDisplayName;
-
-        return "Ivy " + id.Replace("ivy-", "").Replace("-", " ");
+        });
     }
 }

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
@@ -46,6 +46,15 @@ public sealed class OpenAiProxyCli : IAgentCli
                     new AgentProfileDefault(ProfileTier.Quick, "claude-haiku-5", "low"),
                 ];
             }
+            if (baseUrl != null && (baseUrl.Contains("generativelanguage.googleapis.com") || baseUrl.Contains("gemini") || baseUrl.Contains("google")))
+            {
+                return
+                [
+                    new AgentProfileDefault(ProfileTier.Deep, "gemini-3.1-pro", "high"),
+                    new AgentProfileDefault(ProfileTier.Balanced, "gemini-3.6-flash", "medium"),
+                    new AgentProfileDefault(ProfileTier.Quick, "gemini-3.7-flash", "low"),
+                ];
+            }
             if (baseUrl != null && baseUrl.Contains("api.berget.ai"))
             {
                 return
@@ -83,6 +92,10 @@ public sealed class OpenAiProxyCli : IAgentCli
             else if (baseUrl != null && baseUrl.Contains("api.anthropic.com"))
             {
                 model = "claude-sonnet-5";
+            }
+            else if (baseUrl != null && (baseUrl.Contains("generativelanguage.googleapis.com") || baseUrl.Contains("gemini") || baseUrl.Contains("google")))
+            {
+                model = "gemini-3.6-flash";
             }
             else if (baseUrl != null && baseUrl.Contains("api.berget.ai"))
             {

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
@@ -28,16 +28,39 @@ public sealed class OpenAiProxyCli : IAgentCli
         get
         {
             var baseUrl = _baseUrlProvider();
+            if (baseUrl != null && baseUrl.Contains("llmproxy.ivy.app"))
+            {
+                return
+                [
+                    new AgentProfileDefault(ProfileTier.Deep, "ivy-stem", "max"),
+                    new AgentProfileDefault(ProfileTier.Balanced, "ivy-root", "high"),
+                    new AgentProfileDefault(ProfileTier.Quick, "ivy-leaf", "low"),
+                ];
+            }
+            if (baseUrl != null && baseUrl.Contains("api.anthropic.com"))
+            {
+                return
+                [
+                    new AgentProfileDefault(ProfileTier.Deep, "claude-opus-5", "max"),
+                    new AgentProfileDefault(ProfileTier.Balanced, "claude-sonnet-5", "high"),
+                    new AgentProfileDefault(ProfileTier.Quick, "claude-haiku-5", "low"),
+                ];
+            }
             if (baseUrl != null && baseUrl.Contains("api.berget.ai"))
             {
                 return
                 [
-                    new AgentProfileDefault(ProfileTier.Deep, "moonshotai/Kimi-K3", null),
-                    new AgentProfileDefault(ProfileTier.Balanced, "moonshotai/Kimi-K3", null),
-                    new AgentProfileDefault(ProfileTier.Quick, "moonshotai/Kimi-K3", null),
+                    new AgentProfileDefault(ProfileTier.Deep, "moonshotai/Kimi-K3", "max"),
+                    new AgentProfileDefault(ProfileTier.Balanced, "moonshotai/Kimi-K3", "high"),
+                    new AgentProfileDefault(ProfileTier.Quick, "moonshotai/Kimi-K3", "low"),
                 ];
             }
-            return _inner.DefaultProfiles;
+            return
+            [
+                new AgentProfileDefault(ProfileTier.Deep, "gpt-5.6-sol", "high"),
+                new AgentProfileDefault(ProfileTier.Balanced, "gpt-5.6-terra", "medium"),
+                new AgentProfileDefault(ProfileTier.Quick, "gpt-5.6-luna", "low"),
+            ];
         }
     }
 
@@ -50,15 +73,25 @@ public sealed class OpenAiProxyCli : IAgentCli
     public AgentProcessSpec BuildProcessSpec(AgentLaunchConfig config)
     {
         var baseUrl = _baseUrlProvider();
-        var isBerget = baseUrl?.Contains("api.berget.ai") ?? false;
         var model = config.Model;
-        if (isBerget && (string.IsNullOrEmpty(model) || model == "default" || model.Equals("kimi-k3", StringComparison.OrdinalIgnoreCase)))
+        if (string.IsNullOrEmpty(model) || model == "default")
         {
-            model = "moonshotai/Kimi-K3";
-        }
-        else if (string.IsNullOrEmpty(model))
-        {
-            model = "moonshotai/Kimi-K3";
+            if (baseUrl != null && baseUrl.Contains("llmproxy.ivy.app"))
+            {
+                model = "ivy-stem";
+            }
+            else if (baseUrl != null && baseUrl.Contains("api.anthropic.com"))
+            {
+                model = "claude-sonnet-5";
+            }
+            else if (baseUrl != null && baseUrl.Contains("api.berget.ai"))
+            {
+                model = "moonshotai/Kimi-K3";
+            }
+            else
+            {
+                model = "gpt-5.6-terra";
+            }
         }
 
         config = config with { Model = model };

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
@@ -32,9 +32,9 @@ public sealed class OpenAiProxyCli : IAgentCli
             {
                 return
                 [
-                    new AgentProfileDefault(ProfileTier.Deep, "ivy-stem", "max"),
-                    new AgentProfileDefault(ProfileTier.Balanced, "ivy-root", "high"),
-                    new AgentProfileDefault(ProfileTier.Quick, "ivy-leaf", "low"),
+                    new AgentProfileDefault(ProfileTier.Deep, "claude-opus-5", "max"),
+                    new AgentProfileDefault(ProfileTier.Balanced, "gemini-3.7-flash", "medium"),
+                    new AgentProfileDefault(ProfileTier.Quick, "gemini-3.7-flash", "low"),
                 ];
             }
             if (baseUrl != null && baseUrl.Contains("api.anthropic.com"))
@@ -87,7 +87,7 @@ public sealed class OpenAiProxyCli : IAgentCli
         {
             if (baseUrl != null && baseUrl.Contains("llmproxy.ivy.app"))
             {
-                model = "ivy-stem";
+                model = "claude-opus-5";
             }
             else if (baseUrl != null && baseUrl.Contains("api.anthropic.com"))
             {
@@ -95,7 +95,7 @@ public sealed class OpenAiProxyCli : IAgentCli
             }
             else if (baseUrl != null && (baseUrl.Contains("generativelanguage.googleapis.com") || baseUrl.Contains("gemini") || baseUrl.Contains("google")))
             {
-                model = "gemini-3.6-flash";
+                model = "gemini-3.7-flash";
             }
             else if (baseUrl != null && baseUrl.Contains("api.berget.ai"))
             {

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs
@@ -50,9 +50,9 @@ public sealed class OpenAiProxyCli : IAgentCli
             {
                 return
                 [
-                    new AgentProfileDefault(ProfileTier.Deep, "gemini-3.1-pro", "high"),
-                    new AgentProfileDefault(ProfileTier.Balanced, "gemini-3.6-flash", "medium"),
-                    new AgentProfileDefault(ProfileTier.Quick, "gemini-3.7-flash", "low"),
+                    new AgentProfileDefault(ProfileTier.Deep, "gemini-3.7-flash", "high"),
+                    new AgentProfileDefault(ProfileTier.Balanced, "gemini-3.7-flash", "medium"),
+                    new AgentProfileDefault(ProfileTier.Quick, "gemini-3.7-flash", "medium"),
                 ];
             }
             if (baseUrl != null && baseUrl.Contains("api.berget.ai"))

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyHealthCheck.cs
@@ -78,14 +78,6 @@ public sealed class OpenAiProxyHealthCheck : IAgentHealthCheck
 
     public async Task<ModelValidationResult> ValidateModelAsync(string model, CancellationToken ct = default)
     {
-        if (!string.IsNullOrEmpty(model) && !string.Equals(model, "default", StringComparison.OrdinalIgnoreCase))
-            return new ModelValidationResult
-            {
-                Status = ModelValidationStatus.Unknown,
-                Model = model,
-                ErrorMessage = "OpenAI Proxy does not support model validation for non-default models",
-            };
-
         var baseUrl = _baseUrlProvider();
         var apiKey = _apiKeyProvider();
 
@@ -99,33 +91,7 @@ public sealed class OpenAiProxyHealthCheck : IAgentHealthCheck
             };
         }
 
-        var binaryPath = IvyBinaryResolver.Resolve();
-        var originalEnv = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
-        var originalUrl = Environment.GetEnvironmentVariable("ANTHROPIC_BASE_URL");
-        try
-        {
-            Environment.SetEnvironmentVariable("ANTHROPIC_BASE_URL", baseUrl);
-            Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", apiKey);
-
-            var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
-                binaryPath, ["run", "ping"],
-                TimeSpan.FromSeconds(30), ct);
-
-            if (exitCode == 0)
-                return new ModelValidationResult { Status = ModelValidationStatus.Ok, Model = model };
-
-            return new ModelValidationResult
-            {
-                Status = ModelValidationStatus.Unknown,
-                Model = model,
-                ErrorMessage = stderr,
-            };
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("ANTHROPIC_API_KEY", originalEnv);
-            Environment.SetEnvironmentVariable("ANTHROPIC_BASE_URL", originalUrl);
-        }
+        return await LlmEndpointTester.TestModelPromptAsync(baseUrl, apiKey, model, ct);
     }
 
     public Task<bool> RunAuthFlowAsync(AuthFlowCallbacks callbacks, CancellationToken ct = default)

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
@@ -40,6 +40,10 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
         var baseUrl = _baseUrlProvider?.Invoke();
         var apiKey = _apiKeyProvider?.Invoke();
         var models = await FetchModelsFromEndpointAsync(baseUrl, apiKey, ct);
+        if (models.Count == 0)
+        {
+            models = GetStaticModels();
+        }
         return new ModelCatalogResult
         {
             AgentId = AgentId,
@@ -51,12 +55,11 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
 
     public static async Task<IReadOnlyList<ModelInfo>> FetchModelsFromEndpointAsync(string? baseUrl, string? apiKey, CancellationToken ct = default)
     {
-        var staticModels = GetModelsForBaseUrl(baseUrl);
         var url = baseUrl?.Trim().TrimEnd('/') ?? "";
 
         if (string.IsNullOrEmpty(url))
         {
-            return staticModels;
+            return Array.Empty<ModelInfo>();
         }
 
         try
@@ -89,15 +92,6 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
                     }
                 }
 
-                // Add any remaining static models from the provider that were not in the fetched list
-                foreach (var sm in staticModels)
-                {
-                    if (!result.Any(r => r.Id.Equals(sm.Id, StringComparison.OrdinalIgnoreCase)))
-                    {
-                        result.Add(sm);
-                    }
-                }
-
                 return result
                     .DistinctBy(m => m.Id, StringComparer.OrdinalIgnoreCase)
                     .ToList();
@@ -105,10 +99,10 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
         }
         catch
         {
-            // Fallback to static models on error
+            // Fallback to empty on error
         }
 
-        return staticModels;
+        return Array.Empty<ModelInfo>();
     }
 
     private static async Task<List<(string Id, string? Name)>?> TryFetchModelsHttpAsync(string baseUrl, string? apiKey, CancellationToken ct)
@@ -148,6 +142,10 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
                     else
                     {
                         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+                        if (baseUrl.Contains("ivy.app") || baseUrl.Contains("llmproxy"))
+                        {
+                            request.Headers.Add("x-api-key", apiKey);
+                        }
                     }
                 }
 

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
@@ -1,14 +1,20 @@
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.Claude;
+using Ivy.Tendril.Agents.Providers.Codex;
+using Ivy.Tendril.Agents.Providers.Gemini;
+using Ivy.Tendril.Agents.Providers.Ivy;
 using Ivy.Tendril.Agents.Providers.OpenCode;
 
 namespace Ivy.Tendril.Agents.Providers.OpenAiProxy;
 
 public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
 {
-    private static readonly ModelCapabilities DefaultCaps =
-        ModelCapabilities.CodeGeneration | ModelCapabilities.ToolUse | ModelCapabilities.Streaming;
+    private static readonly IvyModelCatalog IvyCatalog = new();
+    private static readonly ClaudeModelCatalog ClaudeCatalog = new();
+    private static readonly CodexModelCatalog CodexCatalog = new();
+    private static readonly GeminiModelCatalog GeminiCatalog = new();
+    private static readonly OpenCodeModelCatalog OpenCodeCatalog = new();
 
-    private readonly OpenCodeModelCatalog _inner = new();
     private readonly Func<string?>? _baseUrlProvider;
 
     public OpenAiProxyModelCatalog(Func<string?>? baseUrlProvider = null)
@@ -24,16 +30,16 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
         return GetModelsForBaseUrl(baseUrl);
     }
 
-    public async Task<ModelCatalogResult> GetModelsAsync(CancellationToken ct = default)
+    public Task<ModelCatalogResult> GetModelsAsync(CancellationToken ct = default)
     {
         var staticModels = GetStaticModels();
-        return new ModelCatalogResult
+        return Task.FromResult(new ModelCatalogResult
         {
             AgentId = AgentId,
             Models = staticModels,
             Source = ModelCatalogSource.Static,
             RetrievedAt = DateTimeOffset.UtcNow,
-        };
+        });
     }
 
     public static IReadOnlyList<ModelInfo> GetModelsForBaseUrl(string? baseUrl)
@@ -41,77 +47,51 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
         var url = baseUrl ?? "";
         if (url.Contains("llmproxy.ivy.app") || url.Contains("ivy.app"))
         {
-            return
-            [
-                new ModelInfo { Id = "ivy-stem", DisplayName = "Ivy Stem", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy", IsDefault = true },
-                new ModelInfo { Id = "ivy-root", DisplayName = "Ivy Root", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy" },
-                new ModelInfo { Id = "ivy-leaf", DisplayName = "Ivy Leaf", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy" },
-            ];
+            return IvyCatalog.GetStaticModels();
         }
 
         if (url.Contains("api.berget.ai"))
         {
             return
             [
-                new ModelInfo { Id = "moonshotai/Kimi-K3", DisplayName = "Kimi K3", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "berget", IsDefault = true, ContextWindow = 200000 },
-                new ModelInfo { Id = "kimi-k2", DisplayName = "Kimi K2", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "berget", ContextWindow = 200000 },
-                new ModelInfo { Id = "deepseek-ai/DeepSeek-V3", DisplayName = "DeepSeek V3", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "berget", ContextWindow = 128000 },
-                new ModelInfo { Id = "deepseek-ai/DeepSeek-R1", DisplayName = "DeepSeek R1", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "berget", ContextWindow = 128000 },
-                new ModelInfo { Id = "Qwen/Qwen2.5-Coder-32B-Instruct", DisplayName = "Qwen 2.5 Coder 32B", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "berget", ContextWindow = 128000 },
+                .. OpenCodeCatalog.GetStaticModels().Where(m => m.Id != "default"),
+                new ModelInfo
+                {
+                    Id = "Qwen/Qwen2.5-Coder-32B-Instruct",
+                    DisplayName = "Qwen 2.5 Coder 32B",
+                    Capabilities = ModelCapabilities.CodeGeneration | ModelCapabilities.ToolUse | ModelCapabilities.Streaming,
+                    SupportedEfforts = EffortLevels.OpenCode,
+                    Provider = "berget",
+                    ContextWindow = 128000,
+                }
             ];
         }
 
         if (url.Contains("api.anthropic.com"))
         {
-            return
-            [
-                new ModelInfo { Id = "claude-opus-5", DisplayName = "Claude Opus 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic", IsDefault = true },
-                new ModelInfo { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
-                new ModelInfo { Id = "claude-haiku-5", DisplayName = "Claude Haiku 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
-                new ModelInfo { Id = "claude-opus-4-7", DisplayName = "Claude Opus 4.7", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
-                new ModelInfo { Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
-                new ModelInfo { Id = "claude-haiku-4-5", DisplayName = "Claude Haiku 4.5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
-                new ModelInfo { Id = "claude-3-7-sonnet", DisplayName = "Claude 3.7 Sonnet", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
-                new ModelInfo { Id = "claude-3-5-sonnet", DisplayName = "Claude 3.5 Sonnet", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
-                new ModelInfo { Id = "claude-3-5-haiku", DisplayName = "Claude 3.5 Haiku", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
-            ];
+            return ClaudeCatalog.GetStaticModels();
+        }
+
+        if (url.Contains("generativelanguage.googleapis.com") || url.Contains("gemini") || url.Contains("google"))
+        {
+            return GeminiCatalog.GetStaticModels();
         }
 
         if (url.Contains("api.openai.com") || string.IsNullOrEmpty(url))
         {
-            return
-            [
-                new ModelInfo { Id = "gpt-5.6-sol", DisplayName = "GPT-5.6-Sol", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", IsDefault = true, ContextWindow = 400000 },
-                new ModelInfo { Id = "gpt-5.6-terra", DisplayName = "GPT-5.6-Terra", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 272000 },
-                new ModelInfo { Id = "gpt-5.6-luna", DisplayName = "GPT-5.6-Luna", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 272000 },
-                new ModelInfo { Id = "gpt-5.5", DisplayName = "GPT-5.5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 400000 },
-                new ModelInfo { Id = "gpt-5.4", DisplayName = "GPT-5.4", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 400000 },
-                new ModelInfo { Id = "gpt-5.4-mini", DisplayName = "GPT-5.4 Mini", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 400000 },
-                new ModelInfo { Id = "gpt-4o", DisplayName = "GPT-4o", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 128000 },
-                new ModelInfo { Id = "gpt-4o-mini", DisplayName = "GPT-4o Mini", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 128000 },
-                new ModelInfo { Id = "o3", DisplayName = "O3", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 200000 },
-                new ModelInfo { Id = "o3-mini", DisplayName = "O3 Mini", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 200000 },
-                new ModelInfo { Id = "o1", DisplayName = "O1", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 200000 },
-            ];
+            return CodexCatalog.GetStaticModels();
         }
 
-        // Custom URL: return unified list
-        return
-        [
-            new ModelInfo { Id = "gpt-5.6-sol", DisplayName = "GPT-5.6-Sol", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", IsDefault = true, ContextWindow = 400000 },
-            new ModelInfo { Id = "gpt-5.6-terra", DisplayName = "GPT-5.6-Terra", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 272000 },
-            new ModelInfo { Id = "gpt-5.6-luna", DisplayName = "GPT-5.6-Luna", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 272000 },
-            new ModelInfo { Id = "claude-opus-5", DisplayName = "Claude Opus 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
-            new ModelInfo { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
-            new ModelInfo { Id = "claude-haiku-5", DisplayName = "Claude Haiku 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
-            new ModelInfo { Id = "claude-3-7-sonnet", DisplayName = "Claude 3.7 Sonnet", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
-            new ModelInfo { Id = "claude-3-5-sonnet", DisplayName = "Claude 3.5 Sonnet", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
-            new ModelInfo { Id = "moonshotai/Kimi-K3", DisplayName = "Kimi K3", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "moonshot" },
-            new ModelInfo { Id = "deepseek-ai/DeepSeek-V3", DisplayName = "DeepSeek V3", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "deepseek" },
-            new ModelInfo { Id = "deepseek-ai/DeepSeek-R1", DisplayName = "DeepSeek R1", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "deepseek" },
-            new ModelInfo { Id = "ivy-stem", DisplayName = "Ivy Stem", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy" },
-            new ModelInfo { Id = "ivy-root", DisplayName = "Ivy Root", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy" },
-            new ModelInfo { Id = "ivy-leaf", DisplayName = "Ivy Leaf", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy" },
-        ];
+        // Custom URL: return unified list of OpenAI, Claude (including 4.6, 4.7, 4.8, 5), Google, OpenCode, and Ivy models
+        var combined = new List<ModelInfo>();
+        combined.AddRange(CodexCatalog.GetStaticModels());
+        combined.AddRange(ClaudeCatalog.GetStaticModels());
+        combined.AddRange(GeminiCatalog.GetStaticModels());
+        combined.AddRange(OpenCodeCatalog.GetStaticModels().Where(m => m.Id != "default"));
+        combined.AddRange(IvyCatalog.GetStaticModels());
+
+        return combined
+            .DistinctBy(m => m.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 }

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
@@ -1,3 +1,5 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Providers.Claude;
 using Ivy.Tendril.Agents.Providers.Codex;
@@ -9,6 +11,7 @@ namespace Ivy.Tendril.Agents.Providers.OpenAiProxy;
 
 public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
 {
+    private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromSeconds(8) };
     private static readonly IvyModelCatalog IvyCatalog = new();
     private static readonly ClaudeModelCatalog ClaudeCatalog = new();
     private static readonly CodexModelCatalog CodexCatalog = new();
@@ -16,10 +19,12 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
     private static readonly OpenCodeModelCatalog OpenCodeCatalog = new();
 
     private readonly Func<string?>? _baseUrlProvider;
+    private readonly Func<string?>? _apiKeyProvider;
 
-    public OpenAiProxyModelCatalog(Func<string?>? baseUrlProvider = null)
+    public OpenAiProxyModelCatalog(Func<string?>? baseUrlProvider = null, Func<string?>? apiKeyProvider = null)
     {
         _baseUrlProvider = baseUrlProvider;
+        _apiKeyProvider = apiKeyProvider;
     }
 
     public string AgentId => Abstractions.AgentId.OpenAiProxy;
@@ -30,16 +35,198 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
         return GetModelsForBaseUrl(baseUrl);
     }
 
-    public Task<ModelCatalogResult> GetModelsAsync(CancellationToken ct = default)
+    public async Task<ModelCatalogResult> GetModelsAsync(CancellationToken ct = default)
     {
-        var staticModels = GetStaticModels();
-        return Task.FromResult(new ModelCatalogResult
+        var baseUrl = _baseUrlProvider?.Invoke();
+        var apiKey = _apiKeyProvider?.Invoke();
+        var models = await FetchModelsFromEndpointAsync(baseUrl, apiKey, ct);
+        return new ModelCatalogResult
         {
             AgentId = AgentId,
-            Models = staticModels,
-            Source = ModelCatalogSource.Static,
+            Models = models,
+            Source = ModelCatalogSource.Dynamic,
             RetrievedAt = DateTimeOffset.UtcNow,
-        });
+        };
+    }
+
+    public static async Task<IReadOnlyList<ModelInfo>> FetchModelsFromEndpointAsync(string? baseUrl, string? apiKey, CancellationToken ct = default)
+    {
+        var staticModels = GetModelsForBaseUrl(baseUrl);
+        var url = baseUrl?.Trim().TrimEnd('/') ?? "";
+
+        if (string.IsNullOrEmpty(url) || url.Contains("llmproxy.ivy.app") || url.Contains("ivy.app"))
+        {
+            return staticModels;
+        }
+
+        try
+        {
+            var fetched = await TryFetchModelsHttpAsync(url, apiKey, ct);
+            if (fetched is { Count: > 0 })
+            {
+                var allKnownLookup = new IModelCatalogProvider[] { CodexCatalog, ClaudeCatalog, GeminiCatalog, IvyCatalog, OpenCodeCatalog }
+                    .SelectMany(c => c.GetStaticModels())
+                    .DistinctBy(m => m.Id, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(m => m.Id, StringComparer.OrdinalIgnoreCase);
+
+                var result = new List<ModelInfo>();
+                foreach (var (id, name) in fetched)
+                {
+                    if (allKnownLookup.TryGetValue(id, out var known))
+                    {
+                        result.Add(known);
+                    }
+                    else
+                    {
+                        result.Add(new ModelInfo
+                        {
+                            Id = id,
+                            DisplayName = !string.IsNullOrEmpty(name) && name != id ? name : id,
+                            Capabilities = ModelCapabilities.CodeGeneration | ModelCapabilities.ToolUse | ModelCapabilities.Streaming,
+                            SupportedEfforts = EffortLevels.Codex,
+                            Provider = "custom",
+                        });
+                    }
+                }
+
+                // Add any remaining static models from the provider that were not in the fetched list
+                foreach (var sm in staticModels)
+                {
+                    if (!result.Any(r => r.Id.Equals(sm.Id, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        result.Add(sm);
+                    }
+                }
+
+                return result
+                    .DistinctBy(m => m.Id, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            }
+        }
+        catch
+        {
+            // Fallback to static models on error
+        }
+
+        return staticModels;
+    }
+
+    private static async Task<List<(string Id, string? Name)>?> TryFetchModelsHttpAsync(string baseUrl, string? apiKey, CancellationToken ct)
+    {
+        var isAnthropic = baseUrl.Contains("api.anthropic.com");
+        var urlsToTry = new List<string>();
+
+        if (isAnthropic)
+        {
+            urlsToTry.Add("https://api.anthropic.com/v1/models");
+        }
+        else
+        {
+            if (baseUrl.EndsWith("/v1", StringComparison.OrdinalIgnoreCase))
+            {
+                urlsToTry.Add($"{baseUrl}/models");
+            }
+            else
+            {
+                urlsToTry.Add($"{baseUrl}/v1/models");
+                urlsToTry.Add($"{baseUrl}/models");
+            }
+        }
+
+        foreach (var endpointUrl in urlsToTry)
+        {
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, endpointUrl);
+                if (!string.IsNullOrWhiteSpace(apiKey))
+                {
+                    if (isAnthropic)
+                    {
+                        request.Headers.Add("x-api-key", apiKey);
+                        request.Headers.Add("anthropic-version", "2023-06-01");
+                    }
+                    else
+                    {
+                        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+                    }
+                }
+
+                using var response = await HttpClient.SendAsync(request, ct);
+                if (response.IsSuccessStatusCode)
+                {
+                    var json = await response.Content.ReadAsStringAsync(ct);
+                    var models = ParseModelsJson(json);
+                    if (models.Count > 0)
+                    {
+                        return models;
+                    }
+                }
+            }
+            catch
+            {
+                // Continue to next URL attempt
+            }
+        }
+
+        return null;
+    }
+
+    private static List<(string Id, string? Name)> ParseModelsJson(string json)
+    {
+        var list = new List<(string Id, string? Name)>();
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            // OpenAI / Anthropic format: { "data": [ { "id": "...", "display_name": "..." } ] }
+            if (root.TryGetProperty("data", out var dataEl) && dataEl.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in dataEl.EnumerateArray())
+                {
+                    if (item.TryGetProperty("id", out var idEl) && idEl.GetString() is { } id && !string.IsNullOrWhiteSpace(id))
+                    {
+                        string? name = null;
+                        if (item.TryGetProperty("display_name", out var dnEl)) name = dnEl.GetString();
+                        else if (item.TryGetProperty("name", out var nEl)) name = nEl.GetString();
+                        list.Add((id, name));
+                    }
+                }
+            }
+            // Ollama format: { "models": [ { "name": "...", "model": "..." } ] }
+            else if (root.TryGetProperty("models", out var modelsEl) && modelsEl.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in modelsEl.EnumerateArray())
+                {
+                    string? id = null;
+                    if (item.TryGetProperty("name", out var nEl)) id = nEl.GetString();
+                    else if (item.TryGetProperty("model", out var mEl)) id = mEl.GetString();
+                    else if (item.TryGetProperty("id", out var idEl)) id = idEl.GetString();
+
+                    if (!string.IsNullOrWhiteSpace(id))
+                    {
+                        list.Add((id, id));
+                    }
+                }
+            }
+            // Direct array: [ { "id": "..." } ]
+            else if (root.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in root.EnumerateArray())
+                {
+                    if (item.TryGetProperty("id", out var idEl) && idEl.GetString() is { } id && !string.IsNullOrWhiteSpace(id))
+                    {
+                        list.Add((id, id));
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Ignore parse errors
+        }
+
+        return list;
     }
 
     public static IReadOnlyList<ModelInfo> GetModelsForBaseUrl(string? baseUrl)

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
@@ -18,74 +18,100 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
 
     public string AgentId => Abstractions.AgentId.OpenAiProxy;
 
-    private bool IsBerget => _baseUrlProvider?.Invoke()?.Contains("api.berget.ai") ?? false;
-
     public IReadOnlyList<ModelInfo> GetStaticModels()
     {
-        if (IsBerget)
-        {
-            return
-            [
-                new ModelInfo
-                {
-                    Id = "moonshotai/Kimi-K3",
-                    DisplayName = "Kimi K3",
-                    Capabilities = DefaultCaps,
-                    Provider = "berget",
-                    IsDefault = true,
-                    ContextWindow = 200000,
-                }
-            ];
-        }
-
-        return _inner.GetStaticModels().Select(m => new ModelInfo
-        {
-            Id = m.Id,
-            DisplayName = m.DisplayName.Replace("OpenCode", "OpenAI Proxy"),
-            Capabilities = m.Capabilities,
-            Provider = "openaiproxy",
-            IsDefault = m.IsDefault,
-            ContextWindow = m.ContextWindow,
-            InputPerMillion = m.InputPerMillion,
-            OutputPerMillion = m.OutputPerMillion,
-            CacheReadPerMillion = m.CacheReadPerMillion,
-            CacheWritePerMillion = m.CacheWritePerMillion,
-        }).ToList();
+        var baseUrl = _baseUrlProvider?.Invoke();
+        return GetModelsForBaseUrl(baseUrl);
     }
 
     public async Task<ModelCatalogResult> GetModelsAsync(CancellationToken ct = default)
     {
-        if (IsBerget)
-        {
-            return new ModelCatalogResult
-            {
-                AgentId = AgentId,
-                Models = GetStaticModels(),
-                Source = ModelCatalogSource.Static,
-                RetrievedAt = DateTimeOffset.UtcNow,
-            };
-        }
-
-        var result = await _inner.GetModelsAsync(ct);
+        var staticModels = GetStaticModels();
         return new ModelCatalogResult
         {
             AgentId = AgentId,
-            Models = result.Models.Select(m => new ModelInfo
-            {
-                Id = m.Id,
-                DisplayName = m.DisplayName.Replace("OpenCode", "OpenAI Proxy"),
-                Capabilities = m.Capabilities,
-                Provider = "openaiproxy",
-                IsDefault = m.IsDefault,
-                ContextWindow = m.ContextWindow,
-                InputPerMillion = m.InputPerMillion,
-                OutputPerMillion = m.OutputPerMillion,
-                CacheReadPerMillion = m.CacheReadPerMillion,
-                CacheWritePerMillion = m.CacheWritePerMillion,
-            }).ToList(),
-            Source = result.Source,
-            RetrievedAt = result.RetrievedAt,
-            ExpiresAt = result.ExpiresAt,
+            Models = staticModels,
+            Source = ModelCatalogSource.Static,
+            RetrievedAt = DateTimeOffset.UtcNow,
         };
+    }
+
+    public static IReadOnlyList<ModelInfo> GetModelsForBaseUrl(string? baseUrl)
+    {
+        var url = baseUrl ?? "";
+        if (url.Contains("llmproxy.ivy.app") || url.Contains("ivy.app"))
+        {
+            return
+            [
+                new ModelInfo { Id = "ivy-stem", DisplayName = "Ivy Stem", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy", IsDefault = true },
+                new ModelInfo { Id = "ivy-root", DisplayName = "Ivy Root", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy" },
+                new ModelInfo { Id = "ivy-leaf", DisplayName = "Ivy Leaf", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy" },
+            ];
+        }
+
+        if (url.Contains("api.berget.ai"))
+        {
+            return
+            [
+                new ModelInfo { Id = "moonshotai/Kimi-K3", DisplayName = "Kimi K3", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "berget", IsDefault = true, ContextWindow = 200000 },
+                new ModelInfo { Id = "kimi-k2", DisplayName = "Kimi K2", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "berget", ContextWindow = 200000 },
+                new ModelInfo { Id = "deepseek-ai/DeepSeek-V3", DisplayName = "DeepSeek V3", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "berget", ContextWindow = 128000 },
+                new ModelInfo { Id = "deepseek-ai/DeepSeek-R1", DisplayName = "DeepSeek R1", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "berget", ContextWindow = 128000 },
+                new ModelInfo { Id = "Qwen/Qwen2.5-Coder-32B-Instruct", DisplayName = "Qwen 2.5 Coder 32B", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "berget", ContextWindow = 128000 },
+            ];
+        }
+
+        if (url.Contains("api.anthropic.com"))
+        {
+            return
+            [
+                new ModelInfo { Id = "claude-opus-5", DisplayName = "Claude Opus 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic", IsDefault = true },
+                new ModelInfo { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+                new ModelInfo { Id = "claude-haiku-5", DisplayName = "Claude Haiku 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+                new ModelInfo { Id = "claude-opus-4-7", DisplayName = "Claude Opus 4.7", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+                new ModelInfo { Id = "claude-sonnet-4-6", DisplayName = "Claude Sonnet 4.6", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+                new ModelInfo { Id = "claude-haiku-4-5", DisplayName = "Claude Haiku 4.5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+                new ModelInfo { Id = "claude-3-7-sonnet", DisplayName = "Claude 3.7 Sonnet", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+                new ModelInfo { Id = "claude-3-5-sonnet", DisplayName = "Claude 3.5 Sonnet", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+                new ModelInfo { Id = "claude-3-5-haiku", DisplayName = "Claude 3.5 Haiku", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+            ];
+        }
+
+        if (url.Contains("api.openai.com") || string.IsNullOrEmpty(url))
+        {
+            return
+            [
+                new ModelInfo { Id = "gpt-5.6-sol", DisplayName = "GPT-5.6-Sol", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", IsDefault = true, ContextWindow = 400000 },
+                new ModelInfo { Id = "gpt-5.6-terra", DisplayName = "GPT-5.6-Terra", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 272000 },
+                new ModelInfo { Id = "gpt-5.6-luna", DisplayName = "GPT-5.6-Luna", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 272000 },
+                new ModelInfo { Id = "gpt-5.5", DisplayName = "GPT-5.5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 400000 },
+                new ModelInfo { Id = "gpt-5.4", DisplayName = "GPT-5.4", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 400000 },
+                new ModelInfo { Id = "gpt-5.4-mini", DisplayName = "GPT-5.4 Mini", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 400000 },
+                new ModelInfo { Id = "gpt-4o", DisplayName = "GPT-4o", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 128000 },
+                new ModelInfo { Id = "gpt-4o-mini", DisplayName = "GPT-4o Mini", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 128000 },
+                new ModelInfo { Id = "o3", DisplayName = "O3", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 200000 },
+                new ModelInfo { Id = "o3-mini", DisplayName = "O3 Mini", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 200000 },
+                new ModelInfo { Id = "o1", DisplayName = "O1", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 200000 },
+            ];
+        }
+
+        // Custom URL: return unified list
+        return
+        [
+            new ModelInfo { Id = "gpt-5.6-sol", DisplayName = "GPT-5.6-Sol", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", IsDefault = true, ContextWindow = 400000 },
+            new ModelInfo { Id = "gpt-5.6-terra", DisplayName = "GPT-5.6-Terra", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 272000 },
+            new ModelInfo { Id = "gpt-5.6-luna", DisplayName = "GPT-5.6-Luna", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Codex, Provider = "openai", ContextWindow = 272000 },
+            new ModelInfo { Id = "claude-opus-5", DisplayName = "Claude Opus 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+            new ModelInfo { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+            new ModelInfo { Id = "claude-haiku-5", DisplayName = "Claude Haiku 5", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+            new ModelInfo { Id = "claude-3-7-sonnet", DisplayName = "Claude 3.7 Sonnet", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+            new ModelInfo { Id = "claude-3-5-sonnet", DisplayName = "Claude 3.5 Sonnet", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Claude, Provider = "anthropic" },
+            new ModelInfo { Id = "moonshotai/Kimi-K3", DisplayName = "Kimi K3", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "moonshot" },
+            new ModelInfo { Id = "deepseek-ai/DeepSeek-V3", DisplayName = "DeepSeek V3", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "deepseek" },
+            new ModelInfo { Id = "deepseek-ai/DeepSeek-R1", DisplayName = "DeepSeek R1", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.OpenCode, Provider = "deepseek" },
+            new ModelInfo { Id = "ivy-stem", DisplayName = "Ivy Stem", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy" },
+            new ModelInfo { Id = "ivy-root", DisplayName = "Ivy Root", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy" },
+            new ModelInfo { Id = "ivy-leaf", DisplayName = "Ivy Leaf", Capabilities = DefaultCaps, SupportedEfforts = EffortLevels.Ivy, Provider = "ivy" },
+        ];
     }
 }

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
@@ -281,4 +281,136 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
             .DistinctBy(m => m.Id, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }
+
+    public static async Task<(bool Success, string? ErrorMessage)> TestModelEndpointAsync(
+        string? baseUrl,
+        string? apiKey,
+        string model,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(model) || model == "__custom__" || model == "default")
+        {
+            return (false, "Please specify a valid model name.");
+        }
+
+        var url = baseUrl?.Trim().TrimEnd('/') ?? "";
+        if (string.IsNullOrEmpty(url))
+        {
+            url = "https://api.openai.com";
+        }
+
+        var isAnthropic = url.Contains("api.anthropic.com");
+        var isIvy = url.Contains("llmproxy.ivy.app") || url.Contains("ivy.app");
+
+        var endpointsToTry = new List<(string Url, bool IsAnthropic)>();
+        if (isAnthropic)
+        {
+            endpointsToTry.Add(("https://api.anthropic.com/v1/messages", true));
+        }
+        else if (isIvy)
+        {
+            endpointsToTry.Add(($"{url}/v1/chat/completions", false));
+            endpointsToTry.Add(($"{url}/chat/completions", false));
+            endpointsToTry.Add(($"{url}/v1/messages", true));
+        }
+        else
+        {
+            if (url.EndsWith("/v1", StringComparison.OrdinalIgnoreCase))
+            {
+                endpointsToTry.Add(($"{url}/chat/completions", false));
+            }
+            else
+            {
+                endpointsToTry.Add(($"{url}/v1/chat/completions", false));
+                endpointsToTry.Add(($"{url}/chat/completions", false));
+            }
+        }
+
+        string? lastError = null;
+
+        foreach (var (endpointUrl, useAnthropicFormat) in endpointsToTry)
+        {
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, endpointUrl);
+                if (!string.IsNullOrWhiteSpace(apiKey))
+                {
+                    if (useAnthropicFormat)
+                    {
+                        request.Headers.Add("x-api-key", apiKey);
+                        request.Headers.Add("anthropic-version", "2023-06-01");
+                    }
+                    else
+                    {
+                        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+                    }
+                }
+
+                object payload = useAnthropicFormat
+                    ? new
+                    {
+                        model,
+                        max_tokens = 5,
+                        messages = new[] { new { role = "user", content = "hi" } }
+                    }
+                    : new
+                    {
+                        model,
+                        max_tokens = 5,
+                        messages = new[] { new { role = "user", content = "hi" } }
+                    };
+
+                var jsonPayload = JsonSerializer.Serialize(payload);
+                request.Content = new StringContent(jsonPayload, System.Text.Encoding.UTF8, "application/json");
+
+                using var response = await HttpClient.SendAsync(request, ct);
+                if (response.IsSuccessStatusCode)
+                {
+                    return (true, null);
+                }
+
+                var errorBody = await response.Content.ReadAsStringAsync(ct);
+                lastError = ExtractErrorMessage(response.StatusCode, errorBody);
+            }
+            catch (Exception ex)
+            {
+                lastError = ex.Message;
+            }
+        }
+
+        return (false, lastError ?? "Failed to connect to endpoint.");
+    }
+
+    private static string ExtractErrorMessage(System.Net.HttpStatusCode statusCode, string responseBody)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(responseBody);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("error", out var errorEl))
+            {
+                if (errorEl.ValueKind == JsonValueKind.String)
+                {
+                    return errorEl.GetString() ?? $"HTTP {(int)statusCode}";
+                }
+                if (errorEl.TryGetProperty("message", out var msgEl))
+                {
+                    return msgEl.GetString() ?? $"HTTP {(int)statusCode}";
+                }
+            }
+            if (root.TryGetProperty("message", out var directMsgEl))
+            {
+                return directMsgEl.GetString() ?? $"HTTP {(int)statusCode}";
+            }
+        }
+        catch
+        {
+            if (!string.IsNullOrWhiteSpace(responseBody) && responseBody.Length < 200)
+            {
+                return $"{statusCode}: {responseBody.Trim()}";
+            }
+        }
+
+        return $"HTTP {(int)statusCode} ({statusCode})";
+    }
 }

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs
@@ -54,7 +54,7 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
         var staticModels = GetModelsForBaseUrl(baseUrl);
         var url = baseUrl?.Trim().TrimEnd('/') ?? "";
 
-        if (string.IsNullOrEmpty(url) || url.Contains("llmproxy.ivy.app") || url.Contains("ivy.app"))
+        if (string.IsNullOrEmpty(url))
         {
             return staticModels;
         }
@@ -383,6 +383,11 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
 
     private static string ExtractErrorMessage(System.Net.HttpStatusCode statusCode, string responseBody)
     {
+        if (string.IsNullOrWhiteSpace(responseBody))
+        {
+            return $"HTTP {(int)statusCode} ({statusCode})";
+        }
+
         try
         {
             using var doc = JsonDocument.Parse(responseBody);
@@ -405,9 +410,16 @@ public sealed class OpenAiProxyModelCatalog : IModelCatalogProvider
         }
         catch
         {
-            if (!string.IsNullOrWhiteSpace(responseBody) && responseBody.Length < 200)
+            var trimmed = responseBody.Trim();
+            var match = System.Text.RegularExpressions.Regex.Match(trimmed, @"['""](?:error|message)['""]\s*:\s*['""]([^'""]+)['""]");
+            if (match.Success)
             {
-                return $"{statusCode}: {responseBody.Trim()}";
+                return match.Groups[1].Value;
+            }
+
+            if (trimmed.Length < 200)
+            {
+                return trimmed;
             }
         }
 

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
@@ -44,6 +44,15 @@ public sealed class OpenAiProxyPty : IAgentPty
                     new AgentProfileDefault(ProfileTier.Quick, "claude-haiku-5", "low"),
                 ];
             }
+            if (baseUrl != null && (baseUrl.Contains("generativelanguage.googleapis.com") || baseUrl.Contains("gemini") || baseUrl.Contains("google")))
+            {
+                return
+                [
+                    new AgentProfileDefault(ProfileTier.Deep, "gemini-3.1-pro", "high"),
+                    new AgentProfileDefault(ProfileTier.Balanced, "gemini-3.6-flash", "medium"),
+                    new AgentProfileDefault(ProfileTier.Quick, "gemini-3.7-flash", "low"),
+                ];
+            }
             if (baseUrl != null && baseUrl.Contains("api.berget.ai"))
             {
                 return
@@ -80,6 +89,10 @@ public sealed class OpenAiProxyPty : IAgentPty
             else if (baseUrl != null && baseUrl.Contains("api.anthropic.com"))
             {
                 config = config with { Model = "claude-sonnet-5" };
+            }
+            else if (baseUrl != null && (baseUrl.Contains("generativelanguage.googleapis.com") || baseUrl.Contains("gemini") || baseUrl.Contains("google")))
+            {
+                config = config with { Model = "gemini-3.6-flash" };
             }
             else if (baseUrl != null && baseUrl.Contains("api.berget.ai"))
             {

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
@@ -48,9 +48,9 @@ public sealed class OpenAiProxyPty : IAgentPty
             {
                 return
                 [
-                    new AgentProfileDefault(ProfileTier.Deep, "gemini-3.1-pro", "high"),
-                    new AgentProfileDefault(ProfileTier.Balanced, "gemini-3.6-flash", "medium"),
-                    new AgentProfileDefault(ProfileTier.Quick, "gemini-3.7-flash", "low"),
+                    new AgentProfileDefault(ProfileTier.Deep, "gemini-3.7-flash", "high"),
+                    new AgentProfileDefault(ProfileTier.Balanced, "gemini-3.7-flash", "medium"),
+                    new AgentProfileDefault(ProfileTier.Quick, "gemini-3.7-flash", "medium"),
                 ];
             }
             if (baseUrl != null && baseUrl.Contains("api.berget.ai"))

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
@@ -26,16 +26,39 @@ public sealed class OpenAiProxyPty : IAgentPty
         get
         {
             var baseUrl = _baseUrlProvider();
+            if (baseUrl != null && baseUrl.Contains("llmproxy.ivy.app"))
+            {
+                return
+                [
+                    new AgentProfileDefault(ProfileTier.Deep, "ivy-stem", "max"),
+                    new AgentProfileDefault(ProfileTier.Balanced, "ivy-root", "high"),
+                    new AgentProfileDefault(ProfileTier.Quick, "ivy-leaf", "low"),
+                ];
+            }
+            if (baseUrl != null && baseUrl.Contains("api.anthropic.com"))
+            {
+                return
+                [
+                    new AgentProfileDefault(ProfileTier.Deep, "claude-opus-5", "max"),
+                    new AgentProfileDefault(ProfileTier.Balanced, "claude-sonnet-5", "high"),
+                    new AgentProfileDefault(ProfileTier.Quick, "claude-haiku-5", "low"),
+                ];
+            }
             if (baseUrl != null && baseUrl.Contains("api.berget.ai"))
             {
                 return
                 [
-                    new AgentProfileDefault(ProfileTier.Deep, "moonshotai/Kimi-K3", null),
-                    new AgentProfileDefault(ProfileTier.Balanced, "moonshotai/Kimi-K3", null),
-                    new AgentProfileDefault(ProfileTier.Quick, "moonshotai/Kimi-K3", null),
+                    new AgentProfileDefault(ProfileTier.Deep, "moonshotai/Kimi-K3", "max"),
+                    new AgentProfileDefault(ProfileTier.Balanced, "moonshotai/Kimi-K3", "high"),
+                    new AgentProfileDefault(ProfileTier.Quick, "moonshotai/Kimi-K3", "low"),
                 ];
             }
-            return _inner.DefaultProfiles;
+            return
+            [
+                new AgentProfileDefault(ProfileTier.Deep, "gpt-5.6-sol", "high"),
+                new AgentProfileDefault(ProfileTier.Balanced, "gpt-5.6-terra", "medium"),
+                new AgentProfileDefault(ProfileTier.Quick, "gpt-5.6-luna", "low"),
+            ];
         }
     }
     public string? ContextFileName => _inner.ContextFileName;
@@ -47,13 +70,24 @@ public sealed class OpenAiProxyPty : IAgentPty
     public AgentPtySpec BuildPtySpec(AgentPtyConfig config)
     {
         var baseUrl = _baseUrlProvider();
-        var isBerget = baseUrl?.Contains("api.berget.ai") ?? false;
-        if (isBerget)
+        var model = config.Model;
+        if (string.IsNullOrEmpty(model) || model == "default")
         {
-            var model = config.Model;
-            if (string.IsNullOrEmpty(model) || model == "default" || model.Equals("kimi-k3", StringComparison.OrdinalIgnoreCase) || !model.Contains('/'))
+            if (baseUrl != null && baseUrl.Contains("llmproxy.ivy.app"))
+            {
+                config = config with { Model = "ivy-stem" };
+            }
+            else if (baseUrl != null && baseUrl.Contains("api.anthropic.com"))
+            {
+                config = config with { Model = "claude-sonnet-5" };
+            }
+            else if (baseUrl != null && baseUrl.Contains("api.berget.ai"))
             {
                 config = config with { Model = "moonshotai/Kimi-K3" };
+            }
+            else
+            {
+                config = config with { Model = "gpt-5.6-terra" };
             }
         }
 

--- a/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs
@@ -30,9 +30,9 @@ public sealed class OpenAiProxyPty : IAgentPty
             {
                 return
                 [
-                    new AgentProfileDefault(ProfileTier.Deep, "ivy-stem", "max"),
-                    new AgentProfileDefault(ProfileTier.Balanced, "ivy-root", "high"),
-                    new AgentProfileDefault(ProfileTier.Quick, "ivy-leaf", "low"),
+                    new AgentProfileDefault(ProfileTier.Deep, "claude-opus-5", "max"),
+                    new AgentProfileDefault(ProfileTier.Balanced, "gemini-3.7-flash", "medium"),
+                    new AgentProfileDefault(ProfileTier.Quick, "gemini-3.7-flash", "low"),
                 ];
             }
             if (baseUrl != null && baseUrl.Contains("api.anthropic.com"))
@@ -84,7 +84,7 @@ public sealed class OpenAiProxyPty : IAgentPty
         {
             if (baseUrl != null && baseUrl.Contains("llmproxy.ivy.app"))
             {
-                config = config with { Model = "ivy-stem" };
+                config = config with { Model = "claude-opus-5" };
             }
             else if (baseUrl != null && baseUrl.Contains("api.anthropic.com"))
             {
@@ -92,7 +92,7 @@ public sealed class OpenAiProxyPty : IAgentPty
             }
             else if (baseUrl != null && (baseUrl.Contains("generativelanguage.googleapis.com") || baseUrl.Contains("gemini") || baseUrl.Contains("google")))
             {
-                config = config with { Model = "gemini-3.6-flash" };
+                config = config with { Model = "gemini-3.7-flash" };
             }
             else if (baseUrl != null && baseUrl.Contains("api.berget.ai"))
             {

--- a/src/Ivy.Tendril.Agents/Runtime/ModelPricingProvider.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/ModelPricingProvider.cs
@@ -50,9 +50,17 @@ public sealed class ModelPricingProvider : IModelPricingProvider, IModelPricingR
 
                 var hasPricing = model.InputPerMillion > 0 || model.OutputPerMillion > 0;
                 if (hasPricing)
-                    pricing[model.Id] = entry;
+                {
+                    if (!pricing.TryGetValue(model.Id, out var existing) ||
+                        (existing.InputPerMillion == 0 && existing.OutputPerMillion == 0))
+                    {
+                        pricing[model.Id] = entry;
+                    }
+                }
                 else
+                {
                     pricing.TryAdd(model.Id, entry);
+                }
 
             }
         }

--- a/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
@@ -61,24 +61,23 @@ public class OpenAiProxyTests
     }
 
     [Fact]
-    public void IvyModelCatalog_GetStaticModels_ReturnsIvyModelsOnly()
+    public void IvyModelCatalog_GetStaticModels_ReturnsStandardModels()
     {
         var catalog = new IvyModelCatalog();
         var models = catalog.GetStaticModels();
 
-        Assert.Contains(models, m => m.Id == "ivy-stem" && m.DisplayName == "Ivy Stem");
-        Assert.Contains(models, m => m.Id == "ivy-root" && m.DisplayName == "Ivy Root");
-        Assert.Contains(models, m => m.Id == "ivy-leaf" && m.DisplayName == "Ivy Leaf");
-        Assert.All(models, m => Assert.True(m.Id.StartsWith("ivy") || m.Id == "default"));
+        Assert.Contains(models, m => m.Id == "claude-opus-5");
+        Assert.Contains(models, m => m.Id == "gemini-3.7-flash");
+        Assert.Contains(models, m => m.Id == "gpt-5.6-sol");
     }
 
     [Fact]
     public void OpenAiProxyModelCatalog_GetModelsForBaseUrl_ReturnsProviderSpecificModels()
     {
         var ivyModels = OpenAiProxyModelCatalog.GetModelsForBaseUrl("https://llmproxy.ivy.app");
-        Assert.Contains(ivyModels, m => m.Id == "ivy-stem");
-        Assert.Contains(ivyModels, m => m.Id == "ivy-root");
-        Assert.Contains(ivyModels, m => m.Id == "ivy-leaf");
+        Assert.Contains(ivyModels, m => m.Id == "claude-opus-5");
+        Assert.Contains(ivyModels, m => m.Id == "gemini-3.7-flash");
+        Assert.Contains(ivyModels, m => m.Id == "gpt-5.6-sol");
 
         var anthropicModels = OpenAiProxyModelCatalog.GetModelsForBaseUrl("https://api.anthropic.com/v1");
         Assert.Contains(anthropicModels, m => m.Id == "claude-opus-5");
@@ -113,16 +112,32 @@ public class OpenAiProxyTests
         var cli = new IvyCli();
         var defaults = cli.DefaultProfiles;
 
-        Assert.Equal("ivy-stem", defaults.First(p => p.Tier == ProfileTier.Deep).Model);
-        Assert.Equal("ivy-root", defaults.First(p => p.Tier == ProfileTier.Balanced).Model);
-        Assert.Equal("ivy-leaf", defaults.First(p => p.Tier == ProfileTier.Quick).Model);
+        var deep = defaults.First(p => p.Tier == ProfileTier.Deep);
+        var balanced = defaults.First(p => p.Tier == ProfileTier.Balanced);
+        var quick = defaults.First(p => p.Tier == ProfileTier.Quick);
+
+        Assert.Equal("claude-opus-5", deep.Model);
+        Assert.Equal("max", deep.Effort);
+        Assert.Equal("gemini-3.7-flash", balanced.Model);
+        Assert.Equal("medium", balanced.Effort);
+        Assert.Equal("gemini-3.7-flash", quick.Model);
+        Assert.Equal("low", quick.Effort);
     }
 
     [Fact]
     public void OpenAiProxyCli_DefaultProfiles_FollowsBaseUrl()
     {
         var ivyCli = new OpenAiProxyCli(baseUrlProvider: () => "https://llmproxy.ivy.app");
-        Assert.Equal("ivy-stem", ivyCli.DefaultProfiles.First(p => p.Tier == ProfileTier.Deep).Model);
+        var ivyDeep = ivyCli.DefaultProfiles.First(p => p.Tier == ProfileTier.Deep);
+        var ivyBalanced = ivyCli.DefaultProfiles.First(p => p.Tier == ProfileTier.Balanced);
+        var ivyQuick = ivyCli.DefaultProfiles.First(p => p.Tier == ProfileTier.Quick);
+
+        Assert.Equal("claude-opus-5", ivyDeep.Model);
+        Assert.Equal("max", ivyDeep.Effort);
+        Assert.Equal("gemini-3.7-flash", ivyBalanced.Model);
+        Assert.Equal("medium", ivyBalanced.Effort);
+        Assert.Equal("gemini-3.7-flash", ivyQuick.Model);
+        Assert.Equal("low", ivyQuick.Effort);
 
         var anthropicCli = new OpenAiProxyCli(baseUrlProvider: () => "https://api.anthropic.com/v1");
         Assert.Equal("claude-opus-5", anthropicCli.DefaultProfiles.First(p => p.Tier == ProfileTier.Deep).Model);

--- a/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
@@ -82,7 +82,15 @@ public class OpenAiProxyTests
 
         var anthropicModels = OpenAiProxyModelCatalog.GetModelsForBaseUrl("https://api.anthropic.com/v1");
         Assert.Contains(anthropicModels, m => m.Id == "claude-opus-5");
+        Assert.Contains(anthropicModels, m => m.Id == "claude-opus-4-8");
+        Assert.Contains(anthropicModels, m => m.Id == "claude-opus-4-7");
+        Assert.Contains(anthropicModels, m => m.Id == "claude-opus-4-6");
         Assert.Contains(anthropicModels, m => m.Id == "claude-sonnet-5");
+        Assert.Contains(anthropicModels, m => m.Id == "claude-sonnet-4-6");
+
+        var googleModels = OpenAiProxyModelCatalog.GetModelsForBaseUrl("https://generativelanguage.googleapis.com/v1beta");
+        Assert.Contains(googleModels, m => m.Id == "gemini-3.7-flash");
+        Assert.Contains(googleModels, m => m.Id == "gemini-3.6-flash");
 
         var openaiModels = OpenAiProxyModelCatalog.GetModelsForBaseUrl("https://api.openai.com");
         Assert.Contains(openaiModels, m => m.Id == "gpt-5.6-sol");
@@ -90,6 +98,13 @@ public class OpenAiProxyTests
 
         var bergetModels = OpenAiProxyModelCatalog.GetModelsForBaseUrl("https://api.berget.ai/v1");
         Assert.Contains(bergetModels, m => m.Id == "moonshotai/Kimi-K3");
+
+        var customModels = OpenAiProxyModelCatalog.GetModelsForBaseUrl("https://custom-proxy.internal");
+        Assert.Contains(customModels, m => m.Id == "claude-opus-4-8");
+        Assert.Contains(customModels, m => m.Id == "claude-opus-4-7");
+        Assert.Contains(customModels, m => m.Id == "claude-sonnet-4-6");
+        Assert.Contains(customModels, m => m.Id == "gemini-3.7-flash");
+        Assert.Contains(customModels, m => m.Id == "gpt-5.6-sol");
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
@@ -142,4 +142,12 @@ public class OpenAiProxyTests
         Assert.Equal("gemini-3.7-flash", googleQuick.Model);
         Assert.Equal("medium", googleQuick.Effort);
     }
+
+    [Fact]
+    public async Task OpenAiProxyModelCatalog_FetchModelsFromEndpointAsync_ReturnsStaticFallbackWhenOffline()
+    {
+        var models = await OpenAiProxyModelCatalog.FetchModelsFromEndpointAsync("http://127.0.0.1:54321/v1", "sk-test");
+        Assert.NotEmpty(models);
+        Assert.Contains(models, m => m.Id == "gpt-5.6-sol");
+    }
 }

--- a/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
@@ -129,5 +129,17 @@ public class OpenAiProxyTests
 
         var openaiCli = new OpenAiProxyCli(baseUrlProvider: () => "https://api.openai.com");
         Assert.Equal("gpt-5.6-sol", openaiCli.DefaultProfiles.First(p => p.Tier == ProfileTier.Deep).Model);
+
+        var googleCli = new OpenAiProxyCli(baseUrlProvider: () => "https://generativelanguage.googleapis.com/v1beta");
+        var googleDeep = googleCli.DefaultProfiles.First(p => p.Tier == ProfileTier.Deep);
+        var googleBalanced = googleCli.DefaultProfiles.First(p => p.Tier == ProfileTier.Balanced);
+        var googleQuick = googleCli.DefaultProfiles.First(p => p.Tier == ProfileTier.Quick);
+
+        Assert.Equal("gemini-3.7-flash", googleDeep.Model);
+        Assert.Equal("high", googleDeep.Effort);
+        Assert.Equal("gemini-3.7-flash", googleBalanced.Model);
+        Assert.Equal("medium", googleBalanced.Effort);
+        Assert.Equal("gemini-3.7-flash", googleQuick.Model);
+        Assert.Equal("medium", googleQuick.Effort);
     }
 }

--- a/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
@@ -159,11 +159,19 @@ public class OpenAiProxyTests
     }
 
     [Fact]
-    public async Task OpenAiProxyModelCatalog_FetchModelsFromEndpointAsync_ReturnsStaticFallbackWhenOffline()
+    public async Task OpenAiProxyModelCatalog_FetchModelsFromEndpointAsync_ReturnsEmptyWhenOffline()
     {
         var models = await OpenAiProxyModelCatalog.FetchModelsFromEndpointAsync("http://127.0.0.1:54321/v1", "sk-test");
-        Assert.NotEmpty(models);
-        Assert.Contains(models, m => m.Id == "gpt-5.6-sol");
+        Assert.Empty(models);
+    }
+
+    [Fact]
+    public async Task OpenAiProxyModelCatalog_GetModelsAsync_ReturnsStaticFallbackWhenOffline()
+    {
+        var catalog = new OpenAiProxyModelCatalog(() => "http://127.0.0.1:54321/v1", () => "sk-test");
+        var result = await catalog.GetModelsAsync();
+        Assert.NotEmpty(result.Models);
+        Assert.Contains(result.Models, m => m.Id == "gpt-5.6-sol");
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
@@ -71,4 +71,48 @@ public class OpenAiProxyTests
         Assert.Contains(models, m => m.Id == "ivy-leaf" && m.DisplayName == "Ivy Leaf");
         Assert.All(models, m => Assert.True(m.Id.StartsWith("ivy") || m.Id == "default"));
     }
+
+    [Fact]
+    public void OpenAiProxyModelCatalog_GetModelsForBaseUrl_ReturnsProviderSpecificModels()
+    {
+        var ivyModels = OpenAiProxyModelCatalog.GetModelsForBaseUrl("https://llmproxy.ivy.app");
+        Assert.Contains(ivyModels, m => m.Id == "ivy-stem");
+        Assert.Contains(ivyModels, m => m.Id == "ivy-root");
+        Assert.Contains(ivyModels, m => m.Id == "ivy-leaf");
+
+        var anthropicModels = OpenAiProxyModelCatalog.GetModelsForBaseUrl("https://api.anthropic.com/v1");
+        Assert.Contains(anthropicModels, m => m.Id == "claude-opus-5");
+        Assert.Contains(anthropicModels, m => m.Id == "claude-sonnet-5");
+
+        var openaiModels = OpenAiProxyModelCatalog.GetModelsForBaseUrl("https://api.openai.com");
+        Assert.Contains(openaiModels, m => m.Id == "gpt-5.6-sol");
+        Assert.Contains(openaiModels, m => m.Id == "gpt-5.6-terra");
+
+        var bergetModels = OpenAiProxyModelCatalog.GetModelsForBaseUrl("https://api.berget.ai/v1");
+        Assert.Contains(bergetModels, m => m.Id == "moonshotai/Kimi-K3");
+    }
+
+    [Fact]
+    public void IvyCli_DefaultProfiles_ReturnsIvyModels()
+    {
+        var cli = new IvyCli();
+        var defaults = cli.DefaultProfiles;
+
+        Assert.Equal("ivy-stem", defaults.First(p => p.Tier == ProfileTier.Deep).Model);
+        Assert.Equal("ivy-root", defaults.First(p => p.Tier == ProfileTier.Balanced).Model);
+        Assert.Equal("ivy-leaf", defaults.First(p => p.Tier == ProfileTier.Quick).Model);
+    }
+
+    [Fact]
+    public void OpenAiProxyCli_DefaultProfiles_FollowsBaseUrl()
+    {
+        var ivyCli = new OpenAiProxyCli(baseUrlProvider: () => "https://llmproxy.ivy.app");
+        Assert.Equal("ivy-stem", ivyCli.DefaultProfiles.First(p => p.Tier == ProfileTier.Deep).Model);
+
+        var anthropicCli = new OpenAiProxyCli(baseUrlProvider: () => "https://api.anthropic.com/v1");
+        Assert.Equal("claude-opus-5", anthropicCli.DefaultProfiles.First(p => p.Tier == ProfileTier.Deep).Model);
+
+        var openaiCli = new OpenAiProxyCli(baseUrlProvider: () => "https://api.openai.com");
+        Assert.Equal("gpt-5.6-sol", openaiCli.DefaultProfiles.First(p => p.Tier == ProfileTier.Deep).Model);
+    }
 }

--- a/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/OpenAiProxyTests.cs
@@ -150,4 +150,16 @@ public class OpenAiProxyTests
         Assert.NotEmpty(models);
         Assert.Contains(models, m => m.Id == "gpt-5.6-sol");
     }
+
+    [Fact]
+    public async Task OpenAiProxyModelCatalog_TestModelEndpointAsync_RejectsInvalidModelName()
+    {
+        var (okEmpty, errEmpty) = await OpenAiProxyModelCatalog.TestModelEndpointAsync("https://api.openai.com", "sk-test", "");
+        var (okCustom, errCustom) = await OpenAiProxyModelCatalog.TestModelEndpointAsync("https://api.openai.com", "sk-test", "__custom__");
+
+        Assert.False(okEmpty);
+        Assert.False(okCustom);
+        Assert.Contains("valid", errEmpty, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("valid", errCustom, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -104,6 +104,9 @@ public class CodingAgentStepView(
         var byoSubStep = UseState(0);
         var isFetchingModels = UseState(false);
         var fetchedModels = UseState<IReadOnlyList<ModelInfo>?>(null);
+        var isTestingModels = UseState(false);
+        var testFeedback = UseState<string?>(null);
+        var isTestSuccess = UseState<bool?>(null);
         var customDeepText = UseState("");
         var customBalancedText = UseState("");
         var customQuickText = UseState("");
@@ -121,6 +124,8 @@ public class CodingAgentStepView(
                 selectedAgent.Set(agentKey);
                 byoSubStep.Set(0);
                 fetchedModels.Set(null);
+                testFeedback.Set(null);
+                isTestSuccess.Set(null);
                 error.Set(null);
                 if (agentKey != "openaiproxy_card" && agentKey != "anthropic_card" && agentKey != "berget_card")
                 {
@@ -246,20 +251,36 @@ public class CodingAgentStepView(
                                        var models = await OpenAiProxyModelCatalog.FetchModelsFromEndpointAsync(baseUrl, openAiProxyApiKey.Value);
                                        fetchedModels.Set(models);
 
-                                       if (models.Count > 0)
+                                       // Set default profile models appropriately
+                                       if (isIvy)
                                        {
-                                           if (!models.Any(m => m.Id.Equals(deepModel.Value, StringComparison.OrdinalIgnoreCase)) && deepModel.Value != "__custom__")
-                                           {
-                                               deepModel.Set(models[0].Id);
-                                           }
-                                           if (!models.Any(m => m.Id.Equals(balancedModel.Value, StringComparison.OrdinalIgnoreCase)) && balancedModel.Value != "__custom__")
-                                           {
-                                               balancedModel.Set(models.Count > 1 ? models[1].Id : models[0].Id);
-                                           }
-                                           if (!models.Any(m => m.Id.Equals(quickModel.Value, StringComparison.OrdinalIgnoreCase)) && quickModel.Value != "__custom__")
-                                           {
-                                               quickModel.Set(models.Count > 2 ? models[2].Id : models[0].Id);
-                                           }
+                                           deepModel.Set("ivy-stem");
+                                           balancedModel.Set("ivy-root");
+                                           quickModel.Set("ivy-leaf");
+                                       }
+                                       else if (isAnthropicCard)
+                                       {
+                                           deepModel.Set(models.Any(m => m.Id == "claude-opus-5") ? "claude-opus-5" : (models.FirstOrDefault()?.Id ?? "claude-opus-5"));
+                                           balancedModel.Set(models.Any(m => m.Id == "claude-sonnet-5") ? "claude-sonnet-5" : (models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "claude-sonnet-5"));
+                                           quickModel.Set(models.Any(m => m.Id == "claude-haiku-5") ? "claude-haiku-5" : (models.ElementAtOrDefault(2)?.Id ?? models.FirstOrDefault()?.Id ?? "claude-haiku-5"));
+                                       }
+                                       else if (isBergetCard)
+                                       {
+                                           deepModel.Set("moonshotai/Kimi-K3");
+                                           balancedModel.Set("moonshotai/Kimi-K3");
+                                           quickModel.Set("moonshotai/Kimi-K3");
+                                       }
+                                       else if (isGoogle)
+                                       {
+                                           deepModel.Set("gemini-3.7-flash");
+                                           balancedModel.Set("gemini-3.7-flash");
+                                           quickModel.Set("gemini-3.7-flash");
+                                       }
+                                       else
+                                       {
+                                           deepModel.Set(models.Any(m => m.Id == "gpt-5.6-sol") ? "gpt-5.6-sol" : (models.FirstOrDefault()?.Id ?? "gpt-5.6-sol"));
+                                           balancedModel.Set(models.Any(m => m.Id == "gpt-5.6-terra") ? "gpt-5.6-terra" : (models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "gpt-5.6-terra"));
+                                           quickModel.Set(models.Any(m => m.Id == "gpt-5.6-luna") ? "gpt-5.6-luna" : (models.ElementAtOrDefault(2)?.Id ?? models.FirstOrDefault()?.Id ?? "gpt-5.6-luna"));
                                        }
 
                                        byoSubStep.Set(1);
@@ -282,6 +303,20 @@ public class CodingAgentStepView(
                 .Select(m => new Option<string>(m.DisplayName, m.Id))
                 .Concat([new Option<string>("+ Custom Model Name...", "__custom__")])
                 .ToArray<IAnyOption>();
+
+            // Ensure valid selected values
+            if (deepModel.Value == "default" || (!modelsList.Any(m => m.Id.Equals(deepModel.Value, StringComparison.OrdinalIgnoreCase)) && deepModel.Value != "__custom__"))
+            {
+                deepModel.Set(modelsList.FirstOrDefault()?.Id ?? "__custom__");
+            }
+            if (balancedModel.Value == "default" || (!modelsList.Any(m => m.Id.Equals(balancedModel.Value, StringComparison.OrdinalIgnoreCase)) && balancedModel.Value != "__custom__"))
+            {
+                balancedModel.Set(modelsList.ElementAtOrDefault(1)?.Id ?? modelsList.FirstOrDefault()?.Id ?? "__custom__");
+            }
+            if (quickModel.Value == "default" || (!modelsList.Any(m => m.Id.Equals(quickModel.Value, StringComparison.OrdinalIgnoreCase)) && quickModel.Value != "__custom__"))
+            {
+                quickModel.Set(modelsList.ElementAtOrDefault(2)?.Id ?? modelsList.FirstOrDefault()?.Id ?? "__custom__");
+            }
 
             object profileModels = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
                 | Text.Block("Profile Models").Bold()
@@ -306,6 +341,11 @@ public class CodingAgentStepView(
                    | Text.H3($"{cardTitle} — Select Models")
                    | (error.Value != null ? Text.Danger(error.Value) : null!)
                    | profileModels
+                   | (testFeedback.Value != null
+                       ? (isTestSuccess.Value == true
+                           ? Text.Success($"✓ {testFeedback.Value}")
+                           : Text.Danger($"✗ {testFeedback.Value}"))
+                       : null!)
                    | (Layout.Horizontal()
                        | new Button("Back")
                            .Ghost()
@@ -313,6 +353,89 @@ public class CodingAgentStepView(
                            {
                                byoSubStep.Set(0);
                                error.Set(null);
+                               testFeedback.Set(null);
+                               isTestSuccess.Set(null);
+                           })
+                       | new Button("Test Endpoint")
+                           .Outline()
+                           .Loading(isTestingModels.Value)
+                           .OnClick(async () =>
+                           {
+                               testFeedback.Set(null);
+                               isTestSuccess.Set(null);
+                               error.Set(null);
+
+                               var dm = deepModel.Value == "__custom__"
+                                   ? customDeepText.Value.Trim()
+                                   : deepModel.Value;
+                               var bm = balancedModel.Value == "__custom__"
+                                   ? customBalancedText.Value.Trim()
+                                   : balancedModel.Value;
+                               var qm = quickModel.Value == "__custom__"
+                                   ? customQuickText.Value.Trim()
+                                   : quickModel.Value;
+
+                               if (string.IsNullOrWhiteSpace(dm) || dm == "__custom__")
+                               {
+                                   testFeedback.Set("Please specify a valid model for Deep profile.");
+                                   isTestSuccess.Set(false);
+                                   return;
+                               }
+                               if (string.IsNullOrWhiteSpace(bm) || bm == "__custom__")
+                               {
+                                   testFeedback.Set("Please specify a valid model for Balanced profile.");
+                                   isTestSuccess.Set(false);
+                                   return;
+                               }
+                               if (string.IsNullOrWhiteSpace(qm) || qm == "__custom__")
+                               {
+                                   testFeedback.Set("Please specify a valid model for Quick profile.");
+                                   isTestSuccess.Set(false);
+                                   return;
+                               }
+
+                               var baseUrl = isBergetCard || string.IsNullOrWhiteSpace(openAiProxyBaseUrl.Value)
+                                   ? defaultUrl
+                                   : openAiProxyBaseUrl.Value;
+
+                               isTestingModels.Set(true);
+                               try
+                               {
+                                   var modelsToTest = new (string Tier, string Model)[]
+                                   {
+                                       ("Deep", dm),
+                                       ("Balanced", bm),
+                                       ("Quick", qm)
+                                   };
+
+                                   var uniqueModels = modelsToTest
+                                       .GroupBy(m => m.Model, StringComparer.OrdinalIgnoreCase)
+                                       .Select(g => (Tiers: string.Join("/", g.Select(x => x.Tier)), Model: g.Key))
+                                       .ToList();
+
+                                   foreach (var (tier, modelId) in uniqueModels)
+                                   {
+                                       var (ok, err) = await OpenAiProxyModelCatalog.TestModelEndpointAsync(baseUrl, openAiProxyApiKey.Value, modelId);
+                                       if (!ok)
+                                       {
+                                           testFeedback.Set($"{tier} model '{modelId}' failed: {err}");
+                                           isTestSuccess.Set(false);
+                                           return;
+                                       }
+                                   }
+
+                                   testFeedback.Set("All profile models responded successfully!");
+                                   isTestSuccess.Set(true);
+                               }
+                               catch (Exception ex)
+                               {
+                                   testFeedback.Set($"Test error: {ex.Message}");
+                                   isTestSuccess.Set(false);
+                               }
+                               finally
+                               {
+                                   isTestingModels.Set(false);
+                               }
                            })
                        | new Button("Continue")
                            .Primary()
@@ -378,7 +501,7 @@ public class CodingAgentStepView(
             : (selectedAgent.Value == "anthropic_card" ? "Anthropic"
             : (selectedAgent.Value == "openaiproxy" ? "OpenAI Proxy" : selectedAgent.Value))));
 
-        return Layout.Vertical().Margin(0, 0, 0, 2)
+        return Layout.Vertical()
                | Text.Block(progressMessage.Value ?? $"Setting Up {selectedLabel}")
                | (progressValue.Value != null
                    ? new Progress(progressValue.Value.Value)

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Providers.OpenAiProxy;
 using Ivy.Tendril.Apps.Onboarding.Models;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
@@ -95,6 +96,11 @@ public class CodingAgentStepView(
             GetOpenAiProxyApiKeyFromConfig(config)
         );
 
+        var deepModel = UseState("default");
+        var balancedModel = UseState("default");
+        var quickModel = UseState("default");
+        var lastDetectedProvider = UseState<string?>(null);
+
         var (installDialog, showInstallDialog) = UseTrigger<InstallDialogArgs>((isOpen, args) =>
             new InstallMissingDialog(isOpen, args));
 
@@ -116,18 +122,68 @@ public class CodingAgentStepView(
 
         if (progressMessage.Value is null && (selectedAgent.Value == "openaiproxy_card" || selectedAgent.Value == "anthropic_card" || selectedAgent.Value == "berget_card"))
         {
-            var isAnthropicCard = selectedAgent.Value == "anthropic_card";
-            var isBergetCard = selectedAgent.Value == "berget_card";
-            var cardTitle = isBergetCard ? "Setup Berget AI" : (isAnthropicCard ? "Setup Anthropic" : "Setup OpenAI");
-            var defaultUrl = isBergetCard ? "https://api.berget.ai/v1" : (isAnthropicCard ? "https://api.anthropic.com/v1" : "https://api.openai.com");
+            var isIvy = openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app") || openAiProxyBaseUrl.Value.Contains("ivy.app");
+            var isAnthropicCard = !isIvy && (selectedAgent.Value == "anthropic_card" || openAiProxyBaseUrl.Value.Contains("api.anthropic.com"));
+            var isBergetCard = !isIvy && (selectedAgent.Value == "berget_card" || openAiProxyBaseUrl.Value.Contains("api.berget.ai"));
+
+            var cardTitle = isIvy
+                ? "Setup Ivy Proxy"
+                : (isBergetCard
+                    ? "Setup Berget AI"
+                    : (isAnthropicCard
+                        ? "Setup Anthropic"
+                        : "Setup OpenAI"));
+
+            var defaultUrl = isIvy
+                ? "https://llmproxy.ivy.app"
+                : (isBergetCard
+                    ? "https://api.berget.ai/v1"
+                    : (isAnthropicCard
+                        ? "https://api.anthropic.com/v1"
+                        : "https://api.openai.com"));
 
             if (string.IsNullOrWhiteSpace(openAiProxyBaseUrl.Value) ||
                 (isBergetCard && !openAiProxyBaseUrl.Value.Contains("api.berget.ai")) ||
                 (isAnthropicCard && (openAiProxyBaseUrl.Value == "https://api.openai.com" || openAiProxyBaseUrl.Value.Contains("api.berget.ai"))) ||
-                (!isAnthropicCard && !isBergetCard && (openAiProxyBaseUrl.Value.Contains("api.anthropic.com") || openAiProxyBaseUrl.Value.Contains("api.berget.ai"))))
+                (!isAnthropicCard && !isBergetCard && !isIvy && (openAiProxyBaseUrl.Value.Contains("api.anthropic.com") || openAiProxyBaseUrl.Value.Contains("api.berget.ai"))))
             {
                 openAiProxyBaseUrl.Set(defaultUrl);
             }
+
+            var currentProviderKey = isIvy ? "ivy" : (isAnthropicCard ? "anthropic" : (isBergetCard ? "berget" : "openai"));
+            if (lastDetectedProvider.Value != currentProviderKey)
+            {
+                lastDetectedProvider.Set(currentProviderKey);
+                if (isIvy)
+                {
+                    deepModel.Set("ivy-stem");
+                    balancedModel.Set("ivy-root");
+                    quickModel.Set("ivy-leaf");
+                }
+                else if (isAnthropicCard)
+                {
+                    deepModel.Set("claude-opus-5");
+                    balancedModel.Set("claude-sonnet-5");
+                    quickModel.Set("claude-haiku-5");
+                }
+                else if (isBergetCard)
+                {
+                    deepModel.Set("moonshotai/Kimi-K3");
+                    balancedModel.Set("moonshotai/Kimi-K3");
+                    quickModel.Set("moonshotai/Kimi-K3");
+                }
+                else
+                {
+                    deepModel.Set("gpt-5.6-sol");
+                    balancedModel.Set("gpt-5.6-terra");
+                    quickModel.Set("gpt-5.6-luna");
+                }
+            }
+
+            var availableModels = OpenAiProxyModelCatalog.GetModelsForBaseUrl(openAiProxyBaseUrl.Value);
+            var modelOptions = availableModels
+                .Select(m => new Option<string>(m.DisplayName, m.Id))
+                .ToArray<IAnyOption>();
 
             object agentInputs = isBergetCard
                 ? (Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
@@ -142,11 +198,18 @@ public class CodingAgentStepView(
                         .WithField()
                         .Label("API Key"));
 
-            return Layout.Vertical().Margin(0, 0, 0, 2)
+            object profileModels = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                | Text.Block("Profile Models").Bold()
+                | deepModel.ToSelectInput(modelOptions).WithField().Label("Deep")
+                | balancedModel.ToSelectInput(modelOptions).WithField().Label("Balanced")
+                | quickModel.ToSelectInput(modelOptions).WithField().Label("Quick");
+
+            return Layout.Vertical()
                    | Text.H3(cardTitle)
                    | (error.Value != null ? Text.Danger(error.Value) : null!)
                    | agentInputs
-                   | (Layout.Horizontal().Margin(2, 0, 0, 0)
+                   | profileModels
+                   | (Layout.Horizontal()
                        | new Button("Back")
                            .Ghost()
                            .OnClick(() =>
@@ -168,15 +231,29 @@ public class CodingAgentStepView(
                                    ? defaultUrl
                                    : openAiProxyBaseUrl.Value;
 
-                               SaveOpenAiProxyBaseUrl(config, baseUrl);
-                               SaveOpenAiProxyApiKey(config, openAiProxyApiKey.Value);
-                               if (isBergetCard)
+                               var targetAgent = isIvy ? "ivy" : "openaiproxy";
+                               var dm = deepModel.Value;
+                               var bm = balancedModel.Value;
+                               var qm = quickModel.Value;
+
+                               if (isIvy)
                                {
-                                   SaveProfiles(config, "openaiproxy", "moonshotai/Kimi-K3", "moonshotai/Kimi-K3", "moonshotai/Kimi-K3");
+                                   SaveProfiles(config, "ivy", dm, bm, qm);
+                                   SaveIvyApiKey(config, openAiProxyApiKey.Value);
+                                   SaveOpenAiProxyApiKey(config, "");
+                                   SaveOpenAiProxyBaseUrl(config, "");
+                               }
+                               else
+                               {
+                                   SaveProfiles(config, "openaiproxy", dm, bm, qm);
+                                   SaveOpenAiProxyBaseUrl(config, baseUrl);
+                                   SaveOpenAiProxyApiKey(config, openAiProxyApiKey.Value);
+                                   SaveIvyApiKey(config, "");
                                }
 
+                               config.Settings.CodingAgent = targetAgent;
                                config.SaveSettings();
-                               _ = RunFlowAsync("openaiproxy");
+                               _ = RunFlowAsync(targetAgent);
                            })
                    );
         }
@@ -429,6 +506,27 @@ public class CodingAgentStepView(
         if (ac == null)
         {
             ac = new AgentConfig { Name = "openaiproxy" };
+            config.Settings.CodingAgents.Add(ac);
+        }
+
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            ac.EnvironmentVariables.Remove("ANTHROPIC_API_KEY");
+        }
+        else
+        {
+            ac.EnvironmentVariables["ANTHROPIC_API_KEY"] = apiKey;
+        }
+    }
+
+    private static void SaveIvyApiKey(IConfigService config, string apiKey)
+    {
+        var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
+            AgentProviderFactory.NormalizeAgentName(a.Name).Equals("ivy", StringComparison.OrdinalIgnoreCase));
+
+        if (ac == null)
+        {
+            ac = new AgentConfig { Name = "ivy" };
             config.Settings.CodingAgents.Add(ac);
         }
 

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -105,6 +105,7 @@ public class CodingAgentStepView(
         var isFetchingModels = UseState(false);
         var fetchedModels = UseState<IReadOnlyList<ModelInfo>?>(null);
         var isTestingModels = UseState(false);
+        var useCustomModelNames = UseState(false);
         var apiKeyError = UseState<string?>(null);
         var baseUrlError = UseState<string?>(null);
         var deepModelError = UseState<string?>(null);
@@ -129,6 +130,7 @@ public class CodingAgentStepView(
                 selectedAgent.Set(agentKey);
                 byoSubStep.Set(0);
                 fetchedModels.Set(null);
+                useCustomModelNames.Set(false);
                 apiKeyError.Set(null);
                 baseUrlError.Set(null);
                 deepModelError.Set(null);
@@ -145,6 +147,9 @@ public class CodingAgentStepView(
                     deepModel.Set("moonshotai/Kimi-K3");
                     balancedModel.Set("moonshotai/Kimi-K3");
                     quickModel.Set("moonshotai/Kimi-K3");
+                    customDeepText.Set("moonshotai/Kimi-K3");
+                    customBalancedText.Set("moonshotai/Kimi-K3");
+                    customQuickText.Set("moonshotai/Kimi-K3");
                 }
                 else if (agentKey == "anthropic_card")
                 {
@@ -153,6 +158,9 @@ public class CodingAgentStepView(
                     deepModel.Set("claude-opus-5");
                     balancedModel.Set("claude-sonnet-5");
                     quickModel.Set("claude-haiku-5");
+                    customDeepText.Set("claude-opus-5");
+                    customBalancedText.Set("claude-sonnet-5");
+                    customQuickText.Set("claude-haiku-5");
                 }
                 else if (agentKey == "openaiproxy_card")
                 {
@@ -167,9 +175,15 @@ public class CodingAgentStepView(
                     }
                     var isIvyUrl = openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app");
                     lastDetectedProvider.Set(isIvyUrl ? "ivy" : "openai");
-                    deepModel.Set(isIvyUrl ? "claude-opus-5" : "gpt-5.6-sol");
-                    balancedModel.Set(isIvyUrl ? "gemini-3.7-flash" : "gpt-5.6-terra");
-                    quickModel.Set(isIvyUrl ? "gemini-3.7-flash" : "gpt-5.6-luna");
+                    var deepDefault = isIvyUrl ? "claude-opus-5" : "gpt-5.6-sol";
+                    var balancedDefault = isIvyUrl ? "gemini-3.7-flash" : "gpt-5.6-terra";
+                    var quickDefault = isIvyUrl ? "gemini-3.7-flash" : "gpt-5.6-luna";
+                    deepModel.Set(deepDefault);
+                    balancedModel.Set(balancedDefault);
+                    quickModel.Set(quickDefault);
+                    customDeepText.Set(deepDefault);
+                    customBalancedText.Set(balancedDefault);
+                    customQuickText.Set(quickDefault);
                 }
                 else
                 {
@@ -210,30 +224,45 @@ public class CodingAgentStepView(
                     deepModel.Set("claude-opus-5");
                     balancedModel.Set("gemini-3.7-flash");
                     quickModel.Set("gemini-3.7-flash");
+                    customDeepText.Set("claude-opus-5");
+                    customBalancedText.Set("gemini-3.7-flash");
+                    customQuickText.Set("gemini-3.7-flash");
                 }
                 else if (isAnthropicCard)
                 {
                     deepModel.Set("claude-opus-5");
                     balancedModel.Set("claude-sonnet-5");
                     quickModel.Set("claude-haiku-5");
+                    customDeepText.Set("claude-opus-5");
+                    customBalancedText.Set("claude-sonnet-5");
+                    customQuickText.Set("claude-haiku-5");
                 }
                 else if (isBergetCard)
                 {
                     deepModel.Set("moonshotai/Kimi-K3");
                     balancedModel.Set("moonshotai/Kimi-K3");
                     quickModel.Set("moonshotai/Kimi-K3");
+                    customDeepText.Set("moonshotai/Kimi-K3");
+                    customBalancedText.Set("moonshotai/Kimi-K3");
+                    customQuickText.Set("moonshotai/Kimi-K3");
                 }
                 else if (isGoogle)
                 {
                     deepModel.Set("gemini-3.7-flash");
                     balancedModel.Set("gemini-3.7-flash");
                     quickModel.Set("gemini-3.7-flash");
+                    customDeepText.Set("gemini-3.7-flash");
+                    customBalancedText.Set("gemini-3.7-flash");
+                    customQuickText.Set("gemini-3.7-flash");
                 }
                 else
                 {
                     deepModel.Set("gpt-5.6-sol");
                     balancedModel.Set("gpt-5.6-terra");
                     quickModel.Set("gpt-5.6-luna");
+                    customDeepText.Set("gpt-5.6-sol");
+                    customBalancedText.Set("gpt-5.6-terra");
+                    customQuickText.Set("gpt-5.6-luna");
                 }
             }
 
@@ -302,36 +331,62 @@ public class CodingAgentStepView(
                                        var models = await OpenAiProxyModelCatalog.FetchModelsFromEndpointAsync(baseUrl, openAiProxyApiKey.Value);
                                        fetchedModels.Set(models);
 
-                                       // Set default profile models appropriately
-                                       if (isIvy)
+                                       if (models is { Count: > 0 })
                                        {
-                                           deepModel.Set(models.Any(m => m.Id == "claude-opus-5") ? "claude-opus-5" : (models.FirstOrDefault()?.Id ?? "claude-opus-5"));
-                                           balancedModel.Set(models.Any(m => m.Id == "gemini-3.7-flash") ? "gemini-3.7-flash" : (models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "gemini-3.7-flash"));
-                                           quickModel.Set(models.Any(m => m.Id == "gemini-3.7-flash") ? "gemini-3.7-flash" : (models.ElementAtOrDefault(2)?.Id ?? models.FirstOrDefault()?.Id ?? "gemini-3.7-flash"));
-                                       }
-                                       else if (isAnthropicCard)
-                                       {
-                                           deepModel.Set(models.Any(m => m.Id == "claude-opus-5") ? "claude-opus-5" : (models.FirstOrDefault()?.Id ?? "claude-opus-5"));
-                                           balancedModel.Set(models.Any(m => m.Id == "claude-sonnet-5") ? "claude-sonnet-5" : (models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "claude-sonnet-5"));
-                                           quickModel.Set(models.Any(m => m.Id == "claude-haiku-5") ? "claude-haiku-5" : (models.ElementAtOrDefault(2)?.Id ?? models.FirstOrDefault()?.Id ?? "claude-haiku-5"));
-                                       }
-                                       else if (isBergetCard)
-                                       {
-                                           deepModel.Set("moonshotai/Kimi-K3");
-                                           balancedModel.Set("moonshotai/Kimi-K3");
-                                           quickModel.Set("moonshotai/Kimi-K3");
-                                       }
-                                       else if (isGoogle)
-                                       {
-                                           deepModel.Set("gemini-3.7-flash");
-                                           balancedModel.Set("gemini-3.7-flash");
-                                           quickModel.Set("gemini-3.7-flash");
+                                           useCustomModelNames.Set(false);
+
+                                           var deep = isIvy
+                                               ? (models.FirstOrDefault(m => m.Id.Contains("opus", StringComparison.OrdinalIgnoreCase))?.Id ?? models.FirstOrDefault()?.Id ?? "")
+                                               : (isAnthropicCard
+                                                   ? (models.FirstOrDefault(m => m.Id.Contains("opus", StringComparison.OrdinalIgnoreCase))?.Id ?? models.FirstOrDefault()?.Id ?? "")
+                                                   : (isBergetCard
+                                                       ? (models.FirstOrDefault(m => m.Id.Contains("kimi", StringComparison.OrdinalIgnoreCase))?.Id ?? models.FirstOrDefault()?.Id ?? "")
+                                                       : (models.FirstOrDefault(m => m.Id.Contains("sol", StringComparison.OrdinalIgnoreCase))?.Id
+                                                          ?? models.FirstOrDefault(m => m.Id.Contains("gpt-4o", StringComparison.OrdinalIgnoreCase) && !m.Id.Contains("mini", StringComparison.OrdinalIgnoreCase))?.Id
+                                                          ?? models.FirstOrDefault()?.Id ?? "")));
+
+                                           var balanced = isIvy
+                                               ? (models.FirstOrDefault(m => m.Id.Contains("flash", StringComparison.OrdinalIgnoreCase))?.Id ?? models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "")
+                                               : (isAnthropicCard
+                                                   ? (models.FirstOrDefault(m => m.Id.Contains("sonnet", StringComparison.OrdinalIgnoreCase))?.Id ?? models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "")
+                                                   : (isBergetCard
+                                                       ? (models.FirstOrDefault(m => m.Id.Contains("kimi", StringComparison.OrdinalIgnoreCase))?.Id ?? models.FirstOrDefault()?.Id ?? "")
+                                                       : (models.FirstOrDefault(m => m.Id.Contains("terra", StringComparison.OrdinalIgnoreCase))?.Id
+                                                          ?? models.FirstOrDefault(m => m.Id.Contains("gpt-4o", StringComparison.OrdinalIgnoreCase) && !m.Id.Contains("mini", StringComparison.OrdinalIgnoreCase))?.Id
+                                                          ?? models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "")));
+
+                                           var quick = isIvy
+                                               ? (models.FirstOrDefault(m => m.Id.Contains("flash", StringComparison.OrdinalIgnoreCase))?.Id ?? models.ElementAtOrDefault(2)?.Id ?? models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "")
+                                               : (isAnthropicCard
+                                                   ? (models.FirstOrDefault(m => m.Id.Contains("haiku", StringComparison.OrdinalIgnoreCase))?.Id ?? models.ElementAtOrDefault(2)?.Id ?? models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "")
+                                                   : (isBergetCard
+                                                       ? (models.FirstOrDefault(m => m.Id.Contains("kimi", StringComparison.OrdinalIgnoreCase))?.Id ?? models.FirstOrDefault()?.Id ?? "")
+                                                       : (models.FirstOrDefault(m => m.Id.Contains("luna", StringComparison.OrdinalIgnoreCase))?.Id
+                                                          ?? models.FirstOrDefault(m => m.Id.Contains("mini", StringComparison.OrdinalIgnoreCase))?.Id
+                                                          ?? models.ElementAtOrDefault(2)?.Id ?? models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "")));
+
+                                           deepModel.Set(deep);
+                                           balancedModel.Set(balanced);
+                                           quickModel.Set(quick);
+                                           customDeepText.Set(deep);
+                                           customBalancedText.Set(balanced);
+                                           customQuickText.Set(quick);
                                        }
                                        else
                                        {
-                                           deepModel.Set(models.Any(m => m.Id == "gpt-5.6-sol") ? "gpt-5.6-sol" : (models.FirstOrDefault()?.Id ?? "gpt-5.6-sol"));
-                                           balancedModel.Set(models.Any(m => m.Id == "gpt-5.6-terra") ? "gpt-5.6-terra" : (models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "gpt-5.6-terra"));
-                                           quickModel.Set(models.Any(m => m.Id == "gpt-5.6-luna") ? "gpt-5.6-luna" : (models.ElementAtOrDefault(2)?.Id ?? models.FirstOrDefault()?.Id ?? "gpt-5.6-luna"));
+                                           useCustomModelNames.Set(true);
+                                           if (string.IsNullOrWhiteSpace(customDeepText.Value))
+                                           {
+                                               customDeepText.Set(isIvy || isAnthropicCard ? "claude-opus-5" : (isBergetCard ? "moonshotai/Kimi-K3" : "gpt-5.6-sol"));
+                                           }
+                                           if (string.IsNullOrWhiteSpace(customBalancedText.Value))
+                                           {
+                                               customBalancedText.Set(isIvy || isAnthropicCard ? "claude-sonnet-5" : (isBergetCard ? "moonshotai/Kimi-K3" : "gpt-5.6-terra"));
+                                           }
+                                           if (string.IsNullOrWhiteSpace(customQuickText.Value))
+                                           {
+                                               customQuickText.Set(isIvy || isAnthropicCard ? "claude-haiku-5" : (isBergetCard ? "moonshotai/Kimi-K3" : "gpt-5.6-luna"));
+                                           }
                                        }
 
                                        byoSubStep.Set(1);
@@ -349,62 +404,71 @@ public class CodingAgentStepView(
             }
 
             // SubStep 1: Model Selection
-            var modelsList = fetchedModels.Value ?? OpenAiProxyModelCatalog.GetModelsForBaseUrl(openAiProxyBaseUrl.Value);
-            var modelOptions = modelsList
+            var availableModels = fetchedModels.Value ?? Array.Empty<ModelInfo>();
+            var hasAvailableModels = availableModels.Count > 0;
+            var isCustomMode = useCustomModelNames.Value || !hasAvailableModels;
+
+            var modelOptions = availableModels
                 .Select(m => new Option<string>(m.DisplayName, m.Id))
-                .Concat([new Option<string>("+ Custom Model Name...", "__custom__")])
                 .ToArray<IAnyOption>();
 
-            // Ensure valid selected values
-            if (deepModel.Value == "default" || (!modelsList.Any(m => m.Id.Equals(deepModel.Value, StringComparison.OrdinalIgnoreCase)) && deepModel.Value != "__custom__"))
+            // Ensure valid selected values if in dropdown mode
+            if (!isCustomMode && hasAvailableModels)
             {
-                deepModel.Set(modelsList.FirstOrDefault()?.Id ?? "__custom__");
-            }
-            if (balancedModel.Value == "default" || (!modelsList.Any(m => m.Id.Equals(balancedModel.Value, StringComparison.OrdinalIgnoreCase)) && balancedModel.Value != "__custom__"))
-            {
-                balancedModel.Set(modelsList.ElementAtOrDefault(1)?.Id ?? modelsList.FirstOrDefault()?.Id ?? "__custom__");
-            }
-            if (quickModel.Value == "default" || (!modelsList.Any(m => m.Id.Equals(quickModel.Value, StringComparison.OrdinalIgnoreCase)) && quickModel.Value != "__custom__"))
-            {
-                quickModel.Set(modelsList.ElementAtOrDefault(2)?.Id ?? modelsList.FirstOrDefault()?.Id ?? "__custom__");
+                if (string.IsNullOrEmpty(deepModel.Value) || !availableModels.Any(m => m.Id.Equals(deepModel.Value, StringComparison.OrdinalIgnoreCase)))
+                {
+                    deepModel.Set(availableModels.FirstOrDefault()?.Id ?? "");
+                }
+                if (string.IsNullOrEmpty(balancedModel.Value) || !availableModels.Any(m => m.Id.Equals(balancedModel.Value, StringComparison.OrdinalIgnoreCase)))
+                {
+                    balancedModel.Set(availableModels.ElementAtOrDefault(1)?.Id ?? availableModels.FirstOrDefault()?.Id ?? "");
+                }
+                if (string.IsNullOrEmpty(quickModel.Value) || !availableModels.Any(m => m.Id.Equals(quickModel.Value, StringComparison.OrdinalIgnoreCase)))
+                {
+                    quickModel.Set(availableModels.ElementAtOrDefault(2)?.Id ?? availableModels.FirstOrDefault()?.Id ?? "");
+                }
             }
 
-            object profileModels = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
-                | Text.Block("Profile Models").Bold()
-                | Text.Muted("Select models from your endpoint or type in a custom model name.").Small()
-                | (Layout.Vertical()
+            object profileModels;
+
+            if (isCustomMode)
+            {
+                profileModels = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                    | (hasAvailableModels ? useCustomModelNames.ToSwitchInput(label: "Custom model names") : null!)
+                    | Text.Block("Profile Models").Bold()
+                    | Text.Muted("Enter the model names to use for each profile level.").Small()
+                    | customDeepText.ToTextInput("e.g. gpt-4o")
+                        .Invalid(deepModelError.Value)
+                        .WithField()
+                        .Label("Deep Profile Model Name")
+                    | customBalancedText.ToTextInput("e.g. gpt-4o-mini")
+                        .Invalid(balancedModelError.Value)
+                        .WithField()
+                        .Label("Balanced Profile Model Name")
+                    | customQuickText.ToTextInput("e.g. gpt-4o-mini")
+                        .Invalid(quickModelError.Value)
+                        .WithField()
+                        .Label("Quick Profile Model Name");
+            }
+            else
+            {
+                profileModels = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                    | useCustomModelNames.ToSwitchInput(label: "Custom model names")
+                    | Text.Block("Profile Models").Bold()
+                    | Text.Muted("Select models from your endpoint for each profile level.").Small()
                     | deepModel.ToSelectInput(modelOptions)
                         .Invalid(deepModelError.Value)
                         .WithField()
                         .Label("Deep Profile")
-                    | (deepModel.Value == "__custom__"
-                        ? customDeepText.ToTextInput("e.g. gpt-4-turbo")
-                            .Invalid(deepModelError.Value)
-                            .WithField()
-                            .Label("Custom Deep Model Name")
-                        : null))
-                | (Layout.Vertical()
                     | balancedModel.ToSelectInput(modelOptions)
                         .Invalid(balancedModelError.Value)
                         .WithField()
                         .Label("Balanced Profile")
-                    | (balancedModel.Value == "__custom__"
-                        ? customBalancedText.ToTextInput("e.g. gpt-4-turbo")
-                            .Invalid(balancedModelError.Value)
-                            .WithField()
-                            .Label("Custom Balanced Model Name")
-                        : null))
-                | (Layout.Vertical()
                     | quickModel.ToSelectInput(modelOptions)
                         .Invalid(quickModelError.Value)
                         .WithField()
-                        .Label("Quick Profile")
-                    | (quickModel.Value == "__custom__"
-                        ? customQuickText.ToTextInput("e.g. gpt-4-mini")
-                            .Invalid(quickModelError.Value)
-                            .WithField()
-                            .Label("Custom Quick Model Name")
-                        : null));
+                        .Label("Quick Profile");
+            }
 
             return Layout.Vertical()
                    | Text.H3($"{cardTitle} — Select Models")
@@ -436,28 +500,28 @@ public class CodingAgentStepView(
                                testSuccessMessage.Set(null);
                                generalError.Set(null);
 
-                               var dm = deepModel.Value == "__custom__"
+                               var dm = isCustomMode
                                    ? customDeepText.Value.Trim()
                                    : deepModel.Value;
-                               var bm = balancedModel.Value == "__custom__"
+                               var bm = isCustomMode
                                    ? customBalancedText.Value.Trim()
                                    : balancedModel.Value;
-                               var qm = quickModel.Value == "__custom__"
+                               var qm = isCustomMode
                                    ? customQuickText.Value.Trim()
                                    : quickModel.Value;
 
                                var hasValidationErr = false;
-                               if (string.IsNullOrWhiteSpace(dm) || dm == "__custom__")
+                               if (string.IsNullOrWhiteSpace(dm))
                                {
                                    deepModelError.Set("Please specify a valid model for Deep profile.");
                                    hasValidationErr = true;
                                }
-                               if (string.IsNullOrWhiteSpace(bm) || bm == "__custom__")
+                               if (string.IsNullOrWhiteSpace(bm))
                                {
                                    balancedModelError.Set("Please specify a valid model for Balanced profile.");
                                    hasValidationErr = true;
                                }
-                               if (string.IsNullOrWhiteSpace(qm) || qm == "__custom__")
+                               if (string.IsNullOrWhiteSpace(qm))
                                {
                                    quickModelError.Set("Please specify a valid model for Quick profile.");
                                    hasValidationErr = true;
@@ -515,28 +579,28 @@ public class CodingAgentStepView(
                                generalError.Set(null);
                                testSuccessMessage.Set(null);
 
-                               var dm = deepModel.Value == "__custom__"
+                               var dm = isCustomMode
                                    ? customDeepText.Value.Trim()
                                    : deepModel.Value;
-                               var bm = balancedModel.Value == "__custom__"
+                               var bm = isCustomMode
                                    ? customBalancedText.Value.Trim()
                                    : balancedModel.Value;
-                               var qm = quickModel.Value == "__custom__"
+                               var qm = isCustomMode
                                    ? customQuickText.Value.Trim()
                                    : quickModel.Value;
 
                                var hasValidationErr = false;
-                               if (string.IsNullOrWhiteSpace(dm) || dm == "__custom__")
+                               if (string.IsNullOrWhiteSpace(dm))
                                {
                                    deepModelError.Set("Please specify a valid model for Deep profile.");
                                    hasValidationErr = true;
                                }
-                               if (string.IsNullOrWhiteSpace(bm) || bm == "__custom__")
+                               if (string.IsNullOrWhiteSpace(bm))
                                {
                                    balancedModelError.Set("Please specify a valid model for Balanced profile.");
                                    hasValidationErr = true;
                                }
-                               if (string.IsNullOrWhiteSpace(qm) || qm == "__custom__")
+                               if (string.IsNullOrWhiteSpace(qm))
                                {
                                    quickModelError.Set("Please specify a valid model for Quick profile.");
                                    hasValidationErr = true;

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -171,9 +171,9 @@ public class CodingAgentStepView(
                 lastDetectedProvider.Set(currentProviderKey);
                 if (isIvy)
                 {
-                    deepModel.Set("ivy-stem");
-                    balancedModel.Set("ivy-root");
-                    quickModel.Set("ivy-leaf");
+                    deepModel.Set("claude-opus-5");
+                    balancedModel.Set("gemini-3.7-flash");
+                    quickModel.Set("gemini-3.7-flash");
                 }
                 else if (isAnthropicCard)
                 {
@@ -254,9 +254,9 @@ public class CodingAgentStepView(
                                        // Set default profile models appropriately
                                        if (isIvy)
                                        {
-                                           deepModel.Set("ivy-stem");
-                                           balancedModel.Set("ivy-root");
-                                           quickModel.Set("ivy-leaf");
+                                           deepModel.Set("claude-opus-5");
+                                           balancedModel.Set("gemini-3.7-flash");
+                                           quickModel.Set("gemini-3.7-flash");
                                        }
                                        else if (isAnthropicCard)
                                        {

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -105,8 +105,13 @@ public class CodingAgentStepView(
         var isFetchingModels = UseState(false);
         var fetchedModels = UseState<IReadOnlyList<ModelInfo>?>(null);
         var isTestingModels = UseState(false);
-        var testFeedback = UseState<string?>(null);
-        var isTestSuccess = UseState<bool?>(null);
+        var apiKeyError = UseState<string?>(null);
+        var baseUrlError = UseState<string?>(null);
+        var deepModelError = UseState<string?>(null);
+        var balancedModelError = UseState<string?>(null);
+        var quickModelError = UseState<string?>(null);
+        var testSuccessMessage = UseState<string?>(null);
+        var generalError = UseState<string?>(null);
         var customDeepText = UseState("");
         var customBalancedText = UseState("");
         var customQuickText = UseState("");
@@ -124,8 +129,13 @@ public class CodingAgentStepView(
                 selectedAgent.Set(agentKey);
                 byoSubStep.Set(0);
                 fetchedModels.Set(null);
-                testFeedback.Set(null);
-                isTestSuccess.Set(null);
+                apiKeyError.Set(null);
+                baseUrlError.Set(null);
+                deepModelError.Set(null);
+                balancedModelError.Set(null);
+                quickModelError.Set(null);
+                testSuccessMessage.Set(null);
+                generalError.Set(null);
                 error.Set(null);
                 if (agentKey != "openaiproxy_card" && agentKey != "anthropic_card" && agentKey != "berget_card")
                 {
@@ -206,19 +216,22 @@ public class CodingAgentStepView(
                 object agentInputs = isBergetCard
                     ? (Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
                         | openAiProxyApiKey.ToPasswordInput("sk-...")
+                            .Invalid(apiKeyError.Value)
                             .WithField()
                             .Label("API Key"))
                     : (Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
                         | openAiProxyBaseUrl.ToTextInput(defaultUrl)
+                            .Invalid(baseUrlError.Value)
                             .WithField()
                             .Label("API Base URL")
                         | openAiProxyApiKey.ToPasswordInput("sk-...")
+                            .Invalid(apiKeyError.Value)
                             .WithField()
                             .Label("API Key"));
 
                 return Layout.Vertical()
                        | Text.H3(cardTitle)
-                       | (error.Value != null ? Text.Danger(error.Value) : null!)
+                       | (generalError.Value != null ? Callout.Error(generalError.Value) : null!)
                        | agentInputs
                        | (Layout.Horizontal()
                            | new Button("Back")
@@ -227,24 +240,36 @@ public class CodingAgentStepView(
                                {
                                    selectedAgent.Set(null);
                                    error.Set(null);
+                                   generalError.Set(null);
+                                   apiKeyError.Set(null);
+                                   baseUrlError.Set(null);
                                })
                            | new Button("Continue")
                                .Primary()
                                .Loading(isFetchingModels.Value)
                                .OnClick(async () =>
                                {
+                                   apiKeyError.Set(null);
+                                   baseUrlError.Set(null);
+                                   generalError.Set(null);
+
                                    if (string.IsNullOrWhiteSpace(openAiProxyApiKey.Value))
                                    {
-                                       error.Set("API Key is required.");
+                                       apiKeyError.Set("API Key is required.");
                                        return;
                                    }
-
-                                   error.Set(null);
-                                   isFetchingModels.Set(true);
 
                                    var baseUrl = isBergetCard || string.IsNullOrWhiteSpace(openAiProxyBaseUrl.Value)
                                        ? defaultUrl
                                        : openAiProxyBaseUrl.Value;
+
+                                   if (!isBergetCard && string.IsNullOrWhiteSpace(baseUrl))
+                                   {
+                                       baseUrlError.Set("API Base URL is required.");
+                                       return;
+                                   }
+
+                                   isFetchingModels.Set(true);
 
                                    try
                                    {
@@ -254,9 +279,9 @@ public class CodingAgentStepView(
                                        // Set default profile models appropriately
                                        if (isIvy)
                                        {
-                                           deepModel.Set("claude-opus-5");
-                                           balancedModel.Set("gemini-3.7-flash");
-                                           quickModel.Set("gemini-3.7-flash");
+                                           deepModel.Set(models.Any(m => m.Id == "claude-opus-5") ? "claude-opus-5" : (models.FirstOrDefault()?.Id ?? "claude-opus-5"));
+                                           balancedModel.Set(models.Any(m => m.Id == "gemini-3.7-flash") ? "gemini-3.7-flash" : (models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "gemini-3.7-flash"));
+                                           quickModel.Set(models.Any(m => m.Id == "gemini-3.7-flash") ? "gemini-3.7-flash" : (models.ElementAtOrDefault(2)?.Id ?? models.FirstOrDefault()?.Id ?? "gemini-3.7-flash"));
                                        }
                                        else if (isAnthropicCard)
                                        {
@@ -287,7 +312,7 @@ public class CodingAgentStepView(
                                    }
                                    catch (Exception ex)
                                    {
-                                       error.Set($"Failed to fetch models: {ex.Message}");
+                                       generalError.Set($"Failed to fetch models: {ex.Message}");
                                    }
                                    finally
                                    {
@@ -322,29 +347,45 @@ public class CodingAgentStepView(
                 | Text.Block("Profile Models").Bold()
                 | Text.Muted("Select models from your endpoint or type in a custom model name.").Small()
                 | (Layout.Vertical()
-                    | deepModel.ToSelectInput(modelOptions).WithField().Label("Deep Profile")
+                    | deepModel.ToSelectInput(modelOptions)
+                        .Invalid(deepModelError.Value)
+                        .WithField()
+                        .Label("Deep Profile")
                     | (deepModel.Value == "__custom__"
-                        ? customDeepText.ToTextInput("e.g. gpt-4-turbo").WithField().Label("Custom Deep Model Name")
+                        ? customDeepText.ToTextInput("e.g. gpt-4-turbo")
+                            .Invalid(deepModelError.Value)
+                            .WithField()
+                            .Label("Custom Deep Model Name")
                         : null))
                 | (Layout.Vertical()
-                    | balancedModel.ToSelectInput(modelOptions).WithField().Label("Balanced Profile")
+                    | balancedModel.ToSelectInput(modelOptions)
+                        .Invalid(balancedModelError.Value)
+                        .WithField()
+                        .Label("Balanced Profile")
                     | (balancedModel.Value == "__custom__"
-                        ? customBalancedText.ToTextInput("e.g. gpt-4-turbo").WithField().Label("Custom Balanced Model Name")
+                        ? customBalancedText.ToTextInput("e.g. gpt-4-turbo")
+                            .Invalid(balancedModelError.Value)
+                            .WithField()
+                            .Label("Custom Balanced Model Name")
                         : null))
                 | (Layout.Vertical()
-                    | quickModel.ToSelectInput(modelOptions).WithField().Label("Quick Profile")
+                    | quickModel.ToSelectInput(modelOptions)
+                        .Invalid(quickModelError.Value)
+                        .WithField()
+                        .Label("Quick Profile")
                     | (quickModel.Value == "__custom__"
-                        ? customQuickText.ToTextInput("e.g. gpt-4-mini").WithField().Label("Custom Quick Model Name")
+                        ? customQuickText.ToTextInput("e.g. gpt-4-mini")
+                            .Invalid(quickModelError.Value)
+                            .WithField()
+                            .Label("Custom Quick Model Name")
                         : null));
 
             return Layout.Vertical()
                    | Text.H3($"{cardTitle} — Select Models")
-                   | (error.Value != null ? Text.Danger(error.Value) : null!)
+                   | (generalError.Value != null ? Callout.Error(generalError.Value) : null!)
                    | profileModels
-                   | (testFeedback.Value != null
-                       ? (isTestSuccess.Value == true
-                           ? Text.Success($"✓ {testFeedback.Value}")
-                           : Text.Danger($"✗ {testFeedback.Value}"))
+                   | (testSuccessMessage.Value != null
+                       ? Callout.Success(testSuccessMessage.Value)
                        : null!)
                    | (Layout.Horizontal()
                        | new Button("Back")
@@ -352,18 +393,22 @@ public class CodingAgentStepView(
                            .OnClick(() =>
                            {
                                byoSubStep.Set(0);
-                               error.Set(null);
-                               testFeedback.Set(null);
-                               isTestSuccess.Set(null);
+                               deepModelError.Set(null);
+                               balancedModelError.Set(null);
+                               quickModelError.Set(null);
+                               testSuccessMessage.Set(null);
+                               generalError.Set(null);
                            })
                        | new Button("Test Endpoint")
                            .Outline()
                            .Loading(isTestingModels.Value)
                            .OnClick(async () =>
                            {
-                               testFeedback.Set(null);
-                               isTestSuccess.Set(null);
-                               error.Set(null);
+                               deepModelError.Set(null);
+                               balancedModelError.Set(null);
+                               quickModelError.Set(null);
+                               testSuccessMessage.Set(null);
+                               generalError.Set(null);
 
                                var dm = deepModel.Value == "__custom__"
                                    ? customDeepText.Value.Trim()
@@ -375,24 +420,24 @@ public class CodingAgentStepView(
                                    ? customQuickText.Value.Trim()
                                    : quickModel.Value;
 
+                               var hasValidationErr = false;
                                if (string.IsNullOrWhiteSpace(dm) || dm == "__custom__")
                                {
-                                   testFeedback.Set("Please specify a valid model for Deep profile.");
-                                   isTestSuccess.Set(false);
-                                   return;
+                                   deepModelError.Set("Please specify a valid model for Deep profile.");
+                                   hasValidationErr = true;
                                }
                                if (string.IsNullOrWhiteSpace(bm) || bm == "__custom__")
                                {
-                                   testFeedback.Set("Please specify a valid model for Balanced profile.");
-                                   isTestSuccess.Set(false);
-                                   return;
+                                   balancedModelError.Set("Please specify a valid model for Balanced profile.");
+                                   hasValidationErr = true;
                                }
                                if (string.IsNullOrWhiteSpace(qm) || qm == "__custom__")
                                {
-                                   testFeedback.Set("Please specify a valid model for Quick profile.");
-                                   isTestSuccess.Set(false);
-                                   return;
+                                   quickModelError.Set("Please specify a valid model for Quick profile.");
+                                   hasValidationErr = true;
                                }
+
+                               if (hasValidationErr) return;
 
                                var baseUrl = isBergetCard || string.IsNullOrWhiteSpace(openAiProxyBaseUrl.Value)
                                    ? defaultUrl
@@ -401,36 +446,33 @@ public class CodingAgentStepView(
                                isTestingModels.Set(true);
                                try
                                {
-                                   var modelsToTest = new (string Tier, string Model)[]
-                                   {
-                                       ("Deep", dm),
-                                       ("Balanced", bm),
-                                       ("Quick", qm)
-                                   };
+                                   var tested = new Dictionary<string, (bool Ok, string? Err)>(StringComparer.OrdinalIgnoreCase);
 
-                                   var uniqueModels = modelsToTest
-                                       .GroupBy(m => m.Model, StringComparer.OrdinalIgnoreCase)
-                                       .Select(g => (Tiers: string.Join("/", g.Select(x => x.Tier)), Model: g.Key))
-                                       .ToList();
-
-                                   foreach (var (tier, modelId) in uniqueModels)
+                                   async Task<(bool Ok, string? Err)> TestOnceAsync(string modelId)
                                    {
-                                       var (ok, err) = await OpenAiProxyModelCatalog.TestModelEndpointAsync(baseUrl, openAiProxyApiKey.Value, modelId);
-                                       if (!ok)
-                                       {
-                                           testFeedback.Set($"{tier} model '{modelId}' failed: {err}");
-                                           isTestSuccess.Set(false);
-                                           return;
-                                       }
+                                       if (tested.TryGetValue(modelId, out var existing)) return existing;
+                                       var res = await OpenAiProxyModelCatalog.TestModelEndpointAsync(baseUrl, openAiProxyApiKey.Value, modelId);
+                                       tested[modelId] = res;
+                                       return res;
                                    }
 
-                                   testFeedback.Set("All profile models responded successfully!");
-                                   isTestSuccess.Set(true);
+                                   var deepRes = await TestOnceAsync(dm);
+                                   if (!deepRes.Ok) deepModelError.Set(deepRes.Err);
+
+                                   var balancedRes = await TestOnceAsync(bm);
+                                   if (!balancedRes.Ok) balancedModelError.Set(balancedRes.Err);
+
+                                   var quickRes = await TestOnceAsync(qm);
+                                   if (!quickRes.Ok) quickModelError.Set(quickRes.Err);
+
+                                   if (deepRes.Ok && balancedRes.Ok && quickRes.Ok)
+                                   {
+                                       testSuccessMessage.Set("All profile models responded successfully!");
+                                   }
                                }
                                catch (Exception ex)
                                {
-                                   testFeedback.Set($"Test error: {ex.Message}");
-                                   isTestSuccess.Set(false);
+                                   generalError.Set($"Test error: {ex.Message}");
                                }
                                finally
                                {
@@ -441,6 +483,12 @@ public class CodingAgentStepView(
                            .Primary()
                            .OnClick(() =>
                            {
+                               deepModelError.Set(null);
+                               balancedModelError.Set(null);
+                               quickModelError.Set(null);
+                               generalError.Set(null);
+                               testSuccessMessage.Set(null);
+
                                var dm = deepModel.Value == "__custom__"
                                    ? customDeepText.Value.Trim()
                                    : deepModel.Value;
@@ -451,21 +499,24 @@ public class CodingAgentStepView(
                                    ? customQuickText.Value.Trim()
                                    : quickModel.Value;
 
+                               var hasValidationErr = false;
                                if (string.IsNullOrWhiteSpace(dm) || dm == "__custom__")
                                {
-                                   error.Set("Please specify a valid model for Deep profile.");
-                                   return;
+                                   deepModelError.Set("Please specify a valid model for Deep profile.");
+                                   hasValidationErr = true;
                                }
                                if (string.IsNullOrWhiteSpace(bm) || bm == "__custom__")
                                {
-                                   error.Set("Please specify a valid model for Balanced profile.");
-                                   return;
+                                   balancedModelError.Set("Please specify a valid model for Balanced profile.");
+                                   hasValidationErr = true;
                                }
                                if (string.IsNullOrWhiteSpace(qm) || qm == "__custom__")
                                {
-                                   error.Set("Please specify a valid model for Quick profile.");
-                                   return;
+                                   quickModelError.Set("Please specify a valid model for Quick profile.");
+                                   hasValidationErr = true;
                                }
+
+                               if (hasValidationErr) return;
 
                                var baseUrl = isBergetCard || string.IsNullOrWhiteSpace(openAiProxyBaseUrl.Value)
                                    ? defaultUrl

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -137,7 +137,41 @@ public class CodingAgentStepView(
                 testSuccessMessage.Set(null);
                 generalError.Set(null);
                 error.Set(null);
-                if (agentKey != "openaiproxy_card" && agentKey != "anthropic_card" && agentKey != "berget_card")
+
+                if (agentKey == "berget_card")
+                {
+                    openAiProxyBaseUrl.Set("https://api.berget.ai/v1");
+                    lastDetectedProvider.Set("berget");
+                    deepModel.Set("moonshotai/Kimi-K3");
+                    balancedModel.Set("moonshotai/Kimi-K3");
+                    quickModel.Set("moonshotai/Kimi-K3");
+                }
+                else if (agentKey == "anthropic_card")
+                {
+                    openAiProxyBaseUrl.Set("https://api.anthropic.com/v1");
+                    lastDetectedProvider.Set("anthropic");
+                    deepModel.Set("claude-opus-5");
+                    balancedModel.Set("claude-sonnet-5");
+                    quickModel.Set("claude-haiku-5");
+                }
+                else if (agentKey == "openaiproxy_card")
+                {
+                    var existingUrl = GetOpenAiProxyBaseUrlFromConfig(config);
+                    if (!string.IsNullOrEmpty(existingUrl) && !existingUrl.Contains("api.berget.ai") && !existingUrl.Contains("api.anthropic.com"))
+                    {
+                        openAiProxyBaseUrl.Set(existingUrl);
+                    }
+                    else
+                    {
+                        openAiProxyBaseUrl.Set("https://api.openai.com");
+                    }
+                    var isIvyUrl = openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app");
+                    lastDetectedProvider.Set(isIvyUrl ? "ivy" : "openai");
+                    deepModel.Set(isIvyUrl ? "claude-opus-5" : "gpt-5.6-sol");
+                    balancedModel.Set(isIvyUrl ? "gemini-3.7-flash" : "gpt-5.6-terra");
+                    quickModel.Set(isIvyUrl ? "gemini-3.7-flash" : "gpt-5.6-luna");
+                }
+                else
                 {
                     _ = RunFlowAsync(agentKey);
                 }
@@ -146,9 +180,9 @@ public class CodingAgentStepView(
 
         if (progressMessage.Value is null && (selectedAgent.Value == "openaiproxy_card" || selectedAgent.Value == "anthropic_card" || selectedAgent.Value == "berget_card"))
         {
-            var isIvy = openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app") || openAiProxyBaseUrl.Value.Contains("ivy.app");
-            var isAnthropicCard = !isIvy && (selectedAgent.Value == "anthropic_card" || openAiProxyBaseUrl.Value.Contains("api.anthropic.com"));
-            var isBergetCard = !isIvy && (selectedAgent.Value == "berget_card" || openAiProxyBaseUrl.Value.Contains("api.berget.ai"));
+            var isBergetCard = selectedAgent.Value == "berget_card";
+            var isAnthropicCard = selectedAgent.Value == "anthropic_card";
+            var isIvy = !isBergetCard && !isAnthropicCard && (openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app") || openAiProxyBaseUrl.Value.Contains("ivy.app"));
 
             var cardTitle = isIvy
                 ? "Setup Ivy Proxy"
@@ -165,14 +199,6 @@ public class CodingAgentStepView(
                     : (isAnthropicCard
                         ? "https://api.anthropic.com/v1"
                         : "https://api.openai.com"));
-
-            if (string.IsNullOrWhiteSpace(openAiProxyBaseUrl.Value) ||
-                (isBergetCard && !openAiProxyBaseUrl.Value.Contains("api.berget.ai")) ||
-                (isAnthropicCard && (openAiProxyBaseUrl.Value == "https://api.openai.com" || openAiProxyBaseUrl.Value.Contains("api.berget.ai"))) ||
-                (!isAnthropicCard && !isBergetCard && !isIvy && (openAiProxyBaseUrl.Value.Contains("api.anthropic.com") || openAiProxyBaseUrl.Value.Contains("api.berget.ai"))))
-            {
-                openAiProxyBaseUrl.Set(defaultUrl);
-            }
 
             var isGoogle = !isIvy && !isAnthropicCard && !isBergetCard && (openAiProxyBaseUrl.Value.Contains("generativelanguage.googleapis.com") || openAiProxyBaseUrl.Value.Contains("gemini") || openAiProxyBaseUrl.Value.Contains("google"));
             var currentProviderKey = isIvy ? "ivy" : (isAnthropicCard ? "anthropic" : (isBergetCard ? "berget" : (isGoogle ? "google" : "openai")));

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -101,6 +101,13 @@ public class CodingAgentStepView(
         var quickModel = UseState("default");
         var lastDetectedProvider = UseState<string?>(null);
 
+        var byoSubStep = UseState(0);
+        var isFetchingModels = UseState(false);
+        var fetchedModels = UseState<IReadOnlyList<ModelInfo>?>(null);
+        var customDeepText = UseState("");
+        var customBalancedText = UseState("");
+        var customQuickText = UseState("");
+
         var (installDialog, showInstallDialog) = UseTrigger<InstallDialogArgs>((isOpen, args) =>
             new InstallMissingDialog(isOpen, args));
 
@@ -112,6 +119,8 @@ public class CodingAgentStepView(
             return BuildPicker(visibleAgents, agentKey =>
             {
                 selectedAgent.Set(agentKey);
+                byoSubStep.Set(0);
+                fetchedModels.Set(null);
                 error.Set(null);
                 if (agentKey != "openaiproxy_card" && agentKey != "anthropic_card" && agentKey != "berget_card")
                 {
@@ -187,50 +196,151 @@ public class CodingAgentStepView(
                 }
             }
 
-            var availableModels = OpenAiProxyModelCatalog.GetModelsForBaseUrl(openAiProxyBaseUrl.Value);
-            var modelOptions = availableModels
-                .Select(m => new Option<string>(m.DisplayName, m.Id))
-                .ToArray<IAnyOption>();
+            if (byoSubStep.Value == 0)
+            {
+                object agentInputs = isBergetCard
+                    ? (Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                        | openAiProxyApiKey.ToPasswordInput("sk-...")
+                            .WithField()
+                            .Label("API Key"))
+                    : (Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                        | openAiProxyBaseUrl.ToTextInput(defaultUrl)
+                            .WithField()
+                            .Label("API Base URL")
+                        | openAiProxyApiKey.ToPasswordInput("sk-...")
+                            .WithField()
+                            .Label("API Key"));
 
-            object agentInputs = isBergetCard
-                ? (Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
-                    | openAiProxyApiKey.ToPasswordInput("...")
-                        .WithField()
-                        .Label("API Key"))
-                : (Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
-                    | openAiProxyBaseUrl.ToTextInput(defaultUrl)
-                        .WithField()
-                        .Label("API Base URL")
-                    | openAiProxyApiKey.ToPasswordInput("sk-...")
-                        .WithField()
-                        .Label("API Key"));
+                return Layout.Vertical()
+                       | Text.H3(cardTitle)
+                       | (error.Value != null ? Text.Danger(error.Value) : null!)
+                       | agentInputs
+                       | (Layout.Horizontal()
+                           | new Button("Back")
+                               .Ghost()
+                               .OnClick(() =>
+                               {
+                                   selectedAgent.Set(null);
+                                   error.Set(null);
+                               })
+                           | new Button("Continue")
+                               .Primary()
+                               .Loading(isFetchingModels.Value)
+                               .OnClick(async () =>
+                               {
+                                   if (string.IsNullOrWhiteSpace(openAiProxyApiKey.Value))
+                                   {
+                                       error.Set("API Key is required.");
+                                       return;
+                                   }
+
+                                   error.Set(null);
+                                   isFetchingModels.Set(true);
+
+                                   var baseUrl = isBergetCard || string.IsNullOrWhiteSpace(openAiProxyBaseUrl.Value)
+                                       ? defaultUrl
+                                       : openAiProxyBaseUrl.Value;
+
+                                   try
+                                   {
+                                       var models = await OpenAiProxyModelCatalog.FetchModelsFromEndpointAsync(baseUrl, openAiProxyApiKey.Value);
+                                       fetchedModels.Set(models);
+
+                                       if (models.Count > 0)
+                                       {
+                                           if (!models.Any(m => m.Id.Equals(deepModel.Value, StringComparison.OrdinalIgnoreCase)) && deepModel.Value != "__custom__")
+                                           {
+                                               deepModel.Set(models[0].Id);
+                                           }
+                                           if (!models.Any(m => m.Id.Equals(balancedModel.Value, StringComparison.OrdinalIgnoreCase)) && balancedModel.Value != "__custom__")
+                                           {
+                                               balancedModel.Set(models.Count > 1 ? models[1].Id : models[0].Id);
+                                           }
+                                           if (!models.Any(m => m.Id.Equals(quickModel.Value, StringComparison.OrdinalIgnoreCase)) && quickModel.Value != "__custom__")
+                                           {
+                                               quickModel.Set(models.Count > 2 ? models[2].Id : models[0].Id);
+                                           }
+                                       }
+
+                                       byoSubStep.Set(1);
+                                   }
+                                   catch (Exception ex)
+                                   {
+                                       error.Set($"Failed to fetch models: {ex.Message}");
+                                   }
+                                   finally
+                                   {
+                                       isFetchingModels.Set(false);
+                                   }
+                               })
+                       );
+            }
+
+            // SubStep 1: Model Selection
+            var modelsList = fetchedModels.Value ?? OpenAiProxyModelCatalog.GetModelsForBaseUrl(openAiProxyBaseUrl.Value);
+            var modelOptions = modelsList
+                .Select(m => new Option<string>(m.DisplayName, m.Id))
+                .Concat([new Option<string>("+ Custom Model Name...", "__custom__")])
+                .ToArray<IAnyOption>();
 
             object profileModels = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
                 | Text.Block("Profile Models").Bold()
-                | deepModel.ToSelectInput(modelOptions).WithField().Label("Deep")
-                | balancedModel.ToSelectInput(modelOptions).WithField().Label("Balanced")
-                | quickModel.ToSelectInput(modelOptions).WithField().Label("Quick");
+                | Text.Muted("Select models from your endpoint or type in a custom model name.").Small()
+                | (Layout.Vertical()
+                    | deepModel.ToSelectInput(modelOptions).WithField().Label("Deep Profile")
+                    | (deepModel.Value == "__custom__"
+                        ? customDeepText.ToTextInput("e.g. gpt-4-turbo").WithField().Label("Custom Deep Model Name")
+                        : null))
+                | (Layout.Vertical()
+                    | balancedModel.ToSelectInput(modelOptions).WithField().Label("Balanced Profile")
+                    | (balancedModel.Value == "__custom__"
+                        ? customBalancedText.ToTextInput("e.g. gpt-4-turbo").WithField().Label("Custom Balanced Model Name")
+                        : null))
+                | (Layout.Vertical()
+                    | quickModel.ToSelectInput(modelOptions).WithField().Label("Quick Profile")
+                    | (quickModel.Value == "__custom__"
+                        ? customQuickText.ToTextInput("e.g. gpt-4-mini").WithField().Label("Custom Quick Model Name")
+                        : null));
 
             return Layout.Vertical()
-                   | Text.H3(cardTitle)
+                   | Text.H3($"{cardTitle} — Select Models")
                    | (error.Value != null ? Text.Danger(error.Value) : null!)
-                   | agentInputs
                    | profileModels
                    | (Layout.Horizontal()
                        | new Button("Back")
                            .Ghost()
                            .OnClick(() =>
                            {
-                               selectedAgent.Set(null);
+                               byoSubStep.Set(0);
                                error.Set(null);
                            })
                        | new Button("Continue")
                            .Primary()
                            .OnClick(() =>
                            {
-                               if (string.IsNullOrWhiteSpace(openAiProxyApiKey.Value))
+                               var dm = deepModel.Value == "__custom__"
+                                   ? customDeepText.Value.Trim()
+                                   : deepModel.Value;
+                               var bm = balancedModel.Value == "__custom__"
+                                   ? customBalancedText.Value.Trim()
+                                   : balancedModel.Value;
+                               var qm = quickModel.Value == "__custom__"
+                                   ? customQuickText.Value.Trim()
+                                   : quickModel.Value;
+
+                               if (string.IsNullOrWhiteSpace(dm) || dm == "__custom__")
                                {
-                                   error.Set("API Key is required.");
+                                   error.Set("Please specify a valid model for Deep profile.");
+                                   return;
+                               }
+                               if (string.IsNullOrWhiteSpace(bm) || bm == "__custom__")
+                               {
+                                   error.Set("Please specify a valid model for Balanced profile.");
+                                   return;
+                               }
+                               if (string.IsNullOrWhiteSpace(qm) || qm == "__custom__")
+                               {
+                                   error.Set("Please specify a valid model for Quick profile.");
                                    return;
                                }
 
@@ -239,9 +349,6 @@ public class CodingAgentStepView(
                                    : openAiProxyBaseUrl.Value;
 
                                var targetAgent = isIvy ? "ivy" : "openaiproxy";
-                               var dm = deepModel.Value;
-                               var bm = balancedModel.Value;
-                               var qm = quickModel.Value;
 
                                if (isIvy)
                                {

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Helpers;
 using Ivy.Tendril.Agents.Providers.OpenAiProxy;
 using Ivy.Tendril.Apps.Onboarding.Models;
 using Ivy.Tendril.Helpers;
@@ -331,39 +332,19 @@ public class CodingAgentStepView(
                                        var models = await OpenAiProxyModelCatalog.FetchModelsFromEndpointAsync(baseUrl, openAiProxyApiKey.Value);
                                        fetchedModels.Set(models);
 
+                                       var isGoogleCard = !isIvy && !isAnthropicCard && !isBergetCard && (baseUrl.Contains("generativelanguage.googleapis.com") || baseUrl.Contains("gemini") || baseUrl.Contains("google"));
+
                                        if (models is { Count: > 0 })
                                        {
                                            useCustomModelNames.Set(false);
 
-                                           var deep = isIvy
-                                               ? (models.FirstOrDefault(m => m.Id.Contains("opus", StringComparison.OrdinalIgnoreCase))?.Id ?? models.FirstOrDefault()?.Id ?? "")
-                                               : (isAnthropicCard
-                                                   ? (models.FirstOrDefault(m => m.Id.Contains("opus", StringComparison.OrdinalIgnoreCase))?.Id ?? models.FirstOrDefault()?.Id ?? "")
-                                                   : (isBergetCard
-                                                       ? (models.FirstOrDefault(m => m.Id.Contains("kimi", StringComparison.OrdinalIgnoreCase))?.Id ?? models.FirstOrDefault()?.Id ?? "")
-                                                       : (models.FirstOrDefault(m => m.Id.Contains("sol", StringComparison.OrdinalIgnoreCase))?.Id
-                                                          ?? models.FirstOrDefault(m => m.Id.Contains("gpt-4o", StringComparison.OrdinalIgnoreCase) && !m.Id.Contains("mini", StringComparison.OrdinalIgnoreCase))?.Id
-                                                          ?? models.FirstOrDefault()?.Id ?? "")));
-
-                                           var balanced = isIvy
-                                               ? (models.FirstOrDefault(m => m.Id.Contains("flash", StringComparison.OrdinalIgnoreCase))?.Id ?? models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "")
-                                               : (isAnthropicCard
-                                                   ? (models.FirstOrDefault(m => m.Id.Contains("sonnet", StringComparison.OrdinalIgnoreCase))?.Id ?? models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "")
-                                                   : (isBergetCard
-                                                       ? (models.FirstOrDefault(m => m.Id.Contains("kimi", StringComparison.OrdinalIgnoreCase))?.Id ?? models.FirstOrDefault()?.Id ?? "")
-                                                       : (models.FirstOrDefault(m => m.Id.Contains("terra", StringComparison.OrdinalIgnoreCase))?.Id
-                                                          ?? models.FirstOrDefault(m => m.Id.Contains("gpt-4o", StringComparison.OrdinalIgnoreCase) && !m.Id.Contains("mini", StringComparison.OrdinalIgnoreCase))?.Id
-                                                          ?? models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "")));
-
-                                           var quick = isIvy
-                                               ? (models.FirstOrDefault(m => m.Id.Contains("flash", StringComparison.OrdinalIgnoreCase))?.Id ?? models.ElementAtOrDefault(2)?.Id ?? models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "")
-                                               : (isAnthropicCard
-                                                   ? (models.FirstOrDefault(m => m.Id.Contains("haiku", StringComparison.OrdinalIgnoreCase))?.Id ?? models.ElementAtOrDefault(2)?.Id ?? models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "")
-                                                   : (isBergetCard
-                                                       ? (models.FirstOrDefault(m => m.Id.Contains("kimi", StringComparison.OrdinalIgnoreCase))?.Id ?? models.FirstOrDefault()?.Id ?? "")
-                                                       : (models.FirstOrDefault(m => m.Id.Contains("luna", StringComparison.OrdinalIgnoreCase))?.Id
-                                                          ?? models.FirstOrDefault(m => m.Id.Contains("mini", StringComparison.OrdinalIgnoreCase))?.Id
-                                                          ?? models.ElementAtOrDefault(2)?.Id ?? models.ElementAtOrDefault(1)?.Id ?? models.FirstOrDefault()?.Id ?? "")));
+                                           var (deep, balanced, quick) = ModelProfileSelector.SelectDefaults(
+                                               models,
+                                               isIvy: isIvy,
+                                               isAnthropic: isAnthropicCard,
+                                               isBerget: isBergetCard,
+                                               isGoogle: isGoogleCard,
+                                               isOpenAi: !isIvy && !isAnthropicCard && !isBergetCard && !isGoogleCard);
 
                                            deepModel.Set(deep);
                                            balancedModel.Set(balanced);
@@ -375,18 +356,20 @@ public class CodingAgentStepView(
                                        else
                                        {
                                            useCustomModelNames.Set(true);
+                                           var (fallbackDeep, fallbackBalanced, fallbackQuick) = ModelProfileSelector.SelectDefaults(
+                                               null,
+                                               isIvy: isIvy,
+                                               isAnthropic: isAnthropicCard,
+                                               isBerget: isBergetCard,
+                                               isGoogle: isGoogleCard,
+                                               isOpenAi: !isIvy && !isAnthropicCard && !isBergetCard && !isGoogleCard);
+
                                            if (string.IsNullOrWhiteSpace(customDeepText.Value))
-                                           {
-                                               customDeepText.Set(isIvy || isAnthropicCard ? "claude-opus-5" : (isBergetCard ? "moonshotai/Kimi-K3" : "gpt-5.6-sol"));
-                                           }
+                                               customDeepText.Set(fallbackDeep);
                                            if (string.IsNullOrWhiteSpace(customBalancedText.Value))
-                                           {
-                                               customBalancedText.Set(isIvy || isAnthropicCard ? "claude-sonnet-5" : (isBergetCard ? "moonshotai/Kimi-K3" : "gpt-5.6-terra"));
-                                           }
+                                               customBalancedText.Set(fallbackBalanced);
                                            if (string.IsNullOrWhiteSpace(customQuickText.Value))
-                                           {
-                                               customQuickText.Set(isIvy || isAnthropicCard ? "claude-haiku-5" : (isBergetCard ? "moonshotai/Kimi-K3" : "gpt-5.6-luna"));
-                                           }
+                                               customQuickText.Set(fallbackQuick);
                                        }
 
                                        byoSubStep.Set(1);
@@ -415,17 +398,26 @@ public class CodingAgentStepView(
             // Ensure valid selected values if in dropdown mode
             if (!isCustomMode && hasAvailableModels)
             {
+                var isGoogleCard = !isIvy && !isAnthropicCard && !isBergetCard && (openAiProxyBaseUrl.Value.Contains("generativelanguage.googleapis.com") || openAiProxyBaseUrl.Value.Contains("gemini") || openAiProxyBaseUrl.Value.Contains("google"));
+                var (defaultDeep, defaultBalanced, defaultQuick) = ModelProfileSelector.SelectDefaults(
+                    availableModels,
+                    isIvy: isIvy,
+                    isAnthropic: isAnthropicCard,
+                    isBerget: isBergetCard,
+                    isGoogle: isGoogleCard,
+                    isOpenAi: !isIvy && !isAnthropicCard && !isBergetCard && !isGoogleCard);
+
                 if (string.IsNullOrEmpty(deepModel.Value) || !availableModels.Any(m => m.Id.Equals(deepModel.Value, StringComparison.OrdinalIgnoreCase)))
                 {
-                    deepModel.Set(availableModels.FirstOrDefault()?.Id ?? "");
+                    deepModel.Set(defaultDeep);
                 }
                 if (string.IsNullOrEmpty(balancedModel.Value) || !availableModels.Any(m => m.Id.Equals(balancedModel.Value, StringComparison.OrdinalIgnoreCase)))
                 {
-                    balancedModel.Set(availableModels.ElementAtOrDefault(1)?.Id ?? availableModels.FirstOrDefault()?.Id ?? "");
+                    balancedModel.Set(defaultBalanced);
                 }
                 if (string.IsNullOrEmpty(quickModel.Value) || !availableModels.Any(m => m.Id.Equals(quickModel.Value, StringComparison.OrdinalIgnoreCase)))
                 {
-                    quickModel.Set(availableModels.ElementAtOrDefault(2)?.Id ?? availableModels.FirstOrDefault()?.Id ?? "");
+                    quickModel.Set(defaultQuick);
                 }
             }
 

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -150,7 +150,8 @@ public class CodingAgentStepView(
                 openAiProxyBaseUrl.Set(defaultUrl);
             }
 
-            var currentProviderKey = isIvy ? "ivy" : (isAnthropicCard ? "anthropic" : (isBergetCard ? "berget" : "openai"));
+            var isGoogle = !isIvy && !isAnthropicCard && !isBergetCard && (openAiProxyBaseUrl.Value.Contains("generativelanguage.googleapis.com") || openAiProxyBaseUrl.Value.Contains("gemini") || openAiProxyBaseUrl.Value.Contains("google"));
+            var currentProviderKey = isIvy ? "ivy" : (isAnthropicCard ? "anthropic" : (isBergetCard ? "berget" : (isGoogle ? "google" : "openai")));
             if (lastDetectedProvider.Value != currentProviderKey)
             {
                 lastDetectedProvider.Set(currentProviderKey);
@@ -171,6 +172,12 @@ public class CodingAgentStepView(
                     deepModel.Set("moonshotai/Kimi-K3");
                     balancedModel.Set("moonshotai/Kimi-K3");
                     quickModel.Set("moonshotai/Kimi-K3");
+                }
+                else if (isGoogle)
+                {
+                    deepModel.Set("gemini-3.7-flash");
+                    balancedModel.Set("gemini-3.7-flash");
+                    quickModel.Set("gemini-3.7-flash");
                 }
                 else
                 {

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Net.Http;
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Helpers;
 using Ivy.Tendril.Agents.Providers.Ivy;
 using Ivy.Tendril.Apps.Settings.Dialogs;
 using Ivy.Tendril.Helpers;
@@ -105,26 +106,23 @@ public class CodingAgentSetupView : ViewBase
             var balancedEff = GetProfileEffort(config, realAgentId, "balanced");
             var quickEff = GetProfileEffort(config, realAgentId, "quick");
 
-            if (deep == "default")
+            if (deep == "default" || balanced == "default" || quick == "default")
             {
-                if (realAgentId == "ivy") deep = "claude-opus-5";
-                else if (selectedAgent.Value == "anthropic_card") deep = "claude-opus-5";
-                else if (isBerget) deep = "moonshotai/Kimi-K3";
-                else if (selectedAgent.Value == "openaiproxy_card") deep = "gpt-5.6-sol";
-            }
-            if (balanced == "default")
-            {
-                if (realAgentId == "ivy") balanced = "gemini-3.7-flash";
-                else if (selectedAgent.Value == "anthropic_card") balanced = "claude-sonnet-5";
-                else if (isBerget) balanced = "moonshotai/Kimi-K3";
-                else if (selectedAgent.Value == "openaiproxy_card") balanced = "gpt-5.6-terra";
-            }
-            if (quick == "default")
-            {
-                if (realAgentId == "ivy") quick = "gemini-3.7-flash";
-                else if (selectedAgent.Value == "anthropic_card") quick = "claude-haiku-5";
-                else if (isBerget) quick = "moonshotai/Kimi-K3";
-                else if (selectedAgent.Value == "openaiproxy_card") quick = "gpt-5.6-luna";
+                var isIvyAgent = realAgentId == "ivy" || openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app");
+                var isAnthropicAgent = selectedAgent.Value == "anthropic_card" || openAiProxyBaseUrl.Value.Contains("api.anthropic.com");
+                var isGoogleAgent = openAiProxyBaseUrl.Value.Contains("generativelanguage.googleapis.com") || openAiProxyBaseUrl.Value.Contains("gemini") || openAiProxyBaseUrl.Value.Contains("google");
+
+                var (defDeep, defBalanced, defQuick) = ModelProfileSelector.SelectDefaults(
+                    null,
+                    isIvy: isIvyAgent,
+                    isAnthropic: isAnthropicAgent,
+                    isBerget: isBerget,
+                    isGoogle: isGoogleAgent,
+                    isOpenAi: !isIvyAgent && !isAnthropicAgent && !isBerget && !isGoogleAgent);
+
+                if (deep == "default") deep = defDeep;
+                if (balanced == "default") balanced = defBalanced;
+                if (quick == "default") quick = defQuick;
             }
 
             deepModel.Set(deep);

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -70,6 +70,7 @@ public class CodingAgentSetupView : ViewBase
         var deepEffort = UseState(GetProfileEffort(config, config.Settings.CodingAgent, "deep"));
         var balancedEffort = UseState(GetProfileEffort(config, config.Settings.CodingAgent, "balanced"));
         var quickEffort = UseState(GetProfileEffort(config, config.Settings.CodingAgent, "quick"));
+        var useCustomModelNames = UseState(false);
         var lastRealAgent = UseState(config.Settings.CodingAgent);
         var showTestDialog = UseState(false);
         var testAgentId = UseState(config.Settings.CodingAgent);
@@ -138,10 +139,21 @@ public class CodingAgentSetupView : ViewBase
         }
 
         var models = modelsQuery.Value ?? [];
+        var knownModelIds = new HashSet<string>(models.Select(m => m.Id), StringComparer.OrdinalIgnoreCase);
+        var extraOptions = new List<Option<string>>();
+        foreach (var m in new[] { deepModel.Value, balancedModel.Value, quickModel.Value })
+        {
+            if (!string.IsNullOrEmpty(m) && m != "default" && !knownModelIds.Contains(m) && extraOptions.All(o => (string?)o.Value != m))
+            {
+                extraOptions.Add(new Option<string>(m, m));
+            }
+        }
+
         var modelOptions = new[] { new Option<string>("Default", "default") }
             .Concat(models
                 .Where(m => m.Id != "default")
                 .Select(m => new Option<string>(m.DisplayName, m.Id)))
+            .Concat(extraOptions)
             .ToArray<IAnyOption>();
 
         var isIvy = selectedAgent.Value == "openaiproxy_card" && openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app");
@@ -333,24 +345,43 @@ public class CodingAgentSetupView : ViewBase
                     .Label("Ollama Host");
         }
 
+        var isByo = isIvy || isBerget || isAnthropic || isOpenAi;
+        var hasFetchedModels = models.Length > 0;
+        var isCustomMode = isByo && (useCustomModelNames.Value || !hasFetchedModels);
+
         var profileModels = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+            | (isByo && hasFetchedModels ? useCustomModelNames.ToSwitchInput(label: "Custom model names") : null!)
             | Text.Block("Profile Models").Bold()
-            | Text.Muted("Promptwares are configured to use different profiles depending on the complexity of the task. You can specify what model and effort level to use for each profile.").Small()
+            | Text.Muted(isCustomMode
+                ? "Specify custom model names and effort level to use for each profile."
+                : "Promptwares are configured to use different profiles depending on the complexity of the task. You can specify what model and effort level to use for each profile.").Small()
             | (supportsEffort
                 ? (object)(Layout.Vertical()
                     | (Layout.Horizontal()
-                        | deepModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Deep").Width(Size.Fraction(0.65f))
+                        | (isCustomMode
+                            ? deepModel.ToTextInput("e.g. gpt-4o").WithField().Label("Deep").Width(Size.Fraction(0.65f))
+                            : deepModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Deep").Width(Size.Fraction(0.65f)))
                         | deepEffort.ToSelectInput(GetEffortOptions(deepModel.Value)).WithField().Label("Effort").Width(Size.Fraction(0.35f)))
                     | (Layout.Horizontal()
-                        | balancedModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Balanced").Width(Size.Fraction(0.65f))
+                        | (isCustomMode
+                            ? balancedModel.ToTextInput("e.g. gpt-4o-mini").WithField().Label("Balanced").Width(Size.Fraction(0.65f))
+                            : balancedModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Balanced").Width(Size.Fraction(0.65f)))
                         | balancedEffort.ToSelectInput(GetEffortOptions(balancedModel.Value)).WithField().Label("Effort").Width(Size.Fraction(0.35f)))
                     | (Layout.Horizontal()
-                        | quickModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Quick").Width(Size.Fraction(0.65f))
+                        | (isCustomMode
+                            ? quickModel.ToTextInput("e.g. gpt-4o-mini").WithField().Label("Quick").Width(Size.Fraction(0.65f))
+                            : quickModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Quick").Width(Size.Fraction(0.65f)))
                         | quickEffort.ToSelectInput(GetEffortOptions(quickModel.Value)).WithField().Label("Effort").Width(Size.Fraction(0.35f))))
                 : (Layout.Vertical()
-                    | deepModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Deep")
-                    | balancedModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Balanced")
-                    | quickModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Quick")));
+                    | (isCustomMode
+                        ? deepModel.ToTextInput("e.g. gpt-4o").WithField().Label("Deep")
+                        : deepModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Deep"))
+                    | (isCustomMode
+                        ? balancedModel.ToTextInput("e.g. gpt-4o-mini").WithField().Label("Balanced")
+                        : balancedModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Balanced"))
+                    | (isCustomMode
+                        ? quickModel.ToTextInput("e.g. gpt-4o-mini").WithField().Label("Quick")
+                        : quickModel.ToSelectInput(modelOptions).Loading(modelsQuery.Loading).WithField().Label("Quick"))));
 
         return Layout.Vertical()
                | Text.Block("Coding Agent").Bold()

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -321,7 +321,7 @@ public class CodingAgentSetupView : ViewBase
         else if (selectedAgent.Value == "berget_card")
         {
             agentInputs = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
-                | openAiProxyApiKey.ToPasswordInput("...")
+                | openAiProxyApiKey.ToPasswordInput("sk-...")
                     .WithField()
                     .Label("API Key");
         }

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -95,7 +95,7 @@ public class CodingAgentSetupView : ViewBase
             ? (openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app") ? "ivy" : "openaiproxy")
             : (selectedAgent.Value == "anthropic_card" || isBerget ? "openaiproxy" : selectedAgent.Value);
 
-        if (lastRealAgent.Value != realAgentId || (isBerget && deepModel.Value == "default"))
+        if (lastRealAgent.Value != realAgentId || deepModel.Value == "default")
         {
             var deep = GetProfileModel(config, realAgentId, "deep");
             var balanced = GetProfileModel(config, realAgentId, "balanced");
@@ -104,9 +104,31 @@ public class CodingAgentSetupView : ViewBase
             var balancedEff = GetProfileEffort(config, realAgentId, "balanced");
             var quickEff = GetProfileEffort(config, realAgentId, "quick");
 
-            deepModel.Set(deep == "default" && isBerget ? "moonshotai/Kimi-K3" : deep);
-            balancedModel.Set(balanced == "default" && isBerget ? "moonshotai/Kimi-K3" : balanced);
-            quickModel.Set(quick == "default" && isBerget ? "moonshotai/Kimi-K3" : quick);
+            if (deep == "default")
+            {
+                if (realAgentId == "ivy") deep = "ivy-stem";
+                else if (selectedAgent.Value == "anthropic_card") deep = "claude-opus-5";
+                else if (isBerget) deep = "moonshotai/Kimi-K3";
+                else if (selectedAgent.Value == "openaiproxy_card") deep = "gpt-5.6-sol";
+            }
+            if (balanced == "default")
+            {
+                if (realAgentId == "ivy") balanced = "ivy-root";
+                else if (selectedAgent.Value == "anthropic_card") balanced = "claude-sonnet-5";
+                else if (isBerget) balanced = "moonshotai/Kimi-K3";
+                else if (selectedAgent.Value == "openaiproxy_card") balanced = "gpt-5.6-terra";
+            }
+            if (quick == "default")
+            {
+                if (realAgentId == "ivy") quick = "ivy-leaf";
+                else if (selectedAgent.Value == "anthropic_card") quick = "claude-haiku-5";
+                else if (isBerget) quick = "moonshotai/Kimi-K3";
+                else if (selectedAgent.Value == "openaiproxy_card") quick = "gpt-5.6-luna";
+            }
+
+            deepModel.Set(deep);
+            balancedModel.Set(balanced);
+            quickModel.Set(quick);
             deepEffort.Set(deepEff);
             balancedEffort.Set(balancedEff);
             quickEffort.Set(quickEff);
@@ -242,23 +264,36 @@ public class CodingAgentSetupView : ViewBase
             ).Width(Size.Full()).Height(Size.Full()).OnClick(() =>
             {
                 selectedAgent.Set(a.Key);
-                if (a.Key == "openaiproxy_card" && (openAiProxyBaseUrl.Value.Contains("api.anthropic.com") || openAiProxyBaseUrl.Value.Contains("api.berget.ai")))
+                if (a.Key == "openaiproxy_card")
                 {
-                    openAiProxyBaseUrl.Set("https://api.openai.com");
+                    if (openAiProxyBaseUrl.Value.Contains("api.anthropic.com") || openAiProxyBaseUrl.Value.Contains("api.berget.ai"))
+                    {
+                        openAiProxyBaseUrl.Set("https://api.openai.com");
+                    }
+                    var isIvyUrl = openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app");
+                    deepModel.Set(isIvyUrl ? "ivy-stem" : "gpt-5.6-sol");
+                    balancedModel.Set(isIvyUrl ? "ivy-root" : "gpt-5.6-terra");
+                    quickModel.Set(isIvyUrl ? "ivy-leaf" : "gpt-5.6-luna");
                 }
-                else if (a.Key == "anthropic_card" && (string.IsNullOrEmpty(openAiProxyBaseUrl.Value) || openAiProxyBaseUrl.Value.Contains("api.openai.com") || openAiProxyBaseUrl.Value.Contains("api.berget.ai")))
+                else if (a.Key == "anthropic_card")
                 {
-                    openAiProxyBaseUrl.Set("https://api.anthropic.com/v1");
+                    if (string.IsNullOrEmpty(openAiProxyBaseUrl.Value) || openAiProxyBaseUrl.Value.Contains("api.openai.com") || openAiProxyBaseUrl.Value.Contains("api.berget.ai") || openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app"))
+                    {
+                        openAiProxyBaseUrl.Set("https://api.anthropic.com/v1");
+                    }
+                    deepModel.Set("claude-opus-5");
+                    balancedModel.Set("claude-sonnet-5");
+                    quickModel.Set("claude-haiku-5");
                 }
                 else if (a.Key == "berget_card")
                 {
-                    if (string.IsNullOrEmpty(openAiProxyBaseUrl.Value) || openAiProxyBaseUrl.Value.Contains("api.openai.com") || openAiProxyBaseUrl.Value.Contains("api.anthropic.com"))
+                    if (string.IsNullOrEmpty(openAiProxyBaseUrl.Value) || openAiProxyBaseUrl.Value.Contains("api.openai.com") || openAiProxyBaseUrl.Value.Contains("api.anthropic.com") || openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app"))
                     {
                         openAiProxyBaseUrl.Set("https://api.berget.ai/v1");
                     }
-                    if (deepModel.Value == "default") deepModel.Set("moonshotai/Kimi-K3");
-                    if (balancedModel.Value == "default") balancedModel.Set("moonshotai/Kimi-K3");
-                    if (quickModel.Value == "default") quickModel.Set("moonshotai/Kimi-K3");
+                    deepModel.Set("moonshotai/Kimi-K3");
+                    balancedModel.Set("moonshotai/Kimi-K3");
+                    quickModel.Set("moonshotai/Kimi-K3");
                 }
             }));
 

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -106,21 +106,21 @@ public class CodingAgentSetupView : ViewBase
 
             if (deep == "default")
             {
-                if (realAgentId == "ivy") deep = "ivy-stem";
+                if (realAgentId == "ivy") deep = "claude-opus-5";
                 else if (selectedAgent.Value == "anthropic_card") deep = "claude-opus-5";
                 else if (isBerget) deep = "moonshotai/Kimi-K3";
                 else if (selectedAgent.Value == "openaiproxy_card") deep = "gpt-5.6-sol";
             }
             if (balanced == "default")
             {
-                if (realAgentId == "ivy") balanced = "ivy-root";
+                if (realAgentId == "ivy") balanced = "gemini-3.7-flash";
                 else if (selectedAgent.Value == "anthropic_card") balanced = "claude-sonnet-5";
                 else if (isBerget) balanced = "moonshotai/Kimi-K3";
                 else if (selectedAgent.Value == "openaiproxy_card") balanced = "gpt-5.6-terra";
             }
             if (quick == "default")
             {
-                if (realAgentId == "ivy") quick = "ivy-leaf";
+                if (realAgentId == "ivy") quick = "gemini-3.7-flash";
                 else if (selectedAgent.Value == "anthropic_card") quick = "claude-haiku-5";
                 else if (isBerget) quick = "moonshotai/Kimi-K3";
                 else if (selectedAgent.Value == "openaiproxy_card") quick = "gpt-5.6-luna";
@@ -271,9 +271,9 @@ public class CodingAgentSetupView : ViewBase
                         openAiProxyBaseUrl.Set("https://api.openai.com");
                     }
                     var isIvyUrl = openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app");
-                    deepModel.Set(isIvyUrl ? "ivy-stem" : "gpt-5.6-sol");
-                    balancedModel.Set(isIvyUrl ? "ivy-root" : "gpt-5.6-terra");
-                    quickModel.Set(isIvyUrl ? "ivy-leaf" : "gpt-5.6-luna");
+                    deepModel.Set(isIvyUrl ? "claude-opus-5" : "gpt-5.6-sol");
+                    balancedModel.Set(isIvyUrl ? "gemini-3.7-flash" : "gpt-5.6-terra");
+                    quickModel.Set(isIvyUrl ? "gemini-3.7-flash" : "gpt-5.6-luna");
                 }
                 else if (a.Key == "anthropic_card")
                 {

--- a/src/Ivy.Tendril/Apps/Settings/Dialogs/AgentTestDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Dialogs/AgentTestDialog.cs
@@ -122,9 +122,8 @@ public class AgentTestDialog(
                             modelResult.ErrorMessage ?? "Invalid model", modelResult.ErrorMessage),
                         ModelValidationStatus.AuthError => new AgentTestResult($"Model: {entry.DisplayName}", TestStatus.Failed,
                             modelResult.ErrorMessage ?? "Auth error", modelResult.ErrorMessage),
-                        ModelValidationStatus.Timeout => new AgentTestResult($"Model: {entry.DisplayName}", TestStatus.Warning,
-                            "Timed out", modelResult.ErrorMessage),
-                        _ => new AgentTestResult($"Model: {entry.DisplayName}", TestStatus.Warning,
+                        _ => new AgentTestResult($"Model: {entry.DisplayName}",
+                            modelResult.ErrorMessage != null ? TestStatus.Failed : TestStatus.Warning,
                             modelResult.ErrorMessage ?? "Unknown", modelResult.ErrorMessage)
                     };
                     testResults.Set([.. results]);

--- a/src/Ivy.Tendril/Services/AgentProviderFactory.cs
+++ b/src/Ivy.Tendril/Services/AgentProviderFactory.cs
@@ -120,33 +120,41 @@ public static class AgentProviderFactory
         IAgentCli cli,
         List<string> extraArgs)
     {
-        if (string.IsNullOrEmpty(profileName))
-            return ("", "");
-
         var agentConfig = settings.CodingAgents.FirstOrDefault(a =>
             NormalizeAgentName(a.Name).Equals(codingAgent, StringComparison.OrdinalIgnoreCase));
 
-        if (agentConfig == null)
+        if (agentConfig == null && string.IsNullOrEmpty(profileName))
             return ("", "");
 
-        var profile = agentConfig.Profiles.FirstOrDefault(p =>
-            p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+        AgentProfileConfig? profile = null;
+        if (!string.IsNullOrEmpty(profileName) && agentConfig != null)
+        {
+            profile = agentConfig.Profiles.FirstOrDefault(p =>
+                p.Name.Equals(profileName, StringComparison.OrdinalIgnoreCase));
+        }
 
-        if (profile == null)
-            return ("", "");
+        if (profile == null && agentConfig != null && agentConfig.Profiles.Count > 0)
+        {
+            profile = agentConfig.Profiles.FirstOrDefault(p => p.Name.Equals("balanced", StringComparison.OrdinalIgnoreCase))
+                ?? agentConfig.Profiles.FirstOrDefault(p => p.Name.Equals("default", StringComparison.OrdinalIgnoreCase))
+                ?? agentConfig.Profiles.FirstOrDefault(p => !string.IsNullOrEmpty(p.Model) && !p.Model.Equals("default", StringComparison.OrdinalIgnoreCase));
+        }
 
         var model = "";
         var effort = "";
 
-        if (!string.IsNullOrEmpty(profile.Model) &&
-            !profile.Model.Equals("default", StringComparison.OrdinalIgnoreCase) &&
-            cli.Capabilities.HasFlag(AgentCapabilities.ModelSelection))
-            model = profile.Model;
-        if (!string.IsNullOrEmpty(profile.Effort) &&
-            cli.Capabilities.HasFlag(AgentCapabilities.EffortControl))
-            effort = profile.Effort;
-        if (!string.IsNullOrWhiteSpace(profile.Arguments))
-            extraArgs.AddRange(SplitArgs(profile.Arguments));
+        if (profile != null)
+        {
+            if (!string.IsNullOrEmpty(profile.Model) &&
+                !profile.Model.Equals("default", StringComparison.OrdinalIgnoreCase) &&
+                cli.Capabilities.HasFlag(AgentCapabilities.ModelSelection))
+                model = profile.Model;
+            if (!string.IsNullOrEmpty(profile.Effort) &&
+                cli.Capabilities.HasFlag(AgentCapabilities.EffortControl))
+                effort = profile.Effort;
+            if (!string.IsNullOrWhiteSpace(profile.Arguments))
+                extraArgs.AddRange(SplitArgs(profile.Arguments));
+        }
 
         return (model, effort);
     }

--- a/src/build_local_installer.sh
+++ b/src/build_local_installer.sh
@@ -126,7 +126,6 @@ cat << 'EOF' > expanded-pkg/1.pkg/Scripts/postinstall
 #!/bin/sh
 rm -rf /tmp/velopack/IvyTendril
 sudo -u "$USER" rm -rf ~/Library/Caches/velopack/IvyTendril
-sudo -u "$USER" env VELOPACK_FIRSTRUN=1 open "$2/Ivy Tendril.app/"
 
 # Path to the installed app certificate
 APP_PATH="$2/Ivy Tendril.app"
@@ -142,6 +141,8 @@ if [ -f "$CERT_PATH" ]; then
   echo "Trusting Ivy Tendril localhost certificate system-wide..."
   security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$CERT_PATH" || true
 fi
+
+sudo -u "$USER" env VELOPACK_FIRSTRUN=1 open "$APP_PATH"
 exit 0
 EOF
 chmod +x expanded-pkg/1.pkg/Scripts/postinstall

--- a/src/build_local_installer.sh
+++ b/src/build_local_installer.sh
@@ -24,12 +24,18 @@ chmod +x "$PUBLISH_DIR/Ivy.Tendril"
 "$PUBLISH_DIR/Ivy.Tendril" generate-certs "$PUBLISH_DIR/certs"
 
 echo "=== 2.1. Bundling Ivy Agent CLI ==="
-IVY_AGENT_VERSION="v0.1.5"
-URL_IVY_AGENT="https://cdn.ivy.app/ivy-agent-cli/releases/download/$IVY_AGENT_VERSION/ivy-agent-cli-darwin-arm64.tar.gz"
-echo "Downloading Ivy Agent CLI..."
-curl -L -o ivy-agent.tar.gz "$URL_IVY_AGENT"
-tar -xzf ivy-agent.tar.gz -C "$PUBLISH_DIR"
-rm ivy-agent.tar.gz
+LOCAL_IVY_AGENT="/Users/rorychatt/git/ivy/ivy-agent-cli/packages/ivy-agent/dist/ivy-agent-darwin-arm64/bin/ivy-agent"
+if [ -f "$LOCAL_IVY_AGENT" ]; then
+  echo "Using locally built Ivy Agent CLI from $LOCAL_IVY_AGENT"
+  cp "$LOCAL_IVY_AGENT" "$PUBLISH_DIR/ivy-agent"
+else
+  IVY_AGENT_VERSION="v0.1.5"
+  URL_IVY_AGENT="https://cdn.ivy.app/ivy-agent-cli/releases/download/$IVY_AGENT_VERSION/ivy-agent-cli-darwin-arm64.tar.gz"
+  echo "Downloading Ivy Agent CLI..."
+  curl -L -o ivy-agent.tar.gz "$URL_IVY_AGENT"
+  tar -xzf ivy-agent.tar.gz -C "$PUBLISH_DIR"
+  rm ivy-agent.tar.gz
+fi
 chmod +x "$PUBLISH_DIR/ivy-agent"
 
 echo "=== 3. Creating .app Bundle Structure ==="


### PR DESCRIPTION
## Summary
- Added full model selection (Deep, Balanced, Quick) in Onboarding step for Bring Your Own LLM (OpenAI, Anthropic, Berget AI, Ivy Proxy, and custom base URLs).
- Updated [OpenAiProxyModelCatalog](file:///Users/rorychatt/git/ivy/Ivy-Tendril/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyModelCatalog.cs) to return provider-specific model lists based on the configured Base URL:
  - **Ivy Proxy** (`llmproxy.ivy.app`): 3 Ivy models (`ivy-stem`, `ivy-root`, `ivy-leaf`).
  - **OpenAI**: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-4o`, etc.
  - **Anthropic**: `claude-opus-5`, `claude-sonnet-5`, `claude-haiku-5`, etc.
  - **Berget AI**: `moonshotai/Kimi-K3`, `deepseek-ai/DeepSeek-V3`, `deepseek-ai/DeepSeek-R1`, etc.
- Removed hardcoded `moonshotai/Kimi-K3` overrides from [OpenAiProxyCli](file:///Users/rorychatt/git/ivy/Ivy-Tendril/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyCli.cs) and [OpenAiProxyPty](file:///Users/rorychatt/git/ivy/Ivy-Tendril/src/Ivy.Tendril.Agents/Providers/OpenAiProxy/OpenAiProxyPty.cs) when OpenAI, Anthropic, or Ivy URLs are used.
- Fixed [IvyCli](file:///Users/rorychatt/git/ivy/Ivy-Tendril/src/Ivy.Tendril.Agents/Providers/Ivy/IvyCli.cs) `DefaultProfiles` to properly return `ivy-stem`, `ivy-root`, and `ivy-leaf`.