### PR TITLE
[00093] Stop the Worktree Reaper Orphaning Unpushed Plan Commits

### DIFF
--- a/src/Ivy.Tendril.Test/GitTabDataBuilderTests.cs
+++ b/src/Ivy.Tendril.Test/GitTabDataBuilderTests.cs
@@ -14,11 +14,11 @@ public class GitTabDataBuilderTests : IDisposable
             Directory.Delete(_tempDir, recursive: true);
     }
 
-    private static PlanFile CreatePlan(string folderPath, List<string> commits, List<string> prs)
+    private static PlanFile CreatePlan(string folderPath, List<string> commits, List<string> prs, List<string>? repos = null)
     {
         var metadata = new PlanMetadata(
             1, "Test", "Bug", "Test Plan", PlanStatus.Draft,
-            [], commits, prs, [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
+            repos ?? [], commits, prs, [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null);
         return new PlanFile(metadata, "", folderPath, "");
     }
 
@@ -147,11 +147,80 @@ public class GitTabDataBuilderTests : IDisposable
         Assert.Equal("upstream/main", Assert.Single(data2.WorktreeSections).BaseBranch);
     }
 
+    [Fact]
+    public void BuildGitTabData_ReportsRefStatus_ForCommitsNoWorktreeAccountsFor()
+    {
+        var planFolder = Path.Combine(_tempDir, "plan-refstatus");
+        Directory.CreateDirectory(planFolder);
+        var plan = CreatePlan(planFolder, ["aaaaaaa1", "bbbbbbb2"], [], repos: ["/tmp/repo-a"]);
+
+        var gitService = new StubGitService
+        {
+            RefStatusByRepo =
+            {
+                ["/tmp/repo-a"] = new Dictionary<string, CommitRefStatus>
+                {
+                    ["aaaaaaa1"] = CommitRefStatus.Reachable,
+                    ["bbbbbbb2"] = CommitRefStatus.Unreachable
+                }
+            }
+        };
+
+        var data = GitTabDataBuilder.BuildGitTabData(CommitRows("aaaaaaa1", "bbbbbbb2"), plan, null!, gitService);
+
+        Assert.Equal(2, data.UnassociatedCommitRows.Count);
+        Assert.NotNull(data.UnassociatedCommitRefStatus);
+        Assert.Equal(CommitRefStatus.Reachable, data.UnassociatedCommitRefStatus!["aaaaaaa1"]);
+        Assert.Equal(CommitRefStatus.Unreachable, data.UnassociatedCommitRefStatus["bbbbbbb2"]);
+    }
+
+    [Fact]
+    public void BuildGitTabData_RefStatus_KeepsTheAnswerFromTheRepoThatHasTheCommit()
+    {
+        // A commit lives in one repo of a multi-repo plan. The other repo has never heard of it, and
+        // that must not be mistaken for the commit being gone.
+        var planFolder = Path.Combine(_tempDir, "plan-multirepo");
+        Directory.CreateDirectory(planFolder);
+        var plan = CreatePlan(planFolder, ["aaaaaaa1"], [], repos: ["/tmp/repo-a", "/tmp/repo-b"]);
+
+        var gitService = new StubGitService
+        {
+            RefStatusByRepo =
+            {
+                ["/tmp/repo-a"] = new Dictionary<string, CommitRefStatus> { ["aaaaaaa1"] = CommitRefStatus.Missing },
+                ["/tmp/repo-b"] = new Dictionary<string, CommitRefStatus> { ["aaaaaaa1"] = CommitRefStatus.Unreachable }
+            }
+        };
+
+        var data = GitTabDataBuilder.BuildGitTabData(CommitRows("aaaaaaa1"), plan, null!, gitService);
+
+        Assert.Equal(CommitRefStatus.Unreachable, data.UnassociatedCommitRefStatus!["aaaaaaa1"]);
+    }
+
+    [Fact]
+    public void BuildGitTabData_RefStatus_IsEmpty_WhenNoRepoCanAnswer()
+    {
+        // Nothing is claimed about a commit the plan's repos could not be queried for, so the Git tab
+        // shows it exactly as it does today rather than badging it as at risk.
+        var planFolder = Path.Combine(_tempDir, "plan-norepo");
+        Directory.CreateDirectory(planFolder);
+        var plan = CreatePlan(planFolder, ["aaaaaaa1"], [], repos: ["/tmp/repo-missing"]);
+
+        var data = GitTabDataBuilder.BuildGitTabData(CommitRows("aaaaaaa1"), plan, null!, new StubGitService());
+
+        Assert.NotNull(data.UnassociatedCommitRefStatus);
+        Assert.Empty(data.UnassociatedCommitRefStatus!);
+    }
+
+    private static List<PlanContentHelpers.CommitRow> CommitRows(params string[] hashes) =>
+        hashes.Select(h => new PlanContentHelpers.CommitRow(h, h[..7], $"Commit {h}", 1)).ToList();
+
     private class StubGitService : IGitService
     {
         public List<WorktreeInfo> Worktrees { get; set; } = [];
         public WorktreeBaseInfo? WorktreeBase { get; set; }
         public bool WorktreeBaseFails { get; set; }
+        public Dictionary<string, Dictionary<string, CommitRefStatus>> RefStatusByRepo { get; } = new();
 
         public GitResult<string> GetCommitTitle(string repoPath, string commitHash) =>
             GitResult<string>.Failure(GitError.CommandFailed, "Not implemented in stub");
@@ -182,6 +251,15 @@ public class GitTabDataBuilderTests : IDisposable
 
         public GitResult<List<string>> GetReachableCommits(string repoPath, IEnumerable<string> candidateHashes) =>
             GitResult<List<string>>.Success([]);
+
+        public GitResult<Dictionary<string, CommitRefStatus>> GetCommitRefStatus(string repoPath, IEnumerable<string> commitHashes)
+        {
+            if (!RefStatusByRepo.TryGetValue(repoPath, out var known))
+                return GitResult<Dictionary<string, CommitRefStatus>>.Failure(GitError.InvalidRepoPath, $"Unknown repo: {repoPath}");
+
+            return GitResult<Dictionary<string, CommitRefStatus>>.Success(
+                commitHashes.ToDictionary(h => h, h => known.TryGetValue(h, out var status) ? status : CommitRefStatus.Missing));
+        }
 
         public GitResult<DirtyRepoResult> GetRepoDirtyState(string repoPath, string expectedBaseBranch) =>
             GitResult<DirtyRepoResult>.Failure(GitError.CommandFailed, "Not implemented in stub");

--- a/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
+++ b/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
@@ -476,6 +476,12 @@ public class PlanContentHelpersTests
             return GitResult<List<string>>.Success(candidateHashes.ToList());
         }
 
+        public GitResult<Dictionary<string, CommitRefStatus>> GetCommitRefStatus(string repoPath, IEnumerable<string> commitHashes)
+        {
+            return GitResult<Dictionary<string, CommitRefStatus>>.Success(
+                commitHashes.ToDictionary(h => h, _ => CommitRefStatus.Reachable));
+        }
+
         public GitResult<DirtyRepoResult> GetRepoDirtyState(string repoPath, string expectedBaseBranch)
         {
             return GitResult<DirtyRepoResult>.Success(new DirtyRepoResult());

--- a/src/Ivy.Tendril.Test/Services/GitServiceTests.cs
+++ b/src/Ivy.Tendril.Test/Services/GitServiceTests.cs
@@ -305,4 +305,39 @@ public class GitServiceTests : IDisposable
 
         Assert.False(result.IsSuccess);
     }
+
+    [Fact]
+    public void GetCommitRefStatus_SeparatesReachableFromOrphanedAndAbsentCommits()
+    {
+        // Reproduces what the reaper used to leave behind: a commit made on a branch that was then
+        // deleted still exists as an object, but nothing reaches it.
+        var service = CreateService();
+        var reachable = GetCommitHash();
+
+        RunGit("checkout -b doomed");
+        File.WriteAllText(Path.Combine(_testRepoPath, "orphan.txt"), "work with no ref");
+        RunGit("add orphan.txt");
+        RunGit("commit -m \"Work that outlives its branch\"");
+        var orphaned = GetCommitHash();
+        RunGit("checkout -");
+        RunGit("branch -D doomed");
+
+        var result = service.GetCommitRefStatus(_testRepoPath, [reachable, orphaned, "0123456789abcdef0123456789abcdef01234567"]);
+
+        Assert.True(result.IsSuccess);
+        var statuses = result.Value!;
+        Assert.Equal(CommitRefStatus.Reachable, statuses[reachable]);
+        Assert.Equal(CommitRefStatus.Unreachable, statuses[orphaned]);
+        Assert.Equal(CommitRefStatus.Missing, statuses["0123456789abcdef0123456789abcdef01234567"]);
+    }
+
+    [Fact]
+    public void GetCommitRefStatus_ReturnsFailureForInvalidRepo()
+    {
+        var service = CreateService();
+
+        var result = service.GetCommitRefStatus("/nonexistent/path", ["abc1234"]);
+
+        Assert.False(result.IsSuccess);
+    }
 }

--- a/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -1,3 +1,4 @@
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -21,8 +22,19 @@ public class WorktreeCleanupServiceTests : IDisposable
     public void Dispose()
     {
         _service.Dispose();
-        if (Directory.Exists(_tempDir))
+        if (!Directory.Exists(_tempDir)) return;
+
+        try
+        {
+            // Tests that build a real git repo leave read-only files under .git/objects, which plain
+            // Directory.Delete refuses with UnauthorizedAccessException.
+            WorktreeCleanupService.ClearReadOnlyAttributes(_tempDir);
             Directory.Delete(_tempDir, true);
+        }
+        catch
+        {
+            // Best-effort temp cleanup.
+        }
     }
 
     private string CreatePlan(string folderName, string state, DateTime? updated = null)
@@ -688,6 +700,107 @@ public class WorktreeCleanupServiceTests : IDisposable
         WorktreeCleanupService.RemoveWorktrees(dir, logger);
 
         Assert.False(Directory.Exists(worktreeDir), "Worktree should be cleaned up even if daemon stop fails");
+    }
+
+    [Fact]
+    public void RemoveWorktrees_PreserveUnpushed_KeepsBranchHoldingUnpushedCommits()
+    {
+        // The plan-00070 hazard: the plan branch is the only ref holding the commits execution
+        // produced. The worktree directory is still reclaimed — only the ref survives.
+        var (planDir, repo, branch) = CreatePlanWithRealWorktree("22000-UnpushedWork", "Failed", withOwnCommit: true);
+
+        var logEntries = new List<string>();
+        WorktreeCleanupService.RemoveWorktrees(planDir, new CapturingLogger(logEntries), null,
+            BranchDeleteMode.PreserveUnpushed);
+
+        Assert.False(Directory.Exists(Path.Combine(planDir, "Worktrees", "Repo")), "Worktree directory should still be reclaimed");
+        Assert.True(BranchExists(repo, branch), "Branch holding unpushed commits must not be deleted");
+        Assert.Contains(logEntries, e => e.Contains("Kept branch") && e.Contains(branch));
+    }
+
+    [Fact]
+    public void RemoveWorktrees_PreserveUnpushed_DeletesBranchWithNothingToLose()
+    {
+        // Safe delete succeeds when the branch is fully merged into its base, so a plan branch that
+        // produced no commits of its own is still cleaned up rather than accumulating.
+        var (planDir, repo, branch) = CreatePlanWithRealWorktree("22001-NoOwnCommits", "Failed", withOwnCommit: false);
+
+        WorktreeCleanupService.RemoveWorktrees(planDir, NullLogger<WorktreeCleanupService>.Instance, null,
+            BranchDeleteMode.PreserveUnpushed);
+
+        Assert.False(BranchExists(repo, branch), "A branch merged into its base holds nothing to lose and should be deleted");
+    }
+
+    [Fact]
+    public void RemoveWorktrees_Force_StillDeletesBranchHoldingUnpushedCommits()
+    {
+        // Explicit user actions (Complete, Discard, Reset to Draft, deleting the plan) keep the old
+        // behavior: the user asked for this work to go away and is present to notice.
+        var (planDir, repo, branch) = CreatePlanWithRealWorktree("22002-ForcedAway", "Failed", withOwnCommit: true);
+
+        WorktreeCleanupService.RemoveWorktrees(planDir, NullLogger<WorktreeCleanupService>.Instance);
+
+        Assert.False(BranchExists(repo, branch), "Force mode should delete the branch regardless of what it holds");
+    }
+
+    [Fact]
+    public void CleanupPlanWorktrees_ReapsWorktree_ButKeepsBranch_ForStalePlanWithUnpushedCommits()
+    {
+        // End to end through the unattended reaper: an idle Failed plan past the stale window still
+        // loses its worktree, but its commits stay reachable.
+        var (planDir, repo, branch) = CreatePlanWithRealWorktree("22003-StaleFailed", "Failed",
+            withOwnCommit: true, updated: DateTime.UtcNow.AddDays(-8));
+
+        WorktreeCleanupService.CleanupPlanWorktrees(planDir);
+
+        Assert.False(Directory.Exists(Path.Combine(planDir, "Worktrees")), "Stale Failed plan should still have its worktree reaped");
+        Assert.True(BranchExists(repo, branch), "Reaping must not orphan the commits the branch is the only ref for");
+    }
+
+    /// <summary>
+    ///     Builds a plan folder whose <c>Worktrees/Repo</c> is a real git worktree of a real
+    ///     throwaway repo, on the branch name <see cref="WorktreeCleanupService.RemoveWorktrees" />
+    ///     derives from the folder name. Returns the plan folder, the parent repo, and the branch.
+    /// </summary>
+    private (string PlanDir, string RepoPath, string Branch) CreatePlanWithRealWorktree(
+        string folderName, string state, bool withOwnCommit, DateTime? updated = null)
+    {
+        var planDir = CreatePlan(folderName, state, updated);
+
+        var repoPath = Path.Combine(_tempDir, $"repo-{folderName}");
+        Directory.CreateDirectory(repoPath);
+        RunGit(repoPath, "init");
+        RunGit(repoPath, "config user.email test@example.com");
+        RunGit(repoPath, "config user.name TestUser");
+        File.WriteAllText(Path.Combine(repoPath, "base.txt"), "base");
+        RunGit(repoPath, "add base.txt");
+        RunGit(repoPath, "commit -m \"Initial commit\"");
+
+        var branch = $"tendril/{folderName}";
+        var worktreePath = Path.Combine(planDir, "Worktrees", "Repo");
+        RunGit(repoPath, $"worktree add -b \"{branch}\" \"{worktreePath}\"");
+
+        if (withOwnCommit)
+        {
+            File.WriteAllText(Path.Combine(worktreePath, "work.txt"), "unpushed work");
+            RunGit(worktreePath, "add work.txt");
+            RunGit(worktreePath, "commit -m \"Plan work that exists nowhere else\"");
+        }
+
+        return (planDir, repoPath, branch);
+    }
+
+    private static bool BranchExists(string repoPath, string branch)
+    {
+        var (exitCode, _, _) = GitHelper.RunGit($"rev-parse --verify --quiet \"refs/heads/{branch}\"", repoPath, 10000);
+        return exitCode == 0;
+    }
+
+    private static void RunGit(string workingDir, string args)
+    {
+        var (exitCode, _, stdErr) = GitHelper.RunGit(args, workingDir, 30000);
+        if (exitCode != 0)
+            throw new InvalidOperationException($"git {args} failed in {workingDir}: {stdErr}");
     }
 
     private class LoggerAdapter(ILogger inner) : ILogger<WorktreeCleanupService>

--- a/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -53,7 +53,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     {
         // Truly active/transient states are never reaped, regardless of age. (Draft is handled by
         // the stale-reaper tests — it IS reaped once idle. Review is never reaped either, but for a
-        // different reason; see RunCleanup_NeverReaps_ActiveStates_EvenWhenOld.)
+        // different reason; see RunCleanup_NeverReaps_UnreapableStates_EvenWhenOld.)
         var activeStates = new[] { "Creating", "Executing", "Updating", "Blocked" };
         foreach (var state in activeStates)
         {
@@ -577,11 +577,12 @@ public class WorktreeCleanupServiceTests : IDisposable
     }
 
     [Fact]
-    public void RunCleanup_NeverReaps_ActiveStates_EvenWhenOld()
+    public void RunCleanup_NeverReaps_UnreapableStates_EvenWhenOld()
     {
-        // Review is in this list for a different reason than the active/transient states: execution
-        // has finished and produced commits, and reaping would force-delete the only branch holding
-        // them. Like the active states, it is never reaped regardless of age.
+        // These states are exempt for two different reasons, which is why the set is named for what
+        // it does (never reaped) rather than for "active": Creating/Executing/Updating/Blocked are
+        // transient, while Review has finished and produced commits, and reaping would force-delete
+        // the only branch holding them. What they share is that no idle age makes them reapable.
         var states = new[] { "Creating", "Executing", "Updating", "Blocked", "Review" };
         foreach (var state in states)
         {

--- a/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs
@@ -51,8 +51,9 @@ public class WorktreeCleanupServiceTests : IDisposable
     [Fact]
     public void RunCleanup_Skips_Active_State_Plans()
     {
-        // Truly active/transient states are never reaped, regardless of age. (Draft and
-        // Review are handled by the stale-reaper tests — they ARE reaped once idle.)
+        // Truly active/transient states are never reaped, regardless of age. (Draft is handled by
+        // the stale-reaper tests — it IS reaped once idle. Review is never reaped either, but for a
+        // different reason; see RunCleanup_NeverReaps_ActiveStates_EvenWhenOld.)
         var activeStates = new[] { "Creating", "Executing", "Updating", "Blocked" };
         foreach (var state in activeStates)
         {
@@ -537,9 +538,10 @@ public class WorktreeCleanupServiceTests : IDisposable
     [Fact]
     public void RunCleanup_Reaps_StaleRecoveryStates_PastReaperWindow()
     {
-        // Failed/Draft/Review keep their worktree for recovery/resume, but once the
-        // plan has been idle past the reaper window the worktree is reclaimed.
-        var states = new[] { "Failed", "Draft", "Review" };
+        // Failed/Draft hold disposable work that re-executing recreates, so once the plan has been
+        // idle past the reaper window the worktree is reclaimed. (Review is excluded — see
+        // CleanupPlanWorktrees_NeverReapsReview_EvenFarPastTheStaleWindow.)
+        var states = new[] { "Failed", "Draft" };
         foreach (var state in states)
         {
             var dir = CreatePlan($"15{Array.IndexOf(states, state):D3}-{state}Stale", state, DateTime.UtcNow.AddDays(-8));
@@ -558,7 +560,7 @@ public class WorktreeCleanupServiceTests : IDisposable
     [Fact]
     public void RunCleanup_Keeps_StaleRecoveryStates_WithinReaperWindow()
     {
-        var states = new[] { "Failed", "Draft", "Review" };
+        var states = new[] { "Failed", "Draft" };
         foreach (var state in states)
         {
             var dir = CreatePlan($"16{Array.IndexOf(states, state):D3}-{state}Fresh", state, DateTime.UtcNow.AddHours(-2));
@@ -577,7 +579,10 @@ public class WorktreeCleanupServiceTests : IDisposable
     [Fact]
     public void RunCleanup_NeverReaps_ActiveStates_EvenWhenOld()
     {
-        var states = new[] { "Creating", "Executing", "Updating", "Blocked" };
+        // Review is in this list for a different reason than the active/transient states: execution
+        // has finished and produced commits, and reaping would force-delete the only branch holding
+        // them. Like the active states, it is never reaped regardless of age.
+        var states = new[] { "Creating", "Executing", "Updating", "Blocked", "Review" };
         foreach (var state in states)
         {
             var dir = CreatePlan($"17{Array.IndexOf(states, state):D3}-{state}Old", state, DateTime.UtcNow.AddDays(-30));
@@ -589,8 +594,22 @@ public class WorktreeCleanupServiceTests : IDisposable
         foreach (var state in states)
         {
             var worktreesDir = Path.Combine(_plansDir, $"17{Array.IndexOf(states, state):D3}-{state}Old", "Worktrees");
-            Assert.True(Directory.Exists(worktreesDir), $"Active {state} plan should never be reaped regardless of age");
+            Assert.True(Directory.Exists(worktreesDir), $"{state} plan should never be reaped regardless of age");
         }
+    }
+
+    [Fact]
+    public void CleanupPlanWorktrees_NeverReapsReview_EvenFarPastTheStaleWindow()
+    {
+        // A Review plan waits on a human, and its branch is the only ref holding the commits
+        // execution produced. No idle window makes it eligible for the automatic reaper.
+        var dir = CreatePlan("21000-ReviewLongIdle", "Review", DateTime.UtcNow.AddDays(-60));
+        CreateWorktreeDir(dir, "Repo");
+
+        WorktreeCleanupService.CleanupPlanWorktrees(dir);
+
+        Assert.True(Directory.Exists(Path.Combine(dir, "Worktrees")),
+            "Review plan idle 60 days should still keep its worktree");
     }
 
     [Fact]
@@ -636,11 +655,19 @@ public class WorktreeCleanupServiceTests : IDisposable
         Assert.Equal(terminal, WorktreeCleanupService.ResolveGrace("Icebox", terminal, stale));
         Assert.Equal(stale, WorktreeCleanupService.ResolveGrace("Failed", terminal, stale));
         Assert.Equal(stale, WorktreeCleanupService.ResolveGrace("Draft", terminal, stale));
-        Assert.Equal(stale, WorktreeCleanupService.ResolveGrace("Review", terminal, stale));
         Assert.Null(WorktreeCleanupService.ResolveGrace("Creating", terminal, stale));
         Assert.Null(WorktreeCleanupService.ResolveGrace("Executing", terminal, stale));
         Assert.Null(WorktreeCleanupService.ResolveGrace("Updating", terminal, stale));
         Assert.Null(WorktreeCleanupService.ResolveGrace("Blocked", terminal, stale));
+    }
+
+    [Fact]
+    public void ResolveGrace_ReturnsNull_ForReview()
+    {
+        var terminal = TimeSpan.FromMinutes(10);
+        var stale = TimeSpan.FromDays(7);
+
+        Assert.Null(WorktreeCleanupService.ResolveGrace("Review", terminal, stale));
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Apps/Views/Tabs/GitTabView.cs
+++ b/src/Ivy.Tendril/Apps/Views/Tabs/GitTabView.cs
@@ -24,6 +24,11 @@ public class GitTabView(
 
         gitLayout |= Text.H2("Worktrees");
 
+        if (gitData.WorktreeSections.Count == 0)
+        {
+            gitLayout |= RenderNoWorktreesState();
+        }
+
         foreach (var section in gitData.WorktreeSections)
         {
             var isSyncing = syncingPaths?.Contains(section.Path) == true;
@@ -37,7 +42,13 @@ public class GitTabView(
                 gitLayout |= commitWarning;
 
             gitLayout |= Text.Block("Commits").Bold();
-            gitLayout |= RenderCommitTable(gitData.UnassociatedCommitRows);
+
+            var refStatus = gitData.UnassociatedCommitRefStatus;
+            var unreachableCallout = BuildUnreachableCommitsCallout(gitData.UnassociatedCommitRows, refStatus);
+            if (unreachableCallout != null)
+                gitLayout |= unreachableCallout;
+
+            gitLayout |= RenderCommitTable(gitData.UnassociatedCommitRows, refStatus);
         }
 
         if (plan.Prs.Count > 0)
@@ -63,6 +74,70 @@ public class GitTabView(
         }
 
         return gitLayout;
+    }
+
+    /// <summary>
+    ///     Replaces the bare "Worktrees" heading over empty space with a statement of why there is
+    ///     nothing to list. The tab is only rendered at all when the plan has commits or PRs, so an
+    ///     empty worktree list means the worktree went away, not that nothing ever happened.
+    /// </summary>
+    private object RenderNoWorktreesState()
+    {
+        var reason = plan.Status switch
+        {
+            PlanStatus.Completed or PlanStatus.Skipped or PlanStatus.Icebox =>
+                "removed after the plan reached its final state",
+            PlanStatus.Failed or PlanStatus.Draft =>
+                "never created, or reclaimed by the stale reaper once the plan sat idle past its window",
+            _ => "removed, or never created"
+        };
+
+        return new Card() |
+               (Layout.Vertical().Gap(0).AlignContent(Align.Center)
+                | Icons.GitBranchPlus.ToIcon().Color(Colors.Muted)
+                | Text.Muted($"No worktrees — {reason}"));
+    }
+
+    /// <summary>
+    ///     Warns when commits the plan recorded are held by no ref. Such a commit exists only as a
+    ///     loose object and is destroyed by the next <c>git gc</c> in its repo, so saying so is the
+    ///     difference between recovering the work and losing it.
+    /// </summary>
+    private static object? BuildUnreachableCommitsCallout(
+        List<PlanContentHelpers.CommitRow> commitRows,
+        IReadOnlyDictionary<string, CommitRefStatus>? refStatus)
+    {
+        if (refStatus == null || refStatus.Count == 0) return null;
+
+        var unreachable = commitRows.Where(r => StatusOf(r, refStatus) == CommitRefStatus.Unreachable).ToList();
+        var missing = commitRows.Where(r => StatusOf(r, refStatus) == CommitRefStatus.Missing).ToList();
+        if (unreachable.Count == 0 && missing.Count == 0) return null;
+
+        var parts = new List<string>();
+
+        if (unreachable.Count > 0)
+        {
+            var hashes = string.Join(", ", unreachable.Select(r => $"`{r.ShortHash}`"));
+            parts.Add(
+                $"{Count(unreachable.Count, "commit")} reachable from no branch, tag or remote: {hashes}. " +
+                "They exist only as loose objects, so the next `git gc` in the repo destroys them. " +
+                "Give one a ref to keep it: `git branch recover/<name> <hash>`.");
+        }
+
+        if (missing.Count > 0)
+        {
+            var hashes = string.Join(", ", missing.Select(r => $"`{r.ShortHash}`"));
+            parts.Add(
+                $"{Count(missing.Count, "commit")} not found in the plan's repos at all: {hashes}. " +
+                "Either the object was already pruned, or the repo it was made in is not one of the plan's repos.");
+        }
+
+        return Callout.Error(string.Join("\n\n", parts), "Commits At Risk");
+
+        static CommitRefStatus StatusOf(PlanContentHelpers.CommitRow row, IReadOnlyDictionary<string, CommitRefStatus> map) =>
+            map.TryGetValue(row.Hash, out var status) ? status : CommitRefStatus.Reachable;
+
+        static string Count(int n, string noun) => n == 1 ? $"1 {noun} is" : $"{n} {noun}s are";
     }
 
     private object RenderWorktreeSection(
@@ -158,7 +233,8 @@ public class GitTabView(
         return sectionLayout;
     }
 
-    private object RenderCommitTable(List<PlanContentHelpers.CommitRow> commitRows)
+    private object RenderCommitTable(List<PlanContentHelpers.CommitRow> commitRows,
+        IReadOnlyDictionary<string, CommitRefStatus>? refStatus = null)
     {
         var tableRows = commitRows.Select(row => new CommitTableRow(
             row.ShortHash,
@@ -170,11 +246,20 @@ public class GitTabView(
         return new TableBuilder<CommitTableRow>(tableRows)
             .Order(t => t.Commit, t => t.Message, t => t.Files)
             .Builder(t => t.Commit, f => f.Func<CommitTableRow, string>(shortHash =>
-                new Button(shortHash).Inline().OnClick(() =>
-                {
-                    var row = tableRows.First(r => r.Commit == shortHash);
-                    setOpenCommit(row.Hash);
-                })))
+            {
+                var row = tableRows.First(r => r.Commit == shortHash);
+                var link = new Button(shortHash).Inline().OnClick(() => setOpenCommit(row.Hash));
+
+                var status = refStatus != null && refStatus.TryGetValue(row.Hash, out var s)
+                    ? s
+                    : CommitRefStatus.Reachable;
+                if (status == CommitRefStatus.Reachable) return link;
+
+                return Layout.Horizontal().Gap(2).AlignContent(Align.Left)
+                       | link
+                       | new Badge(status == CommitRefStatus.Missing ? "not found" : "unreachable")
+                           .Variant(BadgeVariant.Destructive).Small();
+            }))
             .Remove(t => t.Hash)
             .ColumnWidth(t => t.Message, Size.Grow());
     }

--- a/src/Ivy.Tendril/Helpers/GitTabDataBuilder.cs
+++ b/src/Ivy.Tendril/Helpers/GitTabDataBuilder.cs
@@ -7,7 +7,12 @@ public static class GitTabDataBuilder
 {
     public record GitTabData(
         List<WorktreeSection> WorktreeSections,
-        List<PlanContentHelpers.CommitRow> UnassociatedCommitRows
+        List<PlanContentHelpers.CommitRow> UnassociatedCommitRows,
+        // Ref status for the unassociated commits only. Commits listed under a worktree section are
+        // ancestors of that worktree's HEAD and so reachable by definition; the unassociated ones
+        // are those no surviving worktree accounts for, which is exactly where a commit can turn
+        // out to be reachable from nothing at all.
+        Dictionary<string, CommitRefStatus>? UnassociatedCommitRefStatus = null
     );
 
     public record WorktreeSection(
@@ -71,7 +76,42 @@ public static class GitTabDataBuilder
             .Where(r => !assignedCommitHashes.Contains(r.Hash))
             .ToList();
 
-        return new GitTabData(sections, unassigned);
+        return new GitTabData(sections, unassigned, ResolveRefStatus(plan, config, gitService, unassigned));
+    }
+
+    /// <summary>
+    ///     Asks each of the plan's repos whether it still holds the given commits, and keeps the best
+    ///     answer per commit: a commit lives in exactly one of a multi-repo plan's repos, so a repo
+    ///     that has never heard of it must not mask the repo that has.
+    /// </summary>
+    private static Dictionary<string, CommitRefStatus> ResolveRefStatus(
+        PlanFile plan, IConfigService config, IGitService gitService, List<PlanContentHelpers.CommitRow> rows)
+    {
+        var statuses = new Dictionary<string, CommitRefStatus>(StringComparer.OrdinalIgnoreCase);
+        if (rows.Count == 0) return statuses;
+
+        var hashes = rows.Select(r => r.Hash).ToList();
+        foreach (var repo in plan.GetEffectiveRepoPaths(config))
+        {
+            var result = gitService.GetCommitRefStatus(repo, hashes);
+            if (!result.IsSuccess || result.Value == null) continue;
+
+            foreach (var (hash, status) in result.Value)
+            {
+                if (!statuses.TryGetValue(hash, out var current) || Rank(status) < Rank(current))
+                    statuses[hash] = status;
+            }
+        }
+
+        return statuses;
+
+        // Reachable is the most informative answer, Missing the least.
+        static int Rank(CommitRefStatus status) => status switch
+        {
+            CommitRefStatus.Reachable => 0,
+            CommitRefStatus.Unreachable => 1,
+            _ => 2
+        };
     }
 
     private static WorktreeSection? BuildSectionForWorktree(

--- a/src/Ivy.Tendril/Services/Git/GitResult.cs
+++ b/src/Ivy.Tendril/Services/Git/GitResult.cs
@@ -9,6 +9,23 @@ public enum GitError
     UnknownError
 }
 
+/// <summary>
+///     Whether a commit a plan recorded is still held alive by a ref in the repo it was made in.
+///     Once a plan's worktree and branch are gone, its commits can survive as nothing but loose
+///     objects, which the next <c>git gc</c> in that repo prunes.
+/// </summary>
+public enum CommitRefStatus
+{
+    /// <summary>Some ref — a branch, a remote-tracking branch or a tag — contains the commit.</summary>
+    Reachable,
+
+    /// <summary>The commit object exists, but no ref reaches it. It is one <c>git gc</c> from gone.</summary>
+    Unreachable,
+
+    /// <summary>The commit object is not in the repo at all.</summary>
+    Missing
+}
+
 public enum DirtyReason
 {
     NotOnExpectedBranch,

--- a/src/Ivy.Tendril/Services/Git/GitService.cs
+++ b/src/Ivy.Tendril/Services/Git/GitService.cs
@@ -379,6 +379,53 @@ public class GitService : IGitService
         }
     }
 
+    /// <summary>
+    ///     Classifies each commit as reachable from a ref, unreachable (a loose object the next
+    ///     <c>git gc</c> prunes), or absent from this repo. Unlike
+    ///     <see cref="GetReachableCommits" />, which asks whether a commit is an ancestor of one
+    ///     worktree's HEAD, this asks whether <em>anything at all</em> still holds the commit.
+    /// </summary>
+    public GitResult<Dictionary<string, CommitRefStatus>> GetCommitRefStatus(string repoPath, IEnumerable<string> commitHashes)
+    {
+        try
+        {
+            if (!Directory.Exists(repoPath))
+                return GitResult<Dictionary<string, CommitRefStatus>>.Failure(GitError.InvalidRepoPath, $"Repository path does not exist: {repoPath}");
+
+            var statuses = new Dictionary<string, CommitRefStatus>(StringComparer.OrdinalIgnoreCase);
+            foreach (var hash in commitHashes.Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                var (existsExit, _) = RunGitCommand(repoPath, $"cat-file -e {hash}^{{commit}}");
+                if (existsExit != 0)
+                {
+                    statuses[hash] = CommitRefStatus.Missing;
+                    continue;
+                }
+
+                var (refsExit, refsOutput) = RunGitCommand(repoPath, $"for-each-ref --count=1 --contains={hash} --format=%(refname)");
+
+                // A non-zero exit means the question could not be answered (an old git without
+                // --contains, a timeout). Report Reachable rather than raise a false alarm about
+                // work being one `git gc` from destruction.
+                statuses[hash] = refsExit != 0 || !string.IsNullOrWhiteSpace(refsOutput)
+                    ? CommitRefStatus.Reachable
+                    : CommitRefStatus.Unreachable;
+            }
+
+            return GitResult<Dictionary<string, CommitRefStatus>>.Success(statuses);
+        }
+        catch (FileNotFoundException ex)
+        {
+            _logger.LogWarning(ex, "Git executable not found");
+            return GitResult<Dictionary<string, CommitRefStatus>>.Failure(GitError.GitNotFound, "Git executable not found");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unknown error executing git command");
+            return GitResult<Dictionary<string, CommitRefStatus>>.Failure(GitError.UnknownError, ex.Message);
+        }
+    }
+
     public GitResult<WorktreeBaseInfo?> GetWorktreeBase(string repoPath)
     {
         try

--- a/src/Ivy.Tendril/Services/Git/IGitService.cs
+++ b/src/Ivy.Tendril/Services/Git/IGitService.cs
@@ -12,6 +12,7 @@ public interface IGitService
     GitResult<Dictionary<string, (string Title, int FileCount)>> GetCommitSummaries(string repoPath, IEnumerable<string> commitHashes);
     GitResult<bool> HasUncommittedChanges(string repoPath);
     GitResult<List<string>> GetReachableCommits(string repoPath, IEnumerable<string> candidateHashes);
+    GitResult<Dictionary<string, CommitRefStatus>> GetCommitRefStatus(string repoPath, IEnumerable<string> commitHashes);
     GitResult<DirtyRepoResult> GetRepoDirtyState(string repoPath, string expectedBaseBranch);
     GitResult<WorktreeBaseInfo?> GetWorktreeBase(string repoPath);
 }

--- a/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
@@ -10,6 +10,30 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace Ivy.Tendril.Services.Git;
 
+/// <summary>
+///     How a plan's branch is disposed of once its worktree has been removed. The branch is often the
+///     only ref holding the commits execution produced, so who asked for the removal decides whether
+///     destroying it is acceptable.
+/// </summary>
+internal enum BranchDeleteMode
+{
+    /// <summary>
+    ///     <c>git branch -D</c>: deletes the branch whatever it holds. Used by explicit user actions
+    ///     — Complete, Discard, Reset to Draft, deleting the plan or its ExecutePlan job — where the
+    ///     user has asked for this work to go away and is present to notice.
+    /// </summary>
+    Force,
+
+    /// <summary>
+    ///     <c>git branch -d</c>: git refuses to delete a branch holding commits that are not merged
+    ///     into its base or upstream, and those branches are kept and logged instead. Used by the
+    ///     unattended reaper, which runs on a timer with nobody watching and so must never silently
+    ///     orphan commits. The worktree directory is reclaimed either way — only the 41-byte ref
+    ///     survives.
+    /// </summary>
+    PreserveUnpushed
+}
+
 public class WorktreeCleanupService : IStartable, IDisposable
 {
     private static readonly Regex SafeTitleRegex = new(@"^\d{5}-(.+)", RegexOptions.Compiled);
@@ -139,7 +163,10 @@ public class WorktreeCleanupService : IStartable, IDisposable
         logger?.LogInformation("Cleaning up worktrees for plan {PlanFolder} (state: {State}, updated: {Updated})",
             Path.GetFileName(planFolderPath), planYaml.State, planYaml.Updated.ToString("o", CultureInfo.InvariantCulture));
 
-        RemoveWorktrees(planFolderPath, logger, lifecycleLogger);
+        // The reaper runs unattended on a timer, so it never force-deletes a branch: a Failed or
+        // Draft plan can hold good commits its verifications never got to, and nothing would warn
+        // before they became unreachable.
+        RemoveWorktrees(planFolderPath, logger, lifecycleLogger, BranchDeleteMode.PreserveUnpushed);
 
         // Safety net: RemoveWorktrees should have removed all directories
         foreach (var wtDir in Directory.GetDirectories(worktreesDir))
@@ -427,7 +454,14 @@ public class WorktreeCleanupService : IStartable, IDisposable
         });
     }
 
-    internal static void RemoveWorktrees(string planFolderPath, ILogger? logger = null, IWorktreeLifecycleLogger? lifecycleLogger = null)
+    /// <summary>
+    ///     Removes every git worktree under a plan's <c>Worktrees</c> directory and disposes of the
+    ///     plan's branch according to <paramref name="branchDeleteMode" />. Defaults to
+    ///     <see cref="BranchDeleteMode.Force" /> so explicit user actions keep behaving as before;
+    ///     the automatic reaper passes <see cref="BranchDeleteMode.PreserveUnpushed" />.
+    /// </summary>
+    internal static void RemoveWorktrees(string planFolderPath, ILogger? logger = null, IWorktreeLifecycleLogger? lifecycleLogger = null,
+        BranchDeleteMode branchDeleteMode = BranchDeleteMode.Force)
     {
         var worktreesDir = Path.Combine(planFolderPath, "Worktrees");
         if (!Directory.Exists(worktreesDir)) return;
@@ -490,17 +524,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
                 process.WaitForExitOrKill(10000);
                 lifecycleLogger?.LogCleanupSuccess(planId, wtDir);
 
-                try
-                {
-                    var branchPsi = GitHelper.MakeGitStartInfo($"branch -D \"{branchName}\"", repoRoot);
-                    using var branchProcess = Process.Start(branchPsi);
-                    branchProcess.WaitForExitOrKill(10000);
-                    logger?.LogInformation("Deleted branch {BranchName} for worktree {WorktreeDir}", branchName, Path.GetFileName(wtDir));
-                }
-                catch (Exception branchEx)
-                {
-                    logger?.LogWarning(branchEx, "Failed to delete branch {BranchName} for worktree {WorktreeDir}", branchName, Path.GetFileName(wtDir));
-                }
+                DeletePlanBranch(repoRoot, branchName, branchDeleteMode, Path.GetFileName(wtDir), logger);
             }
             catch (Exception ex)
             {
@@ -508,6 +532,78 @@ public class WorktreeCleanupService : IStartable, IDisposable
             }
         }
     }
+
+    /// <summary>
+    ///     Deletes a plan's branch once its worktree has been removed.
+    /// </summary>
+    /// <remarks>
+    ///     Under <see cref="BranchDeleteMode.PreserveUnpushed" /> this prefers git's safe delete
+    ///     (<c>branch -d</c>), which refuses when the branch still holds commits that are not merged
+    ///     into its base or upstream. Safe delete also refuses a branch whose commits were pushed but
+    ///     which has no upstream configured, so a refusal is followed by an explicit check for a
+    ///     remote-tracking ref containing the tip: if one exists the commits outlive the branch and
+    ///     <c>branch -D</c> is safe. Otherwise the branch is kept and logged — a 41-byte ref costs far
+    ///     less than the commits it is the only ref for.
+    /// </remarks>
+    internal static void DeletePlanBranch(string repoRoot, string branchName, BranchDeleteMode mode,
+        string? worktreeName = null, ILogger? logger = null)
+    {
+        try
+        {
+            if (mode == BranchDeleteMode.Force)
+            {
+                ForceDeleteBranch(repoRoot, branchName, worktreeName, logger);
+                return;
+            }
+
+            var (safeExit, _, safeErr) = GitHelper.RunGit($"branch -d \"{branchName}\"", repoRoot, 10000);
+            if (safeExit == 0)
+            {
+                logger?.LogInformation("Deleted branch {BranchName} for worktree {WorktreeDir} (fully merged)",
+                    branchName, worktreeName);
+                return;
+            }
+
+            // No such branch — already deleted by a previous pass, or never created. Nothing to keep.
+            var (tipExit, tipOut, _) = GitHelper.RunGit($"rev-parse --verify --quiet \"refs/heads/{branchName}\"", repoRoot, 10000);
+            var tip = tipOut.Trim();
+            if (tipExit != 0 || string.IsNullOrEmpty(tip))
+            {
+                logger?.LogDebug("Branch {BranchName} does not exist in {RepoRoot}; nothing to delete", branchName, repoRoot);
+                return;
+            }
+
+            var (remotesExit, remotes, _) = GitHelper.RunGit($"branch -r --contains {tip}", repoRoot, 10000);
+            if (remotesExit == 0 && !string.IsNullOrWhiteSpace(remotes))
+            {
+                ForceDeleteBranch(repoRoot, branchName, worktreeName, logger);
+                return;
+            }
+
+            logger?.LogWarning(
+                "Kept branch {BranchName} ({Tip}) in {RepoRoot}: it holds commits that are on no remote and are not merged " +
+                "into its base or upstream, so deleting it would leave them reachable from nothing and the next `git gc` " +
+                "would destroy them. Its worktree was still reclaimed; push the branch, or delete it manually with " +
+                "`git branch -D`, once the work is no longer needed. git said: {Reason}",
+                branchName, Shorten(tip), repoRoot, safeErr.Trim());
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Failed to delete branch {BranchName} for worktree {WorktreeDir}", branchName, worktreeName);
+        }
+    }
+
+    private static void ForceDeleteBranch(string repoRoot, string branchName, string? worktreeName, ILogger? logger)
+    {
+        var (exitCode, _, stdErr) = GitHelper.RunGit($"branch -D \"{branchName}\"", repoRoot, 10000);
+        if (exitCode == 0)
+            logger?.LogInformation("Deleted branch {BranchName} for worktree {WorktreeDir}", branchName, worktreeName);
+        else
+            logger?.LogWarning("Failed to delete branch {BranchName} for worktree {WorktreeDir}: {Error}",
+                branchName, worktreeName, stdErr.Trim());
+    }
+
+    private static string Shorten(string hash) => hash.Length > 7 ? hash[..7] : hash;
 
     internal static string ExtractSafeTitle(string planFolderPath)
     {

--- a/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
@@ -18,11 +18,18 @@ public class WorktreeCleanupService : IStartable, IDisposable
     private static readonly HashSet<string> TerminalStates = new(StringComparer.OrdinalIgnoreCase)
         { nameof(PlanStatus.Completed), nameof(PlanStatus.Skipped), nameof(PlanStatus.Icebox) };
 
-    // Non-terminal states that keep their worktree for recovery/resume (Failed = verifications
-    // failed; Draft/Review = a stopped or reverted execution). The worktree is reaped
-    // only once the plan has been idle past the stale-reaper window. Re-executing recreates it.
+    // Non-terminal states holding disposable work: Failed = a broken execution attempt, Draft = an
+    // unstarted or reverted one. Re-executing recreates whatever they hold, so their worktree is
+    // reclaimed once the plan has been idle past the stale-reaper window.
+    //
+    // Review is deliberately NOT in this set. It means execution finished, produced commits, and a
+    // human is the blocker — there is no equivalent fallback, and reaping runs `git branch -D` on the
+    // only ref holding those commits. A Review plan's worktree and branch must survive until the
+    // human acts, so it is never reaped automatically (ResolveGrace returns null for it). Explicit
+    // user actions — Create PR, Discard, Reset to Draft, deleting the ExecutePlan job or the plan,
+    // and `tendril plan cleanup --force` — call RemoveWorktrees directly and are unaffected.
     private static readonly HashSet<string> StaleReapStates = new(StringComparer.OrdinalIgnoreCase)
-        { nameof(PlanStatus.Failed), nameof(PlanStatus.Draft), nameof(PlanStatus.Review) };
+        { nameof(PlanStatus.Failed), nameof(PlanStatus.Draft) };
 
     private static readonly TimeSpan DefaultTerminalGrace = TimeSpan.FromMinutes(10);
     private static readonly TimeSpan DefaultStaleReaperPeriod = TimeSpan.FromDays(7);
@@ -55,8 +62,9 @@ public class WorktreeCleanupService : IStartable, IDisposable
 
     /// <summary>
     ///     Resolves how long a plan in the given state must be idle before its worktree is reaped,
-    ///     or <c>null</c> for active/transient states (Creating/Executing/Updating/Blocked) whose
-    ///     worktrees are never reaped.
+    ///     or <c>null</c> for states whose worktrees are never reaped automatically: the
+    ///     active/transient ones (Creating/Executing/Updating/Blocked) and Review, which holds
+    ///     finished, unpushed work while it waits on a human.
     /// </summary>
     internal static TimeSpan? ResolveGrace(string state, TimeSpan terminalGrace, TimeSpan staleReaperPeriod)
     {


### PR DESCRIPTION
# Summary

## Changes

Removed `Review` from `WorktreeCleanupService.StaleReapStates`, so the background worktree reaper no
longer deletes a `Review` plan's worktree — and, critically, no longer runs `git branch -D` on the
plan's branch, which was the only ref holding the commits execution produced. `Review` now behaves
like the active/transient states: `ResolveGrace` returns `null` for it and `CleanupPlanWorktrees`
returns early, at any idle age. Explicit user actions (Create PR, Discard, Reset to Draft, deleting
the job or plan, `tendril plan cleanup --force`) call `RemoveWorktrees` directly and are unchanged.

## API Changes

None. `StaleReapStates` is `private static readonly`, `ResolveGrace` is `internal` and keeps its
signature, and no constant or constructor parameter was added or removed. This is a pure behavior
change to the automatic reaper's state policy.

## Files Modified

**Service**
- `src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs` — dropped `nameof(PlanStatus.Review)`
  from `StaleReapStates`; replaced the comment above it with an explicit statement of why
  `Failed`/`Draft` are reapable and `Review` is not; updated the `ResolveGrace` XML doc to name
  `Review` among the states that are never reaped.

**Tests**
- `src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs` — added
  `CleanupPlanWorktrees_NeverReapsReview_EvenFarPastTheStaleWindow` (60-day-idle `Review` plan keeps
  its worktree) and `ResolveGrace_ReturnsNull_ForReview`; moved `Review` out of the two stale-reap
  test arrays and into `RunCleanup_NeverReaps_ActiveStates_EvenWhenOld`; dropped the stale
  `Review` assertion from `ResolveGrace_MapsStatesToWindows`.

## Manual Testing

The reaper is a 30-minute background timer with a 7-day window, so it is not practical to observe
end to end by waiting. To verify by hand:

1. **Confirm the exemption directly.** Run the scoped suite in the worktree:
   `dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj --filter "FullyQualifiedName~Ivy.Tendril.Test.WorktreeCleanupServiceTests"`.
   `CleanupPlanWorktrees_NeverReapsReview_EvenFarPastTheStaleWindow` ages a `Review` plan 60 days and
   asserts its `Worktrees` directory survives; it fails on the pre-change code.
2. **Check the two live at-risk plans.** Plans `00083-InteractiveQuestionBlocksInDraftMarkdown`
   (9 unpushed commits) and `00084-ShowTokenAndCostBreakdownSheetFromJobCostCells` (5) sit in
   `Review` with worktrees present and were last updated 2026-08-14. With this change deployed,
   `D:\Plans\<folder>\Worktrees\` and their `tendril/000NN-…` branches should still exist after
   2026-08-21 (the old 7-day deadline). Before this change they would have been reaped that day.
3. **Confirm explicit removal still works.** Open a `Review` plan in the Review app and press
   Discard. Its `Worktrees` directory should disappear promptly — Discard bypasses the grace check,
   so the exemption must not make a `Review` worktree undeletable.

Note the accepted tradeoff: `Review` worktrees now accumulate on disk until a human acts on the
plan. That is intended — finished work is never destroyed to reclaim disk space.

---

## Fix: Rename RunCleanup_NeverReaps_ActiveStates_EvenWhenOld

The test now asserts over `{ Creating, Executing, Updating, Blocked, Review }`, but `Review` is not an
active/transient state — it is exempt because it holds finished, unpushed commits. Renamed to
`RunCleanup_NeverReaps_UnreapableStates_EvenWhenOld`, which names what the set actually has in common
(no idle age makes them reapable), and rewrote the comment to state both reasons rather than fold
`Review` into "active". No behavior change.

### Files Modified

- `src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs` — renamed the test and updated the
  cross-reference to it in `RunCleanup_Skips_Active_State_Plans`.

## Fix: Stop the reaper force-deleting branches that hold unpushed commits

Exempting `Review` closed one state; `Failed` and `Draft` are still reaped after 7 idle days (and
`Completed`/`Skipped`/`Icebox` after 10 minutes), and `RemoveWorktrees` ran an unconditional
`git branch -D` on the plan branch immediately after removing the worktree. A `Failed` plan whose
verifications broke *after* it produced good commits therefore lost them exactly the way plan 00070
did, unattended and with no warning.

`RemoveWorktrees` now takes a `BranchDeleteMode`. The automatic reaper passes `PreserveUnpushed`,
which tries git's safe delete (`git branch -d`) and falls back to `-D` only when a remote-tracking ref
contains the branch tip — safe delete also refuses a *pushed* branch that has no upstream configured,
so that second check prevents the conservative path from hoarding branches whose commits are already
on a remote. When neither holds, the branch is kept and logged with its tip and a recovery hint; the
worktree directory is reclaimed either way, so the cost is a 41-byte ref.

Explicit user actions — Complete, Discard, Reset to Draft, deleting the plan or its ExecutePlan job —
keep the default `Force` mode. Those are deliberate, attended requests to remove the work.

### Files Modified

- `src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs` — added the `BranchDeleteMode` enum and
  `DeletePlanBranch`/`ForceDeleteBranch`; `RemoveWorktrees` takes the mode (defaulting to `Force`);
  `CleanupPlanWorktrees` passes `PreserveUnpushed`.
- `src/Ivy.Tendril.Test/WorktreeCleanupServiceTests.cs` — four tests over real git repos and
  worktrees: a branch holding unpushed commits survives `PreserveUnpushed` (worktree still gone), a
  branch merged into its base is still deleted, `Force` still deletes regardless, and the same
  guarantee end to end through `CleanupPlanWorktrees` for a stale `Failed` plan. Teardown now clears
  read-only attributes, which git leaves on objects under `.git`.

## Fix: Report a missing worktree and unreachable commits on the Git tab

The symptom that started this plan: for a plan whose worktree is gone, the Git tab rendered a bare
**Worktrees** heading over empty space followed by an unexplained **Commits** table, with nothing
saying the listed commits were reachable from no ref and one `git gc` from destruction.

- An empty worktree list is now an explicit empty state that says why, chosen by plan state:
  removal after a final state, versus the stale reaper reclaiming a plan that sat idle.
- New `GitService.GetCommitRefStatus` classifies a commit as `Reachable`, `Unreachable` (the object
  exists but no ref holds it) or `Missing`. This is a different question from the existing
  `GetReachableCommits`, which asks whether a commit is an ancestor of one worktree's HEAD.
- `GitTabDataBuilder` resolves that for the commits no surviving worktree accounts for, across the
  plan's repos, keeping the answer from the repo that actually has the commit.
- The tab badges those rows (`unreachable` / `not found`) and adds a callout naming the short hashes
  and the `git branch recover/<name> <hash>` escape hatch.

When git cannot answer — an old git without `for-each-ref --contains`, a timeout, an unreadable repo
— the commit is reported `Reachable` and the tab looks exactly as it does today. A false "your work
is about to be destroyed" is worse than no warning.

### Files Modified

**Service**
- `src/Ivy.Tendril/Services/Git/GitResult.cs` — new `CommitRefStatus` enum.
- `src/Ivy.Tendril/Services/Git/IGitService.cs`, `GitService.cs` — new `GetCommitRefStatus`.

**UI**
- `src/Ivy.Tendril/Helpers/GitTabDataBuilder.cs` — `GitTabData.UnassociatedCommitRefStatus` plus the
  per-repo resolution that fills it.
- `src/Ivy.Tendril/Apps/Views/Tabs/GitTabView.cs` — `RenderNoWorktreesState`,
  `BuildUnreachableCommitsCallout`, and the badge in the commit-hash column.

**Tests**
- `src/Ivy.Tendril.Test/Services/GitServiceTests.cs` — real-git coverage of all three statuses,
  including a commit orphaned by deleting its branch.
- `src/Ivy.Tendril.Test/GitTabDataBuilderTests.cs` — status is reported for unassociated commits, the
  repo that has the commit wins in a multi-repo plan, and nothing is claimed when no repo can answer.
- `src/Ivy.Tendril.Test/PlanContentHelpersTests.cs` — fake `IGitService` implements the new member.

### Manual Testing

The user-facing part of this retry is the Git tab, so it is worth looking at:

1. **Empty state.** Open a plan whose worktree is gone but which has commits — plan
   `00070-AddQRCodeGeneratorTool` is exactly this case. The **Worktrees** heading is now followed by a
   card reading *"No worktrees — removed after the plan reached its final state"* (or the stale-reaper
   wording for a `Failed`/`Draft` plan) instead of empty space.
2. **Unreachable badges.** On that same plan, the four commits should each carry a red `unreachable`
   badge next to the hash, with a **Commits At Risk** callout above the table naming them — unless the
   branch has since been restored by hand, in which case they render unbadged as before.
3. **No false alarms.** Open any plan with a live worktree. Its commits sit under the worktree section
   and are unbadged, and no callout appears.


---
## Commits
- 4f6bee67 Report a missing worktree and unreachable commits on the Git tab
- 0c13e77a Stop the reaper force-deleting branches that hold unpushed commits
- e8c8d449 Rename RunCleanup_NeverReaps_ActiveStates_EvenWhenOld to _UnreapableStates_
- 70c4991e Never automatically reap Review plan worktrees

---
Created using [Ivy Tendril](https://ivy.app).
