### PR TITLE
[00679] Remove Unused allPlans Parameter From Drafts ActionBarView

### DIFF
--- a/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs
@@ -9,7 +9,6 @@ namespace Ivy.Tendril.Apps.Drafts;
 
 public class ActionBarView(
     PlanFile selectedPlan,
-    List<PlanFile> allPlans,
     IState<PlanFile?> selectedPlanState,
     IState<bool> isEditingState,
     IState<string> editContentState,

--- a/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/ContentView.cs
@@ -282,7 +282,6 @@ public class ContentView(
 
         var actionBar = new ActionBarView(
             selectedPlan,
-            allPlans,
             selectedPlanState,
             isEditing,
             editContent,


### PR DESCRIPTION
# Summary

## Changes

Removed the unused `allPlans` parameter from the Drafts app's `ActionBarView` primary constructor and its corresponding argument at the single call site in `ContentView.cs`. This parameter was declared but never used in the action bar's `Build()` method, making it dead code after PR #2104 removed the Previous/Next navigation buttons.

## API Changes

**Internal change only (no public API impact):**
- `ActionBarView` constructor signature changed from 16 to 15 parameters
- Removed: `List<PlanFile> allPlans` (second parameter, line 12)
- Single call site updated in `ContentView.cs:283`

`ActionBarView` is an internal class used only within the Drafts app. No other code references it.

## Files Modified

**Core changes:**
- `src/Ivy.Tendril/Apps/Drafts/ActionBarView.cs` - Removed parameter declaration
- `src/Ivy.Tendril/Apps/Drafts/ContentView.cs` - Removed argument from constructor call

## Manual Testing

**Test:** Verify the Drafts action bar still renders correctly
1. Launch the Tendril app
2. Navigate to the Drafts app in the sidebar
3. Select any draft plan
4. **Observe:** The action bar displays Edit, Update, Split, Expand, Delete buttons (or their responsive equivalents in the overflow dropdown)
5. Click the overflow menu (⋮) button
6. **Observe:** The dropdown opens with all menu items (Discuss, Create Issue, Open in File Manager, etc.)
7. **Observe:** The "n/m plans" counter displays above the plan list
8. On mobile/narrow window, **observe:** The mobile plan picker dropdown still appears and functions

All UI elements should work exactly as before. The change was internal code cleanup with no observable behavior changes.

---

**Commits:**
- 26f51f2b

---
Created using [Ivy Tendril](https://ivy.app).
