### PR TITLE
[00004] Put About Section Behind Beta Flag

### DIFF
--- a/src/Ivy.Tendril.Test/AppShell/TendrilAppShellHelpMenuTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/TendrilAppShellHelpMenuTests.cs
@@ -1,0 +1,26 @@
+using Ivy.Tendril.AppShell;
+
+namespace Ivy.Tendril.Test.AppShell;
+
+public class TendrilAppShellHelpMenuTests
+{
+    [Fact]
+    public void BuildHelpMenuItems_BetaDisabled_ExcludesAboutMenuItem()
+    {
+        var items = TendrilAppShell.BuildHelpMenuItems(isBeta: false, client: null, navigator: null);
+
+        Assert.Equal(3, items.Length);
+        Assert.DoesNotContain(items, item => item.Label == "About");
+        Assert.Equal(["Documentation", "Discord", "Report Issue"], items.Select(i => i.Label));
+    }
+
+    [Fact]
+    public void BuildHelpMenuItems_BetaEnabled_IncludesAboutMenuItem()
+    {
+        var items = TendrilAppShell.BuildHelpMenuItems(isBeta: true, client: null, navigator: null);
+
+        Assert.Equal(4, items.Length);
+        Assert.Contains(items, item => item.Label == "About");
+        Assert.Equal(["Documentation", "Discord", "Report Issue", "About"], items.Select(i => i.Label));
+    }
+}

--- a/src/Ivy.Tendril.Test/Apps/AboutAppTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/AboutAppTests.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using Ivy.Tendril.Apps;
+
+namespace Ivy.Tendril.Test.Apps;
+
+public class AboutAppTests
+{
+    [Fact]
+    public void AboutApp_HasAppAttribute_WithExpectedProperties()
+    {
+        var appAttr = typeof(AboutApp).GetCustomAttribute<AppAttribute>();
+        Assert.NotNull(appAttr);
+        Assert.Equal("About", appAttr.Title);
+        Assert.Equal(Icons.Info, appAttr.Icon);
+        Assert.False(appAttr.IsVisible);
+    }
+}

--- a/src/Ivy.Tendril.Test/Helpers/BetaHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/BetaHelperTests.cs
@@ -1,0 +1,64 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Test.Helpers;
+
+[Collection("EnvironmentTests")]
+public class BetaHelperTests : IDisposable
+{
+    private readonly string? _originalTendrilBeta;
+    private readonly string? _originalIvyBeta;
+
+    public BetaHelperTests()
+    {
+        _originalTendrilBeta = Environment.GetEnvironmentVariable("TENDRIL_BETA");
+        _originalIvyBeta = Environment.GetEnvironmentVariable("IVY_BETA");
+
+        Environment.SetEnvironmentVariable("TENDRIL_BETA", null);
+        Environment.SetEnvironmentVariable("IVY_BETA", null);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_BETA", _originalTendrilBeta);
+        Environment.SetEnvironmentVariable("IVY_BETA", _originalIvyBeta);
+    }
+
+    [Fact]
+    public void IsBeta_TendrilArgsBetaTrue_ReturnsTrue()
+    {
+        var args = new TendrilArgs { Beta = true };
+        Assert.True(BetaHelper.IsBeta(tendrilArgs: args));
+    }
+
+    [Fact]
+    public void IsBeta_ConfigSettingsBetaTrue_ReturnsTrue()
+    {
+        var settings = new TendrilSettings { Beta = true };
+        Assert.True(BetaHelper.IsBeta(settings));
+    }
+
+    [Fact]
+    public void IsBeta_TendrilBetaEnvVarSetToOne_ReturnsTrue()
+    {
+        Environment.SetEnvironmentVariable("TENDRIL_BETA", "1");
+        Assert.True(BetaHelper.IsBeta());
+    }
+
+    [Fact]
+    public void IsBeta_IvyBetaEnvVarSetToOne_ReturnsTrue()
+    {
+        Environment.SetEnvironmentVariable("IVY_BETA", "1");
+        Assert.True(BetaHelper.IsBeta());
+    }
+
+    [Fact]
+    public void IsBeta_AllDisabled_ReturnsFalse()
+    {
+        var args = new TendrilArgs { Beta = false };
+        var settings = new TendrilSettings { Beta = false };
+
+        Assert.False(BetaHelper.IsBeta(args, settings));
+    }
+}

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -104,6 +104,23 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         }
     }
 
+    internal static MenuItem[] BuildHelpMenuItems(bool isBeta, IClientProvider? client, INavigator? navigator)
+    {
+        var items = new List<MenuItem>
+        {
+            MenuItem.Default("Documentation").Icon(Icons.ExternalLink).OnSelect(() => client?.OpenUrl(Constants.DocsUrl)),
+            MenuItem.Default("Discord").Icon(Icons.Discord).OnSelect(() => client?.OpenUrl(Constants.DiscordUrl)),
+            MenuItem.Default("Report Issue").Icon(Icons.Bug).OnSelect(() => client?.OpenUrl(Constants.IssuesUrl))
+        };
+
+        if (isBeta)
+        {
+            items.Add(MenuItem.Default("About").Icon(Icons.Info).OnSelect(() => navigator?.Navigate<AboutApp>()));
+        }
+
+        return items.ToArray();
+    }
+
     private static bool ShouldShowBadge(MenuItem item, Dictionary<string, int> badges, out string badgeText)
     {
         badgeText = string.Empty;
@@ -184,6 +201,9 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         var navigate = Context.UseSignal<NavigateSignal, NavigateArgs, Unit>();
         var navigator = UseNavigation();
         var newsArticles = UseState(Array.Empty<SidebarNewsArticle>());
+        var jobService = UseService<IJobService>();
+        Context.TryUseService<DesktopWindow>(out var desktopWindow);
+        Context.TryUseService<TendrilArgs>(out var tendrilArgs);
 
         var (importIssuesDialog, showImportIssuesDialog) = UseTrigger((isOpen) =>
         {
@@ -196,8 +216,6 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             if (!isOpen.Value || info == null) return null;
             return new UpdateTendrilDialog(isOpen, info);
         });
-
-
 
         UseEffect(async () =>
         {
@@ -235,8 +253,6 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             return Disposable.Create(() => config.SettingsReloaded -= OnSettingsReloaded);
         });
 
-        var jobService = UseService<IJobService>();
-        Context.TryUseService<DesktopWindow>(out var desktopWindow);
         var isDesktop = desktopWindow != null;
 
         UseEffect(() =>
@@ -578,6 +594,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             OnCtrlRightClickSelect = new EventHandler<Event<SidebarMenu, object>>(OnCtrlRightClickSelect)
         };
 
+        var isBeta = BetaHelper.IsBeta(tendrilArgs, config);
+
         var settingsMenuItems = new[]
         {
             MenuItem.Default("Configuration")
@@ -638,12 +656,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             MenuItem.Default("Help")
                 .Tag("$help")
                 .Icon(Icons.CircleQuestionMark)
-                .Children(
-                    MenuItem.Default("Documentation").Icon(Icons.ExternalLink).OnSelect(() => client.OpenUrl(Constants.DocsUrl)),
-                    MenuItem.Default("Discord").Icon(Icons.Discord).OnSelect(() => client.OpenUrl(Constants.DiscordUrl)),
-                    MenuItem.Default("Report Issue").Icon(Icons.Bug).OnSelect(() => client.OpenUrl(Constants.IssuesUrl)),
-                    MenuItem.Default("About").Icon(Icons.Info).OnSelect(() => navigator.Navigate<AboutApp>())
-                ),
+                .Children(BuildHelpMenuItems(isBeta, client, navigator)),
         };
 
         var settingsTrigger = new Button("Settings")

--- a/src/Ivy.Tendril/Apps/AboutApp.cs
+++ b/src/Ivy.Tendril/Apps/AboutApp.cs
@@ -1,9 +1,32 @@
 using Ivy.Tendril.Apps.Settings;
+using Ivy.Tendril.Apps.Views;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Apps;
 
 [App(title: "About", icon: Icons.Info, isVisible: false)]
 public class AboutApp : ViewBase
 {
-    public override object Build() => new AboutSetupView();
+    public override object Build()
+    {
+        var config = UseService<IConfigService>();
+        Context.TryUseService<TendrilArgs>(out var tendrilArgs);
+        var navigator = UseNavigation();
+
+        var isBeta = BetaHelper.IsBeta(tendrilArgs, config);
+        if (!isBeta)
+        {
+            var button = new Button("Open Advanced Settings")
+                .Icon(Icons.Cog)
+                .OnClick(() => navigator.Navigate<SettingsApp>(new SettingsAppArgs(Section: "advanced")));
+
+            return new NoContentView(
+                "Beta Feature",
+                "The About page is a beta feature. You can enable beta features in Advanced Settings.",
+                button);
+        }
+
+        return new AboutSetupView();
+    }
 }

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -27,10 +27,7 @@ public class ProjectInputStepView(
         var jobService = UseService<IJobService>();
         var client = UseService<IClientProvider>();
 
-        var isBeta = (tendrilArgs?.Beta ?? false) ||
-                     (config?.Settings?.Beta ?? false) ||
-                     Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" ||
-                     Environment.GetEnvironmentVariable("IVY_BETA") == "1";
+        var isBeta = BetaHelper.IsBeta(tendrilArgs, config);
 
         UseEffect(() =>
         {

--- a/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectBladeView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectBladeView.cs
@@ -134,10 +134,7 @@ public class EditProjectBladeView(
             })
             .WithTooltip(hasInvalidRepos ? "Fix or remove invalid repositories before saving" : null);
 
-        var isBeta = (tendrilArgs?.Beta ?? false) ||
-                     (config?.Settings?.Beta ?? false) ||
-                     Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" ||
-                     Environment.GetEnvironmentVariable("IVY_BETA") == "1";
+        var isBeta = BetaHelper.IsBeta(tendrilArgs, config);
 
         var tabs = new List<Tab>
         {

--- a/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
@@ -68,10 +68,7 @@ public class ProjectDetailView(
         var (importSkillsDialog, openImportSkillsDialog) = UseTrigger((IState<bool> isOpen) =>
             new ImportRepoAssetsDialog(isOpen, ImportAssetKind.Skills, projectIndex >= 0 && projectIndex < config.Settings.Projects.Count ? config.Settings.Projects[projectIndex].Name : "", repos.Value, config, client, skills: skills));
 
-        var isBeta = (tendrilArgs?.Beta ?? false) ||
-                     (config?.Settings?.Beta ?? false) ||
-                     Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" ||
-                     Environment.GetEnvironmentVariable("IVY_BETA") == "1";
+        var isBeta = BetaHelper.IsBeta(tendrilArgs, config);
 
         // Auto-save settings on state changes
         void SaveProjectChanges()

--- a/src/Ivy.Tendril/Helpers/BetaHelper.cs
+++ b/src/Ivy.Tendril/Helpers/BetaHelper.cs
@@ -1,0 +1,29 @@
+namespace Ivy.Tendril.Helpers;
+
+using Ivy.Tendril.Services;
+
+public static class BetaHelper
+{
+    public static bool IsBeta(TendrilArgs? tendrilArgs = null, IConfigService? config = null)
+    {
+        return (tendrilArgs?.Beta ?? false)
+            || (config?.Settings?.Beta ?? false)
+            || Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1"
+            || Environment.GetEnvironmentVariable("IVY_BETA") == "1";
+    }
+
+    public static bool IsBeta(TendrilArgs? tendrilArgs, TendrilSettings? settings)
+    {
+        return (tendrilArgs?.Beta ?? false)
+            || (settings?.Beta ?? false)
+            || Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1"
+            || Environment.GetEnvironmentVariable("IVY_BETA") == "1";
+    }
+
+    public static bool IsBeta(TendrilSettings? settings)
+    {
+        return (settings?.Beta ?? false)
+            || Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1"
+            || Environment.GetEnvironmentVariable("IVY_BETA") == "1";
+    }
+}

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -2,6 +2,7 @@ using System.ClientModel;
 using Ivy.Core.Exceptions;
 using Ivy.Tendril.Agents;
 using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,10 +33,7 @@ internal static class ServiceRegistration
 
         server.Services.AddAgentInfrastructure(opts =>
         {
-            opts.IncludeBetaProviders = (tendrilArgs?.Beta ?? false) ||
-                                        configService.Settings.Beta ||
-                                        Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" ||
-                                        Environment.GetEnvironmentVariable("IVY_BETA") == "1";
+            opts.IncludeBetaProviders = BetaHelper.IsBeta(tendrilArgs, configService);
 
             opts.IvyApiKeyProviderFactory = sp =>
             {

--- a/src/Ivy.Tendril/TendrilServer.cs
+++ b/src/Ivy.Tendril/TendrilServer.cs
@@ -89,10 +89,7 @@ public static class TendrilServer
             app.UseAssets(server.Args, app.Services.GetRequiredService<ILogger<Server>>(), "Assets", "tendril/assets");
         });
 
-        var isBeta = tendrilArgs.Beta ||
-                     configService.Settings.Beta ||
-                     Environment.GetEnvironmentVariable("TENDRIL_BETA") == "1" ||
-                     Environment.GetEnvironmentVariable("IVY_BETA") == "1";
+        var isBeta = BetaHelper.IsBeta(tendrilArgs, configService);
 
         var assembly = typeof(TendrilServer).Assembly;
         server.AppRepository.AddFactory(() => AppHelpers.GetApps(assembly)


### PR DESCRIPTION
Fixes #2129

# Summary

## Changes

The About section in Tendril is now gated behind a beta flag. A centralized `BetaHelper` utility detects whether beta mode is active across CLI arguments, configuration settings, and environment variables. The sidebar Help dropdown menu omits the About entry when beta mode is disabled, and direct navigation to `AboutApp` displays a helpful fallback view directing users to Advanced Settings to enable beta features.

## API Changes

- `BetaHelper` (new static class in `Ivy.Tendril.Helpers` providing `IsBeta` methods)
- `TendrilAppShell.BuildHelpMenuItems` (new internal static method in `Ivy.Tendril.AppShell`)

## Files Modified

- `src/Ivy.Tendril/Helpers/BetaHelper.cs`: Centralized beta mode detection helper
- `src/Ivy.Tendril/AppShell/TendrilAppShell.cs`: Extracted `BuildHelpMenuItems` and gated About menu item on `isBeta`
- `src/Ivy.Tendril/Apps/AboutApp.cs`: Added beta check with fallback `NoContentView` directing to Advanced Settings
- `src/Ivy.Tendril/ServiceRegistration.cs`, `src/Ivy.Tendril/TendrilServer.cs`, `src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs`, `src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs`, `src/Ivy.Tendril/Apps/Settings/Blades/EditProjectBladeView.cs`: Unified beta checking via `BetaHelper.IsBeta`
- `src/Ivy.Tendril.Test/Helpers/BetaHelperTests.cs`: Unit tests for `BetaHelper`
- `src/Ivy.Tendril.Test/AppShell/TendrilAppShellHelpMenuTests.cs`: Unit tests for Help menu items under beta and non-beta modes
- `src/Ivy.Tendril.Test/Apps/AboutAppTests.cs`: Unit tests for `AboutApp` metadata

## Manual Testing

1. Launch Tendril without beta flags:
   - Click on the "Help" menu in the sidebar footer.
   - Verify "Documentation", "Discord", and "Report Issue" are displayed, and "About" is not listed.
   - Navigate directly to `/about` (or trigger `AboutApp` via command/URL).
   - Observe the fallback screen explaining that About is a beta feature with an "Open Advanced Settings" button.
   - Click "Open Advanced Settings" and verify it navigates to Settings with the Advanced section selected.
2. Launch Tendril with beta enabled (`--beta` or setting `Settings.Beta: true` in config or `TENDRIL_BETA=1`):
   - Click on the "Help" menu in the sidebar footer.
   - Verify the "About" option is present with its Info icon.
   - Click "About" and verify the About page opens showing system environment and software toolchain info.

---
* 16d00eef Put About section behind beta flag (#00004)

---
Created using [Ivy Tendril](https://ivy.app).