### PR TITLE
[00003] Prevent Playwright E2E Verification Hangs on Connection Refused and Base Path Mismatches

### DIFF
--- a/src/Ivy.Tendril.Test/Commands/PromptwareDryRunTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/PromptwareDryRunTests.cs
@@ -89,6 +89,8 @@ public class PromptwareDryRunTests : IDisposable
                 profile: balanced
               SetupProject:
                 profile: deep
+              AddProject:
+                profile: deep
             projects:
             - name: TestProject
               repos:
@@ -102,7 +104,7 @@ public class PromptwareDryRunTests : IDisposable
     private string CreateFallbackPromptwareDir()
     {
         var root = Path.Combine(_tempDir, "Promptwares");
-        foreach (var name in new[] { "CreatePlan", "ExecutePlan", "ExpandPlan", "UpdatePlan", "SplitPlan", "CreatePr", "CreateIssue", "SetupProject" })
+        foreach (var name in new[] { "CreatePlan", "ExecutePlan", "ExpandPlan", "UpdatePlan", "SplitPlan", "CreatePr", "CreateIssue", "SetupProject", "AddProject" })
         {
             var dir = Path.Combine(root, name);
             Directory.CreateDirectory(dir);
@@ -327,12 +329,62 @@ public class PromptwareDryRunTests : IDisposable
         Assert.Contains("effort: max", output);
     }
 
+    [Fact]
+    public void SetupProject_ContainsPlaywrightE2EGuidance()
+    {
+        var output = RunDryRun("SetupProject", ["ProjectName=TestProject", "Instructions=Setup verifications"]);
+
+        Assert.Contains("PlaywrightTest", output);
+        Assert.Contains("max-failures", output);
+        Assert.Contains("Pre-flight HTTP probe", output);
+    }
+
+    // ==================== AddProject ====================
+
+    [Fact]
+    public void AddProject_CompilesFirmware()
+    {
+        var output = RunDryRun("AddProject", ["ProjectName=TestProject", "ReposJson=[]", "Instructions=Setup verifications"]);
+
+        Assert.Contains("ProjectName: TestProject", output);
+        Assert.Contains("Instructions: Setup verifications", output);
+        Assert.Contains("## Program", output);
+    }
+
+    [Fact]
+    public void AddProject_ResolvesDeepProfile()
+    {
+        var output = RunDryRun("AddProject", ["ProjectName=TestProject", "Instructions=Setup"]);
+
+        Assert.Contains("model: opus", output);
+        Assert.Contains("effort: max", output);
+    }
+
+    [Fact]
+    public void AddProject_ContainsPlaywrightE2EGuidance()
+    {
+        var output = RunDryRun("AddProject", ["ProjectName=TestProject", "Instructions=Setup verifications"]);
+
+        Assert.Contains("PlaywrightTest", output);
+        Assert.Contains("max-failures", output);
+        Assert.Contains("Pre-flight HTTP probe", output);
+    }
+
     // ==================== Cross-cutting ====================
+
+    [Fact]
+    public void ExecutePlan_ContainsPlaywrightE2EGuidance()
+    {
+        var output = RunDryRun("ExecutePlan", ["PlanFolder=/tmp/plans/00001-Test"]);
+
+        Assert.Contains("max-failures", output);
+        Assert.Contains("E2E and browser tests", output);
+    }
 
     [Fact]
     public void AllPromptwareNames_ResolveWithoutError()
     {
-        var promptwares = new[] { "CreatePlan", "ExecutePlan", "ExpandPlan", "UpdatePlan", "SplitPlan", "CreatePr", "CreateIssue", "SetupProject" };
+        var promptwares = new[] { "CreatePlan", "ExecutePlan", "ExpandPlan", "UpdatePlan", "SplitPlan", "CreatePr", "CreateIssue", "SetupProject", "AddProject" };
 
         foreach (var name in promptwares)
         {

--- a/src/Ivy.Tendril.Test/SetupProjectPromptwareTests.cs
+++ b/src/Ivy.Tendril.Test/SetupProjectPromptwareTests.cs
@@ -609,6 +609,74 @@ public class SetupProjectPromptwareTests : IDisposable
         Assert.Contains("--browse", action.Command);
     }
 
+    // ==================== Playwright E2E Stack Tests ====================
+
+    [Fact]
+    public void PlaywrightStack_AddVerificationsAndReviewAction()
+    {
+        var repoPath = CreateRepo("MyPlaywrightApp", "package.json", "playwright.config.ts", "vite.config.ts", "e2e/app.spec.ts");
+        WriteConfig($"""
+            projects:
+            - name: MyPlaywrightApp
+              repos:
+              - path: {repoPath}
+            verifications:
+            - name: CheckResult
+              prompt: Verify the implementation matches the plan.
+            codingAgent: claude
+            codingAgents:
+            - name: claude
+              profiles:
+              - name: deep
+                model: opus
+                effort: max
+            """);
+
+        var config = LoadConfig();
+        config.Settings.Verifications.Add(new VerificationConfig
+        {
+            Name = "NpmLint",
+            Prompt = "Run `npm run lint` on changed files and fix any errors."
+        });
+        config.Settings.Verifications.Add(new VerificationConfig
+        {
+            Name = "NpmBuild",
+            Prompt = "Run `npm run build` and verify success."
+        });
+        config.Settings.Verifications.Add(new VerificationConfig
+        {
+            Name = "PlaywrightTest",
+            Prompt = "Run Playwright test suite with fail-fast (`--max-failures=1`), pre-flight HTTP probe against dev server base URL, and verify baseURL/base path."
+        });
+        config.SaveSettings();
+
+        var config2 = LoadConfig();
+        var project = config2.Settings.Projects[0];
+        project.Verifications.Add(new ProjectVerificationRef { Name = "NpmLint", Required = true });
+        project.Verifications.Add(new ProjectVerificationRef { Name = "NpmBuild", Required = true });
+        project.Verifications.Add(new ProjectVerificationRef { Name = "PlaywrightTest", Required = true });
+        project.Verifications.Add(new ProjectVerificationRef { Name = "CheckResult", Required = true });
+        project.ReviewActions.Add(new ReviewActionConfig
+        {
+            Name = "Dev",
+            Condition = "Test-Path \"worktrees/MyPlaywrightApp/package.json\"",
+            Command = "cd worktrees/MyPlaywrightApp && npm install && npm run dev -- --open"
+        });
+        config2.SaveSettings();
+
+        var result = LoadConfig();
+        Assert.Equal(4, result.Settings.Verifications.Count);
+        Assert.Contains(result.Settings.Verifications, v => v.Name == "PlaywrightTest");
+        var playwrightVer = result.Settings.Verifications.First(v => v.Name == "PlaywrightTest");
+        Assert.Contains("max-failures", playwrightVer.Prompt);
+        Assert.Contains("pre-flight", playwrightVer.Prompt);
+
+        var proj = result.Settings.Projects[0];
+        Assert.Equal(4, proj.Verifications.Count);
+        Assert.Single(proj.ReviewActions);
+        Assert.Contains("npm run dev", proj.ReviewActions[0].Command);
+    }
+
     private static readonly object ConsoleLock = new();
 
     private static string CaptureConsoleOutput(Action action)

--- a/src/Ivy.Tendril/Promptwares/AGENTS.md
+++ b/src/Ivy.Tendril/Promptwares/AGENTS.md
@@ -13,3 +13,6 @@ Shipped promptwares are used by all Tendril customers across different teams, te
 - **Config over convention.** Anything that varies between customers belongs in configuration (injected via the firmware header or **Projects** section), not in Program.md. If you find yourself writing "if using X, do Y" for a customer-specific X, it should be a config option instead.
 - **Keep it concise.** The limiting factor is a human reading the plan. Every sentence must earn its place.
 - **Loopback only for servers.** When promptwares write tests, demo/sample applications, or mock servers that listen on a port, configure them to bind to loopback (127.0.0.1 or localhost) instead of all network interfaces (0.0.0.0). Binding to 0.0.0.0 requires elevated permissions or is blocked on some operating systems and sandboxed environments, leading to "listen EPERM" errors.
+- **Fail-fast on E2E / browser tests.** E2E test runs (such as Playwright) should specify fail-fast (`--max-failures=1` or `maxFailures: 1`) during automated verification to prevent retry cascades on unreachable servers or connection refused errors (`net::ERR_CONNECTION_REFUSED`).
+- **Base path awareness.** When writing or running tests against application servers, ensure test navigation URLs match the server's configured base path (such as `base: '/<project>/'` in `vite.config.ts`).
+

--- a/src/Ivy.Tendril/Promptwares/AddProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/AddProject/Program.md
@@ -78,6 +78,7 @@ For each detected tech stack, ensure the following verification definitions exis
 - Format/Lint: `DotnetFormat`, `NpmLint`, `PythonLint`, `RustClippy`, `GoFmt`
 - Build: `DotnetBuild`, `NpmBuild`, `PythonBuild`, `RustBuild`, `GoBuild`
 - Test: `DotnetTest`, `NpmTest`, `PythonTest`, `RustTest`, `GoTest`
+- E2E / Browser: `PlaywrightTest`, `NpmTest` (when Playwright or browser test suites are detected)
 
 **Example verification prompts by stack:**
 
@@ -89,6 +90,7 @@ For each detected tech stack, ensure the following verification definitions exis
 | JS/TS | NpmLint | Run `npm run lint` / `pnpm lint` (or equivalent) on changed files |
 | JS/TS | NpmBuild | Run `npm run build` / `pnpm build` (or equivalent) and verify success |
 | JS/TS | NpmTest | Run `npm test` / `pnpm test` with appropriate filter |
+| E2E | PlaywrightTest | Run Playwright test suite with fail-fast (`--max-failures=1`), pre-flight HTTP probe, and verify baseURL/base path |
 | Python | PythonLint | Run linter (black/ruff/flake8) on changed .py files |
 | Python | PythonTest | Run `pytest` with filter from plan's Tests section |
 | Rust | RustClippy | Run `cargo clippy -- -D warnings` |
@@ -97,6 +99,13 @@ For each detected tech stack, ensure the following verification definitions exis
 | Go | GoFmt | Run `gofmt` on changed .go files |
 | Go | GoBuild | Run `go build ./...` and verify success |
 | Go | GoTest | Run `go test` with filter from plan's Tests section |
+
+**E2E and Playwright verification guidance:**
+
+When generating verification prompts for projects that use Playwright or browser E2E test suites (e.g. `PlaywrightTest` or E2E `NpmTest`):
+1. **Pre-flight HTTP probe**: Instruct agents to perform a lightweight HTTP probe (e.g. `curl -f -s http://127.0.0.1:<port><base-path> || exit 1` or PowerShell `Invoke-WebRequest`) against the dev server base URL before launching Playwright to confirm the server is listening and returning HTTP 200.
+2. **Fail-fast flags**: Pass fail-fast options (`--max-failures=1` or `maxFailures: 1`) so that unhandled connection refused (`net::ERR_CONNECTION_REFUSED`, `ECONNREFUSED`) or initial failures terminate the test suite immediately instead of running through exhaustive retry loops.
+3. **Base path validation**: Validate that `baseURL` or navigation URLs match any configured dev server base path (such as `base: '/<project>/'` in `vite.config.ts`).
 
 For each verification:
 1. Check if it already exists in `tendril verification list`

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -325,6 +325,9 @@ Work exclusively in the worktree directories. Follow the plan's latest revision:
 2. **Solution** - Execute the implementation steps in the worktree
 3. **Tests** - Write and run all tests specified in the plan
    - **Loopback only for servers:** When writing tests, demo apps, or mock servers that listen on a port, always bind to loopback (127.0.0.1 or ::1) instead of 0.0.0.0. Binding to all interfaces (0.0.0.0) is blocked and triggers "listen EPERM" errors on some systems.
+   - **E2E and browser tests:** When writing or running E2E tests (e.g. Playwright):
+     - Verify local dev servers are bound and responsive on loopback (`127.0.0.1` or `localhost`) and that base path URLs match prior to launching E2E test suites.
+     - Require fail-fast detection (`--max-failures=1` or `maxFailures: 1`) when connection errors occur during test execution to prevent test suite hangs and retry cascades.
 
 **Status cadence:** During implementation, if any sub-task takes longer than 90 seconds, issue an intermediate status update describing the current activity (e.g., `"Implementing: writing tests..."`, `"Implementing: fixing lint errors..."`, `"Implementing: reading reference code..."`). The user should never see the same status message for more than ~90 seconds.
 
@@ -398,6 +401,7 @@ For each `Pending` verification (in listed order):
 2. Fetch its full prompt: `tendril verification get <Name>`
 3. **Check if delegated:** The **Projects** section indicates which verifications are delegated — follow the prompt's instructions to invoke it as an external process. If the external process cannot be invoked (CLI broken, file lock, etc.), set the verification to `Fail` immediately. Do NOT attempt to do the verification inline or write the report yourself.
 4. Execute the prompt in the worktree directory
+   - **E2E and browser verifications:** Before running browser or Playwright test suites, perform a quick HTTP probe against the dev server base URL to confirm the server is running and reachable. Use fail-fast options (`--max-failures=1`) so that connection refused errors fail immediately instead of entering lengthy retry loops. Validate that `baseURL` matches the dev server's configured base path.
 5. If it fails: diagnose, fix the issue, **commit the fix** (e.g. `Fix lint errors from Build`), and re-run. Repeat until it passes (fail the plan after 3+ failed attempts).
 6. Document all fix commits via CLI: `tendril plan add-commit <plan-id> <sha>`
 7. Update the verification status via CLI: `tendril plan set-verification <plan-id> <Name> Pass` (or `Fail`)

--- a/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
@@ -77,6 +77,7 @@ For each detected tech stack, ensure the following verification definitions exis
 - Format/Lint: `DotnetFormat`, `NpmLint`, `PythonLint`, `RustClippy`, `GoFmt`
 - Build: `DotnetBuild`, `NpmBuild`, `PythonBuild`, `RustBuild`, `GoBuild`
 - Test: `DotnetTest`, `NpmTest`, `PythonTest`, `RustTest`, `GoTest`
+- E2E / Browser: `PlaywrightTest`, `NpmTest` (when Playwright or browser test suites are detected)
 
 **Example verification prompts by stack:**
 
@@ -88,6 +89,7 @@ For each detected tech stack, ensure the following verification definitions exis
 | JS/TS | NpmLint | Run `npm run lint` / `pnpm lint` (or equivalent) on changed files |
 | JS/TS | NpmBuild | Run `npm run build` / `pnpm build` (or equivalent) and verify success |
 | JS/TS | NpmTest | Run `npm test` / `pnpm test` with appropriate filter |
+| E2E | PlaywrightTest | Run Playwright test suite with fail-fast (`--max-failures=1`), pre-flight HTTP probe, and verify baseURL/base path |
 | Python | PythonLint | Run linter (black/ruff/flake8) on changed .py files |
 | Python | PythonTest | Run `pytest` with filter from plan's Tests section |
 | Rust | RustClippy | Run `cargo clippy -- -D warnings` |
@@ -96,6 +98,13 @@ For each detected tech stack, ensure the following verification definitions exis
 | Go | GoFmt | Run `gofmt` on changed .go files |
 | Go | GoBuild | Run `go build ./...` and verify success |
 | Go | GoTest | Run `go test` with filter from plan's Tests section |
+
+**E2E and Playwright verification guidance:**
+
+When generating verification prompts for projects that use Playwright or browser E2E test suites (e.g. `PlaywrightTest` or E2E `NpmTest`):
+1. **Pre-flight HTTP probe**: Instruct agents to perform a lightweight HTTP probe (e.g. `curl -f -s http://127.0.0.1:<port><base-path> || exit 1` or PowerShell `Invoke-WebRequest`) against the dev server base URL before launching Playwright to confirm the server is listening and returning HTTP 200.
+2. **Fail-fast flags**: Pass fail-fast options (`--max-failures=1` or `maxFailures: 1`) so that unhandled connection refused (`net::ERR_CONNECTION_REFUSED`, `ECONNREFUSED`) or initial failures terminate the test suite immediately instead of running through exhaustive retry loops.
+3. **Base path validation**: Validate that `baseURL` or navigation URLs match any configured dev server base path (such as `base: '/<project>/'` in `vite.config.ts`).
 
 For each verification:
 1. Check if it already exists in `tendril verification list`


### PR DESCRIPTION
Fixes #1914

# Summary

## Changes

Added explicit instructions and guidelines across SetupProject, AddProject, and ExecutePlan promptwares to prevent Playwright and browser E2E test verification hangs. Verification prompts and execution flows now enforce pre-flight HTTP health probes, fail-fast test execution flags (`--max-failures=1`), and base path/host URL validation before launching test suites.

## API Changes

None.

## Files Modified

- Promptwares:
  - `src/Ivy.Tendril/Promptwares/SetupProject/Program.md` (added Playwright/E2E verification naming, prompt guidance, pre-flight checks, and fail-fast flags)
  - `src/Ivy.Tendril/Promptwares/AddProject/Program.md` (added Playwright/E2E verification naming, prompt guidance, pre-flight checks, and fail-fast flags)
  - `src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md` (added E2E dev server and base path verification guidance in Step 4 and Step 7)
  - `src/Ivy.Tendril/Promptwares/AGENTS.md` (added promptware authoring rules for E2E fail-fast and base path awareness)
- Tests:
  - `src/Ivy.Tendril.Test/Commands/PromptwareDryRunTests.cs` (added AddProject promptware dry-run tests and E2E firmware content checks)
  - `src/Ivy.Tendril.Test/SetupProjectPromptwareTests.cs` (added Playwright stack verification configuration test)

## Manual Testing

1. Run the test suite: `dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj --filter "FullyQualifiedName~PromptwareDryRunTests|FullyQualifiedName~SetupProjectPromptwareTests"`
2. Verify that all promptware dry-run compilation tests for SetupProject, AddProject, and ExecutePlan pass and contain the updated E2E instructions.

---
- 73ae9bb6 Add Playwright and E2E fail-fast and base path guidance (Plan 00003)

---
Created using [Ivy Tendril](https://ivy.app).