### PR TITLE
[00019] Add Open Source Software Information and Attribution

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Setup/AboutSetupViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Setup/AboutSetupViewTests.cs
@@ -1,0 +1,102 @@
+using Ivy.Tendril.Apps.Settings;
+
+namespace Ivy.Tendril.Test.Apps.Setup;
+
+public class AboutSetupViewTests
+{
+    [Fact]
+    public void BundledToolInfo_ConstructsWithValidProperties()
+    {
+        var toolInfo = new AboutSetupView.BundledToolInfo(
+            Tool: "OpenCode CLI",
+            Status: "Bundled",
+            License: "MIT License",
+            Version: "1.0.0",
+            Location: "/path/to/opencode");
+
+        Assert.Equal("OpenCode CLI", toolInfo.Tool);
+        Assert.Equal("Bundled", toolInfo.Status);
+        Assert.Equal("MIT License", toolInfo.License);
+        Assert.Equal("1.0.0", toolInfo.Version);
+        Assert.Equal("/path/to/opencode", toolInfo.Location);
+    }
+
+    [Fact]
+    public void GetDefaultToolchain_ContainsExpectedToolsAndLicenses()
+    {
+        var tools = AboutSetupView.GetDefaultToolchain(
+            isIvyAgentBundled: true,
+            ivyAgentPath: "/bin/ivy-agent",
+            ivyAgentVersion: "1.0.0",
+            isDotnetBundled: true,
+            dotnetPath: "/bin/dotnet",
+            dotnetVersion: "10.0.100",
+            isPwshBundled: false,
+            pwshPath: "/bin/pwsh",
+            pwshVersion: "7.4.0",
+            gitVersion: "2.40.0");
+
+        Assert.NotNull(tools);
+        Assert.Equal(4, tools.Length);
+
+        var openCode = Assert.Single(tools, t => t.Tool == "OpenCode CLI");
+        Assert.Equal("Bundled", openCode.Status);
+        Assert.Equal("MIT License", openCode.License);
+        Assert.Equal("1.0.0", openCode.Version);
+        Assert.Equal("/bin/ivy-agent", openCode.Location);
+
+        var dotnet = Assert.Single(tools, t => t.Tool == ".NET SDK / Runtime");
+        Assert.Equal("Bundled SDK", dotnet.Status);
+        Assert.Equal("MIT License", dotnet.License);
+        Assert.Equal("10.0.100", dotnet.Version);
+        Assert.Equal("/bin/dotnet", dotnet.Location);
+
+        var pwsh = Assert.Single(tools, t => t.Tool == "PowerShell");
+        Assert.Equal("MIT License", pwsh.License);
+        Assert.Equal("7.4.0", pwsh.Version);
+        Assert.Equal("/bin/pwsh", pwsh.Location);
+
+        var git = Assert.Single(tools, t => t.Tool == "Git");
+        Assert.Equal("System Tool", git.Status);
+        Assert.Equal("GPL v2", git.License);
+        Assert.Equal("2.40.0", git.Version);
+        Assert.Equal("git", git.Location);
+    }
+
+    [Fact]
+    public void GetDefaultToolchain_WhenNotBundled_HandlesStatusCorrectly()
+    {
+        var tools = AboutSetupView.GetDefaultToolchain(
+            isIvyAgentBundled: false,
+            ivyAgentPath: "/nonexistent/ivy-agent",
+            ivyAgentVersion: "Not configured",
+            isDotnetBundled: false,
+            dotnetPath: "/system/dotnet",
+            dotnetVersion: "10.0.100",
+            isPwshBundled: false,
+            pwshPath: "/nonexistent/pwsh",
+            pwshVersion: "Not configured",
+            gitVersion: "Not available");
+
+        Assert.NotNull(tools);
+
+        var openCode = Assert.Single(tools, t => t.Tool == "OpenCode CLI");
+        Assert.Equal("Not Found", openCode.Status);
+        Assert.Equal("MIT License", openCode.License);
+
+        var dotnet = Assert.Single(tools, t => t.Tool == ".NET SDK / Runtime");
+        Assert.Equal("Runtime", dotnet.Status);
+        Assert.Equal("MIT License", dotnet.License);
+
+        var pwsh = Assert.Single(tools, t => t.Tool == "PowerShell");
+        Assert.Equal("Not Found", pwsh.Status);
+        Assert.Equal("MIT License", pwsh.License);
+    }
+
+    [Fact]
+    public void AboutSetupView_CanBeInstantiated()
+    {
+        var view = new AboutSetupView();
+        Assert.NotNull(view);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -193,7 +193,7 @@ public class CodingAgentStepView(
                    ? new Progress(progressValue.Value.Value)
                    : null!)
                | (authCode.Value != null
-                   ? Text.Markdown($"**Device code:** `{authCode.Value}` — enter this in your browser if prompted.")
+                   ? Text.Markdown($"**Device code:** `{authCode.Value}` (enter this in your browser if prompted).")
                    : null!)
                | (error.Value != null ? Text.Danger(error.Value) : null!)
                | installDialog;
@@ -326,7 +326,9 @@ public class CodingAgentStepView(
                 Layout.Horizontal()
                     .AlignContent(Align.Center)
                 | a.Logo.ToIcon().Width(Size.Px(32)).Height(Size.Px(32))
-                | Text.Block(a.Label)
+                | (Layout.Vertical()
+                    | Text.Block(a.Label)
+                    | (a.Key == "opencode" ? Text.Muted("Open Source (MIT)").Small() : null!))
             ).OnClick(() => onSelect(a.Key)));
 
         var byoGrid = Layout.Grid().Columns(3);
@@ -345,7 +347,7 @@ public class CodingAgentStepView(
         return Layout.Vertical()
                | Text.H3("What is your coding agent?")
                | Text.Muted(
-                   "Tendril is a coding orchestrator that runs on top of your own coding agent. Pick the agent you'd like to use:")
+                   "Tendril is an open source coding orchestrator that runs on top of your own coding agent or bundled open source engines like OpenCode (MIT License). Pick the agent you'd like to use:")
                | (errorMessage != null ? Text.Danger(errorMessage) : null!)
                | grid
                | byoSection;

--- a/src/Ivy.Tendril/Apps/Settings/AboutSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AboutSetupView.cs
@@ -19,11 +19,33 @@ public class AboutSetupView : ViewBase
         string Runtime,
         string TendrilHome);
 
-    private record BundledToolInfo(
+    public record BundledToolInfo(
         string Tool,
         string Status,
+        string License,
         string Version,
         string Location);
+
+    public static BundledToolInfo[] GetDefaultToolchain(
+        bool isIvyAgentBundled,
+        string ivyAgentPath,
+        string ivyAgentVersion,
+        bool isDotnetBundled,
+        string dotnetPath,
+        string dotnetVersion,
+        bool isPwshBundled,
+        string pwshPath,
+        string pwshVersion,
+        string gitVersion)
+    {
+        return
+        [
+            new BundledToolInfo("OpenCode CLI", isIvyAgentBundled ? "Bundled" : File.Exists(ivyAgentPath) ? "Installed" : "Not Found", "MIT License", ivyAgentVersion, ivyAgentPath),
+            new BundledToolInfo(".NET SDK / Runtime", isDotnetBundled ? "Bundled SDK" : "Runtime", "MIT License", dotnetVersion, dotnetPath),
+            new BundledToolInfo("PowerShell", isPwshBundled ? "Bundled" : File.Exists(pwshPath) ? "System" : "Not Found", "MIT License", pwshVersion, pwshPath),
+            new BundledToolInfo("Git", "System Tool", "GPL v2", gitVersion, "git")
+        ];
+    }
 
     public override object Build()
     {
@@ -71,6 +93,40 @@ public class AboutSetupView : ViewBase
             gitVersionState.Set(FormatVersionOutput(results[3]));
         });
 
+        var ossAttributionCard = new Card(
+            Layout.Vertical().Gap(3)
+                | Text.Block("Tendril is built on open source technologies and bundles open source software (OSS) runtimes to power its autonomous planning and execution engine.")
+                | (Layout.Vertical().Gap(2)
+                    | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                        | Icons.OpenCode.ToIcon().Width(Size.Px(20)).Height(Size.Px(20))
+                        | Text.Block("OpenCode CLI").Bold()
+                        | new Badge("MIT License").Variant(BadgeVariant.Outline).Small()
+                        | Text.Muted("Bundled open-source coding engine (https://github.com/anomalyco/opencode)").Small())
+                    | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                        | Icons.Cpu.ToIcon().Width(Size.Px(20)).Height(Size.Px(20))
+                        | Text.Block(".NET SDK / Runtime").Bold()
+                        | new Badge("MIT License").Variant(BadgeVariant.Outline).Small()
+                        | Text.Muted("Application foundation (https://github.com/dotnet/core)").Small())
+                    | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                        | Icons.Terminal.ToIcon().Width(Size.Px(20)).Height(Size.Px(20))
+                        | Text.Block("PowerShell Core").Bold()
+                        | new Badge("MIT License").Variant(BadgeVariant.Outline).Small()
+                        | Text.Muted("Automation runtime (https://github.com/PowerShell/PowerShell)").Small()))
+                | (Layout.Horizontal().Gap(2)
+                    | new Button("OpenCode Repository")
+                        .Variant(ButtonVariant.Outline)
+                        .Icon(Icons.ExternalLink, Align.Right)
+                        .OnClick(() => client.OpenUrl("https://github.com/anomalyco/opencode"))
+                    | new Button(".NET Repository")
+                        .Variant(ButtonVariant.Outline)
+                        .Icon(Icons.ExternalLink, Align.Right)
+                        .OnClick(() => client.OpenUrl("https://github.com/dotnet/core"))
+                    | new Button("PowerShell Repository")
+                        .Variant(ButtonVariant.Outline)
+                        .Icon(Icons.ExternalLink, Align.Right)
+                        .OnClick(() => client.OpenUrl("https://github.com/PowerShell/PowerShell")))
+        ).Header("Open Source Software & Attribution", icon: Icons.OpenCode);
+
         var systemInfo = new SystemEnvironmentInfo(
             Application: "Tendril",
             Version: $"v{tendrilVersion}",
@@ -93,19 +149,24 @@ public class AboutSetupView : ViewBase
                 .Builder(x => x.TendrilHome, f => f.CopyToClipboard())
         ).Header("System & Environment", icon: Icons.Cpu);
 
-        var toolsList = new[]
-        {
-            new BundledToolInfo("Ivy Agent CLI", isIvyAgentBundled ? "Bundled" : File.Exists(ivyAgentPath) ? "Installed" : "Not Found", ivyAgentVersionState.Value, ivyAgentPath),
-            new BundledToolInfo(".NET SDK / Runtime", isDotnetBundled ? "Bundled SDK" : "Runtime", dotnetVersionState.Value, dotnetPath),
-            new BundledToolInfo("PowerShell", isPwshBundled ? "Bundled" : File.Exists(pwshPath) ? "System" : "Not Found", pwshVersionState.Value, pwshPath),
-            new BundledToolInfo("Git", "System Tool", gitVersionState.Value, "git"),
-        };
+        var toolsList = GetDefaultToolchain(
+            isIvyAgentBundled,
+            ivyAgentPath,
+            ivyAgentVersionState.Value,
+            isDotnetBundled,
+            dotnetPath,
+            dotnetVersionState.Value,
+            isPwshBundled,
+            pwshPath,
+            pwshVersionState.Value,
+            gitVersionState.Value);
 
         var toolsTableCard = new Card(
             toolsList.ToTable()
                 .Width(Size.Full())
                 .Header(x => x.Tool, "Software Tool")
                 .Header(x => x.Status, "Status")
+                .Header(x => x.License, "License")
                 .Header(x => x.Version, "Version")
                 .Header(x => x.Location, "Binary Path")
                 .Builder(x => x.Status, f => f.Func((string status) => status switch
@@ -115,6 +176,7 @@ public class AboutSetupView : ViewBase
                     "System Tool" or "Runtime" => new Badge(status).Variant(BadgeVariant.Outline).Small(),
                     _ => new Badge(status).Variant(BadgeVariant.Destructive).Small()
                 }))
+                .Builder(x => x.License, f => f.Func((string license) => new Badge(license).Variant(BadgeVariant.Outline).Small()))
                 .Builder(x => x.Version, f => f.CopyToClipboard())
                 .Builder(x => x.Location, f => f.CopyToClipboard())
         ).Header("Software Toolchain", icon: Icons.Package);
@@ -122,7 +184,7 @@ public class AboutSetupView : ViewBase
         var systemReport = new StringBuilder()
             .AppendLine($"Tendril: v{tendrilVersion}")
             .AppendLine($"Ivy Framework: v{ivyVersion}")
-            .AppendLine($"Ivy Agent CLI: {ivyAgentVersionState.Value} ({ivyAgentPath})")
+            .AppendLine($"OpenCode / Ivy Agent CLI: {ivyAgentVersionState.Value} ({ivyAgentPath})")
             .AppendLine($".NET SDK: {dotnetVersionState.Value} ({dotnetPath})")
             .AppendLine($"PowerShell: {pwshVersionState.Value} ({pwshPath})")
             .AppendLine($"Git: {gitVersionState.Value}")
@@ -134,7 +196,9 @@ public class AboutSetupView : ViewBase
 
         var header = Layout.Vertical().Width(Size.Full().Max(Size.Units(200)))
             | (Layout.Horizontal()
-                | Text.H2("About Tendril")
+                | (Layout.Vertical()
+                    | Text.H2("About Tendril")
+                    | Text.Muted("Tendril is an open source AI coding orchestrator built on open source technologies.").Small())
                 | new Spacer()
                 | new Button("Copy System Report")
                     .Variant(ButtonVariant.Outline)
@@ -181,6 +245,7 @@ public class AboutSetupView : ViewBase
                     }));
 
         var content = Layout.Vertical().Width(Size.Full().Max(Size.Units(200)))
+            | ossAttributionCard
             | systemDetailsCard
             | toolsTableCard;
 

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -215,7 +215,9 @@ public class CodingAgentSetupView : ViewBase
             current | new Card(
                 Layout.Horizontal()
                 | a.Logo.ToIcon().Width(Size.Px(32)).Height(Size.Px(32))
-                | Text.Block(a.Label)
+                | (Layout.Vertical()
+                    | Text.Block(a.Label)
+                    | (a.Key == "opencode" ? Text.Muted("Open Source (MIT)").Small() : null!))
                 | new Spacer()
                 | (a.Key == selectedAgent.Value ? Icons.Check.ToIcon() : null)
             ).Width(Size.Full()).Height(Size.Full()).OnClick(() =>
@@ -293,6 +295,7 @@ public class CodingAgentSetupView : ViewBase
         else if (selectedAgent.Value == "opencode")
         {
             agentInputs = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                | Text.Muted("OpenCode is an open source AI coding agent. Tendril integrates and bundles OpenCode runtime components under the MIT license.").Small()
                 | ollamaUrl.ToTextInput("http://localhost:11434")
                     .WithField()
                     .Label("Ollama Host");
@@ -319,6 +322,7 @@ public class CodingAgentSetupView : ViewBase
 
         return Layout.Vertical()
                | Text.Block("Coding Agent").Bold()
+               | Text.Muted("Tendril connects to your configured AI coding agent or bundled open source engines like OpenCode.").Small()
                | (Layout.Vertical()
                    .Width(Size.Full().At(Breakpoint.Mobile).And(Breakpoint.Desktop, Size.Units(170)))
                    | topGrid.Width(Size.Full()))


### PR DESCRIPTION
Fixes #2130

# Summary

## Changes

Added an Open Source Software & Attribution card to the top of the About page, highlighting Tendril's open-source foundations and attributing key bundled runtimes (OpenCode CLI, .NET SDK / Runtime, and PowerShell Core under the MIT License) with repository links. Enhanced the Software Toolchain table with a dedicated License column, and updated the Coding Agent settings and onboarding views to clearly note OpenCode's open-source attribution.

## API Changes

- Added public record `Ivy.Tendril.Apps.Settings.AboutSetupView.BundledToolInfo(string Tool, string Status, string License, string Version, string Location)`
- Added public static method `Ivy.Tendril.Apps.Settings.AboutSetupView.GetDefaultToolchain(bool isIvyAgentBundled, string ivyAgentPath, string ivyAgentVersion, bool isDotnetBundled, string dotnetPath, string dotnetVersion, bool isPwshBundled, string pwshPath, string pwshVersion, string gitVersion)`

## Files Modified

- **UI Views**:
  - `src/Ivy.Tendril/Apps/Settings/AboutSetupView.cs`: Added OSS attribution card, toolchain license column, and default toolchain helper.
  - `src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs`: Added OpenCode open-source caption and description.
  - `src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs`: Added OpenCode open-source caption and onboarding description text.
- **Tests**:
  - `src/Ivy.Tendril.Test/Apps/Setup/AboutSetupViewTests.cs`: Added unit tests verifying `BundledToolInfo` properties, license identifiers, and toolchain defaults.

## Manual Testing

1. Open Tendril and navigate to Settings > About.
2. Verify that the "Open Source Software & Attribution" card is displayed at the top with OpenCode CLI, .NET SDK / Runtime, and PowerShell Core, including repository action buttons.
3. Verify that the "Software Toolchain" table includes a "License" column with appropriate badges (e.g. MIT License, GPL v2).
4. Navigate to Settings > Coding Agent and Onboarding > Coding Agent to verify that OpenCode displays an "Open Source (MIT)" badge and explanatory attribution text.

---
## Commits
- eef7caaf Add open source software information and attribution (Plan 00019)

---
Created using [Ivy Tendril](https://ivy.app).
