### PR TITLE
[00024] Fix Horizontal Scrollbar in Chat List Section

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using Ivy;
+using Ivy.Tendril.Apps.Chat;
+using Ivy.Tendril.Apps.Views;
+using Ivy.Tendril.Services;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Chat;
+
+public class SidebarViewTests
+{
+    private class FakeChatHistoryService : IChatHistoryService
+    {
+#pragma warning disable CS0067
+        public event EventHandler? SessionsChanged;
+        public event EventHandler? GeneratingSessionsChanged;
+#pragma warning restore CS0067
+
+        public HashSet<string> GeneratingSessions { get; } = [];
+        public HashSet<string> CompletedSessions { get; } = [];
+        public List<ChatSessionModel> Sessions { get; } = [];
+
+        public IReadOnlyList<ChatSessionModel> GetSessions() => Sessions;
+        public ChatSessionModel? GetSession(string id) => Sessions.Find(s => s.Id == id);
+        public ChatSessionModel CreateSession(string agentId, string modelId, string? title = null, string? effort = null)
+        {
+            var session = new ChatSessionModel(Guid.NewGuid().ToString(), title ?? "New Chat", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, agentId, modelId, [], effort);
+            Sessions.Add(session);
+            return session;
+        }
+        public void SaveSession(ChatSessionModel session) { }
+        public void DeleteSession(string id) => Sessions.RemoveAll(s => s.Id == id);
+        public void RenameSession(string id, string newTitle) { }
+        public ChatMessageModel AddMessage(string sessionId, string role, string content, string? agentId = null, string? modelId = null, string? rawStream = null, string? effort = null)
+        {
+            return new ChatMessageModel(Guid.NewGuid().ToString(), role, content, DateTimeOffset.UtcNow, agentId, modelId, rawStream, effort);
+        }
+        public void SetSessionGenerating(string sessionId, bool isGenerating)
+        {
+            if (isGenerating) GeneratingSessions.Add(sessionId);
+            else { GeneratingSessions.Remove(sessionId); CompletedSessions.Add(sessionId); }
+        }
+        public IReadOnlySet<string> GetGeneratingSessionIds() => GeneratingSessions;
+        public IReadOnlySet<string> GetCompletedSessionIds() => CompletedSessions;
+        public void ClearSessionCompleted(string sessionId) => CompletedSessions.Remove(sessionId);
+    }
+
+    private class TestState<T> : IState<T>
+    {
+        private readonly T _initial;
+
+        public TestState(T initial)
+        {
+            _initial = initial;
+            Value = initial;
+        }
+
+        public T Value { get; set; }
+
+        public IDisposable Subscribe(IObserver<T> observer) => throw new NotImplementedException();
+        public void Dispose() { }
+        public T Set(T value) => Value = value;
+        public T Set(Func<T, T> setter) => Value = setter(Value);
+        public T Reset() => Value = _initial;
+        public IDisposable SubscribeAny(Action action) => throw new NotImplementedException();
+        public IDisposable SubscribeAny(Action<object?> action) => throw new NotImplementedException();
+        public Type GetStateType() => typeof(T);
+        public object? GetValueAsObject() => Value;
+        public IEffectTrigger ToTrigger() => throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void Build_ReturnsHeaderLayout_WithSessionItems()
+    {
+        var service = new FakeChatHistoryService();
+        service.GeneratingSessions.Add("sess-1");
+        service.CompletedSessions.Add("sess-2");
+
+        var sessions = new List<ChatSessionModel>
+        {
+            new("sess-1", "Generating session", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "claude", "opus", []),
+            new("sess-2", "Completed session", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "claude", "sonnet", []),
+            new("sess-3", "Idle session", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "opencode", "deepseek", [])
+        };
+
+        var activeSessionId = new TestState<string?>("sess-1");
+        var sessionVersion = new TestState<int>(1);
+        var selectedAgent = new TestState<string>("claude");
+        var selectedModel = new TestState<string>("opus");
+        var searchState = new TestState<string>("");
+
+        var view = new SidebarView(sessions, activeSessionId, sessionVersion, selectedAgent, selectedModel, searchState, service);
+        var result = view.Build();
+
+        Assert.NotNull(result);
+        Assert.IsType<HeaderLayout>(result);
+    }
+
+    [Fact]
+    public void Build_WithNonMatchingSearch_ShowsNoResults()
+    {
+        var service = new FakeChatHistoryService();
+        var sessions = new List<ChatSessionModel>
+        {
+            new("sess-1", "Generating session", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "claude", "opus", [])
+        };
+
+        var activeSessionId = new TestState<string?>(null);
+        var sessionVersion = new TestState<int>(1);
+        var selectedAgent = new TestState<string>("claude");
+        var selectedModel = new TestState<string>("opus");
+        var searchState = new TestState<string>("xyz non existent");
+
+        var view = new SidebarView(sessions, activeSessionId, sessionVersion, selectedAgent, selectedModel, searchState, service);
+        var result = view.Build();
+
+        Assert.NotNull(result);
+        var headerLayout = Assert.IsType<HeaderLayout>(result);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
@@ -65,14 +65,14 @@ public class SidebarView(
                 object metaLine;
                 if (isGenerating)
                 {
-                    metaLine = Layout.Horizontal().AlignContent(Align.Left)
+                    metaLine = Layout.Horizontal().Gap(1).AlignContent(Align.Left)
                         | new Icon(Icons.LoaderCircle, Colors.Green).Small().WithAnimation(AnimationType.Rotate).Duration(1)
                         | Text.Success("Generating").Small()
                         | Text.Muted($"• {sess.AgentId}").Small();
                 }
                 else if (isCompleted)
                 {
-                    metaLine = Layout.Horizontal().AlignContent(Align.Left)
+                    metaLine = Layout.Horizontal().Gap(1).AlignContent(Align.Left)
                         | new Icon(Icons.Check, Colors.Green).Small()
                         | Text.Success("Completed").Small()
                         | Text.Muted($"• {sess.AgentId}").Small();
@@ -83,12 +83,12 @@ public class SidebarView(
                 }
 
                 object titleBlock = (isGenerating || isCompleted)
-                    ? (Layout.Horizontal().AlignContent(Align.Left)
+                    ? (Layout.Horizontal().Gap(1).AlignContent(Align.Left)
                         | new Icon(Icons.CircleDot, Colors.Green).Small()
                         | Text.Block(displayTitle).Small().NoWrap().Overflow(Overflow.Ellipsis))
                     : Text.Block(displayTitle).Small().NoWrap().Overflow(Overflow.Ellipsis);
 
-                var textStack = Layout.Vertical().AlignContent(Align.Left).Width(Size.Full())
+                var textStack = Layout.Vertical().Gap(0).Width(Size.Full())
                     | titleBlock
                     | metaLine;
 
@@ -106,6 +106,6 @@ public class SidebarView(
             }));
         }
 
-        return new HeaderLayout(sidebarHeader, sidebarContent).Scroll(Scroll.None);
+        return new HeaderLayout(sidebarHeader, sidebarContent);
     }
 }


### PR DESCRIPTION
Fixes #2091

# Summary

## Changes

Fixed unwanted horizontal scrollbar in the Chat application session list sidebar. Removed `Scroll.None` from `HeaderLayout` so that it matches standard sidebar containment, tightened spacing with `Gap(1)` on row elements, and adjusted `textStack` layout to allow proper ellipsis text truncation.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Chat/SidebarView.cs`: Removed `Scroll.None` from `HeaderLayout`, added `Gap(1)` to horizontal badges, and changed `textStack` to `Layout.Vertical().Gap(0)`.
- `src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs`: Added unit tests verifying `SidebarView.Build()` across multiple session states.

## Manual Testing

1. Launch Tendril and open the Chat tab.
2. Create several chat sessions with varying title lengths and states (generating, completed, and standard history).
3. Observe the session list in the sidebar: verify that titles truncate with an ellipsis when long, badges render compactly, and no horizontal scrollbar appears at the bottom of the list.

---
- eee84602 fix(00024): remove horizontal scrollbar in chat list sidebar

---
Created using [Ivy Tendril](https://ivy.app).
