### PR TITLE
[00025] Fix Search Icon Alignment in Create Plan Dialog Dropdown

### DIFF
--- a/src/Ivy.Tendril.Test/CreatePlanDialogTests.cs
+++ b/src/Ivy.Tendril.Test/CreatePlanDialogTests.cs
@@ -1,3 +1,4 @@
+using Ivy;
 using Ivy.Tendril.Apps.Drafts.Dialogs;
 
 namespace Ivy.Tendril.Test;
@@ -74,4 +75,57 @@ public class CreatePlanDialogTests
         Assert.Equal("Add Project", actions[0].Label);
         Assert.DoesNotContain(options, o => o.Value == CreatePlanDialog.AddProjectActionValue);
     }
+
+    [Theory]
+    [InlineData(0, SelectInputVariant.Toggle)]
+    [InlineData(1, SelectInputVariant.Toggle)]
+    [InlineData(6, SelectInputVariant.Toggle)]
+    [InlineData(7, SelectInputVariant.Select)]
+    [InlineData(10, SelectInputVariant.Select)]
+    public void GetProjectPickerVariant_SelectsCorrectVariantBasedOnCount(int count, SelectInputVariant expected)
+    {
+        var variant = CreatePlanDialog.GetProjectPickerVariant(count);
+
+        Assert.Equal(expected, variant);
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, false)]
+    [InlineData(6, false)]
+    [InlineData(7, true)]
+    [InlineData(12, true)]
+    public void IsProjectPickerSearchable_EnablesSearchOnlyWhenMoreThanSixProjects(int count, bool expected)
+    {
+        var searchable = CreatePlanDialog.IsProjectPickerSearchable(count);
+
+        Assert.Equal(expected, searchable);
+    }
+
+    [Fact]
+    public void BuildProjectSelectOptions_MultipleProjects_IncludesAutoAndAddProject()
+    {
+        var projects = new[] { "p1", "p2", "p3", "p4", "p5", "p6", "p7" };
+        var options = CreatePlanDialog.BuildProjectSelectOptions(projects);
+
+        Assert.Equal(9, options.Count);
+        Assert.Equal("Auto", options[0].Value);
+        for (var i = 0; i < projects.Length; i++)
+        {
+            Assert.Equal(projects[i], options[i + 1].Value);
+        }
+        Assert.Equal(CreatePlanDialog.AddProjectActionValue, options[8].Value);
+    }
+
+    [Fact]
+    public void BuildProjectSelectOptions_SingleProject_OmitsAutoAndIncludesAddProject()
+    {
+        var projects = new[] { "Tendril-Services" };
+        var options = CreatePlanDialog.BuildProjectSelectOptions(projects);
+
+        Assert.Equal(2, options.Count);
+        Assert.Equal("Tendril-Services", options[0].Value);
+        Assert.Equal(CreatePlanDialog.AddProjectActionValue, options[1].Value);
+    }
 }
+

--- a/src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/badge-select.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/badge-select.css
@@ -178,3 +178,19 @@
 .bselect-action:hover {
   color: var(--foreground);
 }
+
+/* Dropdown search input in Radix Select popovers */
+[data-radix-select-content] .relative input,
+[data-radix-popper-content-wrapper] [data-radix-select-content] input,
+[data-radix-popper-content-wrapper] input[type="text"] {
+  padding-left: 2.25rem !important;
+}
+
+[data-radix-select-content] .relative svg,
+[data-radix-popper-content-wrapper] [data-radix-select-content] .relative svg,
+[data-radix-popper-content-wrapper] .relative > svg {
+  top: 50% !important;
+  transform: translateY(-50%) !important;
+  pointer-events: none !important;
+}
+

--- a/src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/badge-select.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/badge-select.css.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const cssPath = join(dirname(fileURLToPath(import.meta.url)), "badge-select.css");
+const css = readFileSync(cssPath, "utf-8");
+
+describe("badge-select.css dropdown search input styling", () => {
+  it("forces 2.25rem left padding on search input to prevent overlapping the icon", () => {
+    expect(css).toContain("padding-left: 2.25rem !important;");
+  });
+
+  it("vertically centers search icon and disables pointer events", () => {
+    expect(css).toContain("top: 50% !important;");
+    expect(css).toContain("transform: translateY(-50%) !important;");
+    expect(css).toContain("pointer-events: none !important;");
+  });
+});

--- a/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs
@@ -28,6 +28,8 @@ public class CreatePlanDialog(
 
     internal const string AddProjectActionValue = "__tendril_add_project__";
 
+    internal const int MaxProjectsForToggleVariant = 6;
+
     internal static (BadgeSelectOption[] Options, BadgeSelectOption[] Actions) BuildProjectPickerOptions(
         IReadOnlyList<string> projectNames)
     {
@@ -39,6 +41,26 @@ public class CreatePlanDialog(
         var actions = new[] { new BadgeSelectOption(AddProjectActionValue, "Add Project", "Plus") };
         return (options.ToArray(), actions);
     }
+
+    internal static List<Option<string>> BuildProjectSelectOptions(IReadOnlyList<string> projectNames)
+    {
+        var options = new List<Option<string>>();
+        if (projectNames.Count > 1 || projectNames.Count == 0)
+        {
+            options.Add(new Option<string>("Auto", "Auto", icon: Icons.WandSparkles));
+        }
+        options.AddRange(projectNames.Select(p => new Option<string>(p, p)));
+        options.Add(new Option<string>("+ Add New Project", AddProjectActionValue));
+        return options;
+    }
+
+    internal static SelectInputVariant GetProjectPickerVariant(int projectCount) =>
+        projectCount <= MaxProjectsForToggleVariant
+            ? SelectInputVariant.Toggle
+            : SelectInputVariant.Select;
+
+    internal static bool IsProjectPickerSearchable(int projectCount) =>
+        projectCount > MaxProjectsForToggleVariant;
 
     internal static int ParsePriority(string option) => option.ToLowerInvariant() switch
     {
@@ -137,15 +159,9 @@ public class CreatePlanDialog(
 
         object projectPickerWidget;
 
-        var options = new List<Option<string>>();
-        if (currentProjectNames.Count > 1 || currentProjectNames.Count == 0)
-        {
-            options.Add(new Option<string>("Auto", "Auto", icon: Icons.WandSparkles));
-        }
-        options.AddRange(currentProjectNames.Select(p => new Option<string>(p, p)));
-        options.Add(new Option<string>("+ Add New Project", AddProjectActionValue));
+        var options = BuildProjectSelectOptions(currentProjectNames);
 
-        if (currentProjectNames.Count <= 6)
+        if (GetProjectPickerVariant(currentProjectNames.Count) == SelectInputVariant.Toggle)
         {
             projectPickerWidget = selectedProject.ToSelectInput(options)
                 .Variant(SelectInputVariant.Toggle);
@@ -153,7 +169,7 @@ public class CreatePlanDialog(
         else
         {
             projectPickerWidget = selectedProject.ToSelectInput(options)
-                .Searchable(true)
+                .Searchable(IsProjectPickerSearchable(currentProjectNames.Count))
                 .Placeholder("Select project...")
                 .Variant(SelectInputVariant.Select);
         }


### PR DESCRIPTION
Fixes #2105

# Summary

## Changes

Fixed overlapping search input placeholder text and search icon in searchable select dropdown popovers by adding CSS rules that enforce left padding and vertical centering for the search icon. Refactored project picker configuration logic in the Create Plan dialog and added unit tests for project counts with toggle versus searchable select variants.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/badge-select.css`: Added CSS rules for search input left padding (`2.25rem`) and search icon vertical centering with `pointer-events: none` inside Radix Select content containers.
- `src/Ivy.Tendril.Widgets/frontend/src/BadgeSelect/badge-select.css.test.ts`: Added unit test validating dropdown search input and icon alignment styles.
- `src/Ivy.Tendril/Apps/Drafts/Dialogs/CreatePlanDialog.cs`: Extracted project picker variant selection and options helpers (`GetProjectPickerVariant`, `IsProjectPickerSearchable`, `BuildProjectSelectOptions`).
- `src/Ivy.Tendril.Test/CreatePlanDialogTests.cs`: Added unit tests verifying project picker options and variant selection when project count is <= 6 versus > 6.

## Manual Testing

1. Launch Tendril and open the Drafts / Plans app.
2. Ensure more than 6 projects exist (or add test projects in Settings > Projects so the project list exceeds 6).
3. Click "New Plan" (or press `N` / `Cmd+N`) to open the "Create New Plan" dialog.
4. Click on the project select dropdown to open the popover.
5. Observe the search field: verify the magnifying glass icon is vertically centered on the left, and the placeholder text "Search..." or typed search text begins cleanly to the right of the icon without overlapping.

---
- 00bbfcf9 00025: Add project picker variant helpers and unit tests in CreatePlanDialog
- 0df166a1 00025: Fix search input and icon alignment in select dropdown popovers

---
Created using [Ivy Tendril](https://ivy.app).
