### PR TITLE
[00015] Display Meta Shortcut for Create New Plan on Mac

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Views/NewPlanButtonTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Views/NewPlanButtonTests.cs
@@ -1,0 +1,29 @@
+using System.Runtime.InteropServices;
+using Ivy.Tendril.Apps.Views;
+
+namespace Ivy.Tendril.Test.Apps.Views;
+
+public class NewPlanButtonTests
+{
+    [Fact]
+    public void GetTooltip_WhenMac_ReturnsMacShortcut()
+    {
+        var tooltip = NewPlanButton.GetTooltip(isMac: true);
+        Assert.Equal("New Plan (⌘+⌥+N)", tooltip);
+    }
+
+    [Fact]
+    public void GetTooltip_WhenNonMac_ReturnsCtrlShortcut()
+    {
+        var tooltip = NewPlanButton.GetTooltip(isMac: false);
+        Assert.Equal("New Plan (Ctrl+Alt+N)", tooltip);
+    }
+
+    [Fact]
+    public void GetTooltip_Default_MatchesCurrentPlatform()
+    {
+        var isMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        var expected = isMac ? "New Plan (⌘+⌥+N)" : "New Plan (Ctrl+Alt+N)";
+        Assert.Equal(expected, NewPlanButton.GetTooltip());
+    }
+}

--- a/src/Ivy.Tendril/Apps/Views/NewPlanButton.cs
+++ b/src/Ivy.Tendril/Apps/Views/NewPlanButton.cs
@@ -1,7 +1,15 @@
+using System.Runtime.InteropServices;
+
 namespace Ivy.Tendril.Apps.Views;
 
 public class NewPlanButton(bool collapsed = false) : ViewBase
 {
+    public static string GetTooltip(bool isMac) =>
+        isMac ? "New Plan (⌘+⌥+N)" : "New Plan (Ctrl+Alt+N)";
+
+    public static string GetTooltip() =>
+        GetTooltip(RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
+
     public override object Build()
     {
         return new CreatePlanDialogLauncher(
@@ -11,7 +19,7 @@ public class NewPlanButton(bool collapsed = false) : ViewBase
                     .Width(Size.Full())
                     .Variant(ButtonVariant.Primary)
                     .OnClick(open)
-                    .Tooltip("New Plan (Ctrl+Alt+N)")
+                    .Tooltip(GetTooltip())
                     .ShortcutKey("CTRL+ALT+N")
                 : new Button("New Plan")
                     .Icon(Icons.Plus)


### PR DESCRIPTION
Fixes #2114

# Summary

## Changes

Updated the collapsed sidebar "New Plan" button tooltip to display platform-appropriate keyboard shortcuts (`⌘+⌥+N` on macOS and `Ctrl+Alt+N` on Windows/Linux). Added helper methods in `NewPlanButton` and comprehensive unit tests covering both platforms.

## API Changes

- `public static string Ivy.Tendril.Apps.Views.NewPlanButton.GetTooltip()`: Added parameterless helper returning tooltip text based on current OS platform.
- `public static string Ivy.Tendril.Apps.Views.NewPlanButton.GetTooltip(bool isMac)`: Added helper returning tooltip formatted for Mac or non-Mac platforms.

## Files Modified

- **UI Views**: `src/Ivy.Tendril/Apps/Views/NewPlanButton.cs` (added dynamic tooltip helper methods and updated tooltip invocation)
- **Unit Tests**: `src/Ivy.Tendril.Test/Apps/Views/NewPlanButtonTests.cs` (added unit tests for Mac and non-Mac tooltip strings)

## Manual Testing

1. Launch Tendril app on macOS or Windows/Linux.
2. Collapse the left sidebar using the sidebar toggle icon.
3. Hover over the "+" button (New Plan button) at the top of the collapsed sidebar.
4. On macOS, observe the tooltip displays `New Plan (⌘+⌥+N)`. On Windows/Linux, observe the tooltip displays `New Plan (Ctrl+Alt+N)`.

---
- Display Mac shortcut in NewPlanButton tooltip (00015) (4c5562c5)

---
Created using [Ivy Tendril](https://ivy.app).
