### PR TITLE
[00017] Optimize Jobs DataTable Performance with 100+ Running Jobs

### DIFF
--- a/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
@@ -1,3 +1,5 @@
+using System.Reactive.Linq;
+using Ivy.Core.Hooks;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
@@ -6,6 +8,13 @@ namespace Ivy.Tendril.Test;
 
 public class JobsAppRefreshGatingTests
 {
+    private static (RefreshToken Token, Func<int> RefreshCount) CreateRefreshToken()
+    {
+        var state = new State<(Guid, object?, bool)>((Guid.NewGuid(), null, false));
+        var count = 0;
+        state.Skip(1).Subscribe(_ => count++);
+        return (new RefreshToken(state), () => count);
+    }
     private static JobItem MakeJob(string id, JobStatus status, DateTime? completedAt = null) => new()
     {
         Id = id,
@@ -124,9 +133,48 @@ public class JobsAppRefreshGatingTests
         Assert.Empty(cache);
     }
 
+    [Fact]
+    public void JobChangeHookDisposable_SubscribesOnlyToJobsStructureChanged()
+    {
+        var jobService = new FakeJobService();
+        var (token, refreshCount) = CreateRefreshToken();
+
+        using var hook = JobsApp.JobChangeHookDisposable(jobService, token);
+
+        // JobPropertyChanged should not trigger a refresh
+        jobService.FireJobPropertyChanged();
+        Assert.Equal(0, refreshCount());
+
+        // JobsStructureChanged should trigger a refresh
+        jobService.FireJobsStructureChanged();
+        Assert.Equal(1, refreshCount());
+
+        // Multiple structure changes trigger multiple refreshes
+        jobService.FireJobsStructureChanged();
+        Assert.Equal(2, refreshCount());
+    }
+
+    [Fact]
+    public void JobChangeHookDisposable_Dispose_UnhooksJobsStructureChanged()
+    {
+        var jobService = new FakeJobService();
+        var (token, refreshCount) = CreateRefreshToken();
+
+        var hook = JobsApp.JobChangeHookDisposable(jobService, token);
+        jobService.FireJobsStructureChanged();
+        Assert.Equal(1, refreshCount());
+
+        hook.Dispose();
+        jobService.FireJobsStructureChanged();
+        Assert.Equal(1, refreshCount());
+    }
+
     private class FakeJobService : IJobService
     {
         public List<JobItem> Jobs { get; } = new();
+
+        public void FireJobsStructureChanged() => JobsStructureChanged?.Invoke();
+        public void FireJobPropertyChanged() => JobPropertyChanged?.Invoke();
 
         public string StartJob(JobArgsBase args, string? inboxFilePath = null) => throw new NotSupportedException();
         public void ForceStartJob(string id) => throw new NotSupportedException();

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Hooks.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Hooks.cs
@@ -5,7 +5,7 @@ namespace Ivy.Tendril.Apps.Jobs;
 
 public partial class JobsApp
 {
-    private static IDisposable JobChangeHookDisposable(IJobService jobService, RefreshToken refreshToken)
+    internal static IDisposable JobChangeHookDisposable(IJobService jobService, RefreshToken refreshToken)
     {
         void OnJobsChanged()
         {
@@ -13,11 +13,9 @@ public partial class JobsApp
         }
 
         jobService.JobsStructureChanged += OnJobsChanged;
-        jobService.JobPropertyChanged += OnJobsChanged;
         return Disposable.Create(() =>
         {
             jobService.JobsStructureChanged -= OnJobsChanged;
-            jobService.JobPropertyChanged -= OnJobsChanged;
         });
     }
 


### PR DESCRIPTION
Fixes #1843

# Summary

## Changes

Removed the `JobPropertyChanged` event subscription from `JobChangeHookDisposable` in `JobsApp`. Property updates (such as cost, token count, timer, and status message) now stream through the 1-second cell update mechanism without triggering expensive full-table rebuilds, while structural changes still trigger immediate refreshes.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Jobs/JobsApp.Hooks.cs`: Unhooked `JobPropertyChanged` from `JobChangeHookDisposable`.
- `src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs`: Added unit tests verifying `JobChangeHookDisposable` subscribes only to `JobsStructureChanged`.

## Manual Testing

1. Launch Tendril and navigate to the Jobs tab.
2. Run or simulate multiple concurrent jobs reporting frequent status updates or cost changes.
3. Observe that cell values (Cost, Tokens, Timer, Status message) update smoothly without causing the entire table or row DOM to re-render.
4. Add or stop a job to confirm that structural changes still immediately refresh the table.

---
- c667c18f [00017] Optimize Jobs DataTable performance by unhooking JobPropertyChanged from full table refresh

---
Created using [Ivy Tendril](https://ivy.app).
