### PR TITLE
[00011] Fix Job Prompt Display for All Job Types

### DIFF
--- a/src/Ivy.Tendril.Test/JobsAppPromptDisplayTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppPromptDisplayTests.cs
@@ -62,10 +62,207 @@ public class JobsAppPromptDisplayTests
         Assert.Equal("[GitHub Issue #925](https://github.com/o/r/issues/925)", fullPrompt);
     }
 
+    [Fact]
+    public void GetFullPrompt_RetryPlanArgs_ReturnsChangeRequest()
+    {
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = Constants.JobTypes.RetryPlan,
+            TypedArgs = new RetryPlanArgs("00001-TestPlan", "Fix the failing tests")
+        };
+
+        var fullPrompt = JobsApp.GetFullPrompt(job);
+
+        Assert.Equal("Fix the failing tests", fullPrompt);
+    }
+
+    [Fact]
+    public void GetFullPrompt_UpdatePlanArgs_ReturnsInstructions()
+    {
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = Constants.JobTypes.UpdatePlan,
+            TypedArgs = new UpdatePlanArgs("00001-TestPlan", "Add error handling to service")
+        };
+
+        var fullPrompt = JobsApp.GetFullPrompt(job);
+
+        Assert.Equal("Add error handling to service", fullPrompt);
+    }
+
+    [Fact]
+    public void GetFullPrompt_ExecutePlanArgs_WithNote_ReturnsNote()
+    {
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = Constants.JobTypes.ExecutePlan,
+            TypedArgs = new ExecutePlanArgs("00001-TestPlan", "Special execution note")
+        };
+
+        var fullPrompt = JobsApp.GetFullPrompt(job);
+
+        Assert.Equal("Special execution note", fullPrompt);
+    }
+
+    [Fact]
+    public void GetFullPrompt_ExecutePlanArgs_WithoutNote_ResolvesFromPlan()
+    {
+        var plan = CreateSamplePlan("00001-TestPlan", "Sample Title", "Initial plan prompt");
+        var planService = new FakePlanReaderService { PlanToReturn = plan };
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = Constants.JobTypes.ExecutePlan,
+            PlanFile = "00001-TestPlan",
+            TypedArgs = new ExecutePlanArgs("00001-TestPlan")
+        };
+
+        var fullPrompt = JobsApp.GetFullPrompt(job, planService);
+
+        Assert.Equal("Initial plan prompt", fullPrompt);
+    }
+
+    [Fact]
+    public void GetFullPrompt_AddProjectArgs_ReturnsProjectName()
+    {
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = Constants.JobTypes.AddProject,
+            TypedArgs = new AddProjectArgs("MyProject", [])
+        };
+
+        var fullPrompt = JobsApp.GetFullPrompt(job);
+
+        Assert.Equal("MyProject", fullPrompt);
+    }
+
+    [Fact]
+    public void GetFullPrompt_SetupProjectArgs_ReturnsFolderPath()
+    {
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = Constants.JobTypes.SetupProject,
+            TypedArgs = new SetupProjectArgs("/path/to/project")
+        };
+
+        var fullPrompt = JobsApp.GetFullPrompt(job);
+
+        Assert.Equal("/path/to/project", fullPrompt);
+    }
+
+    [Fact]
+    public void GetFullPrompt_SyncRepoArgs_ReturnsRepoPath()
+    {
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = Constants.JobTypes.SyncRepo,
+            TypedArgs = new SyncRepoArgs("/path/to/repo", "main")
+        };
+
+        var fullPrompt = JobsApp.GetFullPrompt(job);
+
+        Assert.Equal("/path/to/repo", fullPrompt);
+    }
+
+    [Fact]
+    public void GetFullPrompt_CreatePrArgs_WithComment_ReturnsComment()
+    {
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = Constants.JobTypes.CreatePr,
+            TypedArgs = new CreatePrArgs("00001-TestPlan", Comment: "Please review PR promptly")
+        };
+
+        var fullPrompt = JobsApp.GetFullPrompt(job);
+
+        Assert.Equal("Please review PR promptly", fullPrompt);
+    }
+
+    [Fact]
+    public void GetFullPrompt_CreateIssueArgs_WithComment_ReturnsComment()
+    {
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = Constants.JobTypes.CreateIssue,
+            TypedArgs = new CreateIssueArgs("00001-TestPlan", "owner/repo", Comment: "Issue comment details")
+        };
+
+        var fullPrompt = JobsApp.GetFullPrompt(job);
+
+        Assert.Equal("Issue comment details", fullPrompt);
+    }
+
+    [Fact]
+    public void GetPromptDisplay_AddProjectArgs_ReturnsProjectName()
+    {
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = Constants.JobTypes.AddProject,
+            TypedArgs = new AddProjectArgs("MyProject", [])
+        };
+
+        var display = JobsApp.GetPromptDisplay(job, new FakePlanReaderService());
+
+        Assert.Equal("MyProject", display);
+    }
+
+    [Fact]
+    public void GetPromptDisplay_SetupProjectArgs_ReturnsFolderPath()
+    {
+        var job = new JobItem
+        {
+            Id = "job-1",
+            Type = Constants.JobTypes.SetupProject,
+            TypedArgs = new SetupProjectArgs("/path/to/project")
+        };
+
+        var display = JobsApp.GetPromptDisplay(job, new FakePlanReaderService());
+
+        Assert.Equal("/path/to/project", display);
+    }
+
+    private static PlanFile CreateSamplePlan(string folderName, string title, string? initialPrompt)
+    {
+        var metadata = new PlanMetadata(
+            Id: 1,
+            Project: "TestProject",
+            Level: "Feature",
+            Title: title,
+            State: PlanStatus.Draft,
+            Repos: [],
+            Commits: [],
+            Prs: [],
+            Verifications: [],
+            RelatedPlans: [],
+            DependsOn: [],
+            Created: DateTime.UtcNow,
+            Updated: DateTime.UtcNow,
+            InitialPrompt: initialPrompt,
+            SourceUrl: null
+        );
+
+        return new PlanFile(
+            Metadata: metadata,
+            LatestRevisionContent: "",
+            FolderPath: $"/tmp/{folderName}",
+            PlanYamlRaw: ""
+        );
+    }
+
     private class FakePlanReaderService : IPlanReaderService
     {
         public string PlansDirectory => "/tmp";
         public bool IsDatabaseReady => true;
+        public PlanFile? PlanToReturn { get; set; }
 #pragma warning disable CS0067
         public event Action? CountsInvalidated;
 #pragma warning restore CS0067
@@ -85,7 +282,7 @@ public class JobsAppPromptDisplayTests
 
         public PlanFile? GetPlanByFolder(string folderPath)
         {
-            return null;
+            return PlanToReturn;
         }
 
         public List<PlanFile> GetIceboxPlans()

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs
@@ -9,12 +9,35 @@ public partial class JobsApp
 
     internal static string? GetFullPrompt(JobItem job, IPlanReaderService? planService = null)
     {
-        if (job.TypedArgs is CreatePlanArgs cp)
-            return cp.Description;
-
-        if (planService != null && !string.IsNullOrEmpty(job.PlanFile))
+        switch (job.TypedArgs)
         {
-            var fullPath = Path.Combine(planService.PlansDirectory, job.PlanFile);
+            case CreatePlanArgs cp:
+                return cp.Description;
+            case RetryPlanArgs rp when !string.IsNullOrWhiteSpace(rp.ChangeRequest):
+                return rp.ChangeRequest;
+            case UpdatePlanArgs up when !string.IsNullOrWhiteSpace(up.Instructions):
+                return up.Instructions;
+            case ExecutePlanArgs ep when !string.IsNullOrWhiteSpace(ep.Note):
+                return ep.Note;
+            case CreatePrArgs cpr when !string.IsNullOrWhiteSpace(cpr.Comment):
+                return cpr.Comment;
+            case CreateIssueArgs ci when !string.IsNullOrWhiteSpace(ci.Comment):
+                return ci.Comment;
+            case SyncRepoArgs sr:
+                return sr.RepoPath;
+            case AddProjectArgs ap:
+                return ap.ProjectName;
+            case SetupProjectArgs sp:
+                return sp.FolderPath;
+        }
+
+        var planFolder = !string.IsNullOrEmpty(job.PlanFile)
+            ? job.PlanFile
+            : job.TypedArgs?.PlanFolder;
+
+        if (planService != null && !string.IsNullOrEmpty(planFolder))
+        {
+            var fullPath = Path.Combine(planService.PlansDirectory, planFolder);
             var plan = planService.GetPlanByFolder(fullPath);
             if (plan != null)
             {
@@ -25,7 +48,7 @@ public partial class JobsApp
             }
         }
 
-        return job.PlanFile;
+        return !string.IsNullOrEmpty(job.PlanFile) ? job.PlanFile : string.Empty;
     }
 
     internal static string ExtractPlanId(string planFile)
@@ -106,7 +129,7 @@ public partial class JobsApp
     internal static string GetPromptDisplay(JobItem j, IPlanReaderService planService)
     {
         // Try loading plan title from service
-        if (TryGetPlanTitle(j.PlanFile, planService, out var planTitle))
+        if (TryGetPlanTitle(j, planService, out var planTitle))
             return TruncatePrompt(planTitle);
 
         // Try reported title
@@ -121,16 +144,25 @@ public partial class JobsApp
         if (j.TypedArgs is SyncRepoArgs syncArgs)
             return TruncatePrompt(syncArgs.RepoPath);
 
+        // Try AddProject name
+        if (j.TypedArgs is AddProjectArgs addProjArgs)
+            return TruncatePrompt(addProjArgs.ProjectName);
+
+        // Try SetupProject path
+        if (j.TypedArgs is SetupProjectArgs setupProjArgs)
+            return TruncatePrompt(setupProjArgs.FolderPath);
+
         // Fallback to full prompt (resolves InitialPrompt/Title from plan.yaml) or plan file
         return TruncatePrompt(GetFullPrompt(j, planService) ?? j.PlanFile);
     }
 
-    private static bool TryGetPlanTitle(string? planFile, IPlanReaderService planService, out string title)
+    private static bool TryGetPlanTitle(JobItem j, IPlanReaderService planService, out string title)
     {
         title = string.Empty;
-        if (string.IsNullOrEmpty(planFile)) return false;
+        var folder = !string.IsNullOrEmpty(j.PlanFile) ? j.PlanFile : j.TypedArgs?.PlanFolder;
+        if (string.IsNullOrEmpty(folder)) return false;
 
-        var fullPath = Path.Combine(planService.PlansDirectory, planFile);
+        var fullPath = Path.Combine(planService.PlansDirectory, folder);
         var plan = planService.GetPlanByFolder(fullPath);
 
         if (plan != null && !string.IsNullOrEmpty(plan.Title))


### PR DESCRIPTION
Fixes #2112

# Summary

## Changes

Updated `JobsApp.GetFullPrompt` and `JobsApp.GetPromptDisplay` in `JobsApp.Helpers.cs` to properly handle all `JobArgsBase` variants (including `RetryPlanArgs`, `UpdatePlanArgs`, `ExecutePlanArgs`, `CreatePrArgs`, `CreateIssueArgs`, `SyncRepoArgs`, `AddProjectArgs`, and `SetupProjectArgs`). Improved fallback resolution so that plan folders can be resolved from either `PlanFile` or `TypedArgs.PlanFolder`, and added comprehensive unit tests for all job types in `JobsAppPromptDisplayTests.cs`.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Jobs/JobsApp.Helpers.cs`: Added support for all `JobArgsBase` types in `GetFullPrompt`, updated `GetPromptDisplay` to handle project args, and updated `TryGetPlanTitle` to resolve plan folder from both `PlanFile` and `TypedArgs.PlanFolder`.
- `src/Ivy.Tendril.Test/JobsAppPromptDisplayTests.cs`: Added unit tests covering `GetFullPrompt` and `GetPromptDisplay` for all `JobArgsBase` variants.

## Manual Testing

1. Open the Jobs view in the Tendril web UI or run the Jobs app.
2. Trigger or inspect non-CreatePlan jobs (such as `RetryPlan`, `UpdatePlan`, `ExecutePlan` with a note, `AddProject`, or `SetupProject`).
3. Observe that the prompt/title column in the table and the Full Prompt sheet display the relevant instructions, change request, note, project name, or folder path instead of blank or mismatched initial prompts.

---
### Commits
- 150018d8 Fix job prompt display for all job types (Plan 00011)

---
Created using [Ivy Tendril](https://ivy.app).
