### PR TITLE
[00001] Show Newly Added Projects in GitHub Import Without Restart

### DIFF
--- a/src/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -496,6 +496,150 @@ public class GithubServiceTests
         }
     }
 
+    [Fact]
+    public void Should_Return_Newly_Added_Projects_Without_Service_Restart()
+    {
+        var tempDir1 = CreateTempGitRepo("https://github.com/Test-Owner-1/Test-Repo-1.git");
+        var tempDir2 = CreateTempGitRepo("https://github.com/Test-Owner-2/Test-Repo-2.git");
+        try
+        {
+            var settings = new TendrilSettings
+            {
+                Projects = [new ProjectConfig { Name = "Project1", Repos = [new RepoRef { Path = tempDir1 }] }]
+            };
+            var configService = new ConfigService(settings);
+            using var githubService = new GithubService(configService, NullLogger<GithubService>.Instance);
+
+            var initialRepos = githubService.GetRepos();
+            Assert.Single(initialRepos);
+            Assert.Equal("Test-Owner-1", initialRepos[0].Owner);
+            Assert.Equal("Test-Repo-1", initialRepos[0].Name);
+
+            settings.Projects.Add(new ProjectConfig { Name = "Project2", Repos = [new RepoRef { Path = tempDir2 }] });
+
+            var updatedRepos = githubService.GetRepos();
+            Assert.Equal(2, updatedRepos.Count);
+            Assert.Contains(updatedRepos, r => r.Owner == "Test-Owner-1" && r.Name == "Test-Repo-1");
+            Assert.Contains(updatedRepos, r => r.Owner == "Test-Owner-2" && r.Name == "Test-Repo-2");
+        }
+        finally
+        {
+            Directory.Delete(tempDir1, true);
+            Directory.Delete(tempDir2, true);
+        }
+    }
+
+    [Fact]
+    public void SettingsReloaded_Should_Invalidate_Repo_Cache()
+    {
+        var tempDir = CreateTempGitRepo("https://github.com/Initial-Owner/Initial-Repo.git");
+        try
+        {
+            var testConfig = new TestConfigServiceWithEvents(new TendrilSettings
+            {
+                Projects = [new ProjectConfig { Name = "Project1", Repos = [new RepoRef { Path = tempDir }] }]
+            });
+            using var githubService = new GithubService(testConfig, NullLogger<GithubService>.Instance);
+
+            var initial = githubService.GetRepoConfigFromPathCached(tempDir);
+            Assert.NotNull(initial);
+            Assert.Equal("Initial-Owner", initial.Owner);
+            Assert.Equal("Initial-Repo", initial.Name);
+
+            // Change git origin remote on disk
+            RunGit(tempDir, "remote set-url origin https://github.com/Updated-Owner/Updated-Repo.git");
+
+            // Still cached before reload event
+            var beforeReload = githubService.GetRepoConfigFromPathCached(tempDir);
+            Assert.Same(initial, beforeReload);
+
+            // Trigger settings reload
+            testConfig.TriggerReload();
+
+            // After reload, cache was cleared and fresh remote is resolved
+            var afterReload = githubService.GetRepoConfigFromPathCached(tempDir);
+            Assert.NotNull(afterReload);
+            Assert.NotSame(initial, afterReload);
+            Assert.Equal("Updated-Owner", afterReload.Owner);
+            Assert.Equal("Updated-Repo", afterReload.Name);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Dispose_Should_Unsubscribe_From_SettingsReloaded()
+    {
+        var tempDir = CreateTempGitRepo("https://github.com/Initial-Owner/Initial-Repo.git");
+        try
+        {
+            var testConfig = new TestConfigServiceWithEvents(new TendrilSettings
+            {
+                Projects = [new ProjectConfig { Name = "Project1", Repos = [new RepoRef { Path = tempDir }] }]
+            });
+            var githubService = new GithubService(testConfig, NullLogger<GithubService>.Instance);
+
+            var initial = githubService.GetRepoConfigFromPathCached(tempDir);
+            Assert.NotNull(initial);
+
+            githubService.Dispose();
+
+            RunGit(tempDir, "remote set-url origin https://github.com/Updated-Owner/Updated-Repo.git");
+            testConfig.TriggerReload();
+
+            // Cache was not cleared on reload because the service was disposed and unsubscribed
+            var afterReload = githubService.GetRepoConfigFromPathCached(tempDir);
+            Assert.Same(initial, afterReload);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    private class TestConfigServiceWithEvents(TendrilSettings settings) : IConfigService
+    {
+        public TendrilSettings Settings { get; } = settings;
+        public string TendrilHome => "";
+        public string ConfigPath => "";
+        public string PlanFolder => "";
+        public List<ProjectConfig> Projects => Settings.Projects;
+        public List<LevelConfig> Levels => [];
+        public string[] LevelNames => [];
+        public EditorConfig Editor => new();
+        public bool NeedsOnboarding => false;
+        public ConfigParseError? ParseError => null;
+        public event EventHandler? SettingsReloaded;
+
+        public void TriggerReload() => SettingsReloaded?.Invoke(this, EventArgs.Empty);
+
+        public ProjectConfig? GetProject(string name) =>
+            Settings.Projects.FirstOrDefault(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+        public bool TryAutoHeal() => false;
+        public void ResetToDefaults() { }
+        public void RetryLoadConfig() { }
+        public Colors? GetLevelColor(string level) => null;
+        public Colors? GetProjectColor(string projectName) => null;
+        public void SaveSettings() { }
+        public void MutateAndSave(Action<TendrilSettings> mutate) => mutate(Settings);
+        public void ReloadSettings() => TriggerReload();
+        public void SetPendingTendrilHome(string path) { }
+        public string? GetPendingTendrilHome() => null;
+        public void SetPendingProject(ProjectConfig project) { }
+        public ProjectConfig? GetPendingProject() => null;
+        public void SetPendingCodingAgent(string name) { }
+        public string? GetPendingCodingAgent() => null;
+        public void SetPendingVerificationDefinitions(List<VerificationConfig> definitions) { }
+        public List<VerificationConfig>? GetPendingVerificationDefinitions() => null;
+        public void CompleteOnboarding(string tendrilHome) { }
+        public void OpenInEditor(string path) { }
+        public string PolishMarkdown(string content) => content;
+        public void Dispose() { }
+    }
+
     private static string CreateTempGitRepo(string remoteUrl)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"ivy-github-test-{Guid.NewGuid()}");

--- a/src/Ivy.Tendril/Services/Git/GithubService.cs
+++ b/src/Ivy.Tendril/Services/Git/GithubService.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Services.Git;
 
-public class GithubService(IConfigService config, ILogger<GithubService> logger) : IGithubService
+public class GithubService : IGithubService, IDisposable
 {
     public const int DefaultIssueLimit = 1000;
     public const int MaxIssueLimit = 1000;
@@ -17,17 +17,31 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
     // ConcurrentDictionary required: multiple UseQuery calls from different views/dialogs
     // can fetch different repos simultaneously, causing concurrent writes to different keys.
     private readonly ConcurrentDictionary<string, List<string>> _assigneeCache = new();
-    private readonly IConfigService _config = config;
-    private readonly ILogger<GithubService> _logger = logger;
+    private readonly IConfigService _config;
+    private readonly ILogger<GithubService> _logger;
     private readonly ConcurrentDictionary<string, List<string>> _labelCache = new();
     private readonly ConcurrentDictionary<string, RepoConfig?> _repoPathCache = new();
-    private List<RepoConfig>? _repoCache;
+
+    public GithubService(IConfigService config, ILogger<GithubService> logger)
+    {
+        _config = config;
+        _logger = logger;
+        _config.SettingsReloaded += OnSettingsReloaded;
+    }
+
+    private void OnSettingsReloaded(object? sender, EventArgs e)
+    {
+        _repoPathCache.Clear();
+    }
+
+    public void Dispose()
+    {
+        _config.SettingsReloaded -= OnSettingsReloaded;
+        GC.SuppressFinalize(this);
+    }
 
     public List<RepoConfig> GetRepos()
     {
-        if (_repoCache is not null)
-            return _repoCache;
-
         var uniquePaths = _config.Settings.Projects
             .SelectMany(p => p.RepoPaths)
             .Distinct()
@@ -42,12 +56,10 @@ public class GithubService(IConfigService config, ILogger<GithubService> logger)
         }
 
         // Deduplicate by FullName (owner/name)
-        _repoCache = repos
+        return repos
             .GroupBy(r => r.FullName, StringComparer.OrdinalIgnoreCase)
             .Select(g => g.First())
             .ToList();
-
-        return _repoCache;
     }
 
     public async Task<(List<string> assignees, string? error)> GetAssigneesAsync(string owner, string repo)


### PR DESCRIPTION
Fixes #1916

# Summary

## Changes

Removed the static `_repoCache` field in `GithubService` so repository lists are resolved dynamically from `_config.Settings.Projects` on each invocation of `GetRepos()`. Subscribed `GithubService` to `_config.SettingsReloaded` to clear cached repository path mappings when configuration is updated, and implemented `IDisposable` to unsubscribe on teardown.

## API Changes

- `Ivy.Tendril.Services.Git.GithubService`: Implements `System.IDisposable`

## Files Modified

- `src/Ivy.Tendril/Services/Git/GithubService.cs`: Removed `_repoCache`, hooked `SettingsReloaded` to invalidate `_repoPathCache`, and implemented `IDisposable`.
- `src/Ivy.Tendril.Test/GithubServiceTests.cs`: Added unit tests verifying newly added projects appear immediately without restarting, cached paths are cleared on settings reload, and `Dispose()` unhooks events.

## Manual Testing

1. Launch Tendril.
2. Open the GitHub Import Issues dialog and view the repository dropdown.
3. In Settings, add a new project with a valid Git repository URL or path.
4. Return to the GitHub Import Issues dialog and open the repository dropdown.
5. Verify that the newly added repository appears in the list without having to restart Tendril.

---
- 724aa4c2 Plan 00001: Resolve repos dynamically in GithubService and clear path cache on SettingsReloaded

---
Created using [Ivy Tendril](https://ivy.app).
