### PR TITLE
[00010] Add Model Reasoning Support and Codex Configuration

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexCliTests.cs
@@ -50,9 +50,45 @@ public class CodexCliTests
     }
 
     [Fact]
+    public void Capabilities_IncludesEffortControl()
+    {
+        Assert.True(_cli.Capabilities.HasFlag(AgentCapabilities.EffortControl));
+    }
+
+    [Fact]
     public void Capabilities_IncludesExtraArgPassthrough()
     {
         Assert.True(_cli.Capabilities.HasFlag(AgentCapabilities.ExtraArgPassthrough));
+    }
+
+    [Fact]
+    public void SupportedEfforts_ReturnsCodexEffortLevels()
+    {
+        Assert.Equal(EffortLevels.Codex, _cli.SupportedEfforts);
+    }
+
+    [Fact]
+    public void DefaultProfiles_MatchesConfiguredModels()
+    {
+        Assert.Collection(_cli.DefaultProfiles,
+            p =>
+            {
+                Assert.Equal(ProfileTier.Deep, p.Tier);
+                Assert.Equal("gpt-5.6-sol", p.Model);
+                Assert.Equal("high", p.Effort);
+            },
+            p =>
+            {
+                Assert.Equal(ProfileTier.Balanced, p.Tier);
+                Assert.Equal("gpt-5.6-terra", p.Model);
+                Assert.Equal("medium", p.Effort);
+            },
+            p =>
+            {
+                Assert.Equal(ProfileTier.Quick, p.Tier);
+                Assert.Equal("gpt-5.6-luna", p.Model);
+                Assert.Equal("low", p.Effort);
+            });
     }
 
     [Fact]
@@ -199,6 +235,63 @@ public class CodexCliTests
         var modelIdx = spec.Arguments.ToList().IndexOf("--model");
         Assert.True(modelIdx >= 0);
         Assert.Equal("o4-mini", spec.Arguments[modelIdx + 1]);
+    }
+
+    [Fact]
+    public void BuildProcessSpec_WithEffort_IncludesReasoningEffortConfig()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+            Effort = EffortLevel.High,
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        var argList = spec.Arguments.ToList();
+        var idx = argList.IndexOf("-c");
+        Assert.True(idx >= 0);
+        Assert.Contains(argList, a => a == "model_reasoning_effort=\"high\"");
+    }
+
+    [Fact]
+    public void BuildProcessSpec_NoEffort_DoesNotIncludeReasoningEffortConfig()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        Assert.DoesNotContain(spec.Arguments, a => a.StartsWith("model_reasoning_effort"));
+    }
+
+    [Theory]
+    [InlineData(EffortLevel.Low, "low")]
+    [InlineData(EffortLevel.Medium, "medium")]
+    [InlineData(EffortLevel.High, "high")]
+    [InlineData(EffortLevel.XHigh, "xhigh")]
+    [InlineData(EffortLevel.Max, "xhigh")]
+    public void BuildProcessSpec_AllEffortLevels_MapCorrectly(EffortLevel level, string expected)
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+            Effort = level,
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        var argList = spec.Arguments.ToList();
+        var expectedArg = $"model_reasoning_effort=\"{expected}\"";
+        Assert.Contains(expectedArg, argList);
+        var idx = argList.IndexOf(expectedArg);
+        Assert.True(idx > 0);
+        Assert.Equal("-c", argList[idx - 1]);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexPtyTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexPtyTests.cs
@@ -8,6 +8,18 @@ public class CodexPtyTests
     private readonly CodexPty _pty = new();
 
     [Fact]
+    public void Capabilities_IncludesEffortControl()
+    {
+        Assert.True(_pty.Capabilities.HasFlag(AgentCapabilities.EffortControl));
+    }
+
+    [Fact]
+    public void SupportedEfforts_ReturnsCodexEffortLevels()
+    {
+        Assert.Equal(EffortLevels.Codex, _pty.SupportedEfforts);
+    }
+
+    [Fact]
     public void BuildPtySpec_FullAuto_UsesSandboxAndApprovalFlags()
     {
         var config = new AgentPtyConfig

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexCli.cs
@@ -13,6 +13,7 @@ public sealed class CodexCli : IAgentCli
         AgentCapabilities.StdinPrompt |
         AgentCapabilities.StreamJsonOutput |
         AgentCapabilities.ModelSelection |
+        AgentCapabilities.EffortControl |
         AgentCapabilities.DirectoryRestriction |
         AgentCapabilities.HealthCheck |
         AgentCapabilities.ExtraArgPassthrough;
@@ -23,10 +24,12 @@ public sealed class CodexCli : IAgentCli
 
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles { get; } =
     [
-        new(ProfileTier.Deep, null, "high"),
-        new(ProfileTier.Balanced, null, "medium"),
-        new(ProfileTier.Quick, null, "low"),
+        new(ProfileTier.Deep, "gpt-5.6-sol", "high"),
+        new(ProfileTier.Balanced, "gpt-5.6-terra", "medium"),
+        new(ProfileTier.Quick, "gpt-5.6-luna", "low"),
     ];
+
+    public IReadOnlyList<EffortOption> SupportedEfforts => EffortLevels.Codex;
 
     private static readonly FrozenDictionary<string, string> ToolNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
     {
@@ -74,6 +77,21 @@ public sealed class CodexCli : IAgentCli
         {
             args.Add("--model");
             args.Add(config.Model);
+        }
+
+        if (config.Effort is not null)
+        {
+            var effort = config.Effort.Value switch
+            {
+                EffortLevel.Low => "low",
+                EffortLevel.Medium => "medium",
+                EffortLevel.High => "high",
+                EffortLevel.XHigh => "xhigh",
+                EffortLevel.Max => "xhigh",
+                _ => "medium"
+            };
+            args.Add("-c");
+            args.Add($"model_reasoning_effort=\"{effort}\"");
         }
 
         var extractedDirs = ExtractWritableDirectories(config.AllowedTools);

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexPty.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexPty.cs
@@ -12,12 +12,14 @@ public sealed class CodexPty : IAgentPty
         AgentCapabilities.StdinPrompt |
         AgentCapabilities.StreamJsonOutput |
         AgentCapabilities.ModelSelection |
+        AgentCapabilities.EffortControl |
         AgentCapabilities.DirectoryRestriction |
         AgentCapabilities.HealthCheck |
         AgentCapabilities.ExtraArgPassthrough;
 
     public TransportKind SupportedTransports => TransportKind.Pty;
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles => [];
+    public IReadOnlyList<EffortOption> SupportedEfforts => EffortLevels.Codex;
 
     public string? ContextFileName => "AGENTS.md";
 

--- a/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
+++ b/src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs
@@ -228,7 +228,7 @@ public class AgentProviderFactoryTests
 
         Assert.Equal("codex", resolution.AgentId);
         Assert.Equal("o4-mini", resolution.Model);
-        Assert.Equal("", resolution.Effort); // Codex CLI doesn't support EffortControl
+        Assert.Equal("medium", resolution.Effort);
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Commands/ModelsCommand.cs
+++ b/src/Ivy.Tendril/Commands/ModelsCommand.cs
@@ -85,7 +85,7 @@ public sealed class ModelsCommand(IAgentRunner runner) : AsyncCommand<ModelsComm
         var headers = new[]
         {
             "Model", "Display Name", "Input $/M", "Output $/M", "Cache R $/M", "Cache W $/M",
-            "Source", "Default", "Vision"
+            "Source", "Default", "Vision", "Reasoning"
         };
 
         var sourceIndex = new Dictionary<string, int>();
@@ -107,6 +107,7 @@ public sealed class ModelsCommand(IAgentRunner runner) : AsyncCommand<ModelsComm
             }
 
             var hasVision = model.Capabilities.HasFlag(ModelCapabilities.ImageInput) ? CliOutput.Glyph(true) : "-";
+            var hasReasoning = model.Capabilities.HasFlag(ModelCapabilities.Reasoning) ? CliOutput.Glyph(true) : "-";
 
             rows.Add(new[]
             {
@@ -118,7 +119,8 @@ public sealed class ModelsCommand(IAgentRunner runner) : AsyncCommand<ModelsComm
                 FormatPrice(model.CacheWritePerMillion),
                 sourceRef,
                 isDefault,
-                hasVision
+                hasVision,
+                hasReasoning
             });
         }
 


### PR DESCRIPTION
Fixes #2107

# Summary

## Changes

Added model reasoning effort support to the Codex coding agent provider and updated Codex default profile models to gpt-5.6-sol, gpt-5.6-terra, and gpt-5.6-luna. In addition, added a Reasoning capability column to the models CLI output table.

## API Changes

- Added `AgentCapabilities.EffortControl` flag to `CodexCli.Capabilities` and `CodexPty.Capabilities`.
- Exposed `SupportedEfforts => EffortLevels.Codex;` on `CodexCli` and `CodexPty`.
- Configured default models in `CodexCli.DefaultProfiles`: `gpt-5.6-sol` (Deep), `gpt-5.6-terra` (Balanced), and `gpt-5.6-luna` (Quick).
- Added `Reasoning` column to `ModelsCommand` table output rendering `ModelCapabilities.Reasoning`.

## Files Modified

- **Agents:** `src/Ivy.Tendril.Agents/Providers/Codex/CodexCli.cs`, `src/Ivy.Tendril.Agents/Providers/Codex/CodexPty.cs`
- **CLI Commands:** `src/Ivy.Tendril/Commands/ModelsCommand.cs`
- **Tests:** `src/Ivy.Tendril.Agents.Test/Codex/CodexCliTests.cs`, `src/Ivy.Tendril.Agents.Test/Codex/CodexPtyTests.cs`, `src/Ivy.Tendril.Test/Agents/AgentProviderFactoryTests.cs`

## Manual Testing

1. Run `tendril models --agent codex` in the terminal.
2. Verify that the table output includes a `Reasoning` column alongside `Vision` and correctly displays reasoning support for Codex models.
3. Verify that the default profiles for Codex show `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.

---
- 6314a2a1 Add model reasoning support and Codex configuration (Plan 00010)

---
Created using [Ivy Tendril](https://ivy.app).
