### PR TITLE
Support owner/repo worktree path structure in plans (#2136)

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril.TeamIvyConfig/Promptwares/SetupProject/Program.md
@@ -153,15 +153,15 @@ Inspect each repo to determine how to run the application. For website projects,
 
 For each review action:
 - **name**: Short descriptive name (e.g. "App", "Docs", "Frontend", "API")
-- **condition**: A `Test-Path` expression that checks if the worktree path exists (e.g. `Test-Path "Worktrees/<RepoName>/src/<Project>"`).
-  - **`<RepoName>` is the leaf repository folder name** (e.g. `ivy-tendril`, `ivy-framework`), **NOT** an organization prefix or GitHub URL path (e.g. do **NOT** use `ivy-interactive/ivy-tendril`). Tendril checks out plan worktrees directly into `Worktrees/<RepoName>`.
+- **condition**: A `Test-Path` expression that checks if the worktree path exists (e.g. `Test-Path "Worktrees/<owner>/<repo>/src/<Project>"` or `Test-Path "Worktrees/<repo>/src/<Project>"`).
+  - The repo path under `Worktrees/` preserves the repo origin structure (e.g. `<owner>/<repo>` such as `ivy-interactive/ivy-tendril` for repos under `Repos/<owner>/<repo>` or from GitHub).
   - **Do NOT use a leading slash or backslash** (e.g. use `Test-Path "Worktrees/..."`, NOT `Test-Path "\Worktrees/..."`), as leading slashes cause PowerShell to resolve relative to the drive root instead of the plan working directory.
-- **command**: The command to launch the application. Always use `Worktrees/<RepoName>/...` (the leaf repository folder name) in paths and project arguments.
+- **command**: The command to launch the application.
 
 ```bash
 tendril project add-review-action <project-name> "<name>" \
   --command="<launch command>" \
-  --condition="Test-Path \"Worktrees/<RepoName>/<path>\""
+  --condition="Test-Path \"Worktrees/<owner>/<repo>/<path>\""
 ```
 
 ### 4. Set the Stack Hash

--- a/src/Ivy.Tendril.Test/Commands/CliDispatcherTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/CliDispatcherTests.cs
@@ -140,6 +140,7 @@ public class CliDispatcherTests
     public void IsPortInUse_ReturnsFalse_WhenPortIsFree()
     {
         var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Server.SetSocketOption(System.Net.Sockets.SocketOptionLevel.Socket, System.Net.Sockets.SocketOptionName.ReuseAddress, true);
         probe.Start();
         var port = ((IPEndPoint)probe.LocalEndpoint).Port;
         probe.Stop();

--- a/src/Ivy.Tendril.Test/WorktreeHelperTests.cs
+++ b/src/Ivy.Tendril.Test/WorktreeHelperTests.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using System.Linq;
+using Ivy.Tendril.Helpers;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class WorktreeHelperTests
+{
+    [Theory]
+    [InlineData(@"/Users/test/.tendril/Projects/my-proj/Repos/ivy-interactive/ivy-tendril", "ivy-interactive/ivy-tendril")]
+    [InlineData(@"/Users/test/.tendril/Projects/my-proj/Repos/my-org/sub/repo", "my-org/sub/repo")]
+    [InlineData(@"C:\Users\test\.tendril\Projects\my-proj\Repos\ivy-interactive\ivy-tendril", @"ivy-interactive\ivy-tendril")]
+    [InlineData(@"/Users/test/git/simple-repo", "simple-repo")]
+    public void DeriveWorktreeRelativePath_ExtractsRepoPathUnderRepos(string input, string expected)
+    {
+        var actual = GitHelper.DeriveWorktreeRelativePath(input);
+        Assert.Equal(expected.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar),
+                     actual.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar));
+    }
+
+    [Fact]
+    public void EnumerateWorktreeDirectories_FindsFlatAndNestedWorktrees()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilWorktreesTest_" + Guid.NewGuid().ToString("N"));
+        var flatWt = Path.Combine(tempDir, "flat-repo");
+        var nestedWt = Path.Combine(tempDir, "owner", "nested-repo");
+        var emptyDir = Path.Combine(tempDir, "empty-dir");
+
+        Directory.CreateDirectory(flatWt);
+        File.WriteAllText(Path.Combine(flatWt, ".git"), "gitdir: ...");
+
+        Directory.CreateDirectory(nestedWt);
+        File.WriteAllText(Path.Combine(nestedWt, ".git"), "gitdir: ...");
+
+        Directory.CreateDirectory(emptyDir);
+
+        try
+        {
+            var worktrees = GitHelper.EnumerateWorktreeDirectories(tempDir).ToList();
+            Assert.Equal(2, worktrees.Count);
+            Assert.Contains(flatWt, worktrees);
+            Assert.Contains(nestedWt, worktrees);
+            Assert.DoesNotContain(emptyDir, worktrees);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -403,7 +403,7 @@ public static class DoctorCommand
         if (!Directory.Exists(worktreesPath))
             return 0;
 
-        return Directory.GetDirectories(worktreesPath).Length;
+        return GitHelper.EnumerateWorktreeDirectories(worktreesPath).Count();
     }
 
     internal static bool HasStaleWorktrees(string planPath)
@@ -414,7 +414,7 @@ public static class DoctorCommand
 
         try
         {
-            foreach (var wtDir in Directory.GetDirectories(worktreesPath))
+            foreach (var wtDir in GitHelper.EnumerateWorktreeDirectories(worktreesPath, includeOrphans: true))
             {
                 var gitFile = Path.Combine(wtDir, ".git");
                 if (!File.Exists(gitFile))
@@ -527,7 +527,7 @@ public static class DoctorCommand
                 var worktreesPath = Path.Combine(planPath, "Worktrees");
                 if (Directory.Exists(worktreesPath))
                 {
-                    foreach (var wtDir in Directory.GetDirectories(worktreesPath))
+                    foreach (var wtDir in GitHelper.EnumerateWorktreeDirectories(worktreesPath, includeOrphans: true))
                     {
                         if (!File.Exists(Path.Combine(wtDir, ".git")))
                             Directory.Delete(wtDir, true);

--- a/src/Ivy.Tendril/Commands/PlanAddWorktreeCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddWorktreeCommand.cs
@@ -45,10 +45,10 @@ public class PlanAddWorktreeCommand : Command<PlanAddWorktreeSettings>
         }
 
         var branchName = DeriveBranchName(planFolder);
-        var repoName = Path.GetFileName(settings.Repo.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        var worktreePath = Path.Combine(planFolder, "Worktrees", repoName);
+        var relWorktreePath = GitHelper.DeriveWorktreeRelativePath(settings.Repo);
+        var worktreePath = Path.Combine(planFolder, "Worktrees", relWorktreePath);
 
-        Directory.CreateDirectory(Path.Combine(planFolder, "Worktrees"));
+        Directory.CreateDirectory(Path.GetDirectoryName(worktreePath)!);
 
         if (Directory.Exists(worktreePath))
         {

--- a/src/Ivy.Tendril/Commands/PlanCleanupCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanCleanupCommand.cs
@@ -37,7 +37,7 @@ public class PlanCleanupCommand : Command<PlanCleanupSettings>
             throw new InvalidOperationException($"Plan is not in a terminal state (current: {plan.State}). Use --force to override.");
 
         var worktreesDir = Path.Combine(planFolder, "Worktrees");
-        if (!Directory.Exists(worktreesDir) || Directory.GetDirectories(worktreesDir).Length == 0)
+        if (!Directory.Exists(worktreesDir) || !GitHelper.EnumerateWorktreeDirectories(worktreesDir).Any())
         {
             AnsiConsole.MarkupLine("[green]No worktrees to clean up.[/]");
             return 0;
@@ -45,7 +45,7 @@ public class PlanCleanupCommand : Command<PlanCleanupSettings>
 
         WorktreeCleanupService.RemoveWorktrees(planFolder);
 
-        var remaining = Directory.Exists(worktreesDir) ? Directory.GetDirectories(worktreesDir).Length : 0;
+        var remaining = Directory.Exists(worktreesDir) ? GitHelper.EnumerateWorktreeDirectories(worktreesDir).Count() : 0;
         if (remaining == 0)
         {
             AnsiConsole.MarkupLine("[green]Worktrees cleaned up successfully.[/]");

--- a/src/Ivy.Tendril/Commands/PlanRemoveWorktreeCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemoveWorktreeCommand.cs
@@ -39,12 +39,23 @@ public class PlanRemoveWorktreeCommand : Command<PlanRemoveWorktreeSettings>
     protected override int Execute(CommandContext context, PlanRemoveWorktreeSettings settings, CancellationToken cancellationToken)
     {
         var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-        var worktreePath = Path.Combine(planFolder, "Worktrees", settings.RepoName);
+        var worktreesDir = Path.Combine(planFolder, "Worktrees");
+        var worktreePath = Path.Combine(worktreesDir, settings.RepoName);
 
         if (!Directory.Exists(worktreePath))
         {
-            AnsiConsole.MarkupLine($"[yellow]Worktree directory not found: {worktreePath.EscapeMarkup()}[/]");
-            return 0;
+            var match = GitHelper.EnumerateWorktreeDirectories(worktreesDir)
+                .FirstOrDefault(w => Path.GetFileName(w).Equals(settings.RepoName, StringComparison.OrdinalIgnoreCase) ||
+                                     Path.GetRelativePath(worktreesDir, w).Replace('\\', '/').Equals(settings.RepoName.Replace('\\', '/'), StringComparison.OrdinalIgnoreCase));
+            if (match != null)
+            {
+                worktreePath = match;
+            }
+            else
+            {
+                AnsiConsole.MarkupLine($"[yellow]Worktree directory not found: {worktreePath.EscapeMarkup()}[/]");
+                return 0;
+            }
         }
 
         var branchName = settings.Branch ?? DeriveBranchName(planFolder);

--- a/src/Ivy.Tendril/Helpers/GitHelper.cs
+++ b/src/Ivy.Tendril/Helpers/GitHelper.cs
@@ -239,4 +239,102 @@ public static class GitHelper
     {
         return RunGitCapture(repoPath, $"show-ref --verify \"{refName}\"", 5000) != null;
     }
+
+    /// <summary>
+    /// Enumerates all worktree directories under a plan's Worktrees directory, supporting both flat
+    /// (Worktrees/repo) and nested (Worktrees/owner/repo) directory structures.
+    /// </summary>
+    public static IEnumerable<string> EnumerateWorktreeDirectories(string worktreesDir, bool includeOrphans = false)
+    {
+        if (!Directory.Exists(worktreesDir)) yield break;
+
+        var topDirs = Directory.GetDirectories(worktreesDir);
+        var hasAnyGitFile = topDirs.Any(d => File.Exists(Path.Combine(d, ".git")) ||
+                                             Directory.GetDirectories(d).Any(sd => File.Exists(Path.Combine(sd, ".git"))));
+
+        foreach (var dir in topDirs)
+        {
+            if (File.Exists(Path.Combine(dir, ".git")))
+            {
+                yield return dir;
+            }
+            else
+            {
+                var subDirs = Directory.GetDirectories(dir);
+                if (subDirs.Length > 0)
+                {
+                    var foundChild = false;
+                    foreach (var subDir in subDirs)
+                    {
+                        if (File.Exists(Path.Combine(subDir, ".git")) || (!hasAnyGitFile && !includeOrphans) || includeOrphans)
+                        {
+                            foundChild = true;
+                            yield return subDir;
+                        }
+                    }
+                    if (!foundChild && includeOrphans)
+                    {
+                        yield return dir;
+                    }
+                }
+                else if (includeOrphans || !hasAnyGitFile)
+                {
+                    yield return dir;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Derives the relative worktree path for a repo (e.g. "ivy-interactive/ivy-tendril" or "my-repo").
+    /// Checks for standard {TENDRIL_HOME}/Projects/{project}/Repos/{owner}/{repo} layout first,
+    /// falls back to git remote origin owner/repo, and finally falls back to the leaf directory name.
+    /// </summary>
+    public static string DeriveWorktreeRelativePath(string repoPath)
+    {
+        var normalized = repoPath.TrimEnd('/', '\\');
+        var matchRepos = Regex.Match(normalized, @"[\\/]Repos[\\/](?<subPath>.+)$", RegexOptions.IgnoreCase);
+        if (matchRepos.Success)
+        {
+            var subPath = matchRepos.Groups["subPath"].Value;
+            if (!string.IsNullOrWhiteSpace(subPath))
+            {
+                return subPath;
+            }
+        }
+
+        if (Directory.Exists(normalized))
+        {
+            try
+            {
+                var (exitCode, url, _) = RunGit("remote get-url origin", normalized, 5000);
+                if (exitCode == 0 && !string.IsNullOrWhiteSpace(url))
+                {
+                    var trimmedUrl = url.Trim();
+                    var isRemoteUrl = trimmedUrl.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                                      trimmedUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
+                                      trimmedUrl.StartsWith("git@", StringComparison.OrdinalIgnoreCase) ||
+                                      trimmedUrl.StartsWith("ssh://", StringComparison.OrdinalIgnoreCase);
+
+                    if (isRemoteUrl)
+                    {
+                        var match = Regex.Match(trimmedUrl, @"[/:](?<owner>[^/]+)/(?<name>[^/]+?)(?:\.git)?$", RegexOptions.IgnoreCase);
+                        if (match.Success)
+                        {
+                            var owner = match.Groups["owner"].Value;
+                            var name = match.Groups["name"].Value;
+                            return Path.Combine(owner, name);
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Best-effort remote lookup
+            }
+        }
+
+        var lastSlash = normalized.LastIndexOfAny(['/', '\\']);
+        return lastSlash >= 0 ? normalized[(lastSlash + 1)..] : normalized;
+    }
 }

--- a/src/Ivy.Tendril/Helpers/GitTabDataBuilder.cs
+++ b/src/Ivy.Tendril/Helpers/GitTabDataBuilder.cs
@@ -64,7 +64,7 @@ public static class GitTabDataBuilder
 
         if (Directory.Exists(worktreesDir))
         {
-            foreach (var repoDir in Directory.GetDirectories(worktreesDir))
+            foreach (var repoDir in GitHelper.EnumerateWorktreeDirectories(worktreesDir))
             {
                 var section = BuildSectionForWorktree(repoDir, allCommitRows, assignedCommitHashes, gitService);
                 if (section != null)

--- a/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
+++ b/src/Ivy.Tendril/Helpers/PlanContentHelpers.cs
@@ -404,7 +404,7 @@ public static class PlanContentHelpers
         var worktreesDir = Path.Combine(plan.FolderPath, "Worktrees");
         if (Directory.Exists(worktreesDir))
         {
-            foreach (var worktree in Directory.GetDirectories(worktreesDir))
+            foreach (var worktree in GitHelper.EnumerateWorktreeDirectories(worktreesDir))
             {
                 var result = BuildFromRepo(worktree, fromUnlistedWorktree: true);
                 if (result != null) return result;

--- a/src/Ivy.Tendril/Promptwares/AddProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/AddProject/Program.md
@@ -157,15 +157,15 @@ Inspect each repo to determine how to run the application. For website projects,
 
 For each review action:
 - **name**: Short descriptive name (e.g. "App", "Docs", "Frontend", "API")
-- **condition**: A `Test-Path` expression that checks if the worktree path exists (e.g. `Test-Path "Worktrees/<RepoName>/src/<Project>"`).
-  - **`<RepoName>` is the leaf repository folder name** (e.g. `ivy-tendril`, `ivy-framework`), **NOT** an organization prefix or GitHub URL path (e.g. do **NOT** use `ivy-interactive/ivy-tendril`). Tendril checks out plan worktrees directly into `Worktrees/<RepoName>`.
+- **condition**: A `Test-Path` expression that checks if the worktree path exists (e.g. `Test-Path "Worktrees/<owner>/<repo>/src/<Project>"` or `Test-Path "Worktrees/<repo>/src/<Project>"`).
+  - The repo path under `Worktrees/` preserves the repo origin structure (e.g. `<owner>/<repo>` such as `ivy-interactive/ivy-tendril` for repos under `Repos/<owner>/<repo>` or from GitHub).
   - **Do NOT use a leading slash or backslash** (e.g. use `Test-Path "Worktrees/..."`, NOT `Test-Path "\Worktrees/..."`), as leading slashes cause PowerShell to resolve relative to the drive root instead of the plan working directory.
-- **command**: The command to launch the application. Always use `Worktrees/<RepoName>/...` (the leaf repository folder name) in paths and project arguments.
+- **command**: The command to launch the application.
 
 ```bash
 tendril project add-review-action <project-name> "<name>" \
   --command="<launch command>" \
-  --condition="Test-Path \"Worktrees/<RepoName>/<path>\""
+  --condition="Test-Path \"Worktrees/<owner>/<repo>/<path>\""
 ```
 
 ### 4. Set the Stack Hash

--- a/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
+++ b/src/Ivy.Tendril/Promptwares/SetupProject/Program.md
@@ -156,15 +156,15 @@ Inspect each repo to determine how to run the application. For website projects,
 
 For each review action:
 - **name**: Short descriptive name (e.g. "App", "Docs", "Frontend", "API")
-- **condition**: A `Test-Path` expression that checks if the worktree path exists (e.g. `Test-Path "Worktrees/<RepoName>/src/<Project>"`).
-  - **`<RepoName>` is the leaf repository folder name** (e.g. `ivy-tendril`, `ivy-framework`), **NOT** an organization prefix or GitHub URL path (e.g. do **NOT** use `ivy-interactive/ivy-tendril`). Tendril checks out plan worktrees directly into `Worktrees/<RepoName>`.
+- **condition**: A `Test-Path` expression that checks if the worktree path exists (e.g. `Test-Path "Worktrees/<owner>/<repo>/src/<Project>"` or `Test-Path "Worktrees/<repo>/src/<Project>"`).
+  - The repo path under `Worktrees/` preserves the repo origin structure (e.g. `<owner>/<repo>` such as `ivy-interactive/ivy-tendril` for repos under `Repos/<owner>/<repo>` or from GitHub).
   - **Do NOT use a leading slash or backslash** (e.g. use `Test-Path "Worktrees/..."`, NOT `Test-Path "\Worktrees/..."`), as leading slashes cause PowerShell to resolve relative to the drive root instead of the plan working directory.
-- **command**: The command to launch the application. Always use `Worktrees/<RepoName>/...` (the leaf repository folder name) in paths and project arguments.
+- **command**: The command to launch the application.
 
 ```bash
 tendril project add-review-action <project-name> "<name>" \
   --command="<launch command>" \
-  --condition="Test-Path \"Worktrees/<RepoName>/<path>\""
+  --condition="Test-Path \"Worktrees/<owner>/<repo>/<path>\""
 ```
 
 ### 4. Set the Stack Hash

--- a/src/Ivy.Tendril/Services/BugReportService.cs
+++ b/src/Ivy.Tendril/Services/BugReportService.cs
@@ -119,8 +119,8 @@ public sealed class BugReportService
         if (!Directory.Exists(worktreesDir))
             return null;
 
-        var dirs = Directory.GetDirectories(worktreesDir);
-        if (dirs.Length == 0)
+        var dirs = GitHelper.EnumerateWorktreeDirectories(worktreesDir).ToList();
+        if (dirs.Count == 0)
             return null;
 
         var sb = new System.Text.StringBuilder();
@@ -130,7 +130,8 @@ public sealed class BugReportService
             var branch = GitField(wtDir, "rev-parse --abbrev-ref HEAD");
             var sha = GitField(wtDir, "rev-parse HEAD");
 
-            sb.AppendLine(Path.GetFileName(wtDir));
+            var relPath = Path.GetRelativePath(worktreesDir, wtDir);
+            sb.AppendLine(relPath);
             sb.AppendLine($"  remote: {remote}");
             sb.AppendLine($"  branch: {branch}");
             sb.AppendLine($"  HEAD:   {sha}");

--- a/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
+++ b/src/Ivy.Tendril/Services/Git/WorktreeCleanupService.cs
@@ -169,7 +169,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
         RemoveWorktrees(planFolderPath, logger, lifecycleLogger, BranchDeleteMode.PreserveUnpushed);
 
         // Safety net: RemoveWorktrees should have removed all directories
-        foreach (var wtDir in Directory.GetDirectories(worktreesDir))
+        foreach (var wtDir in GitHelper.EnumerateWorktreeDirectories(worktreesDir))
         {
             logger?.LogWarning(
                 "Worktree directory still exists after RemoveWorktrees (this should not happen): {Path}",
@@ -471,7 +471,7 @@ public class WorktreeCleanupService : IStartable, IDisposable
         var safeTitle = ExtractSafeTitle(planFolderPath);
         var branchName = $"tendril/{planId}-{safeTitle}";
 
-        foreach (var wtDir in Directory.GetDirectories(worktreesDir))
+        foreach (var wtDir in GitHelper.EnumerateWorktreeDirectories(worktreesDir, includeOrphans: true))
         {
             var gitFile = Path.Combine(wtDir, ".git");
             if (!File.Exists(gitFile))

--- a/src/Ivy.Tendril/Services/Plans/PlanArtifactSyncer.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanArtifactSyncer.cs
@@ -109,15 +109,8 @@ internal class PlanArtifactSyncer
         return changed;
     }
 
-    private static IEnumerable<string> IterateWorktrees(string worktreesDir)
-    {
-        foreach (var wtDir in Directory.GetDirectories(worktreesDir))
-        {
-            var gitFile = Path.Combine(wtDir, ".git");
-            if (File.Exists(gitFile))
-                yield return wtDir;
-        }
-    }
+    private static IEnumerable<string> IterateWorktrees(string worktreesDir) =>
+        GitHelper.EnumerateWorktreeDirectories(worktreesDir);
 
     private List<string> ExtractCommitsFromWorktree(string wtDir, string branchName, PlanYaml plan)
     {


### PR DESCRIPTION
Closes #2136

### Summary of Changes
- **Worktree path derivation**: Added `GitHelper.DeriveWorktreeRelativePath` which preserves the `<owner>/<repo>` structure for repositories (matching `{TENDRIL_HOME}/Projects/<project>/Repos/<owner>/<repo>` and remote origin URLs).
- **Directory enumeration**: Added `GitHelper.EnumerateWorktreeDirectories` supporting both flat (`Worktrees/<repo>`) and nested (`Worktrees/<owner>/<repo>`) worktree layouts across cleanup, artifact syncer, bug report generator, git tab data builder, and doctor command.
- **Promptwares**: Updated `SetupProject` and `AddProject` promptwares to specify `Worktrees/<owner>/<repo>` for review action commands and conditions.
- **Tests**: Added comprehensive unit tests in `WorktreeHelperTests`.