### PR TITLE
fix(settings): polish configuration projects UI layout and button sizes (#2131)

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectBladeView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectBladeView.cs
@@ -161,7 +161,7 @@ public class EditProjectBladeView(
                 {
                     bladeContext.Push(this, new EditProjectMemoryBladeView(config.TendrilHome, editName.Value, fileName, memoryRefresh), title: fileName == null ? "Add Memory" : $"Edit Memory: {fileName}");
                 })
-                | new Button("Add Project Memory").Icon(Icons.Plus).Outline().OnClick(() =>
+                | new Button("Add Project Memory").Icon(Icons.Plus).Outline().Small().OnClick(() =>
                 {
                     bladeContext.Push(this, new EditProjectMemoryBladeView(config.TendrilHome, editName.Value, null, memoryRefresh), title: "Add Project Memory");
                 })
@@ -173,7 +173,7 @@ public class EditProjectBladeView(
                 {
                     bladeContext.Push(this, new EditMcpServerBladeView(idx, editMcpServers), title: idx == null ? "Add MCP Server" : "Edit MCP Server");
                 })
-                | new Button("Add MCP Server").Icon(Icons.Plus).Outline().OnClick(() =>
+                | new Button("Add MCP Server").Icon(Icons.Plus).Outline().Small().OnClick(() =>
                 {
                     bladeContext.Push(this, new EditMcpServerBladeView(null, editMcpServers), title: "Add MCP Server");
                 })
@@ -185,7 +185,7 @@ public class EditProjectBladeView(
                 {
                     bladeContext.Push(this, new EditSkillBladeView(idx, editSkills), title: idx == null ? "Add Custom Skill" : "Edit Custom Skill");
                 })
-                | new Button("Add Custom Skill").Icon(Icons.Plus).Outline().OnClick(() =>
+                | new Button("Add Custom Skill").Icon(Icons.Plus).Outline().Small().OnClick(() =>
                 {
                     bladeContext.Push(this, new EditSkillBladeView(null, editSkills), title: "Add Custom Skill");
                 })
@@ -199,7 +199,7 @@ public class EditProjectBladeView(
             {
                 bladeContext.Push(this, new EditReviewActionBladeView(idx, editReviewActions), title: idx == null ? "Add Review Action" : "Edit Review Action");
             })
-            | new Button("Add Review Action").Icon(Icons.Plus).Outline().OnClick(() =>
+            | new Button("Add Review Action").Icon(Icons.Plus).Outline().Small().OnClick(() =>
             {
                 bladeContext.Push(this, new EditReviewActionBladeView(null, editReviewActions), title: "Add Review Action");
             })
@@ -207,7 +207,7 @@ public class EditProjectBladeView(
         tabs.Add(new Tab("Verifications",
             Layout.Vertical()
             | Text.Block("Quality checks required before plans are marked complete.").Muted().Small()
-            | new Button("Add Verification").Icon(Icons.Plus).Outline().OnClick(() =>
+            | new Button("Add Verification").Icon(Icons.Plus).Outline().Small().OnClick(() =>
             {
                 bladeContext.Push(this, new EditVerificationBladeView(config, client, refreshToken, editVerifications), title: "Add Verification");
             })

--- a/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
@@ -88,10 +88,6 @@ public class ProjectMemoryTableView(
                 | cardHeader
                 | cardBody;
 
-            if (i > 0)
-            {
-                cards |= new Separator();
-            }
             cards |= card;
         }
 
@@ -202,10 +198,6 @@ public class McpServersTableView : ViewBase
                 | cardHeader
                 | cardBody;
 
-            if (i > 0)
-            {
-                cards |= new Separator();
-            }
             cards |= card;
         }
 
@@ -340,10 +332,6 @@ public class SkillsTableView : ViewBase
                 | cardHeader
                 | cardBody;
 
-            if (i > 0)
-            {
-                cards |= new Separator();
-            }
             cards |= card;
         }
 
@@ -396,16 +384,16 @@ public class ReviewActionsTableView(
             ))
             .Header(t => t.Index, "")
             .Builder(t => t.Index, f => f.Func<ReviewActionRow, int>(idx =>
-                Layout.Horizontal()
-                | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() => onEdit(idx))
-                | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
+                Layout.Horizontal().AlignContent(Align.Right)
+                | new Button().Icon(Icons.Pencil).Ghost().Small().Tooltip("Edit").OnClick(() => onEdit(idx))
+                | new Button().Icon(Icons.Trash).Ghost().Small().Tooltip("Delete").OnClick(() =>
                 {
                     var list = new List<ReviewActionConfig>(actions);
                     list.RemoveAt(idx);
                     reviewActions.Set(list);
                 })
             ))
-            .Width(Size.Fit());
+            .Width(Size.Full());
     }
 
     private record ReviewActionRow(string Name, int Index);
@@ -429,16 +417,16 @@ public class ProjectVerificationsTableView(
             ))
             .Header(t => t.Index, "")
             .Builder(t => t.Index, f => f.Func<VerificationRow, int>(idx =>
-                Layout.Horizontal()
-                | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() => onEdit(idx))
-                | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
+                Layout.Horizontal().AlignContent(Align.Right)
+                | new Button().Icon(Icons.Pencil).Ghost().Small().Tooltip("Edit").OnClick(() => onEdit(idx))
+                | new Button().Icon(Icons.Trash).Ghost().Small().Tooltip("Delete").OnClick(() =>
                 {
                     var current = new List<ProjectVerificationRef>(verifications.Value);
                     current.RemoveAt(idx);
                     verifications.Set(current);
                 })
             ))
-            .Width(Size.Fit());
+            .Width(Size.Full());
     }
 
     private record VerificationRow(string Name, int Index);

--- a/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
@@ -249,39 +249,33 @@ public class ProjectDetailView(
         var innerContent = Layout.Vertical().Width(Size.Full().Max(Size.Units(160)))
             // Section 1: Header (Color Picker + Name)
             | nameHeader
-            | new Separator()
 
             // Section 2: Repositories
             | Text.H4("Repositories").Bold()
             | new ProjectRepoPickerView(repos, onAdd: cloneRemoteOnAdd, showBaseBranchPicker: true)
-            | new Separator()
 
             // Section 3: Review Actions
             | Text.H4("Review Actions").Bold()
             | new ReviewActionsTableView(reviewActions, idx => showReviewActionTrigger(idx))
             | new Button("Add Review Action").Icon(Icons.Plus).Outline().Small().OnClick(() => showReviewActionTrigger(null))
-            | new Separator()
 
             // Section 4: Verifications
             | Text.H4("Verifications").Bold()
             | new ProjectVerificationsTableView(verifications, idx => showVerificationTrigger(idx))
             | new Button("Add Verification").Icon(Icons.Plus).Outline().Small().OnClick(() => showVerificationTrigger(null))
-            | new Separator()
 
             // Section 5: Agent Behavior
             | (isBeta
                 ? (object)(Layout.Vertical()
                     | Text.H4("Agent Behavior").Bold()
-                    | autoImplementSelect
-                    | new Separator())
+                    | autoImplementSelect)
                 : null!)
 
             // Section 6: Local Permissions (MCP Tools & Servers)
             | (isBeta
                 ? (object)(Layout.Vertical()
                     | Text.H4("Local Permissions").Bold()
-                    | new McpServersTableView(mcpServers, repos, idx => openMcpSheet(idx), onImport: () => openImportMcpDialog(), onDelete: idx => DeleteMcpServer(idx))
-                    | new Separator())
+                    | new McpServersTableView(mcpServers, repos, idx => openMcpSheet(idx), onImport: () => openImportMcpDialog(), onDelete: idx => DeleteMcpServer(idx)))
                 : null!)
 
             // Section 7: Customizations
@@ -289,13 +283,12 @@ public class ProjectDetailView(
                 ? (object)(Layout.Vertical()
                     | Text.H4("Customizations").Bold()
                     | new ProjectMemoryTableView(config.TendrilHome, project.Name, memoryRefresh, fileName => openMemorySheet(fileName))
-                    | new SkillsTableView(skills, repos, idx => openSkillSheet(idx), onImport: () => openImportSkillsDialog(), onDelete: idx => DeleteSkill(idx))
-                    | new Separator())
+                    | new SkillsTableView(skills, repos, idx => openSkillSheet(idx), onImport: () => openImportSkillsDialog(), onDelete: idx => DeleteSkill(idx)))
                 : null!)
 
             // Section 8: Danger Zone
             | Text.H4("Danger Zone").Bold()
-            | new Button("Delete Project").Destructive().OnClick(() =>
+            | new Button("Delete Project").Destructive().Small().OnClick(() =>
             {
                 onDeleteProject?.Invoke();
             }).WithConfirm(

--- a/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
@@ -93,9 +93,9 @@ public class ProjectRepoPickerView(
 
         if (isDesktop)
         {
-            pickerControls = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.Center).Gap(2)
+            pickerControls = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.Center)
                              | repoInput
-                             | new Button("Browse").Icon(Icons.FolderOpen).Outline()
+                             | new Button("Browse").Icon(Icons.FolderOpen).Outline().Small()
                                  .OnClick(() =>
                                  {
                                      var picked = desktop!.ShowSelectFolderDialog("Select repository folder");
@@ -108,12 +108,12 @@ public class ProjectRepoPickerView(
             pickerControls = repoInput;
         }
 
-        var addButton = new Button("Add Repository").Icon(Icons.Plus)
+        var addButton = new Button("Add Repository").Icon(Icons.Plus).Outline().Small()
             .Disabled(string.IsNullOrWhiteSpace(inputValue.Value) || isAdding.Value)
             .Loading(isAdding.Value)
             .OnClick(() => { _ = AddAsync(); });
 
-        var listLayout = Layout.Vertical().Gap(3);
+        var listLayout = Layout.Vertical();
         var current = repos.Value;
         for (var i = 0; i < current.Count; i++)
         {
@@ -139,29 +139,29 @@ public class ProjectRepoPickerView(
                 }
             }
 
-            object row = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.Center).Gap(2)
+            object row = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.Center)
                          | (validityIcon ?? null!)
                          | pathLabel
                          | new Spacer()
                          | (showBaseBranchPicker
                              ? (object)BuildBaseBranchSelector(repos, idx)
                              : null!)
-                         | new Button().Icon(Icons.X).Ghost().OnClick(() =>
+                         | new Button().Icon(Icons.X).Ghost().Small().OnClick(() =>
                          {
                              var list = new List<RepoRef>(repos.Value);
                              if (idx < list.Count) list.RemoveAt(idx);
                              repos.Set(list);
                          }).WithTooltip("Remove");
 
-            listLayout |= new Box(row).BorderStyle(BorderStyle.None).Background(Colors.Muted).Padding(4, 2, 2, 2).Width(Size.Full());
+            listLayout |= new Box(row).BorderStyle(BorderStyle.None).Background(Colors.Muted).Width(Size.Full());
         }
 
-        var scrollableContent = Layout.Vertical().Gap(3)
+        var scrollableContent = Layout.Vertical()
                | pickerControls
                | (current.Count > 0 ? listLayout : null!)
                | addButton;
 
-        return Layout.Vertical().Width(Size.Full()).Gap(4)
+        return Layout.Vertical().Width(Size.Full())
                | Text.Label("Add one or more Git repositories")
                | (addingError.Value != null ? Text.Danger(addingError.Value) : null!)
                | scrollableContent;


### PR DESCRIPTION
Closes #2131

### Summary of Changes
- **Horizontal Lines**: Removed `new Separator()` divider lines across configuration project sections and inside card lists.
- **Table Spacing & Layout**: Expanded `ReviewActionsTableView` and `ProjectVerificationsTableView` to full width with right-aligned action buttons and ghost icon buttons.
- **Button Sizing**: Standardized button sizing across `ProjectDetailView`, `EditProjectBladeView`, `ProjectTableViews`, and `ProjectRepoPickerView` using `.Outline().Small()` for add triggers and `.Small()` for icon actions.