### PR TITLE
fix: tighten table button columns, standardize button styling and optimize diff rendering

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/PlanDiffView.tsx
@@ -492,6 +492,29 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
       ?.scrollIntoView({ behavior: "smooth", block: "start" });
   }, []);
 
+  // Pre-tokenize all files and hunks once when files/language change, instead of synchronously tokenizing on every render
+  const tokensByFile = useMemo(() => {
+    return files.map((file, fileIndex) => {
+      const meta = fileMeta[fileIndex];
+      const effectiveFilePath = filePath || meta?.newName || meta?.oldName || "";
+      const fileLang = language || getLanguageFromFilePath(effectiveFilePath);
+      if (file.hunks && file.hunks.length > 0) {
+        try {
+          if (fileLang && refractor.registered(fileLang)) {
+            return tokenize(file.hunks, {
+              highlight: true,
+              refractor: refractorAdapter,
+              language: fileLang,
+            });
+          }
+        } catch {
+          // Fallback if language tokenization fails
+        }
+      }
+      return undefined;
+    });
+  }, [files, fileMeta, filePath, language]);
+
   const style: React.CSSProperties = {
     ...getWidth(width),
     ...getHeight(height),
@@ -608,7 +631,7 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
           <div
             key={fileIndex}
             id={elementId}
-            className={`border border-[var(--border)] rounded-md ${isCollapsed ? "mb-0" : "mb-1.5"} bg-[var(--background)] overflow-clip`}
+            className={`ivy-diff-file border border-[var(--border)] rounded-md ${isCollapsed ? "mb-0" : "mb-1.5"} bg-[var(--background)] overflow-clip`}
             style={{ scrollMarginTop: showFileDropdown ? "2rem" : 0 }}
           >
             {hasHeader && (
@@ -717,54 +740,37 @@ export const PlanDiffView: React.FC<PlanDiffViewProps> = ({
                 </div>
               </div>
             )}
-            {!isCollapsed && (() => {
-              const fileLang = language || getLanguageFromFilePath(effectiveFilePath);
-              let fileTokens: any = undefined;
-              if (file.hunks && file.hunks.length > 0) {
-                try {
-                  if (fileLang && refractor.registered(fileLang)) {
-                    fileTokens = tokenize(file.hunks, {
-                      highlight: true,
-                      refractor: refractorAdapter,
-                      language: fileLang,
-                    });
+            {!isCollapsed && (
+              <div className="overflow-x-auto">
+                <Diff
+                  className={`${effectiveViewType === "unified" ? "diff-unified-view" : "diff-split-view"} ${deletions === 0 && additions > 0 ? "diff-no-deletions" : ""} ${additions === 0 && deletions > 0 ? "diff-no-additions" : ""}`}
+                  viewType={effectiveViewType}
+                  diffType={file.type}
+                  hunks={file.hunks}
+                  tokens={tokensByFile[fileIndex]}
+                  renderToken={customRenderToken}
+                  widgets={getWidgets(file.hunks, commentsHidden[fileKey] ?? false)}
+                  gutterEvents={{
+                    onClick: ({ change }) => {
+                      if (change) {
+                        const changeKey = getChangeKey(change);
+                        setActiveFormKeys((prev) => ({ ...prev, [changeKey]: !prev[changeKey] }));
+                      }
+                    },
+                  }}
+                >
+                  {(hunks) =>
+                    hunks.map((hunk) => (
+                      <Hunk key={hunk.content} hunk={hunk} />
+                    ))
                   }
-                } catch {
-                  // Fallback if language tokenization fails
-                }
-              }
-
-              return (
-                <div className="overflow-x-auto">
-                  <Diff
-                    className={`${effectiveViewType === "unified" ? "diff-unified-view" : "diff-split-view"} ${deletions === 0 && additions > 0 ? "diff-no-deletions" : ""} ${additions === 0 && deletions > 0 ? "diff-no-additions" : ""}`}
-                    viewType={effectiveViewType}
-                    diffType={file.type}
-                    hunks={file.hunks}
-                    tokens={fileTokens}
-                    renderToken={customRenderToken}
-                    widgets={getWidgets(file.hunks, commentsHidden[fileKey] ?? false)}
-                    gutterEvents={{
-                      onClick: ({ change }) => {
-                        if (change) {
-                          const changeKey = getChangeKey(change);
-                          setActiveFormKeys((prev) => ({ ...prev, [changeKey]: !prev[changeKey] }));
-                        }
-                      },
-                    }}
-                  >
-                    {(hunks) =>
-                      hunks.map((hunk) => (
-                        <Hunk key={hunk.content} hunk={hunk} />
-                      ))
-                    }
-                  </Diff>
-                </div>
-              );
-            })()}
+                </Diff>
+              </div>
+            )}
           </div>
         );
       })}
     </div>
   );
 };
+

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/plan-diff.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDiffView/plan-diff.css
@@ -402,3 +402,20 @@ td.diff-gutter-empty::after {
   color: var(--foreground) !important;
 }
 
+/* Virtualization / rendering performance for large diffs */
+.ivy-diff-file {
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 400px;
+}
+
+.diff-hunk {
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 150px;
+}
+
+.diff-unified-view,
+.diff-split-view {
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 300px;
+}
+

--- a/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectBladeView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectBladeView.cs
@@ -161,7 +161,7 @@ public class EditProjectBladeView(
                 {
                     bladeContext.Push(this, new EditProjectMemoryBladeView(config.TendrilHome, editName.Value, fileName, memoryRefresh), title: fileName == null ? "Add Memory" : $"Edit Memory: {fileName}");
                 })
-                | new Button("Add Project Memory").Icon(Icons.Plus).Outline().Small().OnClick(() =>
+                | new Button("Add Project Memory").Icon(Icons.Plus).OnClick(() =>
                 {
                     bladeContext.Push(this, new EditProjectMemoryBladeView(config.TendrilHome, editName.Value, null, memoryRefresh), title: "Add Project Memory");
                 })
@@ -173,7 +173,7 @@ public class EditProjectBladeView(
                 {
                     bladeContext.Push(this, new EditMcpServerBladeView(idx, editMcpServers), title: idx == null ? "Add MCP Server" : "Edit MCP Server");
                 })
-                | new Button("Add MCP Server").Icon(Icons.Plus).Outline().Small().OnClick(() =>
+                | new Button("Add MCP Server").Icon(Icons.Plus).OnClick(() =>
                 {
                     bladeContext.Push(this, new EditMcpServerBladeView(null, editMcpServers), title: "Add MCP Server");
                 })
@@ -185,7 +185,7 @@ public class EditProjectBladeView(
                 {
                     bladeContext.Push(this, new EditSkillBladeView(idx, editSkills), title: idx == null ? "Add Custom Skill" : "Edit Custom Skill");
                 })
-                | new Button("Add Custom Skill").Icon(Icons.Plus).Outline().Small().OnClick(() =>
+                | new Button("Add Custom Skill").Icon(Icons.Plus).OnClick(() =>
                 {
                     bladeContext.Push(this, new EditSkillBladeView(null, editSkills), title: "Add Custom Skill");
                 })
@@ -199,7 +199,7 @@ public class EditProjectBladeView(
             {
                 bladeContext.Push(this, new EditReviewActionBladeView(idx, editReviewActions), title: idx == null ? "Add Review Action" : "Edit Review Action");
             })
-            | new Button("Add Review Action").Icon(Icons.Plus).Outline().Small().OnClick(() =>
+            | new Button("Add Review Action").Icon(Icons.Plus).OnClick(() =>
             {
                 bladeContext.Push(this, new EditReviewActionBladeView(null, editReviewActions), title: "Add Review Action");
             })
@@ -207,7 +207,7 @@ public class EditProjectBladeView(
         tabs.Add(new Tab("Verifications",
             Layout.Vertical()
             | Text.Block("Quality checks required before plans are marked complete.").Muted().Small()
-            | new Button("Add Verification").Icon(Icons.Plus).Outline().Small().OnClick(() =>
+            | new Button("Add Verification").Icon(Icons.Plus).OnClick(() =>
             {
                 bladeContext.Push(this, new EditVerificationBladeView(config, client, refreshToken, editVerifications), title: "Add Verification");
             })

--- a/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
@@ -66,13 +66,13 @@ public class ProjectMemoryTableView(
                 | new Badge("Memory").Color(Colors.Blue).Variant(BadgeVariant.Secondary).Small();
 
             var rightGroup = Layout.Horizontal().AlignContent(Align.Right).Width(Size.Fit())
-                | new Button().Icon(Icons.Copy).Ghost().Small().Tooltip("Copy file path").OnClick(() =>
+                | new Button().Icon(Icons.Copy).Ghost().Tooltip("Copy file path").OnClick(() =>
                 {
                     copyToClipboard(fullPath);
                     client.Toast("Copied memory path to clipboard", "Copied");
                 })
-                | new Button().Icon(Icons.Pencil).Ghost().Small().Tooltip("Edit").OnClick(() => onEdit(fileName))
-                | new Button().Icon(Icons.Trash).Ghost().Small().Tooltip("Delete").OnClick(() =>
+                | new Button().Icon(Icons.Pencil).Ghost().Tooltip("Edit").OnClick(() => onEdit(fileName))
+                | new Button().Icon(Icons.Trash).Ghost().Tooltip("Delete").OnClick(() =>
                 {
                     if (File.Exists(fullPath)) File.Delete(fullPath);
                     refreshCounter.Set(refreshCounter.Value + 1);
@@ -103,7 +103,7 @@ public class ProjectMemoryTableView(
         var content = Layout.Vertical()
             | containerBox
             | (Layout.Horizontal().AlignContent(Align.Left)
-                | new Button("Add Project Memory").Icon(Icons.Plus).Outline().Small().OnClick(() => onEdit(null)));
+                | new Button("Add Project Memory").Icon(Icons.Plus).OnClick(() => onEdit(null)));
 
         return new Expandable(header, content).Open(true);
     }
@@ -147,8 +147,8 @@ public class McpServersTableView : ViewBase
             var emptyContent = Layout.Vertical()
                 | Text.Block("No MCP servers configured for this project.").Muted().Small()
                 | (Layout.Horizontal().AlignContent(Align.Left)
-                    | (_onEdit != null ? new Button("Add MCP Server").Icon(Icons.Plus).Outline().Small().OnClick(() => _onEdit(null)) : null)
-                    | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).Outline().Small().OnClick(_onImport) : null));
+                    | (_onEdit != null ? new Button("Add MCP Server").Icon(Icons.Plus).OnClick(() => _onEdit(null)) : null)
+                    | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).OnClick(_onImport) : null));
 
             return new Expandable(header, emptyContent).Open(true);
         }
@@ -167,13 +167,13 @@ public class McpServersTableView : ViewBase
                 | new Badge("MCP").Color(Colors.Green).Variant(BadgeVariant.Secondary).Small();
 
             var rightGroup = Layout.Horizontal().AlignContent(Align.Right).Width(Size.Fit())
-                | new Button().Icon(Icons.Copy).Ghost().Small().Tooltip("Copy command").OnClick(() =>
+                | new Button().Icon(Icons.Copy).Ghost().Tooltip("Copy command").OnClick(() =>
                 {
                     copyToClipboard(fullCmd);
                     client.Toast("Copied command to clipboard", "Copied");
                 })
-                | (_onEdit != null ? new Button().Icon(Icons.Pencil).Ghost().Small().Tooltip("Edit").OnClick(() => _onEdit(idx)) : null)
-                | new Button().Icon(Icons.Trash).Ghost().Small().Tooltip("Delete").OnClick(() =>
+                | (_onEdit != null ? new Button().Icon(Icons.Pencil).Ghost().Tooltip("Edit").OnClick(() => _onEdit(idx)) : null)
+                | new Button().Icon(Icons.Trash).Ghost().Tooltip("Delete").OnClick(() =>
                 {
                     if (_onDelete != null)
                     {
@@ -213,8 +213,8 @@ public class McpServersTableView : ViewBase
         var content = Layout.Vertical()
             | containerBox
             | (Layout.Horizontal().AlignContent(Align.Left)
-                | (_onEdit != null ? new Button("Add MCP Server").Icon(Icons.Plus).Outline().Small().OnClick(() => _onEdit(null)) : null)
-                | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).Outline().Small().OnClick(_onImport) : null));
+                | (_onEdit != null ? new Button("Add MCP Server").Icon(Icons.Plus).OnClick(() => _onEdit(null)) : null)
+                | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).OnClick(_onImport) : null));
 
         return new Expandable(header, content).Open(true);
     }
@@ -258,8 +258,8 @@ public class SkillsTableView : ViewBase
             var emptyContent = Layout.Vertical()
                 | Text.Block("No custom skills configured for this project.").Muted().Small()
                 | (Layout.Horizontal().AlignContent(Align.Left)
-                    | (_onEdit != null ? new Button("Add Custom Skill").Icon(Icons.Plus).Outline().Small().OnClick(() => _onEdit(null)) : null)
-                    | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).Outline().Small().OnClick(_onImport) : null));
+                    | (_onEdit != null ? new Button("Add Custom Skill").Icon(Icons.Plus).OnClick(() => _onEdit(null)) : null)
+                    | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).OnClick(_onImport) : null));
 
             return new Expandable(header, emptyContent).Open(true);
         }
@@ -298,7 +298,7 @@ public class SkillsTableView : ViewBase
             }
 
             var rightGroup = Layout.Horizontal().AlignContent(Align.Right).Width(Size.Fit())
-                | new Button().Icon(Icons.Copy).Ghost().Small().Tooltip("Copy skill path").OnClick(() =>
+                | new Button().Icon(Icons.Copy).Ghost().Tooltip("Copy skill path").OnClick(() =>
                 {
                     if (!string.IsNullOrWhiteSpace(skill.Path))
                     {
@@ -306,8 +306,8 @@ public class SkillsTableView : ViewBase
                         client.Toast("Copied skill path to clipboard", "Copied");
                     }
                 })
-                | (_onEdit != null ? new Button().Icon(Icons.Pencil).Ghost().Small().Tooltip("Edit").OnClick(() => _onEdit(idx)) : null)
-                | new Button().Icon(Icons.Trash).Ghost().Small().Tooltip("Delete").OnClick(() =>
+                | (_onEdit != null ? new Button().Icon(Icons.Pencil).Ghost().Tooltip("Edit").OnClick(() => _onEdit(idx)) : null)
+                | new Button().Icon(Icons.Trash).Ghost().Tooltip("Delete").OnClick(() =>
                 {
                     if (_onDelete != null)
                     {
@@ -347,8 +347,8 @@ public class SkillsTableView : ViewBase
         var content = Layout.Vertical()
             | containerBox
             | (Layout.Horizontal().AlignContent(Align.Left)
-                | (_onEdit != null ? new Button("Add Custom Skill").Icon(Icons.Plus).Outline().Small().OnClick(() => _onEdit(null)) : null)
-                | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).Outline().Small().OnClick(_onImport) : null));
+                | (_onEdit != null ? new Button("Add Custom Skill").Icon(Icons.Plus).OnClick(() => _onEdit(null)) : null)
+                | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).OnClick(_onImport) : null));
 
         return new Expandable(header, content).Open(true);
     }
@@ -380,19 +380,21 @@ public class ReviewActionsTableView(
         return new TableBuilder<ReviewActionRow>(rows)
             .Header(t => t.Name, "Action Name")
             .Builder(t => t.Name, f => f.Func<ReviewActionRow, string>(name =>
-                Text.Block(name).Bold().Small()
+                Text.Block(name).Bold()
             ))
+            .ColumnWidth(t => t.Name, Size.Grow())
             .Header(t => t.Index, "")
             .Builder(t => t.Index, f => f.Func<ReviewActionRow, int>(idx =>
                 Layout.Horizontal().AlignContent(Align.Right)
-                | new Button().Icon(Icons.Pencil).Ghost().Small().Tooltip("Edit").OnClick(() => onEdit(idx))
-                | new Button().Icon(Icons.Trash).Ghost().Small().Tooltip("Delete").OnClick(() =>
+                | new Button().Icon(Icons.Pencil).Ghost().Tooltip("Edit").OnClick(() => onEdit(idx))
+                | new Button().Icon(Icons.Trash).Ghost().Tooltip("Delete").OnClick(() =>
                 {
                     var list = new List<ReviewActionConfig>(actions);
                     list.RemoveAt(idx);
                     reviewActions.Set(list);
                 })
             ))
+            .ColumnWidth(t => t.Index, Size.Fit())
             .Width(Size.Full());
     }
 
@@ -413,19 +415,21 @@ public class ProjectVerificationsTableView(
         return new TableBuilder<VerificationRow>(rows)
             .Header(t => t.Name, "Verification Name")
             .Builder(t => t.Name, f => f.Func<VerificationRow, string>(name =>
-                Text.Block(name).Bold().Small()
+                Text.Block(name).Bold()
             ))
+            .ColumnWidth(t => t.Name, Size.Grow())
             .Header(t => t.Index, "")
             .Builder(t => t.Index, f => f.Func<VerificationRow, int>(idx =>
                 Layout.Horizontal().AlignContent(Align.Right)
-                | new Button().Icon(Icons.Pencil).Ghost().Small().Tooltip("Edit").OnClick(() => onEdit(idx))
-                | new Button().Icon(Icons.Trash).Ghost().Small().Tooltip("Delete").OnClick(() =>
+                | new Button().Icon(Icons.Pencil).Ghost().Tooltip("Edit").OnClick(() => onEdit(idx))
+                | new Button().Icon(Icons.Trash).Ghost().Tooltip("Delete").OnClick(() =>
                 {
                     var current = new List<ProjectVerificationRef>(verifications.Value);
                     current.RemoveAt(idx);
                     verifications.Set(current);
                 })
             ))
+            .ColumnWidth(t => t.Index, Size.Fit())
             .Width(Size.Full());
     }
 

--- a/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
@@ -196,7 +196,7 @@ public class ProjectDetailView(
             ? (Layout.Horizontal().AlignContent(Align.Left)
                | colorInput
                | editName.ToTextInput("Project name...").Small()
-               | new Button().Icon(Icons.Check).Outline().Small().OnClick(() =>
+               | new Button().Icon(Icons.Check).Ghost().OnClick(() =>
                {
                    var newName = editName.Value.Trim();
                    if (!string.IsNullOrWhiteSpace(newName) && !string.Equals(project.Name, newName, StringComparison.OrdinalIgnoreCase))
@@ -210,7 +210,7 @@ public class ProjectDetailView(
                    }
                    isEditingName.Set(false);
                })
-               | new Button().Icon(Icons.X).Outline().Small().OnClick(() =>
+               | new Button().Icon(Icons.X).Ghost().OnClick(() =>
                {
                    editName.Set(project.Name);
                    isEditingName.Set(false);
@@ -218,7 +218,7 @@ public class ProjectDetailView(
             : (Layout.Horizontal().AlignContent(Align.Left)
                | colorInput
                | Text.H2(project.Name).Bold()
-               | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Rename Project").OnClick(() => isEditingName.Set(true)));
+               | new Button().Icon(Icons.Pencil).Ghost().Tooltip("Rename Project").OnClick(() => isEditingName.Set(true)));
 
         // Agent Behavior Dropdown
         var autoImplementSelect = autoImplement.ToSelectInput(new[] { "Auto-Implement Plans", "Always Ask Review" })
@@ -257,12 +257,12 @@ public class ProjectDetailView(
             // Section 3: Review Actions
             | Text.H4("Review Actions").Bold()
             | new ReviewActionsTableView(reviewActions, idx => showReviewActionTrigger(idx))
-            | new Button("Add Review Action").Icon(Icons.Plus).Outline().Small().OnClick(() => showReviewActionTrigger(null))
+            | new Button("Add Review Action").Icon(Icons.Plus).OnClick(() => showReviewActionTrigger(null))
 
             // Section 4: Verifications
             | Text.H4("Verifications").Bold()
             | new ProjectVerificationsTableView(verifications, idx => showVerificationTrigger(idx))
-            | new Button("Add Verification").Icon(Icons.Plus).Outline().Small().OnClick(() => showVerificationTrigger(null))
+            | new Button("Add Verification").Icon(Icons.Plus).OnClick(() => showVerificationTrigger(null))
 
             // Section 5: Agent Behavior
             | (isBeta
@@ -288,7 +288,7 @@ public class ProjectDetailView(
 
             // Section 8: Danger Zone
             | Text.H4("Danger Zone").Bold()
-            | new Button("Delete Project").Destructive().Small().OnClick(() =>
+            | new Button("Delete Project").Destructive().OnClick(() =>
             {
                 onDeleteProject?.Invoke();
             }).WithConfirm(

--- a/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
@@ -95,7 +95,7 @@ public class ProjectRepoPickerView(
         {
             pickerControls = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.Center)
                              | repoInput
-                             | new Button("Browse").Icon(Icons.FolderOpen).Outline().Small()
+                             | new Button("Browse").Icon(Icons.FolderOpen)
                                  .OnClick(() =>
                                  {
                                      var picked = desktop!.ShowSelectFolderDialog("Select repository folder");
@@ -108,7 +108,7 @@ public class ProjectRepoPickerView(
             pickerControls = repoInput;
         }
 
-        var addButton = new Button("Add Repository").Icon(Icons.Plus).Outline().Small()
+        var addButton = new Button("Add Repository").Icon(Icons.Plus)
             .Disabled(string.IsNullOrWhiteSpace(inputValue.Value) || isAdding.Value)
             .Loading(isAdding.Value)
             .OnClick(() => { _ = AddAsync(); });
@@ -146,7 +146,7 @@ public class ProjectRepoPickerView(
                          | (showBaseBranchPicker
                              ? (object)BuildBaseBranchSelector(repos, idx)
                              : null!)
-                         | new Button().Icon(Icons.X).Ghost().Small().OnClick(() =>
+                         | new Button().Icon(Icons.X).Ghost().OnClick(() =>
                          {
                              var list = new List<RepoRef>(repos.Value);
                              if (idx < list.Count) list.RemoveAt(idx);


### PR DESCRIPTION
### Summary of Changes
- **Table Button Column**: Explicitly set `.ColumnWidth(t => t.Index, Size.Fit())` and `.ColumnWidth(t => t.Name, Size.Grow())` in `ReviewActionsTableView` and `ProjectVerificationsTableView` so the button action column is as tight as possible.
- **Button Styling**: Removed `.Outline()` and `.Small()` from buttons across configuration project views and blades to restore standard button scale and styling.
- **Diff Rendering Performance in Tendril**:
  - Added `content-visibility: auto` and `contain-intrinsic-size` to `.ivy-diff-file`, `.diff-hunk`, and diff views in `plan-diff.css`.
  - Memoized syntax tokenization (`tokenize`) with `useMemo` in `PlanDiffView.tsx` to prevent expensive synchronous refractor parsing on every render/scroll frame.