### PR TITLE
fix: restore Size.Fit() tables and Outline().Small() action buttons

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectBladeView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectBladeView.cs
@@ -161,7 +161,7 @@ public class EditProjectBladeView(
                 {
                     bladeContext.Push(this, new EditProjectMemoryBladeView(config.TendrilHome, editName.Value, fileName, memoryRefresh), title: fileName == null ? "Add Memory" : $"Edit Memory: {fileName}");
                 })
-                | new Button("Add Project Memory").Icon(Icons.Plus).OnClick(() =>
+                | new Button("Add Project Memory").Icon(Icons.Plus).Outline().OnClick(() =>
                 {
                     bladeContext.Push(this, new EditProjectMemoryBladeView(config.TendrilHome, editName.Value, null, memoryRefresh), title: "Add Project Memory");
                 })
@@ -173,7 +173,7 @@ public class EditProjectBladeView(
                 {
                     bladeContext.Push(this, new EditMcpServerBladeView(idx, editMcpServers), title: idx == null ? "Add MCP Server" : "Edit MCP Server");
                 })
-                | new Button("Add MCP Server").Icon(Icons.Plus).OnClick(() =>
+                | new Button("Add MCP Server").Icon(Icons.Plus).Outline().OnClick(() =>
                 {
                     bladeContext.Push(this, new EditMcpServerBladeView(null, editMcpServers), title: "Add MCP Server");
                 })
@@ -185,7 +185,7 @@ public class EditProjectBladeView(
                 {
                     bladeContext.Push(this, new EditSkillBladeView(idx, editSkills), title: idx == null ? "Add Custom Skill" : "Edit Custom Skill");
                 })
-                | new Button("Add Custom Skill").Icon(Icons.Plus).OnClick(() =>
+                | new Button("Add Custom Skill").Icon(Icons.Plus).Outline().OnClick(() =>
                 {
                     bladeContext.Push(this, new EditSkillBladeView(null, editSkills), title: "Add Custom Skill");
                 })
@@ -199,7 +199,7 @@ public class EditProjectBladeView(
             {
                 bladeContext.Push(this, new EditReviewActionBladeView(idx, editReviewActions), title: idx == null ? "Add Review Action" : "Edit Review Action");
             })
-            | new Button("Add Review Action").Icon(Icons.Plus).OnClick(() =>
+            | new Button("Add Review Action").Icon(Icons.Plus).Outline().OnClick(() =>
             {
                 bladeContext.Push(this, new EditReviewActionBladeView(null, editReviewActions), title: "Add Review Action");
             })
@@ -207,7 +207,7 @@ public class EditProjectBladeView(
         tabs.Add(new Tab("Verifications",
             Layout.Vertical()
             | Text.Block("Quality checks required before plans are marked complete.").Muted().Small()
-            | new Button("Add Verification").Icon(Icons.Plus).OnClick(() =>
+            | new Button("Add Verification").Icon(Icons.Plus).Outline().OnClick(() =>
             {
                 bladeContext.Push(this, new EditVerificationBladeView(config, client, refreshToken, editVerifications), title: "Add Verification");
             })

--- a/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
@@ -66,13 +66,13 @@ public class ProjectMemoryTableView(
                 | new Badge("Memory").Color(Colors.Blue).Variant(BadgeVariant.Secondary).Small();
 
             var rightGroup = Layout.Horizontal().AlignContent(Align.Right).Width(Size.Fit())
-                | new Button().Icon(Icons.Copy).Ghost().Tooltip("Copy file path").OnClick(() =>
+                | new Button().Icon(Icons.Copy).Outline().Small().Tooltip("Copy file path").OnClick(() =>
                 {
                     copyToClipboard(fullPath);
                     client.Toast("Copied memory path to clipboard", "Copied");
                 })
-                | new Button().Icon(Icons.Pencil).Ghost().Tooltip("Edit").OnClick(() => onEdit(fileName))
-                | new Button().Icon(Icons.Trash).Ghost().Tooltip("Delete").OnClick(() =>
+                | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() => onEdit(fileName))
+                | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
                 {
                     if (File.Exists(fullPath)) File.Delete(fullPath);
                     refreshCounter.Set(refreshCounter.Value + 1);
@@ -103,7 +103,7 @@ public class ProjectMemoryTableView(
         var content = Layout.Vertical()
             | containerBox
             | (Layout.Horizontal().AlignContent(Align.Left)
-                | new Button("Add Project Memory").Icon(Icons.Plus).OnClick(() => onEdit(null)));
+                | new Button("Add Project Memory").Icon(Icons.Plus).Outline().OnClick(() => onEdit(null)));
 
         return new Expandable(header, content).Open(true);
     }
@@ -147,8 +147,8 @@ public class McpServersTableView : ViewBase
             var emptyContent = Layout.Vertical()
                 | Text.Block("No MCP servers configured for this project.").Muted().Small()
                 | (Layout.Horizontal().AlignContent(Align.Left)
-                    | (_onEdit != null ? new Button("Add MCP Server").Icon(Icons.Plus).OnClick(() => _onEdit(null)) : null)
-                    | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).OnClick(_onImport) : null));
+                    | (_onEdit != null ? new Button("Add MCP Server").Icon(Icons.Plus).Outline().OnClick(() => _onEdit(null)) : null)
+                    | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).Outline().OnClick(_onImport) : null));
 
             return new Expandable(header, emptyContent).Open(true);
         }
@@ -167,13 +167,13 @@ public class McpServersTableView : ViewBase
                 | new Badge("MCP").Color(Colors.Green).Variant(BadgeVariant.Secondary).Small();
 
             var rightGroup = Layout.Horizontal().AlignContent(Align.Right).Width(Size.Fit())
-                | new Button().Icon(Icons.Copy).Ghost().Tooltip("Copy command").OnClick(() =>
+                | new Button().Icon(Icons.Copy).Outline().Small().Tooltip("Copy command").OnClick(() =>
                 {
                     copyToClipboard(fullCmd);
                     client.Toast("Copied command to clipboard", "Copied");
                 })
-                | (_onEdit != null ? new Button().Icon(Icons.Pencil).Ghost().Tooltip("Edit").OnClick(() => _onEdit(idx)) : null)
-                | new Button().Icon(Icons.Trash).Ghost().Tooltip("Delete").OnClick(() =>
+                | (_onEdit != null ? new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() => _onEdit(idx)) : null)
+                | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
                 {
                     if (_onDelete != null)
                     {
@@ -213,8 +213,8 @@ public class McpServersTableView : ViewBase
         var content = Layout.Vertical()
             | containerBox
             | (Layout.Horizontal().AlignContent(Align.Left)
-                | (_onEdit != null ? new Button("Add MCP Server").Icon(Icons.Plus).OnClick(() => _onEdit(null)) : null)
-                | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).OnClick(_onImport) : null));
+                | (_onEdit != null ? new Button("Add MCP Server").Icon(Icons.Plus).Outline().OnClick(() => _onEdit(null)) : null)
+                | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).Outline().OnClick(_onImport) : null));
 
         return new Expandable(header, content).Open(true);
     }
@@ -258,8 +258,8 @@ public class SkillsTableView : ViewBase
             var emptyContent = Layout.Vertical()
                 | Text.Block("No custom skills configured for this project.").Muted().Small()
                 | (Layout.Horizontal().AlignContent(Align.Left)
-                    | (_onEdit != null ? new Button("Add Custom Skill").Icon(Icons.Plus).OnClick(() => _onEdit(null)) : null)
-                    | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).OnClick(_onImport) : null));
+                    | (_onEdit != null ? new Button("Add Custom Skill").Icon(Icons.Plus).Outline().OnClick(() => _onEdit(null)) : null)
+                    | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).Outline().OnClick(_onImport) : null));
 
             return new Expandable(header, emptyContent).Open(true);
         }
@@ -298,7 +298,7 @@ public class SkillsTableView : ViewBase
             }
 
             var rightGroup = Layout.Horizontal().AlignContent(Align.Right).Width(Size.Fit())
-                | new Button().Icon(Icons.Copy).Ghost().Tooltip("Copy skill path").OnClick(() =>
+                | new Button().Icon(Icons.Copy).Outline().Small().Tooltip("Copy skill path").OnClick(() =>
                 {
                     if (!string.IsNullOrWhiteSpace(skill.Path))
                     {
@@ -306,8 +306,8 @@ public class SkillsTableView : ViewBase
                         client.Toast("Copied skill path to clipboard", "Copied");
                     }
                 })
-                | (_onEdit != null ? new Button().Icon(Icons.Pencil).Ghost().Tooltip("Edit").OnClick(() => _onEdit(idx)) : null)
-                | new Button().Icon(Icons.Trash).Ghost().Tooltip("Delete").OnClick(() =>
+                | (_onEdit != null ? new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() => _onEdit(idx)) : null)
+                | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
                 {
                     if (_onDelete != null)
                     {
@@ -347,8 +347,8 @@ public class SkillsTableView : ViewBase
         var content = Layout.Vertical()
             | containerBox
             | (Layout.Horizontal().AlignContent(Align.Left)
-                | (_onEdit != null ? new Button("Add Custom Skill").Icon(Icons.Plus).OnClick(() => _onEdit(null)) : null)
-                | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).OnClick(_onImport) : null));
+                | (_onEdit != null ? new Button("Add Custom Skill").Icon(Icons.Plus).Outline().OnClick(() => _onEdit(null)) : null)
+                | (_onImport != null ? new Button("Import from Repository").Icon(Icons.Download).Outline().OnClick(_onImport) : null));
 
         return new Expandable(header, content).Open(true);
     }
@@ -382,20 +382,18 @@ public class ReviewActionsTableView(
             .Builder(t => t.Name, f => f.Func<ReviewActionRow, string>(name =>
                 Text.Block(name).Bold()
             ))
-            .ColumnWidth(t => t.Name, Size.Grow())
             .Header(t => t.Index, "")
             .Builder(t => t.Index, f => f.Func<ReviewActionRow, int>(idx =>
-                Layout.Horizontal().AlignContent(Align.Right)
-                | new Button().Icon(Icons.Pencil).Ghost().Tooltip("Edit").OnClick(() => onEdit(idx))
-                | new Button().Icon(Icons.Trash).Ghost().Tooltip("Delete").OnClick(() =>
+                Layout.Horizontal()
+                | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() => onEdit(idx))
+                | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
                 {
                     var list = new List<ReviewActionConfig>(actions);
                     list.RemoveAt(idx);
                     reviewActions.Set(list);
                 })
             ))
-            .ColumnWidth(t => t.Index, Size.Fit())
-            .Width(Size.Full());
+            .Width(Size.Fit());
     }
 
     private record ReviewActionRow(string Name, int Index);
@@ -417,20 +415,18 @@ public class ProjectVerificationsTableView(
             .Builder(t => t.Name, f => f.Func<VerificationRow, string>(name =>
                 Text.Block(name).Bold()
             ))
-            .ColumnWidth(t => t.Name, Size.Grow())
             .Header(t => t.Index, "")
             .Builder(t => t.Index, f => f.Func<VerificationRow, int>(idx =>
-                Layout.Horizontal().AlignContent(Align.Right)
-                | new Button().Icon(Icons.Pencil).Ghost().Tooltip("Edit").OnClick(() => onEdit(idx))
-                | new Button().Icon(Icons.Trash).Ghost().Tooltip("Delete").OnClick(() =>
+                Layout.Horizontal()
+                | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() => onEdit(idx))
+                | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
                 {
                     var current = new List<ProjectVerificationRef>(verifications.Value);
                     current.RemoveAt(idx);
                     verifications.Set(current);
                 })
             ))
-            .ColumnWidth(t => t.Index, Size.Fit())
-            .Width(Size.Full());
+            .Width(Size.Fit());
     }
 
     private record VerificationRow(string Name, int Index);

--- a/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
@@ -196,7 +196,7 @@ public class ProjectDetailView(
             ? (Layout.Horizontal().AlignContent(Align.Left)
                | colorInput
                | editName.ToTextInput("Project name...").Small()
-               | new Button().Icon(Icons.Check).Ghost().OnClick(() =>
+               | new Button().Icon(Icons.Check).Outline().Small().OnClick(() =>
                {
                    var newName = editName.Value.Trim();
                    if (!string.IsNullOrWhiteSpace(newName) && !string.Equals(project.Name, newName, StringComparison.OrdinalIgnoreCase))
@@ -210,7 +210,7 @@ public class ProjectDetailView(
                    }
                    isEditingName.Set(false);
                })
-               | new Button().Icon(Icons.X).Ghost().OnClick(() =>
+               | new Button().Icon(Icons.X).Outline().Small().OnClick(() =>
                {
                    editName.Set(project.Name);
                    isEditingName.Set(false);
@@ -218,7 +218,7 @@ public class ProjectDetailView(
             : (Layout.Horizontal().AlignContent(Align.Left)
                | colorInput
                | Text.H2(project.Name).Bold()
-               | new Button().Icon(Icons.Pencil).Ghost().Tooltip("Rename Project").OnClick(() => isEditingName.Set(true)));
+               | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Rename Project").OnClick(() => isEditingName.Set(true)));
 
         // Agent Behavior Dropdown
         var autoImplementSelect = autoImplement.ToSelectInput(new[] { "Auto-Implement Plans", "Always Ask Review" })
@@ -257,12 +257,12 @@ public class ProjectDetailView(
             // Section 3: Review Actions
             | Text.H4("Review Actions").Bold()
             | new ReviewActionsTableView(reviewActions, idx => showReviewActionTrigger(idx))
-            | new Button("Add Review Action").Icon(Icons.Plus).OnClick(() => showReviewActionTrigger(null))
+            | new Button("Add Review Action").Icon(Icons.Plus).Outline().OnClick(() => showReviewActionTrigger(null))
 
             // Section 4: Verifications
             | Text.H4("Verifications").Bold()
             | new ProjectVerificationsTableView(verifications, idx => showVerificationTrigger(idx))
-            | new Button("Add Verification").Icon(Icons.Plus).OnClick(() => showVerificationTrigger(null))
+            | new Button("Add Verification").Icon(Icons.Plus).Outline().OnClick(() => showVerificationTrigger(null))
 
             // Section 5: Agent Behavior
             | (isBeta

--- a/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
+++ b/src/Ivy.Tendril/Apps/Views/ProjectRepoPickerView.cs
@@ -95,7 +95,7 @@ public class ProjectRepoPickerView(
         {
             pickerControls = Layout.Horizontal().Width(Size.Full()).AlignContent(Align.Center)
                              | repoInput
-                             | new Button("Browse").Icon(Icons.FolderOpen)
+                             | new Button("Browse").Icon(Icons.FolderOpen).Outline()
                                  .OnClick(() =>
                                  {
                                      var picked = desktop!.ShowSelectFolderDialog("Select repository folder");
@@ -108,7 +108,7 @@ public class ProjectRepoPickerView(
             pickerControls = repoInput;
         }
 
-        var addButton = new Button("Add Repository").Icon(Icons.Plus)
+        var addButton = new Button("Add Repository").Icon(Icons.Plus).Outline()
             .Disabled(string.IsNullOrWhiteSpace(inputValue.Value) || isAdding.Value)
             .Loading(isAdding.Value)
             .OnClick(() => { _ = AddAsync(); });
@@ -146,7 +146,7 @@ public class ProjectRepoPickerView(
                          | (showBaseBranchPicker
                              ? (object)BuildBaseBranchSelector(repos, idx)
                              : null!)
-                         | new Button().Icon(Icons.X).Ghost().OnClick(() =>
+                         | new Button().Icon(Icons.X).Outline().Small().OnClick(() =>
                          {
                              var list = new List<RepoRef>(repos.Value);
                              if (idx < list.Count) list.RemoveAt(idx);


### PR DESCRIPTION
### Summary of Changes
- Configured `.Width(Size.Fit())` on `ReviewActionsTableView` and `ProjectVerificationsTableView` so the entire table and button action column are tight and compact to match onboarding/setup tables.
- Restored `.Outline().Small()` on table and card action buttons (Edit, Delete, Copy) so buttons have visible borders/backgrounds and compact sizing.
- Added `.Outline()` on Add and Browse trigger buttons.