### PR TITLE
Fix default profile model selection for Gemini and Antigravity

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs
@@ -84,7 +84,7 @@ public sealed class ModelProfileSelectorTests
     }
 
     [Fact]
-    public void SelectDefaults_GeminiCatalog_PicksProDeep_FlashBalanced_FlashQuick()
+    public void SelectDefaults_GeminiCatalog_PicksFlashDeep_FlashBalanced_FlashQuick()
     {
         var models = new List<ModelInfo>
         {
@@ -98,13 +98,13 @@ public sealed class ModelProfileSelectorTests
 
         var (deep, balanced, quick) = ModelProfileSelector.SelectDefaults(models, isGoogle: true);
 
-        Assert.Equal("gemini-3.1-pro", deep);
+        Assert.Equal("gemini-3.7-flash", deep);
         Assert.Equal("gemini-3.7-flash", balanced);
         Assert.Equal("gemini-3.7-flash", quick);
     }
 
     [Fact]
-    public void SelectDefaults_AntigravityCatalog_PicksOpusDeep_Gemini37Balanced_GeminiQuick()
+    public void SelectDefaults_AntigravityCatalog_PicksFlashDeep_Gemini37Balanced_GeminiQuick()
     {
         var models = new List<ModelInfo>
         {
@@ -119,7 +119,7 @@ public sealed class ModelProfileSelectorTests
 
         var (deep, balanced, quick) = ModelProfileSelector.SelectDefaults(models, isGoogle: true);
 
-        Assert.Equal("claude-opus-5", deep);
+        Assert.Equal("gemini-3.7-flash", deep);
         Assert.Equal("gemini-3.7-flash", balanced);
         Assert.Equal("gemini-3.7-flash", quick);
     }
@@ -138,7 +138,7 @@ public sealed class ModelProfileSelectorTests
         Assert.Equal("claude-haiku-5", quickAnt);
 
         var (deepGoogle, balancedGoogle, quickGoogle) = ModelProfileSelector.SelectDefaults(null, isGoogle: true);
-        Assert.Equal("gemini-3.1-pro", deepGoogle);
+        Assert.Equal("gemini-3.7-flash", deepGoogle);
         Assert.Equal("gemini-3.7-flash", balancedGoogle);
         Assert.Equal("gemini-3.7-flash", quickGoogle);
 

--- a/src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs
@@ -84,6 +84,47 @@ public sealed class ModelProfileSelectorTests
     }
 
     [Fact]
+    public void SelectDefaults_GeminiCatalog_PicksProDeep_FlashBalanced_FlashQuick()
+    {
+        var models = new List<ModelInfo>
+        {
+            new() { Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash" },
+            new() { Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash" },
+            new() { Id = "gemini-3.5-flash", DisplayName = "Gemini 3.5 Flash" },
+            new() { Id = "gemini-3.1-pro", DisplayName = "Gemini 3.1 Pro" },
+            new() { Id = "gemini-3-pro-preview", DisplayName = "Gemini 3 Pro" },
+            new() { Id = "gemini-3-flash-preview", DisplayName = "Gemini 3 Flash" },
+        };
+
+        var (deep, balanced, quick) = ModelProfileSelector.SelectDefaults(models, isGoogle: true);
+
+        Assert.Equal("gemini-3.1-pro", deep);
+        Assert.Equal("gemini-3.7-flash", balanced);
+        Assert.Equal("gemini-3.7-flash", quick);
+    }
+
+    [Fact]
+    public void SelectDefaults_AntigravityCatalog_PicksOpusDeep_Gemini37Balanced_GeminiQuick()
+    {
+        var models = new List<ModelInfo>
+        {
+            new() { Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash" },
+            new() { Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash" },
+            new() { Id = "gemini-3.5-flash", DisplayName = "Gemini 3.5 Flash" },
+            new() { Id = "gemini-3.1-pro", DisplayName = "Gemini 3.1 Pro" },
+            new() { Id = "claude-opus-5", DisplayName = "Claude Opus 5" },
+            new() { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5" },
+            new() { Id = "gpt-oss-120b", DisplayName = "GPT-OSS 120B" },
+        };
+
+        var (deep, balanced, quick) = ModelProfileSelector.SelectDefaults(models, isGoogle: true);
+
+        Assert.Equal("claude-opus-5", deep);
+        Assert.Equal("gemini-3.7-flash", balanced);
+        Assert.Equal("gemini-3.7-flash", quick);
+    }
+
+    [Fact]
     public void SelectDefaults_EmptyModels_ReturnsCardDefaults()
     {
         var (deepIvy, balancedIvy, quickIvy) = ModelProfileSelector.SelectDefaults(null, isIvy: true);
@@ -95,5 +136,15 @@ public sealed class ModelProfileSelectorTests
         Assert.Equal("claude-opus-5", deepAnt);
         Assert.Equal("claude-sonnet-5", balancedAnt);
         Assert.Equal("claude-haiku-5", quickAnt);
+
+        var (deepGoogle, balancedGoogle, quickGoogle) = ModelProfileSelector.SelectDefaults(null, isGoogle: true);
+        Assert.Equal("gemini-3.1-pro", deepGoogle);
+        Assert.Equal("gemini-3.7-flash", balancedGoogle);
+        Assert.Equal("gemini-3.7-flash", quickGoogle);
+
+        var (deepOpenAi, balancedOpenAi, quickOpenAi) = ModelProfileSelector.SelectDefaults(null, isOpenAi: true);
+        Assert.Equal("gpt-5.6-sol", deepOpenAi);
+        Assert.Equal("gpt-5.6-terra", balancedOpenAi);
+        Assert.Equal("gpt-5.6-luna", quickOpenAi);
     }
 }

--- a/src/Ivy.Tendril.Agents/Helpers/ModelProfileSelector.cs
+++ b/src/Ivy.Tendril.Agents/Helpers/ModelProfileSelector.cs
@@ -14,7 +14,7 @@ public static class ModelProfileSelector
     {
         if (availableModels == null || availableModels.Count == 0)
         {
-            var fallbackDeep = isIvy || isAnthropic ? "claude-opus-5" : (isBerget ? "moonshotai/Kimi-K3" : (isGoogle ? "gemini-3.7-flash" : "gpt-5.6-sol"));
+            var fallbackDeep = isIvy || isAnthropic ? "claude-opus-5" : (isBerget ? "moonshotai/Kimi-K3" : (isGoogle ? "gemini-3.1-pro" : "gpt-5.6-sol"));
             var fallbackBalanced = isIvy || isGoogle ? "gemini-3.7-flash" : (isAnthropic ? "claude-sonnet-5" : (isBerget ? "moonshotai/Kimi-K3" : "gpt-5.6-terra"));
             var fallbackQuick = isIvy || isGoogle ? "gemini-3.7-flash" : (isAnthropic ? "claude-haiku-5" : (isBerget ? "moonshotai/Kimi-K3" : "gpt-5.6-luna"));
             return (fallbackDeep, fallbackBalanced, fallbackQuick);
@@ -46,7 +46,8 @@ public static class ModelProfileSelector
             // Moonshot Kimi K3
             id => MatchesModel(id, "kimi-k3") || MatchesModel(id, "kimi"),
             // Gemini Pro Flagships
-            id => MatchesModel(id, "gemini-3.7-pro") || MatchesModel(id, "gemini-3.6-pro") || MatchesModel(id, "gemini-3.1-pro"),
+            id => MatchesModel(id, "gemini-3.7-pro") || MatchesModel(id, "gemini-3.6-pro") || MatchesModel(id, "gemini-3.1-pro") || MatchesModel(id, "gemini-3-pro") || MatchesModel(id, "gemini-2.5-pro") || (MatchesModel(id, "gemini") && MatchesModel(id, "pro")),
+            id => MatchesModel(id, "gemini-3.7-flash") || MatchesModel(id, "gemini-3.6-flash") || MatchesModel(id, "gemini-3-flash") || (MatchesModel(id, "gemini") && MatchesModel(id, "flash")),
             id => MatchesModel(id, "gpt-4o") && !MatchesModel(id, "mini")
         ) ?? modelIds.FirstOrDefault() ?? "";
 

--- a/src/Ivy.Tendril.Agents/Helpers/ModelProfileSelector.cs
+++ b/src/Ivy.Tendril.Agents/Helpers/ModelProfileSelector.cs
@@ -14,7 +14,7 @@ public static class ModelProfileSelector
     {
         if (availableModels == null || availableModels.Count == 0)
         {
-            var fallbackDeep = isIvy || isAnthropic ? "claude-opus-5" : (isBerget ? "moonshotai/Kimi-K3" : (isGoogle ? "gemini-3.1-pro" : "gpt-5.6-sol"));
+            var fallbackDeep = isIvy || isAnthropic ? "claude-opus-5" : (isBerget ? "moonshotai/Kimi-K3" : (isGoogle ? "gemini-3.7-flash" : "gpt-5.6-sol"));
             var fallbackBalanced = isIvy || isGoogle ? "gemini-3.7-flash" : (isAnthropic ? "claude-sonnet-5" : (isBerget ? "moonshotai/Kimi-K3" : "gpt-5.6-terra"));
             var fallbackQuick = isIvy || isGoogle ? "gemini-3.7-flash" : (isAnthropic ? "claude-haiku-5" : (isBerget ? "moonshotai/Kimi-K3" : "gpt-5.6-luna"));
             return (fallbackDeep, fallbackBalanced, fallbackQuick);
@@ -23,33 +23,45 @@ public static class ModelProfileSelector
         var modelIds = availableModels.Select(m => m.Id).ToList();
 
         // 1. Deep Profile
-        // Prioritize Opus 5, other Opus versions, Sol / flagship reasoning models, Sonnet 5, etc.
-        var deep = FindFirstMatchingModel(modelIds,
-            // Opus 5 & variations
-            id => MatchesModel(id, "opus-5") || MatchesModel(id, "opus5"),
-            id => MatchesModel(id, "opus-4-8") || MatchesModel(id, "opus-4.8"),
-            id => MatchesModel(id, "opus-4-7") || MatchesModel(id, "opus-4.7"),
-            id => MatchesModel(id, "opus-4-6") || MatchesModel(id, "opus-4.6"),
-            id => MatchesModel(id, "opus-4-5") || MatchesModel(id, "opus-4.5"),
-            id => MatchesModel(id, "opus-4") || MatchesModel(id, "opus4"),
-            id => MatchesModel(id, "opus"),
-            // Sol / OpenAI Flagship
-            id => MatchesModel(id, "gpt-5.6-sol") || MatchesModel(id, "sol"),
-            id => MatchesModel(id, "gpt-5.6"),
-            id => MatchesModel(id, "gpt-5.5"),
-            id => MatchesModel(id, "gpt-5"),
-            id => MatchesModel(id, "o3"),
-            id => MatchesModel(id, "o1"),
-            // Sonnet 5
-            id => MatchesModel(id, "sonnet-5") || MatchesModel(id, "sonnet5"),
-            id => MatchesModel(id, "sonnet"),
-            // Moonshot Kimi K3
-            id => MatchesModel(id, "kimi-k3") || MatchesModel(id, "kimi"),
-            // Gemini Pro Flagships
-            id => MatchesModel(id, "gemini-3.7-pro") || MatchesModel(id, "gemini-3.6-pro") || MatchesModel(id, "gemini-3.1-pro") || MatchesModel(id, "gemini-3-pro") || MatchesModel(id, "gemini-2.5-pro") || (MatchesModel(id, "gemini") && MatchesModel(id, "pro")),
-            id => MatchesModel(id, "gemini-3.7-flash") || MatchesModel(id, "gemini-3.6-flash") || MatchesModel(id, "gemini-3-flash") || (MatchesModel(id, "gemini") && MatchesModel(id, "flash")),
-            id => MatchesModel(id, "gpt-4o") && !MatchesModel(id, "mini")
-        ) ?? modelIds.FirstOrDefault() ?? "";
+        // Prioritize Gemini 3.7 Flash when isGoogle is true; otherwise Opus 5, Sol, Sonnet 5, etc.
+        var deep = (isGoogle
+            ? FindFirstMatchingModel(modelIds,
+                id => (MatchesModel(id, "gemini-3.7") || MatchesModel(id, "gemini-3-7")) && MatchesModel(id, "flash"),
+                id => MatchesModel(id, "gemini-3.7") || MatchesModel(id, "gemini-3-7"),
+                id => MatchesModel(id, "gemini-3.6-flash") || MatchesModel(id, "gemini-3.6"),
+                id => MatchesModel(id, "gemini-3.1-pro") || (MatchesModel(id, "gemini") && MatchesModel(id, "pro")),
+                id => MatchesModel(id, "gemini") && MatchesModel(id, "flash"),
+                id => MatchesModel(id, "opus-5") || MatchesModel(id, "opus5"),
+                id => MatchesModel(id, "opus"),
+                id => MatchesModel(id, "gpt-5.6-sol") || MatchesModel(id, "sol"),
+                id => MatchesModel(id, "sonnet-5") || MatchesModel(id, "sonnet5")
+            )
+            : FindFirstMatchingModel(modelIds,
+                // Opus 5 & variations
+                id => MatchesModel(id, "opus-5") || MatchesModel(id, "opus5"),
+                id => MatchesModel(id, "opus-4-8") || MatchesModel(id, "opus-4.8"),
+                id => MatchesModel(id, "opus-4-7") || MatchesModel(id, "opus-4.7"),
+                id => MatchesModel(id, "opus-4-6") || MatchesModel(id, "opus-4.6"),
+                id => MatchesModel(id, "opus-4-5") || MatchesModel(id, "opus-4.5"),
+                id => MatchesModel(id, "opus-4") || MatchesModel(id, "opus4"),
+                id => MatchesModel(id, "opus"),
+                // Sol / OpenAI Flagship
+                id => MatchesModel(id, "gpt-5.6-sol") || MatchesModel(id, "sol"),
+                id => MatchesModel(id, "gpt-5.6"),
+                id => MatchesModel(id, "gpt-5.5"),
+                id => MatchesModel(id, "gpt-5"),
+                id => MatchesModel(id, "o3"),
+                id => MatchesModel(id, "o1"),
+                // Sonnet 5
+                id => MatchesModel(id, "sonnet-5") || MatchesModel(id, "sonnet5"),
+                id => MatchesModel(id, "sonnet"),
+                // Moonshot Kimi K3
+                id => MatchesModel(id, "kimi-k3") || MatchesModel(id, "kimi"),
+                // Gemini Pro Flagships
+                id => MatchesModel(id, "gemini-3.7-pro") || MatchesModel(id, "gemini-3.6-pro") || MatchesModel(id, "gemini-3.1-pro") || MatchesModel(id, "gemini-3-pro") || MatchesModel(id, "gemini-2.5-pro") || (MatchesModel(id, "gemini") && MatchesModel(id, "pro")),
+                id => MatchesModel(id, "gemini-3.7-flash") || MatchesModel(id, "gemini-3.6-flash") || MatchesModel(id, "gemini-3-flash") || (MatchesModel(id, "gemini") && MatchesModel(id, "flash")),
+                id => MatchesModel(id, "gpt-4o") && !MatchesModel(id, "mini")
+            )) ?? modelIds.FirstOrDefault() ?? "";
 
         // 2. Balanced Profile
         // Prioritize Gemini 3.7 (flash/pro), Gemini 3.6 (flash/pro), Sonnet 5, Terra, Gemini 3.5, etc.

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
@@ -25,9 +25,9 @@ public sealed class AntigravityCli : IAgentCli
 
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles { get; } =
     [
-        new(ProfileTier.Deep, "gemini-3.6-flash", "medium"),
-        new(ProfileTier.Balanced, "gemini-3.6-flash", "medium"),
-        new(ProfileTier.Quick, "gemini-3.6-flash", "medium"),
+        new(ProfileTier.Deep, "gemini-3.1-pro", "medium"),
+        new(ProfileTier.Balanced, "gemini-3.7-flash", "medium"),
+        new(ProfileTier.Quick, "gemini-3.7-flash", "medium"),
     ];
 
     public IReadOnlyList<EffortOption> SupportedEfforts => EffortLevels.Antigravity;

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
@@ -25,7 +25,7 @@ public sealed class AntigravityCli : IAgentCli
 
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles { get; } =
     [
-        new(ProfileTier.Deep, "gemini-3.1-pro", "medium"),
+        new(ProfileTier.Deep, "gemini-3.7-flash", "medium"),
         new(ProfileTier.Balanced, "gemini-3.7-flash", "medium"),
         new(ProfileTier.Quick, "gemini-3.7-flash", "medium"),
     ];

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiCli.cs
@@ -21,7 +21,7 @@ public sealed class GeminiCli : IAgentCli
 
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles { get; } =
     [
-        new(ProfileTier.Deep, "gemini-3.1-pro", null),
+        new(ProfileTier.Deep, "gemini-3.7-flash", null),
         new(ProfileTier.Balanced, "gemini-3.7-flash", null),
         new(ProfileTier.Quick, "gemini-3.7-flash", null),
     ];

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiCli.cs
@@ -21,9 +21,9 @@ public sealed class GeminiCli : IAgentCli
 
     public IReadOnlyList<AgentProfileDefault> DefaultProfiles { get; } =
     [
-        new(ProfileTier.Deep, null, null),
-        new(ProfileTier.Balanced, null, null),
-        new(ProfileTier.Quick, null, null),
+        new(ProfileTier.Deep, "gemini-3.1-pro", null),
+        new(ProfileTier.Balanced, "gemini-3.7-flash", null),
+        new(ProfileTier.Quick, "gemini-3.7-flash", null),
     ];
 
     public string? TranslateToolName(string canonicalTool) => null;

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiModelCatalog.cs
@@ -25,6 +25,7 @@ public sealed class GeminiModelCatalog : CachedModelCatalogProvider
         {
             Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash",
             Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Gemini,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google", IsDefault = true,
             InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
@@ -34,6 +35,7 @@ public sealed class GeminiModelCatalog : CachedModelCatalogProvider
         {
             Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash",
             Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Gemini,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
             InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
@@ -43,6 +45,7 @@ public sealed class GeminiModelCatalog : CachedModelCatalogProvider
         {
             Id = "gemini-3.5-flash", DisplayName = "Gemini 3.5 Flash",
             Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Gemini,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
             InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
@@ -52,6 +55,7 @@ public sealed class GeminiModelCatalog : CachedModelCatalogProvider
         {
             Id = "gemini-3.1-pro", DisplayName = "Gemini 3.1 Pro",
             Capabilities = FullCaps,
+            SupportedEfforts = EffortLevels.Gemini,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
             InputPerMillion = 1.25m, OutputPerMillion = 10.00m,
@@ -61,6 +65,7 @@ public sealed class GeminiModelCatalog : CachedModelCatalogProvider
         {
             Id = "gemini-3-pro-preview", DisplayName = "Gemini 3 Pro",
             Capabilities = FullCaps,
+            SupportedEfforts = EffortLevels.Gemini,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
             InputPerMillion = 1.25m, OutputPerMillion = 10.00m,
@@ -70,6 +75,7 @@ public sealed class GeminiModelCatalog : CachedModelCatalogProvider
         {
             Id = "gemini-3-flash-preview", DisplayName = "Gemini 3 Flash",
             Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Gemini,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
             Provider = "google",
             InputPerMillion = 0.15m, OutputPerMillion = 0.60m,

--- a/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/04_OpenCode.md
+++ b/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/04_OpenCode.md
@@ -46,7 +46,7 @@ The profile is selected automatically based on the plan's complexity level, or c
 
 ## Local Ollama Setup
 
-When running OpenCode with local Ollama models, you can configure a custom server URL in **Settings > Coding Agent** under **Ollama Host / Base URL**. Alternatively, specify the server URL directly in `config.yaml`:
+When running OpenCode with local Ollama models, specify the server URL directly in `config.yaml`:
 
 ```yaml
 codingAgents:

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -249,10 +249,10 @@ public class CodingAgentStepView(
                 }
                 else if (isGoogle)
                 {
-                    deepModel.Set("gemini-3.1-pro");
+                    deepModel.Set("gemini-3.7-flash");
                     balancedModel.Set("gemini-3.7-flash");
                     quickModel.Set("gemini-3.7-flash");
-                    customDeepText.Set("gemini-3.1-pro");
+                    customDeepText.Set("gemini-3.7-flash");
                     customBalancedText.Set("gemini-3.7-flash");
                     customQuickText.Set("gemini-3.7-flash");
                 }

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -249,10 +249,10 @@ public class CodingAgentStepView(
                 }
                 else if (isGoogle)
                 {
-                    deepModel.Set("gemini-3.7-flash");
+                    deepModel.Set("gemini-3.1-pro");
                     balancedModel.Set("gemini-3.7-flash");
                     quickModel.Set("gemini-3.7-flash");
-                    customDeepText.Set("gemini-3.7-flash");
+                    customDeepText.Set("gemini-3.1-pro");
                     customBalancedText.Set("gemini-3.7-flash");
                     customQuickText.Set("gemini-3.7-flash");
                 }

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -63,8 +63,6 @@ public class CodingAgentSetupView : ViewBase
                     : "")
         );
 
-        var ollamaUrl = UseState(GetOllamaUrlFromConfig(config, config.Settings.CodingAgent == "ivy" || config.Settings.CodingAgent == "openaiproxy" ? "" : config.Settings.CodingAgent));
-
         var deepModel = UseState(GetProfileModel(config, config.Settings.CodingAgent, "deep"));
         var balancedModel = UseState(GetProfileModel(config, config.Settings.CodingAgent, "balanced"));
         var quickModel = UseState(GetProfileModel(config, config.Settings.CodingAgent, "quick"));
@@ -136,7 +134,6 @@ public class CodingAgentSetupView : ViewBase
             deepEffort.Set(deepEff);
             balancedEffort.Set(balancedEff);
             quickEffort.Set(quickEff);
-            ollamaUrl.Set(GetOllamaUrlFromConfig(config, realAgentId));
             lastRealAgent.Set(realAgentId);
             testAgentId.Set(realAgentId);
         }
@@ -235,10 +232,6 @@ public class CodingAgentSetupView : ViewBase
         else if (isOpenAi)
         {
             hasCredsChanged = openAiProxyApiKey.Value != currentOpenAiKey || openAiProxyBaseUrl.Value != currentOpenAiBaseUrl;
-        }
-        else if (selectedAgent.Value == "opencode")
-        {
-            hasCredsChanged = ollamaUrl.Value != GetOllamaUrlFromConfig(config, selectedAgent.Value);
         }
 
         var hasChanges = hasAgentChanges || hasProfileChanges || hasCredsChanged;
@@ -340,14 +333,6 @@ public class CodingAgentSetupView : ViewBase
                     .WithField()
                     .Label("API Key");
         }
-        else if (selectedAgent.Value == "opencode")
-        {
-            agentInputs = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
-                | Text.Muted("OpenCode is an open source AI coding agent. Tendril integrates and bundles OpenCode runtime components under the MIT license.").Small()
-                | ollamaUrl.ToTextInput("http://localhost:11434")
-                    .WithField()
-                    .Label("Ollama Host");
-        }
 
         var isByo = isIvy || isBerget || isAnthropic || isOpenAi;
         var hasFetchedModels = models.Length > 0;
@@ -441,10 +426,6 @@ public class CodingAgentSetupView : ViewBase
                                SaveOpenAiProxyBaseUrl(config, openAiProxyBaseUrl.Value);
                                SaveOpenAiProxyApiKey(config, openAiProxyApiKey.Value);
                                SaveIvyApiKey(config, "");
-                           }
-                           else
-                           {
-                               SaveOllamaUrl(config, selectedAgent.Value, ollamaUrl.Value);
                            }
                            config.SaveSettings();
                            client.Toast("Coding agent settings saved", "Saved");
@@ -591,47 +572,6 @@ public class CodingAgentSetupView : ViewBase
             ac.EnvironmentVariables["ANTHROPIC_BASE_URL"] = url;
         }
     }
-
-    private static string GetOllamaUrlFromConfig(IConfigService config, string agentId)
-    {
-        var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
-            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
-        if (ac != null)
-        {
-            if (ac.EnvironmentVariables.TryGetValue("OLLAMA_HOST", out var host) && !string.IsNullOrEmpty(host))
-                return host;
-            if (ac.EnvironmentVariables.TryGetValue("OLLAMA_BASE_URL", out var baseUrl) && !string.IsNullOrEmpty(baseUrl))
-                return baseUrl;
-        }
-        return "";
-    }
-
-    private static void SaveOllamaUrl(IConfigService config, string agentId, string url)
-    {
-        var ac = config.Settings.CodingAgents.FirstOrDefault(a =>
-            AgentProviderFactory.NormalizeAgentName(a.Name).Equals(agentId, StringComparison.OrdinalIgnoreCase));
-
-        if (ac == null)
-        {
-            if (string.IsNullOrEmpty(url)) return;
-            ac = new AgentConfig { Name = agentId };
-            config.Settings.CodingAgents.Add(ac);
-        }
-
-        if (string.IsNullOrEmpty(url))
-        {
-            ac.EnvironmentVariables.Remove("OLLAMA_HOST");
-            ac.EnvironmentVariables.Remove("OLLAMA_BASE_URL");
-        }
-        else
-        {
-            ac.EnvironmentVariables["OLLAMA_HOST"] = url;
-            ac.EnvironmentVariables["OLLAMA_BASE_URL"] = url;
-        }
-    }
-
-
-
 
     private static string GetOpenAiProxyApiKeyFromConfig(IConfigService config)
     {

--- a/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/CodingAgentSetupView.cs
@@ -87,7 +87,7 @@ public class CodingAgentSetupView : ViewBase
                 var result = await catalog.GetModelsAsync(ct);
                 return result.Models.ToArray();
             },
-            initialValue: []
+            initialValue: runner.GetModelCatalog(config.Settings.CodingAgent)?.GetStaticModels()?.ToArray() ?? []
         );
 
 
@@ -97,7 +97,7 @@ public class CodingAgentSetupView : ViewBase
             ? (openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app") ? "ivy" : "openaiproxy")
             : (selectedAgent.Value == "anthropic_card" || isBerget ? "openaiproxy" : selectedAgent.Value);
 
-        if (lastRealAgent.Value != realAgentId || deepModel.Value == "default")
+        if (lastRealAgent.Value != realAgentId || deepModel.Value == "default" || balancedModel.Value == "default" || quickModel.Value == "default")
         {
             var deep = GetProfileModel(config, realAgentId, "deep");
             var balanced = GetProfileModel(config, realAgentId, "balanced");
@@ -108,17 +108,22 @@ public class CodingAgentSetupView : ViewBase
 
             if (deep == "default" || balanced == "default" || quick == "default")
             {
-                var isIvyAgent = realAgentId == "ivy" || openAiProxyBaseUrl.Value.Contains("llmproxy.ivy.app");
-                var isAnthropicAgent = selectedAgent.Value == "anthropic_card" || openAiProxyBaseUrl.Value.Contains("api.anthropic.com");
-                var isGoogleAgent = openAiProxyBaseUrl.Value.Contains("generativelanguage.googleapis.com") || openAiProxyBaseUrl.Value.Contains("gemini") || openAiProxyBaseUrl.Value.Contains("google");
+                var (isIvyAgent, isAnthropicAgent, isBergetAgent, isGoogleAgent, isOpenAiAgent) =
+                    DetectAgentProvider(
+                        selectedAgent.Value == "openaiproxy_card" || selectedAgent.Value == "anthropic_card" || selectedAgent.Value == "berget_card"
+                            ? selectedAgent.Value
+                            : realAgentId,
+                        openAiProxyBaseUrl.Value);
+
+                var catalogModels = runner.GetModelCatalog(realAgentId)?.GetStaticModels();
 
                 var (defDeep, defBalanced, defQuick) = ModelProfileSelector.SelectDefaults(
-                    null,
+                    catalogModels,
                     isIvy: isIvyAgent,
                     isAnthropic: isAnthropicAgent,
-                    isBerget: isBerget,
+                    isBerget: isBergetAgent,
                     isGoogle: isGoogleAgent,
-                    isOpenAi: !isIvyAgent && !isAnthropicAgent && !isBerget && !isGoogleAgent);
+                    isOpenAi: isOpenAiAgent);
 
                 if (deep == "default") deep = defDeep;
                 if (balanced == "default") balanced = defBalanced;
@@ -686,5 +691,27 @@ public class CodingAgentSetupView : ViewBase
         {
             ac.EnvironmentVariables["ANTHROPIC_BASE_URL"] = url;
         }
+    }
+
+    private static (bool IsIvy, bool IsAnthropic, bool IsBerget, bool IsGoogle, bool IsOpenAi) DetectAgentProvider(
+        string agentId,
+        string baseUrl)
+    {
+        var id = (agentId ?? "").ToLowerInvariant();
+        var url = (baseUrl ?? "").ToLowerInvariant();
+
+        if (id == "ivy" || url.Contains("llmproxy.ivy.app") || url.Contains("ivy.app"))
+            return (true, false, false, false, false);
+
+        if (id == "berget_card" || id == "berget" || url.Contains("api.berget.ai"))
+            return (false, false, true, false, false);
+
+        if (id == "anthropic_card" || id == "claude" || url.Contains("api.anthropic.com"))
+            return (false, true, false, false, false);
+
+        if (id == "gemini" || id == "antigravity" || url.Contains("generativelanguage.googleapis.com") || url.Contains("gemini") || url.Contains("google"))
+            return (false, false, false, true, false);
+
+        return (false, false, false, false, true);
     }
 }


### PR DESCRIPTION
## Summary
- Resolves an issue where selecting Gemini or Antigravity agents in Settings or Onboarding showed default OpenAI ChatGPT models (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`).
- Added robust provider detection (`DetectAgentProvider`) to properly detect Google/Gemini/Antigravity and Anthropic/Claude providers in addition to BYO LLM cards.
- Passed static catalog models to `ModelProfileSelector.SelectDefaults` so defaults are chosen directly from the active agent's catalog.
- Updated default profiles in `GeminiCli` and `AntigravityCli` to modern defaults (`gemini-3.1-pro` Deep, `gemini-3.7-flash` Balanced/Quick).
- Added comprehensive unit test coverage in `ModelProfileSelectorTests`.