### PR TITLE
Fix stack_hash telemetry, add plan_uuid grouping and three PostHog events

### DIFF
--- a/src/Ivy.Tendril.Test/Services/TelemetryPlanUuidTests.cs
+++ b/src/Ivy.Tendril.Test/Services/TelemetryPlanUuidTests.cs
@@ -1,0 +1,105 @@
+﻿using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Telemetry;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Services;
+
+public class TelemetryPlanUuidTests
+{
+    private const string AnonId = "6f1c9c1e-3a5e-4d1a-9d0f-2a6c4b8e1d33";
+    private const string OtherAnonId = "11111111-2222-3333-4444-555555555555";
+
+    [Fact]
+    public void DerivePlanUuid_IsStableForTheSameInstallAndPlan()
+    {
+        var first = TelemetryService.DerivePlanUuid(AnonId, "00042");
+        var second = TelemetryService.DerivePlanUuid(AnonId, "00042");
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void DerivePlanUuid_NormalizesIntAndZeroPaddedForms()
+    {
+        // PlanReaderService supplies the int form from the database; JobCompletionHandler
+        // supplies the zero-padded form parsed off the folder name. Both must group together.
+        Assert.Equal(
+            TelemetryService.DerivePlanUuid(AnonId, "00042"),
+            TelemetryService.DerivePlanUuid(AnonId, "42"));
+    }
+
+    [Fact]
+    public void DerivePlanUuid_DiffersAcrossPlans()
+    {
+        Assert.NotEqual(
+            TelemetryService.DerivePlanUuid(AnonId, "00042"),
+            TelemetryService.DerivePlanUuid(AnonId, "00043"));
+    }
+
+    [Fact]
+    public void DerivePlanUuid_DiffersAcrossInstallsForTheSamePlanId()
+    {
+        // The whole point: plan ids are a per-install counter, so "00042" exists everywhere.
+        Assert.NotEqual(
+            TelemetryService.DerivePlanUuid(AnonId, "00042"),
+            TelemetryService.DerivePlanUuid(OtherAnonId, "00042"));
+    }
+
+    [Fact]
+    public void DerivePlanUuid_ReturnsCanonicalUuidWithVersionAndVariantBits()
+    {
+        var uuid = TelemetryService.DerivePlanUuid(AnonId, "00042");
+
+        Assert.NotNull(uuid);
+        Assert.Matches("^[0-9a-f]{8}-[0-9a-f]{4}-8[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$", uuid);
+        Assert.True(Guid.TryParse(uuid, out _));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DerivePlanUuid_ReturnsNullWithoutAPlan(string? planId)
+    {
+        Assert.Null(TelemetryService.DerivePlanUuid(AnonId, planId));
+    }
+
+    [Fact]
+    public void DerivePlanUuid_ReturnsNullWhenTelemetryIsDisabled()
+    {
+        // A disabled TelemetryService has an empty distinct id.
+        Assert.Null(TelemetryService.DerivePlanUuid("", "00042"));
+    }
+
+    [Fact]
+    public void ResolvePlanId_ReadsThePlanIdPrefixForPlanScopedJobs()
+    {
+        var job = new JobItem { Type = "ExecutePlan", PlanFile = "00042-SomeTitle" };
+
+        Assert.Equal("00042", job.ResolvePlanId());
+    }
+
+    [Fact]
+    public void ResolvePlanId_FallsBackToReportedIdWhileCreatePlanStillHoldsADescription()
+    {
+        // A CreatePlan job starts with the task description in PlanFile and only acquires a
+        // folder name once VerifyCreatePlanResult runs, so the prefix parse must not match it.
+        var job = new JobItem
+        {
+            Type = "CreatePlan",
+            PlanFile = "Add a settings toggle",
+            ReportedPlanId = "00042"
+        };
+
+        Assert.Equal("00042", job.ResolvePlanId());
+    }
+
+    [Fact]
+    public void ResolvePlanId_YieldsNoPlanUuidForJobsWithNoPlan()
+    {
+        var job = new JobItem { Type = "CreatePlan", PlanFile = "Add a settings toggle" };
+
+        Assert.Equal("", job.ResolvePlanId());
+        Assert.Null(TelemetryService.DerivePlanUuid(AnonId, job.ResolvePlanId()));
+    }
+}

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -311,7 +311,7 @@ public class ProjectAgentStepView(
                | (showHeader ? Text.H3("Setting up your project") : null!)
                | Text.Muted(isCloning.Value
                    ? (progressMessage.Value ?? "Setting up your project...")
-                   : "Tendril is detecting your tech stack and configuring your agentic harness.")
+                   : "Tendril is detecting your tech stack and configuring your agentic harness. This will take a few minutes to treat yourself to a ☕ while you wait.")
                | (error.Value != null ? Text.Danger(error.Value) : null!)
                | (session.Error.Value != null ? Text.Danger(session.Error.Value) : null!)
                | (authCode.Value != null

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectInputStepView.cs
@@ -1,5 +1,6 @@
-using Ivy.Tendril.Helpers;
+﻿using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Telemetry;
 using Ivy.Tendril.Services.Jobs;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Apps.Views;
@@ -26,6 +27,7 @@ public class ProjectInputStepView(
         var tendrilArgs = UseService<TendrilArgs>();
         var jobService = UseService<IJobService>();
         var client = UseService<IClientProvider>();
+        var telemetry = UseService<ITelemetryService>();
 
         var isBeta = BetaHelper.IsBeta(tendrilArgs, config);
 
@@ -64,6 +66,7 @@ public class ProjectInputStepView(
             };
             config.Settings.Projects.Add(newProj);
             try { config.SaveSettings(); } catch { }
+            telemetry?.TrackProjectCreated(new ProjectCreatedContext(newProj.Repos.Count, newProj.StackHash));
 
             jobService?.StartJob(new AddProjectArgs(newProj.Name, newProj.Repos));
             if (client != null)

--- a/src/Ivy.Tendril/Apps/Settings/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AddProjectDialog.cs
@@ -200,7 +200,7 @@ public class AddProjectDialog(
         var title = step.Value switch
         {
             0 => "Add New Project",
-            1 => "Setting Up Project...",
+            1 => "Setting Up Project",
             2 => "Review Project Configuration",
             _ => "Add New Project"
         };

--- a/src/Ivy.Tendril/Apps/Settings/AddProjectDialog.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AddProjectDialog.cs
@@ -1,9 +1,10 @@
-using Ivy.Tendril.Apps.Onboarding;
+﻿using Ivy.Tendril.Apps.Onboarding;
 using Ivy.Tendril.Apps.Onboarding.Models;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Telemetry;
 using Ivy.Tendril.Services.Jobs;
 
 namespace Ivy.Tendril.Apps.Settings;
@@ -18,6 +19,7 @@ public class AddProjectDialog(
     public override object? Build()
     {
         var jobService = UseService<IJobService>();
+        var telemetry = UseService<ITelemetryService>();
         var step = UseState(0);
         var editName = UseState("");
         var editRepos = UseState(new List<RepoRef>());
@@ -137,6 +139,7 @@ public class AddProjectDialog(
                     };
                     config.Settings.Projects.Add(newProj);
                     try { config.SaveSettings(); } catch { }
+                    telemetry?.TrackProjectCreated(new ProjectCreatedContext(newProj.Repos.Count, newProj.StackHash));
 
                     jobService?.StartJob(new AddProjectArgs(newProj.Name, newProj.Repos));
 

--- a/src/Ivy.Tendril/Apps/Settings/AddProjectView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AddProjectView.cs
@@ -1,9 +1,10 @@
-using Ivy.Tendril.Apps.Onboarding;
+﻿using Ivy.Tendril.Apps.Onboarding;
 using Ivy.Tendril.Apps.Onboarding.Models;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Telemetry;
 using Ivy.Tendril.Services.Jobs;
 
 namespace Ivy.Tendril.Apps.Settings;
@@ -17,6 +18,7 @@ public class AddProjectView(
     public override object? Build()
     {
         var jobService = UseService<IJobService>();
+        var telemetry = UseService<ITelemetryService>();
         var step = UseState(0);
         var editName = UseState("");
         var editRepos = UseState(new List<RepoRef>());
@@ -110,6 +112,7 @@ public class AddProjectView(
                     };
                     config.Settings.Projects.Add(newProj);
                     try { config.SaveSettings(); } catch { }
+                    telemetry?.TrackProjectCreated(new ProjectCreatedContext(newProj.Repos.Count, newProj.StackHash));
 
                     jobService?.StartJob(new AddProjectArgs(newProj.Name, newProj.Repos));
 

--- a/src/Ivy.Tendril/Apps/Settings/SecuritySetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/SecuritySetupView.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using Isopoh.Cryptography.Argon2;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
@@ -25,6 +25,7 @@ public class SecuritySetupView : ViewBase
             && passwordsMatch;
 
         var form = Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+                   | new TunnelSetupView()
                    | Text.Block("Session Protection").Bold()
                    | Text.Block("Require a password to access the Tendril interface.").Muted().Small()
                    | isEnabled.ToBoolInput("Enable Password Protection")
@@ -106,8 +107,7 @@ public class SecuritySetupView : ViewBase
                            currentPassword.Set("");
                            newPassword.Set("");
                            confirmPassword.Set("");
-                       })
-                   | new TunnelSetupView();
+                       });
 
         return form;
     }

--- a/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
@@ -67,7 +67,7 @@ public class SettingsApp : ViewBase
             ("Promptwares", TagPromptwares, Icons.Wand),
             ("Levels", TagLevels, Icons.ListOrdered),
             ("Notifications", TagNotifications, Icons.Bell),
-            ("Security & Tunnel", TagSecurity, Icons.Lock),
+            ("Tunnel", TagSecurity, Icons.Lock),
             ("Advanced", TagAdvanced, Icons.Cog),
             ("Newsletter", TagNewsletter, Icons.Mail),
         };
@@ -112,7 +112,7 @@ public class SettingsApp : ViewBase
         rows.Add(SidebarListRow.Build("Promptwares", Icons.Wand, () => selected.Set(TagPromptwares), selectedTag == TagPromptwares));
         rows.Add(SidebarListRow.Build("Levels", Icons.ListOrdered, () => selected.Set(TagLevels), selectedTag == TagLevels));
         rows.Add(SidebarListRow.Build("Notifications", Icons.Bell, () => selected.Set(TagNotifications), selectedTag == TagNotifications));
-        rows.Add(SidebarListRow.Build("Security & Tunnel", Icons.Lock, () => selected.Set(TagSecurity), selectedTag == TagSecurity || selectedTag == TagTunnel));
+        rows.Add(SidebarListRow.Build("Tunnel", Icons.Lock, () => selected.Set(TagSecurity), selectedTag == TagSecurity || selectedTag == TagTunnel));
         rows.Add(SidebarListRow.Build("Advanced", Icons.Cog, () => selected.Set(TagAdvanced), selectedTag == TagAdvanced));
         rows.Add(SidebarListRow.Build("Newsletter", Icons.Mail, () => selected.Set(TagNewsletter), selectedTag == TagNewsletter));
         rows.Add(SidebarListRow.Build("Open config.yaml", Icons.FileText, () => ConfigYamlUiHelper.OpenOrNavigate(config, navigator, client, isDesktop, capturedHost), false));

--- a/src/Ivy.Tendril/Commands/ProjectCommand.cs
+++ b/src/Ivy.Tendril/Commands/ProjectCommand.cs
@@ -1,6 +1,7 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Telemetry;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -579,8 +580,31 @@ public class ProjectAddCommand : Command<ProjectAddSettings>
             });
         });
 
+        TrackProjectCreated(config);
+
         Console.WriteLine($"Added project: {settings.Name}");
         return 0;
+    }
+
+    /// <summary>
+    ///     The CLI runs out-of-process with no DI graph, so it builds and flushes its own client.
+    ///     The wait is bounded because this command is usually invoked by the AddProject promptware
+    ///     from inside an agent run, where a hung flush would stall the job.
+    /// </summary>
+    private static void TrackProjectCreated(ConfigService config)
+    {
+        try
+        {
+            var telemetry = new TelemetryService(config.Settings.Telemetry);
+            // A CLI-created project has no repos yet — they are attached by `project add-repo`.
+            telemetry.TrackProjectCreated(new ProjectCreatedContext(RepoCount: 0));
+            Task.WhenAny(telemetry.FlushAsync(), Task.Delay(TimeSpan.FromSeconds(2)))
+                .GetAwaiter().GetResult();
+        }
+        catch
+        {
+            // Telemetry must never fail the command.
+        }
     }
 }
 

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -182,31 +182,43 @@ internal class JobCompletionHandler
         if (isSuccess)
             TrackSuccessTelemetry(job);
 
-        _telemetryService?.TrackJobCompleted(job.Type, job.Status, job.DurationSeconds, job.Provider);
+        _telemetryService?.TrackJobCompleted(job.Type, job.Status, job.DurationSeconds, job.Provider,
+            job.ResolvePlanId());
         FlushTelemetryAsync();
     }
 
     private void TrackSuccessTelemetry(JobItem job)
     {
-        if (job.TypedArgs is CreatePlanArgs)
+        if (job.TypedArgs is CreatePlanArgs createPlanArgs)
         {
-            var planFolder = job.TypedArgs?.PlanFolder ?? "";
+            // CreatePlanArgs has no PlanFolder — the folder does not exist yet when the job starts.
+            // VerifyCreatePlanResult (which runs earlier in HandleCompletion) records the resolved
+            // folder *name* in job.PlanFile, so resolve it against the plans directory here.
+            var plansDir = _planReaderService?.PlansDirectory;
+            var planFolder = !string.IsNullOrEmpty(plansDir) && !string.IsNullOrEmpty(job.PlanFile)
+                ? Path.Combine(plansDir, job.PlanFile)
+                : "";
+
             var level = "Feature";
-            string? stackHash = null;
+            // Fall back to the project the job was queued for, so stack_hash still lands even when
+            // the plan folder cannot be resolved.
+            var stackHash = _configService?.GetProject(createPlanArgs.Project)?.StackHash;
             if (Directory.Exists(planFolder))
             {
                 var plan = PlanYamlHelper.ReadPlanYaml(planFolder);
                 if (plan != null)
                 {
                     level = plan.Level;
-                    stackHash = _configService?.GetProject(plan.Project)?.StackHash;
+                    stackHash = _configService?.GetProject(plan.Project)?.StackHash ?? stackHash;
                 }
             }
-            _telemetryService?.TrackPlanCreated(new PlanCreatedContext(level, job.DurationSeconds, job.Provider, stackHash));
+            _telemetryService?.TrackPlanCreated(new PlanCreatedContext(level, job.DurationSeconds, job.Provider,
+                stackHash, job.ResolvePlanId()));
         }
         else if (job.TypedArgs is CreatePrArgs)
         {
-            _telemetryService?.TrackPrCreated(new PrCreatedContext(job.DurationSeconds, job.Provider));
+            _telemetryService?.TrackPrCreated(new PrCreatedContext(job.DurationSeconds, job.Provider,
+                job.ResolvePlanId()));
         }
     }
 

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
@@ -939,6 +939,10 @@ public class JobService : IJobService
         // Persist while in flight, not just on completion: the agent reports status over HTTP and
         // must still be resolvable if the master restarts mid-job (#1759).
         PersistJob(job);
+
+        // Tracked here rather than at launch: the job is queued from this point on, even if it
+        // goes straight to Blocked below. Not flushed — job_completed flushes the batch later.
+        _telemetryService?.TrackJobCreated(new JobCreatedContext(job.Type, job.Provider, job.ResolvePlanId()));
 
         if (TryBlockForDependencies(job, skipDependencyCheck))
         {

--- a/src/Ivy.Tendril/Services/OnboardingSetupService.cs
+++ b/src/Ivy.Tendril/Services/OnboardingSetupService.cs
@@ -1,5 +1,6 @@
-using Ivy.Tendril.Agents.Abstractions;
+﻿using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services.Telemetry;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Services;
@@ -7,6 +8,12 @@ namespace Ivy.Tendril.Services;
 public class OnboardingSetupService(IConfigService config, IAgentRunner agentRunner, IServiceProvider services, ILogger<OnboardingSetupService> logger) : IOnboardingSetupService
 {
     private readonly ILogger<OnboardingSetupService> _logger = logger;
+
+    /// <summary>
+    ///     Resolved lazily rather than injected: onboarding runs before TendrilHome exists, and
+    ///     several services in the graph throw when constructed in that state.
+    /// </summary>
+    private ITelemetryService? Telemetry => services?.GetService(typeof(ITelemetryService)) as ITelemetryService;
 
     public async Task BootstrapTendrilHomeAsync(string tendrilHome)
     {
@@ -121,6 +128,8 @@ public class OnboardingSetupService(IConfigService config, IAgentRunner agentRun
             config.Settings.Projects.Add(pendingProject);
             config.SaveSettings();
             _logger.LogInformation("Pending project '{Name}' committed", pendingProject.Name);
+            Telemetry?.TrackProjectCreated(
+                new ProjectCreatedContext(pendingProject.Repos.Count, pendingProject.StackHash));
         }
 
         return Task.CompletedTask;
@@ -138,6 +147,15 @@ public class OnboardingSetupService(IConfigService config, IAgentRunner agentRun
         await CommitPendingProjectAsync();
 
         _logger.LogInformation("Configuration saved");
+
+        var telemetry = Telemetry;
+        if (telemetry != null)
+        {
+            telemetry.TrackOnboardingCompleted(
+                new OnboardingCompletedContext(config.Settings.Projects.Count, config.Settings.CodingAgent));
+            // Onboarding is often followed by a restart, so this event must not sit in the batch.
+            await telemetry.FlushAsync();
+        }
     }
 
     public Task RemoveProjectVerificationAsync(string projectName, string verificationName)

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text.RegularExpressions;
 using Ivy.Helpers;
 using Ivy.Tendril.Helpers;
@@ -205,7 +205,7 @@ public class PlanReaderService(
         {
             var currentPlan = GetPlanByFolder(Path.Combine(PlansDirectory, folderName));
             var oldState = currentPlan?.Status.ToString() ?? "Unknown";
-            telemetryService?.TrackPlanStateTransition(oldState, newState.ToString());
+            telemetryService?.TrackPlanStateTransition(oldState, newState.ToString(), planId.Value.ToString());
 
             // Flush telemetry events to ensure they reach PostHog
             if (telemetryService != null)
@@ -771,7 +771,8 @@ public class PlanReaderService(
         {
             var currentPlan = GetPlanByFolder(Path.Combine(PlansDirectory, folderName));
             var oldState = currentPlan?.Status.ToString() ?? "Unknown";
-            telemetryService?.TrackPlanStateTransition(oldState, PlanStatus.Executing.ToString());
+            telemetryService?.TrackPlanStateTransition(oldState, PlanStatus.Executing.ToString(),
+                planId.Value.ToString());
         }
 
         // Update database atomically for all three mutations.
@@ -827,7 +828,8 @@ public class PlanReaderService(
         {
             var currentPlan = GetPlanByFolder(Path.Combine(PlansDirectory, folderName));
             var oldState = currentPlan?.Status.ToString() ?? "Unknown";
-            telemetryService?.TrackPlanStateTransition(oldState, PlanStatus.Executing.ToString());
+            telemetryService?.TrackPlanStateTransition(oldState, PlanStatus.Executing.ToString(),
+                planId.Value.ToString());
         }
 
         // Update database atomically for all mutations.

--- a/src/Ivy.Tendril/Services/Telemetry/ITelemetryService.cs
+++ b/src/Ivy.Tendril/Services/Telemetry/ITelemetryService.cs
@@ -1,4 +1,4 @@
-using Ivy.Tendril.Apps.Jobs;
+﻿using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Models;
 
 namespace Ivy.Tendril.Services.Telemetry;
@@ -7,10 +7,14 @@ public interface ITelemetryService
 {
     string AnonymousId { get; }
     void TrackAppStarted(AppStartContext context);
+    void TrackOnboardingCompleted(OnboardingCompletedContext context);
+    void TrackProjectCreated(ProjectCreatedContext context);
     void TrackPlanCreated(PlanCreatedContext context);
+    void TrackJobCreated(JobCreatedContext context);
     void TrackPrCreated(PrCreatedContext context);
-    void TrackJobCompleted(string jobType, JobStatus status, int? durationSeconds, string? agent = null);
-    void TrackPlanStateTransition(string fromState, string toState);
+    void TrackJobCompleted(string jobType, JobStatus status, int? durationSeconds, string? agent = null,
+        string? planId = null);
+    void TrackPlanStateTransition(string fromState, string toState, string? planId = null);
     Task IdentifyAsync(string appVersion);
     Task FlushAsync();
 }
@@ -20,12 +24,31 @@ public record AppStartContext(
     int ProjectCount,
     bool LlmConfigured);
 
+public record OnboardingCompletedContext(
+    int ProjectCount,
+    string? Agent = null);
+
+/// <param name="StackHash">
+///     Usually null: SetupProject assigns the stack hash after the project exists, so it is only
+///     populated here when a project is created from an already-analyzed configuration.
+/// </param>
+public record ProjectCreatedContext(
+    int RepoCount,
+    string? StackHash = null);
+
+public record JobCreatedContext(
+    string JobType,
+    string? Agent = null,
+    string? PlanId = null);
+
 public record PlanCreatedContext(
     string Level,
     int? DurationSeconds,
     string? Agent = null,
-    string? StackHash = null);
+    string? StackHash = null,
+    string? PlanId = null);
 
 public record PrCreatedContext(
     int? DurationSeconds,
-    string? Agent = null);
+    string? Agent = null,
+    string? PlanId = null);

--- a/src/Ivy.Tendril/Services/Telemetry/TelemetryService.cs
+++ b/src/Ivy.Tendril/Services/Telemetry/TelemetryService.cs
@@ -1,3 +1,5 @@
+﻿using System.Security.Cryptography;
+using System.Text;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Models;
@@ -114,6 +116,61 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
         }
     }
 
+    public void TrackOnboardingCompleted(OnboardingCompletedContext context)
+    {
+        try
+        {
+            var properties = new Dictionary<string, object>
+            {
+                ["project_count"] = context.ProjectCount
+            };
+            if (context.Agent != null) properties["agent"] = context.Agent;
+            _client?.Capture(_distinctId, "onboarding_completed", properties);
+            _logger?.LogDebug("Tracked onboarding_completed event");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to track onboarding_completed event");
+        }
+    }
+
+    public void TrackProjectCreated(ProjectCreatedContext context)
+    {
+        try
+        {
+            var properties = new Dictionary<string, object>
+            {
+                ["repo_count"] = context.RepoCount
+            };
+            if (context.StackHash != null) properties["stack_hash"] = context.StackHash;
+            _client?.Capture(_distinctId, "project_created", properties);
+            _logger?.LogDebug("Tracked project_created event");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to track project_created event");
+        }
+    }
+
+    public void TrackJobCreated(JobCreatedContext context)
+    {
+        try
+        {
+            var properties = new Dictionary<string, object>
+            {
+                ["job_type"] = context.JobType
+            };
+            if (context.Agent != null) properties["agent"] = context.Agent;
+            AddPlanUuid(properties, context.PlanId);
+            _client?.Capture(_distinctId, "job_created", properties);
+            _logger?.LogDebug("Tracked job_created event: {JobType}", context.JobType);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to track job_created event");
+        }
+    }
+
     public void TrackPlanCreated(PlanCreatedContext context)
     {
         try
@@ -125,6 +182,7 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
             };
             if (context.Agent != null) properties["agent"] = context.Agent;
             if (context.StackHash != null) properties["stack_hash"] = context.StackHash;
+            AddPlanUuid(properties, context.PlanId);
             _client?.Capture(_distinctId, "plan_created", properties);
             _logger?.LogDebug("Tracked plan_created event");
         }
@@ -143,6 +201,7 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
                 ["duration_seconds"] = context.DurationSeconds ?? 0
             };
             if (context.Agent != null) properties["agent"] = context.Agent;
+            AddPlanUuid(properties, context.PlanId);
             _client?.Capture(_distinctId, "pr_created", properties);
             _logger?.LogDebug("Tracked pr_created event");
         }
@@ -152,7 +211,8 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
         }
     }
 
-    public void TrackJobCompleted(string jobType, JobStatus status, int? durationSeconds, string? agent = null)
+    public void TrackJobCompleted(string jobType, JobStatus status, int? durationSeconds, string? agent = null,
+        string? planId = null)
     {
         try
         {
@@ -163,6 +223,7 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
                 ["duration_seconds"] = durationSeconds ?? 0
             };
             if (agent != null) properties["agent"] = agent;
+            AddPlanUuid(properties, planId);
             _client?.Capture(_distinctId, "job_completed", properties);
             _logger?.LogDebug("Tracked job_completed event: {JobType} - {Status}", jobType, status);
         }
@@ -172,21 +233,54 @@ public class TelemetryService : ITelemetryService, IAsyncDisposable
         }
     }
 
-    public void TrackPlanStateTransition(string fromState, string toState)
+    public void TrackPlanStateTransition(string fromState, string toState, string? planId = null)
     {
         try
         {
-            _client?.Capture(_distinctId, "plan_state_transition", new Dictionary<string, object>
+            var properties = new Dictionary<string, object>
             {
                 ["from_state"] = fromState,
                 ["to_state"] = toState
-            });
+            };
+            AddPlanUuid(properties, planId);
+            _client?.Capture(_distinctId, "plan_state_transition", properties);
             _logger?.LogDebug("Tracked plan_state_transition event: {FromState} -> {ToState}", fromState, toState);
         }
         catch (Exception ex)
         {
             _logger?.LogError(ex, "Failed to track plan_state_transition event");
         }
+    }
+
+    private void AddPlanUuid(Dictionary<string, object> properties, string? planId)
+    {
+        var planUuid = DerivePlanUuid(_distinctId, planId);
+        if (planUuid != null) properties["plan_uuid"] = planUuid;
+    }
+
+    /// <summary>
+    ///     Stable, globally unique identifier for a plan, used to group its events in PostHog.
+    ///     Plan ids are a per-install sequential counter (see PlanYamlHelper.AllocatePlanId), so
+    ///     "00042" exists on every install and would merge unrelated users' plans. Hashing it with
+    ///     the anonymous id makes it unique per install and one-way, so the raw counter never
+    ///     leaves the machine. Ids are normalized to D5 first so the int-shaped form (42) taken
+    ///     from the database and the folder-shaped form ("00042") derive the same value.
+    /// </summary>
+    /// <returns>A canonical UUID string, or null when there is no plan or no anonymous id.</returns>
+    internal static string? DerivePlanUuid(string distinctId, string? planId)
+    {
+        if (string.IsNullOrWhiteSpace(planId) || string.IsNullOrEmpty(distinctId)) return null;
+
+        var trimmed = planId.Trim();
+        var normalized = int.TryParse(trimmed, out var n) ? n.ToString("D5") : trimmed;
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes($"tendril-plan:{distinctId}:{normalized}"));
+
+        var bytes = hash[..16];
+        bytes[6] = (byte)((bytes[6] & 0x0F) | 0x80); // RFC 9562 version 8 (custom)
+        bytes[8] = (byte)((bytes[8] & 0x3F) | 0x80); // RFC 9562 variant
+
+        var hex = Convert.ToHexString(bytes).ToLowerInvariant();
+        return $"{hex[..8]}-{hex[8..12]}-{hex[12..16]}-{hex[16..20]}-{hex[20..]}";
     }
 
     public async Task FlushAsync()


### PR DESCRIPTION
## Fix: `stack_hash` was never reaching PostHog

`CreatePlanArgs` is the one plan-job args record with no `PlanFolder` override — the folder doesn't exist when the job is queued — so `TrackSuccessTelemetry` read `""`, `Directory.Exists("")` was always false, and `plan.yaml` was never opened. `stack_hash` was therefore never sent, and `level` was always the hardcoded `"Feature"`.

Now resolved from `job.PlanFile`, which `VerifyCreatePlanResult` records earlier in `HandleCompletion`, with a fallback to the queued project so `stack_hash` still lands when the folder can't be resolved.

**Historical data won't backfill** — existing `plan_created` events lack `stack_hash` and all report `level: Feature`. Filter dashboards to events after this ships.

## New: `plan_uuid` for grouping a plan's events

Plan ids are a per-install sequential counter (`PlanYamlHelper.AllocatePlanId`), so `00042` exists on every install and can't be sent as-is. `plan_uuid` is a SHA-256 of the anonymous id + plan id, stamped with RFC 9562 version 8 / variant bits — globally unique, one-way, and the raw counter never leaves the machine.

Ids are normalized to `D5` first, so the int form from the database (`42`) and the folder-name form (`"00042"`) derive the same UUID. Without that the grouping would silently split.

Added to `plan_created`, `pr_created`, `job_completed`, `plan_state_transition`, and `job_created`.

## New events

| Event | Properties |
|---|---|
| `onboarding_completed` | `project_count`, `agent` |
| `project_created` | `repo_count`, `stack_hash` |
| `job_created` | `job_type`, `agent`, `plan_uuid` |

`project_created` fires from all four in-app creation paths plus the CLI. The CLI runs out-of-process with no DI, so it builds and flushes its own client with a 2s bounded wait — the AddProject promptware invokes it from inside an agent run, where a hung flush would stall the job. `onboarding_completed` flushes immediately (onboarding is often followed by a restart); `job_created` deliberately does not (high volume, `job_completed` flushes the batch).

### ⚠️ `project_created.stack_hash` will be null in practice

`SetupProject` assigns `stackHash` *after* the project exists, via `tendril project set <name> stackHash <hash>`. The property is wired but won't populate today. If the goal is "what stacks do our users run", the event worth adding next is one fired from `ProjectSetCommand` when the field is written.

## Tests

12 new tests in `TelemetryPlanUuidTests.cs` covering UUID stability, int/zero-padded equivalence, distinctness across plans and installs, canonical shape, and null cases.

Full suite: 2329 passed, 1 skipped. (`PromptwareDeployerTests.CreatePrProgram_UsesUniqueTempFileForPrBody` fails only when built to a redirected output directory — it locates its fixture by walking up from `AppContext.BaseDirectory`. Unrelated to these changes.)

Also carries a pre-existing unpushed local commit, `9040aeba "Copy fixes"`.
