### PR TITLE
[00002] Remove Spaces from Configuration Enum Encodings

### DIFF
--- a/src/Ivy.Tendril.TeamIvyConfig/config.yaml
+++ b/src/Ivy.Tendril.TeamIvyConfig/config.yaml
@@ -46,9 +46,9 @@ projects:
   skills: []
   securityPreset: Custom
   outsideFileAccessPolicy: Allow
-  terminalAutoExecution: Always Proceed
-  sandboxMode: Inherit General
-  autoImplementPlans: Always Ask Review
+  terminalAutoExecution: AlwaysProceed
+  sandboxMode: InheritGeneral
+  autoImplementPlans: AlwaysAskReview
   filePermissions: []
   networkAccessRules: []
   allowedTerminalCommands: []
@@ -87,9 +87,9 @@ projects:
   skills: []
   securityPreset: Custom
   outsideFileAccessPolicy: Allow
-  terminalAutoExecution: Always Proceed
-  sandboxMode: Inherit General
-  autoImplementPlans: Inherit General
+  terminalAutoExecution: AlwaysProceed
+  sandboxMode: InheritGeneral
+  autoImplementPlans: InheritGeneral
   filePermissions: []
   networkAccessRules: []
   allowedTerminalCommands: []
@@ -127,9 +127,9 @@ projects:
   skills: []
   securityPreset: Custom
   outsideFileAccessPolicy: Allow
-  terminalAutoExecution: Always Proceed
-  sandboxMode: Inherit General
-  autoImplementPlans: Inherit General
+  terminalAutoExecution: AlwaysProceed
+  sandboxMode: InheritGeneral
+  autoImplementPlans: InheritGeneral
   filePermissions: []
   networkAccessRules: []
   allowedTerminalCommands: []
@@ -159,9 +159,9 @@ projects:
   skills: []
   securityPreset: Custom
   outsideFileAccessPolicy: Allow
-  terminalAutoExecution: Always Proceed
-  sandboxMode: Inherit General
-  autoImplementPlans: Inherit General
+  terminalAutoExecution: AlwaysProceed
+  sandboxMode: InheritGeneral
+  autoImplementPlans: InheritGeneral
   filePermissions: []
   networkAccessRules: []
   allowedTerminalCommands: []
@@ -195,9 +195,9 @@ projects:
   skills: []
   securityPreset: Custom
   outsideFileAccessPolicy: Allow
-  terminalAutoExecution: Always Proceed
-  sandboxMode: Inherit General
-  autoImplementPlans: Inherit General
+  terminalAutoExecution: AlwaysProceed
+  sandboxMode: InheritGeneral
+  autoImplementPlans: InheritGeneral
   filePermissions: []
   networkAccessRules: []
   allowedTerminalCommands: []
@@ -235,9 +235,9 @@ projects:
   skills: []
   securityPreset: Custom
   outsideFileAccessPolicy: Allow
-  terminalAutoExecution: Always Proceed
-  sandboxMode: Inherit General
-  autoImplementPlans: Inherit General
+  terminalAutoExecution: AlwaysProceed
+  sandboxMode: InheritGeneral
+  autoImplementPlans: InheritGeneral
   filePermissions: []
   networkAccessRules: []
   allowedTerminalCommands: []
@@ -278,9 +278,9 @@ projects:
   skills: []
   securityPreset: Custom
   outsideFileAccessPolicy: Allow
-  terminalAutoExecution: Always Proceed
-  sandboxMode: Inherit General
-  autoImplementPlans: Inherit General
+  terminalAutoExecution: AlwaysProceed
+  sandboxMode: InheritGeneral
+  autoImplementPlans: InheritGeneral
   filePermissions: []
   networkAccessRules: []
   allowedTerminalCommands: []

--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1981,4 +1981,146 @@ sidebarOpen: false
             Directory.Delete(tempDir, true);
         }
     }
+
+    [Theory]
+    [InlineData("Always Proceed", "AlwaysProceed")]
+    [InlineData("Inherit General", "InheritGeneral")]
+    [InlineData("Always Ask", "AlwaysAsk")]
+    [InlineData("AlwaysProceed", "AlwaysProceed")]
+    [InlineData("", "AlwaysProceed")]
+    [InlineData(null, "AlwaysProceed")]
+    public void MigrateTerminalAutoExecution_HandlesVariousInputs(string? input, string expected)
+    {
+        var result = ConfigService.MigrateTerminalAutoExecution(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("Inherit General", "InheritGeneral")]
+    [InlineData("InheritGeneral", "InheritGeneral")]
+    [InlineData("Disabled", "Disabled")]
+    [InlineData("Enabled", "Enabled")]
+    [InlineData("", "InheritGeneral")]
+    [InlineData(null, "InheritGeneral")]
+    public void MigrateSandboxMode_HandlesVariousInputs(string? input, string expected)
+    {
+        var result = ConfigService.MigrateSandboxMode(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("Auto-Implement Plans", "AutoImplementPlans")]
+    [InlineData("Auto Implement Plans", "AutoImplementPlans")]
+    [InlineData("Auto-implement plans", "AutoImplementPlans")]
+    [InlineData("Always Ask Review", "AlwaysAskReview")]
+    [InlineData("Always Ask", "AlwaysAskReview")]
+    [InlineData("Inherit General", "InheritGeneral")]
+    [InlineData("AutoImplementPlans", "AutoImplementPlans")]
+    [InlineData("AlwaysAskReview", "AlwaysAskReview")]
+    [InlineData("InheritGeneral", "InheritGeneral")]
+    [InlineData("", "InheritGeneral")]
+    [InlineData(null, "InheritGeneral")]
+    public void MigrateAutoImplementPlans_HandlesVariousInputs(string? input, string expected)
+    {
+        var result = ConfigService.MigrateAutoImplementPlans(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Should_Normalize_Legacy_Space_Separated_Enum_Values_On_Load()
+    {
+        var yaml = @"
+projects:
+  - name: LegacyProject
+    terminalAutoExecution: Always Proceed
+    sandboxMode: Inherit General
+    autoImplementPlans: Always Ask Review
+    repos: []
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            Assert.NotNull(service.Settings);
+            Assert.Single(service.Settings.Projects);
+
+            var project = service.Settings.Projects[0];
+            Assert.Equal("AlwaysProceed", project.TerminalAutoExecution);
+            Assert.Equal("InheritGeneral", project.SandboxMode);
+            Assert.Equal("AlwaysAskReview", project.AutoImplementPlans);
+
+            var savedYaml = File.ReadAllText(Path.Combine(tempDir, "config.yaml"));
+            Assert.Contains("terminalAutoExecution: AlwaysProceed", savedYaml);
+            Assert.Contains("sandboxMode: InheritGeneral", savedYaml);
+            Assert.Contains("autoImplementPlans: AlwaysAskReview", savedYaml);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Should_Normalize_AutoImplementPlans_Legacy_Variations_On_Load()
+    {
+        var yaml = @"
+projects:
+  - name: AutoProject
+    autoImplementPlans: Auto-Implement Plans
+    repos: []
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        var service = new ConfigService(new TendrilSettings());
+
+        try
+        {
+            service.SetTendrilHome(tempDir);
+
+            Assert.NotNull(service.Settings);
+            var project = service.Settings.Projects[0];
+            Assert.Equal("AutoImplementPlans", project.AutoImplementPlans);
+
+            var savedYaml = File.ReadAllText(Path.Combine(tempDir, "config.yaml"));
+            Assert.Contains("autoImplementPlans: AutoImplementPlans", savedYaml);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void Should_Serialize_And_Deserialize_ProjectConfig_With_SpaceFree_Enum_Values()
+    {
+        var settings = new TendrilSettings
+        {
+            Projects = new List<ProjectConfig>
+            {
+                new()
+                {
+                    Name = "ModernProject",
+                    TerminalAutoExecution = "AlwaysProceed",
+                    SandboxMode = "InheritGeneral",
+                    AutoImplementPlans = "AutoImplementPlans"
+                }
+            }
+        };
+
+        var yaml = YamlHelper.SerializerCompact.Serialize(settings);
+        Assert.Contains("terminalAutoExecution: AlwaysProceed", yaml);
+        Assert.Contains("sandboxMode: InheritGeneral", yaml);
+        Assert.Contains("autoImplementPlans: AutoImplementPlans", yaml);
+
+        var deserialized = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml);
+        Assert.NotNull(deserialized);
+        Assert.Single(deserialized.Projects);
+        var project = deserialized.Projects[0];
+        Assert.Equal("AlwaysProceed", project.TerminalAutoExecution);
+        Assert.Equal("InheritGeneral", project.SandboxMode);
+        Assert.Equal("AutoImplementPlans", project.AutoImplementPlans);
+    }
 }
+

--- a/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
@@ -30,7 +30,11 @@ public class ProjectDetailView(
         var projectColor = UseState<Colors?>(() => projectIndex >= 0 && projectIndex < config.Settings.Projects.Count && Enum.TryParse<Colors>(config.Settings.Projects[projectIndex].Color, true, out var c) ? c : Colors.Slate);
 
         // Agent Behavior State
-        var autoImplement = UseState(() => projectIndex >= 0 && projectIndex < config.Settings.Projects.Count ? (config.Settings.Projects[projectIndex].AutoImplementPlans == "Auto-Implement Plans" ? "Auto-Implement Plans" : "Always Ask Review") : "Always Ask Review");
+        var autoImplement = UseState(() => projectIndex >= 0 && projectIndex < config.Settings.Projects.Count
+            ? (config.Settings.Projects[projectIndex].AutoImplementPlans is "AutoImplementPlans" or "Auto-Implement Plans"
+                ? "AutoImplementPlans"
+                : "AlwaysAskReview")
+            : "AlwaysAskReview");
 
         // Repositories State
         var repos = UseState(() => projectIndex >= 0 && projectIndex < config.Settings.Projects.Count ? new List<RepoRef>(config.Settings.Projects[projectIndex].Repos) : new List<RepoRef>());
@@ -221,7 +225,12 @@ public class ProjectDetailView(
                | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Rename Project").OnClick(() => isEditingName.Set(true)));
 
         // Agent Behavior Dropdown
-        var autoImplementSelect = autoImplement.ToSelectInput(new[] { "Auto-Implement Plans", "Always Ask Review" })
+        var autoImplementOptions = new[]
+        {
+            new Option<string>("Auto-Implement Plans", "AutoImplementPlans"),
+            new Option<string>("Always Ask Review", "AlwaysAskReview")
+        };
+        var autoImplementSelect = autoImplement.ToSelectInput(autoImplementOptions)
             .WithField().Label("Artifact Review / Auto-Implement Policy");
 
         Func<RepoRef, Task<RepoRef?>> cloneRemoteOnAdd = async draft =>

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -68,9 +68,9 @@ public record ProjectConfig
 
     public string SecurityPreset { get; set; } = "Custom";
     public string OutsideFileAccessPolicy { get; set; } = "Allow";
-    public string TerminalAutoExecution { get; set; } = "Always Proceed";
-    public string SandboxMode { get; set; } = "Inherit General";
-    public string AutoImplementPlans { get; set; } = "Inherit General";
+    public string TerminalAutoExecution { get; set; } = "AlwaysProceed";
+    public string SandboxMode { get; set; } = "InheritGeneral";
+    public string AutoImplementPlans { get; set; } = "InheritGeneral";
 
     public List<FileAccessRuleConfig> FilePermissions { get; set; } = new();
     public List<NetworkAccessRuleConfig> NetworkAccessRules { get; set; } = new();
@@ -369,6 +369,7 @@ public class ConfigService : IConfigService, IDisposable
 
             MigrateProjectColors();
             MigrateLevelColors();
+            MigrateProjectEnumEncodings();
             CreateConfigBackup();
 
             return (true, settings);
@@ -399,6 +400,9 @@ public class ConfigService : IConfigService, IDisposable
     private void FinalizeConfiguration()
     {
         ValidateSettings();
+        MigrateProjectColors();
+        MigrateLevelColors();
+        MigrateProjectEnumEncodings();
         VariableExpansion.InitializeUserSecrets(_logger);
         ExpandSettingsVariables();
         ExpandRepoPaths();
@@ -654,6 +658,7 @@ public class ConfigService : IConfigService, IDisposable
             ValidateSettings();
             MigrateProjectColors();
             MigrateLevelColors();
+            MigrateProjectEnumEncodings();
             _levelNamesCache = null;
             VariableExpansion.InitializeUserSecrets(_logger);
             ExpandSettingsVariables();
@@ -828,6 +833,7 @@ public class ConfigService : IConfigService, IDisposable
                     Settings = restored;
                     MigrateProjectColors();
                     MigrateLevelColors();
+                    MigrateProjectEnumEncodings();
                     VariableExpansion.InitializeUserSecrets(_logger);
                     ExpandSettingsVariables();
                     ExpandRepoPaths();
@@ -871,6 +877,7 @@ public class ConfigService : IConfigService, IDisposable
             Settings = YamlHelper.Deserializer.Deserialize<TendrilSettings>(yaml) ?? new TendrilSettings();
             MigrateProjectColors();
             MigrateLevelColors();
+            MigrateProjectEnumEncodings();
             CreateConfigBackup();
             ParseError = null;
             NeedsOnboarding = false;
@@ -1031,6 +1038,92 @@ public class ConfigService : IConfigService, IDisposable
         }
     }
 
+    internal static string MigrateTerminalAutoExecution(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return "AlwaysProceed";
+        return value.Trim() switch
+        {
+            "Always Proceed" => "AlwaysProceed",
+            "Inherit General" => "InheritGeneral",
+            "Always Ask" => "AlwaysAsk",
+            var s when s.Replace(" ", "") is var cleaned && (cleaned == "AlwaysProceed" || cleaned == "InheritGeneral" || cleaned == "AlwaysAsk") => cleaned,
+            _ => value.Replace(" ", "")
+        };
+    }
+
+    internal static string MigrateSandboxMode(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return "InheritGeneral";
+        return value.Trim() switch
+        {
+            "Inherit General" => "InheritGeneral",
+            var s when s.Replace(" ", "") is var cleaned && (cleaned == "InheritGeneral" || cleaned == "Disabled" || cleaned == "Enabled") => cleaned,
+            _ => value.Replace(" ", "")
+        };
+    }
+
+    internal static string MigrateAutoImplementPlans(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return "InheritGeneral";
+        return value.Trim() switch
+        {
+            "Auto-Implement Plans" or "Auto Implement Plans" or "Auto-implement plans" => "AutoImplementPlans",
+            "Always Ask Review" or "Always Ask" => "AlwaysAskReview",
+            "Inherit General" => "InheritGeneral",
+            var s when s.Replace("-", "").Replace(" ", "") is var cleaned && (cleaned == "AutoImplementPlans" || cleaned == "AlwaysAskReview" || cleaned == "InheritGeneral") => cleaned,
+            _ => value.Replace("-", "").Replace(" ", "")
+        };
+    }
+
+    internal static bool NormalizeProjectEnumEncodings(ProjectConfig project)
+    {
+        if (project == null) return false;
+        var changed = false;
+
+        var term = MigrateTerminalAutoExecution(project.TerminalAutoExecution);
+        if (term != project.TerminalAutoExecution)
+        {
+            project.TerminalAutoExecution = term;
+            changed = true;
+        }
+
+        var sandbox = MigrateSandboxMode(project.SandboxMode);
+        if (sandbox != project.SandboxMode)
+        {
+            project.SandboxMode = sandbox;
+            changed = true;
+        }
+
+        var autoImpl = MigrateAutoImplementPlans(project.AutoImplementPlans);
+        if (autoImpl != project.AutoImplementPlans)
+        {
+            project.AutoImplementPlans = autoImpl;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    private void MigrateProjectEnumEncodings()
+    {
+        if (Settings?.Projects == null) return;
+
+        var needsSave = false;
+        foreach (var project in Settings.Projects)
+        {
+            if (NormalizeProjectEnumEncodings(project))
+            {
+                needsSave = true;
+            }
+        }
+
+        if (needsSave && File.Exists(ConfigPath))
+        {
+            var yaml = YamlHelper.SerializerCompact.Serialize(Settings);
+            FileHelper.WriteAllText(ConfigPath, yaml);
+        }
+    }
+
     internal void SetTendrilHome(string tendrilHome)
     {
         TendrilHome = tendrilHome;
@@ -1061,6 +1154,7 @@ public class ConfigService : IConfigService, IDisposable
         ValidateSettings();
         MigrateProjectColors();
         MigrateLevelColors();
+        MigrateProjectEnumEncodings();
         _levelNamesCache = null;
         VariableExpansion.InitializeUserSecrets(_logger);
         ExpandSettingsVariables();

--- a/src/Ivy.Tendril/Services/Vault/VaultModels.cs
+++ b/src/Ivy.Tendril/Services/Vault/VaultModels.cs
@@ -55,9 +55,9 @@ public record VaultProjectManifest
 
     public string SecurityPreset { get; set; } = "Custom";
     public string OutsideFileAccessPolicy { get; set; } = "Allow";
-    public string TerminalAutoExecution { get; set; } = "Always Proceed";
-    public string SandboxMode { get; set; } = "Inherit General";
-    public string AutoImplementPlans { get; set; } = "Inherit General";
+    public string TerminalAutoExecution { get; set; } = "AlwaysProceed";
+    public string SandboxMode { get; set; } = "InheritGeneral";
+    public string AutoImplementPlans { get; set; } = "InheritGeneral";
 }
 
 public record VaultPermissionsManifest
@@ -66,8 +66,8 @@ public record VaultPermissionsManifest
     public List<NetworkAccessRuleConfig> NetworkAccessRules { get; set; } = new();
     public List<string> AllowedTerminalCommands { get; set; } = new();
     public string OutsideFileAccessPolicy { get; set; } = "Allow";
-    public string TerminalAutoExecution { get; set; } = "Always Proceed";
-    public string SandboxMode { get; set; } = "Inherit General";
+    public string TerminalAutoExecution { get; set; } = "AlwaysProceed";
+    public string SandboxMode { get; set; } = "InheritGeneral";
 }
 
 public record VaultCatalogItem


### PR DESCRIPTION
Fixes #2162

# Summary

## Changes

Updated project configuration enum encodings to use space-free identifiers (`AlwaysProceed`, `InheritGeneral`, `AutoImplementPlans`, `AlwaysAskReview`) across models, YAML files, and UI dropdowns. Added backward-compatible loading and migration in `ConfigService` to normalize legacy configurations containing spaces and persist the clean representation.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Services/ConfigService.cs` - Updated default property encodings and added normalization and migration logic for enum values.
- `src/Ivy.Tendril/Services/Vault/VaultModels.cs` - Updated default property encodings for vault manifests.
- `src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs` - Updated auto-implement select input options and state binding to use space-free strings.
- `src/Ivy.Tendril.TeamIvyConfig/config.yaml` - Normalized enum encodings across all project configuration entries.
- `src/Ivy.Tendril.Test/ConfigServiceTests.cs` - Added unit tests for serialization, deserialization, migration, and backward compatibility.

## Manual Testing

1. Launch Tendril and navigate to Settings -> Projects.
2. Select a project and inspect the "Artifact Review / Auto-Implement Policy" dropdown.
3. Toggle the selection between "Always Ask Review" and "Auto-Implement Plans" and verify that configuration saves and loads properly without errors.

---
* eff016a1 - Remove spaces from configuration enum encodings (Plan 00002)

---
Created using [Ivy Tendril](https://ivy.app).