### PR TITLE
[00008] Fix Cross Platform File URI Parsing in FileSheet and MarkdownHelper

### DIFF
--- a/src/Ivy.Tendril.Test/Helpers/PathHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/PathHelperTests.cs
@@ -172,4 +172,41 @@ public class PathHelperTests
         PathHelper.EnsureWindowsCliSetup();
         PathHelper.EnsureCliSymlink();
     }
+
+    [Theory]
+    [InlineData("file:///Users/username/file.cs", "/Users/username/file.cs")]
+    [InlineData("file:///Users/username/My%20Folder/file.cs", "/Users/username/My Folder/file.cs")]
+    [InlineData("file:///Users/username/file.cs#L10", "/Users/username/file.cs")]
+    [InlineData("file:///Users/username/file.cs#10", "/Users/username/file.cs")]
+    [InlineData("file:///Users/username/file.cs#L10-20", "/Users/username/file.cs")]
+    [InlineData("file:///Users/username/file.cs:42", "/Users/username/file.cs")]
+    [InlineData("file:///Users/username/file.cs:10-20", "/Users/username/file.cs")]
+    [InlineData("file:///C:/project/file.cs", "C:/project/file.cs")]
+    [InlineData("file:////C:/project/file.cs", "C:/project/file.cs")]
+    [InlineData("file:///C:/My%20Project/file.cs", "C:/My Project/file.cs")]
+    [InlineData("file:///C:/project/file.cs#L42", "C:/project/file.cs")]
+    [InlineData("file:///C:/project/file.cs:42", "C:/project/file.cs")]
+    [InlineData("file://Users/username/file.cs", "/Users/username/file.cs")]
+    [InlineData("file://localhost/Users/username/file.cs", "/Users/username/file.cs")]
+    [InlineData("FILE:///Users/username/file.cs", "/Users/username/file.cs")]
+    [InlineData("FILE:///D:/test/readme.md", "D:/test/readme.md")]
+    public void ExtractPathFromFileUri_ValidFileUris_ExtractsExpectedPath(string uri, string expected)
+    {
+        var result = PathHelper.ExtractPathFromFileUri(uri);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("http://example.com/page")]
+    [InlineData("https://example.com/page")]
+    [InlineData("plan://01234")]
+    [InlineData("ftp://example.com/file.txt")]
+    public void ExtractPathFromFileUri_InvalidOrNonFileUri_ReturnsNull(string? uri)
+    {
+        var result = PathHelper.ExtractPathFromFileUri(uri);
+        Assert.Null(result);
+    }
 }

--- a/src/Ivy.Tendril.Test/MarkdownHelperTests.cs
+++ b/src/Ivy.Tendril.Test/MarkdownHelperTests.cs
@@ -25,7 +25,8 @@ public class MarkdownHelperTests : IDisposable
         var tempFile = Path.GetTempFileName();
         try
         {
-            var markdown = $"[test.txt](file:///{tempFile.Replace("\\", "/")})";
+            var tempUrlPath = tempFile.Replace("\\", "/").TrimStart('/');
+            var markdown = $"[test.txt](file:///{tempUrlPath})";
             var result = MarkdownHelper.AnnotateBrokenFileLinks(markdown);
             Assert.DoesNotContain("⚠️", result);
             Assert.Equal(markdown, result);
@@ -37,12 +38,47 @@ public class MarkdownHelperTests : IDisposable
     }
 
     [Fact]
+    public void AnnotateBrokenFileLinks_ValidLinkWithAnchor_RemainsUnchanged()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var tempUrlPath = tempFile.Replace("\\", "/").TrimStart('/');
+            var markdown = $"[test.txt:42](file:///{tempUrlPath}#L42)";
+            var result = MarkdownHelper.AnnotateBrokenFileLinks(markdown);
+            Assert.DoesNotContain("⚠️", result);
+            Assert.Equal(markdown, result);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void AnnotateBrokenFileLinks_ValidLinkWithSpacesAndPercentEncoding_RemainsUnchanged()
+    {
+        var subDir = Path.Combine(_tempDir.Path, "My Folder");
+        Directory.CreateDirectory(subDir);
+        var tempFile = Path.Combine(subDir, "test file.txt");
+        File.WriteAllText(tempFile, "hello");
+
+        var tempUrlPath = tempFile.Replace("\\", "/").TrimStart('/');
+        var encodedUrlPath = string.Join("/", tempUrlPath.Split('/').Select(Uri.EscapeDataString));
+        var markdown = $"[test file.txt](file:///{encodedUrlPath})";
+        var result = MarkdownHelper.AnnotateBrokenFileLinks(markdown);
+        Assert.DoesNotContain("⚠️", result);
+        Assert.Equal(markdown, result);
+    }
+
+    [Fact]
     public void AnnotateBrokenFileLinks_MixedLinks_OnlyAnnotatesBroken()
     {
         var tempFile = Path.GetTempFileName();
         try
         {
-            var validLink = $"[valid.txt](file:///{tempFile.Replace("\\", "/")})";
+            var tempUrlPath = tempFile.Replace("\\", "/").TrimStart('/');
+            var validLink = $"[valid.txt](file:///{tempUrlPath})";
             var brokenLink = "[broken.cs](file:///C:/nonexistent/broken.cs)";
             var markdown = $"See {validLink} and {brokenLink} for details.";
 
@@ -118,7 +154,8 @@ public class MarkdownHelperTests : IDisposable
         try
         {
             Directory.CreateDirectory(tempPlansDir);
-            var validFileLink = $"[valid.txt](file:///{tempFile.Replace("\\", "/")})";
+            var tempUrlPath = tempFile.Replace("\\", "/").TrimStart('/');
+            var validFileLink = $"[valid.txt](file:///{tempUrlPath})";
             var brokenPlanLink = "[Plan 99999](plan://99999)";
             var markdown = $"See {validFileLink} and {brokenPlanLink}";
 
@@ -174,7 +211,8 @@ public class MarkdownHelperTests : IDisposable
         try
         {
             Directory.CreateDirectory(Path.Combine(tempPlansDir, "01234-TestPlan"));
-            var validFileLink = $"[valid.txt](file:///{tempFile.Replace("\\", "/")})";
+            var tempUrlPath = tempFile.Replace("\\", "/").TrimStart('/');
+            var validFileLink = $"[valid.txt](file:///{tempUrlPath})";
             var validPlanLink = "[Plan 01234](plan://01234)";
             var markdown = $"See {validFileLink} and {validPlanLink}";
 

--- a/src/Ivy.Tendril.Test/Services/FileSheetTests.cs
+++ b/src/Ivy.Tendril.Test/Services/FileSheetTests.cs
@@ -38,6 +38,41 @@ public class FileSheetTests
     }
 
     [Fact]
+    public void CreateLinkClickHandler_CapturesUnixFilePath_WhenUnixFileUrlProvided()
+    {
+        var state = new TestState<string?>(null);
+        var handler = FileSheet.CreateLinkClickHandler(state);
+
+        handler("file:///Users/username/repo/file.cs");
+
+        Assert.Equal("/Users/username/repo/file.cs", state.Value);
+    }
+
+    [Fact]
+    public void CreateLinkClickHandler_UnescapesPercentEncodedSpaces()
+    {
+        var state = new TestState<string?>(null);
+        var handler = FileSheet.CreateLinkClickHandler(state);
+
+        handler("file:///Users/username/My%20Project/file.cs");
+
+        Assert.Equal("/Users/username/My Project/file.cs", state.Value);
+    }
+
+    [Fact]
+    public void CreateLinkClickHandler_StripsAnchorOrLineNumber()
+    {
+        var state = new TestState<string?>(null);
+        var handler = FileSheet.CreateLinkClickHandler(state);
+
+        handler("file:///Users/username/file.cs#L42");
+        Assert.Equal("/Users/username/file.cs", state.Value);
+
+        handler("file:///Users/username/file.cs:42");
+        Assert.Equal("/Users/username/file.cs", state.Value);
+    }
+
+    [Fact]
     public void CreateLinkClickHandler_InvokesPlanCallback_WhenPlanUrlProvided()
     {
         var fileState = new TestState<string?>(null);

--- a/src/Ivy.Tendril/Apps/Views/Sheets/FileSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/FileSheet.cs
@@ -14,9 +14,9 @@ public class FileSheet(
     {
         return url =>
         {
-            if (url.StartsWith("file:///", StringComparison.OrdinalIgnoreCase))
+            var filePath = PathHelper.ExtractPathFromFileUri(url);
+            if (filePath != null)
             {
-                var filePath = url["file:///".Length..];
                 openFileState.Set(filePath);
             }
             else if (url.StartsWith("plan://", StringComparison.OrdinalIgnoreCase))

--- a/src/Ivy.Tendril/Helpers/MarkdownHelper.cs
+++ b/src/Ivy.Tendril/Helpers/MarkdownHelper.cs
@@ -22,9 +22,9 @@ public static partial class MarkdownHelper
         {
             var linkText = match.Groups[1].Value;
             var url = match.Groups[2].Value;
-            var filePath = url["file:///".Length..];
+            var filePath = PathHelper.ExtractPathFromFileUri(url);
 
-            if (File.Exists(filePath))
+            if (filePath != null && File.Exists(filePath))
                 return match.Value;
 
             return $"[{linkText} \u26a0\ufe0f]({url})";

--- a/src/Ivy.Tendril/Helpers/PathHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PathHelper.cs
@@ -650,4 +650,53 @@ public static class PathHelper
 
         return Path.GetFullPath(path);
     }
+
+    /// <summary>
+    /// Extracts a local filesystem path from a file:/// URI, handling cross-platform differences
+    /// between Windows and Unix/macOS, stripping line number/anchor suffixes, decoding percent-encoded
+    /// characters, and normalizing paths.
+    /// </summary>
+    public static string? ExtractPathFromFileUri(string? uri)
+    {
+        if (string.IsNullOrWhiteSpace(uri))
+            return null;
+
+        var trimmed = uri.Trim();
+        string rawPath;
+        if (trimmed.StartsWith("file:///", StringComparison.OrdinalIgnoreCase))
+        {
+            rawPath = trimmed["file:///".Length..];
+        }
+        else if (trimmed.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
+        {
+            rawPath = trimmed["file://".Length..];
+        }
+        else
+        {
+            return null;
+        }
+
+        if (rawPath.StartsWith("localhost/", StringComparison.OrdinalIgnoreCase))
+        {
+            rawPath = rawPath["localhost".Length..];
+        }
+
+        // Remove trailing anchor or line number suffix (such as #L\d+, #\d+, :\d+, #L\d+-\d+, etc.)
+        rawPath = Regex.Replace(rawPath, @"(?:(?:#L?|:)\d+(?:-\d+)?|#.*)$", "", RegexOptions.IgnoreCase);
+
+        // Decode percent-encoded characters
+        rawPath = Uri.UnescapeDataString(rawPath);
+
+        // Strip extraneous leading slashes before a Windows drive letter (e.g., "/C:/..." or "///C:/...")
+        rawPath = Regex.Replace(rawPath, @"^/+(?=[a-zA-Z]:)", "");
+
+        // If not starting with a Windows drive letter (e.g. "C:"), ensure Unix absolute path starts with '/'
+        var isWindowsDrive = Regex.IsMatch(rawPath, @"^[a-zA-Z]:");
+        if (!isWindowsDrive && !rawPath.StartsWith('/'))
+        {
+            rawPath = "/" + rawPath;
+        }
+
+        return rawPath;
+    }
 }


### PR DESCRIPTION
# Summary

## Changes

Fixed cross-platform `file:///` URI parsing across Tendril by introducing `PathHelper.ExtractPathFromFileUri` and updating `FileSheet` and `MarkdownHelper`. On macOS and Linux, `file:///` URLs now properly resolve to absolute filesystem paths with the leading root slash `/`, while preserving Windows drive paths, stripping trailing anchors and line numbers, and decoding percent-encoded characters.

## API Changes

- Added `public static string? ExtractPathFromFileUri(string? uri)` to `Ivy.Tendril.Helpers.PathHelper`.

## Files Modified

- `src/Ivy.Tendril/Helpers/PathHelper.cs`
- `src/Ivy.Tendril/Helpers/MarkdownHelper.cs`
- `src/Ivy.Tendril/Apps/Views/Sheets/FileSheet.cs`
- `src/Ivy.Tendril.Test/Helpers/PathHelperTests.cs`
- `src/Ivy.Tendril.Test/Services/FileSheetTests.cs`
- `src/Ivy.Tendril.Test/MarkdownHelperTests.cs`

## Manual Testing

1. Launch Tendril on macOS or Linux (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj`).
2. Open any plan or revision containing local file links (e.g. `[File.cs](file:///Users/.../File.cs)`).
3. Observe that valid file links do not display broken warning indicators (⚠️).
4. Click on the file link and verify that the `FileSheet` modal opens with the file content loaded properly instead of showing "File not found.".

---
### Commits

- 7d1c9624 Fix cross-platform file:/// URI parsing in FileSheet and MarkdownHelper (Plan 00008)

---
Created using [Ivy Tendril](https://ivy.app).
