### PR TITLE
[00010] Disable Back Button During Model Fetch in Onboarding Coding Agent Step

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Onboarding/CodingAgentStepViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Onboarding/CodingAgentStepViewTests.cs
@@ -94,4 +94,57 @@ public class CodingAgentStepViewTests
         var completedContinue = new Button("Continue").Disabled(isTestingModels.Value);
         Assert.False(completedContinue.Disabled);
     }
+
+    [Fact]
+    public void BackButton_WhenFetchingModels_IsDisabled()
+    {
+        var isFetchingModels = new State<bool>(true);
+
+        var button = new Button("Back")
+            .Ghost()
+            .Disabled(isFetchingModels.Value);
+
+        Assert.True(button.Disabled);
+    }
+
+    [Fact]
+    public void BackButton_WhenNotFetchingModels_IsNotDisabled()
+    {
+        var isFetchingModels = new State<bool>(false);
+
+        var button = new Button("Back")
+            .Ghost()
+            .Disabled(isFetchingModels.Value);
+
+        Assert.False(button.Disabled);
+    }
+
+    [Fact]
+    public void ModelFetchLifecycle_TracksDisabledStateCorrectly()
+    {
+        var isFetchingModels = new State<bool>(false);
+
+        // Initial state: not fetching, buttons enabled
+        Assert.False(isFetchingModels.Value);
+        var initialBack = new Button("Back").Disabled(isFetchingModels.Value);
+        var initialContinue = new Button("Continue").Disabled(isFetchingModels.Value);
+        Assert.False(initialBack.Disabled);
+        Assert.False(initialContinue.Disabled);
+
+        // Start fetching: state becomes true, buttons disabled
+        isFetchingModels.Set(true);
+        Assert.True(isFetchingModels.Value);
+        var fetchingBack = new Button("Back").Disabled(isFetchingModels.Value);
+        var fetchingContinue = new Button("Continue").Disabled(isFetchingModels.Value);
+        Assert.True(fetchingBack.Disabled);
+        Assert.True(fetchingContinue.Disabled);
+
+        // Complete fetching (finally block sets false): buttons re-enabled
+        isFetchingModels.Set(false);
+        Assert.False(isFetchingModels.Value);
+        var completedBack = new Button("Back").Disabled(isFetchingModels.Value);
+        var completedContinue = new Button("Continue").Disabled(isFetchingModels.Value);
+        Assert.False(completedBack.Disabled);
+        Assert.False(completedContinue.Disabled);
+    }
 }

--- a/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs
@@ -292,6 +292,7 @@ public class CodingAgentStepView(
                        | (Layout.Horizontal()
                            | new Button("Back")
                                .Ghost()
+                               .Disabled(isFetchingModels.Value)
                                .OnClick(() =>
                                {
                                    selectedAgent.Set(null);
@@ -303,6 +304,7 @@ public class CodingAgentStepView(
                            | new Button("Continue")
                                .Primary()
                                .Loading(isFetchingModels.Value)
+                               .Disabled(isFetchingModels.Value)
                                .OnClick(async () =>
                                {
                                    apiKeyError.Set(null);


### PR DESCRIPTION
# Summary

## Changes

Disabled the Back button and explicitly disabled the Continue button during model fetching (`isFetchingModels.Value == true`) in SubStep 0 of the onboarding Coding Agent configuration flow. Added corresponding unit tests to verify disabled state transitions.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Onboarding/CodingAgentStepView.cs` — Added `.Disabled(isFetchingModels.Value)` to Back and Continue buttons in SubStep 0.
- `src/Ivy.Tendril.Test/Apps/Onboarding/CodingAgentStepViewTests.cs` — Added unit tests verifying button disabled states during model fetch lifecycle.

## Manual Testing

1. Launch Tendril and navigate to the Onboarding wizard (or reset onboarding state).
2. Proceed to the Coding Agent step.
3. Select an OpenAI-compatible / BYO provider (such as Anthropic, OpenAI, or Berget AI).
4. Enter an API key and click "Continue".
5. While the model fetch request is loading, observe that the "Back" button is disabled and unclickable, preventing accidental state resets or concurrent navigation while the network request is in flight.

---
- 5f58bf7c Disable Back button during model fetch in onboarding CodingAgentStep (Plan 00010)

---
Created using [Ivy Tendril](https://ivy.app).