### PR TITLE
[00006] Add Theme Selection with DaisyUI Inspired Color Schemes

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigCliCommandTests.cs
@@ -209,4 +209,42 @@ public class ConfigCliCommandTests : IDisposable
         Assert.True(new ConfigSetSettings { Key = "planTemplate", FilePath = "f.txt" }.Validate().Successful);
         Assert.True(new ConfigSetSettings { Key = "planTemplate", Stdin = true }.Validate().Successful);
     }
+
+    [Fact]
+    public void Set_Theme_Persists()
+    {
+        var config = CreateConfig();
+        ConfigSetCommand.ApplyField(config.Settings, "theme", "cupcake");
+        config.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal("cupcake", reloaded.Settings.Theme);
+        Assert.Equal("cupcake", ConfigGetCommand.ReadField(reloaded.Settings, "theme"));
+    }
+
+    [Fact]
+    public void Set_Theme_MixedCase_ResolvesCanonicalId()
+    {
+        var config = CreateConfig();
+        ConfigSetCommand.ApplyField(config.Settings, "theme", "DrAcUlA");
+        config.SaveSettings();
+
+        Assert.Equal("dracula", CreateConfig().Settings.Theme);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Set_Theme_Empty_Throws(string value)
+    {
+        Assert.Throws<ArgumentException>(() => ConfigSetCommand.ApplyField(CreateConfig().Settings, "theme", value));
+    }
+
+    [Fact]
+    public void Set_Theme_Unknown_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => ConfigSetCommand.ApplyField(CreateConfig().Settings, "theme", "nonexistent_theme"));
+        Assert.Contains("Valid themes", ex.Message);
+    }
 }

--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -1981,4 +1981,53 @@ sidebarOpen: false
             Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void Theme_Setting_DefaultsAndPersists()
+    {
+        var yaml = @"
+theme: cupcake
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        PathHelper.DefaultTendrilHomeOverride = tempDir;
+        try
+        {
+            using var service = new ConfigService();
+            Assert.Equal("cupcake", service.Settings.Theme);
+
+            service.Settings.Theme = "dracula";
+            service.SaveSettings();
+
+            var yamlOnDisk = File.ReadAllText(Path.Combine(tempDir, "config.yaml"));
+            Assert.Contains("theme: dracula", yamlOnDisk);
+        }
+        finally
+        {
+            PathHelper.DefaultTendrilHomeOverride = null;
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("invalid_theme_name")]
+    public void Theme_Setting_InvalidOrEmpty_FallsBackToDefault(string theme)
+    {
+        var yaml = $@"
+theme: {theme}
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        PathHelper.DefaultTendrilHomeOverride = tempDir;
+        try
+        {
+            using var service = new ConfigService();
+            Assert.Equal("default", service.Settings.Theme);
+        }
+        finally
+        {
+            PathHelper.DefaultTendrilHomeOverride = null;
+            Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril.Test/Mcp/ConfigToolsTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/ConfigToolsTests.cs
@@ -146,4 +146,21 @@ public class ConfigToolsTests : IDisposable
         Assert.StartsWith("Error:", result);
         Assert.Contains("Valid fields", result);
     }
+
+    [Fact]
+    public void SetConfig_Theme_UpdatesAndPersists()
+    {
+        var result = _tools.SetConfig("theme", "cupcake");
+        Assert.StartsWith("Updated theme", result);
+        Assert.Equal("cupcake", _tools.GetConfig("theme"));
+        Assert.Equal("cupcake", new ConfigService().Settings.Theme);
+    }
+
+    [Fact]
+    public void SetConfig_Theme_Unknown_ReturnsError()
+    {
+        var result = _tools.SetConfig("theme", "nonexistent");
+        Assert.StartsWith("Error:", result);
+        Assert.Contains("Valid themes", result);
+    }
 }

--- a/src/Ivy.Tendril.Test/Themes/ThemeRegistryTests.cs
+++ b/src/Ivy.Tendril.Test/Themes/ThemeRegistryTests.cs
@@ -1,0 +1,76 @@
+using Ivy.Tendril.Themes;
+
+namespace Ivy.Tendril.Test.Themes;
+
+public class ThemeRegistryTests
+{
+    [Fact]
+    public void Registry_ContainsAtLeastTwelveThemes()
+    {
+        Assert.True(TendrilThemes.All.Count >= 12, $"Expected at least 12 themes, found {TendrilThemes.All.Count}");
+    }
+
+    [Theory]
+    [InlineData("default")]
+    [InlineData("cupcake")]
+    [InlineData("cyberpunk")]
+    [InlineData("synthwave")]
+    [InlineData("retro")]
+    [InlineData("dracula")]
+    [InlineData("nord")]
+    [InlineData("forest")]
+    [InlineData("aqua")]
+    [InlineData("valentine")]
+    [InlineData("sunset")]
+    [InlineData("coffee")]
+    [InlineData("dim")]
+    [InlineData("luxury")]
+    public void CoreThemes_AreRegistered(string themeId)
+    {
+        var theme = TendrilThemes.GetTheme(themeId);
+        Assert.NotNull(theme);
+        Assert.Equal(themeId, theme.Id, ignoreCase: true);
+    }
+
+    [Fact]
+    public void AllThemes_HaveValidProperties()
+    {
+        foreach (var theme in TendrilThemes.All)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(theme.Id), "Theme Id cannot be empty");
+            Assert.False(string.IsNullOrWhiteSpace(theme.Name), $"Theme {theme.Id} Name cannot be empty");
+            Assert.False(string.IsNullOrWhiteSpace(theme.Description), $"Theme {theme.Id} Description cannot be empty");
+            Assert.NotNull(theme.PreviewColors);
+            Assert.True(theme.PreviewColors.Length >= 4, $"Theme {theme.Id} should have at least 4 preview colors");
+            Assert.All(theme.PreviewColors, c => Assert.StartsWith("#", c));
+            Assert.NotNull(theme.IvyTheme);
+            Assert.NotNull(theme.IvyTheme.Colors);
+            Assert.NotNull(theme.IvyTheme.Colors.Light);
+            Assert.NotNull(theme.IvyTheme.Colors.Dark);
+        }
+    }
+
+    [Fact]
+    public void GetTheme_CaseInsensitive_ReturnsMatchingTheme()
+    {
+        var themeLower = TendrilThemes.GetTheme("cupcake");
+        var themeUpper = TendrilThemes.GetTheme("CUPCAKE");
+        var themeMixed = TendrilThemes.GetTheme("CupCake");
+
+        Assert.Same(themeLower, themeUpper);
+        Assert.Same(themeLower, themeMixed);
+        Assert.Equal("cupcake", themeLower.Id);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("unknown_theme_123")]
+    public void GetTheme_UnknownOrEmpty_ReturnsDefault(string? themeId)
+    {
+        var theme = TendrilThemes.GetTheme(themeId);
+        Assert.NotNull(theme);
+        Assert.Equal(TendrilThemes.Default.Id, theme.Id);
+    }
+}

--- a/src/Ivy.Tendril/AGENTS.md
+++ b/src/Ivy.Tendril/AGENTS.md
@@ -69,7 +69,7 @@ The server runs over stdio and exposes these tools:
 - **`tendril_list_plans`** — Query plans by state, project, or date range (returns up to 50 results)
 - **`tendril_inbox`** — Create a new plan by writing to the Tendril inbox (picked up by InboxWatcherService)
 - **`tendril_transition_plan`** — Change a plan's state (e.g., Draft → Executing)
-- **`tendril_get_config`** — Get a top-level config value (`codingAgent`, `jobTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate`)
+- **`tendril_get_config`** — Get a top-level config value (`codingAgent`, `jobTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate`, `theme`)
 - **`tendril_set_config`** — Set a top-level config value (integer fields are bounds-checked)
 
 ### Authentication

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -15,6 +15,7 @@ using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Themes;
 using Ivy.Widgets.Internal;
 using Microsoft.Extensions.Logging;
 
@@ -287,14 +288,21 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         UseEffect(() => { menuItems.Set(BuildMenuItems(appRepository, status.Value, config, agentRunner, shareContext.IsShareMode)); },
             appRepository.Reloaded.ToTrigger(), status);
 
-        // Rebuild the menu when settings are saved (e.g. the coding agent changes), so the
-        // branded "Agent" item updates immediately without needing a reload.
+        // Apply configured theme on mount
+        UseEffect(() =>
+        {
+            TendrilThemes.ApplyTheme(client, config.Settings.Theme);
+        });
+
+        // Rebuild the menu and reapply theme when settings are saved (e.g. the coding agent or theme changes),
+        // so the UI updates immediately without needing a reload.
         UseEffect(() =>
         {
             void OnSettingsReloaded(object? sender, EventArgs e)
             {
                 menuItems.Set(BuildMenuItems(appRepository, status.Value, config, agentRunner, shareContext.IsShareMode));
                 sidebarOpen.Set(config.Settings.SidebarOpen);
+                TendrilThemes.ApplyTheme(client, config.Settings.Theme);
             }
             config.SettingsReloaded += OnSettingsReloaded;
             return Disposable.Create(() => config.SettingsReloaded -= OnSettingsReloaded);

--- a/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
@@ -9,44 +9,45 @@ public class AppearanceSetupView : ViewBase
     {
         var config = UseService<IConfigService>();
         var client = UseService<IClientProvider>();
+        var selectedTheme = UseState(() => config.Settings.Theme ?? "default");
+        var initialized = UseState(false);
+
+        UseEffect(() =>
+        {
+            if (!initialized.Value)
+            {
+                initialized.Set(true);
+                return;
+            }
+
+            var themeId = selectedTheme.Value;
+            if (string.IsNullOrWhiteSpace(themeId)) themeId = "default";
+            var theme = TendrilThemes.GetTheme(themeId);
+            TendrilThemes.ApplyTheme(client, theme.Id);
+            config.Settings.Theme = theme.Id;
+            config.SaveSettings();
+            client.Toast($"Theme set to {theme.Name}", "Saved");
+        }, selectedTheme);
+
+        var themeOptions = TendrilThemes.All
+            .Select(t => new Option<string>($"{t.Name} ({(t.IsDark ? "Dark" : "Light")})", t.Id))
+            .ToArray<IAnyOption>();
+
+        var activeTheme = TendrilThemes.GetTheme(selectedTheme.Value);
+        var swatches = Layout.Horizontal().Gap(1)
+            | activeTheme.PreviewColors.Select(color =>
+                new Svg($"<svg width='20' height='20' viewBox='0 0 20 20'><circle cx='10' cy='10' r='9' fill='{color}' stroke='rgba(128,128,128,0.3)' stroke-width='1.5'/></svg>")
+                    .Width(Size.Px(20))
+                    .Height(Size.Px(20))
+            ).ToArray();
+
+        var themeSelector = Layout.Vertical().Gap(2)
+            | selectedTheme.ToSelectInput(themeOptions)
+            | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+                | swatches
+                | Text.Muted(activeTheme.Description).Small());
 
         var isSidebarOpen = config.Settings.SidebarOpen;
-        var currentThemeId = config.Settings.Theme ?? "default";
-
-        var themeGrid = Layout.Grid()
-            .Columns(1.At(Breakpoint.Mobile).And(Breakpoint.Tablet, 2).And(Breakpoint.Desktop, 2))
-            .Gap(3);
-
-        themeGrid = TendrilThemes.All.Aggregate(themeGrid, (current, theme) =>
-        {
-            var isSelected = theme.Id.Equals(currentThemeId, StringComparison.OrdinalIgnoreCase);
-
-            var swatches = Layout.Horizontal().Gap(1)
-                | theme.PreviewColors.Select(color =>
-                    new Svg($"<svg width='20' height='20' viewBox='0 0 20 20'><circle cx='10' cy='10' r='9' fill='{color}' stroke='rgba(128,128,128,0.3)' stroke-width='1.5'/></svg>")
-                        .Width(Size.Px(20))
-                        .Height(Size.Px(20))
-                ).ToArray();
-
-            var cardContent = Layout.Vertical().Gap(2)
-                | (Layout.Horizontal().AlignContent(Align.Center)
-                    | Text.Block(theme.Name).Bold()
-                    | new Badge(theme.IsDark ? "Dark" : "Light", theme.IsDark ? BadgeVariant.Secondary : BadgeVariant.Outline).Small()
-                    | new Spacer()
-                    | (isSelected ? new Badge("Active", BadgeVariant.Success).Small().Icon(Icons.Check) : null))
-                | Text.Muted(theme.Description).Small()
-                | swatches;
-
-            return current | new Card(cardContent)
-                .Width(Size.Full())
-                .OnClick(() =>
-                {
-                    TendrilThemes.ApplyTheme(client, theme.Id);
-                    config.Settings.Theme = theme.Id;
-                    config.SaveSettings();
-                    client.Toast($"Theme set to {theme.Name}", "Saved");
-                });
-        });
 
         return Layout.Vertical().Width(Size.Auto().Max(Size.Units(120))).Gap(4)
                | Text.Block("Appearance").Bold()
@@ -61,7 +62,7 @@ public class AppearanceSetupView : ViewBase
                | new Separator()
                | Text.Block("Theme").Bold()
                | Text.Muted("Choose a DaisyUI-inspired color scheme preset for Tendril.").Small()
-               | themeGrid
+               | themeSelector
                | new Separator()
                | Text.Block("Main Sidebar").Bold()
                | Text.Muted("Choose the default state for the main sidebar on startup.").Small()

--- a/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Themes;
 
 namespace Ivy.Tendril.Apps.Settings;
 
@@ -10,8 +11,44 @@ public class AppearanceSetupView : ViewBase
         var client = UseService<IClientProvider>();
 
         var isSidebarOpen = config.Settings.SidebarOpen;
+        var currentThemeId = config.Settings.Theme ?? "default";
 
-        return Layout.Vertical().Width(Size.Auto().Max(Size.Units(120)))
+        var themeGrid = Layout.Grid()
+            .Columns(1.At(Breakpoint.Mobile).And(Breakpoint.Tablet, 2).And(Breakpoint.Desktop, 2))
+            .Gap(3);
+
+        themeGrid = TendrilThemes.All.Aggregate(themeGrid, (current, theme) =>
+        {
+            var isSelected = theme.Id.Equals(currentThemeId, StringComparison.OrdinalIgnoreCase);
+
+            var swatches = Layout.Horizontal().Gap(1)
+                | theme.PreviewColors.Select(color =>
+                    new Svg($"<svg width='20' height='20' viewBox='0 0 20 20'><circle cx='10' cy='10' r='9' fill='{color}' stroke='rgba(128,128,128,0.3)' stroke-width='1.5'/></svg>")
+                        .Width(Size.Px(20))
+                        .Height(Size.Px(20))
+                ).ToArray();
+
+            var cardContent = Layout.Vertical().Gap(2)
+                | (Layout.Horizontal().AlignContent(Align.Center)
+                    | Text.Block(theme.Name).Bold()
+                    | new Badge(theme.IsDark ? "Dark" : "Light", theme.IsDark ? BadgeVariant.Secondary : BadgeVariant.Outline).Small()
+                    | new Spacer()
+                    | (isSelected ? new Badge("Active", BadgeVariant.Success).Small().Icon(Icons.Check) : null))
+                | Text.Muted(theme.Description).Small()
+                | swatches;
+
+            return current | new Card(cardContent)
+                .Width(Size.Full())
+                .OnClick(() =>
+                {
+                    TendrilThemes.ApplyTheme(client, theme.Id);
+                    config.Settings.Theme = theme.Id;
+                    config.SaveSettings();
+                    client.Toast($"Theme set to {theme.Name}", "Saved");
+                });
+        });
+
+        return Layout.Vertical().Width(Size.Auto().Max(Size.Units(120))).Gap(4)
                | Text.Block("Appearance").Bold()
                | Text.Muted("Choose how Tendril appears. System matches your OS setting.").Small()
                | (Layout.Horizontal()
@@ -21,6 +58,11 @@ public class AppearanceSetupView : ViewBase
                       .OnClick(() => client.SetThemeMode(ThemeMode.Dark))
                   | new Button("System").Variant(ButtonVariant.Outline).Icon(Icons.SunMoon)
                       .OnClick(() => client.SetThemeMode(ThemeMode.System)))
+               | new Separator()
+               | Text.Block("Theme").Bold()
+               | Text.Muted("Choose a DaisyUI-inspired color scheme preset for Tendril.").Small()
+               | themeGrid
+               | new Separator()
                | Text.Block("Main Sidebar").Bold()
                | Text.Muted("Choose the default state for the main sidebar on startup.").Small()
                | (Layout.Horizontal()

--- a/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
@@ -30,7 +30,7 @@ public class AppearanceSetupView : ViewBase
         }, selectedTheme);
 
         var themeOptions = TendrilThemes.All
-            .Select(t => new Option<string>($"{t.Name} ({(t.IsDark ? "Dark" : "Light")})", t.Id))
+            .Select(t => new Option<string>(t.Name, t.Id))
             .ToArray<IAnyOption>();
 
         var activeTheme = TendrilThemes.GetTheme(selectedTheme.Value);
@@ -43,9 +43,7 @@ public class AppearanceSetupView : ViewBase
 
         var themeSelector = Layout.Vertical().Gap(2)
             | selectedTheme.ToSelectInput(themeOptions)
-            | (Layout.Horizontal().Gap(2).AlignContent(Align.Center)
-                | swatches
-                | Text.Muted(activeTheme.Description).Small());
+            | swatches;
 
         var isSidebarOpen = config.Settings.SidebarOpen;
 

--- a/src/Ivy.Tendril/Commands/ConfigCommand.cs
+++ b/src/Ivy.Tendril/Commands/ConfigCommand.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Themes;
 using Spectre.Console.Cli;
 
 namespace Ivy.Tendril.Commands;
@@ -11,9 +12,9 @@ namespace Ivy.Tendril.Commands;
 public class ConfigGetSettings : CommandSettings
 {
     internal static readonly string[] ValidFields =
-        ["codingAgent", "jobTimeout", "staleOutputTimeout", "gitTimeout", "maxConcurrentJobs", "planTemplate"];
+        ["codingAgent", "jobTimeout", "staleOutputTimeout", "gitTimeout", "maxConcurrentJobs", "planTemplate", "theme"];
 
-    [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate)")]
+    [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme)")]
     [CommandArgument(0, "<key>")]
     public string Key { get; set; } = "";
 
@@ -25,7 +26,7 @@ public class ConfigGetSettings : CommandSettings
 
 public class ConfigSetSettings : CommandSettings
 {
-    [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate)")]
+    [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme)")]
     [CommandArgument(0, "<key>")]
     public string Key { get; set; } = "";
 
@@ -74,6 +75,7 @@ public class ConfigGetCommand : Command<ConfigGetSettings>
         "gittimeout" => s.GitTimeout.ToString(),
         "maxconcurrentjobs" => s.MaxConcurrentJobs.ToString(),
         "plantemplate" => s.PlanTemplate,
+        "theme" => s.Theme,
         _ => throw new ArgumentException(UnknownFieldMessage(field))
     };
 
@@ -113,8 +115,22 @@ public class ConfigSetCommand(IAgentRunner runner) : Command<ConfigSetSettings>
             case "gittimeout": s.GitTimeout = ParseBoundedInt(value, "gitTimeout", 1, 30); break;
             case "maxconcurrentjobs": s.MaxConcurrentJobs = ParseBoundedInt(value, "maxConcurrentJobs", 1, 512); break;
             case "plantemplate": s.PlanTemplate = value; break;
+            case "theme": s.Theme = ValidateTheme(value); break;
             default: throw new ArgumentException(ConfigGetCommand.UnknownFieldMessage(field));
         }
+    }
+
+    internal static string ValidateTheme(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("theme cannot be empty.");
+
+        var match = TendrilThemes.All.FirstOrDefault(t => t.Id.Equals(value.Trim(), StringComparison.OrdinalIgnoreCase));
+        if (match == null)
+            throw new ArgumentException(
+                $"Unknown theme '{value}'. Valid themes: {string.Join(", ", TendrilThemes.All.Select(t => t.Id))}");
+
+        return match.Id;
     }
 
     // Rejects empty and, when the known-agent set is supplied, unknown agents. Returns the

--- a/src/Ivy.Tendril/Mcp/Tools/ConfigTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/ConfigTools.cs
@@ -20,7 +20,7 @@ public sealed class ConfigTools : AuthenticatedToolBase
 
     [McpServerTool(Name = "tendril_get_config"), Description("Get a top-level Tendril config value")]
     public string GetConfig(
-        [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate)")] string key)
+        [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme)")] string key)
     {
         // Reuses the same field switch as `tendril config get` so the two surfaces never drift.
         return ExecuteAuthenticated(() => ConfigGetCommand.ReadField(_configService.Settings, key));
@@ -28,7 +28,7 @@ public sealed class ConfigTools : AuthenticatedToolBase
 
     [McpServerTool(Name = "tendril_set_config"), Description("Set a top-level Tendril config value")]
     public string SetConfig(
-        [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate)")] string key,
+        [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme)")] string key,
         [Description("New value. Integer fields are bounds-checked; planTemplate may be long or multiline.")] string value)
     {
         return ExecuteAuthenticated(() =>

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -243,7 +243,7 @@ These commands are for internal use by other promptwares (e.g., a verification s
 | `tendril config get <key>` | Print a top-level config value |
 | `tendril config set <key> <value>` | Set a top-level config value (use `--file`/`--stdin` for multiline values) |
 
-Valid keys: `codingAgent`, `jobTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate`. Example: `tendril config get planTemplate` prints the configured Plan Template.
+Valid keys: `codingAgent`, `jobTimeout`, `staleOutputTimeout`, `gitTimeout`, `maxConcurrentJobs`, `planTemplate`, `theme`. Example: `tendril config get planTemplate` prints the configured Plan Template.
 
 ## Adding & Configuring Projects
 

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Themes;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
@@ -223,6 +224,7 @@ public class TendrilSettings
     public bool Telemetry { get; set; } = true;
     public bool DesktopNotifications { get; set; } = true;
     public bool SidebarOpen { get; set; } = true;
+    public string Theme { get; set; } = "default";
     public bool Beta { get; set; } = false;
     public string? DismissedUpdateVersion { get; set; }
 
@@ -532,6 +534,16 @@ public class ConfigService : IConfigService, IDisposable
             _logger.LogWarning("MaxConcurrentJobs {Value} is out of bounds (1-512). Using default 20.",
                 Settings.MaxConcurrentJobs);
             Settings.MaxConcurrentJobs = 20;
+        }
+
+        // Theme: fallback to default if null, empty, or unrecognised
+        if (string.IsNullOrWhiteSpace(Settings.Theme))
+        {
+            Settings.Theme = "default";
+        }
+        else
+        {
+            Settings.Theme = TendrilThemes.GetTheme(Settings.Theme).Id;
         }
     }
 

--- a/src/Ivy.Tendril/Themes/TendrilThemes.cs
+++ b/src/Ivy.Tendril/Themes/TendrilThemes.cs
@@ -1,0 +1,1062 @@
+namespace Ivy.Tendril.Themes;
+
+public class TendrilThemeDescriptor
+{
+    public string Id { get; init; } = "";
+    public string Name { get; init; } = "";
+    public string Description { get; init; } = "";
+    public bool IsDark { get; init; }
+    public string[] PreviewColors { get; init; } = [];
+    public Theme IvyTheme { get; init; } = Theme.Default;
+}
+
+public static class TendrilThemes
+{
+    public static readonly TendrilThemeDescriptor Default = new()
+    {
+        Id = "default",
+        Name = "Default",
+        Description = "Standard clean Tendril theme with slate light and dark zinc",
+        IsDark = false,
+        PreviewColors = ["#18181b", "#71717a", "#27272a", "#ffffff"],
+        IvyTheme = Theme.Default
+    };
+
+    public static readonly TendrilThemeDescriptor Cupcake = new()
+    {
+        Id = "cupcake",
+        Name = "Cupcake",
+        Description = "Warm cream background with soft teal, pastel pink, and amber accents",
+        IsDark = false,
+        PreviewColors = ["#65c3c8", "#ef9fbc", "#eeaf3a", "#faf7f5"],
+        IvyTheme = new Theme
+        {
+            Name = "Cupcake",
+            FontFamily = "Geist",
+            FontSize = "16px",
+            BorderRadiusBoxes = Theme.Default.BorderRadiusBoxes,
+            BorderRadiusFields = Theme.Default.BorderRadiusFields,
+            BorderRadiusSelectors = Theme.Default.BorderRadiusSelectors,
+            Colors = new ThemeColorScheme
+            {
+                Light = new ThemeColors
+                {
+                    Primary = "#65c3c8",
+                    PrimaryForeground = "#1d232a",
+                    Secondary = "#ef9fbc",
+                    SecondaryForeground = "#1d232a",
+                    Accent = "#eeaf3a",
+                    AccentForeground = "#1d232a",
+                    Background = "#faf7f5",
+                    Foreground = "#291334",
+                    Destructive = "#f87272",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#36d399",
+                    SuccessForeground = "#1d232a",
+                    Warning = "#fbbd23",
+                    WarningForeground = "#1d232a",
+                    Info = "#3abff8",
+                    InfoForeground = "#1d232a",
+                    Border = "#e7e2df",
+                    Input = "#f3eeea",
+                    Ring = "#65c3c8",
+                    Muted = "#eae5e1",
+                    MutedForeground = "#8f827d",
+                    Card = "#ffffff",
+                    CardForeground = "#291334",
+                    Popover = "#faf7f5",
+                    PopoverForeground = "#291334"
+                },
+                Dark = new ThemeColors
+                {
+                    Primary = "#65c3c8",
+                    PrimaryForeground = "#1d232a",
+                    Secondary = "#ef9fbc",
+                    SecondaryForeground = "#1d232a",
+                    Accent = "#eeaf3a",
+                    AccentForeground = "#1d232a",
+                    Background = "#231a28",
+                    Foreground = "#faf7f5",
+                    Destructive = "#f87272",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#36d399",
+                    SuccessForeground = "#1d232a",
+                    Warning = "#fbbd23",
+                    WarningForeground = "#1d232a",
+                    Info = "#3abff8",
+                    InfoForeground = "#1d232a",
+                    Border = "#44344e",
+                    Input = "#2f2436",
+                    Ring = "#65c3c8",
+                    Muted = "#3a2d43",
+                    MutedForeground = "#bbaabf",
+                    Card = "#2f2436",
+                    CardForeground = "#faf7f5",
+                    Popover = "#231a28",
+                    PopoverForeground = "#faf7f5"
+                }
+            }
+        }
+    };
+
+    public static readonly TendrilThemeDescriptor Cyberpunk = new()
+    {
+        Id = "cyberpunk",
+        Name = "Cyberpunk",
+        Description = "High-contrast neon yellow, vivid pink, and cyber cyan",
+        IsDark = true,
+        PreviewColors = ["#ffee00", "#ff7598", "#2dd4bf", "#111111"],
+        IvyTheme = new Theme
+        {
+            Name = "Cyberpunk",
+            FontFamily = "Geist",
+            FontSize = "16px",
+            BorderRadiusBoxes = "0px",
+            BorderRadiusFields = "0px",
+            BorderRadiusSelectors = "0px",
+            Colors = new ThemeColorScheme
+            {
+                Light = new ThemeColors
+                {
+                    Primary = "#d4b800",
+                    PrimaryForeground = "#000000",
+                    Secondary = "#ff7598",
+                    SecondaryForeground = "#000000",
+                    Accent = "#0d9488",
+                    AccentForeground = "#ffffff",
+                    Background = "#ffffeb",
+                    Foreground = "#1a1a1a",
+                    Destructive = "#dc2626",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#0d9488",
+                    SuccessForeground = "#ffffff",
+                    Warning = "#d97706",
+                    WarningForeground = "#ffffff",
+                    Info = "#0284c7",
+                    InfoForeground = "#ffffff",
+                    Border = "#e5df8a",
+                    Input = "#fbf6c7",
+                    Ring = "#d4b800",
+                    Muted = "#f3eed0",
+                    MutedForeground = "#716b50",
+                    Card = "#ffffff",
+                    CardForeground = "#1a1a1a",
+                    Popover = "#ffffeb",
+                    PopoverForeground = "#1a1a1a"
+                },
+                Dark = new ThemeColors
+                {
+                    Primary = "#ffee00",
+                    PrimaryForeground = "#000000",
+                    Secondary = "#ff7598",
+                    SecondaryForeground = "#000000",
+                    Accent = "#2dd4bf",
+                    AccentForeground = "#000000",
+                    Background = "#111111",
+                    Foreground = "#ffee00",
+                    Destructive = "#ff5555",
+                    DestructiveForeground = "#000000",
+                    Success = "#2dd4bf",
+                    SuccessForeground = "#000000",
+                    Warning = "#ffaa00",
+                    WarningForeground = "#000000",
+                    Info = "#00ddff",
+                    InfoForeground = "#000000",
+                    Border = "#ffee00",
+                    Input = "#222222",
+                    Ring = "#ffee00",
+                    Muted = "#262626",
+                    MutedForeground = "#888888",
+                    Card = "#1a1a1a",
+                    CardForeground = "#ffee00",
+                    Popover = "#111111",
+                    PopoverForeground = "#ffee00"
+                }
+            }
+        }
+    };
+
+    public static readonly TendrilThemeDescriptor Synthwave = new()
+    {
+        Id = "synthwave",
+        Name = "Synthwave",
+        Description = "80s retro neon purple background with hot pink and electric cyan",
+        IsDark = true,
+        PreviewColors = ["#e779c1", "#58c7f3", "#f3cc30", "#1a103c"],
+        IvyTheme = new Theme
+        {
+            Name = "Synthwave",
+            FontFamily = "Geist",
+            FontSize = "16px",
+            BorderRadiusBoxes = Theme.Default.BorderRadiusBoxes,
+            BorderRadiusFields = Theme.Default.BorderRadiusFields,
+            BorderRadiusSelectors = Theme.Default.BorderRadiusSelectors,
+            Colors = new ThemeColorScheme
+            {
+                Light = new ThemeColors
+                {
+                    Primary = "#d946ef",
+                    PrimaryForeground = "#ffffff",
+                    Secondary = "#0284c7",
+                    SecondaryForeground = "#ffffff",
+                    Accent = "#eab308",
+                    AccentForeground = "#000000",
+                    Background = "#faf5ff",
+                    Foreground = "#1e1035",
+                    Destructive = "#ef4444",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#10b981",
+                    SuccessForeground = "#ffffff",
+                    Warning = "#f59e0b",
+                    WarningForeground = "#ffffff",
+                    Info = "#06b6d4",
+                    InfoForeground = "#ffffff",
+                    Border = "#e9d5ff",
+                    Input = "#f3e8ff",
+                    Ring = "#d946ef",
+                    Muted = "#ede4f8",
+                    MutedForeground = "#7e6c98",
+                    Card = "#ffffff",
+                    CardForeground = "#1e1035",
+                    Popover = "#faf5ff",
+                    PopoverForeground = "#1e1035"
+                },
+                Dark = new ThemeColors
+                {
+                    Primary = "#e779c1",
+                    PrimaryForeground = "#1a103c",
+                    Secondary = "#58c7f3",
+                    SecondaryForeground = "#1a103c",
+                    Accent = "#f3cc30",
+                    AccentForeground = "#1a103c",
+                    Background = "#1a103c",
+                    Foreground = "#f3e8ff",
+                    Destructive = "#ff5757",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#2dd4bf",
+                    SuccessForeground = "#1a103c",
+                    Warning = "#f3cc30",
+                    WarningForeground = "#1a103c",
+                    Info = "#58c7f3",
+                    InfoForeground = "#1a103c",
+                    Border = "#3b266e",
+                    Input = "#291b54",
+                    Ring = "#e779c1",
+                    Muted = "#2d1c5b",
+                    MutedForeground = "#a78bfa",
+                    Card = "#24184c",
+                    CardForeground = "#f3e8ff",
+                    Popover = "#1a103c",
+                    PopoverForeground = "#f3e8ff"
+                }
+            }
+        }
+    };
+
+    public static readonly TendrilThemeDescriptor Retro = new()
+    {
+        Id = "retro",
+        Name = "Retro",
+        Description = "Nostalgic warm cream, terracotta primary, sage secondary, and warm gold",
+        IsDark = false,
+        PreviewColors = ["#ef9995", "#a4cbb4", "#ebdc99", "#ece3ca"],
+        IvyTheme = new Theme
+        {
+            Name = "Retro",
+            FontFamily = "Geist",
+            FontSize = "16px",
+            BorderRadiusBoxes = "0.5rem",
+            BorderRadiusFields = "0.5rem",
+            BorderRadiusSelectors = "0.5rem",
+            Colors = new ThemeColorScheme
+            {
+                Light = new ThemeColors
+                {
+                    Primary = "#ef9995",
+                    PrimaryForeground = "#282425",
+                    Secondary = "#a4cbb4",
+                    SecondaryForeground = "#282425",
+                    Accent = "#ebdc99",
+                    AccentForeground = "#282425",
+                    Background = "#ece3ca",
+                    Foreground = "#282425",
+                    Destructive = "#dc2626",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#65a30d",
+                    SuccessForeground = "#ffffff",
+                    Warning = "#d97706",
+                    WarningForeground = "#ffffff",
+                    Info = "#0284c7",
+                    InfoForeground = "#ffffff",
+                    Border = "#d5c79e",
+                    Input = "#ded1a9",
+                    Ring = "#ef9995",
+                    Muted = "#dcd0aa",
+                    MutedForeground = "#7d735a",
+                    Card = "#e4d8b4",
+                    CardForeground = "#282425",
+                    Popover = "#ece3ca",
+                    PopoverForeground = "#282425"
+                },
+                Dark = new ThemeColors
+                {
+                    Primary = "#ef9995",
+                    PrimaryForeground = "#282425",
+                    Secondary = "#a4cbb4",
+                    SecondaryForeground = "#282425",
+                    Accent = "#ebdc99",
+                    AccentForeground = "#282425",
+                    Background = "#25211e",
+                    Foreground = "#ece3ca",
+                    Destructive = "#f87171",
+                    DestructiveForeground = "#1a1a1a",
+                    Success = "#a3e635",
+                    SuccessForeground = "#1a1a1a",
+                    Warning = "#fbbf24",
+                    WarningForeground = "#1a1a1a",
+                    Info = "#38bdf8",
+                    InfoForeground = "#1a1a1a",
+                    Border = "#453e39",
+                    Input = "#312c28",
+                    Ring = "#ef9995",
+                    Muted = "#3a3430",
+                    MutedForeground = "#b8ab96",
+                    Card = "#312c28",
+                    CardForeground = "#ece3ca",
+                    Popover = "#25211e",
+                    PopoverForeground = "#ece3ca"
+                }
+            }
+        }
+    };
+
+    public static readonly TendrilThemeDescriptor Dracula = new()
+    {
+        Id = "dracula",
+        Name = "Dracula",
+        Description = "Classic dark violet background with purple, pink, and cyan accents",
+        IsDark = true,
+        PreviewColors = ["#bd93f9", "#ff79c6", "#8be9fd", "#282a36"],
+        IvyTheme = new Theme
+        {
+            Name = "Dracula",
+            FontFamily = "Geist",
+            FontSize = "16px",
+            BorderRadiusBoxes = Theme.Default.BorderRadiusBoxes,
+            BorderRadiusFields = Theme.Default.BorderRadiusFields,
+            BorderRadiusSelectors = Theme.Default.BorderRadiusSelectors,
+            Colors = new ThemeColorScheme
+            {
+                Light = new ThemeColors
+                {
+                    Primary = "#7c3aed",
+                    PrimaryForeground = "#ffffff",
+                    Secondary = "#db2777",
+                    SecondaryForeground = "#ffffff",
+                    Accent = "#0891b2",
+                    AccentForeground = "#ffffff",
+                    Background = "#f8f7fc",
+                    Foreground = "#282a36",
+                    Destructive = "#e11d48",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#16a34a",
+                    SuccessForeground = "#ffffff",
+                    Warning = "#ca8a04",
+                    WarningForeground = "#ffffff",
+                    Info = "#0284c7",
+                    InfoForeground = "#ffffff",
+                    Border = "#e2e0ed",
+                    Input = "#f0eef7",
+                    Ring = "#7c3aed",
+                    Muted = "#eae8f3",
+                    MutedForeground = "#6272a4",
+                    Card = "#ffffff",
+                    CardForeground = "#282a36",
+                    Popover = "#f8f7fc",
+                    PopoverForeground = "#282a36"
+                },
+                Dark = new ThemeColors
+                {
+                    Primary = "#bd93f9",
+                    PrimaryForeground = "#282a36",
+                    Secondary = "#ff79c6",
+                    SecondaryForeground = "#282a36",
+                    Accent = "#8be9fd",
+                    AccentForeground = "#282a36",
+                    Background = "#282a36",
+                    Foreground = "#f8f8f2",
+                    Destructive = "#ff5555",
+                    DestructiveForeground = "#f8f8f2",
+                    Success = "#50fa7b",
+                    SuccessForeground = "#282a36",
+                    Warning = "#f1fa8c",
+                    WarningForeground = "#282a36",
+                    Info = "#8be9fd",
+                    InfoForeground = "#282a36",
+                    Border = "#44475a",
+                    Input = "#383a59",
+                    Ring = "#bd93f9",
+                    Muted = "#44475a",
+                    MutedForeground = "#6272a4",
+                    Card = "#343746",
+                    CardForeground = "#f8f8f2",
+                    Popover = "#282a36",
+                    PopoverForeground = "#f8f8f2"
+                }
+            }
+        }
+    };
+
+    public static readonly TendrilThemeDescriptor Nord = new()
+    {
+        Id = "nord",
+        Name = "Nord",
+        Description = "Arctic cool palette with slate background, frost blue, and polar night darks",
+        IsDark = true,
+        PreviewColors = ["#88c0d0", "#81a1c1", "#5e81ac", "#2e3440"],
+        IvyTheme = new Theme
+        {
+            Name = "Nord",
+            FontFamily = "Geist",
+            FontSize = "16px",
+            BorderRadiusBoxes = Theme.Default.BorderRadiusBoxes,
+            BorderRadiusFields = Theme.Default.BorderRadiusFields,
+            BorderRadiusSelectors = Theme.Default.BorderRadiusSelectors,
+            Colors = new ThemeColorScheme
+            {
+                Light = new ThemeColors
+                {
+                    Primary = "#5e81ac",
+                    PrimaryForeground = "#ffffff",
+                    Secondary = "#81a1c1",
+                    SecondaryForeground = "#2e3440",
+                    Accent = "#88c0d0",
+                    AccentForeground = "#2e3440",
+                    Background = "#eceff4",
+                    Foreground = "#2e3440",
+                    Destructive = "#bf616a",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#a3be8c",
+                    SuccessForeground = "#2e3440",
+                    Warning = "#ebcb8b",
+                    WarningForeground = "#2e3440",
+                    Info = "#88c0d0",
+                    InfoForeground = "#2e3440",
+                    Border = "#d8dee9",
+                    Input = "#e5e9f0",
+                    Ring = "#5e81ac",
+                    Muted = "#d8dee9",
+                    MutedForeground = "#4c566a",
+                    Card = "#e5e9f0",
+                    CardForeground = "#2e3440",
+                    Popover = "#eceff4",
+                    PopoverForeground = "#2e3440"
+                },
+                Dark = new ThemeColors
+                {
+                    Primary = "#88c0d0",
+                    PrimaryForeground = "#2e3440",
+                    Secondary = "#81a1c1",
+                    SecondaryForeground = "#2e3440",
+                    Accent = "#5e81ac",
+                    AccentForeground = "#eceff4",
+                    Background = "#2e3440",
+                    Foreground = "#eceff4",
+                    Destructive = "#bf616a",
+                    DestructiveForeground = "#eceff4",
+                    Success = "#a3be8c",
+                    SuccessForeground = "#2e3440",
+                    Warning = "#ebcb8b",
+                    WarningForeground = "#2e3440",
+                    Info = "#88c0d0",
+                    InfoForeground = "#2e3440",
+                    Border = "#4c566a",
+                    Input = "#3b4252",
+                    Ring = "#88c0d0",
+                    Muted = "#434c5e",
+                    MutedForeground = "#d8dee9",
+                    Card = "#3b4252",
+                    CardForeground = "#eceff4",
+                    Popover = "#2e3440",
+                    PopoverForeground = "#eceff4"
+                }
+            }
+        }
+    };
+
+    public static readonly TendrilThemeDescriptor Forest = new()
+    {
+        Id = "forest",
+        Name = "Forest",
+        Description = "Deep earthy woodland dark background with fresh emerald and forest green",
+        IsDark = true,
+        PreviewColors = ["#1eb854", "#1fd65f", "#1db954", "#171212"],
+        IvyTheme = new Theme
+        {
+            Name = "Forest",
+            FontFamily = "Geist",
+            FontSize = "16px",
+            BorderRadiusBoxes = Theme.Default.BorderRadiusBoxes,
+            BorderRadiusFields = Theme.Default.BorderRadiusFields,
+            BorderRadiusSelectors = Theme.Default.BorderRadiusSelectors,
+            Colors = new ThemeColorScheme
+            {
+                Light = new ThemeColors
+                {
+                    Primary = "#15803d",
+                    PrimaryForeground = "#ffffff",
+                    Secondary = "#16a34a",
+                    SecondaryForeground = "#ffffff",
+                    Accent = "#86efac",
+                    AccentForeground = "#14532d",
+                    Background = "#f0fdf4",
+                    Foreground = "#14532d",
+                    Destructive = "#dc2626",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#16a34a",
+                    SuccessForeground = "#ffffff",
+                    Warning = "#d97706",
+                    WarningForeground = "#ffffff",
+                    Info = "#0284c7",
+                    InfoForeground = "#ffffff",
+                    Border = "#bbf7d0",
+                    Input = "#dcfce7",
+                    Ring = "#15803d",
+                    Muted = "#dcfce7",
+                    MutedForeground = "#4ade80",
+                    Card = "#ffffff",
+                    CardForeground = "#14532d",
+                    Popover = "#f0fdf4",
+                    PopoverForeground = "#14532d"
+                },
+                Dark = new ThemeColors
+                {
+                    Primary = "#1eb854",
+                    PrimaryForeground = "#000000",
+                    Secondary = "#1fd65f",
+                    SecondaryForeground = "#000000",
+                    Accent = "#137736",
+                    AccentForeground = "#ffffff",
+                    Background = "#171212",
+                    Foreground = "#ebfaef",
+                    Destructive = "#e11d48",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#1eb854",
+                    SuccessForeground = "#000000",
+                    Warning = "#f59e0b",
+                    WarningForeground = "#000000",
+                    Info = "#06b6d4",
+                    InfoForeground = "#000000",
+                    Border = "#2f2727",
+                    Input = "#231c1c",
+                    Ring = "#1eb854",
+                    Muted = "#282020",
+                    MutedForeground = "#8a9e8e",
+                    Card = "#1f1919",
+                    CardForeground = "#ebfaef",
+                    Popover = "#171212",
+                    PopoverForeground = "#ebfaef"
+                }
+            }
+        }
+    };
+
+    public static readonly TendrilThemeDescriptor Aqua = new()
+    {
+        Id = "aqua",
+        Name = "Aqua",
+        Description = "Deep marine ocean background with electric cyan and sky blue accents",
+        IsDark = true,
+        PreviewColors = ["#09ecf3", "#70a6ff", "#134074", "#0b2545"],
+        IvyTheme = new Theme
+        {
+            Name = "Aqua",
+            FontFamily = "Geist",
+            FontSize = "16px",
+            BorderRadiusBoxes = Theme.Default.BorderRadiusBoxes,
+            BorderRadiusFields = Theme.Default.BorderRadiusFields,
+            BorderRadiusSelectors = Theme.Default.BorderRadiusSelectors,
+            Colors = new ThemeColorScheme
+            {
+                Light = new ThemeColors
+                {
+                    Primary = "#0284c7",
+                    PrimaryForeground = "#ffffff",
+                    Secondary = "#38bdf8",
+                    SecondaryForeground = "#0b2545",
+                    Accent = "#bae6fd",
+                    AccentForeground = "#0369a1",
+                    Background = "#f0f9ff",
+                    Foreground = "#0c4a6e",
+                    Destructive = "#dc2626",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#16a34a",
+                    SuccessForeground = "#ffffff",
+                    Warning = "#d97706",
+                    WarningForeground = "#ffffff",
+                    Info = "#0284c7",
+                    InfoForeground = "#ffffff",
+                    Border = "#bae6fd",
+                    Input = "#e0f2fe",
+                    Ring = "#0284c7",
+                    Muted = "#e0f2fe",
+                    MutedForeground = "#0284c7",
+                    Card = "#ffffff",
+                    CardForeground = "#0c4a6e",
+                    Popover = "#f0f9ff",
+                    PopoverForeground = "#0c4a6e"
+                },
+                Dark = new ThemeColors
+                {
+                    Primary = "#09ecf3",
+                    PrimaryForeground = "#0b2545",
+                    Secondary = "#70a6ff",
+                    SecondaryForeground = "#0b2545",
+                    Accent = "#577399",
+                    AccentForeground = "#ffffff",
+                    Background = "#0b2545",
+                    Foreground = "#eef4f8",
+                    Destructive = "#ff5757",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#00e676",
+                    SuccessForeground = "#0b2545",
+                    Warning = "#ffeb3b",
+                    WarningForeground = "#0b2545",
+                    Info = "#09ecf3",
+                    InfoForeground = "#0b2545",
+                    Border = "#134074",
+                    Input = "#113866",
+                    Ring = "#09ecf3",
+                    Muted = "#134074",
+                    MutedForeground = "#8da9c4",
+                    Card = "#13315c",
+                    CardForeground = "#eef4f8",
+                    Popover = "#0b2545",
+                    PopoverForeground = "#eef4f8"
+                }
+            }
+        }
+    };
+
+    public static readonly TendrilThemeDescriptor Valentine = new()
+    {
+        Id = "valentine",
+        Name = "Valentine",
+        Description = "Romantic blush theme with soft pink background, rose pink, and lavender",
+        IsDark = false,
+        PreviewColors = ["#e96d7b", "#a991f7", "#88dbdd", "#f0d6e8"],
+        IvyTheme = new Theme
+        {
+            Name = "Valentine",
+            FontFamily = "Geist",
+            FontSize = "16px",
+            BorderRadiusBoxes = "1rem",
+            BorderRadiusFields = "1rem",
+            BorderRadiusSelectors = "1rem",
+            Colors = new ThemeColorScheme
+            {
+                Light = new ThemeColors
+                {
+                    Primary = "#e96d7b",
+                    PrimaryForeground = "#ffffff",
+                    Secondary = "#a991f7",
+                    SecondaryForeground = "#ffffff",
+                    Accent = "#88dbdd",
+                    AccentForeground = "#291e25",
+                    Background = "#f0d6e8",
+                    Foreground = "#632c3b",
+                    Destructive = "#e11d48",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#10b981",
+                    SuccessForeground = "#ffffff",
+                    Warning = "#f59e0b",
+                    WarningForeground = "#ffffff",
+                    Info = "#06b6d4",
+                    InfoForeground = "#ffffff",
+                    Border = "#deb0cf",
+                    Input = "#ebd0e2",
+                    Ring = "#e96d7b",
+                    Muted = "#e4c0d7",
+                    MutedForeground = "#9c6077",
+                    Card = "#e8c4dc",
+                    CardForeground = "#632c3b",
+                    Popover = "#f0d6e8",
+                    PopoverForeground = "#632c3b"
+                },
+                Dark = new ThemeColors
+                {
+                    Primary = "#f472b6",
+                    PrimaryForeground = "#371b26",
+                    Secondary = "#c084fc",
+                    SecondaryForeground = "#371b26",
+                    Accent = "#67e8f9",
+                    AccentForeground = "#371b26",
+                    Background = "#2a1523",
+                    Foreground = "#fce7f3",
+                    Destructive = "#fb7185",
+                    DestructiveForeground = "#1f1218",
+                    Success = "#34d399",
+                    SuccessForeground = "#1f1218",
+                    Warning = "#fbbf24",
+                    WarningForeground = "#1f1218",
+                    Info = "#38bdf8",
+                    InfoForeground = "#1f1218",
+                    Border = "#4f2642",
+                    Input = "#381c2f",
+                    Ring = "#f472b6",
+                    Muted = "#422037",
+                    MutedForeground = "#d49bbd",
+                    Card = "#381c2f",
+                    CardForeground = "#fce7f3",
+                    Popover = "#2a1523",
+                    PopoverForeground = "#fce7f3"
+                }
+            }
+        }
+    };
+
+    public static readonly TendrilThemeDescriptor Sunset = new()
+    {
+        Id = "sunset",
+        Name = "Sunset",
+        Description = "Dusk gradient dark background with coral orange, sunset rose, and amber",
+        IsDark = true,
+        PreviewColors = ["#ff865b", "#fd6f9c", "#f3a683", "#121c2a"],
+        IvyTheme = new Theme
+        {
+            Name = "Sunset",
+            FontFamily = "Geist",
+            FontSize = "16px",
+            BorderRadiusBoxes = Theme.Default.BorderRadiusBoxes,
+            BorderRadiusFields = Theme.Default.BorderRadiusFields,
+            BorderRadiusSelectors = Theme.Default.BorderRadiusSelectors,
+            Colors = new ThemeColorScheme
+            {
+                Light = new ThemeColors
+                {
+                    Primary = "#f97316",
+                    PrimaryForeground = "#ffffff",
+                    Secondary = "#f43f5e",
+                    SecondaryForeground = "#ffffff",
+                    Accent = "#fb923c",
+                    AccentForeground = "#ffffff",
+                    Background = "#fff7ed",
+                    Foreground = "#431407",
+                    Destructive = "#dc2626",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#16a34a",
+                    SuccessForeground = "#ffffff",
+                    Warning = "#d97706",
+                    WarningForeground = "#ffffff",
+                    Info = "#0284c7",
+                    InfoForeground = "#ffffff",
+                    Border = "#fed7aa",
+                    Input = "#ffedd5",
+                    Ring = "#f97316",
+                    Muted = "#ffedd5",
+                    MutedForeground = "#c2410c",
+                    Card = "#ffffff",
+                    CardForeground = "#431407",
+                    Popover = "#fff7ed",
+                    PopoverForeground = "#431407"
+                },
+                Dark = new ThemeColors
+                {
+                    Primary = "#ff865b",
+                    PrimaryForeground = "#121c2a",
+                    Secondary = "#fd6f9c",
+                    SecondaryForeground = "#121c2a",
+                    Accent = "#f3a683",
+                    AccentForeground = "#121c2a",
+                    Background = "#121c2a",
+                    Foreground = "#f8e9e2",
+                    Destructive = "#ff5757",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#2dd4bf",
+                    SuccessForeground = "#121c2a",
+                    Warning = "#fcd34d",
+                    WarningForeground = "#121c2a",
+                    Info = "#60a5fa",
+                    InfoForeground = "#121c2a",
+                    Border = "#273a54",
+                    Input = "#1e2e44",
+                    Ring = "#ff865b",
+                    Muted = "#22344c",
+                    MutedForeground = "#9fb3cb",
+                    Card = "#1b293d",
+                    CardForeground = "#f8e9e2",
+                    Popover = "#121c2a",
+                    PopoverForeground = "#f8e9e2"
+                }
+            }
+        }
+    };
+
+    public static readonly TendrilThemeDescriptor Coffee = new()
+    {
+        Id = "coffee",
+        Name = "Coffee",
+        Description = "Rich espresso dark background with caramel and warm roasted accents",
+        IsDark = true,
+        PreviewColors = ["#db924b", "#dc944c", "#94633b", "#20161f"],
+        IvyTheme = new Theme
+        {
+            Name = "Coffee",
+            FontFamily = "Geist",
+            FontSize = "16px",
+            BorderRadiusBoxes = Theme.Default.BorderRadiusBoxes,
+            BorderRadiusFields = Theme.Default.BorderRadiusFields,
+            BorderRadiusSelectors = Theme.Default.BorderRadiusSelectors,
+            Colors = new ThemeColorScheme
+            {
+                Light = new ThemeColors
+                {
+                    Primary = "#b45309",
+                    PrimaryForeground = "#ffffff",
+                    Secondary = "#d97706",
+                    SecondaryForeground = "#ffffff",
+                    Accent = "#fef3c7",
+                    AccentForeground = "#78350f",
+                    Background = "#fdfbf7",
+                    Foreground = "#451a03",
+                    Destructive = "#dc2626",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#16a34a",
+                    SuccessForeground = "#ffffff",
+                    Warning = "#d97706",
+                    WarningForeground = "#ffffff",
+                    Info = "#0284c7",
+                    InfoForeground = "#ffffff",
+                    Border = "#e7dfd5",
+                    Input = "#f5eee6",
+                    Ring = "#b45309",
+                    Muted = "#f5eee6",
+                    MutedForeground = "#92400e",
+                    Card = "#ffffff",
+                    CardForeground = "#451a03",
+                    Popover = "#fdfbf7",
+                    PopoverForeground = "#451a03"
+                },
+                Dark = new ThemeColors
+                {
+                    Primary = "#db924b",
+                    PrimaryForeground = "#20161f",
+                    Secondary = "#dc944c",
+                    SecondaryForeground = "#20161f",
+                    Accent = "#94633b",
+                    AccentForeground = "#ffffff",
+                    Background = "#20161f",
+                    Foreground = "#ddd0b9",
+                    Destructive = "#ef4444",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#22c55e",
+                    SuccessForeground = "#20161f",
+                    Warning = "#eab308",
+                    WarningForeground = "#20161f",
+                    Info = "#38bdf8",
+                    InfoForeground = "#20161f",
+                    Border = "#3f2d3d",
+                    Input = "#2d202b",
+                    Ring = "#db924b",
+                    Muted = "#342632",
+                    MutedForeground = "#a89587",
+                    Card = "#2a1e29",
+                    CardForeground = "#ddd0b9",
+                    Popover = "#20161f",
+                    PopoverForeground = "#ddd0b9"
+                }
+            }
+        }
+    };
+
+    public static readonly TendrilThemeDescriptor Dim = new()
+    {
+        Id = "dim",
+        Name = "Dim",
+        Description = "Modern muted charcoal dark background with mint green and slate blue",
+        IsDark = true,
+        PreviewColors = ["#9fe88d", "#79a7d3", "#ff7ac6", "#2a303c"],
+        IvyTheme = new Theme
+        {
+            Name = "Dim",
+            FontFamily = "Geist",
+            FontSize = "16px",
+            BorderRadiusBoxes = Theme.Default.BorderRadiusBoxes,
+            BorderRadiusFields = Theme.Default.BorderRadiusFields,
+            BorderRadiusSelectors = Theme.Default.BorderRadiusSelectors,
+            Colors = new ThemeColorScheme
+            {
+                Light = new ThemeColors
+                {
+                    Primary = "#16a34a",
+                    PrimaryForeground = "#ffffff",
+                    Secondary = "#2563eb",
+                    SecondaryForeground = "#ffffff",
+                    Accent = "#db2777",
+                    AccentForeground = "#ffffff",
+                    Background = "#f8fafc",
+                    Foreground = "#1e293b",
+                    Destructive = "#ef4444",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#16a34a",
+                    SuccessForeground = "#ffffff",
+                    Warning = "#f59e0b",
+                    WarningForeground = "#ffffff",
+                    Info = "#2563eb",
+                    InfoForeground = "#ffffff",
+                    Border = "#e2e8f0",
+                    Input = "#f1f5f9",
+                    Ring = "#16a34a",
+                    Muted = "#f1f5f9",
+                    MutedForeground = "#64748b",
+                    Card = "#ffffff",
+                    CardForeground = "#1e293b",
+                    Popover = "#f8fafc",
+                    PopoverForeground = "#1e293b"
+                },
+                Dark = new ThemeColors
+                {
+                    Primary = "#9fe88d",
+                    PrimaryForeground = "#193614",
+                    Secondary = "#79a7d3",
+                    SecondaryForeground = "#16283b",
+                    Accent = "#ff7ac6",
+                    AccentForeground = "#3a1329",
+                    Background = "#2a303c",
+                    Foreground = "#a6adba",
+                    Destructive = "#ff6e6e",
+                    DestructiveForeground = "#2a303c",
+                    Success = "#9fe88d",
+                    SuccessForeground = "#193614",
+                    Warning = "#f3cc30",
+                    WarningForeground = "#2a303c",
+                    Info = "#79a7d3",
+                    InfoForeground = "#16283b",
+                    Border = "#383f4d",
+                    Input = "#222731",
+                    Ring = "#9fe88d",
+                    Muted = "#313846",
+                    MutedForeground = "#798497",
+                    Card = "#242933",
+                    CardForeground = "#a6adba",
+                    Popover = "#2a303c",
+                    PopoverForeground = "#a6adba"
+                }
+            }
+        }
+    };
+
+    public static readonly TendrilThemeDescriptor Luxury = new()
+    {
+        Id = "luxury",
+        Name = "Luxury",
+        Description = "Premium dark gold theme with deep obsidian background and champagne accents",
+        IsDark = true,
+        PreviewColors = ["#dca54c", "#e0d8b0", "#ff7598", "#09090b"],
+        IvyTheme = new Theme
+        {
+            Name = "Luxury",
+            FontFamily = "Geist",
+            FontSize = "16px",
+            BorderRadiusBoxes = Theme.Default.BorderRadiusBoxes,
+            BorderRadiusFields = Theme.Default.BorderRadiusFields,
+            BorderRadiusSelectors = Theme.Default.BorderRadiusSelectors,
+            Colors = new ThemeColorScheme
+            {
+                Light = new ThemeColors
+                {
+                    Primary = "#b45309",
+                    PrimaryForeground = "#ffffff",
+                    Secondary = "#78350f",
+                    SecondaryForeground = "#ffffff",
+                    Accent = "#fef3c7",
+                    AccentForeground = "#78350f",
+                    Background = "#fafaf9",
+                    Foreground = "#1c1917",
+                    Destructive = "#dc2626",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#16a34a",
+                    SuccessForeground = "#ffffff",
+                    Warning = "#d97706",
+                    WarningForeground = "#ffffff",
+                    Info = "#0284c7",
+                    InfoForeground = "#ffffff",
+                    Border = "#e7e5e4",
+                    Input = "#f5f5f4",
+                    Ring = "#b45309",
+                    Muted = "#f5f5f4",
+                    MutedForeground = "#78716c",
+                    Card = "#ffffff",
+                    CardForeground = "#1c1917",
+                    Popover = "#fafaf9",
+                    PopoverForeground = "#1c1917"
+                },
+                Dark = new ThemeColors
+                {
+                    Primary = "#dca54c",
+                    PrimaryForeground = "#150e04",
+                    Secondary = "#e0d8b0",
+                    SecondaryForeground = "#150e04",
+                    Accent = "#c28833",
+                    AccentForeground = "#ffffff",
+                    Background = "#09090b",
+                    Foreground = "#f5f5f5",
+                    Destructive = "#ef4444",
+                    DestructiveForeground = "#ffffff",
+                    Success = "#22c55e",
+                    SuccessForeground = "#09090b",
+                    Warning = "#dca54c",
+                    WarningForeground = "#09090b",
+                    Info = "#38bdf8",
+                    InfoForeground = "#09090b",
+                    Border = "#27272a",
+                    Input = "#1c1c21",
+                    Ring = "#dca54c",
+                    Muted = "#202026",
+                    MutedForeground = "#a1a1aa",
+                    Card = "#141418",
+                    CardForeground = "#f5f5f5",
+                    Popover = "#09090b",
+                    PopoverForeground = "#f5f5f5"
+                }
+            }
+        }
+    };
+
+    public static readonly IReadOnlyList<TendrilThemeDescriptor> All =
+    [
+        Default,
+        Cupcake,
+        Cyberpunk,
+        Synthwave,
+        Retro,
+        Dracula,
+        Nord,
+        Forest,
+        Aqua,
+        Valentine,
+        Sunset,
+        Coffee,
+        Dim,
+        Luxury
+    ];
+
+    private static readonly Dictionary<string, TendrilThemeDescriptor> ThemesById =
+        All.ToDictionary(t => t.Id, t => t, StringComparer.OrdinalIgnoreCase);
+
+    public static TendrilThemeDescriptor GetTheme(string? id)
+    {
+        if (!string.IsNullOrWhiteSpace(id) && ThemesById.TryGetValue(id.Trim(), out var theme))
+            return theme;
+        return Default;
+    }
+
+    public static void ApplyTheme(IClientProvider client, string? themeId)
+    {
+        var descriptor = GetTheme(themeId);
+        var themeService = new ThemeService();
+        themeService.SetTheme(descriptor.IvyTheme);
+        var css = themeService.GenerateThemeCss();
+        client.ApplyTheme(css);
+    }
+}

--- a/src/Ivy.Tendril/example.config.yaml
+++ b/src/Ivy.Tendril/example.config.yaml
@@ -6,6 +6,7 @@ jobTimeout: 30
 staleOutputTimeout: 10
 gitTimeout: 10  # Timeout in seconds for git operations (default: 10)
 maxConcurrentJobs: 20  # Maximum number of jobs to run concurrently (default: 20)
+theme: default  # UI theme preset (default, cupcake, cyberpunk, synthwave, retro, dracula, nord, forest, aqua, valentine, sunset, coffee, dim, luxury)
 
 # Variable Expansion Support:
 # - %TENDRIL_HOME% - Expands to TENDRIL_HOME env var (useful in hooks, verification prompts, and allowedTools paths)


### PR DESCRIPTION
# Summary

## Changes

Added theme selection to Tendril featuring 14 DaisyUI-inspired color schemes (Default, Cupcake, Cyberpunk, Synthwave, Retro, Dracula, Nord, Forest, Aqua, Valentine, Sunset, Coffee, Dim, Luxury). Users can preview and select themes directly from the Appearance settings view, with choices persisted across sessions in configuration and applied seamlessly upon startup and reload.

## API Changes

- Added `Ivy.Tendril.Themes.TendrilThemes` registry with `All`, `GetTheme(string? id)`, and `ApplyTheme(IClientProvider client, string? themeId)`.
- Added `Ivy.Tendril.Themes.TendrilThemeDescriptor` defining theme metadata (`Id`, `Name`, `Description`, `IsDark`, `PreviewColors`, `IvyTheme`).
- Added `public string Theme { get; set; } = "default";` to `TendrilSettings`.
- Extended `tendril config get theme` and `tendril config set theme <name>` CLI commands with theme validation.
- Extended `tendril_get_config` and `tendril_set_config` MCP tools to support the `theme` key.

## Files Modified

- **Themes**:
  - `src/Ivy.Tendril/Themes/TendrilThemes.cs` (new theme registry with 14 DaisyUI-inspired color palettes)
- **Configuration & CLI**:
  - `src/Ivy.Tendril/Services/ConfigService.cs` (added `Theme` setting property and validation)
  - `src/Ivy.Tendril/Commands/ConfigCommand.cs` (added `theme` field handling and CLI validation)
  - `src/Ivy.Tendril/Mcp/Tools/ConfigTools.cs` (exposed `theme` in MCP tool descriptions)
  - `src/Ivy.Tendril/example.config.yaml` (documented `theme` config option)
  - `src/Ivy.Tendril/AGENTS.md` & `src/Ivy.Tendril/Prompts/AgentPrompt.md` (documented `theme` config key)
- **UI & AppShell**:
  - `src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs` (interactive theme picker cards with 4-color swatches and active indicator)
  - `src/Ivy.Tendril/AppShell/TendrilAppShell.cs` (applies configured theme on shell mount and settings reload)
- **Tests**:
  - `src/Ivy.Tendril.Test/Themes/ThemeRegistryTests.cs` (unit tests for theme registry)
  - `src/Ivy.Tendril.Test/ConfigServiceTests.cs` (unit tests for theme persistence and fallback)
  - `src/Ivy.Tendril.Test/ConfigCliCommandTests.cs` (unit tests for `tendril config set/get theme`)
  - `src/Ivy.Tendril.Test/Mcp/ConfigToolsTests.cs` (unit tests for MCP config tools with theme)

## Manual Testing

1. Launch Tendril application or run `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`.
2. Navigate to **Settings** -> **Appearance**.
3. Observe the **Theme** section displaying a select dropdown populated with all 14 DaisyUI-inspired themes, along with 4-color preview swatches and description for the active theme.
4. Select **Cupcake**, **Dracula**, or **Cyberpunk** from the dropdown. Observe the application UI immediately changing colors, a confirmation toast appearing, and the preview swatches updating.
5. Reload or restart the application; verify that the selected theme persists.
6. Verify via CLI: `tendril config get theme` returns the selected theme name, and `tendril config set theme synthwave` changes and persists the theme.

## Fix: Replace Theme Cards Grid with Select Dropdown

Replaced the large vertical grid of theme cards in Appearance settings with a compact select dropdown per reviewer feedback. The selected theme displays inline preview swatches and description, persisting changes immediately to configuration and applying the theme in real time.

### Files Modified

- `src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs` (switched theme selection UI from card grid to select input with swatch preview)

## Fix: Remove Light/Dark Phrases and Theme Description

Removed "(Dark)" and "(Light)" phrases from the theme options in the select dropdown and removed the placeholder description text underneath the dropdown, displaying only the theme names and the color preview swatches per reviewer feedback.

### Files Modified

- `src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs` (simplified theme select options to theme names only and removed theme description text)

---
- `ad38842c` feat(themes): add DaisyUI-inspired color schemes registry (00006)
- `6ae01b7d` feat(config): add theme setting with CLI and MCP support (00006)
- `ec23a74e` feat(ui): add theme selector in Appearance settings and shell integration (00006)
- `296f60fd` test(themes): add unit and integration tests for themes and configuration (00006)
- `ea329b00` refactor(appearance): replace theme cards with select dropdown per review feedback (00006)
- `5907ce4c` refactor(appearance): remove light/dark phrases and theme descriptions from theme selector (00006)

---
Created using [Ivy Tendril](https://ivy.app).
