### PR TITLE
[00011] Add Confirmation Dialog for Deleting Chats with Keyboard Shortcut

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom";
 
@@ -130,7 +130,7 @@ describe("ChatWidget Queued Messages UI", () => {
     expect(screen.queryByText("Queued Messages")).not.toBeInTheDocument();
   });
 
-  it("renders delete button next to chat title and emits OnDeleteSession", () => {
+  it("renders delete button next to chat title, opens confirmation dialog, and emits OnDeleteSession upon confirmation", () => {
     const handleEvent = vi.fn();
     const session = {
       id: "sess-123",
@@ -157,11 +157,115 @@ describe("ChatWidget Queued Messages UI", () => {
 
     fireEvent.click(deleteBtn);
 
+    // Dialog is open
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("Delete Chat")).toBeInTheDocument();
+    expect(within(dialog).getByText(/Are you sure you want to delete/i)).toBeInTheDocument();
+    expect(within(dialog).getByText(/My Great Chat/i)).toBeInTheDocument();
+    expect(handleEvent).not.toHaveBeenCalled();
+
+    // Confirm deletion
+    const confirmDeleteBtn = within(dialog).getByRole("button", { name: /Delete/i });
+    fireEvent.click(confirmDeleteBtn);
+
     expect(handleEvent).toHaveBeenCalledWith(
       "OnDeleteSession",
       "test-chat",
       ["sess-123"]
     );
+    expect(screen.queryByText("Delete Chat")).not.toBeInTheDocument();
+  });
+
+  it("dismisses delete confirmation dialog when Cancel is clicked, Escape is pressed, or backdrop is clicked without emitting OnDeleteSession", () => {
+    const handleEvent = vi.fn();
+    const session = {
+      id: "sess-123",
+      title: "My Great Chat",
+      agentId: "antigravity",
+      modelId: "gemini-3.7-flash",
+      createdAt: "2026-08-15T12:00:00Z",
+      updatedAt: "2026-08-15T12:30:00Z",
+      messages: [],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-123"
+        sessions={[session]}
+        events={["OnDeleteSession"]}
+        eventHandler={handleEvent}
+      />
+    );
+
+    const deleteBtn = screen.getByRole("button", { name: /Delete chat session/i });
+
+    // 1. Cancel button
+    fireEvent.click(deleteBtn);
+    expect(screen.getByText("Delete Chat")).toBeInTheDocument();
+
+    const cancelBtn = screen.getByRole("button", { name: /Cancel/i });
+    fireEvent.click(cancelBtn);
+    expect(screen.queryByText("Delete Chat")).not.toBeInTheDocument();
+    expect(handleEvent).not.toHaveBeenCalled();
+
+    // 2. Escape key
+    fireEvent.click(deleteBtn);
+    expect(screen.getByText("Delete Chat")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByText("Delete Chat")).not.toBeInTheDocument();
+    expect(handleEvent).not.toHaveBeenCalled();
+
+    // 3. Backdrop click
+    fireEvent.click(deleteBtn);
+    const dialogOverlay = screen.getByRole("dialog");
+    fireEvent.click(dialogOverlay);
+    expect(screen.queryByText("Delete Chat")).not.toBeInTheDocument();
+    expect(handleEvent).not.toHaveBeenCalled();
+  });
+
+  it("confirms deletion via Ctrl+Enter and Cmd+Enter keyboard shortcuts", () => {
+    const handleEvent = vi.fn();
+    const session = {
+      id: "sess-123",
+      title: "My Great Chat",
+      agentId: "antigravity",
+      modelId: "gemini-3.7-flash",
+      createdAt: "2026-08-15T12:00:00Z",
+      updatedAt: "2026-08-15T12:30:00Z",
+      messages: [],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-123"
+        sessions={[session]}
+        events={["OnDeleteSession"]}
+        eventHandler={handleEvent}
+      />
+    );
+
+    const deleteBtn = screen.getByRole("button", { name: /Delete chat session/i });
+
+    // Ctrl+Enter
+    fireEvent.click(deleteBtn);
+    expect(screen.getByText("Delete Chat")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Enter", ctrlKey: true });
+    expect(handleEvent).toHaveBeenCalledTimes(1);
+    expect(handleEvent).toHaveBeenCalledWith("OnDeleteSession", "test-chat", ["sess-123"]);
+    expect(screen.queryByText("Delete Chat")).not.toBeInTheDocument();
+
+    // Cmd+Enter
+    fireEvent.click(deleteBtn);
+    expect(screen.getByText("Delete Chat")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Enter", metaKey: true });
+    expect(handleEvent).toHaveBeenCalledTimes(2);
+    expect(handleEvent).toHaveBeenLastCalledWith("OnDeleteSession", "test-chat", ["sess-123"]);
+    expect(screen.queryByText("Delete Chat")).not.toBeInTheDocument();
   });
 
   it("renders effort picker and emits OnEffortChanged when changed", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -347,6 +347,7 @@ export function ChatWidget({
   const [editingQueuedId, setEditingQueuedId] = useState<string | null>(null);
   const [editingQueuedText, setEditingQueuedText] = useState("");
   const [pendingRenames, setPendingRenames] = useState<Record<string, string>>({});
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -355,6 +356,47 @@ export function ChatWidget({
   const initialPromptRef = useRef<string>("");
 
   const activeSession = sessions.find((s) => s.id === activeSessionId);
+
+  useEffect(() => {
+    setShowDeleteConfirm(false);
+  }, [activeSessionId]);
+
+  const handleDeleteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setShowDeleteConfirm(true);
+  };
+
+  const handleDeleteConfirm = () => {
+    if (activeSession) {
+      emit("OnDeleteSession", activeSession.id);
+    }
+    setShowDeleteConfirm(false);
+  };
+
+  const handleDeleteCancel = () => {
+    setShowDeleteConfirm(false);
+  };
+
+  useEffect(() => {
+    if (!showDeleteConfirm) return;
+
+    const handleDialogKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+        e.preventDefault();
+        e.stopPropagation();
+        handleDeleteConfirm();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        handleDeleteCancel();
+      }
+    };
+
+    window.addEventListener("keydown", handleDialogKeyDown, true);
+    return () => {
+      window.removeEventListener("keydown", handleDialogKeyDown, true);
+    };
+  }, [showDeleteConfirm, activeSession]);
 
   // Clear pending renames once they appear in props
   useEffect(() => {
@@ -754,10 +796,7 @@ export function ChatWidget({
               <button
                 type="button"
                 className="chat-header-delete-btn"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  emit("OnDeleteSession", activeSession.id);
-                }}
+                onClick={handleDeleteClick}
                 title="Delete chat session"
                 aria-label="Delete chat session"
               >
@@ -1132,6 +1171,60 @@ export function ChatWidget({
           </div>
         </div>
       </div>
+
+      {showDeleteConfirm &&
+        activeSession &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            className="chat-confirm-overlay"
+            onClick={handleDeleteCancel}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="chat-delete-confirm-title"
+          >
+            <div
+              className="chat-confirm-modal"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="chat-confirm-header">
+                <h3 id="chat-delete-confirm-title" className="chat-confirm-title">
+                  Delete Chat
+                </h3>
+              </div>
+              <div className="chat-confirm-body">
+                <p className="chat-confirm-desc">
+                  Are you sure you want to delete{" "}
+                  {activeSession.title ? (
+                    <strong>&ldquo;{activeSession.title}&rdquo;</strong>
+                  ) : (
+                    "this chat session"
+                  )}
+                  ? This action cannot be undone.
+                </p>
+              </div>
+              <div className="chat-confirm-actions">
+                <button
+                  type="button"
+                  className="chat-confirm-btn cancel"
+                  onClick={handleDeleteCancel}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="chat-confirm-btn delete"
+                  onClick={handleDeleteConfirm}
+                  autoFocus
+                >
+                  <span>Delete</span>
+                  <kbd className="chat-shortcut-hint">Ctrl+Enter</kbd>
+                </button>
+              </div>
+            </div>
+          </div>,
+          document.body
+        )}
     </div>
   );
 }

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -1215,3 +1215,134 @@ button .text-muted {
   background-color: color-mix(in srgb, var(--destructive) 15%, transparent);
 }
 
+/* Delete Confirmation Dialog */
+.chat-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  backdrop-filter: blur(2px);
+  animation: chat-confirm-fade-in 0.15s ease-out;
+}
+
+@keyframes chat-confirm-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.chat-confirm-modal {
+  background-color: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius, 8px);
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.3), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
+  padding: 1.25rem;
+  max-width: 400px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  color: var(--foreground);
+  animation: chat-confirm-scale-in 0.15s ease-out;
+}
+
+@keyframes chat-confirm-scale-in {
+  from {
+    transform: scale(0.95);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.chat-confirm-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.chat-confirm-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.chat-confirm-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.chat-confirm-desc {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+  line-height: 1.4;
+}
+
+.chat-confirm-desc strong {
+  color: var(--foreground);
+}
+
+.chat-confirm-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.chat-confirm-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border-radius: var(--radius, 6px);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  border: 1px solid transparent;
+  font-family: inherit;
+}
+
+.chat-confirm-btn.cancel {
+  background-color: var(--secondary);
+  color: var(--secondary-foreground);
+  border-color: var(--border);
+}
+
+.chat-confirm-btn.cancel:hover {
+  background-color: var(--accent);
+  color: var(--accent-foreground);
+}
+
+.chat-confirm-btn.delete {
+  background-color: var(--destructive);
+  color: var(--destructive-foreground, #fff);
+  border-color: var(--destructive);
+}
+
+.chat-confirm-btn.delete:hover {
+  opacity: 0.9;
+}
+
+.chat-confirm-btn.delete .chat-shortcut-hint {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: inherit;
+  border: none;
+  font-size: 0.6875rem;
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+}
+
+


### PR DESCRIPTION
# Summary

## Changes

Added a confirmation modal dialog when deleting chat sessions in the Chat widget, preventing accidental deletions and supporting fast keyboard shortcuts (Ctrl+Enter / Cmd+Enter to confirm, Escape to cancel).

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx`: Added confirmation dialog state, portal modal, and global keyboard shortcuts.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css`: Added styles for confirmation modal dialog, overlay backdrop, and shortcut badge.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx`: Updated and expanded unit tests for delete confirmation dialog, cancellation, and keyboard shortcut approvals.

## Manual Testing

1. Open the Chat application.
2. Select an existing chat session with messages.
3. Click the trash icon in the header next to the chat title: verify that a modal confirmation dialog appears with the chat title, Cancel button, and Delete button with the `Ctrl+Enter` shortcut hint.
4. Click Cancel or press Escape or click outside the dialog: verify the dialog closes and the chat session is not deleted.
5. Click the trash icon again and press `Ctrl+Enter` (or `Cmd+Enter` on macOS) or click Delete: verify that the chat session is deleted and the dialog closes.

---
- c42785ef3a282b296efda68ea2b9ded46e825432: Plan 00011: Add confirmation dialog for deleting chats with keyboard shortcut

---
Created using [Ivy Tendril](https://ivy.app).
