### PR TITLE
[00012] Agentic Chat Session Naming on Initial Response

### DIFF
--- a/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
@@ -56,7 +56,7 @@ public class ChatHistoryServiceTests
             var updatedSession = service.GetSession(session.Id);
             Assert.NotNull(updatedSession);
             Assert.Single(updatedSession.Messages);
-            Assert.Equal("Hello agent", updatedSession.Title);
+            Assert.Equal("New Chat", updatedSession.Title);
         }
         finally
         {

--- a/src/Ivy.Tendril.Test/ChatSessionNamingServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatSessionNamingServiceTests.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class ChatSessionNamingServiceTests
+{
+    private class MockAgentRunner : IAgentRunner
+    {
+        public Func<AgentResolutionContext, CancellationToken, Task<ResultEvent>>? RunToCompletionHandler { get; set; }
+        public AgentResolutionContext? LastContext { get; private set; }
+
+        public IReadOnlyList<string> RegisteredAgents => ["claude", "opencode"];
+        public IReadOnlyList<IAgentSession> ActiveSessions => [];
+        public IObservable<IAgentSession> Sessions => throw new NotImplementedException();
+
+        public IAgentCli GetCli(string agentId) => throw new NotImplementedException();
+        public IEventParser GetParser(string agentId) => throw new NotImplementedException();
+        public IAgentHealthCheck GetHealthCheck(string agentId) => throw new NotImplementedException();
+        public IAgentDescriptor GetDescriptor(string agentId) => throw new NotImplementedException();
+        public IFailureAnalyzer? GetFailureAnalyzer(string agentId) => null;
+        public ISessionCostParser? GetCostParser(string agentId) => null;
+        public IAgentPty? GetPty(string agentId) => null;
+        public IModelCatalogProvider? GetModelCatalog(string agentId) => null;
+        public IEnumerable<IModelCatalogProvider> ModelCatalogs => [];
+
+        public Task<IAgentSession> LaunchAsync(AgentResolutionContext context, CancellationToken ct = default)
+            => throw new NotImplementedException();
+
+        public Task<ResultEvent> RunToCompletionAsync(AgentResolutionContext context, CancellationToken ct = default)
+        {
+            LastContext = context;
+            if (RunToCompletionHandler != null)
+            {
+                return RunToCompletionHandler(context, ct);
+            }
+
+            return Task.FromResult(new ResultEvent
+            {
+                Kind = AgentEventKind.Result,
+                IsSuccess = true,
+                Response = "Fixing User Authentication"
+            });
+        }
+
+        public Task StopAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private (ChatHistoryService ChatService, ConfigService ConfigService, string TempDir) CreateServices()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilNamingTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        var config = new ConfigService(new TendrilSettings(), tempDir);
+        var chat = new ChatHistoryService(config);
+        return (chat, config, tempDir);
+    }
+
+    [Fact]
+    public void BuildPrompt_FormatsPromptWithUserAndAssistantMessages()
+    {
+        var userPrompt = "How do I fix the database connection?";
+        var assistantResponse = "You need to update the connection string in config.yaml.";
+
+        var prompt = ChatSessionNamingService.BuildPrompt(userPrompt, assistantResponse);
+
+        Assert.Contains("How do I fix the database connection?", prompt);
+        Assert.Contains("You need to update the connection string in config.yaml.", prompt);
+        Assert.Contains("short 3 to 6 word title", prompt);
+    }
+
+    [Theory]
+    [InlineData("### User Authentication Flow", "User Authentication Flow")]
+    [InlineData("# **Fixing Database Deadlocks**", "Fixing Database Deadlocks")]
+    [InlineData("`Refactoring Service Layer`", "Refactoring Service Layer")]
+    [InlineData("*Updating Unit Tests*", "Updating Unit Tests")]
+    public void CleanGeneratedTitle_StripsMarkdownHeadingsAndFormatting(string raw, string expected)
+    {
+        var cleaned = ChatSessionNamingService.CleanGeneratedTitle(raw);
+        Assert.Equal(expected, cleaned);
+    }
+
+    [Theory]
+    [InlineData("Title: Debugging Login API", "Debugging Login API")]
+    [InlineData("title: \"Optimizing Memory Usage\"", "Optimizing Memory Usage")]
+    [InlineData("Topic: 'Configuring Docker Container'", "Configuring Docker Container")]
+    [InlineData("Subject: Resolving Merge Conflicts", "Resolving Merge Conflicts")]
+    [InlineData("“Refactoring Navigation Bar”", "Refactoring Navigation Bar")]
+    public void CleanGeneratedTitle_StripsPrefixesAndQuotes(string raw, string expected)
+    {
+        var cleaned = ChatSessionNamingService.CleanGeneratedTitle(raw);
+        Assert.Equal(expected, cleaned);
+    }
+
+    [Theory]
+    [InlineData("Fixing Build Errors...", "Fixing Build Errors")]
+    [InlineData("Adding Dark Mode Support…", "Adding Dark Mode Support")]
+    [InlineData("Updating API Routes.", "Updating API Routes")]
+    [InlineData("Investigating High CPU Usage!", "Investigating High CPU Usage")]
+    [InlineData("Why is the test failing?", "Why is the test failing")]
+    public void CleanGeneratedTitle_StripsTrailingPunctuationAndEllipses(string raw, string expected)
+    {
+        var cleaned = ChatSessionNamingService.CleanGeneratedTitle(raw);
+        Assert.Equal(expected, cleaned);
+    }
+
+    [Fact]
+    public void CleanGeneratedTitle_EnforcesMaxLength()
+    {
+        var veryLongTitle = "This is an extremely long title that exceeds the maximum allowable length of fifty characters";
+        var cleaned = ChatSessionNamingService.CleanGeneratedTitle(veryLongTitle);
+
+        Assert.NotNull(cleaned);
+        Assert.True(cleaned.Length <= 50);
+        Assert.Equal(veryLongTitle[..50].Trim(), cleaned);
+    }
+
+    [Fact]
+    public async Task GenerateAndSetTitleAsync_RenamesSession_WhenTitleIsNewChat()
+    {
+        var (chatService, configService, tempDir) = CreateServices();
+        try
+        {
+            var runner = new MockAgentRunner
+            {
+                RunToCompletionHandler = (_, _) => Task.FromResult(new ResultEvent
+                {
+                    Kind = AgentEventKind.Result,
+                    IsSuccess = true,
+                    Response = "Title: \"Configuring Redis Cache\"."
+                })
+            };
+
+            var namingService = new ChatSessionNamingService(
+                runner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+
+            var session = chatService.CreateSession("claude", "sonnet");
+            chatService.AddMessage(session.Id, "user", "How do I configure Redis cache?");
+            chatService.AddMessage(session.Id, "assistant", "You can configure Redis in settings.");
+
+            await namingService.GenerateAndSetTitleAsync(
+                session.Id,
+                "How do I configure Redis cache?",
+                "You can configure Redis in settings.",
+                "claude",
+                "sonnet");
+
+            var updatedSession = chatService.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            Assert.Equal("Configuring Redis Cache", updatedSession.Title);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAndSetTitleAsync_DoesNotRename_WhenTitleAlreadyCustomized()
+    {
+        var (chatService, configService, tempDir) = CreateServices();
+        try
+        {
+            var runner = new MockAgentRunner
+            {
+                RunToCompletionHandler = (_, _) => Task.FromResult(new ResultEvent
+                {
+                    Kind = AgentEventKind.Result,
+                    IsSuccess = true,
+                    Response = "Generated Redis Cache Title"
+                })
+            };
+
+            var namingService = new ChatSessionNamingService(
+                runner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+
+            var session = chatService.CreateSession("claude", "sonnet", "Customized User Title");
+            chatService.AddMessage(session.Id, "user", "How do I configure Redis cache?");
+            chatService.AddMessage(session.Id, "assistant", "You can configure Redis in settings.");
+
+            await namingService.GenerateAndSetTitleAsync(
+                session.Id,
+                "How do I configure Redis cache?",
+                "You can configure Redis in settings.",
+                "claude",
+                "sonnet");
+
+            var updatedSession = chatService.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            Assert.Equal("Customized User Title", updatedSession.Title);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAndSetTitleAsync_HandlesRunnerFailureGracefully()
+    {
+        var (chatService, configService, tempDir) = CreateServices();
+        try
+        {
+            var runner = new MockAgentRunner
+            {
+                RunToCompletionHandler = (_, _) => Task.FromResult(new ResultEvent
+                {
+                    Kind = AgentEventKind.Result,
+                    IsSuccess = false,
+                    Error = "Model rate limit exceeded",
+                    ExitCode = 1
+                })
+            };
+
+            var namingService = new ChatSessionNamingService(
+                runner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+
+            var session = chatService.CreateSession("claude", "sonnet");
+            chatService.AddMessage(session.Id, "user", "Prompt");
+            chatService.AddMessage(session.Id, "assistant", "Response");
+
+            await namingService.GenerateAndSetTitleAsync(
+                session.Id,
+                "Prompt",
+                "Response",
+                "claude",
+                "sonnet");
+
+            var updatedSession = chatService.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            Assert.Equal("New Chat", updatedSession.Title);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task GenerateAndSetTitleAsync_HandlesRunnerTimeoutGracefully()
+    {
+        var (chatService, configService, tempDir) = CreateServices();
+        try
+        {
+            var runner = new MockAgentRunner
+            {
+                RunToCompletionHandler = async (_, ct) =>
+                {
+                    await Task.Delay(50, ct);
+                    throw new OperationCanceledException();
+                }
+            };
+
+            var namingService = new ChatSessionNamingService(
+                runner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+
+            var session = chatService.CreateSession("claude", "sonnet");
+            chatService.AddMessage(session.Id, "user", "Prompt");
+            chatService.AddMessage(session.Id, "assistant", "Response");
+
+            await namingService.GenerateAndSetTitleAsync(
+                session.Id,
+                "Prompt",
+                "Response",
+                "claude",
+                "sonnet");
+
+            var updatedSession = chatService.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            Assert.Equal("New Chat", updatedSession.Title);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -29,6 +29,7 @@ public class ChatApp : ViewBase
         var configService = UseService<IConfigService>();
         var chatService = UseService<IChatHistoryService>();
         var agentRunner = UseService<IAgentRunner>();
+        var namingService = UseService<IChatSessionNamingService>();
         var serializer = UseService<IEventSerializer>();
 
         var activeSessionId = UseState<string?>(args?.SessionId);
@@ -299,6 +300,28 @@ public class ChatApp : ViewBase
                     if (rawLines.Count > 0) fullRawStream = string.Join("\n", rawLines);
                 }
                 chatService.AddMessage(targetSessionId, "assistant", responseContent, selectedAgent.Value, selectedModel.Value, rawStream: fullRawStream, effort: selectedEffort.Value);
+
+                var currentSession = chatService.GetSession(targetSessionId);
+                if (currentSession != null &&
+                    (currentSession.Title == "New Chat" || string.IsNullOrWhiteSpace(currentSession.Title)) &&
+                    currentSession.Messages.Count == 2)
+                {
+                    var firstUserMsg = currentSession.Messages.FirstOrDefault(m => m.Role == "user")?.Content;
+                    if (!string.IsNullOrWhiteSpace(firstUserMsg))
+                    {
+                        var agentId = selectedAgent.Value;
+                        var modelId = selectedModel.Value;
+                        _ = Task.Run(async () =>
+                        {
+                            await namingService.GenerateAndSetTitleAsync(
+                                targetSessionId,
+                                firstUserMsg,
+                                responseContent,
+                                agentId,
+                                modelId);
+                        });
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -22,6 +22,7 @@ internal static class ServiceRegistration
         server.Services.AddSingleton<IConfigService>(configService);
         server.Services.AddSingleton<ConfigService>(configService);
         server.Services.AddSingleton<IChatHistoryService, ChatHistoryService>();
+        server.Services.AddSingleton<IChatSessionNamingService, ChatSessionNamingService>();
         server.Services.AddSingleton<ICreatePlanPreferences, CreatePlanPreferences>();
 
         Program.SetConfigServiceForCleanup(configService);

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -235,18 +235,8 @@ public class ChatHistoryService : IChatHistoryService
 
             var updatedMessages = new List<ChatMessageModel>(session.Messages) { msg };
 
-            // Auto update title from first user message if title is "New Chat"
-            var title = CleanTitle(session.Title);
-            if ((title == "New Chat" || string.IsNullOrWhiteSpace(title)) && role == "user" && !string.IsNullOrWhiteSpace(content))
-            {
-                var firstLine = content.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? content;
-                var clean = firstLine.Trim();
-                title = clean.Length > 50 ? clean[..50].Trim() : clean;
-            }
-
             var updatedSession = session with
             {
-                Title = title,
                 UpdatedAt = DateTimeOffset.UtcNow,
                 AgentId = agentId ?? session.AgentId,
                 ModelId = modelId ?? session.ModelId,

--- a/src/Ivy.Tendril/Services/ChatSessionNamingService.cs
+++ b/src/Ivy.Tendril/Services/ChatSessionNamingService.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services;
+
+public interface IChatSessionNamingService
+{
+    Task GenerateAndSetTitleAsync(
+        string sessionId,
+        string userPrompt,
+        string assistantResponse,
+        string? agentId = null,
+        string? modelId = null,
+        CancellationToken ct = default);
+}
+
+public class ChatSessionNamingService : IChatSessionNamingService
+{
+    private readonly IAgentRunner _agentRunner;
+    private readonly IConfigService _configService;
+    private readonly IChatHistoryService _chatHistoryService;
+    private readonly ILogger<ChatSessionNamingService> _logger;
+
+    public ChatSessionNamingService(
+        IAgentRunner agentRunner,
+        IConfigService configService,
+        IChatHistoryService chatHistoryService,
+        ILogger<ChatSessionNamingService> logger)
+    {
+        _agentRunner = agentRunner;
+        _configService = configService;
+        _chatHistoryService = chatHistoryService;
+        _logger = logger;
+    }
+
+    public async Task GenerateAndSetTitleAsync(
+        string sessionId,
+        string userPrompt,
+        string assistantResponse,
+        string? agentId = null,
+        string? modelId = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId) ||
+            string.IsNullOrWhiteSpace(userPrompt) ||
+            string.IsNullOrWhiteSpace(assistantResponse))
+        {
+            return;
+        }
+
+        try
+        {
+            var session = _chatHistoryService.GetSession(sessionId);
+            if (session == null || !IsDefaultTitle(session.Title))
+            {
+                return;
+            }
+
+            var prompt = BuildPrompt(userPrompt, assistantResponse);
+            var effectiveAgentId = !string.IsNullOrEmpty(agentId) ? agentId : (_configService.Settings.CodingAgent ?? "claude");
+
+            var context = AgentLaunchHelper.PrepareResolutionContext(
+                _configService,
+                _agentRunner,
+                effectiveAgentId,
+                prompt,
+                modelOverride: modelId,
+                permissionMode: PermissionMode.FullAuto);
+
+            context = context with
+            {
+                TimeoutPolicy = new TimeoutPolicy
+                {
+                    TotalTimeout = TimeSpan.FromSeconds(30),
+                    StartupTimeout = TimeSpan.FromSeconds(15),
+                    IdleTimeout = TimeSpan.FromSeconds(15),
+                }
+            };
+
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, timeoutCts.Token);
+
+            var result = await _agentRunner.RunToCompletionAsync(context, linkedCts.Token);
+
+            if (!result.IsSuccess || string.IsNullOrWhiteSpace(result.Response))
+            {
+                _logger.LogWarning("Failed to generate title for chat session {SessionId}: {Error}", sessionId, result.Error ?? "Empty response");
+                return;
+            }
+
+            var cleanedTitle = CleanGeneratedTitle(result.Response);
+            if (string.IsNullOrWhiteSpace(cleanedTitle) || IsDefaultTitle(cleanedTitle))
+            {
+                _logger.LogDebug("Generated title for chat session {SessionId} was empty or default after cleaning", sessionId);
+                return;
+            }
+
+            // Verify the session still exists and has not been renamed by the user
+            var latestSession = _chatHistoryService.GetSession(sessionId);
+            if (latestSession != null && IsDefaultTitle(latestSession.Title))
+            {
+                _chatHistoryService.RenameSession(sessionId, cleanedTitle);
+                _logger.LogInformation("Renamed chat session {SessionId} to '{Title}'", sessionId, cleanedTitle);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning("Title generation timed out for chat session {SessionId}", sessionId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error generating title for chat session {SessionId}", sessionId);
+        }
+    }
+
+    public static bool IsDefaultTitle(string? title)
+    {
+        if (string.IsNullOrWhiteSpace(title)) return true;
+        var clean = title.Trim();
+        return clean.Equals("New Chat", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static string BuildPrompt(string userPrompt, string assistantResponse)
+    {
+        return $"""
+Generate a short 3 to 6 word title describing the conversation topic based on the following user message and assistant reply.
+Output ONLY the title text. Do not include quotes, markdown headings, prefixes like "Title:", or trailing punctuation.
+
+User:
+{userPrompt}
+
+Assistant:
+{assistantResponse}
+""";
+    }
+
+    public static string? CleanGeneratedTitle(string? rawResponse)
+    {
+        if (string.IsNullOrWhiteSpace(rawResponse)) return null;
+
+        // Take the first non-empty line
+        var lines = rawResponse.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var firstLine = lines.FirstOrDefault(l => !string.IsNullOrWhiteSpace(l));
+        if (string.IsNullOrWhiteSpace(firstLine)) return null;
+
+        var title = firstLine.Trim();
+
+        string[] prefixes = ["Title:", "title:", "TITLE:", "Topic:", "topic:", "TOPIC:", "Subject:", "subject:", "Name:", "name:"];
+
+        string previous;
+        do
+        {
+            previous = title;
+
+            // Strip markdown headings: #, ##, ###, etc.
+            while (title.StartsWith('#'))
+            {
+                title = title.TrimStart('#').TrimStart();
+            }
+
+            // Strip bold/italic/code markdown formatting
+            title = StripWrappingFormatting(title);
+
+            // Strip prefixes
+            foreach (var prefix in prefixes)
+            {
+                if (title.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    title = title[prefix.Length..].Trim();
+                    break;
+                }
+            }
+
+            // Strip surrounding quotes
+            title = title.Trim('"', '\'', '`', '“', '”', '«', '»');
+
+            // Strip trailing punctuation: ., ..., …, !, ?, :, ;, etc.
+            while (title.EndsWith("...") || title.EndsWith("…"))
+            {
+                if (title.EndsWith("..."))
+                    title = title[..^3].TrimEnd();
+                else if (title.EndsWith("…"))
+                    title = title[..^1].TrimEnd();
+            }
+            title = title.TrimEnd('.', '!', '?', ':', ';', ',');
+
+            // Strip surrounding quotes again
+            title = title.Trim('"', '\'', '`', '“', '”', '«', '»');
+
+            title = title.Trim();
+        } while (title != previous && !string.IsNullOrWhiteSpace(title));
+
+        if (string.IsNullOrWhiteSpace(title)) return null;
+
+        // Enforce maximum length of 50 characters
+        if (title.Length > 50)
+        {
+            title = title[..50].Trim();
+        }
+
+        return string.IsNullOrWhiteSpace(title) ? null : title;
+    }
+
+    private static string StripWrappingFormatting(string text)
+    {
+        var result = text.Trim();
+        if (result.StartsWith("**") && result.EndsWith("**") && result.Length >= 4)
+        {
+            result = result[2..^2].Trim();
+        }
+        else if (result.StartsWith('*') && result.EndsWith('*') && result.Length >= 2)
+        {
+            result = result[1..^1].Trim();
+        }
+        else if (result.StartsWith('`') && result.EndsWith('`') && result.Length >= 2)
+        {
+            result = result[1..^1].Trim();
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
# Summary

## Changes

Implemented agentic chat session naming. Instead of naively truncating the first line of the initial user prompt, Tendril now invokes an AI model asynchronously upon the assistant's first response to generate a concise, semantically meaningful title.

## API Changes

- Added `Ivy.Tendril.Services.IChatSessionNamingService` and `Ivy.Tendril.Services.ChatSessionNamingService` with method `GenerateAndSetTitleAsync(string sessionId, string userPrompt, string assistantResponse, string? agentId = null, string? modelId = null, CancellationToken ct = default)`

## Files Modified

- `src/Ivy.Tendril/Services/ChatSessionNamingService.cs`: Implementation of `IChatSessionNamingService` providing prompt generation, resolution context execution, output sanitization, and title updating.
- `src/Ivy.Tendril/Services/ChatHistoryService.cs`: Removed prompt slicing logic on first user message.
- `src/Ivy.Tendril/ServiceRegistration.cs`: Registered `IChatSessionNamingService` as singleton in DI.
- `src/Ivy.Tendril/Apps/Chat/ChatApp.cs`: Injected `IChatSessionNamingService` and triggered background naming task upon completing the initial assistant response.
- `src/Ivy.Tendril.Test/ChatSessionNamingServiceTests.cs`: Unit tests for title prompt generation, output sanitization, session renaming, and error/timeout handling.
- `src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs`: Updated test to assert default title remains intact when adding user message.

## Manual Testing

1. Launch Tendril and navigate to the Chat app.
2. Create a new chat session (initially named "New Chat").
3. Send a user prompt (e.g. "Can you help me configure PostgreSQL connection pooling in .NET?").
4. Wait for the assistant to finish generating its response.
5. Observe that the chat session in the sidebar is automatically updated from "New Chat" to a concise generated title (e.g. "PostgreSQL Connection Pooling").

---
## Commits
- 7314dae5 Implement agentic chat session naming on initial response (Plan 00012)
- a65f00d2 Add unit tests for ChatSessionNamingService and update ChatHistoryServiceTests (Plan 00012)

---
Created using [Ivy Tendril](https://ivy.app).