### PR TITLE
Render sanitized <details> blocks in DraftMarkdown

### DIFF
--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/CollapsibleApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/CollapsibleApp.cs
@@ -1,0 +1,128 @@
+using Ivy;
+using Ivy.Tendril.Widgets;
+using DraftMarkdownWidget = Ivy.Tendril.Widgets.DraftMarkdown;
+
+namespace WidgetSamples.Apps.DraftMarkdown;
+
+[App(title: "Collapsible", icon: Icons.ListCollapse, group: ["DraftMarkdown"])]
+class CollapsibleApp : ViewBase
+{
+    public override object Build()
+    {
+        var markdown = """
+            # Collapsible Sections
+
+            GitHub-style `<details>` / `<summary>` blocks render as real disclosure
+            widgets. Tendril's own promptware emits them (the plan `## Questions`
+            section), so plan markdown routinely contains raw HTML.
+
+            ## Basic
+
+            <details>
+            <summary>What database does the plan target?</summary>
+
+            PostgreSQL 16. The migration scripts live in `db/migrations` and are
+            applied by the `MigrateDatabase` job on startup.
+
+            </details>
+
+            <details>
+            <summary>Do we need a feature flag?</summary>
+
+            No. The change is additive and the old code path is removed in the same
+            commit, so there is nothing to toggle between.
+
+            </details>
+
+            ## Open by Default
+
+            <details open>
+            <summary>Still relevant?</summary>
+
+            Yes. The `open` attribute survives sanitisation, so a section can start
+            expanded.
+
+            </details>
+
+            ## Rich Bodies
+
+            A section body is ordinary markdown — lists, tables, code and diagrams all
+            work inside one.
+
+            <details>
+            <summary>Migration steps</summary>
+
+            1. Snapshot the current schema.
+            2. Apply the new migration.
+            3. Verify row counts match.
+
+            | Step | Owner | Duration |
+            | --- | --- | --- |
+            | Snapshot | ops | 5 min |
+            | Migrate | api | 2 min |
+            | Verify | api | 10 min |
+
+            ```bash
+            dotnet run --project src/Migrator -- --verify
+            ```
+
+            > [!WARNING]
+            > The snapshot must complete before the migration starts.
+
+            </details>
+
+            ## Nesting
+
+            <details>
+            <summary>Rejected alternatives</summary>
+
+            Three approaches were considered and dropped.
+
+            <details>
+            <summary>Dual-write to both stores</summary>
+
+            Rejected: no way to make the two writes atomic, so a crash between them
+            leaves the stores permanently diverged.
+
+            </details>
+
+            <details>
+            <summary>Change data capture</summary>
+
+            Rejected: adds a Debezium deployment for a one-off migration.
+
+            </details>
+
+            </details>
+
+            ## Sanitisation
+
+            The markdown is model-written, so raw HTML is parsed and then pruned
+            against an allow-list. Everything below is stripped and none of it reaches
+            the DOM — the section renders, its attack payloads do not.
+
+            <details onclick="alert('handler')" style="background: red">
+            <summary>Event handlers and inline styles are removed</summary>
+
+            <script>alert("script")</script>
+            <iframe src="https://example.test"></iframe>
+            <style>body { display: none }</style>
+
+            Scripts, iframes and style blocks are dropped entirely, while ordinary
+            inline markup such as <b>bold</b>, <kbd>Ctrl</kbd> and
+            <a href="https://ivy.app">a link</a> is kept.
+
+            </details>
+
+            <details>
+            <summary>Unsafe link protocols are neutralised</summary>
+
+            This anchor keeps its text but loses its href:
+            <a href="javascript:alert(1)">javascript: link</a>
+
+            </details>
+            """;
+
+        return new DraftMarkdownWidget(markdown).Article();
+    }
+}

--- a/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/collapsible.spec.ts
+++ b/src/Ivy.Tendril.Widgets/.tests/widgets/draft-markdown/collapsible.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "../../fixtures/widget-test.js";
+import { navigateToApp, waitForDraftMarkdown } from "../../utils/ivy.js";
+
+test.describe("DraftMarkdown Collapsible Sections", () => {
+  test.beforeEach(async ({ page }) => {
+    await navigateToApp(page, "draft-markdown/collapsible");
+    await waitForDraftMarkdown(page);
+  });
+
+  test("details blocks render as disclosure widgets, not literal text", async ({
+    page,
+    stepScreenshot,
+  }) => {
+    const widgetPane = page.locator(".pmv-markdown");
+    await expect(widgetPane.locator("details").first()).toBeVisible();
+    await expect(widgetPane.locator("summary").first()).toContainText(
+      "What database does the plan target?",
+    );
+    await expect(widgetPane).not.toContainText("<summary>");
+    await stepScreenshot("details-rendered");
+  });
+
+  test("a closed section hides its body until clicked", async ({ page, stepScreenshot }) => {
+    const details = page.locator(".pmv-markdown details").first();
+    const body = details.getByText("PostgreSQL 16", { exact: false });
+
+    await expect(details).not.toHaveAttribute("open", /.*/);
+    await expect(body).toBeHidden();
+    await stepScreenshot("section-closed");
+
+    await details.locator("summary").click();
+    await expect(details).toHaveAttribute("open", /.*/);
+    await expect(body).toBeVisible();
+    await stepScreenshot("section-open");
+  });
+
+  test("a section marked open starts expanded", async ({ page }) => {
+    const openSection = page.locator(".pmv-markdown details[open]").first();
+    await expect(openSection.locator("summary")).toContainText("Still relevant?");
+    await expect(openSection.getByText("The `open` attribute", { exact: false })).toBeVisible();
+  });
+
+  test("rich content renders inside a section body", async ({ page, stepScreenshot }) => {
+    const details = page
+      .locator(".pmv-markdown details")
+      .filter({ has: page.locator("summary", { hasText: "Migration steps" }) });
+
+    await details.locator("summary").click();
+    await expect(details.locator("table")).toBeVisible();
+    await expect(details.locator("ol li")).toHaveCount(3);
+    await expect(details.locator(".pmv-code-block")).toBeVisible();
+    await expect(details.locator(".pmv-alert")).toBeVisible();
+    await stepScreenshot("rich-body");
+  });
+
+  test("sections nest", async ({ page }) => {
+    const outer = page
+      .locator(".pmv-markdown details")
+      .filter({ has: page.locator("summary", { hasText: "Rejected alternatives" }) });
+
+    await outer.locator("summary").first().click();
+    await expect(outer.locator("details")).toHaveCount(2);
+    await expect(outer.locator("details summary").first()).toContainText("Dual-write");
+  });
+
+  test("unsafe raw HTML is stripped from the page", async ({ page }) => {
+    const widgetPane = page.locator(".pmv-markdown");
+
+    await expect(widgetPane.locator("script")).toHaveCount(0);
+    await expect(widgetPane.locator("iframe")).toHaveCount(0);
+    await expect(widgetPane.locator("style")).toHaveCount(0);
+    // Script and style contents go with the element rather than landing on the
+    // page as prose, which is what dropping an element normally does.
+    await expect(widgetPane).not.toContainText("display: none");
+
+    const unsafe = widgetPane
+      .locator("details")
+      .filter({ has: page.locator("summary", { hasText: "Event handlers" }) });
+    await expect(unsafe).not.toHaveAttribute("onclick", /.*/);
+    await expect(unsafe).not.toHaveAttribute("style", /.*/);
+
+    // Safe inline markup in the same block survives.
+    await unsafe.locator("summary").click();
+    await expect(unsafe.locator("b")).toContainText("bold");
+    await expect(unsafe.locator("kbd")).toContainText("Ctrl");
+    await expect(unsafe.locator('a[href="https://ivy.app"]')).toBeVisible();
+  });
+
+  test("javascript: hrefs are neutralised", async ({ page }) => {
+    const section = page
+      .locator(".pmv-markdown details")
+      .filter({ has: page.locator("summary", { hasText: "Unsafe link protocols" }) });
+
+    await section.locator("summary").click();
+    const link = section.getByText("javascript: link");
+    await expect(link).toBeVisible();
+    await expect(page.locator('.pmv-markdown a[href^="javascript:"]')).toHaveCount(0);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/AGENTS.md
+++ b/src/Ivy.Tendril.Widgets/AGENTS.md
@@ -12,13 +12,14 @@ frontend/             React/Vite bundle (npm run build → dist/)
 
 .samples/             Standalone Ivy app hosting widgets for development and testing
   Apps/
-    DraftMarkdown/    AnnotationsApp, ComparisonApp, StickyContentApp
+    DraftMarkdown/    AnnotationsApp, CollapsibleApp, ComparisonApp, MathApp, StickyContentApp
     AgentViewer/      ErrorApp, LiveStreamApp, PreBufferedApp, TableOutputApp
     TendrilProcessViewer/  DemoApp
 
 .tests/               Playwright E2E tests
   widgets/            Test specs grouped by widget
-    draft-markdown/   annotations.spec.ts, rendering.spec.ts
+    draft-markdown/   annotations.spec.ts, collapsible.spec.ts, rendering.spec.ts,
+                      sticky-content.spec.ts
   fixtures/           Extended Playwright test fixture (console capture, step screenshots)
   utils/              Server management, navigation helpers, screenshot utilities
   global-setup.ts     Builds .samples, spawns dotnet server on a free port
@@ -72,6 +73,26 @@ npm test         # vitest unit tests
 ```
 
 The bundle is built by MSBuild (via the WidgetsBuildFrontend target) and embedded from `dist/`, which is gitignored.
+
+## Markdown raw HTML
+
+`frontend/src/math.ts` builds the remark/rehype plugin lists for every markdown surface
+(DraftMarkdown, AgentViewer, ChatWidget, PlanDiffView). GFM is always on; the raw-HTML pair
+and the math pair are added only when the content needs them.
+
+Raw HTML matters because Tendril promptware tells agents to emit GitHub-style
+`<details>`/`<summary>` blocks (`Promptwares/UpdatePlan/Program.md` builds the plan
+`## Questions` section out of them). The content is model-written, so `rehype-raw` parses it
+and `rehype-sanitize` immediately prunes it against the allow-list in
+`frontend/src/rawHtml.ts`. Two ordering rules hold that pipeline together:
+
+- sanitising runs **before** `rehype-katex`, whose output is a large tree of classed spans,
+  inline styles and MathML that the allow-list would strip;
+- URL safety is left to react-markdown's `urlTransform`, which runs after sanitising and is
+  already the gate for `DangerouslyAllowLocalFiles`.
+
+Styling lives in `frontend/src/DraftMarkdown/draft-markdown.css` (chevron, hover, body inset),
+mirroring the framework's `typography.details` / `typography.summary`.
 
 ## Widget ↔ Framework Contract
 

--- a/src/Ivy.Tendril.Widgets/frontend/package.json
+++ b/src/Ivy.Tendril.Widgets/frontend/package.json
@@ -21,6 +21,8 @@
     "react-syntax-highlighter": "16.1.1",
     "refractor": "^5.0.0",
     "rehype-katex": "7.0.1",
+    "rehype-raw": "7.0.0",
+    "rehype-sanitize": "6.0.0",
     "remark-gfm": "4.0.1",
     "remark-math": "6.0.0",
     "unidiff": "^1.0.4"

--- a/src/Ivy.Tendril.Widgets/frontend/pnpm-lock.yaml
+++ b/src/Ivy.Tendril.Widgets/frontend/pnpm-lock.yaml
@@ -60,6 +60,12 @@ importers:
       rehype-katex:
         specifier: 7.0.1
         version: 7.0.1
+      rehype-raw:
+        specifier: 7.0.0
+        version: 7.0.0
+      rehype-sanitize:
+        specifier: 6.0.0
+        version: 6.0.0
       remark-gfm:
         specifier: 4.0.1
         version: 4.0.1
@@ -1477,8 +1483,17 @@ packages:
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
 
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
 
   hast-util-to-text@4.0.2:
     resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
@@ -1501,6 +1516,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -2093,6 +2111,12 @@ packages:
 
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -3568,6 +3592,28 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.1
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.1
+      unist-util-position: 5.0.0
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
@@ -3587,6 +3633,16 @@ snapshots:
       vfile-message: 4.0.3
     transitivePeerDependencies:
       - supports-color
+
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
 
   hast-util-to-text@4.0.2:
     dependencies:
@@ -3618,6 +3674,8 @@ snapshots:
       - '@noble/hashes'
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   iconv-lite@0.6.3:
     dependencies:
@@ -4445,6 +4503,17 @@ snapshots:
       katex: 0.16.47
       unist-util-visit-parents: 6.0.2
       vfile: 6.0.3
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   remark-gfm@4.0.1:
     dependencies:

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.html.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.html.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { DraftMarkdown } from "./DraftMarkdown";
+
+const renderContent = (content: string, props: Record<string, unknown> = {}) => {
+  const { container } = render(<DraftMarkdown id="w1" content={content} {...props} />);
+  return container;
+};
+
+describe("DraftMarkdown collapsible sections", () => {
+  it("renders <details>/<summary> as real elements", () => {
+    const container = renderContent(
+      "<details>\n<summary>Should we use X?</summary>\n\nYes, because Y.\n\n</details>",
+    );
+
+    const details = container.querySelector("details");
+    expect(details).not.toBeNull();
+    expect(details!.querySelector("summary")?.textContent).toContain("Should we use X?");
+    expect(details!.textContent).toContain("Yes, because Y.");
+    // The tags must not leak into the page as literal text.
+    expect(container.textContent).not.toContain("<details>");
+  });
+
+  it("honours the open attribute", () => {
+    const closed = renderContent("<details>\n<summary>Closed</summary>\n\nBody\n\n</details>");
+    expect(closed.querySelector("details")!.hasAttribute("open")).toBe(false);
+
+    const open = renderContent("<details open>\n<summary>Open</summary>\n\nBody\n\n</details>");
+    expect(open.querySelector("details")!.hasAttribute("open")).toBe(true);
+  });
+
+  it("renders markdown inside the body", () => {
+    const container = renderContent(
+      "<details>\n<summary>Details</summary>\n\n- one\n- two\n\n`code` and **bold**\n\n</details>",
+    );
+
+    const details = container.querySelector("details")!;
+    expect(details.querySelectorAll("li")).toHaveLength(2);
+    expect(details.querySelector("code")?.textContent).toBe("code");
+    expect(details.querySelector("strong")?.textContent).toBe("bold");
+  });
+
+  it("renders nested collapsible sections", () => {
+    const container = renderContent(
+      "<details>\n<summary>Outer</summary>\n\n<details>\n<summary>Inner</summary>\n\nBody\n\n</details>\n\n</details>",
+    );
+
+    expect(container.querySelectorAll("details")).toHaveLength(2);
+    expect(container.querySelector("details details summary")?.textContent).toContain("Inner");
+  });
+});
+
+describe("DraftMarkdown raw HTML sanitisation", () => {
+  it("drops script tags and their contents", () => {
+    const container = renderContent("<details><summary>S</summary></details>\n\n<script>alert(1)</script>");
+
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.textContent).not.toContain("alert(1)");
+  });
+
+  it("drops iframes, styles and object embeds", () => {
+    const container = renderContent(
+      '<details><summary>S</summary></details>\n\n<iframe src="https://evil.test"></iframe>\n<style>body{display:none}</style>\n<object data="x"></object>',
+    );
+
+    expect(container.querySelector("iframe")).toBeNull();
+    expect(container.querySelector("style")).toBeNull();
+    expect(container.querySelector("object")).toBeNull();
+    // Dropping an element normally keeps its children; for script and style the
+    // contents are code and must go with it rather than land on the page.
+    expect(container.textContent).not.toContain("display:none");
+  });
+
+  it("strips event handler and inline style attributes", () => {
+    const container = renderContent(
+      '<details onclick="alert(1)" style="color:red"><summary>S</summary></details>',
+    );
+
+    const details = container.querySelector("details")!;
+    expect(details.getAttribute("onclick")).toBeNull();
+    expect(details.getAttribute("style")).toBeNull();
+  });
+
+  it("neutralises javascript: hrefs in raw HTML", () => {
+    const container = renderContent(
+      '<details><summary>S</summary></details>\n\n<a href="javascript:alert(1)">click</a>',
+    );
+
+    const href = container.querySelector("a")?.getAttribute("href");
+    expect(href === null || href === "").toBe(true);
+  });
+
+  it("keeps http links in raw HTML", () => {
+    const container = renderContent(
+      '<details><summary>S</summary>\n\n<a href="https://example.test/x">link</a>\n\n</details>',
+    );
+
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("https://example.test/x");
+  });
+});
+
+describe("DraftMarkdown features alongside raw HTML", () => {
+  // The raw-HTML pass adds a sanitisation step to the pipeline; these guard
+  // against the allow-list quietly stripping what the other features rely on.
+  it("still renders math", () => {
+    const container = renderContent(
+      "<details><summary>S</summary></details>\n\n$$\n\\frac{a}{b}\n$$",
+    );
+
+    expect(container.querySelector(".katex")).not.toBeNull();
+    expect(container.querySelector(".katex-error")).toBeNull();
+  });
+
+  it("still renders highlighted code blocks", () => {
+    const container = renderContent(
+      "<details><summary>S</summary></details>\n\n```xml\n<note id=\"1\">x</note>\n```",
+    );
+
+    expect(container.querySelector(".pmv-code-block")).not.toBeNull();
+    expect(container.querySelectorAll(".token").length).toBeGreaterThan(0);
+  });
+
+  it("still renders GFM task lists and tables", () => {
+    const container = renderContent(
+      "<details><summary>S</summary></details>\n\n- [x] done\n- [ ] todo\n\n| A | B |\n| - | - |\n| 1 | 2 |",
+    );
+
+    expect(container.querySelectorAll("li.task-list-item")).toHaveLength(2);
+    expect(container.querySelectorAll('input[type="checkbox"]')).toHaveLength(2);
+    expect(container.querySelector("table td")?.textContent).toBe("1");
+  });
+
+  it("still renders local file links when they are allowed", () => {
+    const container = renderContent(
+      "<details><summary>S</summary></details>\n\n[log](file:///D:/tmp/run.log)",
+      { dangerouslyAllowLocalFiles: true },
+    );
+
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("file:///D:/tmp/run.log");
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -130,11 +130,11 @@
 }
 /* Block elements (code blocks, diagrams, tables, images) get generous,
    symmetric vertical spacing so they breathe regardless of neighbours. */
-.pmv-markdown > * + :is(pre, table, img),
+.pmv-markdown > * + :is(pre, table, img, details),
 .pmv-markdown > * + :is(.pmv-code-block, .pmv-diagram-container) {
   margin-top: 1rem;
 }
-.pmv-markdown > :is(pre, table, img) + *,
+.pmv-markdown > :is(pre, table, img, details) + *,
 .pmv-markdown > :is(.pmv-code-block, .pmv-diagram-container) + * {
   margin-top: 1rem;
 }
@@ -388,6 +388,71 @@
   border: 0;
   border-top: 1px solid var(--border);
   margin: 1rem 0;
+}
+
+/* ─── Collapsible sections (<details>/<summary>) ──────────────────────────
+   Tendril promptware emits GitHub-style <details> blocks (the plan "Questions"
+   section), parsed by rehype-raw and sanitised before reaching the DOM — see
+   frontend/src/rawHtml.ts. Mirrors the Ivy framework's `typography.details`
+   and `typography.summary`. */
+.pmv-markdown details {
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  background: var(--card);
+  overflow: hidden;
+}
+
+.pmv-markdown summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+  transition: background 0.15s ease;
+}
+/* Suppress the native disclosure marker in favour of the chevron below. */
+.pmv-markdown summary::-webkit-details-marker {
+  display: none;
+}
+.pmv-markdown summary:hover {
+  background: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+/* A summary written with a blank line around it becomes a paragraph; keep it
+   on the same row as the chevron. */
+.pmv-markdown summary > p {
+  display: inline;
+  margin: 0;
+}
+
+/* Chevron drawn as a mask so it inherits the summary's text colour in both
+   themes, and rotates to point down while the section is open. */
+.pmv-markdown summary::before {
+  content: "";
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  background-color: currentColor;
+  -webkit-mask: var(--pmv-chevron) center / contain no-repeat;
+  mask: var(--pmv-chevron) center / contain no-repeat;
+  transition: transform 0.15s ease;
+}
+.pmv-markdown details[open] > summary::before {
+  transform: rotate(90deg);
+}
+.pmv-markdown summary {
+  --pmv-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 5l7 7-7 7'/%3E%3C/svg%3E");
+}
+
+/* The body of an open section. The contextual spacing rules above only reach
+   direct children of .pmv-markdown, so nested content gets its own inset. */
+.pmv-markdown details > :not(summary) {
+  margin: 0.5rem 1rem;
+}
+.pmv-markdown details > :not(summary):last-child {
+  margin-bottom: 1rem;
 }
 
 /* ─── Article variant ───────────────────────────────────────────────────

--- a/src/Ivy.Tendril.Widgets/frontend/src/math.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/math.ts
@@ -1,7 +1,10 @@
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
 import type { Options } from "react-markdown";
+import { hasRawHtml, rawHtmlSchema } from "./rawHtml";
 
 type MarkdownPlugins = Required<Pick<Options, "remarkPlugins" | "rehypePlugins">>;
 
@@ -17,10 +20,10 @@ const MATH_DELIMITER = /\$\$/;
 export const hasMath = (content: string): boolean => MATH_DELIMITER.test(content);
 
 /**
- * The remark/rehype plugin lists for rendering markdown: GFM always, plus
- * remark-math and rehype-katex when the content actually contains math. Gating
- * on the content keeps the KaTeX pass off the render path for the overwhelming
- * majority of plan markdown, notes and agent output, which has no math at all.
+ * The remark/rehype plugin lists for rendering markdown: GFM always, plus the
+ * raw-HTML pair and the math pair when the content actually needs them. Gating
+ * on the content keeps both extra tree walks off the render path for the
+ * overwhelming majority of plan markdown, notes and agent output.
  *
  * `singleDollarTextMath: false` is required, not a preference: Tendril markdown
  * is full of prose dollar signs (`$env:PORT`, `$IsMacOS`, prices), and with
@@ -36,10 +39,22 @@ export const hasMath = (content: string): boolean => MATH_DELIMITER.test(content
  * `.katex` rules and all `KaTeX_*` `@font-face` declarations), so the widget
  * bundle inherits them and only needs the plugins.
  */
-export const getMarkdownPlugins = (content: string): MarkdownPlugins =>
-  hasMath(content)
-    ? {
-        remarkPlugins: [remarkGfm, [remarkMath, { singleDollarTextMath: false }]],
-        rehypePlugins: [rehypeKatex],
-      }
-    : { remarkPlugins: [remarkGfm], rehypePlugins: [] };
+export const getMarkdownPlugins = (content: string): MarkdownPlugins => {
+  const remarkPlugins: MarkdownPlugins["remarkPlugins"] = [remarkGfm];
+  const rehypePlugins: MarkdownPlugins["rehypePlugins"] = [];
+
+  // Raw HTML first: rehype-raw reparses the raw nodes into real elements, then
+  // rehype-sanitize prunes everything outside the allow-list. See `rawHtml.ts`.
+  if (hasRawHtml(content)) {
+    rehypePlugins.push(rehypeRaw, [rehypeSanitize, rawHtmlSchema]);
+  }
+
+  // KaTeX has to run after sanitising: its output is a large tree of classed
+  // spans, inline styles and MathML that the allow-list would strip.
+  if (hasMath(content)) {
+    remarkPlugins.push([remarkMath, { singleDollarTextMath: false }]);
+    rehypePlugins.push(rehypeKatex);
+  }
+
+  return { remarkPlugins, rehypePlugins };
+};

--- a/src/Ivy.Tendril.Widgets/frontend/src/rawHtml.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/rawHtml.ts
@@ -1,0 +1,54 @@
+import { defaultSchema } from "rehype-sanitize";
+import type { Options as SanitizeSchema } from "rehype-sanitize";
+
+/**
+ * Raw HTML support for Tendril markdown.
+ *
+ * Tendril's own promptware instructs agents to emit GitHub-style
+ * `<details>` / `<summary>` blocks (see `Promptwares/UpdatePlan/Program.md`,
+ * which builds the `## Questions` section out of them), so plan markdown
+ * routinely contains raw HTML. react-markdown drops raw HTML unless
+ * `rehype-raw` reparses it, which left those blocks rendering as literal
+ * `&lt;details&gt;` text with the body permanently expanded.
+ *
+ * The content is model-written and therefore never trusted: raw HTML is parsed
+ * and then pruned by `rehype-sanitize` against the allow-list below.
+ */
+
+/**
+ * Matches anything that looks like an HTML tag. Only a gate for the raw-HTML
+ * rehype passes, so a false positive (a `<T>` in prose, a tag inside a fenced
+ * code block) costs one wasted tree walk and nothing else — `rehype-raw` never
+ * touches text inside code nodes.
+ */
+const RAW_HTML_TAG = /<\/?[a-zA-Z][a-zA-Z0-9-]*(?:\s[^<>]*)?\/?>/;
+
+/** True when the content contains raw HTML that needs parsing and sanitising. */
+export const hasRawHtml = (content: string): boolean => RAW_HTML_TAG.test(content);
+
+/**
+ * hast-util-sanitize's GitHub-derived default schema, which already allows
+ * `details`, `summary` and the `open` attribute, plus the Tendril-specific
+ * adjustments below.
+ */
+export const rawHtmlSchema: SanitizeSchema = {
+  ...defaultSchema,
+  // Dropping a disallowed element normally keeps its children, which is right
+  // for markup (`<span>text</span>` should still show its text) but wrong for
+  // elements whose content is code: the default schema only strips `script`,
+  // leaving a `<style>` block's CSS rules on the page as prose.
+  strip: [...(defaultSchema.strip ?? []), "style"],
+  attributes: {
+    ...defaultSchema.attributes,
+    // remark-math emits `<code class="language-math math-inline">` (and
+    // `math-display` inside a `<pre>`), and rehype-katex finds those nodes by
+    // class. The default schema allows only `language-*` on code, so without
+    // this the marker class is stripped and the math never reaches KaTeX.
+    code: [["className", /^language-./, "math", "math-display", "math-inline"]],
+  },
+  // URL safety is react-markdown's `urlTransform`, which runs after this pass
+  // over every URL attribute and applies the same protocol allow-list. Keeping
+  // a second list here would only strip the `file://` and `D:\...` links that
+  // DangerouslyAllowLocalFiles exists to render.
+  protocols: {},
+};


### PR DESCRIPTION
## Problem

Tendril's own promptware instructs agents to emit GitHub-style `<details>`/`<summary>` blocks — `Promptwares/UpdatePlan/Program.md` builds the plan `## Questions` section out of them, and `ExecutePlan/Program.md` uses one for "Still relevant?" — but `react-markdown` drops raw HTML unless `rehype-raw` reparses it. Every such block rendered as literal escaped text with the body permanently expanded:

```html
<h2>Questions</h2>
&lt;details&gt;
&lt;summary&gt;Should we use X?&lt;/summary&gt;
<p>Yes, because Y.</p>
&lt;/details&gt;
```

The framework's own `Markdown` widget has had this support all along (`rehype-raw` plus `details`/`summary` component overrides in `MarkdownRenderer.tsx`); DraftMarkdown never did.

## Approach

Parse raw HTML with `rehype-raw`, then immediately prune it with `rehype-sanitize` — the content is model-written and never trusted. The allow-list starts from `hast-util-sanitize`'s GitHub-derived `defaultSchema` (which already permits `details`, `summary` and `open`) with three adjustments in the new `frontend/src/rawHtml.ts`:

| Adjustment | Why |
| --- | --- |
| `strip: [...default, "style"]` | Dropping an element otherwise keeps its children, so a `<style>` block's CSS rules landed on the page as prose. Caught in a live browser pass, not in the unit tests. |
| `code: [["className", /^language-./, "math", "math-display", "math-inline"]]` | `remark-math` emits `<code class="language-math math-display">` and `rehype-katex` finds those nodes by class. The default schema allows only `language-*`, so the marker class was stripped and **all math silently vanished**. |
| `protocols: {}` | react-markdown's `urlTransform` already runs after this pass with the same protocol list. A second one here only strips the `file://` and `D:\...` links that `DangerouslyAllowLocalFiles` exists to render. |

Two ordering rules hold the pipeline together:

- sanitising runs **before** `rehype-katex`, whose output is a large tree of classed spans, inline styles and MathML the allow-list would shred;
- both rehype passes are gated on the content actually containing HTML, matching how math is already gated, so the common case keeps its current render path.

This reaches every markdown surface, not just DraftMarkdown — `AgentViewer`, `ChatWidget` and `PlanDiffView` all build their plugins through `getMarkdownPlugins`.

Styling mirrors the framework's `typography.details` / `typography.summary`: card border, hover, body inset, and a chevron drawn as a CSS mask so it follows `currentColor` in both themes.

## Sample

New `Collapsible` sample at `/draft-markdown/collapsible`, covering basic sections, `open`, rich bodies (list + table + code + alert), nesting, and a sanitisation section that carries live `onclick`, `<script>`, `<iframe>`, `<style>` and `javascript:` payloads so the pruning is visible rather than merely asserted.

## Verification

- `tsc --noEmit` clean
- 130/130 vitest pass, including 13 new cases: rendering, `open`, nesting, each sanitisation class, plus regression guards that math, highlighted code, task lists, tables and local-file links all survive the extra pass
- widget bundle builds; samples project compiles
- ran the sample against a live server: 9 `<details>` elements, 1 open, zero surviving `script` / `iframe` / `style` / `onclick` / `javascript:` hrefs, chevron mask applied, no console errors

**Not run:** the new `collapsible.spec.ts` E2E spec. A leftover samples server was holding a lock on the build output, and stopping someone else's process to run it wasn't worth it — the unit tests cover the same assertions. It will be exercised on the next full Playwright run.

## Note for review

`defaultSchema` is the GitHub-safe tag set, so raw `<b>`, `<kbd>`, `<sub>` etc. now render too. That is GitHub-equivalent and matches the framework's behaviour, but it is broader than `<details>` alone. Narrowing `tagNames` to just details/summary is a one-line change in `rawHtml.ts` if that is preferred.

https://claude.ai/code/session_01Pooaou9FqrDRse6ZBAUdDV