### PR TITLE
[00025] Remove Deep Column from Jobs Table

### DIFF
--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 
@@ -24,7 +24,6 @@ public partial class JobsApp
                 PlanId = planId,
                 Plan = JobsApp.GetPromptDisplay(j, planService),
                 Type = j.Type,
-                Profile = JobCostModelBuilder.FormatProfile(j) ?? "",
                 Project = string.Join(", ", ProjectHelper.ParseProjects(j.Project)),
                 Timer = JobsApp.FormatTimer(j),
                 Cost = j.Cost.HasValue ? FormatHelper.FormatCost(j.Cost.Value) : "",

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Tendril.Apps.Drafts;
+using Ivy.Tendril.Apps.Drafts;
 using Ivy.Tendril.Apps.Jobs.Dialogs;
 using Ivy.Tendril.Apps.Review;
 using Ivy.Tendril.Models;
@@ -63,7 +63,6 @@ public partial class JobsApp
             .Height(Size.Full())
             .Header(t => t.Status, "Status")
             .Header(t => t.Type, "Type")
-            .Header(t => t.Profile, "Profile")
             .Header(t => t.PlanId, "Plan")
             .Header(t => t.Plan, "Prompt/Title")
             .Header(t => t.Project, "Project")
@@ -79,7 +78,6 @@ public partial class JobsApp
             .Width(t => t.Status, Size.Px(100))
             .Width(t => t.PlanId, Size.Px(80))
             .Width(t => t.Type, Size.Px(100))
-            .Width(t => t.Profile, Size.Px(90))
             .Width(t => t.Plan, Size.Px(250))
             .Width(t => t.Project, Size.Px(150))
             .Width(t => t.Timer, Size.Px(80))

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reactive.Subjects;
 using System.Text.Json.Serialization;
@@ -352,8 +352,6 @@ public record JobItemRow
     public string PlanId { get; init; } = "";
     public string Plan { get; init; } = "";
     public string Type { get; init; } = "";
-    /// <summary>Execution profile the job ran under, capitalised. Empty when none was recorded.</summary>
-    public string Profile { get; init; } = "";
     public string Project { get; init; } = "";
     public string Timer { get; init; } = "";
     public string AgentOutput { get; init; } = "";


### PR DESCRIPTION
Fixes #2200

# Summary

## Changes

Removed the "Profile" / "Deep" execution profile column from the Jobs DataTable UI. The execution profile information continues to be preserved in background job models and displayed within the Job Cost details sheet.

## API Changes

- Removed `Profile` property from the internal UI model `JobItemRow`.

## Files Modified

- `src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs`: Removed Profile column header and width configuration from the data table builder.
- `src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs`: Removed Profile property initialization when mapping jobs to table rows.
- `src/Ivy.Tendril/Models/JobModels.cs`: Removed Profile property from the `JobItemRow` record definition.

## Manual Testing

1. Launch Tendril or run the Jobs App.
2. Navigate to the Jobs view.
3. Observe that the "Profile" column (which rendered "Deep" or "Balanced") is no longer present in the Jobs data table.
4. Click on the Cost or Tokens column for any job with an execution profile to open the Job Cost Sheet, and verify the profile is still visible in the cost drill-down.

---
- 47aaad29 Plan 00025: Remove Deep column from Jobs table

---
Created using [Ivy Tendril](https://ivy.app).
