### PR TITLE
[00035] Show Selected Light Dark Mode in Appearance Settings

### DIFF
--- a/src/Ivy.Tendril.Test/ConfigCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigCliCommandTests.cs
@@ -247,4 +247,37 @@ public class ConfigCliCommandTests : IDisposable
             () => ConfigSetCommand.ApplyField(CreateConfig().Settings, "theme", "nonexistent_theme"));
         Assert.Contains("Valid themes", ex.Message);
     }
+
+    [Theory]
+    [InlineData("light", "light")]
+    [InlineData("dark", "dark")]
+    [InlineData("system", "system")]
+    [InlineData("LiGhT", "light")]
+    [InlineData("DARK", "dark")]
+    public void Set_ThemeMode_Persists(string input, string expected)
+    {
+        var config = CreateConfig();
+        ConfigSetCommand.ApplyField(config.Settings, "themeMode", input);
+        config.SaveSettings();
+
+        var reloaded = CreateConfig();
+        Assert.Equal(expected, reloaded.Settings.ThemeMode);
+        Assert.Equal(expected, ConfigGetCommand.ReadField(reloaded.Settings, "themeMode"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Set_ThemeMode_Empty_Throws(string value)
+    {
+        Assert.Throws<ArgumentException>(() => ConfigSetCommand.ApplyField(CreateConfig().Settings, "themeMode", value));
+    }
+
+    [Fact]
+    public void Set_ThemeMode_Unknown_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => ConfigSetCommand.ApplyField(CreateConfig().Settings, "themeMode", "nonexistent_mode"));
+        Assert.Contains("Valid modes", ex.Message);
+    }
 }

--- a/src/Ivy.Tendril.Test/ConfigServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ConfigServiceTests.cs
@@ -2031,6 +2031,55 @@ theme: {theme}
         }
     }
 
+    [Fact]
+    public void ThemeMode_Setting_DefaultsAndPersists()
+    {
+        var yaml = @"
+themeMode: dark
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        PathHelper.DefaultTendrilHomeOverride = tempDir;
+        try
+        {
+            using var service = new ConfigService();
+            Assert.Equal("dark", service.Settings.ThemeMode);
+
+            service.Settings.ThemeMode = "light";
+            service.SaveSettings();
+
+            var yamlOnDisk = File.ReadAllText(Path.Combine(tempDir, "config.yaml"));
+            Assert.Contains("themeMode: light", yamlOnDisk);
+        }
+        finally
+        {
+            PathHelper.DefaultTendrilHomeOverride = null;
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("invalid_mode")]
+    public void ThemeMode_Setting_InvalidOrEmpty_FallsBackToSystem(string mode)
+    {
+        var yaml = $@"
+themeMode: {mode}
+";
+        var tempDir = CreateTempConfigFile(yaml);
+        PathHelper.DefaultTendrilHomeOverride = tempDir;
+        try
+        {
+            using var service = new ConfigService();
+            Assert.Equal("system", service.Settings.ThemeMode);
+        }
+        finally
+        {
+            PathHelper.DefaultTendrilHomeOverride = null;
+            Directory.Delete(tempDir, true);
+        }
+    }
+
     [Theory]
     [InlineData("Always Proceed", "AlwaysProceed")]
     [InlineData("Inherit General", "InheritGeneral")]

--- a/src/Ivy.Tendril.Test/Mcp/ConfigToolsTests.cs
+++ b/src/Ivy.Tendril.Test/Mcp/ConfigToolsTests.cs
@@ -163,4 +163,21 @@ public class ConfigToolsTests : IDisposable
         Assert.StartsWith("Error:", result);
         Assert.Contains("Valid themes", result);
     }
+
+    [Fact]
+    public void SetConfig_ThemeMode_UpdatesAndPersists()
+    {
+        var result = _tools.SetConfig("themeMode", "dark");
+        Assert.StartsWith("Updated themeMode", result);
+        Assert.Equal("dark", _tools.GetConfig("themeMode"));
+        Assert.Equal("dark", new ConfigService().Settings.ThemeMode);
+    }
+
+    [Fact]
+    public void SetConfig_ThemeMode_Unknown_ReturnsError()
+    {
+        var result = _tools.SetConfig("themeMode", "nonexistent");
+        Assert.StartsWith("Error:", result);
+        Assert.Contains("Valid modes", result);
+    }
 }

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -292,6 +292,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
         UseEffect(() =>
         {
             TendrilThemes.ApplyTheme(client, config.Settings.Theme);
+            TendrilThemes.ApplyThemeMode(client, config.Settings.ThemeMode);
         });
 
         // Rebuild the menu and reapply theme when settings are saved (e.g. the coding agent or theme changes),
@@ -303,6 +304,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 menuItems.Set(BuildMenuItems(appRepository, status.Value, config, agentRunner, shareContext.IsShareMode));
                 sidebarOpen.Set(config.Settings.SidebarOpen);
                 TendrilThemes.ApplyTheme(client, config.Settings.Theme);
+                TendrilThemes.ApplyThemeMode(client, config.Settings.ThemeMode);
             }
             config.SettingsReloaded += OnSettingsReloaded;
             return Disposable.Create(() => config.SettingsReloaded -= OnSettingsReloaded);

--- a/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
@@ -9,6 +9,7 @@ public class AppearanceSetupView : ViewBase
     {
         var config = UseService<IConfigService>();
         var client = UseService<IClientProvider>();
+        var themeMode = UseState(() => config.Settings.ThemeMode ?? "system");
         var selectedTheme = UseState(() => config.Settings.Theme ?? "default");
         var lastAppliedTheme = UseState(() => config.Settings.Theme ?? "default");
 
@@ -49,12 +50,39 @@ public class AppearanceSetupView : ViewBase
                | Text.Block("Appearance").Bold()
                | Text.Muted("Choose how Tendril appears. System matches your OS setting.").Small()
                | (Layout.Horizontal()
-                  | new Button("Light").Variant(ButtonVariant.Outline).Icon(Icons.Sun)
-                      .OnClick(() => client.SetThemeMode(ThemeMode.Light))
-                  | new Button("Dark").Variant(ButtonVariant.Outline).Icon(Icons.Moon)
-                      .OnClick(() => client.SetThemeMode(ThemeMode.Dark))
-                  | new Button("System").Variant(ButtonVariant.Outline).Icon(Icons.SunMoon)
-                      .OnClick(() => client.SetThemeMode(ThemeMode.System)))
+                  | new Button("Light")
+                      .Variant(themeMode.Value.Equals("light", StringComparison.OrdinalIgnoreCase) ? ButtonVariant.Primary : ButtonVariant.Outline)
+                      .Icon(Icons.Sun)
+                      .OnClick(() =>
+                      {
+                          themeMode.Set("light");
+                          client.SetThemeMode(ThemeMode.Light);
+                          config.Settings.ThemeMode = "light";
+                          config.SaveSettings();
+                          client.Toast("Appearance set to Light", "Saved");
+                      })
+                  | new Button("Dark")
+                      .Variant(themeMode.Value.Equals("dark", StringComparison.OrdinalIgnoreCase) ? ButtonVariant.Primary : ButtonVariant.Outline)
+                      .Icon(Icons.Moon)
+                      .OnClick(() =>
+                      {
+                          themeMode.Set("dark");
+                          client.SetThemeMode(ThemeMode.Dark);
+                          config.Settings.ThemeMode = "dark";
+                          config.SaveSettings();
+                          client.Toast("Appearance set to Dark", "Saved");
+                      })
+                  | new Button("System")
+                      .Variant(themeMode.Value.Equals("system", StringComparison.OrdinalIgnoreCase) ? ButtonVariant.Primary : ButtonVariant.Outline)
+                      .Icon(Icons.SunMoon)
+                      .OnClick(() =>
+                      {
+                          themeMode.Set("system");
+                          client.SetThemeMode(ThemeMode.System);
+                          config.Settings.ThemeMode = "system";
+                          config.SaveSettings();
+                          client.Toast("Appearance set to System", "Saved");
+                      }))
                | Text.Block("Theme").Bold()
                | Text.Muted("Choose a color scheme preset for Tendril.").Small()
                | themeSelector

--- a/src/Ivy.Tendril/Commands/ConfigCommand.cs
+++ b/src/Ivy.Tendril/Commands/ConfigCommand.cs
@@ -12,9 +12,9 @@ namespace Ivy.Tendril.Commands;
 public class ConfigGetSettings : CommandSettings
 {
     internal static readonly string[] ValidFields =
-        ["codingAgent", "jobTimeout", "staleOutputTimeout", "gitTimeout", "maxConcurrentJobs", "planTemplate", "theme"];
+        ["codingAgent", "jobTimeout", "staleOutputTimeout", "gitTimeout", "maxConcurrentJobs", "planTemplate", "theme", "themeMode"];
 
-    [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme)")]
+    [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme, themeMode)")]
     [CommandArgument(0, "<key>")]
     public string Key { get; set; } = "";
 
@@ -26,7 +26,7 @@ public class ConfigGetSettings : CommandSettings
 
 public class ConfigSetSettings : CommandSettings
 {
-    [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme)")]
+    [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme, themeMode)")]
     [CommandArgument(0, "<key>")]
     public string Key { get; set; } = "";
 
@@ -76,6 +76,7 @@ public class ConfigGetCommand : Command<ConfigGetSettings>
         "maxconcurrentjobs" => s.MaxConcurrentJobs.ToString(),
         "plantemplate" => s.PlanTemplate,
         "theme" => s.Theme,
+        "thememode" => s.ThemeMode,
         _ => throw new ArgumentException(UnknownFieldMessage(field))
     };
 
@@ -116,8 +117,26 @@ public class ConfigSetCommand(IAgentRunner runner) : Command<ConfigSetSettings>
             case "maxconcurrentjobs": s.MaxConcurrentJobs = ParseBoundedInt(value, "maxConcurrentJobs", 1, 512); break;
             case "plantemplate": s.PlanTemplate = value; break;
             case "theme": s.Theme = ValidateTheme(value); break;
+            case "thememode": s.ThemeMode = ValidateThemeMode(value); break;
             default: throw new ArgumentException(ConfigGetCommand.UnknownFieldMessage(field));
         }
+    }
+
+    internal static string ValidateThemeMode(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("themeMode cannot be empty.");
+
+        var trimmed = value.Trim();
+        if (trimmed.Equals("light", StringComparison.OrdinalIgnoreCase))
+            return "light";
+        if (trimmed.Equals("dark", StringComparison.OrdinalIgnoreCase))
+            return "dark";
+        if (trimmed.Equals("system", StringComparison.OrdinalIgnoreCase))
+            return "system";
+
+        throw new ArgumentException(
+            $"Unknown themeMode '{value}'. Valid modes: light, dark, system");
     }
 
     internal static string ValidateTheme(string value)

--- a/src/Ivy.Tendril/Mcp/Tools/ConfigTools.cs
+++ b/src/Ivy.Tendril/Mcp/Tools/ConfigTools.cs
@@ -20,7 +20,7 @@ public sealed class ConfigTools : AuthenticatedToolBase
 
     [McpServerTool(Name = "tendril_get_config"), Description("Get a top-level Tendril config value")]
     public string GetConfig(
-        [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme)")] string key)
+        [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme, themeMode)")] string key)
     {
         // Reuses the same field switch as `tendril config get` so the two surfaces never drift.
         return ExecuteAuthenticated(() => ConfigGetCommand.ReadField(_configService.Settings, key));
@@ -28,7 +28,7 @@ public sealed class ConfigTools : AuthenticatedToolBase
 
     [McpServerTool(Name = "tendril_set_config"), Description("Set a top-level Tendril config value")]
     public string SetConfig(
-        [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme)")] string key,
+        [Description("Config key (codingAgent, jobTimeout, staleOutputTimeout, gitTimeout, maxConcurrentJobs, planTemplate, theme, themeMode)")] string key,
         [Description("New value. Integer fields are bounds-checked; planTemplate may be long or multiline.")] string value)
     {
         return ExecuteAuthenticated(() =>

--- a/src/Ivy.Tendril/Services/ConfigService.cs
+++ b/src/Ivy.Tendril/Services/ConfigService.cs
@@ -226,6 +226,7 @@ public class TendrilSettings
     public bool DesktopNotifications { get; set; } = true;
     public bool SidebarOpen { get; set; } = true;
     public string Theme { get; set; } = "default";
+    public string ThemeMode { get; set; } = "system";
     public bool Beta { get; set; } = false;
     public string? DismissedUpdateVersion { get; set; }
 
@@ -554,6 +555,19 @@ public class ConfigService : IConfigService, IDisposable
         else
         {
             Settings.Theme = TendrilThemes.GetTheme(Settings.Theme).Id;
+        }
+
+        // ThemeMode: fallback to system if null, empty, or unrecognised
+        if (string.IsNullOrWhiteSpace(Settings.ThemeMode) ||
+            (!Settings.ThemeMode.Equals("light", StringComparison.OrdinalIgnoreCase) &&
+             !Settings.ThemeMode.Equals("dark", StringComparison.OrdinalIgnoreCase) &&
+             !Settings.ThemeMode.Equals("system", StringComparison.OrdinalIgnoreCase)))
+        {
+            Settings.ThemeMode = "system";
+        }
+        else
+        {
+            Settings.ThemeMode = Settings.ThemeMode.ToLowerInvariant();
         }
     }
 

--- a/src/Ivy.Tendril/Themes/TendrilThemes.cs
+++ b/src/Ivy.Tendril/Themes/TendrilThemes.cs
@@ -1059,4 +1059,18 @@ public static class TendrilThemes
         var css = themeService.GenerateThemeCss();
         client.ApplyTheme(css);
     }
+
+    public static ThemeMode ParseThemeMode(string? mode)
+    {
+        if (string.Equals(mode, "light", StringComparison.OrdinalIgnoreCase))
+            return ThemeMode.Light;
+        if (string.Equals(mode, "dark", StringComparison.OrdinalIgnoreCase))
+            return ThemeMode.Dark;
+        return ThemeMode.System;
+    }
+
+    public static void ApplyThemeMode(IClientProvider client, string? mode)
+    {
+        client.SetThemeMode(ParseThemeMode(mode));
+    }
 }


### PR DESCRIPTION
Fixes #2199

# Summary

## Changes

Added visual highlighting for the selected light/dark theme mode (Light, Dark, System) in the Appearance settings, using Primary variant for the active option and Outline for inactive options. Persisted the selected mode in `TendrilSettings.ThemeMode`, ensured it is automatically applied on application load and settings reload, and added CLI and MCP configuration support for `themeMode`.

## API Changes

- Added `public string ThemeMode { get; set; } = "system";` property to `TendrilSettings`.
- Added helper methods `TendrilThemes.ParseThemeMode(string? mode)` and `TendrilThemes.ApplyThemeMode(IClientProvider client, string? mode)`.
- Added `themeMode` configuration key support to `tendril config get <key>`, `tendril config set <key> <value>`, `tendril_get_config`, and `tendril_set_config`.

## Files Modified

- `src/Ivy.Tendril/Services/ConfigService.cs`: Added `ThemeMode` property to `TendrilSettings` and validation/normalization in `ValidateSettings`.
- `src/Ivy.Tendril/Themes/TendrilThemes.cs`: Added `ParseThemeMode` and `ApplyThemeMode` helper methods.
- `src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs`: Added `themeMode` state, dynamic button variant styling (`Primary` vs `Outline`), settings persistence, and toast feedback.
- `src/Ivy.Tendril/AppShell/TendrilAppShell.cs`: Applied configured `ThemeMode` on mount and on settings reload.
- `src/Ivy.Tendril/Commands/ConfigCommand.cs`: Added `themeMode` to valid CLI config fields and validation logic.
- `src/Ivy.Tendril/Mcp/Tools/ConfigTools.cs`: Added `themeMode` to MCP tool descriptions.
- `src/Ivy.Tendril.Test/ConfigServiceTests.cs`: Added tests for `ThemeMode` default, persistence, and fallback normalization.
- `src/Ivy.Tendril.Test/ConfigCliCommandTests.cs`: Added tests for `tendril config set/get themeMode`.
- `src/Ivy.Tendril.Test/Mcp/ConfigToolsTests.cs`: Added tests for MCP `tendril_set_config` and `tendril_get_config` with `themeMode`.

## Manual Testing

1. Launch Tendril and navigate to **Settings > Appearance**.
2. Observe that the currently configured theme mode button (e.g. System by default) is styled with a filled Primary button variant, while the other two options use an Outline variant.
3. Click "Dark" (or "Light"): observe that the selected button immediately changes to the Primary variant, the appearance mode switches, a toast notification appears ("Appearance set to Dark"), and the setting persists after reloading the page or restarting the app.

---
7a23067e 00035: Show selected light/dark mode option in Appearance settings and persist ThemeMode

---
Created using [Ivy Tendril](https://ivy.app).
