### PR TITLE
[00032] Fix Markdown Code Block Width Overflow in Drafts

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
@@ -191,7 +191,7 @@ export const AgentViewer: React.FC<AgentViewerProps> = ({
                 <div key={idx} className="aov-markdown aov-assistant">
                   <Markdown
                     {...getMarkdownPlugins(event.text)}
-                    components={{ code: BlockHandler, blockquote: AlertBlockquote }}
+                    components={{ code: BlockHandler, blockquote: AlertBlockquote, pre: ({ children }) => <>{children}</> }}
                   >
                     {event.text}
                   </Markdown>

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx
@@ -58,7 +58,7 @@ export const ResultSummary: React.FC<ResultSummaryProps> = ({ wire }) => {
           <Markdown
             remarkPlugins={plugins.remarkPlugins}
             rehypePlugins={plugins.rehypePlugins}
-            components={{ code: BlockHandler, blockquote: AlertBlockquote }}
+            components={{ code: BlockHandler, blockquote: AlertBlockquote, pre: ({ children }) => <>{children}</> }}
           >
             {wire.response}
           </Markdown>

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -863,7 +863,7 @@ export function ChatWidget({
                       <div className="chat-markdown-body">
                         <ReactMarkdown
                           {...getMarkdownPlugins(msg.content)}
-                          components={{ code: BlockHandler, blockquote: AlertBlockquote }}
+                          components={{ code: BlockHandler, blockquote: AlertBlockquote, pre: ({ children }) => <>{children}</> }}
                         >
                           {msg.content}
                         </ReactMarkdown>

--- a/src/Ivy.Tendril.Widgets/frontend/src/CodeBlock.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/CodeBlock.tsx
@@ -26,6 +26,8 @@ const CheckIcon = () => (
 
 export const codeBlockPreStyle: React.CSSProperties = {
   margin: 0,
+  minWidth: 0,
+  maxWidth: "100%",
   borderRadius: 0,
   background: "transparent",
   padding: "1rem",

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.codeblock.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.codeblock.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { DraftMarkdown } from "./DraftMarkdown";
+
+const renderContent = (content: string) => {
+  const { container } = render(<DraftMarkdown id="w1" content={content} />);
+  return container;
+};
+
+describe("DraftMarkdown code block rendering and width constraints", () => {
+  it("renders a markdown document with long code lines without outer nested pre structure", () => {
+    const longLine = "const veryLongVariableNameThatExtendsFarBeyondNormalWidth = 'some-very-long-string-value-that-would-cause-horizontal-overflow-if-unconstrained';";
+    const markdown = "```typescript\n" + longLine + "\n```";
+    const container = renderContent(markdown);
+
+    const markdownBody = container.querySelector(".pmv-markdown");
+    expect(markdownBody).not.toBeNull();
+
+    // The code block should be a direct child under .pmv-markdown, not wrapped in an outer <pre>
+    const outerPre = markdownBody?.querySelector(":scope > pre");
+    expect(outerPre).toBeNull();
+
+    const codeBlock = container.querySelector(".pmv-code-block");
+    expect(codeBlock).not.toBeNull();
+
+    // Verify there is only one pre tag inside the code block (inner pre), not nested <pre><div ...><pre>
+    const allPres = container.querySelectorAll("pre");
+    expect(allPres.length).toBe(1);
+    expect(codeBlock?.contains(allPres[0])).toBe(true);
+  });
+
+  it("renders code block container with inner pre configured for horizontal scrolling", () => {
+    const markdown = "```javascript\nfunction test() {\n  return 42;\n}\n```";
+    const container = renderContent(markdown);
+
+    const codeBlock = container.querySelector(".pmv-code-block");
+    expect(codeBlock).not.toBeNull();
+
+    const innerPre = codeBlock?.querySelector("pre");
+    expect(innerPre).not.toBeNull();
+    expect(innerPre?.style.overflowX).toBe("auto");
+    expect(innerPre?.style.minWidth).toBe("0px");
+    expect(innerPre?.style.maxWidth).toBe("100%");
+  });
+
+  it("renders fenced code blocks without language and with specified languages correctly as .pmv-code-block", () => {
+    const markdownWithLang = "```csharp\npublic class Foo { }\n```";
+    const markdownNoLang = "```\nplain text content\n```";
+
+    const containerWithLang = renderContent(markdownWithLang);
+    const codeBlockWithLang = containerWithLang.querySelector(".pmv-code-block");
+    expect(codeBlockWithLang).not.toBeNull();
+    expect(containerWithLang.querySelectorAll("pre").length).toBe(1);
+
+    const containerNoLang = renderContent(markdownNoLang);
+    const codeBlockNoLang = containerNoLang.querySelector(".pmv-code-block");
+    expect(codeBlockNoLang).not.toBeNull();
+    expect(containerNoLang.querySelectorAll("pre").length).toBe(1);
+    expect(codeBlockNoLang?.textContent).toContain("plain text content");
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
@@ -326,20 +326,12 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
     [dangerouslyAllowLocalFiles],
   );
 
-  // react-markdown wraps an overridden `code` element in a `pre`. A question form is flow content
-  // and does not belong inside one — inputs there inherit the monospace stack — so the wrapper is
-  // dropped for questions blocks only.
+  // react-markdown wraps an overridden `code` element in a `pre`. BlockHandler already encapsulates
+  // code blocks, diagram renderers, and questions callouts with their own appropriate containers.
+  // Unwrapping the outer `pre` produces clean, valid block-level DOM elements directly under .pmv-markdown.
   const pre = useCallback((props: React.HTMLAttributes<HTMLPreElement>) => {
-    const { children, ...rest } = props;
-    const only = React.Children.count(children) === 1 ? React.Children.toArray(children)[0] : null;
-
-    if (React.isValidElement<{ className?: string }>(only)) {
-      if (/(^|\s)language-questions(_\d+)?(\s|$)/.test(String(only.props.className ?? ""))) {
-        return <>{children}</>;
-      }
-    }
-
-    return <pre {...rest}>{children}</pre>;
+    const { children } = props;
+    return <>{children}</>;
   }, []);
 
   // Math plugins are added only when the content actually contains math

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -29,6 +29,7 @@
    provide: max-width 200 units and a 1.5rem left inset, so the markdown lines up
    exactly with the Details tab content. */
 .pmv-markdown {
+  min-width: 0;
   width: 100%;
   max-width: 50rem; /* 200 units * 0.25rem */
   padding: 0 0 1rem 1.5rem; /* left 1.5rem matches Details' Padding(6,…) */
@@ -71,6 +72,8 @@
 .pmv-markdown {
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  width: 100%;
   color: var(--foreground);
   font-size: 1rem;
   line-height: 1.5;
@@ -119,6 +122,8 @@
 
 /* ─── Contextual spacing (matches framework markdown-spacing.css) ─────── */
 .pmv-markdown > * {
+  min-width: 0;
+  max-width: 100%;
   margin-top: 0;
   margin-bottom: 0;
 }
@@ -264,7 +269,10 @@
 /* Code blocks */
 .pmv-code-block {
   position: relative;
+  min-width: 0;
+  max-width: 100%;
   width: 100%;
+  box-sizing: border-box;
   overflow: hidden;
   border-radius: 0.375rem;
   border: 1px solid var(--border);
@@ -279,6 +287,8 @@
 }
 .pmv-code-block pre {
   margin: 0;
+  min-width: 0;
+  max-width: 100%;
   border-radius: 0;
   background: transparent;
   padding: 1rem;
@@ -286,6 +296,11 @@
   overflow-x: auto;
   font-size: 0.875rem;
   line-height: 1.5;
+}
+.pmv-markdown pre {
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
 }
 .pmv-code-block code,
 .pmv-markdown pre code {


### PR DESCRIPTION
Fixes #2206

# Summary

## Changes

Fixed horizontal width overflow in markdown code blocks within the Drafts view by removing the redundant outer `<pre>` wrapper emitted by `react-markdown` and enforcing flexbox width and overflow constraints in CSS. Code blocks now stay properly constrained to the container width with horizontal scrolling for long lines.

## API Changes

None.

## Files Modified

- **Widgets Frontend**:
  - `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx` (unwrapped outer `pre` wrapper)
  - `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css` (enforced `min-width: 0`, `max-width: 100%`, and overflow rules)
  - `src/Ivy.Tendril.Widgets/frontend/src/CodeBlock.tsx` (added `minWidth: 0` and `maxWidth: 100%` to `codeBlockPreStyle`)
  - `src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/result-summary.tsx` (unwrapped `pre` wrapper in Markdown component)
  - `src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx` (unwrapped `pre` wrapper in Markdown component)
  - `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx` (unwrapped `pre` wrapper in ReactMarkdown component)
- **Tests**:
  - `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.codeblock.test.tsx` (added unit tests for code block rendering and width constraints)

## Manual Testing

1. Open the Drafts view in Tendril for any plan containing code blocks with long lines.
2. Observe that code blocks do not overflow past the document container width.
3. Observe that long code lines scroll horizontally within the code block container.

---
- 95a41cb9 Fix markdown code block width overflow in drafts (Plan 00032)

---
Created using [Ivy Tendril](https://ivy.app).