### PR TITLE
[00029] Remove Gemini 3.5 Flash Model

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityModelCatalogTests.cs
@@ -44,7 +44,6 @@ public class AntigravityModelCatalogTests
     [Theory]
     [InlineData("gemini-3.7-flash")]
     [InlineData("gemini-3.6-flash")]
-    [InlineData("gemini-3.5-flash")]
     [InlineData("gemini-3.1-pro")]
     [InlineData("claude-opus-5")]
     [InlineData("claude-sonnet-5")]
@@ -56,10 +55,10 @@ public class AntigravityModelCatalogTests
     }
 
     [Fact]
-    public void GetStaticModels_DefaultIsGemini36Flash()
+    public void GetStaticModels_DefaultIsGemini37Flash()
     {
         var defaultModel = _catalog.GetStaticModels().Single(m => m.IsDefault);
-        Assert.Equal("gemini-3.6-flash", defaultModel.Id);
+        Assert.Equal("gemini-3.7-flash", defaultModel.Id);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Gemini/GeminiModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Gemini/GeminiModelCatalogTests.cs
@@ -40,15 +40,6 @@ public class GeminiModelCatalogTests
     }
 
     [Fact]
-    public void GetStaticModels_ContainsGemini35Flash()
-    {
-        var models = _catalog.GetStaticModels();
-        var flash = models.FirstOrDefault(m => m.Id == "gemini-3.5-flash");
-        Assert.NotNull(flash);
-        Assert.Equal("Gemini 3.5 Flash", flash!.DisplayName);
-    }
-
-    [Fact]
     public void GetStaticModels_ContainsGemini31Pro()
     {
         var models = _catalog.GetStaticModels();

--- a/src/Ivy.Tendril.Agents.Test/Helpers/ModelCatalogSorterTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Helpers/ModelCatalogSorterTests.cs
@@ -79,7 +79,6 @@ public class ModelCatalogSorterTests
         var models = new List<ModelInfo>
         {
             new() { Id = "gemini-2.0-flash", DisplayName = "Gemini 2.0 Flash", Provider = "google" },
-            new() { Id = "gemini-3.5-flash", DisplayName = "Gemini 3.5 Flash", Provider = "google" },
             new() { Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash", Provider = "google" },
             new() { Id = "gemini-2.5-flash", DisplayName = "Gemini 2.5 Flash", Provider = "google" },
             new() { Id = "gemini-3.1-pro", DisplayName = "Gemini 3.1 Pro", Provider = "google" },
@@ -90,7 +89,6 @@ public class ModelCatalogSorterTests
         var expectedIds = new[]
         {
             "gemini-3.7-flash",
-            "gemini-3.5-flash",
             "gemini-3.1-pro",
             "gemini-2.5-flash",
             "gemini-2.0-flash",
@@ -133,14 +131,12 @@ public class ModelCatalogSorterTests
             new() { Id = "gemini-2.5-flash", DisplayName = "Gemini 2.5 Flash", Provider = "google" },
             new() { Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash", Provider = "google", IsDefault = true },
             new() { Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash", Provider = "google" },
-            new() { Id = "gemini-3.5-flash", DisplayName = "Gemini 3.5 Flash", Provider = "google" },
         };
 
         var sorted = ModelCatalogSorter.Sort(models, preserveDefault: true);
 
         Assert.Equal("gemini-3.6-flash", sorted[0].Id);
         Assert.Equal("gemini-3.7-flash", sorted[1].Id);
-        Assert.Equal("gemini-3.5-flash", sorted[2].Id);
-        Assert.Equal("gemini-2.5-flash", sorted[3].Id);
+        Assert.Equal("gemini-2.5-flash", sorted[2].Id);
     }
 }

--- a/src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs
@@ -90,7 +90,6 @@ public sealed class ModelProfileSelectorTests
         {
             new() { Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash" },
             new() { Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash" },
-            new() { Id = "gemini-3.5-flash", DisplayName = "Gemini 3.5 Flash" },
             new() { Id = "gemini-3.1-pro", DisplayName = "Gemini 3.1 Pro" },
             new() { Id = "gemini-3-pro-preview", DisplayName = "Gemini 3 Pro" },
             new() { Id = "gemini-3-flash-preview", DisplayName = "Gemini 3 Flash" },
@@ -110,7 +109,6 @@ public sealed class ModelProfileSelectorTests
         {
             new() { Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash" },
             new() { Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash" },
-            new() { Id = "gemini-3.5-flash", DisplayName = "Gemini 3.5 Flash" },
             new() { Id = "gemini-3.1-pro", DisplayName = "Gemini 3.1 Pro" },
             new() { Id = "claude-opus-5", DisplayName = "Claude Opus 5" },
             new() { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5" },

--- a/src/Ivy.Tendril.Agents/Helpers/ModelProfilePriorities.cs
+++ b/src/Ivy.Tendril.Agents/Helpers/ModelProfilePriorities.cs
@@ -33,7 +33,7 @@ public static class ModelProfilePriorities
             ],
             [(ModelProviderKind.Ivy, ModelProfileKind.Balanced)] =
             [
-                "gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash", "claude-sonnet-5",
+                "gemini-3.7-flash", "gemini-3.6-flash", "claude-sonnet-5",
                 "claude-sonnet-4-6", "gpt-5.6-terra", "terra", "gemini-2.5-flash"
             ],
             [(ModelProviderKind.Ivy, ModelProfileKind.Quick)] =
@@ -65,7 +65,7 @@ public static class ModelProfilePriorities
             ],
             [(ModelProviderKind.Google, ModelProfileKind.Balanced)] =
             [
-                "gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash", "gemini-2.5-flash", "gemini-2.0-flash"
+                "gemini-3.7-flash", "gemini-3.6-flash", "gemini-2.5-flash", "gemini-2.0-flash"
             ],
             [(ModelProviderKind.Google, ModelProfileKind.Quick)] =
             [

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs
@@ -28,16 +28,6 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
         new()
         {
             Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash",
-            Capabilities = MidCaps,
-            SupportedEfforts = EffortLevels.Antigravity,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
-            Provider = "google",
-            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.0375m,
-        },
-        new()
-        {
-            Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash",
             Capabilities = MidCaps, IsDefault = true,
             SupportedEfforts = EffortLevels.Antigravity,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
@@ -47,7 +37,7 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
         },
         new()
         {
-            Id = "gemini-3.5-flash", DisplayName = "Gemini 3.5 Flash",
+            Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Antigravity,
             ContextWindow = 1_000_000, MaxOutputTokens = 65_536,

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiModelCatalog.cs
@@ -43,16 +43,6 @@ public sealed class GeminiModelCatalog : CachedModelCatalogProvider
         },
         new()
         {
-            Id = "gemini-3.5-flash", DisplayName = "Gemini 3.5 Flash",
-            Capabilities = MidCaps,
-            SupportedEfforts = EffortLevels.Gemini,
-            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
-            Provider = "google",
-            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
-            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.0375m,
-        },
-        new()
-        {
             Id = "gemini-3.1-pro", DisplayName = "Gemini 3.1 Pro",
             Capabilities = FullCaps,
             SupportedEfforts = EffortLevels.Gemini,

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
@@ -185,7 +185,6 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
         // Google
         ("gemini-3.7-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
         ("gemini-3.6-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
-        ("gemini-3.5-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
         ("gemini-3.1-pro",   new(1.25m, 10.00m, 0.3125m, 1.5625m, 1_048_576)),
         ("gemini-2.5-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
         ("gemini-2.5",       new(1.25m, 10.00m, 0.3125m, 1.5625m, 1_048_576)),

--- a/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/05_Gemini.md
+++ b/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/05_Gemini.md
@@ -37,18 +37,17 @@ Tendril maps effort levels to Gemini models:
 |---------|-------|----------|
 | `deep` | gemini-3.1-pro | Complex multi-file changes |
 | `balanced` | gemini-3.7-flash | Standard plan execution |
-| `quick` | gemini-3.5-flash | Simple fixes and small edits |
+| `quick` | gemini-3.7-flash | Simple fixes and small edits |
 
 The profile is selected automatically based on the plan's complexity level, or can be configured per promptware in `config.yaml`.
 
 ## Available Models
 
-- `gemini-3.7-flash` — Next-gen fast and capable reasoning, 1M context (default)
-- `gemini-3.6-flash` — Fast and capable, 1M context
-- `gemini-3.5-flash` — Lightweight and fast, 1M context
-- `gemini-3.1-pro` — Advanced reasoning, 1M context
-- `gemini-3-pro-preview` — Next-gen reasoning (preview)
-- `gemini-3-flash-preview` — Next-gen fast (preview)
+- `gemini-3.7-flash` (default): Next-gen fast and capable reasoning, 1M context
+- `gemini-3.6-flash`: Fast and capable, 1M context
+- `gemini-3.1-pro`: Advanced reasoning, 1M context
+- `gemini-3-pro-preview`: Next-gen reasoning (preview)
+- `gemini-3-flash-preview`: Next-gen fast (preview)
 
 Override the model in config:
 


### PR DESCRIPTION
Fixes #2197

# Summary

## Changes

Removed the deprecated `gemini-3.5-flash` model across all provider catalogs (Gemini, Antigravity, OpenCode), model profile priorities, documentation, and unit tests. Configured `gemini-3.7-flash` as the latest and default model for Gemini and Antigravity catalogs.

## API Changes

- Removed `gemini-3.5-flash` model entry from `GeminiModelCatalog.GetStaticModels()`.
- Removed `gemini-3.5-flash` model entry from `AntigravityModelCatalog.GetStaticModels()`.
- Updated default model in `AntigravityModelCatalog.GetStaticModels()` to `gemini-3.7-flash`.
- Removed `gemini-3.5-flash` pricing entry from `OpenCodeModelCatalog.KnownPricingTable`.
- Removed `gemini-3.5-flash` from `ModelProfilePriorities` Balanced profile candidates for Ivy and Google providers.

## Files Modified

- Catalogs and Profiles:
  - `src/Ivy.Tendril.Agents/Providers/Gemini/GeminiModelCatalog.cs`
  - `src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs`
  - `src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs`
  - `src/Ivy.Tendril.Agents/Helpers/ModelProfilePriorities.cs`
- Documentation:
  - `src/Ivy.Tendril.Docs/Docs/06_CodingAgents/05_Gemini.md`
- Unit Tests:
  - `src/Ivy.Tendril.Agents.Test/Gemini/GeminiModelCatalogTests.cs`
  - `src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityModelCatalogTests.cs`
  - `src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs`
  - `src/Ivy.Tendril.Agents.Test/Helpers/ModelCatalogSorterTests.cs`

## Manual Testing

1. Run unit tests via `dotnet test src/Ivy.Tendril.Agents.Test/Ivy.Tendril.Agents.Test.csproj` and verify all tests pass.
2. Launch the application or check model listing with `tendril models` to confirm `gemini-3.5-flash` is no longer present and `gemini-3.7-flash` is the default model for Gemini and Antigravity providers.

---

### Commits

- 646d00b: Remove gemini-3.5-flash model and set gemini-3.7-flash as default (Plan 00029)

---
Created using [Ivy Tendril](https://ivy.app).
