### PR TITLE
[00031] Fix Non-Completable Draft for Already Solved Issues

### DIFF
--- a/src/Ivy.Tendril.Test/Services/PreExecutionFailureStateTests.cs
+++ b/src/Ivy.Tendril.Test/Services/PreExecutionFailureStateTests.cs
@@ -276,6 +276,72 @@ public class PreExecutionFailureStateTests : IDisposable
         Assert.Equal(nameof(PlanStatus.Skipped), PlanCommandHelpers.ReadPlan(planFolder).State);
     }
 
+    // ---- GetCompletionBlockReason & PlanCompletionAction ---------------------------------
+
+    [Fact]
+    public void GetCompletionBlockReason_PreExecutionFail_NoCommitsNoPrs_ReturnsBlockReason()
+    {
+        var planFolder = CreatePlanFolder("00074-Blocked", nameof(PlanStatus.Review),
+        [
+            ("DotnetBuild", VerificationStatus.Skipped),
+        ]);
+        WritePreExecutionReport(planFolder, "Fail");
+        var service = CreateReaderService();
+
+        var reason = service.GetCompletionBlockReason("00074-Blocked");
+
+        Assert.NotNull(reason);
+        Assert.Contains("Pre-execution validation failed", reason);
+        Assert.Contains(nameof(PlanStatus.Skipped), reason);
+    }
+
+    [Fact]
+    public void GetCompletionBlockReason_PreExecutionPass_ReturnsNull()
+    {
+        var planFolder = CreatePlanFolder("00075-Pass", nameof(PlanStatus.Review),
+        [
+            ("DotnetBuild", VerificationStatus.Pass),
+        ]);
+        WritePreExecutionReport(planFolder, "Pass");
+        var service = CreateReaderService();
+
+        Assert.Null(service.GetCompletionBlockReason("00075-Pass"));
+    }
+
+    [Fact]
+    public void GetCompletionBlockReason_PreExecutionFail_WithCommits_ReturnsNull()
+    {
+        var planFolder = CreatePlanFolder("00076-WithCommits", nameof(PlanStatus.Review),
+        [
+            ("DotnetBuild", VerificationStatus.Pass),
+        ], commits: ["abc1234"]);
+        WritePreExecutionReport(planFolder, "Fail");
+        var service = CreateReaderService();
+
+        Assert.Null(service.GetCompletionBlockReason("00076-WithCommits"));
+    }
+
+    [Fact]
+    public async Task PlanCompletionAction_TryComplete_And_Skip_HandlesPreExecutionFailure()
+    {
+        var planFolder = CreatePlanFolder("00077-ActionTest", nameof(PlanStatus.Review),
+        [
+            ("DotnetBuild", VerificationStatus.Skipped),
+        ]);
+        WritePreExecutionReport(planFolder, "Fail");
+        var service = CreateReaderService();
+        var plan = service.GetPlanByFolder(planFolder)!;
+
+        var failedVerifications = PlanCompletionAction.TryComplete(service, plan);
+        Assert.NotNull(failedVerifications);
+        Assert.Empty(failedVerifications);
+
+        PlanCompletionAction.Skip(service, plan);
+        await service.FlushPendingWritesAsync();
+
+        Assert.Equal(nameof(PlanStatus.Skipped), PlanCommandHelpers.ReadPlan(planFolder).State);
+    }
+
     private class TempDirConfigService(string planFolder) : StubConfigService, IConfigService
     {
         string IConfigService.PlanFolder => planFolder;

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -262,7 +262,7 @@ public class ContentView(
             selectedPlanState.Value!, selectedRecTitles, client,
             planContentQuery.Mutator.Revalidate);
 
-        var header = BuildHeader(selectedPlanState.Value, allPlans, currentIndex, context, showCreatePrDialog, isShareMode, draftComments, shareContext);
+        var header = BuildHeader(selectedPlanState.Value, allPlans, currentIndex, context, showCreatePrDialog, showDiscardDialog, isShareMode, draftComments, shareContext);
         var actionBar = BuildActionBar(
             selectedPlanState.Value, showResetToDraftDialog, showSuggestChangesDialog, showDiscardDialog,
             context, agentRunner, draftComments, isShareMode, isBeta, shareTunnelService, showShareModal);
@@ -290,6 +290,7 @@ public class ContentView(
         int currentIndex,
         ReviewViewContext context,
         Action showCreatePrDialog,
+        Action showDiscardDialog,
         bool isShareMode,
         IState<List<DraftComment>> draftComments,
         IShareContext shareContext)
@@ -385,27 +386,36 @@ public class ContentView(
             }
             else
             {
-                var completePlanBtn = new Button("Complete Plan").Icon(Icons.CircleCheck).OnClick(() =>
+                var completionBlockReason = planService.GetCompletionBlockReason(selectedPlan.FolderName);
+                if (completionBlockReason != null)
                 {
-                    try
+                    var skipPlanBtn = new Button("Skip Plan").Icon(Icons.Ban).OnClick(showDiscardDialog).ShortcutKey("m");
+                    rightSide |= skipPlanBtn.Primary();
+                }
+                else
+                {
+                    var completePlanBtn = new Button("Complete Plan").Icon(Icons.CircleCheck).OnClick(() =>
                     {
-                        // Optimistic UI - update state and refresh immediately
-                        planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
-                    }
-                    catch (PlanTransitionBlockedException ex)
-                    {
-                        // This handler is fire-and-forget, so an uncaught throw would look like a
-                        // silent no-op. Surface the reason and leave the plan where it is.
-                        context.Client.Toast(ex.Message, "Cannot Complete Plan", variant: ToastVariant.Destructive);
-                        return;
-                    }
+                        try
+                        {
+                            // Optimistic UI - update state and refresh immediately
+                            planService.TransitionState(selectedPlan.FolderName, PlanStatus.Completed);
+                        }
+                        catch (PlanTransitionBlockedException ex)
+                        {
+                            // This handler is fire-and-forget, so an uncaught throw would look like a
+                            // silent no-op. Surface the reason and leave the plan where it is.
+                            context.Client.Toast(ex.Message, "Cannot Complete Plan", variant: ToastVariant.Destructive);
+                            return;
+                        }
 
-                    refreshPlans();
+                        refreshPlans();
 
-                    // Fire and forget - clean up worktrees in the background
-                    WorktreeCleanupService.RemoveWorktreesInBackground(selectedPlan.FolderPath);
-                }).ShortcutKey("m");
-                rightSide |= completePlanBtn.Primary();
+                        // Fire and forget - clean up worktrees in the background
+                        WorktreeCleanupService.RemoveWorktreesInBackground(selectedPlan.FolderPath);
+                    }).ShortcutKey("m");
+                    rightSide |= completePlanBtn.Primary();
+                }
             }
 
             return rightSide.Width(isMobile ? Size.Full() : Size.Fit());
@@ -648,6 +658,15 @@ public class ContentView(
 
             var totalArtifacts = (planData.Artifacts.GetValueOrDefault("screenshots")?.Count ?? 0)
                                  + (planData.Artifacts.ContainsKey("sample") ? 1 : 0);
+
+            var completionBlockReason = planService.GetCompletionBlockReason(selectedPlan.FolderName);
+            if (completionBlockReason != null)
+            {
+                content |= Layout.Vertical().Padding(2, 2, 1, 2)
+                    | Callout.Info(
+                        "Pre-execution validation found no changes needed because the issue or task is already resolved. You can discard or skip this plan.",
+                        "No Changes Needed");
+            }
 
             content |= new ReviewActionsBarView(selectedPlan, planData.ReviewActionStates, config);
 

--- a/src/Ivy.Tendril/Helpers/PlanCompletionAction.cs
+++ b/src/Ivy.Tendril/Helpers/PlanCompletionAction.cs
@@ -35,8 +35,20 @@ public static class PlanCompletionAction
     /// </summary>
     public static void ToastBlocked(IClientProvider client, PlanFile plan, IReadOnlyList<string> failed) =>
         client.Toast(
-            $"{string.Join(", ", failed)} failed for plan #{plan.Id}. Re-run the verification, or set it " +
-            "to Skipped with a reason, before completing the plan.",
-            "Verification Failed",
+            failed.Count > 0
+                ? $"{string.Join(", ", failed)} failed for plan #{plan.Id}. Re-run the verification, or set it " +
+                  "to Skipped with a reason, before completing the plan."
+                : $"Pre-execution validation failed for plan #{plan.Id} and no changes were implemented. " +
+                  "Retire it by setting the state to Skipped instead.",
+            failed.Count > 0 ? "Verification Failed" : "Cannot Complete Plan",
             variant: ToastVariant.Destructive);
+
+    /// <summary>
+    ///     Transitions a plan to Skipped and initiates background worktree cleanup.
+    /// </summary>
+    public static void Skip(IPlanReaderService planService, PlanFile plan)
+    {
+        planService.TransitionState(plan.FolderName, PlanStatus.Skipped);
+        WorktreeCleanupService.RemoveWorktreesInBackground(plan.FolderPath);
+    }
 }

--- a/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePlan/Program.md
@@ -52,7 +52,7 @@ If it references related plans with `[number]` syntax (e.g. `[01205]`), find and
 
 **Extract Source URL**: Check if the task description contains a GitHub PR URL (`https://github.com/{owner}/{repo}/pull/{number}`) or issue URL (`https://github.com/{owner}/{repo}/issues/{number}`). If found, store it as `sourceUrl` in plan.yaml.
 
-- **Issue URL**: `gh issue view <url> --json title,body,comments` — fetch the title, body, and comments for context when writing the plan.
+- **Issue URL**: `gh issue view <url> --json title,body,comments,state` - fetch the title, body, state, and comments for context when writing the plan. If the issue is already marked closed or solved on GitHub and verified to already be resolved in the codebase, decline creating the plan as duplicate / already resolved (report status and exit without creating a redundant plan).
 - **PR URL**: the plan must be based on the **review feedback on the PR**, not just its description. Fetch the full conversation:
   ```bash
   # Title, body, top-level conversation comments, and review summaries (with their state: APPROVED / CHANGES_REQUESTED / COMMENTED)

--- a/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
+++ b/src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md
@@ -149,15 +149,15 @@ date: <CurrentTime>
 
 **Note:** This step runs against the original repo (before worktrees are created), since it validates whether the plan's assumptions about the codebase are still accurate.
 
-5. **Self-flagged redundancy check** — In addition to code block validation, scan the plan revision for markers where the plan itself admits it is already done:
+5. **Self-flagged redundancy check** - In addition to code block validation, scan the plan revision for markers where the plan itself admits it is already done:
    - A `<details><summary>Still relevant?</summary>` block whose body starts with `No.`
-   - Phrases like *"Already applied"*, *"This plan is redundant"*, *"This plan is superseded"*, or *"previously attempted … was merged to main via PR #NNNN"* in the `## Problem` or `## Solution` sections.
+   - Phrases like *"Already applied"*, *"This plan is redundant"*, *"This plan is superseded"*, or *"previously attempted ... was merged to main via PR #NNNN"* in the `## Problem` or `## Solution` sections.
 
    If any marker is found, verify the claim: run `gh pr view <cited PR> --json state,mergeCommit` (must be `MERGED`), confirm the cited commit is in `git log origin/<default-branch>`, and byte-compare the plan's proposed code against the current file contents. If all three checks pass, fail **without creating a worktree** (running verifications on unchanged code wastes the time budget and produces a 0-commit PR that CreatePr cannot process):
 
    1. Write `Verification/PreExecution.md` with `result: Fail` and the evidence for each of the three checks.
-   2. Write `Artifacts/summary.md` documenting the no-op.
-   3. Call `tendril job fail TendrilJobId --message="PreExecution failed: <reason>"` and `exit 1`.
+   2. Write `Artifacts/summary.md` documenting the no-op (explicitly explaining that the task was skipped or retired because the changes are already resolved, rather than presenting a completed implementation draft).
+   3. Call `tendril job fail TendrilJobId --message="PreExecution failed: Task already resolved/redundant (<reason>)"` and `exit 1`.
 
    **Do not set the verifications to `Skipped`.** An earlier revision of this document told you to, and
    that is exactly how a never-executed plan reached `Review`: the server's state decision keys on

--- a/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs
@@ -26,6 +26,11 @@ public interface IPlanReaderService
     /// </summary>
     void CompleteWithPartialDelivery(string folderName);
 
+    /// <summary>
+    ///     Returns the reason a plan must not be marked Completed, or null when the transition is fine.
+    /// </summary>
+    string? GetCompletionBlockReason(string folderName) => null;
+
     void ResetToDraft(string folderName);
     void ResetVerificationsForRetry(string folderName);
     void SetVerificationStatus(string folderName, string name, VerificationStatus status);

--- a/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanReaderService.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Ivy.Helpers;
 using Ivy.Tendril.Helpers;
@@ -174,7 +174,7 @@ public class PlanReaderService(
                 throw new PlanTransitionBlockedException(folderName, failed);
 
             // Plan 00103: block on failed pre-execution with no deliverables
-            if (GetCompletionBlockReason(Path.Combine(PlansDirectory, folderName)) is { } blockReason)
+            if (GetCompletionBlockReason(folderName) is { } blockReason)
                 throw new PlanTransitionBlockedException(folderName, newState, blockReason);
         }
 
@@ -240,13 +240,22 @@ public class PlanReaderService(
 
     /// <summary>
     ///     Returns the reason a plan must not be marked Completed, or null when the transition is fine.
+    /// </summary>
+    public string? GetCompletionBlockReason(string folderName)
+    {
+        var planFolder = Path.IsPathRooted(folderName) ? folderName : Path.Combine(PlansDirectory, folderName);
+        return GetCompletionBlockReasonForFolder(planFolder);
+    }
+
+    /// <summary>
+    ///     Returns the reason a plan must not be marked Completed, or null when the transition is fine.
     ///     Blocks a plan whose <c>Verification/PreExecution.md</c> reads <c>result: Fail</c> and which has
     ///     no commits and no PRs: pre-execution rejected the plan's premise and nothing was delivered, so
     ///     Completed would record a phantom owner for work that never happened. The no-commits-and-no-PRs
     ///     conjunct keeps config-only plans (which legitimately have neither, and pass pre-execution) and
     ///     any plan that did real work out of the block. See plan 00103.
     /// </summary>
-    internal static string? GetCompletionBlockReason(string planFolder)
+    internal static string? GetCompletionBlockReasonForFolder(string planFolder)
     {
         if (PlanYamlHelper.ReadPreExecutionResult(planFolder) != VerificationStatus.Fail) return null;
 


### PR DESCRIPTION
Fixes #2135

# Summary

## Changes

Handled non-completable plans whose pre-execution validation failed with 0 commits and 0 PRs by surfacing a primary "Skip Plan" button and informative Callout banner in the Review UI instead of a blocked "Complete Plan" button. Exposed completion block reasons via `IPlanReaderService` and enhanced `PlanCompletionAction` with transition helpers. Updated promptware guidelines in `CreatePlan` and `ExecutePlan` to detect resolved issues and document redundancy.

## API Changes

- Added `string? GetCompletionBlockReason(string folderName)` to `IPlanReaderService` and `PlanReaderService`.
- Added `void Skip(IPlanReaderService planService, PlanFile plan)` to `PlanCompletionAction`.

## Files Modified

- `src/Ivy.Tendril/Services/Plans/IPlanReaderService.cs`: Interface definition for `GetCompletionBlockReason`.
- `src/Ivy.Tendril/Services/Plans/PlanReaderService.cs`: Implementation of `GetCompletionBlockReason` and delegation.
- `src/Ivy.Tendril/Helpers/PlanCompletionAction.cs`: Added `Skip` helper and enhanced blocked toast messaging.
- `src/Ivy.Tendril/Apps/Review/ContentView.cs`: Replaced "Complete Plan" with "Skip Plan" and added informational Callout banner when completion is blocked.
- `src/Ivy.Tendril/Promptwares/CreatePlan/Program.md`: Clarified declining plans when GitHub issues are already closed or resolved.
- `src/Ivy.Tendril/Promptwares/ExecutePlan/Program.md`: Clarified pre-execution redundancy summaries.
- `src/Ivy.Tendril.Test/Services/PreExecutionFailureStateTests.cs`: Unit tests for `GetCompletionBlockReason` and `PlanCompletionAction`.

## Manual Testing

1. Open the Review app in Tendril.
2. Select a plan where pre-execution validation failed with zero commits (or create a mock failed pre-execution report in a test plan).
3. Observe that the primary CTA in the header displays "Skip Plan" instead of "Complete Plan", and an informational Callout banner is displayed informing the user that no changes are needed.
4. Click "Skip Plan" to confirm that the discard modal appears and successfully transitions the plan to Skipped state.

---
- 2bfb254e [00031] Fix non-completable draft for already solved issues

---
Created using [Ivy Tendril](https://ivy.app).
