### PR TITLE
[00036] Fix Chat Session Timeouts with Antigravity Agent by Respecting Configured Timeout Defaults

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityCliTests.cs
@@ -74,16 +74,19 @@ public class AntigravityCliTests
         Assert.Equal("/tmp", spec.WorkingDirectory);
         Assert.Contains("--print", spec.Arguments);
         Assert.Contains("--dangerously-skip-permissions", spec.Arguments);
+        Assert.Contains("--print-timeout", spec.Arguments);
+        var timeoutIdx = spec.Arguments.ToList().IndexOf("--print-timeout");
+        Assert.Equal("1800s", spec.Arguments[timeoutIdx + 1]);
     }
 
     [Fact]
-    public void BuildProcessSpec_WithTimeout_IncludesConfiguredPrintTimeout()
+    public void BuildProcessSpec_WithoutExplicitTimeout_IncludesDefaultPrintTimeout()
     {
         var config = new AgentLaunchConfig
         {
             Prompt = "Hello",
             WorkingDirectory = "/tmp",
-            Timeout = TimeSpan.FromMinutes(30),
+            Timeout = null,
         };
 
         var spec = _cli.BuildProcessSpec(config);
@@ -92,6 +95,24 @@ public class AntigravityCliTests
         var timeoutIdx = args.IndexOf("--print-timeout");
         Assert.True(timeoutIdx >= 0);
         Assert.Equal("1800s", args[timeoutIdx + 1]);
+    }
+
+    [Fact]
+    public void BuildProcessSpec_WithExplicitTimeout_IncludesConfiguredPrintTimeout()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "Hello",
+            WorkingDirectory = "/tmp",
+            Timeout = TimeSpan.FromMinutes(15),
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+        var args = spec.Arguments.ToList();
+
+        var timeoutIdx = args.IndexOf("--print-timeout");
+        Assert.True(timeoutIdx >= 0);
+        Assert.Equal("900s", args[timeoutIdx + 1]);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs
@@ -47,7 +47,8 @@ public sealed class AntigravityCli : IAgentCli
             "--output-format", "stream-json",
         };
 
-        if (config.Timeout is { } timeout && timeout > TimeSpan.Zero)
+        var effectiveTimeout = config.Timeout ?? TimeoutPolicy.Default.TotalTimeout;
+        if (effectiveTimeout is { } timeout && timeout > TimeSpan.Zero)
         {
             args.Add("--print-timeout");
             args.Add($"{(int)timeout.TotalSeconds}s");

--- a/src/Ivy.Tendril.Agents/Runtime/AgentRunner.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/AgentRunner.cs
@@ -141,6 +141,7 @@ public sealed class AgentRunner(ILogger<AgentRunner> logger, ConcurrencyOptions?
             EnvironmentVariables = context.ExtraEnvironment,
             MaxTurns = context.MaxTurns,
             MaxBudgetUsd = context.MaxBudgetUsd,
+            Timeout = context.TimeoutPolicy?.TotalTimeout,
             McpServers = context.McpServers,
             PromptFilePath = context.PromptFilePath,
             SystemPrompt = context.SystemPrompt,

--- a/src/Ivy.Tendril.Test/Helpers/AgentLaunchHelperTests.cs
+++ b/src/Ivy.Tendril.Test/Helpers/AgentLaunchHelperTests.cs
@@ -148,9 +148,49 @@ public class AgentLaunchHelperTests : IDisposable
         Assert.Equal(PermissionMode.FullAuto, context.PermissionMode);
         Assert.NotNull(context.ExtraEnvironment);
         Assert.True(context.ExtraEnvironment.ContainsKey("TENDRIL_HOME"));
+        Assert.NotNull(context.TimeoutPolicy);
+        Assert.Equal(TimeSpan.FromMinutes(config.Settings.JobTimeout), context.TimeoutPolicy.TotalTimeout);
+        Assert.Equal(TimeoutPolicy.Default.IdleTimeout, context.TimeoutPolicy.IdleTimeout);
+        Assert.Equal(TimeoutPolicy.Default.StartupTimeout, context.TimeoutPolicy.StartupTimeout);
 
         // AGENTS.md should be written to the working directory for Antigravity
         var agentsMd = Path.Combine(_tempDir.Path, "AGENTS.md");
         Assert.True(File.Exists(agentsMd));
+    }
+
+    [Fact]
+    public void PrepareResolutionContext_WithCustomJobTimeout_SetsTimeoutPolicy()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        config.Settings.JobTimeout = 45;
+        var runner = TestAgentRunner.Create();
+
+        var context = AgentLaunchHelper.PrepareResolutionContext(
+            config,
+            runner,
+            "antigravity",
+            "Do a task"
+        );
+
+        Assert.NotNull(context.TimeoutPolicy);
+        Assert.Equal(TimeSpan.FromMinutes(45), context.TimeoutPolicy.TotalTimeout);
+    }
+
+    [Fact]
+    public void PrepareResolutionContext_WithZeroOrNegativeJobTimeout_DefaultsTo30Minutes()
+    {
+        var config = new TestPlanConfigService(_tempDir.Path, tendrilHome: _tempDir.Path);
+        config.Settings.JobTimeout = 0;
+        var runner = TestAgentRunner.Create();
+
+        var context = AgentLaunchHelper.PrepareResolutionContext(
+            config,
+            runner,
+            "antigravity",
+            "Do a task"
+        );
+
+        Assert.NotNull(context.TimeoutPolicy);
+        Assert.Equal(TimeSpan.FromMinutes(30), context.TimeoutPolicy.TotalTimeout);
     }
 }

--- a/src/Ivy.Tendril/Helpers/AgentLaunchHelper.cs
+++ b/src/Ivy.Tendril/Helpers/AgentLaunchHelper.cs
@@ -139,6 +139,18 @@ public static class AgentLaunchHelper
         var resolvedEffort = effortOverride ?? ResolveEffort(config, runner, agentId);
         var env = GetEnvironment(config, agentId);
 
+        var jobTimeoutMinutes = config.Settings.JobTimeout;
+        var totalTimeout = jobTimeoutMinutes > 0
+            ? TimeSpan.FromMinutes(jobTimeoutMinutes)
+            : TimeSpan.FromMinutes(30);
+
+        var timeoutPolicy = new TimeoutPolicy
+        {
+            TotalTimeout = totalTimeout,
+            IdleTimeout = TimeoutPolicy.Default.IdleTimeout,
+            StartupTimeout = TimeoutPolicy.Default.StartupTimeout,
+        };
+
         return new AgentResolutionContext
         {
             AgentId = agentId,
@@ -149,6 +161,7 @@ public static class AgentLaunchHelper
             WorkingDirectory = workDir,
             PermissionMode = permissionMode,
             ExtraEnvironment = env,
+            TimeoutPolicy = timeoutPolicy,
         };
     }
 


### PR DESCRIPTION
# Summary

## Changes

Fixed chat session premature timeouts when running the Antigravity agent by correctly setting TimeoutPolicy in AgentLaunchHelper, propagating TotalTimeout to AgentLaunchConfig in AgentRunner, and defaulting to TimeoutPolicy.Default.TotalTimeout in AntigravityCli.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Helpers/AgentLaunchHelper.cs`: Configured TimeoutPolicy in PrepareResolutionContext based on JobTimeout setting.
- `src/Ivy.Tendril.Agents/Runtime/AgentRunner.cs`: Set Timeout on AgentLaunchConfig from TimeoutPolicy.TotalTimeout in LaunchAsync.
- `src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityCli.cs`: Fallback to TimeoutPolicy.Default.TotalTimeout when config.Timeout is null in BuildProcessSpec.
- `src/Ivy.Tendril.Test/Helpers/AgentLaunchHelperTests.cs`: Added tests for TimeoutPolicy population and default/custom timeout configuration.
- `src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityCliTests.cs`: Added tests for default and explicit --print-timeout arguments.

## Manual Testing

1. Configure `JobTimeout` in `config.yaml` or leave at default (30 minutes).
2. Start a chat session or launch an Antigravity agent task.
3. Observe process arguments passed to `agy` or verify that `--print-timeout 1800s` (or configured duration) is present.

---
## Commits
- 47a7aeb1: Fix chat session timeouts with Antigravity agent by respecting configured timeout defaults (#00036)

---
Created using [Ivy Tendril](https://ivy.app).
