### PR TITLE
[00039] Reduce Checkmark and Completed Status Spacing in Chat Sidebar

### DIFF
--- a/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
@@ -71,7 +71,7 @@ public class SidebarView(
                 }
                 else if (isCompleted)
                 {
-                    metaLine = Layout.Horizontal().AlignContent(Align.Left)
+                    metaLine = Layout.Horizontal().AlignContent(Align.Left).Gap(1)
                         | new Icon(Icons.Check, Colors.Green).Small()
                         | Text.Success("Completed").Small()
                         | Text.Muted($"• {sess.AgentId}").Small();


### PR DESCRIPTION
# Summary

## Changes

Added `.Gap(1)` to the completed session status horizontal layout in the chat sidebar. This reduces the visual spacing between the green checkmark icon, the "Completed" text label, and the agent ID.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Chat/SidebarView.cs` - Configured `.Gap(1)` on the completed session metaLine horizontal layout.

## Manual Testing

1. Run the Ivy Tendril app:
   `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`
2. Navigate to the Chat view.
3. Check the session list in the sidebar for a completed session that is not currently selected.
4. Verify the checkmark icon, "Completed" text, and agent ID are displayed with compact `Gap(1)` spacing.

---
- b4bad533 Plan 00039: Reduce checkmark and completed status spacing in chat sidebar

---
Created using [Ivy Tendril](https://ivy.app).
