### PR TITLE
[00038] Prohibit Direct Codebase Edits in Chat Sessions and Enforce Plan Creation

### DIFF
--- a/src/Ivy.Tendril.Test/Commands/AgentInstructionsCommandTests.cs
+++ b/src/Ivy.Tendril.Test/Commands/AgentInstructionsCommandTests.cs
@@ -82,4 +82,22 @@ public class AgentInstructionsCommandTests
 
         Assert.NotNull(prompt);
     }
+
+    [Fact]
+    public void AgentInstructions_ContainsDirectCodeEditProhibition_AndPlanEnforcement()
+    {
+        var (app, tendrilHome) = BuildApp();
+        var config = new TestPlanConfigService(
+            repoDir: Path.GetTempPath(),
+            tendrilHome: tendrilHome);
+
+        var compiled = AgentPromptCompiler.Compile(config);
+        Assert.NotNull(compiled);
+        Assert.Contains("Direct Code Modification Prohibited", compiled);
+        Assert.Contains("tendril job start CreatePlan", compiled);
+
+        var output = CaptureConsoleOut(() => app.Run(["agent-instructions"]));
+        Assert.Contains("Direct Code Modification Prohibited", output);
+        Assert.Contains("tendril job start CreatePlan", output);
+    }
 }

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -4,7 +4,7 @@ Tendril is a plan management and agentic orchestration system. It manages a pipe
 
 **Task → Plan → Execution → Verification → PR → Merge**
 
-You are an interactive assistant for the human operator. Users open this session to create plans, debug failures, inspect plan state, work on the Tendril codebase, or ask questions about the system.
+You are an interactive assistant for the human operator. Users open this session to create plans, debug failures, inspect plan state, explore the codebase (read-only), or ask questions about the system.
 
 ## Environment
 
@@ -56,6 +56,28 @@ CreatePlan ──► Draft
 - `dependsOn` blocks execution until all dependencies are Completed AND their PRs merged
 - Verifications (Build, Test, Format, CheckResult) gate progress from Executing to Review
 - Plans execute in isolated git worktrees, never in the original repos
+
+## Direct Code Modification Prohibited
+
+Coding agents in interactive chat sessions are strictly prohibited from directly creating, editing, or deleting files in repository directories. Repository access during chat sessions is strictly read-only.
+
+All codebase changes (bug fixes, feature additions, refactorings, or updates) must go through the Tendril plan execution pipeline:
+
+**Task → Plan → Execution (in isolated git worktrees) → Verification → PR → Merge**
+
+When a user requests code changes, bug fixes, or new features:
+1. **Research (Read-Only)**: Inspect, search, and analyze the codebase to understand the problem and design a solution.
+2. **Start a Plan**: Create a Tendril plan using the CLI:
+   ```bash
+   tendril job start CreatePlan --description="<task description>" --project="<project-name>"
+   ```
+3. **Do Not Edit Code Directly**: Never modify workspace or repository files directly from the chat session.
+
+### Permitted Chat Actions
+- Reading, searching, and analyzing source code.
+- Answering architectural and technical questions.
+- Inspecting plan, job, and verification states.
+- Managing plans and starting promptware jobs (`CreatePlan`, `ExecutePlan`, `RetryPlan`, `AddProject`, `SetupProject`).
 
 ## Promptwares
 
@@ -267,8 +289,9 @@ When the user mentions a project, application, or codebase (e.g. "my coal miner 
 
 ## Important Notes
 
+- **Never directly modify, create, or delete repository files during chat sessions.** All code changes must be planned and executed via Tendril plans (`tendril job start CreatePlan`).
 - **Never read or write `plan.yaml` directly** -- always use `tendril plan` CLI commands.
-- **`tendril job start` and `tendril job status` require the Tendril server to be running.** They communicate via HTTP to the master instance (discovered via `TENDRIL_HOME/.master`). `tendril job add-log` does not need the server — it writes straight to disk.
+- **`tendril job start` and `tendril job status` require the Tendril server to be running.** They communicate via HTTP to the master instance (discovered via `TENDRIL_HOME/.master`). `tendril job add-log` does not need the server -- it writes straight to disk.
 - Verification statuses: `Pending`, `Pass`, `Fail`, `Skipped`.
 - Plan states: `Draft`, `Creating`, `Updating`, `Executing`, `Review`, `Failed`, `Completed`, `Skipped`, `Blocked`, `Icebox`.
 - To create a new plan, start a CreatePlan job: `tendril job start CreatePlan --description="<description>" --project="<project>"`. Use the lower-level `tendril plan create` / `write-revision` commands only to edit an existing plan's content, never to create a new plan from scratch.


### PR DESCRIPTION
# Summary

## Changes

Updated `AgentPrompt.md` to strictly prohibit direct codebase edits during interactive chat sessions and enforce creating Tendril plans for all code changes. Added comprehensive unit tests in `AgentInstructionsCommandTests.cs` to verify both compiled instructions and CLI command output enforce these rules.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Prompts/AgentPrompt.md`: Added direct code modification prohibition rules, plan creation workflows, and permitted chat actions.
- `src/Ivy.Tendril.Test/Commands/AgentInstructionsCommandTests.cs`: Added unit test `AgentInstructions_ContainsDirectCodeEditProhibition_AndPlanEnforcement`.

## Manual Testing

1. Run `tendril agent-instructions` from the command line.
2. Verify the output contains the `## Direct Code Modification Prohibited` section and `tendril job start CreatePlan` instructions.
3. Run `dotnet test src/Ivy.Tendril/Ivy.Tendril.slnx --filter "FullyQualifiedName~Ivy.Tendril.Test.Commands.AgentInstructionsCommandTests"` and confirm all tests pass.

---
### Commits
- bd546cae: Prohibit direct codebase edits in chat sessions and enforce plan creation (Plan 00038)

---
Created using [Ivy Tendril](https://ivy.app).
