### PR TITLE
[00043] Add Gap to Generating Session Layout in Sidebar View

### DIFF
--- a/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
@@ -65,7 +65,7 @@ public class SidebarView(
                 object metaLine;
                 if (isGenerating)
                 {
-                    metaLine = Layout.Horizontal().AlignContent(Align.Left)
+                    metaLine = Layout.Horizontal().AlignContent(Align.Left).Gap(1)
                         | new Icon(Icons.LoaderCircle).Small().WithAnimation(AnimationType.Rotate).Duration(1)
                         | Text.Muted(sess.AgentId).Small();
                 }


### PR DESCRIPTION
# Summary

## Changes

Added `.Gap(1)` to the generating session status layout in `SidebarView.cs`. This adds consistent spacing between the spinning loader icon and the agent ID text, aligning with the completed session layout.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Chat/SidebarView.cs` (Chat App): Added `.Gap(1)` to `Layout.Horizontal().AlignContent(Align.Left)` for generating session item metadata.

## Manual Testing

1. Launch Tendril and navigate to Chat.
2. Trigger an agent response generation in a session.
3. Observe the session entry in the sidebar: verify there is consistent 1-unit spacing between the spinning loader icon and the agent ID label.

---
- a2064305: Add gap to generating session layout in SidebarView (#00043)

---
Created using [Ivy Tendril](https://ivy.app).
