### PR TITLE
fix(docker): build staging image from source so PR previews run the PR branch

### DIFF
--- a/.github/docker/Dockerfile.tendril-staging
+++ b/.github/docker/Dockerfile.tendril-staging
@@ -1,15 +1,32 @@
-# Ivy Tendril staging image — extends the release image for ephemeral PR preview deployments.
+# Ivy Tendril staging image — builds from source for ephemeral PR preview deployments.
 # Differences from Dockerfile.tendril-release:
+#   - Builds Tendril from the build context instead of installing the published
+#     NuGet tool, so the deployed app is the PR branch under review (not the last release)
 #   - Bootstraps TENDRIL_HOME with a default config.yaml on first start (no setup wizard)
 #   - Designed for stateless deploys: no persistent volume needed
 # Required env vars: ANTHROPIC_AUTH_TOKEN (or ANTHROPIC_API_KEY), ANTHROPIC_BASE_URL
 # Optional env vars: TENDRIL_AUTH_USERNAME, TENDRIL_AUTH_PASSWORD, PORT (default 8000)
 
-# ── Stage 1: install Tendril + PowerShell as dotnet global tools ───────────────
+# ── Stage 1: build Tendril from source + install PowerShell as dotnet tool ────
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
-RUN dotnet tool install --global Ivy.Tendril \
- && dotnet tool install --global PowerShell
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_NOLOGO=1
+ENV PATH="$PATH:/root/.dotnet/tools"
+
+# PowerShell: needed at runtime by Tendril AND needed now for pack-promptwares.ps1
+RUN dotnet tool install --global PowerShell
+
+WORKDIR /src
+COPY . .
+
+# Publish Tendril from source so the preview runs the PR branch's code.
+# Publishing=true → Directory.Build.props sets IvySource=false → Ivy Framework
+# comes from NuGet (no need to clone Ivy-Framework). Our local changes are baked in.
+RUN dotnet publish src/Ivy.Tendril/Ivy.Tendril.csproj \
+    -c Release \
+    -p:Publishing=true \
+    -o /app
 
 # ── Stage 2: runtime image with all CLI dependencies ──────────────────────────
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
@@ -32,8 +49,11 @@ ENV HOMEDIR=/home/tendril
 ENV TENDRIL_HOME=/data/tendril
 ENV PORT=8000
 
-# Copy Tendril + PowerShell global tools from build stage (root → tendril user home)
+# Copy PowerShell global tool from build stage (root → tendril user home)
 COPY --from=build --chown=tendril:tendril /root/.dotnet/tools /home/tendril/.dotnet/tools
+
+# Copy published Tendril app from build stage
+COPY --from=build --chown=tendril:tendril /app /home/tendril/tendril-app
 
 # Copy Node.js from official image (avoids flaky apt mirrors — same pattern as Dockerfile.tendril-docs)
 COPY --from=node:22-bookworm-slim /usr/local/bin/node /usr/local/bin/node
@@ -87,4 +107,4 @@ EXPOSE 8000
 
 USER tendril
 
-CMD ["tendril", "--web"]
+CMD ["dotnet", "/home/tendril/tendril-app/Ivy.Tendril.dll", "--web"]

--- a/.github/docker/Dockerfile.tendril-staging
+++ b/.github/docker/Dockerfile.tendril-staging
@@ -17,6 +17,14 @@ ENV PATH="$PATH:/root/.dotnet/tools"
 # PowerShell: needed at runtime by Tendril AND needed now for pack-promptwares.ps1
 RUN dotnet tool install --global PowerShell
 
+# Node is required *at build time*: Ivy.Tendril.Widgets.csproj shells out to npx/pnpm
+# to build the widgets frontend, which is then embedded into the assembly.
+# The sdk image has no Node, so without this the publish fails on `npx: not found`.
+COPY --from=node:22-bookworm-slim /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:22-bookworm-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+ && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
 WORKDIR /src
 COPY . .
 


### PR DESCRIPTION
## Problem

Sliplane PR previews were not showing the PR's code — they showed the last released Tendril.

`Dockerfile.tendril-staging` installed Tendril from NuGet:

```dockerfile
RUN dotnet tool install --global Ivy.Tendril \
 && dotnet tool install --global PowerShell
```

`dotnet tool install --global Ivy.Tendril` downloads the last published stable release (currently trailing `1.1.37` in `src/Directory.Build.props`) and never reads the build context. Sliplane clones the PR branch, builds this Dockerfile, and the Dockerfile throws the checkout away.

The deploy succeeds and the container is healthy — it's just running the wrong code. That presents as a stale-image / caching problem, which is what sent us looking at the image tag.

## Fix

Build from source, matching the approach already used by `Dockerfile.tendril-source`:

1. **Stage 1** — replace the `Ivy.Tendril` tool install with `COPY . .` + `dotnet publish src/Ivy.Tendril/Ivy.Tendril.csproj -c Release -p:Publishing=true -o /app`. `Publishing=true` forces `IvySource=false` (`src/Directory.Build.props:7`), so Ivy Framework still comes from NuGet and there's no need to clone Ivy-Framework. The PowerShell tool install stays — it's needed at runtime.
2. **Stage 2** — `COPY --from=build /app /home/tendril/tendril-app`.
3. **`CMD`** — `dotnet /home/tendril/tendril-app/Ivy.Tendril.dll --web`, since the global-tool `tendril` shim no longer exists.

Staging keeps both traits that distinguish it from `-release`: the `config.yaml` bootstrap before `VOLUME` (no setup wizard on a stateless deploy) and no persistent volume.

## Verification

Docker isn't available on this machine, so the image build itself is unverified. The changed step — the publish — was run directly and succeeds:

- `dotnet publish -c Release -p:Publishing=true` exits 0
- `Ivy.Tendril.dll` is produced at the path `CMD` targets
- the widgets frontend bundle is embedded in `Ivy.Tendril.Widgets.dll` (9MB, `EmbeddedResource` per `Ivy.Tendril.Widgets.csproj:46-51`), so the preview gets a working frontend

**Please confirm the image builds in CI/Sliplane before merging.**

## Sliplane-side checks

Two things I can't see from the repo and that should be confirmed, since either would cause the same symptom independently:

- the service's Dockerfile path points at `.github/docker/Dockerfile.tendril-staging` and not `-release`
- the build context is the repo root (both `COPY . .` and the `src/Ivy.Tendril/example.config.yaml` copies assume it)

## Tradeoff

Preview deploys are now meaningfully slower — each one compiles Tendril and builds the widgets frontend instead of downloading a package. That's the unavoidable cost of previewing the actual branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)