### PR TITLE
[00056] Fix Chat App Sidebar Font Colors on Hover in Custom Themes Like Forest

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
@@ -118,4 +118,38 @@ public class SidebarViewTests
         Assert.NotNull(result);
         var headerLayout = Assert.IsType<HeaderLayout>(result);
     }
+
+    [Fact]
+    public void Build_RendersSelectedAndUnselectedSessionButtons_WithCorrectVariants()
+    {
+        var service = new FakeChatHistoryService();
+        var sessions = new List<ChatSessionModel>
+        {
+            new("sess-1", "Selected session", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "claude", "opus", []),
+            new("sess-2", "Unselected session", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, "claude", "sonnet", [])
+        };
+
+        var activeSessionId = new TestState<string?>("sess-1");
+        var sessionVersion = new TestState<int>(1);
+        var selectedAgent = new TestState<string>("claude");
+        var selectedModel = new TestState<string>("opus");
+        var searchState = new TestState<string>("");
+
+        var view = new SidebarView(sessions, activeSessionId, sessionVersion, selectedAgent, selectedModel, searchState, service);
+        var result = view.Build();
+
+        Assert.NotNull(result);
+        var headerLayout = Assert.IsType<HeaderLayout>(result);
+        var contentSlot = Assert.IsType<Slot>(headerLayout.Children[1]);
+        var list = Assert.IsType<List>(contentSlot.Children[0]);
+        Assert.NotNull(list.Children);
+        Assert.Equal(2, list.Children.Length);
+
+        var selectedBtn = Assert.IsType<Button>(list.Children[0]);
+        Assert.Equal(ButtonVariant.Secondary, selectedBtn.Variant);
+
+        var unselectedBtn = Assert.IsType<Button>(list.Children[1]);
+        Assert.Equal(ButtonVariant.Ghost, unselectedBtn.Variant);
+    }
 }
+

--- a/src/Ivy.Tendril.Test/Themes/ThemeRegistryTests.cs
+++ b/src/Ivy.Tendril.Test/Themes/ThemeRegistryTests.cs
@@ -101,5 +101,19 @@ public class ThemeRegistryTests
         Assert.NotEqual(dark.Background, dark.AccentForeground, StringComparer.OrdinalIgnoreCase);
         Assert.NotEqual(dark.Accent, dark.AccentForeground, StringComparer.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public void ForestTheme_DarkColors_HaveProperAccentContrast()
+    {
+        var forest = TendrilThemes.GetTheme("forest");
+        Assert.NotNull(forest);
+        Assert.NotNull(forest.IvyTheme?.Colors?.Dark);
+        var dark = forest.IvyTheme.Colors.Dark;
+        Assert.Equal("#243328", dark.Accent, ignoreCase: true);
+        Assert.Equal("#ebfaef", dark.AccentForeground, ignoreCase: true);
+        Assert.NotEqual(dark.Background, dark.AccentForeground, StringComparer.OrdinalIgnoreCase);
+        Assert.NotEqual(dark.Accent, dark.AccentForeground, StringComparer.OrdinalIgnoreCase);
+    }
 }
+
 

--- a/src/Ivy.Tendril/Themes/TendrilThemes.cs
+++ b/src/Ivy.Tendril/Themes/TendrilThemes.cs
@@ -490,7 +490,7 @@ public static class TendrilThemes
         Name = "Forest",
         Description = "Deep earthy woodland dark background with fresh emerald and forest green",
         IsDark = true,
-        PreviewColors = ["#1eb854", "#1fd65f", "#1db954", "#171212"],
+        PreviewColors = ["#1eb854", "#1fd65f", "#243328", "#171212"],
         IvyTheme = new Theme
         {
             Name = "Forest",
@@ -535,8 +535,8 @@ public static class TendrilThemes
                     PrimaryForeground = "#000000",
                     Secondary = "#1fd65f",
                     SecondaryForeground = "#000000",
-                    Accent = "#1db954",
-                    AccentForeground = "#000000",
+                    Accent = "#243328",
+                    AccentForeground = "#ebfaef",
                     Background = "#171212",
                     Foreground = "#ebfaef",
                     Destructive = "#e11d48",


### PR DESCRIPTION
# Summary

## Changes

Updated the Forest dark theme color tokens to use a subtle moss green accent background and light foreground for high contrast. Added unit tests for theme accent contrast and sidebar session button variant rendering.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Themes/TendrilThemes.cs`: Updated Forest dark theme `Accent`, `AccentForeground`, and `PreviewColors` tokens.
- `src/Ivy.Tendril.Test/Themes/ThemeRegistryTests.cs`: Added `ForestTheme_DarkColors_HaveProperAccentContrast` test.
- `src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs`: Added `Build_RendersSelectedAndUnselectedSessionButtons_WithCorrectVariants` test.

## Manual Testing

1. Launch Tendril and open Settings.
2. Switch Theme to "Forest" and ensure Dark mode is active.
3. Open the Chat application and observe the sessions in the sidebar.
4. Hover over unselected chat sessions and verify that the session title, timestamp, and agent badge remain clearly legible with high contrast against the hover background.

---
- f39e200c Fix Forest dark theme accent contrast on sidebar hover [00056]

---
Created using [Ivy Tendril](https://ivy.app).
