### PR TITLE
[00050] Remove Action Column From Review Actions In Project Settings

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
@@ -379,7 +379,7 @@ public class ReviewActionsTableView(
         var actions = reviewActions.Value;
         if (actions.Count == 0) return null;
 
-        var rows = actions.Select((a, i) => new ReviewActionRow(a.Name, i, a)).ToList();
+        var rows = actions.Select((a, i) => new ReviewActionRow(a.Name, i)).ToList();
 
         return new TableBuilder<ReviewActionRow>(rows)
             .Header(t => t.Name, "Action Name")
@@ -389,7 +389,7 @@ public class ReviewActionsTableView(
             .Header(t => t.Index, "")
             .Builder(t => t.Index, f => f.Func<ReviewActionRow, int>(idx =>
             {
-                var action = rows[idx].Action;
+                var action = actions[idx];
                 return Layout.Horizontal().Gap(1)
                     | new Button().Icon(Icons.Play).Outline().Small().Tooltip("Run / Preview Action").OnClick(() =>
                     {
@@ -413,7 +413,7 @@ public class ReviewActionsTableView(
             .Width(Size.Fit());
     }
 
-    private record ReviewActionRow(string Name, int Index, ReviewActionConfig Action);
+    private record ReviewActionRow(string Name, int Index);
 }
 
 public class ProjectVerificationsTableView(


### PR DESCRIPTION
# Summary

## Changes

Removed the extraneous "Action" column from the Review Actions table in Project Settings and Onboarding. The row record now only includes the action name and index, preventing the table builder from rendering an unconfigured third column containing the serialized action object.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs`: Updated `ReviewActionRow` record definition, row mapping, and button builder action index lookup in `ReviewActionsTableView`.

## Manual Testing

1. Open Tendril Settings and navigate to Projects (or open Onboarding).
2. Select a project that has configured Review Actions.
3. Observe the Review Actions table: it should contain only two columns ("Action Name" and the button actions column: Run, Edit, Delete), without any additional "Action" column displaying stringified object properties.

---
### Commits
- 99a061dd [00050] Remove Action column from Review Actions in project settings

---
Created using [Ivy Tendril](https://ivy.app).
