### PR TITLE
[00063] Use Code Input for Review Action Command and Condition Fields

### DIFF
--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
@@ -148,8 +148,8 @@ internal class OnboardingEditReviewActionDialog(
             new DialogBody(
                 Layout.Vertical()
                 | editName.ToTextInput("Action name...").WithField().Label("Name").Required()
-                | editCommand.ToTextareaInput("e.g. dotnet test").Rows(2).WithField().Label("Command").Required()
-                | editCondition.ToTextareaInput("e.g. ${hasChanges}").Rows(2).WithField().Label("Condition")
+                | editCommand.ToCodeInput("e.g. dotnet test").WithField().Label("Command").Required()
+                | editCondition.ToCodeInput("e.g. ${hasChanges}").WithField().Label("Condition")
             ),
             new DialogFooter(
                 new Button("Cancel").Outline().OnClick(() => isOpen.Set(false)),

--- a/src/Ivy.Tendril/Apps/Settings/Blades/EditReviewActionBladeView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/EditReviewActionBladeView.cs
@@ -28,8 +28,8 @@ public class EditReviewActionBladeView(
 
         return Layout.Vertical()
             | editName.ToTextInput("Action name...").WithField().Label("Name").Required()
-            | editCommand.ToTextareaInput("e.g. dotnet test").Rows(2).WithField().Label("Command").Required()
-            | editCondition.ToTextareaInput("e.g. ${hasChanges}").Rows(2).WithField().Label("Condition")
+            | editCommand.ToCodeInput("e.g. dotnet test").WithField().Label("Command").Required()
+            | editCondition.ToCodeInput("e.g. ${hasChanges}").WithField().Label("Condition")
             | Layout.Horizontal()
                 | new Button("Cancel").Outline().OnClick(() => bladeContext.Pop(this))
                 | new Button(isNew ? "Add" : "Save").Primary().OnClick(() =>


### PR DESCRIPTION
# Summary

## Changes

Replaced `ToTextareaInput` with `ToCodeInput` for the Command and Condition input fields in both `EditReviewActionBladeView` and `ProjectCrudStepView`. This provides monospace code formatting and prevents browser/OS smart punctuation substitutions (such as converting double hyphens into em dashes) when entering CLI commands and condition expressions.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Settings/Blades/EditReviewActionBladeView.cs`: Configured Command and Condition inputs with `ToCodeInput`.
- `src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs`: Configured Command and Condition inputs with `ToCodeInput`.

## Manual Testing

1. Launch Tendril and navigate to Settings > Projects (or open the onboarding project setup dialog).
2. Open the dialog/blade to add or edit a Review Action.
3. Type a command containing double dashes (e.g. `dotnet test --filter "..."`) into the Command field.
4. Observe that the input renders in monospace font and does not convert `--` into an em dash.

---
### Commits
- 4f84dd05 Use CodeInput for ReviewAction Command and Condition fields (Plan 00063)

---
Created using [Ivy Tendril](https://ivy.app).
