### PR TITLE
[00067] Use CodeInput for MCP Server Environment Variables

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/Blades/EditMcpServerBladeView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/EditMcpServerBladeView.cs
@@ -33,7 +33,7 @@ public class EditMcpServerBladeView(
             | editName.ToTextInput("Server name (e.g. sqlite)...").WithField().Label("Name").Required()
             | editCommand.ToTextInput("Command executable (e.g. npx)...").WithField().Label("Command").Required()
             | editArguments.ToTextInput("Arguments (e.g. -y @modelcontextprotocol/server-sqlite)...").WithField().Label("Arguments")
-            | editEnv.ToTextareaInput("Environment variables (KEY=VALUE per line)...").Rows(3).WithField().Label("Environment Variables")
+            | editEnv.ToCodeInput("Environment variables (KEY=VALUE per line)...").WithField().Label("Environment Variables")
             | Layout.Horizontal()
                 | new Button("Cancel").Outline().OnClick(() => bladeContext.Pop(this))
                 | new Button(isNew ? "Add" : "Save").Primary().OnClick(() =>

--- a/src/Ivy.Tendril/Apps/Settings/Sheets/EditMcpServerSheet.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Sheets/EditMcpServerSheet.cs
@@ -34,7 +34,7 @@ public class EditMcpServerSheet(
             | editName.ToTextInput("Server name (e.g. sqlite)...").WithField().Label("Name").Required()
             | editCommand.ToTextInput("Command executable (e.g. npx)...").WithField().Label("Command").Required()
             | editArguments.ToTextInput("Arguments (e.g. -y @modelcontextprotocol/server-sqlite)...").WithField().Label("Arguments")
-            | editEnv.ToTextareaInput("Environment variables (KEY=VALUE per line)...").Rows(3).WithField().Label("Environment Variables")
+            | editEnv.ToCodeInput("Environment variables (KEY=VALUE per line)...").WithField().Label("Environment Variables")
             | (Layout.Horizontal().AlignContent(Align.Right)
                | new Button("Cancel").Outline().OnClick(() => isOpen.Set(false))
                | new Button(isNew ? "Add" : "Save").Primary().OnClick(() =>


### PR DESCRIPTION
# Summary

## Changes

Updated the environment variables input field in MCP server settings to use `ToCodeInput` instead of `ToTextareaInput`. This enables monospace editing and prevents automatic quote/dash substitutions when configuring KEY=VALUE pairs.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Settings/Blades/EditMcpServerBladeView.cs`: Switched environment variables field from `ToTextareaInput` to `ToCodeInput`.
- `src/Ivy.Tendril/Apps/Settings/Sheets/EditMcpServerSheet.cs`: Switched environment variables field from `ToTextareaInput` to `ToCodeInput`.

## Manual Testing

1. Open the Tendril application (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse`).
2. Navigate to Settings -> MCP Servers.
3. Click "Add MCP Server" or edit an existing server entry.
4. Observe that the "Environment Variables" field renders as a code editor input with monospace font.
5. Enter sample KEY=VALUE pairs and verify that quotes and dashes are preserved without smart substitutions.

---
### Commits
93144cd1 Plan 00067: Use CodeInput for MCP server environment variables

---
Created using [Ivy Tendril](https://ivy.app).