### PR TITLE
[00068] Fix Orphaned Ghost Blocked Jobs in SQLite and Output View

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -543,6 +543,58 @@ public class JobServiceRetryBlockedTests : IDisposable
         Directory.Delete(plansDir, true);
     }
 
+    [Fact]
+    public void RetryBlockedJobs_WhenDependenciesSatisfied_DeletesBlockedJobFromDatabase()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var plansDir = CreatePlansDirectory(("01100-DepPlan", "Completed"));
+        var dependentPlan = CreatePlanFolder("Draft", ["01100-DepPlan"]);
+
+        var planReader = new FakePlanReaderService(plansDir);
+        var db = new FakeDatabaseService();
+        var service = new JobService(
+            TimeSpan.FromMinutes(30),
+            TimeSpan.FromMinutes(10),
+            planReaderService: planReader,
+            database: db);
+
+        var blockedId = service.CreateTestJob(new ExecutePlanArgs(dependentPlan));
+        var blockedJob = service.GetJob(blockedId)!;
+        blockedJob.Status = JobStatus.Blocked;
+
+        var completingId = service.CreateTestJob(new CreatePrArgs(Path.GetTempPath()));
+
+        service.CompleteJob(completingId, 0);
+
+        Assert.Null(service.GetJob(blockedId));
+        Assert.Contains(blockedId, db.DeletedJobIds);
+
+        Directory.Delete(dependentPlan, true);
+        Directory.Delete(plansDir, true);
+    }
+
+    [Fact]
+    public void ForceStartJob_BlockedJob_DeletesOldRecordFromDatabase()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var db = new FakeDatabaseService();
+        var service = new JobService(
+            TimeSpan.FromMinutes(30),
+            TimeSpan.FromMinutes(10),
+            database: db);
+
+        var blockedId = service.CreateTestJob(new ExecutePlanArgs("/path/to/plan"));
+        var blockedJob = service.GetJob(blockedId)!;
+        blockedJob.Status = JobStatus.Blocked;
+
+        service.ForceStartJob(blockedId);
+
+        Assert.Null(service.GetJob(blockedId));
+        Assert.Contains(blockedId, db.DeletedJobIds);
+    }
+
     /// <summary>
     ///     Minimal fake that provides PlansDirectory for dependency checking.
     /// </summary>
@@ -699,6 +751,180 @@ public class JobServiceRetryBlockedTests : IDisposable
         }
 
         public void AcceptRecommendationsAndRetry(string folderName, IReadOnlyCollection<string> titles)
+        {
+        }
+    }
+
+    private class FakeDatabaseService : IPlanDatabaseService
+    {
+        public List<JobItem> Jobs { get; } = new();
+        public List<string> DeletedJobIds { get; } = new();
+        public List<string> UpsertedJobIds { get; } = new();
+
+        public List<JobItem> GetRecentJobs(int limit = 100)
+        {
+            return Jobs.ToList();
+        }
+
+        public JobItem? GetJobById(string id)
+        {
+            return Jobs.FirstOrDefault(j => j.Id == id);
+        }
+
+        public List<JobItem> GetJobsForPlan(string planFile)
+        {
+            return Jobs.Where(j => j.PlanFile == planFile).ToList();
+        }
+
+        public void DeleteJob(string id)
+        {
+            DeletedJobIds.Add(id);
+            Jobs.RemoveAll(j => j.Id == id);
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public List<PlanFile> GetPlans(PlanStatus? statusFilter = null)
+        {
+            return [];
+        }
+
+        public PlanFile? GetPlanByFolder(string folderPath)
+        {
+            return null;
+        }
+
+        public PlanFile? GetPlanById(int planId)
+        {
+            return null;
+        }
+
+        public PlanReaderService.PlanCountSnapshot ComputePlanCounts()
+        {
+            return new PlanReaderService.PlanCountSnapshot(0, 0, 0, 0, 0, 0);
+        }
+
+        public DashboardModels GetDashboardData(string? projectFilter)
+        {
+            return new DashboardModels(0, 0, 0, 0, 0, 0, 0, [], []);
+        }
+
+        public List<(DateOnly Date, int Count)> GetCompletedPrsByDay(int days = 30)
+        {
+            return [];
+        }
+
+        public decimal GetPlanTotalCost(int planId)
+        {
+            return 0;
+        }
+
+        public int GetPlanTotalTokens(int planId)
+        {
+            return 0;
+        }
+
+        public List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7, string? projectFilter = null)
+        {
+            return [];
+        }
+
+        public List<Recommendation> GetRecommendations()
+        {
+            return [];
+        }
+
+        public int GetPendingRecommendationsCount()
+        {
+            return 0;
+        }
+
+        public List<PlanFile> SearchPlans(string query)
+        {
+            return [];
+        }
+
+        public void RebuildFtsIndex()
+        {
+        }
+
+        public void UpdatePlanState(int planId, PlanStatus state)
+        {
+        }
+
+        public void UpdatePlanContent(int planId, string latestRevisionContent, int revisionCount)
+        {
+        }
+
+        public void UpdateRecommendationState(int planId, string recommendationTitle, string newState, string? declineReason)
+        {
+        }
+
+        public void UpsertPlan(PlanFile plan)
+        {
+        }
+
+        public void DeletePlan(int planId)
+        {
+        }
+
+        public void UpsertCosts(int planId, List<CostEntry> costs)
+        {
+        }
+
+        public void UpsertRecommendations(int planId, string folderName, List<RecommendationYaml> recommendations,
+            string project, string planTitle, DateTime updated, PlanStatus status)
+        {
+        }
+
+        public void BulkUpsertPlans(List<PlanFile> plans, bool forceOverwrite = false)
+        {
+        }
+
+        public HashSet<int> GetTerminalPlanIds()
+        {
+            return [];
+        }
+
+        public void UpsertJob(JobItem job)
+        {
+            UpsertedJobIds.Add(job.Id);
+            Jobs.RemoveAll(j => j.Id == job.Id);
+            Jobs.Add(job);
+        }
+
+        public List<string> PurgeOldJobs(int keepCount = 500)
+        {
+            return [];
+        }
+
+        public Dictionary<string, PrInfo> GetAllPrStatuses()
+        {
+            return new Dictionary<string, PrInfo>();
+        }
+
+        public void UpsertPrStatus(string prUrl, string owner, string repo, string status, string branch, DateTime lastChecked)
+        {
+        }
+
+        public List<string> GetNonMergedPrUrls()
+        {
+            return [];
+        }
+
+        public long GetDatabaseSize()
+        {
+            return 0;
+        }
+
+        public DateTime GetLastSyncTime()
+        {
+            return DateTime.UtcNow;
+        }
+
+        public void SetLastSyncTime(DateTime time)
         {
         }
     }

--- a/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceStartupTests.cs
@@ -334,6 +334,50 @@ public class JobServiceStartupTests
     }
 
     [Fact]
+    public void ReconcileRestoredJob_BlockedJobWithCompletedPlan_MarksFailedOrCleansUp()
+    {
+        var tendrilHome = Path.Combine(Path.GetTempPath(), $"tendril-blocked-test-{Guid.NewGuid()}");
+        var plansDir = Path.Combine(tendrilHome, "Plans");
+        var planFolder = Path.Combine(plansDir, "00042-MyPlan");
+        Directory.CreateDirectory(planFolder);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(planFolder, "plan.yaml"),
+                "state: Completed\nproject: TestProject\nlevel: Feature\ntitle: My Plan\ncreated: 2026-01-01T00:00:00Z\nupdated: 2026-01-01T00:00:00Z\ndependsOn: []\nprs: []\ncommits: []\nverifications: []\nrelatedPlans: []\nrepos: []\n");
+
+            var db = new FakeDatabaseService
+            {
+                Jobs =
+                {
+                    new JobItem
+                    {
+                        Id = "job-blocked-ghost",
+                        Type = "ExecutePlan",
+                        Status = JobStatus.Blocked,
+                        PlanFile = planFolder,
+                        TypedArgs = new ExecutePlanArgs(planFolder)
+                    }
+                }
+            };
+
+            var config = new FakeConfigService(tendrilHome);
+            var service = new JobService(config, database: db);
+
+            var job = service.GetJob("job-blocked-ghost");
+            Assert.NotNull(job);
+            Assert.Equal(JobStatus.Failed, job!.Status);
+            Assert.Equal("Superseded by subsequent execution or plan completed", job.StatusMessage);
+            Assert.NotNull(job.CompletedAt);
+            Assert.Contains("job-blocked-ghost", db.UpsertedJobIds);
+        }
+        finally
+        {
+            try { Directory.Delete(tendrilHome, true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
     public void StartJob_PersistsJobToDatabaseWhileStillRunning()
     {
         var db = new FakeDatabaseService();
@@ -442,6 +486,7 @@ public class JobServiceStartupTests
     private class FakeDatabaseService : IPlanDatabaseService
     {
         public List<JobItem> Jobs { get; } = new();
+        public List<string> DeletedJobIds { get; } = new();
 
         /// <summary>Ids passed to <see cref="UpsertJob" />, in call order.</summary>
         public List<string> UpsertedJobIds { get; } = new();
@@ -452,7 +497,7 @@ public class JobServiceStartupTests
         {
             if (ThrowOnGetRecentJobs) throw new Exception("DB error");
             // Snapshot: LoadHistoricalJobs iterates the result while reconciling, and reconciling
-            // a job persists it back via UpsertJob — mutating Jobs directly here would corrupt
+            // a job persists it back via UpsertJob, mutating Jobs directly here would corrupt
             // that iteration.
             return Jobs.ToList();
         }
@@ -469,6 +514,8 @@ public class JobServiceStartupTests
 
         public void DeleteJob(string id)
         {
+            DeletedJobIds.Add(id);
+            Jobs.RemoveAll(j => j.Id == id);
         }
 
         public void Dispose()

--- a/src/Ivy.Tendril.Test/JobServiceWaitForJobsTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceWaitForJobsTests.cs
@@ -268,4 +268,201 @@ public class JobServiceWaitForJobsTests
         Assert.Contains($"ExecutePlan of plan 00075 (job {dep1Id})", job.StatusMessage);
         Assert.Contains($"CreatePlan (job {dep2Id})", job.StatusMessage);
     }
+
+    [Fact]
+    public void HandleWaitForJobsDependents_UnblockedJob_DeletesOldRecordFromDatabase()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var db = new FakeDatabaseService();
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            database: db,
+            maxConcurrentJobs: 5);
+
+        var depId = service.CreateTestJob(new CreatePlanArgs("Dep job", "Auto"));
+
+        var waitingId = service.StartJob(new CreatePlanArgs("Waiting job", "Auto") { WaitForJobs = [depId] });
+        Assert.Equal(JobStatus.Blocked, service.GetJob(waitingId)!.Status);
+
+        service.CompleteJob(depId, 0);
+
+        // The blocked job should have been removed from memory and deleted from the database
+        Assert.Null(service.GetJob(waitingId));
+        Assert.Contains(waitingId, db.DeletedJobIds);
+    }
+
+    private class FakeDatabaseService : IPlanDatabaseService
+    {
+        public List<JobItem> Jobs { get; } = new();
+        public List<string> DeletedJobIds { get; } = new();
+        public List<string> UpsertedJobIds { get; } = new();
+
+        public List<JobItem> GetRecentJobs(int limit = 100)
+        {
+            return Jobs.ToList();
+        }
+
+        public JobItem? GetJobById(string id)
+        {
+            return Jobs.FirstOrDefault(j => j.Id == id);
+        }
+
+        public List<JobItem> GetJobsForPlan(string planFile)
+        {
+            return Jobs.Where(j => j.PlanFile == planFile).ToList();
+        }
+
+        public void DeleteJob(string id)
+        {
+            DeletedJobIds.Add(id);
+            Jobs.RemoveAll(j => j.Id == id);
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public List<PlanFile> GetPlans(PlanStatus? statusFilter = null)
+        {
+            return [];
+        }
+
+        public PlanFile? GetPlanByFolder(string folderPath)
+        {
+            return null;
+        }
+
+        public PlanFile? GetPlanById(int planId)
+        {
+            return null;
+        }
+
+        public PlanReaderService.PlanCountSnapshot ComputePlanCounts()
+        {
+            return new PlanReaderService.PlanCountSnapshot(0, 0, 0, 0, 0, 0);
+        }
+
+        public DashboardModels GetDashboardData(string? projectFilter)
+        {
+            return new DashboardModels(0, 0, 0, 0, 0, 0, 0, [], []);
+        }
+
+        public List<(DateOnly Date, int Count)> GetCompletedPrsByDay(int days = 30)
+        {
+            return [];
+        }
+
+        public decimal GetPlanTotalCost(int planId)
+        {
+            return 0;
+        }
+
+        public int GetPlanTotalTokens(int planId)
+        {
+            return 0;
+        }
+
+        public List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7, string? projectFilter = null)
+        {
+            return [];
+        }
+
+        public List<Recommendation> GetRecommendations()
+        {
+            return [];
+        }
+
+        public int GetPendingRecommendationsCount()
+        {
+            return 0;
+        }
+
+        public List<PlanFile> SearchPlans(string query)
+        {
+            return [];
+        }
+
+        public void RebuildFtsIndex()
+        {
+        }
+
+        public void UpdatePlanState(int planId, PlanStatus state)
+        {
+        }
+
+        public void UpdatePlanContent(int planId, string latestRevisionContent, int revisionCount)
+        {
+        }
+
+        public void UpdateRecommendationState(int planId, string recommendationTitle, string newState, string? declineReason)
+        {
+        }
+
+        public void UpsertPlan(PlanFile plan)
+        {
+        }
+
+        public void DeletePlan(int planId)
+        {
+        }
+
+        public void UpsertCosts(int planId, List<CostEntry> costs)
+        {
+        }
+
+        public void UpsertRecommendations(int planId, string folderName, List<RecommendationYaml> recommendations,
+            string project, string planTitle, DateTime updated, PlanStatus status)
+        {
+        }
+
+        public void BulkUpsertPlans(List<PlanFile> plans, bool forceOverwrite = false)
+        {
+        }
+
+        public HashSet<int> GetTerminalPlanIds()
+        {
+            return [];
+        }
+
+        public void UpsertJob(JobItem job)
+        {
+            UpsertedJobIds.Add(job.Id);
+            Jobs.RemoveAll(j => j.Id == job.Id);
+            Jobs.Add(job);
+        }
+
+        public List<string> PurgeOldJobs(int keepCount = 500)
+        {
+            return [];
+        }
+
+        public Dictionary<string, PrInfo> GetAllPrStatuses()
+        {
+            return new Dictionary<string, PrInfo>();
+        }
+
+        public void UpsertPrStatus(string prUrl, string owner, string repo, string status, string branch, DateTime lastChecked)
+        {
+        }
+
+        public List<string> GetNonMergedPrUrls()
+        {
+            return [];
+        }
+
+        public long GetDatabaseSize()
+        {
+            return 0;
+        }
+
+        public DateTime GetLastSyncTime()
+        {
+            return DateTime.UtcNow;
+        }
+
+        public void SetLastSyncTime(DateTime time)
+        {
+        }
+    }
 }

--- a/src/Ivy.Tendril/Apps/Jobs/Sheets/OutputSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Sheets/OutputSheet.cs
@@ -20,8 +20,34 @@ public class OutputSheet(string jobId, IJobService jobService) : ViewBase
             ? job.OutputObservable.Subscribe(line => outputStream.Write(line))
             : null);
 
-        if (job is null || (job.OutputLines.IsEmpty && job.Status != JobStatus.Running))
+        if (job is null)
             return Text.P("No output available.");
+
+        if (job.OutputLines.IsEmpty && job.Status != JobStatus.Running)
+        {
+            if (!string.IsNullOrEmpty(job.StatusMessage))
+            {
+                return Layout.Vertical()
+                    .Gap(2)
+                    | Callout.Info(job.StatusMessage, $"Job {job.Status}");
+            }
+
+            if (job.Status == JobStatus.Blocked)
+            {
+                return Layout.Vertical()
+                    .Gap(2)
+                    | Callout.Info("Waiting for dependencies or preceding jobs to complete.", "Job Blocked");
+            }
+
+            if (job.Status == JobStatus.Pending)
+            {
+                return Layout.Vertical()
+                    .Gap(2)
+                    | Callout.Info("Job is queued and waiting to start.", "Job Pending");
+            }
+
+            return Text.P("No output available.");
+        }
 
         if (job.Status != JobStatus.Running)
         {

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -49,7 +49,8 @@ internal class JobCompletionHandler
         Action<JobItem> persistJob,
         Action<JobNotification> raiseNotification,
         Action raisePropertyChanged,
-        Func<JobArgsBase, string> startJobSkipDepCheck)
+        Func<JobArgsBase, string> startJobSkipDepCheck,
+        Action<string>? deleteJob = null)
     {
         var isSuccess = job.Status == JobStatus.Completed;
 
@@ -67,10 +68,10 @@ internal class JobCompletionHandler
         // so the user can inspect or resume. Worktree cleanup happens only on explicit
         // user actions (Delete ExecutePlan, Complete Plan, Reset to Draft).
 
-        HandleWaitForJobsDependents(job, jobs, raiseNotification, startJobSkipDepCheck, persistJob);
+        HandleWaitForJobsDependents(job, jobs, raiseNotification, startJobSkipDepCheck, persistJob, deleteJob);
 
         if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or CreatePrArgs)
-            _dependencyChecker.RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
+            _dependencyChecker.RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck, deleteJob);
 
         if (isSuccess && job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or CreatePrArgs or CreateIssueArgs)
         {
@@ -943,7 +944,8 @@ internal class JobCompletionHandler
         ConcurrentDictionary<string, JobItem> jobs,
         Action<JobNotification> raiseNotification,
         Func<JobArgsBase, string> startJobSkipDepCheck,
-        Action<JobItem>? persistJob = null)
+        Action<JobItem>? persistJob = null,
+        Action<string>? deleteJob = null)
     {
         var queue = new Queue<JobItem>();
         queue.Enqueue(completedJob);
@@ -984,6 +986,7 @@ internal class JobCompletionHandler
                     continue;
 
                 jobs.TryRemove(waitingJob.Id, out _);
+                deleteJob?.Invoke(waitingJob.Id);
                 startJobSkipDepCheck(waitingJob.TypedArgs!);
 
                 raiseNotification(new JobNotification(
@@ -1013,8 +1016,9 @@ internal class JobCompletionHandler
     internal void HandleRetryBlockedJobs(
         ConcurrentDictionary<string, JobItem> jobs,
         Action<JobNotification> raiseNotification,
-        Func<JobArgsBase, string> startJobSkipDepCheck)
-        => _dependencyChecker.RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck);
+        Func<JobArgsBase, string> startJobSkipDepCheck,
+        Action<string>? deleteJob = null)
+        => _dependencyChecker.RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck, deleteJob);
 
     internal void WriteJobLog(JobItem job)
     {

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -138,7 +138,7 @@ public class JobService : IJobService
         // so its appender stays open until DisposeResources below.
         job.CloseRawLog();
         _completionHandler.HandleCompletion(
-            job, _jobs, PersistJob, RaiseNotification, RaiseJobsPropertyChanged, StartJobSkipDepCheck);
+            job, _jobs, PersistJob, RaiseNotification, RaiseJobsPropertyChanged, StartJobSkipDepCheck, DeleteJobFromDatabase);
 
         if (job.Status == JobStatus.Completed)
             job.StatusMessage = null;
@@ -290,9 +290,9 @@ public class JobService : IJobService
         PersistJob(job);
 
         if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or CreatePrArgs)
-            _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck);
+            _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck, DeleteJobFromDatabase);
 
-        _completionHandler.HandleWaitForJobsDependents(job, _jobs, RaiseNotification, StartJobSkipDepCheck, PersistJob);
+        _completionHandler.HandleWaitForJobsDependents(job, _jobs, RaiseNotification, StartJobSkipDepCheck, PersistJob, DeleteJobFromDatabase);
 
         RaiseJobsStructureChanged();
 
@@ -336,16 +336,16 @@ public class JobService : IJobService
         if (_jobs.TryRemove(id, out var removed))
         {
             removed.DisposeResources(_logger);
-            try { _database?.DeleteJob(id); } catch { /* Best-effort */ }
+            DeleteJobFromDatabase(id);
             // The job's four artifacts in <TendrilHome>/Jobs/ are deliberately kept: deleting a job removes
             // it from the UI and the database, not the forensic record of what it did.
 
             ApplyDeletePlanState(removed);
 
             if (removed.TypedArgs is ExecutePlanArgs or RetryPlanArgs or CreatePrArgs)
-                _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck);
+                _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck, DeleteJobFromDatabase);
 
-            _completionHandler.HandleWaitForJobsDependents(removed, _jobs, RaiseNotification, StartJobSkipDepCheck, PersistJob);
+            _completionHandler.HandleWaitForJobsDependents(removed, _jobs, RaiseNotification, StartJobSkipDepCheck, PersistJob, DeleteJobFromDatabase);
         }
         RaiseJobsStructureChanged();
     }
@@ -421,7 +421,7 @@ public class JobService : IJobService
         {
             var hasBlocked = _jobs.Values.Any(j => j.Status == JobStatus.Blocked);
             if (hasBlocked)
-                _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck);
+                _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck, DeleteJobFromDatabase);
         }
         catch
         {
@@ -683,7 +683,7 @@ public class JobService : IJobService
     ///     Decides what to do with a non-terminal job restored from the database after a master
     ///     restart. If its agent process is still alive the job keeps running detached (this process
     ///     holds no Process handle for it); otherwise it is marked Failed so it doesn't linger as a
-    ///     ghost. Blocked jobs are left alone — the 60s blocked-job timer and ForceStartJob own them.
+    ///     ghost.
     /// </summary>
     private void ReconcileRestoredJob(JobItem job)
     {
@@ -713,6 +713,76 @@ public class JobService : IJobService
                     }
                 }
             }
+        }
+
+        if (job.Status == JobStatus.Blocked)
+        {
+            var plansDir = _planReaderService?.PlansDirectory
+                ?? (_configService != null ? Path.Combine(_configService.TendrilHome, "Plans") : null);
+
+            var planFolder = job.TypedArgs?.PlanFolder ?? job.PlanFile;
+            string? resolvedFolder = null;
+            if (!string.IsNullOrEmpty(planFolder))
+            {
+                if (Directory.Exists(planFolder))
+                {
+                    resolvedFolder = planFolder;
+                }
+                else if (!string.IsNullOrEmpty(plansDir) && Directory.Exists(plansDir))
+                {
+                    var combined = Path.Combine(plansDir, planFolder);
+                    if (Directory.Exists(combined))
+                    {
+                        resolvedFolder = combined;
+                    }
+                    else
+                    {
+                        var planId = PlanYamlHelper.ExtractPlanIdFromFolder(planFolder);
+                        if (!string.IsNullOrEmpty(planId))
+                            resolvedFolder = PlanYamlHelper.FindPlanFolderById(plansDir, planId);
+                    }
+                }
+            }
+
+            var hasOtherActiveJob = !string.IsNullOrEmpty(resolvedFolder) && _jobs.Values.Any(j =>
+                j.Id != job.Id &&
+                j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending &&
+                (string.Equals(j.PlanFile, resolvedFolder, StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(j.TypedArgs?.PlanFolder, resolvedFolder, StringComparison.OrdinalIgnoreCase)));
+
+            var isPlanCompletedOrExecuting = false;
+            if (resolvedFolder != null && File.Exists(Path.Combine(resolvedFolder, "plan.yaml")))
+            {
+                var planYaml = PlanYamlHelper.ReadPlanYaml(resolvedFolder);
+                if (planYaml != null)
+                {
+                    var state = planYaml.State;
+                    if (state.Equals(nameof(PlanStatus.Completed), StringComparison.OrdinalIgnoreCase) ||
+                        state.Equals(nameof(PlanStatus.Review), StringComparison.OrdinalIgnoreCase) ||
+                        state.Equals(nameof(PlanStatus.Executing), StringComparison.OrdinalIgnoreCase) ||
+                        state.Equals(nameof(PlanStatus.Skipped), StringComparison.OrdinalIgnoreCase))
+                    {
+                        isPlanCompletedOrExecuting = true;
+                    }
+                }
+            }
+            else if (resolvedFolder == null && !string.IsNullOrEmpty(planFolder))
+            {
+                isPlanCompletedOrExecuting = true;
+            }
+
+            if (hasOtherActiveJob || isPlanCompletedOrExecuting)
+            {
+                job.Status = JobStatus.Failed;
+                job.StatusMessage = "Superseded by subsequent execution or plan completed";
+                job.CompletedAt = DateTime.UtcNow;
+                PersistJob(job);
+                _logger.LogInformation(
+                    "Job {JobId}: Reconciled restored Blocked job to Failed (superseded or plan completed)", job.Id);
+                return;
+            }
+
+            return;
         }
 
         if (job.Status is not (JobStatus.Pending or JobStatus.Queued or JobStatus.Running))
@@ -745,7 +815,7 @@ public class JobService : IJobService
             job.StatusMessage = "Interrupted by Tendril master restart";
             job.CompletedAt = DateTime.UtcNow;
             PersistJob(job);
-            _logger.LogWarning("Job {JobId}: Marked Failed — interrupted by a Tendril master restart", job.Id);
+            _logger.LogWarning("Job {JobId}: Marked Failed (interrupted by a Tendril master restart)", job.Id);
         }
     }
 
@@ -855,6 +925,18 @@ public class JobService : IJobService
         }
     }
 
+    private void DeleteJobFromDatabase(string id)
+    {
+        try
+        {
+            _database?.DeleteJob(id);
+        }
+        catch
+        {
+            /* Best-effort */
+        }
+    }
+
     private void RaiseJobsChanged()
     {
         if (_syncContext != null)
@@ -924,6 +1006,8 @@ public class JobService : IJobService
         var typedArgs = job.TypedArgs;
 
         if (!_jobs.TryRemove(id, out _)) return;
+
+        DeleteJobFromDatabase(id);
 
         // Plan transition is handled centrally by StartJobInternal.
         StartJobInternal(typedArgs, inboxFilePath: null, skipDependencyCheck: true, skipWaitForCheck: true);

--- a/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
+++ b/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
@@ -90,7 +90,8 @@ internal class DependencyChecker
     internal void RetryBlockedJobs(
         ConcurrentDictionary<string, JobItem> jobs,
         Action<JobNotification> raiseNotification,
-        Func<JobArgsBase, string> startJobSkipDepCheck)
+        Func<JobArgsBase, string> startJobSkipDepCheck,
+        Action<string>? deleteJob = null)
     {
         var blockedJobs = jobs.Values
             .Where(j => j is { Status: JobStatus.Blocked, TypedArgs: ExecutePlanArgs or RetryPlanArgs })
@@ -102,7 +103,7 @@ internal class DependencyChecker
             if (string.IsNullOrEmpty(planFolder)) continue;
 
             // A job blocked on sibling jobs (WaitForJobs) is retried by
-            // JobCompletionHandler.HandleWaitForJobsDependents when those jobs finish — not here.
+            // JobCompletionHandler.HandleWaitForJobsDependents when those jobs finish, not here.
             // Restarting it while its WaitForJobs are still pending would immediately re-block it,
             // producing a spurious "Job Unblocked" + "Job Blocked" notification pair (issue #1538).
             if (HasPendingWaitForJobs(blockedJob, jobs)) continue;
@@ -112,6 +113,7 @@ internal class DependencyChecker
 
             if (HasActiveJobForPlan(planFolder, jobs)) continue;
             if (!jobs.TryRemove(blockedJob.Id, out _)) continue;
+            deleteJob?.Invoke(blockedJob.Id);
 
             PlanYamlHelper.SetPlanStateByFolder(planFolder, nameof(PlanStatus.Creating));
             startJobSkipDepCheck(blockedJob.TypedArgs!);


### PR DESCRIPTION
# Summary

## Changes

Fixed orphaned ghost blocked jobs from remaining in SQLite with NULL CompletedAt when unblocked, retried, or force-started, preventing them from persistently reappearing upon server restart. Added startup reconciliation for historical blocked jobs and improved empty output presentation for blocked and pending jobs in OutputSheet.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Services/Plans/DependencyChecker.cs`: Added `deleteJob` callback invocation when auto-retrying blocked jobs.
- `src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs`: Added `deleteJob` callback invocation when unblocking waiting jobs in `HandleWaitForJobsDependents`.
- `src/Ivy.Tendril/Services/Jobs/JobService.cs`: Added `DeleteJobFromDatabase` helper, deleted obsolete database records on force-starting and unblocking, and added Blocked job reconciliation in `ReconcileRestoredJob`.
- `src/Ivy.Tendril/Apps/Jobs/Sheets/OutputSheet.cs`: Rendered status callout for Blocked/Pending jobs or jobs with a status message when output stream is empty.
- `src/Ivy.Tendril.Test/JobServiceStartupTests.cs`: Added startup reconciliation tests for historical blocked jobs.
- `src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs`: Added database deletion tests for auto-retried and force-started blocked jobs.
- `src/Ivy.Tendril.Test/JobServiceWaitForJobsTests.cs`: Added database deletion tests for dependent unblocked jobs.

## Manual Testing

1. Open the Jobs view in Tendril.
2. Queue a job that becomes Blocked waiting for dependencies or preceding jobs.
3. Click the job to open the OutputSheet: observe the clear Callout with the blocked status message instead of "No output available.".
4. When the dependency finishes or when Force Start is clicked, observe that the placeholder blocked record is cleanly removed from the database and replaced by the running execution.


---
- cf27bcfe Clean up superseded blocked jobs and improve output presentation (Plan 00068)

---
Created using [Ivy Tendril](https://ivy.app).