### PR TITLE
[00070] Persist and Display Queued Messages Across Chat App Sessions

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
@@ -46,6 +46,12 @@ public class DeleteSessionDialogTests
         public IReadOnlySet<string> GetGeneratingSessionIds() => GeneratingSessions;
         public IReadOnlySet<string> GetCompletedSessionIds() => CompletedSessions;
         public void ClearSessionCompleted(string sessionId) => CompletedSessions.Remove(sessionId);
+        public IReadOnlyList<ChatQueuedItem> GetQueuedMessages(string sessionId) => [];
+        public ChatQueuedItem EnqueueMessage(string sessionId, Ivy.Tendril.Widgets.ChatSendMessageDto dto) => new(Guid.NewGuid().ToString(), dto.Prompt, dto.Attachments, DateTimeOffset.UtcNow);
+        public bool TryDequeueMessage(string sessionId, out ChatQueuedItem? item) { item = null; return false; }
+        public bool RemoveQueuedMessage(string sessionId, string queueId) => false;
+        public bool UpdateQueuedMessage(string sessionId, string queueId, string prompt) => false;
+        public void ClearQueuedMessages(string sessionId) { }
     }
 
     private class TestState<T> : IState<T>

--- a/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
@@ -44,6 +44,12 @@ public class SidebarViewTests
         public IReadOnlySet<string> GetGeneratingSessionIds() => GeneratingSessions;
         public IReadOnlySet<string> GetCompletedSessionIds() => CompletedSessions;
         public void ClearSessionCompleted(string sessionId) => CompletedSessions.Remove(sessionId);
+        public IReadOnlyList<ChatQueuedItem> GetQueuedMessages(string sessionId) => [];
+        public ChatQueuedItem EnqueueMessage(string sessionId, Ivy.Tendril.Widgets.ChatSendMessageDto dto) => new(Guid.NewGuid().ToString(), dto.Prompt, dto.Attachments, DateTimeOffset.UtcNow);
+        public bool TryDequeueMessage(string sessionId, out ChatQueuedItem? item) { item = null; return false; }
+        public bool RemoveQueuedMessage(string sessionId, string queueId) => false;
+        public bool UpdateQueuedMessage(string sessionId, string queueId, string prompt) => false;
+        public void ClearQueuedMessages(string sessionId) { }
     }
 
     private class TestState<T> : IState<T>

--- a/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
@@ -210,4 +210,119 @@ public class ChatHistoryServiceTests
                 Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void QueuedMessages_Enqueue_Get_And_Dequeue_FIFO()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "opus");
+            var eventFiredCount = 0;
+            service.GeneratingSessionsChanged += (s, e) => eventFiredCount++;
+
+            var dto1 = new Ivy.Tendril.Widgets.ChatSendMessageDto("First message", null, session.Id);
+            var dto2 = new Ivy.Tendril.Widgets.ChatSendMessageDto("Second message", null, session.Id);
+
+            var item1 = service.EnqueueMessage(session.Id, dto1);
+            var item2 = service.EnqueueMessage(session.Id, dto2);
+
+            Assert.NotNull(item1);
+            Assert.NotNull(item2);
+            Assert.Equal(2, eventFiredCount);
+
+            var queued = service.GetQueuedMessages(session.Id);
+            Assert.Equal(2, queued.Count);
+            Assert.Equal("First message", queued[0].Prompt);
+            Assert.Equal("Second message", queued[1].Prompt);
+
+            var dequeued1 = service.TryDequeueMessage(session.Id, out var next1);
+            Assert.True(dequeued1);
+            Assert.NotNull(next1);
+            Assert.Equal(item1.Id, next1.Id);
+            Assert.Equal("First message", next1.Prompt);
+
+            var queuedAfterFirst = service.GetQueuedMessages(session.Id);
+            Assert.Single(queuedAfterFirst);
+            Assert.Equal("Second message", queuedAfterFirst[0].Prompt);
+
+            var dequeued2 = service.TryDequeueMessage(session.Id, out var next2);
+            Assert.True(dequeued2);
+            Assert.NotNull(next2);
+            Assert.Equal(item2.Id, next2.Id);
+
+            var dequeuedEmpty = service.TryDequeueMessage(session.Id, out var nextEmpty);
+            Assert.False(dequeuedEmpty);
+            Assert.Null(nextEmpty);
+            Assert.Empty(service.GetQueuedMessages(session.Id));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void QueuedMessages_Remove_Update_And_Clear()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "opus");
+            var dto1 = new Ivy.Tendril.Widgets.ChatSendMessageDto("Item 1", null, session.Id);
+            var dto2 = new Ivy.Tendril.Widgets.ChatSendMessageDto("Item 2", null, session.Id);
+            var dto3 = new Ivy.Tendril.Widgets.ChatSendMessageDto("Item 3", null, session.Id);
+
+            var item1 = service.EnqueueMessage(session.Id, dto1);
+            var item2 = service.EnqueueMessage(session.Id, dto2);
+            var item3 = service.EnqueueMessage(session.Id, dto3);
+
+            // Update item2
+            var updated = service.UpdateQueuedMessage(session.Id, item2.Id, "Item 2 Updated");
+            Assert.True(updated);
+
+            var queued = service.GetQueuedMessages(session.Id);
+            Assert.Equal(3, queued.Count);
+            Assert.Equal("Item 2 Updated", queued[1].Prompt);
+
+            // Remove item1
+            var removed = service.RemoveQueuedMessage(session.Id, item1.Id);
+            Assert.True(removed);
+
+            var queuedAfterRemove = service.GetQueuedMessages(session.Id);
+            Assert.Equal(2, queuedAfterRemove.Count);
+            Assert.Equal("Item 2 Updated", queuedAfterRemove[0].Prompt);
+            Assert.Equal("Item 3", queuedAfterRemove[1].Prompt);
+
+            // Clear session queued messages
+            service.ClearQueuedMessages(session.Id);
+            Assert.Empty(service.GetQueuedMessages(session.Id));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void DeleteSession_CleansUpQueuedMessages()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "opus");
+            service.EnqueueMessage(session.Id, new Ivy.Tendril.Widgets.ChatSendMessageDto("Queued item", null, session.Id));
+            Assert.Single(service.GetQueuedMessages(session.Id));
+
+            service.DeleteSession(session.Id);
+            Assert.Empty(service.GetQueuedMessages(session.Id));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril.Widgets/ChatWidget.cs
+++ b/src/Ivy.Tendril.Widgets/ChatWidget.cs
@@ -40,6 +40,12 @@ public record ChatAttachmentDto(
     string? LocalPath = null
 );
 
+public record ChatQueuedMessageDto(
+    string Id,
+    string Prompt,
+    List<ChatAttachmentDto>? Attachments = null
+);
+
 public record ChatSendMessageDto(
     string Prompt,
     List<ChatAttachmentDto>? Attachments = null,
@@ -67,6 +73,7 @@ public record ChatWidget : WidgetBase<ChatWidget>
     [Prop] public bool IsStreaming { get; init; } = false;
     [Prop] public string? StreamingText { get; init; }
     [Prop] public IWriteStream<string>? StreamingStream { get; init; }
+    [Prop] public List<ChatQueuedMessageDto> QueuedMessages { get; init; } = new();
 
     [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnSelectSession { get; init; }
     [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnDeleteSession { get; init; }
@@ -77,4 +84,7 @@ public record ChatWidget : WidgetBase<ChatWidget>
     [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnAgentChanged { get; init; }
     [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnModelChanged { get; init; }
     [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnEffortChanged { get; init; }
+    [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnDeleteQueuedMessage { get; init; }
+    [Event] public Func<Event<ChatWidget, string[]>, ValueTask>? OnUpdateQueuedMessage { get; init; }
+    [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnSendQueuedNow { get; init; }
 }

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -130,6 +130,94 @@ describe("ChatWidget Queued Messages UI", () => {
     expect(screen.queryByText("Queued Messages")).not.toBeInTheDocument();
   });
 
+  it("renders queued messages passed via props upon mount and handles session switches", () => {
+    const queuedItems = [
+      { id: "q-1", prompt: "persisted queued prompt 1" },
+      { id: "q-2", prompt: "persisted queued prompt 2" },
+    ];
+
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-1"
+        isStreaming={true}
+        queuedMessages={queuedItems}
+      />
+    );
+
+    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("persisted queued prompt 1")).toBeInTheDocument();
+    expect(screen.getByText("persisted queued prompt 2")).toBeInTheDocument();
+
+    // Rerender with empty queue (e.g. switched to another session)
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-2"
+        isStreaming={false}
+        queuedMessages={[]}
+      />
+    );
+
+    expect(screen.queryByText("Queued Messages")).not.toBeInTheDocument();
+    expect(screen.queryByText("persisted queued prompt 1")).not.toBeInTheDocument();
+  });
+
+  it("emits backend sync events OnDeleteQueuedMessage, OnUpdateQueuedMessage, and OnSendQueuedNow", () => {
+    const handleEvent = vi.fn();
+    const queuedItems = [
+      { id: "q-edit", prompt: "to be edited" },
+      { id: "q-del", prompt: "to be deleted" },
+      { id: "q-send", prompt: "to be sent now" },
+    ];
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-1"
+        isStreaming={true}
+        queuedMessages={queuedItems}
+        events={["OnDeleteQueuedMessage", "OnUpdateQueuedMessage", "OnSendQueuedNow"]}
+        eventHandler={handleEvent}
+      />
+    );
+
+    // Edit item
+    const editBtns = screen.getAllByRole("button", { name: /Edit message/i });
+    fireEvent.click(editBtns[0]);
+    const editInput = screen.getByDisplayValue("to be edited");
+    fireEvent.change(editInput, { target: { value: "edited content" } });
+    const saveBtn = screen.getByRole("button", { name: /Save/i });
+    fireEvent.click(saveBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnUpdateQueuedMessage",
+      "test-chat",
+      ["q-edit", "edited content"]
+    );
+
+    // Delete item
+    const deleteBtns = screen.getAllByRole("button", { name: /Delete message/i });
+    fireEvent.click(deleteBtns[1]);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnDeleteQueuedMessage",
+      "test-chat",
+      ["q-del"]
+    );
+
+    // Send item now
+    const sendNowBtns = screen.getAllByRole("button", { name: /Send now/i });
+    fireEvent.click(sendNowBtns[1]);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnSendQueuedNow",
+      "test-chat",
+      ["q-send"]
+    );
+  });
+
   it("renders delete button next to chat title and directly emits OnDeleteSession upon click", () => {
     const handleEvent = vi.fn();
     const session = {

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -180,6 +180,12 @@ export interface ChatAttachmentDto {
   previewUrl?: string;
 }
 
+export interface ChatQueuedMessageDto {
+  id: string;
+  prompt: string;
+  attachments?: ChatAttachmentDto[];
+}
+
 type IvyEventHandler = (eventName: string, widgetId: string, args: unknown[]) => void;
 
 export interface ChatWidgetProps {
@@ -198,6 +204,7 @@ export interface ChatWidgetProps {
   streamingText?: string;
   streamingStream?: { id: string };
   subscribeToStream?: (streamId: string, onData: (data: unknown) => void) => () => void;
+  queuedMessages?: ChatQueuedMessageDto[];
   events?: string[];
   eventHandler?: IvyEventHandler;
 }
@@ -314,12 +321,6 @@ export function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-interface QueuedItem {
-  id: string;
-  prompt: string;
-  attachments: ChatAttachmentDto[];
-}
-
 export function ChatWidget({
   id,
   activeSessionId,
@@ -336,6 +337,7 @@ export function ChatWidget({
   streamingText = "",
   streamingStream: _streamingStream,
   subscribeToStream: _subscribeToStream,
+  queuedMessages: queuedMessagesProp,
   events = [],
   eventHandler,
 }: ChatWidgetProps) {
@@ -344,7 +346,7 @@ export function ChatWidget({
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editingTitleText, setEditingTitleText] = useState("");
   const [attachments, setAttachments] = useState<ChatAttachmentDto[]>([]);
-  const [queuedMessages, setQueuedMessages] = useState<QueuedItem[]>([]);
+  const [queuedMessages, setQueuedMessages] = useState<ChatQueuedMessageDto[]>(queuedMessagesProp || []);
   const [collapsedQueue, setCollapsedQueue] = useState(false);
   const [editingQueuedId, setEditingQueuedId] = useState<string | null>(null);
   const [editingQueuedText, setEditingQueuedText] = useState("");
@@ -359,6 +361,12 @@ export function ChatWidget({
   const activeSession = sessions.find((s) => s.id === activeSessionId);
   const totalAttachmentSize = attachments.reduce((sum, att) => sum + (att.size || 0), 0);
   const isPayloadOversized = totalAttachmentSize > MAX_PAYLOAD_BYTES;
+
+  useEffect(() => {
+    if (queuedMessagesProp !== undefined) {
+      setQueuedMessages(queuedMessagesProp);
+    }
+  }, [queuedMessagesProp]);
 
   const handleDeleteClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -454,12 +462,16 @@ export function ChatWidget({
     const item = queuedMessages.find((q) => q.id === queueId);
     if (!item) return;
 
-    const payload = { prompt: item.prompt, attachments: item.attachments, sessionId: activeSessionId };
-    emit("OnSendMessage", payload);
+    if (events.includes("OnSendQueuedNow")) {
+      emit("OnSendQueuedNow", queueId);
+    } else {
+      const payload = { prompt: item.prompt, attachments: item.attachments, sessionId: activeSessionId };
+      emit("OnSendMessage", payload);
+    }
     setQueuedMessages((prev) => prev.filter((q) => q.id !== queueId));
   };
 
-  const handleStartEditQueued = (item: QueuedItem) => {
+  const handleStartEditQueued = (item: ChatQueuedMessageDto) => {
     setEditingQueuedId(item.id);
     setEditingQueuedText(item.prompt);
   };
@@ -469,6 +481,7 @@ export function ChatWidget({
     if (!trimmed) {
       handleDeleteQueued(queueId);
     } else {
+      emit("OnUpdateQueuedMessage", queueId, trimmed);
       setQueuedMessages((prev) =>
         prev.map((q) => (q.id === queueId ? { ...q, prompt: trimmed } : q))
       );
@@ -483,6 +496,7 @@ export function ChatWidget({
   };
 
   const handleDeleteQueued = (queueId: string) => {
+    emit("OnDeleteQueuedMessage", queueId);
     setQueuedMessages((prev) => prev.filter((q) => q.id !== queueId));
     if (editingQueuedId === queueId) {
       setEditingQueuedId(null);

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -48,7 +48,6 @@ public class ChatApp : ViewBase
         var liveSessionStreams = UseState(new Dictionary<string, string>());
         var activeSessionRef = UseRef<IAgentSession?>(null);
         var runningSessionIds = UseState(() => new HashSet<string>(chatService.GetGeneratingSessionIds()));
-        var messageQueue = UseRef(new ConcurrentQueue<ChatSendMessageDto>());
         var initialHandled = UseRef(false);
 
         var searchState = UseState("");
@@ -360,27 +359,10 @@ public class ChatApp : ViewBase
                 map.Remove(targetSessionId);
                 liveSessionStreams.Set(map);
 
-                var remainingItems = new List<ChatSendMessageDto>();
-                ChatSendMessageDto? nextForSession = null;
-                while (messageQueue.Value.TryDequeue(out var item))
+                if (chatService.TryDequeueMessage(targetSessionId, out var nextQueuedItem) && nextQueuedItem != null)
                 {
-                    if (nextForSession == null && (item.SessionId == targetSessionId || string.IsNullOrEmpty(item.SessionId)))
-                    {
-                        nextForSession = item;
-                    }
-                    else
-                    {
-                        remainingItems.Add(item);
-                    }
-                }
-                foreach (var rem in remainingItems)
-                {
-                    messageQueue.Value.Enqueue(rem);
-                }
-
-                if (nextForSession != null)
-                {
-                    _ = ExecuteSendMessage(nextForSession);
+                    var nextDto = new ChatSendMessageDto(nextQueuedItem.Prompt, nextQueuedItem.Attachments, targetSessionId);
+                    _ = ExecuteSendMessage(nextDto);
                 }
             }
         }
@@ -403,7 +385,7 @@ public class ChatApp : ViewBase
 
             if (runningSessionIds.Value.Contains(targetSessionId))
             {
-                messageQueue.Value.Enqueue(pinnedDto);
+                chatService.EnqueueMessage(targetSessionId, pinnedDto);
             }
             else
             {
@@ -445,7 +427,6 @@ public class ChatApp : ViewBase
             streamingSessionId,
             runningSessionIds,
             liveSessionStreams,
-            messageQueue,
             activeSessionRef,
             sessionDtos,
             agentDtos,

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -24,7 +24,6 @@ public class ContentView(
     IState<string?> streamingSessionId,
     IState<HashSet<string>> runningSessionIds,
     IState<Dictionary<string, string>> liveSessionStreams,
-    IRef<ConcurrentQueue<ChatSendMessageDto>> messageQueue,
     IRef<IAgentSession?> activeSessionRef,
     List<ChatSessionDto> sessionDtos,
     List<AgentOptionDto> agentDtos,
@@ -68,6 +67,16 @@ public class ContentView(
 
         var deleteDialog = new DeleteSessionDialog(deletingSessionId, sessionToDelete, chatService, activeSessionId, sessionVersion);
 
+        var activeQueuedItems = activeSessionId.Value != null
+            ? chatService.GetQueuedMessages(activeSessionId.Value)
+            : Array.Empty<ChatQueuedItem>();
+
+        var queuedMessageDtos = activeQueuedItems.Select(q => new ChatQueuedMessageDto(
+            q.Id,
+            q.Prompt,
+            q.Attachments
+        )).ToList();
+
         var chatWidget = new ChatWidget
         {
             ActiveSessionId = activeSessionId.Value,
@@ -82,6 +91,7 @@ public class ContentView(
             SupportsEffort = supportsEffort,
             IsStreaming = activeSessionId.Value != null && runningSessionIds.Value.Contains(activeSessionId.Value),
             StreamingText = activeSessionLiveStream,
+            QueuedMessages = queuedMessageDtos,
 
             OnSelectSession = e =>
             {
@@ -115,7 +125,10 @@ public class ContentView(
             },
             OnCancelStream = async _ =>
             {
-                while (messageQueue.Value.TryDequeue(out var _)) { }
+                if (activeSessionId.Value != null)
+                {
+                    chatService.ClearQueuedMessages(activeSessionId.Value);
+                }
                 try
                 {
                     if (activeSessionRef.Value != null)
@@ -152,6 +165,36 @@ public class ContentView(
             OnEffortChanged = e =>
             {
                 selectedEffort.Set(e.Value);
+                return ValueTask.CompletedTask;
+            },
+            OnDeleteQueuedMessage = e =>
+            {
+                if (activeSessionId.Value != null && !string.IsNullOrEmpty(e.Value))
+                {
+                    chatService.RemoveQueuedMessage(activeSessionId.Value, e.Value);
+                }
+                return ValueTask.CompletedTask;
+            },
+            OnUpdateQueuedMessage = e =>
+            {
+                if (activeSessionId.Value != null && e.Value != null && e.Value.Length >= 2)
+                {
+                    chatService.UpdateQueuedMessage(activeSessionId.Value, e.Value[0], e.Value[1]);
+                }
+                return ValueTask.CompletedTask;
+            },
+            OnSendQueuedNow = e =>
+            {
+                if (activeSessionId.Value != null && !string.IsNullOrEmpty(e.Value))
+                {
+                    var items = chatService.GetQueuedMessages(activeSessionId.Value);
+                    var item = items.FirstOrDefault(q => q.Id == e.Value);
+                    if (item != null)
+                    {
+                        chatService.RemoveQueuedMessage(activeSessionId.Value, e.Value);
+                        sendMessage(new ChatSendMessageDto(item.Prompt, item.Attachments, activeSessionId.Value));
+                    }
+                }
                 return ValueTask.CompletedTask;
             }
         }

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using Ivy.Tendril.Widgets;
 
 namespace Ivy.Tendril.Services;
 
@@ -13,6 +14,7 @@ public class ChatHistoryService : IChatHistoryService
     private readonly ConcurrentDictionary<string, ChatSessionModel> _sessions = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, byte> _generatingSessions = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, byte> _completedSessions = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, List<ChatQueuedItem>> _queuedMessages = new(StringComparer.OrdinalIgnoreCase);
     private readonly object _lock = new();
 
     public event EventHandler? SessionsChanged;
@@ -54,6 +56,128 @@ public class ChatHistoryService : IChatHistoryService
     {
         if (string.IsNullOrEmpty(sessionId)) return;
         if (_completedSessions.TryRemove(sessionId, out _))
+        {
+            GeneratingSessionsChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public IReadOnlyList<ChatQueuedItem> GetQueuedMessages(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return Array.Empty<ChatQueuedItem>();
+        lock (_lock)
+        {
+            if (_queuedMessages.TryGetValue(sessionId, out var list))
+            {
+                return list.ToList();
+            }
+            return Array.Empty<ChatQueuedItem>();
+        }
+    }
+
+    public ChatQueuedItem EnqueueMessage(string sessionId, ChatSendMessageDto dto)
+    {
+        var item = new ChatQueuedItem(
+            Id: Guid.NewGuid().ToString("N"),
+            Prompt: dto.Prompt,
+            Attachments: dto.Attachments != null ? new List<ChatAttachmentDto>(dto.Attachments) : null,
+            CreatedAt: DateTimeOffset.UtcNow
+        );
+        lock (_lock)
+        {
+            if (!_queuedMessages.TryGetValue(sessionId, out var list))
+            {
+                list = new List<ChatQueuedItem>();
+                _queuedMessages[sessionId] = list;
+            }
+            list.Add(item);
+        }
+        GeneratingSessionsChanged?.Invoke(this, EventArgs.Empty);
+        return item;
+    }
+
+    public bool TryDequeueMessage(string sessionId, out ChatQueuedItem? item)
+    {
+        item = null;
+        if (string.IsNullOrEmpty(sessionId)) return false;
+        bool dequeued = false;
+        lock (_lock)
+        {
+            if (_queuedMessages.TryGetValue(sessionId, out var list) && list.Count > 0)
+            {
+                item = list[0];
+                list.RemoveAt(0);
+                if (list.Count == 0)
+                {
+                    _queuedMessages.TryRemove(sessionId, out _);
+                }
+                dequeued = true;
+            }
+        }
+        if (dequeued)
+        {
+            GeneratingSessionsChanged?.Invoke(this, EventArgs.Empty);
+        }
+        return dequeued;
+    }
+
+    public bool RemoveQueuedMessage(string sessionId, string queueId)
+    {
+        if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(queueId)) return false;
+        bool removed = false;
+        lock (_lock)
+        {
+            if (_queuedMessages.TryGetValue(sessionId, out var list))
+            {
+                var count = list.RemoveAll(q => q.Id == queueId);
+                if (count > 0)
+                {
+                    removed = true;
+                    if (list.Count == 0)
+                    {
+                        _queuedMessages.TryRemove(sessionId, out _);
+                    }
+                }
+            }
+        }
+        if (removed)
+        {
+            GeneratingSessionsChanged?.Invoke(this, EventArgs.Empty);
+        }
+        return removed;
+    }
+
+    public bool UpdateQueuedMessage(string sessionId, string queueId, string prompt)
+    {
+        if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(queueId)) return false;
+        bool updated = false;
+        lock (_lock)
+        {
+            if (_queuedMessages.TryGetValue(sessionId, out var list))
+            {
+                var idx = list.FindIndex(q => q.Id == queueId);
+                if (idx >= 0)
+                {
+                    list[idx] = list[idx] with { Prompt = prompt };
+                    updated = true;
+                }
+            }
+        }
+        if (updated)
+        {
+            GeneratingSessionsChanged?.Invoke(this, EventArgs.Empty);
+        }
+        return updated;
+    }
+
+    public void ClearQueuedMessages(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return;
+        bool cleared = false;
+        lock (_lock)
+        {
+            cleared = _queuedMessages.TryRemove(sessionId, out _);
+        }
+        if (cleared)
         {
             GeneratingSessionsChanged?.Invoke(this, EventArgs.Empty);
         }
@@ -178,6 +302,7 @@ public class ChatHistoryService : IChatHistoryService
     {
         if (string.IsNullOrEmpty(id)) return;
         _sessions.TryRemove(id, out _);
+        _queuedMessages.TryRemove(id, out _);
 
         try
         {

--- a/src/Ivy.Tendril/Services/IChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/IChatHistoryService.cs
@@ -1,7 +1,15 @@
 using System;
 using System.Collections.Generic;
+using Ivy.Tendril.Widgets;
 
 namespace Ivy.Tendril.Services;
+
+public record ChatQueuedItem(
+    string Id,
+    string Prompt,
+    List<ChatAttachmentDto>? Attachments,
+    DateTimeOffset CreatedAt
+);
 
 public record ChatMessageModel(
     string Id,
@@ -40,4 +48,10 @@ public interface IChatHistoryService
     IReadOnlySet<string> GetGeneratingSessionIds();
     IReadOnlySet<string> GetCompletedSessionIds();
     void ClearSessionCompleted(string sessionId);
+    IReadOnlyList<ChatQueuedItem> GetQueuedMessages(string sessionId);
+    ChatQueuedItem EnqueueMessage(string sessionId, ChatSendMessageDto dto);
+    bool TryDequeueMessage(string sessionId, out ChatQueuedItem? item);
+    bool RemoveQueuedMessage(string sessionId, string queueId);
+    bool UpdateQueuedMessage(string sessionId, string queueId, string prompt);
+    void ClearQueuedMessages(string sessionId);
 }


### PR DESCRIPTION
# Summary

## Changes

Implemented persistent queued messages in the Chat app across view remounts and sessions. Queued messages are now managed centrally in `IChatHistoryService` instead of local view state, passed to `ChatWidget` as props, and synchronized via backend events when edited, deleted, or sent immediately.

## API Changes

- `IChatHistoryService`: Added `GetQueuedMessages`, `EnqueueMessage`, `TryDequeueMessage`, `RemoveQueuedMessage`, `UpdateQueuedMessage`, `ClearQueuedMessages` methods and `ChatQueuedItem` record.
- `ChatWidget`: Added `QueuedMessages` prop, `ChatQueuedMessageDto` record, and `OnDeleteQueuedMessage`, `OnUpdateQueuedMessage`, `OnSendQueuedNow` events.

## Files Modified

- `src/Ivy.Tendril/Services/IChatHistoryService.cs`: Defined `ChatQueuedItem` and queue management methods on the interface.
- `src/Ivy.Tendril/Services/ChatHistoryService.cs`: Implemented thread-safe queue storage and methods per session.
- `src/Ivy.Tendril.Widgets/ChatWidget.cs`: Added `ChatQueuedMessageDto`, `QueuedMessages` property, and sync event definitions.
- `src/Ivy.Tendril/Apps/Chat/ChatApp.cs`: Replaced local `messageQueue` with `IChatHistoryService` queue integration and automatic dequeue on completion.
- `src/Ivy.Tendril/Apps/Chat/ContentView.cs`: Passed `QueuedMessages` prop and bound queue sync events.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx`: Accepted `queuedMessages` prop, updated state sync, and emitted backend events.
- `src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs`: Added unit tests for FIFO dequeue, update, remove, and clear behavior.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx`: Added unit tests for queued message prop mounting and backend event emission.

## Manual Testing

1. Launch Tendril and navigate to the Chat app.
2. Send a prompt to an agent to start generation (status: generating).
3. While the agent is responding, type a second prompt and click "Queue" (or press Enter). Verify the message appears in the "Queued Messages" panel.
4. Navigate away from the Chat app (e.g. open Plans or Drafts) and return to the Chat app. Verify the queued message is still visible in the queue panel.
5. Edit or delete a queued message using the pencil or trash icons. Verify the queue updates accordingly.
6. Wait for the agent to finish the initial message. Verify the queued message automatically begins execution.

---

## Commits
- 58221cd5: [00070] Persist and display queued messages across chat app sessions

---
Created using [Ivy Tendril](https://ivy.app).
