### PR TITLE
[00030] Implement Search Functionality with Keyboard Shortcut Ctrl+F

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.search.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.search.test.tsx
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { DraftMarkdown } from "./DraftMarkdown";
+
+describe("DraftMarkdown in-page search functionality", () => {
+  beforeEach(() => {
+    // Mock scrollIntoView in jsdom
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  const sampleMarkdown = `
+# Title of Document
+
+This is the first paragraph with some keyword content to search.
+
+## Section Header with keyword
+
+Another paragraph mentioning keyword multiple times: keyword and KEYWORD.
+`;
+
+  it("opens search overlay and focuses search input when Ctrl+F or Cmd+F is pressed", () => {
+    const { container } = render(<DraftMarkdown id="w1" content={sampleMarkdown} />);
+
+    // Initially search overlay is not in the DOM
+    expect(container.querySelector(".pmv-search-overlay")).toBeNull();
+
+    // Trigger Ctrl+F
+    act(() => {
+      fireEvent.keyDown(document, { key: "f", ctrlKey: true });
+    });
+
+    const searchOverlay = container.querySelector(".pmv-search-overlay");
+    expect(searchOverlay).not.toBeNull();
+
+    const searchInput = screen.getByPlaceholderText("Find in document...");
+    expect(searchInput).not.toBeNull();
+    expect(document.activeElement).toBe(searchInput);
+  });
+
+  it("opens search overlay when Cmd+F is pressed (macOS shortcut)", () => {
+    const { container } = render(<DraftMarkdown id="w1" content={sampleMarkdown} />);
+
+    act(() => {
+      fireEvent.keyDown(document, { key: "f", metaKey: true });
+    });
+
+    expect(container.querySelector(".pmv-search-overlay")).not.toBeNull();
+  });
+
+  it("highlights matching text elements and displays correct match counts when typing query", () => {
+    const { container } = render(<DraftMarkdown id="w1" content={sampleMarkdown} />);
+
+    // Open search overlay
+    act(() => {
+      fireEvent.keyDown(document, { key: "f", ctrlKey: true });
+    });
+
+    const searchInput = screen.getByPlaceholderText("Find in document...");
+
+    // Type query "keyword"
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: "keyword" } });
+    });
+
+    const highlights = container.querySelectorAll(".pmv-search-highlight");
+    // "keyword" appears 5 times in sampleMarkdown (case-insensitive)
+    expect(highlights.length).toBe(5);
+
+    const counter = container.querySelector(".pmv-search-count");
+    expect(counter?.textContent).toBe("1 of 5");
+
+    // The first match should have the active highlight class
+    expect(highlights[0].classList.contains("pmv-search-highlight--active")).toBe(true);
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("displays 'No matches' when query does not match any content", () => {
+    const { container } = render(<DraftMarkdown id="w1" content={sampleMarkdown} />);
+
+    act(() => {
+      fireEvent.keyDown(document, { key: "f", ctrlKey: true });
+    });
+
+    const searchInput = screen.getByPlaceholderText("Find in document...");
+
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: "nonexistentterm" } });
+    });
+
+    const highlights = container.querySelectorAll(".pmv-search-highlight");
+    expect(highlights.length).toBe(0);
+
+    const counter = container.querySelector(".pmv-search-count");
+    expect(counter?.textContent).toBe("No matches");
+  });
+
+  it("cycles through matching elements using Enter / Shift+Enter in search input", () => {
+    const { container } = render(<DraftMarkdown id="w1" content={sampleMarkdown} />);
+
+    act(() => {
+      fireEvent.keyDown(document, { key: "f", ctrlKey: true });
+    });
+
+    const searchInput = screen.getByPlaceholderText("Find in document...");
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: "keyword" } });
+    });
+
+    let highlights = container.querySelectorAll(".pmv-search-highlight");
+    expect(highlights[0].classList.contains("pmv-search-highlight--active")).toBe(true);
+    let counter = container.querySelector(".pmv-search-count");
+    expect(counter?.textContent).toBe("1 of 5");
+
+    // Press Enter to go to next match (index 1)
+    act(() => {
+      fireEvent.keyDown(searchInput, { key: "Enter" });
+    });
+
+    highlights = container.querySelectorAll(".pmv-search-highlight");
+    expect(highlights[1].classList.contains("pmv-search-highlight--active")).toBe(true);
+    expect(highlights[0].classList.contains("pmv-search-highlight--active")).toBe(false);
+    counter = container.querySelector(".pmv-search-count");
+    expect(counter?.textContent).toBe("2 of 5");
+
+    // Press Shift+Enter to go to previous match (index 0)
+    act(() => {
+      fireEvent.keyDown(searchInput, { key: "Enter", shiftKey: true });
+    });
+
+    highlights = container.querySelectorAll(".pmv-search-highlight");
+    expect(highlights[0].classList.contains("pmv-search-highlight--active")).toBe(true);
+    counter = container.querySelector(".pmv-search-count");
+    expect(counter?.textContent).toBe("1 of 5");
+
+    // Press Shift+Enter again to wrap around to last match (index 4)
+    act(() => {
+      fireEvent.keyDown(searchInput, { key: "Enter", shiftKey: true });
+    });
+
+    highlights = container.querySelectorAll(".pmv-search-highlight");
+    expect(highlights[4].classList.contains("pmv-search-highlight--active")).toBe(true);
+    counter = container.querySelector(".pmv-search-count");
+    expect(counter?.textContent).toBe("5 of 5");
+  });
+
+  it("cycles through matching elements using Next and Previous buttons", () => {
+    const { container } = render(<DraftMarkdown id="w1" content={sampleMarkdown} />);
+
+    act(() => {
+      fireEvent.keyDown(document, { key: "f", ctrlKey: true });
+    });
+
+    const searchInput = screen.getByPlaceholderText("Find in document...");
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: "keyword" } });
+    });
+
+    const nextBtn = screen.getByTitle("Next match (Enter)");
+    const prevBtn = screen.getByTitle("Previous match (Shift+Enter)");
+
+    // Click Next button
+    act(() => {
+      fireEvent.click(nextBtn);
+    });
+
+    let highlights = container.querySelectorAll(".pmv-search-highlight");
+    expect(highlights[1].classList.contains("pmv-search-highlight--active")).toBe(true);
+    let counter = container.querySelector(".pmv-search-count");
+    expect(counter?.textContent).toBe("2 of 5");
+
+    // Click Previous button
+    act(() => {
+      fireEvent.click(prevBtn);
+    });
+
+    highlights = container.querySelectorAll(".pmv-search-highlight");
+    expect(highlights[0].classList.contains("pmv-search-highlight--active")).toBe(true);
+    counter = container.querySelector(".pmv-search-count");
+    expect(counter?.textContent).toBe("1 of 5");
+  });
+
+  it("closes search overlay and clears all highlight spans on Escape key in search input", () => {
+    const { container } = render(<DraftMarkdown id="w1" content={sampleMarkdown} />);
+
+    act(() => {
+      fireEvent.keyDown(document, { key: "f", ctrlKey: true });
+    });
+
+    const searchInput = screen.getByPlaceholderText("Find in document...");
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: "keyword" } });
+    });
+
+    expect(container.querySelectorAll(".pmv-search-highlight").length).toBe(5);
+
+    // Press Escape
+    act(() => {
+      fireEvent.keyDown(searchInput, { key: "Escape" });
+    });
+
+    expect(container.querySelector(".pmv-search-overlay")).toBeNull();
+    expect(container.querySelectorAll(".pmv-search-highlight").length).toBe(0);
+  });
+
+  it("closes search overlay and clears all highlight spans when clicking Close button", () => {
+    const { container } = render(<DraftMarkdown id="w1" content={sampleMarkdown} />);
+
+    act(() => {
+      fireEvent.keyDown(document, { key: "f", ctrlKey: true });
+    });
+
+    const searchInput = screen.getByPlaceholderText("Find in document...");
+    act(() => {
+      fireEvent.change(searchInput, { target: { value: "keyword" } });
+    });
+
+    expect(container.querySelectorAll(".pmv-search-highlight").length).toBe(5);
+
+    const closeBtn = screen.getByTitle("Close (Escape)");
+    act(() => {
+      fireEvent.click(closeBtn);
+    });
+
+    expect(container.querySelector(".pmv-search-overlay")).toBeNull();
+    expect(container.querySelectorAll(".pmv-search-highlight").length).toBe(0);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.search.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.search.test.tsx
@@ -225,7 +225,7 @@ Another paragraph mentioning keyword multiple times: keyword and KEYWORD.
     expect(container.querySelectorAll(".pmv-search-highlight").length).toBe(0);
   });
 
-  it("renders search overlay inside sticky container above TOC content", () => {
+  it("renders search overlay floating on top by z-axis inside root container without displacing content", () => {
     const { container } = render(
       <DraftMarkdown
         id="w1"
@@ -238,16 +238,19 @@ Another paragraph mentioning keyword multiple times: keyword and KEYWORD.
       fireEvent.keyDown(document, { key: "f", ctrlKey: true });
     });
 
-    const sticky = container.querySelector(".pmv-sticky");
+    const root = container.querySelector(".pmv-root");
+    const shell = container.querySelector(".pmv-shell");
     const searchOverlay = container.querySelector(".pmv-search-overlay");
     const toc = container.querySelector(".sample-toc");
 
-    expect(sticky).not.toBeNull();
+    expect(root).not.toBeNull();
+    expect(shell).not.toBeNull();
     expect(searchOverlay).not.toBeNull();
     expect(toc).not.toBeNull();
-    expect(sticky?.contains(searchOverlay)).toBe(true);
-    expect(sticky?.contains(toc)).toBe(true);
-    // Search overlay precedes TOC in DOM order inside sticky container
-    expect(searchOverlay?.compareDocumentPosition(toc!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(root?.contains(searchOverlay)).toBe(true);
+    expect(root?.contains(shell)).toBe(true);
+    // Search overlay is rendered floating in root on top by z-axis, not inside pmv-sticky displacing TOC
+    const sticky = container.querySelector(".pmv-sticky");
+    expect(sticky?.contains(searchOverlay)).toBe(false);
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.search.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.search.test.tsx
@@ -225,23 +225,29 @@ Another paragraph mentioning keyword multiple times: keyword and KEYWORD.
     expect(container.querySelectorAll(".pmv-search-highlight").length).toBe(0);
   });
 
-  it("renders search overlay floating inside root container alongside the scrollable shell", () => {
-    const { container } = render(<DraftMarkdown id="w1" content={sampleMarkdown} />);
+  it("renders search overlay inside sticky container above TOC content", () => {
+    const { container } = render(
+      <DraftMarkdown
+        id="w1"
+        content={sampleMarkdown}
+        slots={{ StickyContent: [<div key="toc" className="sample-toc">TOC</div>] }}
+      />,
+    );
 
     act(() => {
       fireEvent.keyDown(document, { key: "f", ctrlKey: true });
     });
 
-    const root = container.querySelector(".pmv-root");
-    const shell = container.querySelector(".pmv-shell");
+    const sticky = container.querySelector(".pmv-sticky");
     const searchOverlay = container.querySelector(".pmv-search-overlay");
+    const toc = container.querySelector(".sample-toc");
 
-    expect(root).not.toBeNull();
-    expect(shell).not.toBeNull();
+    expect(sticky).not.toBeNull();
     expect(searchOverlay).not.toBeNull();
-    expect(root?.contains(searchOverlay)).toBe(true);
-    expect(root?.contains(shell)).toBe(true);
-    // Overlay is a sibling of the scrollable shell in pmv-root, not inside pmv-shell flex row
-    expect(shell?.contains(searchOverlay)).toBe(false);
+    expect(toc).not.toBeNull();
+    expect(sticky?.contains(searchOverlay)).toBe(true);
+    expect(sticky?.contains(toc)).toBe(true);
+    // Search overlay precedes TOC in DOM order inside sticky container
+    expect(searchOverlay?.compareDocumentPosition(toc!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.search.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.search.test.tsx
@@ -224,4 +224,24 @@ Another paragraph mentioning keyword multiple times: keyword and KEYWORD.
     expect(container.querySelector(".pmv-search-overlay")).toBeNull();
     expect(container.querySelectorAll(".pmv-search-highlight").length).toBe(0);
   });
+
+  it("renders search overlay floating inside root container alongside the scrollable shell", () => {
+    const { container } = render(<DraftMarkdown id="w1" content={sampleMarkdown} />);
+
+    act(() => {
+      fireEvent.keyDown(document, { key: "f", ctrlKey: true });
+    });
+
+    const root = container.querySelector(".pmv-root");
+    const shell = container.querySelector(".pmv-shell");
+    const searchOverlay = container.querySelector(".pmv-search-overlay");
+
+    expect(root).not.toBeNull();
+    expect(shell).not.toBeNull();
+    expect(searchOverlay).not.toBeNull();
+    expect(root?.contains(searchOverlay)).toBe(true);
+    expect(root?.contains(shell)).toBe(true);
+    // Overlay is a sibling of the scrollable shell in pmv-root, not inside pmv-shell flex row
+    expect(shell?.contains(searchOverlay)).toBe(false);
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
@@ -452,28 +452,24 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
 
   return (
     <div className="pmv-root" style={shellStyle}>
+      {isSearchOpen && (
+        <SearchOverlay
+          query={searchQuery}
+          onQueryChange={setSearchQuery}
+          matchCount={matches.length}
+          currentIndex={activeMatchIndex}
+          onNext={handleNextMatch}
+          onPrevious={handlePreviousMatch}
+          onClose={handleCloseSearch}
+        />
+      )}
       <div ref={shellRef} className="pmv-shell">
         <div className="pmv-body">
           <div ref={contentRef} className={article ? "pmv-markdown pmv-article" : "pmv-markdown"}>
             <QuestionsAnswerContext.Provider value={answerCallback}>{markdownTree}</QuestionsAnswerContext.Provider>
           </div>
         </div>
-        {(hasFixed || isSearchOpen) && (
-          <div className="pmv-sticky">
-            {isSearchOpen && (
-              <SearchOverlay
-                query={searchQuery}
-                onQueryChange={setSearchQuery}
-                matchCount={matches.length}
-                currentIndex={activeMatchIndex}
-                onNext={handleNextMatch}
-                onPrevious={handlePreviousMatch}
-                onClose={handleCloseSearch}
-              />
-            )}
-            {fixed}
-          </div>
-        )}
+        {hasFixed && <div className="pmv-sticky">{fixed}</div>}
 
         {annotationsEnabled && selectionToolbar && selectionAnchor && (
           <SelectionToolbar

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
@@ -452,24 +452,28 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
 
   return (
     <div className="pmv-root" style={shellStyle}>
-      {isSearchOpen && (
-        <SearchOverlay
-          query={searchQuery}
-          onQueryChange={setSearchQuery}
-          matchCount={matches.length}
-          currentIndex={activeMatchIndex}
-          onNext={handleNextMatch}
-          onPrevious={handlePreviousMatch}
-          onClose={handleCloseSearch}
-        />
-      )}
       <div ref={shellRef} className="pmv-shell">
         <div className="pmv-body">
           <div ref={contentRef} className={article ? "pmv-markdown pmv-article" : "pmv-markdown"}>
             <QuestionsAnswerContext.Provider value={answerCallback}>{markdownTree}</QuestionsAnswerContext.Provider>
           </div>
         </div>
-        {hasFixed && <div className="pmv-sticky">{fixed}</div>}
+        {(hasFixed || isSearchOpen) && (
+          <div className="pmv-sticky">
+            {isSearchOpen && (
+              <SearchOverlay
+                query={searchQuery}
+                onQueryChange={setSearchQuery}
+                matchCount={matches.length}
+                currentIndex={activeMatchIndex}
+                onNext={handleNextMatch}
+                onPrevious={handlePreviousMatch}
+                onClose={handleCloseSearch}
+              />
+            )}
+            {fixed}
+          </div>
+        )}
 
         {annotationsEnabled && selectionToolbar && selectionAnchor && (
           <SelectionToolbar

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
@@ -451,7 +451,7 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
   };
 
   return (
-    <div ref={shellRef} className="pmv-shell" style={shellStyle}>
+    <div className="pmv-root" style={shellStyle}>
       {isSearchOpen && (
         <SearchOverlay
           query={searchQuery}
@@ -463,41 +463,43 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
           onClose={handleCloseSearch}
         />
       )}
-      <div className="pmv-body">
-        <div ref={contentRef} className={article ? "pmv-markdown pmv-article" : "pmv-markdown"}>
-          <QuestionsAnswerContext.Provider value={answerCallback}>{markdownTree}</QuestionsAnswerContext.Provider>
+      <div ref={shellRef} className="pmv-shell">
+        <div className="pmv-body">
+          <div ref={contentRef} className={article ? "pmv-markdown pmv-article" : "pmv-markdown"}>
+            <QuestionsAnswerContext.Provider value={answerCallback}>{markdownTree}</QuestionsAnswerContext.Provider>
+          </div>
         </div>
-      </div>
-      {hasFixed && <div className="pmv-sticky">{fixed}</div>}
+        {hasFixed && <div className="pmv-sticky">{fixed}</div>}
 
-      {annotationsEnabled && selectionToolbar && selectionAnchor && (
-        <SelectionToolbar
-          position={selectionAnchor.position}
-          visible={selectionAnchor.visible}
-          onAddComment={handleAddComment}
-        />
-      )}
-      {annotationsEnabled && addPopover && addAnchor && (
-        <AddAnnotationPopover
-          position={addAnchor.position}
-          visible={addAnchor.visible}
-          selectedText={addPopover.selectedText}
-          onAdd={handleAddAnnotation}
-          onCancel={() => setAddPopover(null)}
-        />
-      )}
-      {annotationsEnabled && editPopover && editAnchor && (
-        <EditAnnotationPopover
-          position={editAnchor.position}
-          visible={editAnchor.visible}
-          annotation={editPopover}
-          currentAuthor={currentAuthor}
-          onSave={handleEditAnnotation}
-          onToggleResolve={handleToggleResolveAnnotation}
-          onRemove={handleRemoveAnnotation}
-          onCancel={() => setEditPopover(null)}
-        />
-      )}
+        {annotationsEnabled && selectionToolbar && selectionAnchor && (
+          <SelectionToolbar
+            position={selectionAnchor.position}
+            visible={selectionAnchor.visible}
+            onAddComment={handleAddComment}
+          />
+        )}
+        {annotationsEnabled && addPopover && addAnchor && (
+          <AddAnnotationPopover
+            position={addAnchor.position}
+            visible={addAnchor.visible}
+            selectedText={addPopover.selectedText}
+            onAdd={handleAddAnnotation}
+            onCancel={() => setAddPopover(null)}
+          />
+        )}
+        {annotationsEnabled && editPopover && editAnchor && (
+          <EditAnnotationPopover
+            position={editAnchor.position}
+            visible={editAnchor.visible}
+            annotation={editPopover}
+            currentAuthor={currentAuthor}
+            onSave={handleEditAnnotation}
+            onToggleResolve={handleToggleResolveAnnotation}
+            onRemove={handleRemoveAnnotation}
+            onCancel={() => setEditPopover(null)}
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx
@@ -14,6 +14,8 @@ import { tagQuestionBlocks } from "./questionsSource";
 import { QuestionsAnswerContext } from "./questionsContext";
 import type { AnswerCallback } from "./questionsContext";
 import { useAnchoredPosition } from "./useAnchoredPosition";
+import { SearchOverlay } from "./SearchOverlay";
+import { applySearchHighlights, clearSearchHighlights } from "./searchUtils";
 
 type IvyEventHandler = (eventName: string, widgetId: string, args: unknown[]) => void;
 
@@ -63,6 +65,12 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
   const [addPopover, setAddPopover] = useState<SelectionState | null>(null);
   const [editPopover, setEditPopover] = useState<MarkdownAnnotation | null>(null);
 
+  // In-page search state
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [matches, setMatches] = useState<HTMLElement[]>([]);
+  const [activeMatchIndex, setActiveMatchIndex] = useState(-1);
+
   // Re-measured on scroll/resize so the fixed-position toolbar/popovers stay
   // lined up with the text they anchor to, instead of the one-shot rect
   // captured at mouseup/click time.
@@ -72,6 +80,73 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
 
   const annotationsEnabled = events.includes("OnAnnotationsChange");
   const questionsEnabled = events.includes("OnAnswersChange");
+
+  // Keyboard shortcut Ctrl+F / Cmd+F to open in-page search
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.key === "f" || e.key === "F" || e.code === "KeyF") && (e.metaKey || e.ctrlKey) && !e.altKey) {
+        e.preventDefault();
+        setIsSearchOpen(true);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  // Update search highlights when search query, open state, or markdown content changes
+  useEffect(() => {
+    if (!contentRef.current) return;
+    if (isSearchOpen && searchQuery.trim()) {
+      const foundMarks = applySearchHighlights(contentRef.current, searchQuery);
+      setMatches(foundMarks);
+      if (foundMarks.length > 0) {
+        setActiveMatchIndex(0);
+      } else {
+        setActiveMatchIndex(-1);
+      }
+    } else {
+      clearSearchHighlights(contentRef.current);
+      setMatches([]);
+      setActiveMatchIndex(-1);
+    }
+  }, [isSearchOpen, searchQuery, content]);
+
+  // Update active highlight class and scroll into view when activeMatchIndex changes
+  useEffect(() => {
+    if (!isSearchOpen || matches.length === 0 || activeMatchIndex < 0) return;
+    matches.forEach((mark, index) => {
+      if (index === activeMatchIndex) {
+        mark.classList.add("pmv-search-highlight--active");
+        mark.scrollIntoView?.({ behavior: "smooth", block: "center" });
+      } else {
+        mark.classList.remove("pmv-search-highlight--active");
+      }
+    });
+  }, [activeMatchIndex, matches, isSearchOpen]);
+
+  const handleNextMatch = useCallback(() => {
+    if (matches.length === 0) return;
+    setActiveMatchIndex((prev) => (prev + 1) % matches.length);
+  }, [matches.length]);
+
+  const handlePreviousMatch = useCallback(() => {
+    if (matches.length === 0) return;
+    setActiveMatchIndex((prev) => (prev - 1 + matches.length) % matches.length);
+  }, [matches.length]);
+
+  const handleCloseSearch = useCallback(() => {
+    setIsSearchOpen(false);
+    setSearchQuery("");
+  }, []);
+
+  // Clean up search highlights on unmount
+  useEffect(() => {
+    return () => {
+      if (contentRef.current) {
+        clearSearchHighlights(contentRef.current);
+      }
+    };
+  }, []);
 
   // Reports one changed question. `Answer` carries all three states without a sentinel: null
   // clears the question back to unanswered, an empty list is an explicit skip, and a non-empty
@@ -377,6 +452,17 @@ export const DraftMarkdown: React.FC<DraftMarkdownProps> = ({
 
   return (
     <div ref={shellRef} className="pmv-shell" style={shellStyle}>
+      {isSearchOpen && (
+        <SearchOverlay
+          query={searchQuery}
+          onQueryChange={setSearchQuery}
+          matchCount={matches.length}
+          currentIndex={activeMatchIndex}
+          onNext={handleNextMatch}
+          onPrevious={handlePreviousMatch}
+          onClose={handleCloseSearch}
+        />
+      )}
       <div className="pmv-body">
         <div ref={contentRef} className={article ? "pmv-markdown pmv-article" : "pmv-markdown"}>
           <QuestionsAnswerContext.Provider value={answerCallback}>{markdownTree}</QuestionsAnswerContext.Provider>

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/SearchOverlay.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/SearchOverlay.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useRef } from "react";
+
+interface SearchOverlayProps {
+  query: string;
+  onQueryChange: (query: string) => void;
+  matchCount: number;
+  currentIndex: number;
+  onNext: () => void;
+  onPrevious: () => void;
+  onClose: () => void;
+}
+
+export const SearchOverlay: React.FC<SearchOverlayProps> = ({
+  query,
+  onQueryChange,
+  matchCount,
+  currentIndex,
+  onNext,
+  onPrevious,
+  onClose,
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (e.shiftKey) {
+        onPrevious();
+      } else {
+        onNext();
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  const counterText = query.trim()
+    ? matchCount === 0
+      ? "No matches"
+      : `${currentIndex + 1} of ${matchCount}`
+    : "";
+
+  return (
+    <div className="pmv-search-overlay" role="search">
+      <input
+        ref={inputRef}
+        type="text"
+        className="pmv-search-input"
+        placeholder="Find in document..."
+        aria-label="Find in document"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+      />
+      {counterText && <span className="pmv-search-count">{counterText}</span>}
+      <button
+        type="button"
+        className="pmv-search-btn"
+        onClick={onPrevious}
+        disabled={matchCount === 0}
+        aria-label="Previous match"
+        title="Previous match (Shift+Enter)"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="18 15 12 9 6 15" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        className="pmv-search-btn"
+        onClick={onNext}
+        disabled={matchCount === 0}
+        aria-label="Next match"
+        title="Next match (Enter)"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        className="pmv-search-btn pmv-search-btn--close"
+        onClick={onClose}
+        aria-label="Close search"
+        title="Close (Escape)"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+    </div>
+  );
+};

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/SearchOverlay.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/SearchOverlay.tsx
@@ -48,53 +48,70 @@ export const SearchOverlay: React.FC<SearchOverlayProps> = ({
 
   return (
     <div className="pmv-search-overlay" role="search">
-      <input
-        ref={inputRef}
-        type="text"
-        className="pmv-search-input"
-        placeholder="Find in document..."
-        aria-label="Find in document"
-        value={query}
-        onChange={(e) => onQueryChange(e.target.value)}
-        onKeyDown={handleKeyDown}
-      />
+      <div className="pmv-search-input-wrapper">
+        <svg
+          className="pmv-search-icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+        <input
+          ref={inputRef}
+          type="text"
+          className="pmv-search-input"
+          placeholder="Find in document..."
+          aria-label="Find in document"
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
       {counterText && <span className="pmv-search-count">{counterText}</span>}
-      <button
-        type="button"
-        className="pmv-search-btn"
-        onClick={onPrevious}
-        disabled={matchCount === 0}
-        aria-label="Previous match"
-        title="Previous match (Shift+Enter)"
-      >
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <polyline points="18 15 12 9 6 15" />
-        </svg>
-      </button>
-      <button
-        type="button"
-        className="pmv-search-btn"
-        onClick={onNext}
-        disabled={matchCount === 0}
-        aria-label="Next match"
-        title="Next match (Enter)"
-      >
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <polyline points="6 9 12 15 18 9" />
-        </svg>
-      </button>
-      <button
-        type="button"
-        className="pmv-search-btn pmv-search-btn--close"
-        onClick={onClose}
-        aria-label="Close search"
-        title="Close (Escape)"
-      >
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <line x1="18" y1="6" x2="6" y2="18" />
-          <line x1="6" y1="6" x2="18" y2="18" />
-        </svg>
-      </button>
+      <div className="pmv-search-actions">
+        <button
+          type="button"
+          className="pmv-search-btn"
+          onClick={onPrevious}
+          disabled={matchCount === 0}
+          aria-label="Previous match"
+          title="Previous match (Shift+Enter)"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="18 15 12 9 6 15" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          className="pmv-search-btn"
+          onClick={onNext}
+          disabled={matchCount === 0}
+          aria-label="Next match"
+          title="Next match (Enter)"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
+        <div className="pmv-search-divider" />
+        <button
+          type="button"
+          className="pmv-search-btn pmv-search-btn--close"
+          onClick={onClose}
+          aria-label="Close search"
+          title="Close (Escape)"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -2,6 +2,13 @@
 @tailwind utilities;
 
 /* ─── Layout: scrollable markdown body + pinned fixed slot ──────────────── */
+.pmv-root {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
 .pmv-shell {
   display: flex;
   flex-direction: row;
@@ -1181,35 +1188,63 @@
   background: rgba(255, 255, 255, 0.2);
 }
 
-/* ─── In-page Search Overlay ────────────────────────────────────────── */
+/* ─── In-page Search Overlay (Chromium / Dialog Style) ───────────────── */
 .pmv-search-overlay {
-  position: sticky;
+  position: absolute;
   top: 0.75rem;
   right: 1.5rem;
-  z-index: 50;
-  margin-left: auto;
+  z-index: 100;
   display: flex;
   align-items: center;
-  gap: 0.375rem;
-  padding: 0.375rem 0.5rem;
+  gap: 0.5rem;
+  padding: 0.375rem 0.625rem;
   border-radius: 0.5rem;
   border: 1px solid var(--border);
   background: var(--popover, var(--card));
   color: var(--popover-foreground, var(--foreground));
-  box-shadow: 0 4px 12px rgb(0 0 0 / 0.15);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18), 0 2px 6px rgba(0, 0, 0, 0.08);
   font-family: inherit;
+  backdrop-filter: blur(8px);
+  animation: pmv-search-fade-in 0.12s ease-out;
+}
+
+@keyframes pmv-search-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.pmv-search-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.pmv-search-icon {
+  position: absolute;
+  left: 0.5rem;
+  width: 0.875rem;
+  height: 0.875rem;
+  color: var(--muted-foreground);
+  pointer-events: none;
 }
 
 .pmv-search-input {
-  width: 12rem;
-  height: 1.75rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.25rem;
+  width: 13rem;
+  height: 1.875rem;
+  padding: 0.25rem 0.5rem 0.25rem 1.75rem;
+  border-radius: 0.375rem;
   border: 1px solid var(--input, var(--border));
   background: var(--background);
   color: var(--foreground);
   font-size: 0.8125rem;
   outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .pmv-search-input:focus {
@@ -1224,6 +1259,20 @@
   min-width: 3.5rem;
   text-align: center;
   user-select: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.pmv-search-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.pmv-search-divider {
+  width: 1px;
+  height: 1.25rem;
+  background: var(--border);
+  margin: 0 0.125rem;
 }
 
 .pmv-search-btn {
@@ -1238,7 +1287,7 @@
   color: var(--foreground);
   cursor: pointer;
   padding: 0;
-  transition: background 0.15s ease;
+  transition: background 0.15s ease, color 0.15s ease;
 }
 
 .pmv-search-btn:hover:not(:disabled) {
@@ -1246,13 +1295,27 @@
 }
 
 .pmv-search-btn:disabled {
-  opacity: 0.4;
+  opacity: 0.35;
   cursor: not-allowed;
 }
 
 .pmv-search-btn svg {
   width: 1rem;
   height: 1rem;
+}
+
+@media (max-width: 640px) {
+  .pmv-search-overlay {
+    top: 0.5rem;
+    right: 0.5rem;
+    left: 0.5rem;
+    max-width: calc(100% - 1rem);
+  }
+  .pmv-search-input {
+    flex: 1 1 auto;
+    width: auto;
+    min-width: 0;
+  }
 }
 
 .pmv-search-highlight {

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -1180,3 +1180,102 @@
 .pmv-img-overlay-close:hover {
   background: rgba(255, 255, 255, 0.2);
 }
+
+/* ─── In-page Search Overlay ────────────────────────────────────────── */
+.pmv-search-overlay {
+  position: sticky;
+  top: 0.75rem;
+  right: 1.5rem;
+  z-index: 50;
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  background: var(--popover, var(--card));
+  color: var(--popover-foreground, var(--foreground));
+  box-shadow: 0 4px 12px rgb(0 0 0 / 0.15);
+  font-family: inherit;
+}
+
+.pmv-search-input {
+  width: 12rem;
+  height: 1.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--input, var(--border));
+  background: var(--background);
+  color: var(--foreground);
+  font-size: 0.8125rem;
+  outline: none;
+}
+
+.pmv-search-input:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 1px var(--primary);
+}
+
+.pmv-search-count {
+  font-size: 0.75rem;
+  color: var(--muted-foreground, var(--text-secondary));
+  white-space: nowrap;
+  min-width: 3.5rem;
+  text-align: center;
+  user-select: none;
+}
+
+.pmv-search-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.25rem;
+  border: none;
+  background: transparent;
+  color: var(--foreground);
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.15s ease;
+}
+
+.pmv-search-btn:hover:not(:disabled) {
+  background: var(--muted);
+}
+
+.pmv-search-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.pmv-search-btn svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.pmv-search-highlight {
+  background: hsl(48 96% 76% / 0.85);
+  color: inherit;
+  border-radius: 0.125rem;
+  padding: 0 0.1rem;
+}
+
+:root.dark .pmv-search-highlight {
+  background: hsl(48 80% 30% / 0.85);
+  color: inherit;
+}
+
+.pmv-search-highlight--active {
+  background: hsl(25 95% 53% / 0.95);
+  color: white;
+  border-radius: 0.125rem;
+  padding: 0 0.1rem;
+}
+
+:root.dark .pmv-search-highlight--active {
+  background: hsl(25 95% 53% / 0.95);
+  color: white;
+}
+

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -51,9 +51,6 @@
   top: 0;
   z-index: 10;
   padding: 0 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
 }
 
 @media (max-width: 1024px) {
@@ -1193,6 +1190,10 @@
 
 /* ─── In-page Search Overlay ────────────────────────────────────────── */
 .pmv-search-overlay {
+  position: absolute;
+  top: 0.75rem;
+  right: 1.5rem;
+  z-index: 100;
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -1201,13 +1202,11 @@
   border: 1px solid var(--border);
   background: var(--popover, var(--card));
   color: var(--popover-foreground, var(--foreground));
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12), 0 1px 3px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18), 0 2px 6px rgba(0, 0, 0, 0.08);
   font-family: inherit;
   backdrop-filter: blur(8px);
   animation: pmv-search-fade-in 0.12s ease-out;
   box-sizing: border-box;
-  width: 100%;
-  max-width: 100%;
 }
 
 @keyframes pmv-search-fade-in {
@@ -1225,8 +1224,6 @@
   position: relative;
   display: flex;
   align-items: center;
-  flex: 1 1 auto;
-  min-width: 0;
 }
 
 .pmv-search-icon {
@@ -1239,8 +1236,7 @@
 }
 
 .pmv-search-input {
-  width: 100%;
-  min-width: 0;
+  width: 13rem;
   height: 1.875rem;
   padding: 0.25rem 0.5rem 0.25rem 1.75rem;
   border-radius: 0.375rem;
@@ -1309,6 +1305,20 @@
 .pmv-search-btn svg {
   width: 1rem;
   height: 1rem;
+}
+
+@media (max-width: 640px) {
+  .pmv-search-overlay {
+    top: 0.5rem;
+    right: 0.5rem;
+    left: 0.5rem;
+    max-width: calc(100% - 1rem);
+  }
+  .pmv-search-input {
+    flex: 1 1 auto;
+    width: auto;
+    min-width: 0;
+  }
 }
 
 .pmv-search-highlight {

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css
@@ -51,6 +51,9 @@
   top: 0;
   z-index: 10;
   padding: 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 @media (max-width: 1024px) {
@@ -1188,12 +1191,8 @@
   background: rgba(255, 255, 255, 0.2);
 }
 
-/* ─── In-page Search Overlay (Chromium / Dialog Style) ───────────────── */
+/* ─── In-page Search Overlay ────────────────────────────────────────── */
 .pmv-search-overlay {
-  position: absolute;
-  top: 0.75rem;
-  right: 1.5rem;
-  z-index: 100;
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -1202,10 +1201,13 @@
   border: 1px solid var(--border);
   background: var(--popover, var(--card));
   color: var(--popover-foreground, var(--foreground));
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18), 0 2px 6px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12), 0 1px 3px rgba(0, 0, 0, 0.08);
   font-family: inherit;
   backdrop-filter: blur(8px);
   animation: pmv-search-fade-in 0.12s ease-out;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
 }
 
 @keyframes pmv-search-fade-in {
@@ -1223,6 +1225,8 @@
   position: relative;
   display: flex;
   align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .pmv-search-icon {
@@ -1235,7 +1239,8 @@
 }
 
 .pmv-search-input {
-  width: 13rem;
+  width: 100%;
+  min-width: 0;
   height: 1.875rem;
   padding: 0.25rem 0.5rem 0.25rem 1.75rem;
   border-radius: 0.375rem;
@@ -1260,12 +1265,14 @@
   text-align: center;
   user-select: none;
   font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
 }
 
 .pmv-search-actions {
   display: flex;
   align-items: center;
   gap: 0.25rem;
+  flex-shrink: 0;
 }
 
 .pmv-search-divider {
@@ -1302,20 +1309,6 @@
 .pmv-search-btn svg {
   width: 1rem;
   height: 1rem;
-}
-
-@media (max-width: 640px) {
-  .pmv-search-overlay {
-    top: 0.5rem;
-    right: 0.5rem;
-    left: 0.5rem;
-    max-width: calc(100% - 1rem);
-  }
-  .pmv-search-input {
-    flex: 1 1 auto;
-    width: auto;
-    min-width: 0;
-  }
 }
 
 .pmv-search-highlight {

--- a/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/searchUtils.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/searchUtils.ts
@@ -1,0 +1,74 @@
+export function clearSearchHighlights(root: HTMLElement): void {
+  const highlights = Array.from(root.querySelectorAll<HTMLElement>("mark.pmv-search-highlight"));
+  const parentsToNormalize = new Set<Node>();
+  for (const mark of highlights) {
+    const parent = mark.parentNode;
+    if (!parent) continue;
+    parentsToNormalize.add(parent);
+    while (mark.firstChild) {
+      parent.insertBefore(mark.firstChild, mark);
+    }
+    parent.removeChild(mark);
+  }
+  for (const parent of parentsToNormalize) {
+    parent.normalize();
+  }
+}
+
+export function applySearchHighlights(root: HTMLElement, query: string): HTMLElement[] {
+  clearSearchHighlights(root);
+  if (!query || !query.trim()) {
+    return [];
+  }
+
+  const textNodes: Text[] = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const parent = node.parentElement;
+      if (!parent) return NodeFilter.FILTER_REJECT;
+      if (parent.closest(".pmv-search-overlay, .pmv-popover, .pmv-selection-toolbar, script, style")) {
+        return NodeFilter.FILTER_REJECT;
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+
+  let currentNode = walker.nextNode();
+  while (currentNode) {
+    textNodes.push(currentNode as Text);
+    currentNode = walker.nextNode();
+  }
+
+  const createdMarks: HTMLElement[] = [];
+  const lowerQuery = query.toLowerCase();
+
+  for (const textNode of textNodes) {
+    const text = textNode.nodeValue || "";
+    const lowerText = text.toLowerCase();
+    if (!lowerText.includes(lowerQuery)) continue;
+
+    const fragment = document.createDocumentFragment();
+    let lastIndex = 0;
+    let matchIndex: number;
+
+    while ((matchIndex = lowerText.indexOf(lowerQuery, lastIndex)) !== -1) {
+      if (matchIndex > lastIndex) {
+        fragment.appendChild(document.createTextNode(text.substring(lastIndex, matchIndex)));
+      }
+      const mark = document.createElement("mark");
+      mark.className = "pmv-search-highlight";
+      mark.textContent = text.substring(matchIndex, matchIndex + query.length);
+      fragment.appendChild(mark);
+      createdMarks.push(mark);
+      lastIndex = matchIndex + query.length;
+    }
+
+    if (lastIndex < text.length) {
+      fragment.appendChild(document.createTextNode(text.substring(lastIndex)));
+    }
+
+    textNode.parentNode?.replaceChild(fragment, textNode);
+  }
+
+  return createdMarks;
+}


### PR DESCRIPTION
Fixes #2133

# Summary

## Changes

Implemented an in-page search bar overlay for the `DraftMarkdown` widget accessible via the `Ctrl+F` (or `Cmd+F` on macOS) keyboard shortcut. The search overlay highlights text matches dynamically across the document, supports cycling through occurrences with Next/Previous buttons and Enter/Shift+Enter keys, scrolls matches into view, displays match counts, and clears highlights on close.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx`  -  Added keyboard shortcut listener (`Ctrl+F`/`Cmd+F`), search overlay state management, active match indexing, and scrolling.
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/SearchOverlay.tsx`  -  Created search input overlay component with match count, previous/next controls, and close action.
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/searchUtils.ts`  -  Implemented DOM text node search walker, highlight wrapper creation (`<mark>`), and cleanup functions.
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css`  -  Styled the search overlay and match highlight styles (including active match styling and dark mode support).
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.search.test.tsx`  -  Added unit test suite covering search shortcut, highlighting, cycling, and dismissal.

## Manual Testing

1. Open the Tendril application (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse`).
2. Navigate to any plan in Drafts, Review, or Icebox containing a markdown revision.
3. Press `Ctrl+F` (or `Cmd+F` on macOS) while viewing the document.
4. Verify the search bar overlay opens in the top-right corner with the input auto-focused.
5. Type a search term that exists in the document; verify matches are highlighted with a counter (e.g. "1 of 5").
6. Press `Enter` or click the Next button; verify the active highlight advances and scrolls into view.
7. Press `Escape` or click the Close button; verify the search bar closes and all highlights are removed.

## Fix: Floating Dialog Search Overlay

Updated the search overlay layout so that it renders floating over the document in a top-level relative container rather than as a flex item in the scrollable row. This ensures opening search does not displace or resize the markdown content, and styles the search overlay like a Chromium browser / floating dialog search bar.

### Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx`
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/SearchOverlay.tsx`
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css`
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.search.test.tsx`

## Fix: Position Search Overlay Above TOC

Positioned the search overlay inside the top-right sticky container directly above the TOC/StickyContent instead of using an absolute overlay that collided with the TOC card header. This ensures the search bar is cleanly placed at the top-right of the widget, visually above the TOC, and stays pinned during document scrolling.

### Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx`
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css`
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.search.test.tsx`

## Fix: Render Search Overlay on Top by Z-Axis

Updated the search overlay positioning per reviewer feedback to render floating on top via the z-axis (with absolute positioning and z-index) rather than stacking above the TOC or StickyContent in the DOM layout flow. This prevents the search bar from pushing down or shifting sticky sidebar elements while keeping it floating cleanly in the top-right corner.

### Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.tsx`
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/draft-markdown.css`
- `src/Ivy.Tendril.Widgets/frontend/src/DraftMarkdown/DraftMarkdown.search.test.tsx`





---
## Commits
- 73f321ed Plan 00030: Position search overlay on top by z-axis without shifting layout
- 24309988 Plan 00030: Position search overlay at top of sticky container above TOC
- b0703747 Plan 00030: Position search overlay over markdown view in dialog style without shifting layout
- e02efdce Plan 00030: Implement in-page search functionality with Ctrl+F / Cmd+F in DraftMarkdown

---
Created using [Ivy Tendril](https://ivy.app).