### PR TITLE
[00065] Fix ChatApp File Attachment Uploads by Switching to HTTP Multipart Upload

### DIFF
--- a/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
@@ -325,4 +325,23 @@ public class ChatHistoryServiceTests
                 Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void ChatAttachmentDto_SupportsFileIdAndLocalPath()
+    {
+        var att = new Ivy.Tendril.Widgets.ChatAttachmentDto(
+            Name: "report.pdf",
+            ContentType: "application/pdf",
+            Size: 1024,
+            LocalPath: "/tmp/attachments/report.pdf",
+            FileId: "att-12345"
+        );
+
+        Assert.Equal("report.pdf", att.Name);
+        Assert.Equal("application/pdf", att.ContentType);
+        Assert.Equal(1024, att.Size);
+        Assert.Null(att.Base64Data);
+        Assert.Equal("/tmp/attachments/report.pdf", att.LocalPath);
+        Assert.Equal("att-12345", att.FileId);
+    }
 }

--- a/src/Ivy.Tendril.Widgets/ChatWidget.cs
+++ b/src/Ivy.Tendril.Widgets/ChatWidget.cs
@@ -37,7 +37,8 @@ public record ChatAttachmentDto(
     string ContentType,
     long Size,
     string? Base64Data = null,
-    string? LocalPath = null
+    string? LocalPath = null,
+    string? FileId = null
 );
 
 public record ChatQueuedMessageDto(
@@ -62,6 +63,7 @@ public record ChatWidget : WidgetBase<ChatWidget>
 {
     [Prop] public string? ActiveSessionId { get; init; }
     [Prop] public string? StreamingSessionId { get; init; }
+    [Prop] public string? UploadUrl { get; init; }
     [Prop] public List<ChatSessionDto> Sessions { get; init; } = new();
     [Prop] public List<AgentOptionDto> Agents { get; init; } = new();
     [Prop] public List<ModelOptionDto> Models { get; init; } = new();

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -532,4 +532,147 @@ describe("ChatWidget File Uploads and Attachments", () => {
     expect(sendBtn).toBeDisabled();
     expect(sendBtn).toHaveAttribute("title", "Attachments exceed the 50 MB limit");
   });
+
+  it("uploads files via HTTP multipart POST when uploadUrl is provided and sends metadata without base64", async () => {
+    const handleEvent = vi.fn();
+    let capturedXhr: any = null;
+
+    class MockXMLHttpRequest {
+      open = vi.fn();
+      send = vi.fn();
+      upload = { onprogress: null as any };
+      onload: any = null;
+      onerror: any = null;
+      status = 200;
+      constructor() {
+        capturedXhr = this;
+      }
+    }
+
+    const origXHR = window.XMLHttpRequest;
+    (window as any).XMLHttpRequest = MockXMLHttpRequest;
+
+    try {
+      render(
+        <ChatWidget
+          id="test-chat"
+          activeSessionId="sess-1"
+          uploadUrl="/ivy/upload/conn-1/up-1"
+          events={["OnSendMessage"]}
+          eventHandler={handleEvent}
+        />
+      );
+
+      const textarea = screen.getByPlaceholderText(/Ask/i);
+      const sendBtn = screen.getByRole("button", { name: /Send/i });
+
+      const file = new File(["test-image-content"], "photo.png", { type: "image/png" });
+      fireEvent.paste(textarea, {
+        clipboardData: { files: [file], items: [] },
+        preventDefault: vi.fn(),
+      });
+
+      await waitFor(() => {
+        expect(capturedXhr).not.toBeNull();
+        expect(capturedXhr.open).toHaveBeenCalledWith("POST", "/ivy/upload/conn-1/up-1", true);
+        expect(capturedXhr.send).toHaveBeenCalledWith(expect.any(FormData));
+      });
+
+      // While uploading, send button should be disabled
+      expect(sendBtn).toBeDisabled();
+
+      // Complete the upload
+      capturedXhr.status = 200;
+      capturedXhr.onload();
+
+      await waitFor(() => {
+        expect(sendBtn).not.toBeDisabled();
+      });
+
+      fireEvent.change(textarea, { target: { value: "Look at this photo" } });
+      fireEvent.click(sendBtn);
+
+      expect(handleEvent).toHaveBeenCalledWith(
+        "OnSendMessage",
+        "test-chat",
+        expect.arrayContaining([
+          expect.objectContaining({
+            prompt: "Look at this photo",
+            sessionId: "sess-1",
+            attachments: expect.arrayContaining([
+              expect.objectContaining({
+                name: "photo.png",
+                contentType: "image/png",
+                base64Data: undefined,
+              }),
+            ]),
+          }),
+        ])
+      );
+    } finally {
+      window.XMLHttpRequest = origXHR;
+    }
+  });
+
+  it("displays upload progress and failure state on HTTP upload error", async () => {
+    let capturedXhr: any = null;
+
+    class MockXMLHttpRequest {
+      open = vi.fn();
+      send = vi.fn();
+      upload = { onprogress: null as any };
+      onload: any = null;
+      onerror: any = null;
+      status = 500;
+      constructor() {
+        capturedXhr = this;
+      }
+    }
+
+    const origXHR = window.XMLHttpRequest;
+    (window as any).XMLHttpRequest = MockXMLHttpRequest;
+
+    try {
+      render(
+        <ChatWidget
+          id="test-chat"
+          activeSessionId="sess-1"
+          uploadUrl="/ivy/upload/conn-1/up-1"
+        />
+      );
+
+      const textarea = screen.getByPlaceholderText(/Ask/i);
+      const sendBtn = screen.getByRole("button", { name: /Send/i });
+
+      const file = new File(["sample data"], "data.csv", { type: "text/csv" });
+      fireEvent.paste(textarea, {
+        clipboardData: { files: [file], items: [] },
+        preventDefault: vi.fn(),
+      });
+
+      await waitFor(() => {
+        expect(capturedXhr).not.toBeNull();
+      });
+
+      // Trigger progress
+      capturedXhr.upload.onprogress?.({ lengthComputable: true, loaded: 50, total: 100 });
+
+      await waitFor(() => {
+        expect(screen.getByText("50%")).toBeInTheDocument();
+      });
+
+      // Trigger failure
+      capturedXhr.status = 500;
+      capturedXhr.onload();
+
+      await waitFor(() => {
+        expect(screen.getByText("Failed")).toBeInTheDocument();
+      });
+
+      // Send button remains disabled when there is no text or valid finished attachments
+      expect(sendBtn).toBeDisabled();
+    } finally {
+      window.XMLHttpRequest = origXHR;
+    }
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -178,6 +178,10 @@ export interface ChatAttachmentDto {
   localPath?: string;
   lineCount?: number;
   previewUrl?: string;
+  fileId?: string;
+  uploadProgress?: number;
+  uploadStatus?: "pending" | "uploading" | "finished" | "failed";
+  error?: string;
 }
 
 export interface ChatQueuedMessageDto {
@@ -192,6 +196,7 @@ export interface ChatWidgetProps {
   id: string;
   activeSessionId?: string | null;
   streamingSessionId?: string | null;
+  uploadUrl?: string;
   sessions?: ChatSessionDto[];
   agents?: AgentOptionDto[];
   models?: ModelOptionDto[];
@@ -325,6 +330,7 @@ export function ChatWidget({
   id,
   activeSessionId,
   streamingSessionId: _streamingSessionId,
+  uploadUrl,
   sessions = [],
   agents = [],
   models = [],
@@ -361,6 +367,19 @@ export function ChatWidget({
   const activeSession = sessions.find((s) => s.id === activeSessionId);
   const totalAttachmentSize = attachments.reduce((sum, att) => sum + (att.size || 0), 0);
   const isPayloadOversized = totalAttachmentSize > MAX_PAYLOAD_BYTES;
+  const isUploading = attachments.some((att) => att.uploadStatus === "uploading");
+  const isAnyFailed = attachments.some((att) => att.uploadStatus === "failed");
+  const hasValidAttachments = attachments.some((att) => att.uploadStatus === "finished" || !att.uploadStatus);
+  const isSendDisabled = isPayloadOversized || isUploading || isAnyFailed || (!promptText.trim() && !hasValidAttachments);
+  const sendTitle = isPayloadOversized
+    ? "Attachments exceed the 50 MB limit"
+    : isUploading
+    ? "Files are uploading..."
+    : isAnyFailed
+    ? "Some attachments failed to upload"
+    : isStreaming
+    ? "Queue message"
+    : "Send message";
 
   useEffect(() => {
     if (queuedMessagesProp !== undefined) {
@@ -435,13 +454,23 @@ export function ChatWidget({
   const handleSendMessage = () => {
     const trimmed = promptText.trim();
     if (!trimmed && attachments.length === 0) return;
-    if (isPayloadOversized) return;
+    if (isPayloadOversized || isUploading) return;
 
-    const payload = { prompt: trimmed, attachments, sessionId: activeSessionId };
+    const validAttachments = attachments.filter((att) => att.uploadStatus !== "failed");
+    const payloadAttachments = validAttachments.map((att) => ({
+      name: att.name,
+      contentType: att.contentType,
+      size: att.size,
+      localPath: att.localPath,
+      fileId: att.fileId,
+      base64Data: att.base64Data || undefined,
+    }));
+
+    const payload = { prompt: trimmed, attachments: payloadAttachments, sessionId: activeSessionId };
     if (isStreaming) {
       setQueuedMessages((prev) => [
         ...prev,
-        { id: `q-${Date.now()}-${Math.random()}`, prompt: trimmed, attachments },
+        { id: `q-${Date.now()}-${Math.random()}`, prompt: trimmed, attachments: payloadAttachments },
       ]);
     }
 
@@ -509,6 +538,7 @@ export function ChatWidget({
     if (list.length === 0) return;
 
     const newAttachments: ChatAttachmentDto[] = [];
+    const filesToUpload: { file: File; fileId: string; fileName: string }[] = [];
 
     for (let i = 0; i < list.length; i++) {
       const file = list[i];
@@ -518,6 +548,7 @@ export function ChatWidget({
         file.name && file.name.trim() !== "" && file.name !== "blob"
           ? file.name
           : `file_${Date.now()}_${i}.${ext}`;
+      const fileId = `att-${Date.now()}-${i}-${Math.random().toString(36).substring(2, 9)}`;
 
       let lineCount: number | undefined;
       if (
@@ -557,33 +588,139 @@ export function ChatWidget({
         }
       }
 
-      let base64Data = "";
-      try {
-        if (typeof FileReader !== "undefined") {
-          base64Data = await new Promise<string>((resolve) => {
-            const reader = new FileReader();
-            reader.onload = (evt) => {
-              resolve((evt.target?.result as string) || "");
-            };
-            reader.onerror = () => resolve("");
-            reader.readAsDataURL(file);
-          });
+      if (uploadUrl) {
+        newAttachments.push({
+          name: fileName,
+          contentType: mimeType,
+          size: file.size || 0,
+          lineCount,
+          previewUrl,
+          fileId,
+          uploadStatus: "uploading",
+          uploadProgress: 0,
+        });
+        filesToUpload.push({ file, fileId, fileName });
+      } else {
+        let base64Data = "";
+        try {
+          if (typeof FileReader !== "undefined") {
+            base64Data = await new Promise<string>((resolve) => {
+              const reader = new FileReader();
+              reader.onload = (evt) => {
+                resolve((evt.target?.result as string) || "");
+              };
+              reader.onerror = () => resolve("");
+              reader.readAsDataURL(file);
+            });
+          }
+        } catch {
+          base64Data = "";
         }
-      } catch {
-        base64Data = "";
-      }
 
-      newAttachments.push({
-        name: fileName,
-        contentType: mimeType,
-        size: file.size || 0,
-        base64Data,
-        lineCount,
-        previewUrl,
-      });
+        newAttachments.push({
+          name: fileName,
+          contentType: mimeType,
+          size: file.size || 0,
+          base64Data,
+          lineCount,
+          previewUrl,
+          fileId,
+          uploadStatus: "finished",
+          uploadProgress: 100,
+        });
+      }
     }
 
     setAttachments((prev) => [...prev, ...newAttachments]);
+
+    if (uploadUrl && filesToUpload.length > 0) {
+      for (const { file, fileId, fileName } of filesToUpload) {
+        const formData = new FormData();
+        formData.append("file", file, fileName);
+
+        if (typeof XMLHttpRequest !== "undefined") {
+          const xhr = new XMLHttpRequest();
+          xhr.open("POST", uploadUrl, true);
+
+          if (xhr.upload) {
+            xhr.upload.onprogress = (evt) => {
+              if (evt.lengthComputable) {
+                const percent = Math.round((evt.loaded / evt.total) * 100);
+                setAttachments((prev) =>
+                  prev.map((att) =>
+                    att.fileId === fileId ? { ...att, uploadProgress: percent } : att
+                  )
+                );
+              }
+            };
+          }
+
+          xhr.onload = () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+              setAttachments((prev) =>
+                prev.map((att) =>
+                  att.fileId === fileId
+                    ? { ...att, uploadStatus: "finished", uploadProgress: 100 }
+                    : att
+                )
+              );
+            } else {
+              setAttachments((prev) =>
+                prev.map((att) =>
+                  att.fileId === fileId
+                    ? { ...att, uploadStatus: "failed", error: `Upload failed (status ${xhr.status})` }
+                    : att
+                )
+              );
+            }
+          };
+
+          xhr.onerror = () => {
+            setAttachments((prev) =>
+              prev.map((att) =>
+                att.fileId === fileId
+                  ? { ...att, uploadStatus: "failed", error: "Upload failed: Network error" }
+                  : att
+              )
+            );
+          };
+
+          xhr.send(formData);
+        } else if (typeof fetch !== "undefined") {
+          try {
+            const resp = await fetch(uploadUrl, {
+              method: "POST",
+              body: formData,
+            });
+            if (resp.ok) {
+              setAttachments((prev) =>
+                prev.map((att) =>
+                  att.fileId === fileId
+                    ? { ...att, uploadStatus: "finished", uploadProgress: 100 }
+                    : att
+                )
+              );
+            } else {
+              setAttachments((prev) =>
+                prev.map((att) =>
+                  att.fileId === fileId
+                    ? { ...att, uploadStatus: "failed", error: `Upload failed (status ${resp.status})` }
+                    : att
+                )
+              );
+            }
+          } catch (err) {
+            setAttachments((prev) =>
+              prev.map((att) =>
+                att.fileId === fileId
+                  ? { ...att, uploadStatus: "failed", error: `Upload failed: ${err}` }
+                  : att
+              )
+            );
+          }
+        }
+      }
+    }
   };
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -1023,7 +1160,7 @@ export function ChatWidget({
                   const badge = getFileExtBadge(att.name);
 
                   return (
-                    <div key={idx} className="chat-thumbnail-card" title={att.name}>
+                    <div key={att.fileId || idx} className={`chat-thumbnail-card ${att.uploadStatus === "failed" ? "upload-failed" : ""}`} title={att.name}>
                       {/* Background Preview for images/PDFs */}
                       {(isImage || isPdf) && previewSrc && (
                         <div className="chat-thumbnail-preview-container">
@@ -1033,6 +1170,23 @@ export function ChatWidget({
                             <PdfThumbnail url={previewSrc} />
                           )}
                           <div className="chat-thumbnail-preview-overlay" />
+                        </div>
+                      )}
+
+                      {/* Uploading progress overlay */}
+                      {att.uploadStatus === "uploading" && (
+                        <div className="chat-thumbnail-uploading-overlay">
+                          <div className="chat-thumbnail-progress-bar-container">
+                            <div className="chat-thumbnail-progress-bar" style={{ width: `${att.uploadProgress ?? 0}%` }} />
+                          </div>
+                          <span className="chat-thumbnail-progress-text">{att.uploadProgress ?? 0}%</span>
+                        </div>
+                      )}
+
+                      {/* Failed badge */}
+                      {att.uploadStatus === "failed" && (
+                        <div className="chat-thumbnail-failed-badge" title={att.error || "Upload failed"}>
+                          Failed
                         </div>
                       )}
 
@@ -1137,9 +1291,9 @@ export function ChatWidget({
                     <button
                       type="button"
                       className="chat-send-btn"
-                      disabled={isPayloadOversized || (!promptText.trim() && attachments.length === 0)}
+                      disabled={isSendDisabled}
                       onClick={handleSendMessage}
-                      title={isPayloadOversized ? "Attachments exceed the 50 MB limit" : "Queue message"}
+                      title={sendTitle}
                     >
                       <span>Queue</span>
                       <kbd className="chat-shortcut-hint">↵</kbd>
@@ -1149,9 +1303,9 @@ export function ChatWidget({
                   <button
                     type="button"
                     className="chat-send-btn"
-                    disabled={isPayloadOversized || (!promptText.trim() && attachments.length === 0)}
+                    disabled={isSendDisabled}
                     onClick={handleSendMessage}
-                    title={isPayloadOversized ? "Attachments exceed the 50 MB limit" : "Send message"}
+                    title={sendTitle}
                   >
                     <span>Send</span>
                     <kbd className="chat-shortcut-hint">↵</kbd>

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -687,6 +687,56 @@
   width: fit-content;
 }
 
+.chat-thumbnail-card.upload-failed {
+  border-color: var(--destructive, #ef4444);
+}
+
+.chat-thumbnail-uploading-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 15;
+  border-radius: var(--radius, 8px);
+  gap: 4px;
+}
+
+.chat-thumbnail-progress-bar-container {
+  width: 80%;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.chat-thumbnail-progress-bar {
+  height: 100%;
+  background: var(--primary, #3b82f6);
+  transition: width 0.15s ease;
+}
+
+.chat-thumbnail-progress-text {
+  font-size: 0.65rem;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.chat-thumbnail-failed-badge {
+  position: absolute;
+  bottom: 6px;
+  left: 6px;
+  background: var(--destructive, #ef4444);
+  color: #ffffff;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  z-index: 15;
+}
+
 /* User Message Attachments */
 .chat-user-message-body {
   display: flex;

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -192,7 +192,10 @@ public class ChatApp : ViewBase
                     {
                         var rawName = Path.GetFileName(att.Name);
                         var fileName = !string.IsNullOrWhiteSpace(rawName) ? rawName : $"file_{Guid.NewGuid():N}.bin";
-                        var filePath = Path.Combine(attachDir, fileName);
+                        var filePath = !string.IsNullOrWhiteSpace(att.LocalPath) && File.Exists(att.LocalPath)
+                            ? att.LocalPath
+                            : Path.Combine(attachDir, fileName);
+
                         if (!string.IsNullOrEmpty(att.Base64Data))
                         {
                             var base64 = att.Base64Data.Contains(",")
@@ -201,7 +204,15 @@ public class ChatApp : ViewBase
                             var bytes = Convert.FromBase64String(base64);
                             File.WriteAllBytes(filePath, bytes);
                         }
-                        attachedFilePaths.Add(filePath);
+
+                        if (File.Exists(filePath))
+                        {
+                            attachedFilePaths.Add(filePath);
+                        }
+                        else
+                        {
+                            attachmentErrors.Add($"Attachment '{att.Name}' was not found at {filePath}");
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Ivy;
@@ -36,7 +37,19 @@ public class ContentView(
 {
     public override object Build()
     {
+        var configService = UseService<IConfigService>();
         var deletingSessionId = UseState<string?>(null);
+
+        var upload = UseUpload(async (fileUpload, stream, ct) =>
+        {
+            var attachDir = Path.Combine(configService.TendrilHome, "Attachments", activeSessionId.Value ?? "temp");
+            Directory.CreateDirectory(attachDir);
+            var rawName = Path.GetFileName(fileUpload.FileName);
+            var safeFileName = string.IsNullOrWhiteSpace(rawName) ? $"file_{Guid.NewGuid():N}.bin" : rawName;
+            var filePath = Path.Combine(attachDir, safeFileName);
+            await using var fileStream = File.Create(filePath);
+            await stream.CopyToAsync(fileStream, ct);
+        });
 
         if (activeSession == null)
         {
@@ -81,6 +94,7 @@ public class ContentView(
         {
             ActiveSessionId = activeSessionId.Value,
             StreamingSessionId = streamingSessionId.Value,
+            UploadUrl = upload.Value.UploadUrl,
             Sessions = sessionDtos,
             Agents = agentDtos,
             Models = modelDtos,


### PR DESCRIPTION
# Summary

## Changes

Switched ChatApp and ChatWidget file and image attachment uploads from base64 WebSocket transfer to direct HTTP multipart POST uploads using Ivy's `UseUpload` hook. This eliminates SignalR `InvalidDataException` disconnects caused by the 1 MB WebSocket payload limit when attaching large screenshots, images, or documents, while providing upload progress tracking and instant blob previews.

## API Changes

- Added `[Prop] public string? UploadUrl { get; init; }` to `ChatWidget`.
- Updated `ChatAttachmentDto` with optional `string? FileId = null` property.
- Added `uploadUrl?: string` to `ChatWidgetProps` in TypeScript.
- Added `fileId?: string`, `uploadProgress?: number`, `uploadStatus?: 'pending' | 'uploading' | 'finished' | 'failed'`, and `error?: string` to `ChatAttachmentDto` in TypeScript.

## Files Modified

- `src/Ivy.Tendril.Widgets/ChatWidget.cs`: Added `UploadUrl` prop to `ChatWidget` and `FileId` to `ChatAttachmentDto`.
- `src/Ivy.Tendril/Apps/Chat/ContentView.cs`: Registered Ivy `UseUpload` hook to handle multipart uploads into session attachment directories and passed `UploadUrl` to `ChatWidget`.
- `src/Ivy.Tendril/Apps/Chat/ChatApp.cs`: Updated `ExecuteSendMessage` to resolve files from session attachment directories with backwards compatibility for `LocalPath` and `Base64Data`.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx`: Implemented HTTP multipart upload with progress tracking and omission of base64 data in `OnSendMessage`.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css`: Added styles for upload progress bar overlay and upload failure badge.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx`: Added unit tests for HTTP multipart uploads and failure handling.
- `src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs`: Added unit tests for `ChatAttachmentDto` model.

## Manual Testing

1. Launch the Tendril desktop application (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse`).
2. Navigate to the Chat app from the sidebar.
3. Paste or drag-and-drop a large image (e.g. 2 MB to 10 MB screenshot or photo).
4. Observe the upload progress indicator in the attachment preview card completing quickly without WebSocket errors.
5. Send the message and verify the agent receives the prompt with the attached file path and replies without disconnecting.

---
## Commits
- d1b8db11 Plan 00065: Implement HTTP multipart upload in ChatWidget with progress tracking
- fb8cfa38 Plan 00065: Add UseUpload hook and HTTP multipart attachment handling for ChatApp

---
Created using [Ivy Tendril](https://ivy.app).