### PR TITLE
[00045] Use Code Input for Project Memory Markdown Content

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Settings/MarkdownFieldBuildersTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Settings/MarkdownFieldBuildersTests.cs
@@ -1,0 +1,52 @@
+using Ivy.Core.Hooks;
+using Ivy.Tendril.Apps.Settings;
+
+namespace Ivy.Tendril.Test.Apps.Settings;
+
+public class MarkdownFieldBuildersTests
+{
+    [Fact]
+    public void BuildProjectMemoryContentField_ProducesCodeInputWithMarkdownLanguage()
+    {
+        var content = new State<string>("# content");
+
+        var field = MarkdownFieldBuilders.BuildProjectMemoryContentField(content);
+
+        Assert.Single(field.Children);
+        var codeInput = Assert.IsType<CodeInputBase>(field.Children.Single());
+        Assert.Equal(Languages.Markdown, codeInput.Language);
+        Assert.Equal("Content (Markdown)", field.Label);
+        Assert.True(field.Required);
+        Assert.Equal("Markdown memory content (e.g. tech stack, rules, architectural conventions)...", codeInput.Placeholder);
+    }
+
+    [Fact]
+    public void BuildSkillInstructionsField_ProducesCodeInputWithMarkdownLanguage()
+    {
+        var instructions = new State<string>("# instructions");
+
+        var field = MarkdownFieldBuilders.BuildSkillInstructionsField(instructions);
+
+        Assert.Single(field.Children);
+        var codeInput = Assert.IsType<CodeInputBase>(field.Children.Single());
+        Assert.Equal(Languages.Markdown, codeInput.Language);
+        Assert.Equal("Inline Instructions", field.Label);
+        Assert.False(field.Required);
+        Assert.Equal("Instructions / markdown rules...", codeInput.Placeholder);
+    }
+
+    [Fact]
+    public void BuildProjectContextField_ProducesCodeInputWithMarkdownLanguage()
+    {
+        var context = new State<string>("# context");
+
+        var field = MarkdownFieldBuilders.BuildProjectContextField(context);
+
+        Assert.Single(field.Children);
+        var codeInput = Assert.IsType<CodeInputBase>(field.Children.Single());
+        Assert.Equal(Languages.Markdown, codeInput.Language);
+        Assert.Equal("Context / Prompt", field.Label);
+        Assert.False(field.Required);
+        Assert.Equal("Project context or prompt for AI agents...", codeInput.Placeholder);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectBladeView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectBladeView.cs
@@ -143,7 +143,7 @@ public class EditProjectBladeView(
                 | Text.Block("Configure the project's name, color, and AI context.").Muted().Small()
                 | editName.ToTextInput("Project name...").Invalid(nameError).WithField().Label("Name")
                 | editColor.ToColorInput().Variant(ColorInputVariant.SwatchPicker).Nullable().WithField().Label("Color")
-                | editContext.ToTextareaInput("Project context or prompt for AI agents...").Rows(4).WithField().Label("Context / Prompt")
+                | MarkdownFieldBuilders.BuildProjectContextField(editContext)
             ),
             new Tab("Repositories",
                 Layout.Vertical()

--- a/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectMemoryBladeView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/EditProjectMemoryBladeView.cs
@@ -32,7 +32,7 @@ public class EditProjectMemoryBladeView(
 
         return Layout.Vertical()
             | editFileName.ToTextInput("Memory filename (e.g. stack.md, conventions.md)...").WithField().Label("Filename").Required()
-            | editContent.ToTextareaInput("Markdown memory content (e.g. tech stack, rules, architectural conventions)...").Rows(8).WithField().Label("Content (Markdown)").Required()
+            | MarkdownFieldBuilders.BuildProjectMemoryContentField(editContent)
             | Layout.Horizontal()
                 | new Button("Cancel").Outline().OnClick(() => bladeContext.Pop(this))
                 | new Button(isNew ? "Add" : "Save").Primary().OnClick(() =>

--- a/src/Ivy.Tendril/Apps/Settings/Blades/EditSkillBladeView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/EditSkillBladeView.cs
@@ -32,7 +32,7 @@ public class EditSkillBladeView(
         return Layout.Vertical()
             | editName.ToTextInput("Skill name (e.g. code-review)...").WithField().Label("Name").Required()
             | editDescription.ToTextInput("Short description...").WithField().Label("Description")
-            | editInstructions.ToTextareaInput("Instructions / markdown rules...").Rows(5).WithField().Label("Inline Instructions")
+            | MarkdownFieldBuilders.BuildSkillInstructionsField(editInstructions)
             | editPath.ToTextInput("Path to skill folder/file (e.g. %TENDRIL_HOME%/Skills/my-skill)...").WithField().Label("File/Folder Path")
             | Layout.Horizontal()
                 | new Button("Cancel").Outline().OnClick(() => bladeContext.Pop(this))

--- a/src/Ivy.Tendril/Apps/Settings/MarkdownFieldBuilders.cs
+++ b/src/Ivy.Tendril/Apps/Settings/MarkdownFieldBuilders.cs
@@ -1,0 +1,29 @@
+namespace Ivy.Tendril.Apps.Settings;
+
+/// <summary>
+/// Shared markdown field builders for project settings editors (memory, skills, context).
+/// Single source for sheet/blade pairs so duplicate implementations cannot drift.
+/// </summary>
+public static class MarkdownFieldBuilders
+{
+    public static Field BuildProjectMemoryContentField(IState<string> content) =>
+        content.ToCodeInput("Markdown memory content (e.g. tech stack, rules, architectural conventions)...")
+            .Language(Languages.Markdown)
+            .Height(Size.Units(80))
+            .Width(Size.Full())
+            .WithField().Label("Content (Markdown)").Required();
+
+    public static Field BuildSkillInstructionsField(IState<string> instructions) =>
+        instructions.ToCodeInput("Instructions / markdown rules...")
+            .Language(Languages.Markdown)
+            .Height(Size.Units(50))
+            .Width(Size.Full())
+            .WithField().Label("Inline Instructions");
+
+    public static Field BuildProjectContextField(IState<string> context) =>
+        context.ToCodeInput("Project context or prompt for AI agents...")
+            .Language(Languages.Markdown)
+            .Height(Size.Units(50))
+            .Width(Size.Full())
+            .WithField().Label("Context / Prompt");
+}

--- a/src/Ivy.Tendril/Apps/Settings/Sheets/EditProjectMemorySheet.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Sheets/EditProjectMemorySheet.cs
@@ -32,7 +32,7 @@ public class EditProjectMemorySheet(
 
         var sheetContent = Layout.Vertical()
             | editFileName.ToTextInput("Memory filename (e.g. stack.md, conventions.md)...").WithField().Label("Filename").Required()
-            | editContent.ToTextareaInput("Markdown memory content (e.g. tech stack, rules, architectural conventions)...").Rows(8).WithField().Label("Content (Markdown)").Required()
+            | MarkdownFieldBuilders.BuildProjectMemoryContentField(editContent)
             | (Layout.Horizontal().AlignContent(Align.Right)
                | new Button("Cancel").Outline().OnClick(() => isOpen.Set(false))
                | new Button(isNew ? "Add" : "Save").Primary().OnClick(() =>

--- a/src/Ivy.Tendril/Apps/Settings/Sheets/EditSkillSheet.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Sheets/EditSkillSheet.cs
@@ -33,7 +33,7 @@ public class EditSkillSheet(
         var sheetContent = Layout.Vertical()
             | editName.ToTextInput("Skill name (e.g. code-review)...").WithField().Label("Name").Required()
             | editDescription.ToTextInput("Short description...").WithField().Label("Description")
-            | editInstructions.ToTextareaInput("Instructions / markdown rules...").Rows(5).WithField().Label("Inline Instructions")
+            | MarkdownFieldBuilders.BuildSkillInstructionsField(editInstructions)
             | editPath.ToTextInput("Path to skill folder/file (e.g. %TENDRIL_HOME%/Skills/my-skill)...").WithField().Label("File/Folder Path")
             | (Layout.Horizontal().AlignContent(Align.Right)
                | new Button("Cancel").Outline().OnClick(() => isOpen.Set(false))


### PR DESCRIPTION
# Summary

## Changes

Replaced plain textareas with markdown `CodeInput` fields in project settings to enable syntax highlighting and monospace fonts for markdown content editing. Created a shared `MarkdownFieldBuilders` class to prevent duplicate implementations from drifting between sheet and blade view pairs.

## API Changes

**New class:**
- `MarkdownFieldBuilders` (static) with three field builder methods:
  - `BuildProjectMemoryContentField(IState<string> content)`
  - `BuildSkillInstructionsField(IState<string> instructions)`
  - `BuildProjectContextField(IState<string> context)`

**Modified views:**
- `EditProjectMemorySheet` - now uses `CodeInput` instead of textarea
- `EditProjectMemoryBladeView` - now uses `CodeInput` instead of textarea
- `EditSkillSheet` - now uses `CodeInput` instead of textarea
- `EditSkillBladeView` - now uses `CodeInput` instead of textarea
- `EditProjectBladeView` - now uses `CodeInput` instead of textarea (Basic tab)

## Files Modified

**Implementation:**
- `src/Ivy.Tendril/Apps/Settings/MarkdownFieldBuilders.cs` (new)
- `src/Ivy.Tendril/Apps/Settings/Sheets/EditProjectMemorySheet.cs`
- `src/Ivy.Tendril/Apps/Settings/Blades/EditProjectMemoryBladeView.cs`
- `src/Ivy.Tendril/Apps/Settings/Sheets/EditSkillSheet.cs`
- `src/Ivy.Tendril/Apps/Settings/Blades/EditSkillBladeView.cs`
- `src/Ivy.Tendril/Apps/Settings/Blades/EditProjectBladeView.cs`

**Tests:**
- `src/Ivy.Tendril.Test/Apps/Settings/MarkdownFieldBuildersTests.cs` (new)

## Manual Testing

1. Run Tendril with beta features enabled (project memories and custom skills require beta mode)
2. Navigate to Settings → Projects → pick a project → Customizations → Project Memories → Add Project Memory
3. Verify the "Content (Markdown)" field is a code editor with syntax highlighting, monospace font, and larger height (80 units)
4. Navigate to Settings → Projects → pick a project → Customizations → Custom Skills → Add Custom Skill
5. Verify the "Inline Instructions" field is a code editor with syntax highlighting and medium height (50 units)
6. Navigate to Settings → Projects → pick a project → Basic tab → Context / Prompt field
7. Verify the field is a code editor with syntax highlighting and medium height (50 units)
8. Test entering markdown content with headers, lists, and code blocks to confirm syntax highlighting works
9. Save and reload each form to verify content persists correctly

---

## Commits

- 923f4e92 Replace markdown textareas with CodeInput fields in project settings
- 1afbecb3 Fix missing GetActivityStats interface implementation in test fakes
- bd25fa1b Replace markdown textareas with CodeInput fields in project settings
- 199c31d3 Fix test assertions to use IsAssignableFrom instead of IsType

---
Created using [Ivy Tendril](https://ivy.app).
