### PR TITLE
[00011] Configure Codex Permissions and Sandbox Policies for Worktree Execution

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexCliTests.cs
@@ -194,7 +194,9 @@ public class CodexCliTests
         Assert.Equal("codex", spec.FileName);
         Assert.Contains("exec", spec.Arguments);
         Assert.Contains("--sandbox", spec.Arguments);
-        Assert.Contains("workspace-write", spec.Arguments);
+        Assert.Contains("danger-full-access", spec.Arguments);
+        Assert.Contains("--ask-for-approval", spec.Arguments);
+        Assert.Contains("never", spec.Arguments);
         Assert.Contains("--json", spec.Arguments);
         Assert.Contains("--skip-git-repo-check", spec.Arguments);
         Assert.Contains("-", spec.Arguments);
@@ -204,12 +206,98 @@ public class CodexCliTests
     }
 
     [Fact]
+    public void BuildProcessSpec_PermissionMode_FullAuto_SetsCorrectSandboxAndPermissions()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+            PermissionMode = PermissionMode.FullAuto,
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        var argList = spec.Arguments.ToList();
+        var sandboxIdx = argList.IndexOf("--sandbox");
+        Assert.True(sandboxIdx >= 0);
+        Assert.Equal("danger-full-access", argList[sandboxIdx + 1]);
+
+        var approvalIdx = argList.IndexOf("--ask-for-approval");
+        Assert.True(approvalIdx >= 0);
+        Assert.Equal("never", argList[approvalIdx + 1]);
+    }
+
+    [Fact]
+    public void BuildProcessSpec_PermissionMode_AcceptEdits_SetsWorkspaceWriteWithDiskPermissions()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+            PermissionMode = PermissionMode.AcceptEdits,
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        var argList = spec.Arguments.ToList();
+        var sandboxIdx = argList.IndexOf("--sandbox");
+        Assert.True(sandboxIdx >= 0);
+        Assert.Equal("workspace-write", argList[sandboxIdx + 1]);
+
+        Assert.Contains("sandbox_workspace_write.network_access=true", argList);
+        Assert.Contains("sandbox_permissions=[\"disk-full-read-access\"]", argList);
+
+        var approvalIdx = argList.IndexOf("--ask-for-approval");
+        Assert.True(approvalIdx >= 0);
+        Assert.Equal("never", argList[approvalIdx + 1]);
+    }
+
+    [Fact]
+    public void BuildProcessSpec_PermissionMode_Plan_SetsReadOnlySandbox()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+            PermissionMode = PermissionMode.Plan,
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        var argList = spec.Arguments.ToList();
+        var sandboxIdx = argList.IndexOf("--sandbox");
+        Assert.True(sandboxIdx >= 0);
+        Assert.Equal("read-only", argList[sandboxIdx + 1]);
+    }
+
+    [Fact]
+    public void BuildProcessSpec_PermissionMode_Default_SetsWorkspaceWrite()
+    {
+        var config = new AgentLaunchConfig
+        {
+            Prompt = "test",
+            WorkingDirectory = "/tmp",
+            PermissionMode = PermissionMode.Default,
+        };
+
+        var spec = _cli.BuildProcessSpec(config);
+
+        var argList = spec.Arguments.ToList();
+        var sandboxIdx = argList.IndexOf("--sandbox");
+        Assert.True(sandboxIdx >= 0);
+        Assert.Equal("workspace-write", argList[sandboxIdx + 1]);
+
+        Assert.Contains("sandbox_workspace_write.network_access=true", argList);
+    }
+
+    [Fact]
     public void BuildProcessSpec_EnablesNetworkAccessInWorkspaceWriteSandbox()
     {
         var config = new AgentLaunchConfig
         {
             Prompt = "Hello",
             WorkingDirectory = "/tmp",
+            PermissionMode = PermissionMode.Default,
         };
 
         var spec = _cli.BuildProcessSpec(config);

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexCli.cs
@@ -64,14 +64,44 @@ public sealed class CodexCli : IAgentCli
 
     public AgentProcessSpec BuildProcessSpec(AgentLaunchConfig config)
     {
-        var args = new List<string>
+        var args = new List<string> { "exec" };
+
+        switch (config.PermissionMode)
         {
-            "exec",
-            "--sandbox", "workspace-write",
-            "-c", "sandbox_workspace_write.network_access=true",
-            "--json",
-            "--skip-git-repo-check",
-        };
+            case PermissionMode.FullAuto:
+                args.Add("--sandbox");
+                args.Add("danger-full-access");
+                args.Add("--ask-for-approval");
+                args.Add("never");
+                break;
+
+            case PermissionMode.AcceptEdits:
+                args.Add("--sandbox");
+                args.Add("workspace-write");
+                args.Add("-c");
+                args.Add("sandbox_workspace_write.network_access=true");
+                args.Add("-c");
+                args.Add("sandbox_permissions=[\"disk-full-read-access\"]");
+                args.Add("--ask-for-approval");
+                args.Add("never");
+                break;
+
+            case PermissionMode.Plan:
+                args.Add("--sandbox");
+                args.Add("read-only");
+                break;
+
+            case PermissionMode.Default:
+            default:
+                args.Add("--sandbox");
+                args.Add("workspace-write");
+                args.Add("-c");
+                args.Add("sandbox_workspace_write.network_access=true");
+                break;
+        }
+
+        args.Add("--json");
+        args.Add("--skip-git-repo-check");
 
         if (!string.IsNullOrEmpty(config.Model))
         {


### PR DESCRIPTION
Fixes #2264

# Summary

## Changes

Updated `CodexCli.BuildProcessSpec` to configure sandbox policies and approval modes based on `AgentLaunchConfig.PermissionMode`. For automated execution modes like `FullAuto` and `AcceptEdits`, Codex is configured with appropriate sandbox options, disk read/write permissions, and `--ask-for-approval never` to allow autonomous worktree operations without hanging on interactive confirmations.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Agents/Providers/Codex/CodexCli.cs`: Mapped `PermissionMode` to Codex CLI sandbox and approval options.
- `src/Ivy.Tendril.Agents.Test/Codex/CodexCliTests.cs`: Added unit test coverage for `FullAuto`, `AcceptEdits`, `Plan`, and `Default` permission modes.

## Manual Testing

N/A: Internal agent process configuration change covered by unit tests in `CodexCliTests`.

---
- 759421ec Configure Codex permissions and sandbox policies for worktree execution (Plan 00011)

---
Created using [Ivy Tendril](https://ivy.app).
