### PR TITLE
[00007] Fix Search Icon Flicker When Switching Views

### DIFF
--- a/src/Ivy.Tendril.Test/AppShell/TendrilAppShellSidebarTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/TendrilAppShellSidebarTests.cs
@@ -1,0 +1,27 @@
+using static Ivy.Tendril.AppShell.TendrilAppShell;
+
+namespace Ivy.Tendril.Test.AppShell;
+
+public class TendrilAppShellSidebarTests
+{
+    [Theory]
+    [InlineData("plans", true)]
+    [InlineData("drafts", true)]
+    [InlineData("review", true)]
+    [InlineData("recommendations", true)]
+    [InlineData("PLANS", true)]
+    [InlineData("Review", true)]
+    [InlineData("RECOMMENDATIONS", true)]
+    [InlineData("settings", false)]
+    [InlineData("jobs", false)]
+    [InlineData("icebox", false)]
+    [InlineData("agent", false)]
+    [InlineData("$setup", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void HasSidebarSection_ReturnsExpectedValue(string? appId, bool expected)
+    {
+        var result = HasSidebarSection(appId);
+        Assert.Equal(expected, result);
+    }
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { ShellSidebarSection } from "./ShellSidebarSection";
+import { ShellContext } from "./ShellContext";
+import { ShellSectionItemDto } from "./types";
+
+const mockItems: ShellSectionItemDto[] = [
+  { id: "00001-PlanA", title: "Plan A", tag: "#1" },
+  { id: "00002-PlanB", title: "Plan B", tag: "#2" },
+];
+
+describe("ShellSidebarSection", () => {
+  it("renders the section header, title, and search button when searchable", () => {
+    const onSearch = vi.fn();
+    render(
+      <ShellSidebarSection
+        id="sec-1"
+        title="Plans"
+        items={mockItems}
+        searchable={true}
+        events={["OnSearch", "OnSelectItem"]}
+        eventHandler={onSearch}
+      />,
+    );
+
+    expect(screen.getByText("Plans")).toBeInTheDocument();
+    const searchBtn = screen.getByRole("button", { name: /search plans/i });
+    expect(searchBtn).toBeInTheDocument();
+
+    fireEvent.click(searchBtn);
+    expect(onSearch).toHaveBeenCalledWith("OnSearch", "sec-1", []);
+  });
+
+  it("emits OnSelectItem when an item is clicked", () => {
+    const eventHandler = vi.fn();
+    render(
+      <ShellSidebarSection
+        id="sec-1"
+        title="Plans"
+        items={mockItems}
+        searchable={true}
+        events={["OnSelectItem"]}
+        eventHandler={eventHandler}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Plan A"));
+    expect(eventHandler).toHaveBeenCalledWith("OnSelectItem", "sec-1", ["00001-PlanA"]);
+  });
+
+  it("retains search button when props update between different views", () => {
+    const { rerender } = render(
+      <ShellSidebarSection
+        id="sec-1"
+        title="Plans"
+        items={mockItems}
+        searchable={true}
+        events={["OnSearch"]}
+        eventHandler={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /search plans/i })).toBeInTheDocument();
+    expect(screen.getByText("Plans")).toBeInTheDocument();
+
+    const reviewItems: ShellSectionItemDto[] = [
+      { id: "00003-PlanC", title: "Plan C", tag: "#3" },
+    ];
+
+    rerender(
+      <ShellSidebarSection
+        id="sec-1"
+        title="Review"
+        items={reviewItems}
+        searchable={true}
+        events={["OnSearch"]}
+        eventHandler={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /search plans/i })).toBeInTheDocument();
+    expect(screen.getByText("Review")).toBeInTheDocument();
+    expect(screen.getByText("Plan C")).toBeInTheDocument();
+  });
+
+  it("renders collapsed rail view with search button", () => {
+    const onSearch = vi.fn();
+    render(
+      <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
+        <ShellSidebarSection
+          id="sec-1"
+          title="Plans"
+          items={mockItems}
+          searchable={true}
+          events={["OnSearch"]}
+          eventHandler={onSearch}
+        />
+      </ShellContext.Provider>,
+    );
+
+    const railSearchBtn = screen.getByRole("button", { name: /search plans/i });
+    expect(railSearchBtn).toBeInTheDocument();
+    expect(railSearchBtn).toHaveClass("tsh-rail-search");
+
+    fireEvent.click(railSearchBtn);
+    expect(onSearch).toHaveBeenCalledWith("OnSearch", "sec-1", []);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
@@ -760,6 +760,7 @@
   justify-content: space-between;
   padding: 0 12px;
   flex-shrink: 0;
+  min-height: 20px;
 }
 
 .tsh-section-title {

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -120,6 +120,14 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
     // The Agent app id (and its menu-item Tag) collapses to "agent" via AppHelpers.GetApp.
     private const string AgentAppId = "agent";
 
+    private static readonly HashSet<string> SidebarSectionAppIds = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "review", "plans", "drafts", "recommendations"
+    };
+
+    internal static bool HasSidebarSection(string? appId) =>
+        appId != null && SidebarSectionAppIds.Contains(appId);
+
     private static readonly HashSet<string> ShareAllowedAppIds = new(StringComparer.OrdinalIgnoreCase)
     {
         "review", "plans"
@@ -459,10 +467,12 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             currentApp.Set(appHost);
             selectedIndex.Set((int?)null);
 
-            // The sidebar section belongs to the page app; drop it when the page changes so a
-            // stale list never shows while the next app publishes its own.
+            // The sidebar section belongs to the page app; drop it when the page changes to an
+            // app without a sidebar list. Retain it when transitioning between apps that both
+            // display sidebar sections so the header and search button do not flicker.
             if (sidebarList.Value is { } list &&
-                !string.Equals(list.AppId, effectiveAppId, StringComparison.OrdinalIgnoreCase))
+                !string.Equals(list.AppId, effectiveAppId, StringComparison.OrdinalIgnoreCase) &&
+                !HasSidebarSection(effectiveAppId))
                 sidebarList.Set((ShellSidebarListState?)null);
 
             if (effectiveAppId != null) SetAppTitle(effectiveAppId);
@@ -696,7 +706,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
         object? section = null;
         if (sidebarList.Value is { } list &&
-            string.Equals(list.AppId, currentApp.Value?.AppId, StringComparison.OrdinalIgnoreCase))
+            (string.Equals(list.AppId, currentApp.Value?.AppId, StringComparison.OrdinalIgnoreCase) ||
+             HasSidebarSection(currentApp.Value?.AppId)))
         {
             var capturedList = list;
             section = new ShellSidebarSection()


### PR DESCRIPTION
Fixes #2246

# Summary

## Changes

Fixed search icon and sidebar header flicker when switching between sidebar views (such as Plans, Review, and Recommendations). Retained sidebar list state across transitions between compatible sidebar apps in `TendrilAppShell` so `ShellSidebarSection` stays mounted, and established stable header dimensions in CSS.

## API Changes

None.

## Files Modified

- Backend:
  - `src/Ivy.Tendril/AppShell/TendrilAppShell.cs`: Retained sidebar section and list state during transitions between apps that display sidebar lists.
  - `src/Ivy.Tendril.Test/AppShell/TendrilAppShellSidebarTests.cs`: Added unit tests for sidebar section detection.
- Frontend:
  - `src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css`: Added min-height to `.tsh-section-header` for stable layout dimensions.
  - `src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx`: Added unit tests for `ShellSidebarSection` rendering and search button persistence.

## Manual Testing

1. Launch the Tendril desktop app or web interface.
2. Navigate between the "Plans" and "Review" views by clicking the respective sidebar nav items.
3. Observe the search icon and header area under the nav items.
4. Verify that the search icon and header remain smoothly mounted with zero layout flicker or jumping when toggling between views.

---
- c140e67f Fix search icon flicker when switching views (Plan 00007)

---
Created using [Ivy Tendril](https://ivy.app).
