### PR TITLE
[00009] Add Support for Gemini 3.8 Flash Model

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityModelCatalogTests.cs
@@ -42,6 +42,7 @@ public class AntigravityModelCatalogTests
     }
 
     [Theory]
+    [InlineData("gemini-3.8-flash")]
     [InlineData("gemini-3.7-flash")]
     [InlineData("gemini-3.6-flash")]
     [InlineData("gemini-3.1-pro")]
@@ -56,6 +57,18 @@ public class AntigravityModelCatalogTests
     {
         var models = _catalog.GetStaticModels();
         Assert.Contains(models, m => m.Id == expectedId);
+    }
+
+    [Fact]
+    public void GetStaticModels_ContainsGemini38Flash()
+    {
+        var models = _catalog.GetStaticModels();
+        var flash = models.FirstOrDefault(m => m.Id == "gemini-3.8-flash");
+        Assert.NotNull(flash);
+        Assert.Equal("Gemini 3.8 Flash", flash!.DisplayName);
+        Assert.Equal("google", flash.Provider);
+        Assert.Equal(0.15m, flash.InputPerMillion);
+        Assert.Equal(0.60m, flash.OutputPerMillion);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Gemini/GeminiModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Gemini/GeminiModelCatalogTests.cs
@@ -21,6 +21,16 @@ public class GeminiModelCatalogTests
     }
 
     [Fact]
+    public void GetStaticModels_ContainsGemini38Flash()
+    {
+        var models = _catalog.GetStaticModels();
+        var flash = models.FirstOrDefault(m => m.Id == "gemini-3.8-flash");
+        Assert.NotNull(flash);
+        Assert.Equal("Gemini 3.8 Flash", flash!.DisplayName);
+        Assert.Equal("google", flash.Provider);
+    }
+
+    [Fact]
     public void GetStaticModels_ContainsGemini37Flash()
     {
         var models = _catalog.GetStaticModels();

--- a/src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs
@@ -7,6 +7,27 @@ namespace Ivy.Tendril.Agents.Test.Helpers;
 public sealed class ModelProfileSelectorTests
 {
     [Fact]
+    public void SelectDefaults_IvyProxy_PicksOpus5Deep_Gemini38Balanced_GeminiQuick()
+    {
+        var models = new List<ModelInfo>
+        {
+            new() { Id = "claude-opus-4", DisplayName = "Claude Opus 4" },
+            new() { Id = "claude-opus-5", DisplayName = "Claude Opus 5" },
+            new() { Id = "claude-sonnet-5", DisplayName = "Claude Sonnet 5" },
+            new() { Id = "gemini-2.5-flash-lite", DisplayName = "Gemini 2.5 Flash Lite" },
+            new() { Id = "gemini-3.8-flash", DisplayName = "Gemini 3.8 Flash" },
+            new() { Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash" },
+            new() { Id = "gemini-3.6-flash", DisplayName = "Gemini 3.6 Flash" },
+        };
+
+        var (deep, balanced, quick) = ModelProfileSelector.SelectDefaults(models, isIvy: true);
+
+        Assert.Equal("claude-opus-5", deep);
+        Assert.Equal("gemini-3.8-flash", balanced);
+        Assert.Equal("gemini-3.8-flash", quick);
+    }
+
+    [Fact]
     public void SelectDefaults_IvyProxy_PicksOpus5Deep_Gemini37Balanced_GeminiQuick()
     {
         var models = new List<ModelInfo>
@@ -127,8 +148,8 @@ public sealed class ModelProfileSelectorTests
     {
         var (deepIvy, balancedIvy, quickIvy) = ModelProfileSelector.SelectDefaults(null, isIvy: true);
         Assert.Equal("claude-fable-5", deepIvy);
-        Assert.Equal("gemini-3.7-flash", balancedIvy);
-        Assert.Equal("gemini-3.7-flash", quickIvy);
+        Assert.Equal("gemini-3.8-flash", balancedIvy);
+        Assert.Equal("gemini-3.8-flash", quickIvy);
 
         var (deepAnt, balancedAnt, quickAnt) = ModelProfileSelector.SelectDefaults(null, isAnthropic: true);
         Assert.Equal("claude-fable-5", deepAnt);
@@ -136,9 +157,9 @@ public sealed class ModelProfileSelectorTests
         Assert.Equal("claude-haiku-5-1", quickAnt);
 
         var (deepGoogle, balancedGoogle, quickGoogle) = ModelProfileSelector.SelectDefaults(null, isGoogle: true);
-        Assert.Equal("gemini-3.7-flash", deepGoogle);
-        Assert.Equal("gemini-3.7-flash", balancedGoogle);
-        Assert.Equal("gemini-3.7-flash", quickGoogle);
+        Assert.Equal("gemini-3.8-flash", deepGoogle);
+        Assert.Equal("gemini-3.8-flash", balancedGoogle);
+        Assert.Equal("gemini-3.8-flash", quickGoogle);
 
         var (deepOpenAi, balancedOpenAi, quickOpenAi) = ModelProfileSelector.SelectDefaults(null, isOpenAi: true);
         Assert.Equal("gpt-5.6-sol", deepOpenAi);
@@ -156,8 +177,8 @@ public sealed class ModelProfileSelectorTests
 
         var (deepCode, balancedCode, quickCode) = ModelProfileSelector.SelectDefaults(null, ModelProviderKind.OpenCode);
         Assert.Equal("claude-fable-5", deepCode);
-        Assert.Equal("gemini-3.7-flash", balancedCode);
-        Assert.Equal("gemini-3.7-flash", quickCode);
+        Assert.Equal("gemini-3.8-flash", balancedCode);
+        Assert.Equal("gemini-3.8-flash", quickCode);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents/Helpers/ModelProfilePriorities.cs
+++ b/src/Ivy.Tendril.Agents/Helpers/ModelProfilePriorities.cs
@@ -29,16 +29,16 @@ public static class ModelProfilePriorities
             [(ModelProviderKind.Ivy, ModelProfileKind.Deep)] =
             [
                 "claude-fable-5", "claude-opus-5-1", "claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-5",
-                "claude-opus-4", "opus", "gpt-5.6-sol", "sol", "claude-sonnet-5", "gemini-3.7-flash"
+                "claude-opus-4", "opus", "gpt-5.6-sol", "sol", "claude-sonnet-5", "gemini-3.8-flash", "gemini-3.7-flash"
             ],
             [(ModelProviderKind.Ivy, ModelProfileKind.Balanced)] =
             [
-                "gemini-3.7-flash", "gemini-3.6-flash", "claude-sonnet-5-1", "claude-5.1", "claude-sonnet-5",
+                "gemini-3.8-flash", "gemini-3.7-flash", "gemini-3.6-flash", "claude-sonnet-5-1", "claude-5.1", "claude-sonnet-5",
                 "claude-sonnet-4-6", "gpt-5.6-terra", "terra", "gemini-2.5-flash"
             ],
             [(ModelProviderKind.Ivy, ModelProfileKind.Quick)] =
             [
-                "gemini-3.7-flash", "gemini-3.6-flash", "gemini-2.5-flash", "claude-haiku-5-1", "claude-haiku-4-5",
+                "gemini-3.8-flash", "gemini-3.7-flash", "gemini-3.6-flash", "gemini-2.5-flash", "claude-haiku-5-1", "claude-haiku-4-5",
                 "claude-haiku-5", "gpt-5.6-luna", "luna", "gpt-4o-mini"
             ],
 
@@ -60,16 +60,16 @@ public static class ModelProfilePriorities
             // === Google / Gemini ===
             [(ModelProviderKind.Google, ModelProfileKind.Deep)] =
             [
-                "gemini-3.7-flash", "gemini-3.7-pro", "gemini-3.6-flash", "gemini-3.6-pro", "gemini-3.1-pro",
+                "gemini-3.8-flash", "gemini-3.7-flash", "gemini-3.7-pro", "gemini-3.6-flash", "gemini-3.6-pro", "gemini-3.1-pro",
                 "gemini-3-pro", "gemini-2.5-pro", "gemini-2.5-flash"
             ],
             [(ModelProviderKind.Google, ModelProfileKind.Balanced)] =
             [
-                "gemini-3.7-flash", "gemini-3.6-flash", "gemini-2.5-flash", "gemini-2.0-flash"
+                "gemini-3.8-flash", "gemini-3.7-flash", "gemini-3.6-flash", "gemini-2.5-flash", "gemini-2.0-flash"
             ],
             [(ModelProviderKind.Google, ModelProfileKind.Quick)] =
             [
-                "gemini-3.7-flash", "gemini-3.6-flash", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.0-flash"
+                "gemini-3.8-flash", "gemini-3.7-flash", "gemini-3.6-flash", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.0-flash"
             ],
 
             // === OpenAI Direct ===
@@ -103,29 +103,29 @@ public static class ModelProfilePriorities
             // === OpenCode ===
             [(ModelProviderKind.OpenCode, ModelProfileKind.Deep)] =
             [
-                "claude-fable-5", "claude-opus-5-1", "claude-opus-5", "gpt-5.6-sol", "gemini-3.7-flash", "claude-sonnet-5"
+                "claude-fable-5", "claude-opus-5-1", "claude-opus-5", "gpt-5.6-sol", "gemini-3.8-flash", "gemini-3.7-flash", "claude-sonnet-5"
             ],
             [(ModelProviderKind.OpenCode, ModelProfileKind.Balanced)] =
             [
-                "gemini-3.7-flash", "claude-sonnet-5-1", "claude-5.1", "claude-sonnet-5", "gpt-5.6-terra"
+                "gemini-3.8-flash", "gemini-3.7-flash", "claude-sonnet-5-1", "claude-5.1", "claude-sonnet-5", "gpt-5.6-terra"
             ],
             [(ModelProviderKind.OpenCode, ModelProfileKind.Quick)] =
             [
-                "gemini-3.7-flash", "claude-haiku-4-5", "gpt-5.6-luna"
+                "gemini-3.8-flash", "gemini-3.7-flash", "claude-haiku-4-5", "gpt-5.6-luna"
             ],
 
             // === Generic / Fallback ===
             [(ModelProviderKind.Generic, ModelProfileKind.Deep)] =
             [
-                "gpt-5.6-sol", "claude-fable-5", "claude-opus-5-1", "claude-opus-5", "gemini-3.7-flash", "claude-sonnet-5", "gpt-4o"
+                "gpt-5.6-sol", "claude-fable-5", "claude-opus-5-1", "claude-opus-5", "gemini-3.8-flash", "gemini-3.7-flash", "claude-sonnet-5", "gpt-4o"
             ],
             [(ModelProviderKind.Generic, ModelProfileKind.Balanced)] =
             [
-                "gpt-5.6-terra", "gemini-3.7-flash", "claude-sonnet-5-1", "claude-5.1", "claude-sonnet-5", "gpt-4o"
+                "gpt-5.6-terra", "gemini-3.8-flash", "gemini-3.7-flash", "claude-sonnet-5-1", "claude-5.1", "claude-sonnet-5", "gpt-4o"
             ],
             [(ModelProviderKind.Generic, ModelProfileKind.Quick)] =
             [
-                "gpt-5.6-luna", "gemini-3.7-flash", "claude-haiku-4-5", "gpt-4o-mini"
+                "gpt-5.6-luna", "gemini-3.8-flash", "gemini-3.7-flash", "claude-haiku-4-5", "gpt-4o-mini"
             ],
         }.ToFrozenDictionary();
 

--- a/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs
@@ -27,6 +27,16 @@ public sealed class AntigravityModelCatalog : CachedModelCatalogProvider
     [
         new()
         {
+            Id = "gemini-3.8-flash", DisplayName = "Gemini 3.8 Flash",
+            Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Antigravity,
+            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
+            Provider = "google",
+            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
+            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.0375m,
+        },
+        new()
+        {
             Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash",
             Capabilities = MidCaps, IsDefault = true,
             SupportedEfforts = EffortLevels.Antigravity,

--- a/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Gemini/GeminiModelCatalog.cs
@@ -23,6 +23,16 @@ public sealed class GeminiModelCatalog : CachedModelCatalogProvider
     [
         new()
         {
+            Id = "gemini-3.8-flash", DisplayName = "Gemini 3.8 Flash",
+            Capabilities = MidCaps,
+            SupportedEfforts = EffortLevels.Gemini,
+            ContextWindow = 1_000_000, MaxOutputTokens = 65_536,
+            Provider = "google",
+            InputPerMillion = 0.15m, OutputPerMillion = 0.60m,
+            CacheWritePerMillion = 0m, CacheReadPerMillion = 0.0375m,
+        },
+        new()
+        {
             Id = "gemini-3.7-flash", DisplayName = "Gemini 3.7 Flash",
             Capabilities = MidCaps,
             SupportedEfforts = EffortLevels.Gemini,

--- a/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs
@@ -210,6 +210,7 @@ public sealed class OpenCodeModelCatalog : CachedModelCatalogProvider
         ("o1-pro",        new(150.00m, 600.00m, 0m, 0m, 128_000)),
         ("o1",            new(15.00m, 60.00m, 7.50m, 18.75m, 200_000)),
         // Google
+        ("gemini-3.8-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
         ("gemini-3.7-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
         ("gemini-3.6-flash", new(0.15m, 3.50m, 0.0375m, 0.15m, 1_048_576)),
         ("gemini-3.1-pro",   new(1.25m, 10.00m, 0.3125m, 1.5625m, 1_048_576)),

--- a/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/05_Gemini.md
+++ b/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/05_Gemini.md
@@ -43,6 +43,7 @@ The profile is selected automatically based on the plan's complexity level, or c
 
 ## Available Models
 
+- `gemini-3.8-flash`: Next-gen fast and capable reasoning, 1M context
 - `gemini-3.7-flash` (default): Next-gen fast and capable reasoning, 1M context
 - `gemini-3.6-flash`: Fast and capable, 1M context
 - `gemini-3.1-pro`: Advanced reasoning, 1M context


### PR DESCRIPTION
Fixes #2266

# Summary

## Changes

Added support for the Google Gemini 3.8 Flash model (`gemini-3.8-flash`) across agent catalogs, default model profile priorities, known pricing tables, and user documentation. Updated test suites covering model catalogs and profile resolution.

## API Changes

- Added `gemini-3.8-flash` model definition to `AntigravityModelCatalog` and `GeminiModelCatalog`
- Added `gemini-3.8-flash` pricing entry to `OpenCodeModelCatalog`
- Updated `ModelProfilePriorities` to rank `gemini-3.8-flash` ahead of `gemini-3.7-flash` for Ivy, Google, OpenCode, and Generic providers

## Files Modified

- `src/Ivy.Tendril.Agents/Providers/Antigravity/AntigravityModelCatalog.cs`: Added `gemini-3.8-flash` model definition
- `src/Ivy.Tendril.Agents/Providers/Gemini/GeminiModelCatalog.cs`: Added `gemini-3.8-flash` model definition
- `src/Ivy.Tendril.Agents/Providers/OpenCode/OpenCodeModelCatalog.cs`: Added `gemini-3.8-flash` pricing entry
- `src/Ivy.Tendril.Agents/Helpers/ModelProfilePriorities.cs`: Updated priority candidate lists
- `src/Ivy.Tendril.Docs/Docs/06_CodingAgents/05_Gemini.md`: Added `gemini-3.8-flash` to available models list
- `src/Ivy.Tendril.Agents.Test/Antigravity/AntigravityModelCatalogTests.cs`: Added unit tests for `gemini-3.8-flash`
- `src/Ivy.Tendril.Agents.Test/Gemini/GeminiModelCatalogTests.cs`: Added unit tests for `gemini-3.8-flash`
- `src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs`: Updated default model tests

## Manual Testing

1. Open Tendril Settings > Coding Agent or check models via `tendril models`.
2. Observe `gemini-3.8-flash` is listed under supported Google and Gemini models with correct pricing.

---
## Commits

- 8d1abd38 Add support for Gemini 3.8 Flash model (Plan 00009)

---
Created using [Ivy Tendril](https://ivy.app).
