### PR TITLE
fix(codex): parse error events, report failures in onboarding, and inspect stdout in health check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ x86/
 .ivy/
 **/tmp_out/
 msbuild.binlog
+crash.log
+**/crash.log
 
 ## Updater binaries (CI-generated, embedded as resources)
 **/PublishedBinaries/

--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexCliTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexCliTests.cs
@@ -195,8 +195,7 @@ public class CodexCliTests
         Assert.Contains("exec", spec.Arguments);
         Assert.Contains("--sandbox", spec.Arguments);
         Assert.Contains("danger-full-access", spec.Arguments);
-        Assert.Contains("--ask-for-approval", spec.Arguments);
-        Assert.Contains("never", spec.Arguments);
+        Assert.Contains("approval_policy=\"never\"", spec.Arguments);
         Assert.Contains("--json", spec.Arguments);
         Assert.Contains("--skip-git-repo-check", spec.Arguments);
         Assert.Contains("-", spec.Arguments);
@@ -222,9 +221,8 @@ public class CodexCliTests
         Assert.True(sandboxIdx >= 0);
         Assert.Equal("danger-full-access", argList[sandboxIdx + 1]);
 
-        var approvalIdx = argList.IndexOf("--ask-for-approval");
+        var approvalIdx = argList.IndexOf("approval_policy=\"never\"");
         Assert.True(approvalIdx >= 0);
-        Assert.Equal("never", argList[approvalIdx + 1]);
     }
 
     [Fact]
@@ -247,9 +245,8 @@ public class CodexCliTests
         Assert.Contains("sandbox_workspace_write.network_access=true", argList);
         Assert.Contains("sandbox_permissions=[\"disk-full-read-access\"]", argList);
 
-        var approvalIdx = argList.IndexOf("--ask-for-approval");
+        var approvalIdx = argList.IndexOf("approval_policy=\"never\"");
         Assert.True(approvalIdx >= 0);
-        Assert.Equal("never", argList[approvalIdx + 1]);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexEventParserTests.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Providers.Codex;
 
 namespace Ivy.Tendril.Agents.Test.Codex;
@@ -282,5 +282,54 @@ public class CodexEventParserTests
 
         Assert.Single(events);
         Assert.IsType<UnknownEvent>(events[0]);
+    }
+
+    [Fact]
+    public void ParseLine_ErrorWithNestedJson_ReturnsCleanErrorEvent()
+    {
+        var json = """{"type":"error","message":"{\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.\"}}"}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Single(events);
+        var err = Assert.IsType<ErrorEvent>(events[0]);
+        Assert.Equal(AgentEventKind.Error, err.Kind);
+        Assert.Equal("The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.", err.Message);
+        Assert.False(err.IsAuthError);
+    }
+
+    [Fact]
+    public void ParseLine_ErrorWithPlainString_ReturnsErrorEvent()
+    {
+        var json = """{"type":"error","message":"You've hit your usage limit. To continue using Codex and get access to GPT-5.3-Codex, start a free trial of Plus today."}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Single(events);
+        var err = Assert.IsType<ErrorEvent>(events[0]);
+        Assert.Equal(AgentEventKind.Error, err.Kind);
+        Assert.Contains("hit your usage limit", err.Message);
+    }
+
+    [Fact]
+    public void ParseLine_TurnFailed_ReturnsErrorEvent()
+    {
+        var json = """{"type":"turn.failed","error":{"message":"The request timed out."}}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Single(events);
+        var err = Assert.IsType<ErrorEvent>(events[0]);
+        Assert.Equal(AgentEventKind.Error, err.Kind);
+        Assert.Equal("The request timed out.", err.Message);
+    }
+
+    [Fact]
+    public void ParseLine_ItemCompleted_Error_ReturnsErrorEvent()
+    {
+        var json = """{"type":"item.completed","item":{"id":"item_0","type":"error","message":"Model metadata not found."}}""";
+        var events = _parser.ParseLine(json);
+
+        Assert.Single(events);
+        var err = Assert.IsType<ErrorEvent>(events[0]);
+        Assert.Equal(AgentEventKind.Error, err.Kind);
+        Assert.Equal("Model metadata not found.", err.Message);
     }
 }

--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexEventParserTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexEventParserTests.cs
@@ -332,4 +332,23 @@ public class CodexEventParserTests
         Assert.Equal(AgentEventKind.Error, err.Kind);
         Assert.Equal("Model metadata not found.", err.Message);
     }
+
+    [Fact]
+    public void BuildResult_WithTextEvents_PopulatesResponse()
+    {
+        var agentMsgJson = """{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"Yep, alive and ready."}}""";
+        var turnCompletedJson = """{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5}}""";
+
+        var events = new List<AgentEvent>();
+        events.AddRange(_parser.ParseLine(agentMsgJson));
+        events.AddRange(_parser.ParseLine(turnCompletedJson));
+
+        var result = _parser.BuildResult(events, 0);
+
+        Assert.NotNull(result);
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Yep, alive and ready.", result.Response);
+        Assert.NotNull(result.Usage);
+        Assert.Equal(10, result.Usage.InputTokens);
+    }
 }

--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexFailureAnalyzerTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexFailureAnalyzerTests.cs
@@ -225,4 +225,54 @@ public class CodexFailureAnalyzerTests
 
         Assert.NotEmpty(result.ContextLines);
     }
+
+    [Fact]
+    public void Analyze_ErrorEvent_UnsupportedModel_ReturnsInvalidModel()
+    {
+        var ctx = new FailureContext
+        {
+            Events =
+            [
+                new ErrorEvent
+                {
+                    Kind = AgentEventKind.Error,
+                    Message = "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+                    RawLine = "",
+                }
+            ],
+            AgentId = AgentId.Codex,
+            ExitCode = 1,
+        };
+
+        var result = _analyzer.Analyze(ctx);
+
+        Assert.Equal(FailureKind.InvalidModel, result.Kind);
+        Assert.False(result.IsRetryable);
+        Assert.Contains("gpt-5.6-sol", result.Reason);
+    }
+
+    [Fact]
+    public void Analyze_ErrorEvent_UsageLimit_ReturnsRateLimit()
+    {
+        var ctx = new FailureContext
+        {
+            Events =
+            [
+                new ErrorEvent
+                {
+                    Kind = AgentEventKind.Error,
+                    Message = "You've hit your usage limit. To continue using Codex and get access to GPT-5.3-Codex, start a free trial of Plus today.",
+                    RawLine = "",
+                }
+            ],
+            AgentId = AgentId.Codex,
+            ExitCode = 1,
+        };
+
+        var result = _analyzer.Analyze(ctx);
+
+        Assert.Equal(FailureKind.RateLimit, result.Kind);
+        Assert.True(result.IsRetryable);
+        Assert.Contains("hit your usage limit", result.Reason);
+    }
 }

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexCli.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexCli.cs
@@ -71,8 +71,8 @@ public sealed class CodexCli : IAgentCli
             case PermissionMode.FullAuto:
                 args.Add("--sandbox");
                 args.Add("danger-full-access");
-                args.Add("--ask-for-approval");
-                args.Add("never");
+                args.Add("-c");
+                args.Add("approval_policy=\"never\"");
                 break;
 
             case PermissionMode.AcceptEdits:
@@ -82,8 +82,8 @@ public sealed class CodexCli : IAgentCli
                 args.Add("sandbox_workspace_write.network_access=true");
                 args.Add("-c");
                 args.Add("sandbox_permissions=[\"disk-full-read-access\"]");
-                args.Add("--ask-for-approval");
-                args.Add("never");
+                args.Add("-c");
+                args.Add("approval_policy=\"never\"");
                 break;
 
             case PermissionMode.Plan:

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexEventParser.cs
@@ -59,10 +59,20 @@ public sealed class CodexEventParser : IEventParser
 
     public ResultEvent? BuildResult(IReadOnlyList<AgentEvent> events, int exitCode)
     {
+        string? responseText = null;
+        var textEvents = events.OfType<TextEvent>().Where(t => !string.IsNullOrWhiteSpace(t.Text)).ToList();
+        if (textEvents.Count > 0)
+        {
+            responseText = string.Join("\n\n", textEvents.Select(t => t.Text));
+        }
+
         for (var i = events.Count - 1; i >= 0; i--)
         {
             if (events[i] is ResultEvent result)
-                return result with { ExitCode = exitCode };
+            {
+                var response = !string.IsNullOrWhiteSpace(result.Response) ? result.Response : responseText;
+                return result with { ExitCode = exitCode, Response = response };
+            }
         }
 
         return new ResultEvent
@@ -70,6 +80,7 @@ public sealed class CodexEventParser : IEventParser
             Kind = AgentEventKind.Result,
             IsSuccess = exitCode == 0,
             ExitCode = exitCode,
+            Response = responseText,
         };
     }
 

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexEventParser.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexEventParser.cs
@@ -1,4 +1,4 @@
-﻿using System.Buffers;
+using System.Buffers;
 using System.Text;
 using System.Text.Json;
 using Ivy.Tendril.Agents.Abstractions;
@@ -40,6 +40,8 @@ public sealed class CodexEventParser : IEventParser
                 "thread.started" => ParseThreadStarted(root, rawLine),
                 "item.completed" => ParseItemCompleted(root, rawLine),
                 "turn.completed" => ParseTurnCompleted(root, rawLine),
+                "error" => ParseError(root, rawLine),
+                "turn.failed" => ParseTurnFailed(root, rawLine),
                 _ => [new UnknownEvent { Kind = AgentEventKind.Unknown, Content = rawLine, RawLine = rawLine }]
             };
         }
@@ -124,6 +126,7 @@ public sealed class CodexEventParser : IEventParser
         {
             "agent_message" => ParseAgentMessage(item, itemId, rawLine),
             "command_execution" => ParseCommandExecution(item, itemId, rawLine),
+            "error" => ParseItemError(item, itemId, rawLine),
             _ => [new UnknownEvent { Kind = AgentEventKind.Unknown, Content = rawLine, RawLine = rawLine }]
         };
     }
@@ -194,5 +197,97 @@ public sealed class CodexEventParser : IEventParser
             Usage = usage,
             RawLine = rawLine,
         }];
+    }
+
+    private static IReadOnlyList<AgentEvent> ParseItemError(JsonElement item, string itemId, string rawLine)
+    {
+        var rawMsg = item.TryGetProperty("message", out var msgProp) ? msgProp.GetString() ?? "" : "";
+        var cleanMsg = ExtractErrorMessage(rawMsg);
+        return [new ErrorEvent
+        {
+            Kind = AgentEventKind.Error,
+            Message = cleanMsg,
+            RawLine = rawLine,
+        }];
+    }
+
+    private static IReadOnlyList<AgentEvent> ParseError(JsonElement root, string rawLine)
+    {
+        var rawMsg = root.TryGetProperty("message", out var msgProp) ? msgProp.GetString() ?? "" : "";
+        var cleanMsg = ExtractErrorMessage(rawMsg);
+        var isAuth = cleanMsg.Contains("auth", StringComparison.OrdinalIgnoreCase) ||
+                     cleanMsg.Contains("login", StringComparison.OrdinalIgnoreCase) ||
+                     cleanMsg.Contains("unauthorized", StringComparison.OrdinalIgnoreCase);
+
+        return [new ErrorEvent
+        {
+            Kind = AgentEventKind.Error,
+            Message = cleanMsg,
+            IsAuthError = isAuth,
+            RawLine = rawLine,
+        }];
+    }
+
+    private static IReadOnlyList<AgentEvent> ParseTurnFailed(JsonElement root, string rawLine)
+    {
+        var rawMsg = "";
+        if (root.TryGetProperty("error", out var errEl))
+        {
+            if (errEl.ValueKind == JsonValueKind.Object && errEl.TryGetProperty("message", out var msgProp))
+                rawMsg = msgProp.GetString() ?? "";
+            else if (errEl.ValueKind == JsonValueKind.String)
+                rawMsg = errEl.GetString() ?? "";
+        }
+
+        var cleanMsg = ExtractErrorMessage(rawMsg);
+        if (string.IsNullOrWhiteSpace(cleanMsg))
+            cleanMsg = "Turn failed";
+
+        var isAuth = cleanMsg.Contains("auth", StringComparison.OrdinalIgnoreCase) ||
+                     cleanMsg.Contains("login", StringComparison.OrdinalIgnoreCase) ||
+                     cleanMsg.Contains("unauthorized", StringComparison.OrdinalIgnoreCase);
+
+        return [new ErrorEvent
+        {
+            Kind = AgentEventKind.Error,
+            Message = cleanMsg,
+            IsAuthError = isAuth,
+            RawLine = rawLine,
+        }];
+    }
+
+    internal static string ExtractErrorMessage(string rawMessage)
+    {
+        if (string.IsNullOrWhiteSpace(rawMessage)) return "";
+
+        var trimmed = rawMessage.Trim();
+        if (trimmed.StartsWith('{') && trimmed.EndsWith('}'))
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(trimmed);
+                var root = doc.RootElement;
+                if (root.TryGetProperty("error", out var errorEl))
+                {
+                    if (errorEl.ValueKind == JsonValueKind.Object &&
+                        errorEl.TryGetProperty("message", out var nestedMsg) &&
+                        nestedMsg.GetString() is { } msg)
+                    {
+                        return msg;
+                    }
+                    if (errorEl.ValueKind == JsonValueKind.String && errorEl.GetString() is { } str)
+                    {
+                        return str;
+                    }
+                }
+                if (root.TryGetProperty("message", out var msgEl) && msgEl.GetString() is { } m)
+                {
+                    return m;
+                }
+            }
+            catch (JsonException) { }
+        }
+
+        return rawMessage;
     }
 }

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexFailureAnalyzer.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexFailureAnalyzer.cs
@@ -19,65 +19,82 @@ public sealed class CodexFailureAnalyzer : IFailureAnalyzer
             };
         }
 
+        var errorEvent = context.Events.OfType<ErrorEvent>().LastOrDefault();
+        var errorText = errorEvent?.Message ?? "";
         var stderr = string.Join("\n", context.StderrLines);
+        var combined = string.IsNullOrWhiteSpace(errorText) ? stderr : $"{errorText}\n{stderr}";
 
-        if (ContainsAny(stderr, "rate limit", "429", "too many requests"))
+        if (ContainsAny(combined, "rate limit", "429", "too many requests", "usage limit", "hit your usage limit"))
         {
             return new FailureAnalysis
             {
                 Kind = FailureKind.RateLimit,
-                Reason = "Rate limited by the API",
+                Reason = !string.IsNullOrWhiteSpace(errorText) ? errorText : "Rate limited or usage limit reached by Codex API",
                 ContextLines = context.StderrLines,
                 IsRetryable = true,
-                Suggestion = "Wait before retrying or switch to a different model",
+                Suggestion = "Wait before retrying, upgrade your ChatGPT plan, or switch to a different model or agent",
             };
         }
 
-        if (ContainsAny(stderr, "auth", "login", "sign in", "unauthorized", "401", "403"))
+        if (ContainsAny(combined, "not supported when using Codex with a ChatGPT account", "not supported"))
+        {
+            return new FailureAnalysis
+            {
+                Kind = FailureKind.InvalidModel,
+                Reason = !string.IsNullOrWhiteSpace(errorText) ? errorText : "The specified model is not supported with this account",
+                ContextLines = context.StderrLines,
+                IsRetryable = false,
+                Suggestion = "Select a supported model (e.g. gpt-5.6-terra) or authenticate with an API key",
+            };
+        }
+
+        if (ContainsAny(combined, "auth", "login", "sign in", "unauthorized", "401", "403"))
         {
             return new FailureAnalysis
             {
                 Kind = FailureKind.AuthError,
-                Reason = "Authentication failure",
+                Reason = !string.IsNullOrWhiteSpace(errorText) ? errorText : "Authentication failure",
                 ContextLines = context.StderrLines,
                 IsRetryable = false,
                 Suggestion = "Run 'codex login' to authenticate",
             };
         }
 
-        if (ContainsAny(stderr, "model", "invalid model", "not found", "does not exist", "not supported"))
+        if (ContainsAny(combined, "model", "invalid model", "not found", "does not exist"))
         {
             return new FailureAnalysis
             {
                 Kind = FailureKind.InvalidModel,
-                Reason = "The specified model is not available",
+                Reason = !string.IsNullOrWhiteSpace(errorText) ? errorText : "The specified model is not available",
                 ContextLines = context.StderrLines,
                 IsRetryable = false,
-                Suggestion = "Check model name or use a different model (e.g., o4-mini, o3)",
+                Suggestion = "Check model name or use a different model (e.g., gpt-5.6-terra, o4-mini)",
             };
         }
 
-        if (ContainsAny(stderr, "network", "connection", "ECONNREFUSED", "ETIMEDOUT", "dns"))
+        if (ContainsAny(combined, "network", "connection", "ECONNREFUSED", "ETIMEDOUT", "dns"))
         {
             return new FailureAnalysis
             {
                 Kind = FailureKind.NetworkError,
-                Reason = "Network connectivity issue",
+                Reason = !string.IsNullOrWhiteSpace(errorText) ? errorText : "Network connectivity issue",
                 ContextLines = context.StderrLines,
                 IsRetryable = true,
                 Suggestion = "Check network connection and retry",
             };
         }
 
-        var lastStderr = context.StderrLines.LastOrDefault(l => !string.IsNullOrWhiteSpace(l));
+        var lastMessage = !string.IsNullOrWhiteSpace(errorText)
+            ? errorText
+            : context.StderrLines.LastOrDefault(l => !string.IsNullOrWhiteSpace(l));
 
         if (context.ExitCode is not null and not 0)
         {
             return new FailureAnalysis
             {
                 Kind = FailureKind.ProcessCrash,
-                Reason = lastStderr != null
-                    ? $"Codex exited with code {context.ExitCode}: {lastStderr}"
+                Reason = lastMessage != null
+                    ? $"Codex exited with code {context.ExitCode}: {lastMessage}"
                     : $"Codex exited with code {context.ExitCode}",
                 ContextLines = context.StderrLines,
                 IsRetryable = true,
@@ -87,8 +104,8 @@ public sealed class CodexFailureAnalyzer : IFailureAnalyzer
         return new FailureAnalysis
         {
             Kind = FailureKind.Unknown,
-            Reason = lastStderr != null
-                ? $"Codex failed: {lastStderr}"
+            Reason = lastMessage != null
+                ? $"Codex failed: {lastMessage}"
                 : $"Codex failed with an unknown error (exit code {context.ExitCode?.ToString() ?? "unknown"})",
             ContextLines = context.StderrLines,
             IsRetryable = false,

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexHealthCheck.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexHealthCheck.cs
@@ -63,7 +63,7 @@ public sealed class CodexHealthCheck : IAgentHealthCheck
             ? (IReadOnlyList<string>)["exec", "--full-auto", "--json", "--skip-git-repo-check", "-"]
             : ["exec", "--full-auto", "--json", "--skip-git-repo-check", "--model", model, "-"];
 
-        var (exitCode, _, stderr) = await HealthCheckRunner.RunAsync(
+        var (exitCode, stdout, stderr) = await HealthCheckRunner.RunAsync(
             "codex", args, TimeSpan.FromSeconds(5), ct);
 
         // Timeout means the process started successfully (model was accepted)
@@ -73,31 +73,35 @@ public sealed class CodexHealthCheck : IAgentHealthCheck
         if (exitCode == 0)
             return new ModelValidationResult { Status = ModelValidationStatus.Ok, Model = model };
 
-        if (stderr.Contains("model", StringComparison.OrdinalIgnoreCase) &&
-            (stderr.Contains("invalid", StringComparison.OrdinalIgnoreCase) ||
-             stderr.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
-             stderr.Contains("not supported", StringComparison.OrdinalIgnoreCase)))
+        var combined = $"{stdout}\n{stderr}";
+        var cleanError = CodexEventParser.ExtractErrorMessage(stdout);
+        var effectiveError = !string.IsNullOrWhiteSpace(cleanError) ? cleanError : stderr;
+
+        if (combined.Contains("model", StringComparison.OrdinalIgnoreCase) &&
+            (combined.Contains("invalid", StringComparison.OrdinalIgnoreCase) ||
+             combined.Contains("not found", StringComparison.OrdinalIgnoreCase) ||
+             combined.Contains("not supported", StringComparison.OrdinalIgnoreCase)))
             return new ModelValidationResult
             {
                 Status = ModelValidationStatus.InvalidModel,
                 Model = model,
-                ErrorMessage = stderr,
+                ErrorMessage = effectiveError,
             };
 
-        if (stderr.Contains("auth", StringComparison.OrdinalIgnoreCase) ||
-            stderr.Contains("unauthorized", StringComparison.OrdinalIgnoreCase))
+        if (combined.Contains("auth", StringComparison.OrdinalIgnoreCase) ||
+            combined.Contains("unauthorized", StringComparison.OrdinalIgnoreCase))
             return new ModelValidationResult
             {
                 Status = ModelValidationStatus.AuthError,
                 Model = model,
-                ErrorMessage = stderr,
+                ErrorMessage = effectiveError,
             };
 
         return new ModelValidationResult
         {
             Status = ModelValidationStatus.Unknown,
             Model = model,
-            ErrorMessage = stderr,
+            ErrorMessage = effectiveError,
         };
     }
 

--- a/src/Ivy.Tendril.Agents/Runtime/AgentSession.cs
+++ b/src/Ivy.Tendril.Agents/Runtime/AgentSession.cs
@@ -357,6 +357,11 @@ public sealed class AgentSession : IAgentSession
         }
 
         await _cts.CancelAsync();
+
+        if (!_completion.Task.IsCompleted)
+        {
+            Complete(_process.HasExited ? _process.ExitCode : -1, SessionState.Stopped);
+        }
     }
 
     public async Task KillAsync()
@@ -369,6 +374,11 @@ public sealed class AgentSession : IAgentSession
             await _completion.Task.WaitAsync(TimeSpan.FromSeconds(5));
         }
         catch { }
+
+        if (!_completion.Task.IsCompleted)
+        {
+            Complete(_process.HasExited ? _process.ExitCode : -1, SessionState.Failed);
+        }
     }
 
     public Task RespondToPermissionAsync(string requestId, PermissionDecision decision, CancellationToken ct = default)

--- a/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
@@ -43,6 +43,7 @@ public class DeleteSessionDialogTests
             if (isGenerating) GeneratingSessions.Add(sessionId);
             else { GeneratingSessions.Remove(sessionId); CompletedSessions.Add(sessionId); }
         }
+        public void ClearAllGeneratingSessions() => GeneratingSessions.Clear();
         public IReadOnlySet<string> GetGeneratingSessionIds() => GeneratingSessions;
         public IReadOnlySet<string> GetCompletedSessionIds() => CompletedSessions;
         public void ClearSessionCompleted(string sessionId) => CompletedSessions.Remove(sessionId);

--- a/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
@@ -94,9 +94,10 @@ public class SidebarViewTests
         var sessionVersion = new TestState<int>(1);
         var selectedAgent = new TestState<string>("claude");
         var selectedModel = new TestState<string>("opus");
+        var selectedEffort = new TestState<string>("default");
         var searchState = new TestState<string>("");
 
-        var view = new SidebarView(sessions, activeSessionId, sessionVersion, selectedAgent, selectedModel, searchState, service);
+        var view = new SidebarView(sessions, activeSessionId, sessionVersion, selectedAgent, selectedModel, selectedEffort, searchState, service, _ => { });
         var result = view.Build();
 
         Assert.NotNull(result);
@@ -116,9 +117,10 @@ public class SidebarViewTests
         var sessionVersion = new TestState<int>(1);
         var selectedAgent = new TestState<string>("claude");
         var selectedModel = new TestState<string>("opus");
+        var selectedEffort = new TestState<string>("default");
         var searchState = new TestState<string>("xyz non existent");
 
-        var view = new SidebarView(sessions, activeSessionId, sessionVersion, selectedAgent, selectedModel, searchState, service);
+        var view = new SidebarView(sessions, activeSessionId, sessionVersion, selectedAgent, selectedModel, selectedEffort, searchState, service, _ => { });
         var result = view.Build();
 
         Assert.NotNull(result);
@@ -139,9 +141,10 @@ public class SidebarViewTests
         var sessionVersion = new TestState<int>(1);
         var selectedAgent = new TestState<string>("claude");
         var selectedModel = new TestState<string>("opus");
+        var selectedEffort = new TestState<string>("default");
         var searchState = new TestState<string>("");
 
-        var view = new SidebarView(sessions, activeSessionId, sessionVersion, selectedAgent, selectedModel, searchState, service);
+        var view = new SidebarView(sessions, activeSessionId, sessionVersion, selectedAgent, selectedModel, selectedEffort, searchState, service, _ => { });
         var result = view.Build();
 
         Assert.NotNull(result);

--- a/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
@@ -41,6 +41,7 @@ public class SidebarViewTests
             if (isGenerating) GeneratingSessions.Add(sessionId);
             else { GeneratingSessions.Remove(sessionId); CompletedSessions.Add(sessionId); }
         }
+        public void ClearAllGeneratingSessions() => GeneratingSessions.Clear();
         public IReadOnlySet<string> GetGeneratingSessionIds() => GeneratingSessions;
         public IReadOnlySet<string> GetCompletedSessionIds() => CompletedSessions;
         public void ClearSessionCompleted(string sessionId) => CompletedSessions.Remove(sessionId);

--- a/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
@@ -48,7 +48,7 @@ public class ChatExecutionIntegrationTest
             var serializer = new JsonEventSerializer();
 
             var session = chatService.CreateSession("codex", "gpt-5.6-sol");
-            var userMsg = "Say 'hello world' and nothing else.";
+            var userMsg = "test. Alive?";
 
             chatService.AddMessage(session.Id, "user", userMsg, "codex", "gpt-5.6-sol");
 
@@ -313,100 +313,4 @@ public class ChatExecutionIntegrationTest
             }
         }
     }
-
-    [Fact]
-    public async Task ChatApp_TriggerSendMessage_UpdatesIsStreamingAndDoesNotDeadlock()
-    {
-        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatTriggerTest_" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(tempDir);
-
-        try
-        {
-            var config = new TendrilSettings { CodingAgent = "codex" };
-            var configService = new ConfigService(config, tempDir);
-            var chatService = new ChatHistoryService(configService);
-            var agentRunner = TestAgentRunner.Create();
-            var serializer = new JsonEventSerializer();
-
-            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
-
-            var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
-            services.AddSingleton<IConfigService>(configService);
-            services.AddSingleton<IChatHistoryService>(chatService);
-            services.AddSingleton<IAgentRunner>(agentRunner);
-            services.AddSingleton<IEventSerializer>(serializer);
-            var appContext = (Ivy.AppContext)Activator.CreateInstance(
-                typeof(Ivy.AppContext),
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
-                null,
-                new object?[] { "conn1", "mach1", "chat", "chat", null, "http", "localhost", null },
-                null)!;
-            services.AddSingleton(appContext);
-            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
-            services.AddSingleton<IChatSessionNamingService>(namingService);
-            services.AddSingleton<IUploadService>(new Ivy.UploadService("conn1", null!));
-
-            var sp = services.BuildServiceProvider();
-
-            var app = new Ivy.Tendril.Apps.Chat.ChatApp();
-            var contentBuilder = new Ivy.ContentBuilder();
-            var tree = new Ivy.Core.WidgetTree(app, contentBuilder, sp);
-
-            await tree.BuildAsync();
-
-            var rootWidget = tree.GetWidgets();
-            Assert.NotNull(rootWidget);
-
-            var chatWidget = FindWidget<Ivy.Tendril.Widgets.ChatWidget>(rootWidget);
-            Assert.NotNull(chatWidget);
-            Assert.False(chatWidget.IsStreaming);
-
-            var args = new System.Text.Json.Nodes.JsonArray
-            {
-                new System.Text.Json.Nodes.JsonObject
-                {
-                    ["prompt"] = "Hello test",
-                    ["sessionId"] = session.Id
-                }
-            };
-
-            _output.WriteLine($"Triggering OnSendMessage on widget {chatWidget.Id}");
-            var triggered = await tree.TriggerEventAsync(chatWidget.Id, "OnSendMessage", args);
-            Assert.True(triggered);
-
-            // Wait for refresh to propagate
-            await Task.Delay(200);
-
-            var updatedRoot = tree.GetWidgets();
-            var updatedChatWidget = FindWidget<Ivy.Tendril.Widgets.ChatWidget>(updatedRoot);
-            Assert.NotNull(updatedChatWidget);
-            _output.WriteLine($"Updated ChatWidget IsStreaming: {updatedChatWidget.IsStreaming}");
-            Assert.True(updatedChatWidget.IsStreaming, "ChatWidget.IsStreaming should be true while executing!");
-        }
-        finally
-        {
-            if (Directory.Exists(tempDir))
-            {
-                try { Directory.Delete(tempDir, true); } catch { }
-            }
-        }
-    }
-
-    private static T? FindWidget<T>(Ivy.Core.IWidget widget) where T : class, Ivy.Core.IWidget
-    {
-        if (widget is T match) return match;
-        if (widget.Children != null)
-        {
-            foreach (var child in widget.Children)
-            {
-                if (child is Ivy.Core.IWidget w)
-                {
-                    var found = FindWidget<T>(w);
-                    if (found != null) return found;
-                }
-            }
-        }
-        return null;
-    }
 }
-

--- a/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
@@ -48,7 +48,7 @@ public class ChatExecutionIntegrationTest
             var serializer = new JsonEventSerializer();
 
             var session = chatService.CreateSession("codex", "gpt-5.6-sol");
-            var userMsg = "test. Alive?";
+            var userMsg = "Say 'hello world' and nothing else.";
 
             chatService.AddMessage(session.Id, "user", userMsg, "codex", "gpt-5.6-sol");
 
@@ -313,4 +313,100 @@ public class ChatExecutionIntegrationTest
             }
         }
     }
+
+    [Fact]
+    public async Task ChatApp_TriggerSendMessage_UpdatesIsStreamingAndDoesNotDeadlock()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatTriggerTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+            services.AddSingleton<IConfigService>(configService);
+            services.AddSingleton<IChatHistoryService>(chatService);
+            services.AddSingleton<IAgentRunner>(agentRunner);
+            services.AddSingleton<IEventSerializer>(serializer);
+            var appContext = (Ivy.AppContext)Activator.CreateInstance(
+                typeof(Ivy.AppContext),
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                null,
+                new object?[] { "conn1", "mach1", "chat", "chat", null, "http", "localhost", null },
+                null)!;
+            services.AddSingleton(appContext);
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            services.AddSingleton<IChatSessionNamingService>(namingService);
+            services.AddSingleton<IUploadService>(new Ivy.UploadService("conn1", null!));
+
+            var sp = services.BuildServiceProvider();
+
+            var app = new Ivy.Tendril.Apps.Chat.ChatApp();
+            var contentBuilder = new Ivy.ContentBuilder();
+            var tree = new Ivy.Core.WidgetTree(app, contentBuilder, sp);
+
+            await tree.BuildAsync();
+
+            var rootWidget = tree.GetWidgets();
+            Assert.NotNull(rootWidget);
+
+            var chatWidget = FindWidget<Ivy.Tendril.Widgets.ChatWidget>(rootWidget);
+            Assert.NotNull(chatWidget);
+            Assert.False(chatWidget.IsStreaming);
+
+            var args = new System.Text.Json.Nodes.JsonArray
+            {
+                new System.Text.Json.Nodes.JsonObject
+                {
+                    ["prompt"] = "Hello test",
+                    ["sessionId"] = session.Id
+                }
+            };
+
+            _output.WriteLine($"Triggering OnSendMessage on widget {chatWidget.Id}");
+            var triggered = await tree.TriggerEventAsync(chatWidget.Id, "OnSendMessage", args);
+            Assert.True(triggered);
+
+            // Wait for refresh to propagate
+            await Task.Delay(200);
+
+            var updatedRoot = tree.GetWidgets();
+            var updatedChatWidget = FindWidget<Ivy.Tendril.Widgets.ChatWidget>(updatedRoot);
+            Assert.NotNull(updatedChatWidget);
+            _output.WriteLine($"Updated ChatWidget IsStreaming: {updatedChatWidget.IsStreaming}");
+            Assert.True(updatedChatWidget.IsStreaming, "ChatWidget.IsStreaming should be true while executing!");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    private static T? FindWidget<T>(Ivy.Core.IWidget widget) where T : class, Ivy.Core.IWidget
+    {
+        if (widget is T match) return match;
+        if (widget.Children != null)
+        {
+            foreach (var child in widget.Children)
+            {
+                if (child is Ivy.Core.IWidget w)
+                {
+                    var found = FindWidget<T>(w);
+                    if (found != null) return found;
+                }
+            }
+        }
+        return null;
+    }
 }
+

--- a/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
@@ -617,6 +617,53 @@ public class ChatExecutionIntegrationTest
         return services.BuildServiceProvider();
     }
 
+    [Fact]
+    public async Task ChatApp_Build_WithLargeRawStreamMessages_SerializesSuccessfully()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatLargeStreamTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        var chatsDir = Path.Combine(tempDir, "Chats");
+        Directory.CreateDirectory(chatsDir);
+
+        var realChatFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril", "Chats", "26d45c6819b34286a2eb3cdbef35b1e5.json");
+        if (File.Exists(realChatFile))
+        {
+            File.Copy(realChatFile, Path.Combine(chatsDir, "26d45c6819b34286a2eb3cdbef35b1e5.json"));
+        }
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+
+            var sp = CreateServiceProvider(configService, chatService, agentRunner, serializer);
+
+            var app = new Ivy.Tendril.Apps.Chat.ChatApp();
+            var contentBuilder = new Ivy.ContentBuilder();
+            var tree = new Ivy.Core.WidgetTree(app, contentBuilder, sp);
+
+            var buildTask = tree.BuildAsync();
+            var completedTask = await Task.WhenAny(buildTask, Task.Delay(5000));
+            Assert.True(completedTask == buildTask, "tree.BuildAsync timed out!");
+
+            var widgets = tree.GetWidgets();
+            Assert.NotNull(widgets);
+            var serialized = widgets.Serialize();
+            Assert.NotNull(serialized);
+            _output.WriteLine($"Serialized widgets successfully: {serialized.ToJsonString().Length} chars");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
     private sealed class DummyClientProvider : IClientProvider
     {
         public IClientSender Sender { get; set; } = new DummyClientSender();
@@ -627,4 +674,5 @@ public class ChatExecutionIntegrationTest
         public void Send(string method, object? data) { }
     }
 }
+
 

--- a/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
@@ -159,23 +159,7 @@ public class ChatExecutionIntegrationTest
             _output.WriteLine($"Session: {s.Id}, Title: {s.Title}, Messages: {s.Messages.Count}");
         }
 
-        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
-        services.AddSingleton<IConfigService>(configService);
-        services.AddSingleton<IChatHistoryService>(chatService);
-        services.AddSingleton<IAgentRunner>(agentRunner);
-        services.AddSingleton<IEventSerializer>(serializer);
-        var appContext = (Ivy.AppContext)Activator.CreateInstance(
-            typeof(Ivy.AppContext),
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
-            null,
-            new object?[] { "conn1", "mach1", "chat", "chat", null, "http", "localhost", null },
-            null)!;
-        services.AddSingleton(appContext);
-        var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
-        services.AddSingleton<IChatSessionNamingService>(namingService);
-        services.AddSingleton<IUploadService>(new Ivy.UploadService("conn1", null!));
-
-        var sp = services.BuildServiceProvider();
+        var sp = CreateServiceProvider(configService, chatService, agentRunner, serializer);
 
         var app = new Ivy.Tendril.Apps.Chat.ChatApp();
         var contentBuilder = new Ivy.ContentBuilder();
@@ -212,23 +196,7 @@ public class ChatExecutionIntegrationTest
             var agentRunner = TestAgentRunner.Create();
             var serializer = new JsonEventSerializer();
 
-            var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
-            services.AddSingleton<IConfigService>(configService);
-            services.AddSingleton<IChatHistoryService>(chatService);
-            services.AddSingleton<IAgentRunner>(agentRunner);
-            services.AddSingleton<IEventSerializer>(serializer);
-            var appContext = (Ivy.AppContext)Activator.CreateInstance(
-                typeof(Ivy.AppContext),
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
-                null,
-                new object?[] { "conn1", "mach1", "chat", "chat", null, "http", "localhost", null },
-                null)!;
-            services.AddSingleton(appContext);
-            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
-            services.AddSingleton<IChatSessionNamingService>(namingService);
-            services.AddSingleton<IUploadService>(new Ivy.UploadService("conn1", null!));
-
-            var sp = services.BuildServiceProvider();
+            var sp = CreateServiceProvider(configService, chatService, agentRunner, serializer);
 
             var app = new Ivy.Tendril.Apps.Chat.ChatApp();
             var contentBuilder = new Ivy.ContentBuilder();
@@ -268,22 +236,7 @@ public class ChatExecutionIntegrationTest
             var sess = chatService.CreateSession("codex", "gpt-5.6-sol");
             chatService.AddMessage(sess.Id, "user", "test", "codex", "gpt-5.6-sol");
 
-            var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
-            services.AddSingleton<IConfigService>(configService);
-            services.AddSingleton<IChatHistoryService>(chatService);
-            services.AddSingleton<IAgentRunner>(agentRunner);
-            services.AddSingleton<IEventSerializer>(serializer);
-            var appContext = (Ivy.AppContext)Activator.CreateInstance(
-                typeof(Ivy.AppContext),
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
-                null,
-                new object?[] { "conn1", "mach1", "chat", "chat", null, "http", "localhost", null },
-                null)!;
-            services.AddSingleton(appContext);
-            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
-            services.AddSingleton<IChatSessionNamingService>(namingService);
-
-            var sp = services.BuildServiceProvider();
+            var sp = CreateServiceProvider(configService, chatService, agentRunner, serializer);
             var ctx = new Ivy.Core.Hooks.ViewContext(() => { }, null, sp);
 
             var app = new Ivy.Tendril.Apps.Chat.ChatApp();
@@ -313,4 +266,365 @@ public class ChatExecutionIntegrationTest
             }
         }
     }
+
+    [Fact]
+    public async Task ChatExecutionService_CancelAsync_ClearsGeneratingStateAndClosesStream()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatCancelTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+
+            var execService = new ChatExecutionService(configService, chatService, agentRunner, namingService, serializer);
+
+            var sess = chatService.CreateSession("codex", "gpt-5.6-sol");
+            _ = execService.SendMessageAsync(sess.Id, "Hello");
+
+            Assert.True(execService.IsGenerating(sess.Id));
+            Assert.True(chatService.GetGeneratingSessionIds().Contains(sess.Id));
+
+            // Verify live stream observable is subscribable
+            var observable = execService.GetLiveStreamObservable(sess.Id);
+            Assert.NotNull(observable);
+
+            // Now cancel
+            await execService.CancelAsync(sess.Id);
+
+            Assert.False(execService.IsGenerating(sess.Id));
+            Assert.False(chatService.GetGeneratingSessionIds().Contains(sess.Id));
+            Assert.Equal("", execService.GetStreamSnapshot(sess.Id));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ChatExecutionService_LiveStreamObservable_EmitsEventsToSubscriber()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatStreamTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+
+            var execService = new ChatExecutionService(configService, chatService, agentRunner, namingService, serializer);
+
+            var sess = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            var receivedEvents = new List<string>();
+
+            // Subscribe to live stream observable before launch
+            var observable = execService.GetLiveStreamObservable(sess.Id);
+            Assert.NotNull(observable);
+
+            using var sub = observable.Subscribe(line => receivedEvents.Add(line));
+
+            // Start sending message
+            _ = execService.SendMessageAsync(sess.Id, "Hello");
+
+            // Verify session is marked generating immediately
+            Assert.True(execService.IsGenerating(sess.Id));
+
+            // Cancel to complete cleanly
+            await execService.CancelAsync(sess.Id);
+            Assert.False(execService.IsGenerating(sess.Id));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void ChatApp_MultiSession_OmitsMessagesForInactiveSessions()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatMultiSessionTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+
+            var sess1 = chatService.CreateSession("codex", "gpt-5.6-sol");
+            chatService.AddMessage(sess1.Id, "user", "msg1", "codex", "gpt-5.6-sol");
+            var sess2 = chatService.CreateSession("codex", "gpt-5.6-sol");
+            chatService.AddMessage(sess2.Id, "user", "msg2", "codex", "gpt-5.6-sol");
+
+            var sp = CreateServiceProvider(configService, chatService, agentRunner, serializer);
+            var ctx = new Ivy.Core.Hooks.ViewContext(() => { }, null, sp);
+
+            var app = new Ivy.Tendril.Apps.Chat.ChatApp();
+            app.BeforeBuild(ctx);
+            var built = app.Build();
+            app.AfterBuild();
+            ctx.Reset();
+
+            Assert.NotNull(built);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ChatExecutionService_StaleGeneratingState_SelfHealsAndDoesNotBlockNewMessage()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatStaleTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+
+            var execService = new ChatExecutionService(configService, chatService, agentRunner, namingService, serializer);
+
+            var sess = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            // Simulate orphaned generating state in chatService without active execution
+            chatService.SetSessionGenerating(sess.Id, true);
+
+            // IsGenerating is pure: returns false when no active execution exists
+            Assert.False(execService.IsGenerating(sess.Id));
+
+            // Sending a message must execute directly and NOT enqueue
+            _ = execService.SendMessageAsync(sess.Id, "can you do this again?");
+
+            // Verify message was not enqueued
+            Assert.Empty(chatService.GetQueuedMessages(sess.Id));
+
+            // Verify session is now genuinely generating
+            Assert.True(execService.IsGenerating(sess.Id));
+
+            // Clean up
+            await execService.CancelAsync(sess.Id);
+            Assert.False(execService.IsGenerating(sess.Id));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ChatApp_LiveExecution_StreamsSnapshotAndUpdatesView()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatAppLiveTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+
+            var sess = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            var sp = CreateServiceProvider(configService, chatService, agentRunner, serializer);
+            var execService = (ChatExecutionService)sp.GetRequiredService<IChatExecutionService>();
+
+            var ctxApp = new Ivy.Core.Hooks.ViewContext(() => { }, null, sp);
+            var ctxContent = new Ivy.Core.Hooks.ViewContext(() => { }, null, sp);
+
+            var app = new Ivy.Tendril.Apps.Chat.ChatApp();
+            app.BeforeBuild(ctxApp);
+            var built1 = app.Build() as Ivy.SidebarLayout;
+            app.AfterBuild();
+            ctxApp.Reset();
+
+            Assert.NotNull(built1);
+            var contentView1 = built1.Children.OfType<Ivy.Slot>().First(s => s.Name == "MainContent").Children.First() as Ivy.Tendril.Apps.Chat.ContentView;
+            Assert.NotNull(contentView1);
+
+            // Initial build: not generating, empty stream snapshot
+            contentView1.BeforeBuild(ctxContent);
+            var builtWidget1 = contentView1.Build() as Ivy.Fragment;
+            Assert.NotNull(builtWidget1);
+            var layoutView1 = builtWidget1.Children[0] as Ivy.LayoutView;
+            Assert.NotNull(layoutView1);
+            var stack1 = layoutView1.Build() as Ivy.Core.AbstractWidget;
+            Assert.NotNull(stack1);
+            var chatWidget1 = stack1.Children[0] as Ivy.Tendril.Widgets.ChatWidget;
+            contentView1.AfterBuild();
+            ctxContent.Reset();
+
+            Assert.NotNull(chatWidget1);
+            Assert.False(chatWidget1.IsStreaming);
+            Assert.Equal(string.Empty, chatWidget1.StreamingText);
+
+            // Now send a message
+            _ = execService.SendMessageAsync(sess.Id, "Hello streaming test");
+
+            // Session is now generating
+            Assert.True(execService.IsGenerating(sess.Id));
+
+            // Emit some live stream events
+            execService.EmitStreamLine(sess.Id, "{\"kind\":\"thinking\",\"content\":\"thinking deeply\"}");
+            execService.EmitStreamLine(sess.Id, "{\"kind\":\"text\",\"text\":\"hello world\"}");
+
+            // Verify GetStreamSnapshot returns the emitted lines
+            var snapshot = execService.GetStreamSnapshot(sess.Id);
+            Assert.Contains("thinking deeply", snapshot);
+            Assert.Contains("hello world", snapshot);
+
+            // Re-render ChatApp
+            app.BeforeBuild(ctxApp);
+            var built2 = app.Build() as Ivy.SidebarLayout;
+            app.AfterBuild();
+            ctxApp.Reset();
+
+            var contentView2 = built2!.Children.OfType<Ivy.Slot>().First(s => s.Name == "MainContent").Children.First() as Ivy.Tendril.Apps.Chat.ContentView;
+            Assert.NotNull(contentView2);
+
+            var ctxContent2 = new Ivy.Core.Hooks.ViewContext(() => { }, null, sp);
+            contentView2.BeforeBuild(ctxContent2);
+            var builtWidget2 = contentView2.Build() as Ivy.Fragment;
+            Assert.NotNull(builtWidget2);
+            var layoutView2 = builtWidget2.Children[0] as Ivy.LayoutView;
+            Assert.NotNull(layoutView2);
+            var stack2 = layoutView2.Build() as Ivy.Core.AbstractWidget;
+            Assert.NotNull(stack2);
+            var chatWidget2 = stack2.Children[0] as Ivy.Tendril.Widgets.ChatWidget;
+            contentView2.AfterBuild();
+            ctxContent2.Reset();
+
+            Assert.NotNull(chatWidget2);
+            Assert.True(chatWidget2.IsStreaming);
+            Assert.Contains("thinking deeply", chatWidget2.StreamingText);
+            Assert.Contains("hello world", chatWidget2.StreamingText);
+
+            // Clean up
+            await execService.CancelAsync(sess.Id);
+            Assert.False(execService.IsGenerating(sess.Id));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void ChatExecutionService_LiveStreamObservable_DoesNotReplayPastEvents()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatNoReplayTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+
+            var execService = new ChatExecutionService(configService, chatService, agentRunner, namingService, serializer);
+
+            var sess = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            var observable = execService.GetLiveStreamObservable(sess.Id);
+            var receivedLines = new List<string>();
+
+            // Emit an event before subscribing
+            execService.EmitStreamLine(sess.Id, "line 1");
+
+            // Now subscribe
+            using var sub = observable.Subscribe(line => receivedLines.Add(line));
+
+            // Verify line 1 was NOT replayed
+            Assert.Empty(receivedLines);
+
+            // Emit a new event
+            execService.EmitStreamLine(sess.Id, "line 2");
+
+            // Verify only line 2 was received
+            Assert.Single(receivedLines);
+            Assert.Equal("line 2", receivedLines[0]);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    private static IServiceProvider CreateServiceProvider(
+        IConfigService configService,
+        IChatHistoryService chatService,
+        IAgentRunner agentRunner,
+        IEventSerializer serializer)
+    {
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        services.AddSingleton(configService);
+        services.AddSingleton(chatService);
+        services.AddSingleton(agentRunner);
+        services.AddSingleton(serializer);
+        var appContext = (Ivy.AppContext)Activator.CreateInstance(
+            typeof(Ivy.AppContext),
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+            null,
+            new object?[] { "conn1", "mach1", "chat", "chat", null, "http", "localhost", null },
+            null)!;
+        services.AddSingleton(appContext);
+        var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+        services.AddSingleton<IChatSessionNamingService>(namingService);
+        services.AddSingleton<IChatExecutionService, ChatExecutionService>();
+        services.AddSingleton<IUploadService>(new Ivy.UploadService("conn1", null!));
+        services.AddSingleton<IClientProvider>(new DummyClientProvider());
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class DummyClientProvider : IClientProvider
+    {
+        public IClientSender Sender { get; set; } = new DummyClientSender();
+    }
+
+    private sealed class DummyClientSender : IClientSender
+    {
+        public void Send(string method, object? data) { }
+    }
 }
+

--- a/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
@@ -1,0 +1,206 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Helpers;
+using Ivy.Tendril.Agents.Runtime;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Widgets;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Ivy.Tendril.Test;
+
+public class ChatExecutionIntegrationTest
+{
+    private readonly ITestOutputHelper _output;
+
+    public ChatExecutionIntegrationTest(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task SendMessage_WithCodex_ExecutesAndAddsAssistantMessage()
+    {
+        if (Ivy.Tendril.Agents.Helpers.BinaryResolver.FindOnPath("codex") == null)
+            return;
+
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatExecTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings
+            {
+                CodingAgent = "codex"
+            };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+            var userMsg = "test. Alive?";
+
+            chatService.AddMessage(session.Id, "user", userMsg, "codex", "gpt-5.6-sol");
+
+            var sess = chatService.GetSession(session.Id);
+            Assert.NotNull(sess);
+            Assert.Single(sess.Messages);
+
+            var fullAgentPrompt = "# Current User Request\n" + userMsg;
+            var context = AgentLaunchHelper.PrepareResolutionContext(
+                configService,
+                agentRunner,
+                "codex",
+                fullAgentPrompt,
+                modelOverride: "gpt-5.6-sol",
+                effortOverride: null,
+                permissionMode: PermissionMode.FullAuto);
+
+            _output.WriteLine($"Launching agent with workdir {context.WorkingDirectory}");
+
+            var agentSession = await agentRunner.LaunchAsync(context);
+            _output.WriteLine($"Session launched: {agentSession.SessionId}");
+
+            var rawLines = new System.Collections.Generic.List<string>();
+            string? lastTextEvent = null;
+            var rawLock = new object();
+
+            using var sub = agentSession.Events.Subscribe(evt =>
+            {
+                try
+                {
+                    _output.WriteLine($"Event received: {evt.Kind}");
+                    if (evt is TextEvent textEvt && !string.IsNullOrWhiteSpace(textEvt.Text))
+                    {
+                        _output.WriteLine($"TextEvent: {textEvt.Text}");
+                        lock (rawLock)
+                        {
+                            lastTextEvent = textEvt.Text;
+                        }
+                    }
+
+                    var wireJson = serializer.Serialize(evt);
+                    if (!string.IsNullOrEmpty(wireJson))
+                    {
+                        lock (rawLock)
+                        {
+                            rawLines.Add(wireJson);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _output.WriteLine($"Subscribe ex: {ex}");
+                }
+            });
+
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var result = await agentSession.WaitForCompletionAsync(timeoutCts.Token);
+            _output.WriteLine($"WaitForCompletionAsync returned: Success={result.IsSuccess}, ExitCode={result.ExitCode}, Response={result.Response}");
+
+            string? collectedText = null;
+            string? fullRawStream = null;
+            lock (rawLock)
+            {
+                collectedText = lastTextEvent;
+                if (rawLines.Count > 0) fullRawStream = string.Join("\n", rawLines);
+            }
+
+            var responseContent = !string.IsNullOrWhiteSpace(result.Response)
+                ? result.Response
+                : (!string.IsNullOrWhiteSpace(collectedText)
+                    ? collectedText
+                    : (result.IsSuccess ? "Task completed successfully." : "Agent execution completed with status code " + (result.ExitCode?.ToString() ?? "unknown")));
+
+            _output.WriteLine($"Final responseContent: {responseContent}");
+
+            chatService.AddMessage(session.Id, "assistant", responseContent, "codex", "gpt-5.6-sol", rawStream: fullRawStream);
+
+            var updatedSession = chatService.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            Assert.Equal(2, updatedSession.Messages.Count);
+            Assert.Equal("assistant", updatedSession.Messages[1].Role);
+            _output.WriteLine($"Session verified with {updatedSession.Messages.Count} messages");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void ChatApp_Build_WithExistingSession_RendersSuccessfully()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatBuildTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+
+            var sess = chatService.CreateSession("codex", "gpt-5.6-sol");
+            chatService.AddMessage(sess.Id, "user", "test", "codex", "gpt-5.6-sol");
+
+            var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+            services.AddSingleton<IConfigService>(configService);
+            services.AddSingleton<IChatHistoryService>(chatService);
+            services.AddSingleton<IAgentRunner>(agentRunner);
+            services.AddSingleton<IEventSerializer>(serializer);
+            var appContext = (Ivy.AppContext)Activator.CreateInstance(
+                typeof(Ivy.AppContext),
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                null,
+                new object?[] { "conn1", "mach1", "chat", "chat", null, "http", "localhost", null },
+                null)!;
+            services.AddSingleton(appContext);
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            services.AddSingleton<IChatSessionNamingService>(namingService);
+
+            var sp = services.BuildServiceProvider();
+            var ctx = new Ivy.Core.Hooks.ViewContext(() => { }, null, sp);
+
+            var app = new Ivy.Tendril.Apps.Chat.ChatApp();
+            app.BeforeBuild(ctx);
+            var built = app.Build();
+            app.AfterBuild();
+            ctx.Reset();
+
+            Assert.NotNull(built);
+            _output.WriteLine($"ChatApp.Build returned: {built.GetType().Name}");
+
+            int refreshCount = 0;
+            ctx = new Ivy.Core.Hooks.ViewContext(() => { refreshCount++; }, null, sp);
+            app.BeforeBuild(ctx);
+            built = app.Build();
+            app.AfterBuild();
+            ctx.Reset();
+
+            _output.WriteLine($"Refresh count after second build: {refreshCount}");
+            Assert.True(refreshCount <= 2, $"Refresh count was too high: {refreshCount}");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionIntegrationTest.cs
@@ -142,6 +142,116 @@ public class ChatExecutionIntegrationTest
     }
 
     [Fact]
+    public async Task WidgetTree_BuildAsync_WithRealUserTendrilDir_Succeeds()
+    {
+        var tendrilDir = "/Users/rorychatt/.tendril";
+        if (!Directory.Exists(tendrilDir)) return;
+
+        var configService = new ConfigService(new TendrilSettings { CodingAgent = "codex" }, tendrilDir);
+        var chatService = new ChatHistoryService(configService);
+        var agentRunner = TestAgentRunner.Create();
+        var serializer = new JsonEventSerializer();
+
+        var sessions = chatService.GetSessions();
+        _output.WriteLine($"Found {sessions.Count} sessions in real .tendril dir");
+        foreach (var s in sessions)
+        {
+            _output.WriteLine($"Session: {s.Id}, Title: {s.Title}, Messages: {s.Messages.Count}");
+        }
+
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        services.AddSingleton<IConfigService>(configService);
+        services.AddSingleton<IChatHistoryService>(chatService);
+        services.AddSingleton<IAgentRunner>(agentRunner);
+        services.AddSingleton<IEventSerializer>(serializer);
+        var appContext = (Ivy.AppContext)Activator.CreateInstance(
+            typeof(Ivy.AppContext),
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+            null,
+            new object?[] { "conn1", "mach1", "chat", "chat", null, "http", "localhost", null },
+            null)!;
+        services.AddSingleton(appContext);
+        var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+        services.AddSingleton<IChatSessionNamingService>(namingService);
+        services.AddSingleton<IUploadService>(new Ivy.UploadService("conn1", null!));
+
+        var sp = services.BuildServiceProvider();
+
+        var app = new Ivy.Tendril.Apps.Chat.ChatApp();
+        var contentBuilder = new Ivy.ContentBuilder();
+        var tree = new Ivy.Core.WidgetTree(app, contentBuilder, sp);
+
+        var buildTask = tree.BuildAsync();
+        var completedTask = await Task.WhenAny(buildTask, Task.Delay(5000));
+        Assert.True(completedTask == buildTask, "tree.BuildAsync with real .tendril timed out!");
+
+        var widgets = tree.GetWidgets();
+        Assert.NotNull(widgets);
+        _output.WriteLine($"Real tree built successfully! Root: {widgets.GetType().Name}");
+    }
+
+    [Fact]
+    public void AppDescriptor_ForChatApp_HasIdChat()
+    {
+        var descriptor = Ivy.Core.Apps.AppHelpers.GetApp(typeof(Ivy.Tendril.Apps.Chat.ChatApp));
+        _output.WriteLine($"ChatApp descriptor ID: '{descriptor.Id}', Title: '{descriptor.Title}'");
+        Assert.Equal("chat", descriptor.Id);
+    }
+
+    [Fact]
+    public async Task WidgetTree_BuildAsync_ForChatApp_CompletesSuccessfully()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatTreeTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+
+            var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+            services.AddSingleton<IConfigService>(configService);
+            services.AddSingleton<IChatHistoryService>(chatService);
+            services.AddSingleton<IAgentRunner>(agentRunner);
+            services.AddSingleton<IEventSerializer>(serializer);
+            var appContext = (Ivy.AppContext)Activator.CreateInstance(
+                typeof(Ivy.AppContext),
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                null,
+                new object?[] { "conn1", "mach1", "chat", "chat", null, "http", "localhost", null },
+                null)!;
+            services.AddSingleton(appContext);
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            services.AddSingleton<IChatSessionNamingService>(namingService);
+            services.AddSingleton<IUploadService>(new Ivy.UploadService("conn1", null!));
+
+            var sp = services.BuildServiceProvider();
+
+            var app = new Ivy.Tendril.Apps.Chat.ChatApp();
+            var contentBuilder = new Ivy.ContentBuilder();
+            var tree = new Ivy.Core.WidgetTree(app, contentBuilder, sp);
+
+            var buildTask = tree.BuildAsync();
+            var completedTask = await Task.WhenAny(buildTask, Task.Delay(5000));
+            Assert.True(completedTask == buildTask, "tree.BuildAsync timed out!");
+
+            var widgets = tree.GetWidgets();
+            Assert.NotNull(widgets);
+            _output.WriteLine($"Tree root widget: {widgets.GetType().Name}");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
     public void ChatApp_Build_WithExistingSession_RendersSuccessfully()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatBuildTest_" + Guid.NewGuid().ToString("N"));

--- a/src/Ivy.Tendril.Widgets/ChatWidget.cs
+++ b/src/Ivy.Tendril.Widgets/ChatWidget.cs
@@ -74,7 +74,6 @@ public record ChatWidget : WidgetBase<ChatWidget>
     [Prop] public bool SupportsEffort { get; init; } = true;
     [Prop] public bool IsStreaming { get; init; } = false;
     [Prop] public string? StreamingText { get; init; }
-    [Prop] public IWriteStream<string>? StreamingStream { get; init; }
     [Prop] public List<ChatQueuedMessageDto> QueuedMessages { get; init; } = new();
 
     [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnSelectSession { get; init; }

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
@@ -183,7 +183,7 @@ export const AgentViewer: React.FC<AgentViewerProps> = ({
               return null;
           }
         })}
-        {showStatusLabel && !isComplete && (
+        {showStatusLabel && (
           <div className="aov-status-row">
             <AnimatedStatus statusText={statusText} isComplete={isComplete} />
           </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
@@ -183,7 +183,7 @@ export const AgentViewer: React.FC<AgentViewerProps> = ({
               return null;
           }
         })}
-        {showStatusLabel && (
+        {showStatusLabel && !isComplete && (
           <div className="aov-status-row">
             <AnimatedStatus statusText={statusText} isComplete={isComplete} />
           </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import Markdown from "react-markdown";
 import "./agent-output.css";
 import type { EventHandler, PresentationEvent } from "./types";
@@ -31,8 +31,6 @@ function buildSuppressIndices(events: PresentationEvent[]): Set<number> {
   return indices;
 }
 
-type StreamSubscriber = (streamId: string, onData: (data: unknown) => void) => () => void;
-
 interface AgentViewerProps {
   id: string;
   width?: string;
@@ -40,8 +38,6 @@ interface AgentViewerProps {
   eventHandler: EventHandler;
   events?: string[];
   jsonStream?: string;
-  stream?: { id: string };
-  subscribeToStream?: StreamSubscriber;
   autoScroll?: boolean;
   showThinking?: boolean;
   showSystemEvents?: boolean;
@@ -57,8 +53,6 @@ export const AgentViewer: React.FC<AgentViewerProps> = ({
   eventHandler,
   events: enabledEvents = [],
   jsonStream,
-  stream,
-  subscribeToStream,
   autoScroll = true,
   showThinking = false,
   showSystemEvents = false,
@@ -66,32 +60,9 @@ export const AgentViewer: React.FC<AgentViewerProps> = ({
   statusLabelOverride,
   groupToolCalls = false,
 }) => {
-  const [streamedLines, setStreamedLines] = useState<string[]>([]);
-
-  useEffect(() => {
-    setStreamedLines([]);
-  }, [jsonStream]);
-
-  useEffect(() => {
-    if (!stream?.id || !subscribeToStream) return;
-    const unsubscribe = subscribeToStream(stream.id, (data) => {
-      if (typeof data === "string") {
-        setStreamedLines((prev) => [...prev, data]);
-      }
-    });
-    return unsubscribe;
-  }, [stream?.id, subscribeToStream]);
-
-  const combinedStream = useMemo(() => {
-    const parts: string[] = [];
-    if (jsonStream) parts.push(jsonStream);
-    if (streamedLines.length > 0) parts.push(streamedLines.join("\n"));
-    return parts.join("\n");
-  }, [jsonStream, streamedLines]);
-
   const parsedEvents = useMemo<PresentationEvent[]>(
-    () => parseEventWireStream(combinedStream),
-    [combinedStream],
+    () => (jsonStream ? parseEventWireStream(jsonStream) : []),
+    [jsonStream],
   );
 
   const derived = useMemo(() => deriveStatus(parsedEvents), [parsedEvents]);

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/agent-output.css
@@ -85,6 +85,10 @@
   min-width: 0;
 }
 
+.aov-status-done .aov-status-icon {
+  color: #10b981;
+}
+
 .aov-status-icon {
   display: inline-flex;
   align-items: center;

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/status.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/status.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { deriveStatus } from "./status";
+import type { PresentationEvent } from "./types";
+
+describe("deriveStatus", () => {
+  it("returns Completed when last event is successful result", () => {
+    const events: PresentationEvent[] = [
+      { kind: "assistant-text", text: "Finished job." },
+      {
+        kind: "result",
+        wire: {
+          kind: "result",
+          timestamp: "2026-09-04T10:00:00Z",
+          is_success: true,
+        },
+      },
+    ];
+
+    const status = deriveStatus(events);
+    expect(status.complete).toBe(true);
+    expect(status.text).toBe("Completed");
+  });
+
+  it("returns Completed even if trailing non-terminal events follow result", () => {
+    const events: PresentationEvent[] = [
+      {
+        kind: "result",
+        wire: {
+          kind: "result",
+          timestamp: "2026-09-04T10:00:00Z",
+          is_success: true,
+        },
+      },
+    ];
+
+    const status = deriveStatus(events);
+    expect(status.complete).toBe(true);
+    expect(status.text).toBe("Completed");
+  });
+
+  it("returns Failed when result event has is_success = false", () => {
+    const events: PresentationEvent[] = [
+      {
+        kind: "result",
+        wire: {
+          kind: "result",
+          timestamp: "2026-09-04T10:00:00Z",
+          is_success: false,
+        },
+      },
+    ];
+
+    const status = deriveStatus(events);
+    expect(status.complete).toBe(true);
+    expect(status.text).toBe("Failed");
+  });
+
+  it("returns Failed when error event is present", () => {
+    const events: PresentationEvent[] = [
+      { kind: "error", message: "Process crashed" },
+    ];
+
+    const status = deriveStatus(events);
+    expect(status.complete).toBe(true);
+    expect(status.text).toBe("Failed");
+  });
+
+  it("returns tool label when tool is active without result", () => {
+    const events: PresentationEvent[] = [
+      {
+        kind: "tool-use",
+        tool: {
+          toolUseId: "t1",
+          name: "Read",
+          input: { file_path: "/path/to/test.ts" },
+        },
+      },
+    ];
+
+    const status = deriveStatus(events);
+    expect(status.complete).toBe(false);
+    expect(status.text).toBe("Reading test.ts");
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/status.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/status.ts
@@ -13,9 +13,14 @@ export interface DerivedStatus {
 export function deriveStatus(events: PresentationEvent[]): DerivedStatus {
   if (events.length === 0) return { text: "Starting…", complete: false };
 
-  const last = events[events.length - 1];
-  if (last.kind === "result") {
-    return { text: last.wire.is_success ? "Completed" : "Failed", complete: true };
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.kind === "result") {
+      return { text: e.wire.is_success ? "Completed" : "Failed", complete: true };
+    }
+    if (e.kind === "error") {
+      return { text: "Failed", complete: true };
+    }
   }
 
   for (let i = events.length - 1; i >= 0; i--) {
@@ -25,6 +30,7 @@ export function deriveStatus(events: PresentationEvent[]): DerivedStatus {
     }
   }
 
+  const last = events[events.length - 1];
   if (last.kind === "assistant-text") return { text: "Thinking…", complete: false };
   if (last.kind === "thinking") return { text: "Thinking…", complete: false };
   return { text: "Working…", complete: false };

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -768,4 +768,52 @@ describe("ChatWidget File Uploads and Attachments", () => {
     expect(screen.getByText("test. Alive?")).toBeInTheDocument();
     expect(screen.queryByText("Start a conversation")).not.toBeInTheDocument();
   });
+
+  it("optimistically displays assistant Starting status and switches Send button to Stop/Queue immediately upon clicking Send", async () => {
+    const handleEvent = vi.fn();
+    const session = {
+      id: "sess-1",
+      title: "Active Chat",
+      agentId: "codex",
+      modelId: "gpt-5.6-sol",
+      createdAt: "2026-09-03T10:00:00Z",
+      updatedAt: "2026-09-03T10:00:00Z",
+      messages: [],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-1"
+        selectedAgent="codex"
+        sessions={[session]}
+        eventHandler={handleEvent}
+        events={["OnSendMessage", "OnCancelStream"]}
+      />
+    );
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    fireEvent.change(textarea, { target: { value: "retry again" } });
+
+    const sendBtn = screen.getByRole("button", { name: /Send/i });
+    expect(sendBtn).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Stop/i })).not.toBeInTheDocument();
+
+    fireEvent.click(sendBtn);
+
+    // Immediately shows Stop and Queue buttons without waiting for server props
+    expect(screen.getByRole("button", { name: /Stop/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Queue/i })).toBeInTheDocument();
+
+    // Immediately shows the Starting... status indicator
+    expect(screen.getByText("Starting…")).toBeInTheDocument();
+
+    // Clicking Stop cancels optimistic stream
+    const stopBtn = screen.getByRole("button", { name: /Stop/i });
+    fireEvent.click(stopBtn);
+    expect(handleEvent).toHaveBeenCalledWith("OnCancelStream", "test-chat", []);
+    expect(screen.queryByRole("button", { name: /Stop/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Send/i })).toBeInTheDocument();
+  });
 });
+

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -218,6 +218,97 @@ describe("ChatWidget Queued Messages UI", () => {
     );
   });
 
+  it("preserves optimistically queued message when in-flight queuedMessages prop is empty", () => {
+    const handleEvent = vi.fn();
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        isStreaming={true}
+        activeSessionId="sess-1"
+        queuedMessages={[]}
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />
+    );
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const queueBtn = screen.getByRole("button", { name: /Queue/i });
+
+    fireEvent.change(textarea, { target: { value: "optimistic prompt" } });
+    fireEvent.click(queueBtn);
+
+    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
+    expect(screen.getByText("optimistic prompt")).toBeInTheDocument();
+
+    // Simulate in-flight SignalR update where server hasn't yet included the queued message
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        isStreaming={true}
+        activeSessionId="sess-1"
+        queuedMessages={[]}
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />
+    );
+
+    // Should still be visible optimistically!
+    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
+    expect(screen.getByText("optimistic prompt")).toBeInTheDocument();
+
+    // When server confirms the queued message
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        isStreaming={true}
+        activeSessionId="sess-1"
+        queuedMessages={[{ id: "guid-server-123", prompt: "optimistic prompt" }]}
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />
+    );
+
+    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
+    expect(screen.getByText("optimistic prompt")).toBeInTheDocument();
+  });
+
+  it("does not drop queued message when its content matches an existing historical message", () => {
+    const handleEvent = vi.fn();
+    const session = {
+      id: "sess-repeat",
+      title: "Repeat Test",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: "2026-08-15T12:00:00Z",
+      updatedAt: "2026-08-15T12:30:00Z",
+      messages: [{ id: "m-1", role: "user" as const, content: "what can you do?", timestamp: "10:00" }],
+      status: "generating" as const,
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        isStreaming={true}
+        activeSessionId="sess-repeat"
+        sessions={[session]}
+        queuedMessages={[]}
+        events={["OnSendMessage"]}
+        eventHandler={handleEvent}
+      />
+    );
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    const queueBtn = screen.getByRole("button", { name: /Queue/i });
+
+    fireEvent.change(textarea, { target: { value: "what can you do?" } });
+    fireEvent.click(queueBtn);
+
+    expect(screen.getByText("Queued Messages")).toBeInTheDocument();
+    // Verify it is inside the queued panel
+    const queuedItem = document.querySelector(".chat-queued-item-text");
+    expect(queuedItem).toHaveTextContent("what can you do?");
+  });
+
   it("renders delete button next to chat title and directly emits OnDeleteSession upon click", () => {
     const handleEvent = vi.fn();
     const session = {

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -729,4 +729,43 @@ describe("ChatWidget File Uploads and Attachments", () => {
       window.XMLHttpRequest = origXHR;
     }
   });
+
+  it("optimistically displays user message immediately upon clicking Send", async () => {
+    const handleEvent = vi.fn();
+    const session = {
+      id: "sess-empty",
+      title: "New Chat",
+      agentId: "codex",
+      modelId: "gpt-5.6-sol",
+      createdAt: "2026-09-03T10:00:00Z",
+      updatedAt: "2026-09-03T10:00:00Z",
+      messages: [],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-empty"
+        sessions={[session]}
+        eventHandler={handleEvent}
+        events={["OnSendMessage"]}
+      />
+    );
+
+    expect(screen.getByText("Start a conversation")).toBeInTheDocument();
+
+    const textarea = screen.getByPlaceholderText(/Ask/i);
+    fireEvent.change(textarea, { target: { value: "test. Alive?" } });
+
+    const sendBtn = screen.getByRole("button", { name: /Send/i });
+    fireEvent.click(sendBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith("OnSendMessage", "test-chat", [
+      { prompt: "test. Alive?", attachments: [], sessionId: "sess-empty" },
+    ]);
+
+    // Optimistic message should appear immediately without waiting for props update!
+    expect(screen.getByText("test. Alive?")).toBeInTheDocument();
+    expect(screen.queryByText("Start a conversation")).not.toBeInTheDocument();
+  });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -1060,7 +1060,7 @@ export function ChatWidget({
                       autoScroll={false}
                       showThinking={true}
                       showSystemEvents={false}
-                      showStatusLabel={false}
+                      showStatusLabel={true}
                       groupToolCalls={true}
                       eventHandler={noopEventHandler}
                     />

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -351,6 +351,7 @@ export function ChatWidget({
   const [editingQueuedId, setEditingQueuedId] = useState<string | null>(null);
   const [editingQueuedText, setEditingQueuedText] = useState("");
   const [pendingRenames, setPendingRenames] = useState<Record<string, string>>({});
+  const [optimisticMessages, setOptimisticMessages] = useState<Record<string, ChatMessageDto[]>>({});
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -359,6 +360,8 @@ export function ChatWidget({
   const initialPromptRef = useRef<string>("");
 
   const activeSession = sessions.find((s) => s.id === activeSessionId);
+  const currentOptimistic = (activeSessionId && optimisticMessages[activeSessionId]) || [];
+  const displayMessages = [...(activeSession?.messages || []), ...currentOptimistic];
   const totalAttachmentSize = attachments.reduce((sum, att) => sum + (att.size || 0), 0);
   const isPayloadOversized = totalAttachmentSize > MAX_PAYLOAD_BYTES;
   const isUploading = attachments.some((att) => att.uploadStatus === "uploading");
@@ -406,7 +409,24 @@ export function ChatWidget({
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [activeSession?.messages, isStreaming, streamingText, queuedMessages]);
+  }, [activeSession?.messages, displayMessages.length, isStreaming, streamingText, queuedMessages]);
+
+  useEffect(() => {
+    if (activeSessionId && sessions.length > 0) {
+      const sess = sessions.find((s) => s.id === activeSessionId);
+      if (sess?.messages && sess.messages.length > 0) {
+        setOptimisticMessages((prev) => {
+          const current = prev[activeSessionId];
+          if (!current || current.length === 0) return prev;
+          const remaining = current.filter(
+            (opt) => !sess.messages.some((m) => m.role === "user" && m.content.startsWith(opt.content))
+          );
+          if (remaining.length === current.length) return prev;
+          return { ...prev, [activeSessionId]: remaining };
+        });
+      }
+    }
+  }, [sessions, activeSessionId]);
 
   useEffect(() => {
     if (activeSession?.messages) {
@@ -485,6 +505,19 @@ export function ChatWidget({
         ...prev,
         { id: `q-${Date.now()}-${Math.random()}`, prompt: trimmed, attachments: payloadAttachments },
       ]);
+    } else if (activeSessionId) {
+      const optMsg: ChatMessageDto = {
+        id: `opt-${Date.now()}-${Math.random()}`,
+        role: "user",
+        content: trimmed,
+        timestamp: new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }),
+        agentId: selectedAgent,
+        modelId: selectedModel,
+      };
+      setOptimisticMessages((prev) => ({
+        ...prev,
+        [activeSessionId]: [...(prev[activeSessionId] || []), optMsg],
+      }));
     }
 
     emit("OnSendMessage", payload);
@@ -949,8 +982,8 @@ export function ChatWidget({
 
         {/* Message List Container */}
         <div className="chat-messages-container">
-          {activeSession && activeSession.messages && activeSession.messages.length > 0 ? (
-            activeSession.messages.map((msg) => (
+          {activeSession && displayMessages.length > 0 ? (
+            displayMessages.map((msg) => (
               <div key={msg.id} className={`chat-message-row ${msg.role}`}>
                 <div className="chat-message-bubble" style={msg.role === "assistant" && msg.rawStream ? { width: "85%", maxWidth: "85%" } : undefined}>
                   {msg.role === "assistant" && (

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -378,7 +378,14 @@ export function ChatWidget({
 
   useEffect(() => {
     if (queuedMessagesProp !== undefined) {
-      setQueuedMessages(queuedMessagesProp);
+      setQueuedMessages((prev) => {
+        const optimistic = prev.filter(
+          (item) =>
+            item.id.startsWith("q-") &&
+            !queuedMessagesProp.some((p) => p.prompt === item.prompt)
+        );
+        return [...queuedMessagesProp, ...optimistic];
+      });
     }
   }, [queuedMessagesProp]);
 
@@ -415,6 +422,7 @@ export function ChatWidget({
 
   useEffect(() => {
     setOptimisticStreaming(null);
+    setQueuedMessages(queuedMessagesProp || []);
   }, [activeSessionId]);
 
   useEffect(() => {
@@ -456,13 +464,6 @@ export function ChatWidget({
     }
   }, [sessions, activeSessionId]);
 
-  useEffect(() => {
-    if (activeSession?.messages) {
-      setQueuedMessages((prev) =>
-        prev.filter((q) => !activeSession.messages.some((m) => m.content === q.prompt))
-      );
-    }
-  }, [activeSession?.messages]);
 
   const adjustTextareaHeight = () => {
     const el = textareaRef.current;

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -201,8 +201,6 @@ export interface ChatWidgetProps {
   supportsEffort?: boolean;
   isStreaming?: boolean;
   streamingText?: string;
-  streamingStream?: { id: string };
-  subscribeToStream?: (streamId: string, onData: (data: unknown) => void) => () => void;
   queuedMessages?: ChatQueuedMessageDto[];
   events?: string[];
   eventHandler?: IvyEventHandler;
@@ -335,8 +333,6 @@ export function ChatWidget({
   supportsEffort = true,
   isStreaming = false,
   streamingText = "",
-  streamingStream: _streamingStream,
-  subscribeToStream: _subscribeToStream,
   queuedMessages: queuedMessagesProp,
   events = [],
   eventHandler,
@@ -352,6 +348,7 @@ export function ChatWidget({
   const [editingQueuedText, setEditingQueuedText] = useState("");
   const [pendingRenames, setPendingRenames] = useState<Record<string, string>>({});
   const [optimisticMessages, setOptimisticMessages] = useState<Record<string, ChatMessageDto[]>>({});
+  const [optimisticStreaming, setOptimisticStreaming] = useState<string | null>(null);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -368,13 +365,14 @@ export function ChatWidget({
   const isAnyFailed = attachments.some((att) => att.uploadStatus === "failed");
   const hasValidAttachments = attachments.some((att) => att.uploadStatus === "finished" || !att.uploadStatus);
   const isSendDisabled = isPayloadOversized || isUploading || isAnyFailed || (!promptText.trim() && !hasValidAttachments);
+  const effectiveIsStreaming = isStreaming || (optimisticStreaming !== null && (optimisticStreaming === activeSessionId || optimisticStreaming === "__active__"));
   const sendTitle = isPayloadOversized
     ? "Attachments exceed the 50 MB limit"
     : isUploading
     ? "Files are uploading..."
     : isAnyFailed
     ? "Some attachments failed to upload"
-    : isStreaming
+    : effectiveIsStreaming
     ? "Queue message"
     : "Send message";
 
@@ -407,9 +405,39 @@ export function ChatWidget({
     }
   }, [sessions, pendingRenames]);
 
+  const prevIsStreamingRef = useRef(isStreaming);
+  useEffect(() => {
+    if (prevIsStreamingRef.current && !isStreaming) {
+      setOptimisticStreaming(null);
+    }
+    prevIsStreamingRef.current = isStreaming;
+  }, [isStreaming]);
+
+  useEffect(() => {
+    setOptimisticStreaming(null);
+  }, [activeSessionId]);
+
+  useEffect(() => {
+    if (!isStreaming && optimisticStreaming) {
+      const msgs = activeSession?.messages;
+      if (msgs && msgs.length > 0 && msgs[msgs.length - 1].role === "assistant") {
+        setOptimisticStreaming(null);
+      }
+    }
+  }, [isStreaming, optimisticStreaming, activeSession?.messages]);
+
+  useEffect(() => {
+    if (optimisticStreaming) {
+      const timer = setTimeout(() => {
+        setOptimisticStreaming(null);
+      }, 60000);
+      return () => clearTimeout(timer);
+    }
+  }, [optimisticStreaming]);
+
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [activeSession?.messages, displayMessages.length, isStreaming, streamingText, queuedMessages]);
+  }, [activeSession?.messages, displayMessages.length, effectiveIsStreaming, streamingText, queuedMessages]);
 
   useEffect(() => {
     if (activeSessionId && sessions.length > 0) {
@@ -500,24 +528,27 @@ export function ChatWidget({
     }));
 
     const payload = { prompt: trimmed, attachments: payloadAttachments, sessionId: activeSessionId };
-    if (isStreaming) {
+    if (effectiveIsStreaming) {
       setQueuedMessages((prev) => [
         ...prev,
         { id: `q-${Date.now()}-${Math.random()}`, prompt: trimmed, attachments: payloadAttachments },
       ]);
-    } else if (activeSessionId) {
-      const optMsg: ChatMessageDto = {
-        id: `opt-${Date.now()}-${Math.random()}`,
-        role: "user",
-        content: trimmed,
-        timestamp: new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }),
-        agentId: selectedAgent,
-        modelId: selectedModel,
-      };
-      setOptimisticMessages((prev) => ({
-        ...prev,
-        [activeSessionId]: [...(prev[activeSessionId] || []), optMsg],
-      }));
+    } else {
+      setOptimisticStreaming(activeSessionId || "__active__");
+      if (activeSessionId) {
+        const optMsg: ChatMessageDto = {
+          id: `opt-${Date.now()}-${Math.random()}`,
+          role: "user",
+          content: trimmed,
+          timestamp: new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }),
+          agentId: selectedAgent,
+          modelId: selectedModel,
+        };
+        setOptimisticMessages((prev) => ({
+          ...prev,
+          [activeSessionId]: [...(prev[activeSessionId] || []), optMsg],
+        }));
+      }
     }
 
     emit("OnSendMessage", payload);
@@ -529,6 +560,7 @@ export function ChatWidget({
   };
 
   const handleCancelStream = () => {
+    setOptimisticStreaming(null);
     setQueuedMessages([]);
     emit("OnCancelStream");
   };
@@ -1057,7 +1089,7 @@ export function ChatWidget({
             </div>
           )}
 
-          {isStreaming && (
+          {effectiveIsStreaming && (
             <div className="chat-message-row assistant">
               <div className="chat-message-bubble" style={{ width: "85%", maxWidth: "85%" }}>
                 <div className="chat-message-header">
@@ -1329,7 +1361,7 @@ export function ChatWidget({
               </div>
 
               <div className="chat-input-actions-right">
-                {isStreaming ? (
+                {effectiveIsStreaming ? (
                   <>
                     <button
                       type="button"

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -1061,7 +1061,7 @@ export function ChatWidget({
                       autoScroll={false}
                       showThinking={true}
                       showSystemEvents={false}
-                      showStatusLabel={true}
+                      showStatusLabel={false}
                       groupToolCalls={true}
                       eventHandler={noopEventHandler}
                     />

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -733,9 +733,11 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
 
         // ----- Content + session tabs -----
 
-        object? pageContent = currentApp.Value;
+        object? pageContent = currentApp.Value != null
+            ? currentApp.Value.Key(currentApp.Value.AppId + (currentApp.Value.AppArgs != null ? ":" + currentApp.Value.AppArgs : ""))
+            : null;
         if (pageContent == null && settings.WallpaperAppId != null)
-            pageContent = new AppHost(settings.WallpaperAppId, null, args.ConnectionId);
+            pageContent = new AppHost(settings.WallpaperAppId, null, args.ConnectionId).Key(settings.WallpaperAppId);
 
         var sessionContents = tabs.Value
             .Select(t => (object?)t.AppHost.Key(StringHelper.GetShortHash(t.Id + t.RefreshToken)))

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -57,14 +57,7 @@ public class ChatApp : ViewBase
         {
             void OnSessionsChanged(object? sender, EventArgs e) => sessionVersion.Set(v => v + 1);
 
-            void OnGeneratingChanged(object? sender, EventArgs e)
-            {
-                if (!string.IsNullOrEmpty(activeSessionId.Value))
-                {
-                    chatService.ClearSessionCompleted(activeSessionId.Value);
-                }
-                sessionVersion.Set(v => v + 1);
-            }
+            void OnGeneratingChanged(object? sender, EventArgs e) => sessionVersion.Set(v => v + 1);
 
             void OnStreamUpdated(string sessId)
             {
@@ -80,7 +73,6 @@ public class ChatApp : ViewBase
                 if (!string.IsNullOrEmpty(activeSessionId.Value) &&
                     string.Equals(sessId, activeSessionId.Value, StringComparison.OrdinalIgnoreCase))
                 {
-                    chatService.ClearSessionCompleted(activeSessionId.Value);
                     streamVersion.Set(v => v + 1);
                     sessionVersion.Set(v => v + 1);
                 }

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -1,19 +1,13 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Reactive.Disposables;
 using Ivy;
 using Ivy.Core;
-using Ivy.Core.Hooks;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Helpers;
 using Ivy.Tendril.Agents.Providers;
-using Ivy.Tendril.Agents.Runtime;
-using Ivy.Tendril.Apps.Chat.Dialogs;
+using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Widgets;
@@ -28,9 +22,8 @@ public class ChatApp : ViewBase
         var args = UseArgs<ChatAppArgs>();
         var configService = UseService<IConfigService>();
         var chatService = UseService<IChatHistoryService>();
+        var executionService = UseService<IChatExecutionService>();
         var agentRunner = UseService<IAgentRunner>();
-        var namingService = UseService<IChatSessionNamingService>();
-        var serializer = UseService<IEventSerializer>();
 
         var activeSessionId = UseState<string?>(() =>
         {
@@ -56,39 +49,61 @@ public class ChatApp : ViewBase
             var sess = !string.IsNullOrEmpty(args?.SessionId) ? chatService.GetSession(args.SessionId) : chatService.GetSessions().FirstOrDefault();
             return sess?.Effort ?? "default";
         });
-        var isStreaming = UseState(false);
-        var streamingSessionId = UseState<string?>(null);
-        var liveSessionStreams = UseState(new Dictionary<string, string>());
-        var activeSessionRef = UseRef<IAgentSession?>(null);
-        var runningSessionIds = UseState(() => new HashSet<string>(chatService.GetGeneratingSessionIds()));
-        var initialHandled = UseRef(false);
-
         var searchState = UseState("");
+        var initialHandled = UseRef(false);
+        var streamVersion = UseState(0);
 
         UseEffect(() =>
         {
             void OnSessionsChanged(object? sender, EventArgs e) => sessionVersion.Set(v => v + 1);
-            void OnGeneratingSessionsChanged(object? sender, EventArgs e)
+
+            void OnGeneratingChanged(object? sender, EventArgs e)
             {
-                runningSessionIds.Set(new HashSet<string>(chatService.GetGeneratingSessionIds()));
+                if (!string.IsNullOrEmpty(activeSessionId.Value))
+                {
+                    chatService.ClearSessionCompleted(activeSessionId.Value);
+                }
+                sessionVersion.Set(v => v + 1);
+            }
+
+            void OnStreamUpdated(string sessId)
+            {
+                if (!string.IsNullOrEmpty(activeSessionId.Value) &&
+                    string.Equals(sessId, activeSessionId.Value, StringComparison.OrdinalIgnoreCase))
+                {
+                    streamVersion.Set(v => v + 1);
+                }
+            }
+
+            void OnSessionGeneratingChanged(string sessId)
+            {
+                if (!string.IsNullOrEmpty(activeSessionId.Value) &&
+                    string.Equals(sessId, activeSessionId.Value, StringComparison.OrdinalIgnoreCase))
+                {
+                    chatService.ClearSessionCompleted(activeSessionId.Value);
+                    streamVersion.Set(v => v + 1);
+                    sessionVersion.Set(v => v + 1);
+                }
             }
 
             chatService.SessionsChanged += OnSessionsChanged;
-            chatService.GeneratingSessionsChanged += OnGeneratingSessionsChanged;
-            return Disposable.Create(() =>
-            {
-                chatService.SessionsChanged -= OnSessionsChanged;
-                chatService.GeneratingSessionsChanged -= OnGeneratingSessionsChanged;
-            });
-        });
+            chatService.GeneratingSessionsChanged += OnGeneratingChanged;
+            executionService.StreamUpdated += OnStreamUpdated;
+            executionService.SessionGeneratingChanged += OnSessionGeneratingChanged;
 
-        UseEffect(() =>
-        {
             if (!string.IsNullOrEmpty(activeSessionId.Value))
             {
                 chatService.ClearSessionCompleted(activeSessionId.Value);
             }
-        }, [activeSessionId]);
+
+            return Disposable.Create(() =>
+            {
+                chatService.SessionsChanged -= OnSessionsChanged;
+                chatService.GeneratingSessionsChanged -= OnGeneratingChanged;
+                executionService.StreamUpdated -= OnStreamUpdated;
+                executionService.SessionGeneratingChanged -= OnSessionGeneratingChanged;
+            });
+        });
 
         void SelectSession(string sessionId)
         {
@@ -104,9 +119,12 @@ public class ChatApp : ViewBase
         }
 
         var currentVersion = sessionVersion.Value;
+        _ = streamVersion.Value;
         var sessions = chatService.GetSessions();
         var currentSessionId = activeSessionId.Value;
         var activeSession = currentSessionId != null ? chatService.GetSession(currentSessionId) : null;
+        var isSessionGenerating = currentSessionId != null && executionService.IsGenerating(currentSessionId);
+        var streamSnapshot = isSessionGenerating ? executionService.GetStreamSnapshot(currentSessionId!) : string.Empty;
 
         var registeredAgentIds = agentRunner.RegisteredAgents;
         if (registeredAgentIds.Count == 0)
@@ -132,10 +150,14 @@ public class ChatApp : ViewBase
             ? selectedEffort.Value
             : "default";
 
+        // Compact DTO serialization: only serialize full message history for the active session,
+        // preventing massive SignalR payload bloat when a user has hundreds of sessions.
         var sessionDtos = sessions.Select(s =>
         {
-            var isGenerating = runningSessionIds.Value.Contains(s.Id);
+            var isGenerating = executionService.IsGenerating(s.Id);
             var status = isGenerating ? "generating" : "done";
+            var isActive = s.Id == currentSessionId;
+
             return new ChatSessionDto(
                 s.Id,
                 s.Title,
@@ -143,271 +165,30 @@ public class ChatApp : ViewBase
                 s.ModelId,
                 s.CreatedAt.ToString("o"),
                 s.UpdatedAt.ToString("o"),
-                s.Messages.Select(m => new ChatMessageDto(
-                    m.Id,
-                    m.Role,
-                    m.Content,
-                    m.Timestamp.ToString("t"),
-                    m.AgentId,
-                    m.ModelId,
-                    m.RawStream,
-                    m.Effort
-                )).ToList(),
+                isActive
+                    ? s.Messages.Select(m => new ChatMessageDto(
+                        m.Id,
+                        m.Role,
+                        m.Content,
+                        m.Timestamp.ToString("t"),
+                        m.AgentId,
+                        m.ModelId,
+                        m.RawStream,
+                        m.Effort
+                    )).ToList()
+                    : [],
                 status,
                 s.Effort
             );
         }).ToList();
 
-        async Task ExecuteSendMessage(ChatSendMessageDto dto)
-        {
-            var userPrompt = dto.Prompt?.Trim() ?? "";
-            var attachments = dto.Attachments ?? [];
-            if (string.IsNullOrWhiteSpace(userPrompt) && attachments.Count == 0) return;
-
-            string targetSessionId = dto.SessionId ?? "";
-            if (string.IsNullOrEmpty(targetSessionId)) return;
-
-            var targetAgent = selectedAgent.Value;
-            var targetModel = effectiveModel;
-            var targetEffort = effectiveEffort;
-
-            var runningSet = new HashSet<string>(runningSessionIds.Value) { targetSessionId };
-            runningSessionIds.Set(runningSet);
-            streamingSessionId.Set(targetSessionId);
-            chatService.SetSessionGenerating(targetSessionId, true);
-
-            try
-            {
-                var attachedFilePaths = new List<string>();
-                var attachmentErrors = new List<string>();
-                if (attachments.Count > 0)
-                {
-                    var attachDir = Path.Combine(configService.TendrilHome, "Attachments", targetSessionId);
-                    if (!Directory.Exists(attachDir))
-                    {
-                        Directory.CreateDirectory(attachDir);
-                    }
-
-                    foreach (var att in attachments)
-                    {
-                        try
-                        {
-                            var rawName = Path.GetFileName(att.Name);
-                            var fileName = !string.IsNullOrWhiteSpace(rawName)
-                                ? string.Concat(rawName.Split(Path.GetInvalidFileNameChars()))
-                                : $"file_{Guid.NewGuid():N}.bin";
-                            if (string.IsNullOrWhiteSpace(fileName)) fileName = $"file_{Guid.NewGuid():N}.bin";
-                            var filePath = !string.IsNullOrWhiteSpace(att.LocalPath) && File.Exists(att.LocalPath)
-                                ? att.LocalPath
-                                : Path.Combine(attachDir, fileName);
-
-                            if (!string.IsNullOrEmpty(att.Base64Data))
-                            {
-                                var base64 = att.Base64Data.Contains(",")
-                                    ? att.Base64Data[(att.Base64Data.IndexOf(",") + 1)..]
-                                    : att.Base64Data;
-                                var bytes = Convert.FromBase64String(base64);
-                                File.WriteAllBytes(filePath, bytes);
-                            }
-
-                            if (File.Exists(filePath))
-                            {
-                                attachedFilePaths.Add(filePath);
-                            }
-                            else
-                            {
-                                attachmentErrors.Add($"Attachment '{att.Name}' was not found at {filePath}");
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            attachmentErrors.Add($"Failed to process attachment '{att.Name}': {ex.Message}");
-                        }
-                    }
-                }
-
-                var promptWithAttachments = userPrompt;
-                if (attachedFilePaths.Count > 0)
-                {
-                    var sb = new StringBuilder();
-                    if (!string.IsNullOrWhiteSpace(userPrompt))
-                    {
-                        sb.AppendLine(userPrompt);
-                        sb.AppendLine();
-                    }
-                    sb.AppendLine("[Attached Files]:");
-                    foreach (var path in attachedFilePaths)
-                    {
-                        sb.AppendLine($"- {path}");
-                    }
-                    promptWithAttachments = sb.ToString().TrimEnd();
-                }
-
-                if (attachmentErrors.Count > 0)
-                {
-                    var warning = "Warning: Some attachments could not be processed:\n" + string.Join("\n", attachmentErrors.Select(e => $"- {e}"));
-                    chatService.AddMessage(targetSessionId, "assistant", warning, selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
-                }
-
-                var sess = chatService.GetSession(targetSessionId);
-                var history = sess?.Messages ?? [];
-
-                var agentPromptBuilder = new StringBuilder();
-                if (history.Count > 0)
-                {
-                    agentPromptBuilder.AppendLine("# Previous Conversation Discussion History");
-                    agentPromptBuilder.AppendLine("The following is the previous conversation history in this chat session:");
-                    agentPromptBuilder.AppendLine();
-
-                    foreach (var prevMsg in history)
-                    {
-                        var roleLabel = prevMsg.Role.Equals("user", StringComparison.OrdinalIgnoreCase) ? "User" : "Assistant";
-                        agentPromptBuilder.AppendLine($"### {roleLabel}");
-                        agentPromptBuilder.AppendLine(prevMsg.Content);
-                        agentPromptBuilder.AppendLine();
-                    }
-
-                    agentPromptBuilder.AppendLine("---");
-                    agentPromptBuilder.AppendLine();
-                }
-
-                agentPromptBuilder.AppendLine("# Current User Request");
-                agentPromptBuilder.AppendLine(promptWithAttachments);
-
-                var fullAgentPrompt = agentPromptBuilder.ToString();
-
-                chatService.AddMessage(targetSessionId, "user", promptWithAttachments, targetAgent, targetModel, effort: targetEffort);
-                isStreaming.Set(true);
-
-                var effortOverride = targetEffort != "default" ? AgentProviderFactory.ParseEffort(targetEffort) : null;
-                var context = AgentLaunchHelper.PrepareResolutionContext(
-                    configService,
-                    agentRunner,
-                    targetAgent,
-                    fullAgentPrompt,
-                    modelOverride: targetModel,
-                    effortOverride: effortOverride,
-                    permissionMode: PermissionMode.FullAuto);
-
-                var session = await agentRunner.LaunchAsync(context);
-                activeSessionRef.Value = session;
-
-                var rawLines = new List<string>();
-                string? lastTextEvent = null;
-                var rawLock = new object();
-
-                using var sub = session.Events.Subscribe(evt =>
-                {
-                    try
-                    {
-                        if (evt is TextEvent textEvt && !string.IsNullOrWhiteSpace(textEvt.Text))
-                        {
-                            lock (rawLock)
-                            {
-                                lastTextEvent = textEvt.Text;
-                            }
-                        }
-
-                        var wireJson = serializer.Serialize(evt);
-                        if (!string.IsNullOrEmpty(wireJson))
-                        {
-                            lock (rawLock)
-                            {
-                                rawLines.Add(wireJson);
-                                var map = new Dictionary<string, string>(liveSessionStreams.Value)
-                                {
-                                    [targetSessionId] = string.Join("\n", rawLines)
-                                };
-                                liveSessionStreams.Set(map);
-                            }
-                        }
-                    }
-                    catch
-                    {
-                        // Ignore serialization exceptions
-                    }
-                });
-
-                var jobTimeoutMinutes = configService.Settings.JobTimeout;
-                var totalTimeout = jobTimeoutMinutes > 0
-                    ? TimeSpan.FromMinutes(jobTimeoutMinutes)
-                    : TimeSpan.FromMinutes(15);
-                using var timeoutCts = new CancellationTokenSource(totalTimeout);
-
-                var result = await session.WaitForCompletionAsync(timeoutCts.Token);
-
-                string? collectedText = null;
-                string? fullRawStream = null;
-                lock (rawLock)
-                {
-                    collectedText = lastTextEvent;
-                    if (rawLines.Count > 0) fullRawStream = string.Join("\n", rawLines);
-                }
-
-                var responseContent = !string.IsNullOrWhiteSpace(result.Response)
-                    ? result.Response
-                    : (!string.IsNullOrWhiteSpace(collectedText)
-                        ? collectedText
-                        : (result.IsSuccess ? "Task completed successfully." : "Agent execution completed with status code " + (result.ExitCode?.ToString() ?? "unknown")));
-
-                chatService.AddMessage(targetSessionId, "assistant", responseContent, targetAgent, targetModel, rawStream: fullRawStream, effort: targetEffort);
-
-                var currentSession = chatService.GetSession(targetSessionId);
-                if (currentSession != null &&
-                    (currentSession.Title == "New Chat" || string.IsNullOrWhiteSpace(currentSession.Title)) &&
-                    currentSession.Messages.Count == 2)
-                {
-                    var firstUserMsg = currentSession.Messages.FirstOrDefault(m => m.Role == "user")?.Content;
-                    if (!string.IsNullOrWhiteSpace(firstUserMsg))
-                    {
-                        var agentId = targetAgent;
-                        var modelId = targetModel;
-                        _ = Task.Run(async () =>
-                        {
-                            await namingService.GenerateAndSetTitleAsync(
-                                targetSessionId,
-                                firstUserMsg,
-                                responseContent,
-                                agentId,
-                                modelId);
-                        });
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                chatService.AddMessage(targetSessionId, "assistant", $"Error executing request: {ex.Message}", targetAgent, targetModel, effort: targetEffort);
-            }
-            finally
-            {
-                activeSessionRef.Value = null;
-                isStreaming.Set(false);
-                streamingSessionId.Set(null);
-
-                var finishedSet = new HashSet<string>(runningSessionIds.Value);
-                finishedSet.Remove(targetSessionId);
-                runningSessionIds.Set(finishedSet);
-                chatService.SetSessionGenerating(targetSessionId, false);
-
-                var map = new Dictionary<string, string>(liveSessionStreams.Value);
-                map.Remove(targetSessionId);
-                liveSessionStreams.Set(map);
-
-                if (chatService.TryDequeueMessage(targetSessionId, out var nextQueuedItem) && nextQueuedItem != null)
-                {
-                    var nextDto = new ChatSendMessageDto(nextQueuedItem.Prompt, nextQueuedItem.Attachments, targetSessionId);
-                    _ = ExecuteSendMessage(nextDto);
-                }
-            }
-        }
-
         void SendMessage(ChatSendMessageDto dto)
         {
-            var userPrompt = dto.Prompt?.Trim() ?? "";
+            var userPrompt = dto.Prompt?.Trim() ?? string.Empty;
             var attachments = dto.Attachments ?? [];
             if (string.IsNullOrWhiteSpace(userPrompt) && attachments.Count == 0) return;
 
-            string targetSessionId = !string.IsNullOrEmpty(dto.SessionId) ? dto.SessionId : (activeSessionId.Value ?? "");
+            string targetSessionId = !string.IsNullOrEmpty(dto.SessionId) ? dto.SessionId : (activeSessionId.Value ?? string.Empty);
             if (string.IsNullOrEmpty(targetSessionId))
             {
                 var newSess = chatService.CreateSession(selectedAgent.Value, effectiveModel, effort: effectiveEffort);
@@ -415,16 +196,16 @@ public class ChatApp : ViewBase
                 SelectSession(targetSessionId);
             }
 
-            var pinnedDto = new ChatSendMessageDto(userPrompt, dto.Attachments, targetSessionId);
+            sessionVersion.Set(v => v + 1);
+            streamVersion.Set(v => v + 1);
 
-            if (runningSessionIds.Value.Contains(targetSessionId))
-            {
-                chatService.EnqueueMessage(targetSessionId, pinnedDto);
-            }
-            else
-            {
-                _ = ExecuteSendMessage(pinnedDto);
-            }
+            _ = executionService.SendMessageAsync(
+                targetSessionId,
+                userPrompt,
+                attachments,
+                selectedAgent.Value,
+                effectiveModel,
+                effectiveEffort);
         }
 
         if (!initialHandled.Value && !string.IsNullOrEmpty(args?.Prompt))
@@ -459,17 +240,15 @@ public class ChatApp : ViewBase
             selectedAgent,
             selectedModel,
             selectedEffort,
-            isStreaming,
-            streamingSessionId,
-            runningSessionIds,
-            liveSessionStreams,
-            activeSessionRef,
             sessionDtos,
             agentDtos,
             modelDtos,
             currentEffortOptions,
             supportsEffort,
+            isSessionGenerating,
+            streamSnapshot,
             chatService,
+            executionService,
             agentRunner,
             SendMessage,
             SelectSession

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -32,17 +32,30 @@ public class ChatApp : ViewBase
         var namingService = UseService<IChatSessionNamingService>();
         var serializer = UseService<IEventSerializer>();
 
-        var activeSessionId = UseState<string?>(args?.SessionId);
+        var activeSessionId = UseState<string?>(() =>
+        {
+            if (!string.IsNullOrEmpty(args?.SessionId)) return args.SessionId;
+            return chatService.GetSessions().FirstOrDefault()?.Id;
+        });
         var sessionVersion = UseState(0);
-        var selectedAgent = UseState(() => configService.Settings.CodingAgent ?? "claude");
+        var selectedAgent = UseState(() =>
+        {
+            var sess = !string.IsNullOrEmpty(args?.SessionId) ? chatService.GetSession(args.SessionId) : chatService.GetSessions().FirstOrDefault();
+            return sess?.AgentId ?? configService.Settings.CodingAgent ?? "claude";
+        });
         var selectedModel = UseState(() =>
         {
-            var agent = configService.Settings.CodingAgent ?? "claude";
+            var sess = !string.IsNullOrEmpty(args?.SessionId) ? chatService.GetSession(args.SessionId) : chatService.GetSessions().FirstOrDefault();
+            if (!string.IsNullOrEmpty(sess?.ModelId)) return sess.ModelId;
+            var agent = sess?.AgentId ?? configService.Settings.CodingAgent ?? "claude";
             var initialModels = GetModelsForAgent(agentRunner, agent);
             return initialModels.Count > 0 ? initialModels[0].Id : "default";
         });
-        var selectedEffort = UseState("default");
-        var lastSyncedSessionId = UseRef<string?>(null);
+        var selectedEffort = UseState(() =>
+        {
+            var sess = !string.IsNullOrEmpty(args?.SessionId) ? chatService.GetSession(args.SessionId) : chatService.GetSessions().FirstOrDefault();
+            return sess?.Effort ?? "default";
+        });
         var isStreaming = UseState(false);
         var streamingSessionId = UseState<string?>(null);
         var liveSessionStreams = UseState(new Dictionary<string, string>());
@@ -57,7 +70,6 @@ public class ChatApp : ViewBase
             void OnSessionsChanged(object? sender, EventArgs e) => sessionVersion.Set(v => v + 1);
             void OnGeneratingSessionsChanged(object? sender, EventArgs e)
             {
-                sessionVersion.Set(v => v + 1);
                 runningSessionIds.Set(new HashSet<string>(chatService.GetGeneratingSessionIds()));
             }
 
@@ -70,44 +82,23 @@ public class ChatApp : ViewBase
             });
         });
 
+        void SelectSession(string sessionId)
+        {
+            activeSessionId.Set(sessionId);
+            chatService.ClearSessionCompleted(sessionId);
+            var sess = chatService.GetSession(sessionId);
+            if (sess != null)
+            {
+                if (!string.IsNullOrEmpty(sess.AgentId)) selectedAgent.Set(sess.AgentId);
+                if (!string.IsNullOrEmpty(sess.ModelId)) selectedModel.Set(sess.ModelId);
+                if (!string.IsNullOrEmpty(sess.Effort)) selectedEffort.Set(sess.Effort);
+            }
+        }
+
         var currentVersion = sessionVersion.Value;
         var sessions = chatService.GetSessions();
         var currentSessionId = activeSessionId.Value;
-        if (sessions.Count == 0 && currentSessionId == null && string.IsNullOrEmpty(args?.Prompt))
-        {
-            var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
-            currentSessionId = newSess.Id;
-            activeSessionId.Set(currentSessionId);
-            sessions = chatService.GetSessions();
-        }
-        else if (currentSessionId == null && sessions.Count > 0 && string.IsNullOrEmpty(args?.Prompt))
-        {
-            currentSessionId = sessions[0].Id;
-            activeSessionId.Set(currentSessionId);
-        }
-
         var activeSession = currentSessionId != null ? chatService.GetSession(currentSessionId) : null;
-        if (activeSession != null)
-        {
-            chatService.ClearSessionCompleted(activeSession.Id);
-        }
-
-        if (activeSession != null && lastSyncedSessionId.Value != activeSession.Id)
-        {
-            lastSyncedSessionId.Value = activeSession.Id;
-            if (!string.IsNullOrEmpty(activeSession.AgentId))
-            {
-                selectedAgent.Set(activeSession.AgentId);
-            }
-            if (!string.IsNullOrEmpty(activeSession.ModelId))
-            {
-                selectedModel.Set(activeSession.ModelId);
-            }
-            if (!string.IsNullOrEmpty(activeSession.Effort))
-            {
-                selectedEffort.Set(activeSession.Effort);
-            }
-        }
 
         var registeredAgentIds = agentRunner.RegisteredAgents;
         if (registeredAgentIds.Count == 0)
@@ -122,22 +113,16 @@ public class ChatApp : ViewBase
         }).ToList();
 
         var currentModelOptions = GetModelsForAgent(agentRunner, selectedAgent.Value);
+        var effectiveModel = currentModelOptions.Any(m => m.Id.Equals(selectedModel.Value, StringComparison.OrdinalIgnoreCase))
+            ? selectedModel.Value
+            : (currentModelOptions.Count > 0 ? currentModelOptions[0].Id : selectedModel.Value);
         var modelDtos = currentModelOptions.Select(m => new ModelOptionDto(m.Id, m.DisplayName)).ToList();
 
-        if (!currentModelOptions.Any(m => m.Id.Equals(selectedModel.Value, StringComparison.OrdinalIgnoreCase)))
-        {
-            if (currentModelOptions.Count > 0)
-            {
-                selectedModel.Set(currentModelOptions[0].Id);
-            }
-        }
-
         var supportsEffort = DoesAgentSupportEffort(agentRunner, selectedAgent.Value);
-        var currentEffortOptions = GetEffortsForAgentAndModel(agentRunner, selectedAgent.Value, selectedModel.Value);
-        if (!currentEffortOptions.Any(e => e.Id.Equals(selectedEffort.Value, StringComparison.OrdinalIgnoreCase)))
-        {
-            selectedEffort.Set("default");
-        }
+        var currentEffortOptions = GetEffortsForAgentAndModel(agentRunner, selectedAgent.Value, effectiveModel);
+        var effectiveEffort = currentEffortOptions.Any(e => e.Id.Equals(selectedEffort.Value, StringComparison.OrdinalIgnoreCase))
+            ? selectedEffort.Value
+            : "default";
 
         var sessionDtos = sessions.Select(s =>
         {
@@ -277,18 +262,22 @@ public class ChatApp : ViewBase
 
             var fullAgentPrompt = agentPromptBuilder.ToString();
 
-            chatService.AddMessage(targetSessionId, "user", promptWithAttachments, selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
+            var targetAgent = selectedAgent.Value;
+            var targetModel = effectiveModel;
+            var targetEffort = effectiveEffort;
+
+            chatService.AddMessage(targetSessionId, "user", promptWithAttachments, targetAgent, targetModel, effort: targetEffort);
             isStreaming.Set(true);
 
             try
             {
-                var effortOverride = selectedEffort.Value != "default" ? AgentProviderFactory.ParseEffort(selectedEffort.Value) : null;
+                var effortOverride = targetEffort != "default" ? AgentProviderFactory.ParseEffort(targetEffort) : null;
                 var context = AgentLaunchHelper.PrepareResolutionContext(
                     configService,
                     agentRunner,
-                    selectedAgent.Value,
+                    targetAgent,
                     fullAgentPrompt,
-                    modelOverride: selectedModel.Value,
+                    modelOverride: targetModel,
                     effortOverride: effortOverride,
                     permissionMode: PermissionMode.FullAuto);
 
@@ -353,7 +342,7 @@ public class ChatApp : ViewBase
                         ? collectedText
                         : (result.IsSuccess ? "Task completed successfully." : "Agent execution completed with status code " + (result.ExitCode?.ToString() ?? "unknown")));
 
-                chatService.AddMessage(targetSessionId, "assistant", responseContent, selectedAgent.Value, selectedModel.Value, rawStream: fullRawStream, effort: selectedEffort.Value);
+                chatService.AddMessage(targetSessionId, "assistant", responseContent, targetAgent, targetModel, rawStream: fullRawStream, effort: targetEffort);
 
                 var currentSession = chatService.GetSession(targetSessionId);
                 if (currentSession != null &&
@@ -363,8 +352,8 @@ public class ChatApp : ViewBase
                     var firstUserMsg = currentSession.Messages.FirstOrDefault(m => m.Role == "user")?.Content;
                     if (!string.IsNullOrWhiteSpace(firstUserMsg))
                     {
-                        var agentId = selectedAgent.Value;
-                        var modelId = selectedModel.Value;
+                        var agentId = targetAgent;
+                        var modelId = targetModel;
                         _ = Task.Run(async () =>
                         {
                             await namingService.GenerateAndSetTitleAsync(
@@ -379,7 +368,7 @@ public class ChatApp : ViewBase
             }
             catch (Exception ex)
             {
-                chatService.AddMessage(targetSessionId, "assistant", $"Error executing request: {ex.Message}", selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
+                chatService.AddMessage(targetSessionId, "assistant", $"Error executing request: {ex.Message}", targetAgent, targetModel, effort: targetEffort);
             }
             finally
             {
@@ -413,9 +402,9 @@ public class ChatApp : ViewBase
             string targetSessionId = !string.IsNullOrEmpty(dto.SessionId) ? dto.SessionId : (activeSessionId.Value ?? "");
             if (string.IsNullOrEmpty(targetSessionId))
             {
-                var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
+                var newSess = chatService.CreateSession(selectedAgent.Value, effectiveModel, effort: effectiveEffort);
                 targetSessionId = newSess.Id;
-                activeSessionId.Set(targetSessionId);
+                SelectSession(targetSessionId);
             }
 
             var pinnedDto = new ChatSendMessageDto(userPrompt, dto.Attachments, targetSessionId);
@@ -436,9 +425,9 @@ public class ChatApp : ViewBase
             var targetId = activeSessionId.Value;
             if (string.IsNullOrEmpty(targetId))
             {
-                var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
+                var newSess = chatService.CreateSession(selectedAgent.Value, effectiveModel, effort: effectiveEffort);
                 targetId = newSess.Id;
-                activeSessionId.Set(targetId);
+                SelectSession(targetId);
             }
             SendMessage(new ChatSendMessageDto(args.Prompt, null, targetId));
         }
@@ -449,8 +438,10 @@ public class ChatApp : ViewBase
             sessionVersion,
             selectedAgent,
             selectedModel,
+            selectedEffort,
             searchState,
-            chatService
+            chatService,
+            SelectSession
         );
 
         var content = new ContentView(
@@ -472,7 +463,8 @@ public class ChatApp : ViewBase
             supportsEffort,
             chatService,
             agentRunner,
-            SendMessage
+            SendMessage,
+            SelectSession
         );
 
         return new SidebarLayout(content, sidebar).SidebarContentScroll(Scroll.None);

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -296,7 +295,6 @@ public class ChatApp : ViewBase
                 var rawLines = new List<string>();
                 string? lastTextEvent = null;
                 var rawLock = new object();
-                var lastStreamUpdateTicks = 0L;
 
                 using var sub = session.Events.Subscribe(evt =>
                 {
@@ -313,20 +311,12 @@ public class ChatApp : ViewBase
                         var wireJson = serializer.Serialize(evt);
                         if (!string.IsNullOrEmpty(wireJson))
                         {
-                            string fullStream;
                             lock (rawLock)
                             {
                                 rawLines.Add(wireJson);
-                                fullStream = string.Join("\n", rawLines);
-                            }
-
-                            var now = Stopwatch.GetTimestamp();
-                            if (lastStreamUpdateTicks == 0 || Stopwatch.GetElapsedTime(lastStreamUpdateTicks).TotalMilliseconds >= 60)
-                            {
-                                lastStreamUpdateTicks = now;
                                 var map = new Dictionary<string, string>(liveSessionStreams.Value)
                                 {
-                                    [targetSessionId] = fullStream
+                                    [targetSessionId] = string.Join("\n", rawLines)
                                 };
                                 liveSessionStreams.Set(map);
                             }
@@ -360,11 +350,6 @@ public class ChatApp : ViewBase
                         ? collectedText
                         : (result.IsSuccess ? "Task completed successfully." : "Agent execution completed with status code " + (result.ExitCode?.ToString() ?? "unknown")));
 
-                if (string.IsNullOrWhiteSpace(responseContent))
-                {
-                    responseContent = "Task completed with no output.";
-                }
-
                 chatService.AddMessage(targetSessionId, "assistant", responseContent, targetAgent, targetModel, rawStream: fullRawStream, effort: targetEffort);
 
                 var currentSession = chatService.GetSession(targetSessionId);
@@ -395,7 +380,6 @@ public class ChatApp : ViewBase
             }
             finally
             {
-                chatService.SetSessionGenerating(targetSessionId, false);
                 activeSessionRef.Value = null;
                 isStreaming.Set(false);
                 streamingSessionId.Set(null);
@@ -403,6 +387,7 @@ public class ChatApp : ViewBase
                 var finishedSet = new HashSet<string>(runningSessionIds.Value);
                 finishedSet.Remove(targetSessionId);
                 runningSessionIds.Set(finishedSet);
+                chatService.SetSessionGenerating(targetSessionId, false);
 
                 var map = new Dictionary<string, string>(liveSessionStreams.Value);
                 map.Remove(targetSessionId);

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -72,18 +72,21 @@ public class ChatApp : ViewBase
 
         var currentVersion = sessionVersion.Value;
         var sessions = chatService.GetSessions();
-        if (sessions.Count == 0 && activeSessionId.Value == null && string.IsNullOrEmpty(args?.Prompt))
+        var currentSessionId = activeSessionId.Value;
+        if (sessions.Count == 0 && currentSessionId == null && string.IsNullOrEmpty(args?.Prompt))
         {
             var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
-            activeSessionId.Set(newSess.Id);
+            currentSessionId = newSess.Id;
+            activeSessionId.Set(currentSessionId);
             sessions = chatService.GetSessions();
         }
-        else if (activeSessionId.Value == null && sessions.Count > 0 && !initialHandled.Value && string.IsNullOrEmpty(args?.Prompt))
+        else if (currentSessionId == null && sessions.Count > 0 && string.IsNullOrEmpty(args?.Prompt))
         {
-            activeSessionId.Set(sessions[0].Id);
+            currentSessionId = sessions[0].Id;
+            activeSessionId.Set(currentSessionId);
         }
 
-        var activeSession = activeSessionId.Value != null ? chatService.GetSession(activeSessionId.Value) : null;
+        var activeSession = currentSessionId != null ? chatService.GetSession(currentSessionId) : null;
         if (activeSession != null)
         {
             chatService.ClearSessionCompleted(activeSession.Id);
@@ -293,12 +296,21 @@ public class ChatApp : ViewBase
                 activeSessionRef.Value = session;
 
                 var rawLines = new List<string>();
+                string? lastTextEvent = null;
                 var rawLock = new object();
 
                 using var sub = session.Events.Subscribe(evt =>
                 {
                     try
                     {
+                        if (evt is TextEvent textEvt && !string.IsNullOrWhiteSpace(textEvt.Text))
+                        {
+                            lock (rawLock)
+                            {
+                                lastTextEvent = textEvt.Text;
+                            }
+                        }
+
                         var wireJson = serializer.Serialize(evt);
                         if (!string.IsNullOrEmpty(wireJson))
                         {
@@ -319,17 +331,28 @@ public class ChatApp : ViewBase
                     }
                 });
 
-                var result = await session.WaitForCompletionAsync();
+                var jobTimeoutMinutes = configService.Settings.JobTimeout;
+                var totalTimeout = jobTimeoutMinutes > 0
+                    ? TimeSpan.FromMinutes(jobTimeoutMinutes)
+                    : TimeSpan.FromMinutes(15);
+                using var timeoutCts = new CancellationTokenSource(totalTimeout);
 
-                var responseContent = !string.IsNullOrWhiteSpace(result.Response)
-                    ? result.Response
-                    : (result.IsSuccess ? "Task completed successfully." : "Agent execution completed with status code " + (result.ExitCode?.ToString() ?? "unknown"));
+                var result = await session.WaitForCompletionAsync(timeoutCts.Token);
 
+                string? collectedText = null;
                 string? fullRawStream = null;
                 lock (rawLock)
                 {
+                    collectedText = lastTextEvent;
                     if (rawLines.Count > 0) fullRawStream = string.Join("\n", rawLines);
                 }
+
+                var responseContent = !string.IsNullOrWhiteSpace(result.Response)
+                    ? result.Response
+                    : (!string.IsNullOrWhiteSpace(collectedText)
+                        ? collectedText
+                        : (result.IsSuccess ? "Task completed successfully." : "Agent execution completed with status code " + (result.ExitCode?.ToString() ?? "unknown")));
+
                 chatService.AddMessage(targetSessionId, "assistant", responseContent, selectedAgent.Value, selectedModel.Value, rawStream: fullRawStream, effort: selectedEffort.Value);
 
                 var currentSession = chatService.GetSession(targetSessionId);
@@ -513,20 +536,6 @@ public class ChatApp : ViewBase
         var catalog = runner.GetModelCatalog(normalized);
         if (catalog != null)
         {
-            try
-            {
-                var asyncResult = catalog.GetModelsAsync().GetAwaiter().GetResult();
-                if (asyncResult != null && asyncResult.Models.Count > 0)
-                {
-                    var sorted = ModelCatalogSorter.Sort(asyncResult.Models);
-                    return sorted.Select(m => (m.Id, m.DisplayName ?? m.Id)).ToList();
-                }
-            }
-            catch
-            {
-                // Fallback to static model catalog if discovery times out or throws
-            }
-
             var staticModels = catalog.GetStaticModels();
             if (staticModels != null && staticModels.Count > 0)
             {

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -295,6 +296,7 @@ public class ChatApp : ViewBase
                 var rawLines = new List<string>();
                 string? lastTextEvent = null;
                 var rawLock = new object();
+                var lastStreamUpdateTicks = 0L;
 
                 using var sub = session.Events.Subscribe(evt =>
                 {
@@ -311,12 +313,20 @@ public class ChatApp : ViewBase
                         var wireJson = serializer.Serialize(evt);
                         if (!string.IsNullOrEmpty(wireJson))
                         {
+                            string fullStream;
                             lock (rawLock)
                             {
                                 rawLines.Add(wireJson);
+                                fullStream = string.Join("\n", rawLines);
+                            }
+
+                            var now = Stopwatch.GetTimestamp();
+                            if (lastStreamUpdateTicks == 0 || Stopwatch.GetElapsedTime(lastStreamUpdateTicks).TotalMilliseconds >= 60)
+                            {
+                                lastStreamUpdateTicks = now;
                                 var map = new Dictionary<string, string>(liveSessionStreams.Value)
                                 {
-                                    [targetSessionId] = string.Join("\n", rawLines)
+                                    [targetSessionId] = fullStream
                                 };
                                 liveSessionStreams.Set(map);
                             }
@@ -350,6 +360,11 @@ public class ChatApp : ViewBase
                         ? collectedText
                         : (result.IsSuccess ? "Task completed successfully." : "Agent execution completed with status code " + (result.ExitCode?.ToString() ?? "unknown")));
 
+                if (string.IsNullOrWhiteSpace(responseContent))
+                {
+                    responseContent = "Task completed with no output.";
+                }
+
                 chatService.AddMessage(targetSessionId, "assistant", responseContent, targetAgent, targetModel, rawStream: fullRawStream, effort: targetEffort);
 
                 var currentSession = chatService.GetSession(targetSessionId);
@@ -380,6 +395,7 @@ public class ChatApp : ViewBase
             }
             finally
             {
+                chatService.SetSessionGenerating(targetSessionId, false);
                 activeSessionRef.Value = null;
                 isStreaming.Set(false);
                 streamingSessionId.Set(null);
@@ -387,7 +403,6 @@ public class ChatApp : ViewBase
                 var finishedSet = new HashSet<string>(runningSessionIds.Value);
                 finishedSet.Remove(targetSessionId);
                 runningSessionIds.Set(finishedSet);
-                chatService.SetSessionGenerating(targetSessionId, false);
 
                 var map = new Dictionary<string, string>(liveSessionStreams.Value);
                 map.Remove(targetSessionId);

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -82,6 +82,14 @@ public class ChatApp : ViewBase
             });
         });
 
+        UseEffect(() =>
+        {
+            if (!string.IsNullOrEmpty(activeSessionId.Value))
+            {
+                chatService.ClearSessionCompleted(activeSessionId.Value);
+            }
+        }, [activeSessionId]);
+
         void SelectSession(string sessionId)
         {
             activeSessionId.Set(sessionId);
@@ -159,118 +167,118 @@ public class ChatApp : ViewBase
             string targetSessionId = dto.SessionId ?? "";
             if (string.IsNullOrEmpty(targetSessionId)) return;
 
+            var targetAgent = selectedAgent.Value;
+            var targetModel = effectiveModel;
+            var targetEffort = effectiveEffort;
+
             var runningSet = new HashSet<string>(runningSessionIds.Value) { targetSessionId };
             runningSessionIds.Set(runningSet);
             streamingSessionId.Set(targetSessionId);
             chatService.SetSessionGenerating(targetSessionId, true);
 
-            var attachedFilePaths = new List<string>();
-            var attachmentErrors = new List<string>();
-            if (attachments.Count > 0)
+            try
             {
-                var attachDir = Path.Combine(configService.TendrilHome, "Attachments", targetSessionId);
-                if (!Directory.Exists(attachDir))
+                var attachedFilePaths = new List<string>();
+                var attachmentErrors = new List<string>();
+                if (attachments.Count > 0)
                 {
-                    Directory.CreateDirectory(attachDir);
-                }
-
-                foreach (var att in attachments)
-                {
-                    try
+                    var attachDir = Path.Combine(configService.TendrilHome, "Attachments", targetSessionId);
+                    if (!Directory.Exists(attachDir))
                     {
-                        var rawName = Path.GetFileName(att.Name);
-                        var fileName = !string.IsNullOrWhiteSpace(rawName)
-                            ? string.Concat(rawName.Split(Path.GetInvalidFileNameChars()))
-                            : $"file_{Guid.NewGuid():N}.bin";
-                        if (string.IsNullOrWhiteSpace(fileName)) fileName = $"file_{Guid.NewGuid():N}.bin";
-                        var filePath = !string.IsNullOrWhiteSpace(att.LocalPath) && File.Exists(att.LocalPath)
-                            ? att.LocalPath
-                            : Path.Combine(attachDir, fileName);
+                        Directory.CreateDirectory(attachDir);
+                    }
 
-                        if (!string.IsNullOrEmpty(att.Base64Data))
+                    foreach (var att in attachments)
+                    {
+                        try
                         {
-                            var base64 = att.Base64Data.Contains(",")
-                                ? att.Base64Data[(att.Base64Data.IndexOf(",") + 1)..]
-                                : att.Base64Data;
-                            var bytes = Convert.FromBase64String(base64);
-                            File.WriteAllBytes(filePath, bytes);
-                        }
+                            var rawName = Path.GetFileName(att.Name);
+                            var fileName = !string.IsNullOrWhiteSpace(rawName)
+                                ? string.Concat(rawName.Split(Path.GetInvalidFileNameChars()))
+                                : $"file_{Guid.NewGuid():N}.bin";
+                            if (string.IsNullOrWhiteSpace(fileName)) fileName = $"file_{Guid.NewGuid():N}.bin";
+                            var filePath = !string.IsNullOrWhiteSpace(att.LocalPath) && File.Exists(att.LocalPath)
+                                ? att.LocalPath
+                                : Path.Combine(attachDir, fileName);
 
-                        if (File.Exists(filePath))
-                        {
-                            attachedFilePaths.Add(filePath);
+                            if (!string.IsNullOrEmpty(att.Base64Data))
+                            {
+                                var base64 = att.Base64Data.Contains(",")
+                                    ? att.Base64Data[(att.Base64Data.IndexOf(",") + 1)..]
+                                    : att.Base64Data;
+                                var bytes = Convert.FromBase64String(base64);
+                                File.WriteAllBytes(filePath, bytes);
+                            }
+
+                            if (File.Exists(filePath))
+                            {
+                                attachedFilePaths.Add(filePath);
+                            }
+                            else
+                            {
+                                attachmentErrors.Add($"Attachment '{att.Name}' was not found at {filePath}");
+                            }
                         }
-                        else
+                        catch (Exception ex)
                         {
-                            attachmentErrors.Add($"Attachment '{att.Name}' was not found at {filePath}");
+                            attachmentErrors.Add($"Failed to process attachment '{att.Name}': {ex.Message}");
                         }
                     }
-                    catch (Exception ex)
+                }
+
+                var promptWithAttachments = userPrompt;
+                if (attachedFilePaths.Count > 0)
+                {
+                    var sb = new StringBuilder();
+                    if (!string.IsNullOrWhiteSpace(userPrompt))
                     {
-                        attachmentErrors.Add($"Failed to process attachment '{att.Name}': {ex.Message}");
+                        sb.AppendLine(userPrompt);
+                        sb.AppendLine();
                     }
+                    sb.AppendLine("[Attached Files]:");
+                    foreach (var path in attachedFilePaths)
+                    {
+                        sb.AppendLine($"- {path}");
+                    }
+                    promptWithAttachments = sb.ToString().TrimEnd();
                 }
-            }
 
-            var promptWithAttachments = userPrompt;
-            if (attachedFilePaths.Count > 0)
-            {
-                var sb = new StringBuilder();
-                if (!string.IsNullOrWhiteSpace(userPrompt))
+                if (attachmentErrors.Count > 0)
                 {
-                    sb.AppendLine(userPrompt);
-                    sb.AppendLine();
+                    var warning = "Warning: Some attachments could not be processed:\n" + string.Join("\n", attachmentErrors.Select(e => $"- {e}"));
+                    chatService.AddMessage(targetSessionId, "assistant", warning, selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
                 }
-                sb.AppendLine("[Attached Files]:");
-                foreach (var path in attachedFilePaths)
+
+                var sess = chatService.GetSession(targetSessionId);
+                var history = sess?.Messages ?? [];
+
+                var agentPromptBuilder = new StringBuilder();
+                if (history.Count > 0)
                 {
-                    sb.AppendLine($"- {path}");
-                }
-                promptWithAttachments = sb.ToString().TrimEnd();
-            }
+                    agentPromptBuilder.AppendLine("# Previous Conversation Discussion History");
+                    agentPromptBuilder.AppendLine("The following is the previous conversation history in this chat session:");
+                    agentPromptBuilder.AppendLine();
 
-            if (attachmentErrors.Count > 0)
-            {
-                var warning = "Warning: Some attachments could not be processed:\n" + string.Join("\n", attachmentErrors.Select(e => $"- {e}"));
-                chatService.AddMessage(targetSessionId, "assistant", warning, selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
-            }
+                    foreach (var prevMsg in history)
+                    {
+                        var roleLabel = prevMsg.Role.Equals("user", StringComparison.OrdinalIgnoreCase) ? "User" : "Assistant";
+                        agentPromptBuilder.AppendLine($"### {roleLabel}");
+                        agentPromptBuilder.AppendLine(prevMsg.Content);
+                        agentPromptBuilder.AppendLine();
+                    }
 
-            var sess = chatService.GetSession(targetSessionId);
-            var history = sess?.Messages ?? [];
-
-            var agentPromptBuilder = new StringBuilder();
-            if (history.Count > 0)
-            {
-                agentPromptBuilder.AppendLine("# Previous Conversation Discussion History");
-                agentPromptBuilder.AppendLine("The following is the previous conversation history in this chat session:");
-                agentPromptBuilder.AppendLine();
-
-                foreach (var prevMsg in history)
-                {
-                    var roleLabel = prevMsg.Role.Equals("user", StringComparison.OrdinalIgnoreCase) ? "User" : "Assistant";
-                    agentPromptBuilder.AppendLine($"### {roleLabel}");
-                    agentPromptBuilder.AppendLine(prevMsg.Content);
+                    agentPromptBuilder.AppendLine("---");
                     agentPromptBuilder.AppendLine();
                 }
 
-                agentPromptBuilder.AppendLine("---");
-                agentPromptBuilder.AppendLine();
-            }
+                agentPromptBuilder.AppendLine("# Current User Request");
+                agentPromptBuilder.AppendLine(promptWithAttachments);
 
-            agentPromptBuilder.AppendLine("# Current User Request");
-            agentPromptBuilder.AppendLine(promptWithAttachments);
+                var fullAgentPrompt = agentPromptBuilder.ToString();
 
-            var fullAgentPrompt = agentPromptBuilder.ToString();
+                chatService.AddMessage(targetSessionId, "user", promptWithAttachments, targetAgent, targetModel, effort: targetEffort);
+                isStreaming.Set(true);
 
-            var targetAgent = selectedAgent.Value;
-            var targetModel = effectiveModel;
-            var targetEffort = effectiveEffort;
-
-            chatService.AddMessage(targetSessionId, "user", promptWithAttachments, targetAgent, targetModel, effort: targetEffort);
-            isStreaming.Set(true);
-
-            try
-            {
                 var effortOverride = targetEffort != "default" ? AgentProviderFactory.ParseEffort(targetEffort) : null;
                 var context = AgentLaunchHelper.PrepareResolutionContext(
                     configService,

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -188,9 +188,6 @@ public class ChatApp : ViewBase
                 SelectSession(targetSessionId);
             }
 
-            sessionVersion.Set(v => v + 1);
-            streamVersion.Set(v => v + 1);
-
             _ = executionService.SendMessageAsync(
                 targetSessionId,
                 userPrompt,
@@ -198,6 +195,9 @@ public class ChatApp : ViewBase
                 selectedAgent.Value,
                 effectiveModel,
                 effectiveEffort);
+
+            sessionVersion.Set(v => v + 1);
+            streamVersion.Set(v => v + 1);
         }
 
         if (!initialHandled.Value && !string.IsNullOrEmpty(args?.Prompt))

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -21,17 +20,15 @@ public class ContentView(
     IState<string> selectedAgent,
     IState<string> selectedModel,
     IState<string> selectedEffort,
-    IState<bool> isStreaming,
-    IState<string?> streamingSessionId,
-    IState<HashSet<string>> runningSessionIds,
-    IState<Dictionary<string, string>> liveSessionStreams,
-    IRef<IAgentSession?> activeSessionRef,
     List<ChatSessionDto> sessionDtos,
     List<AgentOptionDto> agentDtos,
     List<ModelOptionDto> modelDtos,
     List<EffortOptionDto> effortDtos,
     bool supportsEffort,
+    bool isStreaming,
+    string streamingText,
     IChatHistoryService chatService,
+    IChatExecutionService executionService,
     IAgentRunner agentRunner,
     Action<ChatSendMessageDto> sendMessage,
     Action<string> selectSession) : ViewBase
@@ -74,10 +71,6 @@ public class ContentView(
                 | newChatBtn;
         }
 
-        string activeSessionLiveStream = activeSessionId.Value != null && liveSessionStreams.Value.TryGetValue(activeSessionId.Value, out var streamText)
-            ? streamText
-            : "";
-
         var sessionToDelete = deletingSessionId.Value != null
             ? chatService.GetSession(deletingSessionId.Value) ?? activeSession
             : activeSession;
@@ -97,7 +90,6 @@ public class ContentView(
         var chatWidget = new ChatWidget
         {
             ActiveSessionId = activeSessionId.Value,
-            StreamingSessionId = streamingSessionId.Value,
             UploadUrl = upload.Value.UploadUrl,
             Sessions = sessionDtos,
             Agents = agentDtos,
@@ -107,8 +99,8 @@ public class ContentView(
             SelectedModel = selectedModel.Value,
             SelectedEffort = selectedEffort.Value,
             SupportsEffort = supportsEffort,
-            IsStreaming = activeSessionId.Value != null && runningSessionIds.Value.Contains(activeSessionId.Value),
-            StreamingText = activeSessionLiveStream,
+            IsStreaming = isStreaming,
+            StreamingText = streamingText,
             QueuedMessages = queuedMessageDtos,
 
             OnSelectSession = e =>
@@ -149,22 +141,8 @@ public class ContentView(
                 if (activeSessionId.Value != null)
                 {
                     chatService.ClearQueuedMessages(activeSessionId.Value);
+                    await executionService.CancelAsync(activeSessionId.Value);
                 }
-                try
-                {
-                    if (activeSessionRef.Value != null)
-                    {
-                        await activeSessionRef.Value.StopAsync();
-                    }
-                }
-                catch
-                {
-                    // Ignore cancel exceptions
-                }
-                isStreaming.Set(false);
-                streamingSessionId.Set(null);
-                runningSessionIds.Set(new HashSet<string>());
-                liveSessionStreams.Set(new Dictionary<string, string>());
             },
             OnAgentChanged = e =>
             {

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -53,6 +53,8 @@ public class ContentView(
             await stream.CopyToAsync(fileStream, ct);
         });
 
+        _ = sessionVersion.Value;
+
         if (activeSession == null)
         {
             var newChatBtn = new Button("Start New Chat")

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -33,7 +33,8 @@ public class ContentView(
     bool supportsEffort,
     IChatHistoryService chatService,
     IAgentRunner agentRunner,
-    Action<ChatSendMessageDto> sendMessage) : ViewBase
+    Action<ChatSendMessageDto> sendMessage,
+    Action<string> selectSession) : ViewBase
 {
     public override object Build()
     {
@@ -63,8 +64,7 @@ public class ContentView(
                 .OnClick(() =>
                 {
                     var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
-                    activeSessionId.Set(newSess.Id);
-                    sessionVersion.Set(v => v + 1);
+                    selectSession(newSess.Id);
                 });
 
             return Layout.Vertical().AlignContent(Align.Center).Width(Size.Full()).Height(Size.Full())
@@ -113,7 +113,10 @@ public class ContentView(
 
             OnSelectSession = e =>
             {
-                activeSessionId.Set(e.Value);
+                if (!string.IsNullOrEmpty(e.Value))
+                {
+                    selectSession(e.Value);
+                }
                 return ValueTask.CompletedTask;
             },
             OnDeleteSession = e =>
@@ -133,7 +136,7 @@ public class ContentView(
             OnCreateSession = _ =>
             {
                 var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
-                activeSessionId.Set(newSess.Id);
+                selectSession(newSess.Id);
                 return ValueTask.CompletedTask;
             },
             OnSendMessage = e =>

--- a/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/SidebarView.cs
@@ -15,8 +15,10 @@ public class SidebarView(
     IState<int> sessionVersion,
     IState<string> selectedAgent,
     IState<string> selectedModel,
+    IState<string> selectedEffort,
     IState<string> searchState,
-    IChatHistoryService chatService) : ViewBase
+    IChatHistoryService chatService,
+    Action<string> selectSession) : ViewBase
 {
     public override object Build()
     {
@@ -25,9 +27,8 @@ public class SidebarView(
             .Ghost()
             .OnClick(() =>
             {
-                var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value);
-                activeSessionId.Set(newSess.Id);
-                sessionVersion.Set(v => v + 1);
+                var newSess = chatService.CreateSession(selectedAgent.Value, selectedModel.Value, effort: selectedEffort.Value);
+                selectSession(newSess.Id);
             });
 
         var searchInput = searchState.ToSearchInput()
@@ -65,13 +66,13 @@ public class SidebarView(
                 object metaLine;
                 if (isGenerating)
                 {
-                    metaLine = Layout.Horizontal().AlignContent(Align.Left).Gap(1)
+                    metaLine = Layout.Horizontal().AlignContent(Align.Left)
                         | new Icon(Icons.LoaderCircle).Small().WithAnimation(AnimationType.Rotate).Duration(1)
                         | Text.Muted(sess.AgentId).Small();
                 }
                 else if (isCompleted)
                 {
-                    metaLine = Layout.Horizontal().AlignContent(Align.Left).Gap(1)
+                    metaLine = Layout.Horizontal().AlignContent(Align.Left)
                         | new Icon(Icons.Check, Colors.Green).Small()
                         | Text.Success("Completed").Small()
                         | Text.Muted($"• {sess.AgentId}").Small();
@@ -92,8 +93,7 @@ public class SidebarView(
                     .Content(textStack)
                     .OnClick(() =>
                     {
-                        chatService.ClearSessionCompleted(sess.Id);
-                        activeSessionId.Set(sess.Id);
+                        selectSession(sess.Id);
                     })
                     .BorderRadius(BorderRadius.None);
 

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectAgentStepView.cs
@@ -239,6 +239,60 @@ public class ProjectAgentStepView(
                     try
                     {
                         await handle.Completion;
+                        if (handle.ExitCode is not null and not 0 && !session.Cancelled.Value)
+                        {
+                            var failureReason = handle.LogJob?.ReportedFailureReason;
+                            if (string.IsNullOrWhiteSpace(failureReason))
+                            {
+                                var lastError = handle.LogJob?.OutputLines
+                                    .Reverse()
+                                    .Select(line =>
+                                    {
+                                        try
+                                        {
+                                            using var d = System.Text.Json.JsonDocument.Parse(line);
+                                            if (d.RootElement.TryGetProperty("kind", out var k) && k.GetString() == "error" &&
+                                                d.RootElement.TryGetProperty("message", out var m))
+                                                return m.GetString();
+                                        }
+                                        catch { }
+                                        return null;
+                                    })
+                                    .FirstOrDefault(m => !string.IsNullOrWhiteSpace(m));
+
+                                failureReason = lastError;
+                            }
+
+                            if (string.IsNullOrWhiteSpace(failureReason))
+                            {
+                                var analyzer = agentRunner.GetFailureAnalyzer(handle.Provider);
+                                if (analyzer != null && handle.LogJob != null)
+                                {
+                                    var stderrLines = handle.LogJob.OutputLines
+                                        .Where(l => l.StartsWith("[stderr] "))
+                                        .Select(l => l["[stderr] ".Length..])
+                                        .ToList();
+                                    var analysis = analyzer.Analyze(new FailureContext
+                                    {
+                                        Events = [],
+                                        StderrLines = stderrLines,
+                                        ExitCode = handle.ExitCode,
+                                        TimedOut = false,
+                                        IdleTimeout = false,
+                                        AgentId = handle.Provider
+                                    });
+                                    if (analysis.Kind != FailureKind.Unknown)
+                                        failureReason = analysis.Reason;
+                                }
+                            }
+
+                            if (string.IsNullOrWhiteSpace(failureReason))
+                            {
+                                failureReason = $"Setup failed with exit code {handle.ExitCode}";
+                            }
+
+                            session.Error.Set(failureReason);
+                        }
                     }
                     catch (OperationCanceledException) { }
                     catch (Exception ex)
@@ -288,9 +342,9 @@ public class ProjectAgentStepView(
 
         // The agent output stream always renders while the agent is running. Before any
         // output arrives, the AgentViewer's own status label (below the stream) shows the
-        // "Starting…" loading indicator, so we don't render a separate Loading() above it —
+        // "Starting…" loading indicator, so we don't render a separate Loading() above it:
         // that avoided a layout shift when the bordered/padded Box swapped in on first output.
-        var showStream = !isCloning.Value && (session.Running.Value || session.HasOutput.Value || aboutToStart);
+        var showStream = !isCloning.Value && (session.Running.Value || session.HasOutput.Value || aboutToStart || session.Error.Value != null);
 
         var viewer = new AgentViewer()
             .Stream(session.Stream)
@@ -307,7 +361,7 @@ public class ProjectAgentStepView(
             }
         };
 
-        return Layout.Vertical().Margin(0, 0, 0, 2)
+        return Layout.Vertical()
                | (showHeader ? Text.H3("Setting up your project") : null!)
                | Text.Muted(isCloning.Value
                    ? (progressMessage.Value ?? "Setting up your project...")
@@ -324,7 +378,6 @@ public class ProjectAgentStepView(
                    ? (object)new Box(viewer)
                         .Width(Size.Full())
                         .Height(Size.Units(100).Max(Size.Fraction(0.6f)))
-                        .Padding(4, 4, 0, 4)
                    : null!)
                | buttonArea
                | (showHeader ? (object)new Spacer().Height(Size.Units(4)) : null!)

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
@@ -49,7 +49,7 @@ public class ProjectCrudStepView(
 
         var allVerifications = config.Settings.Verifications;
         var verificationRows = (project?.Verifications ?? [])
-            .Select(pv => new VerificationRow(pv.Name))
+            .Select((pv, i) => new VerificationRow(pv.Name, i))
             .ToList();
 
         var verificationTable = new TableBuilder<VerificationRow>(verificationRows)
@@ -57,34 +57,36 @@ public class ProjectCrudStepView(
             .Builder(t => t.Name, f => f.Func<VerificationRow, string>(name =>
                 Text.Block(name).Bold()
             ))
-            .Header(t => t.Name, "")
-            .Builder(t => t.Name, f => f.Func<VerificationRow, string>(vName =>
-                Layout.Horizontal().Gap(1)
-                | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() =>
-                    showVerificationTrigger(vName))
-                | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
-                {
-                    showVerificationAlert($"Are you sure you want to delete '{vName}'?", result =>
+            .Header(t => t.Index, "")
+            .Builder(t => t.Index, f => f.Func<VerificationRow, int>(idx =>
+            {
+                var vName = verificationRows[idx].Name;
+                return Layout.Horizontal()
+                    | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() =>
+                        showVerificationTrigger(vName))
+                    | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
                     {
-                        if (result == AlertResult.Ok)
+                        showVerificationAlert($"Are you sure you want to delete '{vName}'?", result =>
                         {
-                            allVerifications.RemoveAll(v => v.Name.Equals(vName, StringComparison.OrdinalIgnoreCase));
-                            if (project != null)
-                                project.Verifications.RemoveAll(v => v.Name.Equals(vName, StringComparison.OrdinalIgnoreCase));
-                            try
+                            if (result == AlertResult.Ok)
                             {
-                                config.SaveSettings();
-                                client.Toast($"Verification '{vName}' deleted", "Deleted");
-                                refreshToken.Refresh();
+                                allVerifications.RemoveAll(v => v.Name.Equals(vName, StringComparison.OrdinalIgnoreCase));
+                                if (project != null)
+                                    project.Verifications.RemoveAll(v => v.Name.Equals(vName, StringComparison.OrdinalIgnoreCase));
+                                try
+                                {
+                                    config.SaveSettings();
+                                    client.Toast($"Verification '{vName}' deleted", "Deleted");
+                                    refreshToken.Refresh();
+                                }
+                                catch (Exception ex)
+                                {
+                                    client.Toast($"Failed to delete: {ex.Message}", "Error");
+                                }
                             }
-                            catch (Exception ex)
-                            {
-                                client.Toast($"Failed to delete: {ex.Message}", "Error");
-                            }
-                        }
-                    }, "Delete Verification", AlertButtonSet.OkCancel);
-                })
-            ))
+                        }, "Delete Verification", AlertButtonSet.OkCancel);
+                    });
+            }))
             .Width(Size.Fit());
 
         var buttonArea = Layout.Horizontal().Width(Size.Full())
@@ -94,7 +96,7 @@ public class ProjectCrudStepView(
             | new Button(nextButtonText).Secondary().Large().Icon(Icons.ArrowRight, Align.Right)
                 .OnClick(onNext);
 
-        return Layout.Vertical().Margin(0, 0, 0, 2)
+        return Layout.Vertical()
                | (showHeader ? Text.H3("Review Harness") : null!)
                | Text.Muted("Review and edit the configuration generated for your project.")
                | (Layout.Vertical()
@@ -107,7 +109,7 @@ public class ProjectCrudStepView(
                | (Layout.Vertical()
                   | Text.Block("Review Actions").Bold()
                   | Text.Muted("Commands that makes it easy to start you project for manual testing.")
-                  | new ReviewActionsTableView(reviewActions, idx => showReviewActionTrigger(idx), projectName: projectName.Value)
+                  | new ReviewActionsTableView(reviewActions, idx => showReviewActionTrigger(idx), projectName: projectName.Value, showRun: false)
                   | new Button("Add Review Action").Icon(Icons.Plus).Outline()
                       .OnClick(() => showReviewActionTrigger(null)))
                | new Separator()
@@ -118,7 +120,7 @@ public class ProjectCrudStepView(
                | buttonArea;
     }
 
-    private record VerificationRow(string Name);
+    private record VerificationRow(string Name, int Index);
 }
 
 internal class OnboardingEditReviewActionDialog(

--- a/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
+++ b/src/Ivy.Tendril/Apps/Onboarding/ProjectCrudStepView.cs
@@ -61,7 +61,7 @@ public class ProjectCrudStepView(
             .Builder(t => t.Index, f => f.Func<VerificationRow, int>(idx =>
             {
                 var vName = verificationRows[idx].Name;
-                return Layout.Horizontal()
+                return Layout.Horizontal().Gap(1)
                     | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() =>
                         showVerificationTrigger(vName))
                     | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>

--- a/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
@@ -371,7 +371,8 @@ public class ReviewActionsTableView(
     IState<List<ReviewActionConfig>> reviewActions,
     Action<int?> onEdit,
     string? projectName = null,
-    Action<ReviewActionConfig>? onRun = null) : ViewBase
+    Action<ReviewActionConfig>? onRun = null,
+    bool showRun = true) : ViewBase
 {
     public override object? Build()
     {
@@ -390,8 +391,10 @@ public class ReviewActionsTableView(
             .Builder(t => t.Index, f => f.Func<ReviewActionRow, int>(idx =>
             {
                 var action = actions[idx];
-                return Layout.Horizontal().Gap(1)
-                    | new Button().Icon(Icons.Play).Outline().Small().Tooltip("Run / Preview Action").OnClick(() =>
+                var rowLayout = Layout.Horizontal();
+                if (showRun)
+                {
+                    rowLayout = rowLayout | new Button().Icon(Icons.Play).Outline().Small().Tooltip("Run / Preview Action").OnClick(() =>
                     {
                         if (onRun != null)
                         {
@@ -401,7 +404,9 @@ public class ReviewActionsTableView(
                         {
                             nav.Navigate<ReviewActionApp>(new ReviewActionAppArgs(ActionName: action.Name, ProjectName: projectName));
                         }
-                    })
+                    });
+                }
+                return rowLayout
                     | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() => onEdit(idx))
                     | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
                     {
@@ -434,7 +439,7 @@ public class ProjectVerificationsTableView(
             ))
             .Header(t => t.Index, "")
             .Builder(t => t.Index, f => f.Func<VerificationRow, int>(idx =>
-                Layout.Horizontal().Gap(1)
+                Layout.Horizontal()
                 | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() => onEdit(rows[idx].Name))
                 | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
                 {

--- a/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
+++ b/src/Ivy.Tendril/Apps/Settings/Blades/ProjectTableViews.cs
@@ -391,7 +391,7 @@ public class ReviewActionsTableView(
             .Builder(t => t.Index, f => f.Func<ReviewActionRow, int>(idx =>
             {
                 var action = actions[idx];
-                var rowLayout = Layout.Horizontal();
+                var rowLayout = Layout.Horizontal().Gap(1);
                 if (showRun)
                 {
                     rowLayout = rowLayout | new Button().Icon(Icons.Play).Outline().Small().Tooltip("Run / Preview Action").OnClick(() =>
@@ -439,7 +439,7 @@ public class ProjectVerificationsTableView(
             ))
             .Header(t => t.Index, "")
             .Builder(t => t.Index, f => f.Func<VerificationRow, int>(idx =>
-                Layout.Horizontal()
+                Layout.Horizontal().Gap(1)
                 | new Button().Icon(Icons.Pencil).Outline().Small().Tooltip("Edit").OnClick(() => onEdit(rows[idx].Name))
                 | new Button().Icon(Icons.Trash).Outline().Small().Tooltip("Delete").OnClick(() =>
                 {

--- a/src/Ivy.Tendril/Helpers/PathHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PathHelper.cs
@@ -230,9 +230,7 @@ public static class PathHelper
 
     public static void AugmentPath(bool forceShellPath = false)
     {
-        Ivy.Helpers.CrashLog.Write($"[PathHelper] AugmentPath starting. forceShellPath={forceShellPath}");
         var pathVar = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-        Ivy.Helpers.CrashLog.Write($"[PathHelper] AugmentPath current PATH: '{pathVar}'");
         var separator = OperatingSystem.IsWindows() ? ';' : ':';
         var dirs = new HashSet<string>(pathVar.Split(separator, StringSplitOptions.RemoveEmptyEntries),
             OperatingSystem.IsWindows() || OperatingSystem.IsMacOS() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
@@ -333,8 +331,6 @@ public static class PathHelper
                             if (string.IsNullOrEmpty(existingVal))
                             {
                                 Environment.SetEnvironmentVariable(key, val);
-                                var logValue = IsSecretKey(key) ? "[SECRET REDACTED]" : val;
-                                Ivy.Helpers.CrashLog.Write($"[PathHelper] Imported environment variable from shell: {key}={logValue}");
                             }
                         }
                     }
@@ -351,11 +347,9 @@ public static class PathHelper
         }
 
         var newPath = string.Join(separator, pathList);
-        Ivy.Helpers.CrashLog.Write($"[PathHelper] AugmentPath new PATH: '{newPath}'");
         if (newPath != pathVar)
         {
             Environment.SetEnvironmentVariable("PATH", newPath);
-            Ivy.Helpers.CrashLog.Write("[PathHelper] AugmentPath updated PATH environment variable successfully.");
         }
     }
 
@@ -417,19 +411,16 @@ public static class PathHelper
                     }
 
                     File.CreateSymbolicLink(symlinkPath, exePath);
-                    Ivy.Helpers.CrashLog.Write($"[PathHelper] Created CLI symlink at {symlinkPath} -> {exePath}");
                     break; // Successfully created symlink, no need to try other locations
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     // Fall back to next directory
-                    Ivy.Helpers.CrashLog.Write($"[PathHelper] Failed to create symlink in {binDir}: {ex.Message}");
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            Ivy.Helpers.CrashLog.Write($"[PathHelper] EnsureCliSymlink failed: {ex}");
         }
     }
 
@@ -461,12 +452,10 @@ public static class PathHelper
                 if (!File.Exists(cmdInAppDir) || File.ReadAllText(cmdInAppDir) != cmdContent)
                 {
                     File.WriteAllText(cmdInAppDir, cmdContent, Encoding.ASCII);
-                    Ivy.Helpers.CrashLog.Write($"[PathHelper] Created tendril.cmd at {cmdInAppDir}");
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                Ivy.Helpers.CrashLog.Write($"[PathHelper] Failed to create tendril.cmd in {appDir}: {ex.Message}");
             }
 
             // 2. Create tendril.cmd in %USERPROFILE%\.local\bin for global command access
@@ -484,12 +473,10 @@ public static class PathHelper
                 if (!File.Exists(localBinCmd) || File.ReadAllText(localBinCmd) != localBinCmdContent)
                 {
                     File.WriteAllText(localBinCmd, localBinCmdContent, Encoding.ASCII);
-                    Ivy.Helpers.CrashLog.Write($"[PathHelper] Created tendril.cmd at {localBinCmd}");
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                Ivy.Helpers.CrashLog.Write($"[PathHelper] Failed to create tendril.cmd in .local/bin: {ex.Message}");
             }
 
             // 3. Ensure appDir is present in User PATH environment variable
@@ -501,34 +488,20 @@ public static class PathHelper
                 {
                     var newPath = string.IsNullOrEmpty(userPath) ? appDir : $"{userPath}{Path.PathSeparator}{appDir}";
                     Environment.SetEnvironmentVariable("PATH", newPath, EnvironmentVariableTarget.User);
-                    Ivy.Helpers.CrashLog.Write($"[PathHelper] Added {appDir} to Windows User PATH.");
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                Ivy.Helpers.CrashLog.Write($"[PathHelper] Failed to update User PATH: {ex.Message}");
             }
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            Ivy.Helpers.CrashLog.Write($"[PathHelper] EnsureWindowsCliSetup failed: {ex}");
         }
     }
 
-    private static bool IsSecretKey(string key)
-    {
-        var normalized = key.ToUpperInvariant();
-        return normalized.Contains("KEY") ||
-               normalized.Contains("SECRET") ||
-               normalized.Contains("TOKEN") ||
-               normalized.Contains("PASSWORD") ||
-               normalized.Contains("AUTH") ||
-               normalized.Contains("CREDENTIAL");
-    }
 
     private static Dictionary<string, string>? GetLoginShellEnv()
     {
-        Ivy.Helpers.CrashLog.Write("[PathHelper] GetLoginShellEnv starting");
         var env = RunShellForEnv("-ilc");
         if (env == null || env.Count == 0)
         {
@@ -542,7 +515,6 @@ public static class PathHelper
         try
         {
             var shell = Environment.GetEnvironmentVariable("SHELL");
-            Ivy.Helpers.CrashLog.Write($"[PathHelper] RunShellForEnv: SHELL env var is '{shell ?? "null"}'");
             if (string.IsNullOrEmpty(shell))
             {
                 shell = OperatingSystem.IsMacOS() ? "/bin/zsh" : "/bin/bash";
@@ -556,7 +528,6 @@ public static class PathHelper
                     shell = "/bin/bash";
                 }
             }
-            Ivy.Helpers.CrashLog.Write($"[PathHelper] RunShellForEnv: using shell '{shell}'");
 
             var psi = new ProcessStartInfo
             {
@@ -577,7 +548,6 @@ public static class PathHelper
 
             process.ErrorDataReceived += (_, _) => { }; // Discard standard error asynchronously
 
-            Ivy.Helpers.CrashLog.Write($"[PathHelper] RunShellForEnv: starting process with args: {string.Join(" ", process.StartInfo.ArgumentList)}");
             process.Start();
             process.BeginErrorReadLine();
 
@@ -602,23 +572,16 @@ public static class PathHelper
                             }
                         }
                     }
-                    Ivy.Helpers.CrashLog.Write($"[PathHelper] RunShellForEnv: parsed {res.Count} variables successfully");
                     return res;
-                }
-                else
-                {
-                    Ivy.Helpers.CrashLog.Write("[PathHelper] RunShellForEnv: regex did not match markers");
                 }
             }
             else
             {
-                Ivy.Helpers.CrashLog.Write("[PathHelper] RunShellForEnv: process timed out waiting for exit");
                 try { process.Kill(); } catch { }
             }
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            Ivy.Helpers.CrashLog.Write($"[PathHelper] RunShellForEnv: exception occurred: {ex}");
         }
         return null;
     }

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -23,6 +23,7 @@ internal static class ServiceRegistration
         server.Services.AddSingleton<ConfigService>(configService);
         server.Services.AddSingleton<IChatHistoryService, ChatHistoryService>();
         server.Services.AddSingleton<IChatSessionNamingService, ChatSessionNamingService>();
+        server.Services.AddSingleton<IChatExecutionService, ChatExecutionService>();
         server.Services.AddSingleton<ICreatePlanPreferences, CreatePlanPreferences>();
 
         Program.SetConfigServiceForCleanup(configService);

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -356,8 +356,6 @@ public sealed class ChatExecutionService : IChatExecutionService
             }
             finally
             {
-                StreamUpdated?.Invoke(sessionId);
-
                 if (_activeExecutions.TryRemove(sessionId, out var removedExec))
                 {
                     removedExec.Dispose();
@@ -365,6 +363,7 @@ public sealed class ChatExecutionService : IChatExecutionService
 
                 _chatService.SetSessionGenerating(sessionId, false);
                 SessionGeneratingChanged?.Invoke(sessionId);
+                StreamUpdated?.Invoke(sessionId);
 
                 // Process next queued message if one exists
                 if (_chatService.TryDequeueMessage(sessionId, out var nextQueuedItem) && nextQueuedItem != null)

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -1,0 +1,437 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Helpers;
+using Ivy.Tendril.Agents.Providers;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Widgets;
+using Microsoft.Extensions.Logging;
+
+namespace Ivy.Tendril.Services;
+
+public sealed class ChatExecutionService : IChatExecutionService
+{
+    private readonly IConfigService _configService;
+    private readonly IChatHistoryService _chatService;
+    private readonly IAgentRunner _agentRunner;
+    private readonly IChatSessionNamingService _namingService;
+    private readonly IEventSerializer _serializer;
+    private readonly ILogger<ChatExecutionService> _logger;
+
+    private readonly ConcurrentDictionary<string, ActiveChatExecution> _activeExecutions = new(StringComparer.OrdinalIgnoreCase);
+
+    public event Action<string>? SessionGeneratingChanged;
+    public event Action<string>? StreamUpdated;
+    public event Action<string, string>? StreamLineEmitted;
+
+    internal void EmitStreamLine(string sessionId, string wireJson)
+    {
+        if (_activeExecutions.TryGetValue(sessionId, out var exec))
+        {
+            lock (exec.Lock)
+            {
+                exec.RawLines.Add(wireJson);
+            }
+        }
+        StreamLineEmitted?.Invoke(sessionId, wireJson);
+        StreamUpdated?.Invoke(sessionId);
+    }
+
+    public ChatExecutionService(
+        IConfigService configService,
+        IChatHistoryService chatService,
+        IAgentRunner agentRunner,
+        IChatSessionNamingService namingService,
+        IEventSerializer serializer,
+        ILogger<ChatExecutionService>? logger = null)
+    {
+        _configService = configService;
+        _chatService = chatService;
+        _agentRunner = agentRunner;
+        _namingService = namingService;
+        _serializer = serializer;
+        _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ChatExecutionService>.Instance;
+        _chatService.ClearAllGeneratingSessions();
+    }
+
+    public bool IsGenerating(string sessionId) =>
+        !string.IsNullOrEmpty(sessionId) && _activeExecutions.ContainsKey(sessionId);
+
+    public string GetStreamSnapshot(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return string.Empty;
+        if (_activeExecutions.TryGetValue(sessionId, out var exec))
+        {
+            lock (exec.Lock)
+            {
+                return string.Join("\n", exec.RawLines);
+            }
+        }
+        return string.Empty;
+    }
+
+    public IObservable<string> GetLiveStreamObservable(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return Observable.Empty<string>();
+
+        return Observable.Create<string>(observer =>
+        {
+            Action<string, string> handler = (sessId, line) =>
+            {
+                if (string.Equals(sessId, sessionId, StringComparison.OrdinalIgnoreCase))
+                {
+                    observer.OnNext(line);
+                }
+            };
+
+            StreamLineEmitted += handler;
+            return Disposable.Create(() => StreamLineEmitted -= handler);
+        });
+    }
+
+    public async Task SendMessageAsync(
+        string sessionId,
+        string prompt,
+        IReadOnlyList<ChatAttachmentDto>? attachments = null,
+        string? agentId = null,
+        string? modelId = null,
+        string? effort = null,
+        CancellationToken ct = default)
+    {
+        var userPrompt = prompt?.Trim() ?? string.Empty;
+        var attList = attachments ?? Array.Empty<ChatAttachmentDto>();
+        if (string.IsNullOrWhiteSpace(userPrompt) && attList.Count == 0) return;
+        if (string.IsNullOrEmpty(sessionId)) return;
+
+        // If this session is already running an execution, enqueue this message.
+        if (_activeExecutions.ContainsKey(sessionId))
+        {
+            _chatService.EnqueueMessage(sessionId, new ChatSendMessageDto(userPrompt, attList.ToList(), sessionId));
+            return;
+        }
+
+        var sess = _chatService.GetSession(sessionId);
+        var targetAgent = !string.IsNullOrEmpty(agentId)
+            ? agentId
+            : (sess?.AgentId ?? _configService.Settings.CodingAgent ?? "claude");
+        var targetModel = !string.IsNullOrEmpty(modelId) && modelId != "default"
+            ? modelId
+            : (sess?.ModelId ?? "default");
+        var targetEffort = !string.IsNullOrEmpty(effort)
+            ? effort
+            : (sess?.Effort ?? "default");
+
+        var jobTimeoutMinutes = _configService.Settings.JobTimeout;
+        var totalTimeout = jobTimeoutMinutes > 0
+            ? TimeSpan.FromMinutes(jobTimeoutMinutes)
+            : TimeSpan.FromMinutes(15);
+
+        var cts = new CancellationTokenSource(totalTimeout);
+        var activeExec = new ActiveChatExecution(cts);
+        _activeExecutions[sessionId] = activeExec;
+
+        _chatService.SetSessionGenerating(sessionId, true);
+        SessionGeneratingChanged?.Invoke(sessionId);
+
+        // Process attachments and build user prompt
+        var attachedFilePaths = new List<string>();
+        var attachmentErrors = new List<string>();
+        if (attList.Count > 0)
+        {
+            var attachDir = Path.Combine(_configService.TendrilHome, "Attachments", sessionId);
+            if (!Directory.Exists(attachDir))
+            {
+                Directory.CreateDirectory(attachDir);
+            }
+
+            foreach (var att in attList)
+            {
+                try
+                {
+                    var rawName = Path.GetFileName(att.Name);
+                    var fileName = !string.IsNullOrWhiteSpace(rawName)
+                        ? string.Concat(rawName.Split(Path.GetInvalidFileNameChars()))
+                        : $"file_{Guid.NewGuid():N}.bin";
+                    if (string.IsNullOrWhiteSpace(fileName)) fileName = $"file_{Guid.NewGuid():N}.bin";
+                    var filePath = !string.IsNullOrWhiteSpace(att.LocalPath) && File.Exists(att.LocalPath)
+                        ? att.LocalPath
+                        : Path.Combine(attachDir, fileName);
+
+                    if (!string.IsNullOrEmpty(att.Base64Data))
+                    {
+                        var base64 = att.Base64Data.Contains(",")
+                            ? att.Base64Data[(att.Base64Data.IndexOf(",") + 1)..]
+                            : att.Base64Data;
+                        var bytes = Convert.FromBase64String(base64);
+                        File.WriteAllBytes(filePath, bytes);
+                    }
+
+                    if (File.Exists(filePath))
+                    {
+                        attachedFilePaths.Add(filePath);
+                    }
+                    else
+                    {
+                        attachmentErrors.Add($"Attachment '{att.Name}' was not found at {filePath}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    attachmentErrors.Add($"Failed to process attachment '{att.Name}': {ex.Message}");
+                }
+            }
+        }
+
+        var promptWithAttachments = userPrompt;
+        if (attachedFilePaths.Count > 0)
+        {
+            var sb = new StringBuilder();
+            if (!string.IsNullOrWhiteSpace(userPrompt))
+            {
+                sb.AppendLine(userPrompt);
+                sb.AppendLine();
+            }
+            sb.AppendLine("[Attached Files]:");
+            foreach (var path in attachedFilePaths)
+            {
+                sb.AppendLine($"- {path}");
+            }
+            promptWithAttachments = sb.ToString().TrimEnd();
+        }
+
+        if (attachmentErrors.Count > 0)
+        {
+            var warning = "Warning: Some attachments could not be processed:\n" + string.Join("\n", attachmentErrors.Select(e => $"- {e}"));
+            _chatService.AddMessage(sessionId, "assistant", warning, targetAgent, targetModel, effort: targetEffort);
+        }
+
+        // Add user message to history
+        _chatService.AddMessage(sessionId, "user", promptWithAttachments, targetAgent, targetModel, effort: targetEffort);
+
+        // Build prompt with conversation history
+        var currentSess = _chatService.GetSession(sessionId);
+        var history = currentSess?.Messages ?? [];
+        var agentPromptBuilder = new StringBuilder();
+        if (history.Count > 1) // Prior messages exist before this current user message
+        {
+            agentPromptBuilder.AppendLine("# Previous Conversation Discussion History");
+            agentPromptBuilder.AppendLine("The following is the previous conversation history in this chat session:");
+            agentPromptBuilder.AppendLine();
+
+            // Exclude the last message which is the current user request
+            foreach (var prevMsg in history.Take(history.Count - 1))
+            {
+                var roleLabel = prevMsg.Role.Equals("user", StringComparison.OrdinalIgnoreCase) ? "User" : "Assistant";
+                agentPromptBuilder.AppendLine($"### {roleLabel}");
+                agentPromptBuilder.AppendLine(prevMsg.Content);
+                agentPromptBuilder.AppendLine();
+            }
+
+            agentPromptBuilder.AppendLine("---");
+            agentPromptBuilder.AppendLine();
+        }
+
+        agentPromptBuilder.AppendLine("# Current User Request");
+        agentPromptBuilder.AppendLine(promptWithAttachments);
+        var fullAgentPrompt = agentPromptBuilder.ToString();
+
+        // Launch background agent execution
+        _ = Task.Run(async () =>
+        {
+            var rawLock = new object();
+            var rawLines = new List<string>();
+            string? lastTextEvent = null;
+
+            try
+            {
+                var effortOverride = targetEffort != "default" ? AgentProviderFactory.ParseEffort(targetEffort) : null;
+                var context = AgentLaunchHelper.PrepareResolutionContext(
+                    _configService,
+                    _agentRunner,
+                    targetAgent,
+                    fullAgentPrompt,
+                    modelOverride: targetModel != "default" ? targetModel : null,
+                    effortOverride: effortOverride,
+                    permissionMode: PermissionMode.FullAuto);
+
+                var session = await _agentRunner.LaunchAsync(context, cts.Token);
+                activeExec.Session = session;
+
+                using var sub = session.Events.Subscribe(evt =>
+                {
+                    try
+                    {
+                        if (evt is TextEvent textEvt && !string.IsNullOrWhiteSpace(textEvt.Text))
+                        {
+                            lock (rawLock)
+                            {
+                                lastTextEvent = textEvt.Text;
+                            }
+                        }
+
+                        var wireJson = _serializer.Serialize(evt);
+                        if (!string.IsNullOrEmpty(wireJson))
+                        {
+                            lock (activeExec.Lock)
+                            {
+                                activeExec.RawLines.Add(wireJson);
+                            }
+                            StreamLineEmitted?.Invoke(sessionId, wireJson);
+                            StreamUpdated?.Invoke(sessionId);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug(ex, "Failed to serialize chat event for session {SessionId}", sessionId);
+                    }
+                });
+
+                var result = await session.WaitForCompletionAsync(cts.Token);
+
+                string? collectedText;
+                string? fullRawStream = null;
+                lock (activeExec.Lock)
+                {
+                    collectedText = lastTextEvent;
+                    if (activeExec.RawLines.Count > 0)
+                        fullRawStream = string.Join("\n", activeExec.RawLines);
+                }
+
+                var responseContent = !string.IsNullOrWhiteSpace(result.Response)
+                    ? result.Response
+                    : (!string.IsNullOrWhiteSpace(collectedText)
+                        ? collectedText
+                        : (result.IsSuccess
+                            ? "Task completed successfully."
+                            : "Agent execution completed with status code " + (result.ExitCode?.ToString() ?? "unknown")));
+
+                _chatService.AddMessage(sessionId, "assistant", responseContent, targetAgent, targetModel, rawStream: fullRawStream, effort: targetEffort);
+
+                // Auto-generate title on first exchange
+                var updatedSession = _chatService.GetSession(sessionId);
+                if (updatedSession != null &&
+                    (updatedSession.Title == "New Chat" || string.IsNullOrWhiteSpace(updatedSession.Title)) &&
+                    updatedSession.Messages.Count == 2)
+                {
+                    var firstUserMsg = updatedSession.Messages.FirstOrDefault(m => m.Role == "user")?.Content;
+                    if (!string.IsNullOrWhiteSpace(firstUserMsg))
+                    {
+                        _ = Task.Run(async () =>
+                        {
+                            try
+                            {
+                                await _namingService.GenerateAndSetTitleAsync(
+                                    sessionId,
+                                    firstUserMsg,
+                                    responseContent,
+                                    targetAgent,
+                                    targetModel);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogDebug(ex, "Failed to generate title for session {SessionId}", sessionId);
+                            }
+                        });
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                _chatService.AddMessage(sessionId, "assistant", "Execution was cancelled.", targetAgent, targetModel, effort: targetEffort);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error executing request for session {SessionId}", sessionId);
+                _chatService.AddMessage(sessionId, "assistant", $"Error executing request: {ex.Message}", targetAgent, targetModel, effort: targetEffort);
+            }
+            finally
+            {
+                StreamUpdated?.Invoke(sessionId);
+
+                if (_activeExecutions.TryRemove(sessionId, out var removedExec))
+                {
+                    removedExec.Dispose();
+                }
+
+                _chatService.SetSessionGenerating(sessionId, false);
+                SessionGeneratingChanged?.Invoke(sessionId);
+
+                // Process next queued message if one exists
+                if (_chatService.TryDequeueMessage(sessionId, out var nextQueuedItem) && nextQueuedItem != null)
+                {
+                    _ = SendMessageAsync(sessionId, nextQueuedItem.Prompt, nextQueuedItem.Attachments, targetAgent, targetModel, targetEffort);
+                }
+            }
+        });
+    }
+
+    public async Task CancelAsync(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return;
+
+        if (_activeExecutions.TryRemove(sessionId, out var exec))
+        {
+            try
+            {
+                await exec.Cts.CancelAsync();
+                if (exec.Session != null)
+                {
+                    await exec.Session.StopAsync();
+                }
+                exec.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Exception stopping session {SessionId}", sessionId);
+            }
+        }
+
+        _chatService.ClearQueuedMessages(sessionId);
+        _chatService.SetSessionGenerating(sessionId, false);
+        SessionGeneratingChanged?.Invoke(sessionId);
+        StreamUpdated?.Invoke(sessionId);
+    }
+
+    public void Dispose()
+    {
+        foreach (var (_, exec) in _activeExecutions)
+        {
+            try
+            {
+                exec.Cts.Cancel();
+                exec.Dispose();
+            }
+            catch { }
+        }
+        _activeExecutions.Clear();
+    }
+
+    private sealed class ActiveChatExecution : IDisposable
+    {
+        public IAgentSession? Session { get; set; }
+        public CancellationTokenSource Cts { get; }
+        public List<string> RawLines { get; } = [];
+        public object Lock { get; } = new();
+        public long LastStreamUpdateTicks { get; set; }
+
+        public ActiveChatExecution(CancellationTokenSource cts)
+        {
+            Cts = cts;
+        }
+
+        public void Dispose()
+        {
+            try { Cts.Dispose(); } catch { }
+        }
+    }
+}

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -42,6 +42,15 @@ public class ChatHistoryService : IChatHistoryService
         }
     }
 
+    public void ClearAllGeneratingSessions()
+    {
+        if (!_generatingSessions.IsEmpty)
+        {
+            _generatingSessions.Clear();
+            GeneratingSessionsChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
     public IReadOnlySet<string> GetGeneratingSessionIds()
     {
         return _generatingSessions.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase);

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -15,7 +15,8 @@ public class ChatHistoryService : IChatHistoryService
     private readonly ConcurrentDictionary<string, byte> _generatingSessions = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, byte> _completedSessions = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, List<ChatQueuedItem>> _queuedMessages = new(StringComparer.OrdinalIgnoreCase);
-    private readonly object _lock = new();
+    private readonly object _sessionLock = new();
+    private readonly object _queueLock = new();
 
     public event EventHandler? SessionsChanged;
     public event EventHandler? GeneratingSessionsChanged;
@@ -73,7 +74,7 @@ public class ChatHistoryService : IChatHistoryService
     public IReadOnlyList<ChatQueuedItem> GetQueuedMessages(string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId)) return Array.Empty<ChatQueuedItem>();
-        lock (_lock)
+        lock (_queueLock)
         {
             if (_queuedMessages.TryGetValue(sessionId, out var list))
             {
@@ -91,7 +92,7 @@ public class ChatHistoryService : IChatHistoryService
             Attachments: dto.Attachments != null ? new List<ChatAttachmentDto>(dto.Attachments) : null,
             CreatedAt: DateTimeOffset.UtcNow
         );
-        lock (_lock)
+        lock (_queueLock)
         {
             if (!_queuedMessages.TryGetValue(sessionId, out var list))
             {
@@ -109,7 +110,7 @@ public class ChatHistoryService : IChatHistoryService
         item = null;
         if (string.IsNullOrEmpty(sessionId)) return false;
         bool dequeued = false;
-        lock (_lock)
+        lock (_queueLock)
         {
             if (_queuedMessages.TryGetValue(sessionId, out var list) && list.Count > 0)
             {
@@ -133,7 +134,7 @@ public class ChatHistoryService : IChatHistoryService
     {
         if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(queueId)) return false;
         bool removed = false;
-        lock (_lock)
+        lock (_queueLock)
         {
             if (_queuedMessages.TryGetValue(sessionId, out var list))
             {
@@ -159,7 +160,7 @@ public class ChatHistoryService : IChatHistoryService
     {
         if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(queueId)) return false;
         bool updated = false;
-        lock (_lock)
+        lock (_queueLock)
         {
             if (_queuedMessages.TryGetValue(sessionId, out var list))
             {
@@ -182,7 +183,7 @@ public class ChatHistoryService : IChatHistoryService
     {
         if (string.IsNullOrEmpty(sessionId)) return;
         bool cleared = false;
-        lock (_lock)
+        lock (_queueLock)
         {
             cleared = _queuedMessages.TryRemove(sessionId, out _);
         }
@@ -331,16 +332,21 @@ public class ChatHistoryService : IChatHistoryService
     public void RenameSession(string id, string newTitle)
     {
         if (string.IsNullOrEmpty(id) || string.IsNullOrWhiteSpace(newTitle)) return;
-        lock (_lock)
+        ChatSessionModel? updated = null;
+        lock (_sessionLock)
         {
             var session = GetSession(id);
             if (session == null) return;
-            var updated = session with
+            updated = session with
             {
                 Title = CleanTitle(newTitle),
                 UpdatedAt = DateTimeOffset.UtcNow
             };
             _sessions[id] = updated;
+        }
+
+        if (updated != null)
+        {
             PersistSessionToDisk(updated);
             SessionsChanged?.Invoke(this, EventArgs.Empty);
         }
@@ -348,7 +354,9 @@ public class ChatHistoryService : IChatHistoryService
 
     public ChatMessageModel AddMessage(string sessionId, string role, string content, string? agentId = null, string? modelId = null, string? rawStream = null, string? effort = null)
     {
-        lock (_lock)
+        ChatMessageModel msg;
+        ChatSessionModel updatedSession;
+        lock (_sessionLock)
         {
             var session = GetSession(sessionId);
             if (session == null)
@@ -356,7 +364,7 @@ public class ChatHistoryService : IChatHistoryService
                 session = CreateSession(agentId ?? "claude", modelId ?? "opus", effort: effort);
             }
 
-            var msg = new ChatMessageModel(
+            msg = new ChatMessageModel(
                 Id: Guid.NewGuid().ToString("N"),
                 Role: role,
                 Content: content,
@@ -369,7 +377,7 @@ public class ChatHistoryService : IChatHistoryService
 
             var updatedMessages = new List<ChatMessageModel>(session.Messages) { msg };
 
-            var updatedSession = session with
+            updatedSession = session with
             {
                 UpdatedAt = DateTimeOffset.UtcNow,
                 AgentId = agentId ?? session.AgentId,
@@ -379,10 +387,11 @@ public class ChatHistoryService : IChatHistoryService
             };
 
             _sessions[session.Id] = updatedSession;
-            PersistSessionToDisk(updatedSession);
-            SessionsChanged?.Invoke(this, EventArgs.Empty);
-            return msg;
         }
+
+        PersistSessionToDisk(updatedSession);
+        SessionsChanged?.Invoke(this, EventArgs.Empty);
+        return msg;
     }
 
     private void PersistSessionToDisk(ChatSessionModel session)

--- a/src/Ivy.Tendril/Services/IChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/IChatExecutionService.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ivy.Tendril.Widgets;
+
+namespace Ivy.Tendril.Services;
+
+public interface IChatExecutionService : IDisposable
+{
+    event Action<string>? SessionGeneratingChanged;
+    event Action<string>? StreamUpdated;
+    bool IsGenerating(string sessionId);
+    string GetStreamSnapshot(string sessionId);
+    IObservable<string> GetLiveStreamObservable(string sessionId);
+    Task SendMessageAsync(
+        string sessionId,
+        string prompt,
+        IReadOnlyList<ChatAttachmentDto>? attachments = null,
+        string? agentId = null,
+        string? modelId = null,
+        string? effort = null,
+        CancellationToken ct = default);
+    Task CancelAsync(string sessionId);
+}

--- a/src/Ivy.Tendril/Services/IChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/IChatHistoryService.cs
@@ -45,6 +45,7 @@ public interface IChatHistoryService
     void RenameSession(string id, string newTitle);
     ChatMessageModel AddMessage(string sessionId, string role, string content, string? agentId = null, string? modelId = null, string? rawStream = null, string? effort = null);
     void SetSessionGenerating(string sessionId, bool isGenerating);
+    void ClearAllGeneratingSessions();
     IReadOnlySet<string> GetGeneratingSessionIds();
     IReadOnlySet<string> GetCompletedSessionIds();
     void ClearSessionCompleted(string sessionId);


### PR DESCRIPTION
## Summary

When Codex CLI encountered a failure during onboarding (such as an unsupported model on a ChatGPT account, or reaching a usage/rate limit), three separate issues caused the setup process to silently break with no agents running and an empty UI:

1. **CodexEventParser dropped error events**: Codex in --json mode outputs top-level error, turn.failed, and item.completed (with type: "error"). Previously, CodexEventParser only recognized thread.started, item.completed (agent_message/command_execution), and turn.completed. All error events were returned as UnknownEvent and dropped from the output stream.
2. **CodexHealthCheck and CodexFailureAnalyzer missed stdout errors**: Codex CLI writes JSON errors to stdout instead of stderr. Both components only checked stderr, failing to detect model support issues or usage limits.
3. **ProjectAgentStepView swallowed non-zero exit codes**: When handle.Completion resolved after process exit, it did not check for a non-zero exit code. If no exception was thrown, session.Error remained null and showStream was set to false, hiding the agent viewer and leaving the user with an empty screen.

## Changes

- **CodexEventParser**:
  - Added parsing for "error", "turn.failed", and item.completed with type: "error".
  - Added ExtractErrorMessage helper to unwrap nested JSON error structures.
  - Emits ErrorEvent onto the stream so errors appear live in AgentViewer.
- **CodexFailureAnalyzer**:
  - Now inspects both ErrorEvent objects and stderr lines.
  - Recognizes usage limit messages ("hit your usage limit") as FailureKind.RateLimit.
  - Recognizes account-unsupported models ("not supported when using Codex with a ChatGPT account") as FailureKind.InvalidModel.
- **CodexHealthCheck**:
  - Inspects stdout in addition to stderr during ValidateModelAsync to catch model validation errors emitted as JSON.
- **ProjectAgentStepView**:
  - Evaluates handle.ExitCode when handle.Completion completes.
  - Populates session.Error from the job failure reason, last error event, or failure analyzer.
  - Ensures showStream stays active when session.Error.Value is not null so the viewer and error logs remain visible.
  - Removed custom Margin and Padding invocations to adhere to layout guidelines.
- **Unit Tests**:
  - Added tests for CodexEventParser parsing nested JSON errors, plain string errors, turn failures, and item errors.
  - Added tests for CodexFailureAnalyzer handling ErrorEvents for invalid models and usage limits.

## Verification

- dotnet test src/Ivy.Tendril.Agents.Test/Ivy.Tendril.Agents.Test.csproj --filter "FullyQualifiedName~Codex" passed (137 tests).
- dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj passed (2,863 tests).