### PR TITLE
Make the sidebar nav divider draggable to resize the plan list

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellNav.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellNav.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { ShellNav, NAV_HEIGHT_STORAGE_KEY } from "./ShellNav";
+import { ShellContext } from "./ShellContext";
+import { ShellNavItemDto } from "./types";
+
+const items: ShellNavItemDto[] = [
+  { id: "review", label: "Review", icon: "ThumbsUp" },
+  { id: "drafts", label: "Drafts", icon: "Feather" },
+  { id: "recommendations", label: "Recommendations", icon: "Lightbulb" },
+  { id: "activity", label: "Activity", icon: "Activity" },
+];
+
+const NAV_CONTENT_HEIGHT = 160;
+
+/** jsdom has no layout: give the nav list a content height and put the sidebar
+    body far enough below that the plan-list minimum never clamps the drag. */
+const layOut = (container: HTMLElement) => {
+  const list = container.querySelector(".tsh-nav-items") as HTMLElement;
+  Object.defineProperty(list, "scrollHeight", { configurable: true, value: NAV_CONTENT_HEIGHT });
+  list.getBoundingClientRect = () =>
+    ({ top: 100, bottom: 100 + NAV_CONTENT_HEIGHT, height: NAV_CONTENT_HEIGHT }) as DOMRect;
+  const divider = screen.getByRole("separator") as HTMLElement;
+  divider.getBoundingClientRect = () => ({ top: 260, bottom: 280, height: 20 }) as DOMRect;
+  return { list, divider };
+};
+
+const renderNav = (collapsed = false) => {
+  const utils = render(
+    <ShellContext.Provider value={{ collapsed, toggle: () => {} }}>
+      <div className="tsh-sidebar-body" ref={(el) => {
+        if (el) el.getBoundingClientRect = () => ({ top: 0, bottom: 1000 }) as DOMRect;
+      }}>
+        <ShellNav id="nav-1" items={items} showDivider={true} events={["OnSelect"]} eventHandler={vi.fn()} />
+      </div>
+    </ShellContext.Provider>
+  );
+  return { ...utils, ...layOut(utils.container) };
+};
+
+const drag = (divider: HTMLElement, from: number, to: number) => {
+  fireEvent.pointerDown(divider, { button: 0, clientY: from, pointerId: 1 });
+  fireEvent.pointerMove(divider, { clientY: to, pointerId: 1 });
+  fireEvent.pointerUp(divider, { clientY: to, pointerId: 1 });
+};
+
+describe("ShellNav divider resizing", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("caps the nav height when the divider is dragged up and remembers it", () => {
+    const { list, divider } = renderNav();
+    expect(list.style.maxHeight).toBe("");
+
+    drag(divider, 270, 210);
+
+    expect(list.style.maxHeight).toBe("100px");
+    expect(window.localStorage.getItem(NAV_HEIGHT_STORAGE_KEY)).toBe("100");
+  });
+
+  it("never shrinks below one row", () => {
+    const { list, divider } = renderNav();
+    drag(divider, 270, 0);
+    expect(list.style.maxHeight).toBe("38px");
+  });
+
+  it("drops the cap again once dragged back to the content height", () => {
+    window.localStorage.setItem(NAV_HEIGHT_STORAGE_KEY, "100");
+    const { list, divider } = renderNav();
+    expect(list.style.maxHeight).toBe("100px");
+    list.getBoundingClientRect = () => ({ top: 100, bottom: 200, height: 100 }) as DOMRect;
+
+    drag(divider, 210, 400);
+
+    expect(list.style.maxHeight).toBe("");
+    expect(window.localStorage.getItem(NAV_HEIGHT_STORAGE_KEY)).toBeNull();
+  });
+
+  it("resets to the natural height on double-click", () => {
+    window.localStorage.setItem(NAV_HEIGHT_STORAGE_KEY, "80");
+    const { list, divider } = renderNav();
+    expect(list.style.maxHeight).toBe("80px");
+
+    fireEvent.doubleClick(divider);
+
+    expect(list.style.maxHeight).toBe("");
+    expect(window.localStorage.getItem(NAV_HEIGHT_STORAGE_KEY)).toBeNull();
+  });
+
+  it("is not draggable in the collapsed rail", () => {
+    const { list, divider } = renderNav(true);
+    expect(divider).toHaveAttribute("data-resizable", "false");
+    drag(divider, 270, 210);
+    expect(list.style.maxHeight).toBe("");
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellNav.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellNav.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useRef, useState } from "react";
 import {
   Activity,
   ChartBar,
@@ -40,6 +40,39 @@ const NavIcon: React.FC<{ icon?: string; label: string }> = ({ icon, label }) =>
   return <span style={{ fontSize: 12, fontWeight: 500 }}>{label.charAt(0).toUpperCase()}</span>;
 };
 
+/** One nav row: the nav can never be dragged smaller than this. */
+const MIN_NAV_HEIGHT = 38;
+/** The plan list below the divider always keeps at least this much room. */
+const MIN_LIST_HEIGHT = 96;
+export const NAV_HEIGHT_STORAGE_KEY = "tendril.shell.navHeight";
+
+const readStoredHeight = (): number | null => {
+  try {
+    const raw = window.localStorage.getItem(NAV_HEIGHT_STORAGE_KEY);
+    if (raw == null) return null;
+    const value = Number(raw);
+    return Number.isFinite(value) && value > 0 ? value : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredHeight = (height: number | null) => {
+  try {
+    if (height == null) window.localStorage.removeItem(NAV_HEIGHT_STORAGE_KEY);
+    else window.localStorage.setItem(NAV_HEIGHT_STORAGE_KEY, String(Math.round(height)));
+  } catch {
+    /* storage unavailable (private mode, sandboxed host) — the size just doesn't persist */
+  }
+};
+
+/**
+ * The app menu. When a sidebar section (plan list) follows it, the divider
+ * between the two doubles as a drag handle: dragging it up caps the nav's
+ * height (the items scroll) and hands the room to the list, dragging it down
+ * gives the nav its rows back. Double-click resets to the natural height. The
+ * chosen height is client-side state, remembered in localStorage.
+ */
 export const ShellNav: React.FC<ShellNavProps> = ({
   id,
   events = [],
@@ -48,37 +81,112 @@ export const ShellNav: React.FC<ShellNavProps> = ({
   showDivider = false,
 }) => {
   const { collapsed } = useShell();
+  const itemsRef = useRef<HTMLDivElement>(null);
+  const [navHeight, setNavHeight] = useState<number | null>(readStoredHeight);
+  const [dragging, setDragging] = useState(false);
+  const dragRef = useRef<{ startY: number; startHeight: number; max: number } | null>(null);
 
   const select = (itemId: string) => {
     if (events.includes("OnSelect")) eventHandler("OnSelect", id, [itemId]);
   };
 
+  const resizable = showDivider && !collapsed;
+
+  const onDividerPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const list = itemsRef.current;
+      if (!resizable || e.button !== 0 || !list) return;
+      e.preventDefault();
+      const body = list.closest(".tsh-sidebar-body") ?? list.parentElement;
+      const listRect = list.getBoundingClientRect();
+      const dividerRect = e.currentTarget.getBoundingClientRect();
+      // Room below the divider is everything left in the sidebar body minus the
+      // minimum the plan list keeps; the nav also never grows past its content.
+      const bodyBottom = body ? body.getBoundingClientRect().bottom : Infinity;
+      const available = bodyBottom - listRect.top - dividerRect.height - MIN_LIST_HEIGHT;
+      const max = Math.max(MIN_NAV_HEIGHT, Math.min(list.scrollHeight, available));
+      dragRef.current = { startY: e.clientY, startHeight: listRect.height, max };
+      e.currentTarget.setPointerCapture?.(e.pointerId);
+      setDragging(true);
+    },
+    [resizable]
+  );
+
+  const onDividerPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    const next = drag.startHeight + (e.clientY - drag.startY);
+    setNavHeight(Math.round(Math.min(drag.max, Math.max(MIN_NAV_HEIGHT, next))));
+  }, []);
+
+  const onDividerPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    dragRef.current = null;
+    setDragging(false);
+    e.currentTarget.releasePointerCapture?.(e.pointerId);
+    setNavHeight((height) => {
+      // Dragged all the way back to the content height: forget the cap so the
+      // nav keeps sizing to its rows if items are added later.
+      const list = itemsRef.current;
+      const settled = height != null && list && height >= list.scrollHeight - 1 ? null : height;
+      writeStoredHeight(settled);
+      return settled;
+    });
+  }, []);
+
+  const onDividerDoubleClick = useCallback(() => {
+    if (!resizable) return;
+    setNavHeight(null);
+    writeStoredHeight(null);
+  }, [resizable]);
+
   return (
-    <nav className="tsh-nav">
-      {items.map((item) => (
-        <button
-          key={item.id}
-          className="tsh-nav-item"
-          data-active={item.isActive === true}
-          data-menu-item={item.id}
-          onClick={() => select(item.id)}
-          title={item.label}
-        >
-          <span className="tsh-nav-item-main">
-            <span className="tsh-nav-icon">
-              <NavIcon icon={item.icon} label={item.label} />
+    <nav className="tsh-nav" data-dragging={dragging}>
+      <div
+        className="tsh-nav-items"
+        ref={itemsRef}
+        style={showDivider && navHeight != null ? { maxHeight: navHeight } : undefined}
+      >
+        {items.map((item) => (
+          <button
+            key={item.id}
+            className="tsh-nav-item"
+            data-active={item.isActive === true}
+            data-menu-item={item.id}
+            onClick={() => select(item.id)}
+            title={item.label}
+          >
+            <span className="tsh-nav-item-main">
+              <span className="tsh-nav-icon">
+                <NavIcon icon={item.icon} label={item.label} />
+              </span>
+              <span className="tsh-nav-label">{item.label}</span>
             </span>
-            <span className="tsh-nav-label">{item.label}</span>
-          </span>
-          {item.badge && (
-            <span className="tsh-nav-badge">
-              {/* The rail fits two digits beside the icon; larger counts cap at 99. */}
-              {collapsed && item.badge.length > 2 ? "99" : item.badge}
-            </span>
-          )}
-        </button>
-      ))}
-      {showDivider && <div className="tsh-nav-divider" />}
+            {item.badge && (
+              <span className="tsh-nav-badge">
+                {/* The rail fits two digits beside the icon; larger counts cap at 99. */}
+                {collapsed && item.badge.length > 2 ? "99" : item.badge}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+      {showDivider && (
+        <div
+          className="tsh-nav-divider"
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label="Resize navigation"
+          data-resizable={resizable}
+          data-dragging={dragging}
+          onPointerDown={onDividerPointerDown}
+          onPointerMove={onDividerPointerMove}
+          onPointerUp={onDividerPointerUp}
+          onPointerCancel={onDividerPointerUp}
+          onDoubleClick={onDividerDoubleClick}
+        />
+      )}
     </nav>
   );
 };

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
@@ -487,15 +487,30 @@
 .tsh-nav {
   display: flex;
   flex-direction: column;
-  gap: 2px;
   padding-top: 12px;
   flex-shrink: 0;
+  min-height: 0;
+}
+
+/* The rows live in their own scroll box so the divider below can cap the
+   nav's height (ShellNav sets max-height while the user drags it). */
+.tsh-nav-items {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex-shrink: 0;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: var(--tsh-border) transparent;
 }
 
 .tsh-nav-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-shrink: 0;
   width: 100%;
   min-height: 38px;
   padding: 10px 12px;
@@ -587,7 +602,28 @@
   content: "";
   width: 100%;
   height: 1px;
+  border-radius: 1px;
   background: var(--tsh-border);
+  transition: background-color 150ms ease, height 150ms ease;
+}
+
+/* Between the nav and the plan list the divider is a drag handle: on hover
+   (and while dragging) the hairline thickens and darkens a touch. */
+.tsh-nav-divider[data-resizable="true"] {
+  cursor: row-resize;
+  touch-action: none;
+  user-select: none;
+}
+
+.tsh-nav-divider[data-resizable="true"]:hover::after,
+.tsh-nav-divider[data-dragging="true"]::after {
+  height: 2px;
+  background: color-mix(in srgb, var(--tsh-fg) 22%, var(--tsh-border));
+}
+
+/* While a drag is in flight the row heights must track the pointer, not ease. */
+.tsh-nav[data-dragging="true"] .tsh-nav-items {
+  transition: none;
 }
 
 .tsh-root[data-collapsed="true"] .tsh-nav-item {


### PR DESCRIPTION
## What

The divider between the app nav and the plan list in the sidebar is now a drag handle with a subtle hover effect.

- **Drag up** caps the nav's height (its rows scroll) and hands the room to the plan list.
- **Drag down** gives the rows back; once the nav is back at its natural height the cap is dropped entirely, so newly added nav items are never clipped.
- **Double-click** resets to the natural height.
- The nav never shrinks below one row (38px) and the plan list always keeps at least 96px.
- The chosen height is remembered client-side in `localStorage` (`tendril.shell.navHeight`) so it survives reloads.
- In the collapsed rail the divider is inert.
- Hover (and dragging) thickens the hairline from 1px to 2px, darkens it slightly, and shows a `row-resize` cursor.

## Why

With a tall nav the plan list gets squeezed at smaller window heights; letting the user trade nav rows for list rows keeps both usable.

## Changes

- `ShellNav.tsx`: nav rows moved into a `.tsh-nav-items` scroll box; divider gets pointer handlers (pointer capture, clamped to the nav content height and the room left in the sidebar body).
- `shell.css`: `.tsh-nav-items` scroll box, divider hover/drag styling.
- `ShellNav.test.tsx`: 5 new vitest cases (drag up, one-row floor, uncap on drag back, double-click reset, rail is non-draggable).

No C# changes; persistence is client-only. If it should follow the user like the collapse state does, that needs a widget event plus a settings field.

## Verification

- `npm run build` (tsc + vite) and `vitest run src/Shell`: 9/9 pass.
- Ran the app from the worktree against a scratch `TENDRIL_HOME` with seeded plans and verified in the browser: drag up/down, hover styling, reload persistence, collapsed rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)