### PR TITLE
Fix "Unknown component type" in DraftMarkdown sample apps

### DIFF
--- a/src/Ivy.Tendril.Test/QuestionAnswersTests.cs
+++ b/src/Ivy.Tendril.Test/QuestionAnswersTests.cs
@@ -7,7 +7,7 @@ namespace Ivy.Tendril.Test;
 
 /// <summary>
 ///     <see cref="QuestionAnswers" /> is the host-side merge behind
-///     <c>DraftMarkdown.OnAnswersChange</c>. It lives in the widgets assembly, but it is tested here
+///     <c>PlanMarkdown.OnAnswersChange</c>. It lives in the widgets assembly, but it is tested here
 ///     because this is where <see cref="QuestionBlockParser" /> and
 ///     <see cref="QuestionValidationService" /> are — a merge whose output the validator rejects is a
 ///     bug, and several of these tests assert exactly that round trip.

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/AnnotationsApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/AnnotationsApp.cs
@@ -1,7 +1,7 @@
 using System.Collections.Immutable;
 using Ivy;
 using Ivy.Tendril.Widgets;
-using DraftMarkdownWidget = Ivy.Tendril.Widgets.DraftMarkdown;
+using DraftMarkdownWidget = Ivy.Tendril.Widgets.PlanMarkdown;
 
 namespace WidgetSamples.Apps.DraftMarkdown;
 

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/CollapsibleApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/CollapsibleApp.cs
@@ -1,6 +1,6 @@
 using Ivy;
 using Ivy.Tendril.Widgets;
-using DraftMarkdownWidget = Ivy.Tendril.Widgets.DraftMarkdown;
+using DraftMarkdownWidget = Ivy.Tendril.Widgets.PlanMarkdown;
 
 namespace WidgetSamples.Apps.DraftMarkdown;
 

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/ComparisonApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/ComparisonApp.cs
@@ -1,6 +1,6 @@
 using Ivy;
 using Ivy.Tendril.Widgets;
-using DraftMarkdownWidget = Ivy.Tendril.Widgets.DraftMarkdown;
+using DraftMarkdownWidget = Ivy.Tendril.Widgets.PlanMarkdown;
 
 namespace WidgetSamples.Apps.DraftMarkdown;
 
@@ -147,7 +147,7 @@ class ComparisonApp : ViewBase
                   | new Markdown(markdown).Article().Height(Size.Full()).DangerouslyAllowLocalFiles()
                   )
                | (Layout.Vertical().Width(Size.Fraction(0.5f)).Height(Size.Full())
-                  | Text.Block("DraftMarkdown (Widget)").Bold().Small()
+                  | Text.Block("PlanMarkdown (Widget)").Bold().Small()
                   | new DraftMarkdownWidget(markdown).Article().Height(Size.Full()).DangerouslyAllowLocalFiles()
                   );
     }

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/MathApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/MathApp.cs
@@ -1,6 +1,6 @@
 using Ivy;
 using Ivy.Tendril.Widgets;
-using DraftMarkdownWidget = Ivy.Tendril.Widgets.DraftMarkdown;
+using DraftMarkdownWidget = Ivy.Tendril.Widgets.PlanMarkdown;
 
 namespace WidgetSamples.Apps.DraftMarkdown;
 

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsApp.cs
@@ -1,7 +1,7 @@
 using System.Collections.Immutable;
 using Ivy;
 using Ivy.Tendril.Widgets;
-using DraftMarkdownWidget = Ivy.Tendril.Widgets.DraftMarkdown;
+using DraftMarkdownWidget = Ivy.Tendril.Widgets.PlanMarkdown;
 
 namespace WidgetSamples.Apps.DraftMarkdown;
 

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsEditingApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsEditingApp.cs
@@ -1,6 +1,6 @@
 using Ivy;
 using Ivy.Tendril.Widgets;
-using DraftMarkdownWidget = Ivy.Tendril.Widgets.DraftMarkdown;
+using DraftMarkdownWidget = Ivy.Tendril.Widgets.PlanMarkdown;
 
 namespace WidgetSamples.Apps.DraftMarkdown;
 

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsReviewApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/QuestionsReviewApp.cs
@@ -1,6 +1,6 @@
 using Ivy;
 using Ivy.Tendril.Widgets;
-using DraftMarkdownWidget = Ivy.Tendril.Widgets.DraftMarkdown;
+using DraftMarkdownWidget = Ivy.Tendril.Widgets.PlanMarkdown;
 
 namespace WidgetSamples.Apps.DraftMarkdown;
 

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/StickyContentApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/DraftMarkdown/StickyContentApp.cs
@@ -1,6 +1,6 @@
 using Ivy;
 using Ivy.Tendril.Widgets;
-using DraftMarkdownWidget = Ivy.Tendril.Widgets.DraftMarkdown;
+using DraftMarkdownWidget = Ivy.Tendril.Widgets.PlanMarkdown;
 
 namespace WidgetSamples.Apps.DraftMarkdown;
 
@@ -56,7 +56,7 @@ class StickyContentApp : ViewBase
                         .Header(Text.H4("Navigation"))
                         .Content(BuildTableOfContents());
 
-                    return new DraftMarkdown(markdown)
+                    return new PlanMarkdown(markdown)
                         .Article()
                         .StickyContent(sidebar);
                 }

--- a/src/Ivy.Tendril.Widgets/QuestionAnswers.cs
+++ b/src/Ivy.Tendril.Widgets/QuestionAnswers.cs
@@ -22,7 +22,7 @@ public readonly record struct QuestionBlockSource(int Index, int BodyStart, int 
 /// </summary>
 /// <param name="BlockIndex">0-based index of the <c>questions</c> fence holding it.</param>
 /// <param name="Id">The question's <c>id</c> — unique across the revision, and what
-/// <see cref="DraftMarkdown.ScrollTo" /> addresses.</param>
+/// <see cref="PlanMarkdown.ScrollTo" /> addresses.</param>
 /// <param name="Title">The question itself. Empty when the block omitted it.</param>
 /// <param name="Header">The optional short label shown as an eyebrow above the title.</param>
 /// <param name="HasAnswer">Whether the question carries an <c>answer</c>.</param>
@@ -39,7 +39,7 @@ public readonly record struct QuestionSummary(
     bool IsOptional);
 
 /// <summary>
-///     Merges a <see cref="QuestionAnswer" /> reported by <see cref="DraftMarkdown.OnAnswersChange" />
+///     Merges a <see cref="QuestionAnswer" /> reported by <see cref="PlanMarkdown.OnAnswersChange" />
 ///     back into the markdown it came from.
 ///     <para>
 ///         The widget never rewrites its own document: it reports what changed and the host decides


### PR DESCRIPTION
## What

Migrates the 8 `DraftMarkdown` sample apps off the obsolete `DraftMarkdown` alias and onto `PlanMarkdown`.

Opening any sample in the DraftMarkdown group failed with:

```
Unknown component type: Ivy.Tendril.Widgets.DraftMarkdown
```

## Why

The rename in a3faddce (`refactor(apps): rename Drafts app, services, and widgets to Plans`) renamed the widget `DraftMarkdown` → `PlanMarkdown` and left an `[Obsolete]` subclass behind as a compatibility shim:

```csharp
[Obsolete("Use PlanMarkdown instead")]
public record DraftMarkdown : PlanMarkdown
```

That shim can never render as an external widget:

- `ExternalWidgetAttribute` is declared `Inherited = false`.
- `ExternalWidgetRegistry.ScanAssembly` only registers types carrying the attribute **directly**, keying each on its own `CleanTypeName`. So the registry holds `Ivy.Tendril.Widgets.PlanMarkdown` and nothing else.
- Serialization uses the **concrete** runtime type, so constructing `DraftMarkdown` puts `Ivy.Tendril.Widgets.DraftMarkdown` on the wire — a name with neither a registry entry nor a built-in component.

That commit updated the main app (already on `PlanMarkdown`, never broken) but missed the samples, so **every** app in the DraftMarkdown group was failing, not just Questions.

## Changes

- Repointed the `DraftMarkdownWidget` using-alias at `PlanMarkdown` across all 8 sample files.
- Fixed `new DraftMarkdown(...)` inside StickyContentApp's markdown code sample and the Comparison panel label — both were teaching the broken API.
- Updated three `<see cref>` / `<c>` doc references still pointing at the obsolete type.

Alias-only change; no behavior or API surface is modified.

## Verification

- Build succeeds with **0 warnings** — the obsolete-usage warnings the samples previously emitted are gone.
- Ran the samples app and opened all eight (Annotations, Collapsible, Comparison, Math, Questions, Questions (Editing), Questions (Review), Sticky Content). Each renders, with no widget-related console errors.
- Reproduced the failure and the fix side by side at the same URL (`/draft-markdown/questions`): unfixed build errors, this build renders.

## Note for the reviewer

`DraftMarkdown` is still declared at `src/Ivy.Tendril.Widgets/PlanMarkdown.cs:103` and now has **no remaining users**. Since it is structurally incapable of rendering, it is a trap rather than a working compatibility shim — anyone following the `[Obsolete]` deprecation path hits this same runtime error instead of a clean compile-time warning. I'd suggest deleting it, but that is an API-surface change beyond the scope of this fix, so I left it in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)