### PR TITLE
feat: keep sidebar plan search reachable from every app

### DIFF
--- a/src/Ivy.Tendril.Test/AppShell/TendrilAppShellSidebarTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/TendrilAppShellSidebarTests.cs
@@ -24,4 +24,21 @@ public class TendrilAppShellSidebarTests
         var result = HasSidebarSection(appId);
         Assert.Equal(expected, result);
     }
+
+    [Theory]
+    [InlineData("review", "review", true)]
+    [InlineData("review", "REVIEW", true)]
+    [InlineData("review", "plans", true)]
+    [InlineData("plans", "review", true)]
+    [InlineData("recommendations", "drafts", true)]
+    [InlineData("review", "jobs", false)]
+    [InlineData("review", "settings", false)]
+    [InlineData("review", null, false)]
+    [InlineData(null, "review", false)]
+    [InlineData(null, null, false)]
+    public void UsesSidebarList_ReturnsExpectedValue(string? listAppId, string? currentAppId, bool expected)
+    {
+        var result = UsesSidebarList(listAppId, currentAppId);
+        Assert.Equal(expected, result);
+    }
 }

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx
@@ -85,6 +85,100 @@ describe("ShellSidebarSection", () => {
     expect(screen.getByText("Plan C")).toBeInTheDocument();
   });
 
+  it("replaces the title with a full-width Search button when there is no list", () => {
+    const eventHandler = vi.fn();
+    render(
+      <ShellSidebarSection
+        id="sec-1"
+        searchable={true}
+        events={["OnSearch"]}
+        eventHandler={eventHandler}
+      />,
+    );
+
+    const searchBtn = screen.getByRole("button", { name: /search plans/i });
+    expect(searchBtn).toHaveClass("tsh-section-search-button");
+    expect(screen.getByText("Search")).toBeInTheDocument();
+    expect(screen.getByText("K")).toBeInTheDocument();
+    expect(screen.queryByText("Plans")).not.toBeInTheDocument();
+
+    fireEvent.click(searchBtn);
+    expect(eventHandler).toHaveBeenCalledWith("OnSearch", "sec-1", []);
+  });
+
+  it("replaces the title with the Search button when the list is empty", () => {
+    render(
+      <ShellSidebarSection
+        id="sec-1"
+        title="Review"
+        items={[]}
+        searchable={true}
+        events={["OnSearch"]}
+        eventHandler={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /search plans/i })).toHaveClass(
+      "tsh-section-search-button",
+    );
+    expect(screen.queryByText("Review")).not.toBeInTheDocument();
+  });
+
+  it("keeps the title and icon button while the list has items", () => {
+    render(
+      <ShellSidebarSection
+        id="sec-1"
+        title="Review"
+        items={mockItems}
+        searchable={true}
+        events={["OnSearch"]}
+        eventHandler={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /search plans/i })).toHaveClass("tsh-section-search");
+    expect(screen.getByText("Review")).toBeInTheDocument();
+    expect(screen.queryByText("Search")).not.toBeInTheDocument();
+  });
+
+  it("opens search on Cmd/Ctrl+K, but not while typing in an input", () => {
+    const eventHandler = vi.fn();
+    render(
+      <>
+        <input aria-label="field" />
+        <ShellSidebarSection
+          id="sec-1"
+          searchable={true}
+          events={["OnSearch"]}
+          eventHandler={eventHandler}
+        />
+      </>,
+    );
+
+    fireEvent.keyDown(document.body, { key: "k", ctrlKey: true });
+    expect(eventHandler).toHaveBeenCalledWith("OnSearch", "sec-1", []);
+
+    eventHandler.mockClear();
+    fireEvent.keyDown(screen.getByLabelText("field"), { key: "k", ctrlKey: true });
+    expect(eventHandler).not.toHaveBeenCalled();
+  });
+
+  it("ignores Cmd/Ctrl+K when not searchable", () => {
+    const eventHandler = vi.fn();
+    render(
+      <ShellSidebarSection
+        id="sec-1"
+        items={mockItems}
+        searchable={false}
+        events={["OnSearch"]}
+        eventHandler={eventHandler}
+      />,
+    );
+
+    fireEvent.keyDown(document.body, { key: "k", ctrlKey: true });
+    expect(eventHandler).not.toHaveBeenCalled();
+  });
+
   it("renders collapsed rail view with search button", () => {
     const onSearch = vi.fn();
     render(
@@ -106,5 +200,20 @@ describe("ShellSidebarSection", () => {
 
     fireEvent.click(railSearchBtn);
     expect(onSearch).toHaveBeenCalledWith("OnSearch", "sec-1", []);
+  });
+
+  it("shows the rail search icon without a list", () => {
+    render(
+      <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
+        <ShellSidebarSection
+          id="sec-1"
+          searchable={true}
+          events={["OnSearch"]}
+          eventHandler={vi.fn()}
+        />
+      </ShellContext.Provider>,
+    );
+
+    expect(screen.getByRole("button", { name: /search plans/i })).toHaveClass("tsh-rail-search");
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.tsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useCallback, useEffect } from "react";
 import { Search } from "lucide-react";
 import { useShell } from "./ShellContext";
-import { ShellSectionItemDto, ShellWidgetProps } from "./types";
+import { ShellSectionItemDto, ShellWidgetProps, isEditableTarget, isModKey, modKeyLabel } from "./types";
 import "./shell.css";
+
+const SEARCH_SHORTCUT_KEY = "K";
 
 interface ShellSidebarSectionProps extends ShellWidgetProps {
   title?: string;
@@ -16,6 +18,9 @@ interface ShellSidebarSectionProps extends ShellWidgetProps {
  * The contextual list under the nav — plans for Review/Drafts, recommendations,
  * etc. Published by the active app. In the collapsed rail the list shrinks to
  * narrow ID chips (the row tags, e.g. "#40") with the search button above.
+ * Without a list (other apps, or an app whose list is empty) the header slot
+ * holds a full-width Search button instead of the title, and Cmd/Ctrl+K opens
+ * the search from anywhere in the shell.
  */
 export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
   id,
@@ -31,11 +36,31 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
     if (events.includes("OnSelectItem")) eventHandler("OnSelectItem", id, [itemId]);
   };
 
-  const openSearch = () => {
+  const openSearch = useCallback(() => {
     if (events.includes("OnSearch")) eventHandler("OnSearch", id, []);
-  };
+  }, [events, eventHandler, id]);
+
+  useEffect(() => {
+    if (!searchable) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (
+        isModKey(e) &&
+        !e.shiftKey &&
+        !e.altKey &&
+        e.key.toLowerCase() === SEARCH_SHORTCUT_KEY.toLowerCase() &&
+        !isEditableTarget(e)
+      ) {
+        e.preventDefault();
+        openSearch();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [searchable, openSearch]);
 
   const { collapsed } = useShell();
+  const shortcutHint = `${modKeyLabel()}+${SEARCH_SHORTCUT_KEY}`;
+  const searchTitle = `Search plans (${shortcutHint})`;
 
   // Rail chips get a hover flyout (title + badges) since the chip itself only
   // shows the ID. Fixed-position and portaled so the rail cannot clip it.
@@ -46,6 +71,7 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
   } | null>(null);
 
   const hasHeader = !!title || searchable;
+  const showSearchButton = searchable && (!title || items.length === 0);
 
   if (collapsed) {
     return (
@@ -55,7 +81,7 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
             className="tsh-rail-search"
             onClick={openSearch}
             aria-label="Search plans"
-            title="Search plans"
+            title={searchTitle}
           >
             <Search size={16} />
           </button>
@@ -103,7 +129,26 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
 
   return (
     <div className="tsh-section" data-headerless={!hasHeader}>
-      {hasHeader && (
+      {hasHeader && showSearchButton && (
+        <div className="tsh-section-header" data-search-button="true">
+          <button
+            className="tsh-section-search-button"
+            onClick={openSearch}
+            aria-label="Search plans"
+            title={searchTitle}
+          >
+            <span className="tsh-section-search-button-main">
+              <Search size={16} />
+              <span className="tsh-section-search-button-label">Search</span>
+            </span>
+            <span className="tsh-kbd">
+              <span>{modKeyLabel()}</span>
+              <span>{SEARCH_SHORTCUT_KEY}</span>
+            </span>
+          </button>
+        </div>
+      )}
+      {hasHeader && !showSearchButton && (
         <div className="tsh-section-header">
           <span className="tsh-section-title">{title}</span>
           {searchable && (
@@ -111,7 +156,7 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
               className="tsh-section-search"
               onClick={openSearch}
               aria-label="Search plans"
-              title="Search plans"
+              title={searchTitle}
             >
               <Search size={16} />
             </button>

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
@@ -793,6 +793,56 @@
   color: var(--tsh-row-active-fg);
 }
 
+/* No list to title (other apps, or an empty Review/Drafts list): the header
+   slot becomes a full-width Search row styled like a nav item, with the
+   shortcut hint on the right like the New Plan and agent rows. */
+.tsh-section-header[data-search-button="true"] {
+  padding: 0;
+}
+
+.tsh-section-search-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 38px;
+  padding: 10px 12px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--tsh-fg);
+  cursor: pointer;
+  transition: background-color 150ms ease;
+}
+
+.tsh-section-search-button:hover {
+  background: var(--tsh-row-active);
+  color: var(--tsh-row-active-fg);
+}
+
+.tsh-section-search-button-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  opacity: 0.6;
+  transition: opacity 150ms ease;
+}
+
+.tsh-section-search-button:hover .tsh-section-search-button-main {
+  opacity: 1;
+}
+
+.tsh-section-search-button-label {
+  font-size: 14px;
+  font-weight: 400;
+  white-space: nowrap;
+}
+
+.tsh-section-search-button .tsh-kbd {
+  color: var(--tsh-fg);
+}
+
 .tsh-section-list {
   margin-top: 10px;
   flex: 1;

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -128,6 +128,11 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
     internal static bool HasSidebarSection(string? appId) =>
         appId != null && SidebarSectionAppIds.Contains(appId);
 
+    internal static bool UsesSidebarList(string? listAppId, string? currentAppId) =>
+        listAppId != null &&
+        (string.Equals(listAppId, currentAppId, StringComparison.OrdinalIgnoreCase) ||
+         HasSidebarSection(currentAppId));
+
     private static readonly HashSet<string> ShareAllowedAppIds = new(StringComparer.OrdinalIgnoreCase)
     {
         "review", "plans"
@@ -668,8 +673,8 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             .Version($"v {versionString}")
             .LogoUrl("/tendril/assets/Tendril.svg");
 
-        // The widget handles Cmd/Ctrl+K client-side; the zero-size ghost button keeps the
-        // legacy Ctrl+Alt+N chord working (ShortcutKey is the only shortcut API Ivy exposes).
+        // The widget only shows the shortcut hint; the zero-size ghost button binds the
+        // Ctrl+Alt+N chord (ShortcutKey is the only shortcut API Ivy exposes).
         var newPlanButton = new CreatePlanDialogLauncher(open => new Fragment(
             new ShellNewPlanButton().OnClick(open),
             Layout.Vertical().Height(Size.Px(0)).Width(Size.Px(0))
@@ -704,10 +709,10 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             })
             .OnNewChat(() => OpenApp(new NavigateArgs(AgentAppId)));
 
-        object? section = null;
-        if (sidebarList.Value is { } list &&
-            (string.Equals(list.AppId, currentApp.Value?.AppId, StringComparison.OrdinalIgnoreCase) ||
-             HasSidebarSection(currentApp.Value?.AppId)))
+        // Plan search is always reachable from the sidebar: apps without a list (and lists
+        // with no rows) get the section's full-width Search button in place of the title.
+        ShellSidebarSection section;
+        if (sidebarList.Value is { } list && UsesSidebarList(list.AppId, currentApp.Value?.AppId))
         {
             var capturedList = list;
             section = new ShellSidebarSection()
@@ -719,10 +724,16 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                     OpenApp(new NavigateArgs(capturedList.AppId, capturedList.BuildSelectArgs(itemId))))
                 .OnSearch(showPlanSearchDialog);
         }
+        else
+        {
+            section = new ShellSidebarSection()
+                .Searchable()
+                .OnSearch(showPlanSearchDialog);
+        }
 
         var nav = new ShellNav()
             .Items(BuildNavItems(menuItems.Value, activeNavAppId))
-            .ShowDivider(section != null)
+            .ShowDivider(true)
             .OnSelect(appId => OpenApp(new NavigateArgs(appId)));
 
         var settingsMenu = new DropDownMenu(


### PR DESCRIPTION
The search icon only existed inside the Review/Drafts list header, so apps
without a sidebar list (Jobs, Dashboard, Settings, ...) had no way to open
plan search, and an empty Review/Drafts list showed a title with nothing
under it.

- The shell always renders the sidebar section; without a matching list it
  is a bare searchable section.
- Without a title, or with an empty list, the section header becomes a
  full-width Search button with a Cmd/Ctrl+K hint, styled like the New Plan
  and agent rows. With rows it keeps the title plus the icon button.
- The collapsed rail always shows the search icon.
- Cmd/Ctrl+K opens plan search from anywhere in the shell (ignored while
  typing in inputs or the terminal).

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
