### PR TITLE
feat: add quick actions to sidebar plan flyouts

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/SidebarListActionsTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/SidebarListActionsTests.cs
@@ -1,0 +1,101 @@
+using Ivy.Tendril.AppShell;
+using Ivy.Tendril.Apps.Plans;
+using Ivy.Tendril.Apps.Review;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Widgets;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps;
+
+public class SidebarListActionsTests
+{
+    private static PlanFile CreatePlan(int id, PlanStatus status, List<string>? commits = null, string? sourceUrl = null)
+    {
+        var metadata = new PlanMetadata(
+            id, "Ivy", "Bug", $"Plan {id}", status,
+            [], commits ?? [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, sourceUrl);
+        return new PlanFile(metadata, "", $"/tmp/plans/{id:00000}-Plan", "");
+    }
+
+    [Fact]
+    public void PlansSidebarList_OffersExecuteAction()
+    {
+        var plans = new List<PlanFile> { CreatePlan(1, PlanStatus.Draft) };
+
+        var list = PlansApp.BuildSidebarList(plans, null);
+
+        var action = Assert.Single(list.Items[0].Actions!);
+        Assert.Equal(ShellSidebarActions.Execute, action.Id);
+        Assert.Equal("Execute", action.Label);
+        Assert.True(action.Primary);
+    }
+
+    [Fact]
+    public void PlansSidebarList_HidesActionsWhenNotAllowed()
+    {
+        var plans = new List<PlanFile> { CreatePlan(1, PlanStatus.Draft) };
+
+        var list = PlansApp.BuildSidebarList(plans, null, allowActions: false);
+
+        Assert.Null(list.Items[0].Actions);
+    }
+
+    [Fact]
+    public void PlansSidebarList_ForwardsItemActionHandler()
+    {
+        string? receivedItem = null;
+        string? receivedAction = null;
+        var plans = new List<PlanFile> { CreatePlan(1, PlanStatus.Draft) };
+
+        var list = PlansApp.BuildSidebarList(plans, null, (item, action) =>
+        {
+            receivedItem = item;
+            receivedAction = action;
+        });
+        list.OnItemAction!("00001-Plan", ShellSidebarActions.Execute);
+
+        Assert.Equal("00001-Plan", receivedItem);
+        Assert.Equal(ShellSidebarActions.Execute, receivedAction);
+    }
+
+    [Fact]
+    public void ReviewSidebarList_OffersCreatePrOnlyForPlansWithCommits()
+    {
+        var plans = new List<PlanFile>
+        {
+            CreatePlan(1, PlanStatus.Review, commits: ["abc1234"]),
+            CreatePlan(2, PlanStatus.Review),
+        };
+
+        var list = ReviewApp.BuildSidebarList(plans, null);
+
+        var action = Assert.Single(list.Items[0].Actions!);
+        Assert.Equal(ShellSidebarActions.CreatePr, action.Id);
+        Assert.Equal("Create PR", action.Label);
+        Assert.Null(list.Items[1].Actions);
+    }
+
+    [Fact]
+    public void ReviewSidebarList_LabelsUpdatePrForPullRequestSourcedPlans()
+    {
+        var plans = new List<PlanFile>
+        {
+            CreatePlan(1, PlanStatus.Review, commits: ["abc1234"],
+                sourceUrl: "https://github.com/Ivy-Interactive/Ivy-Tendril/pull/42"),
+        };
+
+        var list = ReviewApp.BuildSidebarList(plans, null);
+
+        Assert.Equal("Update PR", Assert.Single(list.Items[0].Actions!).Label);
+    }
+
+    [Fact]
+    public void ReviewSidebarList_HidesActionsWhenNotAllowed()
+    {
+        var plans = new List<PlanFile> { CreatePlan(1, PlanStatus.Review, commits: ["abc1234"]) };
+
+        var list = ReviewApp.BuildSidebarList(plans, null, allowActions: false);
+
+        Assert.Null(list.Items[0].Actions);
+    }
+}

--- a/src/Ivy.Tendril.Widgets/ShellDtos.cs
+++ b/src/Ivy.Tendril.Widgets/ShellDtos.cs
@@ -9,6 +9,15 @@ public record ShellBadgeDto(string Label, string Kind = "neutral")
     public static ShellBadgeDto Warning(string label) => new(label, "warning");
 }
 
-public record ShellSectionItemDto(string Id, string Title, string? Tag = null, List<ShellBadgeDto>? Badges = null);
+public record ShellItemActionDto(string Id, string Label, string? Icon = null, bool Primary = false);
+
+public record ShellSectionItemDto(
+    string Id,
+    string Title,
+    string? Tag = null,
+    List<ShellBadgeDto>? Badges = null,
+    List<ShellItemActionDto>? Actions = null);
+
+public record ShellItemActionEvent(string ItemId, string ActionId);
 
 public record ShellTabDto(string Id, string Title);

--- a/src/Ivy.Tendril.Widgets/ShellSidebarSection.cs
+++ b/src/Ivy.Tendril.Widgets/ShellSidebarSection.cs
@@ -16,6 +16,7 @@ public record ShellSidebarSection : WidgetBase<ShellSidebarSection>
 
     [Event] public EventHandler<Event<ShellSidebarSection, string>>? OnSelectItem { get; init; }
     [Event] public EventHandler<Event<ShellSidebarSection>>? OnSearch { get; init; }
+    [Event] public EventHandler<Event<ShellSidebarSection, ShellItemActionEvent>>? OnItemAction { get; init; }
 }
 
 public static class ShellSidebarSectionExtensions
@@ -40,4 +41,7 @@ public static class ShellSidebarSectionExtensions
 
     public static ShellSidebarSection OnSearch(this ShellSidebarSection w, Action handler) =>
         w with { OnSearch = new(_ => { handler(); return ValueTask.CompletedTask; }) };
+
+    public static ShellSidebarSection OnItemAction(this ShellSidebarSection w, Action<string, string> handler) =>
+        w with { OnItemAction = new(e => { handler(e.Value.ItemId, e.Value.ActionId); return ValueTask.CompletedTask; }) };
 }

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { ShellSidebarSection } from "./ShellSidebarSection";
@@ -11,7 +11,36 @@ const mockItems: ShellSectionItemDto[] = [
   { id: "00002-PlanB", title: "Plan B", tag: "#2" },
 ];
 
+const actionItems: ShellSectionItemDto[] = [
+  {
+    id: "00001-PlanA",
+    title: "Plan A",
+    tag: "#1",
+    badges: [{ label: "Ivy", kind: "project" }],
+    actions: [{ id: "execute", label: "Execute", icon: "Rocket", primary: true }],
+  },
+  { id: "00002-PlanB", title: "Plan B", tag: "#2" },
+];
+
+const renderRail = (items: ShellSectionItemDto[], eventHandler = vi.fn(), events = ["OnItemAction"]) =>
+  render(
+    <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
+      <ShellSidebarSection
+        id="sec-1"
+        title="Plans"
+        items={items}
+        searchable={true}
+        events={events}
+        eventHandler={eventHandler}
+      />
+    </ShellContext.Provider>,
+  );
+
 describe("ShellSidebarSection", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("renders the section header, title, and search button when searchable", () => {
     const onSearch = vi.fn();
     render(
@@ -87,18 +116,7 @@ describe("ShellSidebarSection", () => {
 
   it("renders collapsed rail view with search button", () => {
     const onSearch = vi.fn();
-    render(
-      <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
-        <ShellSidebarSection
-          id="sec-1"
-          title="Plans"
-          items={mockItems}
-          searchable={true}
-          events={["OnSearch"]}
-          eventHandler={onSearch}
-        />
-      </ShellContext.Provider>,
-    );
+    renderRail(mockItems, onSearch, ["OnSearch"]);
 
     const railSearchBtn = screen.getByRole("button", { name: /search plans/i });
     expect(railSearchBtn).toBeInTheDocument();
@@ -106,5 +124,61 @@ describe("ShellSidebarSection", () => {
 
     fireEvent.click(railSearchBtn);
     expect(onSearch).toHaveBeenCalledWith("OnSearch", "sec-1", []);
+  });
+
+  it("shows title, badges, and action buttons in the rail flyout", () => {
+    renderRail(actionItems);
+
+    fireEvent.mouseEnter(screen.getByRole("button", { name: "#1" }));
+
+    const flyout = screen.getByRole("tooltip");
+    expect(flyout).toHaveTextContent("Plan A");
+    expect(flyout).toHaveTextContent("Ivy");
+    const executeBtn = screen.getByRole("button", { name: /execute/i });
+    expect(executeBtn).toHaveAttribute("data-primary", "true");
+  });
+
+  it("emits OnItemAction with the item and action ids and closes the flyout", () => {
+    const eventHandler = vi.fn();
+    renderRail(actionItems, eventHandler);
+
+    fireEvent.mouseEnter(screen.getByRole("button", { name: "#1" }));
+    fireEvent.click(screen.getByRole("button", { name: /execute/i }));
+
+    expect(eventHandler).toHaveBeenCalledWith("OnItemAction", "sec-1", [
+      { itemId: "00001-PlanA", actionId: "execute" },
+    ]);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("renders no action buttons for items without actions", () => {
+    renderRail(actionItems);
+
+    fireEvent.mouseEnter(screen.getByRole("button", { name: "#2" }));
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Plan B");
+    expect(screen.queryByRole("button", { name: /execute/i })).toBeNull();
+  });
+
+  it("keeps the flyout open while the pointer moves into it", () => {
+    vi.useFakeTimers();
+    renderRail(actionItems);
+
+    const chip = screen.getByRole("button", { name: "#1" });
+    fireEvent.mouseEnter(chip);
+    fireEvent.mouseLeave(chip);
+    fireEvent.mouseEnter(screen.getByRole("tooltip"));
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(screen.getByRole("tooltip"));
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.queryByRole("tooltip")).toBeNull();
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellSidebarSection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Search } from "lucide-react";
+import { GitPullRequest, LucideIcon, Rocket, Search } from "lucide-react";
 import { useShell } from "./ShellContext";
 import { ShellSectionItemDto, ShellWidgetProps } from "./types";
 import "./shell.css";
@@ -11,6 +11,14 @@ interface ShellSidebarSectionProps extends ShellWidgetProps {
   searchable?: boolean;
   emptyText?: string;
 }
+
+const actionIcons: Record<string, LucideIcon> = {
+  Rocket,
+  GitPullRequest,
+};
+
+const FLYOUT_CLOSE_DELAY_MS = 150;
+const FLYOUT_VIEWPORT_MARGIN_PX = 8;
 
 /**
  * The contextual list under the nav — plans for Review/Drafts, recommendations,
@@ -37,13 +45,55 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
 
   const { collapsed } = useShell();
 
-  // Rail chips get a hover flyout (title + badges) since the chip itself only
-  // shows the ID. Fixed-position and portaled so the rail cannot clip it.
+  // Rail chips get a hover flyout (title, badges, actions) since the chip itself
+  // only shows the ID. Fixed-position so the rail cannot clip it.
   const [flyout, setFlyout] = React.useState<{
     item: ShellSectionItemDto;
     top: number;
     left: number;
   } | null>(null);
+  const flyoutRef = React.useRef<HTMLDivElement | null>(null);
+  const closeTimer = React.useRef<number | null>(null);
+
+  const cancelClose = () => {
+    if (closeTimer.current !== null) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  };
+
+  const scheduleClose = () => {
+    cancelClose();
+    closeTimer.current = window.setTimeout(() => {
+      closeTimer.current = null;
+      setFlyout(null);
+    }, FLYOUT_CLOSE_DELAY_MS);
+  };
+
+  const closeFlyout = () => {
+    cancelClose();
+    setFlyout(null);
+  };
+
+  React.useEffect(() => cancelClose, []);
+
+  React.useLayoutEffect(() => {
+    const el = flyoutRef.current;
+    if (!el || !flyout) return;
+    el.style.setProperty("--tsh-flyout-shift", "0px");
+    const rect = el.getBoundingClientRect();
+    const overflowBottom = rect.bottom - (window.innerHeight - FLYOUT_VIEWPORT_MARGIN_PX);
+    const overflowTop = FLYOUT_VIEWPORT_MARGIN_PX - rect.top;
+    let shift = 0;
+    if (overflowBottom > 0) shift = -overflowBottom;
+    else if (overflowTop > 0) shift = overflowTop;
+    if (shift !== 0) el.style.setProperty("--tsh-flyout-shift", `${shift}px`);
+  }, [flyout]);
+
+  const runAction = (itemId: string, actionId: string) => {
+    closeFlyout();
+    if (events.includes("OnItemAction")) eventHandler("OnItemAction", id, [{ itemId, actionId }]);
+  };
 
   const hasHeader = !!title || searchable;
 
@@ -60,7 +110,7 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
             <Search size={16} />
           </button>
         )}
-        <div className="tsh-rail-list" onScroll={() => setFlyout(null)}>
+        <div className="tsh-rail-list" onScroll={closeFlyout}>
           {items.map(
             (item) =>
               item.tag && (
@@ -70,10 +120,11 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
                   data-selected={item.id === selectedId}
                   onClick={() => select(item.id)}
                   onMouseEnter={(e) => {
+                    cancelClose();
                     const r = e.currentTarget.getBoundingClientRect();
                     setFlyout({ item, top: r.top + r.height / 2, left: r.right + 10 });
                   }}
-                  onMouseLeave={() => setFlyout(null)}
+                  onMouseLeave={scheduleClose}
                 >
                   <span className="tsh-rail-item-text">{item.tag}</span>
                 </button>
@@ -82,8 +133,12 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
         </div>
         {flyout && (
           <div
+            ref={flyoutRef}
             className="tsh-rail-tooltip"
+            role="tooltip"
             style={{ top: flyout.top, left: flyout.left }}
+            onMouseEnter={cancelClose}
+            onMouseLeave={scheduleClose}
           >
             <div className="tsh-rail-tooltip-title">{flyout.item.title}</div>
             {flyout.item.badges && flyout.item.badges.length > 0 && (
@@ -93,6 +148,25 @@ export const ShellSidebarSection: React.FC<ShellSidebarSectionProps> = ({
                     {badge.label}
                   </span>
                 ))}
+              </div>
+            )}
+            {flyout.item.actions && flyout.item.actions.length > 0 && (
+              <div className="tsh-rail-tooltip-actions">
+                {flyout.item.actions.map((action) => {
+                  const Icon = action.icon ? actionIcons[action.icon] : undefined;
+                  return (
+                    <button
+                      key={action.id}
+                      type="button"
+                      className="tsh-rail-tooltip-btn"
+                      data-primary={!!action.primary}
+                      onClick={() => runAction(flyout.item.id, action.id)}
+                    >
+                      {Icon && <Icon size={14} />}
+                      <span>{action.label}</span>
+                    </button>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
@@ -724,34 +724,86 @@
   color: var(--tsh-row-active-fg);
 }
 
-/* Hover flyout for a rail plan chip: title plus the row badges. Fixed-position
-   (portaled to <body>) so the sidebar's overflow:hidden cannot clip it. */
+/* Hover flyout for a rail plan chip: title, row badges, and quick actions.
+   Fixed-position so the sidebar's overflow:hidden cannot clip it; it stays
+   interactive so the pointer can move in and press the action buttons. The
+   shift variable is set by the widget to keep the flyout inside the viewport. */
 .tsh-rail-tooltip {
   position: fixed;
-  transform: translateY(-50%);
+  transform: translateY(calc(-50% + var(--tsh-flyout-shift, 0px)));
   z-index: 60;
-  max-width: 260px;
-  padding: 8px 10px;
+  min-width: 240px;
+  max-width: 340px;
+  padding: 12px 14px;
   border: 1px solid var(--tsh-border);
-  border-radius: 8px;
+  border-radius: 10px;
   background: var(--tsh-popover);
   color: var(--tsh-fg);
-  box-shadow: 0 4px 12px color-mix(in srgb, var(--foreground, #000000) 12%, transparent);
-  pointer-events: none;
+  box-shadow: 0 6px 20px color-mix(in srgb, var(--foreground, #000000) 14%, transparent);
   font-family: var(--font-sans, "Geist", sans-serif);
 }
 
 .tsh-rail-tooltip-title {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
-  line-height: 17px;
+  line-height: 20px;
+  color: var(--tsh-fg-title);
 }
 
 .tsh-rail-tooltip-badges {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
-  margin-top: 6px;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.tsh-rail-tooltip .tsh-badge {
+  padding: 2px 7px;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.tsh-rail-tooltip-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.tsh-rail-tooltip-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--tsh-border);
+  border-radius: 6px;
+  background: var(--tsh-surface);
+  color: var(--tsh-fg);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 150ms ease, opacity 150ms ease;
+}
+
+.tsh-rail-tooltip-btn:hover {
+  background: var(--tsh-row-active);
+  color: var(--tsh-row-active-fg);
+}
+
+.tsh-rail-tooltip-btn[data-primary="true"] {
+  border-color: var(--tsh-cta-bg);
+  background: var(--tsh-cta-bg);
+  color: var(--tsh-cta-fg);
+}
+
+.tsh-rail-tooltip-btn[data-primary="true"]:hover {
+  background: var(--tsh-cta-bg);
+  color: var(--tsh-cta-fg);
+  opacity: 0.88;
 }
 
 .tsh-section-header {

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/types.ts
@@ -20,11 +20,19 @@ export interface ShellBadgeDto {
   kind: "project" | "success" | "warning" | "neutral";
 }
 
+export interface ShellItemActionDto {
+  id: string;
+  label: string;
+  icon?: string;
+  primary?: boolean;
+}
+
 export interface ShellSectionItemDto {
   id: string;
   title: string;
   tag?: string;
   badges?: ShellBadgeDto[];
+  actions?: ShellItemActionDto[];
 }
 
 export interface ShellTabDto {

--- a/src/Ivy.Tendril/AppShell/ShellSidebarActions.cs
+++ b/src/Ivy.Tendril/AppShell/ShellSidebarActions.cs
@@ -1,0 +1,9 @@
+namespace Ivy.Tendril.AppShell;
+
+public static class ShellSidebarActions
+{
+    public const string Execute = "execute";
+    public const string CreatePr = "create-pr";
+}
+
+public record ShellSidebarActionRequest(string ItemId, string ActionId);

--- a/src/Ivy.Tendril/AppShell/ShellSidebarListSignal.cs
+++ b/src/Ivy.Tendril/AppShell/ShellSidebarListSignal.cs
@@ -15,7 +15,8 @@ public record ShellSidebarListState(
     List<ShellSectionItemDto> Items,
     string? SelectedId,
     Func<string, object?> BuildSelectArgs,
-    bool Searchable = true);
+    bool Searchable = true,
+    Action<string, string>? OnItemAction = null);
 
 [Signal(BroadcastType.AppShell)]
 public class ShellSidebarListSignal : AbstractSignal<ShellSidebarListState, Unit> { }

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -717,6 +717,11 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
                 .Searchable(list.Searchable)
                 .OnSelectItem(itemId =>
                     OpenApp(new NavigateArgs(capturedList.AppId, capturedList.BuildSelectArgs(itemId))))
+                .OnItemAction((itemId, actionId) =>
+                {
+                    capturedList.OnItemAction?.Invoke(itemId, actionId);
+                    OpenApp(new NavigateArgs(capturedList.AppId, capturedList.BuildSelectArgs(itemId)));
+                })
                 .OnSearch(showPlanSearchDialog);
         }
 

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -3,6 +3,7 @@ using System.Reactive.Disposables;
 using System.Text;
 using System.Text.RegularExpressions;
 using Ivy.Core;
+using Ivy.Tendril.AppShell;
 using Ivy.Tendril.Apps.Plans.Dialogs;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Views;
@@ -25,7 +26,8 @@ public class ContentView(
     IJobService jobService,
     Action refreshPlans,
     IConfigService config,
-    IGitService gitService) : ViewBase
+    IGitService gitService,
+    IState<ShellSidebarActionRequest?> pendingSidebarAction) : ViewBase
 {
     public override object Build()
     {
@@ -174,6 +176,41 @@ public class ContentView(
             revisionContent.Set(selectedPlan?.LatestRevisionContent ?? "");
         }
 
+        void StartExecute()
+        {
+            var plan = selectedPlanState.Value;
+            if (plan is null) return;
+
+            var planQuestions = QuestionAnswers.Read(revisionContent.Value);
+            var answered = planQuestions.Count(q => q.HasAnswer);
+            var unanswered = planQuestions.Count(q => !q.HasAnswer && !q.IsOptional);
+            var activeAnnotationCount = annotations.Value.Count(a => !a.IsResolved);
+
+            runPreflight(plan.Project, result =>
+            {
+                // Unincorporated work first, then unanswered questions: the former
+                // would be ignored outright, the latter merely decided for you.
+                if (activeAnnotationCount > 0 || answered > 0)
+                    showAnnotationsDialog.Set(true);
+                else if (unanswered > 0)
+                    showQuestionsDialog.Set(true);
+                else
+                    ContinueExecute(null, result, pendingWaitJobIds, showDirtyDialog);
+            });
+        }
+
+        UseEffect(() =>
+        {
+            if (pendingSidebarAction.Value is not { } request) return;
+            if (selectedPlanState.Value is not { } plan ||
+                !plan.FolderName.Equals(request.ItemId, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            pendingSidebarAction.Set((ShellSidebarActionRequest?)null);
+            if (request.ActionId == ShellSidebarActions.Execute)
+                StartExecute();
+        }, pendingSidebarAction, selectedPlanState);
+
         if (selectedPlan is null)
             return BuildNoSelectionView(processView);
 
@@ -278,17 +315,7 @@ public class ContentView(
             rightSide |= new Button("Execute").Icon(Icons.Rocket).Primary().ShortcutKey("x")
                             .Loading(isCheckingPreflight)
                             .Disabled(isCheckingPreflight)
-                            .OnClick(() => runPreflight(selectedPlan.Project, result =>
-                            {
-                                // Unincorporated work first, then unanswered questions: the former
-                                // would be ignored outright, the latter merely decided for you.
-                                if (activeAnnotationCount > 0 || answeredQuestions > 0)
-                                    showAnnotationsDialog.Set(true);
-                                else if (unansweredQuestions > 0)
-                                    showQuestionsDialog.Set(true);
-                                else
-                                    ContinueExecute(null, result, pendingWaitJobIds, showDirtyDialog);
-                            }));
+                            .OnClick(StartExecute);
 
             return rightSide.Width(isMobile ? Size.Full() : Size.Fit());
         }
@@ -612,48 +639,48 @@ public class ContentView(
 
     private void LaunchExecute(List<string>? waitJobIds = null)
     {
-        if (selectedPlan is null) return;
+        if (selectedPlanState.Value is not { } plan) return;
 
         var hasWaits = waitJobIds is { Count: > 0 };
 
         // When chained behind an UpdatePlan job the plan is already Updating;
         // JobLauncher sets Executing once the blocked ExecutePlan launches.
         if (!hasWaits)
-            TransitionPlanOptimistically(PlanStatus.Creating);
+            TransitionPlanOptimistically(plan, PlanStatus.Creating);
 
-        jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath) { WaitForJobs = hasWaits ? waitJobIds : null });
+        jobService.StartJob(new ExecutePlanArgs(plan.FolderPath) { WaitForJobs = hasWaits ? waitJobIds : null });
         refreshPlans();
     }
 
     private void LaunchWithSync(PreflightResult preflight, List<string>? waitJobIds = null,
         UntrackedChangesPolicy policy = UntrackedChangesPolicy.Stash)
     {
-        if (selectedPlan is null) return;
+        if (selectedPlanState.Value is not { } plan) return;
 
         var hasWaits = waitJobIds is { Count: > 0 };
         var allWaitIds = hasWaits ? new List<string>(waitJobIds!) : new List<string>();
         foreach (var (repoPath, baseBranch, _) in preflight.DirtyRepos)
         {
-            var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch, selectedPlan.FolderPath, policy));
+            var jobId = jobService.StartJob(new SyncRepoArgs(repoPath, baseBranch, plan.FolderPath, policy));
             allWaitIds.Add(jobId);
         }
 
         // When chained behind an UpdatePlan job the plan is already Updating;
         // JobLauncher sets Executing once the blocked ExecutePlan launches.
         if (!hasWaits)
-            TransitionPlanOptimistically(PlanStatus.Creating);
+            TransitionPlanOptimistically(plan, PlanStatus.Creating);
 
-        jobService.StartJob(new ExecutePlanArgs(selectedPlan.FolderPath) { WaitForJobs = allWaitIds });
+        jobService.StartJob(new ExecutePlanArgs(plan.FolderPath) { WaitForJobs = allWaitIds });
         refreshPlans();
     }
 
     // Optimistically update UI state; the authoritative plan transition (and pre-state
     // snapshot) is performed by JobService.StartJob.
-    private void TransitionPlanOptimistically(PlanStatus status)
+    private void TransitionPlanOptimistically(PlanFile plan, PlanStatus status)
     {
-        var optimisticPlan = selectedPlan! with
+        var optimisticPlan = plan with
         {
-            Metadata = selectedPlan.Metadata with { State = status }
+            Metadata = plan.Metadata with { State = status }
         };
         selectedPlanState.Set(optimisticPlan);
     }
@@ -698,7 +725,7 @@ public class ContentView(
     {
         var prompt = BuildUpdatePrompt(annotations.Value.Where(a => !a.IsResolved), answeredQuestions);
 
-        TransitionPlanOptimistically(PlanStatus.Updating);
+        TransitionPlanOptimistically(selectedPlan!, PlanStatus.Updating);
         var jobId = jobService.StartJob(new UpdatePlanArgs(selectedPlan!.FolderPath, prompt));
         annotations.Set(ImmutableList<MarkdownAnnotation>.Empty);
         if (selectedPlan != null)

--- a/src/Ivy.Tendril/Apps/Plans/PlansApp.cs
+++ b/src/Ivy.Tendril/Apps/Plans/PlansApp.cs
@@ -22,14 +22,22 @@ public class PlansApp : ViewBase
         return badges;
     }
 
-    internal static ShellSidebarListState BuildSidebarList(List<PlanFile> plans, PlanFile? selected)
+    internal static List<ShellItemActionDto>? BuildRowActions(bool allowActions) =>
+        allowActions
+            ? [new ShellItemActionDto(ShellSidebarActions.Execute, "Execute", "Rocket", Primary: true)]
+            : null;
+
+    internal static ShellSidebarListState BuildSidebarList(List<PlanFile> plans, PlanFile? selected,
+        Action<string, string>? onItemAction = null, bool allowActions = true)
     {
         var items = plans
-            .Select(p => new ShellSectionItemDto(p.FolderName, p.Title, $"#{p.Id}", BuildRowBadges(p)))
+            .Select(p => new ShellSectionItemDto(p.FolderName, p.Title, $"#{p.Id}", BuildRowBadges(p),
+                BuildRowActions(allowActions)))
             .ToList();
         return new ShellSidebarListState(
             "plans", "Plans", items, selected?.FolderName,
-            planId => new PlansAppArgs(planId));
+            planId => new PlansAppArgs(planId),
+            OnItemAction: onItemAction);
     }
 
     public override object Build()
@@ -52,6 +60,8 @@ public class PlansApp : ViewBase
         });
         var refreshToken = UseRefreshToken();
         var sidebarListSignal = Context.UseSignal<ShellSidebarListSignal, ShellSidebarListState, Unit>();
+        var shareContext = UseService<Ivy.Tendril.Services.Share.IShareContext>();
+        var pendingSidebarAction = UseState<ShellSidebarActionRequest?>((ShellSidebarActionRequest?)null);
 
         Context.UseInboxAutoRefresh(refreshToken);
 
@@ -118,10 +128,12 @@ public class PlansApp : ViewBase
 
         previousPlans.Value = plans;
 
-        _ = sidebarListSignal.Send(BuildSidebarList(plans, selectedPlanState.Value));
+        _ = sidebarListSignal.Send(BuildSidebarList(plans, selectedPlanState.Value,
+            (itemId, actionId) => pendingSidebarAction.Set(new ShellSidebarActionRequest(itemId, actionId)),
+            allowActions: !shareContext.IsShareMode));
 
         return new ContentView(selectedPlanState.Value, plans, selectedPlanState, planService, jobService,
-            RefreshPlans, configService, gitService);
+            RefreshPlans, configService, gitService, pendingSidebarAction);
 
         void RefreshPlans()
         {

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -32,7 +32,8 @@ public class ContentView(
     IJobService jobService,
     Action refreshPlans,
     IConfigService config,
-    IGitService gitService) : ViewBase
+    IGitService gitService,
+    IState<ShellSidebarActionRequest?> pendingSidebarAction) : ViewBase
 {
     public override object Build()
     {
@@ -242,6 +243,42 @@ public class ContentView(
             return Disposable.Create(() => draftDiffCommentService.CommentsChanged -= OnCommentsChanged);
         });
 
+        void StartCreatePr()
+        {
+            var plan = selectedPlanState.Value;
+            if (plan is null || plan.Commits.Count == 0) return;
+
+            if (plan.IsPullRequestSource)
+            {
+                // Push the fix onto the original PR's branch and leave the PR open for
+                // review. ExecutePlan already based the worktree on the PR's head branch,
+                // so CreatePr's push updates the existing PR (no new PR is created).
+                jobService.StartJob(new CreatePrArgs(
+                    plan.FolderPath,
+                    SolveMergeConflicts: true,
+                    Merge: false,
+                    DeleteBranch: false,
+                    IncludeArtifacts: true));
+                refreshPlans();
+            }
+            else
+            {
+                showCreatePrDialog();
+            }
+        }
+
+        UseEffect(() =>
+        {
+            if (pendingSidebarAction.Value is not { } request) return;
+            if (selectedPlanState.Value is not { } plan ||
+                !plan.FolderName.Equals(request.ItemId, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            pendingSidebarAction.Set((ShellSidebarActionRequest?)null);
+            if (request.ActionId == ShellSidebarActions.CreatePr)
+                StartCreatePr();
+        }, pendingSidebarAction, selectedPlanState);
+
         var isShareMode = shareContext.IsShareMode;
         var isBeta = BetaHelper.IsBeta(tendrilArgs, config);
 
@@ -262,7 +299,7 @@ public class ContentView(
             selectedPlanState.Value!, selectedRecTitles, client,
             planContentQuery.Mutator.Revalidate);
 
-        var header = BuildHeader(selectedPlanState.Value, allPlans, currentIndex, context, showCreatePrDialog, showDiscardDialog, isShareMode, draftComments, shareContext);
+        var header = BuildHeader(selectedPlanState.Value, allPlans, currentIndex, context, StartCreatePr, showDiscardDialog, isShareMode, draftComments, shareContext);
         var actionBar = BuildActionBar(
             selectedPlanState.Value, showResetToDraftDialog, showSuggestChangesDialog, showDiscardDialog,
             context, agentRunner, draftComments, isShareMode, isBeta, shareTunnelService, showShareModal);
@@ -289,7 +326,7 @@ public class ContentView(
         List<PlanFile> allPlans,
         int currentIndex,
         ReviewViewContext context,
-        Action showCreatePrDialog,
+        Action startCreatePr,
         Action showDiscardDialog,
         bool isShareMode,
         IState<List<DraftComment>> draftComments,
@@ -360,26 +397,7 @@ public class ContentView(
                 var isPrUpdate = selectedPlan.IsPullRequestSource;
 
                 var createPrBtn = new Button(isPrUpdate ? "Update PR" : "Create PR")
-                    .Icon(Icons.GitPullRequest).OnClick(() =>
-                {
-                    if (isPrUpdate)
-                    {
-                        // Push the fix onto the original PR's branch and leave the PR open for
-                        // review. ExecutePlan already based the worktree on the PR's head branch,
-                        // so CreatePr's push updates the existing PR (no new PR is created).
-                        jobService.StartJob(new CreatePrArgs(
-                            selectedPlan.FolderPath,
-                            SolveMergeConflicts: true,
-                            Merge: false,
-                            DeleteBranch: false,
-                            IncludeArtifacts: true));
-                        refreshPlans();
-                    }
-                    else
-                    {
-                        showCreatePrDialog();
-                    }
-                }).ShortcutKey("m");
+                    .Icon(Icons.GitPullRequest).OnClick(startCreatePr).ShortcutKey("m");
                 createPrBtn = createPrBtn.Primary();
 
                 rightSide |= createPrBtn;

--- a/src/Ivy.Tendril/Apps/Review/ReviewApp.cs
+++ b/src/Ivy.Tendril/Apps/Review/ReviewApp.cs
@@ -26,14 +26,24 @@ public class ReviewApp : ViewBase
         return badges;
     }
 
-    internal static ShellSidebarListState BuildSidebarList(List<PlanFile> plans, PlanFile? selected)
+    internal static List<ShellItemActionDto>? BuildRowActions(PlanFile plan, bool allowActions)
+    {
+        if (!allowActions || plan.Commits.Count == 0) return null;
+        var label = plan.IsPullRequestSource ? "Update PR" : "Create PR";
+        return [new ShellItemActionDto(ShellSidebarActions.CreatePr, label, "GitPullRequest", Primary: true)];
+    }
+
+    internal static ShellSidebarListState BuildSidebarList(List<PlanFile> plans, PlanFile? selected,
+        Action<string, string>? onItemAction = null, bool allowActions = true)
     {
         var items = plans
-            .Select(p => new ShellSectionItemDto(p.FolderName, p.Title, $"#{p.Id}", BuildRowBadges(p)))
+            .Select(p => new ShellSectionItemDto(p.FolderName, p.Title, $"#{p.Id}", BuildRowBadges(p),
+                BuildRowActions(p, allowActions)))
             .ToList();
         return new ShellSidebarListState(
             "review", "Review", items, selected?.FolderName,
-            planId => new ReviewAppArgs(planId));
+            planId => new ReviewAppArgs(planId),
+            OnItemAction: onItemAction);
     }
 
     public override object Build()
@@ -56,6 +66,8 @@ public class ReviewApp : ViewBase
         });
         var refreshToken = UseRefreshToken();
         var sidebarListSignal = Context.UseSignal<ShellSidebarListSignal, ShellSidebarListState, Unit>();
+        var shareContext = UseService<Ivy.Tendril.Services.Share.IShareContext>();
+        var pendingSidebarAction = UseState<ShellSidebarActionRequest?>((ShellSidebarActionRequest?)null);
 
         Context.UseInboxAutoRefresh(refreshToken);
 
@@ -111,10 +123,12 @@ public class ReviewApp : ViewBase
 
         previousPlans.Value = plans;
 
-        _ = sidebarListSignal.Send(BuildSidebarList(plans, selectedPlanState.Value));
+        _ = sidebarListSignal.Send(BuildSidebarList(plans, selectedPlanState.Value,
+            (itemId, actionId) => pendingSidebarAction.Set(new ShellSidebarActionRequest(itemId, actionId)),
+            allowActions: !shareContext.IsShareMode));
 
         return new ContentView(selectedPlanState, plans, planService, jobService,
-            RefreshPlans, configService, gitService);
+            RefreshPlans, configService, gitService, pendingSidebarAction);
 
         void RefreshPlans()
         {


### PR DESCRIPTION
## Summary
- Collapsed-rail plan flyout is larger with normal font sizes (14px title, 12px badges) and stays open while the pointer moves into it.
- Drafts flyouts get an **Execute** button; Review flyouts get **Create PR** (or **Update PR** for PR-sourced plans) when the plan has commits.
- Actions select the plan and run the same code paths as the header buttons (preflight, annotation/question guards, Create PR dialog). Hidden in share mode.

## Implementation
- `ShellSectionItemDto.Actions` + `OnItemAction` event on `ShellSidebarSection`; `ShellSidebarListState.OnItemAction` delegate.
- Plans/Review apps hold a pending `ShellSidebarActionRequest` state; their content views consume it once the matching plan is selected.

## Testing
- Frontend: 8 `ShellSidebarSection` tests (280 total pass), `tsc` clean.
- C#: 6 new `SidebarListActionsTests`, `dotnet build` of `Ivy.Tendril.csproj` succeeds.
- Verified visually against a scratch `TENDRIL_HOME`: flyout shows title, badges, Execute button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)