### PR TITLE
[00071] Show Project Badge in Plan and Review Headers

### DIFF
--- a/src/Ivy.Tendril.Test/ProjectHelperTests.cs
+++ b/src/Ivy.Tendril.Test/ProjectHelperTests.cs
@@ -1,4 +1,7 @@
+using Ivy;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Test.TestHelpers;
 
 namespace Ivy.Tendril.Test;
 
@@ -41,5 +44,54 @@ public class ProjectHelperTests
     {
         var result = ProjectHelper.FormatProjectsForDisplay(input);
         Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildBadges_NullOrEmpty_ReturnsEmpty(string? input)
+    {
+        var config = new StubConfigService();
+        var badges = ProjectHelper.BuildBadges(input, config).ToList();
+        Assert.Empty(badges);
+    }
+
+    [Fact]
+    public void BuildBadges_SingleProject_ReturnsOutlineBadgeWithConfiguredColor()
+    {
+        var config = new StubConfigService(
+        [
+            new ProjectConfig { Name = "Tendril", Color = "Blue" }
+        ]);
+
+        var badges = ProjectHelper.BuildBadges("Tendril", config).ToList();
+
+        var badge = Assert.Single(badges);
+        Assert.Equal("Tendril", badge.Title);
+        Assert.Equal(BadgeVariant.Outline, badge.Variant);
+        Assert.Equal(Colors.Blue, badge.Color);
+    }
+
+    [Fact]
+    public void BuildBadges_MultipleProjects_ReturnsBadgeForEachProject()
+    {
+        var config = new StubConfigService(
+        [
+            new ProjectConfig { Name = "Tendril", Color = "Blue" },
+            new ProjectConfig { Name = "Framework", Color = "Amber" }
+        ]);
+
+        var badges = ProjectHelper.BuildBadges("Tendril, Framework", config).ToList();
+
+        Assert.Equal(2, badges.Count);
+
+        Assert.Equal("Tendril", badges[0].Title);
+        Assert.Equal(BadgeVariant.Outline, badges[0].Variant);
+        Assert.Equal(Colors.Blue, badges[0].Color);
+
+        Assert.Equal("Framework", badges[1].Title);
+        Assert.Equal(BadgeVariant.Outline, badges[1].Variant);
+        Assert.Equal(Colors.Amber, badges[1].Color);
     }
 }

--- a/src/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs
+++ b/src/Ivy.Tendril.Test/TestHelpers/StubConfigService.cs
@@ -27,7 +27,8 @@ public class StubConfigService(List<ProjectConfig>? projects = null) : IConfigSe
 
     public Colors? GetProjectColor(string projectName)
     {
-        return null;
+        var colorStr = GetProject(projectName)?.Color;
+        return !string.IsNullOrEmpty(colorStr) && Enum.TryParse<Colors>(colorStr, ignoreCase: true, out var c) ? c : null;
     }
 
     public void SaveSettings()

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -259,17 +259,29 @@ public class ContentView(
             {
                 var persona = shareContext.Persona;
                 var initials = Ivy.Tendril.Services.Share.AnonymousPersonaGenerator.GetInitials(persona);
-                var reviewerBadge = Layout.Horizontal().AlignContent(Align.Right)
-                    | new Avatar(initials).Small()
-                    | Text.Block(persona).Small().Bold().NoWrap();
+                var reviewerBadge = Layout.Horizontal().Gap(2).AlignContent(Align.Right);
+
+                foreach (var badge in ProjectHelper.BuildBadges(selectedPlan.Project, config))
+                {
+                    reviewerBadge |= badge;
+                }
+
+                reviewerBadge |= new Avatar(initials).Small();
+                reviewerBadge |= Text.Block(persona).Small().Bold().NoWrap();
                 return reviewerBadge.Width(isMobile ? Size.Full() : Size.Fit());
             }
 
-            var rightSide = Layout.Horizontal().AlignContent(Align.Right)
-                           | Text.Rich()
-                               .NoWrap()
-                               .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
-                               .Muted("plans", word: true);
+            var rightSide = Layout.Horizontal().Gap(2).AlignContent(Align.Right);
+
+            foreach (var badge in ProjectHelper.BuildBadges(selectedPlan.Project, config))
+            {
+                rightSide |= badge;
+            }
+
+            rightSide |= Text.Rich()
+                .NoWrap()
+                .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
+                .Muted("plans", word: true);
 
             var activeAnnotationCount = annotations.Value.Count(a => !a.IsResolved);
             if (activeAnnotationCount > 0 || answeredQuestions > 0)

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -340,17 +340,29 @@ public class ContentView(
             {
                 var persona = shareContext.Persona;
                 var initials = Ivy.Tendril.Services.Share.AnonymousPersonaGenerator.GetInitials(persona);
-                var reviewerBadge = Layout.Horizontal().AlignContent(Align.Right)
-                    | new Avatar(initials).Small()
-                    | Text.Block(persona).Small().Bold().NoWrap();
+                var reviewerBadge = Layout.Horizontal().Gap(2).AlignContent(Align.Right);
+
+                foreach (var badge in ProjectHelper.BuildBadges(selectedPlan.Project, config))
+                {
+                    reviewerBadge |= badge;
+                }
+
+                reviewerBadge |= new Avatar(initials).Small();
+                reviewerBadge |= Text.Block(persona).Small().Bold().NoWrap();
                 return reviewerBadge.Width(isMobile ? Size.Full() : Size.Fit());
             }
 
-            var rightSide = Layout.Horizontal().AlignContent(Align.Right)
-                           | Text.Rich()
-                               .NoWrap()
-                               .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
-                               .Muted("plans", word: true);
+            var rightSide = Layout.Horizontal().Gap(2).AlignContent(Align.Right);
+
+            foreach (var badge in ProjectHelper.BuildBadges(selectedPlan.Project, config))
+            {
+                rightSide |= badge;
+            }
+
+            rightSide |= Text.Rich()
+                .NoWrap()
+                .Bold($"{currentIndex + 1}/{allPlans.Count}", word: true)
+                .Muted("plans", word: true);
 
             if (selectedPlan.Commits.Count > 0)
             {

--- a/src/Ivy.Tendril/Helpers/ProjectHelper.cs
+++ b/src/Ivy.Tendril/Helpers/ProjectHelper.cs
@@ -1,9 +1,21 @@
+using Ivy;
 using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Helpers;
 
 public static class ProjectHelper
 {
+    public static IEnumerable<Badge> BuildBadges(string? projectValue, IConfigService config)
+    {
+        var projects = ParseProjects(projectValue);
+        foreach (var project in projects)
+        {
+            yield return new Badge(project)
+                .Variant(BadgeVariant.Outline)
+                .WithProjectColor(config, project);
+        }
+    }
+
     /// <summary>
     ///     Builds a project-name-to-color-name mapping (e.g. for
     ///     <see cref="LabelsDisplayRenderer.BadgeColorMapping"/>) from the configured projects'


### PR DESCRIPTION
## Problem

When reviewing or approving a plan in Tendril (in either the Plans app for draft execution or the Review app for completing or updating a PR), the header does not indicate which project the plan belongs to. The user must inspect the sidebar row or switch to the Details tab to identify the project.

## Solution

### 1. Add ProjectHelper.BuildBadges helper

In ProjectHelper.cs, add a static helper method `BuildBadges` that parses the plan project string and yields a styled badge for each project.

### 2. Display project badge in Plans app header

Update ContentView.cs in Plans app to prepend project badges to the header controls.

### 3. Display project badge in Review app header

Update ContentView.cs in Review app to prepend project badges to the header controls.

### 4. Update StubConfigService for tests

Implement `GetProjectColor` in StubConfigService so that test configurations can resolve colors.

---

## Commits

- b995b2c836d5893985e5dda79250e9211e01802e Show project badge in plan and review headers (Plan 00071)

---
Created using [Ivy Tendril](https://ivy.app).
