### PR TITLE
[00066] Select Target Branch When Merging Plan in Review

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Review/CreatePrDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Review/CreatePrDialogTests.cs
@@ -1,0 +1,63 @@
+using Ivy;
+using Ivy.Core.Hooks;
+using Ivy.Tendril.Apps.Review.Dialogs;
+
+namespace Ivy.Tendril.Test.Apps.Review;
+
+public class CreatePrDialogTests
+{
+    [Fact]
+    public void BuildTargetBranchField_RendersSearchableSelect_WithProjectConfiguredBranchSelected()
+    {
+        var selectedBranch = new State<string>("development");
+        var isCustomBranch = new State<bool>(false);
+        var customBranchText = new State<string>("");
+        var branches = new[] { "development", "feature/foo", "main" };
+
+        var fieldObj = CreatePrDialog.BuildTargetBranchField(
+            selectedBranch,
+            isCustomBranch,
+            customBranchText,
+            branches,
+            "development");
+
+        Assert.NotNull(fieldObj);
+        var field = Assert.IsType<Field>(fieldObj);
+        Assert.Equal("Target Branch", field.Label);
+        Assert.Contains("development", field.Description);
+
+        var select = Assert.IsType<SelectInput<string>>(Assert.Single(field.Children));
+        Assert.True(select.Searchable);
+        Assert.Equal("development", select.Value);
+    }
+
+    [Fact]
+    public void BuildTargetBranchField_CustomBranchToggle_RendersTextInput()
+    {
+        var selectedBranch = new State<string>("development");
+        var isCustomBranch = new State<bool>(true);
+        var customBranchText = new State<string>("custom-epic-branch");
+        var branches = new[] { "development", "feature/foo", "main" };
+
+        var layoutObj = CreatePrDialog.BuildTargetBranchField(
+            selectedBranch,
+            isCustomBranch,
+            customBranchText,
+            branches,
+            "development");
+
+        Assert.NotNull(layoutObj);
+        var layout = Assert.IsType<LayoutView>(layoutObj);
+
+        var elementsField = typeof(LayoutView).GetField("_elements", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var field = ((System.Collections.IEnumerable)elementsField?.GetValue(layout)!)
+            .Cast<object>()
+            .Select(el => el.GetType().GetProperty("Content")?.GetValue(el))
+            .OfType<Field>()
+            .FirstOrDefault();
+
+        Assert.NotNull(field);
+        var textInput = Assert.IsType<TextInput<string>>(Assert.Single(field.Children));
+        Assert.Equal("custom-epic-branch", textInput.Value);
+    }
+}

--- a/src/Ivy.Tendril.Test/Apps/Review/CreatePrDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Review/CreatePrDialogTests.cs
@@ -24,7 +24,6 @@ public class CreatePrDialogTests
         Assert.NotNull(fieldObj);
         var field = Assert.IsType<Field>(fieldObj);
         Assert.Equal("Target Branch", field.Label);
-        Assert.Contains("development", field.Description);
 
         var select = Assert.IsType<SelectInput<string>>(Assert.Single(field.Children));
         Assert.True(select.Searchable);

--- a/src/Ivy.Tendril.Test/GitTabDataBuilderTests.cs
+++ b/src/Ivy.Tendril.Test/GitTabDataBuilderTests.cs
@@ -268,5 +268,8 @@ public class GitTabDataBuilderTests : IDisposable
             WorktreeBaseFails
                 ? GitResult<WorktreeBaseInfo?>.Failure(GitError.CommandFailed, "Not implemented in stub")
                 : GitResult<WorktreeBaseInfo?>.Success(WorktreeBase);
+
+        public GitResult<List<string>> GetBranches(string repoPath) =>
+            GitResult<List<string>>.Success([]);
     }
 }

--- a/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
+++ b/src/Ivy.Tendril.Test/PlanContentHelpersTests.cs
@@ -489,5 +489,8 @@ public class PlanContentHelpersTests
 
         public GitResult<WorktreeBaseInfo?> GetWorktreeBase(string repoPath) =>
             GitResult<WorktreeBaseInfo?>.Success(null);
+
+        public GitResult<List<string>> GetBranches(string repoPath) =>
+            GitResult<List<string>>.Success([]);
     }
 }

--- a/src/Ivy.Tendril.Test/Services/GitServiceBranchesTests.cs
+++ b/src/Ivy.Tendril.Test/Services/GitServiceBranchesTests.cs
@@ -1,0 +1,94 @@
+using System.Diagnostics;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test.Services;
+
+public class GitServiceBranchesTests : IDisposable
+{
+    private readonly string _testRepoPath;
+    private readonly GitService _gitService;
+
+    public GitServiceBranchesTests()
+    {
+        _testRepoPath = Path.Combine(Path.GetTempPath(), $"git-branches-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_testRepoPath);
+        var configService = new ConfigService(new TendrilSettings());
+        _gitService = new GitService(configService, NullLogger<GitService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRepoPath))
+        {
+            try
+            {
+                Directory.Delete(_testRepoPath, true);
+            }
+            catch
+            {
+                // Best effort cleanup
+            }
+        }
+    }
+
+    private void RunGit(string args)
+    {
+        var psi = new ProcessStartInfo("git", args)
+        {
+            WorkingDirectory = _testRepoPath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        using var process = Process.Start(psi)!;
+        process.WaitForExit();
+    }
+
+    [Fact]
+    public void GetBranches_ParsesAndDeduplicatesRefs()
+    {
+        RunGit("init");
+        RunGit("config user.email test@example.com");
+        RunGit("config user.name TestUser");
+
+        File.WriteAllText(Path.Combine(_testRepoPath, "file.txt"), "hello");
+        RunGit("add file.txt");
+        RunGit("commit -m \"Initial commit\"");
+        RunGit("branch -M main");
+
+        // Create branches
+        RunGit("branch feature/branch-b");
+        RunGit("branch feature/branch-a");
+
+        // Simulate remote refs
+        RunGit("update-ref refs/remotes/origin/main HEAD");
+        RunGit("update-ref refs/remotes/origin/feature/branch-a HEAD");
+        RunGit("update-ref refs/remotes/origin/feature/remote-only HEAD");
+        RunGit("update-ref refs/remotes/origin/HEAD HEAD");
+
+        var result = _gitService.GetBranches(_testRepoPath);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+
+        // HEAD and origin should be excluded
+        Assert.DoesNotContain("HEAD", result.Value, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("origin", result.Value, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("origin/HEAD", result.Value, StringComparer.OrdinalIgnoreCase);
+
+        // Remote prefix should be stripped
+        Assert.DoesNotContain("origin/main", result.Value, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("origin/feature/branch-a", result.Value, StringComparer.OrdinalIgnoreCase);
+
+        // Deduplication: feature/branch-a exists in heads and remotes/origin, should only appear once
+        Assert.Single(result.Value, b => string.Equals(b, "feature/branch-a", StringComparison.OrdinalIgnoreCase));
+
+        // Expected sorted branches
+        var expected = new[] { "feature/branch-a", "feature/branch-b", "feature/remote-only", "main" };
+        Assert.Equal(expected, result.Value);
+    }
+}

--- a/src/Ivy.Tendril.Test/Services/JobLauncherCreatePrBranchTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobLauncherCreatePrBranchTests.cs
@@ -1,0 +1,93 @@
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Ivy.Tendril.Test.Services;
+
+public class JobLauncherCreatePrBranchTests : IDisposable
+{
+    private readonly string _tempTendrilHome;
+
+    public JobLauncherCreatePrBranchTests()
+    {
+        _tempTendrilHome = Path.Combine(Path.GetTempPath(), $"launcher-branch-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempTendrilHome);
+        Directory.CreateDirectory(Path.Combine(_tempTendrilHome, "Promptwares"));
+        Directory.CreateDirectory(Path.Combine(_tempTendrilHome, "Plans"));
+
+        File.WriteAllText(Path.Combine(_tempTendrilHome, "config.yaml"), @"
+projects:
+  - name: TestProject
+    repos:
+      - path: D:\TestRepo
+        baseBranch: development
+");
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempTendrilHome))
+        {
+            try
+            {
+                Directory.Delete(_tempTendrilHome, true);
+            }
+            catch
+            {
+                // Best effort cleanup
+            }
+        }
+    }
+
+    [Fact]
+    public void AddCreatePrOptions_PropagatesPrBaseBranch_ToFirmwareValues()
+    {
+        var job = new JobItem
+        {
+            Id = "pr-1",
+            Type = "CreatePr",
+            TypedArgs = new CreatePrArgs(@"D:\Plans\01234-TestPlan", BaseBranch: "feature/custom-target"),
+            Project = "TestProject"
+        };
+
+        var values = new Dictionary<string, string>();
+        var method = typeof(JobLauncher).GetMethod("AddCreatePrOptions",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        method?.Invoke(null, new object[] { job, values });
+
+        Assert.True(values.ContainsKey("PrBaseBranch"));
+        Assert.Equal("feature/custom-target", values["PrBaseBranch"]);
+    }
+
+    [Fact]
+    public void AddPlanRepos_UsesCustomBaseBranch_WhenCreatePrSpecifiesBaseBranch()
+    {
+        var configService = new ConfigService(new TendrilSettings());
+        configService.SetTendrilHome(_tempTendrilHome);
+        var launcher = new JobLauncher(configService, null, NullLogger<JobLauncher>.Instance, Path.Combine(_tempTendrilHome, "Promptwares"));
+
+        var plan = new PlanYaml
+        {
+            Project = "TestProject",
+            Repos = { @"D:\TestRepo" }
+        };
+
+        var job = new JobItem
+        {
+            Id = "pr-2",
+            Type = "CreatePr",
+            TypedArgs = new CreatePrArgs(@"D:\Plans\01234-TestPlan", BaseBranch: "release/1.2"),
+            Project = "TestProject"
+        };
+
+        var values = new Dictionary<string, string>();
+        var addRepoConfigsMethod = typeof(JobLauncher).GetMethod("AddRepoConfigsIfNeeded",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        addRepoConfigsMethod?.Invoke(launcher, new object[] { job, plan, values });
+
+        Assert.True(values.ContainsKey("RepoConfigs"));
+        var repoConfigs = values["RepoConfigs"];
+        Assert.Contains("baseBranch: release/1.2", repoConfigs);
+        Assert.DoesNotContain("baseBranch: development", repoConfigs);
+    }
+}

--- a/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobLauncherTests.cs
@@ -51,7 +51,7 @@ projects:
     {
         var method = typeof(JobLauncher).GetMethod("BuildRepoConfigsYaml",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        return (string?)method?.Invoke(launcher, new object[] { plan, project });
+        return (string?)method?.Invoke(launcher, new object?[] { plan, project, null });
     }
 
     // prRule is no longer a model field (the Create PR dialog is now always shown, unconditionally).

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs
@@ -1,5 +1,7 @@
+using Ivy.Core.Hooks;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Git;
 using Ivy.Tendril.Helpers;
 
 namespace Ivy.Tendril.Apps.Review.Dialogs;
@@ -10,10 +12,26 @@ public class CreatePrDialog(
     IJobService jobService,
     Action refreshPlans,
     IConfigService config,
-    IGithubService githubService) : ViewBase
+    IGithubService githubService,
+    IGitService? gitService = null) : ViewBase
 {
+    private string GetDefaultBaseBranch()
+    {
+        var repos = selectedPlan?.GetEffectiveRepoPaths(config) ?? [];
+        var repoPath = repos.FirstOrDefault();
+        var projectConfig = selectedPlan != null ? config.GetProject(selectedPlan.Project) : null;
+        var repoRef = projectConfig?.Repos.FirstOrDefault(r =>
+            string.Equals(Path.GetFileName(Environment.ExpandEnvironmentVariables(r.Path)),
+                Path.GetFileName(repoPath ?? ""), StringComparison.OrdinalIgnoreCase));
+        return repoRef?.BaseBranch
+            ?? (repoPath != null ? GitHelper.ResolveDefaultBranch(repoPath, config.TendrilHome) : "main");
+    }
+
+    private string? GetRepoPath() => selectedPlan?.GetEffectiveRepoPaths(config).FirstOrDefault();
+
     public override object? Build()
     {
+        var defaultGitService = UseService<IGitService>();
         var isCreating = UseState(false);
         var createPrSolveMergeConflicts = UseState(true);
         var createPrMerge = UseState(true);
@@ -23,19 +41,28 @@ public class CreatePrDialog(
         var createPrReviewers = UseState(Array.Empty<string>());
         var createPrComment = UseState("");
         var assigneesError = UseState<string?>(null);
+        var selectedBranch = UseState(GetDefaultBaseBranch);
+        var isCustomBranch = UseState(false);
+        var customBranchText = UseState("");
+
+        var branchesQuery = UseQuery<string[], string>(
+            GetRepoPath() ?? "",
+            async (path, _) =>
+            {
+                if (string.IsNullOrEmpty(path)) return [];
+                var git = gitService ?? defaultGitService;
+                var res = git.GetBranches(path);
+                return res.IsSuccess ? res.Value.ToArray() : [];
+            },
+            initialValue: []
+        );
 
         var assigneesQuery = UseQuery<string[], string>(
             selectedPlan?.Project ?? "",
             async (_, _) =>
             {
-                if (selectedPlan is null)
-                {
-                    assigneesError.Set(null);
-                    return Array.Empty<string>();
-                }
-                var repos = selectedPlan.GetEffectiveRepoPaths(config);
-                var repoPath = repos.FirstOrDefault();
-                if (repoPath is null)
+                var repoPath = GetRepoPath();
+                if (selectedPlan is null || repoPath is null)
                 {
                     assigneesError.Set(null);
                     return Array.Empty<string>();
@@ -60,13 +87,15 @@ public class CreatePrDialog(
 
         if (!dialogOpen.Value) return null;
 
-        var multipleBranches = selectedPlan.Repos.Count > 1;
+        var defaultBaseBranch = GetDefaultBaseBranch();
+        var multipleBranches = (selectedPlan?.Repos.Count ?? 0) > 1;
 
         return new Dialog(
             _ => dialogOpen.Set(false),
-            new DialogHeader($"Create PR for #{selectedPlan.Id}"),
+            new DialogHeader($"Create PR for #{selectedPlan?.Id}"),
             new DialogBody(
                 Layout.Vertical().Gap(2)
+                | BuildTargetBranchField(selectedBranch, isCustomBranch, customBranchText, branchesQuery.Value ?? Array.Empty<string>(), defaultBaseBranch)
                 | createPrSolveMergeConflicts.ToBoolInput("Solve Merge Conflicts").AutoFocus()
                 | createPrMerge.ToBoolInput("Merge")
                 | createPrDeleteBranch
@@ -89,9 +118,13 @@ public class CreatePrDialog(
                 new Button("Cancel").Outline().OnClick(() => dialogOpen.Set(false)),
                 new Button("Create PR").Primary().Disabled(isCreating.Value).ShortcutKey("Ctrl+Enter").OnClick(() =>
                 {
-                    if (!isCreating.Value)
+                    if (!isCreating.Value && selectedPlan != null)
                     {
                         isCreating.Set(true);
+                        var targetBaseBranch = isCustomBranch.Value && !string.IsNullOrWhiteSpace(customBranchText.Value)
+                            ? customBranchText.Value.Trim()
+                            : selectedBranch.Value;
+
                         jobService.StartJob(new CreatePrArgs(
                             selectedPlan.FolderPath,
                             SolveMergeConflicts: createPrSolveMergeConflicts.Value,
@@ -100,7 +133,8 @@ public class CreatePrDialog(
                             IncludeArtifacts: createPrIncludeArtifacts.Value,
                             Reviewers: createPrReviewers.Value,
                             Comment: string.IsNullOrEmpty(createPrComment.Value) ? null : createPrComment.Value,
-                            Draft: createPrDraft.Value));
+                            Draft: createPrDraft.Value,
+                            BaseBranch: targetBaseBranch));
                         // Plan transition (and pre-state snapshot) handled by JobService.StartJob.
                         refreshPlans();
                         dialogOpen.Set(false);
@@ -108,5 +142,68 @@ public class CreatePrDialog(
                 })
             )
         ).Width(Size.Rem(30));
+    }
+
+    public static object BuildTargetBranchField(
+        IState<string> selectedBranch,
+        IState<bool> isCustomBranch,
+        IState<string> customBranchText,
+        IReadOnlyList<string> availableBranches,
+        string defaultBranch)
+    {
+        const string customOptionValue = "__custom_branch__";
+
+        if (isCustomBranch.Value)
+        {
+            return Layout.Vertical().Gap(1)
+                | (Layout.Horizontal().AlignContent(Align.Center)
+                    | Text.Label("Target Branch")
+                    | new Spacer()
+                    | new Button("Choose from list").Link().Small().OnClick(() =>
+                    {
+                        isCustomBranch.Set(false);
+                        if (string.IsNullOrWhiteSpace(selectedBranch.Value))
+                            selectedBranch.Set(defaultBranch);
+                    }))
+                | customBranchText.ToTextInput("Enter custom branch name...")
+                    .AutoFocus()
+                    .WithField()
+                    .Description($"Pull request will target this custom branch instead of {defaultBranch}.");
+        }
+
+        var options = new List<Option<string>>();
+        if (!string.IsNullOrEmpty(defaultBranch))
+        {
+            options.Add(new Option<string>($"{defaultBranch} (default)", defaultBranch));
+        }
+
+        foreach (var b in availableBranches)
+        {
+            if (!string.Equals(b, defaultBranch, StringComparison.OrdinalIgnoreCase))
+            {
+                options.Add(new Option<string>(b, b));
+            }
+        }
+
+        options.Add(new Option<string>("+ Custom branch...", customOptionValue));
+
+        var branchBinding = new ConvertedState<string, string>(
+            selectedBranch,
+            v => v,
+            val =>
+            {
+                if (val == customOptionValue)
+                {
+                    isCustomBranch.Set(true);
+                    return selectedBranch.Value;
+                }
+                return val;
+            });
+
+        return branchBinding.ToSelectInput(options)
+            .Searchable(true)
+            .Placeholder("Select target branch...")
+            .WithField().Label("Target Branch")
+            .Description($"Default: {defaultBranch} (configured in project settings)");
     }
 }

--- a/src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs
+++ b/src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs
@@ -203,7 +203,6 @@ public class CreatePrDialog(
         return branchBinding.ToSelectInput(options)
             .Searchable(true)
             .Placeholder("Select target branch...")
-            .WithField().Label("Target Branch")
-            .Description($"Default: {defaultBranch} (configured in project settings)");
+            .WithField().Label("Target Branch");
     }
 }

--- a/src/Ivy.Tendril/Commands/JobStartCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStartCommand.cs
@@ -74,7 +74,7 @@ public class JobStartSettings : CommandSettings
     [CommandOption("--repo-path")]
     public string? RepoPath { get; set; }
 
-    [Description("Base branch for SyncRepo (default: main)")]
+    [Description("Base branch for SyncRepo or CreatePr (default: main)")]
     [CommandOption("--base-branch")]
     public string? BaseBranch { get; set; }
 
@@ -212,7 +212,8 @@ public class JobStartCommand : Command<JobStartSettings>
                 IncludeArtifacts: !settings.NoArtifacts,
                 Reviewers: reviewers,
                 Comment: settings.Comment,
-                Draft: settings.Draft);
+                Draft: settings.Draft,
+                BaseBranch: settings.BaseBranch);
         }
 
         if (string.Equals(jobType, Constants.JobTypes.RetryPlan, StringComparison.OrdinalIgnoreCase))

--- a/src/Ivy.Tendril/Models/JobArgs.cs
+++ b/src/Ivy.Tendril/Models/JobArgs.cs
@@ -81,7 +81,8 @@ public record CreatePrArgs(
     bool IncludeArtifacts = true,
     string[]? Reviewers = null,
     string? Comment = null,
-    bool Draft = false) : JobArgsBase
+    bool Draft = false,
+    string? BaseBranch = null) : JobArgsBase
 {
     public override string Type => Constants.JobTypes.CreatePr;
     public override string PlanFolder => FolderPath;

--- a/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
+++ b/src/Ivy.Tendril/Promptwares/CreatePr/Program.md
@@ -48,6 +48,7 @@ Before processing, read `plan.yaml` and check the `state` field. After reading, 
   - `PrReviewer` — comma-separated GitHub usernames to request as reviewers (default: none)
   - `PrComment` — Review comment text (default: none)
   - `PrDraft` — `true`/`false` (default: `false`)
+  - `PrBaseBranch` — Target branch for pull request (default: repo default branch or project configured base branch)
 
 ### 2. For Each Worktree
 
@@ -148,7 +149,7 @@ concurrent CreatePr jobs share `$TMPDIR`) and pass `--body-file`:
 # last-writer-wins race that swaps PR bodies between plans (#1551).
 body_file=$(mktemp)
 printf '%s' "$body" > "$body_file"
-gh pr create [--draft] --repo <owner/repo> --base <default-branch> --head <branch> \
+gh pr create [--draft] --repo <owner/repo> --base <base-branch> --head <branch> \
   --assignee @me --title "[<planId>] <plan title>" --body-file "$body_file"
 rm -f "$body_file"
 ```
@@ -159,14 +160,14 @@ rm -f "$body_file"
   TITLE="[<planId>] <plan title>"
   body_file=$(mktemp)
   printf '%s' "$body" > "$body_file"
-  gh pr create --repo <owner/repo> --base <default-branch> --head <branch> \
+  gh pr create --repo <owner/repo> --base <base-branch> --head <branch> \
     --assignee @me --title "$TITLE" --body-file "$body_file"
   rm -f "$body_file"
   ```
 
 - **Base branch:**
-  1. Read plan.yaml and get the project name
-  2. For each repo, check the firmware header for `baseBranch` configuration
+  1. Check if `PrBaseBranch` is specified in the firmware header; if present and non-empty, use that branch
+  2. Otherwise, check the firmware header `RepoConfigs` for `baseBranch` configuration for this repo
   3. If configured, use that value
   4. Otherwise, auto-detect via: `gh repo view <owner/repo> --json defaultBranchRef -q .defaultBranchRef.name`
 - **Title:** `[<planId>] <plan title>`
@@ -237,8 +238,8 @@ When the PR status is `CONFLICTING`, resolve the conflict locally:
 3. **Merge the base branch** into the feature branch:
    ```bash
    cd <worktree-or-repo-path>
-   git fetch origin <default-branch>
-   git merge origin/<default-branch>
+   git fetch origin <base-branch>
+   git merge origin/<base-branch>
    ```
 
 4. **Resolve conflicts**: Read each conflicted file (`git diff --name-only --diff-filter=U`), understand both sides, and edit to resolve. Prioritize:
@@ -249,7 +250,7 @@ When the PR status is `CONFLICTING`, resolve the conflict locally:
 5. **Commit the merge**:
    ```bash
    git add -A
-   git commit -m "[<planId>] Resolve merge conflicts with <default-branch>"
+   git commit -m "[<planId>] Resolve merge conflicts with <base-branch>"
    ```
 
 6. **Quick build check** (if build-critical files were involved in conflicts):
@@ -289,9 +290,9 @@ When merging, build the command from the flags:
 ```bash
 gh pr merge <pr-number> --repo <owner/repo> --merge [--delete-branch] --admin
 cd <original-repo-path>
-# Only pull if the local repo is clean (no uncommitted changes, on the default branch)
-if [ -z "$(git status --porcelain)" ] && [ "$(git symbolic-ref --short HEAD)" = "<default-branch>" ]; then
-  git pull origin <default-branch>
+# Only pull if the local repo is clean (no uncommitted changes, on the target base branch)
+if [ -z "$(git status --porcelain)" ] && [ "$(git symbolic-ref --short HEAD)" = "<base-branch>" ]; then
+  git pull origin <base-branch>
 fi
 ```
 

--- a/src/Ivy.Tendril/Services/Git/GitService.cs
+++ b/src/Ivy.Tendril/Services/Git/GitService.cs
@@ -457,6 +457,29 @@ public class GitService : IGitService
         }
     }
 
+    public GitResult<List<string>> GetBranches(string repoPath)
+    {
+        return ExecuteGitCommand(repoPath, "for-each-ref --format=\"%(refname:short)\" refs/heads/ refs/remotes/origin/",
+            output =>
+            {
+                var lines = output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                var branches = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var raw in lines)
+                {
+                    var name = raw.Trim();
+                    if (name.StartsWith("origin/", StringComparison.OrdinalIgnoreCase))
+                        name = name["origin/".Length..];
+                    if (string.Equals(name, "HEAD", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(name, "origin", StringComparison.OrdinalIgnoreCase) ||
+                        name.StartsWith("origin/", StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    if (!string.IsNullOrEmpty(name))
+                        branches.Add(name);
+                }
+                return branches.OrderBy(b => b, StringComparer.OrdinalIgnoreCase).ToList();
+            });
+    }
+
     // --- Infrastructure ---
 
     private GitResult<T> ExecuteGitCommand<T>(string repoPath, string args, Func<string, T> parseOutput)

--- a/src/Ivy.Tendril/Services/Git/IGitService.cs
+++ b/src/Ivy.Tendril/Services/Git/IGitService.cs
@@ -15,6 +15,7 @@ public interface IGitService
     GitResult<Dictionary<string, CommitRefStatus>> GetCommitRefStatus(string repoPath, IEnumerable<string> commitHashes);
     GitResult<DirtyRepoResult> GetRepoDirtyState(string repoPath, string expectedBaseBranch);
     GitResult<WorktreeBaseInfo?> GetWorktreeBase(string repoPath);
+    GitResult<List<string>> GetBranches(string repoPath);
 }
 
 public record WorktreeInfo(string Path, string Branch, string CommitHash);

--- a/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobLauncher.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Linq;
 using Ivy.Helpers;
@@ -608,7 +608,11 @@ internal class JobLauncher
         if (job.TypedArgs is not (ExecutePlanArgs or RetryPlanArgs or CreatePrArgs))
             return;
 
-        var repoConfigs = BuildRepoConfigsYaml(planYaml, job.Project);
+        var baseBranchOverride = job.TypedArgs is CreatePrArgs { BaseBranch: not null } pr && !string.IsNullOrWhiteSpace(pr.BaseBranch)
+            ? pr.BaseBranch.Trim()
+            : null;
+
+        var repoConfigs = BuildRepoConfigsYaml(planYaml, job.Project, baseBranchOverride);
         if (!string.IsNullOrEmpty(repoConfigs))
             values["RepoConfigs"] = repoConfigs;
     }
@@ -631,6 +635,8 @@ internal class JobLauncher
             values["PrReviewer"] = string.Join(",", reviewers);
         if (!string.IsNullOrEmpty(pr.Comment))
             values["PrComment"] = pr.Comment;
+        if (!string.IsNullOrWhiteSpace(pr.BaseBranch))
+            values["PrBaseBranch"] = pr.BaseBranch.Trim();
     }
 
     private static Dictionary<string, string> BuildJobContext(JobItem job, Dictionary<string, string> firmwareValues, string programFolder)
@@ -784,7 +790,7 @@ internal class JobLauncher
     internal static void ResolveCommandShim(ProcessStartInfo psi)
         => AgentProcessHelper.ResolveCommandShim(psi);
 
-    private string? BuildRepoConfigsYaml(PlanYaml plan, string project)
+    private string? BuildRepoConfigsYaml(PlanYaml plan, string project, string? baseBranchOverride = null)
     {
         if (plan.Repos.Count == 0)
             return null;
@@ -796,21 +802,24 @@ internal class JobLauncher
 
         var lines = new List<string>();
 
-        AddPlanRepos(plan, projectConfig, lines);
+        AddPlanRepos(plan, projectConfig, lines, baseBranchOverride);
         AddBuildDependencies(projectConfig, planRepoNames, lines);
 
         return string.Join("\n", lines);
     }
 
-    private void AddPlanRepos(PlanYaml plan, ProjectConfig? projectConfig, List<string> lines)
+    private void AddPlanRepos(PlanYaml plan, ProjectConfig? projectConfig, List<string> lines, string? baseBranchOverride = null)
     {
         foreach (var repoPath in plan.Repos)
         {
             var expanded = Environment.ExpandEnvironmentVariables(repoPath);
             var repoRef = FindProjectRepoConfig(projectConfig, Path.GetFileName(expanded));
+            var baseBranch = !string.IsNullOrWhiteSpace(baseBranchOverride)
+                ? baseBranchOverride
+                : repoRef?.BaseBranch ?? GitHelper.ResolveDefaultBranch(expanded, _configService?.TendrilHome);
             var entry = new RepoConfigEntry(
                 expanded,
-                repoRef?.BaseBranch ?? GitHelper.ResolveDefaultBranch(expanded, _configService?.TendrilHome),
+                baseBranch,
                 ReadOnly: false);
             AddRepoToConfigLines(lines, entry);
         }


### PR DESCRIPTION
Fixes #2283

# Summary

## Changes

Implemented the ability to select or specify a target base branch when opening a pull request from the Review application. Added git branch discovery to `IGitService`, updated `CreatePrDialog` with a searchable branch dropdown and custom branch input, and propagated the selected base branch through `JobLauncher` and `CreatePr` promptware execution.

## API Changes

- `CreatePrArgs`: Added optional `string? BaseBranch = null` constructor parameter.
- `IGitService`: Added `GitResult<List<string>> GetBranches(string repoPath)`.
- `GitService`: Implemented `GetBranches(string repoPath)`.
- `JobStartSettings`: Updated `--base-branch` option description to note support for `CreatePr`.
- `CreatePrDialog`: Added public static method `BuildTargetBranchField(IState<string> selectedBranch, IState<bool> isCustomBranch, IState<string> customBranchText, IReadOnlyList<string> availableBranches, string defaultBranch)`.

## Files Modified

- **Core & Models**:
  - `src/Ivy.Tendril/Models/JobArgs.cs`
  - `src/Ivy.Tendril/Commands/JobStartCommand.cs`
- **Git & Job Services**:
  - `src/Ivy.Tendril/Services/Git/IGitService.cs`
  - `src/Ivy.Tendril/Services/Git/GitService.cs`
  - `src/Ivy.Tendril/Services/Jobs/JobLauncher.cs`
- **UI & Promptwares**:
  - `src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs`
  - `src/Ivy.Tendril/Promptwares/CreatePr/Program.md`
- **Tests**:
  - `src/Ivy.Tendril.Test/Apps/Review/CreatePrDialogTests.cs`
  - `src/Ivy.Tendril.Test/Services/GitServiceBranchesTests.cs`
  - `src/Ivy.Tendril.Test/Services/JobLauncherCreatePrBranchTests.cs`
  - `src/Ivy.Tendril.Test/GitTabDataBuilderTests.cs`
  - `src/Ivy.Tendril.Test/PlanContentHelpersTests.cs`
  - `src/Ivy.Tendril.Test/Services/JobLauncherTests.cs`

## Manual Testing

1. Launch the Tendril desktop application (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`).
2. Open the **Review** tab for an executed plan with commits.
3. Click **Create PR** (or press shortcut `m`).
4. Observe the new **Target Branch** searchable dropdown at the top of the dialog, pre-populated with the repository's configured default branch (e.g., `development`).
5. Open the dropdown to see all discovered local and remote branches.
6. Select `+ Custom branch...` and observe the input field appear allowing you to enter an arbitrary target branch name.
7. Click `Choose from list` to return to the dropdown.
8. Submit the dialog and verify the spawned `CreatePr` job carries the selected target branch in its options and firmware header.

## Fix: Remove description text below target branch selector

Removed the description text "Default: {branch} (configured in project settings)" from below the target branch selector dropdown in the CreatePrDialog. This change improves vertical space utilization in the dialog as requested by the reviewer. The default branch is still clearly indicated in the dropdown options list with "(default)" next to the branch name.

### Files Modified

- `src/Ivy.Tendril/Apps/Review/Dialogs/CreatePrDialog.cs`: Removed `.Description()` call on the branch selector field
- `src/Ivy.Tendril.Test/Apps/Review/CreatePrDialogTests.cs`: Updated test to no longer assert on the removed description

**Note:** This change does not affect user-facing functionality, only the dialog's vertical layout.

---

## Commits
- dfa63254 [00066] Support custom target base branch in CreatePrArgs, GitService, and JobLauncher
- 5dec52b4 [00066] Add target branch selector to CreatePrDialog and update CreatePr promptware
- 62b147c6 [00066] Add tests for branch listing, target branch selector, and job launcher propagation
- b11589e3 [00066] Remove description text below target branch selector to save vertical space

---
Created using [Ivy Tendril](https://ivy.app).
