### PR TITLE
[00087] Render One Project Badge Per Project in Icebox Sidebar

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Icebox/IceboxSidebarViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Icebox/IceboxSidebarViewTests.cs
@@ -1,0 +1,137 @@
+using Ivy;
+using Ivy.Core;
+using Ivy.Tendril.Apps.Icebox;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Test.TestHelpers;
+
+namespace Ivy.Tendril.Test.Apps.Icebox;
+
+public class IceboxSidebarViewTests
+{
+    private static PlanFile Plan(string project) => new(
+        new PlanMetadata(1, project, "Bug", "Test Plan", PlanStatus.Icebox,
+            [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null),
+        "", "/plans/00001-TestPlan", "");
+
+    private static object[] Children(PlanFile plan, IConfigService config) =>
+        ((IWidget)SidebarView.BuildRowBadges(plan, config).Build()!).Children;
+
+    [Fact]
+    public void BuildRowBadges_SingleProject_RendersProjectAndLevelBadge()
+    {
+        var config = new StubConfigService(
+        [
+            new ProjectConfig { Name = "Tendril", Color = "Blue" }
+        ]);
+
+        var children = Children(Plan("Tendril"), config);
+
+        var badges = children.OfType<Badge>().ToList();
+        Assert.Equal(2, badges.Count);
+
+        Assert.Equal("Tendril", badges[0].Title);
+        Assert.Equal(BadgeVariant.Outline, badges[0].Variant);
+        Assert.Equal(Colors.Blue, badges[0].Color);
+
+        Assert.Equal("Bug", badges[1].Title);
+        Assert.Equal(Colors.Gray, badges[1].Color);
+    }
+
+    [Fact]
+    public void BuildRowBadges_MultipleProjects_RendersOneBadgePerProject()
+    {
+        var config = new StubConfigService(
+        [
+            new ProjectConfig { Name = "Tendril", Color = "Blue" },
+            new ProjectConfig { Name = "Framework", Color = "Amber" }
+        ]);
+
+        var children = Children(Plan("Tendril, Framework"), config);
+
+        var badges = children.OfType<Badge>().ToList();
+        Assert.Equal(3, badges.Count);
+
+        Assert.Equal("Tendril", badges[0].Title);
+        Assert.Equal(BadgeVariant.Outline, badges[0].Variant);
+        Assert.Equal(Colors.Blue, badges[0].Color);
+
+        Assert.Equal("Framework", badges[1].Title);
+        Assert.Equal(BadgeVariant.Outline, badges[1].Variant);
+        Assert.Equal(Colors.Amber, badges[1].Color);
+
+        Assert.Equal("Bug", badges[2].Title);
+        Assert.Equal(Colors.Gray, badges[2].Color);
+    }
+
+    [Fact]
+    public void BuildRowBadges_EmptyProject_RendersOnlyLevelBadge()
+    {
+        var config = new StubConfigService();
+
+        var children = Children(Plan(""), config);
+
+        var badges = children.OfType<Badge>().ToList();
+        var badge = Assert.Single(badges);
+        Assert.Equal("Bug", badge.Title);
+    }
+
+    [Fact]
+    public void BuildRowBadges_UnknownProject_RendersUncolouredBadge()
+    {
+        var config = new StubConfigService(
+        [
+            new ProjectConfig { Name = "Tendril", Color = "Blue" }
+        ]);
+
+        var children = Children(Plan("UnknownProject"), config);
+
+        var badges = children.OfType<Badge>().ToList();
+        Assert.Equal(2, badges.Count);
+
+        Assert.Equal("UnknownProject", badges[0].Title);
+        Assert.Equal(BadgeVariant.Outline, badges[0].Variant);
+        Assert.Null(badges[0].Color);
+    }
+
+    [Fact]
+    public void BuildProjectOptions_MultiProjectPlan_CountsEachProjectSeparately()
+    {
+        var plans = new[]
+        {
+            Plan("Tendril, Framework"),
+            Plan("Tendril")
+        };
+
+        var options = SidebarView.BuildProjectOptions(plans, null);
+
+        Assert.Equal(2, options.Length);
+
+        Assert.Equal("Tendril (2)", options[0].Label);
+        Assert.Equal("Tendril", options[0].Value);
+
+        Assert.Equal("Framework (1)", options[1].Label);
+        Assert.Equal("Framework", options[1].Value);
+    }
+
+    [Fact]
+    public void BuildProjectOptions_WithLevelFilter_NarrowsOptionSet()
+    {
+        var planBug = new PlanFile(
+            new PlanMetadata(1, "Tendril", "Bug", "Test Plan", PlanStatus.Icebox,
+                [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null),
+            "", "/plans/00001-TestPlan", "");
+
+        var planFeature = new PlanFile(
+            new PlanMetadata(2, "Framework", "Feature", "Test Plan 2", PlanStatus.Icebox,
+                [], [], [], [], [], [], DateTime.UtcNow, DateTime.UtcNow, null, null),
+            "", "/plans/00002-TestPlan2", "");
+
+        var plans = new[] { planBug, planFeature };
+
+        var options = SidebarView.BuildProjectOptions(plans, "Bug");
+
+        var option = Assert.Single(options);
+        Assert.Equal("Tendril (1)", option.Label);
+        Assert.Equal("Tendril", option.Value);
+    }
+}

--- a/src/Ivy.Tendril.Test/Apps/Icebox/IceboxSidebarViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Icebox/IceboxSidebarViewTests.cs
@@ -2,6 +2,7 @@ using Ivy;
 using Ivy.Core;
 using Ivy.Tendril.Apps.Icebox;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
 using Ivy.Tendril.Test.TestHelpers;
 
 namespace Ivy.Tendril.Test.Apps.Icebox;

--- a/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
+++ b/src/Ivy.Tendril/Apps/Icebox/SidebarView.cs
@@ -14,16 +14,34 @@ public class SidebarView(
     IState<bool> filtersOpen,
     IConfigService config) : ViewBase
 {
-    private object BuildHeader()
+    internal static LayoutView BuildRowBadges(PlanFile plan, IConfigService config)
+    {
+        var badges = Layout.Horizontal().Gap(1);
+
+        foreach (var projectBadge in ProjectHelper.BuildBadges(plan.Project, config))
+            badges |= projectBadge.Small();
+
+        return badges
+               | new Badge(plan.Level).Color(config.GetLevelColor(plan.Level) ?? Colors.Gray).Small();
+    }
+
+    internal static IAnyOption[] BuildProjectOptions(IEnumerable<PlanFile> plans, string? levelFilter)
     {
         var levelFilteredPlans = plans.AsEnumerable();
-        if (levelFilter.Value is { } level)
-            levelFilteredPlans = levelFilteredPlans.Where(p => p.Level == level);
-        var projectCounts = levelFilteredPlans
-            .GroupBy(p => p.Project)
+        if (levelFilter != null)
+            levelFilteredPlans = levelFilteredPlans.Where(p => p.Level == levelFilter);
+
+        return levelFilteredPlans
+            .SelectMany(p => ProjectHelper.ParseProjects(p.Project))
+            .GroupBy(name => name)
             .OrderByDescending(g => g.Count())
             .Select(g => new Option<string>($"{g.Key} ({g.Count()})", g.Key))
             .ToArray<IAnyOption>();
+    }
+
+    private object BuildHeader()
+    {
+        var projectCounts = BuildProjectOptions(plans, levelFilter.Value);
         var levelOptions = config.LevelNames;
 
         var searchInput = textFilter.ToSearchInput()
@@ -65,10 +83,7 @@ public class SidebarView(
         var content = new List(filteredList.Select(plan =>
         {
             var clickablePlan = plan;
-            var badges = Layout.Horizontal().Gap(1)
-                | new Badge(plan.Project).Variant(BadgeVariant.Outline).Small()
-                    .WithProjectColor(config, plan.Project)
-                | new Badge(plan.Level).Color(config.GetLevelColor(plan.Level) ?? Colors.Gray).Small();
+            var badges = BuildRowBadges(plan, config);
 
             return SidebarListRow.Build($"#{plan.Id} {plan.Title}", badges, () => selectedPlanState.Set(clickablePlan),
                 plan.FolderName == selectedPlanState.Value?.FolderName);


### PR DESCRIPTION
## Problem

The Icebox sidebar row is the last place in the app that builds a project badge by hand instead of going through `ProjectHelper.BuildBadges`.

A plan's `project` field can hold a comma separated list. For `project: Tendril, Framework` the current code produces **one** badge titled `Tendril, Framework`, and color lookup fails because nothing matches the whole string.

The project filter dropdown groups plans by the raw string, so a multi-project plan appears as `Tendril, Framework (1)` whose value never matches the split logic in `PlanFilters.ApplyFilters`, making the option non-functional.

## Solution

Both changes are confined to `SidebarView.cs`:

1. **One badge per project in the row**: Extract badge row into `BuildRowBadges`, use `ProjectHelper.BuildBadges` to render one outline badge per project with correct colors.
2. **Project filter counts each project separately**: Flatten before grouping so each project gets its own option and count.

## Commits

- e93b0cbc
- b2478ab96bfd61e2e6f9df559f32b7ea9207a16d

---
Created using [Ivy Tendril](https://ivy.app).
