### PR TITLE
[00016] Align Sidebar Badge Styling Between Collapsed and Expanded States

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellNav.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellNav.test.tsx
@@ -95,3 +95,55 @@ describe("ShellNav divider resizing", () => {
     expect(list.style.maxHeight).toBe("");
   });
 });
+
+describe("ShellNav badges", () => {
+  const badgeItems: ShellNavItemDto[] = [
+    { id: "plans", label: "Plans", icon: "Feather", badge: "7", isActive: true },
+    { id: "review", label: "Review", icon: "ThumbsUp", badge: "1" },
+    { id: "recommendations", label: "Recommendations", icon: "Lightbulb", badge: "105" },
+    { id: "activity", label: "Activity", icon: "Activity" },
+  ];
+
+  it("renders navigation item badges in expanded mode with .tsh-nav-badge", () => {
+    const { container } = render(
+      <ShellContext.Provider value={{ collapsed: false, toggle: () => {} }}>
+        <ShellNav id="nav-1" items={badgeItems} events={[]} eventHandler={vi.fn()} />
+      </ShellContext.Provider>
+    );
+
+    const badges = container.querySelectorAll(".tsh-nav-badge");
+    expect(badges).toHaveLength(3);
+    expect(badges[0]).toHaveTextContent("7");
+    expect(badges[1]).toHaveTextContent("1");
+    expect(badges[2]).toHaveTextContent("105");
+  });
+
+  it("renders navigation item badges in collapsed mode with .tsh-nav-badge and caps large counts", () => {
+    const { container } = render(
+      <ShellContext.Provider value={{ collapsed: true, toggle: () => {} }}>
+        <ShellNav id="nav-1" items={badgeItems} events={[]} eventHandler={vi.fn()} />
+      </ShellContext.Provider>
+    );
+
+    const badges = container.querySelectorAll(".tsh-nav-badge");
+    expect(badges).toHaveLength(3);
+    expect(badges[0]).toHaveTextContent("7");
+    expect(badges[1]).toHaveTextContent("1");
+    expect(badges[2]).toHaveTextContent("99");
+  });
+
+  it("sets data-active='true' on active items and retains the badge element", () => {
+    const { container } = render(
+      <ShellContext.Provider value={{ collapsed: false, toggle: () => {} }}>
+        <ShellNav id="nav-1" items={badgeItems} events={[]} eventHandler={vi.fn()} />
+      </ShellContext.Provider>
+    );
+
+    const activeItem = container.querySelector('.tsh-nav-item[data-active="true"]');
+    expect(activeItem).toBeInTheDocument();
+    expect(activeItem).toHaveAttribute("data-menu-item", "plans");
+    const badge = activeItem?.querySelector(".tsh-nav-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("7");
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
@@ -22,8 +22,6 @@
   --tsh-row-active-fg: var(--foreground, #000000);
   --tsh-badge-bg: var(--muted, #f0f0f0);
   --tsh-badge-bg-active: color-mix(in srgb, var(--accent, #e6e6e6) 45%, var(--background, #ffffff));
-  --tsh-rail-badge-bg: var(--primary, #000000);
-  --tsh-rail-badge-fg: var(--primary-foreground, #ffffff);
   --tsh-cta-bg: var(--primary, #000000);
   --tsh-cta-fg: var(--primary-foreground, #f8f8f8);
   /* Status chips are pale fills with the status color as text: themes pair
@@ -63,8 +61,6 @@
   --tsh-row-active-fg: var(--foreground, #f8f8f8);
   --tsh-badge-bg: var(--muted, #27272a);
   --tsh-badge-bg-active: color-mix(in srgb, var(--accent, #18181b) 55%, var(--background, #000000));
-  --tsh-rail-badge-bg: var(--primary, #ffffff);
-  --tsh-rail-badge-fg: var(--primary-foreground, #000000);
   --tsh-cta-bg: var(--primary, #f8f8f8);
   --tsh-cta-fg: var(--primary-foreground, #000000);
   --tsh-badge-project-bg: color-mix(in srgb, var(--info, #1e3a6d) 28%, var(--card, #000000));
@@ -573,7 +569,7 @@
   align-items: center;
   justify-content: center;
   min-width: 17px;
-  padding: 2px 5px;
+  padding: 2px 4px;
   border-radius: 4px;
   background: var(--tsh-badge-bg);
   font-size: 10px;
@@ -637,25 +633,18 @@
 }
 
 /* Collapsed rail: the label is gone, so the count rides the icon's top-right
-   corner — same look as the expanded badge, inverted colors. */
+   corner with the same look as the expanded badge. */
 .tsh-root[data-collapsed="true"] .tsh-nav-item {
   position: relative;
 }
 
-.tsh-root[data-collapsed="true"] .tsh-nav-badge,
-.tsh-root[data-collapsed="true"] .tsh-nav-item[data-active="true"] .tsh-nav-badge {
+.tsh-root[data-collapsed="true"] .tsh-nav-badge {
   position: absolute;
   top: 3px;
-  /* Anchored just past the 16px icon's right edge so the number never covers
-     it, and left-aligned so longer counts stretch rightward. Padding is a
-     touch tighter than the expanded badge: the rail leaves only ~20px beside
-     the icon, and this keeps a two-digit count inside it (ShellNav caps the
-     rail text at two digits for the same reason). */
-  left: calc(50% + 8px);
+  /* Anchored relative to the 16px icon so the badge remains legible
+     without clipping against the rail boundary. */
+  left: calc(50% + 2px);
   right: auto;
-  padding: 2px 4px;
-  background: var(--tsh-rail-badge-bg);
-  color: var(--tsh-rail-badge-fg);
 }
 
 /* ---------- Sidebar section (plan list) ---------- */


### PR DESCRIPTION
Fixes #2303

# Summary

## Changes

Unified notification badge styling between collapsed and expanded states in the sidebar navigation. Collapsed badges now use the same theme-derived background and text colors as expanded badges, inherit active row badge styling, and position cleanly without clipping against the rail boundary.

## API Changes

None.

## Files Modified

- **Styles**: `src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css` (removed hardcoded rail badge variables and unified collapsed badge tokens and positioning)
- **Tests**: `src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellNav.test.tsx` (added unit tests for badge rendering in expanded and collapsed modes)

## Manual Testing

1. Launch Tendril or run the widget development server (`vp dev` or review action `App`/`Widgets`).
2. Observe the sidebar navigation items (such as Plans, Review, or Recommendations) when counts are present in the expanded sidebar state. Note the badge background and text colors.
3. Collapse the sidebar using the collapse toggle to enter rail mode.
4. Verify that the badges on collapsed nav icons display with the same background and text colors, without inverted black/white fills, and that double-digit numbers are not clipped on the right edge.
5. Click on an item with a badge (e.g., Plans) while collapsed: verify that the active state styling applies cleanly to the badge.

---
- 292fa1d Plan 00016: Align sidebar badge styling between collapsed and expanded states

---
Created using [Ivy Tendril](https://ivy.app).
