### PR TITLE
[00017] Fix Numeric Badges Cut Off in Collapsed Sidebar

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellNav.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellNav.test.tsx
@@ -30,12 +30,21 @@ const layOut = (container: HTMLElement) => {
 const renderNav = (collapsed = false) => {
   const utils = render(
     <ShellContext.Provider value={{ collapsed, toggle: () => {} }}>
-      <div className="tsh-sidebar-body" ref={(el) => {
-        if (el) el.getBoundingClientRect = () => ({ top: 0, bottom: 1000 }) as DOMRect;
-      }}>
-        <ShellNav id="nav-1" items={items} showDivider={true} events={["OnSelect"]} eventHandler={vi.fn()} />
+      <div
+        className="tsh-sidebar-body"
+        ref={(el) => {
+          if (el) el.getBoundingClientRect = () => ({ top: 0, bottom: 1000 }) as DOMRect;
+        }}
+      >
+        <ShellNav
+          id="nav-1"
+          items={items}
+          showDivider={true}
+          events={["OnSelect"]}
+          eventHandler={vi.fn()}
+        />
       </div>
-    </ShellContext.Provider>
+    </ShellContext.Provider>,
   );
   return { ...utils, ...layOut(utils.container) };
 };
@@ -93,5 +102,54 @@ describe("ShellNav divider resizing", () => {
     expect(divider).toHaveAttribute("data-resizable", "false");
     drag(divider, 270, 210);
     expect(list.style.maxHeight).toBe("");
+  });
+});
+
+describe("ShellNav badge rendering", () => {
+  const badgeItems: ShellNavItemDto[] = [
+    { id: "plans", label: "Plans", icon: "ChartBar", badge: "7", isActive: true },
+    { id: "review", label: "Review", icon: "ThumbsUp", badge: "12" },
+    { id: "drafts", label: "Drafts", icon: "Feather", badge: "123" },
+    { id: "settings", label: "Settings", icon: "Activity" },
+  ];
+
+  const renderNavWithBadges = (collapsed = false) => {
+    return render(
+      <ShellContext.Provider value={{ collapsed, toggle: () => {} }}>
+        <ShellNav id="nav-badges" items={badgeItems} events={["OnSelect"]} eventHandler={vi.fn()} />
+      </ShellContext.Provider>,
+    );
+  };
+
+  it("renders navigation items and badges in expanded mode", () => {
+    renderNavWithBadges(false);
+    expect(screen.getByText("Plans")).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("123")).toBeInTheDocument();
+  });
+
+  it("renders navigation items and badges in collapsed mode", () => {
+    renderNavWithBadges(true);
+    expect(screen.getByTitle("Plans")).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+  });
+
+  it("caps badge numbers longer than 2 characters at 99 in collapsed mode", () => {
+    renderNavWithBadges(true);
+    expect(screen.queryByText("123")).toBeNull();
+    expect(screen.getByText("99")).toBeInTheDocument();
+  });
+
+  it("passes data-active=true for active items and preserves badge rendering", () => {
+    renderNavWithBadges(false);
+    const activeItem = screen.getByTitle("Plans");
+    expect(activeItem).toHaveAttribute("data-active", "true");
+    expect(activeItem.querySelector(".tsh-nav-badge")).toHaveTextContent("7");
+
+    const inactiveItem = screen.getByTitle("Review");
+    expect(inactiveItem).toHaveAttribute("data-active", "false");
+    expect(inactiveItem.querySelector(".tsh-nav-badge")).toHaveTextContent("12");
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css
@@ -636,8 +636,8 @@
   opacity: 0;
 }
 
-/* Collapsed rail: the label is gone, so the count rides the icon's top-right
-   corner — same look as the expanded badge, inverted colors. */
+/* Collapsed rail: the label is hidden, so the count rides the top-right
+   corner of the icon, leaving most of the icon visible while avoiding clipping. */
 .tsh-root[data-collapsed="true"] .tsh-nav-item {
   position: relative;
 }
@@ -646,14 +646,13 @@
 .tsh-root[data-collapsed="true"] .tsh-nav-item[data-active="true"] .tsh-nav-badge {
   position: absolute;
   top: 3px;
-  /* Anchored just past the 16px icon's right edge so the number never covers
-     it, and left-aligned so longer counts stretch rightward. Padding is a
-     touch tighter than the expanded badge: the rail leaves only ~20px beside
-     the icon, and this keeps a two-digit count inside it (ShellNav caps the
-     rail text at two digits for the same reason). */
-  left: calc(50% + 8px);
+  /* Anchored on the icon's top-right corner so it leaves >60% of the icon visible
+     while keeping the badge well clear of the right sidebar boundary. */
+  left: calc(50% + 1px);
   right: auto;
-  padding: 2px 4px;
+  min-width: 15px;
+  padding: 1px 3.5px;
+  z-index: 1;
   background: var(--tsh-rail-badge-bg);
   color: var(--tsh-rail-badge-fg);
 }


### PR DESCRIPTION
Fixes #2304

# Summary

## Changes

Fixed numeric notification badges being clipped along the right boundary of the sidebar when in collapsed rail mode. The badge position was adjusted to anchor to the top-right corner of the navigation icon with updated padding, min-width, and z-index, ensuring full badge visibility and clearance while keeping the icon recognizable.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/Shell/shell.css`: Updated `.tsh-root[data-collapsed="true"] .tsh-nav-badge` layout geometry, positioning, min-width, padding, and z-index.
- `src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellNav.test.tsx`: Added unit test suite covering navigation item badge rendering in expanded and collapsed modes, two-digit count capping at 99, and active item attribute handling.

## Manual Testing

1. Launch Tendril and open the web interface.
2. Ensure there are active badges on sidebar navigation items (such as Plans, Review, or Recommendations).
3. Collapse the sidebar by clicking the collapse toggle button in the header.
4. Observe the numeric badges in the collapsed rail: verify each badge pill is positioned over the top-right corner of the item icon with full margins to the sidebar boundary, with no clipping of single-digit or two-digit counts.
5. Re-expand the sidebar and confirm badges render in their default expanded positions next to the item labels.

## Commits

- 39ac6923078bd68355c0babc4eec10228a23620d

---
Created using [Ivy Tendril](https://ivy.app).
