### PR TITLE
[00015] Prevent E2E Tests From Modifying Shell Configuration Files

### DIFF
--- a/src/Ivy.Tendril.Test.End2End/Fixtures/TendrilProcessFixture.cs
+++ b/src/Ivy.Tendril.Test.End2End/Fixtures/TendrilProcessFixture.cs
@@ -44,7 +44,9 @@ public partial class TendrilProcessFixture : IAsyncLifetime
             {
                 ["TENDRIL_HOME"] = TendrilHome,
                 ["TENDRIL_PLANS"] = TendrilPlans,
-                ["TENDRIL_E2E"] = "1"
+                ["TENDRIL_E2E"] = "1",
+                ["TENDRIL_TEST"] = "1",
+                ["TENDRIL_NO_PERSIST_SHELL"] = "1"
             }
         };
 

--- a/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
+++ b/src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Ivy.Tendril.Test;
@@ -49,5 +50,122 @@ public class OnboardingSetupServiceTests : IDisposable
         Assert.Single(savedSettings.Projects);
         Assert.Equal("TestProject", savedSettings.Projects[0].Name);
         Assert.Equal("/tmp/test-repo", savedSettings.Projects[0].Repos[0].Path);
+    }
+
+    [Fact]
+    public async Task BootstrapTendrilHomeAsync_Should_Skip_Shell_And_Pointer_When_TendrilE2E_Set()
+    {
+        var originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        var originalE2E = Environment.GetEnvironmentVariable("TENDRIL_E2E");
+        var tendrilHome = Path.Combine(_tempDir.Path, "bootstrap-home-e2e");
+        var logger = new TestLogger<OnboardingSetupService>();
+        var configService = new ConfigService(new TendrilSettings());
+        var agentRunner = TestAgentRunner.Create();
+        var service = new OnboardingSetupService(configService, agentRunner, null!, logger);
+
+        try
+        {
+            Environment.SetEnvironmentVariable("TENDRIL_E2E", "1");
+            await service.BootstrapTendrilHomeAsync(tendrilHome);
+
+            Assert.Contains("Skipping shell configuration, pointer file, and user environment persistence in test mode", logger.GetOutput());
+
+            var pointerFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril_location");
+            if (File.Exists(pointerFile))
+            {
+                var content = await File.ReadAllTextAsync(pointerFile);
+                Assert.DoesNotContain(tendrilHome, content);
+            }
+
+            var shell = Environment.GetEnvironmentVariable("SHELL") ?? "";
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var rcFile = shell.EndsWith("/zsh") ? Path.Combine(home, ".zshrc")
+                       : shell.EndsWith("/bash") ? Path.Combine(home, ".bashrc")
+                       : Path.Combine(home, ".profile");
+            if (File.Exists(rcFile))
+            {
+                var content = await File.ReadAllTextAsync(rcFile);
+                Assert.DoesNotContain(tendrilHome, content);
+            }
+
+            if (OperatingSystem.IsWindows())
+            {
+                var userVar = Environment.GetEnvironmentVariable("TENDRIL_HOME", EnvironmentVariableTarget.User);
+                Assert.NotEqual(tendrilHome, userVar);
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TENDRIL_HOME", originalTendrilHome);
+            Environment.SetEnvironmentVariable("TENDRIL_E2E", originalE2E);
+        }
+    }
+
+    [Theory]
+    [InlineData("TENDRIL_TEST")]
+    [InlineData("TENDRIL_NO_PERSIST_SHELL")]
+    public async Task BootstrapTendrilHomeAsync_Should_Skip_Shell_And_Pointer_When_Test_Env_Vars_Set(string envVarName)
+    {
+        var originalTendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME");
+        var originalVal = Environment.GetEnvironmentVariable(envVarName);
+        var tendrilHome = Path.Combine(_tempDir.Path, $"bootstrap-home-{envVarName.ToLowerInvariant()}");
+        var logger = new TestLogger<OnboardingSetupService>();
+        var configService = new ConfigService(new TendrilSettings());
+        var agentRunner = TestAgentRunner.Create();
+        var service = new OnboardingSetupService(configService, agentRunner, null!, logger);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(envVarName, "1");
+            await service.BootstrapTendrilHomeAsync(tendrilHome);
+
+            Assert.Contains("Skipping shell configuration, pointer file, and user environment persistence in test mode", logger.GetOutput());
+
+            var pointerFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril_location");
+            if (File.Exists(pointerFile))
+            {
+                var content = await File.ReadAllTextAsync(pointerFile);
+                Assert.DoesNotContain(tendrilHome, content);
+            }
+
+            var shell = Environment.GetEnvironmentVariable("SHELL") ?? "";
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var rcFile = shell.EndsWith("/zsh") ? Path.Combine(home, ".zshrc")
+                       : shell.EndsWith("/bash") ? Path.Combine(home, ".bashrc")
+                       : Path.Combine(home, ".profile");
+            if (File.Exists(rcFile))
+            {
+                var content = await File.ReadAllTextAsync(rcFile);
+                Assert.DoesNotContain(tendrilHome, content);
+            }
+
+            if (OperatingSystem.IsWindows())
+            {
+                var userVar = Environment.GetEnvironmentVariable("TENDRIL_HOME", EnvironmentVariableTarget.User);
+                Assert.NotEqual(tendrilHome, userVar);
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TENDRIL_HOME", originalTendrilHome);
+            Environment.SetEnvironmentVariable(envVarName, originalVal);
+        }
+    }
+
+    private class TestLogger<T> : ILogger<T>
+    {
+        private readonly List<string> _messages = [];
+
+        public string GetOutput() => string.Join(Environment.NewLine, _messages);
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            _messages.Add(formatter(state, exception));
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
     }
 }

--- a/src/Ivy.Tendril/Services/OnboardingSetupService.cs
+++ b/src/Ivy.Tendril/Services/OnboardingSetupService.cs
@@ -1,4 +1,4 @@
-﻿using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services.Telemetry;
 using Microsoft.Extensions.Logging;
@@ -70,6 +70,12 @@ public class OnboardingSetupService(IConfigService config, IAgentRunner agentRun
         _logger.LogInformation("Setting environment variable TENDRIL_HOME={Value}", tendrilHome);
         Environment.SetEnvironmentVariable("TENDRIL_HOME", tendrilHome);
 
+        if (IsTestMode())
+        {
+            _logger.LogInformation("Skipping shell configuration, pointer file, and user environment persistence in test mode");
+            return;
+        }
+
         try
         {
             var pointerFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".tendril_location");
@@ -110,6 +116,13 @@ public class OnboardingSetupService(IConfigService config, IAgentRunner agentRun
         }
 
         _logger.LogInformation("Environment variable persisted (Windows={IsWin})", OperatingSystem.IsWindows());
+    }
+
+    private static bool IsTestMode()
+    {
+        return Environment.GetEnvironmentVariable("TENDRIL_E2E") == "1"
+            || Environment.GetEnvironmentVariable("TENDRIL_TEST") == "1"
+            || Environment.GetEnvironmentVariable("TENDRIL_NO_PERSIST_SHELL") == "1";
     }
 
     public Task CommitPendingProjectAsync()


### PR DESCRIPTION
Fixes #2295

# Summary

## Changes

Prevented onboarding setup from modifying shell configuration files (`.zshrc`, `.bashrc`, `.profile`), `~/.tendril_location`, and Windows user environment variables when executing under test or E2E mode. Added test mode detection (`TENDRIL_E2E`, `TENDRIL_TEST`, `TENDRIL_NO_PERSIST_SHELL`) to `OnboardingSetupService`, updated `TendrilProcessFixture` with defense-in-depth flags, and added comprehensive unit test coverage.

## API Changes

None.

## Files Modified

- **Services**: `src/Ivy.Tendril/Services/OnboardingSetupService.cs` - Added `IsTestMode` check to bypass writing shell rc files, the `.tendril_location` pointer file, and user environment variables.
- **E2E Test Infrastructure**: `src/Ivy.Tendril.Test.End2End/Fixtures/TendrilProcessFixture.cs` - Added `TENDRIL_TEST = "1"` and `TENDRIL_NO_PERSIST_SHELL = "1"` to fixture process environment variables.
- **Unit Tests**: `src/Ivy.Tendril.Test/OnboardingSetupServiceTests.cs` - Added unit tests validating that `BootstrapTendrilHomeAsync` bypasses shell rc and pointer file persistence when test environment flags are set.

## Manual Testing

1. Run unit tests via CLI: `dotnet test src/Ivy.Tendril/Ivy.Tendril.slnx --filter "FullyQualifiedName~OnboardingSetupServiceTests"`.
2. Observe all tests pass with zero errors.
3. Inspect `~/.zshrc` (or `~/.bashrc`) and `~/.tendril_location` to verify no temporary test paths were appended or written.

---

### Commits

164220ef Plan 00015: Prevent E2E tests from modifying shell configuration files

---
Created using [Ivy Tendril](https://ivy.app).