### PR TITLE
[00012] Update Blocked Job Status Message When Dependencies Change

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs
@@ -152,6 +152,58 @@ public class JobServiceRetryBlockedTests : IDisposable
     }
 
     [Fact]
+    public void RetryBlockedJobs_WhenDependencyStillUnsatisfied_UpdatesStatusMessageAndPersists()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        // Create plans directory with two dependencies: Dep1 in Executing, Dep2 in Draft
+        var plansDir = CreatePlansDirectory(("01100-Dep1", "Executing"), ("01101-Dep2", "Draft"));
+
+        // Create the dependent plan that depends on Dep1 and Dep2
+        var dependentPlan = CreatePlanFolder("Draft", ["01100-Dep1", "01101-Dep2"]);
+
+        var planReader = new FakePlanReaderService(plansDir);
+        var db = new FakeDatabaseService();
+        var service = new JobService(
+            TimeSpan.FromMinutes(30),
+            TimeSpan.FromMinutes(10),
+            planReaderService: planReader,
+            database: db);
+
+        // Create a blocked job with status message pointing to Dep1
+        var blockedId = service.CreateTestJob(new ExecutePlanArgs(dependentPlan));
+        var blockedJob = service.GetJob(blockedId)!;
+        blockedJob.Status = JobStatus.Blocked;
+        blockedJob.StatusMessage = "Dependency '01100-Dep1' is 'Executing', not Completed";
+        db.UpsertedJobIds.Clear();
+
+        // Transition Dep1 to Completed
+        var dep1YamlPath = Path.Combine(plansDir, "01100-Dep1", "plan.yaml");
+        var dep1Yaml = File.ReadAllText(dep1YamlPath).Replace("state: Executing", "state: Completed");
+        File.WriteAllText(dep1YamlPath, dep1Yaml);
+
+        // Create a completing job to trigger RetryBlockedJobs
+        var completingId = service.CreateTestJob(new CreatePrArgs(Path.GetTempPath()));
+        service.CompleteJob(completingId, 0);
+
+        // Verify job remains Blocked, but StatusMessage updates to point to Dep2
+        var stillBlocked = service.GetJob(blockedId);
+        Assert.NotNull(stillBlocked);
+        Assert.Equal(JobStatus.Blocked, stillBlocked.Status);
+        Assert.Equal("Dependency '01101-Dep2' is 'Draft', not Completed", stillBlocked.StatusMessage);
+
+        // Verify persistJob was invoked with updated message
+        Assert.Contains(blockedId, db.UpsertedJobIds);
+        var persistedJob = db.GetJobById(blockedId);
+        Assert.NotNull(persistedJob);
+        Assert.Equal("Dependency '01101-Dep2' is 'Draft', not Completed", persistedJob.StatusMessage);
+
+        // Cleanup
+        Directory.Delete(dependentPlan, true);
+        Directory.Delete(plansDir, true);
+    }
+
+    [Fact]
     public void RetryBlockedJobs_WhenJobAlreadyRemoved_DoesNotCreateDuplicate()
     {
         SynchronizationContext.SetSynchronizationContext(null);

--- a/src/Ivy.Tendril.Test/JobServiceWaitForJobsTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceWaitForJobsTests.cs
@@ -90,6 +90,34 @@ public class JobServiceWaitForJobsTests
     }
 
     [Fact]
+    public void HandleWaitForJobsDependents_WhenPartialDependenciesComplete_UpdatesStatusMessage()
+    {
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        var service = new JobService(
+            TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(10),
+            maxConcurrentJobs: 5);
+
+        var depA = service.CreateTestJob(new CreatePlanArgs("Dep A", "Auto"));
+        var depB = service.CreateTestJob(new CreatePlanArgs("Dep B", "Auto"));
+
+        var waitingId = service.StartJob(new CreatePlanArgs("Waiting job", "Auto") { WaitForJobs = [depA, depB] });
+        var waitingJob = service.GetJob(waitingId);
+        Assert.NotNull(waitingJob);
+        Assert.Equal(JobStatus.Blocked, waitingJob.Status);
+        Assert.Contains(depA, waitingJob.StatusMessage);
+        Assert.Contains(depB, waitingJob.StatusMessage);
+
+        service.CompleteJob(depA, 0);
+
+        var stillWaiting = service.GetJob(waitingId);
+        Assert.NotNull(stillWaiting);
+        Assert.Equal(JobStatus.Blocked, stillWaiting.Status);
+        Assert.DoesNotContain(depA, stillWaiting.StatusMessage);
+        Assert.Contains(depB, stillWaiting.StatusMessage);
+    }
+
+    [Fact]
     public void CompleteJob_Failure_CascadesFailureToWaitingJobs()
     {
         SynchronizationContext.SetSynchronizationContext(null);

--- a/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
@@ -119,6 +119,25 @@ public class JobsAppRefreshGatingTests
     }
 
     [Fact]
+    public void BuildDataTableUpdates_EmitsUpdateWhenBlockedJobStatusMessageChanges()
+    {
+        var jobService = new FakeJobService();
+        var job = MakeJob("job-1", JobStatus.Blocked);
+        job.StatusMessage = "Waiting for Dep A";
+        jobService.Jobs.Add(job);
+        var cache = new Dictionary<string, string>();
+
+        JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
+
+        job.StatusMessage = "Waiting for Dep B";
+        var updates = JobsApp.BuildDataTableUpdates(jobService, cache).ToList();
+
+        var update = Assert.Single(updates);
+        Assert.Equal(nameof(JobItemRow.StatusMessage), update.ColumnName);
+        Assert.Equal("Waiting for Dep B", update.Value);
+    }
+
+    [Fact]
     public void BuildDataTableUpdates_PrunesCacheKeysForJobsNoLongerReturned()
     {
         var jobService = new FakeJobService();

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
@@ -86,7 +86,7 @@ public partial class JobsApp
             lastSent.Remove(staleKey);
 
         var candidates = currentJobs
-            .Where(j => j.Status == JobStatus.Running ||
+            .Where(j => j.Status is JobStatus.Running or JobStatus.Blocked ||
                         ((j.Status is JobStatus.Stopped or JobStatus.Failed or JobStatus.Timeout or JobStatus.Completed)
                          && j.CompletedAt.HasValue
                          && DateTime.UtcNow - j.CompletedAt.Value < TimeSpan.FromMinutes(1)))

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -71,7 +71,7 @@ internal class JobCompletionHandler
         HandleWaitForJobsDependents(job, jobs, raiseNotification, startJobSkipDepCheck, persistJob, deleteJob);
 
         if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or CreatePrArgs)
-            _dependencyChecker.RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck, deleteJob);
+            _dependencyChecker.RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck, deleteJob, persistJob);
 
         if (isSuccess && job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or CreatePrArgs or CreateIssueArgs)
         {
@@ -983,7 +983,24 @@ internal class JobCompletionHandler
                                dep.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending or JobStatus.Blocked);
 
                 if (stillPending)
+                {
+                    var remaining = waitingJob.WaitForJobIds!
+                        .Where(id => jobs.TryGetValue(id, out var dep) &&
+                                     dep.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending or JobStatus.Blocked)
+                        .Select(id => jobs[id])
+                        .ToList();
+                    if (remaining.Count > 0)
+                    {
+                        var waitingFor = string.Join(", ", remaining.Select(JobService.DescribeWaitDependency));
+                        var newStatus = $"Waiting for {waitingFor}";
+                        if (waitingJob.StatusMessage != newStatus)
+                        {
+                            waitingJob.StatusMessage = newStatus;
+                            persistJob?.Invoke(waitingJob);
+                        }
+                    }
                     continue;
+                }
 
                 jobs.TryRemove(waitingJob.Id, out _);
                 deleteJob?.Invoke(waitingJob.Id);
@@ -1017,8 +1034,9 @@ internal class JobCompletionHandler
         ConcurrentDictionary<string, JobItem> jobs,
         Action<JobNotification> raiseNotification,
         Func<JobArgsBase, string> startJobSkipDepCheck,
-        Action<string>? deleteJob = null)
-        => _dependencyChecker.RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck, deleteJob);
+        Action<string>? deleteJob = null,
+        Action<JobItem>? persistJob = null)
+        => _dependencyChecker.RetryBlockedJobs(jobs, raiseNotification, startJobSkipDepCheck, deleteJob, persistJob);
 
     internal void WriteJobLog(JobItem job)
     {

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -290,7 +290,7 @@ public class JobService : IJobService
         PersistJob(job);
 
         if (job.TypedArgs is ExecutePlanArgs or RetryPlanArgs or CreatePrArgs)
-            _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck, DeleteJobFromDatabase);
+            _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck, DeleteJobFromDatabase, PersistJob);
 
         _completionHandler.HandleWaitForJobsDependents(job, _jobs, RaiseNotification, StartJobSkipDepCheck, PersistJob, DeleteJobFromDatabase);
 
@@ -343,7 +343,7 @@ public class JobService : IJobService
             ApplyDeletePlanState(removed);
 
             if (removed.TypedArgs is ExecutePlanArgs or RetryPlanArgs or CreatePrArgs)
-                _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck, DeleteJobFromDatabase);
+                _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck, DeleteJobFromDatabase, PersistJob);
 
             _completionHandler.HandleWaitForJobsDependents(removed, _jobs, RaiseNotification, StartJobSkipDepCheck, PersistJob, DeleteJobFromDatabase);
         }
@@ -421,7 +421,7 @@ public class JobService : IJobService
         {
             var hasBlocked = _jobs.Values.Any(j => j.Status == JobStatus.Blocked);
             if (hasBlocked)
-                _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck, DeleteJobFromDatabase);
+                _completionHandler.HandleRetryBlockedJobs(_jobs, RaiseNotification, StartJobSkipDepCheck, DeleteJobFromDatabase, PersistJob);
         }
         catch
         {
@@ -1285,7 +1285,7 @@ public class JobService : IJobService
         return true;
     }
 
-    private static string DescribeWaitDependency(JobItem dep)
+    internal static string DescribeWaitDependency(JobItem dep)
     {
         var planId = dep.ResolvePlanId();
         return string.IsNullOrEmpty(planId)

--- a/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
+++ b/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
@@ -5,6 +5,7 @@ using Ivy.Tendril.Apps;
 using Ivy.Tendril.Apps.PullRequest;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Jobs;
 
 namespace Ivy.Tendril.Services.Plans;
 
@@ -91,7 +92,8 @@ internal class DependencyChecker
         ConcurrentDictionary<string, JobItem> jobs,
         Action<JobNotification> raiseNotification,
         Func<JobArgsBase, string> startJobSkipDepCheck,
-        Action<string>? deleteJob = null)
+        Action<string>? deleteJob = null,
+        Action<JobItem>? persistJob = null)
     {
         var blockedJobs = jobs.Values
             .Where(j => j is { Status: JobStatus.Blocked, TypedArgs: ExecutePlanArgs or RetryPlanArgs })
@@ -106,10 +108,36 @@ internal class DependencyChecker
             // JobCompletionHandler.HandleWaitForJobsDependents when those jobs finish, not here.
             // Restarting it while its WaitForJobs are still pending would immediately re-block it,
             // producing a spurious "Job Unblocked" + "Job Blocked" notification pair (issue #1538).
-            if (HasPendingWaitForJobs(blockedJob, jobs)) continue;
+            if (HasPendingWaitForJobs(blockedJob, jobs))
+            {
+                var remaining = blockedJob.WaitForJobIds!
+                    .Where(id => jobs.TryGetValue(id, out var dep) &&
+                                 dep.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending or JobStatus.Blocked)
+                    .Select(id => jobs[id])
+                    .ToList();
+                if (remaining.Count > 0)
+                {
+                    var waitingFor = string.Join(", ", remaining.Select(JobService.DescribeWaitDependency));
+                    var newStatus = $"Waiting for {waitingFor}";
+                    if (blockedJob.StatusMessage != newStatus)
+                    {
+                        blockedJob.StatusMessage = newStatus;
+                        persistJob?.Invoke(blockedJob);
+                    }
+                }
+                continue;
+            }
 
-            var (ok, _) = CheckDependencies(planFolder);
-            if (!ok) continue;
+            var (ok, blockReason) = CheckDependencies(planFolder);
+            if (!ok)
+            {
+                if (!string.IsNullOrEmpty(blockReason) && blockedJob.StatusMessage != blockReason)
+                {
+                    blockedJob.StatusMessage = blockReason;
+                    persistJob?.Invoke(blockedJob);
+                }
+                continue;
+            }
 
             if (HasActiveJobForPlan(planFolder, jobs)) continue;
             if (!jobs.TryRemove(blockedJob.Id, out _)) continue;


### PR DESCRIPTION
Fixes #2314

# Summary

## Changes

Updated blocked job status message handling when dependencies transition or complete, ensuring stale block and wait reasons are refreshed and persisted. Added real-time table cell update streaming for blocked jobs so the Jobs App UI displays current block reasons without requiring manual page reloads.

## API Changes

None.

## Files Modified

- Backend Services:
  - `src/Ivy.Tendril/Services/Plans/DependencyChecker.cs`: Added `persistJob` parameter to `RetryBlockedJobs`, updated block reason re-evaluation and pending wait-for list computation.
  - `src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs`: Updated `HandleWaitForJobsDependents` to re-filter remaining dependencies and persist updated status messages; forwarded `persistJob` in `HandleRetryBlockedJobs`.
  - `src/Ivy.Tendril/Services/Jobs/JobService.cs`: Changed `DescribeWaitDependency` to internal static; passed `PersistJob` to `HandleRetryBlockedJobs`.
- Jobs App UI:
  - `src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs`: Included `JobStatus.Blocked` in candidate rows evaluated by `BuildDataTableUpdates`.
- Unit Tests:
  - `src/Ivy.Tendril.Test/JobServiceRetryBlockedTests.cs`: Added test verifying status message updates and persistence when dependency transitions.
  - `src/Ivy.Tendril.Test/JobServiceWaitForJobsTests.cs`: Added test verifying status message updates when partial dependencies complete.
  - `src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs`: Added test verifying cell update emission when a blocked job's status message changes.

## Manual Testing

1. Launch Tendril and open the Jobs App.
2. Queue an ExecutePlan job for a plan that depends on two uncompleted plans (DepA and DepB).
3. Observe that the job transitions to "Blocked" with status message referencing DepA.
4. Complete or merge the PR for DepA while leaving DepB incomplete.
5. Observe the Jobs App without refreshing the page: the blocked job status message automatically updates to reference DepB.

---
- 715e7717 Fix blocked job status message updates when dependencies change (Plan 00012)

---
Created using [Ivy Tendril](https://ivy.app).
