### PR TITLE
[00100] Make Jobs Table Headers Match Their Filter Column Names

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableColumnLabelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Jobs/JobsTableColumnLabelTests.cs
@@ -1,0 +1,70 @@
+using Ivy.Tendril.Models;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Jobs;
+
+public class JobsTableColumnLabelTests
+{
+    private static readonly Dictionary<string, string> ExpectedLabels = new()
+    {
+        { nameof(JobItemRow.Id), "Id" },
+        { nameof(JobItemRow.Status), "Status" },
+        { nameof(JobItemRow.PlanId), "Plan Id" },
+        { nameof(JobItemRow.Prompt), "Prompt" },
+        { nameof(JobItemRow.Type), "Type" },
+        { nameof(JobItemRow.Project), "Project" },
+        { nameof(JobItemRow.Timer), "Timer" },
+        { nameof(JobItemRow.AgentOutput), "Agent Output" },
+        { nameof(JobItemRow.LastOutputTimestamp), "Last Output Timestamp" },
+        { nameof(JobItemRow.Cost), "Cost" },
+        { nameof(JobItemRow.Tokens), "Tokens" },
+        { nameof(JobItemRow.StatusMessage), "Status Message" },
+        { nameof(JobItemRow.ErrorContext), "Error Context" }
+    };
+
+    [Fact]
+    public void EveryLabelStripsBackToItsFilterToken()
+    {
+        foreach (var (propertyName, expectedLabel) in ExpectedLabels)
+        {
+            var labelWithoutSpaces = expectedLabel.Replace(" ", "");
+            Assert.Equal(propertyName, labelWithoutSpaces);
+        }
+    }
+
+    [Fact]
+    public void FrameworkDerivesTheExpectedLabels()
+    {
+        foreach (var (propertyName, expectedLabel) in ExpectedLabels)
+        {
+            var property = typeof(JobItemRow).GetProperty(propertyName);
+            Assert.NotNull(property);
+
+            var derivedLabel = Ivy.StringHelper.LabelFor(propertyName, property.PropertyType);
+            Assert.Equal(expectedLabel, derivedLabel);
+        }
+    }
+
+    [Fact]
+    public void ExpectedLabelsCoverEveryProperty()
+    {
+        var actualProperties = typeof(JobItemRow)
+            .GetProperties()
+            .Select(p => p.Name)
+            .OrderBy(n => n)
+            .ToArray();
+
+        var expectedProperties = ExpectedLabels.Keys
+            .OrderBy(n => n)
+            .ToArray();
+
+        Assert.Equal(expectedProperties, actualProperties);
+    }
+
+    [Fact]
+    public void PromptColumnIsNamedForWhatItHolds()
+    {
+        Assert.NotNull(typeof(JobItemRow).GetProperty("Prompt"));
+        Assert.Null(typeof(JobItemRow).GetProperty("Plan"));
+    }
+}

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.Data.cs
@@ -22,7 +22,7 @@ public partial class JobsApp
                 Id = j.Id,
                 Status = JobsApp.FormatStatusBadge(j.Status),
                 PlanId = planId,
-                Plan = JobsApp.GetPromptDisplay(j, planService),
+                Prompt = JobsApp.GetPromptDisplay(j, planService),
                 Type = j.Type,
                 Project = string.Join(", ", ProjectHelper.ParseProjects(j.Project)),
                 Timer = JobsApp.FormatTimer(j),

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -61,24 +61,15 @@ public partial class JobsApp
             .UpdateStream(updateStream)
             .Width(Size.Full())
             .Height(Size.Full())
-            .Header(t => t.Status, "Status")
-            .Header(t => t.Type, "Type")
-            .Header(t => t.PlanId, "Plan")
-            .Header(t => t.Plan, "Prompt/Title")
-            .Header(t => t.Project, "Project")
-            .Header(t => t.Timer, "Timer")
-            .Header(t => t.Cost, "Cost")
-            .Header(t => t.Tokens, "Tokens")
-            .Header(t => t.AgentOutput, "Agent Output")
+            // Headers are derived from property names (SplitPascalCase) so filter tokens match visible labels
             .Renderer(t => t.AgentOutput, new AnimatedStatusLabelDisplayRenderer
             {
                 Mode = AnimatedStatusMode.SpinnerTimer
             })
-            .Header(t => t.StatusMessage, "Status")
             .Width(t => t.Status, Size.Px(100))
             .Width(t => t.PlanId, Size.Px(80))
             .Width(t => t.Type, Size.Px(100))
-            .Width(t => t.Plan, Size.Px(250))
+            .Width(t => t.Prompt, Size.Px(250))
             .Width(t => t.Project, Size.Px(150))
             .Width(t => t.Timer, Size.Px(80))
             .Width(t => t.AgentOutput, Size.Px(100))
@@ -104,11 +95,14 @@ public partial class JobsApp
             {
                 BadgeColorMapping = projectColors
             })
-            .Renderer(t => t.Plan, new TextDisplayRenderer())
+            .Renderer(t => t.Prompt, new TextDisplayRenderer())
             .Renderer(t => t.StatusMessage, new TextDisplayRenderer())
             .Hidden(t => t.Id)
             .Hidden(t => t.LastOutputTimestamp)
             .Hidden(t => t.ErrorContext)
+            .Filterable(t => t.Id, false)
+            .Filterable(t => t.LastOutputTimestamp, false)
+            .Filterable(t => t.ErrorContext, false)
             .SortDirection(t => t.Id, SortDirection.Descending)
             .Config(c =>
             {
@@ -202,7 +196,7 @@ public partial class JobsApp
                 return ValueTask.CompletedTask;
             })
             */
-            .OnCellAction(t => t.Plan, e =>
+            .OnCellAction(t => t.Prompt, e =>
             {
                 var id = e.Value.RowId?.ToString();
                 if (!string.IsNullOrEmpty(id))

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -350,7 +350,7 @@ public record JobItemRow
     /// </summary>
     public string Status { get; init; } = "";
     public string PlanId { get; init; } = "";
-    public string Plan { get; init; } = "";
+    public string Prompt { get; init; } = "";
     public string Type { get; init; } = "";
     public string Project { get; init; } = "";
     public string Timer { get; init; } = "";


### PR DESCRIPTION
## Problem

The Jobs table has filtering enabled, and Ivy's filter grammar addresses a column by its **row property name**, never by the header the user reads. Three of the ten headers do not name the property they are bound to, so what a user reads is not what a user can type:

| Header today | Token that actually works | What happens |
| --- | --- | --- |
| Plan | `[PlanId]` | `[Plan]` is valid but filters the prompt column instead, silently |
| Prompt/Title | `[Plan]` | not guessable, and `/` is not part of any token |
| Status (the second one) | `[StatusMessage]` | two columns both read "Status" |

The failure mode is not an error, it is a wrong answer: `[Plan] = "00100"` parses, runs against the prompt text, and returns zero rows with nothing to say the wrong column was filtered.

## Solution

Make the headers match the property names by:

1. **Rename `JobItemRow.Plan` to `Prompt`** - Its value is the prompt display text, so `Prompt` is the accurate name
2. **Delete the ten `.Header()` calls** - Let Ivy derive headers from property names (e.g., `PlanId` → "Plan Id", `StatusMessage` → "Status Message")
3. **Take hidden columns out of the filter list** - Add `.Filterable(t => t.Id, false)` etc. for `Id`, `LastOutputTimestamp`, and `ErrorContext`

After this change:
- "Plan" becomes "Plan Id" (filter: `[PlanId]`)
- "Prompt/Title" becomes "Prompt" (filter: `[Prompt]`)
- Duplicate "Status" becomes "Status Message" (filter: `[StatusMessage]`)

---

**Commits:**
- 534e9c3f

---
Created using [Ivy Tendril](https://ivy.app).
