### PR TITLE
[00014] Add Navigation to Blocking Job from Dependency View

### DIFF
--- a/src/Ivy.Tendril.Test/JobDependencyHelperTests.cs
+++ b/src/Ivy.Tendril.Test/JobDependencyHelperTests.cs
@@ -1,0 +1,264 @@
+using Ivy.Tendril.Apps.Jobs.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class JobDependencyHelperTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _plansDir;
+
+    public JobDependencyHelperTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"JobDepTests_{Guid.NewGuid():N}");
+        _plansDir = Path.Combine(_tempDir, "Plans");
+        Directory.CreateDirectory(_plansDir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+                Directory.Delete(_tempDir, true);
+        }
+        catch
+        {
+            // Ignore cleanup errors
+        }
+    }
+
+    [Fact]
+    public void GetBlockingDependencies_WaitForJobIds_ResolvesBlockingJobs()
+    {
+        var depJob = new JobItem
+        {
+            Id = "job-100",
+            Type = "ExecutePlan",
+            Status = JobStatus.Running,
+            PlanFile = "00012-MyDepPlan"
+        };
+
+        var blockedJob = new JobItem
+        {
+            Id = "job-200",
+            Type = "ExecutePlan",
+            Status = JobStatus.Blocked,
+            WaitForJobIds = ["job-100"]
+        };
+
+        var jobService = new TestJobService([depJob, blockedJob]);
+        var planService = new TestPlanReaderService(_plansDir);
+
+        var blockingDeps = JobDependencyHelper.GetBlockingDependencies(blockedJob, jobService, planService);
+
+        Assert.Single(blockingDeps);
+        Assert.Equal("job-100", blockingDeps[0].JobId);
+        Assert.Equal("ExecutePlan", blockingDeps[0].JobType);
+        Assert.Equal(JobStatus.Running, blockingDeps[0].JobStatus);
+        Assert.Equal("00012", blockingDeps[0].PlanId);
+    }
+
+    [Fact]
+    public void GetBlockingDependencies_PlanDependsOn_WithActiveJob_ResolvesBlockingJob()
+    {
+        // Setup dependency plan folder
+        var depPlanFolder = Path.Combine(_plansDir, "00020-BasePlan");
+        Directory.CreateDirectory(depPlanFolder);
+        File.WriteAllText(Path.Combine(depPlanFolder, "plan.yaml"), "title: Base Plan\nstate: Executing\n");
+
+        // Setup current plan folder with dependsOn
+        var currentPlanFolder = Path.Combine(_plansDir, "00021-DependentPlan");
+        Directory.CreateDirectory(currentPlanFolder);
+        File.WriteAllText(Path.Combine(currentPlanFolder, "plan.yaml"), "title: Dependent Plan\nstate: Blocked\ndependsOn:\n  - 00020-BasePlan\n");
+
+        var depJob = new JobItem
+        {
+            Id = "job-300",
+            Type = "ExecutePlan",
+            Status = JobStatus.Running,
+            PlanFile = "00020-BasePlan"
+        };
+
+        var blockedJob = new JobItem
+        {
+            Id = "job-301",
+            Type = "ExecutePlan",
+            Status = JobStatus.Blocked,
+            PlanFile = "00021-DependentPlan",
+            TypedArgs = new ExecutePlanArgs(currentPlanFolder)
+        };
+
+        var jobService = new TestJobService([depJob, blockedJob]);
+        var planService = new TestPlanReaderService(_plansDir);
+
+        var blockingDeps = JobDependencyHelper.GetBlockingDependencies(blockedJob, jobService, planService);
+
+        Assert.Single(blockingDeps);
+        Assert.Equal("job-300", blockingDeps[0].JobId);
+        Assert.Equal("00020", blockingDeps[0].PlanId);
+        Assert.Equal(JobStatus.Running, blockingDeps[0].JobStatus);
+    }
+
+    [Fact]
+    public void GetBlockingDependencies_PlanDependsOn_WithoutJob_ResolvesBlockingPlan()
+    {
+        // Setup dependency plan folder with no jobs
+        var depPlanFolder = Path.Combine(_plansDir, "00030-PendingPlan");
+        Directory.CreateDirectory(depPlanFolder);
+        File.WriteAllText(Path.Combine(depPlanFolder, "plan.yaml"), "title: Pending Plan\nstate: Draft\n");
+
+        var currentPlanFolder = Path.Combine(_plansDir, "00031-DependentPlan");
+        Directory.CreateDirectory(currentPlanFolder);
+        File.WriteAllText(Path.Combine(currentPlanFolder, "plan.yaml"), "title: Dependent Plan\nstate: Blocked\ndependsOn:\n  - 00030-PendingPlan\n");
+
+        var blockedJob = new JobItem
+        {
+            Id = "job-400",
+            Type = "ExecutePlan",
+            Status = JobStatus.Blocked,
+            PlanFile = "00031-DependentPlan",
+            TypedArgs = new ExecutePlanArgs(currentPlanFolder)
+        };
+
+        var jobService = new TestJobService([blockedJob]);
+        var planService = new TestPlanReaderService(_plansDir);
+
+        var blockingDeps = JobDependencyHelper.GetBlockingDependencies(blockedJob, jobService, planService);
+
+        Assert.Single(blockingDeps);
+        Assert.Null(blockingDeps[0].JobId);
+        Assert.Equal("00030", blockingDeps[0].PlanId);
+        Assert.Equal("00030-PendingPlan", blockingDeps[0].PlanFolder);
+        Assert.Equal("Draft", blockingDeps[0].PlanStatus);
+    }
+
+    [Theory]
+    [InlineData("Waiting for ExecutePlan of plan 00012 (job 00045)", "00045", "00012")]
+    [InlineData("Blocked job 00099 failed", "00099", null)]
+    public void GetBlockingDependencies_FallbackStatusMessage_ResolvesFromPattern(string statusMessage, string expectedJobId, string? expectedPlanId)
+    {
+        var depJob = new JobItem
+        {
+            Id = expectedJobId,
+            Type = "ExecutePlan",
+            Status = JobStatus.Running,
+            PlanFile = expectedPlanId != null ? $"{expectedPlanId}-SomePlan" : ""
+        };
+
+        var blockedJob = new JobItem
+        {
+            Id = "job-500",
+            Type = "ExecutePlan",
+            Status = JobStatus.Blocked,
+            StatusMessage = statusMessage
+        };
+
+        var jobService = new TestJobService([depJob, blockedJob]);
+        var planService = new TestPlanReaderService(_plansDir);
+
+        var blockingDeps = JobDependencyHelper.GetBlockingDependencies(blockedJob, jobService, planService);
+
+        Assert.Single(blockingDeps);
+        Assert.Equal(expectedJobId, blockingDeps[0].JobId);
+        if (expectedPlanId != null)
+        {
+            Assert.Equal(expectedPlanId, blockingDeps[0].PlanId);
+        }
+    }
+
+    [Fact]
+    public void GetBlockingDependencies_FallbackStatusMessage_DependencyPlanPattern()
+    {
+        var blockedJob = new JobItem
+        {
+            Id = "job-600",
+            Type = "ExecutePlan",
+            Status = JobStatus.Blocked,
+            StatusMessage = "Dependency '00050-PreReqPlan' is 'Draft', not Completed"
+        };
+
+        var jobService = new TestJobService([blockedJob]);
+        var planService = new TestPlanReaderService(_plansDir);
+
+        var blockingDeps = JobDependencyHelper.GetBlockingDependencies(blockedJob, jobService, planService);
+
+        Assert.Single(blockingDeps);
+        Assert.Equal("00050", blockingDeps[0].PlanId);
+        Assert.Equal("00050-PreReqPlan", blockingDeps[0].PlanFolder);
+    }
+
+    private class TestJobService(List<JobItem> jobs) : IJobService
+    {
+        public List<JobItem> GetJobs() => jobs;
+        public JobItem? GetJob(string id) => jobs.FirstOrDefault(j => j.Id == id);
+        public List<JobItem> GetJobsForPlan(string planFile) => jobs.Where(j => j.PlanFile == planFile).ToList();
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null) => throw new NotImplementedException();
+        public void ForceStartJob(string id) => throw new NotImplementedException();
+        public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) => throw new NotImplementedException();
+        public void StopJob(string id) => throw new NotImplementedException();
+        public int StopAllJobs() => throw new NotImplementedException();
+        public int StopQueuedJobs() => throw new NotImplementedException();
+        public void DeleteJob(string id) => throw new NotImplementedException();
+        public void ClearCompletedJobs() => throw new NotImplementedException();
+        public void ClearFailedJobs() => throw new NotImplementedException();
+        public void ClearAllJobs() => throw new NotImplementedException();
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => throw new NotImplementedException();
+        public bool ReportJobFailure(string id, string message) => throw new NotImplementedException();
+        public bool IsInboxFileTracked(string filePath) => false;
+        public void Dispose() { }
+#pragma warning disable CS0067
+        public event Action? JobsChanged;
+        public event Action? JobsStructureChanged;
+        public event Action? JobPropertyChanged;
+        public event Action<JobNotification>? NotificationReady;
+#pragma warning restore CS0067
+    }
+
+    private class TestPlanReaderService(string plansDirectory) : IPlanReaderService
+    {
+        public string PlansDirectory => plansDirectory;
+        public bool IsDatabaseReady => true;
+        public List<PlanFile> GetPlans(PlanStatus? statusFilter = null) => [];
+        public PlanFile? GetPlanByFolder(string folderPath) => null;
+        public List<PlanFile> GetIceboxPlans() => [];
+        public void TransitionState(string folderName, PlanStatus newState) { }
+        public IReadOnlyList<string> GetFailedVerifications(string folderName) => [];
+        public void CompleteWithPartialDelivery(string folderName) { }
+        public void ResetToDraft(string folderName) { }
+        public void ResetVerificationsForRetry(string folderName) { }
+        public void SetVerificationStatus(string folderName, string name, VerificationStatus status) { }
+        public void SaveRevision(string folderName, string content) { }
+        public void RevertRevision(string folderName) { }
+        public string ReadLatestRevision(string folderName) => "";
+        public List<(int Number, string Content, DateTime Modified)> GetRevisions(string folderName) => [];
+        public void DeletePlan(string folderName) { }
+        public string ReadRawPlan(string folderName) => "";
+        public void SavePlan(string folderName, string fullContent) { }
+        public void UpdateLatestRevision(string folderName, string content) { }
+        public DashboardModels GetDashboardData(string? projectFilter) => throw new NotImplementedException();
+        public DashboardActivityStats GetDashboardActivity(int monthsBack = 24) => throw new NotImplementedException();
+        public List<(DateOnly Date, int Count)> GetCompletedPrsByDay(int days) => [];
+        public decimal GetPlanTotalCost(string folderPath) => 0;
+        public int GetPlanTotalTokens(string folderPath) => 0;
+        public List<HourlyTokenBurn> GetHourlyTokenBurn(int days = 7, string? projectFilter = null) => [];
+        public List<Recommendation> GetRecommendations() => [];
+        public int GetPendingRecommendationsCount() => 0;
+        public PlanReaderService.PlanCountSnapshot ComputePlanCounts() => throw new NotImplementedException();
+        public void UpdateRecommendationState(string planFolderName, string recommendationTitle, string newState, string? declineReason = null) { }
+        public List<RecommendationYaml> GetRecommendationsForPlan(string folderName) => [];
+        public void AcceptRecommendationAndRetry(string folderName, string recommendationTitle) { }
+        public void AcceptRecommendationsAndRetry(string folderName, IReadOnlyCollection<string> titles) { }
+        public void SyncPlanArtifacts(string planFolder) { }
+        public void InvalidateCaches() { }
+        public Task FlushPendingWritesAsync() => Task.CompletedTask;
+        public void MigratePlans() { }
+        public void RecoverStuckPlans() { }
+#pragma warning disable CS0067
+        public event Action? CountsInvalidated;
+#pragma warning restore CS0067
+    }
+}

--- a/src/Ivy.Tendril.Test/JobsAppNavigationTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppNavigationTests.cs
@@ -1,0 +1,32 @@
+using Ivy.Tendril.Apps.Jobs;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class JobsAppNavigationTests
+{
+    [Fact]
+    public void JobsAppArgs_DefaultsToNullJobId()
+    {
+        var args = new JobsAppArgs();
+        Assert.Null(args.JobId);
+    }
+
+    [Fact]
+    public void JobsAppArgs_PreservesProvidedJobId()
+    {
+        var args = new JobsAppArgs("00042");
+        Assert.Equal("00042", args.JobId);
+    }
+
+    [Fact]
+    public void JobsAppArgs_EqualityWorks()
+    {
+        var args1 = new JobsAppArgs("00042");
+        var args2 = new JobsAppArgs("00042");
+        var args3 = new JobsAppArgs("00043");
+
+        Assert.Equal(args1, args2);
+        Assert.NotEqual(args1, args3);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Jobs/Helpers/JobDependencyHelper.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Helpers/JobDependencyHelper.cs
@@ -1,0 +1,228 @@
+using System.Text.RegularExpressions;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
+
+namespace Ivy.Tendril.Apps.Jobs.Helpers;
+
+public record BlockingDependency
+{
+    public string? JobId { get; init; }
+    public string? JobType { get; init; }
+    public JobStatus? JobStatus { get; init; }
+    public string? PlanId { get; init; }
+    public string? PlanFolder { get; init; }
+    public string? PlanStatus { get; init; }
+    public string? Title { get; init; }
+}
+
+public static class JobDependencyHelper
+{
+    public static IReadOnlyList<BlockingDependency> GetBlockingDependencies(
+        JobItem job,
+        IJobService? jobService,
+        IPlanReaderService? planService)
+    {
+        var results = new List<BlockingDependency>();
+
+        // 1. Explicit job dependencies (WaitForJobIds)
+        if (job.WaitForJobIds is { Count: > 0 })
+        {
+            var allJobs = jobService?.GetJobs() ?? [];
+            foreach (var waitForId in job.WaitForJobIds)
+            {
+                var depJob = allJobs.FirstOrDefault(j => j.Id == waitForId);
+                if (depJob != null)
+                {
+                    var depPlanId = depJob.ResolvePlanId();
+                    PlanFile? depPlan = null;
+                    if (!string.IsNullOrEmpty(depPlanId) && planService != null)
+                    {
+                        depPlan = planService.GetPlans().FirstOrDefault(p =>
+                            p.Id.ToString("D5") == depPlanId ||
+                            p.FolderName.StartsWith(depPlanId, StringComparison.OrdinalIgnoreCase));
+                    }
+
+                    var title = depPlan?.Title ?? JobsApp.GetFullPrompt(depJob, planService);
+                    results.Add(new BlockingDependency
+                    {
+                        JobId = depJob.Id,
+                        JobType = depJob.Type,
+                        JobStatus = depJob.Status,
+                        PlanId = string.IsNullOrEmpty(depPlanId) ? null : depPlanId,
+                        PlanFolder = depPlan?.FolderName ?? (!string.IsNullOrEmpty(depJob.PlanFile) ? depJob.PlanFile : null),
+                        PlanStatus = depPlan?.Status.ToString(),
+                        Title = title
+                    });
+                }
+                else
+                {
+                    results.Add(new BlockingDependency
+                    {
+                        JobId = waitForId,
+                        Title = $"Job {waitForId}"
+                    });
+                }
+            }
+        }
+
+        // 2. Plan dependencies (DependsOn from plan.yaml)
+        string? planFolder = null;
+        if (job.TypedArgs is ExecutePlanArgs execArgs)
+        {
+            planFolder = execArgs.PlanFolder;
+        }
+        else if (job.TypedArgs is RetryPlanArgs retryArgs)
+        {
+            planFolder = retryArgs.PlanFolder;
+        }
+        else if (!string.IsNullOrEmpty(job.PlanFile) && planService?.PlansDirectory != null)
+        {
+            var candidate = Path.IsPathRooted(job.PlanFile)
+                ? job.PlanFile
+                : Path.Combine(planService.PlansDirectory, job.PlanFile);
+            if (Directory.Exists(candidate))
+            {
+                planFolder = candidate;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(planFolder))
+        {
+            var planYaml = PlanYamlHelper.ReadPlanYaml(planFolder);
+            if (planYaml?.DependsOn is { Count: > 0 })
+            {
+                var allJobs = jobService?.GetJobs() ?? [];
+                var allPlans = planService?.GetPlans() ?? [];
+
+                foreach (var dep in planYaml.DependsOn)
+                {
+                    var depPlanId = PlanYamlHelper.ExtractPlanIdFromFolder(dep) ??
+                                    (int.TryParse(dep, out var n) ? $"{n:D5}" : dep);
+
+                    var depPlan = allPlans.FirstOrDefault(p =>
+                        p.FolderName.Equals(dep, StringComparison.OrdinalIgnoreCase) ||
+                        p.FolderName.StartsWith(depPlanId + "-", StringComparison.OrdinalIgnoreCase) ||
+                        p.Id.ToString("D5") == depPlanId);
+
+                    PlanYaml? depPlanYaml = null;
+                    if (depPlan == null && planService?.PlansDirectory != null)
+                    {
+                        var depPath = Path.IsPathRooted(dep)
+                            ? dep
+                            : Path.Combine(planService.PlansDirectory, dep);
+                        if (Directory.Exists(depPath))
+                        {
+                            depPlanYaml = PlanYamlHelper.ReadPlanYaml(depPath);
+                        }
+                    }
+
+                    var matchingJobs = allJobs
+                        .Where(j => j.ResolvePlanId() == depPlanId ||
+                                    JobsApp.ExtractPlanId(j.PlanFile) == depPlanId ||
+                                    j.ReportedPlanId == depPlanId)
+                        .ToList();
+
+                    var depJob = matchingJobs
+                        .OrderByDescending(j => j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending or JobStatus.Blocked)
+                        .ThenByDescending(j => j.StartedAt)
+                        .FirstOrDefault();
+
+                    var planState = depPlan?.Status.ToString() ?? depPlanYaml?.State;
+                    var planTitle = depPlan?.Title ?? depPlanYaml?.Title;
+
+                    if (depJob != null)
+                    {
+                        results.Add(new BlockingDependency
+                        {
+                            JobId = depJob.Id,
+                            JobType = depJob.Type,
+                            JobStatus = depJob.Status,
+                            PlanId = depPlanId,
+                            PlanFolder = depPlan?.FolderName ?? dep,
+                            PlanStatus = planState,
+                            Title = planTitle ?? JobsApp.GetFullPrompt(depJob, planService)
+                        });
+                    }
+                    else
+                    {
+                        results.Add(new BlockingDependency
+                        {
+                            PlanId = depPlanId,
+                            PlanFolder = depPlan?.FolderName ?? dep,
+                            PlanStatus = planState,
+                            Title = planTitle ?? dep
+                        });
+                    }
+                }
+            }
+        }
+
+        // 3. Fallback: Parse patterns from StatusMessage if no explicit dependencies resolved
+        if (results.Count == 0 && !string.IsNullOrEmpty(job.StatusMessage))
+        {
+            var allJobs = jobService?.GetJobs() ?? [];
+
+            // Pattern A: "(job 00045)"
+            var jobMatches = Regex.Matches(job.StatusMessage, @"\(job\s+([^\)]+)\)");
+            foreach (Match match in jobMatches)
+            {
+                var jobId = match.Groups[1].Value.Trim();
+                var depJob = allJobs.FirstOrDefault(j => j.Id == jobId);
+                results.Add(new BlockingDependency
+                {
+                    JobId = jobId,
+                    JobType = depJob?.Type,
+                    JobStatus = depJob?.Status,
+                    PlanId = depJob?.ResolvePlanId(),
+                    Title = depJob != null ? JobsApp.GetFullPrompt(depJob, planService) : $"Job {jobId}"
+                });
+            }
+
+            // Pattern B: "Blocked job 00045 failed"
+            var blockedJobMatch = Regex.Match(job.StatusMessage, @"[Bb]locked job\s+(\S+)\s+failed");
+            if (blockedJobMatch.Success)
+            {
+                var jobId = blockedJobMatch.Groups[1].Value.Trim();
+                var depJob = allJobs.FirstOrDefault(j => j.Id == jobId);
+                results.Add(new BlockingDependency
+                {
+                    JobId = jobId,
+                    JobType = depJob?.Type,
+                    JobStatus = depJob?.Status,
+                    PlanId = depJob?.ResolvePlanId(),
+                    Title = depJob != null ? JobsApp.GetFullPrompt(depJob, planService) : $"Job {jobId}"
+                });
+            }
+
+            // Pattern C: "Dependency '00015-SomePlan'..."
+            var depMatches = Regex.Matches(job.StatusMessage, @"Dependency\s+'([^']+)'");
+            foreach (Match match in depMatches)
+            {
+                var dep = match.Groups[1].Value.Trim();
+                var depPlanId = PlanYamlHelper.ExtractPlanIdFromFolder(dep) ?? dep;
+                var depJob = allJobs.FirstOrDefault(j =>
+                    j.ResolvePlanId() == depPlanId ||
+                    JobsApp.ExtractPlanId(j.PlanFile) == depPlanId ||
+                    j.ReportedPlanId == depPlanId);
+
+                results.Add(new BlockingDependency
+                {
+                    JobId = depJob?.Id,
+                    JobType = depJob?.Type,
+                    JobStatus = depJob?.Status,
+                    PlanId = depPlanId,
+                    PlanFolder = dep,
+                    Title = dep
+                });
+            }
+        }
+
+        // Deduplicate
+        return results
+            .GroupBy(r => !string.IsNullOrEmpty(r.JobId) ? $"job:{r.JobId}" : $"plan:{r.PlanId ?? r.PlanFolder}")
+            .Select(g => g.First())
+            .ToList();
+    }
+}

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Apps.Jobs.Dialogs;
+using Ivy.Tendril.Apps.Jobs.Helpers;
 using Ivy.Tendril.Apps.Review;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
@@ -187,21 +188,45 @@ public partial class JobsApp
                     showCost(id);
                 return ValueTask.CompletedTask;
             })
-            /*
             .OnCellAction(t => t.StatusMessage, e =>
             {
                 var id = e.Value.RowId?.ToString();
                 if (!string.IsNullOrEmpty(id))
                 {
                     var job = jobs.FirstOrDefault(j => j.Id == id);
-                    if (job?.Status is JobStatus.Failed or JobStatus.Timeout)
+                    if (job?.Status == JobStatus.Blocked)
                     {
-                        showOutput.Set(id);
+                        var blockingDeps = JobDependencyHelper.GetBlockingDependencies(job, jobService, planService);
+                        var firstJob = blockingDeps.FirstOrDefault(d => !string.IsNullOrEmpty(d.JobId));
+                        if (firstJob != null)
+                        {
+                            showOutput(firstJob.JobId!);
+                        }
+                        else
+                        {
+                            var firstPlan = blockingDeps.FirstOrDefault(d => !string.IsNullOrEmpty(d.PlanFolder) || !string.IsNullOrEmpty(d.PlanId));
+                            if (firstPlan != null)
+                            {
+                                var folderOrId = firstPlan.PlanFolder ?? firstPlan.PlanId!;
+                                var fullPath = Path.Combine(planService.PlansDirectory, folderOrId);
+                                if (Directory.Exists(fullPath))
+                                {
+                                    showPlan(fullPath);
+                                }
+                                else
+                                {
+                                    nav.Navigate<PlansApp>(new PlansAppArgs(folderOrId));
+                                }
+                            }
+                        }
+                    }
+                    else if (job?.Status is JobStatus.Failed or JobStatus.Timeout)
+                    {
+                        showOutput(id);
                     }
                 }
                 return ValueTask.CompletedTask;
             })
-            */
             .OnCellAction(t => t.Plan, e =>
             {
                 var id = e.Value.RowId?.ToString();
@@ -236,6 +261,24 @@ public partial class JobsApp
 
                 if (job?.Status is JobStatus.Blocked)
                 {
+                    var blockingDeps = JobDependencyHelper.GetBlockingDependencies(job, jobService, planService);
+                    var firstJob = blockingDeps.FirstOrDefault(d => !string.IsNullOrEmpty(d.JobId));
+                    if (firstJob != null)
+                    {
+                        actions.Add(new MenuItem("View Blocking Job", Icon: Icons.ArrowRight, Tag: $"view-blocking-job:{firstJob.JobId}")
+                            .Tooltip($"Navigate to blocking job {firstJob.JobId}"));
+                    }
+                    else
+                    {
+                        var firstPlan = blockingDeps.FirstOrDefault(d => !string.IsNullOrEmpty(d.PlanFolder) || !string.IsNullOrEmpty(d.PlanId));
+                        if (firstPlan != null)
+                        {
+                            var folderOrId = firstPlan.PlanFolder ?? firstPlan.PlanId!;
+                            actions.Add(new MenuItem("View Blocking Plan", Icon: Icons.ArrowRight, Tag: $"view-blocking-plan:{folderOrId}")
+                                .Tooltip($"Navigate to blocking plan {firstPlan.PlanId ?? folderOrId}"));
+                        }
+                    }
+
                     actions.Add(new MenuItem("Force Start", Icon: Icons.Zap, Tag: "force-start-job")
                         .Tooltip("Force start this blocked job"));
                 }
@@ -292,6 +335,30 @@ public partial class JobsApp
                     else if (tag == "debug-job")
                     {
                         showDebug?.Invoke(job.Id);
+                    }
+                    else if (tag?.StartsWith("view-blocking-job:") == true)
+                    {
+                        var blockingJobId = tag["view-blocking-job:".Length..];
+                        if (!string.IsNullOrEmpty(blockingJobId))
+                        {
+                            showOutput(blockingJobId);
+                        }
+                    }
+                    else if (tag?.StartsWith("view-blocking-plan:") == true)
+                    {
+                        var folderOrId = tag["view-blocking-plan:".Length..];
+                        if (!string.IsNullOrEmpty(folderOrId))
+                        {
+                            var fullPath = Path.Combine(planService.PlansDirectory, folderOrId);
+                            if (Directory.Exists(fullPath))
+                            {
+                                showPlan(fullPath);
+                            }
+                            else
+                            {
+                                nav.Navigate<PlansApp>(new PlansAppArgs(folderOrId));
+                            }
+                        }
                     }
                     else if (tag == "delete-job")
                     {

--- a/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsApp.cs
@@ -17,6 +17,7 @@ public partial class JobsApp : ViewBase
         var client = UseService<IClientProvider>();
         var config = UseService<IConfigService>();
         var nav = UseNavigation();
+        var args = UseArgs<JobsAppArgs>();
         var refreshToken = UseRefreshToken();
         var openFile = UseState<string?>(null);
         var confirmDeleteOpen = UseState(false);
@@ -46,6 +47,17 @@ public partial class JobsApp : ViewBase
                 new OutputSheet(jobId, jobService),
                 title
             ).Width(UxHelper.SheetWidth).Resizable();
+        });
+
+        var handledJobId = UseRef<string?>(null);
+        UseEffect(() =>
+        {
+            if (!string.IsNullOrEmpty(args?.JobId) && handledJobId.Value != args.JobId)
+            {
+                handledJobId.Value = args.JobId;
+                showOutput(args.JobId);
+            }
+            return (IDisposable?)null;
         });
 
         var (promptSheet, showPrompt) = UseTrigger<string>((isOpen, promptText) =>

--- a/src/Ivy.Tendril/Apps/Jobs/JobsAppArgs.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/JobsAppArgs.cs
@@ -1,0 +1,3 @@
+namespace Ivy.Tendril.Apps.Jobs;
+
+public record JobsAppArgs(string? JobId = null);

--- a/src/Ivy.Tendril/Apps/Jobs/Sheets/OutputSheet.cs
+++ b/src/Ivy.Tendril/Apps/Jobs/Sheets/OutputSheet.cs
@@ -1,4 +1,7 @@
+using Ivy.Tendril.Apps.Jobs.Helpers;
+using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Plans;
 using Ivy.Tendril.Widgets;
 
 namespace Ivy.Tendril.Apps.Jobs.Sheets;
@@ -9,6 +12,8 @@ public class OutputSheet(string jobId, IJobService jobService) : ViewBase
     {
         var outputStream = UseStream<string>();
         var initialSnapshot = UseRef<string?>(null);
+        var nav = UseNavigation();
+        var planService = UseService<IPlanReaderService>();
 
         var job = jobService.GetJob(jobId);
 
@@ -23,6 +28,48 @@ public class OutputSheet(string jobId, IJobService jobService) : ViewBase
         if (job is null)
             return Text.P("No output available.");
 
+        if (job.Status == JobStatus.Blocked)
+        {
+            var blockingDeps = JobDependencyHelper.GetBlockingDependencies(job, jobService, planService);
+
+            var message = !string.IsNullOrEmpty(job.StatusMessage)
+                ? job.StatusMessage
+                : "Waiting for dependencies or preceding jobs to complete.";
+
+            var layout = Layout.Vertical().Gap(3)
+                         | Callout.Info(message, "Job Blocked");
+
+            if (blockingDeps.Count > 0)
+            {
+                var buttons = Layout.Horizontal().Gap(2);
+                foreach (var dep in blockingDeps)
+                {
+                    if (!string.IsNullOrEmpty(dep.JobId))
+                    {
+                        var label = dep.JobStatus.HasValue && !string.IsNullOrEmpty(dep.JobType)
+                            ? $"View Job {dep.JobId} ({dep.JobType} - {dep.JobStatus})"
+                            : $"View Job {dep.JobId}";
+                        buttons |= new Button(label)
+                            .Icon(Icons.ArrowRight)
+                            .Primary()
+                            .OnClick(() => nav.Navigate<JobsApp>(new JobsAppArgs(dep.JobId)));
+                    }
+                    else if (!string.IsNullOrEmpty(dep.PlanId) || !string.IsNullOrEmpty(dep.PlanFolder))
+                    {
+                        var planTarget = dep.PlanFolder ?? dep.PlanId!;
+                        var planDisplay = dep.PlanId ?? dep.PlanFolder;
+                        buttons |= new Button($"View Plan {planDisplay}")
+                            .Icon(Icons.ArrowRight)
+                            .Outline()
+                            .OnClick(() => nav.Navigate<PlansApp>(new PlansAppArgs(planTarget)));
+                    }
+                }
+                layout |= buttons;
+            }
+
+            return layout;
+        }
+
         if (job.OutputLines.IsEmpty && job.Status != JobStatus.Running)
         {
             if (!string.IsNullOrEmpty(job.StatusMessage))
@@ -30,13 +77,6 @@ public class OutputSheet(string jobId, IJobService jobService) : ViewBase
                 return Layout.Vertical()
                     .Gap(2)
                     | Callout.Info(job.StatusMessage, $"Job {job.Status}");
-            }
-
-            if (job.Status == JobStatus.Blocked)
-            {
-                return Layout.Vertical()
-                    .Gap(2)
-                    | Callout.Info("Waiting for dependencies or preceding jobs to complete.", "Job Blocked");
             }
 
             if (job.Status == JobStatus.Pending)

--- a/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
+++ b/src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs
@@ -3,6 +3,8 @@ using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Apps.Agent;
 using Ivy.Tendril.Apps.Jobs;
 using Ivy.Tendril.Apps.Jobs.Dialogs;
+using Ivy.Tendril.Apps.Jobs.Helpers;
+using Ivy.Tendril.Apps.Plans;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
@@ -117,6 +119,36 @@ public class JobDebugSheet(
         header |= new Button($"Debug with {agentBranding.Label}").Icon(agentBranding.Icon).Outline()
             .OnClick(() => showDebugAgentDialog());
 #endif
+
+        if (job.Status == JobStatus.Blocked)
+        {
+            var blockingDeps = JobDependencyHelper.GetBlockingDependencies(job, jobService, planService);
+            var firstJob = blockingDeps.FirstOrDefault(d => !string.IsNullOrEmpty(d.JobId));
+            if (firstJob != null)
+            {
+                header |= new Button($"View Blocking Job ({firstJob.JobId})").Icon(Icons.ArrowRight).Primary()
+                    .OnClick(() =>
+                    {
+                        nav.Navigate<JobsApp>(new JobsAppArgs(firstJob.JobId));
+                        closeSheet();
+                    });
+            }
+            else
+            {
+                var firstPlan = blockingDeps.FirstOrDefault(d => !string.IsNullOrEmpty(d.PlanFolder) || !string.IsNullOrEmpty(d.PlanId));
+                if (firstPlan != null)
+                {
+                    var planTarget = firstPlan.PlanFolder ?? firstPlan.PlanId!;
+                    var planDisplay = firstPlan.PlanId ?? firstPlan.PlanFolder;
+                    header |= new Button($"View Blocking Plan ({planDisplay})").Icon(Icons.ArrowRight).Outline()
+                        .OnClick(() =>
+                        {
+                            nav.Navigate<PlansApp>(new PlansAppArgs(planTarget));
+                            closeSheet();
+                        });
+                }
+            }
+        }
 
         return new Fragment(
             new HeaderLayout(header, detailsView).Size(Size.Full()),


### PR DESCRIPTION
Fixes #2315

# Summary

## Changes

Added direct navigation to blocking jobs and plans from blocked job views. Users can now click on the status message in the Jobs table, select context menu row actions, or click action buttons in the Output and Job Debug sheets to jump directly to the blocking job or dependency plan.

## API Changes

- Added `Ivy.Tendril.Apps.Jobs.JobsAppArgs`: record supporting deep linking to a specific job (`string? JobId = null`).
- Added `Ivy.Tendril.Apps.Jobs.Helpers.JobDependencyHelper`: helper class with method `GetBlockingDependencies(JobItem, IJobService?, IPlanReaderService?)`.
- Added `Ivy.Tendril.Apps.Jobs.Helpers.BlockingDependency`: record modeling resolved blocking dependencies (`JobId`, `JobType`, `JobStatus`, `PlanId`, `PlanFolder`, `PlanStatus`, `Title`).

## Files Modified

- **Jobs App**:
  - `src/Ivy.Tendril/Apps/Jobs/JobsApp.cs`: Added `JobsAppArgs` parameter handling and automatic opening of target job output upon navigation.
  - `src/Ivy.Tendril/Apps/Jobs/JobsApp.DataTable.cs`: Added click action on `StatusMessage` column and row context actions ("View Blocking Job", "View Blocking Plan") for blocked jobs.
  - `src/Ivy.Tendril/Apps/Jobs/JobsAppArgs.cs`: New record definition for JobsApp navigation arguments.
  - `src/Ivy.Tendril/Apps/Jobs/Helpers/JobDependencyHelper.cs`: New dependency resolution helper for blocked jobs.
  - `src/Ivy.Tendril/Apps/Jobs/Sheets/OutputSheet.cs`: Added interactive navigation buttons for blocking jobs and plans when viewing output of a blocked job.
  - `src/Ivy.Tendril/Apps/Views/Sheets/JobDebugSheet.cs`: Added "View Blocking Job" / "View Blocking Plan" button in the debug sheet header when viewing a blocked job.
- **Tests**:
  - `src/Ivy.Tendril.Test/JobDependencyHelperTests.cs`: Comprehensive unit tests covering job dependencies, plan dependencies with active/inactive jobs, and fallback regex parsing.
  - `src/Ivy.Tendril.Test/JobsAppNavigationTests.cs`: Tests verifying `JobsAppArgs` construction and equality.

## Manual Testing

1. Launch the Tendril desktop application (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse`).
2. Navigate to the Jobs app.
3. If a job is in the `Blocked` status:
   - Click directly on the `StatusMessage` cell in the Jobs table: the blocking job's output sheet (or dependency plan) will open.
   - Right-click or open the row action menu on the blocked job: observe the "View Blocking Job" (or "View Blocking Plan") action. Clicking it navigates to the dependency.
   - Open the Output sheet for the blocked job: observe the action buttons rendered below the callout banner (e.g. "View Job 00042 (ExecutePlan - Running)" or "View Plan 00012"). Clicking navigates to that job or plan.
   - Open the Job Debug sheet for the blocked job: observe the "View Blocking Job" button in the header layout. Clicking navigates to the blocking job.

---

## Commits

- 8b362d1d Add navigation to blocking job from dependency view (Plan 00014)

---
Created using [Ivy Tendril](https://ivy.app).