### PR TITLE
[00013] Fix Unanswered Questions Count in Execution Dialog

### DIFF
--- a/src/Ivy.Tendril.Test/ContentViewTests.cs
+++ b/src/Ivy.Tendril.Test/ContentViewTests.cs
@@ -312,4 +312,53 @@ public class ContentViewTests
 
         Assert.Empty(selected);
     }
+
+    [Fact]
+    public void CountUnansweredQuestions_IncludesOptionalQuestionsWithoutAnswers()
+    {
+        var questions = new QuestionSummary[]
+        {
+            new(0, "q1", "Question 1", null, HasAnswer: false, IsOptional: false),
+            new(0, "q2", "Question 2", null, HasAnswer: false, IsOptional: true),
+            new(0, "q3", "Question 3", null, HasAnswer: true, IsOptional: false),
+            new(0, "q4", "Question 4", null, HasAnswer: true, IsOptional: true),
+        };
+
+        var count = ContentView.CountUnansweredQuestions(questions);
+
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public void CountUnansweredQuestions_FromMarkdown_CountsBothRequiredAndOptionalUnanswered()
+    {
+        var markdown = """
+            # Test Plan
+
+            ```questions
+            - id: req-q
+              question: "Required question"
+              options:
+                - text: "Option A"
+                - text: "Option B"
+            - id: opt-q
+              question: "Optional question"
+              optional: true
+              options:
+                - text: "Option A"
+                - text: "Option B"
+            - id: answered-opt-q
+              question: "Answered optional question"
+              optional: true
+              answer: "Option A"
+              options:
+                - text: "Option A"
+                - text: "Option B"
+            ```
+            """;
+
+        var count = ContentView.CountUnansweredQuestions(markdown);
+
+        Assert.Equal(2, count);
+    }
 }

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -181,8 +181,7 @@ public class ContentView(
 
         var questions = QuestionAnswers.Read(revisionContent.Value);
         var answeredQuestions = questions.Count(q => q.HasAnswer);
-        // Optional questions are never outstanding: the plan is complete without them.
-        var unansweredQuestions = questions.Count(q => !q.HasAnswer && !q.IsOptional);
+        var unansweredQuestions = CountUnansweredQuestions(questions);
 
         void ApplyAnswer(QuestionAnswer answer)
         {
@@ -770,6 +769,14 @@ public class ContentView(
 
         return sb.ToString().TrimEnd();
     }
+
+    internal static int CountUnansweredQuestions(IEnumerable<QuestionSummary> questions) =>
+        questions.Count(q => !q.HasAnswer);
+
+    internal static int CountUnansweredQuestions(string? revisionContent) =>
+        string.IsNullOrEmpty(revisionContent)
+            ? 0
+            : CountUnansweredQuestions(QuestionAnswers.Read(revisionContent));
 
     private record PlanContentData(
         string? SummaryMarkdown,

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/UnansweredQuestionsDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/UnansweredQuestionsDialog.cs
@@ -5,8 +5,7 @@ namespace Ivy.Tendril.Apps.Plans.Dialogs;
 ///     <para>
 ///         Not a block: an unanswered question means "you decide", and ExecutePlan resolves one
 ///         itself by taking the <c>recommended</c> option. This is the confirmation that you meant
-///         to let it. Optional questions are never counted here — the plan is complete without
-///         them, so they are not something to warn about.
+///         to let it.
 ///     </para>
 /// </summary>
 public class UnansweredQuestionsDialog(


### PR DESCRIPTION
Fixes #2317

# Summary

## Changes

Updated unanswered questions counting in `ContentView` to count all questions without an answer regardless of whether they are marked optional. Updated documentation comments in `UnansweredQuestionsDialog` and inline comments in `ContentView` to reflect that all unanswered questions are counted. Added comprehensive unit tests in `ContentViewTests`.

## API Changes

- `ContentView.CountUnansweredQuestions(IEnumerable<QuestionSummary> questions)` (internal static)
- `ContentView.CountUnansweredQuestions(string? revisionContent)` (internal static)

## Files Modified

- `src/Ivy.Tendril/Apps/Plans/ContentView.cs`: Updated question counting logic and removed outdated comment. Added internal helper methods.
- `src/Ivy.Tendril/Apps/Plans/Dialogs/UnansweredQuestionsDialog.cs`: Updated XML documentation comment to remove stale note that optional questions are excluded.
- `src/Ivy.Tendril.Test/ContentViewTests.cs`: Added unit tests covering unanswered question counts for required and optional questions.

## Manual Testing

1. Open Tendril in browser or desktop app.
2. Navigate to a plan that contains unanswered questions including at least one optional question (or create a draft plan containing both required and optional unanswered questions in a questions block).
3. Click the Execute button to open the Unanswered Questions confirmation dialog.
4. Verify the dialog message accurately reports the total count of unanswered questions, including any optional ones.

---

## Commits
- 0528605 Plan 00013: Include optional questions in unanswered questions count

---
Created using [Ivy Tendril](https://ivy.app).
