### PR TITLE
fix(plans): replace draft terminology with plans in process viewer, dashboard, and empty states

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
@@ -78,7 +78,7 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
   };
 
   const statusItems = [
-    { icon: <Feather size={16} />, count: draftCount, label: "Drafts", event: "OnDrafts" },
+    { icon: <Feather size={16} />, count: draftCount, label: "Plans", event: "OnDrafts" },
     { icon: <Sprout size={16} />, count: inProgressCount, label: "In Progress", event: "OnJobs" },
     { icon: <Eye size={16} />, count: reviewCount, label: "Ready For Review", event: "OnReview" },
     { icon: <Check size={16} />, count: completedCount, label: "Completed", event: "OnJobs" },

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/TendrilProcessViewer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilProcessViewer/TendrilProcessViewer.tsx
@@ -100,14 +100,14 @@ export const TendrilProcessViewer: React.FC<TendrilProcessViewerProps> = ({
           onClick={() => fireEvent("OnJobs")}
         />
 
-        {/* Drafts with updating loop */}
+        {/* Plans with updating loop */}
         <div className="tpv-stage-wrapper">
           {updatingPlansCount > 0 && (
             <LoopArrow count={updatingPlansCount} onClick={() => fireEvent("OnJobs")} />
           )}
           <button className="tpv-box tpv-box-stage" onClick={() => fireEvent("OnDrafts")}>
             <Feather size={14} className="tpv-box-stage-icon" />
-            <span className="tpv-box-label">Drafts{draftCount > 0 && <span className="tpv-box-count">{draftCount}</span>}</span>
+            <span className="tpv-box-label">Plans{draftCount > 0 && <span className="tpv-box-count">{draftCount}</span>}</span>
           </button>
         </div>
 

--- a/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ActionBarView.cs
@@ -42,13 +42,13 @@ public class ActionBarView(
         var isBeta = BetaHelper.IsBeta(tendrilArgs, config);
         var (agentLabel, agentIcon) = AgentBranding.For(config.Settings.CodingAgent, agentRunner, config);
 
-        void HandleShareDraft()
+        void HandleSharePlan()
         {
             if (shareTunnelService.IsConnected && !string.IsNullOrEmpty(shareTunnelService.TunnelUrl))
             {
                 var link = shareTunnelService.GetShareUrlForPlan(selectedPlan.FolderName, isReview: false);
                 copyToClipboard(link);
-                client.Toast("Draft share link copied to clipboard", "Link Copied");
+                client.Toast("Plan share link copied to clipboard", "Link Copied");
             }
             else
             {
@@ -60,7 +60,7 @@ public class ActionBarView(
         {
             // Share / Read-only mode: only Share and Copy Plan buttons
             return Layout.Horizontal().AlignContent(Align.Left).Gap(2)
-                | new Button("Share Draft").Icon(Icons.Share2).Outline().OnClick(HandleShareDraft)
+                | new Button("Share Plan").Icon(Icons.Share2).Outline().OnClick(HandleSharePlan)
                 | new Button("Copy Plan").Icon(Icons.ClipboardCopy).Ghost().OnClick(() =>
                 {
                     var exported = PlanExportHelper.ExportToClipboard(selectedPlan);
@@ -201,7 +201,7 @@ public class ActionBarView(
         if (isBeta)
         {
             minimalDropdownItems.Add(new MenuItem("Share", Icon: Icons.Share2, Tag: "Share")
-                .OnSelect(HandleShareDraft));
+                .OnSelect(HandleSharePlan));
         }
         minimalDropdownItems.AddRange(new[]
         {
@@ -223,7 +223,7 @@ public class ActionBarView(
         if (isBeta)
         {
             actionBar |= new Button("Share").Icon(Icons.Share2).Outline()
-                .OnClick(HandleShareDraft).CompactUp();
+                .OnClick(HandleSharePlan).CompactUp();
         }
 
         actionBar = actionBar

--- a/src/Ivy.Tendril/Apps/Plans/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Plans/ContentView.cs
@@ -462,7 +462,7 @@ public class ContentView(
     private object BuildNoSelectionView(object processView)
     {
         if (allPlans.Count == 0)
-            return new NoContentView("No draft plans", "Plans you create will appear here", processView);
+            return new NoContentView("No plans", "Plans you create will appear here", processView);
 
         return Layout.Vertical().AlignContent(Align.Center).Height(Size.Full())
                | Text.Muted("Select a plan from the sidebar");

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/UpdatePlanDialog.cs
@@ -83,7 +83,7 @@ public class UpdatePlanDialog(
             new DialogHeader($"Update Plan #{_selectedPlan.Id}"),
             new DialogBody(
                 Layout.Vertical()
-                | Text.P("Provide instructions for revising this draft plan.")
+                | Text.P("Provide instructions for revising this plan.")
                 | (hasActiveJob ? Text.P("⚠️ UpdatePlan is already running for this plan. Please wait...").Color(Colors.Warning) : null)
                 | new Ivy.Tendril.Widgets.ContentInput
                 {


### PR DESCRIPTION
## Summary
Replaces old "Draft" terminology with "Plans" across the wallpaper / empty states and UI:

- **Wallpaper Process Viewer**: Updates stage box label from `Drafts` to `Plans` in the process pipeline (`[New Plan +] -> [Plans] -> [Review]`).
- **Dashboard**: Updates the status card label from `"Drafts"` to `"Plans"`.
- **Plans Empty State**: Changes title from `"No draft plans"` to `"No plans"` in `ContentView.cs`.
- **Action Bar & Dialogs**: Updates action bar button to `"Share Plan"`, toast notification to `"Plan share link copied to clipboard"`, and update dialog description to `"Provide instructions for revising this plan."`.

## Verification
- Built frontend widgets bundle and ran vitest (all 290 tests pass).
- Built `Ivy.Tendril.csproj` and ran Plans tests (all 148 tests pass).