### PR TITLE
[00147] Fix Flaky Hanging Hook Test by Making Hook Guards Injectable

### DIFF
--- a/src/Ivy.Tendril.Test/JobServiceHookTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceHookTests.cs
@@ -354,7 +354,9 @@ public class JobServiceHookTests : IDisposable
     // Regression for the #1455 class: a before-hook runs synchronously in the un-monitored pre-launch
     // window (before JobMonitor/TimeoutCts exist), so a hook that never returns would wedge the launch
     // forever with no timeout able to fire. The hook process must be force-killed at its guard
-    // (10s for conditions, 30s for actions) rather than blocking on a ReadToEnd that never completes.
+    // (defaults: 10s for conditions, 30s for actions) rather than blocking on a ReadToEnd that never
+    // completes. This test overrides the condition guard to 1s so the test runtime does not track
+    // pwsh startup and thread pool contention on a loaded machine.
     [Fact]
     public async Task RunHooks_HangingBeforeHook_IsKilledAndDoesNotWedgeLaunch()
     {
@@ -364,23 +366,34 @@ public class JobServiceHookTests : IDisposable
             {
                 Name = "Hanging Hook",
                 When = "before",
-                Condition = "Start-Sleep -Seconds 120; $true", // never returns within the 10s guard
+                Condition = "Start-Sleep -Seconds 120; $true", // never returns within any guard
                 Action = "Write-Host should-not-run"
             }
         };
         var (service, _) = CreateServiceWithHooks(hooks);
+        // The assertion is that a hung hook is killed at its guard, so run a guard the test can afford:
+        // with the real 10s this test measured 10s against a 30s allowance, leaving pwsh startup and
+        // machine load to fit in the remainder. Start-Sleep -Seconds 120 outlives any guard, so the kill
+        // path is identical.
+        service.HookConditionTimeout = TimeSpan.FromSeconds(1);
         var planFolder = CreateTempPlanFolder();
 
         try
         {
-            // StartJob runs before-hooks synchronously; if the hang regressed it would not return.
-            var startTask = Task.Run(() => service.StartJob(new ExecutePlanArgs(planFolder)));
-            var completed = await Task.WhenAny(startTask, Task.Delay(TimeSpan.FromSeconds(30)));
-            Assert.Equal(startTask, completed);
+            // A dedicated thread, not the thread pool: before-hooks run synchronously inside StartJob and
+            // block, so on a pool saturated by other suites the work item can sit queued while the allowance
+            // below is already counting.
+            var startTask = Task.Factory.StartNew(
+                () => service.StartJob(new ExecutePlanArgs(planFolder)),
+                TaskCreationOptions.LongRunning);
+            var allowance = TimeSpan.FromSeconds(30);
+            var completed = await Task.WhenAny(startTask, Task.Delay(allowance));
+            Assert.True(completed == startTask,
+                $"StartJob did not return within {allowance.TotalSeconds:0}s despite a 1s hook guard: a hung before-hook wedged the launch.");
 
             var job = service.GetJob(await startTask)!;
             Assert.Contains(job.OutputLines,
-                l => l.Contains("[hook:Hanging Hook]") && l.Contains("timed out"));
+                l => l.Contains("[hook:Hanging Hook]") && l.Contains("Condition timed out after 1s"));
             Assert.DoesNotContain(job.OutputLines, l => l.Contains("should-not-run"));
 
             service.CompleteJob(job.Id, 0);
@@ -389,6 +402,17 @@ public class JobServiceHookTests : IDisposable
         {
             Directory.Delete(planFolder, true);
         }
+    }
+
+    [Fact]
+    public void HookGuards_DefaultToProductionValues()
+    {
+        // Guards the seam added for RunHooks_HangingBeforeHook_IsKilledAndDoesNotWedgeLaunch: a test
+        // shortens these, so nothing should be able to ship the shortened values.
+        var (service, _) = CreateServiceWithHooks(new List<PromptwareHookConfig>());
+
+        Assert.Equal(TimeSpan.FromSeconds(10), service.HookConditionTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(30), service.HookActionTimeout);
     }
 
     [Fact]

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -23,6 +23,11 @@ internal class JobCompletionHandler
     private readonly PlanArtifactSyncer _artifactSyncer;
     private readonly DependencyChecker _dependencyChecker;
 
+    // Guards for the pwsh processes a hook spawns. Settable so a test can exercise the kill path
+    // without paying the real guard in wall clock time, matching JobService.JobTimeout.
+    internal TimeSpan HookConditionTimeout { get; set; } = TimeSpan.FromSeconds(10);
+    internal TimeSpan HookActionTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
     internal JobCompletionHandler(
         IConfigService? configService,
         ILogger logger,
@@ -419,7 +424,7 @@ internal class JobCompletionHandler
         }
     }
 
-    private static bool EvaluateHookCondition(PromptwareHookConfig hook, string planFolder, JobItem job)
+    private bool EvaluateHookCondition(PromptwareHookConfig hook, string planFolder, JobItem job)
     {
         if (string.IsNullOrWhiteSpace(hook.Condition))
             return true;
@@ -449,13 +454,13 @@ internal class JobCompletionHandler
         // class). The reads complete when the pipes close on exit or kill.
         var condOutTask = condProc.StandardOutput.ReadToEndAsync();
         var condErrTask = condProc.StandardError.ReadToEndAsync();
-        var condExitedNormally = condProc.WaitForExitOrKill(10000);
+        var condExitedNormally = condProc.WaitForExitOrKill((int)HookConditionTimeout.TotalMilliseconds);
         var condOutput = HarvestHookStream(condOutTask);
         _ = HarvestHookStream(condErrTask); // drain to prevent a full stderr pipe from wedging the read
 
         if (!condExitedNormally)
         {
-            job.EnqueueSystemOutput($"[hook:{hook.Name}] Condition timed out after 10s and was terminated, skipping");
+            job.EnqueueSystemOutput($"[hook:{hook.Name}] Condition timed out after {HookConditionTimeout.TotalSeconds:0.##}s and was terminated, skipping");
             return false;
         }
 
@@ -516,7 +521,7 @@ internal class JobCompletionHandler
         // class). The reads complete when the pipes close on exit or kill.
         var outTask = actionProc.StandardOutput.ReadToEndAsync();
         var errTask = actionProc.StandardError.ReadToEndAsync();
-        var exitedNormally = actionProc.WaitForExitOrKill(30000);
+        var exitedNormally = actionProc.WaitForExitOrKill((int)HookActionTimeout.TotalMilliseconds);
         var output = HarvestHookStream(outTask);
         var stderr = HarvestHookStream(errTask);
 
@@ -526,7 +531,7 @@ internal class JobCompletionHandler
             job.EnqueueSystemOutput($"[hook:{hook.Name}] [stderr] {stderr}");
 
         if (!exitedNormally)
-            job.EnqueueSystemOutput($"[hook:{hook.Name}] Hook timed out after 30s and was terminated");
+            job.EnqueueSystemOutput($"[hook:{hook.Name}] Hook timed out after {HookActionTimeout.TotalSeconds:0.##}s and was terminated");
         else if (actionProc.ExitCode != 0)
             job.EnqueueSystemOutput($"[hook:{hook.Name}] Hook failed with exit code {actionProc.ExitCode}");
     }

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -1407,6 +1407,18 @@ public class JobService : IJobService
         set => _staleOutputTimeout = value;
     }
 
+    internal TimeSpan HookConditionTimeout
+    {
+        get => _completionHandler.HookConditionTimeout;
+        set => _completionHandler.HookConditionTimeout = value;
+    }
+
+    internal TimeSpan HookActionTimeout
+    {
+        get => _completionHandler.HookActionTimeout;
+        set => _completionHandler.HookActionTimeout = value;
+    }
+
 
     private void ProcessJobQueue()
     {


### PR DESCRIPTION
## Problem

JobServiceHookTests.RunHooks_HangingBeforeHook_IsKilledAndDoesNotWedgeLaunch failed once in four full-suite runs during execution. It spawns PowerShell running Start-Sleep -Seconds 120, expects a 10 second guard to kill it, and allows 30 seconds for the whole thing.

The test has a pass margin of about 3x, but nothing in the test is cheap enough to absorb a loaded machine. Two load-sensitive costs sit inside that margin:

1. **pwsh startup** - The bundled PowerShell startup can take seconds under contention or antivirus scanning
2. **Thread pool scheduling** - Before-hooks run synchronously inside StartJob, so Task.Run parks a pool thread on a blocking WaitForExit. When the pool is saturated by other suites, the work item may not start for seconds while the 30s allowance is already counting.

## Solution

Make the two hook guards injectable as internal test seam properties on JobService, matching the existing JobTimeout and StaleOutputTimeout. The hanging test then injects a 1s condition guard, which drops its expected runtime from 10s to about 1s while keeping the 30s allowance unchanged (roughly 30x headroom instead of 3x).

### Changes:
1. **JobCompletionHandler** - Replace hard coded guards with injectable TimeSpan properties (HookConditionTimeout, HookActionTimeout)
2. **JobService** - Expose the guards to the test project via pass-through properties
3. **JobServiceHookTests** - Inject 1s guard in the hanging test and replace Task.Run with dedicated thread to avoid pool contention
4. **New test** - HookGuards_DefaultToProductionValues pins the production defaults (10s condition, 30s action)

---

**Commits:**
- 6a30990d Make hook guards injectable to fix flaky test

---
Created using [Ivy Tendril](https://ivy.app).
