### PR TITLE
[00207] Stop Hijacking Cmd+A for the New Agent Chat Shortcut

### DIFF
--- a/src/Ivy.Tendril.Test/AppShell/ShellAgentButtonDefaultsTests.cs
+++ b/src/Ivy.Tendril.Test/AppShell/ShellAgentButtonDefaultsTests.cs
@@ -1,0 +1,15 @@
+using Ivy.Tendril.Widgets;
+
+namespace Ivy.Tendril.Test.AppShell;
+
+public class ShellAgentButtonDefaultsTests
+{
+    [Fact]
+    public void ShortcutKey_Default_ReturnsA()
+    {
+        // Contract pin: the letter "A" is the value both C# and TSX sides agree on.
+        // This test verifies the default value — it does NOT cover the chord behavior
+        // (Cmd+Opt+A / Ctrl+Alt+A), which is exercised by ShellAgentButton.test.tsx.
+        Assert.Equal("A", new ShellAgentButton().ShortcutKey);
+    }
+}

--- a/src/Ivy.Tendril.Widgets/ShellAgentButton.cs
+++ b/src/Ivy.Tendril.Widgets/ShellAgentButton.cs
@@ -13,7 +13,7 @@ public record ShellAgentButton : WidgetBase<ShellAgentButton>
     /// <summary>Icon name from AgentBranding.IconFor (e.g. "ClaudeCode"); mapped to a brand SVG client-side.</summary>
     [Prop] public string? Icon { get; init; }
 
-    /// <summary>Key combined with the platform command key (Cmd/Ctrl), handled client-side.</summary>
+    /// <summary>Single letter combined with Cmd+Opt (macOS) or Ctrl+Alt (Windows/Linux), handled client-side.</summary>
     [Prop] public string ShortcutKey { get; init; } = "A";
 
     /// <summary>Highlights the row while an agent session is the visible pane.</summary>

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { ShellAgentButton } from "./ShellAgentButton";
+
+describe("ShellAgentButton", () => {
+  it("fires OnNewChat on Ctrl+Alt+A", () => {
+    const handler = vi.fn();
+    render(
+      <ShellAgentButton
+        id="agent"
+        events={["OnNewChat"]}
+        eventHandler={handler}
+        label="Claude Code"
+      />
+    );
+
+    fireEvent.keyDown(document.body, {
+      key: "a",
+      code: "KeyA",
+      ctrlKey: true,
+      altKey: true,
+    });
+
+    expect(handler).toHaveBeenCalledWith("OnNewChat", "agent", []);
+  });
+
+  it("does NOT fire OnNewChat on plain Ctrl+A (regression guard for #2338)", () => {
+    const handler = vi.fn();
+    render(
+      <ShellAgentButton
+        id="agent"
+        events={["OnNewChat"]}
+        eventHandler={handler}
+        label="Claude Code"
+      />
+    );
+
+    const notPrevented = fireEvent.keyDown(document.body, {
+      key: "a",
+      code: "KeyA",
+      ctrlKey: true,
+    });
+
+    expect(notPrevented).toBe(true); // event was NOT prevented
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("ignores the chord while typing", () => {
+    const handler = vi.fn();
+    const { container } = render(
+      <div>
+        <input aria-label="field" />
+        <ShellAgentButton
+          id="agent"
+          events={["OnNewChat"]}
+          eventHandler={handler}
+          label="Claude Code"
+        />
+      </div>
+    );
+
+    const input = container.querySelector('input[aria-label="field"]')!;
+    fireEvent.keyDown(input, {
+      key: "a",
+      code: "KeyA",
+      ctrlKey: true,
+      altKey: true,
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("renders three-segment hint and tooltip", () => {
+    const { container } = render(
+      <ShellAgentButton
+        id="agent"
+        events={["OnNewChat"]}
+        eventHandler={vi.fn()}
+        label="Claude Code"
+      />
+    );
+
+    const button = container.querySelector("button.tsh-agent")!;
+    expect(button.title).toBe("Claude Code (Ctrl+Alt+A)");
+
+    const kbd = container.querySelector(".tsh-kbd")!;
+    const spans = kbd.querySelectorAll("span");
+    expect(spans).toHaveLength(3);
+    expect(spans[0].textContent).toBe("Ctrl");
+    expect(spans[1].textContent).toBe("Alt");
+    expect(spans[2].textContent).toBe("A");
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.test.tsx
@@ -80,7 +80,7 @@ describe("ShellAgentButton", () => {
       />
     );
 
-    const button = container.querySelector("button.tsh-agent")!;
+    const button = container.querySelector("button.tsh-agent") as HTMLButtonElement;
     expect(button.title).toBe("Claude Code (Ctrl+Alt+A)");
 
     const kbd = container.querySelector(".tsh-kbd")!;

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from "react";
 import { BrandIcon } from "./brandIcons";
-import { ShellWidgetProps, isEditableTarget, isModKey, modKeyLabel } from "./types";
+import { ShellWidgetProps, isEditableTarget, isModKey, isMac } from "./types";
 import "./shell.css";
 
 interface ShellAgentButtonProps extends ShellWidgetProps {
@@ -12,8 +12,8 @@ interface ShellAgentButtonProps extends ShellWidgetProps {
 
 /**
  * The coding-agent row: clicking it opens the latest agent session, and
- * Cmd/Ctrl+shortcutKey starts a new one. The shortcut is ignored while typing
- * so it never fights select-all in inputs.
+ * Cmd+Opt+shortcutKey (macOS) / Ctrl+Alt+shortcutKey (Windows/Linux) starts a
+ * new one. The shortcut is ignored while typing.
  */
 export const ShellAgentButton: React.FC<ShellAgentButtonProps> = ({
   id,
@@ -34,11 +34,13 @@ export const ShellAgentButton: React.FC<ShellAgentButtonProps> = ({
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      // shortcutKey is a single letter, so the Key prefix composes correctly
       if (
         isModKey(e) &&
+        e.altKey &&
         !e.shiftKey &&
-        !e.altKey &&
-        e.key.toLowerCase() === shortcutKey.toLowerCase() &&
+        (e.code === `Key${shortcutKey.toUpperCase()}` ||
+          e.key.toLowerCase() === shortcutKey.toLowerCase()) &&
         !isEditableTarget(e)
       ) {
         e.preventDefault();
@@ -49,13 +51,15 @@ export const ShellAgentButton: React.FC<ShellAgentButtonProps> = ({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [fireNewChat, shortcutKey]);
 
+  const hintKeys = isMac() ? ["⌘", "⌥", shortcutKey] : ["Ctrl", "Alt", shortcutKey];
+
   return (
     <div className="tsh-agent-wrap">
       <button
         className="tsh-agent"
         data-active={isActive}
         onClick={fireOpen}
-        title={label}
+        title={`${label} (${hintKeys.join("+")})`}
       >
         <span className="tsh-agent-brand">
           <span className="tsh-agent-icon">
@@ -65,8 +69,9 @@ export const ShellAgentButton: React.FC<ShellAgentButtonProps> = ({
         </span>
         <span className="tsh-agent-actions">
           <span className="tsh-kbd">
-            <span>{modKeyLabel()}</span>
-            <span>{shortcutKey}</span>
+            {hintKeys.map((k) => (
+              <span key={k}>{k}</span>
+            ))}
           </span>
         </span>
       </button>


### PR DESCRIPTION
Fixes #2338

# Summary

## Changes

Changed the agent chat shortcut from Cmd+A to Cmd+Opt+A (macOS) / Ctrl+Alt+A (Windows/Linux) to stop hijacking the system Select All command. The new chord matches the shape of the New Plan shortcut (Cmd+Opt+N) directly above it in the sidebar.

## API Changes

**Modified components:**
- `ShellAgentButton` - The keyboard shortcut now requires Alt/Option in addition to the platform command key. The `ShortcutKey` property contract is unchanged (still a single letter, default "A"), but the rendered hint and actual chord now include Alt.

**No breaking changes** - The server-side API is unchanged. Existing call sites do not need updates.

## Files Modified

**Widget implementation:**
- `src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.tsx` - Updated keyboard handler to require Alt, added e.code check for physical key matching, rendered three-segment hint, updated doc comment
- `src/Ivy.Tendril.Widgets/ShellAgentButton.cs` - Updated doc comment to reflect new chord

**Tests:**
- `src/Ivy.Tendril.Widgets/frontend/src/Shell/ShellAgentButton.test.tsx` (new) - Four test cases including regression guard for #2338
- `src/Ivy.Tendril.Test/AppShell/ShellAgentButtonDefaultsTests.cs` (new) - Contract pin for default shortcut key value

## Manual Testing

1. Run the application: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`
2. Navigate to any app (Plans, Jobs, Review, etc.)
3. With focus on a text-containing area (plan markdown, diff viewer, logs), press Cmd+A (macOS) or Ctrl+A (Windows)
   - **Expected:** Text is selected (Select All works)
   - **Before this fix:** A new agent chat session opened instead
4. Press Cmd+Opt+A (macOS) or Ctrl+Alt+A (Windows)
   - **Expected:** A new agent chat session opens in the sidebar
5. Observe the sidebar agent button's keyboard hint
   - **Expected (macOS):** Shows three segments: ⌘ ⌥ A
   - **Expected (Windows/Linux):** Shows three segments: Ctrl Alt A
6. Hover over the agent button
   - **Expected tooltip (macOS):** "Claude Code (⌘+⌥+A)"
   - **Expected tooltip (Windows/Linux):** "Claude Code (Ctrl+Alt+A)"

**Note:** The TypeScript tests can be run manually to verify the keyboard behavior:
```bash
cd src/Ivy.Tendril.Widgets/frontend
./node_modules/.bin/vitest run src/Shell/ShellAgentButton.test.tsx
```

---

## Commits

- f98f4f03 Fix TypeScript error in ShellAgentButton.test.tsx
- 5eea328f Change agent chat shortcut from Cmd+A to Cmd+Opt+A

---
Created using [Ivy Tendril](https://ivy.app).
