### PR TITLE
[00214] Bound Worktree Path Length by Shortening Plan Folder Names

### DIFF
--- a/src/Ivy.Tendril.Test/PathBudgetCheckTests.cs
+++ b/src/Ivy.Tendril.Test/PathBudgetCheckTests.cs
@@ -1,0 +1,83 @@
+using Ivy.Tendril.Commands.DoctorChecks;
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test;
+
+public class PathBudgetCheckTests
+{
+    [Fact]
+    public void Classify_ReturnsOkAtMaxBudget()
+    {
+        var result = PathBudgetCheck.Classify(95);
+
+        Assert.Equal(StatusKind.Ok, result);
+    }
+
+    [Fact]
+    public void Classify_ReturnsWarnAt96()
+    {
+        var result = PathBudgetCheck.Classify(96);
+
+        Assert.Equal(StatusKind.Warn, result);
+    }
+
+    [Fact]
+    public void Classify_ReturnsWarnAt125()
+    {
+        var result = PathBudgetCheck.Classify(125);
+
+        Assert.Equal(StatusKind.Warn, result);
+    }
+
+    [Fact]
+    public void Classify_ReturnsErrorAt126()
+    {
+        var result = PathBudgetCheck.Classify(126);
+
+        Assert.Equal(StatusKind.Error, result);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithLegacyFolders_ReportsWarnButNoError()
+    {
+        using var fixture = new TempDirectoryFixture();
+        var plansRoot = fixture.TempDirectory;
+
+        var legacyFolderName = "00001-" + new string('A', 60);
+        Directory.CreateDirectory(Path.Combine(plansRoot, legacyFolderName));
+
+        var mockConfigService = new MockConfigService { PlansFolder = plansRoot };
+        var check = new PathBudgetCheck(mockConfigService);
+
+        var result = await check.RunAsync();
+
+        Assert.False(result.HasErrors, "Legacy folders should not cause HasErrors to be true");
+        var legacyStatus = result.Statuses.FirstOrDefault(s => s.Label == "Legacy plan folders over budget");
+        Assert.NotNull(legacyStatus);
+        Assert.Equal(StatusKind.Warn, legacyStatus.Kind);
+        Assert.Contains("1 folder", legacyStatus.Value);
+    }
+
+    private class MockConfigService : Services.IConfigService
+    {
+        public string PlansFolder { get; set; } = string.Empty;
+        public List<Models.ProjectConfig> Projects { get; } = new();
+
+        public string ConfigPath => string.Empty;
+        public string TendrilHome => string.Empty;
+        public string? DefaultExecutionProfile => null;
+        public List<Models.Level> Levels => new();
+        public List<Models.VerificationConfig> Verifications => new();
+        public Dictionary<string, string> ReviewActions => new();
+        public Models.LLMConfig LLM => new();
+        public string? AppsUri => null;
+        public List<string> PinnedTools => new();
+        public bool McpEnabled => false;
+        public List<Models.McpServerConfig> McpServers => new();
+
+        public string? GetAppUri(string appName) => null;
+        public Models.ProjectConfig? GetProject(string projectName) => null;
+        public Models.VerificationConfig? GetVerification(string verificationName) => null;
+        public void Reload() { }
+    }
+}

--- a/src/Ivy.Tendril.Test/PathBudgetCheckTests.cs
+++ b/src/Ivy.Tendril.Test/PathBudgetCheckTests.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Commands.DoctorChecks;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
 
 namespace Ivy.Tendril.Test;
 
@@ -41,7 +42,7 @@ public class PathBudgetCheckTests
     public async Task RunAsync_WithLegacyFolders_ReportsWarnButNoError()
     {
         using var fixture = new TempDirectoryFixture();
-        var plansRoot = fixture.TempDirectory;
+        var plansRoot = fixture.Path;
 
         var legacyFolderName = "00001-" + new string('A', 60);
         Directory.CreateDirectory(Path.Combine(plansRoot, legacyFolderName));
@@ -58,38 +59,40 @@ public class PathBudgetCheckTests
         Assert.Contains("1 folder", legacyStatus.Value);
     }
 
-    private class MockConfigService : Services.IConfigService
+    private class MockConfigService : IConfigService
     {
         public string PlanFolder { get; set; } = string.Empty;
-        public List<Services.ProjectConfig> Projects { get; } = new();
+        public List<ProjectConfig> Projects { get; } = new();
 
-        public Services.TendrilSettings Settings => new();
+        public TendrilSettings Settings => new();
         public string ConfigPath => string.Empty;
         public string TendrilHome => string.Empty;
-        public List<Services.LevelConfig> Levels => new();
+        public List<LevelConfig> Levels => new();
         public string[] LevelNames => Array.Empty<string>();
-        public Services.EditorConfig Editor => new();
+        public EditorConfig Editor => new();
         public bool NeedsOnboarding => false;
-        public Services.ConfigParseError? ParseError => null;
+        public ConfigParseError? ParseError => null;
 
-        public Services.ProjectConfig? GetProject(string name) => null;
+        public ProjectConfig? GetProject(string name) => null;
         public bool TryAutoHeal() => false;
         public void ResetToDefaults() { }
         public void RetryLoadConfig() { }
         public Ivy.Colors? GetLevelColor(string level) => null;
         public Ivy.Colors? GetProjectColor(string projectName) => null;
         public void SaveSettings() { }
-        public void MutateAndSave(Action<Services.TendrilSettings> mutate) { }
+        public void MutateAndSave(Action<TendrilSettings> mutate) { }
         public void ReloadSettings() { }
+#pragma warning disable CS0067
         public event EventHandler? SettingsReloaded;
+#pragma warning restore CS0067
         public void SetPendingTendrilHome(string path) { }
         public string? GetPendingTendrilHome() => null;
-        public void SetPendingProject(Services.ProjectConfig project) { }
-        public Services.ProjectConfig? GetPendingProject() => null;
+        public void SetPendingProject(ProjectConfig project) { }
+        public ProjectConfig? GetPendingProject() => null;
         public void SetPendingCodingAgent(string name) { }
         public string? GetPendingCodingAgent() => null;
-        public void SetPendingVerificationDefinitions(List<Services.VerificationConfig> definitions) { }
-        public List<Services.VerificationConfig>? GetPendingVerificationDefinitions() => null;
+        public void SetPendingVerificationDefinitions(List<VerificationConfig> definitions) { }
+        public List<VerificationConfig>? GetPendingVerificationDefinitions() => null;
         public void CompleteOnboarding(string tendrilHome) { }
         public void OpenInEditor(string path) { }
         public string PolishMarkdown(string content) => content;

--- a/src/Ivy.Tendril.Test/PathBudgetCheckTests.cs
+++ b/src/Ivy.Tendril.Test/PathBudgetCheckTests.cs
@@ -46,7 +46,7 @@ public class PathBudgetCheckTests
         var legacyFolderName = "00001-" + new string('A', 60);
         Directory.CreateDirectory(Path.Combine(plansRoot, legacyFolderName));
 
-        var mockConfigService = new MockConfigService { PlansFolder = plansRoot };
+        var mockConfigService = new MockConfigService { PlanFolder = plansRoot };
         var check = new PathBudgetCheck(mockConfigService);
 
         var result = await check.RunAsync();
@@ -60,24 +60,39 @@ public class PathBudgetCheckTests
 
     private class MockConfigService : Services.IConfigService
     {
-        public string PlansFolder { get; set; } = string.Empty;
-        public List<Models.ProjectConfig> Projects { get; } = new();
+        public string PlanFolder { get; set; } = string.Empty;
+        public List<Services.ProjectConfig> Projects { get; } = new();
 
+        public Services.TendrilSettings Settings => new();
         public string ConfigPath => string.Empty;
         public string TendrilHome => string.Empty;
-        public string? DefaultExecutionProfile => null;
-        public List<Models.Level> Levels => new();
-        public List<Models.VerificationConfig> Verifications => new();
-        public Dictionary<string, string> ReviewActions => new();
-        public Models.LLMConfig LLM => new();
-        public string? AppsUri => null;
-        public List<string> PinnedTools => new();
-        public bool McpEnabled => false;
-        public List<Models.McpServerConfig> McpServers => new();
+        public List<Services.LevelConfig> Levels => new();
+        public string[] LevelNames => Array.Empty<string>();
+        public Services.EditorConfig Editor => new();
+        public bool NeedsOnboarding => false;
+        public Services.ConfigParseError? ParseError => null;
 
-        public string? GetAppUri(string appName) => null;
-        public Models.ProjectConfig? GetProject(string projectName) => null;
-        public Models.VerificationConfig? GetVerification(string verificationName) => null;
-        public void Reload() { }
+        public Services.ProjectConfig? GetProject(string name) => null;
+        public bool TryAutoHeal() => false;
+        public void ResetToDefaults() { }
+        public void RetryLoadConfig() { }
+        public Ivy.Colors? GetLevelColor(string level) => null;
+        public Ivy.Colors? GetProjectColor(string projectName) => null;
+        public void SaveSettings() { }
+        public void MutateAndSave(Action<Services.TendrilSettings> mutate) { }
+        public void ReloadSettings() { }
+        public event EventHandler? SettingsReloaded;
+        public void SetPendingTendrilHome(string path) { }
+        public string? GetPendingTendrilHome() => null;
+        public void SetPendingProject(Services.ProjectConfig project) { }
+        public Services.ProjectConfig? GetPendingProject() => null;
+        public void SetPendingCodingAgent(string name) { }
+        public string? GetPendingCodingAgent() => null;
+        public void SetPendingVerificationDefinitions(List<Services.VerificationConfig> definitions) { }
+        public List<Services.VerificationConfig>? GetPendingVerificationDefinitions() => null;
+        public void CompleteOnboarding(string tendrilHome) { }
+        public void OpenInEditor(string path) { }
+        public string PolishMarkdown(string content) => content;
+        public void Dispose() { }
     }
 }

--- a/src/Ivy.Tendril.Test/PlanYamlHelperVerificationTests.cs
+++ b/src/Ivy.Tendril.Test/PlanYamlHelperVerificationTests.cs
@@ -147,4 +147,36 @@ public class PlanYamlHelperVerificationTests
     {
         Assert.Equal("TestPlan", PlanYamlHelper.ExtractSafeTitleFromFolder("00015-TestPlan"));
     }
+
+    [Fact]
+    public void ToSafeTitle_TruncatesLongTitleToMaxLength()
+    {
+        var longTitle = new string('A', 200);
+
+        var result = PlanYamlHelper.ToSafeTitle(longTitle);
+
+        Assert.Equal(PlanYamlHelper.SafeTitleMaxLength, result.Length);
+    }
+
+    [Fact]
+    public void ToSafeTitle_ShortTitleIsUntouched()
+    {
+        var shortTitle = "Fix Login Bug";
+
+        var result = PlanYamlHelper.ToSafeTitle(shortTitle);
+
+        Assert.Equal("FixLoginBug", result);
+        Assert.True(result.Length <= PlanYamlHelper.SafeTitleMaxLength);
+    }
+
+    [Fact]
+    public void ToSafeTitle_ResultIsAlphanumericAfterTruncation()
+    {
+        var titleWithSpecialChars = new string('A', 15) + "!@#$%^&*()" + new string('B', 15);
+
+        var result = PlanYamlHelper.ToSafeTitle(titleWithSpecialChars);
+
+        Assert.All(result, c => Assert.True(char.IsLetterOrDigit(c)));
+        Assert.True(result.Length <= PlanYamlHelper.SafeTitleMaxLength);
+    }
 }

--- a/src/Ivy.Tendril.Test/WorktreePathBudgetTests.cs
+++ b/src/Ivy.Tendril.Test/WorktreePathBudgetTests.cs
@@ -1,0 +1,115 @@
+using Ivy.Tendril.Helpers;
+
+namespace Ivy.Tendril.Test;
+
+public class WorktreePathBudgetTests
+{
+    [Fact]
+    public void WorstCaseWorktreeRootLength_ReturnsExpectedLengthForNewCap()
+    {
+        var plansRoot = 17; // D:\.tendril\Plans
+        var repoPath = 31; // SpaceCorps\components-storybook
+
+        var result = WorktreePathHelper.WorstCaseWorktreeRootLength(plansRoot, repoPath);
+
+        Assert.Equal(90, result);
+    }
+
+    [Fact]
+    public void WorstCaseWorktreeRootLength_ReturnsExpectedLengthForLegacyCap()
+    {
+        var plansRoot = 17; // D:\.tendril\Plans
+        var repoPath = 31; // SpaceCorps\components-storybook
+        var legacyFolderLength = 66; // 5 (ID) + 1 (dash) + 60 (old SafeTitleMaxLength)
+
+        var result = WorktreePathHelper.WorstCaseWorktreeRootLength(plansRoot, repoPath, legacyFolderLength);
+
+        Assert.Equal(126, result);
+    }
+
+    [Theory]
+    [InlineData(133, 259)] // components-storybook tsgolint.exe
+    [InlineData(138, 259)] // ivy-tendril tsgolint.exe
+    [InlineData(133, 246)] // foundry tsgolint.CMD
+    [InlineData(148, 246)] // deepest nested components-storybook .CMD
+    public void WorstCaseWorktreeRoot_PlusLauncherSuffix_FitsWithinCeiling(int launcherSuffix, int ceiling)
+    {
+        var worstCaseRoot = 90;
+
+        var totalLength = worstCaseRoot + 1 + launcherSuffix;
+
+        Assert.True(totalLength <= ceiling, $"Total length {totalLength} exceeds ceiling {ceiling}");
+    }
+
+    [Fact]
+    public void WorstCaseWorktreeRoot_PlusUnreachableLauncher_ExpectedToExceed()
+    {
+        var worstCaseRoot = 90;
+        var unreachableLauncherSuffix = 185; // tsserver.CMD
+        var cmdCeiling = 246;
+
+        var totalLength = worstCaseRoot + 1 + unreachableLauncherSuffix;
+
+        Assert.True(totalLength > cmdCeiling, "tsserver.CMD is expected to exceed the ceiling and remain unreachable");
+    }
+
+    [Fact]
+    public void MaxWorktreeRootLength_IsGreaterThanOrEqualToWorstCaseAtShippedCap()
+    {
+        var plansRoot = 17;
+        var repoPath = 31;
+        var worstCase = WorktreePathHelper.WorstCaseWorktreeRootLength(plansRoot, repoPath);
+
+        Assert.True(WorktreePathHelper.MaxWorktreeRootLength >= worstCase,
+            $"MaxWorktreeRootLength {WorktreePathHelper.MaxWorktreeRootLength} must be >= worst case {worstCase}");
+    }
+
+    [Fact]
+    public void TryGetPlanFolderFromWorktree_NestedLayout_ReturnsTrue()
+    {
+        var plansRoot = Path.Combine(Path.GetTempPath(), "TestPlans");
+        var planFolder = Path.Combine(plansRoot, "00214-TestPlan");
+        var worktreePath = Path.Combine(planFolder, "Worktrees", "owner", "repo");
+
+        var result = WorktreePathHelper.TryGetPlanFolderFromWorktree(worktreePath, out var recoveredPlanFolder);
+
+        Assert.True(result);
+        Assert.Equal(planFolder, recoveredPlanFolder);
+    }
+
+    [Fact]
+    public void TryGetPlanFolderFromWorktree_FlatLayout_ReturnsTrue()
+    {
+        var plansRoot = Path.Combine(Path.GetTempPath(), "TestPlans");
+        var planFolder = Path.Combine(plansRoot, "00214-TestPlan");
+        var worktreePath = Path.Combine(planFolder, "Worktrees", "repo");
+
+        var result = WorktreePathHelper.TryGetPlanFolderFromWorktree(worktreePath, out var recoveredPlanFolder);
+
+        Assert.True(result);
+        Assert.Equal(planFolder, recoveredPlanFolder);
+    }
+
+    [Fact]
+    public void TryGetPlanFolderFromWorktree_NoWorktreesAncestor_ReturnsFalse()
+    {
+        var pathWithoutWorktrees = Path.Combine(Path.GetTempPath(), "SomeOtherPath", "NotAWorktree");
+
+        var result = WorktreePathHelper.TryGetPlanFolderFromWorktree(pathWithoutWorktrees, out var planFolder);
+
+        Assert.False(result);
+        Assert.Equal(string.Empty, planFolder);
+    }
+
+    [Fact]
+    public void TryGetPlanFolderFromWorktree_WorktreesDirectoryItself_ReturnsFalse()
+    {
+        var plansRoot = Path.Combine(Path.GetTempPath(), "TestPlans");
+        var planFolder = Path.Combine(plansRoot, "00214-TestPlan");
+        var worktreesDir = Path.Combine(planFolder, "Worktrees");
+
+        var result = WorktreePathHelper.TryGetPlanFolderFromWorktree(worktreesDir, out var recoveredPlanFolder);
+
+        Assert.False(result);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Review/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Review/ContentView.cs
@@ -913,12 +913,18 @@ public class ContentView(
 
             if (exitCode == 0)
             {
-                var planFolder = Path.GetFullPath(Path.Combine(worktreePath, "..", ".."));
-                planService.SyncPlanArtifacts(planFolder);
-                var refreshed = planService.GetPlanByFolderFromDisk(planFolder);
-                if (refreshed != null)
-                    selectedPlanState.Set(refreshed);
-                client.Toast("Worktree synchronized successfully", "Synchronized");
+                if (WorktreePathHelper.TryGetPlanFolderFromWorktree(worktreePath, out var planFolder))
+                {
+                    planService.SyncPlanArtifacts(planFolder);
+                    var refreshed = planService.GetPlanByFolderFromDisk(planFolder);
+                    if (refreshed != null)
+                        selectedPlanState.Set(refreshed);
+                    client.Toast("Worktree synchronized successfully", "Synchronized");
+                }
+                else
+                {
+                    client.Toast("Failed to locate plan folder from worktree path", "Synchronization failed");
+                }
             }
             else
             {

--- a/src/Ivy.Tendril/Commands/DoctorChecks/PathBudgetCheck.cs
+++ b/src/Ivy.Tendril/Commands/DoctorChecks/PathBudgetCheck.cs
@@ -19,7 +19,7 @@ internal class PathBudgetCheck : IDoctorCheck
         var statuses = new List<CheckStatus>();
         var hasErrors = false;
 
-        var plansRoot = _configService.PlansFolder;
+        var plansRoot = _configService.PlanFolder;
         var plansRootLength = plansRoot.Length;
         statuses.Add(new CheckStatus("Plans root", $"{plansRoot} ({plansRootLength} chars)", StatusKind.Ok));
 
@@ -30,7 +30,7 @@ internal class PathBudgetCheck : IDoctorCheck
         {
             foreach (var repo in project.Repos)
             {
-                var relPath = GitHelper.DeriveWorktreeRelativePath(repo);
+                var relPath = GitHelper.DeriveWorktreeRelativePath(repo.Path);
                 if (relPath.Length > longestRepoPathLength)
                 {
                     longestRepoPath = relPath;

--- a/src/Ivy.Tendril/Commands/DoctorChecks/PathBudgetCheck.cs
+++ b/src/Ivy.Tendril/Commands/DoctorChecks/PathBudgetCheck.cs
@@ -1,0 +1,111 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+
+namespace Ivy.Tendril.Commands.DoctorChecks;
+
+internal class PathBudgetCheck : IDoctorCheck
+{
+    private readonly IConfigService _configService;
+
+    public PathBudgetCheck(IConfigService configService)
+    {
+        _configService = configService;
+    }
+
+    public string Name => "Path Budget";
+
+    public async Task<CheckResult> RunAsync()
+    {
+        var statuses = new List<CheckStatus>();
+        var hasErrors = false;
+
+        var plansRoot = _configService.PlansFolder;
+        var plansRootLength = plansRoot.Length;
+        statuses.Add(new CheckStatus("Plans root", $"{plansRoot} ({plansRootLength} chars)", StatusKind.Ok));
+
+        var longestRepoPath = string.Empty;
+        var longestRepoPathLength = 0;
+
+        foreach (var project in _configService.Projects)
+        {
+            foreach (var repo in project.Repos)
+            {
+                var relPath = GitHelper.DeriveWorktreeRelativePath(repo);
+                if (relPath.Length > longestRepoPathLength)
+                {
+                    longestRepoPath = relPath;
+                    longestRepoPathLength = relPath.Length;
+                }
+            }
+        }
+
+        if (string.IsNullOrEmpty(longestRepoPath))
+        {
+            statuses.Add(new CheckStatus("Longest repo path", "No repos configured", StatusKind.Warn));
+        }
+        else
+        {
+            statuses.Add(new CheckStatus("Longest repo path", $"{longestRepoPath} ({longestRepoPathLength} chars)", StatusKind.Ok));
+        }
+
+        var worstCaseLength = WorktreePathHelper.WorstCaseWorktreeRootLength(plansRootLength, longestRepoPathLength);
+        var headroom = WorktreePathHelper.MaxWorktreeRootLength - worstCaseLength;
+        var classification = Classify(worstCaseLength);
+
+        statuses.Add(new CheckStatus(
+            "Worst-case worktree root",
+            $"{worstCaseLength} chars (headroom: {headroom})",
+            classification));
+
+        if (classification == StatusKind.Error)
+        {
+            hasErrors = true;
+        }
+
+        var legacyCount = 0;
+        var longestLegacyFolder = string.Empty;
+        var longestLegacyLength = 0;
+
+        if (Directory.Exists(plansRoot))
+        {
+            var maxAllowedFolderLength = 5 + 1 + PlanYamlHelper.SafeTitleMaxLength;
+
+            foreach (var dir in Directory.GetDirectories(plansRoot))
+            {
+                var folderName = Path.GetFileName(dir);
+                if (folderName.Length > maxAllowedFolderLength)
+                {
+                    legacyCount++;
+                    if (folderName.Length > longestLegacyLength)
+                    {
+                        longestLegacyFolder = folderName;
+                        longestLegacyLength = folderName.Length;
+                    }
+                }
+            }
+        }
+
+        if (legacyCount > 0)
+        {
+            statuses.Add(new CheckStatus(
+                "Legacy plan folders over budget",
+                $"{legacyCount} folders (longest: {longestLegacyFolder} at {longestLegacyLength} chars)",
+                StatusKind.Warn));
+        }
+        else
+        {
+            statuses.Add(new CheckStatus("Legacy plan folders over budget", "None", StatusKind.Ok));
+        }
+
+        return await Task.FromResult(new CheckResult(hasErrors, statuses));
+    }
+
+    internal static StatusKind Classify(int worstCaseRootLength)
+    {
+        if (worstCaseRootLength <= WorktreePathHelper.MaxWorktreeRootLength)
+            return StatusKind.Ok;
+        if (worstCaseRootLength <= 125)
+            return StatusKind.Warn;
+        return StatusKind.Error;
+    }
+}

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -43,6 +43,7 @@ public static class DoctorCommand
         var checks = new IDoctorCheck[]
         {
             new InstallationCheck(),
+            new PathBudgetCheck(configService),
             new EnvironmentCheck(),
             new SoftwareCheck(configService, agentRunner),
             new DatabaseCheck(),

--- a/src/Ivy.Tendril/Commands/PlanAddWorktreeCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanAddWorktreeCommand.cs
@@ -45,8 +45,7 @@ public class PlanAddWorktreeCommand : Command<PlanAddWorktreeSettings>
         }
 
         var branchName = DeriveBranchName(planFolder);
-        var relWorktreePath = GitHelper.DeriveWorktreeRelativePath(settings.Repo);
-        var worktreePath = Path.Combine(planFolder, "Worktrees", relWorktreePath);
+        var worktreePath = WorktreePathHelper.GetWorktreePath(planFolder, settings.Repo);
 
         Directory.CreateDirectory(Path.GetDirectoryName(worktreePath)!);
 

--- a/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanYamlHelper.cs
@@ -278,12 +278,18 @@ internal static class PlanYamlHelper
         return dashIdx > 0 ? folderName[(dashIdx + 1)..] : null;
     }
 
+    /// <summary>
+    /// Maximum length for the SafeTitle component of a plan folder name.
+    /// Set to keep worktree paths below the Windows process creation limit.
+    /// </summary>
+    internal const int SafeTitleMaxLength = 24;
+
     internal static string ToSafeTitle(string title)
     {
         var words = title.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         var safe = string.Concat(words.Select(w =>
             char.ToUpperInvariant(w[0]) + w[1..]));
         safe = Regex.Replace(safe, @"[^a-zA-Z0-9]", "");
-        return safe.Length > 60 ? safe[..60] : safe;
+        return safe.Length > SafeTitleMaxLength ? safe[..SafeTitleMaxLength] : safe;
     }
 }

--- a/src/Ivy.Tendril/Helpers/WorktreePathHelper.cs
+++ b/src/Ivy.Tendril/Helpers/WorktreePathHelper.cs
@@ -1,0 +1,73 @@
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+/// Helper for composing and analyzing worktree paths.
+/// Centralizes worktree path logic to keep the worktree root inside the Windows process creation budget.
+/// </summary>
+internal static class WorktreePathHelper
+{
+    /// <summary>
+    /// Maximum allowed worktree root length in characters.
+    /// Derived from the .CMD ceiling (246) minus 1 for path separator minus 150 for documented launcher suffix allowance.
+    /// This ensures spawned executables remain below the Windows MAX_PATH limit for process creation.
+    /// </summary>
+    internal const int MaxWorktreeRootLength = 95;
+
+    /// <summary>
+    /// Returns the path to the Worktrees directory for a given plan folder.
+    /// </summary>
+    public static string GetWorktreesDir(string planFolder)
+    {
+        return Path.Combine(planFolder, "Worktrees");
+    }
+
+    /// <summary>
+    /// Returns the full worktree path for a given plan folder and repo path.
+    /// </summary>
+    public static string GetWorktreePath(string planFolder, string repoPath)
+    {
+        var relWorktreePath = GitHelper.DeriveWorktreeRelativePath(repoPath);
+        return Path.Combine(planFolder, "Worktrees", relWorktreePath);
+    }
+
+    /// <summary>
+    /// Attempts to recover the plan folder from a worktree path by walking up until finding a "Worktrees" ancestor.
+    /// Handles both nested (Worktrees/owner/repo) and flat (Worktrees/repo) layouts.
+    /// </summary>
+    public static bool TryGetPlanFolderFromWorktree(string worktreePath, out string planFolder)
+    {
+        planFolder = string.Empty;
+        var current = Path.GetFullPath(worktreePath);
+
+        while (!string.IsNullOrEmpty(current))
+        {
+            var parent = Path.GetDirectoryName(current);
+            if (string.IsNullOrEmpty(parent) || parent == current)
+                break;
+
+            var parentName = Path.GetFileName(parent);
+            if (string.Equals(parentName, "Worktrees", StringComparison.OrdinalIgnoreCase))
+            {
+                planFolder = Path.GetDirectoryName(parent)!;
+                return true;
+            }
+
+            current = parent;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Computes the worst-case worktree root length for the given plans root and relative repo path.
+    /// The worktree root is the path before any build tool spawns executables.
+    /// </summary>
+    /// <param name="plansRootLength">Length of the plans root directory path</param>
+    /// <param name="relativeRepoPathLength">Length of the relative repo path (e.g., "owner/repo")</param>
+    /// <param name="folderNameLength">Optional folder name length; defaults to worst-case folder name length</param>
+    public static int WorstCaseWorktreeRootLength(int plansRootLength, int relativeRepoPathLength, int? folderNameLength = null)
+    {
+        var maxFolderLength = folderNameLength ?? (5 + 1 + PlanYamlHelper.SafeTitleMaxLength);
+        return plansRootLength + 1 + maxFolderLength + 1 + "Worktrees".Length + 1 + relativeRepoPathLength;
+    }
+}

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -34,7 +34,7 @@ Plans live under `planFolder` from `config.yaml`.
 `{ID:D5}-{SafeTitle}` — e.g. `01098-MakeAnEmptyAppCalledReview`
 
 - **ID**: 5-digit value from `.counter`
-- **SafeTitle**: Title-cased, first 60 chars of description, alphanumeric only, no spaces (e.g. `"Fix login bug"` – `FixLoginBug`)
+- **SafeTitle**: Title-cased, first 24 chars of description, alphanumeric only, no spaces (e.g. `"Fix login bug"` – `FixLoginBug`). The 24-character cap keeps worktree paths within the Windows process creation budget (MAX_PATH limit).
 
 **SafeTitle is for the folder name only.** It is derived automatically from the title by the CLI — do not pass it anywhere. The plan's `title` field is a separate, **human-readable** string (Title Case *with spaces*). Never reuse the PascalCase SafeTitle form as the `title`.
 


### PR DESCRIPTION
Fixes #2333

# Summary

## Changes

Shortened plan folder names by reducing the SafeTitle cap from 60 to 24 characters, ensuring worktree paths stay within the Windows process creation budget (MAX_PATH limit of 260 characters). Added centralized worktree path logic and a doctor check to validate path budget health.

## API Changes

**New Public Types:**
- `WorktreePathHelper` - Helper class for composing and analyzing worktree paths
  - `MaxWorktreeRootLength` const (95 characters)
  - `GetWorktreesDir(string planFolder)` - Returns Worktrees directory path
  - `GetWorktreePath(string planFolder, string repoPath)` - Returns full worktree path
  - `TryGetPlanFolderFromWorktree(string worktreePath, out string planFolder)` - Recovers plan folder from worktree path
  - `WorstCaseWorktreeRootLength(int plansRootLength, int relativeRepoPathLength, int? folderNameLength = null)` - Computes worst-case path length

**Modified Constants:**
- `PlanYamlHelper.SafeTitleMaxLength` - Changed from 60 to 24

**New Doctor Check:**
- `PathBudgetCheck` - Reports path budget health (plans root, longest repo path, worst-case worktree root, legacy folders)

## Files Modified

**Core Implementation:**
- `src/Ivy.Tendril/Helpers/WorktreePathHelper.cs` (new)
- `src/Ivy.Tendril/Helpers/PlanYamlHelper.cs`
- `src/Ivy.Tendril/Commands/PlanAddWorktreeCommand.cs`
- `src/Ivy.Tendril/Apps/Review/ContentView.cs`

**Doctor Checks:**
- `src/Ivy.Tendril/Commands/DoctorChecks/PathBudgetCheck.cs` (new)
- `src/Ivy.Tendril/Commands/DoctorCommand.cs`

**Documentation:**
- `src/Ivy.Tendril/Prompts/Plans.md`

**Tests:**
- `src/Ivy.Tendril.Test/WorktreePathBudgetTests.cs` (new)
- `src/Ivy.Tendril.Test/PathBudgetCheckTests.cs` (new)
- `src/Ivy.Tendril.Test/PlanYamlHelperVerificationTests.cs`

## Manual Testing

1. Run `tendril doctor` and verify the "Path Budget" section shows:
   - Plans root path with character count
   - Longest repo path
   - Worst-case worktree root length with headroom
   - Legacy plan folders count (if any)
   - Status should be "Ok" if worst-case ≤ 95 chars

2. Create a new plan with a long title (e.g., "Fix the problem where the user interface does not respond correctly") and verify:
   - The plan folder name is truncated to ~30 characters (5 digits + dash + 24 chars)
   - `tendril plan add-worktree` succeeds
   - The worktree path length fits within the budget

3. In an existing plan's Review tab, click "Synchronize" on the Git tab and verify:
   - The synchronization succeeds
   - No error toast appears about locating the plan folder

---

## Commits

- Fix test compilation errors (78d14c87)
- Fix PathBudgetCheck compilation errors (960e3b62)

---
Created using [Ivy Tendril](https://ivy.app).
