### PR TITLE
[00216] Stop Recording Cited PR URLs as a Plan's Own Pull Request

### DIFF
--- a/src/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
+++ b/src/Ivy.Tendril.Test/DoctorCommandPlansTests.cs
@@ -499,6 +499,106 @@ public class DoctorCommandPlansTests : IDisposable
         Assert.Equal(Path.Combine(laundered, "Verification", "PreExecution.md"), found[0].ReportPath);
     }
 
+    // Plan 00216: the sweep for PRs a plan records but did not open. The head branch is the ownership
+    // record, so every case below injects one instead of asking gh for it.
+    private static string CompletedWithPr(string prUrl) =>
+        $"""
+         state: Completed
+         project: Tendril
+         title: Test Plan
+         repos:
+         - /dummy/repo
+         commits: []
+         prs:
+           - {prUrl}
+         """;
+
+    private static Func<string, DoctorCommand.PrHeadLookup> HeadBranches(Dictionary<string, string> heads) =>
+        url => heads.TryGetValue(url, out var head)
+            ? new DoctorCommand.PrHeadLookup(true, head, "")
+            : new DoctorCommand.PrHeadLookup(false, "",
+                "GraphQL: Could not resolve to a PullRequest with the number of 61");
+
+    [Fact]
+    public void FindMisattributedPrCandidates_HeadBranchNamesAnotherPlan_IsFlagged()
+    {
+        const string url = "https://github.com/SpaceCorps/components-storybook/pull/61";
+        CreatePlan("00077-CitedAForeignPr", CompletedWithPr(url));
+
+        var report = DoctorCommand.FindMisattributedPrCandidates(
+            DoctorCommand.ScanPlans(_plansDir),
+            HeadBranches(new Dictionary<string, string> { [url] = "tendril/00173-RouteAlertBlockquote" }));
+
+        Assert.Equal(1, report.UrlsChecked);
+        Assert.Empty(report.Unresolved);
+        var flagged = Assert.Single(report.Misattributed);
+        Assert.Equal("00077", flagged.PlanId);
+        Assert.Equal(url, flagged.Url);
+        Assert.Equal("00173", flagged.NamedPlanId);
+    }
+
+    [Fact]
+    public void FindMisattributedPrCandidates_HeadBranchNamesTheRecordingPlan_IsClean()
+    {
+        const string url = "https://github.com/SpaceCorps/components-storybook/pull/19";
+        CreatePlan("00077-OwnPr", CompletedWithPr(url));
+
+        var report = DoctorCommand.FindMisattributedPrCandidates(
+            DoctorCommand.ScanPlans(_plansDir),
+            HeadBranches(new Dictionary<string, string> { [url] = "tendril/00077-OwnPr" }));
+
+        Assert.Equal(1, report.UrlsChecked);
+        Assert.Empty(report.Misattributed);
+        Assert.Empty(report.Unresolved);
+    }
+
+    [Fact]
+    public void FindMisattributedPrCandidates_NonTendrilHeadBranch_IsClean()
+    {
+        // A PR opened by hand names no plan in its head branch, so there is no ownership to compare.
+        const string url = "https://github.com/Ivy-Interactive/Ivy-Tendril/pull/2344";
+        CreatePlan("00080-HandOpenedPr", CompletedWithPr(url));
+
+        var report = DoctorCommand.FindMisattributedPrCandidates(
+            DoctorCommand.ScanPlans(_plansDir),
+            HeadBranches(new Dictionary<string, string> { [url] = "fix/typo-in-readme" }));
+
+        Assert.Empty(report.Misattributed);
+        Assert.Empty(report.Unresolved);
+    }
+
+    [Fact]
+    public void FindMisattributedPrCandidates_UnresolvableUrl_IsReportedApart()
+    {
+        const string url = "https://github.com/SpaceCorps/components-storybook/pull/61";
+        CreatePlan("00077-PhantomPr", CompletedWithPr(url));
+
+        var report = DoctorCommand.FindMisattributedPrCandidates(
+            DoctorCommand.ScanPlans(_plansDir),
+            HeadBranches([]));
+
+        Assert.Empty(report.Misattributed);
+        var unresolved = Assert.Single(report.Unresolved);
+        Assert.Equal("00077", unresolved.PlanId);
+        Assert.Equal(url, unresolved.Url);
+        Assert.Contains("Could not resolve to a PullRequest", unresolved.Reason);
+    }
+
+    [Fact]
+    public void FindMisattributedPrCandidates_DoesNotMutatePlanYaml()
+    {
+        const string url = "https://github.com/SpaceCorps/components-storybook/pull/61";
+        var planDir = CreatePlan("00077-HistoricalRecord", CompletedWithPr(url));
+        var yamlPath = Path.Combine(planDir, "plan.yaml");
+        var before = File.ReadAllText(yamlPath);
+
+        DoctorCommand.FindMisattributedPrCandidates(
+            DoctorCommand.ScanPlans(_plansDir),
+            HeadBranches(new Dictionary<string, string> { [url] = "tendril/00173-RouteAlertBlockquote" }));
+
+        Assert.Equal(before, File.ReadAllText(yamlPath));
+    }
+
     private static void WritePreExecutionReport(string planDir, string result)
     {
         var verificationDir = Path.Combine(planDir, "Verification");

--- a/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceDependencyAutoRetryTests.cs
@@ -1,5 +1,6 @@
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Plans;
 
 namespace Ivy.Tendril.Test;
 
@@ -27,7 +28,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
             planReaderService: planReader);
     }
 
-    private string CreatePlanFolder(string name, string state, List<string>? dependsOn = null)
+    private string CreatePlanFolder(string name, string state, List<string>? dependsOn = null, string? prUrl = null)
     {
         var folder = Path.Combine(_plansDir, name);
         Directory.CreateDirectory(folder);
@@ -40,6 +41,8 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
         else
             depsYaml = "dependsOn: []";
 
+        var prsYaml = prUrl == null ? "prs: []" : $"prs:\n- '{prUrl}'";
+
         File.WriteAllText(Path.Combine(folder, "plan.yaml"), $"""
                                                               state: {state}
                                                               project: Tendril
@@ -49,7 +52,7 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
                                                               updated: 2026-04-01T00:00:00Z
                                                               repos:
                                                               - {repoDir}
-                                                              prs: []
+                                                              {prsYaml}
                                                               commits: []
                                                               verifications: []
                                                               relatedPlans: []
@@ -57,6 +60,95 @@ public class JobServiceDependencyAutoRetryTests : IDisposable
                                                               """);
 
         return folder;
+    }
+
+    // ==================== DependencyChecker PR gate (issue #2336) ====================
+
+    private DependencyChecker CreateChecker(Func<string, DependencyChecker.PrLookup> resolver) =>
+        new(new StubPlanReaderService(_plansDir)) { PrStateResolver = resolver };
+
+    [Fact]
+    public void CheckDependencies_WhenDependencyPrIsMerged_IsSatisfied()
+    {
+        const string prUrl = "https://github.com/owner/repo/pull/19";
+        _ = CreatePlanFolder("03200-DepPlan", "Completed", prUrl: prUrl);
+        var planA = CreatePlanFolder("03201-PlanA", "Draft", ["03200-DepPlan"]);
+
+        var checker = CreateChecker(_ => new DependencyChecker.PrLookup(0, "MERGED", ""));
+        var (ok, reason) = checker.CheckDependencies(planA);
+
+        Assert.True(ok);
+        Assert.Null(reason);
+    }
+
+    [Fact]
+    public void CheckDependencies_WhenDependencyPrIsOpen_BlocksSayingNotMerged()
+    {
+        const string prUrl = "https://github.com/owner/repo/pull/19";
+        _ = CreatePlanFolder("03210-DepPlan", "Completed", prUrl: prUrl);
+        var planA = CreatePlanFolder("03211-PlanA", "Draft", ["03210-DepPlan"]);
+
+        var checker = CreateChecker(_ => new DependencyChecker.PrLookup(0, "OPEN", ""));
+        var (ok, reason) = checker.CheckDependencies(planA);
+
+        Assert.False(ok);
+        Assert.Equal($"Dependency '03210-DepPlan' PR {prUrl} is 'OPEN', not MERGED", reason);
+    }
+
+    [Fact]
+    public void CheckDependencies_WhenGhCannotResolveThePr_BlocksWithGhsOwnReason()
+    {
+        // Plan 00077 recorded pull/61, a number that did not exist. gh writes the GraphQL error to
+        // stderr and nothing to stdout, so the gate used to report "is '', not MERGED".
+        const string prUrl = "https://github.com/SpaceCorps/components-storybook/pull/61";
+        _ = CreatePlanFolder("03220-DepPlan", "Completed", prUrl: prUrl);
+        var planA = CreatePlanFolder("03221-PlanA", "Draft", ["03220-DepPlan"]);
+
+        var checker = CreateChecker(_ => new DependencyChecker.PrLookup(
+            1, "", "GraphQL: Could not resolve to a PullRequest with the number of 61. (repository.pullRequest)"));
+        var (ok, reason) = checker.CheckDependencies(planA);
+
+        Assert.False(ok);
+        Assert.Equal(
+            $"Dependency '03220-DepPlan' PR {prUrl} could not be resolved " +
+            "(gh: GraphQL: Could not resolve to a PullRequest with the number of 61. (repository.pullRequest))",
+            reason);
+        Assert.DoesNotContain("not MERGED", reason);
+    }
+
+    [Fact]
+    public void CheckDependencies_WhenGhSucceedsButPrintsNothing_BlocksAsUnresolved()
+    {
+        // Exit 0 with empty stdout is the shape an auth failure took before gh started exiting 1 on
+        // it. Neither null nor MERGED, so the old code blocked with an empty-quoted state.
+        const string prUrl = "https://github.com/owner/repo/pull/19";
+        _ = CreatePlanFolder("03230-DepPlan", "Completed", prUrl: prUrl);
+        var planA = CreatePlanFolder("03231-PlanA", "Draft", ["03230-DepPlan"]);
+
+        var checker = CreateChecker(_ => new DependencyChecker.PrLookup(0, "", ""));
+        var (ok, reason) = checker.CheckDependencies(planA);
+
+        Assert.False(ok);
+        Assert.Equal(
+            $"Dependency '03230-DepPlan' PR {prUrl} could not be resolved (gh exited 0 with no output)",
+            reason);
+    }
+
+    [Fact]
+    public void CheckDependencies_TruncatesALongGhErrorSoItFitsAStatusMessage()
+    {
+        const string prUrl = "https://github.com/owner/repo/pull/19";
+        _ = CreatePlanFolder("03240-DepPlan", "Completed", prUrl: prUrl);
+        var planA = CreatePlanFolder("03241-PlanA", "Draft", ["03240-DepPlan"]);
+
+        var checker = CreateChecker(_ => new DependencyChecker.PrLookup(
+            1, "", new string('x', 500) + "\nsecond line of stderr"));
+        var (ok, reason) = checker.CheckDependencies(planA);
+
+        Assert.False(ok);
+        Assert.NotNull(reason);
+        Assert.Contains("gh: " + new string('x', 200) + "...", reason);
+        Assert.DoesNotContain("second line of stderr", reason);
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCliCommandTests.cs
@@ -730,6 +730,70 @@ public class PlanCliCommandTests : IDisposable
         Assert.Equal(2, result.Prs.Count);
     }
 
+    // ==================== PlanRemovePr ====================
+
+    [Fact]
+    public void RemovePr_RemovesTheUrl()
+    {
+        CreatePlanFolder("20055", "RemovePrTest");
+        var folder = PlanCommandHelpers.ResolvePlanFolder("20055");
+        var plan = PlanCommandHelpers.ReadPlan(folder);
+        plan.Prs.Add("https://github.com/org/repo/pull/19");
+        plan.Prs.Add("https://github.com/org/repo/pull/61");
+        PlanCommandHelpers.WritePlan(folder, plan);
+
+        PlanRemovePrCommand.RemovePr(folder, "https://github.com/org/repo/pull/61");
+
+        var result = ReadPlan("20055");
+        Assert.Equal(["https://github.com/org/repo/pull/19"], result.Prs);
+    }
+
+    [Fact]
+    public void RemovePr_MatchesADifferentlyFormattedUrl()
+    {
+        // A URL reaches plan.yaml in whatever form the agent had it in, so the repair has to accept
+        // the base form for a PR recorded with a /files suffix.
+        CreatePlanFolder("20056", "RemovePrSuffixTest");
+        var folder = PlanCommandHelpers.ResolvePlanFolder("20056");
+        var plan = PlanCommandHelpers.ReadPlan(folder);
+        plan.Prs.Add("https://github.com/org/repo/pull/61/files");
+        PlanCommandHelpers.WritePlan(folder, plan);
+
+        PlanRemovePrCommand.RemovePr(folder, "https://github.com/org/repo/pull/61");
+
+        Assert.Empty(ReadPlan("20056").Prs);
+    }
+
+    [Fact]
+    public void RemovePr_ThrowsWhenNotPresent()
+    {
+        CreatePlanFolder("20057", "RemovePrMissingTest");
+        var folder = PlanCommandHelpers.ResolvePlanFolder("20057");
+        var plan = PlanCommandHelpers.ReadPlan(folder);
+        plan.Prs.Add("https://github.com/org/repo/pull/19");
+        PlanCommandHelpers.WritePlan(folder, plan);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            PlanRemovePrCommand.RemovePr(folder, "https://github.com/org/repo/pull/61"));
+        Assert.Contains("PR not found", ex.Message);
+
+        // Nothing else was touched: a miss must not rewrite the plan.
+        Assert.Equal(["https://github.com/org/repo/pull/19"], ReadPlan("20057").Prs);
+    }
+
+    [Fact]
+    public void RemovePr_DoesNotMatchADifferentPrOnTheSameRepo()
+    {
+        CreatePlanFolder("20058", "RemovePrNeighbourTest");
+        var folder = PlanCommandHelpers.ResolvePlanFolder("20058");
+        var plan = PlanCommandHelpers.ReadPlan(folder);
+        plan.Prs.Add("https://github.com/org/repo/pull/6");
+        PlanCommandHelpers.WritePlan(folder, plan);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            PlanRemovePrCommand.RemovePr(folder, "https://github.com/org/repo/pull/61"));
+    }
+
     // ==================== PlanAddCommit ====================
 
     [Fact]

--- a/src/Ivy.Tendril.Test/Services/JobCompletionCreatePrTests.cs
+++ b/src/Ivy.Tendril.Test/Services/JobCompletionCreatePrTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.IO;
 using System.Linq;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Runtime;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services.Jobs;
@@ -13,7 +15,10 @@ namespace Ivy.Tendril.Test.Services;
 ///     Covers the CreatePr safety net in <see cref="JobCompletionHandler.ReconcileCreatePrResult" />:
 ///     when the agent creates a PR but skips the Program.md step-6 closeout, Tendril must still
 ///     record the PR URL and mark the plan Completed so it surfaces in the Pull Requests app instead
-///     of being stranded in Drafts — while ignoring PR URLs that don't belong to this plan's repos.
+///     of being stranded in Drafts, while ignoring PR URLs that don't belong to this plan. Issue #2336
+///     is the second half: a URL the agent merely cited in the PR body it was writing got recorded as
+///     the plan's own PR, 12 times over, because the scan read every eventwire entry as if it were
+///     command output.
 /// </summary>
 public class JobCompletionCreatePrTests : IDisposable
 {
@@ -42,7 +47,12 @@ public class JobCompletionCreatePrTests : IDisposable
         planWatcherService: null,
         promptsRoot: _tempDir.Path);
 
-    private void WritePlan(string state, string[]? prs = null, bool withRepo = true, string[]? commits = null)
+    private void WritePlan(
+        string state,
+        string[]? prs = null,
+        bool withRepo = true,
+        string[]? commits = null,
+        string[]? extraRepos = null)
     {
         var plan = new PlanYaml
         {
@@ -51,6 +61,13 @@ public class JobCompletionCreatePrTests : IDisposable
             Title = "Add JWT Tester Tool",
         };
         if (withRepo) plan.Repos.Add(_repoDir);
+        if (extraRepos != null)
+            foreach (var repo in extraRepos)
+            {
+                var path = Path.Combine(_tempDir.Path, repo);
+                Directory.CreateDirectory(path);
+                plan.Repos.Add(path);
+            }
         if (prs != null) plan.Prs.AddRange(prs);
         if (commits != null) plan.Commits.AddRange(commits);
         PlanCommandHelpers.WritePlan(_planFolder, plan);
@@ -68,11 +85,41 @@ public class JobCompletionCreatePrTests : IDisposable
         return job;
     }
 
+    /// <summary>
+    ///     A job whose OutputLines hold real serialized eventwire entries, which is the only thing
+    ///     production ever puts there: <c>JobItem.EnqueueOutput</c> serializes every parsed event, and
+    ///     even <c>EnqueueSystemOutput</c> wraps its message in a TextEvent. Every case below goes
+    ///     through here, because a fixture of plain prose lines cannot tell a passing filter from an
+    ///     absent one.
+    /// </summary>
+    private JobItem JobWithEvents(params AgentEvent[] events)
+    {
+        var serializer = new JsonEventSerializer();
+        return JobWithOutput(events.Select(serializer.Serialize).ToArray());
+    }
+
+    private static ToolResultEvent ToolResult(string output) => new()
+    {
+        Kind = AgentEventKind.ToolResult,
+        ToolUseId = "toolu_01",
+        ToolName = "Bash",
+        Output = output,
+    };
+
+    private static ToolCallEvent ToolCall(string command) => new()
+    {
+        Kind = AgentEventKind.ToolCall,
+        ToolUseId = "toolu_01",
+        ToolName = "Bash",
+        Description = "Prepare PR body in temp file",
+        InputJson = $"{{\"command\":{System.Text.Json.JsonSerializer.Serialize(command)}}}",
+    };
+
     [Fact]
     public void RecordsMissingPr_AndSetsCompleted_WhenAgentSkippedCloseout()
     {
         WritePlan(nameof(PlanStatus.Review)); // agent left it in Review with no PR recorded
-        var job = JobWithOutput($"Created PR {PrUrl}#issuecomment-4851921040");
+        var job = JobWithEvents(ToolResult($"{PrUrl}#issuecomment-4851921040"));
 
         CreateHandler().ReconcileCreatePrResult(job);
 
@@ -85,7 +132,7 @@ public class JobCompletionCreatePrTests : IDisposable
     public void SetsCompleted_EvenWhenPlanWasStuckInDraft()
     {
         WritePlan(nameof(PlanStatus.Draft));
-        var job = JobWithOutput($"opened {PrUrl}");
+        var job = JobWithEvents(ToolResult(PrUrl));
 
         CreateHandler().ReconcileCreatePrResult(job);
 
@@ -95,24 +142,120 @@ public class JobCompletionCreatePrTests : IDisposable
     }
 
     [Fact]
-    public void CompletesWithoutDuplicating_WhenAgentRecordedPrButNotState()
+    public void RecordsPr_WhenBareUrlOnItsOwnLineInToolResult()
     {
-        // Agent recorded the PR with a /files suffix but left the plan in Review.
-        WritePlan(nameof(PlanStatus.Review), prs: new[] { PrUrl + "/files" });
-        var job = JobWithOutput($"existing {PrUrl}");
+        // The exact shape of job 00467's successful `gh pr create`: a progress line, then the URL
+        // alone on the next one.
+        WritePlan(nameof(PlanStatus.Review));
+        var job = JobWithEvents(ToolResult($"Attempt 1: Creating PR...\n{PrUrl}\n"));
 
         CreateHandler().ReconcileCreatePrResult(job);
 
         var plan = PlanCommandHelpers.ReadPlan(_planFolder);
         Assert.Equal(nameof(PlanStatus.Completed), plan.State);
-        Assert.Single(plan.Prs); // canonical dedup: same PR #26 not re-added despite different form
+        Assert.Equal(new[] { PrUrl }, plan.Prs);
+    }
+
+    [Fact]
+    public void IgnoresPrUrl_CitedInsideAToolCallInput()
+    {
+        // Issue #2336 itself. The agent cites a sibling plan's PR in the body it is composing, so the
+        // URL reaches OutputLines as part of a tool_call input, never as command output.
+        const string ownPr = "https://github.com/nielsbosma/lots-of-dev-tools/pull/19";
+        WritePlan(nameof(PlanStatus.Review), prs: new[] { ownPr });
+        var job = JobWithEvents(ToolCall(
+            $"cat > /tmp/body.md <<'EOF'\nBuilds on [Plan 00061]({PrUrl}).\nEOF"));
+
+        CreateHandler().ReconcileCreatePrResult(job);
+
+        var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+        Assert.Equal(new[] { ownPr }, plan.Prs);
+    }
+
+    [Fact]
+    public void IgnoresPrUrl_CitedInProseInsideAToolResult()
+    {
+        // 9 of the 12 corruptions in issue #2336 had the citation echoed back by a tool result (the
+        // heredoc write, `cat` of the body file, `gh pr view` of a sibling), so a tool_result-only
+        // filter is not enough on its own: the URL still has to own its line.
+        const string ownPr = "https://github.com/nielsbosma/lots-of-dev-tools/pull/19";
+        WritePlan(nameof(PlanStatus.Review), prs: new[] { ownPr });
+        var job = JobWithEvents(ToolResult($"Related work: [Plan 00061]({PrUrl}) landed first."));
+
+        CreateHandler().ReconcileCreatePrResult(job);
+
+        var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+        Assert.Equal(new[] { ownPr }, plan.Prs);
+    }
+
+    [Fact]
+    public void IgnoresSecondPrForARepoThatAlreadyHasOne()
+    {
+        // The per-repo guard, with a bare URL in a tool result: this one gets past the line filter, so
+        // it fails if the guard is missing.
+        const string ownPr = "https://github.com/nielsbosma/lots-of-dev-tools/pull/19";
+        WritePlan(nameof(PlanStatus.Review), prs: new[] { ownPr });
+        var job = JobWithEvents(ToolResult(PrUrl));
+
+        CreateHandler().ReconcileCreatePrResult(job);
+
+        var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+        Assert.Equal(new[] { ownPr }, plan.Prs);
+        Assert.Equal(nameof(PlanStatus.Completed), plan.State); // the plan has a PR, so still completed
+    }
+
+    [Fact]
+    public void StillRecords_ForASecondRepoOnAMultiRepoPlan()
+    {
+        // The guard is per repo, not per plan: a two-repo plan whose agent recorded only the first
+        // PR is exactly the case the safety net exists for.
+        const string firstRepoPr = "https://github.com/nielsbosma/lots-of-dev-tools/pull/19";
+        const string secondRepoPr = "https://github.com/nielsbosma/other-tools/pull/4";
+        WritePlan(nameof(PlanStatus.Review), prs: new[] { firstRepoPr }, extraRepos: new[] { "other-tools" });
+        var job = JobWithEvents(ToolResult(secondRepoPr));
+
+        CreateHandler().ReconcileCreatePrResult(job);
+
+        var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+        Assert.Equal(new[] { firstRepoPr, secondRepoPr }, plan.Prs);
+    }
+
+    [Fact]
+    public void CompletesWithoutDuplicating_WhenAgentRecordedPrButNotState()
+    {
+        // Agent recorded the PR with a /files suffix but left the plan in Review. The suffixed form
+        // still marks the repo as having a PR, so the bare URL in the output is not re-added.
+        WritePlan(nameof(PlanStatus.Review), prs: new[] { PrUrl + "/files" });
+        var job = JobWithEvents(ToolResult(PrUrl));
+
+        CreateHandler().ReconcileCreatePrResult(job);
+
+        var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+        Assert.Equal(nameof(PlanStatus.Completed), plan.State);
+        Assert.Single(plan.Prs);
+    }
+
+    [Fact]
+    public void RecordsPrOnce_WhenTheSameBareUrlIsPrintedTwice()
+    {
+        // Keeps the canonical owner/repo#number dedup honest: with no PR recorded the per-repo guard
+        // cannot fire, so the second occurrence is only rejected by the dedup.
+        WritePlan(nameof(PlanStatus.Review));
+        var job = JobWithEvents(
+            ToolResult(PrUrl),
+            ToolResult($"{PrUrl}/"));
+
+        CreateHandler().ReconcileCreatePrResult(job);
+
+        var plan = PlanCommandHelpers.ReadPlan(_planFolder);
+        Assert.Equal(new[] { PrUrl }, plan.Prs);
     }
 
     [Fact]
     public void NoOp_WhenAlreadyRecordedAndCompleted()
     {
         WritePlan(nameof(PlanStatus.Completed), prs: new[] { PrUrl });
-        var job = JobWithOutput($"existing {PrUrl}");
+        var job = JobWithEvents(ToolResult(PrUrl));
 
         CreateHandler().ReconcileCreatePrResult(job);
 
@@ -125,7 +268,7 @@ public class JobCompletionCreatePrTests : IDisposable
     public void LeavesStateUnchanged_WhenNoPrInOutput()
     {
         WritePlan(nameof(PlanStatus.Review)); // e.g. aborted run
-        var job = JobWithOutput("no pull request was created");
+        var job = JobWithEvents(ToolResult("no pull request was created"));
 
         CreateHandler().ReconcileCreatePrResult(job);
 
@@ -138,9 +281,9 @@ public class JobCompletionCreatePrTests : IDisposable
     public void IgnoresForeignRepoPr_NotBelongingToThisPlan()
     {
         WritePlan(nameof(PlanStatus.Review)); // repo is lots-of-dev-tools
-        // A PR URL for a different repo merely echoed in the transcript (e.g. plan.SourceUrl or a
-        // referenced PR) must not be recorded or force-complete the plan.
-        var job = JobWithOutput("see https://github.com/nielsbosma/some-other-repo/pull/99");
+        // A PR URL for a different repo, printed exactly the way `gh pr create` prints one, so the
+        // repo filter is the only thing that can reject it.
+        var job = JobWithEvents(ToolResult("https://github.com/nielsbosma/some-other-repo/pull/99"));
 
         CreateHandler().ReconcileCreatePrResult(job);
 
@@ -154,7 +297,7 @@ public class JobCompletionCreatePrTests : IDisposable
     {
         // Direct-to-main plans have no repos and open no PR; a referenced PR URL must be ignored.
         WritePlan(nameof(PlanStatus.Completed), withRepo: false, commits: new[] { "abc1234" });
-        var job = JobWithOutput($"related {PrUrl}");
+        var job = JobWithEvents(ToolResult(PrUrl));
 
         CreateHandler().ReconcileCreatePrResult(job);
 

--- a/src/Ivy.Tendril/Commands/DoctorCliCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCliCommand.cs
@@ -30,6 +30,10 @@ public class PlanDoctorSettings : CommandSettings
     [Description("Check worktrees only")]
     public bool WorktreesOnly { get; init; }
 
+    [CommandOption("--prs")]
+    [Description("Resolve every recorded PR with gh and report the ones another plan opened (needs network)")]
+    public bool CheckPrs { get; init; }
+
     public override Spectre.Console.ValidationResult Validate()
     {
         return CliValidation.ValidateOneOf(State, "--state", CliValidation.ValidStates);
@@ -58,6 +62,7 @@ public class PlanDoctorCommand : Command<PlanDoctorSettings>
             args.Add(settings.State);
         }
         if (settings.WorktreesOnly) args.Add("--worktrees");
+        if (settings.CheckPrs) args.Add("--prs");
 
         return DoctorCommand.DoctorPlansInternal(args.ToArray());
     }

--- a/src/Ivy.Tendril/Commands/DoctorCommand.cs
+++ b/src/Ivy.Tendril/Commands/DoctorCommand.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using Ivy.Helpers;
 using Ivy.Tendril.Agents;
 using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Models;
@@ -158,6 +160,7 @@ public static class DoctorCommand
         var prune = args.Contains("--prune");
         var stateFilter = GetArgValue(args, "--state");
         var worktreesOnly = args.Contains("--worktrees");
+        var checkPrs = args.Contains("--prs");
 
         var tendrilHome = Environment.GetEnvironmentVariable("TENDRIL_HOME")?.Trim();
         if (string.IsNullOrEmpty(tendrilHome))
@@ -196,6 +199,7 @@ public static class DoctorCommand
 
         PrintPlansTable(results);
         PrintPartialDeliveryCandidates(FindPartialDeliveryCandidates(allResults));
+        if (checkPrs) SweepMisattributedPrs(allResults);
         PrintLaunderedCompletedPlans(allResults);
         PrintPlansSummary(allResults);
 
@@ -767,5 +771,200 @@ public static class DoctorCommand
         AnsiConsole.WriteLine("Review each one, then flag the ones that really were partial:");
         AnsiConsole.WriteLine();
         AnsiConsole.WriteLine("  tendril plan set <id> state Completed --allow-failed-verifications");
+    }
+
+    private const int PrHeadLookupTimeoutMs = 15000;
+
+    /// <summary>
+    ///     Head branch of one PR, or the reason gh could not say. "Not resolved" covers a deleted PR, a
+    ///     repo the token cannot read and a rate limit alike: none of them proves anything about
+    ///     ownership, so they are reported apart from the PRs that are provably someone else's.
+    /// </summary>
+    internal record PrHeadLookup(bool Resolved, string HeadBranch, string Error);
+
+    internal record MisattributedPr(string PlanId, string Title, string Url, string HeadBranch, string NamedPlanId);
+
+    internal record UnresolvedPr(string PlanId, string Title, string Url, string Reason);
+
+    internal record MisattributedPrReport(
+        int UrlsChecked,
+        List<MisattributedPr> Misattributed,
+        List<UnresolvedPr> Unresolved);
+
+    /// <summary>
+    ///     Recorded PRs that belong to a different plan. Tendril opens a PR from a
+    ///     <c>tendril/&lt;plan-folder&gt;</c> head branch, so the head branch is the ownership record: a
+    ///     PR whose head names another plan folder was cited by the plan recording it, not opened by it
+    ///     (issue #2336, plan 00216). A PR with a non-Tendril head branch was opened by hand and has no
+    ///     plan to compare, so it is left alone. Reported, never mutated: every plan this finds is
+    ///     Completed history, and which entry to unpick is the user's call.
+    /// </summary>
+    /// <remarks>
+    ///     Each URL is resolved on its own. It must not be answered from
+    ///     <c>GithubService.GetPrStatusesAsync</c>, whose <c>gh pr list --limit 100</c> window omits most
+    ///     PRs of a busy repo and would report hundreds of healthy PRs as phantom.
+    /// </remarks>
+    /// <param name="headBranchResolver">Seam for gh, so the check is testable without a network.</param>
+    /// <param name="onBegin">Called with the number of URLs about to be resolved, before the first call.</param>
+    internal static MisattributedPrReport FindMisattributedPrCandidates(
+        List<PlanHealthResult> allResults,
+        Func<string, PrHeadLookup>? headBranchResolver = null,
+        Action<int>? onBegin = null)
+    {
+        var resolve = headBranchResolver ?? RunGhHeadRefLookup;
+
+        var recorded = new List<(PlanHealthResult Plan, string Url)>();
+        foreach (var result in allResults)
+        {
+            if (result.FolderPath == null) continue;
+
+            var plan = PlanYamlHelper.ReadPlanYaml(result.FolderPath);
+            if (plan?.Prs == null) continue;
+
+            recorded.AddRange(plan.Prs
+                .Where(url => PrUrlHelper.CanonicalKey(url) != null)
+                .Select(url => (result, url.Trim())));
+        }
+
+        onBegin?.Invoke(recorded.Count);
+
+        var report = new MisattributedPrReport(recorded.Count, [], []);
+
+        foreach (var (plan, url) in recorded)
+        {
+            var lookup = resolve(url);
+            if (!lookup.Resolved)
+            {
+                report.Unresolved.Add(new UnresolvedPr(plan.Id, plan.Title, url, lookup.Error));
+                continue;
+            }
+
+            var namedPlanId = TendrilPlanIdFromBranch(lookup.HeadBranch);
+            if (namedPlanId == null || SamePlanId(namedPlanId, plan.Id)) continue;
+
+            report.Misattributed.Add(
+                new MisattributedPr(plan.Id, plan.Title, url, lookup.HeadBranch, namedPlanId));
+        }
+
+        return report;
+    }
+
+    /// <summary>
+    ///     The plan ID a <c>tendril/00123-Title</c> branch names, or null for a branch Tendril did not
+    ///     create.
+    /// </summary>
+    internal static string? TendrilPlanIdFromBranch(string? headBranch)
+    {
+        if (string.IsNullOrWhiteSpace(headBranch)) return null;
+
+        var match = System.Text.RegularExpressions.Regex.Match(
+            headBranch.Trim(), @"^tendril/(\d+)-",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    // Plan IDs are zero padded to five digits in folder names, but a branch could carry them unpadded.
+    private static bool SamePlanId(string a, string b) =>
+        a.TrimStart('0').Equals(b.TrimStart('0'), StringComparison.Ordinal);
+
+    internal static void PrintMisattributedPrCandidates(MisattributedPrReport report)
+    {
+        if (report.Misattributed.Count > 0)
+        {
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine(
+                $"[yellow]{report.Misattributed.Count} recorded {(report.Misattributed.Count == 1 ? "PR was" : "PRs were")} opened by another plan:[/]");
+            AnsiConsole.WriteLine();
+
+            foreach (var candidate in report.Misattributed)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[grey]  {candidate.PlanId}-{candidate.Title.EscapeMarkup()}  {candidate.Url.EscapeMarkup()}[/]");
+                AnsiConsole.MarkupLine(
+                    $"[grey]    head: {candidate.HeadBranch.EscapeMarkup()} (plan {candidate.NamedPlanId})[/]");
+                AnsiConsole.MarkupLine(
+                    $"[grey]    remove: tendril plan remove-pr {candidate.PlanId} {candidate.Url.EscapeMarkup()}[/]");
+            }
+        }
+
+        if (report.Unresolved.Count > 0)
+        {
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine(
+                $"[yellow]{report.Unresolved.Count} recorded {(report.Unresolved.Count == 1 ? "PR could" : "PRs could")} not be resolved:[/]");
+            AnsiConsole.WriteLine();
+
+            foreach (var unresolved in report.Unresolved)
+            {
+                AnsiConsole.MarkupLine(
+                    $"[grey]  {unresolved.PlanId}-{unresolved.Title.EscapeMarkup()}  {unresolved.Url.EscapeMarkup()}[/]");
+                AnsiConsole.MarkupLine($"[grey]    {unresolved.Reason.EscapeMarkup()}[/]");
+            }
+
+            AnsiConsole.WriteLine();
+            AnsiConsole.WriteLine("A PR gh cannot see may be deleted, or live in a repo this token cannot read.");
+        }
+
+        if (report.Misattributed.Count == 0 && report.Unresolved.Count == 0 && report.UrlsChecked > 0)
+            AnsiConsole.WriteLine($"All {report.UrlsChecked} recorded PRs belong to the plan recording them.");
+    }
+
+    /// <summary>
+    ///     The <c>--prs</c> half of `plan doctor`: the only check here that needs the network, so it is
+    ///     opt in and skipped in silence when gh is missing, to keep `tendril plan doctor` usable offline.
+    /// </summary>
+    private static void SweepMisattributedPrs(List<PlanHealthResult> allResults)
+    {
+        if (!ProcessCheckHelper.CheckCommand("gh", "--version").GetAwaiter().GetResult()) return;
+
+        PrintMisattributedPrCandidates(FindMisattributedPrCandidates(allResults, onBegin: count =>
+        {
+            AnsiConsole.WriteLine();
+            AnsiConsole.WriteLine($"Resolving {count} recorded PR {(count == 1 ? "URL" : "URLs")} with gh...");
+        }));
+    }
+
+    private static PrHeadLookup RunGhHeadRefLookup(string prUrl)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "gh",
+                Arguments = $"pr view \"{prUrl}\" --json headRefName -q .headRefName",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = Path.GetTempPath()
+            };
+            using var proc = Process.Start(psi);
+            if (proc == null) return new PrHeadLookup(false, "", "gh could not be started");
+
+            // Drain both pipes concurrently: the failure path writes to stderr only, and reading one
+            // stream to the end while the other fills its buffer is how this deadlocks.
+            var stdout = proc.StandardOutput.ReadToEndAsync();
+            var stderr = proc.StandardError.ReadToEndAsync();
+
+            if (!proc.WaitForExitOrKill(PrHeadLookupTimeoutMs))
+                return new PrHeadLookup(false, "", $"gh pr view did not finish within {PrHeadLookupTimeoutMs / 1000}s");
+            if (!Task.WaitAll([stdout, stderr], PrHeadLookupTimeoutMs))
+                return new PrHeadLookup(false, "", "gh pr view output could not be read");
+
+            var head = stdout.Result.Trim();
+            if (proc.ExitCode == 0 && head.Length > 0)
+                return new PrHeadLookup(true, head, "");
+
+            var firstErrorLine = stderr.Result
+                .Split('\n')
+                .Select(l => l.Trim())
+                .FirstOrDefault(l => l.Length > 0);
+            return new PrHeadLookup(false, "",
+                firstErrorLine ?? $"gh exited {proc.ExitCode} with no output");
+        }
+        catch (Exception ex)
+        {
+            return new PrHeadLookup(false, "", ex.Message);
+        }
     }
 }

--- a/src/Ivy.Tendril/Commands/PlanRemovePrCommand.cs
+++ b/src/Ivy.Tendril/Commands/PlanRemovePrCommand.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel;
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Services;
+using Spectre.Console.Cli;
+
+namespace Ivy.Tendril.Commands;
+
+public class PlanRemovePrSettings : CommandSettings
+{
+    [Description("Plan ID (e.g., 03430)")]
+    [CommandArgument(0, "<plan-id>")]
+    public string PlanId { get; set; } = "";
+
+    [Description("PR URL (e.g., https://github.com/org/repo/pull/123)")]
+    [CommandArgument(1, "<pr-url>")]
+    public string PrUrl { get; set; } = "";
+
+    public override Spectre.Console.ValidationResult Validate()
+    {
+        return CliValidation.Combine(
+            CliValidation.RequireNonEmpty(PlanId, "plan-id"),
+            CliValidation.RequireNonEmpty(PrUrl, "pr-url"));
+    }
+}
+
+/// <summary>
+///     The repair half of `plan add-pr`. A PR URL that does not belong to a plan has to be removable
+///     without hand editing plan.yaml, because a foreign URL in a dependency's Prs list blocks every
+///     plan that depends on it (issue #2336). Matching is on the canonical owner/repo#number, so a URL
+///     recorded with a /files suffix or a fragment can still be removed by its base form.
+/// </summary>
+public class PlanRemovePrCommand : Command<PlanRemovePrSettings>
+{
+    private readonly IPlanWatcherService _planWatcher;
+
+    public PlanRemovePrCommand(IPlanWatcherService planWatcher)
+    {
+        _planWatcher = planWatcher;
+    }
+
+    protected override int Execute(CommandContext context, PlanRemovePrSettings settings, CancellationToken cancellationToken)
+    {
+        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+
+        RemovePr(planFolder, settings.PrUrl, _planWatcher);
+
+        Console.WriteLine($"Removed PR: {settings.PrUrl}");
+        return 0;
+    }
+
+    /// <summary>
+    ///     Read, remove, write. Separated from <see cref="Execute" /> so it can be exercised without a
+    ///     Spectre command context.
+    /// </summary>
+    internal static void RemovePr(string planFolder, string prUrl, IPlanWatcherService? planWatcher = null)
+    {
+        var plan = PlanCommandHelpers.ReadPlan(planFolder);
+
+        var removed = plan.Prs.RemoveAll(p => PrUrlHelper.SamePr(p, prUrl));
+        if (removed == 0)
+            throw new InvalidOperationException($"PR not found: {prUrl}");
+
+        plan.Updated = DateTime.UtcNow;
+
+        PlanCommandHelpers.WritePlan(planFolder, plan, planWatcher);
+    }
+}

--- a/src/Ivy.Tendril/Helpers/PrUrlHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PrUrlHelper.cs
@@ -1,0 +1,40 @@
+using System.Text.RegularExpressions;
+
+namespace Ivy.Tendril.Helpers;
+
+/// <summary>
+///     Identity of a GitHub PR URL, for the cases that have to compare two URLs that name the same PR.
+///     A URL reaches plan.yaml in whatever form the agent had it in, so the same PR can be recorded as
+///     the base URL, with a trailing slash, with a /files suffix or with a #discussion fragment.
+/// </summary>
+public static class PrUrlHelper
+{
+    private static readonly Regex PrUrlPattern = new(
+        @"^https?://github\.com/(?<owner>[^/\s]+)/(?<repo>[^/\s]+)/pull/(?<number>\d+)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    ///     "owner/repo#number", lower cased, or null when the string is not a GitHub PR URL.
+    /// </summary>
+    public static string? CanonicalKey(string? url)
+    {
+        if (url == null) return null;
+        var m = PrUrlPattern.Match(url.Trim());
+        return m.Success
+            ? $"{m.Groups["owner"].Value}/{m.Groups["repo"].Value}#{m.Groups["number"].Value}".ToLowerInvariant()
+            : null;
+    }
+
+    /// <summary>
+    ///     True when both strings are PR URLs naming the same PR, or when they are byte equal ignoring
+    ///     case. The literal comparison is the fallback for a value that never parsed, so a malformed
+    ///     entry can still be addressed by exactly what is stored.
+    /// </summary>
+    public static bool SamePr(string? a, string? b)
+    {
+        if (string.Equals(a?.Trim(), b?.Trim(), StringComparison.OrdinalIgnoreCase)) return true;
+
+        var keyA = CanonicalKey(a);
+        return keyA != null && keyA == CanonicalKey(b);
+    }
+}

--- a/src/Ivy.Tendril/Program.cs
+++ b/src/Ivy.Tendril/Program.cs
@@ -722,6 +722,8 @@ public class Program
                     .WithDescription("Remove a repository");
                 plan.AddCommand<PlanAddPrCommand>("add-pr")
                     .WithDescription("Add a PR URL");
+                plan.AddCommand<PlanRemovePrCommand>("remove-pr")
+                    .WithDescription("Remove a PR URL");
                 plan.AddCommand<PlanAddCommitCommand>("add-commit")
                     .WithDescription("Add a commit hash");
                 plan.AddCommand<PlanAddRelatedPlanCommand>("add-related-plan")

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -98,6 +98,10 @@ tendril plan remove-repo <plan-id> <repo-path>
 
 # Track PRs and commits
 tendril plan add-pr <plan-id> <pr-url>
+tendril plan remove-pr <plan-id> <pr-url>
+# Matches on owner/repo#number, so a URL recorded with a /files suffix can be removed by its base
+# form. Use it to unpick a PR that was recorded against the wrong plan; `tendril plan doctor --prs`
+# finds those and prints the command for each one.
 tendril plan add-commit <plan-id> <sha>
 
 # Verifications

--- a/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobCompletionHandler.cs
@@ -637,18 +637,50 @@ internal class JobCompletionHandler
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     /// <summary>
+    ///     <see cref="GitHubPrUrlPattern" /> anchored to a whole line, so it only matches a PR URL that
+    ///     stands alone: what `gh pr create` prints, and never a URL cited inside prose, a markdown
+    ///     link or a heredoc. A trailing slash and a trailing `#fragment` are tolerated in the
+    ///     lookahead so the match value stays the canonical base URL.
+    /// </summary>
+    internal static readonly Regex BarePrUrlPattern = new(
+        @"^https?://github\.com/(?<owner>[^/\s]+)/(?<repo>[^/\s]+)/pull/(?<number>\d+)(?=/?(?:#\S*)?$)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
     ///     Safety net for CreatePr. The agent is supposed to record each PR URL via
     ///     `tendril plan add-pr` and set the plan to Completed (Program.md step 6), but a rushed or
-    ///     weak provider can stop after opening the PR and skip that closeout — leaving the PR
+    ///     weak provider can stop after opening the PR and skip that closeout, leaving the PR
     ///     invisible in the Pull Requests app (which filters on Prs.Count > 0) and the plan stuck in
     ///     Drafts. Here we parse PR URLs from the job output, record the ones missing from plan.yaml,
     ///     and mark the plan Completed. A plan that has a PR is Completed regardless of PrMerge; merge
     ///     is tracked separately as PR status.
     ///
-    ///     Only PR URLs whose repo matches one of this plan's repos are trusted — a foreign or
-    ///     SourceUrl PR merely echoed in the transcript must not be recorded or force-complete the
-    ///     plan. Plans with no repos (e.g. direct-to-main scaffolding, which opens no PR) are left
-    ///     untouched. No-ops cleanly when the agent already did the closeout.
+    ///     A URL is only trusted when all of these hold, because <c>OutputLines</c> is the whole
+    ///     eventwire (thinking, prose and tool inputs included), not command output:
+    ///     <list type="number">
+    ///         <item>
+    ///             It arrived in a <see cref="ToolResultEvent" /> and occupies a line of that output on
+    ///             its own (<see cref="BarePrUrlPattern" />). Agents routinely cite a sibling plan's PR
+    ///             in the PR body they build, and issue #2336 is 12 plans that had a cited URL recorded
+    ///             as their own because the old scan read every event kind as if it were output.
+    ///         </item>
+    ///         <item>
+    ///             The plan has no PR recorded yet for that repo. The net exists for an agent that
+    ///             recorded nothing, so it has no business appending a second PR to a repo that already
+    ///             has one. Scoping per repo keeps multi-repo plans reconcilable.
+    ///         </item>
+    ///         <item>
+    ///             The repo segment matches one of this plan's repos, and the canonical
+    ///             owner/repo#number is not already recorded in another form.
+    ///         </item>
+    ///     </list>
+    ///     Plans with no repos (e.g. direct-to-main scaffolding, which opens no PR) are left untouched.
+    ///     No-ops cleanly when the agent already did the closeout.
+    ///
+    ///     The regression risk is narrower reconciliation: if a future prompt captures the URL into a
+    ///     variable instead of letting `gh pr create` print it, the net misses it and the plan stays in
+    ///     Review for a human to complete. That is the behaviour from before the net existed, and it is
+    ///     strictly better than writing a foreign PR into a plan's history.
     /// </summary>
     internal void ReconcileCreatePrResult(JobItem job)
     {
@@ -674,19 +706,39 @@ internal class JobCompletionHandler
                 .Select(CanonicalPrKey)
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-            // Scan the output line-by-line (no whole-transcript allocation), keeping the canonical
-            // base URL for each in-scope, not-yet-recorded PR.
+            // Repos that already have a PR recorded, so the net stays out of their way.
+            var reposWithPr = plan.Prs
+                .Select(p => GitHubPrUrlPattern.Match(p))
+                .Where(m => m.Success)
+                .Select(m => m.Groups["repo"].Value)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            // Scan the eventwire entry by entry (no whole-transcript allocation), keeping the
+            // canonical base URL for each in-scope, not-yet-recorded PR.
             var added = new List<string>();
             if (planRepoNames.Count > 0)
             {
                 var seen = new HashSet<string>(recordedKeys, StringComparer.OrdinalIgnoreCase);
-                foreach (var line in job.OutputLines)
-                    foreach (Match m in GitHubPrUrlPattern.Matches(line))
+                var serializer = new JsonEventSerializer();
+                foreach (var entry in job.OutputLines)
+                {
+                    // Only a tool result is command output. Newlines live as escapes inside the
+                    // serialized entry, so the split has to happen after deserialization.
+                    if (serializer.Deserialize(entry) is not ToolResultEvent { Output: { } output }) continue;
+
+                    foreach (var outputLine in output.Replace("\r", "").Split('\n'))
                     {
-                        if (!planRepoNames.Contains(m.Groups["repo"].Value)) continue;
+                        var m = BarePrUrlPattern.Match(outputLine.Trim());
+                        if (!m.Success) continue;
+
+                        var repo = m.Groups["repo"].Value;
+                        if (!planRepoNames.Contains(repo)) continue;
+                        if (reposWithPr.Contains(repo)) continue;
                         if (!seen.Add(CanonicalPrKey(m))) continue;
+
                         added.Add(m.Value);
                     }
+                }
             }
 
             // Nothing to record and no PR on the plan → leave state to whatever the agent set.

--- a/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
+++ b/src/Ivy.Tendril/Services/Plans/DependencyChecker.cs
@@ -11,12 +11,28 @@ namespace Ivy.Tendril.Services.Plans;
 
 internal class DependencyChecker
 {
+    private const int PrLookupTimeoutMs = 10000;
+
     private readonly IPlanReaderService? _planReaderService;
 
     internal DependencyChecker(IPlanReaderService? planReaderService)
     {
         _planReaderService = planReaderService;
     }
+
+    /// <summary>
+    ///     Outcome of one `gh pr view` lookup. The exit code has to travel with the state: gh writes
+    ///     its GraphQL error to stderr and nothing to stdout, so a deleted PR, an expired token and a
+    ///     rate limit all arrive as an empty state, which the gate used to report as "is '', not
+    ///     MERGED".
+    /// </summary>
+    internal record PrLookup(int ExitCode, string State, string Error);
+
+    /// <summary>
+    ///     Seam for the `gh pr view` call, so a test can assert the block reasons without shelling out
+    ///     to a real gh and a real network.
+    /// </summary>
+    internal Func<string, PrLookup> PrStateResolver { get; set; } = RunGhPrView;
 
     internal (bool Ok, string? BlockReason) CheckDependencies(string planFolder)
     {
@@ -43,7 +59,7 @@ internal class DependencyChecker
         }
     }
 
-    private static (bool Ok, string? BlockReason) CheckSingleDependency(string dep, string plansDir)
+    private (bool Ok, string? BlockReason) CheckSingleDependency(string dep, string plansDir)
     {
         var depFolder = Path.Combine(plansDir, dep);
         var depPlan = PlanYamlHelper.ReadPlanYaml(depFolder);
@@ -56,15 +72,41 @@ internal class DependencyChecker
 
         foreach (var prUrl in depPlan.Prs.Where(PullRequestApp.IsValidUrl))
         {
-            var prState = GetPrState(prUrl);
-            if (prState != null && !prState.Equals("MERGED", StringComparison.OrdinalIgnoreCase))
-                return (false, $"Dependency '{dep}' PR {prUrl} is '{prState}', not MERGED");
+            var lookup = PrStateResolver(prUrl);
+
+            // A state gh never reported is not an unmerged PR, it is a lookup that failed. Stay
+            // blocked either way (a dependency whose merge cannot be confirmed is not satisfied) but
+            // say which of the two it is, so a bad token is not read as an open PR.
+            if (lookup.ExitCode != 0 || lookup.State.Length == 0)
+                return (false, $"Dependency '{dep}' PR {prUrl} could not be resolved ({DescribeLookupFailure(lookup)})");
+
+            if (!lookup.State.Equals("MERGED", StringComparison.OrdinalIgnoreCase))
+                return (false, $"Dependency '{dep}' PR {prUrl} is '{lookup.State}', not MERGED");
         }
 
         return (true, null);
     }
 
-    private static string? GetPrState(string prUrl)
+    /// <summary>
+    ///     First line of gh's stderr, which is where it puts the one sentence that explains the
+    ///     failure. Truncated because the whole thing has to fit a job StatusMessage.
+    /// </summary>
+    private static string DescribeLookupFailure(PrLookup lookup)
+    {
+        var firstLine = lookup.Error
+            .Split('\n')
+            .Select(l => l.Trim())
+            .FirstOrDefault(l => l.Length > 0);
+
+        if (string.IsNullOrEmpty(firstLine))
+            return $"gh exited {lookup.ExitCode} with no output";
+
+        const int maxLength = 200;
+        var message = firstLine.Length > maxLength ? firstLine[..maxLength] + "..." : firstLine;
+        return $"gh: {message}";
+    }
+
+    private static PrLookup RunGhPrView(string prUrl)
     {
         try
         {
@@ -78,9 +120,22 @@ internal class DependencyChecker
                 CreateNoWindow = true
             };
             using var proc = Process.Start(psi);
-            var output = proc?.StandardOutput.ReadToEnd().Trim() ?? "";
-            proc.WaitForExitOrKill(10000);
-            return output;
+            if (proc == null) return new PrLookup(-1, "", "gh could not be started");
+
+            // Drain both pipes concurrently: the error path writes to stderr only, and reading one
+            // stream to the end while the other fills its buffer is how this deadlocks.
+            var stdout = proc.StandardOutput.ReadToEndAsync();
+            var stderr = proc.StandardError.ReadToEndAsync();
+            var exited = proc.WaitForExitOrKill(PrLookupTimeoutMs);
+
+            if (!exited)
+                return new PrLookup(-1, "", $"gh pr view did not finish within {PrLookupTimeoutMs / 1000}s");
+
+            var drained = Task.WaitAll([stdout, stderr], PrLookupTimeoutMs);
+            if (!drained)
+                return new PrLookup(-1, "", "gh pr view output could not be read");
+
+            return new PrLookup(proc.ExitCode, stdout.Result.Trim(), stderr.Result.Trim());
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Fixes #2336

# 00216 Stop Recording Cited PR URLs as a Plan's Own Pull Request

Issue [#2336](https://github.com/Ivy-Interactive/Ivy-Tendril/issues/2336). Branch
`tendril/00216-StopRecordingCitedPRURLsAsAPlansOwnPullRequest`, 4 commits on
`origin/development` at `196ead21`. All four verifications Pass.

## What was wrong

`JobCompletionHandler.ReconcileCreatePrResult` is a safety net: if a CreatePr
agent opens a PR and forgets `tendril plan add-pr`, the net reads the job output
and records it. But `JobItem.OutputLines` is not command output. Every entry is a
serialized eventwire event of any kind, including the agent's own thinking, its
prose and the arguments it passed to Bash. Agents routinely cite a sibling plan's
PR in the PR body they write, so the net recorded citations as the plan's own
work: 12 firings, 12 corruptions, 0 genuine recoveries.

Downstream, `DependencyChecker` read `gh pr view`'s stdout without its exit code.
A PR gh could not resolve came back as the empty string, which is neither null nor
`MERGED`, so a dependent plan blocked with `is '', not MERGED`. Plan 00091 sat in
`Blocked` behind that message with no way to tell a deleted PR from an expired
token.

## What changed

**Reconcile only trusts what `gh pr create` printed** (`661c79d9`). A URL is
recorded only when it arrived in a `ToolResultEvent` and occupies a line of that
output on its own, and only when the plan has no PR yet **for that repo**. Both
rules were measured in the plan against all 12 corrupted jobs: each catches the
genuine PR 12 of 12 times and the foreign PR 0 of 12. The repo filter, the
canonical dedup, the no-repos guard and the force-complete are unchanged.

**The dependency gate says which failure it hit** (`b05f825e`). `GetPrState` is
now `PrLookup(ExitCode, State, Error)`. Unresolvable blocks with
`could not be resolved (gh: <gh's own first stderr line>)`; unmerged still blocks
with `is '<state>', not MERGED`. `PlanValidationService.Validate` was left alone
on purpose: it is offline, synchronous and on the plan-creation hot path.

**`tendril plan remove-pr <plan-id> <pr-url>`** (`8dcfc123`). The repair half of
`add-pr`, which did not exist, so unpicking a bad entry meant hand editing
plan.yaml. Matches on the canonical `owner/repo#number`, so a URL recorded with a
`/files` suffix or a `#fragment` is removable by its base form.

**`tendril plan doctor --prs`** (`d027bcad`). Resolves every recorded PR URL
individually and reports the ones whose head branch names a different plan, with
the exact `remove-pr` line to fix each. Report only, opt in behind `--prs`, silent
no-op when gh is missing. Never routed through `GetPrStatusesAsync`, whose
`--limit 100` window would report hundreds of healthy PRs as phantom.

## Tests

15 new tests, all four classes in the plan's filter green: 161 tests in the
filter, 3041 in the whole unit project, 0 failures.

The negative tests were proved to discriminate by stashing only
`JobCompletionHandler.cs` and re-running: exactly the three cited-URL tests
failed, the accept-path tests passed. Five pre-existing tests in that class were
rewritten onto a serialized-event fixture, because their prose lines never occur
in production and so exercised none of the filter.

## Follow-ups

Recorded as recommendations, both explicitly out of scope here: the `--limit 100`
pagination defect that stores merged PRs as `Open`, and the 12 already-corrupted
plans, which `--prs` now reports but does not repair.

---

## Commits

d027bcad [00216] Report mis-attributed PRs from plan doctor --prs
8dcfc123 [00216] Add tendril plan remove-pr
b05f825e [00216] Tell an unresolvable dependency PR apart from an unmerged one
661c79d9 [00216] Trust only a bare PR URL printed by gh pr create

---
Created using [Ivy Tendril](https://ivy.app).
