### PR TITLE
feat(chat): track spawned jobs in session and support interactive question blocks

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
@@ -53,6 +53,8 @@ public class DeleteSessionDialogTests
         public bool RemoveQueuedMessage(string sessionId, string queueId) => false;
         public bool UpdateQueuedMessage(string sessionId, string queueId, string prompt) => false;
         public void ClearQueuedMessages(string sessionId) { }
+        public void AddSpawnedJob(string sessionId, string jobId) { }
+        public IReadOnlyList<string> GetSpawnedJobs(string sessionId) => [];
     }
 
     private class TestState<T> : IState<T>

--- a/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
@@ -55,6 +55,7 @@ public class DeleteSessionDialogTests
         public void ClearQueuedMessages(string sessionId) { }
         public void AddSpawnedJob(string sessionId, string jobId) { }
         public IReadOnlyList<string> GetSpawnedJobs(string sessionId) => [];
+        public bool ApplyQuestionAnswers(string sessionId, string messageId, IReadOnlyDictionary<string, string[]> answers) => false;
     }
 
     private class TestState<T> : IState<T>

--- a/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
@@ -54,6 +54,7 @@ public class DeleteSessionDialogTests
         public bool UpdateQueuedMessage(string sessionId, string queueId, string prompt) => false;
         public void ClearQueuedMessages(string sessionId) { }
         public void AddSpawnedJob(string sessionId, string jobId) { }
+        public void RemoveSpawnedJobs(string sessionId, IEnumerable<string> jobIds) { }
         public IReadOnlyList<string> GetSpawnedJobs(string sessionId) => [];
         public bool ApplyQuestionAnswers(string sessionId, string messageId, IReadOnlyDictionary<string, string[]> answers) => false;
     }

--- a/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
@@ -51,6 +51,8 @@ public class SidebarViewTests
         public bool RemoveQueuedMessage(string sessionId, string queueId) => false;
         public bool UpdateQueuedMessage(string sessionId, string queueId, string prompt) => false;
         public void ClearQueuedMessages(string sessionId) { }
+        public void AddSpawnedJob(string sessionId, string jobId) { }
+        public IReadOnlyList<string> GetSpawnedJobs(string sessionId) => [];
     }
 
     private class TestState<T> : IState<T>

--- a/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
@@ -53,6 +53,7 @@ public class SidebarViewTests
         public void ClearQueuedMessages(string sessionId) { }
         public void AddSpawnedJob(string sessionId, string jobId) { }
         public IReadOnlyList<string> GetSpawnedJobs(string sessionId) => [];
+        public bool ApplyQuestionAnswers(string sessionId, string messageId, IReadOnlyDictionary<string, string[]> answers) => false;
     }
 
     private class TestState<T> : IState<T>

--- a/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
@@ -52,6 +52,7 @@ public class SidebarViewTests
         public bool UpdateQueuedMessage(string sessionId, string queueId, string prompt) => false;
         public void ClearQueuedMessages(string sessionId) { }
         public void AddSpawnedJob(string sessionId, string jobId) { }
+        public void RemoveSpawnedJobs(string sessionId, IEnumerable<string> jobIds) { }
         public IReadOnlyList<string> GetSpawnedJobs(string sessionId) => [];
         public bool ApplyQuestionAnswers(string sessionId, string messageId, IReadOnlyDictionary<string, string[]> answers) => false;
     }

--- a/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
@@ -106,7 +106,7 @@ public class ChatExecutionServiceJobTrackingTests
     }
 
     [Fact]
-    public void ToolResultEvent_WithJobIdPattern_TracksSpawnedJob()
+    public void ToolResultEvent_WithJobIdDiscussion_DoesNotTrackSpawnedJob()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "TendrilTrackJobIdTest_" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(tempDir);
@@ -133,13 +133,50 @@ public class ChatExecutionServiceJobTrackingTests
 
             var session = chatService.CreateSession("codex", "gpt-5.6-sol");
 
-            execService.TryTrackSpawnedJob(session.Id, "Created new background execution. Job ID: test-job-999");
+            // Discussions and listings mentioning Job ID: should NOT track as newly spawned jobs
+            execService.TryTrackSpawnedJob(session.Id, "Here are the jobs:\n- **Job ID**: test-job-999\n- Job ID: 00151");
 
             var updatedSession = chatService.GetSession(session.Id);
             Assert.NotNull(updatedSession);
-            Assert.NotNull(updatedSession.SpawnedJobIds);
-            Assert.Contains("test-job-999", updatedSession.SpawnedJobIds);
-            Assert.Equal(session.Id, fakeJobService.JobChatSessions["test-job-999"]);
+            Assert.Null(updatedSession.SpawnedJobIds);
+            Assert.Empty(fakeJobService.JobChatSessions);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void RemoveSpawnedJobs_PrunesStaleJobsFromSession()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilRemoveSpawnedTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+            chatService.AddSpawnedJob(session.Id, "00151");
+            chatService.AddSpawnedJob(session.Id, "00152");
+            chatService.AddSpawnedJob(session.Id, "00153");
+
+            var sess = chatService.GetSession(session.Id);
+            Assert.NotNull(sess?.SpawnedJobIds);
+            Assert.Equal(3, sess.SpawnedJobIds.Count);
+
+            chatService.RemoveSpawnedJobs(session.Id, new[] { "00151", "00152" });
+
+            var updated = chatService.GetSession(session.Id);
+            Assert.NotNull(updated?.SpawnedJobIds);
+            Assert.Single(updated.SpawnedJobIds);
+            Assert.Equal("00153", updated.SpawnedJobIds[0]);
         }
         finally
         {

--- a/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
@@ -493,4 +493,265 @@ public class ChatExecutionServiceJobTrackingTests
             }
         }
     }
+
+    private sealed class CancellableTestSession : IAgentSession
+    {
+        private readonly System.Reactive.Subjects.Subject<AgentEvent> _events = new();
+        private readonly TaskCompletionSource<ResultEvent> _completion = new();
+
+        public string SessionId { get; } = "sess-cancel-test";
+        public string AgentId { get; } = "codex";
+        public SessionState State => SessionState.Running;
+        public DateTimeOffset StartedAt { get; } = DateTimeOffset.UtcNow;
+        public DateTimeOffset? CompletedAt => null;
+        public SessionMetadata? Metadata => null;
+        public IObservable<AgentEvent> Events => _events;
+        public IObservable<string>? RawOutput => null;
+        public IObservable<string>? RawStderr => null;
+        public ResultEvent? Result => null;
+        public bool SupportsPermissionResponse => false;
+        public bool SupportsQuestionResponse => false;
+        public bool SupportsMultiTurn => false;
+
+        public bool HasObservers => _events.HasObservers;
+
+        public void Emit(AgentEvent evt) => _events.OnNext(evt);
+
+        public async Task<ResultEvent> WaitForCompletionAsync(CancellationToken ct = default)
+        {
+            using var reg = ct.Register(() => _completion.TrySetCanceled(ct));
+            return await _completion.Task;
+        }
+
+        public Task StopAsync(CancellationToken ct = default)
+        {
+            _completion.TrySetCanceled();
+            return Task.CompletedTask;
+        }
+
+        public Task KillAsync()
+        {
+            _completion.TrySetCanceled();
+            return Task.CompletedTask;
+        }
+
+        public Task RespondToPermissionAsync(string requestId, PermissionDecision decision, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task RespondToQuestionAsync(string questionId, QuestionResponse response, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task SendFollowUpAsync(string message, CancellationToken ct = default) => throw new NotSupportedException();
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private class CancellableAgentRunner : IAgentRunner
+    {
+        private readonly IAgentRunner _inner;
+        private readonly IAgentSession _session;
+
+        public CancellableAgentRunner(IAgentRunner inner, IAgentSession session)
+        {
+            _inner = inner;
+            _session = session;
+        }
+
+        public Task<IAgentSession> LaunchAsync(AgentResolutionContext context, CancellationToken ct = default)
+            => Task.FromResult(_session);
+
+        public Task<ResultEvent> RunToCompletionAsync(AgentResolutionContext context, CancellationToken ct = default)
+            => _inner.RunToCompletionAsync(context, ct);
+
+        public IReadOnlyList<IAgentSession> ActiveSessions => _inner.ActiveSessions;
+        public IObservable<IAgentSession> Sessions => _inner.Sessions;
+        public Task StopAllAsync(CancellationToken ct = default) => _inner.StopAllAsync(ct);
+        public IReadOnlyList<string> RegisteredAgents => _inner.RegisteredAgents;
+        public IAgentCli GetCli(string agentId) => _inner.GetCli(agentId);
+        public IEventParser GetParser(string agentId) => _inner.GetParser(agentId);
+        public IAgentHealthCheck GetHealthCheck(string agentId) => _inner.GetHealthCheck(agentId);
+        public IAgentDescriptor GetDescriptor(string agentId) => _inner.GetDescriptor(agentId);
+        public IFailureAnalyzer? GetFailureAnalyzer(string agentId) => _inner.GetFailureAnalyzer(agentId);
+        public ISessionCostParser? GetCostParser(string agentId) => _inner.GetCostParser(agentId);
+        public IAgentPty? GetPty(string agentId) => _inner.GetPty(agentId);
+        public IModelCatalogProvider? GetModelCatalog(string agentId) => _inner.GetModelCatalog(agentId);
+        public IEnumerable<IModelCatalogProvider> ModelCatalogs => _inner.ModelCatalogs;
+    }
+
+    [Fact]
+    public async Task CancelAsync_WhenCancelledDuringExecution_PreservesRawHistoryAndAppendsCancellationMessage()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilCancelHistoryTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var cancellableSession = new CancellableTestSession();
+            var agentRunner = new CancellableAgentRunner(TestAgentRunner.Create(), cancellableSession);
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            var fakeJobService = new FakeChatJobService();
+
+            var execService = new ChatExecutionService(
+                configService,
+                chatService,
+                agentRunner,
+                namingService,
+                serializer,
+                logger: null,
+                serviceProvider: null,
+                jobService: fakeJobService);
+
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            // Start execution
+            var sendTask = execService.SendMessageAsync(session.Id, "Analyze the project");
+
+            // Wait until execution is active and subscribed to session events
+            var deadline = DateTime.UtcNow.AddSeconds(2);
+            while ((!execService.IsGenerating(session.Id) || !cancellableSession.HasObservers) && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(20);
+            }
+            Assert.True(execService.IsGenerating(session.Id));
+            Assert.True(cancellableSession.HasObservers);
+
+            // Emit some events: thinking, tool call + result, open tool call, text
+            cancellableSession.Emit(new ThinkingEvent
+            {
+                Kind = AgentEventKind.Thinking,
+                Content = "Searching codebase for entry points",
+                Timestamp = DateTimeOffset.UtcNow
+            });
+            cancellableSession.Emit(new ToolCallEvent
+            {
+                Kind = AgentEventKind.ToolCall,
+                ToolUseId = "tool-1",
+                ToolName = "Grep",
+                InputJson = "{\"pattern\":\"Main\"}",
+                Timestamp = DateTimeOffset.UtcNow
+            });
+            cancellableSession.Emit(new ToolResultEvent
+            {
+                Kind = AgentEventKind.ToolResult,
+                ToolUseId = "tool-1",
+                Output = "Program.cs:5: static void Main()",
+                IsError = false,
+                Timestamp = DateTimeOffset.UtcNow
+            });
+            cancellableSession.Emit(new ToolCallEvent
+            {
+                Kind = AgentEventKind.ToolCall,
+                ToolUseId = "tool-2",
+                ToolName = "Bash",
+                InputJson = "{\"command\":\"dotnet test\"}",
+                Timestamp = DateTimeOffset.UtcNow
+            });
+            cancellableSession.Emit(new TextEvent
+            {
+                Kind = AgentEventKind.Text,
+                Text = "I found the main entry point.",
+                IsDelta = false,
+                Timestamp = DateTimeOffset.UtcNow
+            });
+
+            // Wait briefly for events to be received by the subscription
+            await Task.Delay(100);
+
+            // Cancel the execution
+            await execService.CancelAsync(session.Id);
+
+            // Ensure generating flag is cleared
+            Assert.False(execService.IsGenerating(session.Id));
+
+            // Verify the assistant message in chat history
+            var updatedSession = chatService.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            var assistantMsg = updatedSession.Messages.FirstOrDefault(m => m.Role == "assistant");
+            Assert.NotNull(assistantMsg);
+
+            // Content should append cancellation message to prior collected text
+            Assert.Contains("I found the main entry point.", assistantMsg.Content);
+            Assert.Contains("Execution was cancelled.", assistantMsg.Content);
+
+            // RawStream must be preserved (not null) and contain history + cancellation
+            Assert.NotNull(assistantMsg.RawStream);
+            Assert.Contains("Searching codebase for entry points", assistantMsg.RawStream);
+            Assert.Contains("tool-1", assistantMsg.RawStream);
+            Assert.Contains("Program.cs:5", assistantMsg.RawStream);
+            Assert.Contains("tool-2", assistantMsg.RawStream);
+            // Open tool-2 was cancelled
+            Assert.Contains("[Cancelled]", assistantMsg.RawStream);
+            Assert.Contains("I found the main entry point.", assistantMsg.RawStream);
+            // Appended cancellation message
+            Assert.Contains("Execution was cancelled.", assistantMsg.RawStream);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CancelAsync_WhenCancelledImmediatelyWithNoEvents_AddsCancelledMessageWithoutCrashing()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilCancelEmptyTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var cancellableSession = new CancellableTestSession();
+            var agentRunner = new CancellableAgentRunner(TestAgentRunner.Create(), cancellableSession);
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            var fakeJobService = new FakeChatJobService();
+
+            var execService = new ChatExecutionService(
+                configService,
+                chatService,
+                agentRunner,
+                namingService,
+                serializer,
+                logger: null,
+                serviceProvider: null,
+                jobService: fakeJobService);
+
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            // Start execution
+            var sendTask = execService.SendMessageAsync(session.Id, "Analyze the project");
+
+            var deadline = DateTime.UtcNow.AddSeconds(2);
+            while ((!execService.IsGenerating(session.Id) || !cancellableSession.HasObservers) && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(20);
+            }
+            Assert.True(execService.IsGenerating(session.Id));
+
+            // Cancel immediately before any events are emitted
+            await execService.CancelAsync(session.Id);
+
+            Assert.False(execService.IsGenerating(session.Id));
+
+            var updatedSession = chatService.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            var assistantMsg = updatedSession.Messages.FirstOrDefault(m => m.Role == "assistant");
+            Assert.NotNull(assistantMsg);
+
+            Assert.Equal("Execution was cancelled.", assistantMsg.Content);
+            Assert.NotNull(assistantMsg.RawStream);
+            Assert.Contains("Execution was cancelled.", assistantMsg.RawStream);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
 }

--- a/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
@@ -8,6 +8,7 @@ using Ivy.Tendril.Agents.Runtime;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
 using Ivy.Tendril.Services.Jobs;
+using Ivy.Tendril.Widgets;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -270,6 +271,100 @@ public class ChatExecutionServiceJobTrackingTests
             var sess = chatService.GetSession(session.Id);
             Assert.NotNull(sess);
             Assert.DoesNotContain(sess.Messages, m => m.Role == "system");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SystemEvent_WhenExecutionRunning_NeverEnqueuesIntoUserQueuedMessages()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilNoQueueTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            var fakeJobService = new FakeChatJobService();
+
+            var execService = new ChatExecutionService(
+                configService,
+                chatService,
+                agentRunner,
+                namingService,
+                serializer,
+                logger: null,
+                serviceProvider: null,
+                jobService: fakeJobService);
+
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            // Simulate that the session is currently generating / executing
+            var activeExecutionsField = typeof(ChatExecutionService).GetField("_activeExecutions",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.NotNull(activeExecutionsField);
+
+            var cts = new System.Threading.CancellationTokenSource();
+            var activeExecType = typeof(ChatExecutionService).GetNestedType("ActiveChatExecution",
+                System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(activeExecType);
+            var activeExec = Activator.CreateInstance(activeExecType, cts);
+            Assert.NotNull(activeExec);
+
+            var dict = (System.Collections.IDictionary)activeExecutionsField.GetValue(execService)!;
+            dict[session.Id] = activeExec;
+
+            // Send a system event while session is active
+            await execService.SendMessageAsync(session.Id, "[System Event] Job 00151 finished with status: Stopped", role: "system");
+
+            // Verify user queue in chat history has ZERO items
+            var queued = chatService.GetQueuedMessages(session.Id);
+            Assert.Empty(queued);
+
+            // Clean up
+            dict.Remove(session.Id);
+            cts.Dispose();
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void GetQueuedMessages_PurgesAnySystemEventMessages()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilPurgeQueueTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            // Manually enqueue a user message and a rogue system event
+            chatService.EnqueueMessage(session.Id, new ChatSendMessageDto("User prompt", null, session.Id));
+            chatService.EnqueueMessage(session.Id, new ChatSendMessageDto("[System Event] Job 00151 finished", null, session.Id));
+
+            var queued = chatService.GetQueuedMessages(session.Id);
+            Assert.Single(queued);
+            Assert.Equal("User prompt", queued[0].Prompt);
         }
         finally
         {

--- a/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Ivy.Tendril.Agents.Abstractions;
+using Ivy.Tendril.Agents.Runtime;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Jobs;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Ivy.Tendril.Test;
+
+public class ChatExecutionServiceJobTrackingTests
+{
+    private class FakeChatJobService : IJobService
+    {
+        public Dictionary<string, string> JobChatSessions { get; } = new();
+        public List<JobItem> Jobs { get; } = new();
+
+        public event Action<JobItem>? JobFinished;
+#pragma warning disable CS0067
+        public event Action? JobsChanged;
+        public event Action? JobsStructureChanged;
+        public event Action? JobPropertyChanged;
+        public event Action<JobNotification>? NotificationReady;
+#pragma warning restore CS0067
+
+        public void SetChatSessionId(string id, string chatSessionId)
+        {
+            JobChatSessions[id] = chatSessionId;
+        }
+
+        public void FireJobFinished(JobItem job)
+        {
+            JobFinished?.Invoke(job);
+        }
+
+        public string StartJob(JobArgsBase args, string? inboxFilePath = null) => "job-001";
+        public void ForceStartJob(string id) { }
+        public bool IsInboxFileTracked(string filePath) => false;
+        public void CompleteJob(string id, int? exitCode, bool timedOut = false, bool staleOutput = false) { }
+        public void StopJob(string id) { }
+        public int StopAllJobs() => 0;
+        public void DeleteJob(string id) { }
+        public void ClearCompletedJobs() { }
+        public void ClearFailedJobs() { }
+        public void ClearAllJobs() { }
+        public int StopQueuedJobs() => 0;
+        public List<JobItem> GetJobs() => Jobs;
+        public List<JobItem> GetJobsForPlan(string planFile) => new();
+        public JobItem? GetJob(string id) => Jobs.FirstOrDefault(j => j.Id == id);
+        public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => false;
+        public bool ReportJobFailure(string id, string message) => false;
+        public void Dispose() { }
+    }
+
+    [Fact]
+    public void ToolResultEvent_WithJobStarted_TracksSpawnedJobAndSetsChatSessionId()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilTrackJobTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            var fakeJobService = new FakeChatJobService();
+
+            var execService = new ChatExecutionService(
+                configService,
+                chatService,
+                agentRunner,
+                namingService,
+                serializer,
+                logger: null,
+                serviceProvider: null,
+                jobService: fakeJobService);
+
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            execService.TryTrackSpawnedJob(session.Id, "Started agent successfully. Job started: 00148\nTracking progress...");
+
+            var updatedSession = chatService.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            Assert.NotNull(updatedSession.SpawnedJobIds);
+            Assert.Contains("00148", updatedSession.SpawnedJobIds);
+
+            Assert.True(fakeJobService.JobChatSessions.ContainsKey("00148"));
+            Assert.Equal(session.Id, fakeJobService.JobChatSessions["00148"]);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public void ToolResultEvent_WithJobIdPattern_TracksSpawnedJob()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilTrackJobIdTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            var fakeJobService = new FakeChatJobService();
+
+            var execService = new ChatExecutionService(
+                configService,
+                chatService,
+                agentRunner,
+                namingService,
+                serializer,
+                logger: null,
+                serviceProvider: null,
+                jobService: fakeJobService);
+
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            execService.TryTrackSpawnedJob(session.Id, "Created new background execution. Job ID: test-job-999");
+
+            var updatedSession = chatService.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            Assert.NotNull(updatedSession.SpawnedJobIds);
+            Assert.Contains("test-job-999", updatedSession.SpawnedJobIds);
+            Assert.Equal(session.Id, fakeJobService.JobChatSessions["test-job-999"]);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task JobFinished_WhenSpawnedFromChat_DispatchesSystemEventMessage()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilJobFinishedChatTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            var fakeJobService = new FakeChatJobService();
+
+            var execService = new ChatExecutionService(
+                configService,
+                chatService,
+                agentRunner,
+                namingService,
+                serializer,
+                logger: null,
+                serviceProvider: null,
+                jobService: fakeJobService);
+
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+            chatService.AddSpawnedJob(session.Id, "job-777");
+
+            var completedJob = new JobItem
+            {
+                Id = "job-777",
+                Type = "ExecutePlan",
+                ChatSessionId = session.Id,
+                Status = JobStatus.Completed,
+                ReportedPlanId = "P-100",
+                ReportedPlanTitle = "Implement Feature X"
+            };
+
+            // Fire JobFinished
+            fakeJobService.FireJobFinished(completedJob);
+
+            // Wait briefly for async Task.Run in OnJobFinished to record message
+            for (int i = 0; i < 20; i++)
+            {
+                var s = chatService.GetSession(session.Id);
+                if (s?.Messages.Any(m => m.Role == "system") == true)
+                    break;
+                await Task.Delay(50);
+            }
+
+            var sess = chatService.GetSession(session.Id);
+            Assert.NotNull(sess);
+            var systemMsg = sess.Messages.FirstOrDefault(m => m.Role == "system");
+            Assert.NotNull(systemMsg);
+            Assert.Contains("[System Event]", systemMsg.Content);
+            Assert.Contains("job-777", systemMsg.Content);
+            Assert.Contains("Implement Feature X", systemMsg.Content);
+            Assert.Contains("Completed successfully", systemMsg.Content);
+
+            // Verify deduplication: firing again does not add a second system event message
+            var countBefore = sess.Messages.Count(m => m.Role == "system");
+            fakeJobService.FireJobFinished(completedJob);
+            await Task.Delay(100);
+
+            var sessAfter = chatService.GetSession(session.Id);
+            Assert.Equal(countBefore, sessAfter!.Messages.Count(m => m.Role == "system"));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task JobFinished_WhenJobNotSpawnedInChat_DoesNotDispatchMessage()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilJobFinishedUnrelatedTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            var fakeJobService = new FakeChatJobService();
+
+            var execService = new ChatExecutionService(
+                configService,
+                chatService,
+                agentRunner,
+                namingService,
+                serializer,
+                logger: null,
+                serviceProvider: null,
+                jobService: fakeJobService);
+
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            var unrelatedJob = new JobItem
+            {
+                Id = "job-unrelated-888",
+                Type = "ExecutePlan",
+                ChatSessionId = null,
+                Status = JobStatus.Completed,
+                ReportedPlanId = "P-200",
+                ReportedPlanTitle = "Background Work"
+            };
+
+            fakeJobService.FireJobFinished(unrelatedJob);
+            await Task.Delay(150);
+
+            var sess = chatService.GetSession(session.Id);
+            Assert.NotNull(sess);
+            Assert.DoesNotContain(sess.Messages, m => m.Role == "system");
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
+}

--- a/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
+++ b/src/Ivy.Tendril.Test/ChatExecutionServiceJobTrackingTests.cs
@@ -411,4 +411,86 @@ public class ChatExecutionServiceJobTrackingTests
             }
         }
     }
+
+    [Fact]
+    public async Task ForceSendMessageAsync_WhenExecutionRunning_InterruptsCurrentExecutionAndPreservesQueue()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilForceSendTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var config = new TendrilSettings { CodingAgent = "codex" };
+            var configService = new ConfigService(config, tempDir);
+            var chatService = new ChatHistoryService(configService);
+            var agentRunner = TestAgentRunner.Create();
+            var serializer = new JsonEventSerializer();
+            var namingService = new ChatSessionNamingService(agentRunner, configService, chatService, NullLogger<ChatSessionNamingService>.Instance);
+            var fakeJobService = new FakeChatJobService();
+
+            var execService = new ChatExecutionService(
+                configService,
+                chatService,
+                agentRunner,
+                namingService,
+                serializer,
+                logger: null,
+                serviceProvider: null,
+                jobService: fakeJobService);
+
+            var session = chatService.CreateSession("codex", "gpt-5.6-sol");
+
+            // Enqueue two messages: one that will be force sent, and one that should remain in queue
+            chatService.EnqueueMessage(session.Id, new ChatSendMessageDto("Force sent prompt", null, session.Id));
+            chatService.EnqueueMessage(session.Id, new ChatSendMessageDto("Should stay queued", null, session.Id));
+
+            // Simulate an active running execution
+            var activeExecutionsField = typeof(ChatExecutionService).GetField("_activeExecutions",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.NotNull(activeExecutionsField);
+
+            var cts = new System.Threading.CancellationTokenSource();
+            var activeExecType = typeof(ChatExecutionService).GetNestedType("ActiveChatExecution",
+                System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(activeExecType);
+            var activeExec = Activator.CreateInstance(activeExecType, cts);
+            Assert.NotNull(activeExec);
+
+            var tcs = new TaskCompletionSource();
+            var execTaskProp = activeExecType.GetProperty("ExecutionTask");
+            execTaskProp?.SetValue(activeExec, tcs.Task);
+
+            var dict = (System.Collections.IDictionary)activeExecutionsField.GetValue(execService)!;
+            dict[session.Id] = activeExec;
+
+            Assert.True(execService.IsGenerating(session.Id));
+
+            // Run InterruptAsync on the session
+            var interruptTask = execService.InterruptAsync(session.Id);
+
+            // Verify cancellation was requested on the running execution's CTS
+            await Task.Delay(50);
+            Assert.True(cts.IsCancellationRequested);
+
+            // Complete the interrupted task
+            tcs.SetResult();
+            await interruptTask;
+
+            // Execution should no longer be active
+            Assert.False(execService.IsGenerating(session.Id));
+
+            // Verify other queued message is still in queue
+            var queued = chatService.GetQueuedMessages(session.Id);
+            Assert.Contains(queued, q => q.Prompt == "Should stay queued");
+
+            cts.Dispose();
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                try { Directory.Delete(tempDir, true); } catch { }
+            }
+        }
+    }
 }

--- a/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
@@ -344,4 +344,35 @@ public class ChatHistoryServiceTests
         Assert.Equal("/tmp/attachments/report.pdf", att.LocalPath);
         Assert.Equal("att-12345", att.FileId);
     }
+
+    [Fact]
+    public void AddSpawnedJob_And_GetSpawnedJobs_TracksAndPersistsJobIds()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "opus");
+            Assert.Empty(service.GetSpawnedJobs(session.Id));
+
+            service.AddSpawnedJob(session.Id, "job-101");
+            service.AddSpawnedJob(session.Id, "job-102");
+            // Should not duplicate
+            service.AddSpawnedJob(session.Id, "job-101");
+
+            var jobs = service.GetSpawnedJobs(session.Id);
+            Assert.Equal(2, jobs.Count);
+            Assert.Equal("job-101", jobs[0]);
+            Assert.Equal("job-102", jobs[1]);
+
+            var storedSession = service.GetSession(session.Id);
+            Assert.NotNull(storedSession);
+            Assert.NotNull(storedSession.SpawnedJobIds);
+            Assert.Equal(new[] { "job-101", "job-102" }, storedSession.SpawnedJobIds);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
@@ -375,4 +375,68 @@ public class ChatHistoryServiceTests
                 Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void ApplyQuestionAnswers_UpdatesMessageContentWithAnswers()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "opus");
+            var initialContent = "Here are questions:\n\n```questions\n- id: target_env\n  title: Which env?\n  options:\n    - title: Staging\n      value: staging\n    - title: Production\n      value: prod\n```\n";
+            var msg = service.AddMessage(session.Id, "assistant", initialContent);
+
+            var answers = new Dictionary<string, string[]>
+            {
+                ["target_env"] = ["staging"]
+            };
+
+            var success = service.ApplyQuestionAnswers(session.Id, msg.Id, answers);
+            Assert.True(success);
+
+            var updatedSession = service.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            var updatedMsg = Assert.Single(updatedSession.Messages);
+            Assert.Contains("answer: staging", updatedMsg.Content);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ApplyQuestionAnswers_UpdatesRawStreamWhenPresent()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "opus");
+            var initialContent = "Which env?\n\n```questions\n- id: target_env\n  title: Which env?\n  options:\n    - title: Staging\n      value: staging\n```\n";
+            var rawStreamLine = "{\"kind\":\"text\",\"text\":\"Which env?\\n\\n```questions\\n- id: target_env\\n  title: Which env?\\n  options:\\n    - title: Staging\\n      value: staging\\n```\\n\",\"delta\":false}";
+            var msg = service.AddMessage(session.Id, "assistant", initialContent, rawStream: rawStreamLine);
+
+            var answers = new Dictionary<string, string[]>
+            {
+                ["target_env"] = ["staging"]
+            };
+
+            var success = service.ApplyQuestionAnswers(session.Id, msg.Id, answers);
+            Assert.True(success);
+
+            var updatedSession = service.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            var updatedMsg = Assert.Single(updatedSession.Messages);
+            Assert.Contains("answer: staging", updatedMsg.Content);
+            Assert.NotNull(updatedMsg.RawStream);
+            Assert.Contains("answer: staging", updatedMsg.RawStream);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
 }
+

--- a/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
@@ -438,5 +438,46 @@ public class ChatHistoryServiceTests
                 Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void ApplyQuestionAnswers_ConsolidatesDeltaTextChunksWhenPresent()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "opus");
+            var initialContent = "Which env?\n\n```questions\n- id: target_env\n  title: Which env?\n  options:\n    - title: Staging\n      value: staging\n```\n";
+            // Chunks split so no single chunk has the whole YAML block
+            var rawStreamLines = string.Join("\n", new[]
+            {
+                "{\"kind\":\"text\",\"text\":\"Which env?\\n\\n```questions\\n- id: \",\"delta\":true}",
+                "{\"kind\":\"text\",\"text\":\"target_env\\n  title: Which env?\\n  options:\\n    - title: Staging\\n      value: staging\\n```\\n\",\"delta\":true}",
+                "{\"kind\":\"result\",\"response\":\"Which env?\\n\\n```questions\\n- id: target_env\\n  title: Which env?\\n  options:\\n    - title: Staging\\n      value: staging\\n```\\n\",\"is_success\":true}"
+            });
+            var msg = service.AddMessage(session.Id, "assistant", initialContent, rawStream: rawStreamLines);
+
+            var answers = new Dictionary<string, string[]>
+            {
+                ["target_env"] = ["staging"]
+            };
+
+            var success = service.ApplyQuestionAnswers(session.Id, msg.Id, answers);
+            Assert.True(success);
+
+            var updatedSession = service.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            var updatedMsg = Assert.Single(updatedSession.Messages);
+            Assert.Contains("answer: staging", updatedMsg.Content);
+            Assert.NotNull(updatedMsg.RawStream);
+            Assert.Contains("answer: staging", updatedMsg.RawStream);
+            // Verify delta chunks were consolidated to a non-delta text chunk with the updated content
+            Assert.Contains("\"delta\":false", updatedMsg.RawStream);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
 }
 

--- a/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
+++ b/src/Ivy.Tendril.Test/Hooks/UseStartJobTests.cs
@@ -154,6 +154,10 @@ public class UseStartJobTests
             return false;
         }
 
+        public void SetChatSessionId(string id, string chatSessionId)
+        {
+        }
+
         public bool ReportJobFailure(string id, string message)
         {
             return false;
@@ -177,6 +181,7 @@ public class UseStartJobTests
         public event Action? JobsStructureChanged;
         public event Action? JobPropertyChanged;
         public event Action<JobNotification>? NotificationReady;
+        public event Action<JobItem>? JobFinished;
 #pragma warning restore CS0067
     }
 

--- a/src/Ivy.Tendril.Test/InboxControllerTests.cs
+++ b/src/Ivy.Tendril.Test/InboxControllerTests.cs
@@ -140,6 +140,10 @@ public class InboxControllerTests
             return false;
         }
 
+        public void SetChatSessionId(string id, string chatSessionId)
+        {
+        }
+
         public bool ReportJobFailure(string id, string message)
         {
             return false;
@@ -159,6 +163,7 @@ public class InboxControllerTests
         public event Action? JobsStructureChanged;
         public event Action? JobPropertyChanged;
         public event Action<JobNotification>? NotificationReady;
+        public event Action<JobItem>? JobFinished;
 #pragma warning restore CS0067
     }
 }

--- a/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
+++ b/src/Ivy.Tendril.Test/InboxWatcherServiceTests.cs
@@ -239,12 +239,14 @@ public class InboxWatcherServiceTests : IDisposable
         public JobItem? GetJob(string id) => null;
         public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => false;
         public bool ReportJobFailure(string id, string message) => false;
+        public void SetChatSessionId(string id, string chatSessionId) { }
         public void Dispose() { }
 
 #pragma warning disable CS0067
         public event Action? JobsChanged;
         public event Action? JobsStructureChanged;
         public event Action? JobPropertyChanged;
+        public event Action<JobItem>? JobFinished;
         public event Action<JobNotification>? NotificationReady;
 #pragma warning restore CS0067
     }
@@ -392,12 +394,14 @@ public class InboxWatcherServiceTests : IDisposable
         public JobItem? GetJob(string id) => null;
         public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => false;
         public bool ReportJobFailure(string id, string message) => false;
+        public void SetChatSessionId(string id, string chatSessionId) { }
         public void Dispose() { }
 
 #pragma warning disable CS0067
         public event Action? JobsChanged;
         public event Action? JobsStructureChanged;
         public event Action? JobPropertyChanged;
+        public event Action<JobItem>? JobFinished;
         public event Action<JobNotification>? NotificationReady;
 #pragma warning restore CS0067
     }
@@ -431,12 +435,14 @@ public class InboxWatcherServiceTests : IDisposable
         public JobItem? GetJob(string id) => null;
         public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => false;
         public bool ReportJobFailure(string id, string message) => false;
+        public void SetChatSessionId(string id, string chatSessionId) { }
         public void Dispose() { }
 
 #pragma warning disable CS0067
         public event Action? JobsChanged;
         public event Action? JobsStructureChanged;
         public event Action? JobPropertyChanged;
+        public event Action<JobItem>? JobFinished;
         public event Action<JobNotification>? NotificationReady;
 #pragma warning restore CS0067
     }

--- a/src/Ivy.Tendril.Test/JobServiceJobsChangedTests.cs
+++ b/src/Ivy.Tendril.Test/JobServiceJobsChangedTests.cs
@@ -49,4 +49,33 @@ public class JobServiceJobsChangedTests
 
         Assert.True(fired);
     }
+
+    [Fact]
+    public void CreateTestJob_WithChatSessionId_TracksSpawnedJob()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "TendrilChatTest_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var config = new ConfigService(new TendrilSettings(), tempDir);
+            var chatHistory = new ChatHistoryService(config);
+            var session = chatHistory.CreateSession("claude", "opus");
+
+            var service = new JobService(config, chatHistoryService: chatHistory);
+            var args = new ExecutePlanArgs("test-plan") { ChatSessionId = session.Id };
+            var id = service.CreateTestJob(args);
+
+            var job = service.GetJob(id);
+            Assert.NotNull(job);
+            Assert.Equal(session.Id, job.ChatSessionId);
+
+            var spawned = chatHistory.GetSpawnedJobs(session.Id);
+            Assert.Contains(id, spawned);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
+++ b/src/Ivy.Tendril.Test/JobsAppRefreshGatingTests.cs
@@ -209,6 +209,7 @@ public class JobsAppRefreshGatingTests
         public List<JobItem> GetJobsForPlan(string planFile) => throw new NotSupportedException();
         public JobItem? GetJob(string id) => Jobs.FirstOrDefault(j => j.Id == id);
         public bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null) => throw new NotSupportedException();
+        public void SetChatSessionId(string id, string chatSessionId) {}
         public bool ReportJobFailure(string id, string message) => throw new NotSupportedException();
         public bool IsInboxFileTracked(string filePath) => false;
         public void Dispose()
@@ -220,6 +221,7 @@ public class JobsAppRefreshGatingTests
         public event Action? JobsStructureChanged;
         public event Action? JobPropertyChanged;
         public event Action<JobNotification>? NotificationReady;
+        public event Action<JobItem>? JobFinished;
 #pragma warning restore CS0067
     }
 }

--- a/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
+++ b/src/Ivy.Tendril.Test/PlanCountsServiceTests.cs
@@ -252,6 +252,10 @@ public class TendrilProcessStatusServiceTests : IDisposable
             throw new NotImplementedException();
         }
 
+        public void SetChatSessionId(string id, string chatSessionId)
+        {
+        }
+
         public bool ReportJobFailure(string id, string message)
         {
             throw new NotImplementedException();
@@ -276,6 +280,7 @@ public class TendrilProcessStatusServiceTests : IDisposable
         public event Action? JobsStructureChanged;
         public event Action? JobPropertyChanged;
         public event Action<JobNotification>? NotificationReady;
+        public event Action<JobItem>? JobFinished;
 #pragma warning restore CS0067
     }
 

--- a/src/Ivy.Tendril.Widgets/ChatWidget.cs
+++ b/src/Ivy.Tendril.Widgets/ChatWidget.cs
@@ -16,6 +16,15 @@ public record ChatMessageDto(
     string? Effort = null
 );
 
+public record ChatJobDto(
+    string Id,
+    string Type,
+    string Status,
+    string? PlanId = null,
+    string? PlanTitle = null,
+    string? StatusMessage = null
+);
+
 public record ChatSessionDto(
     string Id,
     string Title,
@@ -25,7 +34,8 @@ public record ChatSessionDto(
     string UpdatedAt,
     List<ChatMessageDto> Messages,
     string Status = "done",
-    string? Effort = null
+    string? Effort = null,
+    List<ChatJobDto>? SpawnedJobs = null
 );
 
 public record AgentOptionDto(string Id, string Label);

--- a/src/Ivy.Tendril.Widgets/ChatWidget.cs
+++ b/src/Ivy.Tendril.Widgets/ChatWidget.cs
@@ -63,6 +63,13 @@ public record ChatSendMessageDto(
     string? SessionId = null
 );
 
+public record ChatQuestionAnswerDto(
+    string SessionId,
+    string MessageId,
+    Dictionary<string, string[]> Answers,
+    string ResponseText
+);
+
 [ExternalWidget(
     "frontend/dist/ivy-tendril-widgets.js",
     StylePath = "frontend/dist/ivy-tendril-widgets.css",
@@ -98,4 +105,5 @@ public record ChatWidget : WidgetBase<ChatWidget>
     [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnDeleteQueuedMessage { get; init; }
     [Event] public Func<Event<ChatWidget, string[]>, ValueTask>? OnUpdateQueuedMessage { get; init; }
     [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnSendQueuedNow { get; init; }
+    [Event] public Func<Event<ChatWidget, ChatQuestionAnswerDto>, ValueTask>? OnAnswerQuestion { get; init; }
 }

--- a/src/Ivy.Tendril.Widgets/ChatWidget.cs
+++ b/src/Ivy.Tendril.Widgets/ChatWidget.cs
@@ -60,7 +60,8 @@ public record ChatQueuedMessageDto(
 public record ChatSendMessageDto(
     string Prompt,
     List<ChatAttachmentDto>? Attachments = null,
-    string? SessionId = null
+    string? SessionId = null,
+    bool ForceSend = false
 );
 
 public record ChatQuestionAnswerDto(

--- a/src/Ivy.Tendril.Widgets/ChatWidget.cs
+++ b/src/Ivy.Tendril.Widgets/ChatWidget.cs
@@ -92,6 +92,7 @@ public record ChatWidget : WidgetBase<ChatWidget>
     [Prop] public bool IsStreaming { get; init; } = false;
     [Prop] public string? StreamingText { get; init; }
     [Prop] public List<ChatQueuedMessageDto> QueuedMessages { get; init; } = new();
+    [Prop] public List<ChatJobDto>? RunningJobs { get; init; }
 
     [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnSelectSession { get; init; }
     [Event] public Func<Event<ChatWidget, string>, ValueTask>? OnDeleteSession { get; init; }

--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
@@ -23,7 +23,8 @@ function buildSuppressIndices(events: PresentationEvent[]): Set<number> {
     if (
       cur.kind === "assistant-text" &&
       next.kind === "result" &&
-      next.wire.response?.trim() === cur.text.trim()
+      (next.wire.response?.trim() === cur.text.trim() ||
+        Boolean(next.wire.response && next.wire.response.trim().length > 0))
     ) {
       indices.add(i);
     }

--- a/src/Ivy.Tendril.Widgets/frontend/src/BlockHandler.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/BlockHandler.tsx
@@ -1,7 +1,7 @@
 import React, { lazy, Suspense, useContext } from "react";
 import { CodeBlock } from "./CodeBlock";
 import { QuestionsCallout } from "./PlanMarkdown/QuestionsCallout";
-import { QuestionsAnswerContext } from "./PlanMarkdown/questionsContext";
+import { QuestionsAnswerContext, QuestionsSubmitContext } from "./PlanMarkdown/questionsContext";
 
 /** `questions`, or `questions_<n>` once `tagQuestionBlocks` has stamped the block's index on it. */
 const QUESTIONS_LANG = /^questions(?:_(\d+))?$/;
@@ -13,6 +13,7 @@ export const BlockHandler: React.FC<React.HTMLAttributes<HTMLElement>> = ({ clas
   const match = /language-(\w+)/.exec(String(className || ""));
   const content = String(children).replace(/\n$/, "");
   const onAnswer = useContext(QuestionsAnswerContext);
+  const onSubmit = useContext(QuestionsSubmitContext);
 
   if (match) {
     const lang = match[1];
@@ -40,6 +41,7 @@ export const BlockHandler: React.FC<React.HTMLAttributes<HTMLElement>> = ({ clas
           content={content}
           blockIndex={questions[1] ? Number(questions[1]) : 0}
           onAnswer={onAnswer}
+          onSubmit={onSubmit}
         />
       );
     }

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -957,6 +957,76 @@ describe("ChatWidget File Uploads and Attachments", () => {
       ])
     );
   });
+
+  it("renders interactive questions in chat message and emits OnAnswerQuestion when user submits response", async () => {
+    const handleEvent = vi.fn();
+    const session: ChatSessionDto = {
+      id: "sess-q",
+      title: "Questions Chat",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [
+        {
+          id: "msg-q1",
+          role: "assistant",
+          content: [
+            "Please confirm your choices below:",
+            "```questions",
+            "- id: deploy_target",
+            "  title: Which environment should we deploy to?",
+            "  options:",
+            "    - title: Staging Environment",
+            "      value: staging",
+            "    - title: Production Environment",
+            "      value: prod",
+            "```",
+          ].join("\n"),
+          timestamp: "12:00 PM",
+        },
+      ],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-q"
+        sessions={[session]}
+        eventHandler={handleEvent}
+        events={["OnAnswerQuestion"]}
+      />
+    );
+
+    expect(screen.getByText("Which environment should we deploy to?")).toBeInTheDocument();
+    expect(screen.getByText("Staging Environment")).toBeInTheDocument();
+    expect(screen.getByText("Production Environment")).toBeInTheDocument();
+
+    const submitBtn = screen.getByRole("button", { name: /Submit Response/i });
+    expect(submitBtn).toBeDisabled();
+
+    // Select Staging Environment option
+    const stagingRadio = screen.getByRole("radio", { name: /Staging Environment/i });
+    fireEvent.click(stagingRadio);
+
+    // Submit button should now be enabled
+    expect(submitBtn).not.toBeDisabled();
+
+    fireEvent.click(submitBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnAnswerQuestion",
+      "test-chat",
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionId: "sess-q",
+          messageId: "msg-q1",
+          answers: { deploy_target: ["staging"] },
+          responseText: expect.stringContaining("Staging Environment"),
+        }),
+      ])
+    );
+  });
 });
 
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -5,7 +5,7 @@ import "@testing-library/jest-dom";
 vi.mock("pdfjs-dist", () => ({ GlobalWorkerOptions: {}, getDocument: vi.fn() }));
 vi.mock("pdfjs-dist/build/pdf.worker.mjs?url", () => ({ default: "" }));
 
-import { ChatWidget } from "./ChatWidget";
+import { ChatWidget, type ChatSessionDto } from "./ChatWidget";
 
 describe("ChatWidget Queued Messages UI", () => {
   beforeEach(() => {
@@ -906,5 +906,57 @@ describe("ChatWidget File Uploads and Attachments", () => {
     expect(screen.queryByRole("button", { name: /Stop/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Send/i })).toBeInTheDocument();
   });
+
+  it("displays spawned jobs banner and emits OnSendMessage when reviewing outcomes", () => {
+    const handleEvent = vi.fn();
+    const session: ChatSessionDto = {
+      id: "sess-jobs",
+      title: "Jobs Chat",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [],
+      spawnedJobs: [
+        {
+          id: "job-101",
+          type: "plan",
+          status: "Completed",
+          planTitle: "Add OAuth2 authentication",
+        },
+      ],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-jobs"
+        sessions={[session]}
+        eventHandler={handleEvent}
+        events={["OnSendMessage"]}
+      />
+    );
+
+    expect(screen.getByText(/Spawned Jobs \(1\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 completed/i)).toBeInTheDocument();
+    expect(screen.getByText("Add OAuth2 authentication")).toBeInTheDocument();
+
+    const reviewBtn = screen.getByRole("button", { name: /Ask agent to review outcomes/i });
+    expect(reviewBtn).toBeInTheDocument();
+
+    fireEvent.click(reviewBtn);
+
+    expect(handleEvent).toHaveBeenCalledWith(
+      "OnSendMessage",
+      "test-chat",
+      expect.arrayContaining([
+        expect.objectContaining({
+          prompt: expect.stringContaining("All spawned jobs have completed"),
+          sessionId: "sess-jobs",
+        }),
+      ])
+    );
+  });
 });
+
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -176,6 +176,15 @@ describe("ChatWidget Queued Messages UI", () => {
       <ChatWidget
         id="test-chat"
         activeSessionId="sess-1"
+        sessions={[{
+          id: "sess-1",
+          title: "Session 1",
+          agentId: "claude",
+          modelId: "sonnet",
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          messages: [],
+        }]}
         isStreaming={true}
         queuedMessages={queuedItems}
         events={["OnDeleteQueuedMessage", "OnUpdateQueuedMessage", "OnSendQueuedNow"]}
@@ -216,6 +225,7 @@ describe("ChatWidget Queued Messages UI", () => {
       "test-chat",
       ["q-send"]
     );
+    expect(screen.getByText("to be sent now")).toBeInTheDocument();
   });
 
   it("preserves optimistically queued message when in-flight queuedMessages prop is empty", () => {

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom";
 
@@ -1026,6 +1026,88 @@ describe("ChatWidget File Uploads and Attachments", () => {
         }),
       ])
     );
+  });
+
+  it("renders running jobs header badge and toggles dropdown on click", async () => {
+    const session: ChatSessionDto = {
+      id: "sess-running",
+      title: "Active Job Session",
+      agentId: "antigravity",
+      modelId: "gemini-3.8-flash",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [],
+      spawnedJobs: [
+        {
+          id: "00148",
+          type: "CreatePlan",
+          status: "Running",
+          planTitle: "Test job tracking",
+          statusMessage: "Researching architecture...",
+        },
+      ],
+    };
+
+    const { container } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-running"
+        sessions={[session]}
+      />
+    );
+
+    // Header badge displays running count
+    const badgeBtn = screen.getByRole("button", { name: /View running jobs/i });
+    expect(badgeBtn).toBeInTheDocument();
+    expect(within(badgeBtn).getByText(/1 running/i)).toBeInTheDocument();
+
+    // Click badge to open dropdown
+    fireEvent.click(badgeBtn);
+
+    // Dropdown is open and displays job item details
+    const dropdown = container.querySelector(".chat-jobs-dropdown-menu") as HTMLElement;
+    expect(dropdown).toBeInTheDocument();
+    expect(within(dropdown).getByText("00148")).toBeInTheDocument();
+    expect(within(dropdown).getByText("CreatePlan")).toBeInTheDocument();
+    expect(within(dropdown).getByText("Researching architecture...")).toBeInTheDocument();
+  });
+
+  it("renders system event messages in chat timeline", async () => {
+    const session: ChatSessionDto = {
+      id: "sess-sys",
+      title: "System Notification Session",
+      agentId: "antigravity",
+      modelId: "gemini-3.8-flash",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [
+        {
+          id: "msg-sys-1",
+          role: "system",
+          content: "Job 00148 (CreatePlan) has completed successfully.",
+          timestamp: "10:00 AM",
+        },
+        {
+          id: "msg-ast-1",
+          role: "assistant",
+          content: "I reviewed the plan and it looks great!",
+          timestamp: "10:01 AM",
+        },
+      ],
+    };
+
+    const { container } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-sys"
+        sessions={[session]}
+      />
+    );
+
+    const systemRow = container.querySelector(".chat-system-event-row");
+    expect(systemRow).toBeInTheDocument();
+    expect(screen.getByText("Job 00148 (CreatePlan) has completed successfully.")).toBeInTheDocument();
+    expect(screen.getByText("I reviewed the plan and it looks great!")).toBeInTheDocument();
   });
 });
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -907,7 +907,7 @@ describe("ChatWidget File Uploads and Attachments", () => {
     expect(screen.getByRole("button", { name: /Send/i })).toBeInTheDocument();
   });
 
-  it("displays spawned jobs banner and emits OnSendMessage when reviewing outcomes", () => {
+  it("displays spawned jobs in header badge and emits OnSendMessage when reviewing outcomes from dropdown", () => {
     const handleEvent = vi.fn();
     const session: ChatSessionDto = {
       id: "sess-jobs",
@@ -937,7 +937,18 @@ describe("ChatWidget File Uploads and Attachments", () => {
       />
     );
 
-    expect(screen.getByText(/Spawned Jobs \(1\)/i)).toBeInTheDocument();
+    // Banner directly above chat is removed
+    expect(screen.queryByText(/Spawned Jobs \(/i)).not.toBeInTheDocument();
+
+    // Header badge is displayed
+    const badgeBtn = screen.getByRole("button", { name: /View running jobs/i });
+    expect(badgeBtn).toBeInTheDocument();
+    expect(within(badgeBtn).getByText(/1 jobs/i)).toBeInTheDocument();
+
+    // Open dropdown by clicking badge
+    fireEvent.click(badgeBtn);
+
+    expect(screen.getByText(/Spawned Jobs/i)).toBeInTheDocument();
     expect(screen.getByText(/1 completed/i)).toBeInTheDocument();
     expect(screen.getByText("Add OAuth2 authentication")).toBeInTheDocument();
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
-import { Mic, Bot, Cpu, Zap, MessageSquare, ChevronDown, Check, Pencil, Paperclip, X, Square, ArrowRight, Trash2 } from "lucide-react";
+import { Mic, Bot, Cpu, Zap, MessageSquare, ChevronDown, ChevronUp, Check, CheckCircle2, XCircle, Pencil, Paperclip, X, Square, ArrowRight, Trash2, Loader2, Sparkles } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import * as pdfjsLib from "pdfjs-dist";
 import pdfjsWorker from "pdfjs-dist/build/pdf.worker.mjs?url";
@@ -137,6 +137,15 @@ export interface ChatMessageDto {
   effort?: string;
 }
 
+export interface ChatJobDto {
+  id: string;
+  type: string;
+  status: string;
+  planId?: string;
+  planTitle?: string;
+  statusMessage?: string;
+}
+
 export interface ChatSessionDto {
   id: string;
   title: string;
@@ -147,6 +156,7 @@ export interface ChatSessionDto {
   messages: ChatMessageDto[];
   status?: "generating" | "waiting" | "done";
   effort?: string;
+  spawnedJobs?: ChatJobDto[];
 }
 
 export interface AgentOptionDto {
@@ -317,6 +327,111 @@ export function formatFileSize(bytes: number): string {
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
+
+const ChatSpawnedJobs: React.FC<{
+  jobs: ChatJobDto[];
+  onReviewClick: () => void;
+}> = ({ jobs, onReviewClick }) => {
+  const [expanded, setExpanded] = useState(true);
+
+  const runningCount = jobs.filter((j) => j.status === "Running" || j.status === "Pending").length;
+  const completedCount = jobs.filter((j) => j.status === "Completed").length;
+  const failedCount = jobs.filter((j) => j.status === "Failed").length;
+  const allFinished = runningCount === 0 && jobs.length > 0;
+
+  return (
+    <div className="chat-spawned-jobs-bar">
+      <div className="chat-spawned-jobs-header" onClick={() => setExpanded(!expanded)}>
+        <div className="chat-spawned-jobs-title">
+          <Cpu size={14} className="chat-spawned-jobs-icon" />
+          <span>Spawned Jobs ({jobs.length})</span>
+          <div className="chat-spawned-jobs-chips">
+            {runningCount > 0 && (
+              <span className="chat-job-chip chip-running">
+                <Loader2 size={10} className="spin" />
+                {runningCount} running
+              </span>
+            )}
+            {completedCount > 0 && (
+              <span className="chat-job-chip chip-completed">
+                <Check size={10} />
+                {completedCount} completed
+              </span>
+            )}
+            {failedCount > 0 && (
+              <span className="chat-job-chip chip-failed">
+                <X size={10} />
+                {failedCount} failed
+              </span>
+            )}
+          </div>
+        </div>
+        <button
+          type="button"
+          className="chat-spawned-jobs-toggle"
+          aria-label={expanded ? "Collapse spawned jobs" : "Expand spawned jobs"}
+        >
+          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="chat-spawned-jobs-content">
+          <div className="chat-spawned-jobs-list">
+            {jobs.map((job) => {
+              const isRunning = job.status === "Running";
+              const isCompleted = job.status === "Completed";
+              const isFailed = job.status === "Failed";
+
+              return (
+                <div key={job.id} className={`chat-spawned-job-item ${job.status.toLowerCase()}`}>
+                  <div className="chat-job-status-indicator">
+                    {isRunning && <Loader2 size={13} className="spin" />}
+                    {isCompleted && <CheckCircle2 size={13} />}
+                    {isFailed && <XCircle size={13} />}
+                    {!isRunning && !isCompleted && !isFailed && <span className="chat-job-dot" />}
+                  </div>
+                  <div className="chat-job-details">
+                    <div className="chat-job-meta">
+                      <span className="chat-job-type">{job.type}</span>
+                      <span className="chat-job-id">{job.id}</span>
+                      {job.planTitle && (
+                        <span className="chat-job-plan-title" title={job.planTitle}>
+                          {job.planTitle}
+                        </span>
+                      )}
+                    </div>
+                    {job.statusMessage && (
+                      <div className="chat-job-message" title={job.statusMessage}>
+                        {job.statusMessage}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {allFinished && (
+            <div className="chat-spawned-jobs-review-prompt">
+              <span className="chat-spawned-jobs-review-text">
+                All spawned jobs are complete.
+              </span>
+              <button
+                type="button"
+                className="chat-spawned-jobs-review-btn"
+                onClick={onReviewClick}
+              >
+                <Sparkles size={13} />
+                Ask agent to review outcomes
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
 
 export function ChatWidget({
   id,
@@ -1012,6 +1127,20 @@ export function ChatWidget({
             </div>
           )}
         </div>
+
+        {/* Spawned Jobs Bar */}
+        {activeSession?.spawnedJobs && activeSession.spawnedJobs.length > 0 && (
+          <ChatSpawnedJobs
+            jobs={activeSession.spawnedJobs}
+            onReviewClick={() => {
+              emit("OnSendMessage", {
+                prompt: "All spawned jobs have completed. Please review their outcomes with me and suggest next steps.",
+                attachments: [],
+                sessionId: activeSession.id,
+              });
+            }}
+          />
+        )}
 
         {/* Message List Container */}
         <div className="chat-messages-container">

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -8,6 +8,7 @@ import { AgentViewer } from "../AgentViewer";
 import { getMarkdownPlugins } from "../math";
 import { BlockHandler } from "../BlockHandler";
 import { AlertBlockquote } from "../PlanMarkdown/AlertBlockquote";
+import { QuestionsSubmitContext } from "../PlanMarkdown/questionsContext";
 import { isImageFile, processImageFile } from "../imageUtils";
 import "./chat-widget.css";
 
@@ -592,6 +593,16 @@ export function ChatWidget({
     if (eventHandler && events.includes(eventName)) {
       eventHandler(eventName, id, args);
     }
+  };
+
+  const handleQuestionSubmit = (messageId: string, answers: Record<string, string[]>, responseText: string) => {
+    if (!activeSession) return;
+    emit("OnAnswerQuestion", {
+      sessionId: activeSession.id,
+      messageId,
+      answers,
+      responseText,
+    });
   };
 
   const startHeaderTitleEdit = () => {
@@ -1184,26 +1195,34 @@ export function ChatWidget({
                       );
                     })()
                   ) : msg.rawStream ? (
-                    <AgentViewer
-                      id={`msg-${msg.id}`}
-                      jsonStream={msg.rawStream}
-                      autoScroll={false}
-                      showThinking={true}
-                      showSystemEvents={false}
-                      showStatusLabel={false}
-                      groupToolCalls={true}
-                      eventHandler={noopEventHandler}
-                    />
+                    <QuestionsSubmitContext.Provider
+                      value={(answers, summaryText) => handleQuestionSubmit(msg.id, answers, summaryText)}
+                    >
+                      <AgentViewer
+                        id={`msg-${msg.id}`}
+                        jsonStream={msg.rawStream}
+                        autoScroll={false}
+                        showThinking={true}
+                        showSystemEvents={false}
+                        showStatusLabel={false}
+                        groupToolCalls={true}
+                        eventHandler={noopEventHandler}
+                      />
+                    </QuestionsSubmitContext.Provider>
                   ) : (
                     msg.content && (
-                      <div className="chat-markdown-body">
-                        <ReactMarkdown
-                          {...getMarkdownPlugins(msg.content)}
-                          components={{ code: BlockHandler, blockquote: AlertBlockquote, pre: ({ children }) => <>{children}</> }}
-                        >
-                          {msg.content}
-                        </ReactMarkdown>
-                      </div>
+                      <QuestionsSubmitContext.Provider
+                        value={(answers, summaryText) => handleQuestionSubmit(msg.id, answers, summaryText)}
+                      >
+                        <div className="chat-markdown-body">
+                          <ReactMarkdown
+                            {...getMarkdownPlugins(msg.content)}
+                            components={{ code: BlockHandler, blockquote: AlertBlockquote, pre: ({ children }) => <>{children}</> }}
+                          >
+                            {msg.content}
+                          </ReactMarkdown>
+                        </div>
+                      </QuestionsSubmitContext.Provider>
                     )
                   )}
                 </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -618,10 +618,27 @@ export function ChatWidget({
     const item = queuedMessages.find((q) => q.id === queueId);
     if (!item) return;
 
+    if (activeSessionId && item.prompt) {
+      const optMsg: ChatMessageDto = {
+        id: `opt-${Date.now()}-${Math.random()}`,
+        role: "user",
+        content: item.prompt,
+        timestamp: new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }),
+        agentId: selectedAgent,
+        modelId: selectedModel,
+      };
+      setOptimisticMessages((prev) => ({
+        ...prev,
+        [activeSessionId]: [...(prev[activeSessionId] || []), optMsg],
+      }));
+    }
+
+    setOptimisticStreaming(activeSessionId || "__active__");
+
     if (events.includes("OnSendQueuedNow")) {
       emit("OnSendQueuedNow", queueId);
     } else {
-      const payload = { prompt: item.prompt, attachments: item.attachments, sessionId: activeSessionId };
+      const payload = { prompt: item.prompt, attachments: item.attachments, sessionId: activeSessionId, forceSend: true };
       emit("OnSendMessage", payload);
     }
     setQueuedMessages((prev) => prev.filter((q) => q.id !== queueId));

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -129,7 +129,7 @@ const parseUserMessageContent = (content: string) => {
 
 export interface ChatMessageDto {
   id: string;
-  role: "user" | "assistant";
+  role: "user" | "assistant" | "system";
   content: string;
   timestamp: string;
   agentId?: string;
@@ -213,6 +213,7 @@ export interface ChatWidgetProps {
   isStreaming?: boolean;
   streamingText?: string;
   queuedMessages?: ChatQueuedMessageDto[];
+  runningJobs?: ChatJobDto[];
   events?: string[];
   eventHandler?: IvyEventHandler;
 }
@@ -450,6 +451,7 @@ export function ChatWidget({
   isStreaming = false,
   streamingText = "",
   queuedMessages: queuedMessagesProp,
+  runningJobs = [],
   events = [],
   eventHandler,
 }: ChatWidgetProps) {
@@ -465,14 +467,38 @@ export function ChatWidget({
   const [pendingRenames, setPendingRenames] = useState<Record<string, string>>({});
   const [optimisticMessages, setOptimisticMessages] = useState<Record<string, ChatMessageDto[]>>({});
   const [optimisticStreaming, setOptimisticStreaming] = useState<string | null>(null);
+  const [jobsDropdownOpen, setJobsDropdownOpen] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const recognitionRef = useRef<any>(null);
   const initialPromptRef = useRef<string>("");
+  const jobsDropdownRef = useRef<HTMLDivElement>(null);
 
   const activeSession = sessions.find((s) => s.id === activeSessionId);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (jobsDropdownRef.current && !jobsDropdownRef.current.contains(e.target as Node)) {
+        setJobsDropdownOpen(false);
+      }
+    };
+    if (jobsDropdownOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [jobsDropdownOpen]);
+
+  const sessionSpawnedJobs = activeSession?.spawnedJobs || [];
+  const otherRunningJobs = (runningJobs || []).filter(
+    (rj) => !sessionSpawnedJobs.some((sj) => sj.id === rj.id)
+  );
+  const headerJobs = sessionSpawnedJobs.length > 0 ? sessionSpawnedJobs : otherRunningJobs;
+  const headerRunningCount = headerJobs.filter((j) => j.status === "Running" || j.status === "Pending").length;
+  const headerCompletedCount = headerJobs.filter((j) => j.status === "Completed").length;
+  const headerFailedCount = headerJobs.filter((j) => j.status === "Failed" || j.status === "Timeout").length;
+  const headerAllFinished = headerRunningCount === 0 && headerJobs.length > 0;
   const currentOptimistic = (activeSessionId && optimisticMessages[activeSessionId]) || [];
   const displayMessages = [...(activeSession?.messages || []), ...currentOptimistic];
   const totalAttachmentSize = attachments.reduce((sum, att) => sum + (att.size || 0), 0);
@@ -1126,6 +1152,123 @@ export function ChatWidget({
           </div>
           {activeSession && (
             <div className="chat-header-actions">
+              {headerJobs.length > 0 && (
+                <div className="chat-jobs-badge-container" ref={jobsDropdownRef}>
+                  <button
+                    type="button"
+                    className={`chat-jobs-badge ${headerRunningCount > 0 ? "running" : headerFailedCount > 0 ? "has-failed" : "all-completed"}`}
+                    onClick={() => setJobsDropdownOpen(!jobsDropdownOpen)}
+                    title={headerRunningCount > 0 ? `${headerRunningCount} job(s) running` : "View jobs"}
+                    aria-label="View running jobs"
+                  >
+                    {headerRunningCount > 0 ? (
+                      <>
+                        <Loader2 size={13} className="spin text-blue-400" />
+                        <span className="chat-jobs-badge-text">{headerRunningCount} running</span>
+                        <span className="chat-jobs-pulse-dot" />
+                      </>
+                    ) : headerFailedCount > 0 ? (
+                      <>
+                        <XCircle size={13} className="text-destructive" />
+                        <span className="chat-jobs-badge-text">{headerJobs.length} jobs ({headerFailedCount} failed)</span>
+                      </>
+                    ) : (
+                      <>
+                        <CheckCircle2 size={13} className="text-emerald-500" />
+                        <span className="chat-jobs-badge-text">{headerJobs.length} jobs</span>
+                      </>
+                    )}
+                    <ChevronDown size={12} className={`chat-jobs-badge-chevron ${jobsDropdownOpen ? "open" : ""}`} />
+                  </button>
+
+                  {jobsDropdownOpen && (
+                    <div className="chat-jobs-dropdown-menu">
+                      <div className="chat-jobs-dropdown-header">
+                        <div className="chat-jobs-dropdown-title">
+                          <Cpu size={14} />
+                          <span>{sessionSpawnedJobs.length > 0 ? "Spawned Jobs" : "Running Jobs"} ({headerJobs.length})</span>
+                        </div>
+                        <div className="chat-jobs-dropdown-chips">
+                          {headerRunningCount > 0 && (
+                            <span className="chat-job-chip chip-running">
+                              <Loader2 size={10} className="spin" />
+                              {headerRunningCount} running
+                            </span>
+                          )}
+                          {headerCompletedCount > 0 && (
+                            <span className="chat-job-chip chip-completed">
+                              <Check size={10} />
+                              {headerCompletedCount}
+                            </span>
+                          )}
+                          {headerFailedCount > 0 && (
+                            <span className="chat-job-chip chip-failed">
+                              <X size={10} />
+                              {headerFailedCount}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="chat-jobs-dropdown-list">
+                        {headerJobs.map((job) => {
+                          const isRunning = job.status === "Running" || job.status === "Pending";
+                          const isCompleted = job.status === "Completed";
+                          const isFailed = job.status === "Failed" || job.status === "Timeout";
+
+                          return (
+                            <div key={job.id} className={`chat-jobs-dropdown-item ${job.status.toLowerCase()}`}>
+                              <div className="chat-job-status-indicator">
+                                {isRunning && <Loader2 size={13} className="spin" />}
+                                {isCompleted && <CheckCircle2 size={13} />}
+                                {isFailed && <XCircle size={13} />}
+                                {!isRunning && !isCompleted && !isFailed && <span className="chat-job-dot" />}
+                              </div>
+                              <div className="chat-job-details">
+                                <div className="chat-job-meta">
+                                  <span className="chat-job-type">{job.type}</span>
+                                  <span className="chat-job-id">{job.id}</span>
+                                  {job.planTitle && (
+                                    <span className="chat-job-plan-title" title={job.planTitle}>
+                                      {job.planTitle}
+                                    </span>
+                                  )}
+                                </div>
+                                {job.statusMessage && (
+                                  <div className="chat-job-message" title={job.statusMessage}>
+                                    {job.statusMessage}
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+
+                      {headerAllFinished && (
+                        <div className="chat-jobs-dropdown-footer">
+                          <button
+                            type="button"
+                            className="chat-spawned-jobs-review-btn"
+                            onClick={() => {
+                              setJobsDropdownOpen(false);
+                              emit("OnSendMessage", {
+                                prompt: "All spawned jobs have completed. Please review their outcomes with me and suggest next steps.",
+                                attachments: [],
+                                sessionId: activeSession.id,
+                              });
+                            }}
+                          >
+                            <Sparkles size={13} />
+                            Ask agent to review outcomes
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
               <button
                 type="button"
                 className="chat-header-delete-btn"
@@ -1156,16 +1299,29 @@ export function ChatWidget({
         {/* Message List Container */}
         <div className="chat-messages-container">
           {activeSession && displayMessages.length > 0 ? (
-            displayMessages.map((msg) => (
-              <div key={msg.id} className={`chat-message-row ${msg.role}`}>
-                <div className="chat-message-bubble" style={msg.role === "assistant" && msg.rawStream ? { width: "85%", maxWidth: "85%" } : undefined}>
-                  {msg.role === "assistant" && (
-                    <div className="chat-message-header">
-                      <Bot size={13} className="chat-message-author" />
-                      <span className="chat-message-author">{msg.agentId || selectedAgent}</span>
-                      <span className="chat-message-time">{msg.timestamp}</span>
+            displayMessages.map((msg) => {
+              if (msg.role === "system") {
+                return (
+                  <div key={msg.id} className="chat-system-event-row">
+                    <div className="chat-system-event-pill">
+                      <Sparkles size={13} className="chat-system-event-icon" />
+                      <span className="chat-system-event-text">{msg.content}</span>
+                      <span className="chat-system-event-time">{msg.timestamp}</span>
                     </div>
-                  )}
+                  </div>
+                );
+              }
+
+              return (
+                <div key={msg.id} className={`chat-message-row ${msg.role}`}>
+                  <div className="chat-message-bubble" style={msg.role === "assistant" && msg.rawStream ? { width: "85%", maxWidth: "85%" } : undefined}>
+                    {msg.role === "assistant" && (
+                      <div className="chat-message-header">
+                        <Bot size={13} className="chat-message-author" />
+                        <span className="chat-message-author">{msg.agentId || selectedAgent}</span>
+                        <span className="chat-message-time">{msg.timestamp}</span>
+                      </div>
+                    )}
                   {msg.role === "user" ? (
                     (() => {
                       const { prompt, attachedPaths } = parseUserMessageContent(msg.content);
@@ -1227,7 +1383,8 @@ export function ChatWidget({
                   )}
                 </div>
               </div>
-            ))
+              );
+            })
           ) : (
             <div className="chat-empty-state">
               <MessageSquare size={44} strokeWidth={1.5} />

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -494,7 +494,7 @@ export function ChatWidget({
   const otherRunningJobs = (runningJobs || []).filter(
     (rj) => !sessionSpawnedJobs.some((sj) => sj.id === rj.id)
   );
-  const headerJobs = sessionSpawnedJobs.length > 0 ? sessionSpawnedJobs : otherRunningJobs;
+  const headerJobs = [...sessionSpawnedJobs, ...otherRunningJobs];
   const headerRunningCount = headerJobs.filter((j) => j.status === "Running" || j.status === "Pending").length;
   const headerCompletedCount = headerJobs.filter((j) => j.status === "Completed").length;
   const headerFailedCount = headerJobs.filter((j) => j.status === "Failed" || j.status === "Timeout").length;

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useLayoutEffect } from "react";
 import { createPortal } from "react-dom";
-import { Mic, Bot, Cpu, Zap, MessageSquare, ChevronDown, ChevronUp, Check, CheckCircle2, XCircle, Pencil, Paperclip, X, Square, ArrowRight, Trash2, Loader2, Sparkles } from "lucide-react";
+import { Mic, Bot, Cpu, Zap, MessageSquare, ChevronDown, Check, CheckCircle2, XCircle, Pencil, Paperclip, X, Square, ArrowRight, Trash2, Loader2, Sparkles } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import * as pdfjsLib from "pdfjs-dist";
 import pdfjsWorker from "pdfjs-dist/build/pdf.worker.mjs?url";
@@ -330,110 +330,6 @@ export function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-const ChatSpawnedJobs: React.FC<{
-  jobs: ChatJobDto[];
-  onReviewClick: () => void;
-}> = ({ jobs, onReviewClick }) => {
-  const [expanded, setExpanded] = useState(true);
-
-  const runningCount = jobs.filter((j) => j.status === "Running" || j.status === "Pending").length;
-  const completedCount = jobs.filter((j) => j.status === "Completed").length;
-  const failedCount = jobs.filter((j) => j.status === "Failed").length;
-  const allFinished = runningCount === 0 && jobs.length > 0;
-
-  return (
-    <div className="chat-spawned-jobs-bar">
-      <div className="chat-spawned-jobs-header" onClick={() => setExpanded(!expanded)}>
-        <div className="chat-spawned-jobs-title">
-          <Cpu size={14} className="chat-spawned-jobs-icon" />
-          <span>Spawned Jobs ({jobs.length})</span>
-          <div className="chat-spawned-jobs-chips">
-            {runningCount > 0 && (
-              <span className="chat-job-chip chip-running">
-                <Loader2 size={10} className="spin" />
-                {runningCount} running
-              </span>
-            )}
-            {completedCount > 0 && (
-              <span className="chat-job-chip chip-completed">
-                <Check size={10} />
-                {completedCount} completed
-              </span>
-            )}
-            {failedCount > 0 && (
-              <span className="chat-job-chip chip-failed">
-                <X size={10} />
-                {failedCount} failed
-              </span>
-            )}
-          </div>
-        </div>
-        <button
-          type="button"
-          className="chat-spawned-jobs-toggle"
-          aria-label={expanded ? "Collapse spawned jobs" : "Expand spawned jobs"}
-        >
-          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-        </button>
-      </div>
-
-      {expanded && (
-        <div className="chat-spawned-jobs-content">
-          <div className="chat-spawned-jobs-list">
-            {jobs.map((job) => {
-              const isRunning = job.status === "Running";
-              const isCompleted = job.status === "Completed";
-              const isFailed = job.status === "Failed";
-
-              return (
-                <div key={job.id} className={`chat-spawned-job-item ${job.status.toLowerCase()}`}>
-                  <div className="chat-job-status-indicator">
-                    {isRunning && <Loader2 size={13} className="spin" />}
-                    {isCompleted && <CheckCircle2 size={13} />}
-                    {isFailed && <XCircle size={13} />}
-                    {!isRunning && !isCompleted && !isFailed && <span className="chat-job-dot" />}
-                  </div>
-                  <div className="chat-job-details">
-                    <div className="chat-job-meta">
-                      <span className="chat-job-type">{job.type}</span>
-                      <span className="chat-job-id">{job.id}</span>
-                      {job.planTitle && (
-                        <span className="chat-job-plan-title" title={job.planTitle}>
-                          {job.planTitle}
-                        </span>
-                      )}
-                    </div>
-                    {job.statusMessage && (
-                      <div className="chat-job-message" title={job.statusMessage}>
-                        {job.statusMessage}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-
-          {allFinished && (
-            <div className="chat-spawned-jobs-review-prompt">
-              <span className="chat-spawned-jobs-review-text">
-                All spawned jobs are complete.
-              </span>
-              <button
-                type="button"
-                className="chat-spawned-jobs-review-btn"
-                onClick={onReviewClick}
-              >
-                <Sparkles size={13} />
-                Ask agent to review outcomes
-              </button>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
 
 export function ChatWidget({
   id,
@@ -1198,13 +1094,13 @@ export function ChatWidget({
                           {headerCompletedCount > 0 && (
                             <span className="chat-job-chip chip-completed">
                               <Check size={10} />
-                              {headerCompletedCount}
+                              {headerCompletedCount} completed
                             </span>
                           )}
                           {headerFailedCount > 0 && (
                             <span className="chat-job-chip chip-failed">
                               <X size={10} />
-                              {headerFailedCount}
+                              {headerFailedCount} failed
                             </span>
                           )}
                         </div>
@@ -1282,19 +1178,6 @@ export function ChatWidget({
           )}
         </div>
 
-        {/* Spawned Jobs Bar */}
-        {activeSession?.spawnedJobs && activeSession.spawnedJobs.length > 0 && (
-          <ChatSpawnedJobs
-            jobs={activeSession.spawnedJobs}
-            onReviewClick={() => {
-              emit("OnSendMessage", {
-                prompt: "All spawned jobs have completed. Please review their outcomes with me and suggest next steps.",
-                attachments: [],
-                sessionId: activeSession.id,
-              });
-            }}
-          />
-        )}
 
         {/* Message List Container */}
         <div className="chat-messages-container">

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -1306,5 +1306,248 @@ button[class*="bg-primary"] .text-muted {
   background-color: color-mix(in srgb, var(--destructive) 15%, transparent);
 }
 
+/* Spawned Jobs Bar */
+.chat-spawned-jobs-bar {
+  border-bottom: 1px solid var(--border);
+  background-color: color-mix(in srgb, var(--card) 95%, var(--primary) 5%);
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+}
+
+.chat-spawned-jobs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.15s ease;
+}
+
+.chat-spawned-jobs-header:hover {
+  background-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.chat-spawned-jobs-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.chat-spawned-jobs-icon {
+  color: var(--primary);
+}
+
+.chat-spawned-jobs-chips {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-left: 0.5rem;
+}
+
+.chat-job-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.45rem;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 500;
+}
+
+.chat-job-chip.chip-running {
+  background-color: color-mix(in srgb, #0ea5e9 15%, transparent);
+  color: #0284c7;
+  border: 1px solid color-mix(in srgb, #0ea5e9 30%, transparent);
+}
+
+.chat-job-chip.chip-completed {
+  background-color: color-mix(in srgb, #10b981 15%, transparent);
+  color: #059669;
+  border: 1px solid color-mix(in srgb, #10b981 30%, transparent);
+}
+
+.chat-job-chip.chip-failed {
+  background-color: color-mix(in srgb, #ef4444 15%, transparent);
+  color: #dc2626;
+  border: 1px solid color-mix(in srgb, #ef4444 30%, transparent);
+}
+
+.chat-spawned-jobs-toggle {
+  background: transparent;
+  border: none;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius, 4px);
+}
+
+.chat-spawned-jobs-toggle:hover {
+  color: var(--foreground);
+  background-color: var(--accent);
+}
+
+.chat-spawned-jobs-content {
+  padding: 0.5rem 1rem 0.75rem 1rem;
+  border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.chat-spawned-jobs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.chat-spawned-job-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  background-color: var(--background);
+  border: 1px solid var(--border);
+  border-radius: var(--radius, 6px);
+  font-size: 0.75rem;
+}
+
+.chat-spawned-job-item.running {
+  border-color: color-mix(in srgb, #0ea5e9 40%, var(--border));
+}
+
+.chat-spawned-job-item.completed {
+  border-color: color-mix(in srgb, #10b981 40%, var(--border));
+}
+
+.chat-spawned-job-item.failed {
+  border-color: color-mix(in srgb, #ef4444 40%, var(--border));
+}
+
+.chat-job-status-indicator {
+  margin-top: 0.1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.chat-job-status-indicator .spin {
+  animation: spin 1s linear infinite;
+  color: #0284c7;
+}
+
+.chat-job-status-indicator svg:not(.spin) {
+  color: #059669;
+}
+
+.chat-spawned-job-item.failed .chat-job-status-indicator svg {
+  color: #dc2626;
+}
+
+.chat-job-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--muted-foreground);
+}
+
+.chat-job-details {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.chat-job-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-wrap: wrap;
+}
+
+.chat-job-type {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.625rem;
+  letter-spacing: 0.03em;
+  padding: 0.05rem 0.3rem;
+  border-radius: 3px;
+  background-color: var(--muted);
+  color: var(--foreground);
+}
+
+.chat-job-id {
+  font-family: var(--font-mono, monospace);
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+}
+
+.chat-job-plan-title {
+  font-weight: 500;
+  color: var(--foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
+}
+
+.chat-job-message {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-spawned-jobs-review-prompt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  background-color: color-mix(in srgb, var(--primary) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--primary) 25%, transparent);
+  border-radius: var(--radius, 6px);
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.chat-spawned-jobs-review-text {
+  font-size: 0.75rem;
+  color: var(--foreground);
+  font-weight: 500;
+}
+
+.chat-spawned-jobs-review-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: var(--radius, 4px);
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+  border: none;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+  white-space: nowrap;
+}
+
+.chat-spawned-jobs-review-btn:hover {
+  opacity: 0.9;
+}
+
+
 
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -1548,6 +1548,212 @@ button[class*="bg-primary"] .text-muted {
   opacity: 0.9;
 }
 
+/* Header Jobs Badge & Dropdown */
+.chat-jobs-badge-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
 
+.chat-jobs-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.28rem 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border-radius: 9999px;
+  border: 1px solid var(--border);
+  background-color: var(--secondary);
+  color: var(--foreground);
+  cursor: pointer;
+  transition: all 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+  user-select: none;
+}
 
+.chat-jobs-badge:hover {
+  background-color: var(--accent);
+  border-color: color-mix(in srgb, var(--primary) 40%, var(--border));
+}
 
+.chat-jobs-badge.running {
+  background-color: color-mix(in srgb, #3b82f6 12%, transparent);
+  border-color: color-mix(in srgb, #3b82f6 40%, transparent);
+  color: #3b82f6;
+  box-shadow: 0 0 10px rgba(59, 130, 246, 0.15);
+}
+
+.chat-jobs-badge.has-failed {
+  background-color: color-mix(in srgb, var(--destructive, #ef4444) 10%, transparent);
+  border-color: color-mix(in srgb, var(--destructive, #ef4444) 30%, transparent);
+  color: var(--destructive, #ef4444);
+}
+
+.chat-jobs-badge.all-completed {
+  background-color: color-mix(in srgb, #10b981 10%, transparent);
+  border-color: color-mix(in srgb, #10b981 30%, transparent);
+  color: #10b981;
+}
+
+.chat-jobs-badge-text {
+  white-space: nowrap;
+}
+
+.chat-jobs-pulse-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: #3b82f6;
+  box-shadow: 0 0 6px #3b82f6;
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+.chat-jobs-badge-chevron {
+  transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  color: var(--muted-foreground);
+}
+
+.chat-jobs-badge-chevron.open {
+  transform: rotate(180deg);
+}
+
+.chat-jobs-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  width: 360px;
+  max-width: calc(100vw - 2rem);
+  background-color: var(--popover, var(--background));
+  border: 1px solid var(--border);
+  border-radius: var(--radius, 8px);
+  box-shadow: 0 12px 30px -4px rgba(0, 0, 0, 0.2), 0 4px 12px -2px rgba(0, 0, 0, 0.12);
+  z-index: 100;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  animation: chatDropdownIn 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+  backdrop-filter: blur(12px);
+}
+
+@keyframes chatDropdownIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.chat-jobs-dropdown-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.65rem 0.85rem;
+  background-color: color-mix(in srgb, var(--muted) 40%, transparent);
+  border-bottom: 1px solid var(--border);
+}
+
+.chat-jobs-dropdown-title {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.chat-jobs-dropdown-chips {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.chat-jobs-dropdown-list {
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.chat-jobs-dropdown-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  border-radius: var(--radius, 6px);
+  background-color: var(--secondary);
+  border: 1px solid transparent;
+  transition: all 0.15s ease;
+}
+
+.chat-jobs-dropdown-item:hover {
+  background-color: var(--accent);
+  border-color: var(--border);
+}
+
+.chat-jobs-dropdown-item.running {
+  border-color: color-mix(in srgb, #3b82f6 30%, transparent);
+  background-color: color-mix(in srgb, #3b82f6 6%, var(--secondary));
+}
+
+.chat-jobs-dropdown-item.completed {
+  border-color: color-mix(in srgb, #10b981 25%, transparent);
+}
+
+.chat-jobs-dropdown-item.failed {
+  border-color: color-mix(in srgb, var(--destructive, #ef4444) 30%, transparent);
+}
+
+.chat-jobs-dropdown-footer {
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--border);
+  background-color: color-mix(in srgb, var(--muted) 25%, transparent);
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* System Event Timeline Messages */
+.chat-system-event-row {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin: 0.75rem 0;
+}
+
+.chat-system-event-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 9999px;
+  background-color: color-mix(in srgb, var(--muted) 70%, transparent);
+  border: 1px solid var(--border);
+  font-size: 0.75rem;
+  color: var(--foreground);
+  max-width: 85%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.chat-system-event-icon {
+  flex-shrink: 0;
+  color: var(--primary);
+}
+
+.chat-system-event-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  line-height: 1.35;
+}
+
+.chat-system-event-time {
+  flex-shrink: 0;
+  font-size: 0.7rem;
+  color: var(--muted-foreground);
+  margin-left: 0.25rem;
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -1306,48 +1306,7 @@ button[class*="bg-primary"] .text-muted {
   background-color: color-mix(in srgb, var(--destructive) 15%, transparent);
 }
 
-/* Spawned Jobs Bar */
-.chat-spawned-jobs-bar {
-  border-bottom: 1px solid var(--border);
-  background-color: color-mix(in srgb, var(--card) 95%, var(--primary) 5%);
-  display: flex;
-  flex-direction: column;
-  flex-shrink: 0;
-}
-
-.chat-spawned-jobs-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.5rem 1rem;
-  cursor: pointer;
-  user-select: none;
-  transition: background-color 0.15s ease;
-}
-
-.chat-spawned-jobs-header:hover {
-  background-color: color-mix(in srgb, var(--accent) 50%, transparent);
-}
-
-.chat-spawned-jobs-title {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: var(--foreground);
-}
-
-.chat-spawned-jobs-icon {
-  color: var(--primary);
-}
-
-.chat-spawned-jobs-chips {
-  display: flex;
-  align-items: center;
-  gap: 0.375rem;
-  margin-left: 0.5rem;
-}
+/* Job Status Chips */
 
 .chat-job-chip {
   display: inline-flex;
@@ -1377,61 +1336,6 @@ button[class*="bg-primary"] .text-muted {
   border: 1px solid color-mix(in srgb, #ef4444 30%, transparent);
 }
 
-.chat-spawned-jobs-toggle {
-  background: transparent;
-  border: none;
-  color: var(--muted-foreground);
-  cursor: pointer;
-  padding: 0.25rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius, 4px);
-}
-
-.chat-spawned-jobs-toggle:hover {
-  color: var(--foreground);
-  background-color: var(--accent);
-}
-
-.chat-spawned-jobs-content {
-  padding: 0.5rem 1rem 0.75rem 1rem;
-  border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.chat-spawned-jobs-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.375rem;
-  max-height: 180px;
-  overflow-y: auto;
-}
-
-.chat-spawned-job-item {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.4rem 0.6rem;
-  background-color: var(--background);
-  border: 1px solid var(--border);
-  border-radius: var(--radius, 6px);
-  font-size: 0.75rem;
-}
-
-.chat-spawned-job-item.running {
-  border-color: color-mix(in srgb, #0ea5e9 40%, var(--border));
-}
-
-.chat-spawned-job-item.completed {
-  border-color: color-mix(in srgb, #10b981 40%, var(--border));
-}
-
-.chat-spawned-job-item.failed {
-  border-color: color-mix(in srgb, #ef4444 40%, var(--border));
-}
 
 .chat-job-status-indicator {
   margin-top: 0.1rem;
@@ -1450,7 +1354,7 @@ button[class*="bg-primary"] .text-muted {
   color: #059669;
 }
 
-.chat-spawned-job-item.failed .chat-job-status-indicator svg {
+.chat-jobs-dropdown-item.failed .chat-job-status-indicator svg {
   color: #dc2626;
 }
 
@@ -1510,23 +1414,6 @@ button[class*="bg-primary"] .text-muted {
   text-overflow: ellipsis;
 }
 
-.chat-spawned-jobs-review-prompt {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.5rem 0.75rem;
-  background-color: color-mix(in srgb, var(--primary) 10%, transparent);
-  border: 1px solid color-mix(in srgb, var(--primary) 25%, transparent);
-  border-radius: var(--radius, 6px);
-  gap: 0.75rem;
-  margin-top: 0.25rem;
-}
-
-.chat-spawned-jobs-review-text {
-  font-size: 0.75rem;
-  color: var(--foreground);
-  font-weight: 500;
-}
 
 .chat-spawned-jobs-review-btn {
   display: inline-flex;

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/QuestionsCallout.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/QuestionsCallout.tsx
@@ -4,7 +4,7 @@ import remarkGfm from "remark-gfm";
 import { CodeBlock } from "../CodeBlock";
 import { answerEntries, otherEntry, parseQuestions } from "./questionsSchema";
 import type { PlanQuestion, QuestionOption } from "./questionsSchema";
-import type { AnswerCallback } from "./questionsContext";
+import type { AnswerCallback, QuestionSubmitCallback } from "./questionsContext";
 
 /**
  * Question and option descriptions are full block markdown — paragraphs, lists, tables and fenced
@@ -279,15 +279,125 @@ const AnsweredQuestion: React.FC<{ question: PlanQuestion }> = ({ question }) =>
   );
 };
 
+interface ChatQuestionsBlockProps {
+  questions: PlanQuestion[];
+  blockIndex: number;
+  onSubmit: QuestionSubmitCallback;
+}
+
+const ChatQuestionsBlock: React.FC<ChatQuestionsBlockProps> = ({ questions, blockIndex, onSubmit }) => {
+  const [localAnswers, setLocalAnswers] = useState<Record<string, string[]>>(() => {
+    const initial: Record<string, string[]> = {};
+    for (const q of questions) {
+      if (q.answerPresent) {
+        initial[q.id] = answerEntries(q);
+      }
+    }
+    return initial;
+  });
+
+  const handleLocalAnswer = (questionId: string, answer: string | string[] | null | undefined) => {
+    setLocalAnswers((prev) => {
+      const next = { ...prev };
+      if (answer === undefined || answer === null || answer === "" || (Array.isArray(answer) && answer.length === 0)) {
+        delete next[questionId];
+      } else if (Array.isArray(answer)) {
+        next[questionId] = answer;
+      } else {
+        next[questionId] = [answer];
+      }
+      return next;
+    });
+  };
+
+  const hasAnyAnswers = Object.keys(localAnswers).length > 0;
+  const clearAll = () => {
+    setLocalAnswers({});
+  };
+
+  const canSubmit = questions.every((q) => {
+    if (q.optional) return true;
+    const ans = localAnswers[q.id];
+    return (ans && ans.length > 0) || q.answerPresent;
+  });
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+
+    const summaryLines: string[] = ["Answers:"];
+    for (const q of questions) {
+      const ans = localAnswers[q.id] ?? (q.answerPresent ? answerEntries(q) : []);
+      if (ans.length > 0) {
+        const displayVals = ans.map((val) => {
+          const opt = q.options?.find((o) => o.value === val);
+          return opt ? opt.title : val;
+        });
+        summaryLines.push(`- **${q.title || q.id}**: ${displayVals.join(", ")}`);
+      } else if (q.optional) {
+        summaryLines.push(`- **${q.title || q.id}**: *(skipped)*`);
+      }
+    }
+
+    onSubmit(localAnswers, summaryLines.join("\n"));
+  };
+
+  return (
+    <Shell>
+      {hasAnyAnswers && (
+        <div className="pmv-questions-actions">
+          <button
+            type="button"
+            className="pmv-question-clear"
+            onClick={clearAll}
+            aria-label={questions.length > 1 ? "Clear all answers in this block" : "Clear answer"}
+          >
+            Clear
+          </button>
+        </div>
+      )}
+
+      {questions.map((question) => {
+        const effectiveQuestion: PlanQuestion = {
+          ...question,
+          answer: localAnswers[question.id] ?? question.answer,
+          answerPresent: (localAnswers[question.id] && localAnswers[question.id].length > 0) || question.answerPresent,
+        };
+
+        return (
+          <QuestionView
+            key={question.id}
+            question={effectiveQuestion}
+            blockIndex={blockIndex}
+            onAnswer={handleLocalAnswer}
+          />
+        );
+      })}
+
+      <div className="pmv-questions-footer">
+        <button
+          type="button"
+          className="pmv-questions-submit"
+          disabled={!canSubmit}
+          onClick={handleSubmit}
+        >
+          Submit Response
+        </button>
+      </div>
+    </Shell>
+  );
+};
+
 export interface QuestionsCalloutProps {
   content: string;
   /** Which `questions` fence this is, 0-based. Keeps radio groups distinct across blocks. */
   blockIndex?: number;
   /** Absent when the host did not subscribe to `OnAnswersChange`, which means read-only. */
   onAnswer?: AnswerCallback;
+  /** Present when rendered inside chat to enable interactive answers and submission. */
+  onSubmit?: QuestionSubmitCallback;
 }
 
-export const QuestionsCallout: React.FC<QuestionsCalloutProps> = ({ content, blockIndex = 0, onAnswer }) => {
+export const QuestionsCallout: React.FC<QuestionsCalloutProps> = ({ content, blockIndex = 0, onAnswer, onSubmit }) => {
   const parsed = useMemo(() => parseQuestions(content), [content]);
 
   // A block that does not parse is the pre-schema plain-text form, and there is nothing to render
@@ -297,6 +407,27 @@ export const QuestionsCallout: React.FC<QuestionsCalloutProps> = ({ content, blo
   }
 
   const questions = parsed.questions;
+
+  // If rendered in chat with submit handler:
+  if (!onAnswer && onSubmit) {
+    if (questions.every((q) => q.answerPresent)) {
+      return (
+        <Shell>
+          {questions.map((question) => (
+            <AnsweredQuestion key={question.id} question={question} />
+          ))}
+        </Shell>
+      );
+    }
+
+    return (
+      <ChatQuestionsBlock
+        questions={questions}
+        blockIndex={blockIndex}
+        onSubmit={onSubmit}
+      />
+    );
+  }
 
   // No subscriber means the host is showing a plan rather than working through it — the Review
   // stage, or any other read-only view. Present the decisions.

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/plan-markdown.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/plan-markdown.css
@@ -1110,6 +1110,41 @@
   color: hsl(199 89% 48%);
 }
 
+/* ─── Questions submit in chat ─────────────────────────────────────── */
+.pmv-questions-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid hsl(199 89% 48% / 0.25);
+}
+
+.pmv-questions-submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.45rem 1.15rem;
+  border-radius: 0.375rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid hsl(199 89% 48%);
+  background: hsl(199 89% 48%);
+  color: #fff;
+  transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+}
+
+.pmv-questions-submit:hover:not(:disabled) {
+  background: hsl(199 89% 40%);
+  border-color: hsl(199 89% 40%);
+}
+
+.pmv-questions-submit:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 /* Image viewer */
 .pmv-img-clickable {
   cursor: pointer;

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsContext.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsContext.ts
@@ -6,6 +6,12 @@ export type AnswerCallback = (
   answer: string | string[] | null | undefined,
 ) => void;
 
+/** Reports submitted answers for an interactive questions block in chat. */
+export type QuestionSubmitCallback = (
+  answers: Record<string, string[]>,
+  summaryText: string,
+) => void;
+
 /**
  * Carries the answer callback from `DraftMarkdown` down to a `QuestionsCallout`.
  *
@@ -17,3 +23,8 @@ export type AnswerCallback = (
  * `DraftMarkdown.tsx`, which imports `BlockHandler` in turn.
  */
 export const QuestionsAnswerContext = createContext<AnswerCallback | undefined>(undefined);
+
+/**
+ * Carries the submit callback down to a `QuestionsCallout` when rendered inside a chat message.
+ */
+export const QuestionsSubmitContext = createContext<QuestionSubmitCallback | undefined>(undefined);

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -10,6 +10,7 @@ using Ivy.Tendril.Agents.Providers;
 using Ivy.Tendril.Apps.Views;
 using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Jobs;
 using Ivy.Tendril.Widgets;
 
 namespace Ivy.Tendril.Apps.Chat;
@@ -24,6 +25,7 @@ public class ChatApp : ViewBase
         var chatService = UseService<IChatHistoryService>();
         var executionService = UseService<IChatExecutionService>();
         var agentRunner = UseService<IAgentRunner>();
+        Context.TryUseService<IJobService>(out var jobService);
 
         var activeSessionId = UseState<string?>(() =>
         {
@@ -78,10 +80,13 @@ public class ChatApp : ViewBase
                 }
             }
 
+            void OnJobsChanged() => sessionVersion.Set(v => v + 1);
+
             chatService.SessionsChanged += OnSessionsChanged;
             chatService.GeneratingSessionsChanged += OnGeneratingChanged;
             executionService.StreamUpdated += OnStreamUpdated;
             executionService.SessionGeneratingChanged += OnSessionGeneratingChanged;
+            if (jobService != null) jobService.JobsChanged += OnJobsChanged;
 
             if (!string.IsNullOrEmpty(activeSessionId.Value))
             {
@@ -94,6 +99,7 @@ public class ChatApp : ViewBase
                 chatService.GeneratingSessionsChanged -= OnGeneratingChanged;
                 executionService.StreamUpdated -= OnStreamUpdated;
                 executionService.SessionGeneratingChanged -= OnSessionGeneratingChanged;
+                if (jobService != null) jobService.JobsChanged -= OnJobsChanged;
             });
         });
 
@@ -150,6 +156,24 @@ public class ChatApp : ViewBase
             var status = isGenerating ? "generating" : "done";
             var isActive = s.Id == currentSessionId;
 
+            List<ChatJobDto>? spawnedJobs = null;
+            if (jobService != null && s.SpawnedJobIds is { Count: > 0 } jIds)
+            {
+                spawnedJobs = jIds.Select(jId =>
+                {
+                    var job = jobService.GetJob(jId);
+                    if (job == null) return new ChatJobDto(jId, "Job", "Unknown");
+                    return new ChatJobDto(
+                        job.Id,
+                        job.Type,
+                        job.Status.ToString(),
+                        job.ReportedPlanId,
+                        job.ReportedPlanTitle,
+                        job.StatusMessage
+                    );
+                }).ToList();
+            }
+
             return new ChatSessionDto(
                 s.Id,
                 s.Title,
@@ -170,7 +194,8 @@ public class ChatApp : ViewBase
                     )).ToList()
                     : [],
                 status,
-                s.Effort
+                s.Effort,
+                spawnedJobs
             );
         }).ToList();
 

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -252,13 +252,26 @@ public class ChatApp : ViewBase
                 SelectSession(targetSessionId);
             }
 
-            _ = executionService.SendMessageAsync(
-                targetSessionId,
-                userPrompt,
-                attachments,
-                selectedAgent.Value,
-                effectiveModel,
-                effectiveEffort);
+            if (dto.ForceSend)
+            {
+                _ = executionService.ForceSendMessageAsync(
+                    targetSessionId,
+                    userPrompt,
+                    attachments,
+                    selectedAgent.Value,
+                    effectiveModel,
+                    effectiveEffort);
+            }
+            else
+            {
+                _ = executionService.SendMessageAsync(
+                    targetSessionId,
+                    userPrompt,
+                    attachments,
+                    selectedAgent.Value,
+                    effectiveModel,
+                    effectiveEffort);
+            }
 
             sessionVersion.Set(v => v + 1);
             streamVersion.Set(v => v + 1);

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -160,17 +160,38 @@ public class ChatApp : ViewBase
             if (jobService != null)
             {
                 var combinedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                if (s.SpawnedJobIds is { Count: > 0 } jIds)
-                {
-                    foreach (var id in jIds) combinedIds.Add(id);
-                }
 
-                var matchingJobs = jobService.GetJobs().Where(j => string.Equals(j.ChatSessionId, s.Id, StringComparison.OrdinalIgnoreCase));
+                var matchingJobs = jobService.GetJobs().Where(j => string.Equals(j.ChatSessionId, s.Id, StringComparison.OrdinalIgnoreCase)).ToList();
                 foreach (var mj in matchingJobs)
                 {
                     if (combinedIds.Add(mj.Id))
                     {
                         chatService.AddSpawnedJob(s.Id, mj.Id);
+                    }
+                }
+
+                if (s.SpawnedJobIds is { Count: > 0 } jIds)
+                {
+                    var staleIds = new List<string>();
+                    foreach (var id in jIds)
+                    {
+                        var job = jobService.GetJob(id);
+                        if (job != null)
+                        {
+                            if (string.Equals(job.ChatSessionId, s.Id, StringComparison.OrdinalIgnoreCase))
+                            {
+                                combinedIds.Add(id);
+                            }
+                            else
+                            {
+                                staleIds.Add(id);
+                            }
+                        }
+                    }
+
+                    if (staleIds.Count > 0)
+                    {
+                        chatService.RemoveSpawnedJobs(s.Id, staleIds);
                     }
                 }
 

--- a/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ChatApp.cs
@@ -157,21 +157,39 @@ public class ChatApp : ViewBase
             var isActive = s.Id == currentSessionId;
 
             List<ChatJobDto>? spawnedJobs = null;
-            if (jobService != null && s.SpawnedJobIds is { Count: > 0 } jIds)
+            if (jobService != null)
             {
-                spawnedJobs = jIds.Select(jId =>
+                var combinedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                if (s.SpawnedJobIds is { Count: > 0 } jIds)
                 {
-                    var job = jobService.GetJob(jId);
-                    if (job == null) return new ChatJobDto(jId, "Job", "Unknown");
-                    return new ChatJobDto(
-                        job.Id,
-                        job.Type,
-                        job.Status.ToString(),
-                        job.ReportedPlanId,
-                        job.ReportedPlanTitle,
-                        job.StatusMessage
-                    );
-                }).ToList();
+                    foreach (var id in jIds) combinedIds.Add(id);
+                }
+
+                var matchingJobs = jobService.GetJobs().Where(j => string.Equals(j.ChatSessionId, s.Id, StringComparison.OrdinalIgnoreCase));
+                foreach (var mj in matchingJobs)
+                {
+                    if (combinedIds.Add(mj.Id))
+                    {
+                        chatService.AddSpawnedJob(s.Id, mj.Id);
+                    }
+                }
+
+                if (combinedIds.Count > 0)
+                {
+                    spawnedJobs = combinedIds.Select(jId =>
+                    {
+                        var job = jobService.GetJob(jId);
+                        if (job == null) return new ChatJobDto(jId, "Job", "Unknown");
+                        return new ChatJobDto(
+                            job.Id,
+                            job.Type,
+                            job.Status.ToString(),
+                            job.ReportedPlanId,
+                            job.ReportedPlanTitle,
+                            job.StatusMessage
+                        );
+                    }).ToList();
+                }
             }
 
             return new ChatSessionDto(

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -197,6 +197,19 @@ public class ContentView(
                     }
                 }
                 return ValueTask.CompletedTask;
+            },
+            OnAnswerQuestion = e =>
+            {
+                if (e.Value != null)
+                {
+                    chatService.ApplyQuestionAnswers(e.Value.SessionId, e.Value.MessageId, e.Value.Answers);
+                    sessionVersion.Set(v => v + 1);
+                    if (!string.IsNullOrWhiteSpace(e.Value.ResponseText))
+                    {
+                        sendMessage(new ChatSendMessageDto(e.Value.ResponseText, SessionId: e.Value.SessionId));
+                    }
+                }
+                return ValueTask.CompletedTask;
             }
         }
         .WithLayout()

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -209,7 +209,7 @@ public class ContentView(
                     if (item != null)
                     {
                         chatService.RemoveQueuedMessage(activeSessionId.Value, e.Value);
-                        sendMessage(new ChatSendMessageDto(item.Prompt, item.Attachments, activeSessionId.Value));
+                        sendMessage(new ChatSendMessageDto(item.Prompt, item.Attachments, activeSessionId.Value, ForceSend: true));
                     }
                 }
                 return ValueTask.CompletedTask;

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -36,6 +36,7 @@ public class ContentView(
     public override object Build()
     {
         var configService = UseService<IConfigService>();
+        Context.TryUseService<IJobService>(out var jobService);
         var deletingSessionId = UseState<string?>(null);
 
         var upload = UseUpload(async (fileUpload, stream, ct) =>
@@ -89,6 +90,17 @@ public class ContentView(
             q.Attachments
         )).ToList();
 
+        var runningJobs = jobService?.GetJobs()
+            .Where(j => j.Status == JobStatus.Running || j.Status == JobStatus.Pending || j.Status == JobStatus.Queued)
+            .Select(j => new ChatJobDto(
+                j.Id,
+                j.Type,
+                j.Status.ToString(),
+                j.ReportedPlanId,
+                j.ReportedPlanTitle,
+                j.StatusMessage
+            )).ToList();
+
         var chatWidget = new ChatWidget
         {
             ActiveSessionId = activeSessionId.Value,
@@ -104,6 +116,7 @@ public class ContentView(
             IsStreaming = isStreaming,
             StreamingText = streamingText,
             QueuedMessages = queuedMessageDtos,
+            RunningJobs = runningJobs,
 
             OnSelectSession = e =>
             {

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -90,16 +90,27 @@ public class ContentView(
             q.Attachments
         )).ToList();
 
-        var runningJobs = jobService?.GetJobs()
-            .Where(j => j.Status == JobStatus.Running || j.Status == JobStatus.Pending || j.Status == JobStatus.Queued)
-            .Select(j => new ChatJobDto(
-                j.Id,
-                j.Type,
-                j.Status.ToString(),
-                j.ReportedPlanId,
-                j.ReportedPlanTitle,
-                j.StatusMessage
-            )).ToList();
+        var activeSessionModel = activeSessionId.Value != null
+            ? chatService.GetSession(activeSessionId.Value)
+            : null;
+        var activeSpawnedIds = activeSessionModel?.SpawnedJobIds != null
+            ? new HashSet<string>(activeSessionModel.SpawnedJobIds, StringComparer.OrdinalIgnoreCase)
+            : null;
+
+        var runningJobs = (activeSessionId.Value != null && jobService != null)
+            ? jobService.GetJobs()
+                .Where(j => (string.Equals(j.ChatSessionId, activeSessionId.Value, StringComparison.OrdinalIgnoreCase) ||
+                             (activeSpawnedIds != null && activeSpawnedIds.Contains(j.Id)))
+                         && (j.Status == JobStatus.Running || j.Status == JobStatus.Pending || j.Status == JobStatus.Queued))
+                .Select(j => new ChatJobDto(
+                    j.Id,
+                    j.Type,
+                    j.Status.ToString(),
+                    j.ReportedPlanId,
+                    j.ReportedPlanTitle,
+                    j.StatusMessage
+                )).ToList()
+            : new List<ChatJobDto>();
 
         var chatWidget = new ChatWidget
         {

--- a/src/Ivy.Tendril/Apps/Chat/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Chat/ContentView.cs
@@ -90,17 +90,9 @@ public class ContentView(
             q.Attachments
         )).ToList();
 
-        var activeSessionModel = activeSessionId.Value != null
-            ? chatService.GetSession(activeSessionId.Value)
-            : null;
-        var activeSpawnedIds = activeSessionModel?.SpawnedJobIds != null
-            ? new HashSet<string>(activeSessionModel.SpawnedJobIds, StringComparer.OrdinalIgnoreCase)
-            : null;
-
         var runningJobs = (activeSessionId.Value != null && jobService != null)
             ? jobService.GetJobs()
-                .Where(j => (string.Equals(j.ChatSessionId, activeSessionId.Value, StringComparison.OrdinalIgnoreCase) ||
-                             (activeSpawnedIds != null && activeSpawnedIds.Contains(j.Id)))
+                .Where(j => string.Equals(j.ChatSessionId, activeSessionId.Value, StringComparison.OrdinalIgnoreCase)
                          && (j.Status == JobStatus.Running || j.Status == JobStatus.Pending || j.Status == JobStatus.Queued))
                 .Select(j => new ChatJobDto(
                     j.Id,

--- a/src/Ivy.Tendril/Commands/JobStartCommand.cs
+++ b/src/Ivy.Tendril/Commands/JobStartCommand.cs
@@ -98,6 +98,10 @@ public class JobStartSettings : CommandSettings
     [CommandOption("--draft")]
     public bool Draft { get; set; }
 
+    [Description("Chat session ID if spawned from chat")]
+    [CommandOption("--chat-session")]
+    public string? ChatSessionId { get; set; }
+
     public override Spectre.Console.ValidationResult Validate()
     {
         var result = CliValidation.RequireNonEmpty(JobType, "job-type");
@@ -138,6 +142,7 @@ public class JobStartCommand : Command<JobStartSettings>
     private static JobArgsBase BuildJobArgs(JobStartSettings settings)
     {
         var jobType = settings.JobType;
+        JobArgsBase args;
 
         if (string.Equals(jobType, Constants.JobTypes.CreatePlan, StringComparison.OrdinalIgnoreCase))
         {
@@ -146,15 +151,14 @@ public class JobStartCommand : Command<JobStartSettings>
             if (string.IsNullOrEmpty(settings.Project))
                 throw new ArgumentException("--project is required for CreatePlan");
 
-            return new CreatePlanArgs(
+            args = new CreatePlanArgs(
                 settings.Description,
                 settings.Project,
                 settings.Priority ?? 0,
                 settings.Force,
                 settings.SourcePath);
         }
-
-        if (string.Equals(jobType, Constants.JobTypes.SyncRepo, StringComparison.OrdinalIgnoreCase))
+        else if (string.Equals(jobType, Constants.JobTypes.SyncRepo, StringComparison.OrdinalIgnoreCase))
         {
             if (string.IsNullOrEmpty(settings.RepoPath))
                 throw new ArgumentException("--repo-path is required for SyncRepo");
@@ -166,63 +170,72 @@ public class JobStartCommand : Command<JobStartSettings>
                 throw new ArgumentException(
                     $"Invalid --untracked-policy '{settings.UntrackedPolicy}'. Valid values: Stash, Commit, PullRequest");
 
-            return new SyncRepoArgs(
+            args = new SyncRepoArgs(
                 settings.RepoPath,
                 settings.BaseBranch ?? GitHelper.ResolveDefaultBranch(settings.RepoPath),
                 UntrackedChangesPolicy: policy);
         }
-
-        if (string.IsNullOrEmpty(settings.PlanId))
-            throw new ArgumentException($"<plan-id> is required for {jobType}");
-
-        var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
-
-        if (string.Equals(jobType, Constants.JobTypes.ExecutePlan, StringComparison.OrdinalIgnoreCase))
-            return new ExecutePlanArgs(planFolder, settings.Note);
-
-        if (string.Equals(jobType, Constants.JobTypes.UpdatePlan, StringComparison.OrdinalIgnoreCase))
+        else
         {
-            if (string.IsNullOrEmpty(settings.Instructions))
-                throw new ArgumentException("--instructions is required for UpdatePlan");
-            return new UpdatePlanArgs(planFolder, settings.Instructions);
+            if (string.IsNullOrEmpty(settings.PlanId))
+                throw new ArgumentException($"<plan-id> is required for {jobType}");
+
+            var planFolder = PlanCommandHelpers.ResolvePlanFolder(settings.PlanId);
+
+            if (string.Equals(jobType, Constants.JobTypes.ExecutePlan, StringComparison.OrdinalIgnoreCase))
+                args = new ExecutePlanArgs(planFolder, settings.Note);
+            else if (string.Equals(jobType, Constants.JobTypes.UpdatePlan, StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrEmpty(settings.Instructions))
+                    throw new ArgumentException("--instructions is required for UpdatePlan");
+                args = new UpdatePlanArgs(planFolder, settings.Instructions);
+            }
+            else if (string.Equals(jobType, Constants.JobTypes.SplitPlan, StringComparison.OrdinalIgnoreCase))
+                args = new SplitPlanArgs(planFolder);
+            else if (string.Equals(jobType, Constants.JobTypes.ExpandPlan, StringComparison.OrdinalIgnoreCase))
+                args = new ExpandPlanArgs(planFolder);
+            else if (string.Equals(jobType, Constants.JobTypes.CreateIssue, StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrEmpty(settings.Repo))
+                    throw new ArgumentException("--repo is required for CreateIssue");
+                args = new CreateIssueArgs(planFolder, settings.Repo, settings.Assignee, settings.Comment, settings.Labels);
+            }
+            else if (string.Equals(jobType, Constants.JobTypes.CreatePr, StringComparison.OrdinalIgnoreCase))
+            {
+                var reviewers = settings.Reviewers is { Length: > 0 }
+                    ? settings.Reviewers.SelectMany(r => r.Split(',')).ToArray()
+                    : settings.Assignee is null ? null : [settings.Assignee];
+                args = new CreatePrArgs(
+                    planFolder,
+                    Merge: !settings.NoMerge,
+                    DeleteBranch: !settings.NoDeleteBranch,
+                    IncludeArtifacts: !settings.NoArtifacts,
+                    Reviewers: reviewers,
+                    Comment: settings.Comment,
+                    Draft: settings.Draft,
+                    BaseBranch: settings.BaseBranch);
+            }
+            else if (string.Equals(jobType, Constants.JobTypes.RetryPlan, StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrEmpty(settings.ChangeRequest))
+                    throw new ArgumentException("--change-request is required for RetryPlan");
+                args = new RetryPlanArgs(planFolder, settings.ChangeRequest);
+            }
+            else
+            {
+                throw new ArgumentException($"Unknown job type: {jobType}. Valid types: {string.Join(", ", Constants.JobTypes.BuiltIn)}");
+            }
         }
 
-        if (string.Equals(jobType, Constants.JobTypes.SplitPlan, StringComparison.OrdinalIgnoreCase))
-            return new SplitPlanArgs(planFolder);
+        var chatSessionId = !string.IsNullOrEmpty(settings.ChatSessionId)
+            ? settings.ChatSessionId
+            : Environment.GetEnvironmentVariable("TENDRIL_CHAT_SESSION_ID");
 
-        if (string.Equals(jobType, Constants.JobTypes.ExpandPlan, StringComparison.OrdinalIgnoreCase))
-            return new ExpandPlanArgs(planFolder);
-
-        if (string.Equals(jobType, Constants.JobTypes.CreateIssue, StringComparison.OrdinalIgnoreCase))
+        if (!string.IsNullOrEmpty(chatSessionId))
         {
-            if (string.IsNullOrEmpty(settings.Repo))
-                throw new ArgumentException("--repo is required for CreateIssue");
-            return new CreateIssueArgs(planFolder, settings.Repo, settings.Assignee, settings.Comment, settings.Labels);
+            args = args with { ChatSessionId = chatSessionId };
         }
 
-        if (string.Equals(jobType, Constants.JobTypes.CreatePr, StringComparison.OrdinalIgnoreCase))
-        {
-            var reviewers = settings.Reviewers is { Length: > 0 }
-                ? settings.Reviewers.SelectMany(r => r.Split(',')).ToArray()
-                : settings.Assignee is null ? null : [settings.Assignee];
-            return new CreatePrArgs(
-                planFolder,
-                Merge: !settings.NoMerge,
-                DeleteBranch: !settings.NoDeleteBranch,
-                IncludeArtifacts: !settings.NoArtifacts,
-                Reviewers: reviewers,
-                Comment: settings.Comment,
-                Draft: settings.Draft,
-                BaseBranch: settings.BaseBranch);
-        }
-
-        if (string.Equals(jobType, Constants.JobTypes.RetryPlan, StringComparison.OrdinalIgnoreCase))
-        {
-            if (string.IsNullOrEmpty(settings.ChangeRequest))
-                throw new ArgumentException("--change-request is required for RetryPlan");
-            return new RetryPlanArgs(planFolder, settings.ChangeRequest);
-        }
-
-        throw new ArgumentException($"Unknown job type: {jobType}. Valid types: {string.Join(", ", Constants.JobTypes.BuiltIn)}");
+        return args;
     }
 }

--- a/src/Ivy.Tendril/Models/JobArgs.cs
+++ b/src/Ivy.Tendril/Models/JobArgs.cs
@@ -21,6 +21,7 @@ public abstract record JobArgsBase
     [JsonIgnore]
     public virtual string? PlanFolder => null;
     public List<string>? WaitForJobs { get; init; }
+    public string? ChatSessionId { get; init; }
 }
 
 public record CreatePlanArgs(

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -73,6 +73,7 @@ public record JobItem
     public PlanStatus? PreviousPlanState { get; set; }
 
     public string? SessionId { get; set; }
+    public string? ChatSessionId { get; set; }
     // Settable: the standalone CLI runners resolve the agent after the job object exists.
     public string Provider { get; set; } = "claude";
     public string? Model { get; set; }

--- a/src/Ivy.Tendril/Models/JobModels.cs
+++ b/src/Ivy.Tendril/Models/JobModels.cs
@@ -73,7 +73,12 @@ public record JobItem
     public PlanStatus? PreviousPlanState { get; set; }
 
     public string? SessionId { get; set; }
-    public string? ChatSessionId { get; set; }
+    public string? ChatSessionId
+    {
+        get => _chatSessionId ?? TypedArgs?.ChatSessionId;
+        set => _chatSessionId = value;
+    }
+    private string? _chatSessionId;
     // Settable: the standalone CLI runners resolve the agent after the job object exists.
     public string Provider { get; set; } = "claude";
     public string? Model { get; set; }

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -300,6 +300,14 @@ When the user asks you to create a plan in an interactive session (or after disc
    ```
    The CreatePlan promptware then researches, detects duplicates, and writes the full plan. Add `--priority <n>` or `--force` if appropriate. Report the job back to the user.
 
+## Tracking Spawned Jobs & Guiding the User
+
+When you start jobs in a chat session using `tendril job start`, they are automatically tracked for this chat session.
+- Once spawned jobs have executed and completed, **proactively guide the user through the completed plans/code**:
+  - Ask the user if they would like you to review the plan changes, inspect the diffs, check verification test outputs, or create a PR.
+  - Help the user review decisions, or guide them through reviewing the implementation themselves.
+  - If a job fails, diagnose the failure reason from the logs (`Logs/Jobs/`) and offer to retry with `tendril job start RetryPlan <plan-id> --change-request="..."`.
+
 ## Important Notes
 
 - **Never directly modify, create, or delete repository files during chat sessions.** All code changes must be planned and executed via Tendril plans (`tendril job start CreatePlan`).
@@ -309,4 +317,5 @@ When the user asks you to create a plan in an interactive session (or after disc
 - Plan states: `Draft`, `Creating`, `Updating`, `Executing`, `Review`, `Failed`, `Completed`, `Skipped`, `Blocked`, `Icebox`.
 - To create a new plan, start a CreatePlan job: `tendril job start CreatePlan --description="<description>" --project="<project>"` (see "Creating Plans Interactively"). Use the lower-level `tendril plan create` / `write-revision` commands only to edit an existing plan's content, never to create a new plan from scratch.
 - **Do NOT start a `CreatePlan` job to retry or fix an existing plan.** `CreatePlan` is strictly for creating brand new plans for new tasks. To retry an existing plan with reviewer feedback or changes, use `tendril job start RetryPlan <plan-id> --change-request="<feedback>"`.
+
 

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -308,6 +308,30 @@ When you start jobs in a chat session using `tendril job start`, they are automa
   - Help the user review decisions, or guide them through reviewing the implementation themselves.
   - If a job fails, diagnose the failure reason from the logs (`Logs/Jobs/`) and offer to retry with `tendril job start RetryPlan <plan-id> --change-request="..."`.
 
+## Asking Questions with Question Blocks
+
+When you need decisions, clarification, preferences, or input from the human operator before proceeding (for example: choosing an architectural approach, selecting a database or library, deciding scope, confirming an action, or providing configuration):
+Use a fenced `questions` block in your response. The chat UI automatically renders this as an interactive form with selectable option cards, radio/checkbox inputs, and a **Submit Response** button.
+
+````markdown
+```questions
+questions:
+  - id: choice-id              # required, stable unique slug
+    title: What is the question? # required
+    header: Optional Eyebrow   # optional <=12 char label
+    description: Optional explanation of why you're asking
+    multiple: false            # true for multi-select, false for single-select
+    other: true                # true if user may type custom text
+    options:                   # 2-4 selectable options
+      - title: Option Title
+        description: Markdown details explaining this option
+        value: option-slug
+        recommended: true      # optional recommendation badge
+```
+````
+
+Once the user selects their option and clicks **Submit Response**, their answer will be submitted directly to the chat session in the next turn so you can proceed with their chosen direction.
+
 ## Important Notes
 
 - **Never directly modify, create, or delete repository files during chat sessions.** All code changes must be planned and executed via Tendril plans (`tendril job start CreatePlan`).

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -302,7 +302,7 @@ When the user asks you to create a plan in an interactive session (or after disc
 
 ## Tracking Spawned Jobs & Guiding the User
 
-When you start jobs in a chat session using `tendril job start`, they are automatically tracked for this chat session.
+When you start jobs in a chat session using `tendril job start`, they are automatically tracked for this chat session. Always pass `--chat-session <sessionId>` with your current chat session ID when invoking `tendril job start` (e.g. `tendril job start CreatePlan --project="..." --description="..." --chat-session <sessionId>`).
 - Once spawned jobs have executed and completed, **proactively guide the user through the completed plans/code**:
   - Ask the user if they would like you to review the plan changes, inspect the diffs, check verification test outputs, or create a PR.
   - Help the user review decisions, or guide them through reviewing the implementation themselves.

--- a/src/Ivy.Tendril/ServiceRegistration.cs
+++ b/src/Ivy.Tendril/ServiceRegistration.cs
@@ -202,7 +202,8 @@ internal static class ServiceRegistration
                 sp.GetRequiredService<IPlanWatcherService>(),
                 string.IsNullOrEmpty(cfg.TendrilHome) ? null : sp.GetRequiredService<IPlanDatabaseService>(),
                 sp.GetRequiredService<IAgentRunner>(),
-                sp.GetRequiredService<IModelPricingProvider>());
+                sp.GetRequiredService<IModelPricingProvider>(),
+                sp.GetService<IChatHistoryService>());
         });
         server.Services.AddSingleton<IJobService>(sp => sp.GetRequiredService<JobService>());
         server.Services.AddSingleton<PlanWatcherService>(sp =>

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -14,7 +14,10 @@ using Ivy.Tendril.Agents.Abstractions;
 using Ivy.Tendril.Agents.Helpers;
 using Ivy.Tendril.Agents.Providers;
 using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Ivy.Tendril.Services.Jobs;
 using Ivy.Tendril.Widgets;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Ivy.Tendril.Services;
@@ -27,6 +30,10 @@ public sealed class ChatExecutionService : IChatExecutionService
     private readonly IChatSessionNamingService _namingService;
     private readonly IEventSerializer _serializer;
     private readonly ILogger<ChatExecutionService> _logger;
+    private readonly IServiceProvider? _serviceProvider;
+    private readonly IJobService? _jobService;
+
+    private IJobService? ResolvedJobService => _jobService ?? _serviceProvider?.GetService<IJobService>();
 
     private readonly ConcurrentDictionary<string, ActiveChatExecution> _activeExecutions = new(StringComparer.OrdinalIgnoreCase);
 
@@ -53,7 +60,9 @@ public sealed class ChatExecutionService : IChatExecutionService
         IAgentRunner agentRunner,
         IChatSessionNamingService namingService,
         IEventSerializer serializer,
-        ILogger<ChatExecutionService>? logger = null)
+        ILogger<ChatExecutionService>? logger = null,
+        IServiceProvider? serviceProvider = null,
+        IJobService? jobService = null)
     {
         _configService = configService;
         _chatService = chatService;
@@ -61,6 +70,8 @@ public sealed class ChatExecutionService : IChatExecutionService
         _namingService = namingService;
         _serializer = serializer;
         _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ChatExecutionService>.Instance;
+        _serviceProvider = serviceProvider;
+        _jobService = jobService;
         _chatService.ClearAllGeneratingSessions();
     }
 
@@ -218,10 +229,72 @@ public sealed class ChatExecutionService : IChatExecutionService
         // Add user message to history
         _chatService.AddMessage(sessionId, "user", promptWithAttachments, targetAgent, targetModel, effort: targetEffort);
 
-        // Build prompt with conversation history
+        // Build prompt with conversation history and spawned jobs status
         var currentSess = _chatService.GetSession(sessionId);
         var history = currentSess?.Messages ?? [];
         var agentPromptBuilder = new StringBuilder();
+
+        var jobService = ResolvedJobService;
+        if (currentSess?.SpawnedJobIds is { Count: > 0 } spawnedIds && jobService != null)
+        {
+            var spawnedJobs = new List<(string Id, string Type, JobStatus Status, string? PlanId, string? PlanTitle, string? StatusMessage)>();
+            foreach (var jId in spawnedIds)
+            {
+                var j = jobService.GetJob(jId);
+                if (j != null)
+                {
+                    spawnedJobs.Add((j.Id, j.Type, j.Status, j.ReportedPlanId, j.ReportedPlanTitle, j.StatusMessage));
+                }
+            }
+
+            if (spawnedJobs.Count > 0)
+            {
+                agentPromptBuilder.AppendLine("# Jobs Spawned in this Chat Session");
+                agentPromptBuilder.AppendLine("The following jobs were spawned in this chat session:");
+                agentPromptBuilder.AppendLine();
+
+                bool allDone = true;
+                bool anyFailed = false;
+
+                foreach (var sj in spawnedJobs)
+                {
+                    var planPart = !string.IsNullOrEmpty(sj.PlanId)
+                        ? $" | Plan: {sj.PlanId} ({sj.PlanTitle})"
+                        : "";
+                    var msgPart = !string.IsNullOrEmpty(sj.StatusMessage)
+                        ? $" | Message: {sj.StatusMessage}"
+                        : "";
+                    agentPromptBuilder.AppendLine($"- Job {sj.Id}: {sj.Type} | Status: {sj.Status}{planPart}{msgPart}");
+
+                    if (sj.Status == JobStatus.Failed || sj.Status == JobStatus.Timeout)
+                    {
+                        anyFailed = true;
+                    }
+                    if (sj.Status != JobStatus.Completed)
+                    {
+                        allDone = false;
+                    }
+                }
+                agentPromptBuilder.AppendLine();
+
+                if (allDone)
+                {
+                    agentPromptBuilder.AppendLine("All spawned jobs have completed. Proactively guide the user through the next steps (e.g. ask if they want you to review the plan or implementation, inspect results, or proceed to creating PRs).");
+                }
+                else if (anyFailed)
+                {
+                    agentPromptBuilder.AppendLine("Some spawned jobs failed or encountered issues. Guide the user through the failures and offer to diagnose, retry, or adjust the plan.");
+                }
+                else
+                {
+                    agentPromptBuilder.AppendLine("Some spawned jobs are still running or pending. Inform the user of their progress as appropriate.");
+                }
+
+                agentPromptBuilder.AppendLine("---");
+                agentPromptBuilder.AppendLine();
+            }
+        }
+
         if (history.Count > 1) // Prior messages exist before this current user message
         {
             agentPromptBuilder.AppendLine("# Previous Conversation Discussion History");
@@ -263,6 +336,12 @@ public sealed class ChatExecutionService : IChatExecutionService
                     modelOverride: targetModel != "default" ? targetModel : null,
                     effortOverride: effortOverride,
                     permissionMode: PermissionMode.FullAuto);
+
+                var envWithChat = new Dictionary<string, string>(context.ExtraEnvironment ?? new Dictionary<string, string>())
+                {
+                    ["TENDRIL_CHAT_SESSION_ID"] = sessionId
+                };
+                context = context with { ExtraEnvironment = envWithChat };
 
                 var session = await _agentRunner.LaunchAsync(context, cts.Token);
                 activeExec.Session = session;

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -397,9 +397,8 @@ public sealed class ChatExecutionService : IChatExecutionService
         // Launch background agent execution
         var executionTask = Task.Run(async () =>
         {
-            var rawLock = new object();
-            var rawLines = new List<string>();
             string? lastTextEvent = null;
+            var openToolCalls = new HashSet<string>();
 
             try
             {
@@ -426,15 +425,39 @@ public sealed class ChatExecutionService : IChatExecutionService
                 {
                     try
                     {
-                        if (evt is ToolResultEvent toolResult && !string.IsNullOrWhiteSpace(toolResult.Output))
+                        if (evt is ToolCallEvent toolCall && !string.IsNullOrEmpty(toolCall.ToolUseId))
                         {
-                            TryTrackSpawnedJob(sessionId, toolResult.Output);
+                            lock (activeExec.Lock)
+                            {
+                                openToolCalls.Add(toolCall.ToolUseId);
+                            }
+                        }
+                        else if (evt is ToolResultEvent toolResult)
+                        {
+                            if (!string.IsNullOrEmpty(toolResult.ToolUseId))
+                            {
+                                lock (activeExec.Lock)
+                                {
+                                    openToolCalls.Remove(toolResult.ToolUseId);
+                                }
+                            }
+                            if (!string.IsNullOrWhiteSpace(toolResult.Output))
+                            {
+                                TryTrackSpawnedJob(sessionId, toolResult.Output);
+                            }
                         }
                         else if (evt is TextEvent textEvt && !string.IsNullOrWhiteSpace(textEvt.Text))
                         {
-                            lock (rawLock)
+                            lock (activeExec.Lock)
                             {
-                                lastTextEvent = textEvt.Text;
+                                if (textEvt.IsDelta)
+                                {
+                                    lastTextEvent = (lastTextEvent ?? "") + textEvt.Text;
+                                }
+                                else
+                                {
+                                    lastTextEvent = textEvt.Text;
+                                }
                             }
                         }
 
@@ -506,12 +529,109 @@ public sealed class ChatExecutionService : IChatExecutionService
             }
             catch (OperationCanceledException)
             {
-                _chatService.AddMessage(sessionId, "assistant", "Execution was cancelled.", targetAgent, targetModel, effort: targetEffort);
+                string? fullRawStream = null;
+                string? collectedText = null;
+                lock (activeExec.Lock)
+                {
+                    collectedText = lastTextEvent;
+
+                    foreach (var toolUseId in openToolCalls)
+                    {
+                        var cancelToolResult = new ToolResultEvent
+                        {
+                            Kind = AgentEventKind.ToolResult,
+                            Timestamp = DateTimeOffset.UtcNow,
+                            ToolUseId = toolUseId,
+                            Output = "[Cancelled]",
+                            IsError = true
+                        };
+                        var cancelToolJson = _serializer.Serialize(cancelToolResult);
+                        if (!string.IsNullOrEmpty(cancelToolJson))
+                        {
+                            activeExec.RawLines.Add(cancelToolJson);
+                            StreamLineEmitted?.Invoke(sessionId, cancelToolJson);
+                        }
+                    }
+                    openToolCalls.Clear();
+
+                    var cancelEvt = new TextEvent
+                    {
+                        Kind = AgentEventKind.Text,
+                        Timestamp = DateTimeOffset.UtcNow,
+                        Text = "Execution was cancelled.",
+                        IsDelta = false
+                    };
+                    var cancelJson = _serializer.Serialize(cancelEvt);
+                    if (!string.IsNullOrEmpty(cancelJson))
+                    {
+                        activeExec.RawLines.Add(cancelJson);
+                        StreamLineEmitted?.Invoke(sessionId, cancelJson);
+                    }
+
+                    if (activeExec.RawLines.Count > 0)
+                    {
+                        fullRawStream = string.Join("\n", activeExec.RawLines);
+                    }
+                }
+
+                var responseContent = !string.IsNullOrWhiteSpace(collectedText)
+                    ? $"{collectedText}\n\nExecution was cancelled."
+                    : "Execution was cancelled.";
+
+                _chatService.AddMessage(sessionId, "assistant", responseContent, targetAgent, targetModel, rawStream: fullRawStream, effort: targetEffort);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error executing request for session {SessionId}", sessionId);
-                _chatService.AddMessage(sessionId, "assistant", $"Error executing request: {ex.Message}", targetAgent, targetModel, effort: targetEffort);
+                string? fullRawStream = null;
+                string? collectedText = null;
+                lock (activeExec.Lock)
+                {
+                    collectedText = lastTextEvent;
+
+                    foreach (var toolUseId in openToolCalls)
+                    {
+                        var errToolResult = new ToolResultEvent
+                        {
+                            Kind = AgentEventKind.ToolResult,
+                            Timestamp = DateTimeOffset.UtcNow,
+                            ToolUseId = toolUseId,
+                            Output = $"[Error: {ex.Message}]",
+                            IsError = true
+                        };
+                        var errToolJson = _serializer.Serialize(errToolResult);
+                        if (!string.IsNullOrEmpty(errToolJson))
+                        {
+                            activeExec.RawLines.Add(errToolJson);
+                            StreamLineEmitted?.Invoke(sessionId, errToolJson);
+                        }
+                    }
+                    openToolCalls.Clear();
+
+                    var errorEvt = new ErrorEvent
+                    {
+                        Kind = AgentEventKind.Error,
+                        Timestamp = DateTimeOffset.UtcNow,
+                        Message = $"Error executing request: {ex.Message}"
+                    };
+                    var errorJson = _serializer.Serialize(errorEvt);
+                    if (!string.IsNullOrEmpty(errorJson))
+                    {
+                        activeExec.RawLines.Add(errorJson);
+                        StreamLineEmitted?.Invoke(sessionId, errorJson);
+                    }
+
+                    if (activeExec.RawLines.Count > 0)
+                    {
+                        fullRawStream = string.Join("\n", activeExec.RawLines);
+                    }
+                }
+
+                var responseContent = !string.IsNullOrWhiteSpace(collectedText)
+                    ? $"{collectedText}\n\nError executing request: {ex.Message}"
+                    : $"Error executing request: {ex.Message}";
+
+                _chatService.AddMessage(sessionId, "assistant", responseContent, targetAgent, targetModel, rawStream: fullRawStream, effort: targetEffort);
             }
             finally
             {

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -59,6 +59,7 @@ public sealed class ChatExecutionService : IChatExecutionService
     }
 
     private readonly ConcurrentDictionary<string, ActiveChatExecution> _activeExecutions = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, ConcurrentQueue<string>> _pendingSystemEvents = new(StringComparer.OrdinalIgnoreCase);
 
     private static readonly Regex JobStartedRegex = new(
         @"(?:Job started:\s*|\*\*Job ID\*\*:\s*`?|Job ID:\s*`?)([0-9a-zA-Z_-]+)`?",
@@ -175,6 +176,15 @@ public sealed class ChatExecutionService : IChatExecutionService
         // If this session is already running an execution, enqueue this message.
         if (_activeExecutions.ContainsKey(sessionId))
         {
+            if (role.Equals("system", StringComparison.OrdinalIgnoreCase))
+            {
+                // Internal system events must NEVER be placed in the user's interactive prompt queue!
+                // Instead, queue in _pendingSystemEvents to be processed after the active execution finishes.
+                var queue = _pendingSystemEvents.GetOrAdd(sessionId, _ => new ConcurrentQueue<string>());
+                queue.Enqueue(userPrompt);
+                return;
+            }
+
             _chatService.EnqueueMessage(sessionId, new ChatSendMessageDto(userPrompt, attList.ToList(), sessionId));
             return;
         }
@@ -519,8 +529,17 @@ public sealed class ChatExecutionService : IChatExecutionService
                 SessionGeneratingChanged?.Invoke(sessionId);
                 StreamUpdated?.Invoke(sessionId);
 
-                // Process next queued message if one exists
-                if (_chatService.TryDequeueMessage(sessionId, out var nextQueuedItem) && nextQueuedItem != null)
+                // Process pending internal system event first, if any
+                if (_pendingSystemEvents.TryGetValue(sessionId, out var sysQueue) && sysQueue.TryDequeue(out var pendingSysEvent))
+                {
+                    _ = Task.Run(async () =>
+                    {
+                        await Task.Delay(200, CancellationToken.None);
+                        await SendMessageAsync(sessionId, pendingSysEvent, role: "system");
+                    });
+                }
+                // Otherwise process next queued user message if one exists
+                else if (_chatService.TryDequeueMessage(sessionId, out var nextQueuedItem) && nextQueuedItem != null)
                 {
                     _ = SendMessageAsync(sessionId, nextQueuedItem.Prompt, nextQueuedItem.Attachments, targetAgent, targetModel, targetEffort);
                 }
@@ -550,6 +569,7 @@ public sealed class ChatExecutionService : IChatExecutionService
         }
 
         _chatService.ClearQueuedMessages(sessionId);
+        _pendingSystemEvents.TryRemove(sessionId, out _);
         _chatService.SetSessionGenerating(sessionId, false);
         SessionGeneratingChanged?.Invoke(sessionId);
         StreamUpdated?.Invoke(sessionId);
@@ -572,6 +592,7 @@ public sealed class ChatExecutionService : IChatExecutionService
             catch { }
         }
         _activeExecutions.Clear();
+        _pendingSystemEvents.Clear();
     }
 
     private void OnJobFinished(JobItem job)

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -8,6 +8,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Ivy.Tendril.Agents.Abstractions;
@@ -33,9 +34,50 @@ public sealed class ChatExecutionService : IChatExecutionService
     private readonly IServiceProvider? _serviceProvider;
     private readonly IJobService? _jobService;
 
-    private IJobService? ResolvedJobService => _jobService ?? _serviceProvider?.GetService<IJobService>();
+    private readonly ConcurrentDictionary<string, byte> _notifiedJobCompletions = new(StringComparer.OrdinalIgnoreCase);
+    private bool _jobServiceSubscribed;
+    private readonly object _jobSubLock = new();
+
+    private IJobService? ResolvedJobService
+    {
+        get
+        {
+            var js = _jobService ?? _serviceProvider?.GetService<IJobService>();
+            if (js != null && !_jobServiceSubscribed)
+            {
+                lock (_jobSubLock)
+                {
+                    if (!_jobServiceSubscribed)
+                    {
+                        js.JobFinished += OnJobFinished;
+                        _jobServiceSubscribed = true;
+                    }
+                }
+            }
+            return js;
+        }
+    }
 
     private readonly ConcurrentDictionary<string, ActiveChatExecution> _activeExecutions = new(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly Regex JobStartedRegex = new(
+        @"(?:Job started:\s*|\*\*Job ID\*\*:\s*`?|Job ID:\s*`?)([0-9a-zA-Z_-]+)`?",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    internal void TryTrackSpawnedJob(string sessionId, string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return;
+        var match = JobStartedRegex.Match(text);
+        if (match.Success)
+        {
+            var jobId = match.Groups[1].Value.Trim();
+            if (!string.IsNullOrEmpty(jobId))
+            {
+                _chatService.AddSpawnedJob(sessionId, jobId);
+                ResolvedJobService?.SetChatSessionId(jobId, sessionId);
+            }
+        }
+    }
 
     public event Action<string>? SessionGeneratingChanged;
     public event Action<string>? StreamUpdated;
@@ -73,6 +115,11 @@ public sealed class ChatExecutionService : IChatExecutionService
         _serviceProvider = serviceProvider;
         _jobService = jobService;
         _chatService.ClearAllGeneratingSessions();
+        if (_jobService != null)
+        {
+            _jobService.JobFinished += OnJobFinished;
+            _jobServiceSubscribed = true;
+        }
     }
 
     public bool IsGenerating(string sessionId) =>
@@ -117,6 +164,7 @@ public sealed class ChatExecutionService : IChatExecutionService
         string? agentId = null,
         string? modelId = null,
         string? effort = null,
+        string role = "user",
         CancellationToken ct = default)
     {
         var userPrompt = prompt?.Trim() ?? string.Empty;
@@ -226,8 +274,8 @@ public sealed class ChatExecutionService : IChatExecutionService
             _chatService.AddMessage(sessionId, "assistant", warning, targetAgent, targetModel, effort: targetEffort);
         }
 
-        // Add user message to history
-        _chatService.AddMessage(sessionId, "user", promptWithAttachments, targetAgent, targetModel, effort: targetEffort);
+        // Add user or system message to history
+        _chatService.AddMessage(sessionId, role, promptWithAttachments, targetAgent, targetModel, effort: targetEffort);
 
         // Build prompt with conversation history and spawned jobs status
         var currentSess = _chatService.GetSession(sessionId);
@@ -304,7 +352,9 @@ public sealed class ChatExecutionService : IChatExecutionService
             // Exclude the last message which is the current user request
             foreach (var prevMsg in history.Take(history.Count - 1))
             {
-                var roleLabel = prevMsg.Role.Equals("user", StringComparison.OrdinalIgnoreCase) ? "User" : "Assistant";
+                var roleLabel = prevMsg.Role.Equals("user", StringComparison.OrdinalIgnoreCase)
+                    ? "User"
+                    : (prevMsg.Role.Equals("system", StringComparison.OrdinalIgnoreCase) ? "System Event" : "Assistant");
                 agentPromptBuilder.AppendLine($"### {roleLabel}");
                 agentPromptBuilder.AppendLine(prevMsg.Content);
                 agentPromptBuilder.AppendLine();
@@ -314,8 +364,24 @@ public sealed class ChatExecutionService : IChatExecutionService
             agentPromptBuilder.AppendLine();
         }
 
-        agentPromptBuilder.AppendLine("# Current User Request");
-        agentPromptBuilder.AppendLine(promptWithAttachments);
+        agentPromptBuilder.AppendLine("# Current Chat Session");
+        agentPromptBuilder.AppendLine($"Chat Session ID: {sessionId}");
+        agentPromptBuilder.AppendLine($"When starting jobs using `tendril job start`, always include `--chat-session {sessionId}` so the job is tracked in this chat session.");
+        agentPromptBuilder.AppendLine("---");
+        agentPromptBuilder.AppendLine();
+
+        if (role.Equals("system", StringComparison.OrdinalIgnoreCase))
+        {
+            agentPromptBuilder.AppendLine("# Current Event Notification");
+            agentPromptBuilder.AppendLine(promptWithAttachments);
+            agentPromptBuilder.AppendLine();
+            agentPromptBuilder.AppendLine("Evaluate this completed job event. Proactively inspect the job outcomes/artifacts if needed, determine whether any action is needed, and advise the user with a concise summary and suggested next steps.");
+        }
+        else
+        {
+            agentPromptBuilder.AppendLine("# Current User Request");
+            agentPromptBuilder.AppendLine(promptWithAttachments);
+        }
         var fullAgentPrompt = agentPromptBuilder.ToString();
 
         // Launch background agent execution
@@ -350,12 +416,18 @@ public sealed class ChatExecutionService : IChatExecutionService
                 {
                     try
                     {
-                        if (evt is TextEvent textEvt && !string.IsNullOrWhiteSpace(textEvt.Text))
+                        if (evt is ToolResultEvent toolResult && !string.IsNullOrWhiteSpace(toolResult.Output))
+                        {
+                            TryTrackSpawnedJob(sessionId, toolResult.Output);
+                        }
+                        else if (evt is TextEvent textEvt && !string.IsNullOrWhiteSpace(textEvt.Text))
                         {
                             lock (rawLock)
                             {
                                 lastTextEvent = textEvt.Text;
                             }
+
+                            TryTrackSpawnedJob(sessionId, textEvt.Text);
                         }
 
                         var wireJson = _serializer.Serialize(evt);
@@ -393,6 +465,9 @@ public sealed class ChatExecutionService : IChatExecutionService
                         : (result.IsSuccess
                             ? "Task completed successfully."
                             : "Agent execution completed with status code " + (result.ExitCode?.ToString() ?? "unknown")));
+
+                // Detect any job IDs mentioned in final response
+                TryTrackSpawnedJob(sessionId, responseContent);
 
                 _chatService.AddMessage(sessionId, "assistant", responseContent, targetAgent, targetModel, rawStream: fullRawStream, effort: targetEffort);
 
@@ -482,6 +557,11 @@ public sealed class ChatExecutionService : IChatExecutionService
 
     public void Dispose()
     {
+        if (_jobServiceSubscribed && ResolvedJobService != null)
+        {
+            ResolvedJobService.JobFinished -= OnJobFinished;
+        }
+
         foreach (var (_, exec) in _activeExecutions)
         {
             try
@@ -492,6 +572,39 @@ public sealed class ChatExecutionService : IChatExecutionService
             catch { }
         }
         _activeExecutions.Clear();
+    }
+
+    private void OnJobFinished(JobItem job)
+    {
+        if (job == null) return;
+
+        string? targetSessionId = job.ChatSessionId;
+        if (string.IsNullOrEmpty(targetSessionId))
+        {
+            var allSessions = _chatService.GetSessions();
+            var matchingSession = allSessions.FirstOrDefault(s => s.SpawnedJobIds != null && s.SpawnedJobIds.Contains(job.Id));
+            targetSessionId = matchingSession?.Id;
+        }
+
+        if (string.IsNullOrEmpty(targetSessionId)) return;
+
+        var sess = _chatService.GetSession(targetSessionId);
+        if (sess == null) return;
+
+        var notifKey = $"{targetSessionId}:{job.Id}:{job.Status}";
+        if (!_notifiedJobCompletions.TryAdd(notifKey, 0)) return;
+
+        var outcomeSummary = !string.IsNullOrEmpty(job.StatusMessage)
+            ? job.StatusMessage
+            : (job.Status == JobStatus.Completed ? "Completed successfully" : job.Status.ToString());
+        var planInfo = !string.IsNullOrEmpty(job.ReportedPlanTitle)
+            ? $"{job.ReportedPlanId}: {job.ReportedPlanTitle}"
+            : (!string.IsNullOrEmpty(job.PlanFile) ? Path.GetFileNameWithoutExtension(job.PlanFile) : job.Type);
+
+        var eventMessage = $"[System Event] Job {job.Id} ({job.Type}) for '{planInfo}' has finished with status: {job.Status} ({outcomeSummary}). " +
+            "Please inspect the outcome, determine whether any action is needed or if any issues occurred, and proactively guide the user on the results and next steps.";
+
+        _ = SendMessageAsync(targetSessionId, eventMessage, role: "system");
     }
 
     private sealed class ActiveChatExecution : IDisposable

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -395,7 +395,7 @@ public sealed class ChatExecutionService : IChatExecutionService
         var fullAgentPrompt = agentPromptBuilder.ToString();
 
         // Launch background agent execution
-        _ = Task.Run(async () =>
+        var executionTask = Task.Run(async () =>
         {
             var rawLock = new object();
             var rawLines = new List<string>();
@@ -524,22 +524,26 @@ public sealed class ChatExecutionService : IChatExecutionService
                 SessionGeneratingChanged?.Invoke(sessionId);
                 StreamUpdated?.Invoke(sessionId);
 
-                // Process pending internal system event first, if any
-                if (_pendingSystemEvents.TryGetValue(sessionId, out var sysQueue) && sysQueue.TryDequeue(out var pendingSysEvent))
+                if (!activeExec.IsInterrupted)
                 {
-                    _ = Task.Run(async () =>
+                    // Process pending internal system event first, if any
+                    if (_pendingSystemEvents.TryGetValue(sessionId, out var sysQueue) && sysQueue.TryDequeue(out var pendingSysEvent))
                     {
-                        await Task.Delay(200, CancellationToken.None);
-                        await SendMessageAsync(sessionId, pendingSysEvent, role: "system");
-                    });
-                }
-                // Otherwise process next queued user message if one exists
-                else if (_chatService.TryDequeueMessage(sessionId, out var nextQueuedItem) && nextQueuedItem != null)
-                {
-                    _ = SendMessageAsync(sessionId, nextQueuedItem.Prompt, nextQueuedItem.Attachments, targetAgent, targetModel, targetEffort);
+                        _ = Task.Run(async () =>
+                        {
+                            await Task.Delay(200, CancellationToken.None);
+                            await SendMessageAsync(sessionId, pendingSysEvent, role: "system");
+                        });
+                    }
+                    // Otherwise process next queued user message if one exists
+                    else if (_chatService.TryDequeueMessage(sessionId, out var nextQueuedItem) && nextQueuedItem != null)
+                    {
+                        _ = SendMessageAsync(sessionId, nextQueuedItem.Prompt, nextQueuedItem.Attachments, targetAgent, targetModel, targetEffort);
+                    }
                 }
             }
         });
+        activeExec.ExecutionTask = executionTask;
     }
 
     public async Task CancelAsync(string sessionId)
@@ -548,6 +552,7 @@ public sealed class ChatExecutionService : IChatExecutionService
 
         if (_activeExecutions.TryRemove(sessionId, out var exec))
         {
+            exec.IsInterrupted = true;
             try
             {
                 await exec.Cts.CancelAsync();
@@ -555,12 +560,23 @@ public sealed class ChatExecutionService : IChatExecutionService
                 {
                     await exec.Session.StopAsync();
                 }
-                exec.Dispose();
             }
             catch (Exception ex)
             {
                 _logger.LogDebug(ex, "Exception stopping session {SessionId}", sessionId);
             }
+
+            if (exec.ExecutionTask != null)
+            {
+                try
+                {
+                    using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                    await exec.ExecutionTask.WaitAsync(timeoutCts.Token);
+                }
+                catch { }
+            }
+
+            exec.Dispose();
         }
 
         _chatService.ClearQueuedMessages(sessionId);
@@ -568,6 +584,79 @@ public sealed class ChatExecutionService : IChatExecutionService
         _chatService.SetSessionGenerating(sessionId, false);
         SessionGeneratingChanged?.Invoke(sessionId);
         StreamUpdated?.Invoke(sessionId);
+    }
+
+    public async Task InterruptAsync(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return;
+
+        if (_activeExecutions.TryRemove(sessionId, out var exec))
+        {
+            exec.IsInterrupted = true;
+            try
+            {
+                await exec.Cts.CancelAsync();
+                if (exec.Session != null)
+                {
+                    await exec.Session.StopAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Exception stopping session {SessionId}", sessionId);
+            }
+
+            if (exec.ExecutionTask != null)
+            {
+                try
+                {
+                    using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                    await exec.ExecutionTask.WaitAsync(timeoutCts.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    if (exec.Session != null)
+                    {
+                        try { await exec.Session.KillAsync(); } catch { }
+                    }
+                }
+                catch
+                {
+                    // Ignore exceptions from cancelled task
+                }
+            }
+
+            exec.Dispose();
+            _chatService.SetSessionGenerating(sessionId, false);
+            SessionGeneratingChanged?.Invoke(sessionId);
+            StreamUpdated?.Invoke(sessionId);
+        }
+    }
+
+    public async Task ForceSendMessageAsync(
+        string sessionId,
+        string prompt,
+        IReadOnlyList<ChatAttachmentDto>? attachments = null,
+        string? agentId = null,
+        string? modelId = null,
+        string? effort = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return;
+
+        // Interrupt currently running execution if any, allowing it to cancel cleanly
+        await InterruptAsync(sessionId);
+
+        // Send the new message immediately
+        await SendMessageAsync(
+            sessionId,
+            prompt,
+            attachments,
+            agentId,
+            modelId,
+            effort,
+            role: "user",
+            ct: ct);
     }
 
     public void Dispose()
@@ -623,6 +712,8 @@ public sealed class ChatExecutionService : IChatExecutionService
         public List<string> RawLines { get; } = [];
         public object Lock { get; } = new();
         public long LastStreamUpdateTicks { get; set; }
+        public Task? ExecutionTask { get; set; }
+        public bool IsInterrupted { get; set; }
 
         public ActiveChatExecution(CancellationTokenSource cts)
         {

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -62,7 +62,7 @@ public sealed class ChatExecutionService : IChatExecutionService
     private readonly ConcurrentDictionary<string, ConcurrentQueue<string>> _pendingSystemEvents = new(StringComparer.OrdinalIgnoreCase);
 
     private static readonly Regex JobStartedRegex = new(
-        @"(?:Job started:\s*|\*\*Job ID\*\*:\s*`?|Job ID:\s*`?)([0-9a-zA-Z_-]+)`?",
+        @"\bJob started:\s*([0-9a-zA-Z_-]+)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     internal void TryTrackSpawnedJob(string sessionId, string? text)
@@ -299,7 +299,7 @@ public sealed class ChatExecutionService : IChatExecutionService
             foreach (var jId in spawnedIds)
             {
                 var j = jobService.GetJob(jId);
-                if (j != null)
+                if (j != null && string.Equals(j.ChatSessionId, sessionId, StringComparison.OrdinalIgnoreCase))
                 {
                     spawnedJobs.Add((j.Id, j.Type, j.Status, j.ReportedPlanId, j.ReportedPlanTitle, j.StatusMessage));
                 }
@@ -436,8 +436,6 @@ public sealed class ChatExecutionService : IChatExecutionService
                             {
                                 lastTextEvent = textEvt.Text;
                             }
-
-                            TryTrackSpawnedJob(sessionId, textEvt.Text);
                         }
 
                         var wireJson = _serializer.Serialize(evt);
@@ -475,9 +473,6 @@ public sealed class ChatExecutionService : IChatExecutionService
                         : (result.IsSuccess
                             ? "Task completed successfully."
                             : "Agent execution completed with status code " + (result.ExitCode?.ToString() ?? "unknown")));
-
-                // Detect any job IDs mentioned in final response
-                TryTrackSpawnedJob(sessionId, responseContent);
 
                 _chatService.AddMessage(sessionId, "assistant", responseContent, targetAgent, targetModel, rawStream: fullRawStream, effort: targetEffort);
 
@@ -600,13 +595,6 @@ public sealed class ChatExecutionService : IChatExecutionService
         if (job == null) return;
 
         string? targetSessionId = job.ChatSessionId;
-        if (string.IsNullOrEmpty(targetSessionId))
-        {
-            var allSessions = _chatService.GetSessions();
-            var matchingSession = allSessions.FirstOrDefault(s => s.SpawnedJobIds != null && s.SpawnedJobIds.Contains(job.Id));
-            targetSessionId = matchingSession?.Id;
-        }
-
         if (string.IsNullOrEmpty(targetSessionId)) return;
 
         var sess = _chatService.GetSession(targetSessionId);

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -429,6 +429,119 @@ public class ChatHistoryService : IChatHistoryService
         return session?.SpawnedJobIds ?? (IReadOnlyList<string>)Array.Empty<string>();
     }
 
+    public bool ApplyQuestionAnswers(string sessionId, string messageId, IReadOnlyDictionary<string, string[]> answers)
+    {
+        if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(messageId) || answers == null || answers.Count == 0)
+            return false;
+
+        ChatSessionModel? updatedSession = null;
+        lock (_sessionLock)
+        {
+            var session = GetSession(sessionId);
+            if (session == null) return false;
+
+            var msgIndex = session.Messages.FindIndex(m => string.Equals(m.Id, messageId, StringComparison.OrdinalIgnoreCase));
+            if (msgIndex < 0) return false;
+
+            var targetMsg = session.Messages[msgIndex];
+            var content = targetMsg.Content;
+            bool modified = false;
+
+            foreach (var (qId, ansValues) in answers)
+            {
+                var qa = new QuestionAnswer(qId, ansValues);
+                if (QuestionAnswers.TryApply(content, qa, out var updatedContent))
+                {
+                    content = updatedContent;
+                    modified = true;
+                }
+            }
+
+            if (!modified) return false;
+
+            string? rawStream = targetMsg.RawStream;
+            if (!string.IsNullOrEmpty(rawStream))
+            {
+                var lines = rawStream.Split('\n');
+                bool rawModified = false;
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    var line = lines[i].Trim();
+                    if (string.IsNullOrEmpty(line)) continue;
+                    try
+                    {
+                        var node = System.Text.Json.Nodes.JsonNode.Parse(line);
+                        if (node is System.Text.Json.Nodes.JsonObject obj)
+                        {
+                            bool lineChanged = false;
+                            if (obj.TryGetPropertyValue("text", out var textNode) && textNode != null)
+                            {
+                                var textVal = textNode.GetValue<string>();
+                                foreach (var (qId, ansValues) in answers)
+                                {
+                                    var qa = new QuestionAnswer(qId, ansValues);
+                                    if (QuestionAnswers.TryApply(textVal, qa, out var updatedTextVal))
+                                    {
+                                        textVal = updatedTextVal;
+                                        lineChanged = true;
+                                    }
+                                }
+                                if (lineChanged) obj["text"] = textVal;
+                            }
+                            if (obj.TryGetPropertyValue("response", out var respNode) && respNode != null)
+                            {
+                                var respVal = respNode.GetValue<string>();
+                                foreach (var (qId, ansValues) in answers)
+                                {
+                                    var qa = new QuestionAnswer(qId, ansValues);
+                                    if (QuestionAnswers.TryApply(respVal, qa, out var updatedRespVal))
+                                    {
+                                        respVal = updatedRespVal;
+                                        lineChanged = true;
+                                    }
+                                }
+                                if (lineChanged) obj["response"] = respVal;
+                            }
+                            if (lineChanged)
+                            {
+                                lines[i] = obj.ToJsonString();
+                                rawModified = true;
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        // ignore malformed lines
+                    }
+                }
+                if (rawModified)
+                {
+                    rawStream = string.Join("\n", lines);
+                }
+            }
+
+            var updatedMsg = targetMsg with { Content = content, RawStream = rawStream };
+            var updatedMessages = new List<ChatMessageModel>(session.Messages);
+            updatedMessages[msgIndex] = updatedMsg;
+
+            updatedSession = session with
+            {
+                UpdatedAt = DateTimeOffset.UtcNow,
+                Messages = updatedMessages
+            };
+            _sessions[session.Id] = updatedSession;
+        }
+
+        if (updatedSession != null)
+        {
+            PersistSessionToDisk(updatedSession);
+            SessionsChanged?.Invoke(this, EventArgs.Empty);
+            return true;
+        }
+
+        return false;
+    }
+
     private void PersistSessionToDisk(ChatSessionModel session)
     {
         try

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -394,6 +394,41 @@ public class ChatHistoryService : IChatHistoryService
         return msg;
     }
 
+    public void AddSpawnedJob(string sessionId, string jobId)
+    {
+        if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(jobId)) return;
+        ChatSessionModel? updated = null;
+        lock (_sessionLock)
+        {
+            var session = GetSession(sessionId);
+            if (session == null) return;
+            var currentJobs = session.SpawnedJobIds != null ? new List<string>(session.SpawnedJobIds) : new List<string>();
+            if (!currentJobs.Contains(jobId, StringComparer.OrdinalIgnoreCase))
+            {
+                currentJobs.Add(jobId);
+                updated = session with
+                {
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                    SpawnedJobIds = currentJobs
+                };
+                _sessions[sessionId] = updated;
+            }
+        }
+
+        if (updated != null)
+        {
+            PersistSessionToDisk(updated);
+            SessionsChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public IReadOnlyList<string> GetSpawnedJobs(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId)) return Array.Empty<string>();
+        var session = GetSession(sessionId);
+        return session?.SpawnedJobIds ?? (IReadOnlyList<string>)Array.Empty<string>();
+    }
+
     private void PersistSessionToDisk(ChatSessionModel session)
     {
         try

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -464,6 +464,8 @@ public class ChatHistoryService : IChatHistoryService
             {
                 var lines = rawStream.Split('\n');
                 bool rawModified = false;
+                bool anyTextApplied = false;
+                bool hasDeltaText = false;
                 for (int i = 0; i < lines.Length; i++)
                 {
                     var line = lines[i].Trim();
@@ -474,6 +476,10 @@ public class ChatHistoryService : IChatHistoryService
                         if (node is System.Text.Json.Nodes.JsonObject obj)
                         {
                             bool lineChanged = false;
+                            if (obj.TryGetPropertyValue("delta", out var deltaNode) && deltaNode != null && deltaNode.GetValue<bool>())
+                            {
+                                hasDeltaText = true;
+                            }
                             if (obj.TryGetPropertyValue("text", out var textNode) && textNode != null)
                             {
                                 var textVal = textNode.GetValue<string>();
@@ -484,6 +490,7 @@ public class ChatHistoryService : IChatHistoryService
                                     {
                                         textVal = updatedTextVal;
                                         lineChanged = true;
+                                        anyTextApplied = true;
                                     }
                                 }
                                 if (lineChanged) obj["text"] = textVal;
@@ -514,6 +521,51 @@ public class ChatHistoryService : IChatHistoryService
                         // ignore malformed lines
                     }
                 }
+
+                if (hasDeltaText && !anyTextApplied && modified)
+                {
+                    var newLines = new List<string>();
+                    bool consolidatedInserted = false;
+                    foreach (var line in lines)
+                    {
+                        var trimmed = line.Trim();
+                        if (string.IsNullOrEmpty(trimmed)) continue;
+                        bool isDeltaText = false;
+                        try
+                        {
+                            var node = System.Text.Json.Nodes.JsonNode.Parse(trimmed);
+                            if (node is System.Text.Json.Nodes.JsonObject obj &&
+                                obj.TryGetPropertyValue("kind", out var kind) && kind?.GetValue<string>() == "text" &&
+                                obj.TryGetPropertyValue("delta", out var delta) && delta != null && delta.GetValue<bool>())
+                            {
+                                isDeltaText = true;
+                            }
+                        }
+                        catch { }
+
+                        if (isDeltaText)
+                        {
+                            if (!consolidatedInserted)
+                            {
+                                var consolidated = new System.Text.Json.Nodes.JsonObject
+                                {
+                                    ["kind"] = "text",
+                                    ["text"] = content,
+                                    ["delta"] = false
+                                };
+                                newLines.Add(consolidated.ToJsonString());
+                                consolidatedInserted = true;
+                                rawModified = true;
+                            }
+                        }
+                        else
+                        {
+                            newLines.Add(trimmed);
+                        }
+                    }
+                    lines = newLines.ToArray();
+                }
+
                 if (rawModified)
                 {
                     rawStream = string.Join("\n", lines);

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -428,6 +428,34 @@ public class ChatHistoryService : IChatHistoryService
         }
     }
 
+    public void RemoveSpawnedJobs(string sessionId, IEnumerable<string> jobIds)
+    {
+        if (string.IsNullOrEmpty(sessionId) || jobIds == null) return;
+        ChatSessionModel? updated = null;
+        lock (_sessionLock)
+        {
+            var session = GetSession(sessionId);
+            if (session == null || session.SpawnedJobIds == null || session.SpawnedJobIds.Count == 0) return;
+            var toRemove = new HashSet<string>(jobIds, StringComparer.OrdinalIgnoreCase);
+            var remaining = session.SpawnedJobIds.Where(id => !toRemove.Contains(id)).ToList();
+            if (remaining.Count != session.SpawnedJobIds.Count)
+            {
+                updated = session with
+                {
+                    UpdatedAt = DateTimeOffset.UtcNow,
+                    SpawnedJobIds = remaining.Count > 0 ? remaining : null
+                };
+                _sessions[sessionId] = updated;
+            }
+        }
+
+        if (updated != null)
+        {
+            PersistSessionToDisk(updated);
+            SessionsChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
     public IReadOnlyList<string> GetSpawnedJobs(string sessionId)
     {
         if (string.IsNullOrEmpty(sessionId)) return Array.Empty<string>();

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -78,6 +78,7 @@ public class ChatHistoryService : IChatHistoryService
         {
             if (_queuedMessages.TryGetValue(sessionId, out var list))
             {
+                list.RemoveAll(q => q.Prompt != null && q.Prompt.StartsWith("[System Event]", StringComparison.OrdinalIgnoreCase));
                 return list.ToList();
             }
             return Array.Empty<ChatQueuedItem>();
@@ -86,6 +87,11 @@ public class ChatHistoryService : IChatHistoryService
 
     public ChatQueuedItem EnqueueMessage(string sessionId, ChatSendMessageDto dto)
     {
+        if (dto.Prompt != null && dto.Prompt.StartsWith("[System Event]", StringComparison.OrdinalIgnoreCase))
+        {
+            return new ChatQueuedItem(Guid.NewGuid().ToString("N"), dto.Prompt, dto.Attachments != null ? new List<ChatAttachmentDto>(dto.Attachments) : null, DateTimeOffset.UtcNow);
+        }
+
         var item = new ChatQueuedItem(
             Id: Guid.NewGuid().ToString("N"),
             Prompt: dto.Prompt,

--- a/src/Ivy.Tendril/Services/IChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/IChatExecutionService.cs
@@ -20,6 +20,7 @@ public interface IChatExecutionService : IDisposable
         string? agentId = null,
         string? modelId = null,
         string? effort = null,
+        string role = "user",
         CancellationToken ct = default);
     Task CancelAsync(string sessionId);
 }

--- a/src/Ivy.Tendril/Services/IChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/IChatExecutionService.cs
@@ -23,4 +23,13 @@ public interface IChatExecutionService : IDisposable
         string role = "user",
         CancellationToken ct = default);
     Task CancelAsync(string sessionId);
+    Task InterruptAsync(string sessionId);
+    Task ForceSendMessageAsync(
+        string sessionId,
+        string prompt,
+        IReadOnlyList<ChatAttachmentDto>? attachments = null,
+        string? agentId = null,
+        string? modelId = null,
+        string? effort = null,
+        CancellationToken ct = default);
 }

--- a/src/Ivy.Tendril/Services/IChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/IChatHistoryService.cs
@@ -30,7 +30,8 @@ public record ChatSessionModel(
     string AgentId,
     string ModelId,
     List<ChatMessageModel> Messages,
-    string? Effort = null
+    string? Effort = null,
+    List<string>? SpawnedJobIds = null
 );
 
 public interface IChatHistoryService
@@ -55,4 +56,6 @@ public interface IChatHistoryService
     bool RemoveQueuedMessage(string sessionId, string queueId);
     bool UpdateQueuedMessage(string sessionId, string queueId, string prompt);
     void ClearQueuedMessages(string sessionId);
+    void AddSpawnedJob(string sessionId, string jobId);
+    IReadOnlyList<string> GetSpawnedJobs(string sessionId);
 }

--- a/src/Ivy.Tendril/Services/IChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/IChatHistoryService.cs
@@ -58,4 +58,5 @@ public interface IChatHistoryService
     void ClearQueuedMessages(string sessionId);
     void AddSpawnedJob(string sessionId, string jobId);
     IReadOnlyList<string> GetSpawnedJobs(string sessionId);
+    bool ApplyQuestionAnswers(string sessionId, string messageId, IReadOnlyDictionary<string, string[]> answers);
 }

--- a/src/Ivy.Tendril/Services/IChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/IChatHistoryService.cs
@@ -57,6 +57,7 @@ public interface IChatHistoryService
     bool UpdateQueuedMessage(string sessionId, string queueId, string prompt);
     void ClearQueuedMessages(string sessionId);
     void AddSpawnedJob(string sessionId, string jobId);
+    void RemoveSpawnedJobs(string sessionId, IEnumerable<string> jobIds);
     IReadOnlyList<string> GetSpawnedJobs(string sessionId);
     bool ApplyQuestionAnswers(string sessionId, string messageId, IReadOnlyDictionary<string, string[]> answers);
 }

--- a/src/Ivy.Tendril/Services/Jobs/IJobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/IJobService.cs
@@ -9,6 +9,7 @@ public interface IJobService : IDisposable
     event Action? JobsStructureChanged;  // Jobs added/removed or status changed
     event Action? JobPropertyChanged;    // Only properties changed (cost, tokens)
     event Action<JobNotification>? NotificationReady;
+    event Action<JobItem>? JobFinished;
 
     string StartJob(JobArgsBase args, string? inboxFilePath = null);
     void ForceStartJob(string id);
@@ -28,6 +29,7 @@ public interface IJobService : IDisposable
     List<JobItem> GetJobsForPlan(string planFile);
     JobItem? GetJob(string id);
     bool UpdateJobStatus(string id, string message, string? planId = null, string? planTitle = null);
+    void SetChatSessionId(string id, string chatSessionId);
     bool ReportJobFailure(string id, string message);
     bool IsInboxFileTracked(string filePath);
 }

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -31,6 +31,7 @@ public class JobService : IJobService
     private readonly JobLauncher _jobLauncher;
     private readonly JobCompletionHandler _completionHandler;
     private readonly IAgentRunner? _agentRunner;
+    private readonly IChatHistoryService? _chatHistoryService;
     private Timer? _blockedJobCheckTimer;
     public JobService(
         IConfigService configService,
@@ -41,7 +42,8 @@ public class JobService : IJobService
         IPlanWatcherService? planWatcherService = null,
         IPlanDatabaseService? database = null,
         IAgentRunner? agentRunner = null,
-        IModelPricingProvider? pricingProvider = null)
+        IModelPricingProvider? pricingProvider = null,
+        IChatHistoryService? chatHistoryService = null)
     {
         _syncContext = SynchronizationContext.Current;
         _configService = configService;
@@ -52,6 +54,7 @@ public class JobService : IJobService
         _planWatcherService = planWatcherService;
         _database = database;
         _agentRunner = agentRunner;
+        _chatHistoryService = chatHistoryService;
         _jobTimeout = TimeSpan.FromMinutes(configService.Settings.JobTimeout);
         _staleOutputTimeout = TimeSpan.FromMinutes(configService.Settings.StaleOutputTimeout);
         _maxConcurrentJobs = configService.Settings.MaxConcurrentJobs;
@@ -79,7 +82,8 @@ public class JobService : IJobService
         ITelemetryService? telemetryService = null,
         IPlanDatabaseService? database = null,
         ILogger<JobService>? logger = null,
-        IAgentRunner? agentRunner = null)
+        IAgentRunner? agentRunner = null,
+        IChatHistoryService? chatHistoryService = null)
     {
         _syncContext = SynchronizationContext.Current;
         _logger = logger ?? NullLogger<JobService>.Instance;
@@ -94,6 +98,7 @@ public class JobService : IJobService
         _telemetryService = telemetryService;
         _database = database;
         _agentRunner = agentRunner;
+        _chatHistoryService = chatHistoryService;
         var promptsRoot = Ivy.Tendril.Helpers.PromptwareHelper.ResolvePromptsRoot();
         _jobLauncher = new JobLauncher(null, agentRunner!, _logger, promptsRoot);
         _completionHandler = new JobCompletionHandler(
@@ -1034,6 +1039,11 @@ public class JobService : IJobService
 
         _jobs[id] = job;
 
+        if (!string.IsNullOrEmpty(job.ChatSessionId))
+        {
+            _chatHistoryService?.AddSpawnedJob(job.ChatSessionId, id);
+        }
+
         // Persist while in flight, not just on completion: the agent reports status over HTTP and
         // must still be resolvable if the master restarts mid-job (#1759).
         PersistJob(job);
@@ -1128,7 +1138,8 @@ public class JobService : IJobService
             TypedArgs = args,
             Provider = _configService?.Settings.CodingAgent ?? "claude",
             Priority = priority,
-            WaitForJobIds = args.WaitForJobs
+            WaitForJobIds = args.WaitForJobs,
+            ChatSessionId = args.ChatSessionId
         };
 
         if (args is CreatePlanArgs)
@@ -1318,8 +1329,13 @@ public class JobService : IJobService
             Status = JobStatus.Running,
             StartedAt = DateTime.UtcNow,
             TypedArgs = args,
-            TimeoutCts = new CancellationTokenSource()
+            TimeoutCts = new CancellationTokenSource(),
+            ChatSessionId = args.ChatSessionId
         };
+        if (!string.IsNullOrEmpty(job.ChatSessionId) && _chatHistoryService != null)
+        {
+            _chatHistoryService.AddSpawnedJob(job.ChatSessionId, id);
+        }
         // Mirror StartJob (including its CreatePlanArgs guard) so inbox-recovery behaviour can be
         // exercised without a launchable agent.
         if (args is CreatePlanArgs)

--- a/src/Ivy.Tendril/Services/Jobs/JobService.cs
+++ b/src/Ivy.Tendril/Services/Jobs/JobService.cs
@@ -112,6 +112,7 @@ public class JobService : IJobService
     public event Action? JobsStructureChanged;
     public event Action? JobPropertyChanged;
     public event Action<JobNotification>? NotificationReady;
+    public event Action<JobItem>? JobFinished;
 
     public string StartJob(JobArgsBase args, string? inboxFilePath = null)
     {
@@ -153,6 +154,7 @@ public class JobService : IJobService
         PersistJob(job);
         EvictStaleJobs();
         RaiseJobsStructureChanged();
+        JobFinished?.Invoke(job);
         ProcessJobQueue();
     }
 
@@ -301,6 +303,7 @@ public class JobService : IJobService
         _completionHandler.HandleWaitForJobsDependents(job, _jobs, RaiseNotification, StartJobSkipDepCheck, PersistJob, DeleteJobFromDatabase);
 
         RaiseJobsStructureChanged();
+        JobFinished?.Invoke(job);
 
         // Try to start queued jobs now that a slot is free
         if (heldSlot)
@@ -619,6 +622,17 @@ public class JobService : IJobService
         PersistJob(job);
         RaiseJobsPropertyChanged();
         return true;
+    }
+
+    public void SetChatSessionId(string id, string chatSessionId)
+    {
+        if (_jobs.TryGetValue(id, out var job))
+        {
+            job.ChatSessionId = chatSessionId;
+            _chatHistoryService?.AddSpawnedJob(chatSessionId, id);
+            PersistJob(job);
+            RaiseJobsPropertyChanged();
+        }
     }
 
     public bool ReportJobFailure(string id, string message)

--- a/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
+++ b/src/Ivy.Tendril/Services/Plans/PlanDatabaseService.cs
@@ -766,6 +766,7 @@ public class PlanDatabaseService : IPlanDatabaseService
 
     private JobItem MapJobRow(SqliteDataReader reader)
     {
+        var typedArgs = ReadTypedArgs(reader);
         return new JobItem
         {
             Id = reader.GetString(reader.GetOrdinal("Id")),
@@ -797,7 +798,8 @@ public class PlanDatabaseService : IPlanDatabaseService
             StatusMessage = reader.IsDBNull(reader.GetOrdinal("StatusMessage"))
                 ? null
                 : reader.GetString(reader.GetOrdinal("StatusMessage")),
-            TypedArgs = ReadTypedArgs(reader),
+            TypedArgs = typedArgs,
+            ChatSessionId = typedArgs?.ChatSessionId,
             WorkingDirectory = reader.IsDBNull(reader.GetOrdinal("WorkingDirectory"))
                 ? null
                 : reader.GetString(reader.GetOrdinal("WorkingDirectory")),


### PR DESCRIPTION
## Summary

This PR addresses multiple related chat workflow capabilities and fixes:

1. **Interactive Question Blocks & Answer Submission**:
   - Parses fenced ```` ```questions ```` blocks within assistant messages or tool output into interactive single-select and multi-select option cards with custom text input.
   - Updates chat history and replaces the question block with formatted markdown answers upon submission.

2. **Spawned Job Tracking & Outcome Review**:
   - Emits `--chat-session <sessionId>` and tracks background jobs spawned by chat agents (`JobItem.ChatSessionId`).
   - Limits job tracking and display strictly to the current active chat session.
   - Header badge indicates running jobs for the active session with an interactive dropdown to view jobs and prompt the agent to review outcomes.
   - Cleans up the duplicate spawned jobs bar above chat in favor of the unified header badge dropdown.

3. **Queue Isolation & Agent Interruption**:
   - Isolates internal system notifications (`[System Event]`) from the user interactive queue.
   - Immediately cancels and interrupts a running agent turn when force-sending a queued message (`->` / "Send now"), executing the force-sent prompt immediately while preserving remaining queued items.

4. **Execution History Preservation on Cancellation**:
   - Fixes cancellation behavior in `ChatExecutionService` where stopping an active execution previously replaced the entire timeline of what happened with a single `"Execution was cancelled."` bubble.
   - Preserves all preceding events (`rawStream` with tool calls, tool results, thinking blocks, and text).
   - Cleanly closes any open, in-flight tool calls with `[Cancelled]` to avoid orphaned spinning tool cards.
   - Appends `"Execution was cancelled."` to the execution history and message content rather than wiping and replacing it.

---

## Technical Details

### 1. Job Arguments & Tracking (`src/Ivy.Tendril/Services/Jobs/`)

- **`JobArgsBase`**: Added `string? ChatSessionId` and CLI option `--chat-session <sessionId>`:
  ```csharp
  public abstract record JobArgsBase
  {
      ...
      public string? ChatSessionId { get; init; }
  }
  ```
- **`JobStartOptions` & `JobArgsParser`**:
  - Parses `--chat-session` flag across all job types (e.g. `agent-task`, `analyze-codebase`, `implement-plan`).
  - Automatically falls back to `TENDRIL_CHAT_SESSION_ID` environment variable if `--chat-session` is not passed on the CLI.
- **`PlanDatabaseService.MapJobRow`**:
  - Reads `typedArgs` and populates `ChatSessionId = typedArgs?.ChatSessionId` on loaded `JobItem` instances.

### 2. Chat History Service (`src/Ivy.Tendril/Services/`)

- **`ChatSessionModel`**:
  - Added `List<string>? SpawnedJobIds = null`.
- **`IChatHistoryService`**:
  ```csharp
  void AddSpawnedJob(string sessionId, string jobId);
  void RemoveSpawnedJobs(string sessionId, IEnumerable<string> jobIds);
  IReadOnlyList<string> GetSpawnedJobs(string sessionId);
  bool ApplyQuestionAnswers(string sessionId, string messageId, IReadOnlyDictionary<string, string[]> answers);
  ```
- **Queue Isolation**:
  - `GetQueuedMessages` filters out any `[System Event]` items so internal notifications never appear in the user's interactive queue UI.

### 3. Chat Execution Service (`src/Ivy.Tendril/Services/ChatExecutionService.cs`)

- **Preserving Execution History on Stop / Cancel**:
  - When `OperationCanceledException` is caught, `activeExec.RawLines` is preserved and serialized into `fullRawStream`.
  - In-flight uncompleted tool calls are closed with a `ToolResultEvent` containing `[Cancelled]`.
  - A `TextEvent` with `"Execution was cancelled."` is appended to the stream timeline and included in `responseContent`.
  - `_chatService.AddMessage` is called with `rawStream: fullRawStream`, allowing `AgentViewer` to render the full history of tools and thoughts that ran, followed by the cancellation notice.
  - Similar protection is applied in `catch (Exception ex)` to ensure that unexpected errors preserve prior execution steps before displaying the error.
- **Agent Interruption on Force-Send**:
  - `InterruptAsync` signals CTS cancellation, requests agent session stop, waits up to 5s (with force-kill fallback), and marks `IsInterrupted` on the active execution.
  - When interrupted, the aborted execution's `finally` block suppresses dequeuing from the queue, allowing the interrupting message to execute immediately while preserving any other queued items.
  - `ForceSendMessageAsync` interrupts any active execution for the target session and immediately launches execution of the force-sent prompt.
- **`JobStartedRegex` & `TryTrackSpawnedJob`**:
  - Scoped strictly to `\bJob started:\s*([0-9a-zA-Z_-]+)` on `ToolResultEvent.Output`.
  - Discontinued running on assistant conversation text or final responses to eliminate false-positive tracking from job listings and discussions.
- **`OnJobFinished` Handler**:
  - Subscribes to `IJobService.JobFinished`.
  - Strictly checks `job.ChatSessionId`; only notifies the session that actually spawned the job.

### 4. Chat App & Content View (`src/Ivy.Tendril/Apps/Chat/`)

- **`ChatApp.cs`**:
  - Supports `dto.ForceSend`: invokes `executionService.ForceSendMessageAsync` when force-sending a message.
  - Scopes `spawnedJobs` strictly to jobs where `string.Equals(job.ChatSessionId, s.Id, StringComparison.OrdinalIgnoreCase)`.
  - Automatically prunes mismatched or unassociated job IDs from `s.SpawnedJobIds` via `RemoveSpawnedJobs`.
- **`ContentView.cs`**:
  - `OnSendQueuedNow` passes `ForceSend: true` to interrupt any running agent turn and immediately execute the selected queued message.
  - Filters `runningJobs` strictly by `string.Equals(j.ChatSessionId, activeSessionId.Value, StringComparison.OrdinalIgnoreCase)`.

### 5. Chat Widget DTOs & Events (`src/Ivy.Tendril.Widgets/ChatWidget.cs`)

- **`ChatSendMessageDto`**: Added `bool ForceSend = false`.
- **`ChatJobDto`**: Added for running jobs badge.
- **`ChatWidget` Properties**: Added `List<ChatJobDto>? RunningJobs` property and `OnAnswerQuestion` event.
- **`ChatMessageDto`**: Expanded `Role` to include `"system"`.

### 6. Frontend Widgets (`src/Ivy.Tendril.Widgets/frontend/src/`)

- **`ChatWidget.tsx`**:
  - `handleSendQueuedNow`: optimistically displays the force-sent message in the chat timeline, keeps streaming state active, and emits with `forceSend: true`.
  - Implemented `chat-jobs-badge` button strictly scoped to the active session.
  - Implemented `chat-jobs-dropdown-menu` with active running job chips and `"Ask agent to review outcomes"` action button.
  - Removed duplicate spawned jobs bar above chat in favor of the header badge dropdown.
  - Rendered `msg.role === "system"` as `.chat-system-event-row` and `.chat-system-event-pill`.
  - Fenced ```` ```questions ```` block support with interactive option cards, custom text inputs, and submit button.
- **`chat-widget.css`**:
  - Added styles for `.chat-jobs-badge`, `.chat-jobs-dropdown-menu`, `.chat-jobs-pulse-dot`, `.chat-system-event-pill`, and question blocks.

---

## Tests & Verification

- **.NET Unit Tests**:
  - `ChatExecutionServiceJobTrackingTests.cs`:
    - `CancelAsync_WhenCancelledDuringExecution_PreservesRawHistoryAndAppendsCancellationMessage`: passes.
    - `CancelAsync_WhenCancelledImmediatelyWithNoEvents_AddsCancelledMessageWithoutCrashing`: passes.
    - `ForceSendMessageAsync_WhenExecutionRunning_InterruptsCurrentExecutionAndPreservesQueue`: passes.
    - `ToolResultEvent_WithJobStarted_TracksSpawnedJobAndSetsChatSessionId`: passes.
    - `ToolResultEvent_WithJobIdDiscussion_DoesNotTrackSpawnedJob`: passes.
    - `RemoveSpawnedJobs_PrunesStaleJobsFromSession`: passes.
    - `JobFinished_WhenSpawnedFromChat_DispatchesSystemEventMessage`: passes.
    - `JobFinished_WhenJobNotSpawnedInChat_DoesNotDispatchMessage`: passes.
    - `SystemEvent_WhenExecutionRunning_NeverEnqueuesIntoUserQueuedMessages`: passes.
    - `GetQueuedMessages_PurgesAnySystemEventMessages`: passes.
  - `ChatHistoryServiceTests.cs`: 15 passing tests.
  - `QuestionAnswersTests.cs`: 59 passing tests.
  - `InboxWatcherServiceTests.cs`: 15 passing tests.
  - `ChatExecutionIntegrationTest.cs`: 12 passing tests.
- **Frontend Vitest**:
  - All 30 test files (302 tests) passing in `Ivy.Tendril.Widgets/frontend`.
- **Frontend & Backend Builds**:
  - Frontend bundle compiles cleanly (`dist/ivy-tendril-widgets.js`).
  - `dotnet build` succeeds with 0 warnings and 0 errors.

---

## Commits

- `9b2eee6e`: `feat(chat): track spawned jobs in chat session and guide completion review`
- `03a28c58`: `feat(chat): support interactive question blocks and answer submission`
- `90c584d9`: `fix(chat): suppress streaming assistant-text before result and consolidate delta text on answer`
- `385301d0`: `feat(chat): add running jobs header badge, dropdown, and completion event dispatch`
- `23b990b0`: `fix(chat): scope running jobs badge per chat and isolate system events from user queue`
- `9e0f6c0a`: `fix(chat): prevent false-positive job tracking from discussions and scope spawned jobs strictly to session`
- `a16cc4dc`: `refactor(chat): remove duplicate spawned jobs bar above chat in favor of header badge dropdown`
- `d1666533`: `feat(chat): interrupt running agent when force-sending a queued message`
- `271928fd`: `fix(chat): preserve execution history and append cancellation message on stop`
