### PR TITLE
[00029] Prevent Empty State Flicker on Team Vault Initial Load

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Setup/VaultSetupViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Setup/VaultSetupViewTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using Ivy.Tendril.Apps.Settings;
+using Ivy.Tendril.Services;
+using Ivy.Tendril.Services.Vault;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Setup;
+
+public class VaultSetupViewTests
+{
+    [Fact]
+    public void HasConfiguredVaults_WithConfiguredVaults_ReturnsTrue()
+    {
+        // 1. Settings with enabled vault in Vaults list
+        var settingsWithVaultsList = new TendrilSettings
+        {
+            Vaults = new List<VaultSettings>
+            {
+                new()
+                {
+                    Id = "vault-1",
+                    Name = "Team Vault",
+                    Enabled = true,
+                    RepoUrl = "https://github.com/org/vault.git"
+                }
+            }
+        };
+
+        Assert.True(VaultSetupView.HasConfiguredVaults(settingsWithVaultsList));
+
+        // 2. Settings with enabled single Vault (legacy or singular fallback)
+        var settingsWithSingleVault = new TendrilSettings
+        {
+            Vaults = new List<VaultSettings>(),
+            Vault = new VaultSettings
+            {
+                Id = "vault-single",
+                Name = "Single Vault",
+                Enabled = true,
+                RepoUrl = "https://github.com/org/single-vault.git"
+            }
+        };
+
+        Assert.True(VaultSetupView.HasConfiguredVaults(settingsWithSingleVault));
+    }
+
+    [Fact]
+    public void HasConfiguredVaults_WithoutConfiguredVaults_ReturnsFalse()
+    {
+        // Null settings
+        Assert.False(VaultSetupView.HasConfiguredVaults(null));
+
+        // Empty settings
+        var emptySettings = new TendrilSettings();
+        Assert.False(VaultSetupView.HasConfiguredVaults(emptySettings));
+
+        // Disabled vault in Vaults
+        var disabledVaultsSettings = new TendrilSettings
+        {
+            Vaults = new List<VaultSettings>
+            {
+                new()
+                {
+                    Id = "vault-disabled",
+                    Enabled = false,
+                    RepoUrl = "https://github.com/org/vault.git"
+                }
+            }
+        };
+        Assert.False(VaultSetupView.HasConfiguredVaults(disabledVaultsSettings));
+
+        // Vault with empty or whitespace RepoUrl
+        var emptyRepoUrlSettings = new TendrilSettings
+        {
+            Vaults = new List<VaultSettings>
+            {
+                new()
+                {
+                    Id = "vault-empty-url",
+                    Enabled = true,
+                    RepoUrl = "   "
+                }
+            }
+        };
+        Assert.False(VaultSetupView.HasConfiguredVaults(emptyRepoUrlSettings));
+
+        // Disabled singular Vault
+        var disabledSingleVaultSettings = new TendrilSettings
+        {
+            Vault = new VaultSettings
+            {
+                Id = "vault-single-disabled",
+                Enabled = false,
+                RepoUrl = "https://github.com/org/vault.git"
+            }
+        };
+        Assert.False(VaultSetupView.HasConfiguredVaults(disabledSingleVaultSettings));
+    }
+
+    [Fact]
+    public void GetInitialVaultStatuses_PopulatesConfiguredStatuses()
+    {
+        var lastSynced = DateTimeOffset.UtcNow.AddHours(-2);
+        var settings = new TendrilSettings
+        {
+            Vaults = new List<VaultSettings>
+            {
+                new()
+                {
+                    Id = "v1",
+                    Name = "Vault One",
+                    Enabled = true,
+                    RepoUrl = "https://github.com/org/vault-one.git",
+                    LocalPath = "/path/to/v1",
+                    AlwaysUpToDate = true,
+                    LastSyncedAt = lastSynced
+                },
+                new()
+                {
+                    Id = "v2-disabled",
+                    Name = "Disabled Vault",
+                    Enabled = false,
+                    RepoUrl = "https://github.com/org/vault-two.git"
+                },
+                new()
+                {
+                    Id = "v3",
+                    Name = "",
+                    Enabled = true,
+                    RepoUrl = "https://github.com/org/custom-repo-name.git",
+                    LocalPath = "/path/to/v3",
+                    AlwaysUpToDate = false,
+                    LastSyncedAt = null
+                }
+            }
+        };
+
+        var statuses = VaultSetupView.GetInitialVaultStatuses(settings);
+
+        Assert.NotNull(statuses);
+        Assert.Equal(2, statuses.Count);
+
+        var first = statuses[0];
+        Assert.Equal("v1", first.Id);
+        Assert.Equal("Vault One", first.Name);
+        Assert.True(first.IsConfigured);
+        Assert.Equal("https://github.com/org/vault-one.git", first.RepoUrl);
+        Assert.Equal("/path/to/v1", first.LocalPath);
+        Assert.True(first.AlwaysUpToDate);
+        Assert.Equal(lastSynced, first.LastSyncedAt);
+
+        var second = statuses[1];
+        Assert.Equal("v3", second.Id);
+        Assert.Equal("org/custom-repo-name", second.Name);
+        Assert.True(second.IsConfigured);
+        Assert.Equal("https://github.com/org/custom-repo-name.git", second.RepoUrl);
+        Assert.Equal("/path/to/v3", second.LocalPath);
+        Assert.False(second.AlwaysUpToDate);
+        Assert.Null(second.LastSyncedAt);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Settings/VaultSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/VaultSetupView.cs
@@ -46,11 +46,13 @@ public class VaultSetupView : ViewBase
 
         var vaultsQuery = UseQuery<List<VaultStatus>, string>(
             "vaults_list",
-            async (_, _) => await vaultService.GetVaultsAsync());
+            async (_, _) => await vaultService.GetVaultsAsync(),
+            initialValue: GetInitialVaultStatuses(config.Settings));
 
         var statusQuery = UseQuery<VaultStatus, string>(
             $"vault_status_{selectedVaultId.Value}",
-            async (_, _) => await vaultService.GetStatusAsync(selectedVaultId.Value));
+            async (_, _) => await vaultService.GetStatusAsync(selectedVaultId.Value),
+            initialValue: GetInitialVaultStatus(config.Settings, selectedVaultId.Value));
 
         var catalogQuery = UseQuery<VaultCatalog, string>(
             $"vault_catalog_{selectedVaultId.Value}",
@@ -192,7 +194,7 @@ public class VaultSetupView : ViewBase
             )
             : null;
 
-        if (vaultsList.Count == 0 && !status.IsConfigured)
+        if (!HasConfiguredVaults(config.Settings) && vaultsList.Count == 0 && !status.IsConfigured)
         {
             var notConfiguredLayout = Layout.Vertical().Width(Size.Auto().Max(Size.Units(200)))
                 | Text.Block("Team Configuration Vault").Bold()
@@ -490,7 +492,12 @@ public class VaultSetupView : ViewBase
         }
 
         object projectsSection;
-        if (tableRows.Count == 0)
+        if (catalogQuery.Loading && tableRows.Count == 0)
+        {
+            projectsSection = Layout.Vertical().AlignContent(Align.Left)
+                | Text.Muted("Loading shared projects...");
+        }
+        else if (tableRows.Count == 0)
         {
             projectsSection = Layout.Vertical().AlignContent(Align.Left)
                 | Text.Block("No Shared Projects").Bold()
@@ -537,6 +544,57 @@ public class VaultSetupView : ViewBase
             importDialog,
             confirmDeleteDialog
         );
+    }
+
+    public static bool HasConfiguredVaults(TendrilSettings? settings)
+    {
+        if (settings == null) return false;
+
+        if (settings.Vaults != null && settings.Vaults.Any(v => v.Enabled && !string.IsNullOrWhiteSpace(v.RepoUrl)))
+        {
+            return true;
+        }
+
+        return settings.Vault != null && settings.Vault.Enabled && !string.IsNullOrWhiteSpace(settings.Vault.RepoUrl);
+    }
+
+    public static List<VaultStatus> GetInitialVaultStatuses(TendrilSettings? settings)
+    {
+        var statuses = new List<VaultStatus>();
+        if (settings == null) return statuses;
+
+        var configuredVaults = settings.Vaults?
+            .Where(v => v.Enabled && !string.IsNullOrWhiteSpace(v.RepoUrl))
+            .ToList() ?? new List<VaultSettings>();
+
+        if (configuredVaults.Count == 0 && settings.Vault != null && settings.Vault.Enabled && !string.IsNullOrWhiteSpace(settings.Vault.RepoUrl))
+        {
+            configuredVaults.Add(settings.Vault);
+        }
+
+        foreach (var vault in configuredVaults)
+        {
+            statuses.Add(new VaultStatus
+            {
+                Id = vault.Id,
+                Name = !string.IsNullOrWhiteSpace(vault.Name) ? vault.Name : VaultService.ExtractRepoName(vault.RepoUrl),
+                IsConfigured = true,
+                RepoUrl = vault.RepoUrl,
+                LocalPath = vault.LocalPath,
+                AlwaysUpToDate = vault.AlwaysUpToDate,
+                LastSyncedAt = vault.LastSyncedAt
+            });
+        }
+
+        return statuses;
+    }
+
+    public static VaultStatus GetInitialVaultStatus(TendrilSettings? settings, string? selectedVaultId)
+    {
+        var statuses = GetInitialVaultStatuses(settings);
+        return statuses.FirstOrDefault(v => v.Id == selectedVaultId)
+            ?? statuses.FirstOrDefault()
+            ?? new VaultStatus();
     }
 
     private record VaultDetailsData(


### PR DESCRIPTION
Fixes #2354

# Summary

## Changes

Prevented the Team Vault view from briefly flashing an unconfigured empty state on initial load by computing synchronous vault states from configuration and seeding the asynchronous queries. Also eliminated secondary table flicker in the Shared Projects section by displaying a muted loading state while catalog data is in flight.

## API Changes

Added public static helper methods to `VaultSetupView`:
- `VaultSetupView.HasConfiguredVaults(TendrilSettings? settings)`: Returns whether any enabled vault with a repository URL is configured.
- `VaultSetupView.GetInitialVaultStatuses(TendrilSettings? settings)`: Converts configured settings into a list of configured `VaultStatus` models.
- `VaultSetupView.GetInitialVaultStatus(TendrilSettings? settings, string? selectedVaultId)`: Retrieves the initial `VaultStatus` for a specific vault ID.

## Files Modified

- **UI / Settings View:** `src/Ivy.Tendril/Apps/Settings/VaultSetupView.cs` (seeded `vaultsQuery` and `statusQuery`, guarded empty state rendering, and added shared projects loading state)
- **Unit Tests:** `src/Ivy.Tendril.Test/Apps/Setup/VaultSetupViewTests.cs` (verified vault configuration detection and initial status generation)

## Manual Testing

1. Configure a team vault in Settings or `config.yaml`.
2. Launch Tendril and navigate to Settings > Team Vault.
3. Observe that the vault details and header toolbar appear immediately without an intermediate flash of the "Team Configuration Vault" creation card.
4. Verify that while shared projects load, a loading message appears before rendering the shared projects table or empty state.

---
- 7b5e18a5 Plan 00029: Prevent empty state flicker on Team Vault initial load

---
Created using [Ivy Tendril](https://ivy.app).
