### PR TITLE
[00033] Fix Chat UI Scrollbar Jumps With Markdown Output

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -908,3 +908,170 @@ describe("ChatWidget File Uploads and Attachments", () => {
   });
 });
 
+describe("ChatWidget Streaming Scroll Behavior", () => {
+  const session = {
+    id: "sess-scroll",
+    title: "Scroll Test Chat",
+    agentId: "codex",
+    modelId: "gpt-5",
+    createdAt: "2026-09-03T10:00:00Z",
+    updatedAt: "2026-09-03T10:00:00Z",
+    messages: [
+      {
+        id: "m-1",
+        role: "user" as const,
+        content: "Explain markdown streaming",
+        timestamp: "10:00 AM",
+      },
+    ],
+  };
+
+  it("scrolls to bottom without triggering continuous smooth scroll calls when container is at bottom", () => {
+    const scrollIntoViewMock = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"First chunk"}'
+      />
+    );
+
+    const container = document.querySelector(".chat-messages-container") as HTMLDivElement;
+    expect(container).toBeInTheDocument();
+
+    let currentScrollTop = 600;
+    Object.defineProperty(container, "scrollHeight", { value: 1000, configurable: true, writable: true });
+    Object.defineProperty(container, "clientHeight", { value: 400, configurable: true, writable: true });
+    Object.defineProperty(container, "scrollTop", {
+      get: () => currentScrollTop,
+      set: (v: number) => { currentScrollTop = v; },
+      configurable: true,
+    });
+
+    // Reset any initial scrollIntoView calls from mount
+    scrollIntoViewMock.mockClear();
+
+    // Stream next chunk
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"First chunk and second chunk"}'
+      />
+    );
+
+    // Should update scrollTop to bottom (1000 - 400 = 600) instantly without calling scrollIntoView smooth
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+    expect(currentScrollTop).toBe(600);
+  });
+
+  it("does not force scroll down when user is scrolled up", () => {
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"Initial streaming"}'
+      />
+    );
+
+    const container = document.querySelector(".chat-messages-container") as HTMLDivElement;
+    let currentScrollTop = 600;
+    Object.defineProperty(container, "scrollHeight", { value: 1000, configurable: true, writable: true });
+    Object.defineProperty(container, "clientHeight", { value: 400, configurable: true, writable: true });
+    Object.defineProperty(container, "scrollTop", {
+      get: () => currentScrollTop,
+      set: (v: number) => { currentScrollTop = v; },
+      configurable: true,
+    });
+
+    // User scrolls up to 200px (distance to bottom is 1000 - 200 - 400 = 400px > 50px threshold)
+    currentScrollTop = 200;
+    fireEvent.scroll(container);
+
+    // New stream chunk arrives
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"Initial streaming with more tokens"}'
+      />
+    );
+
+    // Container should remain at user scroll offset (200px) and not be forced down
+    expect(currentScrollTop).toBe(200);
+  });
+
+  it("re-enables auto-scroll when user scrolls back to bottom", () => {
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"Starting stream"}'
+      />
+    );
+
+    const container = document.querySelector(".chat-messages-container") as HTMLDivElement;
+    let currentScrollTop = 600;
+    let height = 1000;
+    Object.defineProperty(container, "scrollHeight", {
+      get: () => height,
+      set: (v: number) => { height = v; },
+      configurable: true,
+    });
+    Object.defineProperty(container, "clientHeight", { value: 400, configurable: true, writable: true });
+    Object.defineProperty(container, "scrollTop", {
+      get: () => currentScrollTop,
+      set: (v: number) => { currentScrollTop = v; },
+      configurable: true,
+    });
+
+    // User scrolls up
+    currentScrollTop = 150;
+    fireEvent.scroll(container);
+
+    // New chunk while scrolled up: stays at 150
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"Starting stream..."}'
+      />
+    );
+    expect(currentScrollTop).toBe(150);
+
+    // User scrolls back near bottom: 580px (1000 - 580 - 400 = 20px <= 50px threshold)
+    currentScrollTop = 580;
+    fireEvent.scroll(container);
+
+    // Height increases with new tokens
+    height = 1200;
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-scroll"
+        sessions={[session]}
+        isStreaming={true}
+        streamingText='{"type":"text_delta","content":"Starting stream... more tokens generated"}'
+      />
+    );
+
+    // Auto-scroll is re-enabled and pins to bottom (1200 - 400 = 800)
+    expect(currentScrollTop).toBe(800);
+  });
+});
+
+

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useLayoutEffect } from "react";
+import React, { useState, useRef, useEffect, useLayoutEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { Mic, Bot, Cpu, Zap, MessageSquare, ChevronDown, Check, Pencil, Paperclip, X, Square, ArrowRight, Trash2 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -351,10 +351,35 @@ export function ChatWidget({
   const [optimisticStreaming, setOptimisticStreaming] = useState<string | null>(null);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const isAtBottomRef = useRef(true);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const recognitionRef = useRef<any>(null);
   const initialPromptRef = useRef<string>("");
+
+  const SCROLL_THRESHOLD = 50;
+
+  const checkIsAtBottom = useCallback((element: HTMLElement) => {
+    const { scrollTop, scrollHeight, clientHeight } = element;
+    return scrollHeight - scrollTop - clientHeight <= SCROLL_THRESHOLD;
+  }, []);
+
+  const scrollToBottom = useCallback((behavior: "auto" | "smooth" = "auto") => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+
+    const targetTop = Math.max(0, container.scrollHeight - container.clientHeight);
+
+    if (behavior === "auto" || typeof container.scrollTo !== "function") {
+      container.scrollTop = targetTop;
+    } else {
+      container.scrollTo({
+        top: targetTop,
+        behavior: "smooth",
+      });
+    }
+  }, []);
 
   const activeSession = sessions.find((s) => s.id === activeSessionId);
   const currentOptimistic = (activeSessionId && optimisticMessages[activeSessionId]) || [];
@@ -423,6 +448,8 @@ export function ChatWidget({
   useEffect(() => {
     setOptimisticStreaming(null);
     setQueuedMessages(queuedMessagesProp || []);
+    isAtBottomRef.current = true;
+    scrollToBottom("auto");
   }, [activeSessionId]);
 
   useEffect(() => {
@@ -444,8 +471,75 @@ export function ChatWidget({
   }, [optimisticStreaming]);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [activeSession?.messages, displayMessages.length, effectiveIsStreaming, streamingText, queuedMessages]);
+    const container = messagesContainerRef.current;
+    if (!container) return;
+
+    const handleScroll = () => {
+      isAtBottomRef.current = checkIsAtBottom(container);
+    };
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      container.removeEventListener("scroll", handleScroll);
+    };
+  }, [checkIsAtBottom]);
+
+  useEffect(() => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+
+    let resizeObserver: ResizeObserver | null = null;
+    let mutationObserver: MutationObserver | null = null;
+
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(() => {
+        if (isAtBottomRef.current) {
+          scrollToBottom("auto");
+        }
+      });
+
+      resizeObserver.observe(container);
+
+      const observed = new WeakSet<Element>();
+      const observeChildren = (root: Element) => {
+        for (const child of Array.from(root.children)) {
+          if (!observed.has(child)) {
+            resizeObserver?.observe(child);
+            observed.add(child);
+          }
+          observeChildren(child);
+        }
+      };
+      observeChildren(container);
+
+      if (typeof MutationObserver !== "undefined") {
+        mutationObserver = new MutationObserver((mutations) => {
+          for (const m of mutations) {
+            m.addedNodes.forEach((n) => {
+              if (n.nodeType === Node.ELEMENT_NODE) {
+                observeChildren(n as Element);
+              }
+            });
+          }
+          if (isAtBottomRef.current) {
+            scrollToBottom("auto");
+          }
+        });
+        mutationObserver.observe(container, { childList: true, subtree: true });
+      }
+    }
+
+    return () => {
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
+    };
+  }, [scrollToBottom]);
+
+  useEffect(() => {
+    if (isAtBottomRef.current) {
+      scrollToBottom("auto");
+    }
+  }, [displayMessages.length, effectiveIsStreaming, streamingText, queuedMessages, scrollToBottom]);
 
   useEffect(() => {
     if (activeSessionId && sessions.length > 0) {
@@ -555,6 +649,10 @@ export function ChatWidget({
     emit("OnSendMessage", payload);
     setPromptText("");
     setAttachments([]);
+    isAtBottomRef.current = true;
+    requestAnimationFrame(() => {
+      scrollToBottom("smooth");
+    });
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
     }
@@ -1014,7 +1112,7 @@ export function ChatWidget({
         </div>
 
         {/* Message List Container */}
-        <div className="chat-messages-container">
+        <div ref={messagesContainerRef} className="chat-messages-container">
           {activeSession && displayMessages.length > 0 ? (
             displayMessages.map((msg) => (
               <div key={msg.id} className={`chat-message-row ${msg.role}`}>
@@ -1100,7 +1198,7 @@ export function ChatWidget({
                 <AgentViewer
                   id={`live-chat-${activeSessionId}`}
                   jsonStream={streamingText}
-                  autoScroll={true}
+                  autoScroll={false}
                   showThinking={true}
                   showSystemEvents={false}
                   showStatusLabel={true}
@@ -1112,7 +1210,7 @@ export function ChatWidget({
           )}
 
 
-          <div ref={messagesEndRef} />
+          <div ref={messagesEndRef} className="chat-messages-bottom-anchor" />
         </div>
 
         {/* Footer & Resizable Input Toolbar */}

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -353,6 +353,12 @@
 .chat-message-row {
   display: flex;
   width: 100%;
+  overflow-anchor: none;
+}
+
+.chat-messages-bottom-anchor {
+  overflow-anchor: auto;
+  height: 1px;
 }
 
 .chat-message-row.user {
@@ -369,6 +375,7 @@
   border-radius: var(--radius, 8px);
   font-size: 0.875rem;
   line-height: 1.5;
+  overflow-wrap: break-word;
 }
 
 .chat-message-row.user .chat-message-bubble {
@@ -427,6 +434,9 @@
   color: var(--foreground);
   font-size: 0.875rem;
   line-height: 1.6;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  max-width: 100%;
 }
 
 .chat-markdown-body p {
@@ -509,12 +519,15 @@
   padding: 0.125rem 0.375rem;
   border-radius: var(--radius, 4px);
   border: 1px solid var(--border);
+  overflow-wrap: break-word;
+  max-width: 100%;
 }
 
 .chat-markdown-body pre {
   margin: 0.75rem 0;
   border-radius: var(--radius, 6px);
-  overflow: hidden;
+  overflow-x: auto;
+  max-width: 100%;
 }
 
 .chat-markdown-body blockquote {
@@ -531,6 +544,9 @@
   border-collapse: collapse;
   margin: 0.75rem 0;
   font-size: 0.8125rem;
+  display: block;
+  overflow-x: auto;
+  max-width: 100%;
 }
 
 .chat-markdown-body th,


### PR DESCRIPTION
Fixes #2357

# Summary

## Changes

Fixed erratic vertical scrollbar jumping during assistant markdown streaming in the Chat UI. Replaced continuous smooth scrolling with direct container scroll management, bottom-pin tracking, instant pin-to-bottom updates, a dynamic sizing observer, CSS scroll anchoring, and coordinated auto-scroll with AgentViewer.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx`: Added `messagesContainerRef`, bottom-pinned tracking with `isAtBottomRef` (50px threshold), container scroll listener, dynamic sizing observer (`ResizeObserver` and `MutationObserver`), instant pin-to-bottom scroll updates during streaming, and disabled child auto-scrolling on live `<AgentViewer>`.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css`: Configured scroll anchoring (`overflow-anchor: none` on `.chat-message-row`, `overflow-anchor: auto` on `.chat-messages-bottom-anchor`), enforced `overflow-wrap: break-word` and `max-width: 100%`, and added `overflow-x: auto` on pre/table/code blocks to prevent layout shifts.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx`: Added comprehensive unit tests for streaming scroll behavior (pin-to-bottom without smooth scroll calls, retaining scroll offset when scrolled up, and re-enabling auto-scroll when scrolled back to bottom).

## Manual Testing

1. Launch the Tendril desktop application or run the widget dev server (`vp dev` in `src/Ivy.Tendril.Widgets/frontend`).
2. Open a chat session and send a prompt that generates multi-token streaming markdown output with headings, lists, code blocks, and tables.
3. Observe that while the assistant streams its response, the scrollbar stays pinned smoothly to the bottom without erratic jumping or flickering.
4. While the stream is still active, scroll up slightly to read earlier messages.
5. Observe that the view stays at your scrolled position and does not forcefully snap back down on every token.
6. Scroll back down near the bottom.
7. Observe that auto-scrolling resumes and stays pinned to the bottom until the stream finishes.

---
### Commits
- `8bcf870` Fix Chat UI scrollbar jumps with markdown output (Plan 00033)

---
Created using [Ivy Tendril](https://ivy.app).