### PR TITLE
[00028] Add Cmd+Enter Shortcut to Unanswered Questions Dialog

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Plans/Dialogs/UnansweredQuestionsDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Plans/Dialogs/UnansweredQuestionsDialogTests.cs
@@ -1,0 +1,116 @@
+using Ivy;
+using Ivy.Core.Hooks;
+using Ivy.Tendril.Apps.Plans.Dialogs;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Plans.Dialogs;
+
+public class UnansweredQuestionsDialogTests
+{
+    private static List<Button> GetFooterButtons(Dialog dialog)
+    {
+        var footer = dialog.Children.OfType<DialogFooter>().FirstOrDefault();
+        Assert.NotNull(footer);
+
+        var buttons = new List<Button>();
+        foreach (var child in footer.Children)
+        {
+            if (child is Button btn)
+            {
+                buttons.Add(btn);
+            }
+            else if (child is LayoutView layout)
+            {
+                var elementsField = typeof(LayoutView).GetField("_elements", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                if (elementsField?.GetValue(layout) is System.Collections.IEnumerable enumerable)
+                {
+                    foreach (var item in enumerable)
+                    {
+                        var content = item?.GetType().GetProperty("Content")?.GetValue(item);
+                        if (content is Button layoutBtn)
+                        {
+                            buttons.Add(layoutBtn);
+                        }
+                    }
+                }
+            }
+        }
+        return buttons;
+    }
+
+    [Fact]
+    public void Build_WhenClosed_ReturnsNull()
+    {
+        var dialogOpen = new State<bool>(false);
+        var continued = false;
+        var dialog = new UnansweredQuestionsDialog(dialogOpen, 3, () => continued = true);
+
+        var result = dialog.Build();
+
+        Assert.Null(result);
+        Assert.False(continued);
+    }
+
+    [Fact]
+    public void Build_WhenOpen_ConfiguresExecuteAnywayButtonWithShortcut()
+    {
+        var dialogOpen = new State<bool>(true);
+        var dialog = new UnansweredQuestionsDialog(dialogOpen, 2, () => { });
+
+        var result = dialog.Build();
+
+        Assert.NotNull(result);
+        var dialogWidget = Assert.IsType<Dialog>(result);
+        var buttons = GetFooterButtons(dialogWidget);
+
+        var executeButton = buttons.FirstOrDefault(b => b.Title == "Execute Anyway");
+        Assert.NotNull(executeButton);
+        Assert.Equal("Ctrl+Enter", executeButton.ShortcutKey);
+    }
+
+    [Fact]
+    public async Task Build_WhenOpen_ExecuteAnywayButtonInvokesContinue()
+    {
+        var dialogOpen = new State<bool>(true);
+        var continued = false;
+        var dialog = new UnansweredQuestionsDialog(dialogOpen, 1, () => continued = true);
+
+        var result = dialog.Build();
+
+        Assert.NotNull(result);
+        var dialogWidget = Assert.IsType<Dialog>(result);
+        var buttons = GetFooterButtons(dialogWidget);
+
+        var executeButton = buttons.FirstOrDefault(b => b.Title == "Execute Anyway");
+        Assert.NotNull(executeButton);
+        Assert.NotNull(executeButton.OnClick);
+
+        await executeButton.OnClick.Invoke(new Event<Button>("click", executeButton));
+
+        Assert.False(dialogOpen.Value);
+        Assert.True(continued);
+    }
+
+    [Fact]
+    public async Task Build_WhenOpen_CancelButtonClosesDialogWithoutInvokingContinue()
+    {
+        var dialogOpen = new State<bool>(true);
+        var continued = false;
+        var dialog = new UnansweredQuestionsDialog(dialogOpen, 1, () => continued = true);
+
+        var result = dialog.Build();
+
+        Assert.NotNull(result);
+        var dialogWidget = Assert.IsType<Dialog>(result);
+        var buttons = GetFooterButtons(dialogWidget);
+
+        var cancelButton = buttons.FirstOrDefault(b => b.Title == "Cancel");
+        Assert.NotNull(cancelButton);
+        Assert.NotNull(cancelButton.OnClick);
+
+        await cancelButton.OnClick.Invoke(new Event<Button>("click", cancelButton));
+
+        Assert.False(dialogOpen.Value);
+        Assert.False(continued);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Plans/Dialogs/UnansweredQuestionsDialog.cs
+++ b/src/Ivy.Tendril/Apps/Plans/Dialogs/UnansweredQuestionsDialog.cs
@@ -31,7 +31,7 @@ public class UnansweredQuestionsDialog(
             new DialogFooter(
                 Layout.Wrap().Gap(4, 2)
                     | new Button("Cancel").Outline().OnClick(() => dialogOpen.Set(false))
-                    | new Button("Execute Anyway").Primary().OnClick(() =>
+                    | new Button("Execute Anyway").Primary().ShortcutKey("Ctrl+Enter").OnClick(() =>
                     {
                         dialogOpen.Set(false);
                         onContinue();


### PR DESCRIPTION
Fixes #2345

# Summary

## Changes

Added the `Ctrl+Enter` keyboard shortcut to the "Execute Anyway" button in `UnansweredQuestionsDialog`. In the Ivy Framework, this shortcut automatically maps to `Cmd+Enter` on macOS and `Ctrl+Enter` on Windows/Linux, enabling users to confirm execution without switching to the mouse.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Plans/Dialogs/UnansweredQuestionsDialog.cs`: Bound `.ShortcutKey("Ctrl+Enter")` to the "Execute Anyway" button.
- `src/Ivy.Tendril.Test/Apps/Plans/Dialogs/UnansweredQuestionsDialogTests.cs`: Added unit tests verifying dialog rendering, button shortcut configuration, and execution continue callback invocation.

## Manual Testing

1. Open the Tendril application.
2. Navigate to the Plans view and select or draft a plan containing unanswered questions blocks.
3. Click the "Execute" button to open the Unanswered Questions confirmation dialog.
4. Press `Cmd+Enter` (on macOS) or `Ctrl+Enter` (on Windows/Linux).
5. Observe that the dialog closes and plan execution begins as expected.

---

## Commits

- bb2be678 Plan 00028: Add Cmd+Enter shortcut to unanswered questions dialog

---
Created using [Ivy Tendril](https://ivy.app).
