### PR TITLE
[00030] Add GPT-6 Astra Support for Codex

### DIFF
--- a/src/Ivy.Tendril.Agents.Test/Codex/CodexModelCatalogTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Codex/CodexModelCatalogTests.cs
@@ -54,4 +54,25 @@ public class CodexModelCatalogTests
         Assert.Equal("codex", result.AgentId);
         Assert.NotEmpty(result.Models);
     }
+
+    [Fact]
+    public void GetStaticModels_ContainsGpt6Astra_WithValidConfiguration()
+    {
+        var models = _catalog.GetStaticModels();
+        var astra = models.FirstOrDefault(m => m.Id == "gpt-6-astra");
+
+        Assert.NotNull(astra);
+        Assert.Equal("GPT-6 Astra", astra.DisplayName);
+        Assert.Equal("openai", astra.Provider);
+        Assert.Equal(10.00m, astra.InputPerMillion);
+        Assert.Equal(40.00m, astra.OutputPerMillion);
+        Assert.Equal(2.50m, astra.CacheReadPerMillion);
+        Assert.Equal(12.50m, astra.CacheWritePerMillion);
+        Assert.Equal(400_000, astra.ContextWindow);
+        Assert.Equal(32_000, astra.MaxOutputTokens);
+        Assert.True(astra.Capabilities.HasFlag(ModelCapabilities.Reasoning));
+        Assert.True(astra.Capabilities.HasFlag(ModelCapabilities.CodeGeneration));
+        Assert.True(astra.Capabilities.HasFlag(ModelCapabilities.ToolUse));
+        Assert.True(astra.Capabilities.HasFlag(ModelCapabilities.Streaming));
+    }
 }

--- a/src/Ivy.Tendril.Agents.Test/Helpers/ModelCatalogSorterTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Helpers/ModelCatalogSorterTests.cs
@@ -85,6 +85,7 @@ public class ModelCatalogSorterTests
             new() { Id = "gpt-4.1", DisplayName = "GPT-4.1", Provider = "openai" },
             new() { Id = "gpt-5.4", DisplayName = "GPT-5.4", Provider = "openai" },
             new() { Id = "o1", DisplayName = "O1", Provider = "openai" },
+            new() { Id = "gpt-6-astra", DisplayName = "GPT-6 Astra", Provider = "openai" },
             new() { Id = "gpt-5.6-terra", DisplayName = "GPT-5.6-Terra", Provider = "openai" },
             new() { Id = "o4-mini", DisplayName = "O4 Mini", Provider = "openai" },
             new() { Id = "gpt-5.6-sol", DisplayName = "GPT-5.6-Sol", Provider = "openai" },
@@ -97,6 +98,7 @@ public class ModelCatalogSorterTests
 
         var expectedIds = new[]
         {
+            "gpt-6-astra",
             "gpt-5.6-sol",
             "gpt-5.6-terra",
             "gpt-5.6-luna",
@@ -109,6 +111,20 @@ public class ModelCatalogSorterTests
         };
 
         Assert.Equal(expectedIds, sorted.Select(m => m.Id).ToArray());
+    }
+
+    [Fact]
+    public void Sort_AstraModel_ResolvesProviderAndSortsAtTop()
+    {
+        var models = new List<ModelInfo>
+        {
+            new() { Id = "gpt-5.6-sol", DisplayName = "GPT-5.6-Sol", Provider = "openai" },
+            new() { Id = "gpt-6-astra", DisplayName = "GPT-6 Astra" },
+        };
+
+        var sorted = ModelCatalogSorter.Sort(models);
+
+        Assert.Equal(new[] { "gpt-6-astra", "gpt-5.6-sol" }, sorted.Select(m => m.Id).ToArray());
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs
@@ -105,6 +105,45 @@ public sealed class ModelProfileSelectorTests
     }
 
     [Fact]
+    public void SelectDefaults_OpenAiOnly_WithGpt6Astra_PicksSolDeepByDefault()
+    {
+        var models = new List<ModelInfo>
+        {
+            new() { Id = "gpt-4o", DisplayName = "GPT-4o" },
+            new() { Id = "gpt-4o-mini", DisplayName = "GPT-4o mini" },
+            new() { Id = "gpt-6-astra", DisplayName = "GPT-6 Astra" },
+            new() { Id = "gpt-5.6-sol", DisplayName = "GPT-5.6 Sol" },
+            new() { Id = "gpt-5.6-terra", DisplayName = "GPT-5.6 Terra" },
+            new() { Id = "gpt-5.6-luna", DisplayName = "GPT-5.6 Luna" },
+        };
+
+        var (deep, balanced, quick) = ModelProfileSelector.SelectDefaults(models, isOpenAi: true);
+
+        Assert.Equal("gpt-5.6-sol", deep);
+        Assert.Equal("gpt-5.6-terra", balanced);
+        Assert.Equal("gpt-5.6-luna", quick);
+    }
+
+    [Fact]
+    public void SelectDefaults_OpenAiOnly_WhenSolMissing_ResolvesGpt6AstraForDeep()
+    {
+        var models = new List<ModelInfo>
+        {
+            new() { Id = "gpt-4o", DisplayName = "GPT-4o" },
+            new() { Id = "gpt-4o-mini", DisplayName = "GPT-4o mini" },
+            new() { Id = "gpt-6-astra", DisplayName = "GPT-6 Astra" },
+            new() { Id = "gpt-5.6-terra", DisplayName = "GPT-5.6 Terra" },
+            new() { Id = "gpt-5.6-luna", DisplayName = "GPT-5.6 Luna" },
+        };
+
+        var (deep, balanced, quick) = ModelProfileSelector.SelectDefaults(models, isOpenAi: true);
+
+        Assert.Equal("gpt-6-astra", deep);
+        Assert.Equal("gpt-5.6-terra", balanced);
+        Assert.Equal("gpt-5.6-luna", quick);
+    }
+
+    [Fact]
     public void SelectDefaults_GeminiCatalog_PicksFlashDeep_FlashBalanced_FlashQuick()
     {
         var models = new List<ModelInfo>

--- a/src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs
+++ b/src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs
@@ -47,6 +47,19 @@ public class ModelPricingProviderTests
     }
 
     [Fact]
+    public void GetPricing_Gpt6Astra_ReturnsPricingAndCacheRates()
+    {
+        var pricing = _provider.GetPricing("gpt-6-astra");
+
+        Assert.NotNull(pricing);
+        Assert.Equal("gpt-6-astra", pricing.Model);
+        Assert.Equal(10.00m, pricing.InputPerMillion);
+        Assert.Equal(40.00m, pricing.OutputPerMillion);
+        Assert.Equal(2.50m, pricing.CacheReadPerMillion);
+        Assert.Equal(12.50m, pricing.CacheWritePerMillion);
+    }
+
+    [Fact]
     public void GetPricing_KnownModel_ReturnsPricing()
     {
         var pricing = _provider.GetPricing("opus");

--- a/src/Ivy.Tendril.Agents/Helpers/ModelCatalogSorter.cs
+++ b/src/Ivy.Tendril.Agents/Helpers/ModelCatalogSorter.cs
@@ -126,7 +126,7 @@ public static class ModelCatalogSorter
 
         var id = model.Id.ToLowerInvariant();
         if (id.Contains("claude") || id.Contains("fable") || id.Contains("opus") || id.Contains("sonnet") || id.Contains("haiku")) return "anthropic";
-        if (id.Contains("gpt") || id.StartsWith("o1") || id.StartsWith("o3") || id.StartsWith("o4") || id.Contains("codex")) return "openai";
+        if (id.Contains("gpt") || id.StartsWith("o1") || id.StartsWith("o3") || id.StartsWith("o4") || id.Contains("codex") || id.Contains("astra")) return "openai";
         if (id.Contains("gemini")) return "google";
         if (id.Contains("kimi") || id.Contains("moonshot")) return "moonshot";
         if (id.Contains("deepseek")) return "deepseek";
@@ -209,7 +209,7 @@ public static class ModelCatalogSorter
     private static ModelRank GetOpenAiRank(string id, string name, string combined)
     {
         // OpenAI Tiers:
-        // Tier 0: GPT-5 Flagships (Sol, Terra, Luna)
+        // Tier 0: GPT-6 / GPT-5 Flagships (Astra, Sol, Terra, Luna)
         // Tier 1: GPT-5.x
         // Tier 2: GPT-4.x
         // Tier 3: O-series (o4, o3, o1)
@@ -219,7 +219,13 @@ public static class ModelCatalogSorter
         int variant = 0;
         Version version;
 
-        if (combined.Contains("sol"))
+        if (combined.Contains("astra"))
+        {
+            tier = 0;
+            subTier = 0;
+            version = ParseOpenAiVersion(id, name, fallbackMajor: 6, fallbackMinor: 0);
+        }
+        else if (combined.Contains("sol"))
         {
             tier = 0;
             subTier = 0;

--- a/src/Ivy.Tendril.Agents/Helpers/ModelProfilePriorities.cs
+++ b/src/Ivy.Tendril.Agents/Helpers/ModelProfilePriorities.cs
@@ -29,7 +29,7 @@ public static class ModelProfilePriorities
             [(ModelProviderKind.Ivy, ModelProfileKind.Deep)] =
             [
                 "claude-fable-5", "claude-opus-5-1", "claude-opus-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-5",
-                "claude-opus-4", "opus", "gpt-5.6-sol", "sol", "claude-sonnet-5", "gemini-3.8-flash", "gemini-3.7-flash"
+                "claude-opus-4", "opus", "gpt-5.6-sol", "gpt-6-astra", "astra", "sol", "claude-sonnet-5", "gemini-3.8-flash", "gemini-3.7-flash"
             ],
             [(ModelProviderKind.Ivy, ModelProfileKind.Balanced)] =
             [
@@ -75,7 +75,7 @@ public static class ModelProfilePriorities
             // === OpenAI Direct ===
             [(ModelProviderKind.OpenAi, ModelProfileKind.Deep)] =
             [
-                "gpt-5.6-sol", "gpt-5.6", "gpt-5.5", "gpt-5", "sol", "o3", "o1", "gpt-4o"
+                "gpt-5.6-sol", "gpt-6-astra", "astra", "gpt-5.6", "gpt-5.5", "gpt-5", "sol", "o3", "o1", "gpt-4o"
             ],
             [(ModelProviderKind.OpenAi, ModelProfileKind.Balanced)] =
             [
@@ -117,7 +117,7 @@ public static class ModelProfilePriorities
             // === Generic / Fallback ===
             [(ModelProviderKind.Generic, ModelProfileKind.Deep)] =
             [
-                "gpt-5.6-sol", "claude-fable-5", "claude-opus-5-1", "claude-opus-5", "gemini-3.8-flash", "gemini-3.7-flash", "claude-sonnet-5", "gpt-4o"
+                "gpt-5.6-sol", "gpt-6-astra", "claude-fable-5", "claude-opus-5-1", "claude-opus-5", "gemini-3.8-flash", "gemini-3.7-flash", "claude-sonnet-5", "gpt-4o"
             ],
             [(ModelProviderKind.Generic, ModelProfileKind.Balanced)] =
             [

--- a/src/Ivy.Tendril.Agents/Providers/Codex/CodexModelCatalog.cs
+++ b/src/Ivy.Tendril.Agents/Providers/Codex/CodexModelCatalog.cs
@@ -19,6 +19,16 @@ public sealed class CodexModelCatalog : CachedModelCatalogProvider
     [
         new()
         {
+            Id = "gpt-6-astra", DisplayName = "GPT-6 Astra",
+            Capabilities = DefaultCaps,
+            SupportedEfforts = EffortLevels.Codex,
+            ContextWindow = 400_000, MaxOutputTokens = 32_000,
+            Provider = "openai",
+            InputPerMillion = 10.00m, OutputPerMillion = 40.00m,
+            CacheReadPerMillion = 2.50m, CacheWritePerMillion = 12.50m,
+        },
+        new()
+        {
             Id = "gpt-5.6-sol", DisplayName = "GPT-5.6-Sol",
             Capabilities = DefaultCaps,
             SupportedEfforts = EffortLevels.Codex,

--- a/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/02_Codex.md
+++ b/src/Ivy.Tendril.Docs/Docs/06_CodingAgents/02_Codex.md
@@ -41,3 +41,7 @@ Tendril maps effort levels to Codex models:
 | `quick` | gpt-5.6-luna | low | Simple fixes and small edits |
 
 The profile is selected automatically based on the plan's complexity level, or can be configured per promptware in `config.yaml`.
+
+### Supported Models
+
+In addition to the default profile models, the Codex catalog supports models such as `gpt-6-astra` for manual selection or custom configuration in `config.yaml`.


### PR DESCRIPTION
Fixes #2356

# Summary

## Changes

Added support for OpenAI's GPT-6 Astra (`gpt-6-astra`) to the Codex model catalog, catalog sorter, and model profile selection priorities. Preserved `gpt-5.6-sol` as the default model for the Deep profile tier in Codex while enabling `gpt-6-astra` for selection, cost calculation, and custom configuration.

## API Changes

None.

## Files Modified

- **Model Catalog & Providers:**
  - `src/Ivy.Tendril.Agents/Providers/Codex/CodexModelCatalog.cs`: Added `gpt-6-astra` static model definition with pricing, token limits, and capabilities.
  - `src/Ivy.Tendril.Agents/Helpers/ModelCatalogSorter.cs`: Added provider resolution and rank sorting for Astra models.
  - `src/Ivy.Tendril.Agents/Helpers/ModelProfilePriorities.cs`: Added `gpt-6-astra` to Deep profile candidates for OpenAI, Ivy, and Generic providers.
- **Documentation:**
  - `src/Ivy.Tendril.Docs/Docs/06_CodingAgents/02_Codex.md`: Documented `gpt-6-astra` availability in the Codex model catalog.
- **Tests:**
  - `src/Ivy.Tendril.Agents.Test/Codex/CodexModelCatalogTests.cs`: Verified static catalog registration and capabilities for `gpt-6-astra`.
  - `src/Ivy.Tendril.Agents.Test/Helpers/ModelCatalogSorterTests.cs`: Verified sorting rank and provider detection for Astra.
  - `src/Ivy.Tendril.Agents.Test/Helpers/ModelProfileSelectorTests.cs`: Verified profile selection behavior.
  - `src/Ivy.Tendril.Agents.Test/Runtime/ModelPricingProviderTests.cs`: Verified pricing rates for `gpt-6-astra`.

## Manual Testing

1. Run the Tendril CLI command `tendril models` in a terminal.
2. Verify that `gpt-6-astra` appears in the list of available models with provider `openai` and correct pricing ($10.00 / $40.00 per million tokens).
3. Check the Codex documentation in the Docs app or browser and confirm `gpt-6-astra` is listed under Supported Models.

---

## Commits

- `6b51170b` Add tests for GPT-6 Astra catalog, sorting, profile selection, and pricing (Plan 00030)
- `998f44dd` Document GPT-6 Astra support in Codex documentation (Plan 00030)
- `b4c18ff7` Add GPT-6 Astra support to Codex catalog, sorting, and profile priorities (Plan 00030)

---
Created using [Ivy Tendril](https://ivy.app).
