### PR TITLE
[00039] Preserve Selected Plan View When New Plan Finishes Generating

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Plans/PlansAppSelectionTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Plans/PlansAppSelectionTests.cs
@@ -1,0 +1,197 @@
+using Ivy.Tendril.Helpers;
+using Ivy.Tendril.Models;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Plans;
+
+public class PlansAppSelectionTests
+{
+    private static PlanFile CreatePlan(int id, string safeTitle, PlanStatus status = PlanStatus.Draft)
+    {
+        var folderName = $"{id:D5}-{safeTitle}";
+        var folderPath = $"/plans/{folderName}";
+        var metadata = new PlanMetadata(
+            id,
+            "ivy-tendril",
+            "Bug",
+            safeTitle,
+            status,
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            DateTime.UtcNow,
+            DateTime.UtcNow,
+            null,
+            null);
+        return new PlanFile(metadata, "# " + safeTitle, folderPath, "state: " + status);
+    }
+
+    [Fact]
+    public void ResolveSelection_WhenNewPlanPrepended_PreservesCurrentlySelectedPlan()
+    {
+        // Arrange: User is currently viewing plan 37
+        var plan38 = CreatePlan(38, "OlderPlan");
+        var plan37 = CreatePlan(37, "SelectedPlan");
+        var previousPlans = new List<PlanFile> { plan38, plan37 };
+
+        var currentSelected = plan37;
+        var savedFolder = plan37.FolderName;
+
+        // Simulate CreatePlan job completing: plan 39 is prepended
+        var plan39 = CreatePlan(39, "NewGeneratedPlan");
+        var currentPlans = new List<PlanFile> { plan39, plan38, plan37 };
+
+        // Act
+        var (selectedPlan, selectedFolder) = PlanSelectionHelper.ResolveSelection(
+            currentSelected,
+            savedFolder,
+            currentPlans,
+            previousPlans,
+            argPlanId: null);
+
+        // Assert: Selection must remain plan 37, not the newly generated plan 39
+        Assert.NotNull(selectedPlan);
+        Assert.Equal(37, selectedPlan.Id);
+        Assert.Equal(plan37.FolderName, selectedFolder);
+    }
+
+    [Fact]
+    public void ResolveSelection_WhenSelectedPlanDeletedOrMoved_FallsBackToAdjacentPlan()
+    {
+        // Arrange: plans list has [40, 39, 38] and user is viewing plan 39 (index 1)
+        var plan40 = CreatePlan(40, "Plan40");
+        var plan39 = CreatePlan(39, "Plan39");
+        var plan38 = CreatePlan(38, "Plan38");
+        var previousPlans = new List<PlanFile> { plan40, plan39, plan38 };
+
+        var currentSelected = plan39;
+        var savedFolder = plan39.FolderName;
+
+        // Plan 39 is deleted or moved to Executing/Review: list becomes [40, 38]
+        var currentPlans = new List<PlanFile> { plan40, plan38 };
+
+        // Act
+        var (selectedPlan, selectedFolder) = PlanSelectionHelper.ResolveSelection(
+            currentSelected,
+            savedFolder,
+            currentPlans,
+            previousPlans,
+            argPlanId: null);
+
+        // Assert: Selection should fall back to adjacent index (index 1 = plan 38)
+        Assert.NotNull(selectedPlan);
+        Assert.Equal(38, selectedPlan.Id);
+        Assert.Equal(plan38.FolderName, selectedFolder);
+    }
+
+    [Fact]
+    public void ResolveSelection_WhenSelectedPlanAtEndOfListDeleted_FallsBackToLastRemainingPlan()
+    {
+        // Arrange: user was viewing the last plan (plan 38 at index 2)
+        var plan40 = CreatePlan(40, "Plan40");
+        var plan39 = CreatePlan(39, "Plan39");
+        var plan38 = CreatePlan(38, "Plan38");
+        var previousPlans = new List<PlanFile> { plan40, plan39, plan38 };
+
+        var currentSelected = plan38;
+        var savedFolder = plan38.FolderName;
+
+        // Plan 38 is deleted: current plans are [40, 39]
+        var currentPlans = new List<PlanFile> { plan40, plan39 };
+
+        // Act
+        var (selectedPlan, selectedFolder) = PlanSelectionHelper.ResolveSelection(
+            currentSelected,
+            savedFolder,
+            currentPlans,
+            previousPlans,
+            argPlanId: null);
+
+        // Assert: Nearest valid index is index 1 = plan 39
+        Assert.NotNull(selectedPlan);
+        Assert.Equal(39, selectedPlan.Id);
+        Assert.Equal(plan39.FolderName, selectedFolder);
+    }
+
+    [Fact]
+    public void ResolveSelection_WhenAllPlansDeleted_ReturnsNull()
+    {
+        var plan40 = CreatePlan(40, "Plan40");
+        var previousPlans = new List<PlanFile> { plan40 };
+        var currentPlans = new List<PlanFile>();
+
+        var (selectedPlan, selectedFolder) = PlanSelectionHelper.ResolveSelection(
+            plan40,
+            plan40.FolderName,
+            currentPlans,
+            previousPlans,
+            argPlanId: null);
+
+        Assert.Null(selectedPlan);
+        Assert.Null(selectedFolder);
+    }
+
+    [Fact]
+    public void ResolveSelection_OnInitialMountWithoutArgs_SelectsFirstPlan()
+    {
+        var plan40 = CreatePlan(40, "Plan40");
+        var plan39 = CreatePlan(39, "Plan39");
+        var currentPlans = new List<PlanFile> { plan40, plan39 };
+        var previousPlans = new List<PlanFile>();
+
+        var (selectedPlan, selectedFolder) = PlanSelectionHelper.ResolveSelection(
+            currentSelected: null,
+            savedFolder: null,
+            currentPlans,
+            previousPlans,
+            argPlanId: null);
+
+        Assert.NotNull(selectedPlan);
+        Assert.Equal(40, selectedPlan.Id);
+        Assert.Equal(plan40.FolderName, selectedFolder);
+    }
+
+    [Fact]
+    public void ResolveSelection_OnInitialMountWithArgs_SelectsSpecifiedPlan()
+    {
+        var plan40 = CreatePlan(40, "Plan40");
+        var plan39 = CreatePlan(39, "Plan39");
+        var currentPlans = new List<PlanFile> { plan40, plan39 };
+        var previousPlans = new List<PlanFile>();
+
+        var (selectedPlan, selectedFolder) = PlanSelectionHelper.ResolveSelection(
+            currentSelected: null,
+            savedFolder: "00039",
+            currentPlans,
+            previousPlans,
+            argPlanId: "00039");
+
+        Assert.NotNull(selectedPlan);
+        Assert.Equal(39, selectedPlan.Id);
+        Assert.Equal(plan39.FolderName, selectedFolder);
+    }
+
+    [Fact]
+    public void ResolveSelection_WhenSelectedPlanUpdated_ReturnsFreshInstanceFromList()
+    {
+        var initialPlan = CreatePlan(39, "Plan39", PlanStatus.Draft);
+        var updatedPlan = CreatePlan(39, "Plan39", PlanStatus.Blocked);
+
+        var previousPlans = new List<PlanFile> { initialPlan };
+        var currentPlans = new List<PlanFile> { updatedPlan };
+
+        var (selectedPlan, selectedFolder) = PlanSelectionHelper.ResolveSelection(
+            initialPlan,
+            initialPlan.FolderName,
+            currentPlans,
+            previousPlans,
+            argPlanId: null);
+
+        Assert.NotNull(selectedPlan);
+        Assert.Same(updatedPlan, selectedPlan);
+        Assert.Equal(PlanStatus.Blocked, selectedPlan.Status);
+    }
+}

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -465,11 +465,32 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             var wasOnSession = selectedIndex.Value != null;
             var effectiveNavigateArgs = navigateArgs with { AppId = effectiveAppId };
 
+            if (effectiveNavigateArgs.AppArgs == null &&
+                string.Equals(previousApp, effectiveAppId, StringComparison.OrdinalIgnoreCase))
+            {
+                if (currentApp.Value?.AppArgs != null)
+                {
+                    effectiveNavigateArgs = effectiveNavigateArgs with { AppArgs = currentApp.Value.AppArgs };
+                }
+                else if (sidebarList.Value is { } currentSidebar &&
+                         string.Equals(currentSidebar.AppId, effectiveAppId, StringComparison.OrdinalIgnoreCase) &&
+                         !string.IsNullOrEmpty(currentSidebar.SelectedId))
+                {
+                    effectiveNavigateArgs = effectiveNavigateArgs with { AppArgs = currentSidebar.BuildSelectArgs(currentSidebar.SelectedId) };
+                }
+            }
+
             var appHost = effectiveAppId != null
                 ? effectiveNavigateArgs.ToAppHost(args.ConnectionId)
                 : null;
 
-            currentApp.Set(appHost);
+            if (currentApp.Value == null ||
+                !string.Equals(previousApp, effectiveAppId, StringComparison.OrdinalIgnoreCase) ||
+                !Equals(currentApp.Value.AppArgs, effectiveNavigateArgs.AppArgs))
+            {
+                currentApp.Set(appHost);
+            }
+
             selectedIndex.Set((int?)null);
 
             // The sidebar section belongs to the page app; drop it when the page changes to an
@@ -583,7 +604,7 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             {
                 // The page is still open behind the sessions; reveal it again.
                 SetAppTitle(page.AppId);
-                RedirectToAppIfNotError(new NavigateArgs(page.AppId));
+                RedirectToAppIfNotError(new NavigateArgs(page.AppId, page.AppArgs));
             }
             else
             {

--- a/src/Ivy.Tendril/Apps/Plans/PlansApp.cs
+++ b/src/Ivy.Tendril/Apps/Plans/PlansApp.cs
@@ -39,14 +39,28 @@ public class PlansApp : ViewBase
         var configService = UseService<IConfigService>();
         var gitService = UseService<IGitService>();
         var args = UseArgs<PlansAppArgs>();
+        var previousPlans = UseRef(new List<PlanFile>());
+        var selectedFolderRef = UseRef<string?>(() =>
+        {
+            if (!string.IsNullOrEmpty(args?.PlanId))
+            {
+                return args.PlanId;
+            }
+            return null;
+        });
         var selectedPlanState = UseState<PlanFile?>(() =>
         {
             if (!string.IsNullOrEmpty(args?.PlanId))
             {
-                return planService.GetPlans().FirstOrDefault(x =>
+                var p = planService.GetPlans().FirstOrDefault(x =>
                     x.FolderName.Equals(args.PlanId, StringComparison.OrdinalIgnoreCase) ||
                     x.Id.ToString() == args.PlanId ||
                     x.FolderName.StartsWith(args.PlanId + "-", StringComparison.OrdinalIgnoreCase));
+                if (p != null)
+                {
+                    selectedFolderRef.Value = p.FolderName;
+                    return p;
+                }
             }
             return null;
         });
@@ -65,13 +79,17 @@ public class PlansApp : ViewBase
                     x.FolderName.StartsWith(args.PlanId + "-", StringComparison.OrdinalIgnoreCase));
                 if (p != null && p.FolderName != selectedPlanState.Value?.FolderName)
                 {
+                    selectedFolderRef.Value = p.FolderName;
                     selectedPlanState.Set(p);
                 }
             }
             return Disposable.Empty;
         });
 
-        var previousPlans = UseRef(new List<PlanFile>());
+        if (selectedPlanState.Value != null)
+        {
+            selectedFolderRef.Value = selectedPlanState.Value.FolderName;
+        }
 
         var activeJobs = jobService.GetJobs()
             .Where(j => j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending or JobStatus.Blocked)
@@ -95,26 +113,18 @@ public class PlansApp : ViewBase
             .OrderByDescending(p => p.Id)
             .ToList();
 
-        // Only auto-select first plan if we didn't navigate here with specific args
-        if (selectedPlanState.Value == null && plans.Count > 0 && string.IsNullOrEmpty(args?.PlanId))
-        {
-            selectedPlanState.Set(plans[0]);
-        }
+        var (resolvedPlan, resolvedFolder) = PlanSelectionHelper.ResolveSelection(
+            selectedPlanState.Value,
+            selectedFolderRef.Value,
+            plans,
+            previousPlans.Value,
+            args?.PlanId);
 
-        if (selectedPlanState.Value is { } selected && plans.All(p => p.FolderName != selected.FolderName))
+        if (!ReferenceEquals(resolvedPlan, selectedPlanState.Value))
         {
-            var oldIndex = previousPlans.Value.FindIndex(p => p.FolderName == selected.FolderName);
-
-            if (plans.Count > 0 && oldIndex >= 0)
-            {
-                var newIndex = Math.Min(oldIndex, plans.Count - 1);
-                selectedPlanState.Set(plans[newIndex]);
-            }
-            else
-            {
-                selectedPlanState.Set(null);
-            }
+            selectedPlanState.Set(resolvedPlan);
         }
+        selectedFolderRef.Value = resolvedFolder;
 
         previousPlans.Value = plans;
 

--- a/src/Ivy.Tendril/Apps/Review/ReviewApp.cs
+++ b/src/Ivy.Tendril/Apps/Review/ReviewApp.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Disposables;
 using Ivy.Tendril.AppShell;
+using Ivy.Tendril.Helpers;
 using Ivy.Tendril.Hooks;
 using Ivy.Tendril.Models;
 using Ivy.Tendril.Services;
@@ -43,14 +44,28 @@ public class ReviewApp : ViewBase
         var configService = UseService<IConfigService>();
         var gitService = UseService<IGitService>();
         var args = UseArgs<ReviewAppArgs>();
+        var previousPlans = UseRef(new List<PlanFile>());
+        var selectedFolderRef = UseRef<string?>(() =>
+        {
+            if (!string.IsNullOrEmpty(args?.PlanId))
+            {
+                return args.PlanId;
+            }
+            return null;
+        });
         var selectedPlanState = UseState<PlanFile?>(() =>
         {
             if (!string.IsNullOrEmpty(args?.PlanId))
             {
-                return planService.GetPlans().FirstOrDefault(x =>
+                var p = planService.GetPlans().FirstOrDefault(x =>
                     x.FolderName.Equals(args.PlanId, StringComparison.OrdinalIgnoreCase) ||
                     x.Id.ToString() == args.PlanId ||
                     x.FolderName.StartsWith(args.PlanId + "-", StringComparison.OrdinalIgnoreCase));
+                if (p != null)
+                {
+                    selectedFolderRef.Value = p.FolderName;
+                    return p;
+                }
             }
             return null;
         });
@@ -69,13 +84,17 @@ public class ReviewApp : ViewBase
                     x.FolderName.StartsWith(args.PlanId + "-", StringComparison.OrdinalIgnoreCase));
                 if (p != null && p.FolderName != selectedPlanState.Value?.FolderName)
                 {
+                    selectedFolderRef.Value = p.FolderName;
                     selectedPlanState.Set(p);
                 }
             }
             return Disposable.Empty;
         });
 
-        var previousPlans = UseRef(new List<PlanFile>());
+        if (selectedPlanState.Value != null)
+        {
+            selectedFolderRef.Value = selectedPlanState.Value.FolderName;
+        }
 
         var activePlanFolders = jobService.GetJobs()
             .Where(j => j.Status is JobStatus.Running or JobStatus.Queued or JobStatus.Pending or JobStatus.Blocked)
@@ -89,25 +108,18 @@ public class ReviewApp : ViewBase
             .OrderByDescending(p => p.Id)
             .ToList();
 
-        // Only auto-select first plan if we didn't navigate here with specific args
-        if (selectedPlanState.Value == null && plans.Count > 0 && string.IsNullOrEmpty(args?.PlanId))
-        {
-            selectedPlanState.Set(plans[0]);
-        }
+        var (resolvedPlan, resolvedFolder) = PlanSelectionHelper.ResolveSelection(
+            selectedPlanState.Value,
+            selectedFolderRef.Value,
+            plans,
+            previousPlans.Value,
+            args?.PlanId);
 
-        if (selectedPlanState.Value is { } selected && plans.All(p => p.FolderName != selected.FolderName))
+        if (!ReferenceEquals(resolvedPlan, selectedPlanState.Value))
         {
-            var oldIndex = previousPlans.Value.FindIndex(p => p.FolderName == selected.FolderName);
-            if (plans.Count > 0 && oldIndex >= 0)
-            {
-                var newIndex = Math.Min(oldIndex, plans.Count - 1);
-                selectedPlanState.Set(plans[newIndex]);
-            }
-            else
-            {
-                selectedPlanState.Set(null);
-            }
+            selectedPlanState.Set(resolvedPlan);
         }
+        selectedFolderRef.Value = resolvedFolder;
 
         previousPlans.Value = plans;
 

--- a/src/Ivy.Tendril/Helpers/PlanSelectionHelper.cs
+++ b/src/Ivy.Tendril/Helpers/PlanSelectionHelper.cs
@@ -1,0 +1,73 @@
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Helpers;
+
+public static class PlanSelectionHelper
+{
+    public static (PlanFile? SelectedPlan, string? SelectedFolder) ResolveSelection(
+        PlanFile? currentSelected,
+        string? savedFolder,
+        IReadOnlyList<PlanFile> currentPlans,
+        IReadOnlyList<PlanFile> previousPlans,
+        string? argPlanId)
+    {
+        if (currentSelected is { } selected)
+        {
+            var matchingPlan = currentPlans.FirstOrDefault(p =>
+                p.FolderName.Equals(selected.FolderName, StringComparison.OrdinalIgnoreCase) ||
+                p.Id == selected.Id);
+
+            if (matchingPlan != null)
+            {
+                return (matchingPlan, matchingPlan.FolderName);
+            }
+
+            var oldIndex = previousPlans.ToList().FindIndex(p =>
+                p.FolderName.Equals(selected.FolderName, StringComparison.OrdinalIgnoreCase) ||
+                p.Id == selected.Id);
+
+            if (currentPlans.Count > 0)
+            {
+                var newIndex = oldIndex >= 0 ? Math.Min(oldIndex, currentPlans.Count - 1) : 0;
+                var fallback = currentPlans[newIndex];
+                return (fallback, fallback.FolderName);
+            }
+
+            return (null, null);
+        }
+
+        if (!string.IsNullOrEmpty(savedFolder))
+        {
+            var matchedSaved = currentPlans.FirstOrDefault(p =>
+                p.FolderName.Equals(savedFolder, StringComparison.OrdinalIgnoreCase) ||
+                p.Id.ToString() == savedFolder ||
+                p.FolderName.StartsWith(savedFolder + "-", StringComparison.OrdinalIgnoreCase));
+
+            if (matchedSaved != null)
+            {
+                return (matchedSaved, matchedSaved.FolderName);
+            }
+
+            var oldIndex = previousPlans.ToList().FindIndex(p =>
+                p.FolderName.Equals(savedFolder, StringComparison.OrdinalIgnoreCase) ||
+                p.Id.ToString() == savedFolder ||
+                p.FolderName.StartsWith(savedFolder + "-", StringComparison.OrdinalIgnoreCase));
+
+            if (currentPlans.Count > 0)
+            {
+                var newIndex = oldIndex >= 0 ? Math.Min(oldIndex, currentPlans.Count - 1) : 0;
+                var fallback = currentPlans[newIndex];
+                return (fallback, fallback.FolderName);
+            }
+
+            return (null, null);
+        }
+
+        if (currentSelected == null && currentPlans.Count > 0 && string.IsNullOrEmpty(argPlanId))
+        {
+            return (currentPlans[0], currentPlans[0].FolderName);
+        }
+
+        return (currentSelected, savedFolder);
+    }
+}


### PR DESCRIPTION
Fixes #2352

# Summary

## Changes

Maintained selected plan view stability across inbox refreshes and new plan generation events in PlansApp and ReviewApp via PlanSelectionHelper. Synchronized shell navigation state in TendrilAppShell to preserve existing AppArgs when transitioning to already-open pages or returning from session tabs.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Helpers/PlanSelectionHelper.cs`: New selection resolution helper ensuring active plan selection is preserved on list updates and safely falls back to adjacent plans when removed.
- `src/Ivy.Tendril/Apps/Plans/PlansApp.cs`: Stabilized selected plan tracking and selection resolution using PlanSelectionHelper.
- `src/Ivy.Tendril/Apps/Review/ReviewApp.cs`: Applied symmetrical plan selection stabilization and fresh metadata updates using PlanSelectionHelper.
- `src/Ivy.Tendril/AppShell/TendrilAppShell.cs`: Preserved AppArgs in HandleOpenPage and OnTabClose to prevent unneeded app remounts and argument loss.
- `src/Ivy.Tendril.Test/Apps/Plans/PlansAppSelectionTests.cs`: Unit test suite verifying selection stability, adjacent fallback, initial auto-selection, and plan instance updates.

## Manual Testing

1. Open the Tendril application and navigate to the Plans view.
2. Select any plan that is not at index 0 (e.g. an older draft plan).
3. Trigger a plan generation task (such as CreatePlan via CLI or dialog).
4. Observe that when the new plan finishes generating and appears at the top of the plans list, the currently selected plan view remains displayed without being replaced.
5. Switch to a session tab (e.g. Agent chat) and then click back to the Plans navigation icon or close the session tab.
6. Verify that the previously viewed plan remains open.

---
### Commits
- 8cf91bdc fix(plans,review,shell): preserve selected plan view across refreshes (plan 00039)

---
Created using [Ivy Tendril](https://ivy.app).
