### PR TITLE
feat(dashboard): tabbed git activity / prs, GitHub daily heatmap, 28-day week mode trend

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
@@ -272,4 +272,63 @@ public class DashboardAppViewModelTests
         // Compared to 4 weeks earlier (index 19, which had i = 4, cost 50m)
         Assert.Equal(50.0, trend.PrevCost[^1]);
     }
+
+    [Fact]
+    public void BuildWeeklyTrend_Projects28DaysWithComparison_WhenDailyStatsAvailable()
+    {
+        var today = new DateTime(2026, 9, 6);
+        var dailyCosts = new List<DashboardDailyCost>
+        {
+            new(new DateOnly(2026, 9, 6), 28.31m, 2500),
+            new(new DateOnly(2026, 9, 5), 18.69m, 1700),
+            new(new DateOnly(2026, 9, 3), 7.53m, 700),
+            // 28 days before Sept 6 is Aug 9
+            new(new DateOnly(2026, 8, 9), 12.50m, 1200)
+        };
+        var dailyPlans = new Dictionary<DateOnly, int>
+        {
+            [new DateOnly(2026, 9, 6)] = 5,
+            [new DateOnly(2026, 8, 9)] = 2
+        };
+
+        var activity = new DashboardActivityStats([], 0m, dailyCosts, null, dailyPlans);
+        var trend = DashboardApp.BuildWeeklyTrend(activity, today);
+
+        Assert.Equal(28, trend.Months.Count);
+        Assert.Equal(28, trend.Cost.Count);
+        Assert.Equal(28, trend.Plans.Count);
+        Assert.Equal(28, trend.PrevCost.Count);
+        Assert.Equal(28, trend.PrevPlans.Count);
+
+        // First label is 27 days before today: Aug 10
+        Assert.Equal("Aug 10", trend.Months[0]);
+        // Last label is today: Sep 6
+        Assert.Equal("Sep 6", trend.Months[^1]);
+
+        // Sept 6 cost
+        Assert.Equal(28.31, trend.Cost[^1]);
+        // Sept 6 plans
+        Assert.Equal(5.0, trend.Plans[^1]);
+        // Sept 6 compared to 28 days earlier (Aug 9)
+        Assert.Equal(12.50, trend.PrevCost[^1]);
+        Assert.Equal(2.0, trend.PrevPlans[^1]);
+    }
+
+    [Fact]
+    public void BuildActivityMonths_IncludesDailyBreakdown()
+    {
+        var firstMonth = new DateTime(2026, 9, 1);
+        var prDays = new List<(DateOnly Date, int Count)>
+        {
+            (new DateOnly(2026, 9, 6), 3)
+        };
+
+        var months = DashboardApp.BuildActivityMonths(prDays, firstMonth);
+        var sep = months[0];
+
+        Assert.NotNull(sep.Days);
+        Assert.Equal(30, sep.Days!.Count);
+        var day6 = sep.Days.First(d => d.Date == "2026-09-06");
+        Assert.Equal(3, day6.Count);
+    }
 }

--- a/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
+++ b/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
@@ -13,7 +13,9 @@ public record DashboardKpiDto(
 
 public record DashboardMonthValueDto(string Label, double Value);
 
-public record DashboardActivityMonthDto(string Label, List<int> Weeks);
+public record DashboardActivityDayDto(string Date, int Count);
+
+public record DashboardActivityMonthDto(string Label, List<int> Weeks, List<DashboardActivityDayDto>? Days = null);
 
 /// <summary>Row in the Active Jobs card. Status is lowercased; "running" spins the row's loader.</summary>
 public record DashboardJobDto(string Id, string PlanId, string Title, string Status);

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useLayoutEffect, useMemo, useRef } from "react";
 import { DashboardActivityMonthDto, rampLevel } from "./types";
 import { HoverTip, useHoverTip } from "./HoverTip";
 
@@ -6,55 +6,202 @@ interface ActivityGridProps {
   months: DashboardActivityMonthDto[];
 }
 
-/** One column per month; each week with activity renders as a cell stacked
-    from the bottom, shaded by that week's intensity relative to the range. */
+interface DayCell {
+  date: string;
+  count: number;
+  dateObj: Date;
+}
+
+interface WeekColumn {
+  monthLabel?: string;
+  days: (DayCell | null)[];
+}
+
+const WEEKDAYS = ["Mon", "", "Wed", "", "Fri", "", ""];
+
+/** GitHub-style contribution heatmap with 7 weekday rows, week columns,
+    month headers, and an intensity ramp legend. */
 export const ActivityGrid: React.FC<ActivityGridProps> = ({ months }) => {
   const { wrapRef, tip, showTip, hideTip } = useHoverTip();
-  const maxWeek = useMemo(
-    () => Math.max(0, ...months.flatMap((m) => m.weeks)),
-    [months],
-  );
+  const scrollRef = useRef<HTMLDivElement>(null);
 
-  if (months.length === 0 || maxWeek === 0) {
+  // Extract all daily records across the months
+  const allDays = useMemo(() => {
+    const days = months.flatMap((m) => m.days ?? []);
+    if (days.length > 0) return days;
+
+    // Fallback if days were not supplied: synthesize days from months & weeks
+    const fallback: { date: string; count: number }[] = [];
+    const today = new Date();
+    for (let mi = 0; mi < months.length; mi++) {
+      const m = months[mi];
+      const monthOffset = months.length - 1 - mi;
+      const d = new Date(today.getFullYear(), today.getMonth() - monthOffset, 1);
+      const daysInMonth = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+      for (let day = 1; day <= daysInMonth; day++) {
+        const curDate = new Date(d.getFullYear(), d.getMonth(), day);
+        const curIso = curDate.toISOString().slice(0, 10);
+        const weekIdx = Math.min(m.weeks.length - 1, Math.floor((day - 1) / 7));
+        const count = m.weeks[weekIdx] ?? 0;
+        fallback.push({ date: curIso, count });
+      }
+    }
+    return fallback;
+  }, [months]);
+
+  // Max daily count for the color ramp
+  const maxDay = useMemo(() => {
+    if (allDays.length === 0) return 0;
+    return Math.max(0, ...allDays.map((d) => d.count));
+  }, [allDays]);
+
+  // Build weekly columns (Monday=0 to Sunday=6)
+  const columns = useMemo<WeekColumn[]>(() => {
+    if (allDays.length === 0) return [];
+
+    const byDate = new Map<string, number>();
+    for (const d of allDays) {
+      byDate.set(d.date, d.count);
+    }
+
+    const firstDateStr = allDays[0].date;
+    const lastDateStr = allDays[allDays.length - 1].date;
+
+    const firstDate = new Date(firstDateStr + "T00:00:00");
+    const lastDate = new Date(lastDateStr + "T00:00:00");
+
+    // Align start to the Monday of the first week
+    const startMonday = new Date(firstDate);
+    const firstDayOfWeek = (firstDate.getDay() + 6) % 7;
+    startMonday.setDate(startMonday.getDate() - firstDayOfWeek);
+
+    const cols: WeekColumn[] = [];
+    const cur = new Date(startMonday);
+    let lastMonth = -1;
+
+    while (cur <= lastDate || (cur.getDay() + 6) % 7 !== 0) {
+      const weekDays: (DayCell | null)[] = [];
+      let monthLabelForWeek: string | undefined = undefined;
+
+      for (let dayIdx = 0; dayIdx < 7; dayIdx++) {
+        const curDateStr = cur.toISOString().slice(0, 10);
+        if (cur < firstDate || cur > lastDate) {
+          weekDays.push(null);
+        } else {
+          const count = byDate.get(curDateStr) ?? 0;
+          weekDays.push({
+            date: curDateStr,
+            count,
+            dateObj: new Date(cur),
+          });
+
+          // Label month when month changes
+          const monthIdx = cur.getMonth();
+          if (monthIdx !== lastMonth && monthLabelForWeek === undefined) {
+            monthLabelForWeek = cur.toLocaleDateString("en-US", { month: "short" });
+            lastMonth = monthIdx;
+          }
+        }
+        cur.setDate(cur.getDate() + 1);
+      }
+
+      cols.push({
+        monthLabel: monthLabelForWeek,
+        days: weekDays,
+      });
+    }
+
+    return cols;
+  }, [allDays]);
+
+  // Auto-scroll to the end (most recent activity) on mount
+  useLayoutEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollRef.current.scrollWidth;
+    }
+  }, [columns]);
+
+  if (months.length === 0) {
     return (
       <div className="tdb-empty-note">
-        No merged pull requests yet
+        No activity yet
       </div>
     );
   }
 
-  // Label every other month when the range is long, always including the last.
-  const step = months.length > 8 ? 2 : 1;
-
   return (
     <div className="tdb-tip-wrap" ref={wrapRef}>
-      <div className="tdb-activity-scroll">
-        <div className="tdb-activity">
-          {months.map((month, monthIndex) => (
-            <div className="tdb-activity-col" key={monthIndex}>
-              {month.weeks.map((count, weekIndex) =>
-                count > 0 ? (
-                  <div
-                    key={weekIndex}
-                    className="tdb-activity-cell"
-                    data-level={rampLevel(count, maxWeek)}
-                    onMouseEnter={showTip(
-                      `${month.label}, week ${weekIndex + 1}`,
-                      `${count} PR${count === 1 ? "" : "s"} merged`,
+      <div className="tdb-activity-wrap">
+        <div className="tdb-activity-scroll" ref={scrollRef}>
+          <div className="tdb-activity-layout">
+            <div className="tdb-activity-weekdays">
+              {WEEKDAYS.map((wd, i) => (
+                <div key={i} className="tdb-activity-weekday">
+                  {wd}
+                </div>
+              ))}
+            </div>
+            <div className="tdb-activity-grid-body">
+              <div className="tdb-activity-months-row">
+                {columns.map((col, idx) => (
+                  <div key={idx} className="tdb-activity-month-col">
+                    {col.monthLabel && (
+                      <span className="tdb-activity-month-label">
+                        {col.monthLabel}
+                      </span>
                     )}
-                    onMouseLeave={hideTip}
-                  />
-                ) : null,
-              )}
+                  </div>
+                ))}
+              </div>
+              <div className="tdb-activity-weeks">
+                {columns.map((col, colIdx) => (
+                  <div key={colIdx} className="tdb-activity-week">
+                    {col.days.map((day, dayIdx) => {
+                      if (!day) {
+                        return (
+                          <div
+                            key={dayIdx}
+                            className="tdb-activity-cell tdb-cell-empty"
+                          />
+                        );
+                      }
+                      const dateText = day.dateObj.toLocaleDateString("en-US", {
+                        weekday: "short",
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      });
+                      const countText =
+                        day.count === 0
+                          ? "No pull requests merged"
+                          : `${day.count} pull request${day.count === 1 ? "" : "s"} merged`;
+
+                      return (
+                        <div
+                          key={dayIdx}
+                          className="tdb-activity-cell"
+                          data-level={rampLevel(day.count, maxDay)}
+                          onMouseEnter={showTip(dateText, countText)}
+                          onMouseLeave={hideTip}
+                        />
+                      );
+                    })}
+                  </div>
+                ))}
+              </div>
             </div>
-          ))}
+          </div>
         </div>
-        <div className="tdb-activity-labels">
-          {months.map((month, monthIndex) => (
-            <div className="tdb-activity-label" key={monthIndex}>
-              {(months.length - 1 - monthIndex) % step === 0 ? month.label : ""}
-            </div>
-          ))}
+        <div className="tdb-activity-footer">
+          <div className="tdb-activity-legend">
+            <span>Less</span>
+            <div className="tdb-activity-cell" data-level={0} />
+            <div className="tdb-activity-cell" data-level={1} />
+            <div className="tdb-activity-cell" data-level={2} />
+            <div className="tdb-activity-cell" data-level={3} />
+            <div className="tdb-activity-cell" data-level={4} />
+            <span>More</span>
+          </div>
         </div>
       </div>
       <HoverTip tip={tip} />

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
@@ -231,67 +231,43 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
 
           <div className="tdb-col tdb-col-side">
             <div className="tdb-update-slot">{slots?.UpdateNotice}</div>
-            {hasSlotContent(slots?.TunnelQr) ? (
-              <>
-                {/* With the tunnel card present, Git Activity and Pull Requests
-                    merge into one tabbed card so the column keeps the same
-                    number of rows as without a tunnel. */}
-                <div className="tdb-block tdb-side-block">
-                  <div className="tdb-side-head">
-                    <div className="tdb-tabs">
-                      <button
-                        type="button"
-                        className="tdb-tab"
-                        data-active={sideTab === "git"}
-                        onClick={() => setSideTab("git")}
-                      >
-                        Git Activity
-                      </button>
-                      <button
-                        type="button"
-                        className="tdb-tab"
-                        data-active={sideTab === "prs"}
-                        onClick={() => setSideTab("prs")}
-                      >
-                        Pull Requests
-                      </button>
-                    </div>
-                  </div>
-                  <div className="tdb-side-body">
-                    {sideTab === "git" ? (
-                      <ActivityGrid months={activity} />
-                    ) : (
-                      <PillBars items={pullRequests} />
-                    )}
-                  </div>
+            <div className="tdb-block tdb-side-block">
+              <div className="tdb-side-head">
+                <div className="tdb-tabs">
+                  <button
+                    type="button"
+                    className="tdb-tab"
+                    data-active={sideTab === "git"}
+                    onClick={() => setSideTab("git")}
+                  >
+                    Git Activity
+                  </button>
+                  <button
+                    type="button"
+                    className="tdb-tab"
+                    data-active={sideTab === "prs"}
+                    onClick={() => setSideTab("prs")}
+                  >
+                    Pull Requests
+                  </button>
                 </div>
-                <div className="tdb-block tdb-side-block tdb-tunnel">
-                  <div className="tdb-side-head">
-                    <div className="tdb-block-title">Tunnel</div>
-                    {slots?.TunnelMenu}
-                  </div>
-                  <div className="tdb-tunnel-body">{slots?.TunnelQr}</div>
+              </div>
+              <div className="tdb-side-body">
+                {sideTab === "git" ? (
+                  <ActivityGrid months={activity} />
+                ) : (
+                  <PillBars items={pullRequests} />
+                )}
+              </div>
+            </div>
+            {hasSlotContent(slots?.TunnelQr) && (
+              <div className="tdb-block tdb-side-block tdb-tunnel">
+                <div className="tdb-side-head">
+                  <div className="tdb-block-title">Tunnel</div>
+                  {slots?.TunnelMenu}
                 </div>
-              </>
-            ) : (
-              <>
-                <div className="tdb-block tdb-side-block">
-                  <div className="tdb-side-head">
-                    <div className="tdb-block-title">Git Activity</div>
-                  </div>
-                  <div className="tdb-side-body">
-                    <ActivityGrid months={activity} />
-                  </div>
-                </div>
-                <div className="tdb-block tdb-side-block">
-                  <div className="tdb-side-head">
-                    <div className="tdb-block-title">Pull Requests</div>
-                  </div>
-                  <div className="tdb-side-body">
-                    <PillBars items={pullRequests} />
-                  </div>
-                </div>
-              </>
+                <div className="tdb-tunnel-body">{slots?.TunnelQr}</div>
+              </div>
             )}
           </div>
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx
@@ -28,8 +28,11 @@ const smoothPath = (points: Point[], maxY?: number): string => {
     const p3 = points[i + 2] ?? p2;
     let c1x = p1.x + (p2.x - p0.x) / 6;
     let c1y = p1.y + (p2.y - p0.y) / 6;
-    let c2x = p2.x + (p3.x - p1.x) / 6;
-    let c2y = p2.y + (p3.y - p1.y) / 6;
+    let c2x = p2.x - (p3.x - p1.x) / 6;
+    let c2y = p2.y - (p3.y - p1.y) / 6;
+    // Enforce monotonicity on x to prevent any backward loops
+    c1x = Math.max(p1.x, Math.min(p2.x, c1x));
+    c2x = Math.max(p1.x, Math.min(p2.x, c2x));
     if (maxY != null) {
       c1y = Math.min(c1y, maxY);
       c2y = Math.min(c2y, maxY);
@@ -163,17 +166,23 @@ export const TrendChart: React.FC<TrendChartProps> = ({
               </text>
             );
           })}
-          {labels.map((label, i) => (
-            <text
-              key={label + i}
-              className="tdb-axis-text"
-              x={plotLeft + (n <= 1 ? plotWidth / 2 : (i / (n - 1)) * plotWidth)}
-              y={height - 6}
-              textAnchor="middle"
-            >
-              {label}
-            </text>
-          ))}
+          {labels.map((label, i) => {
+            const maxVisible = Math.max(4, Math.floor(plotWidth / 60));
+            const step = n > maxVisible ? Math.ceil((n - 1) / maxVisible) : 1;
+            const isVisible = i === 0 || i === n - 1 || i % step === 0;
+            if (!isVisible) return null;
+            return (
+              <text
+                key={label + i}
+                className="tdb-axis-text"
+                x={plotLeft + (n <= 1 ? plotWidth / 2 : (i / (n - 1)) * plotWidth)}
+                y={height - 6}
+                textAnchor="middle"
+              >
+                {label}
+              </text>
+            );
+          })}
           {areaPath && <path d={areaPath} fill={`url(#${gradientId})`} style={{ color: "var(--tdb-fg)" }} />}
           {previousPoints.length > 1 && <path className="tdb-trend-compare" d={smoothPath(previousPoints, zeroY)} />}
           {points.length > 1 && <path className="tdb-trend-line" d={smoothPath(points, zeroY)} />}

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
@@ -494,56 +494,119 @@
   min-height: 0;
 }
 
-/* ---------- Activity grid ---------- */
+/* ---------- Activity grid (GitHub-style daily contribution heatmap) ---------- */
+
+.tdb-activity-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
 
 .tdb-activity-scroll {
   overflow-x: auto;
   scrollbar-width: none;
-  padding-right: 16px;
+  padding-bottom: 4px;
 }
 
-.tdb-activity {
+.tdb-activity-layout {
   display: flex;
-  align-items: flex-end;
   gap: 6px;
-  min-height: 166px;
 }
 
-.tdb-activity-col {
+.tdb-activity-weekdays {
   display: flex;
-  flex-direction: column-reverse;
-  align-items: center;
-  gap: 8px;
-  flex: 1 0 12px;
-  min-width: 12px;
+  flex-direction: column;
+  gap: 3px;
+  padding-top: 18px; /* offset for month headers */
+}
+
+.tdb-activity-weekday {
+  height: 10px;
+  font-size: 9px;
+  line-height: 10px;
+  color: var(--tdb-muted);
+  width: 22px;
+  text-align: right;
+  padding-right: 4px;
+  user-select: none;
+}
+
+.tdb-activity-grid-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tdb-activity-months-row {
+  display: flex;
+  gap: 3px;
+  height: 14px;
+}
+
+.tdb-activity-month-col {
+  width: 10px;
+  position: relative;
+}
+
+.tdb-activity-month-label {
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-size: 10px;
+  line-height: 14px;
+  color: var(--tdb-muted);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.tdb-activity-weeks {
+  display: flex;
+  gap: 3px;
+}
+
+.tdb-activity-week {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
 .tdb-activity-cell {
-  width: 100%;
-  max-width: 18px;
-  aspect-ratio: 1;
+  width: 10px;
+  height: 10px;
   border-radius: 2px;
+  flex-shrink: 0;
 }
 
-.tdb-activity-cell[data-level="0"] { background: color-mix(in srgb, var(--tdb-fg) 5%, transparent); }
+.tdb-activity-cell.tdb-cell-empty {
+  visibility: hidden;
+}
+
+.tdb-activity-cell[data-level="0"] { background: color-mix(in srgb, var(--tdb-fg) 6%, transparent); }
 .tdb-activity-cell[data-level="1"] { background: var(--tdb-ramp-1); }
 .tdb-activity-cell[data-level="2"] { background: var(--tdb-ramp-2); }
 .tdb-activity-cell[data-level="3"] { background: var(--tdb-ramp-3); }
 .tdb-activity-cell[data-level="4"] { background: var(--tdb-ramp-4); }
 
-.tdb-activity-labels {
+.tdb-activity-footer {
   display: flex;
-  gap: 6px;
-  margin-top: 16px;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--tdb-muted);
+  margin-top: 4px;
 }
 
-.tdb-activity-label {
-  flex: 1 0 12px;
-  min-width: 12px;
-  font-size: 12px;
-  color: var(--tdb-muted);
-  text-align: center;
-  white-space: nowrap;
+.tdb-activity-legend {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.tdb-activity-legend .tdb-activity-cell {
+  width: 9px;
+  height: 9px;
 }
 
 .tdb-empty-note {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
@@ -13,9 +13,15 @@ export interface DashboardMonthValueDto {
   value: number;
 }
 
+export interface DashboardActivityDayDto {
+  date: string;
+  count: number;
+}
+
 export interface DashboardActivityMonthDto {
   label: string;
   weeks: number[];
+  days?: DashboardActivityDayDto[];
 }
 
 export interface DashboardJobDto {

--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -119,7 +119,7 @@ public class DashboardApp : ViewBase
             .FailedCount(jobs.Count(j => j.Status == JobStatus.Failed))
             .Kpis(BuildKpis(stats, activity, prDays, today))
             .Trend(BuildTrend(activity))
-            .TrendWeekly(BuildWeeklyTrend(activity))
+            .TrendWeekly(BuildWeeklyTrend(activity, today))
             .PullRequests(activity.Months
                 .TakeLast(6)
                 .Select(m => new DashboardMonthValueDto(MonthLabel(m.Month), m.PrsMerged))
@@ -278,6 +278,8 @@ public class DashboardApp : ViewBase
             prevPlans);
     }
 
+    internal const int TrendDailyWindowDays = 28;
+
     internal static List<DashboardActivityMonthDto> BuildActivityMonths(
         List<(DateOnly Date, int Count)> prDays, DateTime firstMonth)
     {
@@ -290,42 +292,78 @@ public class DashboardApp : ViewBase
             var daysInMonth = DateTime.DaysInMonth(monthStart.Year, monthStart.Month);
             var offset = ((int)monthStart.DayOfWeek + 6) % 7;
             var weeks = new int[(offset + daysInMonth + 6) / 7];
+            var days = new List<DashboardActivityDayDto>(daysInMonth);
 
             for (var day = 1; day <= daysInMonth; day++)
             {
                 var date = new DateOnly(monthStart.Year, monthStart.Month, day);
-                if (byDay.TryGetValue(date, out var count))
-                    weeks[(offset + day - 1) / 7] += count;
+                var count = byDay.GetValueOrDefault(date, 0);
+                weeks[(offset + day - 1) / 7] += count;
+                days.Add(new DashboardActivityDayDto(date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), count));
             }
 
-            months.Add(new DashboardActivityMonthDto(MonthLabel(monthStart.Month), weeks.ToList()));
+            months.Add(new DashboardActivityMonthDto(MonthLabel(monthStart.Month), weeks.ToList(), days));
         }
 
         return months;
     }
 
-    internal static DashboardTrendDto BuildWeeklyTrend(DashboardActivityStats activity)
+    internal static DashboardTrendDto BuildWeeklyTrend(DashboardActivityStats activity, DateTime? todayOverride = null)
     {
+        // If daily costs or daily plans are provided, build 28 daily points for the last 4 weeks (ending today)
+        // compared to the 28 days before that.
+        if (activity.DailyCosts != null || activity.DailyPlans != null)
+        {
+            var today = (todayOverride ?? DateTime.UtcNow).Date;
+            var costsByDay = activity.DailyCosts?.ToDictionary(d => d.Date, d => (double)d.Cost) ?? [];
+            var plansByDay = activity.DailyPlans ?? [];
+
+            var labels = new List<string>(TrendDailyWindowDays);
+            var costs = new List<double>(TrendDailyWindowDays);
+            var plans = new List<double>(TrendDailyWindowDays);
+            var prevCost = new List<double?>(TrendDailyWindowDays);
+            var prevPlans = new List<double?>(TrendDailyWindowDays);
+
+            for (var i = 0; i < TrendDailyWindowDays; i++)
+            {
+                var curDate = DateOnly.FromDateTime(today.AddDays(-TrendDailyWindowDays + 1 + i));
+                var prevDate = curDate.AddDays(-TrendDailyWindowDays);
+
+                labels.Add(FormatDayLabel(curDate));
+                costs.Add(costsByDay.GetValueOrDefault(curDate, 0.0));
+                plans.Add(plansByDay.GetValueOrDefault(curDate, 0));
+
+                prevCost.Add(activity.DailyCosts != null ? costsByDay.GetValueOrDefault(prevDate, 0.0) : null);
+                prevPlans.Add(activity.DailyPlans != null ? plansByDay.GetValueOrDefault(prevDate, 0) : null);
+            }
+
+            return new DashboardTrendDto(labels, costs, plans, prevCost, prevPlans);
+        }
+
+        // Fallback for tests or mocks providing only weekly aggregation
         var all = activity.Weeks ?? [];
         var start = Math.Max(0, all.Count - TrendWeeksShown);
         var window = all.Skip(start).ToList();
 
-        var prevCost = new List<double?>(window.Count);
-        var prevPlans = new List<double?>(window.Count);
+        var fallbackPrevCost = new List<double?>(window.Count);
+        var fallbackPrevPlans = new List<double?>(window.Count);
         for (var i = 0; i < window.Count; i++)
         {
             var prevIndex = start + i - TrendWeeksShown;
-            prevCost.Add(prevIndex >= 0 && prevIndex < all.Count ? (double)all[prevIndex].Cost : null);
-            prevPlans.Add(prevIndex >= 0 && prevIndex < all.Count ? all[prevIndex].PlansCreated : null);
+            fallbackPrevCost.Add(prevIndex >= 0 && prevIndex < all.Count ? (double)all[prevIndex].Cost : null);
+            fallbackPrevPlans.Add(prevIndex >= 0 && prevIndex < all.Count ? all[prevIndex].PlansCreated : null);
         }
 
         return new DashboardTrendDto(
             window.Select(w => FormatWeekLabel(w.WeekStart)).ToList(),
             window.Select(w => (double)w.Cost).ToList(),
             window.Select(w => (double)w.PlansCreated).ToList(),
-            prevCost,
-            prevPlans);
+            fallbackPrevCost,
+            fallbackPrevPlans);
     }
+
+    private static string FormatDayLabel(DateOnly date) =>
+        $"{MonthLabel(date.Month)} {date.Day}";
 
     private static string FormatWeekLabel(DateOnly weekStart) =>
         $"{MonthLabel(weekStart.Month)} {weekStart.Day}";

--- a/src/Ivy.Tendril/Database/DashboardRepository.cs
+++ b/src/Ivy.Tendril/Database/DashboardRepository.cs
@@ -10,7 +10,7 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
     ///     How far back the daily spend series goes. Long enough to project a month from, short enough
     ///     that the COALESCE in its WHERE clause (which rules out an index only scan) stays cheap.
     /// </summary>
-    internal const int DailyCostWindowDays = 30;
+    internal const int DailyCostWindowDays = 60;
 
     private sealed class ReadLockHandle : IDisposable
     {
@@ -287,6 +287,25 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
                 }
             }
 
+            var dailyPlans = new Dictionary<DateOnly, int>();
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.CommandText = """
+                    SELECT DATE(Created) AS d, COUNT(*)
+                    FROM Plans
+                    WHERE Created >= @cutoff
+                    GROUP BY d
+                    """;
+                cmd.Parameters.AddWithValue("@cutoff",
+                    today.AddDays(-(DailyCostWindowDays - 1)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+                using var r = cmd.ExecuteReader();
+                while (r.Read())
+                {
+                    if (DateOnly.TryParse(r.GetString(0), CultureInfo.InvariantCulture, out var day))
+                        dailyPlans[day] = r.GetInt32(1);
+                }
+            }
+
             var months = new List<DashboardMonthStats>(monthsBack);
             for (var i = 0; i < monthsBack; i++)
             {
@@ -382,7 +401,7 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
                 ));
             }
 
-            return new DashboardActivityStats(months, prevWeekAvgCost, dailyCosts, weeks);
+            return new DashboardActivityStats(months, prevWeekAvgCost, dailyCosts, weeks, dailyPlans);
         }
     }
 }

--- a/src/Ivy.Tendril/Models/DashboardModels.cs
+++ b/src/Ivy.Tendril/Models/DashboardModels.cs
@@ -32,7 +32,8 @@ public record DashboardActivityStats(
     List<DashboardMonthStats> Months,
     decimal PrevWeekAvgCostPerPlan,
     List<DashboardDailyCost>? DailyCosts = null,
-    List<DashboardWeekStats>? Weeks = null
+    List<DashboardWeekStats>? Weeks = null,
+    Dictionary<DateOnly, int>? DailyPlans = null
 );
 
 public record DashboardWeekStats(


### PR DESCRIPTION
## Summary
Addresses three dashboard layout, visualization, and data granularity issues:

1. **Unified Top-Right Tabbed Widget (`[ Git Activity ] [ Pull Requests ]`)**:
   - Always renders the top-right block as a single tabbed widget with tabs `Git Activity` and `Pull Requests`.
   - Eliminates the previous split behavior where absence of an active Cloudflare tunnel caused Git Activity and Pull Requests to render as two separate, vertically stretched cards.
   - Preserves conditional rendering of the Tunnel QR code cleanly beneath the tabbed card when active.

2. **GitHub-Style Daily Git Activity Contribution Heatmap**:
   - Redesigned `ActivityGrid` to function like GitHub's contribution calendar:
     - **7 weekday rows** (Monday through Sunday) with "Mon", "Wed", "Fri" labels.
     - **Week columns** spanning history up to today, automatically scrolled to the right so the most recent weeks are immediately visible on mount.
     - **Daily square cells** shaded across 5 intensity ramp levels (`data-level="0"` to `"4"`).
     - **Month headers** placed above columns where new months start.
     - **"Less ... More" legend** in the footer.
     - **Interactive hover tooltips** displaying the formatted date (e.g. `Sunday, Sep 6, 2026`) and merged PR count.
   - Added daily PR breakdown data via `DashboardActivityDayDto` to `DashboardActivityMonthDto.Days`.

3. **28-Day Daily Resolution in Week Mode & Spline Loop Fix**:
   - **Daily Resolution**: In "Week" mode ("Last 4 weeks"), `BuildWeeklyTrend` now provides **28 daily data points** (ending today) compared against the **28 days before that** (previous 4 weeks), rather than aggregating into only 4 weekly data points.
   - **X-Axis Day Labels**: Spaced dynamically across the chart width so daily dates (e.g. `Aug 10`, `Aug 14`, `Aug 18`, ...) never collide on any screen size, while all 28 points remain on the curve and hoverable with full daily date and value in the tooltip.
   - **Catmull-Rom Spline Fix**: Corrected the sign on control point $c_2$ (`+` to `-`) and enforced monotonic $x$-clamping $[p_1.x, p_2.x]$ and baseline $y$-clamping ($\le maxY$) in `TrendChart`, eliminating the backwards spline loop artifact.
   - **Data Queries**: Extended `DailyCostWindowDays` to 60 days in `DashboardRepository` and added daily plans query to support the 4-week comparison window.

## Changes by Component

### Frontend (`Ivy.Tendril.Widgets`)
- `TendrilDashboard.tsx`: Always render the unified tabbed `[ Git Activity ] [ Pull Requests ]` card.
- `ActivityGrid.tsx`: Redesigned as a GitHub-style 7-weekday row contribution heatmap with month labels, auto-scroll, and legend.
- `dashboard.css`: Added styles for the weekday rows, month column offsets, cells, and legend.
- `TrendChart.tsx`: Fixed Catmull-Rom spline formula, enforced $x$ monotonicity and $y$ baseline clamping, and added dynamic x-axis label thinning for dense daily data.
- `types.ts`: Added `DashboardActivityDayDto` and `DashboardActivityMonthDto.days`.

### Backend (`Ivy.Tendril`)
- `TendrilDashboard.cs`: Added `DashboardActivityDayDto` and updated `DashboardActivityMonthDto` to include `Days`.
- `DashboardModels.cs`: Added optional `DailyPlans` dictionary to `DashboardActivityStats`.
- `DashboardRepository.cs`: Expanded daily window to 60 days and added daily plans created query.
- `DashboardApp.cs`: Populated `days` in `BuildActivityMonths` and constructed 28 daily points in `BuildWeeklyTrend`.

### Tests (`Ivy.Tendril.Test`)
- `DashboardAppViewModelTests.cs`: Added unit tests verifying 28-day daily points generation, day-of-week comparison matching, and daily activity breakdown.

## Verification
- `npx vitest run`: All 320 frontend tests passed.
- `npm run build`: Frontend widget bundle built cleanly.
- `dotnet build`: 0 Warnings, 0 Errors.
- `dotnet test --filter "FullyQualifiedName~Dashboard"`: All 44 dashboard tests passed.
- `dotnet test --filter "FullyQualifiedName~PlanDatabaseService"`: All 81 database tests passed.