### PR TITLE
feat(settings): gate issue trackers behind beta flag

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Settings/SettingsAppTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Settings/SettingsAppTests.cs
@@ -1,0 +1,57 @@
+using Ivy.Tendril.Apps.Settings;
+using Xunit;
+
+namespace Ivy.Tendril.Test.Apps.Settings;
+
+public class SettingsAppTests
+{
+    [Fact]
+    public void BuildSections_WhenBetaFalse_DoesNotIncludeIssueTrackersOrVault()
+    {
+        var sections = SettingsApp.BuildSections(isBeta: false);
+
+        Assert.DoesNotContain(sections, s => s.Tag == SettingsApp.TagIssueTrackers);
+        Assert.DoesNotContain(sections, s => s.Tag == SettingsApp.TagVault);
+    }
+
+    [Fact]
+    public void BuildSections_WhenBetaTrue_IncludesIssueTrackersAndVault()
+    {
+        var sections = SettingsApp.BuildSections(isBeta: true);
+
+        Assert.Contains(sections, s => s.Tag == SettingsApp.TagIssueTrackers && s.Label == "Issue Trackers");
+        Assert.Contains(sections, s => s.Tag == SettingsApp.TagVault && s.Label == "Team Vault");
+    }
+
+    [Fact]
+    public void ResolveTagContent_WhenBetaFalse_IssueTrackersFallsBackToDefault()
+    {
+        var view = SettingsApp.ResolveTagContent(SettingsApp.TagIssueTrackers, isBeta: false);
+
+        Assert.IsType<CodingAgentSetupView>(view);
+    }
+
+    [Fact]
+    public void ResolveTagContent_WhenBetaTrue_IssueTrackersReturnsIssueTrackersSetupView()
+    {
+        var view = SettingsApp.ResolveTagContent(SettingsApp.TagIssueTrackers, isBeta: true);
+
+        Assert.IsType<IssueTrackersSetupView>(view);
+    }
+
+    [Fact]
+    public void ResolveTagContent_WhenBetaFalse_VaultFallsBackToDefault()
+    {
+        var view = SettingsApp.ResolveTagContent(SettingsApp.TagVault, isBeta: false);
+
+        Assert.IsType<CodingAgentSetupView>(view);
+    }
+
+    [Fact]
+    public void ResolveTagContent_WhenBetaTrue_VaultReturnsVaultSetupView()
+    {
+        var view = SettingsApp.ResolveTagContent(SettingsApp.TagVault, isBeta: true);
+
+        Assert.IsType<VaultSetupView>(view);
+    }
+}

--- a/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/ProjectDetailView.cs
@@ -412,10 +412,13 @@ public class ProjectDetailView(
             | new ProjectRepoPickerView(repos, onAdd: cloneRemoteOnAdd, showBaseBranchPicker: true)
 
             // Section 3: Issue Trackers
-            | Text.H4("Issue Trackers").Bold()
-            | trackersContent
-            | (Layout.Horizontal().AlignContent(Align.Left)
-                | new Button("Add Issue Tracker").Icon(Icons.Plus).Outline().OnClick(() => openProjectTrackerDialog(null)))
+            | (isBeta
+                ? (object)(Layout.Vertical()
+                    | Text.H4("Issue Trackers").Bold()
+                    | trackersContent
+                    | (Layout.Horizontal().AlignContent(Align.Left)
+                        | new Button("Add Issue Tracker").Icon(Icons.Plus).Outline().OnClick(() => openProjectTrackerDialog(null))))
+                : null!)
 
             // Section 4: Review Actions
             | Text.H4("Review Actions").Bold()

--- a/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
+++ b/src/Ivy.Tendril/Apps/Settings/SettingsApp.cs
@@ -19,8 +19,8 @@ public class SettingsApp : ViewBase
     private const string TagLevels = "levels";
     private const string TagPromptwares = "promptwares";
     internal const string TagProjects = "projects";
-    private const string TagIssueTrackers = "issue-trackers";
-    private const string TagVault = "vault";
+    internal const string TagIssueTrackers = "issue-trackers";
+    internal const string TagVault = "vault";
     private const string TagTunnel = "tunnel";
     private const string TagAdvanced = "advanced";
     private const string TagNewsletter = "newsletter";
@@ -62,29 +62,7 @@ public class SettingsApp : ViewBase
         var projects = config.Settings.Projects;
         var selectedTag = selected.Value;
 
-        var sections = new List<(string Label, string Tag, Icons Icon)>
-        {
-            ("Coding Agent", TagCodingAgent, Icons.Bot),
-            ("Plans", TagPlans, Icons.Feather),
-            ("Appearance", TagAppearance, Icons.Sun),
-            ("Projects", TagProjects, Icons.Folder),
-        };
-
-        if (isBeta)
-        {
-            sections.Add(("Team Vault", TagVault, Icons.FolderGit2));
-        }
-
-        sections.AddRange(new (string Label, string Tag, Icons Icon)[]
-        {
-            ("Promptwares", TagPromptwares, Icons.Wand),
-            ("Issue Trackers", TagIssueTrackers, Icons.SquareCheck),
-            ("Levels", TagLevels, Icons.ListOrdered),
-            ("Notifications", TagNotifications, Icons.Bell),
-            ("Security & Tunneling", TagSecurity, Icons.Lock),
-            ("Advanced", TagAdvanced, Icons.Cog),
-            ("Newsletter", TagNewsletter, Icons.Mail),
-        });
+        var sections = BuildSections(isBeta);
 
         var rows = new List<object>
         {
@@ -129,7 +107,12 @@ public class SettingsApp : ViewBase
         }
 
         rows.Add(SidebarListRow.Build("Promptwares", Icons.Wand, () => selected.Set(TagPromptwares), selectedTag == TagPromptwares));
-        rows.Add(SidebarListRow.Build("Issue Trackers", Icons.SquareCheck, () => selected.Set(TagIssueTrackers), selectedTag == TagIssueTrackers));
+
+        if (isBeta)
+        {
+            rows.Add(SidebarListRow.Build("Issue Trackers", Icons.SquareCheck, () => selected.Set(TagIssueTrackers), selectedTag == TagIssueTrackers));
+        }
+
         rows.Add(SidebarListRow.Build("Levels", Icons.ListOrdered, () => selected.Set(TagLevels), selectedTag == TagLevels));
         rows.Add(SidebarListRow.Build("Notifications", Icons.Bell, () => selected.Set(TagNotifications), selectedTag == TagNotifications));
         rows.Add(SidebarListRow.Build("Security & Tunneling", Icons.Lock, () => selected.Set(TagSecurity), selectedTag == TagSecurity || selectedTag == TagTunnel));
@@ -171,25 +154,11 @@ public class SettingsApp : ViewBase
         }
         else
         {
-            content = selectedTag switch
-            {
-                TagCodingAgent => new CodingAgentSetupView(),
-                TagPlans => new PlansSetupView(),
-                TagAppearance => new AppearanceSetupView(),
-                TagNotifications => new NotificationsSetupView(),
-                TagSecurity => new SecuritySetupView(),
-                TagTunnel => new SecuritySetupView(),
-                TagLevels => new LevelsSetupView(),
-                TagPromptwares => new PromptwaresSetupView(),
-                TagIssueTrackers => new IssueTrackersSetupView(),
-                TagVault when isBeta => new VaultSetupView(),
-                TagProjects => projects.Count > 0
+            content = selectedTag == TagProjects
+                ? (projects.Count > 0
                     ? new ProjectDetailView(0, projects, config, client, refreshToken).Key($"project:{projects[0].Name}")
-                    : new CodingAgentSetupView(),
-                TagAdvanced => new AdvancedSetupView(),
-                TagNewsletter => new NewsletterSetupView(),
-                _ => new CodingAgentSetupView()
-            };
+                    : new CodingAgentSetupView())
+                : ResolveTagContent(selectedTag, isBeta);
         }
 
         var currentLabel = sections.FirstOrDefault(s => s.Tag == selected.Value).Label ?? "Configuration";
@@ -209,4 +178,55 @@ public class SettingsApp : ViewBase
 
         return new SidebarLayout(contentWithMobileHeader, sidebar);
     }
+
+    internal static List<(string Label, string Tag, Icons Icon)> BuildSections(bool isBeta)
+    {
+        var sections = new List<(string Label, string Tag, Icons Icon)>
+        {
+            ("Coding Agent", TagCodingAgent, Icons.Bot),
+            ("Plans", TagPlans, Icons.Feather),
+            ("Appearance", TagAppearance, Icons.Sun),
+            ("Projects", TagProjects, Icons.Folder),
+        };
+
+        if (isBeta)
+        {
+            sections.Add(("Team Vault", TagVault, Icons.FolderGit2));
+        }
+
+        sections.Add(("Promptwares", TagPromptwares, Icons.Wand));
+
+        if (isBeta)
+        {
+            sections.Add(("Issue Trackers", TagIssueTrackers, Icons.SquareCheck));
+        }
+
+        sections.AddRange(new (string Label, string Tag, Icons Icon)[]
+        {
+            ("Levels", TagLevels, Icons.ListOrdered),
+            ("Notifications", TagNotifications, Icons.Bell),
+            ("Security & Tunneling", TagSecurity, Icons.Lock),
+            ("Advanced", TagAdvanced, Icons.Cog),
+            ("Newsletter", TagNewsletter, Icons.Mail),
+        });
+
+        return sections;
+    }
+
+    internal static object ResolveTagContent(string selectedTag, bool isBeta) => selectedTag switch
+    {
+        TagCodingAgent => new CodingAgentSetupView(),
+        TagPlans => new PlansSetupView(),
+        TagAppearance => new AppearanceSetupView(),
+        TagNotifications => new NotificationsSetupView(),
+        TagSecurity => new SecuritySetupView(),
+        TagTunnel => new SecuritySetupView(),
+        TagLevels => new LevelsSetupView(),
+        TagPromptwares => new PromptwaresSetupView(),
+        TagIssueTrackers when isBeta => new IssueTrackersSetupView(),
+        TagVault when isBeta => new VaultSetupView(),
+        TagAdvanced => new AdvancedSetupView(),
+        TagNewsletter => new NewsletterSetupView(),
+        _ => new CodingAgentSetupView()
+    };
 }


### PR DESCRIPTION
## Summary of Changes

Gates the Issue Trackers feature behind the `BetaHelper.IsBeta(...)` flag so that non-beta users do not see the Issue Trackers navigation or configuration.

### Key Changes
1. **SettingsApp (`SettingsApp.cs`)**:
   - `TagIssueTrackers` ("issue-trackers") is now conditionally included in `sections` and `rows` only when `isBeta` is `true`.
   - The content resolution switch (`ResolveTagContent`) now guards `TagIssueTrackers when isBeta => new IssueTrackersSetupView()`. When `isBeta` is `false`, it falls back safely to `CodingAgentSetupView`.
   - Extracted `BuildSections` and `ResolveTagContent` as internal static helpers to enable isolated unit testing.

2. **Project Detail View (`ProjectDetailView.cs`)**:
   - Section 3 ("Issue Trackers") is now conditionally rendered only when `isBeta` is `true`, matching Sections 6-8 (Agent Behavior, Local Permissions, Customizations).

3. **Unit Tests (`SettingsAppTests.cs`)**:
   - Added unit tests verifying:
     - `BuildSections` excludes `TagIssueTrackers` and `TagVault` when `isBeta == false`.
     - `BuildSections` includes `TagIssueTrackers` and `TagVault` when `isBeta == true`.
     - `ResolveTagContent` falls back to default view when `isBeta == false`.
     - `ResolveTagContent` resolves `IssueTrackersSetupView` when `isBeta == true`.
     - `ResolveTagContent` resolves `VaultSetupView` when `isBeta == true` and falls back when `false`.

## Verification
- `dotnet build src/Ivy.Tendril/Ivy.Tendril.csproj`: 0 warnings, 0 errors.
- `dotnet test src/Ivy.Tendril.Test/Ivy.Tendril.Test.csproj`: all 3,124 unit tests pass.
- Adheres to layout and spacing guidelines (no custom `.Gap`, `.Margin`, `.Padding`, or `.WithMargin`).
