### PR TITLE
[00042] Remove Icon from Vault Section

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/VaultSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/VaultSetupView.cs
@@ -314,7 +314,6 @@ public class VaultSetupView : ViewBase
             {
                 var url = !string.IsNullOrEmpty(status.RepoUrl) ? status.RepoUrl : $"https://github.com/{repo}";
                 return Layout.Horizontal().AlignContent(Align.Left)
-                    | Icons.FolderGit2.ToIcon()
                     | new Button(repo).Link().Small().OnClick(() => client.OpenUrl(url))
                     | new Button().Icon(Icons.ExternalLink).Ghost().Small().Tooltip("Open on GitHub").OnClick(() => client.OpenUrl(url));
             }))


### PR DESCRIPTION
Fixes #2369

# Summary

## Changes

Removed the redundant `Icons.FolderGit2` icon from the Vault details row builder in the Team Vault settings view. Only the repository link button and external link icon button are now displayed in the Vault row.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Settings/VaultSetupView.cs`: Removed the folder git icon from the Vault row details layout.

## Manual Testing

1. Launch Tendril: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`
2. Navigate to Settings -> Team Vault.
3. Observe the Vault details table: the Vault row should display the repository button and external link button without a folder git icon preceding them.

---
* d0abda4c Plan 00042: Remove icon from Vault section

---
Created using [Ivy Tendril](https://ivy.app).