### PR TITLE
[00044] Scroll to Selected Question When Navigating Adjacent Questions

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx
@@ -565,6 +565,94 @@ describe("DraftMarkdown interactive questions", () => {
     expect(scrollTo).toHaveBeenCalledTimes(2);
   });
 
+  it("scrolls to the enclosing block for the first question and directly to the question for subsequent questions", () => {
+    const scrollTo = vi.fn();
+    Element.prototype.scrollTo = scrollTo as unknown as Element["scrollTo"];
+
+    const { container, rerender } = render(
+      <DraftMarkdown id="w1" content={TWO_QUESTIONS} events={["OnAnswersChange"]} eventHandler={vi.fn()} />,
+    );
+
+    const shell = container.querySelector(".pmv-shell");
+    const block = container.querySelector(".pmv-questions");
+    const q1 = container.querySelector('[data-question-id="naming"]');
+    const q2 = container.querySelector('[data-question-id="owner"]');
+
+    expect(shell).not.toBeNull();
+    expect(block).not.toBeNull();
+    expect(q1).not.toBeNull();
+    expect(q2).not.toBeNull();
+
+    vi.spyOn(shell!, "getBoundingClientRect").mockReturnValue({
+      top: 50,
+      bottom: 500,
+      left: 0,
+      right: 500,
+      width: 500,
+      height: 450,
+      x: 0,
+      y: 50,
+      toJSON: () => {},
+    });
+
+    vi.spyOn(block!, "getBoundingClientRect").mockReturnValue({
+      top: 100,
+      bottom: 400,
+      left: 0,
+      right: 500,
+      width: 500,
+      height: 300,
+      x: 0,
+      y: 100,
+      toJSON: () => {},
+    });
+
+    vi.spyOn(q1!, "getBoundingClientRect").mockReturnValue({
+      top: 130,
+      bottom: 230,
+      left: 0,
+      right: 500,
+      width: 500,
+      height: 100,
+      x: 0,
+      y: 130,
+      toJSON: () => {},
+    });
+
+    vi.spyOn(q2!, "getBoundingClientRect").mockReturnValue({
+      top: 250,
+      bottom: 350,
+      left: 0,
+      right: 500,
+      width: 500,
+      height: 100,
+      x: 0,
+      y: 250,
+      toJSON: () => {},
+    });
+
+    const draw = (target: { questionId: string; token: number } | null) =>
+      rerender(
+        <DraftMarkdown
+          id="w1"
+          content={TWO_QUESTIONS}
+          events={["OnAnswersChange"]}
+          eventHandler={vi.fn()}
+          scrollTo={target}
+        />,
+      );
+
+    // Navigating to the first question targets the block:
+    // delta = block.top (100) - shell.top (50) - 16 = 34
+    draw({ questionId: "naming", token: 1 });
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 34, behavior: "smooth" });
+
+    // Navigating to the second question targets q2 directly:
+    // delta = q2.top (250) - shell.top (50) - 16 = 184
+    draw({ questionId: "owner", token: 2 });
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 184, behavior: "smooth" });
+  });
+
   it("still wraps an ordinary fence in its code block after the pre override", () => {
     const { container } = renderInteractive("```js\nconst x = 1;\n```");
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.tsx
@@ -203,11 +203,14 @@ export const PlanMarkdown: React.FC<PlanMarkdownProps> = ({
     );
     if (!question) return;
 
-    // Scroll the whole block, not just the question: a question is only answerable in the context
-    // of the fence it sits in, and landing mid-block hides that.
-    const block = question.closest(QUESTIONS_SELECTOR) ?? question;
+    // Scroll the whole block if this is the first question in the fence (to frame its border,
+    // padding, and actions). For subsequent questions in the block, scroll directly to the
+    // question element so it is positioned at the top.
+    const block = question.closest(QUESTIONS_SELECTOR);
+    const isFirstQuestionInBlock = block ? block.querySelector("[data-question-id]") === question : true;
+    const target = isFirstQuestionInBlock && block ? block : question;
     const margin = 16;
-    const delta = block.getBoundingClientRect().top - shell.getBoundingClientRect().top - margin;
+    const delta = target.getBoundingClientRect().top - shell.getBoundingClientRect().top - margin;
 
     // The widget owns its own scroll, so move that rather than calling scrollIntoView, which would
     // also drag every scrollable ancestor of the host page along with it.


### PR DESCRIPTION
Fixes #2373

# Summary

## Changes

Updated the scroll target resolution in the `PlanMarkdown` widget so that clicking on subsequent questions within a multi-question block scrolls directly to that question element instead of always targeting the outer block container. This ensures that navigating to adjacent questions after the first question properly scrolls down to display the selected question and its options.

## API Changes

None.

## Files Modified

- Frontend:
  - `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.tsx`: Updated `scrollTo` effect logic to scroll to `block` if the question is the first question in the block, or to `question` directly for subsequent questions.
  - `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx`: Added unit test verifying that navigating to the first question in a block targets the block container and navigating to subsequent questions targets the question element directly.

## Manual Testing

1. Launch Tendril and navigate to a plan that has multiple questions in a single questions fence (e.g. Q1 and Q2).
2. Click on the first question (Q1) in the Questions card; observe that the viewport scrolls to frame the questions block and Q1.
3. Click on the second question (Q2) in the Questions card.
4. Observe that the viewport scrolls down so that Q2, its title, and options are visible with top margin, rather than remaining stuck at Q1.
5. Click back on Q1; observe that the viewport scrolls back up to frame the questions block and Q1.

---

### Commits

- `bb8476ca` Scroll to selected question when navigating adjacent questions (Plan 00044)

---
Created using [Ivy Tendril](https://ivy.app).
