### PR TITLE
[00043] Isolate Sidebar Collapsed State Per Client

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/TendrilShell.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/TendrilShell.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { TendrilShell, SIDEBAR_COLLAPSED_STORAGE_KEY } from "./TendrilShell";
+import { useShell } from "./ShellContext";
+
+const ToggleButton = () => {
+  const { collapsed, toggle } = useShell();
+  return (
+    <button onClick={toggle} data-testid="toggle-btn">
+      {collapsed ? "Expand" : "Collapse"}
+    </button>
+  );
+};
+
+describe("TendrilShell", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("TendrilShell respects localStorage on mount", () => {
+    window.localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, "true");
+    const { container } = render(
+      <TendrilShell
+        id="shell-1"
+        collapsed={false}
+        eventHandler={vi.fn()}
+      />
+    );
+    const root = container.querySelector(".tsh-root");
+    expect(root).toHaveAttribute("data-collapsed", "true");
+
+    window.localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, "false");
+    const { container: container2 } = render(
+      <TendrilShell
+        id="shell-2"
+        collapsed={true}
+        eventHandler={vi.fn()}
+      />
+    );
+    const root2 = container2.querySelector(".tsh-root");
+    expect(root2).toHaveAttribute("data-collapsed", "false");
+  });
+
+  it("TendrilShell falls back to collapsed prop when localStorage is empty", () => {
+    const { container: container1 } = render(
+      <TendrilShell
+        id="shell-1"
+        collapsed={false}
+        eventHandler={vi.fn()}
+      />
+    );
+    expect(container1.querySelector(".tsh-root")).toHaveAttribute("data-collapsed", "false");
+
+    const { container: container2 } = render(
+      <TendrilShell
+        id="shell-2"
+        collapsed={true}
+        eventHandler={vi.fn()}
+      />
+    );
+    expect(container2.querySelector(".tsh-root")).toHaveAttribute("data-collapsed", "true");
+  });
+
+  it("TendrilShell writes to localStorage and notifies server on toggle", () => {
+    const eventHandler = vi.fn();
+    const { container } = render(
+      <TendrilShell
+        id="shell-1"
+        collapsed={false}
+        events={["OnCollapsedChanged"]}
+        eventHandler={eventHandler}
+        slots={{
+          SidebarHeader: <ToggleButton />,
+        }}
+      />
+    );
+
+    const root = container.querySelector(".tsh-root");
+    expect(root).toHaveAttribute("data-collapsed", "false");
+    expect(window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBeNull();
+
+    fireEvent.click(screen.getByTestId("toggle-btn"));
+
+    expect(root).toHaveAttribute("data-collapsed", "true");
+    expect(window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe("true");
+    expect(eventHandler).toHaveBeenCalledWith("OnCollapsedChanged", "shell-1", [true]);
+
+    fireEvent.click(screen.getByTestId("toggle-btn"));
+
+    expect(root).toHaveAttribute("data-collapsed", "false");
+    expect(window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY)).toBe("false");
+    expect(eventHandler).toHaveBeenCalledWith("OnCollapsedChanged", "shell-1", [false]);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/Shell/TendrilShell.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/Shell/TendrilShell.tsx
@@ -3,6 +3,27 @@ import { ShellContext } from "./ShellContext";
 import { ShellWidgetProps, isModKey } from "./types";
 import "./shell.css";
 
+export const SIDEBAR_COLLAPSED_STORAGE_KEY = "tendril.shell.sidebarCollapsed";
+
+const readStoredCollapsed = (): boolean | null => {
+  try {
+    const raw = window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY);
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredCollapsed = (collapsed: boolean) => {
+  try {
+    window.localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, String(collapsed));
+  } catch {
+    /* storage unavailable (private mode, sandboxed host): the state just doesn't persist */
+  }
+};
+
 interface TendrilShellProps extends ShellWidgetProps {
   collapsed?: boolean;
   activeSessionIndex?: number | null;
@@ -23,8 +44,8 @@ interface TendrilShellProps extends ShellWidgetProps {
  * bordered container holding the white content surface with the session tab
  * strip inside its bottom edge. Collapse is client-side for a smooth
  * animation; the server is notified through OnCollapsedChanged so the state
- * can be persisted. Session panes all stay mounted — only the active one is
- * visible — so agent terminals keep their buffers when switching tabs. The
+ * can be persisted in session. Session panes all stay mounted - only the active one is
+ * visible - so agent terminals keep their buffers when switching tabs. The
  * Hidden slot hosts zero-size utility widgets (shortcut ghosts, chunk
  * warm-ups) without letting them paint.
  */
@@ -37,7 +58,10 @@ export const TendrilShell: React.FC<TendrilShellProps> = ({
   hasTabs = false,
   slots,
 }) => {
-  const [collapsed, setCollapsed] = useState(collapsedProp);
+  const [collapsed, setCollapsed] = useState(() => {
+    const stored = readStoredCollapsed();
+    return stored != null ? stored : collapsedProp;
+  });
   const prevPropRef = useRef(collapsedProp);
   if (collapsedProp !== prevPropRef.current) {
     prevPropRef.current = collapsedProp;
@@ -47,6 +71,7 @@ export const TendrilShell: React.FC<TendrilShellProps> = ({
   const toggle = useCallback(() => {
     setCollapsed((prev) => {
       const next = !prev;
+      writeStoredCollapsed(next);
       if (events.includes("OnCollapsedChanged")) {
         eventHandler("OnCollapsedChanged", id, [next]);
       }

--- a/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
+++ b/src/Ivy.Tendril/AppShell/TendrilAppShell.cs
@@ -311,7 +311,6 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             void OnSettingsReloaded(object? sender, EventArgs e)
             {
                 menuItems.Set(BuildMenuItems(appRepository, status.Value, agentRunner, shareContext.IsShareMode));
-                sidebarOpen.Set(config.Settings.SidebarOpen);
                 TendrilThemes.ApplyTheme(client, config.Settings.Theme);
                 TendrilThemes.ApplyThemeMode(client, config.Settings.ThemeMode);
             }
@@ -842,8 +841,6 @@ public class TendrilAppShell(AppShellSettings settings) : ViewBase
             .OnCollapsedChanged(collapsed =>
             {
                 sidebarOpen.Set(!collapsed);
-                config.Settings.SidebarOpen = !collapsed;
-                config.SaveSettings();
             });
 
         return new Fragment(


### PR DESCRIPTION
Fixes #2370

# Summary

## Changes

Decoupled the sidebar collapse and expand state from global configuration so that collapsing the sidebar in one client does not affect other connected clients or tunnel sessions. Persisted the collapsed state per client in browser localStorage, allowing each browser session to remember its own sidebar preference independently while preserving initial server-configured defaults.

## API Changes

None.

## Files Modified

- **Backend**:
  - `src/Ivy.Tendril/AppShell/TendrilAppShell.cs`: Removed mutation of `config.Settings.SidebarOpen` and call to `config.SaveSettings()` on collapse toggle, and stopped resetting local session state on `SettingsReloaded`.
- **Frontend**:
  - `src/Ivy.Tendril.Widgets/frontend/src/Shell/TendrilShell.tsx`: Added localStorage persistence (`SIDEBAR_COLLAPSED_STORAGE_KEY`) for client-side sidebar state.
  - `src/Ivy.Tendril.Widgets/frontend/src/Shell/TendrilShell.test.tsx`: Added unit test suite verifying localStorage initialization, fallback behavior, and toggle updates.

## Manual Testing

1. Launch the Tendril application (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj`).
2. Open the application in two separate browser windows or tabs (e.g., Tab A and Tab B).
3. In Tab A, collapse the sidebar by clicking the toggle button or pressing Cmd+B / Ctrl+B.
4. Verify that Tab A's sidebar collapses, while Tab B's sidebar remains open and unchanged.
5. Refresh Tab A and verify that its sidebar remains collapsed (persisted via localStorage).
6. In Tab B, collapse the sidebar and refresh; verify both tabs maintain their own independent state.

---

### Commits

- `65752008` Persist sidebar collapsed state per client in localStorage (Plan 00043)
- `25f645a0` Decouple sidebar collapse events from global config (Plan 00043)

---
Created using [Ivy Tendril](https://ivy.app).
