### PR TITLE
[00046] Add Average Reference Line to Dashboard Trend Charts

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import {
   TendrilDashboardProps,
+  computeAverage,
   formatCountTick,
   formatCurrencyTick,
   hasSlotContent,
@@ -107,6 +108,8 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
             formatTick: formatCountTick,
             formatValue: formatPlansValue,
           };
+
+  const average = trendData ? computeAverage(trendData.values) : null;
 
   return (
     <div className="tdb-root remove-parent-padding">
@@ -211,6 +214,12 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
                       <span className="tdb-legend-dash" />
                       {previousTrendName}
                     </span>
+                    {average != null && (
+                      <span className="tdb-legend-item tdb-legend-avg">
+                        <span className="tdb-legend-dash tdb-legend-dash-avg" />
+                        Avg {trendData.formatValue(average)}
+                      </span>
+                    )}
                   </div>
                 </div>
                 <div className="tdb-trend-chart">
@@ -222,6 +231,7 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
                     previousName={previousTrendName}
                     formatTick={trendData.formatTick}
                     formatValue={trendData.formatValue}
+                    average={average}
                   />
                 </div>
               </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx
@@ -1,5 +1,5 @@
 import React, { useId, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { niceTicks } from "./types";
+import { computeAverage, niceTicks } from "./types";
 
 interface TrendChartProps {
   labels: string[];
@@ -9,6 +9,7 @@ interface TrendChartProps {
   previousName: string;
   formatTick: (value: number) => string;
   formatValue: (value: number) => string;
+  average?: number | null;
 }
 
 interface Point {
@@ -58,6 +59,7 @@ export const TrendChart: React.FC<TrendChartProps> = ({
   previousName,
   formatTick,
   formatValue,
+  average,
 }) => {
   const wrapRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ width: 0, height: DEFAULT_HEIGHT });
@@ -112,6 +114,12 @@ export const TrendChart: React.FC<TrendChartProps> = ({
   }, [values, previous, n, plotLeft, plotWidth, zeroY, plotHeight]);
 
   const scaleTop = ticks[ticks.length - 1];
+
+  const avgValue = average !== undefined ? average : computeAverage(values);
+  const avgY =
+    avgValue != null && avgValue > 0 && scaleTop > 0
+      ? zeroY - (avgValue / scaleTop) * plotHeight
+      : null;
 
   const areaPath = useMemo(() => {
     if (points.length < 2) return "";
@@ -184,6 +192,15 @@ export const TrendChart: React.FC<TrendChartProps> = ({
             );
           })}
           {areaPath && <path d={areaPath} fill={`url(#${gradientId})`} style={{ color: "var(--tdb-fg)" }} />}
+          {avgY != null && (
+            <line
+              className="tdb-trend-avg-line"
+              x1={plotLeft}
+              x2={plotLeft + plotWidth}
+              y1={avgY}
+              y2={avgY}
+            />
+          )}
           {previousPoints.length > 1 && <path className="tdb-trend-compare" d={smoothPath(previousPoints, zeroY)} />}
           {points.length > 1 && <path className="tdb-trend-line" d={smoothPath(points, zeroY)} />}
           {hover && (

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
@@ -374,6 +374,14 @@
   flex-shrink: 0;
 }
 
+.tdb-legend-dash-avg {
+  width: 10px;
+  height: 0;
+  border-top: 1.5px dashed var(--tdb-muted);
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
 .tdb-trend-chart {
   margin-top: 16px;
   flex: 1;
@@ -421,6 +429,15 @@
   stroke-dasharray: 5 4;
   stroke-linecap: round;
   stroke-linejoin: round;
+}
+
+.tdb-trend-avg-line {
+  fill: none;
+  stroke: var(--tdb-muted);
+  stroke-width: 1;
+  stroke-dasharray: 4 4;
+  opacity: 0.45;
+  pointer-events: none;
 }
 
 .tdb-chart-tooltip {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
@@ -31,3 +31,15 @@ describe("dashboard.css KPI grid", () => {
     expect(css).toMatch(/\.tdb-kpi-hint\s*\{[^}]*opacity: 0\.7;/);
   });
 });
+
+describe("dashboard.css trend chart average line and legend", () => {
+  it("defines the dashed average legend indicator", () => {
+    expect(css).toContain(".tdb-legend-dash-avg {");
+    expect(css).toMatch(/\.tdb-legend-dash-avg\s*\{[^}]*border-top:\s*1\.5px dashed/);
+  });
+
+  it("defines the subtle dashed horizontal reference line", () => {
+    expect(css).toContain(".tdb-trend-avg-line {");
+    expect(css).toMatch(/\.tdb-trend-avg-line\s*\{[^}]*stroke-dasharray:\s*4 4/);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/helpers.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  computeAverage,
   formatCountTick,
   formatCurrencyTick,
   niceTicks,
@@ -43,5 +44,25 @@ describe("tick formatters", () => {
   it("abbreviates thousands as counts", () => {
     expect(formatCountTick(1500)).toBe("2K");
     expect(formatCountTick(150)).toBe("150");
+  });
+});
+
+describe("computeAverage", () => {
+  it("computes arithmetic mean for integer arrays", () => {
+    expect(computeAverage([10, 20, 30])).toBe(20);
+    expect(computeAverage([5])).toBe(5);
+  });
+
+  it("computes arithmetic mean for decimal arrays", () => {
+    expect(computeAverage([1.5, 2.5, 5.0])).toBe(3);
+  });
+
+  it("handles arrays with zeroes", () => {
+    expect(computeAverage([0, 0, 0])).toBe(0);
+    expect(computeAverage([0, 10])).toBe(5);
+  });
+
+  it("returns null for empty arrays", () => {
+    expect(computeAverage([])).toBeNull();
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
@@ -103,3 +103,10 @@ export const formatCountTick = (value: number): string => {
   if (value >= 1000) return `${Math.round(value / 1000)}K`;
   return String(Math.round(value));
 };
+
+/** Arithmetic mean of non-empty number arrays, returning null when empty. */
+export const computeAverage = (values: number[]): number | null => {
+  if (!values || values.length === 0) return null;
+  const sum = values.reduce((acc, val) => acc + val, 0);
+  return sum / values.length;
+};


### PR DESCRIPTION
# Summary

## Changes

Added period average calculation and visual reference line indicator to Tendril Dashboard trend charts. Users can now see a subtle dashed horizontal reference line across the trend plot along with an average metric pill in the chart legend for both cost and plan metrics across monthly and weekly periods.

## API Changes

- Exported helper function `computeAverage(values: number[]): number | null` in `Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts`.
- Added optional property `average?: number | null` to `TrendChartProps` in `Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx`.

## Files Modified

- Frontend Components:
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts`: added `computeAverage` helper.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx`: added `average` prop support, vertical coordinate calculation, and SVG reference line rendering.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx`: calculated average from trend data, passed prop to `TrendChart`, and added legend item.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css`: styled `.tdb-legend-dash-avg` and `.tdb-trend-avg-line`.
- Tests:
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/helpers.test.ts`: added unit tests for `computeAverage`.
  - `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts`: added style verification tests for average line and legend dash.

## Manual Testing

1. Launch Tendril application or run the widgets dev environment (`cd src/Ivy.Tendril.Widgets/frontend && vp dev`).
2. Navigate to the Tendril Dashboard view.
3. Observe the trend chart under Total Cost and Total Plans:
   - Notice the dashed horizontal reference line rendered across the chart.
   - Notice the "Avg $X" or "Avg X plans" indicator in the legend.
4. Toggle between "Month" and "Week" granularity and verify the average reference line and legend update to reflect the selected period's average.

---
## Commits
- 87454010 Plan 00046: Add average reference line to Dashboard trend charts

---
Created using [Ivy Tendril](https://ivy.app).
