### PR TITLE
[00047] Fix Git Activity Card Layout and Dead Space in Dashboard

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ActivityGrid } from "./ActivityGrid";
+
+describe("ActivityGrid summary metrics", () => {
+  it("renders total merged PRs and active weeks", () => {
+    const months = [
+      { label: "Jan", weeks: [0, 2, 0, 1] },
+      { label: "Feb", weeks: [3, 0, 0, 0] },
+    ];
+    render(<ActivityGrid months={months} />);
+
+    expect(screen.getByText("6")).toBeInTheDocument();
+    expect(screen.getByText("PRs merged")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByText("Active weeks")).toBeInTheDocument();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.tsx
@@ -1,5 +1,9 @@
 import React, { useLayoutEffect, useMemo, useRef } from "react";
-import { DashboardActivityMonthDto, rampLevel } from "./types";
+import {
+  computeActivityMetrics,
+  DashboardActivityMonthDto,
+  rampLevel,
+} from "./types";
 import { HoverTip, useHoverTip } from "./HoverTip";
 
 interface ActivityGridProps {
@@ -24,6 +28,11 @@ const WEEKDAYS = ["Mon", "", "Wed", "", "Fri", "", ""];
 export const ActivityGrid: React.FC<ActivityGridProps> = ({ months }) => {
   const { wrapRef, tip, showTip, hideTip } = useHoverTip();
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  const { totalPrs, activeWeeks } = useMemo(
+    () => computeActivityMetrics(months),
+    [months],
+  );
 
   // Extract all daily records across the months
   const allDays = useMemo(() => {
@@ -201,6 +210,16 @@ export const ActivityGrid: React.FC<ActivityGridProps> = ({ months }) => {
             <div className="tdb-activity-cell" data-level={3} />
             <div className="tdb-activity-cell" data-level={4} />
             <span>More</span>
+          </div>
+        </div>
+        <div className="tdb-activity-metrics">
+          <div className="tdb-activity-metric">
+            <span className="tdb-activity-metric-value">{totalPrs}</span>
+            <span className="tdb-activity-metric-label">PRs merged</span>
+          </div>
+          <div className="tdb-activity-metric">
+            <span className="tdb-activity-metric-value">{activeWeeks}</span>
+            <span className="tdb-activity-metric-label">Active weeks</span>
           </div>
         </div>
       </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
@@ -481,7 +481,6 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
   min-height: 0;
 }
 
@@ -489,7 +488,6 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
   margin-top: 16px;
   min-height: 0;
 }
@@ -501,6 +499,7 @@
   flex-direction: column;
   gap: 8px;
   width: 100%;
+  flex: 1;
 }
 
 .tdb-activity-scroll {
@@ -607,6 +606,32 @@
 .tdb-activity-legend .tdb-activity-cell {
   width: 9px;
   height: 9px;
+}
+
+.tdb-activity-metrics {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-top: auto;
+  padding-top: 16px;
+  border-top: 1px solid var(--tdb-divider);
+}
+
+.tdb-activity-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tdb-activity-metric-value {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--tdb-fg);
+}
+
+.tdb-activity-metric-label {
+  font-size: 12px;
+  color: var(--tdb-muted);
 }
 
 .tdb-empty-note {

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
@@ -31,3 +31,25 @@ describe("dashboard.css KPI grid", () => {
     expect(css).toMatch(/\.tdb-kpi-hint\s*\{[^}]*opacity: 0\.7;/);
   });
 });
+
+describe("dashboard.css side block and git activity layout", () => {
+  it("top-aligns side body and tip wrap by omitting justify-content: flex-end", () => {
+    const sideBodyBlocks = [...css.matchAll(/\.tdb-side-body\s*\{([^}]*)\}/g)].map((m) => m[1]);
+    expect(sideBodyBlocks.length).toBeGreaterThanOrEqual(1);
+    for (const block of sideBodyBlocks) {
+      expect(block).not.toContain("justify-content: flex-end;");
+    }
+
+    const tipWrapBlocks = [...css.matchAll(/\.tdb-tip-wrap\s*\{([^}]*)\}/g)].map((m) => m[1]);
+    expect(tipWrapBlocks.length).toBeGreaterThanOrEqual(1);
+    for (const block of tipWrapBlocks) {
+      expect(block).not.toContain("justify-content: flex-end;");
+    }
+  });
+
+  it("defines activity metrics styles", () => {
+    expect(css).toContain(".tdb-activity-metrics {");
+    expect(css).toMatch(/\.tdb-activity-metrics\s*\{[^}]*display:\s*flex;/);
+    expect(css).toMatch(/\.tdb-activity-metrics\s*\{[^}]*border-top:\s*1px solid var\(--tdb-divider\);/);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/helpers.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  computeActivityMetrics,
   formatCountTick,
   formatCurrencyTick,
   niceTicks,
@@ -45,3 +46,26 @@ describe("tick formatters", () => {
     expect(formatCountTick(150)).toBe("150");
   });
 });
+
+describe("computeActivityMetrics", () => {
+  it("returns 0 for empty months or months without weeks", () => {
+    expect(computeActivityMetrics([])).toEqual({ totalPrs: 0, activeWeeks: 0 });
+    expect(computeActivityMetrics([{ label: "Jan", weeks: [] }])).toEqual({
+      totalPrs: 0,
+      activeWeeks: 0,
+    });
+  });
+
+  it("sums total merged PRs and counts weeks with merged PRs", () => {
+    const months = [
+      { label: "Jan", weeks: [0, 2, 0, 1] },
+      { label: "Feb", weeks: [3, 0, 0, 0] },
+      { label: "Mar", weeks: [0, 0, 0, 0] },
+    ];
+    expect(computeActivityMetrics(months)).toEqual({
+      totalPrs: 6,
+      activeWeeks: 3,
+    });
+  });
+});
+

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
@@ -103,3 +103,22 @@ export const formatCountTick = (value: number): string => {
   if (value >= 1000) return `${Math.round(value / 1000)}K`;
   return String(Math.round(value));
 };
+
+export interface DashboardActivityMetrics {
+  totalPrs: number;
+  activeWeeks: number;
+}
+
+export const computeActivityMetrics = (
+  months: DashboardActivityMonthDto[],
+): DashboardActivityMetrics => {
+  const totalPrs = months.reduce(
+    (acc, m) => acc + (m.weeks ?? []).reduce((wAcc, c) => wAcc + c, 0),
+    0,
+  );
+  const activeWeeks = months.reduce(
+    (acc, m) => acc + (m.weeks ?? []).filter((c) => c > 0).length,
+    0,
+  );
+  return { totalPrs, activeWeeks };
+};


### PR DESCRIPTION
# Summary

## Changes

Top-aligned the Git Activity heatmap under the dashboard card tabs by removing `justify-content: flex-end` from `.tdb-tip-wrap` and `.tdb-side-body` in `dashboard.css`. Added a secondary summary metrics row to `ActivityGrid.tsx` computing total merged pull requests and active weeks to cleanly utilize vertical card height, styled with divider border and muted typography. Rebuilt frontend widget assets and added unit and component tests.

## API Changes

- Added `computeActivityMetrics` and `DashboardActivityMetrics` to `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts`.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css`: Removed `justify-content: flex-end` from `.tdb-tip-wrap` and `.tdb-side-body`, added `flex: 1` to `.tdb-activity-wrap`, and added `.tdb-activity-metrics` styles.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts`: Added `computeActivityMetrics` helper function and `DashboardActivityMetrics` interface.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.tsx`: Integrated `computeActivityMetrics` and rendered summary metric row beneath heatmap.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts`: Added tests verifying removal of flex-end and presence of activity metrics CSS rules.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/helpers.test.ts`: Added unit tests for `computeActivityMetrics`.
- `src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/ActivityGrid.test.tsx`: Added component test verifying summary metrics rendering.

## Manual Testing

1. Run the application: `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`.
2. Open the Dashboard tab in Tendril.
3. Observe the Git Activity card in the right column:
   - The heatmap grid is positioned directly below the tabs without dead space above it.
   - The bottom of the card displays a divider line and summary metrics: total merged PRs and active weeks count.
4. Switch to the Pull Requests tab:
   - Verify that the bar chart continues to align bars correctly to the bottom.

---

### Commits

- `88a2b993` Fix Git Activity card layout and add summary metrics (Plan 00047)

---
Created using [Ivy Tendril](https://ivy.app).
