### PR TITLE
[00051] Fix Inbox GitHub Issue Import Limit Regression

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/InboxAppTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/InboxAppTests.cs
@@ -99,6 +99,18 @@ public class InboxAppTests
     }
 
     [Fact]
+    public void CreateProjectIssueRequest_Uses_DefaultIssueLimit_Without_100_Cap()
+    {
+        var request = InboxApp.CreateProjectIssueRequest("owner", "repo");
+
+        Assert.Equal("owner", request.Owner);
+        Assert.Equal("repo", request.Repo);
+        Assert.Equal(GithubService.DefaultIssueLimit, request.Limit);
+        Assert.Equal(1000, request.Limit);
+        Assert.True(request.Limit > 100);
+    }
+
+    [Fact]
     public void ParseIssuesFromJson_ParsesRepositoryAndUrl()
     {
         var json = """

--- a/src/Ivy.Tendril.Test/GithubServiceTests.cs
+++ b/src/Ivy.Tendril.Test/GithubServiceTests.cs
@@ -250,6 +250,31 @@ public class GithubServiceTests
     }
 
     [Fact]
+    public void BuildMyAssignedIssuesArgs_Uses_Default_Limit()
+    {
+        var args = GithubService.BuildMyAssignedIssuesArgs();
+
+        Assert.Contains("--limit 1000", args);
+        Assert.Contains("search issues --assignee=@me --state=open", args);
+    }
+
+    [Fact]
+    public void BuildMyAssignedIssuesArgs_Respects_Custom_And_Clamped_Limit()
+    {
+        var customArgs = GithubService.BuildMyAssignedIssuesArgs(limit: 250);
+        Assert.Contains("--limit 250", customArgs);
+
+        var aboveMaxArgs = GithubService.BuildMyAssignedIssuesArgs(limit: 5000);
+        Assert.Contains("--limit 1000", aboveMaxArgs);
+
+        var zeroArgs = GithubService.BuildMyAssignedIssuesArgs(limit: 0);
+        Assert.Contains("--limit 1000", zeroArgs);
+
+        var negativeArgs = GithubService.BuildMyAssignedIssuesArgs(limit: -1);
+        Assert.Contains("--limit 1000", negativeArgs);
+    }
+
+    [Fact]
     public async Task GetAssigneesAsync_Returns_Error_When_Command_Fails()
     {
         var configService = new ConfigService(new TendrilSettings());

--- a/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/InboxApp.cs
@@ -152,8 +152,8 @@ public class InboxApp : ViewBase
                         var owner = parts[0];
                         var repoName = parts[1];
 
-                        var (issues, err) = await githubService.SearchIssuesAsync(new IssueSearchRequest(
-                            owner, repoName, Limit: 100));
+                        var (issues, err) = await githubService.SearchIssuesAsync(
+                            CreateProjectIssueRequest(owner, repoName));
 
                         if (err != null && errorMessage.Value == null)
                             errorMessage.Set(err);
@@ -289,6 +289,9 @@ public class InboxApp : ViewBase
             sidebar
         );
     }
+
+    public static IssueSearchRequest CreateProjectIssueRequest(string owner, string repoName) =>
+        new(owner, repoName, Limit: GithubService.DefaultIssueLimit);
 
     public static string GetProjectForRepo(IGithubService githubService, string owner, string repo)
     {

--- a/src/Ivy.Tendril/Services/Git/GithubService.cs
+++ b/src/Ivy.Tendril/Services/Git/GithubService.cs
@@ -76,7 +76,7 @@ public class GithubService : IGithubService, IDisposable
     public async Task<(List<GitHubIssue> issues, string? error)> GetMyAssignedIssuesAsync()
     {
         return await ExecuteGhCliAsync(
-            "search issues --assignee=@me --state=open --limit 100 --json number,title,body,labels,assignees,repository,url,updatedAt",
+            BuildMyAssignedIssuesArgs(),
             ParseIssuesFromJson,
             new List<GitHubIssue>());
     }
@@ -150,6 +150,12 @@ public class GithubService : IGithubService, IDisposable
         if (request.Labels is { Length: > 0 })
             args += $" --label \"{string.Join(",", request.Labels)}\"";
         return args;
+    }
+
+    internal static string BuildMyAssignedIssuesArgs(int limit = DefaultIssueLimit)
+    {
+        var effectiveLimit = limit <= 0 ? DefaultIssueLimit : Math.Min(limit, MaxIssueLimit);
+        return $"search issues --assignee=@me --state=open --limit {effectiveLimit} --json number,title,body,labels,assignees,repository,url,updatedAt";
     }
 
     internal static List<GitHubIssue> ParseIssuesFromJson(string json)


### PR DESCRIPTION
# Summary

## Changes

Removed the hard-coded 100 issue limit regression in the Inbox app and aligned the assigned issues query with the service default. Project repository issue queries now default to 1000 issues via a helper method on `InboxApp`, and `GithubService.GetMyAssignedIssuesAsync` now uses an extracted argument builder that defaults to 1000 with proper clamping bounds.

## API Changes

- Added `public static IssueSearchRequest InboxApp.CreateProjectIssueRequest(string owner, string repoName)`
- Added `internal static string GithubService.BuildMyAssignedIssuesArgs(int limit = DefaultIssueLimit)`

## Files Modified

- **Apps:**
  - `src/Ivy.Tendril/Apps/Inbox/InboxApp.cs`: Added `CreateProjectIssueRequest` helper with `DefaultIssueLimit` (1000) and updated repository issue querying to use it instead of hardcoding limit 100.
- **Services:**
  - `src/Ivy.Tendril/Services/Git/GithubService.cs`: Extracted `BuildMyAssignedIssuesArgs` using `DefaultIssueLimit` (1000) and updated `GetMyAssignedIssuesAsync`.
- **Tests:**
  - `src/Ivy.Tendril.Test/Apps/InboxAppTests.cs`: Added `CreateProjectIssueRequest_Uses_DefaultIssueLimit_Without_100_Cap`.
  - `src/Ivy.Tendril.Test/GithubServiceTests.cs`: Added `BuildMyAssignedIssuesArgs_Uses_Default_Limit` and `BuildMyAssignedIssuesArgs_Respects_Custom_And_Clamped_Limit`.

## Manual Testing

- Launch Tendril with `dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port --beta`.
- Open the **Inbox** app from the sidebar.
- Select a project with more than 100 open issues in its repositories (for example, `ivy-tendril` with `Ivy-Interactive/Ivy-Tendril`).
- Observe that more than 100 issues are loaded into the issue list (all 160+ open issues instead of being capped at 100).
- Select the **My Issues** category and observe that assigned issues are queried up to 1000.

---
## Commits
- 44c0f6da: Plan 00051: Fix Inbox GitHub issue import limit regression and align assigned issues query

---
Created using [Ivy Tendril](https://ivy.app).
