### PR TITLE
[00050] Fix Running Jobs Badge and Spinner Animation in ChatWidget

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -1298,3 +1298,84 @@ describe("ChatWidget Streaming Scroll Behavior", () => {
   });
 });
 
+describe("ChatWidget Running Jobs Badge and Spinner", () => {
+  beforeEach(() => {
+    window.ResizeObserver = class {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    } as any;
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("renders running jobs badge indicator, .spin loader, and .chat-jobs-pulse-dot when runningJobs has active jobs", () => {
+    const session: ChatSessionDto = {
+      id: "sess-0",
+      title: "Session 0",
+      agentId: "agent-1",
+      modelId: "model-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [],
+    };
+    const runningJobs = [
+      { id: "job-1", type: "CreatePlan", status: "Running", planTitle: "Test Plan" },
+    ];
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-0"
+        sessions={[session]}
+        runningJobs={runningJobs}
+      />
+    );
+
+    const badge = screen.getByRole("button", { name: /View running jobs/i });
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass("chat-jobs-badge", "running");
+    expect(within(badge).getByText(/1 running/i)).toBeInTheDocument();
+
+    const spinLoader = badge.querySelector(".spin");
+    expect(spinLoader).toBeInTheDocument();
+
+    const pulseDot = badge.querySelector(".chat-jobs-pulse-dot");
+    expect(pulseDot).toBeInTheDocument();
+  });
+
+  it("renders running jobs badge indicator when active session has spawned running jobs", () => {
+    const session: ChatSessionDto = {
+      id: "sess-1",
+      title: "Session 1",
+      agentId: "agent-1",
+      modelId: "model-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [],
+      spawnedJobs: [
+        { id: "job-2", type: "ExecutePlan", status: "Running", planTitle: "Execution Plan" },
+      ],
+    };
+
+    render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-1"
+        sessions={[session]}
+      />
+    );
+
+    const badge = screen.getByRole("button", { name: /View running jobs/i });
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass("chat-jobs-badge", "running");
+    expect(within(badge).getByText(/1 running/i)).toBeInTheDocument();
+
+    const spinLoader = badge.querySelector(".spin");
+    expect(spinLoader).toBeInTheDocument();
+
+    const pulseDot = badge.querySelector(".chat-jobs-pulse-dot");
+    expect(pulseDot).toBeInTheDocument();
+  });
+});
+
+

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css
@@ -191,7 +191,17 @@
   }
 }
 
-.chat-spin {
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.chat-spin,
+.spin {
   animation: chat-spin 1.2s linear infinite;
 }
 
@@ -1362,7 +1372,7 @@ button[class*="bg-primary"] .text-muted {
 }
 
 .chat-job-status-indicator .spin {
-  animation: spin 1s linear infinite;
+  animation: chat-spin 1s linear infinite;
   color: #0284c7;
 }
 
@@ -1502,13 +1512,26 @@ button[class*="bg-primary"] .text-muted {
   white-space: nowrap;
 }
 
+@keyframes chat-pulse-dot {
+  0%, 100% {
+    transform: scale(0.9);
+    opacity: 0.4;
+    box-shadow: 0 0 2px rgba(59, 130, 246, 0.4);
+  }
+  50% {
+    transform: scale(1.25);
+    opacity: 1;
+    box-shadow: 0 0 8px 2px rgba(59, 130, 246, 0.8);
+  }
+}
+
 .chat-jobs-pulse-dot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
   background-color: #3b82f6;
   box-shadow: 0 0 6px #3b82f6;
-  animation: pulse 1.6s ease-in-out infinite;
+  animation: chat-pulse-dot 1.6s ease-in-out infinite;
 }
 
 .chat-jobs-badge-chevron {


### PR DESCRIPTION
# Summary

## Changes

Fixed running jobs badge icon animation and pulse dot in ChatWidget. Added continuous spinning rotation styles and keyframe definitions for elements using the `.spin` class, and created an enhanced `@keyframes chat-pulse-dot` animation with glow and opacity pulsation.

## API Changes

None.

## Files Modified

- **UI & Styles:**
  - `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/chat-widget.css`: Added `.spin` rule mapped to `@keyframes chat-spin`, aliased `@keyframes spin`, updated `.chat-job-status-indicator .spin`, and defined `@keyframes chat-pulse-dot` with scale, opacity, and box-shadow glow.
- **Tests:**
  - `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx`: Added unit test suite verifying running jobs badge rendering, `.spin` loader element, and `.chat-jobs-pulse-dot` indicator.

## Manual Testing

1. Launch Tendril or run the widgets sample app (`cd src/Ivy.Tendril.Widgets/frontend && vp dev`).
2. Open the Chat view while a background job is executing (e.g. CreatePlan or ExecutePlan).
3. Observe the running jobs badge in the top right header:
   - The `Loader2` spinner icon rotates continuously.
   - The blue pulse dot pulsates smoothly with scale, opacity, and box-shadow glow.
4. Click the running jobs badge to open the dropdown and verify each running job item also displays an active rotating spinner.

---
- 20a204fa Fix running jobs badge and spinner animation in ChatWidget (Plan 00050)

---
Created using [Ivy Tendril](https://ivy.app).
