### PR TITLE
[00048] Make Question Block Parsers Resilient to Unquoted Colons

### DIFF
--- a/src/Ivy.Tendril.Test/QuestionAnswersTests.cs
+++ b/src/Ivy.Tendril.Test/QuestionAnswersTests.cs
@@ -813,4 +813,55 @@ public class QuestionAnswersTests
         Assert.Equal(block.Body, Markdown[block.BodyStart..block.BodyEnd]);
         Assert.StartsWith("questions:", block.Body);
     }
+
+    [Fact]
+    public void Read_AcceptsQuestionsWithUnquotedColons()
+    {
+        var markdown = """
+            ```questions
+            questions:
+              - id: db-choice
+                title: Which database: SQLite or Postgres?
+                header: DB: Select
+                options:
+                  - title: Option 1: SQLite
+                    value: sqlite
+                  - title: Option 2: Postgres
+                    value: postgres
+            ```
+            """;
+
+        var questions = QuestionAnswers.Read(markdown);
+
+        var q = Assert.Single(questions);
+        Assert.Equal("db-choice", q.Id);
+        Assert.Equal("Which database: SQLite or Postgres?", q.Title);
+        Assert.Equal("DB: Select", q.Header);
+    }
+
+    [Fact]
+    public void Apply_UpdatesQuestionsWithUnquotedColons()
+    {
+        var markdown = """
+            ```questions
+            questions:
+              - id: db-choice
+                title: Which database: SQLite or Postgres?
+                header: DB: Select
+                description: Fast embedded database: zero configuration.
+                options:
+                  - title: Option 1: SQLite
+                    description: Fast embedded: zero config
+                    value: sqlite
+                  - title: Option 2: Postgres
+                    value: postgres
+            ```
+            """;
+
+        var updated = QuestionAnswers.Apply(markdown, new QuestionAnswer("db-choice", ["sqlite"]));
+
+        Assert.Contains("answer: sqlite", updated);
+        var q = Question(updated, "db-choice");
+        Assert.Equal(["sqlite"], q.AnswerValues);
+    }
 }

--- a/src/Ivy.Tendril.Test/QuestionValidationServiceTests.cs
+++ b/src/Ivy.Tendril.Test/QuestionValidationServiceTests.cs
@@ -678,4 +678,26 @@ public class QuestionValidationServiceTests
         Assert.Contains(issues, i => i.Message.Contains("duplicate option value 'jwt'"));
         Assert.Contains(issues, i => i.Message.Contains("more than one option is recommended"));
     }
+
+    [Fact]
+    public void Validate_AcceptsQuestionBlocksWithUnquotedColons()
+    {
+        var issues = Validate("""
+            questions:
+              - id: db-choice
+                title: Which database: SQLite or Postgres?
+                header: DB: Select
+                description: Database selection: fast embedded vs scalable client-server.
+                options:
+                  - title: Option 1: SQLite
+                    description: Fast embedded database: zero configuration, high performance.
+                    value: sqlite
+                    recommended: true
+                  - title: Option 2: Postgres
+                    description: Runs `npm test:watch` to verify changes.
+                    value: postgres
+            """);
+
+        Assert.Empty(issues);
+    }
 }

--- a/src/Ivy.Tendril.Widgets/QuestionAnswers.cs
+++ b/src/Ivy.Tendril.Widgets/QuestionAnswers.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using System.Text.RegularExpressions;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.RepresentationModel;
@@ -192,11 +193,167 @@ public static class QuestionAnswers
     // Editing one block body
     // ---------------------------------------------------------------------------------------------
 
+    private static readonly Regex FieldRegex = new(@"^(\s*(?:-\s+)?)(title|header|description):[ \t]*(.*)$", RegexOptions.Compiled);
+    private static readonly Regex BlockScalarRegex = new(@"^[|>][\-+]?\d*(?:\s+.*)?$", RegexOptions.Compiled);
+
+    /// <summary>
+    ///     Sanitizes YAML text in a questions block by wrapping unquoted strings in text fields
+    ///     (<c>title</c>, <c>header</c>, <c>description</c>) in double quotes, making them resilient to colons,
+    ///     code snippets, and formatting. Preserves block scalars (| and &gt;) intact.
+    /// </summary>
+    public static string SanitizeQuestionYaml(string body)
+    {
+        if (string.IsNullOrEmpty(body))
+            return body;
+
+        var newline = DetectNewline(body);
+        var lines = body.Replace("\r\n", "\n").Split('\n');
+        var result = new List<string>(lines.Length);
+
+        var inBlockScalar = false;
+        var blockScalarIndent = 0;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+
+            if (inBlockScalar)
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    result.Add(line);
+                    continue;
+                }
+
+                var indent = IndentOfLine(line);
+                if (indent > blockScalarIndent)
+                {
+                    result.Add(line);
+                    continue;
+                }
+
+                inBlockScalar = false;
+            }
+
+            var match = FieldRegex.Match(line);
+            if (!match.Success)
+            {
+                result.Add(line);
+                continue;
+            }
+
+            var prefix = match.Groups[1].Value;
+            var key = match.Groups[2].Value;
+            var val = match.Groups[3].Value;
+            var trimmedVal = val.Trim();
+
+            if (trimmedVal.Length == 0)
+            {
+                result.Add(line);
+                continue;
+            }
+
+            if (BlockScalarRegex.IsMatch(trimmedVal))
+            {
+                inBlockScalar = true;
+                blockScalarIndent = prefix.Length;
+                result.Add(line);
+                continue;
+            }
+
+            if (IsAlreadyQuoted(trimmedVal))
+            {
+                result.Add(line);
+                continue;
+            }
+
+            var escaped = trimmedVal.Replace("\\", "\\\\").Replace("\"", "\\\"");
+            result.Add($"{prefix}{key}: \"{escaped}\"");
+        }
+
+        return string.Join(newline, result);
+    }
+
+    private static bool IsAlreadyQuoted(string val)
+    {
+        if (val.Length < 2)
+            return false;
+
+        if (val.StartsWith('"'))
+        {
+            var escaped = false;
+            for (var i = 1; i < val.Length; i++)
+            {
+                var c = val[i];
+                if (escaped)
+                {
+                    escaped = false;
+                    continue;
+                }
+                if (c == '\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+                if (c == '"')
+                {
+                    var rest = val[(i + 1)..].Trim();
+                    return rest.Length == 0 || rest.StartsWith('#');
+                }
+            }
+            return false;
+        }
+
+        if (val.StartsWith('\''))
+        {
+            for (var i = 1; i < val.Length; i++)
+            {
+                var c = val[i];
+                if (c == '\'')
+                {
+                    if (i + 1 < val.Length && val[i + 1] == '\'')
+                    {
+                        i++;
+                        continue;
+                    }
+                    var rest = val[(i + 1)..].Trim();
+                    return rest.Length == 0 || rest.StartsWith('#');
+                }
+            }
+            return false;
+        }
+
+        return false;
+    }
+
+    private static int IndentOfLine(string line)
+    {
+        var count = 0;
+        while (count < line.Length && line[count] == ' ')
+            count++;
+        return count;
+    }
+
     private static bool TryEditBody(string body, QuestionAnswer answer, out string edited)
     {
         edited = body;
 
-        if (QuestionNodes(body) is not { } questions)
+        var targetBody = body;
+        var questions = QuestionNodesRaw(body);
+        if (questions is null)
+        {
+            var sanitized = SanitizeQuestionYaml(body);
+            if (sanitized != body)
+            {
+                questions = QuestionNodesRaw(sanitized);
+                if (questions is not null)
+                {
+                    targetBody = sanitized;
+                }
+            }
+        }
+
+        if (questions is null)
             return false;
 
         foreach (var child in questions)
@@ -205,8 +362,8 @@ public static class QuestionAnswers
                 continue;
 
             edited = entry.Style == MappingStyle.Flow
-                ? EditFlowEntry(body, entry, answer.Answer)
-                : EditBlockEntry(body, entry, answer.Answer);
+                ? EditFlowEntry(targetBody, entry, answer.Answer)
+                : EditBlockEntry(targetBody, entry, answer.Answer);
             return true;
         }
 
@@ -215,7 +372,7 @@ public static class QuestionAnswers
 
     /// <summary>
     ///     The question nodes of one block body, in document order, or null when the body is not a
-    ///     questions block this reader can address — the pre-schema plain-text form, or YAML that
+    ///     questions block this reader can address: the pre-schema plain-text form, or YAML that
     ///     does not parse at all.
     ///     <para>
     ///         Three shapes say the same thing, and agents write all three: the canonical
@@ -230,6 +387,16 @@ public static class QuestionAnswers
     ///     </para>
     /// </summary>
     private static List<YamlNode>? QuestionNodes(string body)
+    {
+        var nodes = QuestionNodesRaw(body);
+        if (nodes is not null)
+            return nodes;
+
+        var sanitized = SanitizeQuestionYaml(body);
+        return sanitized != body ? QuestionNodesRaw(sanitized) : null;
+    }
+
+    private static List<YamlNode>? QuestionNodesRaw(string body)
     {
         YamlNode? root;
         try

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsSchema.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsSchema.test.ts
@@ -279,3 +279,107 @@ describe("parseQuestions wrapper-less shapes", () => {
     ).toEqual({ kind: "invalid" });
   });
 });
+
+describe("resilience to unquoted colons and formatting", () => {
+  it("parses questions with unquoted colons in question title", () => {
+    const parsed = parseQuestions(
+      body(
+        "questions:",
+        "  - id: db",
+        "    title: Which database: SQLite or Postgres?",
+        "    options:",
+        "      - title: SQLite",
+        "        value: sqlite",
+        "      - title: Postgres",
+        "        value: postgres",
+      ),
+    );
+    expect(parsed.kind).toBe("questions");
+    if (parsed.kind !== "questions") return;
+    expect(parsed.questions[0].title).toBe("Which database: SQLite or Postgres?");
+  });
+
+  it("parses options with unquoted colons in option title", () => {
+    const parsed = parseQuestions(
+      body(
+        "questions:",
+        "  - id: db",
+        "    title: Choose database",
+        "    options:",
+        "      - title: Option 1: SQLite",
+        "        value: sqlite",
+        "      - title: Option 2: Postgres",
+        "        value: postgres",
+      ),
+    );
+    expect(parsed.kind).toBe("questions");
+    if (parsed.kind !== "questions") return;
+    expect(parsed.questions[0].options?.[0].title).toBe("Option 1: SQLite");
+  });
+
+  it("parses options with unquoted colons in description", () => {
+    const parsed = parseQuestions(
+      body(
+        "questions:",
+        "  - id: db",
+        "    title: Choose database",
+        "    options:",
+        "      - title: SQLite",
+        "        description: Fast embedded database: zero configuration, high performance.",
+        "        value: sqlite",
+        "      - title: Postgres",
+        "        value: postgres",
+      ),
+    );
+    expect(parsed.kind).toBe("questions");
+    if (parsed.kind !== "questions") return;
+    expect(parsed.questions[0].options?.[0].description).toBe(
+      "Fast embedded database: zero configuration, high performance.",
+    );
+  });
+
+  it("parses with inline code containing colons and formatting in description", () => {
+    const parsed = parseQuestions(
+      body(
+        "questions:",
+        "  - id: test-command",
+        "    title: Test runner",
+        "    description: Runs `npm test:watch` to verify changes.",
+        "    options:",
+        "      - title: Watch mode",
+        "        description: Configure with `app.Use: true`.",
+        "        value: watch",
+        "      - title: Single run",
+        "        value: single",
+      ),
+    );
+    expect(parsed.kind).toBe("questions");
+    if (parsed.kind !== "questions") return;
+    expect(parsed.questions[0].description).toBe("Runs `npm test:watch` to verify changes.");
+    expect(parsed.questions[0].options?.[0].description).toBe("Configure with `app.Use: true`.");
+  });
+
+  it("preserves multiline block scalars with colons intact", () => {
+    const parsed = parseQuestions(
+      body(
+        "questions:",
+        "  - id: snippet",
+        "    title: Choose implementation",
+        "    options:",
+        "      - title: Implementation A",
+        "        description: |",
+        "          Here is code with colons:",
+        "          key: value",
+        "          title: not a real title",
+        "        value: a",
+        "      - title: Implementation B",
+        "        value: b",
+      ),
+    );
+    expect(parsed.kind).toBe("questions");
+    if (parsed.kind !== "questions") return;
+    expect(parsed.questions[0].options?.[0].description).toContain("Here is code with colons:");
+    expect(parsed.questions[0].options?.[0].description).toContain("key: value");
+    expect(parsed.questions[0].options?.[0].description).toContain("title: not a real title");
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsSchema.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsSchema.ts
@@ -116,6 +116,124 @@ function readOptions(raw: unknown): QuestionOption[] | undefined {
   }));
 }
 
+function isAlreadyQuoted(val: string): boolean {
+  const trimmed = val.trim();
+  if (trimmed.length < 2) return false;
+
+  if (trimmed.startsWith('"')) {
+    let escaped = false;
+    for (let i = 1; i < trimmed.length; i++) {
+      const c = trimmed[i];
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (c === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (c === '"') {
+        const rest = trimmed.slice(i + 1).trim();
+        return rest.length === 0 || rest.startsWith("#");
+      }
+    }
+    return false;
+  }
+
+  if (trimmed.startsWith("'")) {
+    for (let i = 1; i < trimmed.length; i++) {
+      const c = trimmed[i];
+      if (c === "'") {
+        if (i + 1 < trimmed.length && trimmed[i + 1] === "'") {
+          i++;
+          continue;
+        }
+        const rest = trimmed.slice(i + 1).trim();
+        return rest.length === 0 || rest.startsWith("#");
+      }
+    }
+    return false;
+  }
+
+  return false;
+}
+
+function getIndent(line: string): number {
+  let count = 0;
+  while (count < line.length && line[count] === " ") {
+    count++;
+  }
+  return count;
+}
+
+const FIELD_REGEX = /^(\s*(?:-\s+)?)(title|header|description):[ \t]*(.*)$/;
+const BLOCK_SCALAR_REGEX = /^[|>][\-+]?\d*(?:\s+.*)?$/;
+
+/**
+ * Sanitizes YAML text in a questions block by wrapping unquoted strings in text fields
+ * (`title`, `header`, `description`) in double quotes, making them resilient to colons,
+ * code snippets, and formatting. Preserves block scalars (| and >) intact.
+ */
+export function sanitizeQuestionYaml(body: string): string {
+  const lines = body.replace(/\r\n/g, "\n").split("\n");
+  const result: string[] = [];
+
+  let inBlockScalar = false;
+  let blockScalarIndent = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (inBlockScalar) {
+      if (line.trim().length === 0) {
+        result.push(line);
+        continue;
+      }
+
+      const indent = getIndent(line);
+      if (indent > blockScalarIndent) {
+        result.push(line);
+        continue;
+      }
+
+      inBlockScalar = false;
+    }
+
+    const match = line.match(FIELD_REGEX);
+    if (!match) {
+      result.push(line);
+      continue;
+    }
+
+    const prefix = match[1];
+    const key = match[2];
+    const val = match[3];
+    const trimmedVal = val.trim();
+
+    if (trimmedVal.length === 0) {
+      result.push(line);
+      continue;
+    }
+
+    if (BLOCK_SCALAR_REGEX.test(trimmedVal)) {
+      inBlockScalar = true;
+      blockScalarIndent = prefix.length;
+      result.push(line);
+      continue;
+    }
+
+    if (isAlreadyQuoted(trimmedVal)) {
+      result.push(line);
+      continue;
+    }
+
+    const escaped = trimmedVal.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    result.push(`${prefix}${key}: "${escaped}"`);
+  }
+
+  return result.join("\n");
+}
+
 /**
  * Reads one fence body. Never throws: malformed YAML, prose, and a mapping that is none of the
  * shapes `questionList` knows all come back as `kind: "invalid"`.
@@ -126,13 +244,30 @@ function readOptions(raw: unknown): QuestionOption[] | undefined {
  */
 export function parseQuestions(body: string): ParsedQuestions {
   let raw: unknown;
+  let usedSanitization = false;
   try {
     raw = parse(body);
   } catch {
-    return { kind: "invalid" };
+    try {
+      raw = parse(sanitizeQuestionYaml(body));
+      usedSanitization = true;
+    } catch {
+      return { kind: "invalid" };
+    }
   }
 
-  const list = questionList(raw);
+  let list = questionList(raw);
+  if (list === undefined && !usedSanitization) {
+    try {
+      const sanitized = sanitizeQuestionYaml(body);
+      if (sanitized !== body) {
+        raw = parse(sanitized);
+        list = questionList(raw);
+      }
+    } catch {
+      // ignore
+    }
+  }
   if (list === undefined) return { kind: "invalid" };
 
   const seen = new Set<string>();

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsSource.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsSource.ts
@@ -1,4 +1,5 @@
 import { parseDocument } from "yaml";
+import { sanitizeQuestionYaml } from "./questionsSchema";
 
 /**
  * Locating `questions` fences in markdown source, and editing them in place.
@@ -285,8 +286,18 @@ export function setAnswer(
     throw new Error(`setAnswer: no questions block at index ${blockIndex} (found ${blocks.length})`);
   }
 
-  const doc = parseDocument(dedent(block.body, block.indent));
-  const path = answerPath(doc.toJS(), questionId);
+  const dedented = dedent(block.body, block.indent);
+  let doc = parseDocument(dedented);
+  let path = doc.errors.length === 0 ? answerPath(doc.toJS(), questionId) : null;
+  if (!path) {
+    const sanitized = sanitizeQuestionYaml(dedented);
+    const sanitizedDoc = parseDocument(sanitized);
+    const sanitizedPath = answerPath(sanitizedDoc.toJS(), questionId);
+    if (sanitizedPath) {
+      doc = sanitizedDoc;
+      path = sanitizedPath;
+    }
+  }
   if (!path) {
     throw new Error(`setAnswer: block ${blockIndex} has no question with id "${questionId}"`);
   }

--- a/src/Ivy.Tendril/Helpers/QuestionBlockParser.cs
+++ b/src/Ivy.Tendril/Helpers/QuestionBlockParser.cs
@@ -1,4 +1,5 @@
 using Ivy.Tendril.Models;
+using Ivy.Tendril.Widgets;
 using YamlDotNet.Core;
 using YamlDotNet.RepresentationModel;
 using YamlDotNet.Serialization;
@@ -121,6 +122,12 @@ public static class QuestionBlockParser
         return results;
     }
 
+    /// <summary>
+    ///     Sanitizes YAML text in a questions block by wrapping unquoted strings in text fields
+    ///     (<c>title</c>, <c>header</c>, <c>description</c>) in double quotes.
+    /// </summary>
+    public static string SanitizeQuestionYaml(string body) => QuestionAnswers.SanitizeQuestionYaml(body);
+
     private static ParsedQuestionsBlock Analyze(int line, string body)
     {
         // Pass 1: the raw node, which is the only place that knows whether an `answer` key exists.
@@ -138,7 +145,38 @@ public static class QuestionBlockParser
             loadError = Flatten(ex.Message);
         }
 
-        if (Classify(root) is not { } classified)
+        var classified = Classify(root);
+        var effectiveBody = body;
+
+        if (classified is null)
+        {
+            var sanitized = SanitizeQuestionYaml(body);
+            if (sanitized != body)
+            {
+                try
+                {
+                    var sanitizedStream = new YamlStream();
+                    sanitizedStream.Load(new StringReader(sanitized));
+                    if (sanitizedStream.Documents.Count > 0)
+                    {
+                        var sanitizedRoot = sanitizedStream.Documents[0].RootNode;
+                        if (Classify(sanitizedRoot) is { } sanitizedClassified)
+                        {
+                            root = sanitizedRoot;
+                            classified = sanitizedClassified;
+                            loadError = null;
+                            effectiveBody = sanitized;
+                        }
+                    }
+                }
+                catch (YamlException)
+                {
+                    // Keep original loadError
+                }
+            }
+        }
+
+        if (classified is not { } resolvedClassified)
         {
             // Broken YAML that clearly meant to be structured is an error; anything else is the
             // pre-schema plain-text form, which must never be rejected.
@@ -152,18 +190,40 @@ public static class QuestionBlockParser
         QuestionsBlock? typed;
         try
         {
-            typed = Deserialize(body, classified.Shape);
+            typed = Deserialize(effectiveBody, resolvedClassified.Shape);
         }
         catch (YamlException ex)
         {
-            return new ParsedQuestionsBlock(line, body, null, Flatten(ex.Message), IsLegacy: false);
+            if (effectiveBody == body)
+            {
+                var sanitized = SanitizeQuestionYaml(body);
+                if (sanitized != body)
+                {
+                    try
+                    {
+                        typed = Deserialize(sanitized, resolvedClassified.Shape);
+                    }
+                    catch (YamlException)
+                    {
+                        return new ParsedQuestionsBlock(line, body, null, Flatten(ex.Message), IsLegacy: false);
+                    }
+                }
+                else
+                {
+                    return new ParsedQuestionsBlock(line, body, null, Flatten(ex.Message), IsLegacy: false);
+                }
+            }
+            else
+            {
+                return new ParsedQuestionsBlock(line, body, null, Flatten(ex.Message), IsLegacy: false);
+            }
         }
 
         if (typed is null)
             return new ParsedQuestionsBlock(line, body, null, "block is empty", IsLegacy: false);
 
         return new ParsedQuestionsBlock(
-            line, body, typed with { Questions = StampAnswers(typed.Questions, classified.Entries) }, null, IsLegacy: false);
+            line, body, typed with { Questions = StampAnswers(typed.Questions, resolvedClassified.Entries) }, null, IsLegacy: false);
     }
 
     /// <summary>How a block spells its questions. All three mean the same thing.</summary>

--- a/src/Ivy.Tendril/Prompts/AgentPrompt.md
+++ b/src/Ivy.Tendril/Prompts/AgentPrompt.md
@@ -332,6 +332,10 @@ questions:
 
 Once the user selects their option and clicks **Submit Response**, their answer will be submitted directly to the chat session in the next turn so you can proceed with their chosen direction.
 
+**Formatting rules for question blocks:**
+- Always quote `title`, `header`, and `description` values when they contain colons (`:`), quotes, or code snippets (e.g. `title: "Option: SQLite"` or `description: "Uses `key: val` syntax"`).
+- Use `|` block scalar syntax for any multiline descriptions or code blocks.
+
 ## Important Notes
 
 - **Never directly modify, create, or delete repository files during chat sessions.** All code changes must be planned and executed via Tendril plans (`tendril job start CreatePlan`).

--- a/src/Ivy.Tendril/Prompts/Plans.md
+++ b/src/Ivy.Tendril/Prompts/Plans.md
@@ -377,7 +377,7 @@ questions:
 `````
 
 Use a `|` block scalar for any description spanning more than one line, so blank lines and
-indentation survive YAML parsing intact.
+indentation survive YAML parsing intact. Always quote `title`, `header`, and `description` values when they contain colons (`:`), quotes, or code snippets (e.g. `title: "Option: SQLite"` or `description: "Uses `key: val` syntax"`).
 
 Three shapes fall out of `multiple` / `other` / the presence of `options`:
 


### PR DESCRIPTION
# Summary

## Changes

Implemented YAML sanitization and fallback parsing for question blocks in both frontend TypeScript widgets and backend C# services to make question parsing resilient to unquoted colons, inline code, and formatting in titles, headers, and descriptions. Updated prompt guidance in `AgentPrompt.md` and `Plans.md` to guide AI agents to quote values with special characters and use block scalars for multiline descriptions.

## API Changes

- `Ivy.Tendril.Widgets.QuestionAnswers.SanitizeQuestionYaml(string body)`: Added public static method that sanitizes question YAML text by quoting unquoted string fields (`title`, `header`, `description`) while preserving block scalars (`|`, `>`).
- `Ivy.Tendril.Helpers.QuestionBlockParser.SanitizeQuestionYaml(string body)`: Added public static method that exposes question YAML sanitization in Tendril helpers.
- `sanitizeQuestionYaml(body: string): string`: Exported function in frontend `questionsSchema.ts` providing question YAML sanitization for the React widget.

## Files Modified

- Frontend:
  - `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsSchema.ts`: Added `sanitizeQuestionYaml` and updated `parseQuestions` with fallback.
  - `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsSource.ts`: Updated `setAnswer` with fallback to sanitized parsing.
  - `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsSchema.test.ts`: Added unit test suite covering unquoted colons and formatting.
- Backend:
  - `src/Ivy.Tendril.Widgets/QuestionAnswers.cs`: Added `SanitizeQuestionYaml` and updated `QuestionNodes` and `TryEditBody`.
  - `src/Ivy.Tendril/Helpers/QuestionBlockParser.cs`: Added `SanitizeQuestionYaml` and updated `Analyze` with fallback.
  - `src/Ivy.Tendril.Test/QuestionValidationServiceTests.cs`: Added test for unquoted colons in `QuestionValidationService.Validate`.
  - `src/Ivy.Tendril.Test/QuestionAnswersTests.cs`: Added tests for `QuestionAnswers.Read` and `QuestionAnswers.Apply` with unquoted colons.
- Prompts:
  - `src/Ivy.Tendril/Prompts/AgentPrompt.md`: Added formatting rules for question blocks.
  - `src/Ivy.Tendril/Prompts/Plans.md`: Added instructions to quote values with colons and special characters.

## Manual Testing

1. Launch the Tendril desktop application or view an agent session with a plan containing a question block.
2. In a plan revision or chat response, include an unquoted colon in a question title (e.g. `title: Option 1: SQLite`) or option description (e.g. `description: Fast database: zero configuration`).
3. Observe that the frontend questions widget renders the interactive question cards without falling back to a static code block, and selecting an option persists the answer cleanly.

---
## Commits
- ecedab8f 00048: Make question block parsers resilient to unquoted colons

---
Created using [Ivy Tendril](https://ivy.app).
