### PR TITLE
[00052] Clarify Default Sidebar Setting Description in Appearance Setup View

### DIFF
--- a/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
+++ b/src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs
@@ -112,7 +112,7 @@ public class AppearanceSetupView : ViewBase
                | Text.Muted("Choose a color scheme preset for Tendril.").Small()
                | themeSelector
                | Text.Block("Main Sidebar").Bold()
-               | Text.Muted("Choose the default state for the main sidebar on startup.").Small()
+               | Text.Muted("Choose the default state for the main sidebar for new client sessions.").Small()
                | (Layout.Horizontal()
                   | new Button("Expanded")
                       .Variant(isSidebarOpen ? ButtonVariant.Primary : ButtonVariant.Outline)


### PR DESCRIPTION
# Summary

## Changes

Updated the Main Sidebar description in `AppearanceSetupView.cs` to state that it chooses the default state for new client sessions. This reflects that sidebar collapsed state is isolated per client in browser local storage and prevents confusion regarding global application startup.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Settings/AppearanceSetupView.cs` - Updated description copy for the Main Sidebar configuration setting.

## Manual Testing

1. Launch Tendril or run the App review action:
   ```bash
   dotnet run --project Worktrees/ivy-interactive/ivy-tendril/src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port
   ```
2. Navigate to Settings -> Appearance.
3. Observe the "Main Sidebar" section text: it should display "Choose the default state for the main sidebar for new client sessions."

---
## Commits
- 3ff835b3 Clarify default sidebar setting description in AppearanceSetupView (Plan 00052)

---
Created using [Ivy Tendril](https://ivy.app).
