### PR TITLE
feat(widgets): add PlanDependencyGraph widget

### DIFF
--- a/src/Ivy.Tendril.Widgets/.samples/Apps/PlanDependencyGraph/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/PlanDependencyGraph/DemoApp.cs
@@ -1,0 +1,89 @@
+using Ivy;
+using Ivy.Tendril.Widgets;
+using PlanDependencyGraphWidget = Ivy.Tendril.Widgets.PlanDependencyGraph;
+
+namespace WidgetSamples.Apps.PlanDependencyGraph;
+
+[App(title: "Dependency Graph", icon: Icons.GitBranch, group: ["PlanDependencyGraph"])]
+class DemoApp : ViewBase
+{
+    private static readonly PlanDependencyNodeDto[] Plans =
+    [
+        new("00041", "Plan schema and storage", "Completed", "Tendril"),
+        new("00042", "Dependency checker", "Completed", "Tendril"),
+        new("00043", "Job queue backoff", "Executing", "Tendril"),
+        new("00044", "Auto retry on dependency merge", "Executing", "Tendril"),
+        new("00045", "Dependency graph widget", "Review", "Tendril-Widgets"),
+        new("00046", "Plan detail dependency tab", "Draft", "Tendril"),
+        new("00047", "Blocked plan notifications", "Blocked", "Tendril"),
+        new("00048", "Docs for plan dependencies", "Draft", "Tendril-Docs"),
+        new("00049", "Legacy graph export", "Icebox", "Tendril"),
+    ];
+
+    private static readonly PlanDependencyEdgeDto[] Dependencies =
+    [
+        new("00042", "00041"),
+        new("00043", "00041"),
+        new("00044", "00042"),
+        new("00044", "00043"),
+        new("00045", "00042"),
+        new("00046", "00045"),
+        new("00047", "00044"),
+        new("00047", "00045"),
+        new("00048", "00046"),
+    ];
+
+    public override object Build()
+    {
+        var client = UseService<IClientProvider>();
+        var selected = UseState<string?>(() => null);
+        var horizontal = UseState(false);
+
+        var graph = new PlanDependencyGraphWidget()
+            .Nodes(Plans)
+            .Edges(Dependencies)
+            .SelectedId(selected.Value)
+            .Orientation(horizontal.Value ? "horizontal" : "vertical")
+            .OnNodeClick(id =>
+            {
+                selected.Set(id);
+                client.Toast($"Plan {id} clicked", "OnNodeClick").Info();
+            });
+
+        var toolbar = Layout.Horizontal().Gap(2)
+                      | new Button(horizontal.Value ? "Vertical" : "Horizontal",
+                              () => horizontal.Set(!horizontal.Value))
+                          .Variant(ButtonVariant.Secondary).Small()
+                      | new Button("Clear selection", () => selected.Set((string?)null))
+                          .Variant(ButtonVariant.Secondary).Small()
+                      | Text.Muted(selected.Value is null ? "No plan selected" : $"Selected: {selected.Value}");
+
+        return Layout.Vertical().Gap(2).Height(Size.Full())
+               | toolbar
+               | new Card(graph).Height(Size.Full());
+    }
+}
+
+/// <summary>A plan.yaml can name a dependency that loops back; the widget draws it dashed.</summary>
+[App(title: "Cyclic Graph", icon: Icons.GitBranch, group: ["PlanDependencyGraph"])]
+class CyclicApp : ViewBase
+{
+    public override object Build()
+    {
+        var client = UseService<IClientProvider>();
+
+        var graph = new PlanDependencyGraphWidget()
+            .Nodes(
+                new PlanDependencyNodeDto("00061", "Extract shared client", "Executing"),
+                new PlanDependencyNodeDto("00062", "Move auth into the client", "Draft"),
+                new PlanDependencyNodeDto("00063", "Retire the old client", "Draft"))
+            .Edges(
+                new PlanDependencyEdgeDto("00062", "00061"),
+                new PlanDependencyEdgeDto("00063", "00062"),
+                new PlanDependencyEdgeDto("00061", "00063"))
+            .ShowLegend(false)
+            .OnNodeClick(id => client.Toast($"Plan {id} clicked", "OnNodeClick").Info());
+
+        return new Card(graph).Height(Size.Full());
+    }
+}

--- a/src/Ivy.Tendril.Widgets/AGENTS.md
+++ b/src/Ivy.Tendril.Widgets/AGENTS.md
@@ -16,6 +16,7 @@ frontend/             React/Vite bundle (npm run build → dist/)
     AgentViewer/      ErrorApp, LiveStreamApp, PreBufferedApp, TableOutputApp
     TendrilProcessViewer/  DemoApp
     WebViewer/        DemoApp (inspector), SideBySideApp (two viewers on one page)
+    PlanDependencyGraph/   DemoApp (clickable graph), CyclicApp (a dependency loop)
 
 .tests/               Playwright E2E tests
   widgets/            Test specs grouped by widget
@@ -141,6 +142,24 @@ URL the caller did not name and the allow-list would never see it.
 No cookies travel in either direction, and `Set-Cookie` is not relayed: every proxied site is
 served from the Ivy app's one origin, so a single cookie jar would be shared by all of them.
 Sites that need a session cannot be reviewed signed in.
+
+## PlanDependencyGraph
+
+`PlanDependencyGraph.cs` takes a flat node list plus `PlanDependencyEdgeDto(Plan, DependsOn)`
+edges and fires `OnNodeClick` with the plan id, which is what the host uses to navigate. The
+layout is computed in the browser (`frontend/src/PlanDependencyGraph/layout.ts`), not by a layout
+library: edges are normalized, cycles are found by depth-first search, ranks come from a
+longest-path pass, and the order inside each rank is settled by barycenter sweeps. Everything
+there is a pure function, so `layout.test.ts` covers ranking, ordering and overlap without a DOM.
+
+Three things the widget has to keep doing:
+
+- a cycle is drawn, not dropped. A hand-edited `plan.yaml` can always close a loop, so the edge
+  that closes it is excluded from ranking and rendered dashed;
+- the pointer is captured only once a pan passes the drag threshold. A captured pointer retargets
+  the click to the viewport, which silently swallowed every click on a node;
+- hovering dims the unrelated plans, selecting does not. A selection lives as long as the plan is
+  open in the host, and a permanently dimmed graph is unreadable.
 
 ## Markdown raw HTML
 

--- a/src/Ivy.Tendril.Widgets/PlanDependencyGraph.cs
+++ b/src/Ivy.Tendril.Widgets/PlanDependencyGraph.cs
@@ -1,0 +1,94 @@
+namespace Ivy.Tendril.Widgets;
+
+/// <param name="Id">Plan identity, echoed back by <see cref="PlanDependencyGraph.OnNodeClick"/>.</param>
+/// <param name="Badge">Short label under the title. Defaults to the id when null.</param>
+public record PlanDependencyNodeDto(
+    string Id,
+    string Title,
+    string? Status = null,
+    string? Project = null,
+    string? Level = null,
+    string? Badge = null);
+
+/// <summary><paramref name="Plan"/> depends on <paramref name="DependsOn"/>, which is drawn above it.</summary>
+public record PlanDependencyEdgeDto(string Plan, string DependsOn);
+
+/// <summary>
+/// Layered graph of plans and the plans they depend on. Prerequisites sit at the top (or on the
+/// left when horizontal) and the arrows point at what they unblock. Cycles, which a hand-edited
+/// plan.yaml can always introduce, are drawn dashed rather than dropped.
+/// </summary>
+[ExternalWidget(
+    "frontend/dist/ivy-tendril-widgets.js",
+    StylePath = "frontend/dist/ivy-tendril-widgets.css",
+    ExportName = "PlanDependencyGraph",
+    GlobalName = "IvyTendrilWidgets"
+)]
+public record PlanDependencyGraph : WidgetBase<PlanDependencyGraph>
+{
+    [Prop] public List<PlanDependencyNodeDto> Nodes { get; init; } = new();
+    [Prop] public List<PlanDependencyEdgeDto> Edges { get; init; } = new();
+
+    /// <summary>Plan drawn with the selection ring, typically the one open in the host app.</summary>
+    [Prop] public string? SelectedId { get; init; }
+
+    /// <summary>"vertical" (default) or "horizontal".</summary>
+    [Prop] public string Orientation { get; init; } = "vertical";
+
+    [Prop] public bool ShowLegend { get; init; } = true;
+    [Prop] public string? EmptyMessage { get; init; }
+
+    [Event] public EventHandler<Event<PlanDependencyGraph, string>>? OnNodeClick { get; init; }
+}
+
+public static class PlanDependencyGraphExtensions
+{
+    public static PlanDependencyGraph Nodes(this PlanDependencyGraph w, params PlanDependencyNodeDto[] nodes) =>
+        w with { Nodes = nodes.ToList() };
+
+    public static PlanDependencyGraph Nodes(this PlanDependencyGraph w, IEnumerable<PlanDependencyNodeDto> nodes) =>
+        w with { Nodes = nodes.ToList() };
+
+    public static PlanDependencyGraph Edges(this PlanDependencyGraph w, params PlanDependencyEdgeDto[] edges) =>
+        w with { Edges = edges.ToList() };
+
+    public static PlanDependencyGraph Edges(this PlanDependencyGraph w, IEnumerable<PlanDependencyEdgeDto> edges) =>
+        w with { Edges = edges.ToList() };
+
+    /// <summary>Expands one "plan id to the ids it depends on" map into the edge list.</summary>
+    public static PlanDependencyGraph Dependencies(
+        this PlanDependencyGraph w,
+        IEnumerable<KeyValuePair<string, IEnumerable<string>>> dependsOn) =>
+        w with
+        {
+            Edges = dependsOn
+                .SelectMany(pair => pair.Value.Select(dep => new PlanDependencyEdgeDto(pair.Key, dep)))
+                .ToList()
+        };
+
+    public static PlanDependencyGraph SelectedId(this PlanDependencyGraph w, string? id) =>
+        w with { SelectedId = id };
+
+    public static PlanDependencyGraph Orientation(this PlanDependencyGraph w, string orientation) =>
+        w with { Orientation = orientation };
+
+    public static PlanDependencyGraph Horizontal(this PlanDependencyGraph w) =>
+        w with { Orientation = "horizontal" };
+
+    public static PlanDependencyGraph Vertical(this PlanDependencyGraph w) =>
+        w with { Orientation = "vertical" };
+
+    public static PlanDependencyGraph ShowLegend(this PlanDependencyGraph w, bool show = true) =>
+        w with { ShowLegend = show };
+
+    public static PlanDependencyGraph EmptyMessage(this PlanDependencyGraph w, string? message) =>
+        w with { EmptyMessage = message };
+
+    public static PlanDependencyGraph OnNodeClick(this PlanDependencyGraph w, Action<string> handler) =>
+        w with { OnNodeClick = new(e => { handler(e.Value); return ValueTask.CompletedTask; }) };
+
+    public static PlanDependencyGraph OnNodeClickAsync(
+        this PlanDependencyGraph w,
+        Func<string, ValueTask> handler) =>
+        w with { OnNodeClick = new(e => handler(e.Value)) };
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDependencyGraph/PlanDependencyGraph.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDependencyGraph/PlanDependencyGraph.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { PlanDependencyGraph } from "./PlanDependencyGraph";
+import type { GraphEdge, GraphNode } from "./layout";
+
+const nodes: GraphNode[] = [
+  { id: "00001", title: "Base schema", status: "Completed" },
+  { id: "00002", title: "Import pipeline", status: "Executing" },
+  { id: "00003", title: "Dashboard", status: "Draft" },
+];
+
+const edges: GraphEdge[] = [
+  { plan: "00002", dependsOn: "00001" },
+  { plan: "00003", dependsOn: "00002" },
+];
+
+const renderGraph = (props: Partial<React.ComponentProps<typeof PlanDependencyGraph>> = {}) =>
+  render(<PlanDependencyGraph id="pdg-1" nodes={nodes} edges={edges} {...props} />);
+
+const nodeFor = (title: string) => screen.getByRole("button", { name: new RegExp(title) });
+
+describe("PlanDependencyGraph", () => {
+  it("renders one clickable node per plan", () => {
+    renderGraph();
+    for (const node of nodes) {
+      expect(nodeFor(node.title!)).toBeInTheDocument();
+    }
+  });
+
+  it("emits OnNodeClick with the plan id when a node is clicked", () => {
+    const eventHandler = vi.fn();
+    renderGraph({ events: ["OnNodeClick"], eventHandler });
+
+    fireEvent.click(nodeFor("Import pipeline"));
+
+    expect(eventHandler).toHaveBeenCalledWith("OnNodeClick", "pdg-1", ["00002"]);
+  });
+
+  it("emits OnNodeClick when a focused node is activated from the keyboard", () => {
+    const eventHandler = vi.fn();
+    renderGraph({ events: ["OnNodeClick"], eventHandler });
+
+    fireEvent.keyDown(nodeFor("Dashboard"), { key: "Enter" });
+
+    expect(eventHandler).toHaveBeenCalledWith("OnNodeClick", "pdg-1", ["00003"]);
+  });
+
+  it("stays silent when the host registered no click handler", () => {
+    const eventHandler = vi.fn();
+    renderGraph({ events: [], eventHandler });
+
+    fireEvent.click(nodeFor("Base schema"));
+
+    expect(eventHandler).not.toHaveBeenCalled();
+  });
+
+  it("marks the selected plan as pressed", () => {
+    renderGraph({ selectedId: "00002" });
+
+    expect(nodeFor("Import pipeline")).toHaveAttribute("aria-pressed", "true");
+    expect(nodeFor("Dashboard")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("colors a node by its plan status", () => {
+    const { container } = renderGraph();
+
+    expect(container.querySelector('[data-plan-id="00001"]')?.getAttribute("class")).toContain(
+      "pdg-status-completed"
+    );
+    expect(container.querySelector('[data-plan-id="00003"]')?.getAttribute("class")).toContain(
+      "pdg-status-draft"
+    );
+  });
+
+  it("draws an edge per dependency, pointing from the dependency to the plan", () => {
+    const { container } = renderGraph();
+    const drawn = [...container.querySelectorAll(".pdg-edge")].map((path) => [
+      path.getAttribute("data-from"),
+      path.getAttribute("data-to"),
+    ]);
+
+    expect(drawn).toEqual([
+      ["00001", "00002"],
+      ["00002", "00003"],
+    ]);
+  });
+
+  it("dims the plans that are not connected to the hovered one", () => {
+    const { container } = renderGraph();
+
+    fireEvent.pointerEnter(nodeFor("Base schema"));
+
+    expect(container.querySelector('[data-plan-id="00002"]')?.getAttribute("class")).not.toContain(
+      "is-dimmed"
+    );
+    expect(container.querySelector('[data-plan-id="00003"]')?.getAttribute("class")).toContain(
+      "is-dimmed"
+    );
+  });
+
+  it("highlights the selection's dependencies without dimming the rest of the graph", () => {
+    const { container } = renderGraph({ selectedId: "00002" });
+
+    const classesOf = (selector: string) => container.querySelector(selector)!.getAttribute("class")!;
+    expect(classesOf('[data-plan-id="00001"]')).not.toContain("is-dimmed");
+    expect(classesOf('[data-from="00001"][data-to="00002"]')).toContain("is-active");
+    expect(classesOf('[data-from="00002"][data-to="00003"]')).toContain("is-active");
+  });
+
+  it("shows a legend entry per status in the graph, in plan lifecycle order", () => {
+    renderGraph();
+    const legend = document.querySelector(".pdg-legend")!;
+    expect(legend.textContent).toBe("draftexecutingcompleted");
+  });
+
+  it("shows an empty message instead of an empty canvas", () => {
+    render(<PlanDependencyGraph id="pdg-1" nodes={[]} edges={[]} />);
+    expect(screen.getByText("No plan dependencies to show")).toBeInTheDocument();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDependencyGraph/PlanDependencyGraph.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDependencyGraph/PlanDependencyGraph.tsx
@@ -1,0 +1,358 @@
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Maximize2, Minus, Plus } from "lucide-react";
+import {
+  buildNeighbourIndex,
+  layoutGraph,
+  normalizeEdges,
+  truncateToWidth,
+  type GraphEdge,
+  type GraphNode,
+  type Orientation,
+} from "./layout";
+import "./plan-dependency-graph.css";
+
+type IvyEventHandler = (eventName: string, widgetId: string, args: unknown[]) => void;
+
+export interface PlanDependencyGraphProps {
+  id: string;
+  nodes?: GraphNode[];
+  edges?: GraphEdge[];
+  selectedId?: string | null;
+  orientation?: Orientation;
+  showLegend?: boolean;
+  emptyMessage?: string;
+  events?: string[];
+  eventHandler?: IvyEventHandler;
+}
+
+const EMPTY_NODES: GraphNode[] = [];
+const EMPTY_EDGES: GraphEdge[] = [];
+const EMPTY_EVENTS: string[] = [];
+
+const MIN_ZOOM = 0.25;
+const MAX_ZOOM = 2.5;
+const ZOOM_STEP = 1.25;
+const DRAG_SLOP = 4;
+const TITLE_FONT_SIZE = 13;
+const META_FONT_SIZE = 11;
+
+const KNOWN_STATUSES = [
+  "draft",
+  "creating",
+  "updating",
+  "executing",
+  "review",
+  "completed",
+  "failed",
+  "blocked",
+  "skipped",
+  "icebox",
+];
+
+const statusKey = (status?: string): string => {
+  const value = (status ?? "").trim().toLowerCase();
+  return KNOWN_STATUSES.includes(value) ? value : "unknown";
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+interface Transform {
+  x: number;
+  y: number;
+  k: number;
+}
+
+const IDENTITY: Transform = { x: 0, y: 0, k: 1 };
+
+export const PlanDependencyGraph: React.FC<PlanDependencyGraphProps> = ({
+  id,
+  nodes = EMPTY_NODES,
+  edges = EMPTY_EDGES,
+  selectedId = null,
+  orientation = "vertical",
+  showLegend = true,
+  emptyMessage = "No plan dependencies to show",
+  events = EMPTY_EVENTS,
+  eventHandler,
+}) => {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [transform, setTransform] = useState<Transform>(IDENTITY);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+
+  const cleanEdges = useMemo(() => normalizeEdges(nodes, edges), [nodes, edges]);
+  const layout = useMemo(
+    () => layoutGraph(nodes, cleanEdges, { orientation }),
+    [nodes, cleanEdges, orientation]
+  );
+  const neighbours = useMemo(() => buildNeighbourIndex(cleanEdges), [cleanEdges]);
+  const nodeById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
+
+  // Hovering dims everything the plan is not connected to; a selection only highlights, because a
+  // selected plan is a long-lived state and a permanently dimmed graph is hard to read.
+  const hoverSet = useMemo(() => {
+    if (!hoveredId || !nodeById.has(hoveredId)) return null;
+    return new Set<string>([hoveredId, ...(neighbours.get(hoveredId) ?? [])]);
+  }, [hoveredId, neighbours, nodeById]);
+  const activeId = hoveredId ?? selectedId;
+
+  const fitView = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || layout.width === 0 || layout.height === 0) return;
+    const { clientWidth, clientHeight } = viewport;
+    if (clientWidth === 0 || clientHeight === 0) return;
+    const k = clamp(
+      Math.min(clientWidth / layout.width, clientHeight / layout.height, 1),
+      MIN_ZOOM,
+      MAX_ZOOM
+    );
+    setTransform({
+      k,
+      x: (clientWidth - layout.width * k) / 2,
+      y: (clientHeight - layout.height * k) / 2,
+    });
+  }, [layout.width, layout.height]);
+
+  // A pan or a zoom is the viewer's own framing, so a later resize must not throw it away.
+  const adjustedRef = useRef(false);
+
+  useLayoutEffect(() => {
+    adjustedRef.current = false;
+    fitView();
+  }, [fitView]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      if (!adjustedRef.current) fitView();
+    });
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, [fitView]);
+
+  const zoomBy = useCallback((factor: number, origin?: { x: number; y: number }) => {
+    adjustedRef.current = true;
+    setTransform((current) => {
+      const k = clamp(current.k * factor, MIN_ZOOM, MAX_ZOOM);
+      if (k === current.k) return current;
+      const viewport = viewportRef.current;
+      const anchor = origin ?? {
+        x: (viewport?.clientWidth ?? 0) / 2,
+        y: (viewport?.clientHeight ?? 0) / 2,
+      };
+      const scale = k / current.k;
+      return {
+        k,
+        x: anchor.x - (anchor.x - current.x) * scale,
+        y: anchor.y - (anchor.y - current.y) * scale,
+      };
+    });
+  }, []);
+
+  // Wheel has to be a native non-passive listener; React routes it through a passive root handler.
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const rect = viewport.getBoundingClientRect();
+      const origin = { x: event.clientX - rect.left, y: event.clientY - rect.top };
+      if (event.ctrlKey || event.metaKey || Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
+        zoomBy(event.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP, origin);
+      } else {
+        adjustedRef.current = true;
+        setTransform((current) => ({ ...current, x: current.x - event.deltaX }));
+      }
+    };
+    viewport.addEventListener("wheel", onWheel, { passive: false });
+    return () => viewport.removeEventListener("wheel", onWheel);
+  }, [zoomBy]);
+
+  const dragRef = useRef<{ pointerId: number; x: number; y: number; moved: boolean } | null>(null);
+  const [panning, setPanning] = useState(false);
+
+  const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    dragRef.current = { pointerId: event.pointerId, x: event.clientX, y: event.clientY, moved: false };
+  };
+
+  const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const dx = event.clientX - drag.x;
+    const dy = event.clientY - drag.y;
+    if (!drag.moved && Math.hypot(dx, dy) < DRAG_SLOP) return;
+    if (!drag.moved) {
+      // Capture only once the pointer really is panning: a captured pointer retargets the click
+      // to the viewport, which would swallow every click on a node.
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      adjustedRef.current = true;
+      setPanning(true);
+    }
+    drag.moved = true;
+    drag.x = event.clientX;
+    drag.y = event.clientY;
+    setTransform((current) => ({ ...current, x: current.x + dx, y: current.y + dy }));
+  };
+
+  const endDrag = (event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    dragRef.current = null;
+    setPanning(false);
+  };
+
+  const fireNodeClick = (nodeId: string) => {
+    if (eventHandler && events.includes("OnNodeClick")) {
+      eventHandler("OnNodeClick", id, [nodeId]);
+    }
+  };
+
+  const legendStatuses = useMemo(() => {
+    const present = new Set(nodes.map((node) => statusKey(node.status)));
+    return KNOWN_STATUSES.filter((status) => present.has(status));
+  }, [nodes]);
+
+  if (nodes.length === 0) {
+    return (
+      <div className="pdg-root pdg-empty">
+        <span>{emptyMessage}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pdg-root">
+      <div
+        ref={viewportRef}
+        className={`pdg-viewport${panning ? " is-panning" : ""}`}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+      >
+        <svg
+          className="pdg-canvas"
+          width={layout.width * transform.k}
+          height={layout.height * transform.k}
+          viewBox={`0 0 ${layout.width} ${layout.height}`}
+          style={{ transform: `translate(${transform.x}px, ${transform.y}px)` }}
+          role="img"
+          aria-label="Plan dependency graph"
+        >
+          <defs>
+            <marker
+              id={`pdg-arrow-${id}`}
+              viewBox="0 0 8 8"
+              refX="7"
+              refY="4"
+              markerWidth="7"
+              markerHeight="7"
+              orient="auto-start-reverse"
+            >
+              <path className="pdg-arrow" d="M 0 0 L 8 4 L 0 8 z" />
+            </marker>
+          </defs>
+
+          <g className="pdg-edges">
+            {layout.edges.map((edge) => {
+              const touchesActive = edge.plan === activeId || edge.dependsOn === activeId;
+              const active = activeId !== null && touchesActive;
+              const dimmed = hoverSet !== null && !touchesActive;
+              return (
+                <path
+                  key={`${edge.dependsOn}->${edge.plan}`}
+                  className={`pdg-edge${edge.cyclic ? " is-cyclic" : ""}${active ? " is-active" : ""}${dimmed ? " is-dimmed" : ""}`}
+                  d={edge.path}
+                  markerEnd={`url(#pdg-arrow-${id})`}
+                  data-from={edge.dependsOn}
+                  data-to={edge.plan}
+                />
+              );
+            })}
+          </g>
+
+          <g className="pdg-nodes">
+            {layout.nodes.map((placed) => {
+              const node = nodeById.get(placed.id)!;
+              const status = statusKey(node.status);
+              const selected = selectedId === node.id;
+              const dimmed = hoverSet !== null && !hoverSet.has(node.id);
+              const title = node.title?.trim() || node.id;
+              const meta = [node.badge?.trim() || node.id, node.project?.trim(), node.level?.trim()]
+                .filter(Boolean)
+                .join(" · ");
+              return (
+                <g
+                  key={node.id}
+                  className={`pdg-node pdg-status-${status}${selected ? " is-selected" : ""}${dimmed ? " is-dimmed" : ""}`}
+                  transform={`translate(${placed.x}, ${placed.y})`}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`${title} (${node.status ?? "unknown"})`}
+                  aria-pressed={selected}
+                  data-plan-id={node.id}
+                  onClick={() => fireNodeClick(node.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      fireNodeClick(node.id);
+                    }
+                  }}
+                  onPointerEnter={() => setHoveredId(node.id)}
+                  onPointerLeave={() => setHoveredId((current) => (current === node.id ? null : current))}
+                  onFocus={() => setHoveredId(node.id)}
+                  onBlur={() => setHoveredId((current) => (current === node.id ? null : current))}
+                >
+                  <title>{`${title}${node.status ? ` (${node.status})` : ""}`}</title>
+                  <rect className="pdg-node-box" width={placed.width} height={placed.height} rx={10} />
+                  <rect className="pdg-node-accent" width={4} height={placed.height} rx={2} />
+                  <text className="pdg-node-title" x={16} y={26} fontSize={TITLE_FONT_SIZE}>
+                    {truncateToWidth(title, placed.width - 28, TITLE_FONT_SIZE)}
+                  </text>
+                  <text className="pdg-node-meta" x={16} y={44} fontSize={META_FONT_SIZE}>
+                    {truncateToWidth(meta, placed.width - 28, META_FONT_SIZE)}
+                  </text>
+                  <circle className="pdg-node-dot" cx={placed.width - 14} cy={20} r={4} />
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+
+        <div className="pdg-controls">
+          <button type="button" aria-label="Zoom in" onClick={() => zoomBy(ZOOM_STEP)}>
+            <Plus size={14} />
+          </button>
+          <button type="button" aria-label="Zoom out" onClick={() => zoomBy(1 / ZOOM_STEP)}>
+            <Minus size={14} />
+          </button>
+          <button
+            type="button"
+            aria-label="Fit to view"
+            onClick={() => {
+              adjustedRef.current = false;
+              fitView();
+            }}
+          >
+            <Maximize2 size={14} />
+          </button>
+        </div>
+      </div>
+
+      {showLegend && legendStatuses.length > 0 && (
+        <div className="pdg-legend">
+          {legendStatuses.map((status) => (
+            <span key={status} className={`pdg-legend-item pdg-status-${status}`}>
+              <span className="pdg-legend-dot" />
+              {status}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDependencyGraph/index.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDependencyGraph/index.ts
@@ -1,0 +1,3 @@
+export { PlanDependencyGraph } from "./PlanDependencyGraph";
+export type { PlanDependencyGraphProps } from "./PlanDependencyGraph";
+export type { GraphEdge, GraphNode, Orientation } from "./layout";

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDependencyGraph/layout.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDependencyGraph/layout.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildNeighbourIndex,
+  edgeKey,
+  findCyclicEdges,
+  layoutGraph,
+  normalizeEdges,
+  rankNodes,
+  truncateToWidth,
+  type GraphEdge,
+  type GraphNode,
+} from "./layout";
+
+const nodes = (...ids: string[]): GraphNode[] => ids.map((id) => ({ id, title: id }));
+const edge = (plan: string, dependsOn: string): GraphEdge => ({ plan, dependsOn });
+
+describe("normalizeEdges", () => {
+  it("drops self references", () => {
+    expect(normalizeEdges(nodes("a"), [edge("a", "a")])).toEqual([]);
+  });
+
+  it("drops edges naming a plan that is not in the graph", () => {
+    expect(normalizeEdges(nodes("a"), [edge("a", "ghost")])).toEqual([]);
+  });
+
+  it("keeps one copy of a duplicated edge", () => {
+    expect(normalizeEdges(nodes("a", "b"), [edge("a", "b"), edge("a", "b")])).toEqual([
+      edge("a", "b"),
+    ]);
+  });
+});
+
+describe("rankNodes", () => {
+  it("puts a plan one rank below the deepest thing it depends on", () => {
+    const graph = nodes("a", "b", "c");
+    const links = [edge("b", "a"), edge("c", "b"), edge("c", "a")];
+    const ranks = rankNodes(graph, links, new Set());
+    expect(ranks.get("a")).toBe(0);
+    expect(ranks.get("b")).toBe(1);
+    expect(ranks.get("c")).toBe(2);
+  });
+
+  it("ranks unconnected plans at the top", () => {
+    const ranks = rankNodes(nodes("a", "b"), [], new Set());
+    expect(ranks.get("a")).toBe(0);
+    expect(ranks.get("b")).toBe(0);
+  });
+});
+
+describe("findCyclicEdges", () => {
+  it("finds nothing in an acyclic graph", () => {
+    expect(findCyclicEdges(nodes("a", "b"), [edge("b", "a")]).size).toBe(0);
+  });
+
+  it("marks the edge that closes a loop", () => {
+    const graph = nodes("a", "b", "c");
+    const links = [edge("b", "a"), edge("c", "b"), edge("a", "c")];
+    const cyclic = findCyclicEdges(graph, links);
+    expect(cyclic.size).toBe(1);
+    expect(cyclic.has(edgeKey("c", "a"))).toBe(true);
+  });
+
+  it("still ranks every plan when the graph has a cycle", () => {
+    const graph = nodes("a", "b", "c");
+    const links = [edge("b", "a"), edge("c", "b"), edge("a", "c")];
+    const ranks = rankNodes(graph, links, findCyclicEdges(graph, links));
+    expect([...ranks.values()].every((rank) => Number.isInteger(rank))).toBe(true);
+  });
+});
+
+describe("layoutGraph", () => {
+  it("stacks a dependency chain top to bottom", () => {
+    const layout = layoutGraph(nodes("a", "b", "c"), [edge("b", "a"), edge("c", "b")]);
+    const [a, b, c] = layout.nodes;
+    expect(a.y).toBeLessThan(b.y);
+    expect(b.y).toBeLessThan(c.y);
+    expect(layout.rankCount).toBe(3);
+  });
+
+  it("stacks left to right when horizontal", () => {
+    const layout = layoutGraph(nodes("a", "b"), [edge("b", "a")], { orientation: "horizontal" });
+    const [a, b] = layout.nodes;
+    expect(a.x).toBeLessThan(b.x);
+    expect(a.y).toBeCloseTo(b.y, 5);
+  });
+
+  it("never overlaps two plans in the same rank", () => {
+    const layout = layoutGraph(nodes("root", "a", "b", "c"), [
+      edge("a", "root"),
+      edge("b", "root"),
+      edge("c", "root"),
+    ]);
+    const rankOne = layout.nodes.filter((node) => node.rank === 1).sort((l, r) => l.x - r.x);
+    expect(rankOne).toHaveLength(3);
+    for (let i = 1; i < rankOne.length; i++) {
+      expect(rankOne[i].x).toBeGreaterThanOrEqual(rankOne[i - 1].x + rankOne[i - 1].width);
+    }
+  });
+
+  it("draws one path per edge and flags the cyclic one", () => {
+    const layout = layoutGraph(nodes("a", "b"), [edge("b", "a"), edge("a", "b")]);
+    expect(layout.edges).toHaveLength(2);
+    expect(layout.edges.every((e) => e.path.startsWith("M "))).toBe(true);
+    expect(layout.edges.filter((e) => e.cyclic)).toHaveLength(1);
+  });
+
+  it("sizes the canvas around the placed plans", () => {
+    const layout = layoutGraph(nodes("a", "b"), [edge("b", "a")]);
+    const maxRight = Math.max(...layout.nodes.map((n) => n.x + n.width));
+    const maxBottom = Math.max(...layout.nodes.map((n) => n.y + n.height));
+    expect(layout.width).toBeGreaterThanOrEqual(maxRight);
+    expect(layout.height).toBeGreaterThanOrEqual(maxBottom);
+  });
+
+  it("lays out an empty graph without throwing", () => {
+    const layout = layoutGraph([], []);
+    expect(layout.nodes).toEqual([]);
+    expect(layout.edges).toEqual([]);
+  });
+});
+
+describe("buildNeighbourIndex", () => {
+  it("links both directions of an edge", () => {
+    const index = buildNeighbourIndex([edge("b", "a")]);
+    expect([...index.get("a")!]).toEqual(["b"]);
+    expect([...index.get("b")!]).toEqual(["a"]);
+  });
+});
+
+describe("truncateToWidth", () => {
+  it("leaves a short title alone", () => {
+    expect(truncateToWidth("Short", 200, 13)).toBe("Short");
+  });
+
+  it("cuts a long title and marks it with an ellipsis", () => {
+    const result = truncateToWidth("A plan title far too long for the box", 60, 13);
+    expect(result.endsWith("…")).toBe(true);
+    expect(result.length).toBeLessThan("A plan title far too long for the box".length);
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDependencyGraph/layout.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDependencyGraph/layout.ts
@@ -1,0 +1,380 @@
+export interface GraphNode {
+  id: string;
+  title?: string;
+  status?: string;
+  project?: string;
+  level?: string;
+  badge?: string;
+}
+
+/** `plan` depends on `dependsOn`, so `dependsOn` is laid out above (or left of) `plan`. */
+export interface GraphEdge {
+  plan: string;
+  dependsOn: string;
+}
+
+export type Orientation = "vertical" | "horizontal";
+
+export interface LayoutOptions {
+  orientation?: Orientation;
+  nodeWidth?: number;
+  nodeHeight?: number;
+  gapX?: number;
+  gapY?: number;
+  padding?: number;
+}
+
+export interface LaidOutNode {
+  id: string;
+  rank: number;
+  order: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface LaidOutEdge {
+  plan: string;
+  dependsOn: string;
+  /** True when the edge was part of a cycle and had to be ignored while ranking. */
+  cyclic: boolean;
+  path: string;
+}
+
+export interface GraphLayout {
+  nodes: LaidOutNode[];
+  edges: LaidOutEdge[];
+  width: number;
+  height: number;
+  rankCount: number;
+}
+
+export const DEFAULT_LAYOUT: Required<LayoutOptions> = {
+  orientation: "vertical",
+  nodeWidth: 208,
+  nodeHeight: 62,
+  gapX: 28,
+  gapY: 56,
+  padding: 24,
+};
+
+const BARYCENTER_SWEEPS = 4;
+
+/** Drops self references, duplicates, and edges naming a plan that is not in the node set. */
+export function normalizeEdges(nodes: GraphNode[], edges: GraphEdge[]): GraphEdge[] {
+  const known = new Set(nodes.map((n) => n.id));
+  const seen = new Set<string>();
+  const result: GraphEdge[] = [];
+  for (const edge of edges) {
+    if (!edge || edge.plan === edge.dependsOn) continue;
+    if (!known.has(edge.plan) || !known.has(edge.dependsOn)) continue;
+    const key = `${edge.dependsOn}\u0000${edge.plan}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push({ plan: edge.plan, dependsOn: edge.dependsOn });
+  }
+  return result;
+}
+
+/**
+ * Finds the edges that close a cycle, by depth-first search over the dependency direction.
+ * A plan graph should be acyclic, but a hand-edited plan.yaml can always close a loop and the
+ * widget still has to draw something.
+ */
+export function findCyclicEdges(nodes: GraphNode[], edges: GraphEdge[]): Set<string> {
+  const children = new Map<string, string[]>();
+  for (const node of nodes) children.set(node.id, []);
+  for (const edge of edges) children.get(edge.dependsOn)!.push(edge.plan);
+
+  const cyclic = new Set<string>();
+  const state = new Map<string, 0 | 1 | 2>();
+
+  const visit = (root: string) => {
+    const stack: Array<{ id: string; next: number }> = [{ id: root, next: 0 }];
+    state.set(root, 1);
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1];
+      const kids = children.get(frame.id)!;
+      if (frame.next >= kids.length) {
+        state.set(frame.id, 2);
+        stack.pop();
+        continue;
+      }
+      const child = kids[frame.next++];
+      const seen = state.get(child) ?? 0;
+      if (seen === 1) {
+        cyclic.add(edgeKey(frame.id, child));
+      } else if (seen === 0) {
+        state.set(child, 1);
+        stack.push({ id: child, next: 0 });
+      }
+    }
+  };
+
+  for (const node of nodes) {
+    if ((state.get(node.id) ?? 0) === 0) visit(node.id);
+  }
+  return cyclic;
+}
+
+export function edgeKey(dependsOn: string, plan: string): string {
+  return `${dependsOn}\u0000${plan}`;
+}
+
+/** Longest-path ranking: a plan sits one rank below the deepest thing it depends on. */
+export function rankNodes(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  cyclic: Set<string>
+): Map<string, number> {
+  const parents = new Map<string, string[]>();
+  const children = new Map<string, string[]>();
+  const indegree = new Map<string, number>();
+  for (const node of nodes) {
+    parents.set(node.id, []);
+    children.set(node.id, []);
+    indegree.set(node.id, 0);
+  }
+  for (const edge of edges) {
+    if (cyclic.has(edgeKey(edge.dependsOn, edge.plan))) continue;
+    parents.get(edge.plan)!.push(edge.dependsOn);
+    children.get(edge.dependsOn)!.push(edge.plan);
+    indegree.set(edge.plan, indegree.get(edge.plan)! + 1);
+  }
+
+  const ranks = new Map<string, number>();
+  const queue = nodes.filter((n) => indegree.get(n.id) === 0).map((n) => n.id);
+  for (const id of queue) ranks.set(id, 0);
+
+  for (let i = 0; i < queue.length; i++) {
+    const id = queue[i];
+    for (const child of children.get(id)!) {
+      const rank = Math.max(ranks.get(child) ?? 0, (ranks.get(id) ?? 0) + 1);
+      ranks.set(child, rank);
+      indegree.set(child, indegree.get(child)! - 1);
+      if (indegree.get(child) === 0) queue.push(child);
+    }
+  }
+
+  for (const node of nodes) if (!ranks.has(node.id)) ranks.set(node.id, 0);
+  return ranks;
+}
+
+/**
+ * Orders the nodes inside each rank with barycenter sweeps, which is what keeps edges from
+ * crossing each other more than they have to.
+ */
+export function orderRanks(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  ranks: Map<string, number>
+): string[][] {
+  const rankCount = nodes.reduce((max, n) => Math.max(max, ranks.get(n.id)!), 0) + 1;
+  const layers: string[][] = Array.from({ length: rankCount }, () => []);
+  for (const node of nodes) layers[ranks.get(node.id)!].push(node.id);
+
+  const parents = new Map<string, string[]>();
+  const children = new Map<string, string[]>();
+  for (const node of nodes) {
+    parents.set(node.id, []);
+    children.set(node.id, []);
+  }
+  for (const edge of edges) {
+    parents.get(edge.plan)!.push(edge.dependsOn);
+    children.get(edge.dependsOn)!.push(edge.plan);
+  }
+
+  const positions = new Map<string, number>();
+  const reindex = () => {
+    for (const layer of layers) layer.forEach((id, index) => positions.set(id, index));
+  };
+  reindex();
+
+  const sweep = (layer: string[], neighbours: Map<string, string[]>) => {
+    const scored = layer.map((id, index) => {
+      const related = neighbours.get(id)!.filter((other) => positions.has(other));
+      const barycenter =
+        related.length > 0
+          ? related.reduce((sum, other) => sum + positions.get(other)!, 0) / related.length
+          : index;
+      return { id, barycenter, index };
+    });
+    scored.sort((a, b) => a.barycenter - b.barycenter || a.index - b.index);
+    return scored.map((entry) => entry.id);
+  };
+
+  for (let pass = 0; pass < BARYCENTER_SWEEPS; pass++) {
+    for (let i = 1; i < layers.length; i++) layers[i] = sweep(layers[i], parents);
+    reindex();
+    for (let i = layers.length - 2; i >= 0; i--) layers[i] = sweep(layers[i], children);
+    reindex();
+  }
+
+  return layers;
+}
+
+/**
+ * Cross-axis coordinates. Each rank is pulled toward the average position of its neighbours and
+ * then spread out again so nodes never overlap, which lines chains of plans up vertically.
+ */
+export function assignCrossPositions(
+  layers: string[][],
+  edges: GraphEdge[],
+  size: number,
+  gap: number
+): Map<string, number> {
+  const step = size + gap;
+  const centers = new Map<string, number>();
+  for (const layer of layers) {
+    layer.forEach((id, index) => centers.set(id, index * step + size / 2));
+  }
+
+  const parents = new Map<string, string[]>();
+  const children = new Map<string, string[]>();
+  for (const layer of layers) {
+    for (const id of layer) {
+      parents.set(id, []);
+      children.set(id, []);
+    }
+  }
+  for (const edge of edges) {
+    parents.get(edge.plan)?.push(edge.dependsOn);
+    children.get(edge.dependsOn)?.push(edge.plan);
+  }
+
+  const relax = (layer: string[], neighbours: Map<string, string[]>) => {
+    if (layer.length === 0) return;
+    const desired = layer.map((id) => {
+      const related = neighbours.get(id)!;
+      if (related.length === 0) return centers.get(id)!;
+      return related.reduce((sum, other) => sum + centers.get(other)!, 0) / related.length;
+    });
+
+    const placed = desired.slice();
+    for (let i = 1; i < placed.length; i++) {
+      placed[i] = Math.max(placed[i], placed[i - 1] + step);
+    }
+    const drift =
+      desired.reduce((sum, value) => sum + value, 0) / desired.length -
+      placed.reduce((sum, value) => sum + value, 0) / placed.length;
+    layer.forEach((id, index) => centers.set(id, placed[index] + drift));
+  };
+
+  for (let pass = 0; pass < BARYCENTER_SWEEPS; pass++) {
+    for (let i = 1; i < layers.length; i++) relax(layers[i], parents);
+    for (let i = layers.length - 2; i >= 0; i--) relax(layers[i], children);
+  }
+
+  let min = Infinity;
+  for (const value of centers.values()) min = Math.min(min, value);
+  if (Number.isFinite(min)) {
+    for (const [id, value] of centers) centers.set(id, value - min + size / 2);
+  }
+  return centers;
+}
+
+function edgePath(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  orientation: Orientation
+): string {
+  if (orientation === "vertical") {
+    const delta = Math.max(Math.abs(to.y - from.y) * 0.45, 24);
+    return `M ${from.x} ${from.y} C ${from.x} ${from.y + delta}, ${to.x} ${to.y - delta}, ${to.x} ${to.y}`;
+  }
+  const delta = Math.max(Math.abs(to.x - from.x) * 0.45, 24);
+  return `M ${from.x} ${from.y} C ${from.x + delta} ${from.y}, ${to.x - delta} ${to.y}, ${to.x} ${to.y}`;
+}
+
+export function layoutGraph(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  options: LayoutOptions = {}
+): GraphLayout {
+  const opts = { ...DEFAULT_LAYOUT, ...options };
+  const clean = normalizeEdges(nodes, edges);
+  const cyclic = findCyclicEdges(nodes, clean);
+  const ranks = rankNodes(nodes, clean, cyclic);
+  const layers = orderRanks(nodes, clean, ranks);
+
+  const vertical = opts.orientation === "vertical";
+  const crossSize = vertical ? opts.nodeWidth : opts.nodeHeight;
+  const crossGap = vertical ? opts.gapX : opts.gapY;
+  const mainSize = vertical ? opts.nodeHeight : opts.nodeWidth;
+  const mainGap = vertical ? opts.gapY : opts.gapX;
+  const centers = assignCrossPositions(layers, clean, crossSize, crossGap);
+
+  const laidOut = new Map<string, LaidOutNode>();
+  for (const node of nodes) {
+    const rank = ranks.get(node.id)!;
+    const order = layers[rank].indexOf(node.id);
+    const cross = centers.get(node.id) ?? crossSize / 2;
+    const main = rank * (mainSize + mainGap) + mainSize / 2;
+    laidOut.set(node.id, {
+      id: node.id,
+      rank,
+      order,
+      x: (vertical ? cross : main) - opts.nodeWidth / 2 + opts.padding,
+      y: (vertical ? main : cross) - opts.nodeHeight / 2 + opts.padding,
+      width: opts.nodeWidth,
+      height: opts.nodeHeight,
+    });
+  }
+
+  const anchors = (node: LaidOutNode, side: "out" | "in") =>
+    vertical
+      ? { x: node.x + node.width / 2, y: side === "out" ? node.y + node.height : node.y }
+      : { x: side === "out" ? node.x + node.width : node.x, y: node.y + node.height / 2 };
+
+  const drawnEdges: LaidOutEdge[] = clean.map((edge) => {
+    const from = laidOut.get(edge.dependsOn)!;
+    const to = laidOut.get(edge.plan)!;
+    const isCyclic = cyclic.has(edgeKey(edge.dependsOn, edge.plan));
+    return {
+      plan: edge.plan,
+      dependsOn: edge.dependsOn,
+      cyclic: isCyclic,
+      path: edgePath(anchors(from, "out"), anchors(to, "in"), opts.orientation),
+    };
+  });
+
+  let width = 0;
+  let height = 0;
+  for (const node of laidOut.values()) {
+    width = Math.max(width, node.x + node.width);
+    height = Math.max(height, node.y + node.height);
+  }
+
+  return {
+    nodes: nodes.map((node) => laidOut.get(node.id)!),
+    edges: drawnEdges,
+    width: width + opts.padding,
+    height: height + opts.padding,
+    rankCount: layers.length,
+  };
+}
+
+/** Neighbour index used to highlight everything touching the hovered or selected plan. */
+export function buildNeighbourIndex(edges: GraphEdge[]): Map<string, Set<string>> {
+  const index = new Map<string, Set<string>>();
+  const add = (a: string, b: string) => {
+    if (!index.has(a)) index.set(a, new Set());
+    index.get(a)!.add(b);
+  };
+  for (const edge of edges) {
+    add(edge.plan, edge.dependsOn);
+    add(edge.dependsOn, edge.plan);
+  }
+  return index;
+}
+
+const AVERAGE_CHAR_WIDTH = 0.56;
+
+/** SVG text has no ellipsis, so titles are cut to the box width before rendering. */
+export function truncateToWidth(text: string, maxWidth: number, fontSize: number): string {
+  const budget = Math.floor(maxWidth / (fontSize * AVERAGE_CHAR_WIDTH));
+  if (budget <= 1) return text.length > 1 ? "…" : text;
+  if (text.length <= budget) return text;
+  return `${text.slice(0, budget - 1).trimEnd()}…`;
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanDependencyGraph/plan-dependency-graph.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanDependencyGraph/plan-dependency-graph.css
@@ -1,0 +1,227 @@
+/* Plan dependency graph. Colors are mixed from the host theme tokens so the widget follows
+   whatever Ivy theme the app runs, in light and dark alike. */
+
+.pdg-root {
+  --pdg-bg: var(--background, #ffffff);
+  --pdg-fg: var(--foreground, #000000);
+  --pdg-muted: color-mix(in srgb, var(--foreground, #000000) 55%, transparent);
+  --pdg-line: color-mix(in srgb, var(--foreground, #000000) 32%, transparent);
+  --pdg-node-bg: color-mix(in srgb, var(--foreground, #000000) 3%, var(--background, #ffffff));
+  --pdg-node-border: color-mix(in srgb, var(--foreground, #000000) 14%, transparent);
+  --pdg-grid: color-mix(in srgb, var(--foreground, #000000) 7%, transparent);
+  --pdg-accent: var(--primary, #66e0be);
+
+  --pdg-status: color-mix(in srgb, var(--foreground, #000000) 45%, transparent);
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 240px;
+  font-family: var(--font-sans, "Geist", sans-serif);
+  color: var(--pdg-fg);
+  background: var(--pdg-bg);
+}
+
+.pdg-root,
+.pdg-root * {
+  box-sizing: border-box;
+}
+
+.pdg-empty {
+  align-items: center;
+  justify-content: center;
+  color: var(--pdg-muted);
+  font-size: 0.8125rem;
+}
+
+.pdg-viewport {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  background-image: radial-gradient(var(--pdg-grid) 1px, transparent 1px);
+  background-size: 18px 18px;
+}
+
+.pdg-viewport.is-panning {
+  cursor: grabbing;
+}
+
+.pdg-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: 0 0;
+  overflow: visible;
+}
+
+.pdg-edge {
+  fill: none;
+  stroke: var(--pdg-line);
+  stroke-width: 1.5;
+  transition: stroke 120ms ease, opacity 120ms ease;
+}
+
+.pdg-edge.is-cyclic {
+  stroke-dasharray: 5 4;
+}
+
+.pdg-edge.is-active {
+  stroke: var(--pdg-accent);
+  stroke-width: 2;
+}
+
+.pdg-edge.is-dimmed {
+  opacity: 0.25;
+}
+
+.pdg-arrow {
+  fill: var(--pdg-line);
+}
+
+.pdg-node {
+  cursor: pointer;
+  transition: opacity 120ms ease;
+}
+
+.pdg-node.is-dimmed {
+  opacity: 0.35;
+}
+
+.pdg-node-box {
+  fill: var(--pdg-node-bg);
+  stroke: var(--pdg-node-border);
+  stroke-width: 1;
+}
+
+.pdg-node:hover .pdg-node-box {
+  stroke: var(--pdg-status);
+}
+
+.pdg-node.is-selected .pdg-node-box {
+  stroke: var(--pdg-accent);
+  stroke-width: 2;
+}
+
+.pdg-node:focus {
+  outline: none;
+}
+
+.pdg-node:focus-visible .pdg-node-box {
+  stroke: var(--pdg-accent);
+  stroke-width: 2;
+}
+
+.pdg-node-accent {
+  fill: var(--pdg-status);
+}
+
+.pdg-node-dot {
+  fill: var(--pdg-status);
+}
+
+.pdg-node-title {
+  fill: var(--pdg-fg);
+  font-weight: 500;
+}
+
+.pdg-node-meta {
+  fill: var(--pdg-muted);
+}
+
+.pdg-controls {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pdg-controls button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid var(--pdg-node-border);
+  border-radius: var(--radius, 6px);
+  background: var(--pdg-node-bg);
+  color: var(--pdg-fg);
+  cursor: pointer;
+}
+
+.pdg-controls button:hover {
+  background: var(--accent, var(--pdg-grid));
+}
+
+.pdg-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--pdg-node-border);
+  font-size: 0.6875rem;
+  color: var(--pdg-muted);
+}
+
+.pdg-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  text-transform: capitalize;
+}
+
+.pdg-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--pdg-status);
+}
+
+/* Status palette. Each status sets --pdg-status once; the stripe, dot and legend swatch all
+   read it, so a new status only needs one rule. */
+.pdg-status-draft {
+  --pdg-status: color-mix(in srgb, var(--foreground, #000000) 40%, transparent);
+}
+
+.pdg-status-creating,
+.pdg-status-updating {
+  --pdg-status: #8b7fd4;
+}
+
+.pdg-status-executing {
+  --pdg-status: #3f8ee0;
+}
+
+.pdg-status-review {
+  --pdg-status: #e0a63f;
+}
+
+.pdg-status-completed {
+  --pdg-status: #2fae6b;
+}
+
+.pdg-status-failed {
+  --pdg-status: #d9534f;
+}
+
+.pdg-status-blocked {
+  --pdg-status: #d97a2f;
+}
+
+.pdg-status-skipped,
+.pdg-status-icebox {
+  --pdg-status: color-mix(in srgb, var(--foreground, #000000) 25%, transparent);
+}
+
+.pdg-status-unknown {
+  --pdg-status: color-mix(in srgb, var(--foreground, #000000) 30%, transparent);
+}

--- a/src/Ivy.Tendril.Widgets/frontend/src/index.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/index.ts
@@ -6,6 +6,7 @@ import { SortableVerificationList } from "./SortableVerificationList";
 import { ContentInput } from "./ContentInput/ContentInput";
 import { BadgeSelect } from "./BadgeSelect";
 import { PlanDiffView } from "./PlanDiffView/PlanDiffView";
+import { PlanDependencyGraph } from "./PlanDependencyGraph";
 import { ChatWidget } from "./ChatWidget/ChatWidget";
 import { WebViewer } from "./WebViewer";
 import { TendrilShell } from "./Shell/TendrilShell";
@@ -28,6 +29,7 @@ if (typeof window !== "undefined") {
     ContentInput,
     BadgeSelect,
     PlanDiffView,
+    PlanDependencyGraph,
     ChatWidget,
     WebViewer,
     TendrilShell,
@@ -51,6 +53,7 @@ export {
   ContentInput,
   BadgeSelect,
   PlanDiffView,
+  PlanDependencyGraph,
   ChatWidget,
   WebViewer,
   TendrilShell,


### PR DESCRIPTION
A layered graph of plans and the plans they depend on, with clickable nodes:
prerequisites sit at the top (or on the left when horizontal) and the arrows
point at what they unblock. Clicking or keyboard-activating a node fires
OnNodeClick with the plan id, so the host can navigate to that plan.

The layout is computed in the browser as pure functions (normalize, cycle
detection, longest-path ranking, barycenter ordering, straightening), so it is
covered by unit tests without a DOM. Cycles are drawn dashed rather than
dropped, since a hand-edited plan.yaml can always close a loop.

The viewport pans, zooms around the pointer, and fits on mount; the pointer is
captured only once a pan passes the drag threshold, because a captured pointer
retargets the click to the viewport and would swallow every node click.

Adds .samples/Apps/PlanDependencyGraph with a clickable demo and a cyclic case.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015BAFEkBehdXrGPDHPWsf9r