### PR TITLE
[00054] Remove Duplicate Inbox Loading Feedback

### DIFF
--- a/src/Ivy.Tendril/Apps/Inbox/ContentView.cs
+++ b/src/Ivy.Tendril/Apps/Inbox/ContentView.cs
@@ -193,8 +193,7 @@ public class ContentView(
             return Layout.Vertical().Height(Size.Full())
                 | header
                 | (Layout.Vertical().AlignContent(Align.Center).Height(Size.Grow())
-                    | new Loading()
-                    | Text.Muted("Fetching review requests from GitHub..."));
+                    | new Loading());
         }
 
         if (errorMessage != null)
@@ -351,8 +350,7 @@ public class ContentView(
             return Layout.Vertical().Height(Size.Full())
                 | header
                 | (Layout.Vertical().AlignContent(Align.Center).Height(Size.Grow())
-                    | new Loading()
-                    | Text.Muted("Loading issues from GitHub..."));
+                    | new Loading());
         }
 
         if (errorMessage != null)


### PR DESCRIPTION
# Summary

## Changes

Removed the redundant GitHub-specific status text that appeared alongside the Ivy `Loading` spinner
in the Tendril Inbox's Reviews and Issues initial-fetch states. The spinner's built-in "Loading..."
label is now the only feedback shown, eliminating the duplicate message users saw on first load or
when switching to an uncached view.

## API Changes

None.

## Files Modified

- `src/Ivy.Tendril/Apps/Inbox/ContentView.cs` — removed the `Text.Muted(...)` line following
  `new Loading()` in both the Reviews (`BuildReviewsView`) and Issues initial-fetch branches.

## Manual Testing

1. Run the Tendril app (`dotnet run --project src/Ivy.Tendril/Ivy.Tendril.csproj --browse --find-available-port`) and open the Inbox app.
2. On first load (or after switching to an uncached Issues, Project, or Reviews view) with the GitHub
   request delayed, confirm exactly one centered `Loading` spinner is shown — no second muted status
   line beneath it.
3. Refresh a view that already has rows; confirm the existing table stays visible and only the
   refresh button shows its busy state.
4. Complete the delayed request with populated results, empty results, and an error in turn; confirm
   the data table, the "All Caught Up!" / no-content message, and the error message with Retry button
   render unchanged from before this change.

---
## Commits

- 6f6709de Remove duplicate loading feedback text in Inbox

---
Created using [Ivy Tendril](https://ivy.app).
