### PR TITLE
[00059] Freeze Chat Session Sidebar Order During Generation

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs
@@ -38,7 +38,7 @@ public class DeleteSessionDialogTests
         {
             return new ChatMessageModel(Guid.NewGuid().ToString(), role, content, DateTimeOffset.UtcNow, agentId, modelId, rawStream, effort);
         }
-        public ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true) => null;
+        public ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true) => null;
         public void FlushSession(string sessionId) { }
         public void SetSessionGenerating(string sessionId, bool isGenerating)
         {

--- a/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs
@@ -36,7 +36,7 @@ public class SidebarViewTests
         {
             return new ChatMessageModel(Guid.NewGuid().ToString(), role, content, DateTimeOffset.UtcNow, agentId, modelId, rawStream, effort);
         }
-        public ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true) => null;
+        public ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true) => null;
         public void FlushSession(string sessionId) { }
         public void SetSessionGenerating(string sessionId, bool isGenerating)
         {

--- a/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
+++ b/src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs
@@ -517,4 +517,177 @@ public class ChatHistoryServiceTests
                 Directory.Delete(tempDir, true);
         }
     }
+
+    [Fact]
+    public void UpdateMessage_WithTouchUpdatedAtFalse_LeavesUpdatedAtUnchangedButReplacesContent()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "opus");
+            var msg = service.AddMessage(session.Id, "assistant", "initial");
+            var beforeUpdate = service.GetSession(session.Id)!;
+            var frozenUpdatedAt = beforeUpdate.UpdatedAt.AddMinutes(-5);
+            service.SaveSession(beforeUpdate with { UpdatedAt = frozenUpdatedAt });
+
+            service.UpdateMessage(session.Id, msg.Id, "streamed chunk", flushImmediately: true, touchUpdatedAt: false);
+
+            var updatedSession = service.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            Assert.Equal(frozenUpdatedAt, updatedSession.UpdatedAt);
+            Assert.Equal("streamed chunk", Assert.Single(updatedSession.Messages).Content);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void UpdateMessage_WithDefaults_AdvancesUpdatedAt()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var session = service.CreateSession("claude", "opus");
+            var msg = service.AddMessage(session.Id, "assistant", "initial");
+            var beforeUpdate = service.GetSession(session.Id)!;
+            var staleUpdatedAt = beforeUpdate.UpdatedAt.AddMinutes(-5);
+            service.SaveSession(beforeUpdate with { UpdatedAt = staleUpdatedAt });
+
+            service.UpdateMessage(session.Id, msg.Id, "final content");
+
+            var updatedSession = service.GetSession(session.Id);
+            Assert.NotNull(updatedSession);
+            Assert.True(updatedSession.UpdatedAt > staleUpdatedAt);
+            Assert.Equal("final content", Assert.Single(updatedSession.Messages).Content);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void GetSessions_StaysStableWhileStreamingUpdatesFreezeSortKey()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var sessionA = service.CreateSession("claude", "opus");
+            var msgA = service.AddMessage(sessionA.Id, "assistant", "initial");
+            var sessionB = service.CreateSession("claude", "sonnet");
+
+            var baseTime = DateTimeOffset.UtcNow;
+            service.SaveSession(service.GetSession(sessionA.Id)! with { UpdatedAt = baseTime });
+            service.SaveSession(service.GetSession(sessionB.Id)! with { UpdatedAt = baseTime.AddSeconds(1) });
+
+            for (var i = 0; i < 3; i++)
+            {
+                service.UpdateMessage(sessionA.Id, msgA.Id, $"streamed chunk {i}", flushImmediately: true, touchUpdatedAt: false);
+            }
+
+            var order = service.GetSessions();
+            Assert.Equal(sessionB.Id, order[0].Id);
+            Assert.Equal(sessionA.Id, order[1].Id);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void GetSessions_ReordersAfterTurnCompletion()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var sessionA = service.CreateSession("claude", "opus");
+            var msgA = service.AddMessage(sessionA.Id, "assistant", "initial");
+            var sessionB = service.CreateSession("claude", "sonnet");
+
+            var baseTime = DateTimeOffset.UtcNow.AddMinutes(-10);
+            service.SaveSession(service.GetSession(sessionA.Id)! with { UpdatedAt = baseTime });
+            service.SaveSession(service.GetSession(sessionB.Id)! with { UpdatedAt = baseTime.AddSeconds(1) });
+
+            service.UpdateMessage(sessionA.Id, msgA.Id, "final content");
+
+            var order = service.GetSessions();
+            Assert.Equal(sessionA.Id, order[0].Id);
+            Assert.Equal(sessionB.Id, order[1].Id);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void AddMessage_MovesSessionToHeadOfGetSessions()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var sessionA = service.CreateSession("claude", "opus");
+            var sessionB = service.CreateSession("claude", "sonnet");
+
+            var baseTime = DateTimeOffset.UtcNow.AddMinutes(-10);
+            service.SaveSession(service.GetSession(sessionA.Id)! with { UpdatedAt = baseTime });
+            service.SaveSession(service.GetSession(sessionB.Id)! with { UpdatedAt = baseTime.AddSeconds(1) });
+
+            service.AddMessage(sessionA.Id, "user", "new message");
+
+            var order = service.GetSessions();
+            Assert.Equal(sessionA.Id, order[0].Id);
+            Assert.Equal(sessionB.Id, order[1].Id);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void AddAndRemoveSpawnedJobs_LeaveUpdatedAtAndOrderUnchanged()
+    {
+        var (service, tempDir) = CreateTestService();
+        try
+        {
+            var sessionA = service.CreateSession("claude", "opus");
+            var sessionB = service.CreateSession("claude", "sonnet");
+
+            var baseTime = DateTimeOffset.UtcNow;
+            service.SaveSession(service.GetSession(sessionA.Id)! with { UpdatedAt = baseTime });
+            service.SaveSession(service.GetSession(sessionB.Id)! with { UpdatedAt = baseTime.AddSeconds(1) });
+
+            service.AddSpawnedJob(sessionA.Id, "job-1");
+            var afterAdd = service.GetSession(sessionA.Id)!;
+            Assert.Equal(baseTime, afterAdd.UpdatedAt);
+            Assert.Contains("job-1", service.GetSpawnedJobs(sessionA.Id));
+
+            var orderAfterAdd = service.GetSessions();
+            Assert.Equal(sessionB.Id, orderAfterAdd[0].Id);
+            Assert.Equal(sessionA.Id, orderAfterAdd[1].Id);
+
+            service.RemoveSpawnedJobs(sessionA.Id, new[] { "job-1" });
+            var afterRemove = service.GetSession(sessionA.Id)!;
+            Assert.Equal(baseTime, afterRemove.UpdatedAt);
+            Assert.Empty(service.GetSpawnedJobs(sessionA.Id));
+
+            var orderAfterRemove = service.GetSessions();
+            Assert.Equal(sessionB.Id, orderAfterRemove[0].Id);
+            Assert.Equal(sessionA.Id, orderAfterRemove[1].Id);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
 }

--- a/src/Ivy.Tendril/Services/ChatExecutionService.cs
+++ b/src/Ivy.Tendril/Services/ChatExecutionService.cs
@@ -130,7 +130,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                 }
                 if (!string.IsNullOrEmpty(exec.AssistantMessageId))
                 {
-                    _chatService.UpdateMessage(sessionId, exec.AssistantMessageId, currentText ?? string.Empty, currentRaw, flushImmediately: false);
+                    _chatService.UpdateMessage(sessionId, exec.AssistantMessageId, currentText ?? string.Empty, currentRaw, flushImmediately: false, touchUpdatedAt: false);
                 }
             }
         }
@@ -535,7 +535,7 @@ public sealed class ChatExecutionService : IChatExecutionService
                                     currentText = activeExec.LastText;
                                     currentRaw = activeExec.RawLines.Count > 0 ? string.Join("\n", activeExec.RawLines) : null;
                                 }
-                                _chatService.UpdateMessage(sessionId, assistantMessageId, currentText ?? string.Empty, currentRaw, flushImmediately: false);
+                                _chatService.UpdateMessage(sessionId, assistantMessageId, currentText ?? string.Empty, currentRaw, flushImmediately: false, touchUpdatedAt: false);
                             }
                         }
                     }

--- a/src/Ivy.Tendril/Services/ChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/ChatHistoryService.cs
@@ -428,7 +428,6 @@ public class ChatHistoryService : IChatHistoryService
                 currentJobs.Add(jobId);
                 updated = session with
                 {
-                    UpdatedAt = DateTimeOffset.UtcNow,
                     SpawnedJobIds = currentJobs
                 };
                 _sessions[sessionId] = updated;
@@ -456,7 +455,6 @@ public class ChatHistoryService : IChatHistoryService
             {
                 updated = session with
                 {
-                    UpdatedAt = DateTimeOffset.UtcNow,
                     SpawnedJobIds = remaining.Count > 0 ? remaining : null
                 };
                 _sessions[sessionId] = updated;
@@ -642,7 +640,7 @@ public class ChatHistoryService : IChatHistoryService
         return false;
     }
 
-    public ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true)
+    public ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true)
     {
         if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(messageId)) return null;
 
@@ -669,7 +667,7 @@ public class ChatHistoryService : IChatHistoryService
 
             updatedSession = session with
             {
-                UpdatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = touchUpdatedAt ? DateTimeOffset.UtcNow : session.UpdatedAt,
                 Messages = newMessages
             };
 

--- a/src/Ivy.Tendril/Services/IChatHistoryService.cs
+++ b/src/Ivy.Tendril/Services/IChatHistoryService.cs
@@ -45,7 +45,7 @@ public interface IChatHistoryService
     void DeleteSession(string id);
     void RenameSession(string id, string newTitle);
     ChatMessageModel AddMessage(string sessionId, string role, string content, string? agentId = null, string? modelId = null, string? rawStream = null, string? effort = null);
-    ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true);
+    ChatMessageModel? UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true);
     void FlushSession(string sessionId);
     void SetSessionGenerating(string sessionId, bool isGenerating);
     void ClearAllGeneratingSessions();


### PR DESCRIPTION
# Summary

## Changes

Chat sidebar order no longer shuffles while a session is streaming or when a background promptware
job attaches to a session. `UpdateMessage` gained an opt-out for its `UpdatedAt` bump, the two
throttled mid-stream call sites use it, and job-association bookkeeping (`AddSpawnedJob`/
`RemoveSpawnedJobs`) stopped touching `UpdatedAt` entirely. Turn-completion updates and new user
messages still bump `UpdatedAt` as before, so a session still jumps to the top once per turn and
holds that slot for the duration.

## API Changes

- `IChatHistoryService.UpdateMessage(string sessionId, string messageId, string content, string? rawStream = null, bool flushImmediately = true, bool touchUpdatedAt = true)` — added `touchUpdatedAt` parameter (default `true`, so existing callers are unaffected).

## Files Modified

- `src/Ivy.Tendril/Services/IChatHistoryService.cs` — `UpdateMessage` signature.
- `src/Ivy.Tendril/Services/ChatHistoryService.cs` — `UpdateMessage` honors `touchUpdatedAt`; `AddSpawnedJob`/`RemoveSpawnedJobs` no longer bump `UpdatedAt`.
- `src/Ivy.Tendril/Services/ChatExecutionService.cs` — the two throttled mid-stream `UpdateMessage` calls now pass `touchUpdatedAt: false`.
- `src/Ivy.Tendril.Test/ChatHistoryServiceTests.cs` — 6 new tests covering the frozen/unfrozen sort key and job bookkeeping.
- `src/Ivy.Tendril.Test/Apps/Chat/SidebarViewTests.cs`, `src/Ivy.Tendril.Test/Apps/Chat/DeleteSessionDialogTests.cs` — `FakeChatHistoryService.UpdateMessage` stub updated to the new signature.

## Manual Testing

1. Run the app and open the Chat sidebar.
2. Start two or more chat sessions generating concurrently (or attach a background promptware job to a session while it streams).
3. Observe that each generating session's position in the sidebar stays fixed for the whole turn — the list only reorders once, when a turn completes or a new message is sent — instead of the previous per-second reshuffling.

---
## Commits

- 3817c165 Freeze sidebar sort key during streaming and job bookkeeping
- 5be4d257 Add sidebar ordering stability tests and update fake stubs

---
Created using [Ivy Tendril](https://ivy.app).
