### PR TITLE
[00055] Replace Dashboard Trend Average Line With Rolling 7 Day Average

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
@@ -49,48 +49,118 @@ public class DashboardAppViewModelTests
         Assert.Null(kpi.Direction);
     }
 
+    /// <summary>A daily cost row per day in the inclusive range, priced by <paramref name="cost" />.</summary>
+    private static List<DashboardDailyCost> DailyCosts(DateOnly from, DateOnly to, Func<DateOnly, decimal> cost) =>
+        Enumerable.Range(0, to.DayNumber - from.DayNumber + 1)
+            .Select(i => from.AddDays(i))
+            .Select(day => new DashboardDailyCost(day, cost(day), 0))
+            .ToList();
+
+    /// <summary>Period 11 against a window of 7, so the rolling mean cannot come out flat.</summary>
+    private static decimal Sawtooth(DateOnly date) => (date.DayNumber % 11) * 10m;
+
+    /// <summary>A different value on every day, so an assertion can pin which day was read.</summary>
+    private static decimal Unique(DateOnly date) => date.DayNumber;
+
     [Fact]
-    public void BuildTrend_TakesTrailingTwelveMonths()
+    public void BuildTrend_ProjectsAYearOfDailyPoints()
     {
-        var months = new List<DashboardMonthStats>();
-        for (var month = 1; month <= 12; month++)
-            months.Add(new DashboardMonthStats(2025, month, month, 0, month * 100m, 0));
-        for (var month = 1; month <= 8; month++)
-            months.Add(new DashboardMonthStats(2026, month, month * 2, 0, month * 200m, 0));
+        var today = new DateTime(2026, 9, 6);
+        var dataStart = new DateOnly(2024, 9, 1);
+        var activity = new DashboardActivityStats(
+            [], 0m, DailyCosts(dataStart, new DateOnly(2026, 9, 6), Sawtooth), null, null, dataStart);
 
-        var trend = DashboardApp.BuildTrend(new DashboardActivityStats(months, 0));
+        var trend = DashboardApp.BuildTrend(activity, today);
 
-        Assert.Equal(12, trend.Months.Count);
-        Assert.Equal("Sep", trend.Months[0]);
-        Assert.Equal("Aug", trend.Months[^1]);
-        Assert.Equal(900, trend.Cost[0]);
-        Assert.Equal(1600, trend.Cost[^1]);
-        Assert.Equal(9, trend.Plans[0]);
-        Assert.Equal(16, trend.Plans[^1]);
-        Assert.Null(trend.PrevCost[0]);
-        Assert.Null(trend.PrevCost[3]);
-        Assert.Equal(100, trend.PrevCost[4]);
-        Assert.Equal(800, trend.PrevCost[^1]);
-        Assert.Equal(1, trend.PrevPlans[4]);
-        Assert.Equal(8, trend.PrevPlans[^1]);
+        Assert.NotNull(trend);
+        Assert.Equal(365, trend.Dates.Count);
+        Assert.Equal("2025-09-07", trend.Dates[0]);
+        Assert.Equal("2026-09-06", trend.Dates[^1]);
+        Assert.All(trend.Dates, date => Assert.Matches(@"^\d{4}-\d{2}-\d{2}$", date));
+        Assert.Equal(365, trend.Cost.Count);
+        Assert.Equal(365, trend.RollingCost.Count);
+
+        // The point of the whole exercise: a curve that moves, rather than the one constant the old
+        // reference line drew.
+        Assert.True(trend.RollingCost.Distinct().Count() > 1, "the rolling series is flat");
+
+        // Index 0's window is the six days before the displayed range plus the first day of it.
+        var leading = new DateOnly(2025, 9, 1);
+        var expected = (double)Enumerable.Range(0, 7).Select(i => Sawtooth(leading.AddDays(i))).Average();
+        Assert.NotNull(trend.RollingCost[0]);
+        Assert.Equal(expected, trend.RollingCost[0]!.Value, 6);
     }
 
     [Fact]
-    public void BuildTrend_KeepsShortHistoryAsIs()
+    public void BuildTrend_ComparesTheSameCalendarDayAYearEarlier()
     {
+        var today = new DateTime(2026, 9, 6);
+        var dataStart = new DateOnly(2025, 1, 1);
+        var activity = new DashboardActivityStats(
+            [], 0m, DailyCosts(dataStart, new DateOnly(2026, 9, 6), Unique), null, null, dataStart);
+
+        var trend = DashboardApp.BuildTrend(activity, today);
+
+        Assert.NotNull(trend);
+        // A year before the last displayed day, read by date rather than by bucket offset.
+        Assert.Equal((double)Unique(new DateOnly(2025, 9, 6)), trend.PrevCost[^1]);
+
+        // The comparison day for 2026-01-01 is exactly the first recorded day, so it is known.
+        var firstOfYear = trend.Dates.IndexOf("2026-01-01");
+        Assert.Equal((double)Unique(dataStart), trend.PrevCost[firstOfYear]);
+
+        // One day earlier the comparison falls before any record: unknown, not zero.
+        Assert.Null(trend.PrevCost[firstOfYear - 1]);
+        Assert.Null(trend.PrevCost[0]);
+    }
+
+    [Fact]
+    public void BuildTrend_MapsLeapDayOntoTheTwentyEighth()
+    {
+        // 2027 has no 29th of February. Clamping to the 28th is the calendar behaviour wanted, and the
+        // alternative (a gap in the comparison every fourth year) would read as missing data.
+        var today = new DateTime(2028, 3, 1);
+        var dataStart = new DateOnly(2026, 1, 1);
+        var activity = new DashboardActivityStats(
+            [], 0m, DailyCosts(dataStart, new DateOnly(2028, 3, 1), Unique), null, null, dataStart);
+
+        var trend = DashboardApp.BuildTrend(activity, today);
+
+        Assert.NotNull(trend);
+        var leapDay = trend.Dates.IndexOf("2028-02-29");
+        Assert.True(leapDay >= 0, "the displayed range should contain the leap day");
+        Assert.Equal((double)Unique(new DateOnly(2027, 2, 28)), trend.PrevCost[leapDay]);
+    }
+
+    [Fact]
+    public void BuildTrend_WithoutADailySeries_IsAbsent()
+    {
+        // No monthly fallback: monthly buckets cannot carry a 7 day average or a date axis, so the card
+        // is better absent than plotted from them.
         var months = new List<DashboardMonthStats>
         {
             new(2026, 7, 3, 0, 120m, 0),
             new(2026, 8, 5, 0, 250m, 0)
         };
 
-        var trend = DashboardApp.BuildTrend(new DashboardActivityStats(months, 0));
+        Assert.Null(DashboardApp.BuildTrend(new DashboardActivityStats(months, 0), new DateTime(2026, 9, 6)));
+    }
 
-        Assert.Equal(["Jul", "Aug"], trend.Months);
-        Assert.Equal([120d, 250d], trend.Cost);
-        Assert.Equal([3d, 5d], trend.Plans);
-        Assert.Equal([null, null], trend.PrevCost);
-        Assert.Equal([null, null], trend.PrevPlans);
+    [Fact]
+    public void BuildTrend_EmptyDailySeries_IsAllZerosWithNoRollingAverage()
+    {
+        // A fresh install: the series exists but holds nothing, so every day reads 0 and the curve has
+        // nothing to draw rather than a confident flat line at zero.
+        var activity = new DashboardActivityStats([], 0m, [], null, new Dictionary<DateOnly, int>());
+
+        var trend = DashboardApp.BuildTrend(activity, new DateTime(2026, 9, 6));
+
+        Assert.NotNull(trend);
+        Assert.All(trend.Cost, cost => Assert.Equal(0d, cost));
+        Assert.All(trend.Plans, plans => Assert.Equal(0d, plans));
+        Assert.All(trend.RollingCost, rolling => Assert.Null(rolling));
+        Assert.All(trend.RollingPlans, rolling => Assert.Null(rolling));
+        Assert.All(trend.PrevCost, prev => Assert.Null(prev));
     }
 
     [Fact]
@@ -247,34 +317,7 @@ public class DashboardAppViewModelTests
     }
 
     [Fact]
-    public void BuildWeeklyTrend_ProjectsLastFourWeeksWithComparison()
-    {
-        var today = new DateOnly(2026, 9, 1);
-        var monday = today.AddDays(-(((int)today.DayOfWeek + 6) % 7));
-        var weeks = new List<DashboardWeekStats>();
-        for (var i = 23; i >= 0; i--)
-        {
-            var start = monday.AddDays(-7 * i);
-            weeks.Add(new DashboardWeekStats(start, i + 1, (i + 1) * 2, (i + 1) * 10m, 1000));
-        }
-
-        var activity = new DashboardActivityStats([], 0m, null, weeks);
-        var trend = DashboardApp.BuildWeeklyTrend(activity);
-
-        Assert.Equal(4, trend.Months.Count);
-        Assert.Equal(4, trend.Cost.Count);
-        Assert.Equal(4, trend.Plans.Count);
-        Assert.Equal(4, trend.PrevCost.Count);
-        Assert.Equal(4, trend.PrevPlans.Count);
-
-        // Most recent week (i = 0 in countdown, index 23 in all)
-        Assert.Equal(10.0, trend.Cost[^1]);
-        // Compared to 4 weeks earlier (index 19, which had i = 4, cost 50m)
-        Assert.Equal(50.0, trend.PrevCost[^1]);
-    }
-
-    [Fact]
-    public void BuildWeeklyTrend_Projects28DaysWithComparison_WhenDailyStatsAvailable()
+    public void BuildWeeklyTrend_Projects28DaysWithComparison()
     {
         var today = new DateTime(2026, 9, 6);
         var dailyCosts = new List<DashboardDailyCost>
@@ -294,24 +337,45 @@ public class DashboardAppViewModelTests
         var activity = new DashboardActivityStats([], 0m, dailyCosts, null, dailyPlans);
         var trend = DashboardApp.BuildWeeklyTrend(activity, today);
 
-        Assert.Equal(28, trend.Months.Count);
+        Assert.NotNull(trend);
+        Assert.Equal(28, trend.Dates.Count);
         Assert.Equal(28, trend.Cost.Count);
         Assert.Equal(28, trend.Plans.Count);
         Assert.Equal(28, trend.PrevCost.Count);
         Assert.Equal(28, trend.PrevPlans.Count);
+        Assert.Equal(28, trend.RollingCost.Count);
 
-        // First label is 27 days before today: Aug 10
-        Assert.Equal("Aug 10", trend.Months[0]);
-        // Last label is today: Sep 6
-        Assert.Equal("Sep 6", trend.Months[^1]);
+        // 27 days before today through today, as dates rather than labels.
+        Assert.Equal("2026-08-10", trend.Dates[0]);
+        Assert.Equal("2026-09-06", trend.Dates[^1]);
 
-        // Sept 6 cost
         Assert.Equal(28.31, trend.Cost[^1]);
-        // Sept 6 plans
         Assert.Equal(5.0, trend.Plans[^1]);
+        // Zero-filled: Sept 4 has no rows at all and is present as 0, not missing.
+        Assert.Equal(0d, trend.Cost[trend.Dates.IndexOf("2026-09-04")]);
+
         // Sept 6 compared to 28 days earlier (Aug 9)
         Assert.Equal(12.50, trend.PrevCost[^1]);
         Assert.Equal(2.0, trend.PrevPlans[^1]);
+
+        // Records begin Aug 9 (the fallback for a mock with no DailyDataStart), so the window clears it
+        // on Aug 15 and every day after that has a mean.
+        Assert.Null(trend.RollingCost[trend.Dates.IndexOf("2026-08-14")]);
+        Assert.NotNull(trend.RollingCost[trend.Dates.IndexOf("2026-08-15")]);
+        Assert.True(trend.RollingCost.Distinct().Count() > 1, "the rolling series is flat");
+    }
+
+    [Fact]
+    public void BuildWeeklyTrend_WithoutADailySeries_IsAbsent()
+    {
+        // The weekly-bucket fallback is gone: four weekly buckets cannot make a 7 day average.
+        var monday = new DateOnly(2026, 8, 31);
+        var weeks = Enumerable.Range(0, 24)
+            .Select(i => new DashboardWeekStats(monday.AddDays(-7 * (23 - i)), i + 1, 0, (i + 1) * 10m, 0))
+            .ToList();
+
+        Assert.Null(DashboardApp.BuildWeeklyTrend(
+            new DashboardActivityStats([], 0m, null, weeks), new DateTime(2026, 9, 6)));
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/DashboardActivityStatsTests.cs
+++ b/src/Ivy.Tendril.Test/DashboardActivityStatsTests.cs
@@ -208,6 +208,42 @@ public class DashboardActivityStatsTests : IDisposable
     }
 
     [Fact]
+    public void GetActivityStats_DailyDataStart_IsTheEarliestRecordedDay()
+    {
+        // What separates "a day that cost nothing" from "a day we have no records for". Without it every
+        // rolling average would silently divide over days that never existed.
+        var oldest = DateTime.UtcNow.Date.AddDays(-200);
+        _db.UpsertPlan(CreateTestPlan(1500, PlanStatus.Completed, oldest, oldest));
+        _db.UpsertPlan(CreateTestPlan(1501, PlanStatus.Completed, DateTime.UtcNow, DateTime.UtcNow));
+        _db.UpsertCosts(1501, [new CostEntry("ExecutePlan", 100, 3m, DateTime.UtcNow)]);
+
+        Assert.Equal(DateOnly.FromDateTime(oldest), _db.GetActivityStats().DailyDataStart);
+    }
+
+    [Fact]
+    public void GetActivityStats_DailyDataStart_IsNullOnAnEmptyDatabase()
+    {
+        Assert.Null(_db.GetActivityStats().DailyDataStart);
+    }
+
+    [Fact]
+    public void GetActivityStats_DailySeries_ReachBackPastTheOldSixtyDayWindow()
+    {
+        // The trend chart plots a year of days and compares against the year before it, so a two hundred
+        // day old row has to survive the cutoff the forecast used to set.
+        var longAgo = DateTime.UtcNow.Date.AddDays(-200);
+        _db.UpsertPlan(CreateTestPlan(1500, PlanStatus.Completed, longAgo, longAgo));
+        _db.UpsertCosts(1500, [new CostEntry("ExecutePlan", 900, 6m, longAgo)]);
+
+        var stats = _db.GetActivityStats();
+
+        Assert.NotNull(stats.DailyCosts);
+        Assert.Equal(6m, Assert.Single(stats.DailyCosts, d => d.Date == DateOnly.FromDateTime(longAgo)).Cost);
+        Assert.NotNull(stats.DailyPlans);
+        Assert.Equal(1, stats.DailyPlans[DateOnly.FromDateTime(longAgo)]);
+    }
+
+    [Fact]
     public void GetActivityStats_AggregatesByWeek()
     {
         var now = DateTime.UtcNow;

--- a/src/Ivy.Tendril.Test/Models/RollingAverageCalculatorTests.cs
+++ b/src/Ivy.Tendril.Test/Models/RollingAverageCalculatorTests.cs
@@ -1,0 +1,114 @@
+using Ivy.Tendril.Models;
+
+namespace Ivy.Tendril.Test.Models;
+
+public class RollingAverageCalculatorTests
+{
+    private static readonly DateOnly Day1 = new(2026, 1, 1);
+
+    /// <summary><paramref name="count" /> ascending days, starting <paramref name="offset" /> days after Day 1.</summary>
+    private static List<DateOnly> Days(int count, int offset = 0) =>
+        Enumerable.Range(offset, count).Select(i => Day1.AddDays(i)).ToList();
+
+    /// <summary>1 on Day 1, 2 on Day 2, and so on. 0 before Day 1.</summary>
+    private static double Ramp(DateOnly date)
+    {
+        var index = date.DayNumber - Day1.DayNumber;
+        return index >= 0 ? index + 1 : 0;
+    }
+
+    [Fact]
+    public void Compute_VaryingValues_ProduceANonConstantSeries()
+    {
+        // The regression this calculator exists for: the line it replaced was one horizontal constant,
+        // and a rolling mean that came out flat (or came out as the whole period's average) would be the
+        // same non-information under a new name.
+        var dates = Days(28);
+        // Period 11 against a window of 7, so no window repeats the one before it.
+        double Sawtooth(DateOnly date) => (date.DayNumber % 11) * 10;
+
+        var rolling = RollingAverageCalculator.Compute(dates, Sawtooth, Day1);
+
+        var values = rolling.Skip(RollingAverageCalculator.WindowDays - 1).Select(v => v!.Value).ToList();
+        Assert.True(values.Distinct().Count() > 1, "the rolling series is flat");
+
+        var wholeRangeMean = dates.Select(Sawtooth).Average();
+        Assert.DoesNotContain(wholeRangeMean, values);
+    }
+
+    [Fact]
+    public void Compute_AveragesTheDayAndTheSixBeforeIt()
+    {
+        // Values 1..14 by day: day 7 averages 1..7 and day 14 averages 8..14.
+        var rolling = RollingAverageCalculator.Compute(Days(14), Ramp, Day1);
+
+        Assert.Equal(14, rolling.Count);
+        Assert.Equal(4d, rolling[6]);
+        Assert.Equal(11d, rolling[13]);
+    }
+
+    [Fact]
+    public void Compute_DividesByTheWindowSoAQuietDayCounts()
+    {
+        // Six days at 7 and one at nothing. Dividing by the days that had data would report 7, which is
+        // the whole point of the zero fill: a day that cost nothing pulls the average down.
+        var quietDay = Day1.AddDays(3);
+        double ValueAt(DateOnly date) => date == quietDay ? 0 : 7;
+
+        var rolling = RollingAverageCalculator.Compute(Days(1, 6), ValueAt, Day1);
+
+        Assert.Equal(6d, Assert.Single(rolling));
+    }
+
+    [Fact]
+    public void Compute_ReadsTheSixDaysBeforeTheDisplayedRange()
+    {
+        // Displayed range starts at day 11, so its first mean has to cover days 5..11 — none of which
+        // except day 11 is in the range being plotted.
+        var rolling = RollingAverageCalculator.Compute(Days(3, 10), Ramp, Day1);
+
+        Assert.Equal(8d, rolling[0]);
+        Assert.Equal(9d, rolling[1]);
+        Assert.Equal(10d, rolling[2]);
+    }
+
+    [Fact]
+    public void Compute_IsNullUntilTheWindowClearsTheDataStart()
+    {
+        // Records begin on day 4, so day 10 is the first date whose window (days 4..10) sits entirely
+        // inside recorded history.
+        var dataStart = Day1.AddDays(3);
+
+        var rolling = RollingAverageCalculator.Compute(Days(12), Ramp, dataStart);
+
+        Assert.All(rolling.Take(9), value => Assert.Null(value));
+        Assert.NotNull(rolling[9]);
+        Assert.Equal(7d, rolling[9]);
+        Assert.NotNull(rolling[11]);
+    }
+
+    [Fact]
+    public void Compute_WithoutADataStart_IsAllNull()
+    {
+        var rolling = RollingAverageCalculator.Compute(Days(20), Ramp, null);
+
+        Assert.Equal(20, rolling.Count);
+        Assert.All(rolling, value => Assert.Null(value));
+    }
+
+    [Fact]
+    public void Compute_WithoutDates_IsEmpty()
+    {
+        Assert.Empty(RollingAverageCalculator.Compute([], Ramp, Day1));
+    }
+
+    [Fact]
+    public void Compute_AllZeroWindow_IsZeroNotNull()
+    {
+        // A recorded week of no activity averages 0. Null would say "we have no idea", which is a
+        // different and worse claim.
+        var rolling = RollingAverageCalculator.Compute(Days(10), _ => 0d, Day1);
+
+        Assert.All(rolling.Skip(RollingAverageCalculator.WindowDays - 1), value => Assert.Equal(0d, value));
+    }
+}

--- a/src/Ivy.Tendril.Widgets/.samples/Apps/TendrilDashboard/DemoApp.cs
+++ b/src/Ivy.Tendril.Widgets/.samples/Apps/TendrilDashboard/DemoApp.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Ivy;
 using Ivy.Tendril.Widgets;
 using TendrilDashboardWidget = Ivy.Tendril.Widgets.TendrilDashboard;
@@ -27,10 +28,28 @@ class DemoApp : ViewBase
             .OnReview(() => client.Toast("Review clicked", "OnReview").Info())
             .OnJobs(() => client.Toast("Jobs clicked", "OnJobs").Info());
 
-        var months = new List<string>
+        // A deterministic daily series ending on the date in the header. Weekdays cost noticeably more
+        // than weekends, which is the day-to-day noise the rolling curve is there to smooth.
+        const int trendDays = 365;
+        var trendEnd = new DateOnly(2026, 8, 20);
+        var trendRandom = new Random(11);
+        var trendDates = new List<string>(trendDays);
+        var trendCost = new List<double>(trendDays);
+        var trendPlans = new List<double>(trendDays);
+        for (var i = 0; i < trendDays; i++)
         {
-            "Sep", "Oct", "Nov", "Dec", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug"
-        };
+            var date = trendEnd.AddDays(-(trendDays - 1) + i);
+            var weekend = date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday;
+            trendDates.Add(date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+            trendCost.Add(weekend ? trendRandom.Next(0, 120) : trendRandom.Next(200, 1400));
+            trendPlans.Add(weekend ? trendRandom.Next(0, 2) : trendRandom.Next(2, 12));
+        }
+
+        // Nulls at the start stand for days the comparison period has no records for.
+        var trendPrevCost = trendCost
+            .Select((v, i) => i < 30 ? (double?)null : Math.Round(v * 0.62)).ToList();
+        var trendPrevPlans = trendPlans
+            .Select((v, i) => i < 30 ? (double?)null : Math.Round(v * 0.7)).ToList();
 
         // Mirrors UpdateNoticeView's compact layout: alert + actions, filling
         // the dashboard's fixed 120px update slot.
@@ -92,11 +111,23 @@ class DemoApp : ViewBase
                 new DashboardKpiDto("Avg Cost/Plan", "$0.98", "-0.01%", "down")
             ])
             .Trend(new DashboardTrendDto(
-                months,
-                [12400, 5100, 0, 12800, 24500, 28900, 19600, 23800, 21200, 26500, 24100, 29400],
-                [42, 18, 0, 45, 88, 102, 71, 85, 64, 91, 78, 96],
-                [null, null, 6200, 7900, 11400, 13600, 10800, 14700, 15900, 17200, 18800, 20100],
-                [null, null, 21, 27, 39, 47, 36, 51, 55, 60, 66, 71]))
+                trendDates,
+                trendCost,
+                trendPlans,
+                trendPrevCost,
+                trendPrevPlans,
+                Rolling(trendCost),
+                Rolling(trendPlans)))
+            // The short range is the tail of the same series, so its rolling curve starts six days in
+            // and the gap that leaves is visible in the demo.
+            .TrendWeekly(new DashboardTrendDto(
+                trendDates.TakeLast(28).ToList(),
+                trendCost.TakeLast(28).ToList(),
+                trendPlans.TakeLast(28).ToList(),
+                trendPrevCost.TakeLast(28).ToList(),
+                trendPrevPlans.TakeLast(28).ToList(),
+                Rolling(trendCost.TakeLast(28).ToList()),
+                Rolling(trendPlans.TakeLast(28).ToList())))
             .OnDrafts(() => client.Toast("Drafts clicked", "OnDrafts").Info())
             .OnReview(() => client.Toast("Review clicked", "OnReview").Info())
             .OnJobs(() => client.Toast("Jobs clicked", "OnJobs").Info())
@@ -124,4 +155,15 @@ class DemoApp : ViewBase
 
         return new Fragment(dashboard, toggles);
     }
+
+    /// <summary>
+    ///     Mirrors the server's rolling mean for demo data: null until a full window of days exists, so
+    ///     the curve starts where the history does.
+    /// </summary>
+    private static List<double?> Rolling(List<double> values, int window = 7) =>
+        values
+            .Select((_, i) => i < window - 1
+                ? (double?)null
+                : values.Skip(i - window + 1).Take(window).Average())
+            .ToList();
 }

--- a/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
+++ b/src/Ivy.Tendril.Widgets/TendrilDashboard.cs
@@ -20,12 +20,26 @@ public record DashboardActivityMonthDto(string Label, List<int> Weeks, List<Dash
 /// <summary>Row in the Active Jobs card. Status is lowercased; "running" spins the row's loader.</summary>
 public record DashboardJobDto(string Id, string PlanId, string Title, string Status);
 
+/// <param name="Dates">
+///     One <c>yyyy-MM-dd</c> per plotted day, ascending and contiguous. The frontend formats the axis
+///     and the tooltip from these, so the series carries no pre-rendered labels.
+/// </param>
+/// <param name="PrevCost">
+///     The comparison period's raw value for the same calendar day, or null where that day predates the
+///     records and comparing against it would invent a zero.
+/// </param>
+/// <param name="RollingCost">
+///     A 7 day trailing mean aligned to <paramref name="Dates" />, null where the window reaches back
+///     past the earliest record. A gap here is drawn as a gap in the curve.
+/// </param>
 public record DashboardTrendDto(
-    List<string> Months,
+    List<string> Dates,
     List<double> Cost,
     List<double> Plans,
     List<double?> PrevCost,
-    List<double?> PrevPlans);
+    List<double?> PrevPlans,
+    List<double?> RollingCost,
+    List<double?> RollingPlans);
 
 [ExternalWidget(
     "frontend/dist/ivy-tendril-widgets.js",

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { TendrilDashboard } from "./TendrilDashboard";
+import type { DashboardTrendDto } from "./types";
+
+const PLOT_LEFT = 44;
+const PLOT_WIDTH = 548;
+const CHART_WIDTH = PLOT_LEFT + PLOT_WIDTH + 8;
+
+/** `count` ascending days ending on 2026-09-06. */
+const days = (count: number): string[] =>
+  Array.from({ length: count }, (_, i) => {
+    const date = new Date(Date.UTC(2026, 8, 6));
+    date.setUTCDate(date.getUTCDate() - (count - 1 - i));
+    return date.toISOString().slice(0, 10);
+  });
+
+/**
+ * A trend payload whose cost and plan figures are far enough apart that a tooltip proves which
+ * series and which unit the chart picked up.
+ */
+const trendOf = (
+  count: number,
+  cost: number,
+  plans: number,
+  rollingKnown = true,
+): DashboardTrendDto => {
+  const dates = days(count);
+  return {
+    dates,
+    cost: dates.map(() => cost),
+    plans: dates.map(() => plans),
+    prevCost: dates.map(() => cost / 2),
+    prevPlans: dates.map(() => plans / 2),
+    rollingCost: dates.map((_, i) => (rollingKnown && i >= 6 ? cost : null)),
+    rollingPlans: dates.map((_, i) => (rollingKnown && i >= 6 ? plans : null)),
+  };
+};
+
+const renderDashboard = (
+  trend: DashboardTrendDto | null,
+  trendWeekly: DashboardTrendDto | null = null,
+) =>
+  render(
+    <TendrilDashboard id="dash" eventHandler={vi.fn()} trend={trend} trendWeekly={trendWeekly} />,
+  );
+
+/** The chart's own svg, not the first one in the tree: every status icon is an svg too. */
+const hoverLastPoint = (container: HTMLElement) =>
+  fireEvent.mouseMove(container.querySelector(".tdb-chart-wrap svg")!, {
+    clientX: PLOT_LEFT + PLOT_WIDTH,
+    clientY: 100,
+  });
+
+describe("TendrilDashboard trend legend", () => {
+  beforeEach(() => {
+    Element.prototype.getBoundingClientRect = vi.fn(
+      () => ({ width: CHART_WIDTH, height: 236, top: 0, left: 0, right: CHART_WIDTH, bottom: 236, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect,
+    );
+    globalThis.ResizeObserver = class {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    } as unknown as typeof ResizeObserver;
+  });
+
+  it("names the rolling average and drops the old constant average item", () => {
+    renderDashboard(trendOf(30, 100, 4));
+
+    expect(screen.getByText("7-day average")).toBeInTheDocument();
+    expect(screen.getByText("Last 12 months")).toBeInTheDocument();
+    expect(screen.getByText("Previous year")).toBeInTheDocument();
+    expect(screen.queryByText(/^Avg /)).not.toBeInTheDocument();
+  });
+
+  it("explains the missing curve when no day has a full window yet", () => {
+    const { container } = renderDashboard(trendOf(4, 100, 4, false));
+
+    expect(screen.getByText("7-day average (needs 7 days of history)")).toBeInTheDocument();
+    expect(container.querySelector(".tdb-legend-item-empty")).toBeInTheDocument();
+    expect(container.querySelectorAll(".tdb-trend-avg-curve")).toHaveLength(0);
+  });
+
+  it("keeps the item unmuted once the curve can be drawn", () => {
+    const { container } = renderDashboard(trendOf(30, 100, 4));
+
+    expect(container.querySelector(".tdb-legend-item-empty")).not.toBeInTheDocument();
+    expect(container.querySelectorAll(".tdb-trend-avg-curve")).toHaveLength(1);
+  });
+});
+
+describe("TendrilDashboard range and metric combinations", () => {
+  beforeEach(() => {
+    Element.prototype.getBoundingClientRect = vi.fn(
+      () => ({ width: CHART_WIDTH, height: 236, top: 0, left: 0, right: CHART_WIDTH, bottom: 236, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect,
+    );
+    globalThis.ResizeObserver = class {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    } as unknown as typeof ResizeObserver;
+  });
+
+  // Month and week carry different figures so a toggle that read the wrong payload would show it.
+  const monthly = trendOf(365, 120, 6);
+  const weekly = trendOf(28, 45, 4);
+
+  it("shows the yearly cost series in dollars", () => {
+    const { container } = renderDashboard(monthly, weekly);
+
+    hoverLastPoint(container);
+
+    expect(screen.getByText("Last 12 months: $120.00")).toBeInTheDocument();
+    expect(screen.getByText("7-day average: $120.00")).toBeInTheDocument();
+    expect(screen.getByText("Previous year: $60.00")).toBeInTheDocument();
+  });
+
+  it("shows the yearly plan series counted in plans", () => {
+    const { container } = renderDashboard(monthly, weekly);
+
+    fireEvent.click(screen.getByText("Total Plans"));
+    hoverLastPoint(container);
+
+    expect(screen.getByText("Last 12 months: 6 plans")).toBeInTheDocument();
+    expect(screen.getByText("7-day average: 6 plans")).toBeInTheDocument();
+    expect(screen.getByText("Previous year: 3 plans")).toBeInTheDocument();
+  });
+
+  it("shows the 4 week cost series in dollars", () => {
+    const { container } = renderDashboard(monthly, weekly);
+
+    fireEvent.click(screen.getByText("Week"));
+    hoverLastPoint(container);
+
+    expect(screen.getByText("Last 4 weeks: $45.00")).toBeInTheDocument();
+    expect(screen.getByText("7-day average: $45.00")).toBeInTheDocument();
+    expect(screen.getByText("Previous 4 weeks: $22.50")).toBeInTheDocument();
+  });
+
+  it("shows the 4 week plan series counted in plans", () => {
+    const { container } = renderDashboard(monthly, weekly);
+
+    fireEvent.click(screen.getByText("Week"));
+    fireEvent.click(screen.getByText("Total Plans"));
+    hoverLastPoint(container);
+
+    expect(screen.getByText("Last 4 weeks: 4 plans")).toBeInTheDocument();
+    expect(screen.getByText("7-day average: 4 plans")).toBeInTheDocument();
+    expect(screen.getByText("Previous 4 weeks: 2 plans")).toBeInTheDocument();
+  });
+
+  it("hides the trend card entirely when there is no series", () => {
+    const { container } = renderDashboard(null);
+
+    expect(container.querySelector(".tdb-trend")).not.toBeInTheDocument();
+    expect(screen.queryByText("7-day average")).not.toBeInTheDocument();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TendrilDashboard.tsx
@@ -11,7 +11,6 @@ import {
 } from "lucide-react";
 import {
   TendrilDashboardProps,
-  computeAverage,
   formatCountTick,
   formatCurrencyTick,
   hasSlotContent,
@@ -99,17 +98,20 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
         ? {
             values: activeTrend.cost,
             previous: activeTrend.prevCost,
+            rolling: activeTrend.rollingCost,
             formatTick: formatCurrencyTick,
             formatValue: formatCurrencyValue,
           }
         : {
             values: activeTrend.plans,
             previous: activeTrend.prevPlans,
+            rolling: activeTrend.rollingPlans,
             formatTick: formatCountTick,
             formatValue: formatPlansValue,
           };
 
-  const average = trendData ? computeAverage(trendData.values) : null;
+  const rolling = trendData?.rolling ?? [];
+  const hasRolling = rolling.some((value) => value != null);
 
   return (
     <div className="tdb-root remove-parent-padding">
@@ -214,24 +216,28 @@ export const TendrilDashboard: React.FC<TendrilDashboardProps> = ({
                       <span className="tdb-legend-dash" />
                       {previousTrendName}
                     </span>
-                    {average != null && (
-                      <span className="tdb-legend-item tdb-legend-avg">
-                        <span className="tdb-legend-dash tdb-legend-dash-avg" />
-                        Avg {trendData.formatValue(average)}
-                      </span>
-                    )}
+                    {/* Named even when it cannot be drawn: a fresh install should read why the curve
+                        is missing rather than not know it was meant to be there. */}
+                    <span
+                      className={
+                        "tdb-legend-item" + (hasRolling ? "" : " tdb-legend-item-empty")
+                      }
+                    >
+                      <span className="tdb-legend-line-avg" />
+                      {hasRolling ? "7-day average" : "7-day average (needs 7 days of history)"}
+                    </span>
                   </div>
                 </div>
                 <div className="tdb-trend-chart">
                   <TrendChart
-                    labels={activeTrend!.months}
+                    dates={activeTrend!.dates}
                     values={trendData.values}
                     previous={trendData.previous}
+                    rolling={trendData.rolling}
                     currentName={currentTrendName}
                     previousName={previousTrendName}
                     formatTick={trendData.formatTick}
                     formatValue={trendData.formatValue}
-                    average={average}
                   />
                 </div>
               </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { TrendChart } from "./TrendChart";
+
+const PLOT_LEFT = 44;
+const PLOT_WIDTH = 548;
+const CHART_WIDTH = PLOT_LEFT + PLOT_WIDTH + 8;
+
+/** `count` ascending days ending on 2026-09-06, as the `yyyy-MM-dd` strings the chart plots. */
+const days = (count: number): string[] =>
+  Array.from({ length: count }, (_, i) => {
+    const date = new Date(Date.UTC(2026, 8, 6));
+    date.setUTCDate(date.getUTCDate() - (count - 1 - i));
+    return date.toISOString().slice(0, 10);
+  });
+
+const formatCurrencyValue = (value: number): string => `$${value.toFixed(2)}`;
+
+const renderChart = (props: Partial<React.ComponentProps<typeof TrendChart>> = {}) => {
+  const dates = props.dates ?? days(30);
+  return render(
+    <TrendChart
+      dates={dates}
+      values={props.values ?? dates.map((_, i) => 100 + i * 10)}
+      previous={props.previous}
+      rolling={props.rolling}
+      currentName={props.currentName ?? "Last 12 months"}
+      previousName={props.previousName ?? "Previous year"}
+      formatTick={props.formatTick ?? ((v) => `$${v}`)}
+      formatValue={props.formatValue ?? formatCurrencyValue}
+    />,
+  );
+};
+
+describe("TrendChart rolling average curve", () => {
+  beforeEach(() => {
+    // The SVG is only rendered once the wrapper has been measured, and jsdom measures everything
+    // as zero.
+    Element.prototype.getBoundingClientRect = vi.fn(
+      () => ({ width: CHART_WIDTH, height: 236, top: 0, left: 0, right: CHART_WIDTH, bottom: 236, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect,
+    );
+    globalThis.ResizeObserver = class {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    } as unknown as typeof ResizeObserver;
+  });
+
+  it("draws one curve for a fully covered series and no horizontal reference line", () => {
+    const dates = days(30);
+    const values = dates.map((_, i) => 100 + (i % 11) * 10);
+    const rolling = values.map((_, i) => 100 + i);
+
+    const { container } = renderChart({ dates, values, rolling });
+
+    expect(container.querySelectorAll(".tdb-trend-avg-curve")).toHaveLength(1);
+    expect(container.querySelectorAll(".tdb-trend-avg-line")).toHaveLength(0);
+  });
+
+  it("breaks the curve into a segment per contiguous run of history", () => {
+    // Leading nulls (no full window yet) and a gap in the middle must not be bridged by a line
+    // through days the average was never computed for.
+    const dates = days(20);
+    const rolling: (number | null)[] = dates.map((_, i) =>
+      i < 6 || i === 12 || i === 13 ? null : 200 + i,
+    );
+
+    const { container } = renderChart({ dates, rolling });
+
+    expect(container.querySelectorAll(".tdb-trend-avg-curve")).toHaveLength(2);
+  });
+
+  it("draws nothing when the whole rolling series is unknown", () => {
+    const dates = days(10);
+
+    const { container } = renderChart({ dates, rolling: dates.map(() => null) });
+
+    expect(container.querySelectorAll(".tdb-trend-avg-curve")).toHaveLength(0);
+  });
+
+  it("names the hovered day in full and reports its 7-day average", () => {
+    const dates = days(30);
+    const values = dates.map(() => 50);
+    const rolling = dates.map((_, i) => (i < 6 ? null : 42));
+
+    const { container } = renderChart({ dates, values, rolling });
+
+    fireEvent.mouseMove(container.querySelector("svg")!, {
+      clientX: PLOT_LEFT + PLOT_WIDTH,
+      clientY: 100,
+    });
+
+    expect(screen.getByText("Sun, Sep 6, 2026")).toBeInTheDocument();
+    expect(screen.getByText(/7-day average: \$42\.00/)).toBeInTheDocument();
+  });
+
+  it("omits the average row on a day whose window has no history", () => {
+    const dates = days(30);
+    const rolling = dates.map((_, i) => (i < 6 ? null : 42));
+
+    const { container } = renderChart({ dates, rolling });
+
+    fireEvent.mouseMove(container.querySelector("svg")!, { clientX: PLOT_LEFT, clientY: 100 });
+
+    expect(screen.getByText("Sat, Aug 8, 2026")).toBeInTheDocument();
+    expect(screen.queryByText(/7-day average/)).not.toBeInTheDocument();
+  });
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/TrendChart.tsx
@@ -1,21 +1,42 @@
 import React, { useId, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { computeAverage, niceTicks } from "./types";
+import { computeRollingAverage, formatAxisDate, formatTooltipDate, niceTicks } from "./types";
 
 interface TrendChartProps {
-  labels: string[];
+  /** One `yyyy-MM-dd` per point, ascending and contiguous. Axis ticks and tooltips come from these. */
+  dates: string[];
   values: number[];
   previous?: (number | null)[];
   currentName: string;
   previousName: string;
   formatTick: (value: number) => string;
   formatValue: (value: number) => string;
-  average?: number | null;
+  /**
+   * 7-day trailing mean aligned to `dates`, null where history runs out. Omitted only by a payload
+   * that predates the series, which falls back to a mean of the displayed values.
+   */
+  rolling?: (number | null)[];
 }
 
 interface Point {
   x: number;
   y: number;
 }
+
+/** Contiguous runs of non-null points, so a gap in history breaks the line instead of bridging it. */
+const splitSegments = (points: (Point | null)[]): Point[][] => {
+  const segments: Point[][] = [];
+  let current: Point[] = [];
+  for (const point of points) {
+    if (point == null) {
+      if (current.length > 0) segments.push(current);
+      current = [];
+    } else {
+      current.push(point);
+    }
+  }
+  if (current.length > 0) segments.push(current);
+  return segments;
+};
 
 /** Catmull-Rom spline through the points, as an SVG cubic-bezier path. */
 const smoothPath = (points: Point[], maxY?: number): string => {
@@ -52,14 +73,14 @@ const Y_LABEL_WIDTH = 44;
 const ZERO_LIFT = 6;
 
 export const TrendChart: React.FC<TrendChartProps> = ({
-  labels,
+  dates,
   values,
   previous = [],
   currentName,
   previousName,
   formatTick,
   formatValue,
-  average,
+  rolling,
 }) => {
   const wrapRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ width: 0, height: DEFAULT_HEIGHT });
@@ -88,16 +109,24 @@ export const TrendChart: React.FC<TrendChartProps> = ({
   }, []);
 
   const { width, height } = size;
-  const n = labels.length;
+  const n = dates.length;
   const plotLeft = Y_LABEL_WIDTH;
   const plotWidth = Math.max(0, width - Y_LABEL_WIDTH - PAD_RIGHT);
   const plotBottom = height - PAD_BOTTOM;
   const zeroY = plotBottom - ZERO_LIFT;
   const plotHeight = zeroY - PAD_TOP;
 
-  const { ticks, points, previousPoints } = useMemo(() => {
+  const rollingSeries = useMemo(
+    () => (rolling != null && rolling.length > 0 ? rolling : computeRollingAverage(values)),
+    [rolling, values],
+  );
+
+  const { ticks, points, previousPoints, rollingSegments } = useMemo(() => {
     const previousValues = previous.filter((v): v is number => v != null);
-    const maxValue = Math.max(1, ...values, ...previousValues);
+    // The rolling series counts towards the scale: its first points average days from before the
+    // displayed range, which can sit above everything on screen.
+    const rollingValues = rollingSeries.filter((v): v is number => v != null);
+    const maxValue = Math.max(1, ...values, ...previousValues, ...rollingValues);
     const tickValues = niceTicks(maxValue, 4);
     const scaleMax = tickValues[tickValues.length - 1];
     const toPoint = (value: number, index: number): Point => ({
@@ -110,16 +139,18 @@ export const TrendChart: React.FC<TrendChartProps> = ({
       previousPoints: previous
         .map((value, index) => (value != null ? toPoint(value, index) : null))
         .filter((p): p is Point => p != null),
+      rollingSegments: splitSegments(
+        rollingSeries.map((value, index) => (value != null ? toPoint(value, index) : null)),
+      ),
     };
-  }, [values, previous, n, plotLeft, plotWidth, zeroY, plotHeight]);
+  }, [values, previous, rollingSeries, n, plotLeft, plotWidth, zeroY, plotHeight]);
 
   const scaleTop = ticks[ticks.length - 1];
 
-  const avgValue = average !== undefined ? average : computeAverage(values);
-  const avgY =
-    avgValue != null && avgValue > 0 && scaleTop > 0
-      ? zeroY - (avgValue / scaleTop) * plotHeight
-      : null;
+  // The year is only worth the axis space when the range straddles one, and then only on the points
+  // that are not in the range's own end year.
+  const endYear = n > 0 ? dates[n - 1].slice(0, 4) : "";
+  const spansYears = n > 0 && dates[0].slice(0, 4) !== endYear;
 
   const areaPath = useMemo(() => {
     if (points.length < 2) return "";
@@ -143,6 +174,7 @@ export const TrendChart: React.FC<TrendChartProps> = ({
           index: hoverIndex,
           x: plotLeft + (n <= 1 ? plotWidth / 2 : (hoverIndex / (n - 1)) * plotWidth),
           value: values[hoverIndex],
+          rollingValue: rollingSeries[hoverIndex] ?? null,
           previousValue: previous[hoverIndex] ?? null,
           previousY:
             previous[hoverIndex] != null
@@ -174,34 +206,32 @@ export const TrendChart: React.FC<TrendChartProps> = ({
               </text>
             );
           })}
-          {labels.map((label, i) => {
+          {dates.map((date, i) => {
             const maxVisible = Math.max(4, Math.floor(plotWidth / 60));
             const step = n > maxVisible ? Math.ceil((n - 1) / maxVisible) : 1;
             const isVisible = i === 0 || i === n - 1 || i % step === 0;
             if (!isVisible) return null;
             return (
               <text
-                key={label + i}
+                key={date + i}
                 className="tdb-axis-text"
                 x={plotLeft + (n <= 1 ? plotWidth / 2 : (i / (n - 1)) * plotWidth)}
                 y={height - 6}
                 textAnchor="middle"
               >
-                {label}
+                {formatAxisDate(date, spansYears && date.slice(0, 4) !== endYear)}
               </text>
             );
           })}
           {areaPath && <path d={areaPath} fill={`url(#${gradientId})`} style={{ color: "var(--tdb-fg)" }} />}
-          {avgY != null && (
-            <line
-              className="tdb-trend-avg-line"
-              x1={plotLeft}
-              x2={plotLeft + plotWidth}
-              y1={avgY}
-              y2={avgY}
-            />
-          )}
           {previousPoints.length > 1 && <path className="tdb-trend-compare" d={smoothPath(previousPoints, zeroY)} />}
+          {rollingSegments.map((segment, i) => (
+            <path
+              key={`rolling-${i}`}
+              className="tdb-trend-avg-curve"
+              d={smoothPath(segment, zeroY)}
+            />
+          ))}
           {points.length > 1 && <path className="tdb-trend-line" d={smoothPath(points, zeroY)} />}
           {hover && (
             <g>
@@ -223,11 +253,17 @@ export const TrendChart: React.FC<TrendChartProps> = ({
       )}
       {hover && (
         <div className="tdb-chart-tooltip" style={{ left: hover.x, top: PAD_TOP + 12 }}>
-          <div className="tdb-chart-tooltip-title">{labels[hover.index]}</div>
+          <div className="tdb-chart-tooltip-title">{formatTooltipDate(dates[hover.index])}</div>
           <div className="tdb-chart-tooltip-row">
             <span className="tdb-legend-dot" />
             {currentName}: {formatValue(hover.value)}
           </div>
+          {hover.rollingValue != null && (
+            <div className="tdb-chart-tooltip-row">
+              <span className="tdb-legend-line-avg" />
+              7-day average: {formatValue(hover.rollingValue)}
+            </div>
+          )}
           {hover.previousValue != null && (
             <div className="tdb-chart-tooltip-row">
               <span className="tdb-legend-dash" />

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css
@@ -374,12 +374,17 @@
   flex-shrink: 0;
 }
 
-.tdb-legend-dash-avg {
+.tdb-legend-line-avg {
   width: 10px;
   height: 0;
-  border-top: 1.5px dashed var(--tdb-muted);
-  opacity: 0.6;
+  border-top: 1.5px solid var(--tdb-muted);
+  opacity: 0.8;
   flex-shrink: 0;
+}
+
+/* The 7-day average legend item when there is not enough history to draw its curve. */
+.tdb-legend-item-empty {
+  opacity: 0.6;
 }
 
 .tdb-trend-chart {
@@ -431,12 +436,14 @@
   stroke-linejoin: round;
 }
 
-.tdb-trend-avg-line {
+/* Solid, so the three series read apart: current solid dark, comparison dashed, this one solid muted. */
+.tdb-trend-avg-curve {
   fill: none;
   stroke: var(--tdb-muted);
-  stroke-width: 1;
-  stroke-dasharray: 4 4;
-  opacity: 0.45;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.8;
   pointer-events: none;
 }
 

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/dashboard.css.test.ts
@@ -54,14 +54,22 @@ describe("dashboard.css side block and git activity layout", () => {
   });
 });
 
-describe("dashboard.css trend chart average line and legend", () => {
-  it("defines the dashed average legend indicator", () => {
-    expect(css).toContain(".tdb-legend-dash-avg {");
-    expect(css).toMatch(/\.tdb-legend-dash-avg\s*\{[^}]*border-top:\s*1\.5px dashed/);
+describe("dashboard.css rolling average curve and legend", () => {
+  it("defines the solid muted average legend indicator", () => {
+    expect(css).toContain(".tdb-legend-line-avg {");
+    expect(css).toMatch(/\.tdb-legend-line-avg\s*\{[^}]*border-top:\s*1\.5px solid var\(--tdb-muted\)/);
   });
 
-  it("defines the subtle dashed horizontal reference line", () => {
-    expect(css).toContain(".tdb-trend-avg-line {");
-    expect(css).toMatch(/\.tdb-trend-avg-line\s*\{[^}]*stroke-dasharray:\s*4 4/);
+  it("strokes the rolling curve without filling it", () => {
+    expect(css).toContain(".tdb-trend-avg-curve {");
+    expect(css).toMatch(/\.tdb-trend-avg-curve\s*\{[^}]*fill:\s*none;/);
+    expect(css).toMatch(/\.tdb-trend-avg-curve\s*\{[^}]*stroke:\s*var\(--tdb-muted\);/);
+    // A dash pattern here would put it back in the comparison line's visual language.
+    expect(css).not.toMatch(/\.tdb-trend-avg-curve\s*\{[^}]*stroke-dasharray/);
+  });
+
+  it("no longer carries the constant horizontal reference line", () => {
+    expect(css).not.toContain(".tdb-trend-avg-line");
+    expect(css).not.toContain(".tdb-legend-dash-avg");
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/helpers.test.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/helpers.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   computeActivityMetrics,
   computeAverage,
+  computeRollingAverage,
+  formatAxisDate,
   formatCountTick,
   formatCurrencyTick,
+  formatTooltipDate,
   niceTicks,
   rampLevel,
 } from "./types";
@@ -87,5 +90,72 @@ describe("computeAverage", () => {
 
   it("returns null for empty arrays", () => {
     expect(computeAverage([])).toBeNull();
+  });
+});
+
+describe("computeRollingAverage", () => {
+  it("moves with the data instead of collapsing to one constant", () => {
+    // The whole reason this replaced the average line: a flat result would be the same
+    // non-information under a new name.
+    const values = Array.from({ length: 28 }, (_, i) => (i % 11) * 10);
+
+    const rolling = computeRollingAverage(values).slice(6) as number[];
+
+    expect(new Set(rolling).size).toBeGreaterThan(1);
+  });
+
+  it("leaves the first six entries null, having no full window", () => {
+    const rolling = computeRollingAverage([1, 2, 3, 4, 5, 6, 7, 8]);
+
+    expect(rolling.slice(0, 6)).toEqual([null, null, null, null, null, null]);
+    expect(rolling[6]).not.toBeNull();
+  });
+
+  it("averages each entry with the six before it", () => {
+    const values = Array.from({ length: 14 }, (_, i) => i + 1);
+
+    const rolling = computeRollingAverage(values);
+
+    expect(rolling[6]).toBe(4);
+    expect(rolling[13]).toBe(11);
+  });
+
+  it("divides by the window so a quiet day pulls the mean down", () => {
+    const values = [7, 7, 7, 0, 7, 7, 7];
+
+    expect(computeRollingAverage(values)[6]).toBe(6);
+  });
+
+  it("returns an empty list for no values", () => {
+    expect(computeRollingAverage([])).toEqual([]);
+  });
+});
+
+describe("formatAxisDate", () => {
+  it("reads the day off the string rather than through a UTC Date parse", () => {
+    // `new Date("2026-01-01")` is UTC midnight and renders as Dec 31 west of Greenwich.
+    expect(formatAxisDate("2026-01-01")).toBe("Jan 1");
+    expect(formatAxisDate("2026-12-31")).toBe("Dec 31");
+  });
+
+  it("appends a two digit year only when asked", () => {
+    expect(formatAxisDate("2025-09-07")).toBe("Sep 7");
+    expect(formatAxisDate("2025-09-07", true)).toBe("Sep 7 '25");
+  });
+
+  it("passes through anything that is not a date", () => {
+    expect(formatAxisDate("Sep")).toBe("Sep");
+    expect(formatAxisDate("2026-13-01")).toBe("2026-13-01");
+  });
+});
+
+describe("formatTooltipDate", () => {
+  it("spells out the weekday and year on the local calendar day", () => {
+    expect(formatTooltipDate("2026-01-01")).toBe("Thu, Jan 1, 2026");
+    expect(formatTooltipDate("2026-09-07")).toBe("Mon, Sep 7, 2026");
+  });
+
+  it("passes through anything that is not a date", () => {
+    expect(formatTooltipDate("W36")).toBe("W36");
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/TendrilDashboard/types.ts
@@ -33,11 +33,15 @@ export interface DashboardJobDto {
 }
 
 export interface DashboardTrendDto {
-  months: string[];
+  /** One `yyyy-MM-dd` per plotted day, ascending and contiguous. Labels are derived from these. */
+  dates: string[];
   cost: number[];
   plans: number[];
   prevCost: (number | null)[];
   prevPlans: (number | null)[];
+  /** 7-day trailing mean aligned to `dates`; null where the window reaches past the earliest record. */
+  rollingCost: (number | null)[];
+  rollingPlans: (number | null)[];
 }
 
 export interface TendrilDashboardProps {
@@ -128,4 +132,59 @@ export const computeAverage = (values: number[]): number | null => {
   if (!values || values.length === 0) return null;
   const sum = values.reduce((acc, val) => acc + val, 0);
   return sum / values.length;
+};
+
+export const ROLLING_WINDOW_DAYS = 7;
+
+/**
+ * Trailing mean of each entry and the `window - 1` before it, null for the leading entries that have
+ * no full window. Only a fallback: the server sends a rolling series that also sees the days before
+ * the displayed range, and this one cannot.
+ */
+export const computeRollingAverage = (
+  values: number[],
+  window = ROLLING_WINDOW_DAYS,
+): (number | null)[] =>
+  values.map((_, index) =>
+    index < window - 1
+      ? null
+      : values
+          .slice(index - window + 1, index + 1)
+          .reduce((acc, value) => acc + value, 0) / window,
+  );
+
+const MONTH_NAMES = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/**
+ * Splits `yyyy-MM-dd` by hand rather than through `new Date(iso)`: the string form parses as UTC
+ * midnight and reports the previous day in every negative-offset time zone.
+ */
+const parseIsoDate = (iso: string): { year: number; month: number; day: number } | null => {
+  const parts = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso);
+  if (!parts) return null;
+  const month = Number(parts[2]);
+  if (month < 1 || month > 12) return null;
+  return { year: Number(parts[1]), month, day: Number(parts[3]) };
+};
+
+/** Axis tick for a day: "Sep 7", or "Sep 7 '25" when the year has to be spelled out. */
+export const formatAxisDate = (iso: string, includeYear = false): string => {
+  const parsed = parseIsoDate(iso);
+  if (!parsed) return iso;
+  const base = `${MONTH_NAMES[parsed.month - 1]} ${parsed.day}`;
+  return includeYear ? `${base} '${String(parsed.year).slice(-2)}` : base;
+};
+
+/** Tooltip title for a day: "Sun, Sep 7, 2026". */
+export const formatTooltipDate = (iso: string): string => {
+  const parsed = parseIsoDate(iso);
+  if (!parsed) return iso;
+  // Local Date constructor, for the weekday only; the parts above are already parsed.
+  const weekday = DAY_NAMES[new Date(parsed.year, parsed.month - 1, parsed.day).getDay()];
+  return `${weekday}, ${MONTH_NAMES[parsed.month - 1]} ${parsed.day}, ${parsed.year}`;
 };

--- a/src/Ivy.Tendril/Apps/DashboardApp.cs
+++ b/src/Ivy.Tendril/Apps/DashboardApp.cs
@@ -21,8 +21,6 @@ public class DashboardApp : ViewBase
 {
     private const int ActivityMonths = 16;
     private const int TrendMonthsBack = 24;
-    private const int TrendMonthsShown = 12;
-    private const int TrendWeeksShown = 4;
     private const int ActiveJobsShown = 8;
     private static readonly string[] DayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
@@ -118,7 +116,7 @@ public class DashboardApp : ViewBase
             .CompletedCount(jobs.Count(j => j.Status == JobStatus.Completed))
             .FailedCount(jobs.Count(j => j.Status == JobStatus.Failed))
             .Kpis(BuildKpis(stats, activity, prDays, today))
-            .Trend(BuildTrend(activity))
+            .Trend(BuildTrend(activity, today))
             .TrendWeekly(BuildWeeklyTrend(activity, today))
             .PullRequests(activity.Months
                 .TakeLast(6)
@@ -255,30 +253,91 @@ public class DashboardApp : ViewBase
     private static string FormatCost(decimal cost) =>
         cost >= 100 ? FormatHelper.FormatCost(Math.Round(cost), 0) : FormatHelper.FormatCost(cost);
 
-    internal static DashboardTrendDto BuildTrend(DashboardActivityStats activity)
-    {
-        var all = activity.Months;
-        var start = Math.Max(0, all.Count - TrendMonthsShown);
-        var window = all.Skip(start).ToList();
+    /// <summary>Days the long range plots. A year of them, compared against the same day a year back.</summary>
+    internal const int TrendDailyShownDays = 365;
 
-        var prevCost = new List<double?>(window.Count);
-        var prevPlans = new List<double?>(window.Count);
-        for (var i = 0; i < window.Count; i++)
+    /// <summary>Days the short range plots, and the offset it compares against.</summary>
+    internal const int TrendDailyWindowDays = 28;
+
+    /// <summary>
+    ///     The last twelve months as daily points, compared against the same calendar day a year
+    ///     earlier. Null when no daily series is available.
+    /// </summary>
+    internal static DashboardTrendDto? BuildTrend(
+        DashboardActivityStats activity, DateTime? todayOverride = null) =>
+        BuildDailyTrend(activity, TrendDailyShownDays, date => date.AddYears(-1), todayOverride);
+
+    /// <summary>
+    ///     The last four weeks as daily points, compared against the 28 days before them. Null when no
+    ///     daily series is available.
+    /// </summary>
+    internal static DashboardTrendDto? BuildWeeklyTrend(
+        DashboardActivityStats activity, DateTime? todayOverride = null) =>
+        BuildDailyTrend(activity, TrendDailyWindowDays, date => date.AddDays(-TrendDailyWindowDays), todayOverride);
+
+    /// <summary>
+    ///     One trend card's worth of contiguous daily points ending today, each with a date-aligned
+    ///     comparison and a rolling 7 day mean.
+    /// </summary>
+    /// <remarks>
+    ///     Returns null when neither daily series is present rather than falling back to weekly or
+    ///     monthly buckets. Buckets cannot carry a true 7 day average or a date axis, and plotting them
+    ///     under a "7-day average" label would be the misleading result this contract exists to avoid;
+    ///     the widget renders no trend card at all instead.
+    /// </remarks>
+    internal static DashboardTrendDto? BuildDailyTrend(
+        DashboardActivityStats activity,
+        int days,
+        Func<DateOnly, DateOnly> comparisonDate,
+        DateTime? todayOverride = null)
+    {
+        if (activity.DailyCosts == null && activity.DailyPlans == null)
+            return null;
+
+        var today = DateOnly.FromDateTime((todayOverride ?? DateTime.UtcNow).Date);
+        var costsByDay = activity.DailyCosts?.ToDictionary(d => d.Date, d => (double)d.Cost) ?? [];
+        var plansByDay = activity.DailyPlans ?? [];
+
+        // A mock or a fake supplies a daily series without saying where records begin. The earliest day
+        // it holds is the best stand-in; leaving it null would blank every rolling point.
+        var dataStart = activity.DailyDataStart ?? EarliestRecordedDay(costsByDay, plansByDay);
+
+        var dates = new List<DateOnly>(days);
+        for (var i = 0; i < days; i++)
+            dates.Add(today.AddDays(-days + 1 + i));
+
+        // Zero-filled, so a day with no rows is a plotted 0 rather than a missing point.
+        double CostAt(DateOnly date) => costsByDay.GetValueOrDefault(date, 0.0);
+        double PlansAt(DateOnly date) => plansByDay.GetValueOrDefault(date, 0);
+
+        var prevCost = new List<double?>(days);
+        var prevPlans = new List<double?>(days);
+        foreach (var date in dates)
         {
-            var prevIndex = start + i - 12;
-            prevCost.Add(prevIndex >= 0 ? (double)all[prevIndex].Cost : null);
-            prevPlans.Add(prevIndex >= 0 ? all[prevIndex].PlansCreated : null);
+            // Note that Feb 29 maps to Feb 28 a year earlier, which is the calendar behaviour wanted.
+            var prev = comparisonDate(date);
+            // Before the first recorded day the comparison is unknown, not zero.
+            var known = dataStart != null && prev >= dataStart.Value;
+            prevCost.Add(known && activity.DailyCosts != null ? CostAt(prev) : null);
+            prevPlans.Add(known && activity.DailyPlans != null ? PlansAt(prev) : null);
         }
 
         return new DashboardTrendDto(
-            window.Select(m => MonthLabel(m.Month)).ToList(),
-            window.Select(m => (double)m.Cost).ToList(),
-            window.Select(m => (double)m.PlansCreated).ToList(),
+            dates.Select(d => d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)).ToList(),
+            dates.Select(CostAt).ToList(),
+            dates.Select(PlansAt).ToList(),
             prevCost,
-            prevPlans);
+            prevPlans,
+            RollingAverageCalculator.Compute(dates, CostAt, dataStart),
+            RollingAverageCalculator.Compute(dates, PlansAt, dataStart));
     }
 
-    internal const int TrendDailyWindowDays = 28;
+    private static DateOnly? EarliestRecordedDay(
+        Dictionary<DateOnly, double> costsByDay, Dictionary<DateOnly, int> plansByDay)
+    {
+        var recorded = costsByDay.Keys.Concat(plansByDay.Keys).ToList();
+        return recorded.Count > 0 ? recorded.Min() : null;
+    }
 
     internal static List<DashboardActivityMonthDto> BuildActivityMonths(
         List<(DateOnly Date, int Count)> prDays, DateTime firstMonth)
@@ -308,63 +367,4 @@ public class DashboardApp : ViewBase
         return months;
     }
 
-    internal static DashboardTrendDto BuildWeeklyTrend(DashboardActivityStats activity, DateTime? todayOverride = null)
-    {
-        // If daily costs or daily plans are provided, build 28 daily points for the last 4 weeks (ending today)
-        // compared to the 28 days before that.
-        if (activity.DailyCosts != null || activity.DailyPlans != null)
-        {
-            var today = (todayOverride ?? DateTime.UtcNow).Date;
-            var costsByDay = activity.DailyCosts?.ToDictionary(d => d.Date, d => (double)d.Cost) ?? [];
-            var plansByDay = activity.DailyPlans ?? [];
-
-            var labels = new List<string>(TrendDailyWindowDays);
-            var costs = new List<double>(TrendDailyWindowDays);
-            var plans = new List<double>(TrendDailyWindowDays);
-            var prevCost = new List<double?>(TrendDailyWindowDays);
-            var prevPlans = new List<double?>(TrendDailyWindowDays);
-
-            for (var i = 0; i < TrendDailyWindowDays; i++)
-            {
-                var curDate = DateOnly.FromDateTime(today.AddDays(-TrendDailyWindowDays + 1 + i));
-                var prevDate = curDate.AddDays(-TrendDailyWindowDays);
-
-                labels.Add(FormatDayLabel(curDate));
-                costs.Add(costsByDay.GetValueOrDefault(curDate, 0.0));
-                plans.Add(plansByDay.GetValueOrDefault(curDate, 0));
-
-                prevCost.Add(activity.DailyCosts != null ? costsByDay.GetValueOrDefault(prevDate, 0.0) : null);
-                prevPlans.Add(activity.DailyPlans != null ? plansByDay.GetValueOrDefault(prevDate, 0) : null);
-            }
-
-            return new DashboardTrendDto(labels, costs, plans, prevCost, prevPlans);
-        }
-
-        // Fallback for tests or mocks providing only weekly aggregation
-        var all = activity.Weeks ?? [];
-        var start = Math.Max(0, all.Count - TrendWeeksShown);
-        var window = all.Skip(start).ToList();
-
-        var fallbackPrevCost = new List<double?>(window.Count);
-        var fallbackPrevPlans = new List<double?>(window.Count);
-        for (var i = 0; i < window.Count; i++)
-        {
-            var prevIndex = start + i - TrendWeeksShown;
-            fallbackPrevCost.Add(prevIndex >= 0 && prevIndex < all.Count ? (double)all[prevIndex].Cost : null);
-            fallbackPrevPlans.Add(prevIndex >= 0 && prevIndex < all.Count ? all[prevIndex].PlansCreated : null);
-        }
-
-        return new DashboardTrendDto(
-            window.Select(w => FormatWeekLabel(w.WeekStart)).ToList(),
-            window.Select(w => (double)w.Cost).ToList(),
-            window.Select(w => (double)w.PlansCreated).ToList(),
-            fallbackPrevCost,
-            fallbackPrevPlans);
-    }
-
-    private static string FormatDayLabel(DateOnly date) =>
-        $"{MonthLabel(date.Month)} {date.Day}";
-
-    private static string FormatWeekLabel(DateOnly weekStart) =>
-        $"{MonthLabel(weekStart.Month)} {weekStart.Day}";
 }

--- a/src/Ivy.Tendril/Database/DashboardRepository.cs
+++ b/src/Ivy.Tendril/Database/DashboardRepository.cs
@@ -7,10 +7,11 @@ namespace Ivy.Tendril.Database;
 public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSlim lockSlim)
 {
     /// <summary>
-    ///     How far back the daily spend series goes. Long enough to project a month from, short enough
-    ///     that the COALESCE in its WHERE clause (which rules out an index only scan) stays cheap.
+    ///     How far back the daily series go: 365 days the trend chart plots, six leading days so its
+    ///     first plotted point has a full 7 day rolling window, and 365 more for the prior-year
+    ///     comparison the long range draws against.
     /// </summary>
-    internal const int DailyCostWindowDays = 60;
+    internal const int DailyTrendWindowDays = 736;
 
     private sealed class ReadLockHandle : IDisposable
     {
@@ -274,7 +275,7 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
                     GROUP BY d ORDER BY d
                     """;
                 cmd.Parameters.AddWithValue("@cutoff",
-                    today.AddDays(-(DailyCostWindowDays - 1)).ToString("O", CultureInfo.InvariantCulture));
+                    today.AddDays(-(DailyTrendWindowDays - 1)).ToString("O", CultureInfo.InvariantCulture));
                 using var r = cmd.ExecuteReader();
                 while (r.Read())
                 {
@@ -297,13 +298,32 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
                     GROUP BY d
                     """;
                 cmd.Parameters.AddWithValue("@cutoff",
-                    today.AddDays(-(DailyCostWindowDays - 1)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+                    today.AddDays(-(DailyTrendWindowDays - 1)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
                 using var r = cmd.ExecuteReader();
                 while (r.Read())
                 {
                     if (DateOnly.TryParse(r.GetString(0), CultureInfo.InvariantCulture, out var day))
                         dailyPlans[day] = r.GetInt32(1);
                 }
+            }
+
+            // Where the daily series stop being silent about a gap and start meaning it. Clamped up to
+            // the retrieval window, because a record older than the window is not in the series either.
+            var windowStart = DateOnly.FromDateTime(today.AddDays(-(DailyTrendWindowDays - 1)));
+            DateOnly? dailyDataStart = null;
+            using (var cmd = connection.CreateCommand())
+            {
+                cmd.CommandText = """
+                    SELECT MIN(d) FROM (
+                        SELECT DATE(Created) AS d FROM Plans
+                        UNION ALL
+                        SELECT DATE(COALESCE(c.LogTimestamp, p.Updated)) AS d
+                        FROM Costs c JOIN Plans p ON p.Id = c.PlanId
+                    )
+                    """;
+                if (cmd.ExecuteScalar() is string earliestText
+                    && DateOnly.TryParse(earliestText, CultureInfo.InvariantCulture, out var earliest))
+                    dailyDataStart = earliest > windowStart ? earliest : windowStart;
             }
 
             var months = new List<DashboardMonthStats>(monthsBack);
@@ -401,7 +421,8 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
                 ));
             }
 
-            return new DashboardActivityStats(months, prevWeekAvgCost, dailyCosts, weeks, dailyPlans);
+            return new DashboardActivityStats(
+                months, prevWeekAvgCost, dailyCosts, weeks, dailyPlans, dailyDataStart);
         }
     }
 }

--- a/src/Ivy.Tendril/Models/CostForecast.cs
+++ b/src/Ivy.Tendril/Models/CostForecast.cs
@@ -32,7 +32,10 @@ public record CostForecast(
 /// </summary>
 public static class CostForecastCalculator
 {
-    /// <summary>Matches <c>DashboardRepository.DailyCostWindowDays</c>, and caps a longer history.</summary>
+    /// <summary>
+    ///     The month this projects, at most. Caps a longer history: the series the dashboard supplies
+    ///     reaches back a good deal further than this, for the trend chart's benefit.
+    /// </summary>
     private const int WindowDays = 30;
 
     /// <summary>

--- a/src/Ivy.Tendril/Models/DashboardModels.cs
+++ b/src/Ivy.Tendril/Models/DashboardModels.cs
@@ -25,15 +25,23 @@ public record DashboardDayStats(
 public record ProjectCount(string Project, int Count);
 
 /// <param name="DailyCosts">
-///     A 30 day daily spend series, for projecting the month. Null when the caller did not ask for
-///     one, which is what every test fake supplies; the forecast then renders its no data state.
+///     A daily spend series, for projecting the month and plotting the trend chart. Null when the
+///     caller did not ask for one, which is what every test fake supplies; the forecast then renders
+///     its no data state and the trend card is absent.
+/// </param>
+/// <param name="DailyDataStart">
+///     The earliest day the daily series could hold a record for, clamped up to the start of the
+///     retrieval window. A day on or after it with no rows genuinely cost nothing and created nothing;
+///     a day before it is unknown, and averaging over it would report a figure nobody spent. Null when
+///     there are no records at all.
 /// </param>
 public record DashboardActivityStats(
     List<DashboardMonthStats> Months,
     decimal PrevWeekAvgCostPerPlan,
     List<DashboardDailyCost>? DailyCosts = null,
     List<DashboardWeekStats>? Weeks = null,
-    Dictionary<DateOnly, int>? DailyPlans = null
+    Dictionary<DateOnly, int>? DailyPlans = null,
+    DateOnly? DailyDataStart = null
 );
 
 public record DashboardWeekStats(

--- a/src/Ivy.Tendril/Models/RollingAverage.cs
+++ b/src/Ivy.Tendril/Models/RollingAverage.cs
@@ -1,0 +1,53 @@
+namespace Ivy.Tendril.Models;
+
+/// <summary>
+///     A trailing mean over calendar days. Pure like <see cref="CostForecastCalculator" />: no clock of
+///     its own and no formatting, so the arithmetic can be tested at fixed dates and the caller owns how
+///     it reads.
+/// </summary>
+public static class RollingAverageCalculator
+{
+    /// <summary>Days in one window: the date itself plus the six calendar days before it.</summary>
+    public const int WindowDays = 7;
+
+    /// <summary>
+    ///     Mean of each date and the six calendar days before it. Null where the window reaches before
+    ///     <paramref name="dataStart" />, so an incomplete window is a gap in the curve rather than a
+    ///     value dragged down by days we never recorded.
+    /// </summary>
+    /// <param name="dates">The displayed days. One entry out per entry in.</param>
+    /// <param name="valueAt">
+    ///     That day's value, zero-filled by the caller so a recorded day with no activity contributes 0.
+    ///     Called for the six leading days too, which sit outside <paramref name="dates" />.
+    /// </param>
+    /// <param name="dataStart">
+    ///     The earliest day records exist for. Null means there are none, and every entry is null.
+    /// </param>
+    public static List<double?> Compute(
+        IReadOnlyList<DateOnly> dates,
+        Func<DateOnly, double> valueAt,
+        DateOnly? dataStart)
+    {
+        var result = new List<double?>(dates.Count);
+
+        foreach (var date in dates)
+        {
+            var windowStart = date.AddDays(-(WindowDays - 1));
+            if (dataStart is null || windowStart < dataStart.Value)
+            {
+                result.Add(null);
+                continue;
+            }
+
+            var sum = 0d;
+            for (var offset = 0; offset < WindowDays; offset++)
+                sum += valueAt(windowStart.AddDays(offset));
+
+            // Divided by the window, never by "the days that had data": that is what makes a recorded
+            // day with no activity pull the mean down, which is the honest reading of a quiet week.
+            result.Add(sum / WindowDays);
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
# Plan 00055 — Replace Dashboard Trend Average Line With Rolling 7 Day Average

## What changed

The dashboard trend card drew one horizontal dashed line at the mean of whatever was on screen. It
is now a smoothed curve of the 7-day trailing average, and to make that mean anything the underlying
series had to become daily.

**Both ranges are daily.** The long range plotted 12 monthly buckets and the short range fell back to
4 weekly buckets when the daily series was absent. Both paths are gone. `BuildDailyTrend` emits one
point per calendar day — 365 for the long range, 28 for the short one — with `yyyy-MM-dd` dates
instead of month or day labels. A rolling mean over buckets would have been a "7 buckets" average
wearing a "7-day average" label, so when no daily series exists the builders return null and the card
does not render at all.

**Quiet days now count against the average.** Days with no rows are zero-filled, and the calculator
always divides by 7 rather than by the days that happened to have data, so a week with two idle days
reads lower than a week without them. That is only honest if a zero can be distinguished from an
absence, which is what `DashboardActivityStats.DailyDataStart` is for: the earliest day any plan or
cost row exists, clamped up to the retrieval window. Days on or after it with no rows are genuinely
zero; the rolling value is null until the whole window sits inside recorded history, and a null is a
gap in the curve rather than a number dragged down by days nobody recorded.

**The series reaches further back.** `DailyCostWindowDays = 60` became
`DailyTrendWindowDays = 736`: 365 displayed days, six leading days so the first plotted point has a
full window, and 365 more for the prior-year comparison. The forecast re-applies its own 30 day
cutoff, so it cannot move — the ten `CostForecastCalculatorTests` are in scope for exactly that
reason and all pass.

**The frontend plots it and owns the calendar.** `TrendChart` takes `dates` and `rolling` instead of
`labels` and a scalar `average`, splits the rolling series on nulls into one `.tdb-trend-avg-curve`
path per contiguous run, and draws it over the comparison and under the current line. The rolling
values count towards the y-scale, because the first points average days from before the displayed
range and can sit above everything on screen. Axis ticks and tooltip titles come from the dates,
parsed by hand: `new Date("2026-01-01")` is UTC midnight and renders as December 31 in every
negative-offset time zone.

**The legend is present even when the curve is not.** A fresh install with under seven days of
history sees a muted `7-day average (needs 7 days of history)` rather than a silently missing item.

## Decisions taken

Both question blocks were unanswered, so the recommended option was taken and logged to job 00292:

- **`long-range-span` → `twelve-months-daily`.** 365 daily points, the `Last 12 months` label and the
  prior-year comparison unchanged, 736 day retrieval window. The two alternatives (90 or 30 days)
  would have changed what the toggle means and lost the year-over-year read.
- **`comparison-smoothing` → `raw-comparison`.** The comparison series stays raw daily values, as the
  dashed line does today; only the current series gains a curve.

## Commits

| Commit | Subject |
| --- | --- |
| `40cfcd46` | Add a rolling average calculator and a daily data start |
| `9a9731dd` | Build both trend ranges as daily series with a rolling average |
| `eb06ea56` | Replace the trend chart's average line with a rolling curve |

18 files, +1021 / −212.

## Verification

| Check | Result |
| --- | --- |
| DotnetFormat | Pass — `--verify-no-changes` clean on all ten changed C# files |
| DotnetBuild | Pass — every project the solution owns, `--warnaserror --no-incremental`, 0 warnings |
| DotnetTest | Pass — 60 of 60 in the plan's filter |
| CheckResult | Pass — all eight solution sections implemented as written |
| NpmTest | Pass — 45 of 45 across five files in `src/TendrilDashboard` |
| NpmBuild | Pass — `tsc` clean, bundle built |

Two pre-existing failures were reproduced at the base commit and are unrelated to the dashboard: the
`Ivy.Tendril.Docs` project cannot compile against the published `Ivy.Docs` package (it needs
`Ivy.Docs.Helpers`, which only exists in the framework source), and three `PromptwareDeployerTests`
assert Debug-build behaviour while the verification runs Release. Details in `Verification/`.

`src/Ivy.Tendril/Ivy.Tendril.slnx` lists `../../../Ivy-Framework/src/Ivy/Ivy.csproj`, which resolves
beside the original repository but not beside a worktree, so the solution cannot restore here at all.
Project reference paths were left untouched and no filesystem aliases were created; every project was
built and tested individually instead, where `src/Directory.Build.props` resolves `IvySource=false`
and Ivy comes from its published packages.


---
Created using [Ivy Tendril](https://ivy.app).
