### PR TITLE
[00060] Preserve Chat Question Answers Across Re-renders and Streaming

### DIFF
--- a/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx
@@ -1,9 +1,8 @@
 import React, { useCallback, useEffect, useMemo } from "react";
-import Markdown from "react-markdown";
 import "./agent-output.css";
 import type { EventHandler, PresentationEvent } from "./types";
 import { getHeight, getWidth } from "../styles";
-import { BlockHandler } from "../BlockHandler";
+import { BlockMarkdown } from "../BlockMarkdown";
 import { useAutoScroll } from "./use-auto-scroll";
 import { parseEventWireStream } from "./parse-events";
 import { deriveStatus } from "./status";
@@ -12,8 +11,6 @@ import { ToolUseCard } from "./tool-use-card";
 import { ResultSummary } from "./result-summary";
 import { groupToolUseEvents } from "./group-events";
 import { ToolUseGroup } from "./tool-use-group";
-import { getMarkdownPlugins } from "../math";
-import { AlertBlockquote } from "../PlanMarkdown/AlertBlockquote";
 
 function buildSuppressIndices(events: PresentationEvent[]): Set<number> {
   const indices = new Set<number>();
@@ -161,12 +158,7 @@ export const AgentViewer: React.FC<AgentViewerProps> = ({
             case "assistant-text":
               return (
                 <div key={idx} className="aov-markdown aov-assistant">
-                  <Markdown
-                    {...getMarkdownPlugins(event.text)}
-                    components={{ code: BlockHandler, blockquote: AlertBlockquote, pre: ({ children }) => <>{children}</> }}
-                  >
-                    {event.text}
-                  </Markdown>
+                  <BlockMarkdown content={event.text} />
                 </div>
               );
             case "result":

--- a/src/Ivy.Tendril.Widgets/frontend/src/BlockMarkdown.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/BlockMarkdown.tsx
@@ -1,0 +1,33 @@
+import React, { useMemo } from "react";
+import Markdown from "react-markdown";
+import { getMarkdownPlugins } from "./math";
+import { BlockHandler } from "./BlockHandler";
+import { AlertBlockquote } from "./PlanMarkdown/AlertBlockquote";
+
+/**
+ * Unwraps the `pre` react-markdown wraps a fenced code block in. `BlockHandler` (routed through
+ * `code` below) already supplies its own container, so the outer `pre` is redundant.
+ *
+ * Its identity must stay stable across renders: `QuestionsCallout` renders inside this `pre`, and a
+ * new function identity here is a new React element type, which unmounts and remounts everything
+ * inside it — including in-progress question answers.
+ */
+const UnwrapPre: React.FC<React.HTMLAttributes<HTMLPreElement>> = ({ children }) => <>{children}</>;
+
+const blockMarkdownComponents = { code: BlockHandler, blockquote: AlertBlockquote, pre: UnwrapPre };
+
+/**
+ * The shared markdown renderer for chat and agent output. `components` is a module-level constant
+ * so react-markdown never sees a new `pre` identity, and the whole render is memoized on `content`
+ * so a version bump that doesn't change the text (a streaming chunk for another message, a job
+ * status update) skips the remark/rehype pipeline entirely.
+ */
+export const BlockMarkdown: React.FC<{ content: string }> = React.memo(({ content }) => {
+  const plugins = useMemo(() => getMarkdownPlugins(content), [content]);
+
+  return (
+    <Markdown {...plugins} components={blockMarkdownComponents}>
+      {content}
+    </Markdown>
+  );
+});

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx
@@ -1132,6 +1132,291 @@ describe("ChatWidget File Uploads and Attachments", () => {
   });
 });
 
+describe("ChatWidget Interactive Question Draft Persistence", () => {
+  beforeEach(() => {
+    window.ResizeObserver = class {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    } as any;
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
+
+  const questionsFence = (...lines: string[]) => ["```questions", ...lines, "```"].join("\n");
+
+  const deployQuestion = questionsFence(
+    "- id: deploy_target",
+    "  title: Which environment should we deploy to?",
+    "  options:",
+    "    - title: Staging Environment",
+    "      value: staging",
+    "    - title: Production Environment",
+    "      value: prod",
+  );
+
+  const deployQuestionWithOther = questionsFence(
+    "- id: deploy_target",
+    "  title: Which environment should we deploy to?",
+    "  other: true",
+    "  options:",
+    "    - title: Staging Environment",
+    "      value: staging",
+    "    - title: Production Environment",
+    "      value: prod",
+  );
+
+  const freeTextQuestion = questionsFence("- id: comment", "  title: Anything else?");
+
+  const twoBlockMessage = [
+    "First block:",
+    questionsFence(
+      "- id: color",
+      "  title: Favorite color?",
+      "  options:",
+      "    - title: Red",
+      "      value: red",
+      "    - title: Blue",
+      "      value: blue",
+    ),
+    "Second block:",
+    questionsFence(
+      "- id: size",
+      "  title: Favorite size?",
+      "  options:",
+      "    - title: Small",
+      "      value: small",
+      "    - title: Large",
+      "      value: large",
+    ),
+  ].join("\n\n");
+
+  const sessionWith = (id: string, content: string): ChatSessionDto => ({
+    id,
+    title: id,
+    agentId: "claude",
+    modelId: "opus",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    messages: [
+      {
+        id: `${id}-msg`,
+        role: "assistant",
+        content,
+        timestamp: "12:00 PM",
+      },
+    ],
+  });
+
+  it("keeps a selection through a streamVersion re-render (streaming chunk arriving)", () => {
+    const session = sessionWith("sess-stream", deployQuestion);
+
+    const { rerender } = render(
+      <ChatWidget id="test-chat" activeSessionId="sess-stream" sessions={[session]} events={["OnAnswerQuestion"]} />
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-stream"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+        isStreaming
+        streamingText='{"kind":"text","text":"Working on it...","delta":false}'
+      />
+    );
+
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+    expect(screen.getByRole("button", { name: /Submit Response/i })).not.toBeDisabled();
+  });
+
+  it("never remounts the callout's input across a streamVersion re-render", () => {
+    const session = sessionWith("sess-remount", freeTextQuestion);
+
+    const { rerender } = render(
+      <ChatWidget id="test-chat" activeSessionId="sess-remount" sessions={[session]} events={["OnAnswerQuestion"]} />
+    );
+
+    const inputBefore = screen.getByPlaceholderText("Type your answer");
+
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-remount"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+        isStreaming
+        streamingText='{"kind":"text","text":"Still working...","delta":false}'
+      />
+    );
+
+    expect(screen.getByPlaceholderText("Type your answer")).toBe(inputBefore);
+  });
+
+  it("keeps typed Other text and focus through a sessionVersion re-render (runningJobs change)", () => {
+    const session = sessionWith("sess-other", deployQuestionWithOther);
+
+    const { rerender } = render(
+      <ChatWidget id="test-chat" activeSessionId="sess-other" sessions={[session]} events={["OnAnswerQuestion"]} />
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /^Other$/i }));
+    const otherInput = screen.getByPlaceholderText("Type your answer");
+    otherInput.focus();
+    fireEvent.change(otherInput, { target: { value: "A canary environment" } });
+    expect(otherInput).toHaveValue("A canary environment");
+
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-other"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+        runningJobs={[{ id: "job-1", type: "ExecutePlan", status: "Running" }]}
+      />
+    );
+
+    const otherInputAfter = screen.getByPlaceholderText("Type your answer");
+    expect(otherInputAfter).toBe(otherInput);
+    expect(otherInputAfter).toHaveValue("A canary environment");
+    expect(document.activeElement).toBe(otherInputAfter);
+  });
+
+  it("restores a selection from the draft store after a real remount (switching sessions and back)", () => {
+    const sessionA = sessionWith("sess-a", deployQuestion);
+    const sessionB = sessionWith("sess-b", "Just a plain message, no questions here.");
+
+    const { rerender } = render(
+      <ChatWidget id="test-chat" activeSessionId="sess-a" sessions={[sessionA, sessionB]} events={["OnAnswerQuestion"]} />
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+
+    rerender(
+      <ChatWidget id="test-chat" activeSessionId="sess-b" sessions={[sessionA, sessionB]} events={["OnAnswerQuestion"]} />
+    );
+    expect(screen.queryByRole("radio", { name: /Staging Environment/i })).toBeNull();
+
+    rerender(
+      <ChatWidget id="test-chat" activeSessionId="sess-a" sessions={[sessionA, sessionB]} events={["OnAnswerQuestion"]} />
+    );
+
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+  });
+
+  it("clears the draft on submit, so a later remount starts empty rather than re-offering the old selection", () => {
+    const sessionA = sessionWith("sess-a", deployQuestion);
+    const sessionB = sessionWith("sess-b", "Just a plain message, no questions here.");
+    const handleEvent = vi.fn();
+
+    const { rerender } = render(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-a"
+        sessions={[sessionA, sessionB]}
+        eventHandler={handleEvent}
+        events={["OnAnswerQuestion"]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Submit Response/i }));
+    expect(handleEvent).toHaveBeenCalled();
+
+    // Switch away and back to force a remount of the message row.
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-b"
+        sessions={[sessionA, sessionB]}
+        eventHandler={handleEvent}
+        events={["OnAnswerQuestion"]}
+      />
+    );
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-a"
+        sessions={[sessionA, sessionB]}
+        eventHandler={handleEvent}
+        events={["OnAnswerQuestion"]}
+      />
+    );
+
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).not.toBeChecked();
+    expect(screen.getByRole("button", { name: /Submit Response/i })).toBeDisabled();
+  });
+
+  it("keeps two question blocks in one message independent when only one is answered", () => {
+    const session = sessionWith("sess-two-blocks", twoBlockMessage);
+
+    const { rerender } = render(
+      <ChatWidget id="test-chat" activeSessionId="sess-two-blocks" sessions={[session]} events={["OnAnswerQuestion"]} />
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /^Red$/i }));
+    expect(screen.getByRole("radio", { name: /^Red$/i })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /^Small$/i })).not.toBeChecked();
+
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-two-blocks"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+        isStreaming
+        streamingText='{"kind":"text","text":"Working...","delta":false}'
+      />
+    );
+
+    expect(screen.getByRole("radio", { name: /^Red$/i })).toBeChecked();
+    expect(screen.getByRole("radio", { name: /^Small$/i })).not.toBeChecked();
+  });
+
+  it("keeps a selection made inside a rawStream-rendered questions block through a re-render", () => {
+    const rawStream = JSON.stringify({ kind: "text", text: deployQuestion, delta: false });
+    const session: ChatSessionDto = {
+      id: "sess-raw",
+      title: "Raw Stream Chat",
+      agentId: "claude",
+      modelId: "opus",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [
+        {
+          id: "msg-raw",
+          role: "assistant",
+          content: "",
+          rawStream,
+          timestamp: "12:00 PM",
+        },
+      ],
+    };
+
+    const { rerender } = render(
+      <ChatWidget id="test-chat" activeSessionId="sess-raw" sessions={[session]} events={["OnAnswerQuestion"]} />
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /Staging Environment/i }));
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+
+    rerender(
+      <ChatWidget
+        id="test-chat"
+        activeSessionId="sess-raw"
+        sessions={[session]}
+        events={["OnAnswerQuestion"]}
+        runningJobs={[{ id: "job-2", type: "ExecutePlan", status: "Running" }]}
+      />
+    );
+
+    expect(screen.getByRole("radio", { name: /Staging Environment/i })).toBeChecked();
+  });
+});
+
 describe("ChatWidget Streaming Scroll Behavior", () => {
   const session = {
     id: "sess-scroll",

--- a/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx
@@ -1,14 +1,12 @@
 import React, { useState, useRef, useEffect, useLayoutEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { Mic, Bot, Cpu, Zap, MessageSquare, ChevronDown, Check, CheckCircle2, XCircle, Pencil, Paperclip, X, Square, ArrowRight, Trash2, Loader2, Sparkles } from "lucide-react";
-import ReactMarkdown from "react-markdown";
 import * as pdfjsLib from "pdfjs-dist";
 import pdfjsWorker from "pdfjs-dist/build/pdf.worker.mjs?url";
 import { AgentViewer } from "../AgentViewer";
-import { getMarkdownPlugins } from "../math";
-import { BlockHandler } from "../BlockHandler";
-import { AlertBlockquote } from "../PlanMarkdown/AlertBlockquote";
-import { QuestionsSubmitContext } from "../PlanMarkdown/questionsContext";
+import { BlockMarkdown } from "../BlockMarkdown";
+import { QuestionsDraftContext, QuestionsSubmitContext } from "../PlanMarkdown/questionsContext";
+import type { QuestionSubmitCallback, QuestionsDraftState, QuestionsDraftStore } from "../PlanMarkdown/questionsContext";
 import { isImageFile, processImageFile } from "../imageUtils";
 import "./chat-widget.css";
 
@@ -619,6 +617,47 @@ export function ChatWidget({
       answers,
       responseText,
     });
+  };
+
+  // `handleQuestionSubmit` closes over `activeSession` and `emit`, both rebuilt every render. A ref
+  // to the latest closure plus a per-message-id cached callback keeps the context value identity
+  // stable across renders, so a version bump doesn't re-render every question block's consumers.
+  const handleQuestionSubmitRef = useRef(handleQuestionSubmit);
+  useEffect(() => {
+    handleQuestionSubmitRef.current = handleQuestionSubmit;
+  });
+  const submitHandlersRef = useRef(new Map<string, QuestionSubmitCallback>());
+  const submitHandlerFor = (messageId: string): QuestionSubmitCallback => {
+    let handler = submitHandlersRef.current.get(messageId);
+    if (!handler) {
+      handler = (answers, summaryText) => handleQuestionSubmitRef.current(messageId, answers, summaryText);
+      submitHandlersRef.current.set(messageId, handler);
+    }
+    return handler;
+  };
+
+  // Holds every message's in-progress question-block drafts, keyed by `${messageId}::${blockKey}`.
+  // A ref survives both re-render and remount of the message rows, which is the whole point: the
+  // draft must outlive whatever caused the remount. An entry is dropped only when its block is
+  // submitted (see `QuestionsCallout`'s `store.clear`); nothing else evicts it, so a drafted but
+  // unsubmitted answer survives session switches for as long as the widget stays mounted.
+  const questionDraftsRef = useRef(new Map<string, QuestionsDraftState>());
+  const draftStoresRef = useRef(new Map<string, QuestionsDraftStore>());
+  const draftStoreFor = (messageId: string): QuestionsDraftStore => {
+    let store = draftStoresRef.current.get(messageId);
+    if (!store) {
+      store = {
+        read: (blockKey) => questionDraftsRef.current.get(`${messageId}::${blockKey}`),
+        write: (blockKey, state) => {
+          questionDraftsRef.current.set(`${messageId}::${blockKey}`, state);
+        },
+        clear: (blockKey) => {
+          questionDraftsRef.current.delete(`${messageId}::${blockKey}`);
+        },
+      };
+      draftStoresRef.current.set(messageId, store);
+    }
+    return store;
   };
 
   const startHeaderTitleEdit = () => {
@@ -1349,34 +1388,29 @@ export function ChatWidget({
                       );
                     })()
                   ) : msg.rawStream ? (
-                    <QuestionsSubmitContext.Provider
-                      value={(answers, summaryText) => handleQuestionSubmit(msg.id, answers, summaryText)}
-                    >
-                      <AgentViewer
-                        id={`msg-${msg.id}`}
-                        jsonStream={msg.rawStream}
-                        autoScroll={false}
-                        showThinking={true}
-                        showSystemEvents={false}
-                        showStatusLabel={false}
-                        groupToolCalls={true}
-                        eventHandler={noopEventHandler}
-                      />
-                    </QuestionsSubmitContext.Provider>
+                    <QuestionsDraftContext.Provider value={draftStoreFor(msg.id)}>
+                      <QuestionsSubmitContext.Provider value={submitHandlerFor(msg.id)}>
+                        <AgentViewer
+                          id={`msg-${msg.id}`}
+                          jsonStream={msg.rawStream}
+                          autoScroll={false}
+                          showThinking={true}
+                          showSystemEvents={false}
+                          showStatusLabel={false}
+                          groupToolCalls={true}
+                          eventHandler={noopEventHandler}
+                        />
+                      </QuestionsSubmitContext.Provider>
+                    </QuestionsDraftContext.Provider>
                   ) : (
                     msg.content && (
-                      <QuestionsSubmitContext.Provider
-                        value={(answers, summaryText) => handleQuestionSubmit(msg.id, answers, summaryText)}
-                      >
-                        <div className="chat-markdown-body">
-                          <ReactMarkdown
-                            {...getMarkdownPlugins(msg.content)}
-                            components={{ code: BlockHandler, blockquote: AlertBlockquote, pre: ({ children }) => <>{children}</> }}
-                          >
-                            {msg.content}
-                          </ReactMarkdown>
-                        </div>
-                      </QuestionsSubmitContext.Provider>
+                      <QuestionsDraftContext.Provider value={draftStoreFor(msg.id)}>
+                        <QuestionsSubmitContext.Provider value={submitHandlerFor(msg.id)}>
+                          <div className="chat-markdown-body">
+                            <BlockMarkdown content={msg.content} />
+                          </div>
+                        </QuestionsSubmitContext.Provider>
+                      </QuestionsDraftContext.Provider>
                     )
                   )}
                 </div>

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
 import { PlanMarkdown as DraftMarkdown } from "./PlanMarkdown";
+import { QuestionsCallout } from "./QuestionsCallout";
 
 const renderContent = (content: string) => {
   const { container } = render(<DraftMarkdown id="w1" content={content} />);
@@ -658,5 +659,32 @@ describe("DraftMarkdown interactive questions", () => {
 
     expect(container.querySelector(".pmv-code-block")).not.toBeNull();
     expect(container.querySelector("pre")).not.toBeNull();
+  });
+});
+
+describe("QuestionsCallout without a draft context", () => {
+  // Chat wraps every interactive block in `QuestionsDraftContext.Provider`, but nothing forces
+  // that: `QuestionsCallout` reads the context optionally, and this proves it degrades to the
+  // pre-draft-store behaviour — selection still comes from the document — when no provider is
+  // present, so a plan view (which never provides it) is unaffected by the new context.
+  it("still derives selection from the document and submits normally when no draft store is present", () => {
+    // `QuestionsCallout.content` is the fence body only, unlike `SINGLE` above which still has its
+    // ``` `questions` ``` wrapper for `DraftMarkdown` to dispatch on.
+    const singleBody = SINGLE.split("\n").slice(1, -1).join("\n");
+    const onSubmit = vi.fn();
+    const { container } = render(<QuestionsCallout content={singleBody} onSubmit={onSubmit} />);
+
+    const radios = checks(container);
+    fireEvent.click(radios[0]);
+
+    const submitBtn = container.querySelector<HTMLButtonElement>(".pmv-questions-submit");
+    expect(submitBtn?.disabled).toBe(false);
+
+    fireEvent.click(submitBtn!);
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      { budget: ["per-request"] },
+      expect.stringContaining("Per request"),
+    );
   });
 });

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/QuestionsCallout.tsx
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/QuestionsCallout.tsx
@@ -1,10 +1,11 @@
-import React, { useMemo, useState } from "react";
+import React, { useContext, useMemo, useState } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { CodeBlock } from "../CodeBlock";
 import { answerEntries, otherEntry, parseQuestions } from "./questionsSchema";
 import type { PlanQuestion, QuestionOption } from "./questionsSchema";
-import type { AnswerCallback, QuestionSubmitCallback } from "./questionsContext";
+import { QuestionsDraftContext } from "./questionsContext";
+import type { AnswerCallback, QuestionSubmitCallback, QuestionsDraftState } from "./questionsContext";
 
 /**
  * Question and option descriptions are full block markdown — paragraphs, lists, tables and fenced
@@ -57,9 +58,18 @@ interface QuestionViewProps {
   question: PlanQuestion;
   blockIndex: number;
   onAnswer: AnswerCallback;
+  /** Controlled Other-field open state, from a draft store that outlives this component. */
+  otherOpen?: boolean;
+  onOtherOpenChange?: (open: boolean) => void;
 }
 
-const QuestionView: React.FC<QuestionViewProps> = ({ question, blockIndex, onAnswer }) => {
+const QuestionView: React.FC<QuestionViewProps> = ({
+  question,
+  blockIndex,
+  onAnswer,
+  otherOpen: otherOpenProp,
+  onOtherOpenChange,
+}) => {
   const entries = answerEntries(question);
   const options = question.options ?? [];
   const hasOptions = options.length > 0;
@@ -73,7 +83,11 @@ const QuestionView: React.FC<QuestionViewProps> = ({ question, blockIndex, onAns
   // state proper is still derived from `question` on every render.
   const [draft, setDraft] = useState(typed ?? "");
   const [seenTyped, setSeenTyped] = useState(typed);
-  const [otherOpen, setOtherOpen] = useState(typed !== undefined);
+  const [ownOtherOpen, setOwnOtherOpen] = useState(typed !== undefined);
+  // A draft store is supplied only in chat, where `onOtherOpenChange` takes over as the source of
+  // truth so the open state survives a remount; plan views keep their own transient state.
+  const otherOpen = onOtherOpenChange ? (otherOpenProp ?? false) : ownOtherOpen;
+  const setOtherOpen = onOtherOpenChange ?? setOwnOtherOpen;
   if (typed !== seenTyped) {
     // The document changed underneath us — resync the draft to it.
     setSeenTyped(typed);
@@ -285,34 +299,55 @@ interface ChatQuestionsBlockProps {
   onSubmit: QuestionSubmitCallback;
 }
 
-const ChatQuestionsBlock: React.FC<ChatQuestionsBlockProps> = ({ questions, blockIndex, onSubmit }) => {
-  const [localAnswers, setLocalAnswers] = useState<Record<string, string[]>>(() => {
-    const initial: Record<string, string[]> = {};
-    for (const q of questions) {
-      if (q.answerPresent) {
-        initial[q.id] = answerEntries(q);
-      }
+/** The draft a fresh block starts from: whatever the document already has answered, if anything. */
+const initialDraftFrom = (questions: PlanQuestion[]): QuestionsDraftState => {
+  const answers: Record<string, string[]> = {};
+  const otherOpen: Record<string, boolean> = {};
+  for (const q of questions) {
+    if (q.answerPresent) {
+      answers[q.id] = answerEntries(q);
+      if (otherEntry(q) !== undefined) otherOpen[q.id] = true;
     }
-    return initial;
-  });
+  }
+  return { answers, otherOpen };
+};
+
+const ChatQuestionsBlock: React.FC<ChatQuestionsBlockProps> = ({ questions, blockIndex, onSubmit }) => {
+  // Question ids are unique per block by schema, so this identifies the block within its message
+  // without needing `tagQuestionBlocks`, which the chat paths never run (`blockIndex` is always `0`
+  // there).
+  const blockKey = questions.map((q) => q.id).join("|");
+  const store = useContext(QuestionsDraftContext);
+
+  const [draftState, setDraftState] = useState<QuestionsDraftState>(
+    () => store?.read(blockKey) ?? initialDraftFrom(questions),
+  );
+  const localAnswers = draftState.answers;
+
+  const writeDraft = (next: QuestionsDraftState) => {
+    setDraftState(next);
+    store?.write(blockKey, next);
+  };
 
   const handleLocalAnswer = (questionId: string, answer: string | string[] | null | undefined) => {
-    setLocalAnswers((prev) => {
-      const next = { ...prev };
-      if (answer === undefined || answer === null || answer === "" || (Array.isArray(answer) && answer.length === 0)) {
-        delete next[questionId];
-      } else if (Array.isArray(answer)) {
-        next[questionId] = answer;
-      } else {
-        next[questionId] = [answer];
-      }
-      return next;
-    });
+    const next = { ...localAnswers };
+    if (answer === undefined || answer === null || answer === "" || (Array.isArray(answer) && answer.length === 0)) {
+      delete next[questionId];
+    } else if (Array.isArray(answer)) {
+      next[questionId] = answer;
+    } else {
+      next[questionId] = [answer];
+    }
+    writeDraft({ ...draftState, answers: next });
+  };
+
+  const handleOtherOpenChange = (questionId: string, open: boolean) => {
+    writeDraft({ ...draftState, otherOpen: { ...draftState.otherOpen, [questionId]: open } });
   };
 
   const hasAnyAnswers = Object.keys(localAnswers).length > 0;
   const clearAll = () => {
-    setLocalAnswers({});
+    writeDraft({ answers: {}, otherOpen: {} });
   };
 
   const canSubmit = questions.every((q) => {
@@ -339,6 +374,8 @@ const ChatQuestionsBlock: React.FC<ChatQuestionsBlockProps> = ({ questions, bloc
     }
 
     onSubmit(localAnswers, summaryLines.join("\n"));
+    // The answers now live in the message document, so nothing is left to draft for this block.
+    store?.clear(blockKey);
   };
 
   return (
@@ -369,6 +406,8 @@ const ChatQuestionsBlock: React.FC<ChatQuestionsBlockProps> = ({ questions, bloc
             question={effectiveQuestion}
             blockIndex={blockIndex}
             onAnswer={handleLocalAnswer}
+            otherOpen={draftState.otherOpen[question.id]}
+            onOtherOpenChange={(open) => handleOtherOpenChange(question.id, open)}
           />
         );
       })}

--- a/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsContext.ts
+++ b/src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsContext.ts
@@ -28,3 +28,25 @@ export const QuestionsAnswerContext = createContext<AnswerCallback | undefined>(
  * Carries the submit callback down to a `QuestionsCallout` when rendered inside a chat message.
  */
 export const QuestionsSubmitContext = createContext<QuestionSubmitCallback | undefined>(undefined);
+
+/** In-progress answers for one questions block, before the user submits them. */
+export interface QuestionsDraftState {
+  /** Selected option values and typed free text, by question id. */
+  answers: Record<string, string[]>;
+  /** Whether the Other field is open, by question id. Not derivable when nothing is typed yet. */
+  otherOpen: Record<string, boolean>;
+}
+
+export interface QuestionsDraftStore {
+  read(blockKey: string): QuestionsDraftState | undefined;
+  write(blockKey: string, state: QuestionsDraftState): void;
+  clear(blockKey: string): void;
+}
+
+/**
+ * Carries a per-message draft store down to `QuestionsCallout` so a block's in-progress answers
+ * outlive a remount of the message row (a streaming update, a session switch and back).
+ *
+ * Absent outside chat, which is what keeps plan views on transient state.
+ */
+export const QuestionsDraftContext = createContext<QuestionsDraftStore | undefined>(undefined);


### PR DESCRIPTION
# Summary

## Changes

Fixed two compounding bugs that destroyed in-progress answers to agent-asked questions in the chat
widget whenever unrelated chat activity re-rendered the message list (a streaming chunk, a
background job status change, a session list update):

1. **Unstable `pre` component identity caused a full remount.** `ChatWidget.tsx` and
   `AgentViewer.tsx` each passed react-markdown a fresh inline `pre` arrow function on every
   render. A new function identity is a new React element type, so React unmounted and remounted
   the whole markdown subtree — including the interactive questions callout — on every render, not
   just ones where the message content actually changed. Extracted a shared `BlockMarkdown`
   component with a module-level `pre` override and wrapped it in `React.memo`, so identical
   content skips re-rendering entirely and no `pre` remount ever happens.
2. **No state survived a legitimate remount.** Even with the accidental remounts gone, switching
   chat sessions and back (or a message flipping from a live `rawStream` to persisted `content`)
   still throws away selections and typed text, because they lived only in transient `useState`.
   Added a `QuestionsDraftContext`/`QuestionsDraftStore`, scoped per chat message and keyed per
   question block, that outlives the callout for as long as `ChatWidget` stays mounted. Drafts are
   cleared only on submit — nothing else evicts them.

## API Changes

None. All changes are frontend-only (`Ivy.Tendril.Widgets/frontend/src`); no backend or public
component API changed.

## Files Modified

- `src/Ivy.Tendril.Widgets/frontend/src/BlockMarkdown.tsx` (new) — shared, memoized markdown
  renderer with a stable `pre` override, used by both chat call sites.
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.tsx` — replaced inline
  `ReactMarkdown` with `BlockMarkdown`; added a per-message draft store
  (`questionDraftsRef`/`draftStoresRef`/`draftStoreFor`) and a stable per-message submit callback
  (`handleQuestionSubmitRef`/`submitHandlersRef`), mirroring the existing `attachmentsRef` pattern;
  wired `QuestionsDraftContext.Provider` around both interactive message branches.
- `src/Ivy.Tendril.Widgets/frontend/src/AgentViewer/AgentViewer.tsx` — replaced inline `Markdown`
  with `BlockMarkdown` in the `assistant-text` case.
- `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/questionsContext.ts` — added
  `QuestionsDraftState`, `QuestionsDraftStore`, and `QuestionsDraftContext`.
- `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/QuestionsCallout.tsx` — `ChatQuestionsBlock`
  now reads/writes through the draft store keyed by a joined-question-ids `blockKey`, and clears
  the draft on submit; `QuestionView` accepts optional `otherOpen`/`onOtherOpenChange` to become
  controlled when a draft store is present, falling back to its own state otherwise (plan views
  unaffected).
- `src/Ivy.Tendril.Widgets/frontend/src/ChatWidget/ChatWidget.test.tsx` — 7 new tests covering
  stream-update survival, no-remount DOM identity, Other-text/focus survival across a
  session-version bump, draft restoration across a real session-switch remount, draft clearing on
  submit, two independent question blocks in one message, and the `rawStream`/`AgentViewer` path.
- `src/Ivy.Tendril.Widgets/frontend/src/PlanMarkdown/PlanMarkdown.questions.test.tsx` — 1 new test
  proving `QuestionsCallout` still works correctly with no `QuestionsDraftContext` present (the
  plan-view path).

## Manual Testing

Automated coverage only — no UI changes are visually observable in a way that isn't already
exercised by the new tests (this is a React reconciliation/state-lifetime fix, not a visual
change). Ran:

```
cd src/Ivy.Tendril.Widgets/frontend
vp test --run src/ChatWidget/ChatWidget.test.tsx src/PlanMarkdown/PlanMarkdown.questions.test.tsx \
  src/PlanMarkdown/PlanMarkdown.codeblock.test.tsx src/AgentViewer/tool-use-group.test.tsx src/math.test.tsx
# Test Files  5 passed (5)  |  Tests  97 passed (97)
```

`DotnetBuild` also exercises the TypeScript compiler over the changed frontend source via the
`Ivy.Tendril.Widgets.csproj` `WidgetsBuildFrontend` MSBuild target (`tsc && vite build`), which
succeeded with 0 errors.

---
## Commits
- c68cc458 Preserve chat question answers across re-renders and streaming (Plan 00060)
- 6c6fa04b Add regression tests for question draft persistence (Plan 00060)

---
Created using [Ivy Tendril](https://ivy.app).