### PR TITLE
[00063] Remove the Dead Weekly Bucket Aggregation From Dashboard Activity Stats

### DIFF
--- a/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
+++ b/src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs
@@ -68,7 +68,7 @@ public class DashboardAppViewModelTests
         var today = new DateTime(2026, 9, 6);
         var dataStart = new DateOnly(2024, 9, 1);
         var activity = new DashboardActivityStats(
-            [], 0m, DailyCosts(dataStart, new DateOnly(2026, 9, 6), Sawtooth), null, null, dataStart);
+            [], 0m, DailyCosts(dataStart, new DateOnly(2026, 9, 6), Sawtooth), null, dataStart);
 
         var trend = DashboardApp.BuildTrend(activity, today);
 
@@ -97,7 +97,7 @@ public class DashboardAppViewModelTests
         var today = new DateTime(2026, 9, 6);
         var dataStart = new DateOnly(2025, 1, 1);
         var activity = new DashboardActivityStats(
-            [], 0m, DailyCosts(dataStart, new DateOnly(2026, 9, 6), Unique), null, null, dataStart);
+            [], 0m, DailyCosts(dataStart, new DateOnly(2026, 9, 6), Unique), null, dataStart);
 
         var trend = DashboardApp.BuildTrend(activity, today);
 
@@ -122,7 +122,7 @@ public class DashboardAppViewModelTests
         var today = new DateTime(2028, 3, 1);
         var dataStart = new DateOnly(2026, 1, 1);
         var activity = new DashboardActivityStats(
-            [], 0m, DailyCosts(dataStart, new DateOnly(2028, 3, 1), Unique), null, null, dataStart);
+            [], 0m, DailyCosts(dataStart, new DateOnly(2028, 3, 1), Unique), null, dataStart);
 
         var trend = DashboardApp.BuildTrend(activity, today);
 
@@ -151,7 +151,7 @@ public class DashboardAppViewModelTests
     {
         // A fresh install: the series exists but holds nothing, so every day reads 0 and the curve has
         // nothing to draw rather than a confident flat line at zero.
-        var activity = new DashboardActivityStats([], 0m, [], null, new Dictionary<DateOnly, int>());
+        var activity = new DashboardActivityStats([], 0m, [], new Dictionary<DateOnly, int>());
 
         var trend = DashboardApp.BuildTrend(activity, new DateTime(2026, 9, 6));
 
@@ -334,7 +334,7 @@ public class DashboardAppViewModelTests
             [new DateOnly(2026, 8, 9)] = 2
         };
 
-        var activity = new DashboardActivityStats([], 0m, dailyCosts, null, dailyPlans);
+        var activity = new DashboardActivityStats([], 0m, dailyCosts, dailyPlans);
         var trend = DashboardApp.BuildWeeklyTrend(activity, today);
 
         Assert.NotNull(trend);
@@ -368,14 +368,10 @@ public class DashboardAppViewModelTests
     [Fact]
     public void BuildWeeklyTrend_WithoutADailySeries_IsAbsent()
     {
-        // The weekly-bucket fallback is gone: four weekly buckets cannot make a 7 day average.
-        var monday = new DateOnly(2026, 8, 31);
-        var weeks = Enumerable.Range(0, 24)
-            .Select(i => new DashboardWeekStats(monday.AddDays(-7 * (23 - i)), i + 1, 0, (i + 1) * 10m, 0))
-            .ToList();
-
+        // Weekly buckets are gone from the model entirely: with no daily series there is nothing to
+        // fall back to, so the card is absent rather than plotted from coarser data.
         Assert.Null(DashboardApp.BuildWeeklyTrend(
-            new DashboardActivityStats([], 0m, null, weeks), new DateTime(2026, 9, 6)));
+            new DashboardActivityStats([], 0m), new DateTime(2026, 9, 6)));
     }
 
     [Fact]

--- a/src/Ivy.Tendril.Test/DashboardActivityStatsTests.cs
+++ b/src/Ivy.Tendril.Test/DashboardActivityStatsTests.cs
@@ -242,37 +242,4 @@ public class DashboardActivityStatsTests : IDisposable
         Assert.NotNull(stats.DailyPlans);
         Assert.Equal(1, stats.DailyPlans[DateOnly.FromDateTime(longAgo)]);
     }
-
-    [Fact]
-    public void GetActivityStats_AggregatesByWeek()
-    {
-        var now = DateTime.UtcNow;
-        var monday = now.Date.AddDays(-(((int)now.DayOfWeek + 6) % 7));
-        var lastWeekMonday = monday.AddDays(-7);
-
-        var plan1 = CreateTestPlan(1600, PlanStatus.Completed, monday.AddDays(1), monday.AddDays(1), prCount: 2);
-        var plan2 = CreateTestPlan(1601, PlanStatus.Completed, lastWeekMonday.AddDays(2), lastWeekMonday.AddDays(2), prCount: 1);
-
-        _db.UpsertPlan(plan1);
-        _db.UpsertPlan(plan2);
-        _db.UpsertCosts(1600, [new CostEntry("ExecutePlan", 500, 15m, monday.AddDays(1))]);
-        _db.UpsertCosts(1601, [new CostEntry("ExecutePlan", 200, 5m, lastWeekMonday.AddDays(2))]);
-
-        var stats = _db.GetActivityStats();
-
-        Assert.NotNull(stats.Weeks);
-        Assert.Equal(24, stats.Weeks.Count);
-
-        var thisWeekStats = stats.Weeks[^1];
-        Assert.Equal(DateOnly.FromDateTime(monday), thisWeekStats.WeekStart);
-        Assert.Equal(1, thisWeekStats.PlansCreated);
-        Assert.Equal(2, thisWeekStats.PrsMerged);
-        Assert.Equal(15m, thisWeekStats.Cost);
-
-        var lastWeekStats = stats.Weeks[^2];
-        Assert.Equal(DateOnly.FromDateTime(lastWeekMonday), lastWeekStats.WeekStart);
-        Assert.Equal(1, lastWeekStats.PlansCreated);
-        Assert.Equal(1, lastWeekStats.PrsMerged);
-        Assert.Equal(5m, lastWeekStats.Cost);
-    }
 }

--- a/src/Ivy.Tendril/Database/DashboardRepository.cs
+++ b/src/Ivy.Tendril/Database/DashboardRepository.cs
@@ -341,88 +341,8 @@ public class DashboardRepository(SqliteConnection connection, ReaderWriterLockSl
                 ));
             }
 
-            // Weekly aggregation: 24 weeks back (for 12 weeks current + 12 weeks previous comparison)
-            const int weeksBack = 24;
-            var currentMonday = DateOnly.FromDateTime(today).AddDays(-(((int)today.DayOfWeek + 6) % 7));
-            var firstMonday = currentMonday.AddDays(-7 * (weeksBack - 1));
-            var weekCutoff = firstMonday.ToString("yyyy-MM-dd");
-
-            var weekCreated = new Dictionary<string, int>();
-            var weekPrs = new Dictionary<string, int>();
-            var weekCosts = new Dictionary<string, decimal>();
-            var weekTokens = new Dictionary<string, long>();
-
-            using (var cmd = connection.CreateCommand())
-            {
-                cmd.CommandText = """
-                    SELECT DATE(Created, 'weekday 0', '-6 days') AS yw, COUNT(*)
-                    FROM Plans WHERE Created >= @cutoff GROUP BY yw
-                    """;
-                cmd.Parameters.AddWithValue("@cutoff", weekCutoff);
-                using var r = cmd.ExecuteReader();
-                while (r.Read())
-                {
-                    if (!r.IsDBNull(0))
-                        weekCreated[r.GetString(0)] = r.GetInt32(1);
-                }
-            }
-
-            using (var cmd = connection.CreateCommand())
-            {
-                cmd.CommandText = """
-                    SELECT DATE(p.Updated, 'weekday 0', '-6 days') AS yw, COUNT(*)
-                    FROM PullRequests pr JOIN Plans p ON p.Id = pr.PlanId
-                    WHERE p.Updated >= @cutoff AND p.State = 'Completed'
-                    GROUP BY yw
-                    """;
-                cmd.Parameters.AddWithValue("@cutoff", weekCutoff);
-                using var r = cmd.ExecuteReader();
-                while (r.Read())
-                {
-                    if (!r.IsDBNull(0))
-                        weekPrs[r.GetString(0)] = r.GetInt32(1);
-                }
-            }
-
-            using (var cmd = connection.CreateCommand())
-            {
-                cmd.CommandText = """
-                    SELECT DATE(COALESCE(c.LogTimestamp, p.Updated), 'weekday 0', '-6 days') AS yw,
-                           COALESCE(SUM(c.Cost), 0), SUM(c.Tokens)
-                    FROM Costs c JOIN Plans p ON p.Id = c.PlanId
-                    WHERE COALESCE(c.LogTimestamp, p.Updated) >= @cutoff
-                      AND p.State IN ('Completed', 'Failed', 'Review')
-                    GROUP BY yw
-                    """;
-                cmd.Parameters.AddWithValue("@cutoff", weekCutoff);
-                using var r = cmd.ExecuteReader();
-                while (r.Read())
-                {
-                    if (!r.IsDBNull(0))
-                    {
-                        var key = r.GetString(0);
-                        weekCosts[key] = Convert.ToDecimal(r.GetValue(1), CultureInfo.InvariantCulture);
-                        weekTokens[key] = Convert.ToInt64(r.GetValue(2), CultureInfo.InvariantCulture);
-                    }
-                }
-            }
-
-            var weeks = new List<DashboardWeekStats>(weeksBack);
-            for (var i = 0; i < weeksBack; i++)
-            {
-                var weekStart = firstMonday.AddDays(i * 7);
-                var key = weekStart.ToString("yyyy-MM-dd");
-                weeks.Add(new DashboardWeekStats(
-                    weekStart,
-                    weekCreated.GetValueOrDefault(key),
-                    weekPrs.GetValueOrDefault(key),
-                    weekCosts.GetValueOrDefault(key),
-                    weekTokens.GetValueOrDefault(key)
-                ));
-            }
-
             return new DashboardActivityStats(
-                months, prevWeekAvgCost, dailyCosts, weeks, dailyPlans, dailyDataStart);
+                months, prevWeekAvgCost, dailyCosts, dailyPlans, dailyDataStart);
         }
     }
 }

--- a/src/Ivy.Tendril/Models/DashboardModels.cs
+++ b/src/Ivy.Tendril/Models/DashboardModels.cs
@@ -39,17 +39,8 @@ public record DashboardActivityStats(
     List<DashboardMonthStats> Months,
     decimal PrevWeekAvgCostPerPlan,
     List<DashboardDailyCost>? DailyCosts = null,
-    List<DashboardWeekStats>? Weeks = null,
     Dictionary<DateOnly, int>? DailyPlans = null,
     DateOnly? DailyDataStart = null
-);
-
-public record DashboardWeekStats(
-    DateOnly WeekStart,
-    int PlansCreated,
-    int PrsMerged,
-    decimal Cost,
-    long Tokens
 );
 
 /// <summary>


### PR DESCRIPTION
# Summary

## Changes

Removed `DashboardActivityStats.Weeks` and the three 24-week SQLite aggregation queries in `DashboardRepository.GetActivityStats` that only populated it, since [Plan 00055](plan://00055) already deleted the field's only consumer (the weekly-bucket trend fallback). Every dashboard load now skips three queries whose result nobody read.

## API Changes

- `DashboardActivityStats` record: removed the `Weeks` parameter (previously `List<DashboardWeekStats>? Weeks = null`, positioned between `DailyCosts` and `DailyPlans`). Callers passing arguments positionally past `DailyCosts` need to drop that slot.
- Removed the `DashboardWeekStats` record entirely.

## Files Modified

- `src/Ivy.Tendril/Database/DashboardRepository.cs` - deleted the weekly aggregation block (3 queries + bucket loop) from `GetActivityStats`.
- `src/Ivy.Tendril/Models/DashboardModels.cs` - removed the `Weeks` field and `DashboardWeekStats` record.
- `src/Ivy.Tendril.Test/Apps/DashboardAppViewModelTests.cs` - fixed five positional `DashboardActivityStats` constructions shifted by the removed parameter; rewrote `BuildWeeklyTrend_WithoutADailySeries_IsAbsent` to drop its now-impossible 24-bucket fixture.
- `src/Ivy.Tendril.Test/DashboardActivityStatsTests.cs` - deleted `GetActivityStats_AggregatesByWeek`, which covered only the removed queries.

## Manual Testing

N/A - internal change with no user-facing behavior. The dashboard's trend chart already reads only the daily series (since Plan 00055); this change removes dead backend computation that no view ever displayed.

---
### Commits
- 3e2f536e Update dashboard tests for removed weekly bucket aggregation
- b6a09116 Remove dead weekly bucket aggregation from dashboard activity stats

---
Created using [Ivy Tendril](https://ivy.app).
